### PR TITLE
[TECHNICAL SUPPORT] LPS-114258 Image Editor toolbar is not visible

### DIFF
--- a/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/ImageEditor.scss
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/ImageEditor.scss
@@ -68,7 +68,7 @@ $gray-lighter: lighten($gray-base, 93.5%) !default; // #EEE
 	}
 
 	.lfr-image-editor-tools-container {
-		height: $imageeditor-controls-height + $imageeditor-filters-height;
+		height: $imageeditor-controls-height + $slider-height;
 	}
 
 	.controls {


### PR DESCRIPTION
Hey,

[LPS-114258](https://issues.liferay.com/browse/LPS-114258),

The height was used to be hardcoded: https://github.com/NemethNorbert/liferay-portal/commit/be50afd7e4fb2b613dd3152597911a101bc7595a

I decided to go with the slider height as it seems perfect, but we can hardcode some other value again.

The difference I see from 7.2.x and master, is the generated height for the canvas, however it seems a lot better on master and that value is manipulated by hardcoded values as well.
imageEditor.es.js -> ln470

Please review my changes,
Thanks