### PR TITLE
LPS-114056 - Apply the use of clay content taglib in site-item-selector-web

### DIFF
--- a/modules/apps/journal/journal-content-asset-addon-entry/journal-content-asset-addon-entry-print/build.gradle
+++ b/modules/apps/journal/journal-content-asset-addon-entry/journal-content-asset-addon-entry-print/build.gradle
@@ -5,6 +5,7 @@ dependencies {
 	compileOnly group: "javax.servlet.jsp", name: "javax.servlet.jsp-api", version: "2.3.1"
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
+	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
 	compileOnly project(":apps:journal:journal-api")
 	compileOnly project(":apps:journal:journal-content-asset-addon-entry:journal-content-asset-addon-entry-api")
 	compileOnly project(":core:petra:petra-lang")

--- a/modules/apps/journal/journal-content-asset-addon-entry/journal-content-asset-addon-entry-print/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/journal/journal-content-asset-addon-entry/journal-content-asset-addon-entry-print/src/main/resources/META-INF/resources/init.jsp
@@ -19,6 +19,8 @@
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/clay" prefix="clay" %>
+
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
 <%@ page import="com.liferay.journal.model.JournalArticleDisplay" %><%@

--- a/modules/apps/journal/journal-content-asset-addon-entry/journal-content-asset-addon-entry-print/src/main/resources/META-INF/resources/print.jsp
+++ b/modules/apps/journal/journal-content-asset-addon-entry/journal-content-asset-addon-entry-print/src/main/resources/META-INF/resources/print.jsp
@@ -36,7 +36,9 @@ String viewMode = ParamUtil.getString(request, "viewMode");
 			<portlet:param name="viewMode" value="<%= Constants.PRINT %>" />
 		</portlet:renderURL>
 
-		<div class="autofit-col print-action user-tool-asset-addon-entry">
+		<clay:content-col
+			cssClass="print-action user-tool-asset-addon-entry"
+		>
 			<liferay-ui:icon
 				icon="print"
 				label="<%= true %>"
@@ -45,7 +47,7 @@ String viewMode = ParamUtil.getString(request, "viewMode");
 				message='<%= LanguageUtil.format(request, "print-x-x", new Object[] {"hide-accessible", HtmlUtil.escape(articleDisplay.getTitle())}, false) %>'
 				url='<%= "javascript:" + renderResponse.getNamespace() + "printPage();" %>'
 			/>
-		</div>
+		</clay:content-col>
 
 		<aui:script>
 			function <portlet:namespace />printPage() {

--- a/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/journal_resources.jsp
+++ b/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/journal_resources.jsp
@@ -24,7 +24,7 @@ JournalArticle article = journalContentDisplayContext.getArticle();
 
 <aui:input id='<%= refererPortletName + "ddmTemplateKey" %>' name='<%= refererPortletName + "preferences--ddmTemplateKey--" %>' type="hidden" useNamespace="<%= false %>" value="<%= journalContentDisplayContext.isDefaultTemplate() ? StringPool.BLANK : journalContentDisplayContext.getDDMTemplateKey() %>" />
 
-<div class="sheet-section">
+<clay:sheet-section>
 	<div class="sheet-subtitle">
 		<liferay-ui:message key="layout.types.article" />
 	</div>
@@ -46,12 +46,12 @@ JournalArticle article = journalContentDisplayContext.getArticle();
 			<aui:button cssClass="selector-button" name="removeWebContent" value="remove" />
 		</c:if>
 	</div>
-</div>
+</clay:sheet-section>
 
 <c:if test="<%= article != null %>">
 	<liferay-util:include page="/journal_template.jsp" servletContext="<%= application %>" />
 
-	<div class="sheet-section">
+	<clay:sheet-section>
 		<div class="sheet-subtitle">
 			<liferay-ui:message key="user-tools" />
 		</div>
@@ -68,9 +68,9 @@ JournalArticle article = journalContentDisplayContext.getArticle();
 		}
 		%>
 
-	</div>
+	</clay:sheet-section>
 
-	<div class="sheet-section">
+	<clay:sheet-section>
 		<div class="sheet-subtitle">
 			<liferay-ui:message key="content-metadata" />
 		</div>
@@ -87,13 +87,13 @@ JournalArticle article = journalContentDisplayContext.getArticle();
 		}
 		%>
 
-	</div>
+	</clay:sheet-section>
 
-	<div class="sheet-section">
+	<clay:sheet-section>
 		<div class="sheet-subtitle">
 			<liferay-ui:message key="enable" />
 		</div>
 
 		<aui:input label="view-count-increment" name="preferences--enableViewCountIncrement--" type="toggle-switch" value="<%= journalContentDisplayContext.isEnableViewCountIncrement() %>" />
-	</div>
+	</clay:sheet-section>
 </c:if>

--- a/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/journal_template.jsp
+++ b/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/journal_template.jsp
@@ -23,7 +23,7 @@ DDMStructure ddmStructure = journalContentDisplayContext.getDDMStructure();
 String refererPortletName = ParamUtil.getString(request, "refererPortletName");
 %>
 
-<div class="sheet-section">
+<clay:sheet-section>
 	<div class="sheet-subtitle">
 		<liferay-ui:message key="template" />
 	</div>
@@ -64,7 +64,7 @@ String refererPortletName = ParamUtil.getString(request, "refererPortletName");
 
 		<aui:button id='<%= refererPortletName + "clearddmTemplateButton" %>' useNamespace="<%= false %>" value="clear" />
 	</div>
-</div>
+</clay:sheet-section>
 
 <%
 AssetRendererFactory<JournalArticle> assetRendererFactory = AssetRendererFactoryRegistryUtil.getAssetRendererFactoryByClass(JournalArticle.class);

--- a/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/view.jsp
@@ -206,14 +206,17 @@ if (journalContentDisplayContext.isShowArticle()) {
 	<c:if test="<%= ListUtil.isNotEmpty(selectedUserToolAssetAddonEntries) || (ratingsContentMetadataAssetAddonEntry != null) %>">
 		<div class="separator"><!-- --></div>
 
-		<div class="autofit-float autofit-row autofit-row-center mb-4 user-tool-asset-addon-entries">
-
+		<clay:content-row
+			cssClass="mb-4 user-tool-asset-addon-entries"
+			floatElements="true"
+			verticalAlign="center"
+		>
 			<c:if test="<%= ratingsContentMetadataAssetAddonEntry != null %>">
-				<div class="autofit-col">
+				<clay:content-row>
 					<liferay-asset:asset-addon-entry-display
 						assetAddonEntries="<%= Collections.singletonList(ratingsContentMetadataAssetAddonEntry) %>"
 					/>
-				</div>
+				</clay:content-row>
 			</c:if>
 
 			<c:if test="<%= ListUtil.isNotEmpty(selectedUserToolAssetAddonEntries) %>">
@@ -221,7 +224,7 @@ if (journalContentDisplayContext.isShowArticle()) {
 					assetAddonEntries="<%= selectedUserToolAssetAddonEntries %>"
 				/>
 			</c:if>
-		</div>
+		</clay:content-row>
 	</c:if>
 
 	<%

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
@@ -141,7 +141,7 @@ JournalEditArticleDisplayContext journalEditArticleDisplayContext = new JournalE
 		<clay:container-fluid
 			cssClass="container-view"
 		>
-			<div class="sheet sheet-lg">
+			<clay:sheet>
 				<aui:model-context bean="<%= article %>" defaultLanguageId="<%= journalEditArticleDisplayContext.getDefaultArticleLanguageId() %>" model="<%= JournalArticle.class %>" />
 
 				<liferay-ui:error exception="<%= ArticleContentException.class %>" message="please-enter-valid-content" />
@@ -276,7 +276,7 @@ JournalEditArticleDisplayContext journalEditArticleDisplayContext = new JournalE
 						</c:otherwise>
 					</c:choose>
 				</div>
-			</div>
+			</clay:sheet>
 		</clay:container-fluid>
 	</div>
 </aui:form>

--- a/modules/apps/ratings/ratings-taglib/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/ratings/ratings-taglib/src/main/resources/META-INF/resources/init.jsp
@@ -16,7 +16,8 @@
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 
-<%@ taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
+<%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
+taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/react" prefix="react" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %><%@

--- a/modules/apps/ratings/ratings-taglib/src/main/resources/META-INF/resources/page.jsp
+++ b/modules/apps/ratings/ratings-taglib/src/main/resources/META-INF/resources/page.jsp
@@ -69,8 +69,11 @@ String type = GetterUtil.getString((String)request.getAttribute("liferay-ratings
 	</c:when>
 	<c:when test="<%= type.equals(RatingsType.STARS.getValue()) %>">
 		<div>
-			<div class="autofit-row autofit-row-center ratings ratings-stars">
-				<div class="autofit-col">
+			<clay:content-row
+				cssClass="ratings ratings-stars"
+				verticalAlign="center"
+			>
+				<clay:content-col>
 					<div class="dropdown">
 						<button class="btn btn-outline-borderless btn-outline-secondary dropdown-toggle btn-sm" disabled type="button">
 							<svg class="lexicon-icon lexicon-icon-star-o">
@@ -80,14 +83,14 @@ String type = GetterUtil.getString((String)request.getAttribute("liferay-ratings
 							<span>-</span>
 						</button>
 					</div>
-				</div>
+				</clay:content-col>
 
-				<div class="autofit-col">
+				<clay:content-col>
 					<svg class="lexicon-icon lexicon-icon-star ratings-stars-average-icon">
 						<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/lexicon/icons.svg#star" />
 					</svg>
-				</div>
-			</div>
+				</clay:content-col>
+			</clay:content-row>
 
 			<react:component
 				data="<%= data %>"

--- a/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/info_panel.jsp
+++ b/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/info_panel.jsp
@@ -62,8 +62,12 @@ List<RedirectEntry> redirectEntries = (List<RedirectEntry>)GetterUtil.getObject(
 					<liferay-ui:message key="created-by" />
 				</dt>
 				<dd class="sidebar-dd">
-					<div class="autofit-row sidebar-panel widget-metadata">
-						<div class="autofit-col inline-item-before">
+					<clay:content-row
+						cssClass="sidebar-panel widget-metadata"
+					>
+						<clay:content-col
+							cssClass="inline-item-before"
+						>
 
 							<%
 							User owner = UserLocalServiceUtil.fetchUser(redirectEntry.getUserId());
@@ -73,12 +77,12 @@ List<RedirectEntry> redirectEntries = (List<RedirectEntry>)GetterUtil.getObject(
 								size="sm"
 								user="<%= owner %>"
 							/>
-						</div>
+						</clay:content-col>
 
 						<div class="username">
 							<%= HtmlUtil.escape(owner.getFullName()) %>
 						</div>
-					</div>
+					</clay:content-row>
 				</dd>
 				<dt class="sidebar-dt">
 					<liferay-ui:message key="type" />

--- a/modules/apps/site/site-item-selector-web/src/main/resources/META-INF/resources/view_sites.jsp
+++ b/modules/apps/site/site-item-selector-web/src/main/resources/META-INF/resources/view_sites.jsp
@@ -143,8 +143,8 @@ GroupSearch groupSearch = siteItemSelectorViewDisplayContext.getGroupSearch();
 					<liferay-ui:search-container-column-text>
 						<div class="card card-horizontal">
 							<div class="card-body">
-								<div class="card-row">
-									<div class="autofit-col">
+								<clay:content-row>
+									<clay:content-col>
 										<clay:sticker
 											displayType="secondary"
 										>
@@ -161,9 +161,12 @@ GroupSearch groupSearch = siteItemSelectorViewDisplayContext.getGroupSearch();
 												</c:otherwise>
 											</c:choose>
 										</clay:sticker>
-									</div>
+									</clay:content-col>
 
-									<div class="autofit-col autofit-col-expand autofit-col-gutters">
+									<clay:content-col
+										expand="true"
+										gutters="true"
+									>
 										<aui:a cssClass="card-title selector-button text-truncate" data="<%= data %>" href="javascript:;" title="<%= siteVerticalCard.getSubtitle() %>">
 											<%= siteVerticalCard.getTitle() %>
 										</aui:a>
@@ -173,14 +176,14 @@ GroupSearch groupSearch = siteItemSelectorViewDisplayContext.getGroupSearch();
 												<%= siteVerticalCard.getSubtitle() %>
 											</aui:a>
 										</c:if>
-									</div>
+									</clay:content-col>
 
 									<c:if test="<%= groupItemSelectorCriterion.isAllowNavigation() %>">
-										<div class="autofit-col">
+										<clay:content-col>
 											<aui:a cssClass="btn btn-outline-borderless btn-outline-secondary" href="<%= siteVerticalCard.getHref() %>" target="_blank" />
-										</div>
+										</clay:content-col>
 									</c:if>
-								</div>
+								</clay:content-row>
 							</div>
 						</div>
 					</liferay-ui:search-container-column-text>


### PR DESCRIPTION
@ambrinchaudhary @boton

As part of our effort to Improve HTML Layout Generation Strategies in DXP, here a PR about changing autofit-* and sheet-* for clay:sheet* and clay:content*

This "PR" updates markup with new taglibs. What we expect is to see the same visual design, so no visual changes are required.
The way to validate the changes is to see the same visual result. if is there any previously agreed difference it would be correctly pointed in comments

LPS-114035 - Apply the use of clay content taglib in journal-content
LPS-114036 - Apply the use of clay sheet and clay content taglib
LPS-114037 - Apply the use of clay sheet taglib in journal-web
LPS-114050 - Apply the use of clay content taglib in ratings-taglib
LPS-114051 - Apply the use of clay content taglib in redirect-web
LPS-114056 - Apply the use of clay content taglib in site-item-selector