### PR TITLE
LPS-116864 Add support for default display type to Default Item Selector View

### DIFF
--- a/modules/apps/item-selector/item-selector-api/bnd.bnd
+++ b/modules/apps/item-selector/item-selector-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Item Selector API
 Bundle-SymbolicName: com.liferay.item.selector.api
-Bundle-Version: 5.2.7
+Bundle-Version: 5.3.0
 Export-Package:\
 	com.liferay.item.selector,\
 	com.liferay.item.selector.constants,\

--- a/modules/apps/item-selector/item-selector-api/src/main/java/com/liferay/item/selector/ItemSelectorViewDescriptor.java
+++ b/modules/apps/item-selector/item-selector-api/src/main/java/com/liferay/item/selector/ItemSelectorViewDescriptor.java
@@ -28,6 +28,10 @@ import java.util.Locale;
  */
 public interface ItemSelectorViewDescriptor<T> {
 
+	public default String getDefaultDisplayStyle() {
+		return "icon";
+	}
+
 	public ItemDescriptor getItemDescriptor(T t);
 
 	public ItemSelectorReturnType getItemSelectorReturnType();

--- a/modules/apps/item-selector/item-selector-api/src/main/resources/com/liferay/item/selector/packageinfo
+++ b/modules/apps/item-selector/item-selector-api/src/main/resources/com/liferay/item/selector/packageinfo
@@ -1,1 +1,1 @@
-version 4.2.0
+version 4.3.0

--- a/modules/apps/item-selector/item-selector-web/src/main/java/com/liferay/item/selector/web/internal/display/context/ItemSelectorViewDescriptorRendererDisplayContext.java
+++ b/modules/apps/item-selector/item-selector-web/src/main/java/com/liferay/item/selector/web/internal/display/context/ItemSelectorViewDescriptorRendererDisplayContext.java
@@ -24,7 +24,6 @@ import com.liferay.portal.kernel.portlet.PortletURLUtil;
 import com.liferay.portal.kernel.servlet.taglib.ui.BreadcrumbEntry;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ParamUtil;
-import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 
 import java.util.Arrays;
@@ -66,11 +65,8 @@ public class ItemSelectorViewDescriptorRendererDisplayContext {
 		}
 
 		_displayStyle = ParamUtil.getString(
-			_httpServletRequest, "displayStyle");
-
-		if (Validator.isNull(_displayStyle)) {
-			_displayStyle = "icon";
-		}
+			_httpServletRequest, "displayStyle",
+			_itemSelectorViewDescriptor.getDefaultDisplayStyle());
 
 		return _displayStyle;
 	}

--- a/modules/apps/item-selector/item-selector-web/src/main/java/com/liferay/item/selector/web/internal/display/context/ItemSelectorViewDescriptorRendererManagementToolbarDisplayContext.java
+++ b/modules/apps/item-selector/item-selector-web/src/main/java/com/liferay/item/selector/web/internal/display/context/ItemSelectorViewDescriptorRendererManagementToolbarDisplayContext.java
@@ -69,7 +69,7 @@ public class ItemSelectorViewDescriptorRendererManagementToolbarDisplayContext
 
 	@Override
 	protected String getDefaultDisplayStyle() {
-		return "icon";
+		return _itemSelectorViewDescriptor.getDefaultDisplayStyle();
 	}
 
 	@Override

--- a/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/view_item_selector_view_descriptor.jsp
+++ b/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/view_item_selector_view_descriptor.jsp
@@ -108,7 +108,7 @@ SearchContainer<Object> searchContainer = itemSelectorViewDescriptor.getSearchCo
 							%>
 
 							<c:choose>
-								<c:when test="<%= Validator.isNull(itemDescriptor.getUserName()) %>">
+								<c:when test="<%= Validator.isNotNull(itemDescriptor.getUserName()) %>">
 									<span class="text-default">
 										<liferay-ui:message arguments="<%= new String[] {itemDescriptor.getUserName(), modifiedDateDescription} %>" key="x-modified-x-ago" />
 									</span>

--- a/modules/apps/item-selector/item-selector-web/src/test/java/com/liferay/item/selector/web/internal/display/context/ItemSelectorViewDescriptorRendererDisplayContextTest.java
+++ b/modules/apps/item-selector/item-selector-web/src/test/java/com/liferay/item/selector/web/internal/display/context/ItemSelectorViewDescriptorRendererDisplayContextTest.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.item.selector.web.internal.display.context;
+
+import com.liferay.portal.kernel.test.util.PropsTestUtil;
+
+import java.util.Collections;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * @author Cristina González
+ */
+public class ItemSelectorViewDescriptorRendererDisplayContextTest {
+
+	@BeforeClass
+	public static void setUpClass() {
+		PropsTestUtil.setProps(Collections.emptyMap());
+	}
+
+	@Test
+	public void testGetDisplayStyle() {
+		ItemSelectorViewDescriptorRendererDisplayContext
+			itemSelectorViewDescriptorRendererDisplayContext =
+				new ItemSelectorViewDescriptorRendererDisplayContext(
+					new MockHttpServletRequest(), null, null, null);
+
+		Assert.assertEquals(
+			"icon",
+			itemSelectorViewDescriptorRendererDisplayContext.getDisplayStyle());
+	}
+
+	@Test
+	public void testGetDisplayStyleWithDisplayStyleParameter() {
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setParameter("displayStyle", "descriptive");
+
+		ItemSelectorViewDescriptorRendererDisplayContext
+			itemSelectorViewDescriptorRendererDisplayContext =
+				new ItemSelectorViewDescriptorRendererDisplayContext(
+					mockHttpServletRequest, null, null, null);
+
+		Assert.assertEquals(
+			"descriptive",
+			itemSelectorViewDescriptorRendererDisplayContext.getDisplayStyle());
+	}
+
+}

--- a/modules/apps/item-selector/item-selector-web/src/test/java/com/liferay/item/selector/web/internal/display/context/ItemSelectorViewDescriptorRendererDisplayContextTest.java
+++ b/modules/apps/item-selector/item-selector-web/src/test/java/com/liferay/item/selector/web/internal/display/context/ItemSelectorViewDescriptorRendererDisplayContextTest.java
@@ -14,6 +14,9 @@
 
 package com.liferay.item.selector.web.internal.display.context;
 
+import com.liferay.item.selector.ItemSelectorReturnType;
+import com.liferay.item.selector.ItemSelectorViewDescriptor;
+import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.test.util.PropsTestUtil;
 
 import java.util.Collections;
@@ -39,10 +42,74 @@ public class ItemSelectorViewDescriptorRendererDisplayContextTest {
 		ItemSelectorViewDescriptorRendererDisplayContext
 			itemSelectorViewDescriptorRendererDisplayContext =
 				new ItemSelectorViewDescriptorRendererDisplayContext(
-					new MockHttpServletRequest(), null, null, null);
+					new MockHttpServletRequest(), null,
+					new ItemSelectorViewDescriptor<Object>() {
+
+						@Override
+						public ItemDescriptor getItemDescriptor(Object object) {
+							return null;
+						}
+
+						@Override
+						public ItemSelectorReturnType
+							getItemSelectorReturnType() {
+
+							return null;
+						}
+
+						@Override
+						public SearchContainer<Object> getSearchContainer() {
+							return null;
+						}
+
+					},
+					null);
 
 		Assert.assertEquals(
 			"icon",
+			itemSelectorViewDescriptorRendererDisplayContext.getDisplayStyle());
+	}
+
+	@Test
+	public void testGetDisplayStyleWithDefaultDisplayStyle() {
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setParameter("displayStyle", "descriptive");
+
+		ItemSelectorViewDescriptorRendererDisplayContext
+			itemSelectorViewDescriptorRendererDisplayContext =
+				new ItemSelectorViewDescriptorRendererDisplayContext(
+					mockHttpServletRequest, null,
+					new ItemSelectorViewDescriptor<Object>() {
+
+						@Override
+						public String getDefaultDisplayStyle() {
+							return "descriptive";
+						}
+
+						@Override
+						public ItemDescriptor getItemDescriptor(Object object) {
+							return null;
+						}
+
+						@Override
+						public ItemSelectorReturnType
+							getItemSelectorReturnType() {
+
+							return null;
+						}
+
+						@Override
+						public SearchContainer<Object> getSearchContainer() {
+							return null;
+						}
+
+					},
+					null);
+
+		Assert.assertEquals(
+			"descriptive",
 			itemSelectorViewDescriptorRendererDisplayContext.getDisplayStyle());
 	}
 
@@ -56,7 +123,28 @@ public class ItemSelectorViewDescriptorRendererDisplayContextTest {
 		ItemSelectorViewDescriptorRendererDisplayContext
 			itemSelectorViewDescriptorRendererDisplayContext =
 				new ItemSelectorViewDescriptorRendererDisplayContext(
-					mockHttpServletRequest, null, null, null);
+					mockHttpServletRequest, null,
+					new ItemSelectorViewDescriptor<Object>() {
+
+						@Override
+						public ItemDescriptor getItemDescriptor(Object object) {
+							return null;
+						}
+
+						@Override
+						public ItemSelectorReturnType
+							getItemSelectorReturnType() {
+
+							return null;
+						}
+
+						@Override
+						public SearchContainer<Object> getSearchContainer() {
+							return null;
+						}
+
+					},
+					null);
 
 		Assert.assertEquals(
 			"descriptive",


### PR DESCRIPTION
**Motivation**

Sometimes the 'descriptive' view is a better approach to be selected as the default view of the Item Selector. We can achieve it using a parameter in the URL, but maybe we need to debug it in order to find the right parameter.

**Provided Solution**

I have added a new method getDefaultDisplayStyle to ItemSelectorViewDescriptor, so we can decide in the implementation of the ItemSelectorViewDescriptor the default display Style.

**How to test it**

I have added unit tests for this pull.