### PR TITLE
LPS-114034 - Apply the use of clay content taglib in journal-content-asset-addon-entry-conversions

### DIFF
--- a/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/page.jsp
+++ b/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/page.jsp
@@ -91,12 +91,19 @@ StagingGroupHelper stagingGroupHelper = StagingGroupHelperUtil.getStagingGroupHe
 						String subscriptionOnClick = randomNamespace + "subscribeToComments(" + !subscribed + ");";
 						%>
 
-						<div class="autofit-row mb-4">
-							<span class="autofit-col autofit-col-expand text-secondary text-uppercase">
+						<clay:content-row
+							cssClass="mb-4"
+							floatElements="end"
+						>
+							<clay:content-col
+								containerElement="span"
+								cssClass="text-secondary text-uppercase"
+								expand="true"
+							>
 								<strong><liferay-ui:message arguments="<%= discussion.getDiscussionCommentsCount() %>" key='<%= (discussion.getDiscussionCommentsCount() == 1) ? "x-comment" : "x-comments" %>' /></strong>
-							</span>
+							</clay:content-col>
 
-							<div class="autofit-col autofit-col-end">
+							<clay:content-col>
 								<c:if test="<%= canSubscribe %>">
 									<c:choose>
 										<c:when test="<%= subscribed %>">
@@ -111,8 +118,8 @@ StagingGroupHelper stagingGroupHelper = StagingGroupHelperUtil.getStagingGroupHe
 										</c:otherwise>
 									</c:choose>
 								</c:if>
-							</div>
-						</div>
+							</clay:content-col>
+						</clay:content-row>
 
 						<c:if test="<%= !discussion.isMaxCommentsLimitExceeded() %>">
 							<aui:input name="emailAddress" type="hidden" />
@@ -120,14 +127,21 @@ StagingGroupHelper stagingGroupHelper = StagingGroupHelperUtil.getStagingGroupHe
 							<c:choose>
 								<c:when test="<%= commentSectionDisplayContext.isReplyButtonVisible() %>">
 									<div class="lfr-discussion-reply-container">
-										<div class="autofit-padded-no-gutters autofit-row">
-											<div class="autofit-col lfr-discussion-details">
+										<clay:content-row
+											noGutters="true"
+										>
+											<clay:content-col
+												cssClass="lfr-discussion-details"
+											>
 												<liferay-ui:user-portrait
 													user="<%= user %>"
 												/>
-											</div>
+											</clay:content-col>
 
-											<div class="autofit-col autofit-col-expand lfr-discussion-editor">
+											<clay:content-col
+												cssClass="lfr-discussion-editor"
+												expand="true"
+											>
 												<liferay-editor:editor
 													configKey="commentEditor"
 													contents=""
@@ -144,8 +158,8 @@ StagingGroupHelper stagingGroupHelper = StagingGroupHelperUtil.getStagingGroupHe
 												<aui:button-row>
 													<aui:button cssClass="btn-comment btn-primary btn-sm" disabled="<%= true %>" id="postReplyButton0" onClick='<%= randomNamespace + "postReply(0);" %>' value='<%= themeDisplay.isSignedIn() ? "reply" : "reply-as" %>' />
 												</aui:button-row>
-											</div>
-										</div>
+											</clay:content-col>
+										</clay:content-row>
 									</div>
 								</c:when>
 								<c:otherwise>

--- a/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/view_message_thread.jsp
+++ b/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/view_message_thread.jsp
@@ -43,22 +43,29 @@ Format dateFormatDateTime = FastDateFormatFactoryUtil.getDateTime(locale, timeZo
 <c:if test="<%= commentTreeDisplayContext.isDiscussionVisible() %>">
 	<article class='lfr-discussion <%= (rootDiscussionComment.getCommentId() == discussionComment.getParentCommentId()) ? "lfr-discussion-container" : "" %>'>
 		<div class="comment-container">
-			<div class="autofit-padded-no-gutters-x autofit-row widget-metadata">
-				<div class="autofit-col">
+			<clay:content-row
+				cssClass="widget-metadata"
+				noGutters="x"
+			>
+				<clay:content-col>
 					<liferay-ui:user-portrait
 						cssClass="sticker-lg"
 						userId="<%= discussionComment.getUserId() %>"
 						userName="<%= discussionComment.getUserName() %>"
 					/>
-				</div>
+				</clay:content-col>
 
 				<%
 				User messageUser = discussionComment.getUser();
 				%>
 
-				<div class="autofit-col autofit-col-expand">
-					<div class="autofit-row">
-						<div class="autofit-col autofit-col-expand">
+				<clay:content-col
+					expand="true"
+				>
+					<clay:content-row>
+						<clay:content-col
+							expand="true"
+						>
 							<div class="text-truncate">
 								<liferay-util:whitespace-remover>
 									<aui:a cssClass="username" href="<%= ((messageUser != null) && messageUser.isActive()) ? messageUser.getDisplayURL(themeDisplay) : null %>">
@@ -93,15 +100,19 @@ Format dateFormatDateTime = FastDateFormatFactoryUtil.getDateTime(locale, timeZo
 										User parentMessageUser = parentDiscussionComment.getUser();
 										%>
 
-										<div class="autofit-padded-no-gutters-x autofit-row">
-											<div class="autofit-col">
+										<clay:content-row
+											noGutters="x"
+										>
+											<clay:content-col>
 												<liferay-ui:user-portrait
 													cssClass="sticker-lg"
 													user="<%= parentMessageUser %>"
 												/>
-											</div>
+											</clay:content-col>
 
-											<div class="autofit-col autofit-col-expand">
+											<clay:content-col
+												expand="true"
+											>
 												<div class="username">
 													<%= HtmlUtil.escape(parentDiscussionComment.getUserName()) %>
 												</div>
@@ -113,8 +124,8 @@ Format dateFormatDateTime = FastDateFormatFactoryUtil.getDateTime(locale, timeZo
 												<div class="text-secondary">
 													<liferay-ui:message arguments="<%= LanguageUtil.getTimeDescription(request, System.currentTimeMillis() - parentDiscussionCreateDate.getTime(), true) %>" key="x-ago" translateArguments="<%= false %>" />
 												</div>
-											</div>
-										</div>
+											</clay:content-col>
+										</clay:content-row>
 									</liferay-util:buffer>
 
 									<%
@@ -161,12 +172,12 @@ Format dateFormatDateTime = FastDateFormatFactoryUtil.getDateTime(locale, timeZo
 									<aui:workflow-status model="<%= CommentConstants.getDiscussionClass() %>" showIcon="<%= false %>" showLabel="<%= false %>" status="<%= workflowableComment.getStatus() %>" />
 								</c:if>
 							</div>
-						</div>
-					</div>
-				</div>
+						</clay:content-col>
+					</clay:content-row>
+				</clay:content-col>
 
 				<c:if test="<%= commentTreeDisplayContext.isActionControlsVisible() && (index > 0) %>">
-					<div class="autofit-col">
+					<clay:content-col>
 						<liferay-ui:icon-menu
 							cssClass="actions-menu"
 							direction="left-side"
@@ -189,9 +200,9 @@ Format dateFormatDateTime = FastDateFormatFactoryUtil.getDateTime(locale, timeZo
 								/>
 							</c:if>
 						</liferay-ui:icon-menu>
-					</div>
+					</clay:content-col>
 				</c:if>
-			</div>
+			</clay:content-row>
 
 			<div class="lfr-discussion-body">
 				<div id="<%= randomNamespace %>messageScroll<%= discussionComment.getCommentId() %>">
@@ -232,9 +243,11 @@ Format dateFormatDateTime = FastDateFormatFactoryUtil.getDateTime(locale, timeZo
 					</c:if>
 				</div>
 
-				<div class="autofit-row lfr-discussion-controls">
+				<clay:content-row
+					cssClass="lfr-discussion-controls"
+				>
 					<c:if test="<%= commentTreeDisplayContext.isActionControlsVisible() && commentTreeDisplayContext.isReplyActionControlVisible() %>">
-						<div class="autofit-col">
+						<clay:content-col>
 							<c:if test="<%= !discussion.isMaxCommentsLimitExceeded() %>">
 								<c:choose>
 									<c:when test="<%= commentTreeDisplayContext.isReplyButtonVisible() %>">
@@ -249,11 +262,11 @@ Format dateFormatDateTime = FastDateFormatFactoryUtil.getDateTime(locale, timeZo
 									</c:otherwise>
 								</c:choose>
 							</c:if>
-						</div>
+						</clay:content-col>
 					</c:if>
 
 					<c:if test="<%= commentTreeDisplayContext.isRatingsVisible() %>">
-						<div class="autofit-col">
+						<clay:content-col>
 							<liferay-ratings:ratings
 								className="<%= CommentConstants.getDiscussionClassName() %>"
 								classPK="<%= discussionComment.getCommentId() %>"
@@ -261,23 +274,29 @@ Format dateFormatDateTime = FastDateFormatFactoryUtil.getDateTime(locale, timeZo
 								ratingsEntry="<%= discussionComment.getRatingsEntry() %>"
 								ratingsStats="<%= discussionComment.getRatingsStats() %>"
 							/>
-						</div>
+						</clay:content-col>
 					</c:if>
-				</div>
+				</clay:content-row>
 			</div>
 		</div>
 
 		<div class="lfr-discussion lfr-discussion-form-reply" id='<%= namespace + "postReplyForm" + index %>' style="display: none;">
 			<div class="lfr-discussion-reply-container">
-				<div class="autofit-padded-no-gutters autofit-row">
-					<div class="autofit-col lfr-discussion-details">
+				<clay:content-row
+					noGutters="true"
+				>
+					<clay:content-col
+						cssClass="lfr-discussion-details"
+					>
 						<liferay-ui:user-portrait
 							cssClass="sticker-lg"
 							user="<%= user %>"
 						/>
-					</div>
+					</clay:content-col>
 
-					<div class="autofit-col autofit-col-expand">
+					<clay:content-col
+						expand="true"
+					>
 						<div class="editor-wrapper"></div>
 
 						<aui:button-row>
@@ -298,8 +317,8 @@ Format dateFormatDateTime = FastDateFormatFactoryUtil.getDateTime(locale, timeZo
 								);
 							};
 						</aui:script>
-					</div>
-				</div>
+					</clay:content-col>
+				</clay:content-row>
 			</div>
 		</div>
 

--- a/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/main/resources/META-INF/resources/open_google_docs.jsp
+++ b/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/main/resources/META-INF/resources/open_google_docs.jsp
@@ -36,8 +36,14 @@ String googleDocsRedirect = ParamUtil.getString(request, "googleDocsRedirect");
 	</head>
 
 	<body>
-		<div class="autofit-padded autofit-row autofit-row-center google-docs-toolbar">
-			<div class="autofit-col autofit-col-expand">
+		<clay:content-row
+			cssClass="google-docs-toolbar"
+			padded="true"
+			verticalAlign="center"
+		>
+			<clay:content-col
+				expand="true"
+			>
 				<div class="autofit-section">
 					<portlet:actionURL name="/document_library/edit_in_google_docs" var="checkInURL">
 						<portlet:param name="<%= Constants.CMD %>" value="<%= Constants.CHECKIN %>" />
@@ -55,9 +61,9 @@ String googleDocsRedirect = ParamUtil.getString(request, "googleDocsRedirect");
 						/>
 					</form>
 				</div>
-			</div>
+			</clay:content-col>
 
-			<div class="autofit-col">
+			<clay:content-col>
 				<portlet:actionURL name="/document_library/edit_in_google_docs" var="cancelCheckoutURL">
 					<portlet:param name="<%= Constants.CMD %>" value="<%= Constants.CANCEL_CHECKOUT %>" />
 					<portlet:param name="redirect" value="<%= googleDocsRedirect %>" />
@@ -72,8 +78,8 @@ String googleDocsRedirect = ParamUtil.getString(request, "googleDocsRedirect");
 						type="submit"
 					/>
 				</form>
-			</div>
-		</div>
+			</clay:content-col>
+		</clay:content-row>
 
 		<iframe class="google-docs-iframe" frameborder="0" id="<portlet:namespace />gDocsIFrame" src="<%= GoogleDriveBackgroundTaskConstants.DOCS_GOOGLE_COM_URL + HtmlUtil.escapeAttribute(googleDocsEditURL) %>"></iframe>
 	</body>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/file_entry_history.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/file_entry_history.jsp
@@ -34,7 +34,9 @@
 	%>
 
 		<li class="list-group-item list-group-item-flex">
-			<div class="autofit-col autofit-col-expand">
+			<clay:content-col
+				expand="true"
+			>
 				<div class="list-group-title">
 					<liferay-ui:message arguments="<%= fileVersion.getVersion() %>" key="version-x" />
 				</div>
@@ -53,11 +55,11 @@
 						</c:otherwise>
 					</c:choose>
 				</div>
-			</div>
+			</clay:content-col>
 
-			<div class="autofit-col">
+			<clay:content-col>
 				<liferay-util:include page="/document_library/file_entry_history_action.jsp" servletContext="<%= application %>" />
-			</div>
+			</clay:content-col>
 		</li>
 
 	<%

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info_panel_file_entry.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info_panel_file_entry.jsp
@@ -81,8 +81,12 @@ long assetClassPK = DLAssetHelperUtil.getAssetClassPK(fileEntry, fileVersion);
 			<liferay-dynamic-section:dynamic-section
 				name="com.liferay.document.library.web#/document_library/info_panel_file_entry.jsp#fileEntryOwner"
 			>
-				<div class="autofit-row sidebar-panel widget-metadata">
-					<div class="autofit-col inline-item-before">
+				<clay:content-row
+					cssClass="sidebar-panel widget-metadata"
+				>
+					<clay:content-col
+						cssClass="inline-item-before"
+					>
 
 						<%
 						User owner = UserLocalServiceUtil.fetchUser(fileEntry.getUserId());
@@ -91,11 +95,15 @@ long assetClassPK = DLAssetHelperUtil.getAssetClassPK(fileEntry, fileVersion);
 						<liferay-ui:user-portrait
 							user="<%= owner %>"
 						/>
-					</div>
+					</clay:content-col>
 
-					<div class="autofit-col autofit-col-expand">
-						<div class="autofit-row">
-							<div class="autofit-col autofit-col-expand">
+					<clay:content-col
+						expand="true"
+					>
+						<clay:content-row>
+							<clay:content-col
+								expand="true"
+							>
 								<div class="component-title h4 username">
 									<c:if test="<%= owner != null %>">
 										<a href="<%= owner.isDefaultUser() ? StringPool.BLANK : owner.getDisplayURL(themeDisplay) %>"><%= HtmlUtil.escape(owner.getFullName()) %></a>
@@ -105,10 +113,10 @@ long assetClassPK = DLAssetHelperUtil.getAssetClassPK(fileEntry, fileVersion);
 								<small class="text-muted">
 									<liferay-ui:message key="owner" />
 								</small>
-							</div>
-						</div>
-					</div>
-				</div>
+							</clay:content-col>
+						</clay:content-row>
+					</clay:content-col>
+				</clay:content-row>
 			</liferay-dynamic-section:dynamic-section>
 
 			<c:if test="<%= dlViewFileVersionDisplayContext.isDownloadLinkVisible() || dlViewFileVersionDisplayContext.isSharingLinkVisible() %>">

--- a/modules/apps/item-selector/item-selector-url-web/src/main/resources/META-INF/resources/url.jsp
+++ b/modules/apps/item-selector/item-selector-url-web/src/main/resources/META-INF/resources/url.jsp
@@ -25,12 +25,12 @@ Map<String, Object> data = HashMapBuilder.<String, Object>put(
 %>
 
 <div class="lfr-form-content">
-	<div class="sheet sheet-lg">
+	<clay:sheet>
 		<div class="panel-group panel-group-flush">
 			<react:component
 				data="<%= data %>"
 				module="js/ItemSelectorUrl.es"
 			/>
 		</div>
-	</div>
+	</clay:sheet>
 </div>

--- a/modules/apps/journal/journal-content-asset-addon-entry/journal-content-asset-addon-entry-conversions/src/main/resources/META-INF/resources/conversions.jsp
+++ b/modules/apps/journal/journal-content-asset-addon-entry/journal-content-asset-addon-entry-conversions/src/main/resources/META-INF/resources/conversions.jsp
@@ -24,7 +24,9 @@ String viewMode = ParamUtil.getString(request, "viewMode");
 %>
 
 <c:if test="<%= !viewMode.equals(Constants.PRINT) %>">
-	<div class="autofit-col export-action user-tool-asset-addon-entry">
+	<clay:content-col
+		cssClass="export-action user-tool-asset-addon-entry"
+	>
 		<portlet:resourceURL id="exportArticle" var="exportArticleURL">
 			<portlet:param name="groupId" value="<%= String.valueOf(articleDisplay.getGroupId()) %>" />
 			<portlet:param name="articleId" value="<%= articleDisplay.getArticleId() %>" />
@@ -32,5 +34,5 @@ String viewMode = ParamUtil.getString(request, "viewMode");
 		</portlet:resourceURL>
 
 		<aui:a cssClass="btn btn-outline-borderless btn-outline-secondary btn-sm" href="<%= exportArticleURL.toString() %>" label='<%= LanguageUtil.format(resourceBundle, "x-download-x-as-x", new Object[] {"hide-accessible", HtmlUtil.escape(articleDisplay.getTitle()), StringUtil.toUpperCase(HtmlUtil.escape(extension))}) %>' />
-	</div>
+	</clay:content-col>
 </c:if>


### PR DESCRIPTION
@ambrinchaudhary @boton 

As part of our effort to Improve HTML Layout Generation Strategies in DXP, here a PR about changing autofit-* and sheet-* for clay:sheet* and clay:content*

This "PR" updates markup with new taglibs. What we expect is to see the same visual design, so no visual changes are required.
The way to validate the changes is to see the same visual result. if is there any previously agreed difference it would be correctly pointed in comments

LPS-114015 - comment-taglib
LPS-114023 - journal-content-asset-addon-entry-conversions
LPS-114025 - file_entry_history
LPS-114033 - item-selector-url
LPS-114034 - journal-content