### PR TITLE
LPS-116622 Auto SF

### DIFF
--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/account_role/view_assignees.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/account_role/view_assignees.jsp
@@ -90,7 +90,7 @@ ViewAccountRoleAssigneesManagementToolbarDisplayContext viewAccountRoleAssignees
 
 <liferay-frontend:component
 	componentId="<%= viewAccountRoleAssigneesManagementToolbarDisplayContext.getDefaultEventHandler() %>"
-	context="<%=
+	context='<%=
 		HashMapBuilder.<String, Object>put(
 			"accountEntryName", role.getTitle(locale)
 		).put(
@@ -98,6 +98,6 @@ ViewAccountRoleAssigneesManagementToolbarDisplayContext viewAccountRoleAssignees
 		).put(
 			"selectAccountUsersURL", selectAccountUsersURL
 		).build()
-	%>"
+	%>'
 	module="account_entries_admin/js/AccountUsersManagementToolbarDefaultEventHandler.es"
 />

--- a/modules/apps/translation/translation-test/src/testIntegration/java/com/liferay/translation/importer/test/XLIFFTranslationInfoItemFieldValuesImporterTest.java
+++ b/modules/apps/translation/translation-test/src/testIntegration/java/com/liferay/translation/importer/test/XLIFFTranslationInfoItemFieldValuesImporterTest.java
@@ -59,8 +59,67 @@ public class XLIFFTranslationInfoItemFieldValuesImporterTest {
 		_group = GroupTestUtil.addGroup();
 	}
 
+	@Test(expected = XLIFFFileException.MustHaveValidId.class)
+	public void testImportXLIFF12FailsFileInvalidId() throws Exception {
+		_xliffTranslationInfoItemFieldValuesImporter.importInfoItemFieldValues(
+			_group.getGroupId(),
+			new InfoItemClassPKReference(
+				JournalArticle.class.getName(), RandomTestUtil.randomInt(1, 3)),
+			TranslationTestUtil.readFileToInputStream(
+				"example-1_2-simple.xlf"));
+	}
+
+	@Test(expected = XLIFFFileException.MustBeWellFormed.class)
+	public void testImportXLIFF12FailsFileInvalidVersion() throws Exception {
+		_xliffTranslationInfoItemFieldValuesImporter.importInfoItemFieldValues(
+			_group.getGroupId(),
+			new InfoItemClassPKReference(JournalArticle.class.getName(), 122),
+			TranslationTestUtil.readFileToInputStream(
+				"example-1_2-bad-formed.xlf"));
+	}
+
+	@Test
+	public void testImportXLIFF12VersionDocument() throws Exception {
+		InfoItemFieldValues infoItemFieldValues =
+			_xliffTranslationInfoItemFieldValuesImporter.
+				importInfoItemFieldValues(
+					_group.getGroupId(),
+					new InfoItemClassPKReference(
+						JournalArticle.class.getName(), 122),
+					TranslationTestUtil.readFileToInputStream(
+						"example-1_2-oasis.xlf"));
+
+		Assert.assertNotNull(infoItemFieldValues);
+		Assert.assertNotNull(infoItemFieldValues.getInfoFieldValues());
+
+		Collection<InfoFieldValue<Object>> infoFieldValues =
+			infoItemFieldValues.getInfoFieldValues();
+
+		Assert.assertFalse(infoFieldValues.isEmpty());
+	}
+
+	@Test
+	public void testImportXLIFF12VersionSimpleDocument() throws Exception {
+		InfoItemFieldValues infoItemFieldValues =
+			_xliffTranslationInfoItemFieldValuesImporter.
+				importInfoItemFieldValues(
+					_group.getGroupId(),
+					new InfoItemClassPKReference(
+						JournalArticle.class.getName(), 122),
+					TranslationTestUtil.readFileToInputStream(
+						"example-1_2-simple.xlf"));
+
+		Assert.assertNotNull(infoItemFieldValues);
+		Assert.assertNotNull(infoItemFieldValues.getInfoFieldValues());
+
+		Collection<InfoFieldValue<Object>> infoFieldValues =
+			infoItemFieldValues.getInfoFieldValues();
+
+		Assert.assertFalse(infoFieldValues.isEmpty());
+	}
+
 	@Test(expected = XLIFFFileException.MustBeSupportedLanguage.class)
-	public void testImportXLIFF2FailsFileInvalidGroupLanguage()
+	public void testImportXLIFF20FailsFileInvalidGroupLanguage()
 		throws Exception {
 
 		GroupTestUtil.updateDisplaySettings(
@@ -74,7 +133,7 @@ public class XLIFFTranslationInfoItemFieldValuesImporterTest {
 	}
 
 	@Test(expected = XLIFFFileException.MustHaveValidId.class)
-	public void testImportXLIFF2FailsFileInvalidId() throws Exception {
+	public void testImportXLIFF20FailsFileInvalidId() throws Exception {
 		_xliffTranslationInfoItemFieldValuesImporter.importInfoItemFieldValues(
 			_group.getGroupId(),
 			new InfoItemClassPKReference(
@@ -84,7 +143,7 @@ public class XLIFFTranslationInfoItemFieldValuesImporterTest {
 	}
 
 	@Test(expected = XLIFFFileException.MustBeSupportedLanguage.class)
-	public void testImportXLIFF2FailsFileInvalidLanguage() throws Exception {
+	public void testImportXLIFF20FailsFileInvalidLanguage() throws Exception {
 		_xliffTranslationInfoItemFieldValuesImporter.importInfoItemFieldValues(
 			_group.getGroupId(),
 			new InfoItemClassPKReference(JournalArticle.class.getName(), 122),
@@ -92,16 +151,8 @@ public class XLIFFTranslationInfoItemFieldValuesImporterTest {
 				"test-journal-article-122-pt-PT.xlf"));
 	}
 
-	@Test(expected = XLIFFFileException.MustBeValid.class)
-	public void testImportXLIFF2FailsFileInvalidVersion() throws Exception {
-		_xliffTranslationInfoItemFieldValuesImporter.importInfoItemFieldValues(
-			_group.getGroupId(),
-			new InfoItemClassPKReference(JournalArticle.class.getName(), 122),
-			TranslationTestUtil.readFileToInputStream("example-1_2-oasis.xlf"));
-	}
-
 	@Test(expected = XLIFFFileException.MustBeWellFormed.class)
-	public void testImportXLIFF2FailsFileNoTarget() throws Exception {
+	public void testImportXLIFF20FailsFileNoTarget() throws Exception {
 		_xliffTranslationInfoItemFieldValuesImporter.importInfoItemFieldValues(
 			_group.getGroupId(),
 			new InfoItemClassPKReference(JournalArticle.class.getName(), 122),
@@ -110,7 +161,7 @@ public class XLIFFTranslationInfoItemFieldValuesImporterTest {
 	}
 
 	@Test
-	public void testImportXLIFFXLIFFDocument() throws Exception {
+	public void testImportXLIFF20VersionDocument() throws Exception {
 		InfoItemFieldValues infoItemFieldValues =
 			_xliffTranslationInfoItemFieldValuesImporter.
 				importInfoItemFieldValues(

--- a/modules/apps/translation/translation-test/src/testIntegration/java/com/liferay/translation/info/item/updater/test/JournalArticleInfoItemFieldValuesUpdaterTest.java
+++ b/modules/apps/translation/translation-test/src/testIntegration/java/com/liferay/translation/info/item/updater/test/JournalArticleInfoItemFieldValuesUpdaterTest.java
@@ -84,6 +84,49 @@ public class JournalArticleInfoItemFieldValuesUpdaterTest {
 	}
 
 	@Test
+	public void testUpdateArticleFromInfoItemFieldValues12XLIFFFile()
+		throws Exception {
+
+		JournalArticle journalArticle = JournalTestUtil.addArticle(
+			_group.getGroupId(), 0,
+			PortalUtil.getClassNameId(JournalArticle.class),
+			HashMapBuilder.put(
+				LocaleUtil.US, RandomTestUtil.randomString()
+			).build(),
+			HashMapBuilder.put(
+				LocaleUtil.US, RandomTestUtil.randomString()
+			).build(),
+			HashMapBuilder.put(
+				LocaleUtil.US, RandomTestUtil.randomString()
+			).build(),
+			LocaleUtil.getSiteDefault(), false, true, _serviceContext);
+
+		InfoItemFieldValues infoItemFieldValues =
+			_xliffTranslationInfoItemFieldValuesImporter.
+				importInfoItemFieldValues(
+					_group.getGroupId(),
+					new InfoItemClassPKReference(
+						JournalArticle.class.getName(), 122),
+					TranslationTestUtil.readFileToInputStream(
+						"example-1_2-oasis.xlf"));
+
+		journalArticle =
+			_journalArticleInfoItemFieldValuesUpdater.
+				updateFromInfoItemFieldValues(
+					journalArticle, infoItemFieldValues);
+
+		Assert.assertEquals(
+			"Quetzal", journalArticle.getTitle(LocaleUtil.JAPAN));
+		Assert.assertEquals(
+			"XLIFF データ・マネージャ", journalArticle.getDescription(LocaleUtil.JAPAN));
+		Assert.assertEquals(
+			"<p>XLIFF 文書を編集、または処理 するアプリケーションです。</p>",
+			_getContent(
+				journalArticle.getContent(), "name", LocaleUtil.US,
+				LocaleUtil.JAPAN));
+	}
+
+	@Test
 	public void testUpdateArticleFromInfoItemFieldValuesAddsTranslatedContent()
 		throws Exception {
 

--- a/modules/apps/translation/translation-test/src/testIntegration/resources/com/liferay/translation/dependencies/example-1_2-bad-formed.xlf
+++ b/modules/apps/translation/translation-test/src/testIntegration/resources/com/liferay/translation/dependencies/example-1_2-bad-formed.xlf
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2">
+		<file original="com.liferay.journal.model.JournalArticle:122" source-language="en" target-language="de" tool="okapi" datatype="html">
+		<header/>
+		<body>
+			<trans-unit id="1">
+				<source xml:lang="en-US">Segment one.</source>
+			</trans-unit>
+		</body>
+	</file>
+</xliff>

--- a/modules/apps/translation/translation-test/src/testIntegration/resources/com/liferay/translation/dependencies/example-1_2-oasis.xlf
+++ b/modules/apps/translation/translation-test/src/testIntegration/resources/com/liferay/translation/dependencies/example-1_2-oasis.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2"  version="1.2">
-	<file original="Graphic Example.psd"
+	<file original="com.liferay.journal.model.JournalArticle:122"
 		  source-language="en-US" target-language="ja-JP"
 		  tool="Rainbow" datatype="photoshop">
 		<header>
@@ -18,19 +18,18 @@
 			</phase-group>
 		</header>
 		<body>
-			<trans-unit id="1" maxbytes="14">
+			<trans-unit id="title" maxbytes="14">
 				<source xml:lang="en-US">Quetzal</source>
 				<target xml:lang="ja-JP">Quetzal</target>
 			</trans-unit>
-			<trans-unit id="3" maxbytes="114">
-				<source xml:lang="en-US">An application to manipulate and
-					process XLIFF documents</source>
-				<target xml:lang="ja-JP">XLIFF 文書を編集、または処理
-					するアプリケーションです。</target>
+			<trans-unit id="description" maxbytes="36">
+				<source xml:lang="en-US"><![CDATA[XLIFF Data Manager]]></source>
+				<target xml:lang="ja-JP"><![CDATA[XLIFF データ・マネージャ]]></target>
 			</trans-unit>
-			<trans-unit id="4" maxbytes="36">
-				<source xml:lang="en-US">XLIFF Data Manager</source>
-				<target xml:lang="ja-JP">XLIFF データ・マネージャ</target>
+			<trans-unit id="name" maxbytes="114">
+				<source xml:lang="en-US"><![CDATA[An application to manipulate and
+					process XLIFF documents]]></source>
+				<target xml:lang="ja-JP"><![CDATA[<p>XLIFF 文書を編集、または処理 するアプリケーションです。</p>]]></target>
 			</trans-unit>
 		</body>
 	</file>

--- a/modules/apps/translation/translation-test/src/testIntegration/resources/com/liferay/translation/dependencies/example-1_2-simple.xlf
+++ b/modules/apps/translation/translation-test/src/testIntegration/resources/com/liferay/translation/dependencies/example-1_2-simple.xlf
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2">
+	<file original="com.liferay.journal.model.JournalArticle:122" source-language="en-US" target-language="de-DE" tool="okapi" datatype="html">
+		<header/>
+		<body>
+			<trans-unit id="1">
+				<source xml:lang="en-US">Segment one.</source>
+				<target xml:lang="de-DE">Segment ein.</target>
+			</trans-unit>
+		</body>
+	</file>
+</xliff>

--- a/modules/apps/translation/translation-web/build.gradle
+++ b/modules/apps/translation/translation-web/build.gradle
@@ -1,8 +1,12 @@
 dependencies {
+	compileInclude group: "com.fasterxml.woodstox", name: "woodstox-core", version: "6.2.1"
 	compileInclude group: "com.ibm.icu", name: "icu4j", version: "65.1"
 	compileInclude group: "net.sf.okapi", name: "okapi-core", version: "1.39.0"
+	compileInclude group: "net.sf.okapi.filters", name: "okapi-filter-autoxliff", version: "1.39.0"
+	compileInclude group: "net.sf.okapi.filters", name: "okapi-filter-xliff", version: "1.39.0"
 	compileInclude group: "net.sf.okapi.filters", name: "okapi-filter-xliff2", version: "1.39.0"
 	compileInclude group: "net.sf.okapi.lib", name: "okapi-lib-xliff2", version: "1.39.0"
+	compileInclude group: "org.codehaus.woodstox", name: "stax2-api", version: "4.2.1"
 
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.1"

--- a/modules/apps/translation/translation-web/source-formatter.properties
+++ b/modules/apps/translation/translation-web/source-formatter.properties
@@ -1,0 +1,9 @@
+##
+## Exclusions
+##
+## See https://github.com/liferay/liferay-portal/blob/master/source-formatter.properties
+## for available properties.
+##
+
+source.formatter.excludes=\
+    modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/importer/XLIFFInfoFormTranslationImporter.java

--- a/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/importer/XLIFFInfoFormTranslationImporter.java
+++ b/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/importer/XLIFFInfoFormTranslationImporter.java
@@ -135,9 +135,7 @@ public class XLIFFInfoFormTranslationImporter
 			RawDocument rawDocument = new RawDocument(
 				tempFile.toURI(), encoding, sourceLocaleId, targetLocaleId);
 
-			AutoXLIFFFilter filter = new AutoXLIFFFilter();
-
-			try {
+			try (AutoXLIFFFilter filter = new AutoXLIFFFilter()) {
 				filter.open(rawDocument);
 
 				Stream<Event> stream = filter.stream();
@@ -157,9 +155,6 @@ public class XLIFFInfoFormTranslationImporter
 
 				throw new XLIFFFileException.MustBeValid(
 					okapiIllegalFilterOperationException);
-			}
-			finally {
-				filter.close();
 			}
 		}
 		catch (InvalidParameterException invalidParameterException) {

--- a/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/importer/XLIFFInfoFormTranslationImporter.java
+++ b/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/importer/XLIFFInfoFormTranslationImporter.java
@@ -38,6 +38,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import net.sf.okapi.common.Event;
 import net.sf.okapi.common.LocaleId;
@@ -79,9 +81,6 @@ public class XLIFFInfoFormTranslationImporter
 			InputStream inputStream)
 		throws IOException, XLIFFFileException {
 
-		InfoItemFieldValues infoItemFieldValues = new InfoItemFieldValues(
-			infoItemClassPKReference);
-
 		try {
 			File tempFile = FileUtil.createTempFile(inputStream);
 
@@ -97,74 +96,59 @@ public class XLIFFInfoFormTranslationImporter
 			try {
 				filter.open(document);
 
-				List<InfoFieldValue<Object>> infoFieldValues =
-					new ArrayList<>();
-				Locale targetLocale = null;
+				Stream<Event> stream = filter.stream();
 
-				while (filter.hasNext()) {
-					Event event = filter.next();
+				List<Event> events = stream.collect(Collectors.toList());
 
-					if (event.isStartDocument()) {
-						StartDocument startDocument = event.getStartDocument();
+				if (_isVersion20(events)) {
+					return _getInfoItemFieldValuesXLIFFv20(
+						groupId, infoItemClassPKReference, tempFile);
+				}
 
-						Property versionProperty = startDocument.getProperty(
-							"version");
+				return _getInfoItemFieldValuesXLIFFv12(
+					events, infoItemClassPKReference);
+			}
+			catch (OkapiIllegalFilterOperationException
+						okapiIllegalFilterOperationException) {
 
-						if ((versionProperty != null) &&
-							(GetterUtil.getDouble(versionProperty.getValue()) >=
-								2.0) &&
-							(GetterUtil.getDouble(versionProperty.getValue()) <
-								3.0)) {
+				throw new XLIFFFileException.MustBeValid(
+					okapiIllegalFilterOperationException);
+			}
+			finally {
+				filter.close();
+			}
+		}
+		catch (InvalidParameterException invalidParameterException) {
+			throw new XLIFFFileException.MustHaveValidParameter(
+				invalidParameterException);
+		}
+		catch (XLIFFException xliffException) {
+			throw new XLIFFFileException.MustBeValid(xliffException);
+		}
+	}
 
-							infoFieldValues = _getInfoItemValuesXLIFF20(
-								groupId, infoItemClassPKReference, tempFile);
+	private InfoItemFieldValues _getInfoItemFieldValuesXLIFFv12(
+			List<Event> events,
+			InfoItemClassPKReference infoItemClassPKReference)
+		throws XLIFFFileException {
 
-							break;
-						}
-					}
-					else if (event.isStartSubDocument()) {
-						StartSubDocument startSubdocument =
-							event.getStartSubDocument();
+		_validateDocumentPartVersion(events);
 
-						String original =
-							infoItemClassPKReference.getClassName() +
-								StringPool.COLON +
-									infoItemClassPKReference.getClassPK();
+		StartSubDocument startSubDocument = _getStartSubDocument(events);
 
-						if (!Objects.equals(
-								startSubdocument.getName(), original)) {
+		_validateXLIFFStartSubDocument(
+			infoItemClassPKReference, startSubDocument);
 
-							throw new XLIFFFileException.MustHaveValidId(
-								"File ID is invalid");
-						}
+		Locale targetLocale = _getTargetLocale(startSubDocument);
 
-						Property targetLanguageProperty =
-							startSubdocument.getProperty("targetLanguage");
-
-						String targetLanguage =
-							targetLanguageProperty.getValue();
-
-						targetLocale = LocaleUtil.fromLanguageId(
-							targetLanguage);
-					}
-					else if (event.isDocumentPart()) {
-						DocumentPart documentPart = event.getDocumentPart();
-
-						Property version = documentPart.getProperty("version");
-
-						if ((version != null) &&
-							!Objects.equals("1.2", version.getValue())) {
-
-							throw new XLIFFFileException.MustBeValid(
-								"version must be 1.2");
-						}
-					}
-					else if (event.isTextUnit()) {
+		return InfoItemFieldValues.builder(
+		).<XLIFFFileException>infoFieldValue(
+			consumer -> {
+				for (Event event : events) {
+					if (event.isTextUnit()) {
 						ITextUnit textUnit = event.getTextUnit();
 
-						_validateWellFormedXLIFF12(targetLocale, textUnit);
-
-						String field = textUnit.getId();
+						_validateWellFormedTextUnit(targetLocale, textUnit);
 
 						for (LocaleId targetLocaleId :
 								textUnit.getTargetLocales()) {
@@ -178,41 +162,23 @@ public class XLIFFInfoFormTranslationImporter
 								TextInfoFieldType.INSTANCE,
 								InfoLocalizedValue.<String>builder(
 								).value(
-									targetLocaleId.toJavaLocale(), field
+									targetLocale, textUnit.getId()
 								).build(),
-								true, field);
+								true, textUnit.getId());
 
-							infoFieldValues.add(
-								new InfoFieldValue<Object>(
+							consumer.accept(
+								new InfoFieldValue<>(
 									infoField, firstContent.getText()));
 						}
 					}
 				}
-
-				infoItemFieldValues.addAll(infoFieldValues);
 			}
-			catch (OkapiIllegalFilterOperationException
-						okapiIllegalFilterOperationException) {
-
-				throw new XLIFFFileException.MustBeValid(
-					okapiIllegalFilterOperationException);
-			}
-			finally {
-				filter.close();
-			}
-
-			return infoItemFieldValues;
-		}
-		catch (InvalidParameterException invalidParameterException) {
-			throw new XLIFFFileException.MustHaveValidParameter(
-				invalidParameterException);
-		}
-		catch (XLIFFException xliffException) {
-			throw new XLIFFFileException.MustBeValid(xliffException);
-		}
+		).infoItemClassPKReference(
+			infoItemClassPKReference
+		).build();
 	}
 
-	private List<InfoFieldValue<Object>> _getInfoItemValuesXLIFF20(
+	private InfoItemFieldValues _getInfoItemFieldValuesXLIFFv20(
 			long groupId, InfoItemClassPKReference infoItemClassPKReference,
 			File tempFile)
 		throws XLIFFFileException {
@@ -255,8 +221,7 @@ public class XLIFFInfoFormTranslationImporter
 						true, unit.getId());
 
 					consumer.accept(
-						new InfoFieldValue<>(
-							infoField, value.getPlainText()));
+						new InfoFieldValue<>(infoField, value.getPlainText()));
 				}
 			}
 		).infoItemClassPKReference(
@@ -264,7 +229,72 @@ public class XLIFFInfoFormTranslationImporter
 		).build();
 	}
 
-	private void _validateWellFormedXLIFF12(
+	private StartSubDocument _getStartSubDocument(List<Event> events) {
+		for (Event event : events) {
+			if (event.isStartSubDocument()) {
+				return event.getStartSubDocument();
+			}
+		}
+
+		return null;
+	}
+
+	private Locale _getTargetLocale(StartSubDocument startSubDocument) {
+		Property targetLanguageProperty = startSubDocument.getProperty(
+			"targetLanguage");
+
+		if ((targetLanguageProperty == null) ||
+			(targetLanguageProperty.getValue() == null)) {
+
+			return null;
+		}
+
+		String targetLanguage = targetLanguageProperty.getValue();
+
+		return LocaleUtil.fromLanguageId(targetLanguage);
+	}
+
+	private boolean _isVersion20(List<Event> events) {
+		for (Event event : events) {
+			if (event.isStartDocument()) {
+				StartDocument startDocument = event.getStartDocument();
+
+				Property versionProperty = startDocument.getProperty("version");
+
+				if (versionProperty != null) {
+					double version = GetterUtil.getDouble(
+						versionProperty.getValue());
+
+					if ((version >= 2.0) && (version < 3.0)) {
+						return true;
+					}
+				}
+			}
+		}
+
+		return false;
+	}
+
+	private void _validateDocumentPartVersion(List<Event> events)
+		throws XLIFFFileException.MustBeValid {
+
+		for (Event event : events) {
+			if (event.isDocumentPart()) {
+				DocumentPart documentPart = event.getDocumentPart();
+
+				Property version = documentPart.getProperty("version");
+
+				if ((version != null) &&
+					!Objects.equals("1.2", version.getValue())) {
+
+					throw new XLIFFFileException.MustBeValid(
+						"version must be 1.2");
+				}
+			}
+		}
+	}
+
+	private void _validateWellFormedTextUnit(
 			Locale targetLocale, ITextUnit textUnit)
 		throws XLIFFFileException.MustBeWellFormed {
 
@@ -375,6 +405,35 @@ public class XLIFFInfoFormTranslationImporter
 
 		if (fileNode == null) {
 			throw new XLIFFFileException.MustHaveValidId("File ID is invalid");
+		}
+	}
+
+	private void _validateXLIFFStartSubDocument(
+			InfoItemClassPKReference infoItemClassPKReference,
+			StartSubDocument startSubDocument)
+		throws XLIFFFileException {
+
+		if (startSubDocument == null) {
+			throw new XLIFFFileException.MustBeWellFormed(
+				"The XLIFF file is not well Formed");
+		}
+
+		String original =
+			infoItemClassPKReference.getClassName() + StringPool.COLON +
+				infoItemClassPKReference.getClassPK();
+
+		if (!Objects.equals(startSubDocument.getName(), original)) {
+			throw new XLIFFFileException.MustHaveValidId("File ID is invalid");
+		}
+
+		Property targetLanguageProperty = startSubDocument.getProperty(
+			"targetLanguage");
+
+		if ((targetLanguageProperty == null) ||
+			(targetLanguageProperty.getValue() == null)) {
+
+			throw new XLIFFFileException.MustBeWellFormed(
+				"There is no translation target");
 		}
 	}
 

--- a/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/importer/XLIFFInfoFormTranslationImporter.java
+++ b/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/importer/XLIFFInfoFormTranslationImporter.java
@@ -23,18 +23,34 @@ import com.liferay.info.localized.InfoLocalizedValue;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.translation.exception.XLIFFFileException;
 import com.liferay.translation.importer.TranslationInfoItemFieldValuesImporter;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.Set;
 
+import net.sf.okapi.common.Event;
+import net.sf.okapi.common.LocaleId;
+import net.sf.okapi.common.exceptions.OkapiIllegalFilterOperationException;
+import net.sf.okapi.common.resource.DocumentPart;
+import net.sf.okapi.common.resource.ITextUnit;
+import net.sf.okapi.common.resource.Property;
+import net.sf.okapi.common.resource.RawDocument;
+import net.sf.okapi.common.resource.StartDocument;
+import net.sf.okapi.common.resource.StartSubDocument;
+import net.sf.okapi.common.resource.TextContainer;
+import net.sf.okapi.common.resource.TextFragment;
+import net.sf.okapi.filters.autoxliff.AutoXLIFFFilter;
 import net.sf.okapi.lib.xliff2.InvalidParameterException;
 import net.sf.okapi.lib.xliff2.XLIFFException;
 import net.sf.okapi.lib.xliff2.core.Fragment;
@@ -63,53 +79,129 @@ public class XLIFFInfoFormTranslationImporter
 			InputStream inputStream)
 		throws IOException, XLIFFFileException {
 
+		InfoItemFieldValues infoItemFieldValues = new InfoItemFieldValues(
+			infoItemClassPKReference);
+
 		try {
-			XLIFFDocument xliffDocument = new XLIFFDocument();
+			File tempFile = FileUtil.createTempFile(inputStream);
 
-			xliffDocument.load(FileUtil.createTempFile(inputStream));
+			RawDocument document = new RawDocument(
+				tempFile.toURI(), StringPool.UTF8,
+				LocaleId.fromString(
+					LocaleUtil.toLanguageId(LocaleUtil.getDefault())),
+				LocaleId.fromString(
+					LocaleUtil.toLanguageId(LocaleUtil.getDefault())));
 
-			_validateXLIFFFile(
-				groupId, infoItemClassPKReference, xliffDocument);
+			AutoXLIFFFilter filter = new AutoXLIFFFilter();
 
-			StartXliffData startXliffData = xliffDocument.getStartXliffData();
+			try {
+				filter.open(document);
 
-			Locale targetLocale = LocaleUtil.fromLanguageId(
-				startXliffData.getTargetLanguage(), true, false);
+				List<InfoFieldValue<Object>> infoFieldValues =
+					new ArrayList<>();
+				Locale targetLocale = null;
 
-			return InfoItemFieldValues.builder(
-			).<XLIFFFileException>infoFieldValue(
-				consumer -> {
-					for (Unit unit : xliffDocument.getUnits()) {
-						if (unit.getPartCount() != 1) {
-							throw new XLIFFFileException.MustNotHaveMoreThanOne(
-								"The file only can have one unit");
+				while (filter.hasNext()) {
+					Event event = filter.next();
+
+					if (event.isStartDocument()) {
+						StartDocument startDocument = event.getStartDocument();
+
+						Property versionProperty = startDocument.getProperty(
+							"version");
+
+						if ((versionProperty != null) &&
+							(GetterUtil.getDouble(versionProperty.getValue()) >=
+								2.0) &&
+							(GetterUtil.getDouble(versionProperty.getValue()) <
+								3.0)) {
+
+							infoFieldValues = _getInfoItemValuesXLIFF20(
+								groupId, infoItemClassPKReference, tempFile);
+
+							break;
+						}
+					}
+					else if (event.isStartSubDocument()) {
+						StartSubDocument startSubdocument =
+							event.getStartSubDocument();
+
+						String original =
+							infoItemClassPKReference.getClassName() +
+								StringPool.COLON +
+									infoItemClassPKReference.getClassPK();
+
+						if (!Objects.equals(
+								startSubdocument.getName(), original)) {
+
+							throw new XLIFFFileException.MustHaveValidId(
+								"File ID is invalid");
 						}
 
-						Part valuePart = unit.getPart(0);
+						Property targetLanguageProperty =
+							startSubdocument.getProperty("targetLanguage");
 
-						Fragment value = valuePart.getTarget();
+						String targetLanguage =
+							targetLanguageProperty.getValue();
 
-						if (value == null) {
-							throw new XLIFFFileException.MustBeWellFormed(
-								"There is no translation target");
+						targetLocale = LocaleUtil.fromLanguageId(
+							targetLanguage);
+					}
+					else if (event.isDocumentPart()) {
+						DocumentPart documentPart = event.getDocumentPart();
+
+						Property version = documentPart.getProperty("version");
+
+						if ((version != null) &&
+							!Objects.equals("1.2", version.getValue())) {
+
+							throw new XLIFFFileException.MustBeValid(
+								"version must be 1.2");
 						}
+					}
+					else if (event.isTextUnit()) {
+						ITextUnit textUnit = event.getTextUnit();
 
-						InfoField infoField = new InfoField(
-							TextInfoFieldType.INSTANCE,
-							InfoLocalizedValue.<String>builder(
-							).value(
-								targetLocale, unit.getId()
-							).build(),
-							true, unit.getId());
+						_validateWellFormedXLIFF12(targetLocale, textUnit);
 
-						consumer.accept(
-							new InfoFieldValue<>(
-								infoField, value.getPlainText()));
+						String field = textUnit.getId();
+
+						for (LocaleId targetLocaleId :
+								textUnit.getTargetLocales()) {
+
+							TextContainer value = textUnit.getTarget(
+								targetLocaleId);
+
+							TextFragment firstContent = value.getFirstContent();
+
+							InfoField infoField = new InfoField(
+								TextInfoFieldType.INSTANCE,
+								InfoLocalizedValue.<String>builder(
+								).value(
+									targetLocaleId.toJavaLocale(), field
+								).build(),
+								true, field);
+
+							infoFieldValues.add(
+								new InfoFieldValue<Object>(
+									infoField, firstContent.getText()));
+						}
 					}
 				}
-			).infoItemClassPKReference(
-				infoItemClassPKReference
-			).build();
+
+				infoItemFieldValues.addAll(infoFieldValues);
+			}
+			catch (OkapiIllegalFilterOperationException
+						okapiIllegalFilterOperationException) {
+
+				throw new XLIFFFileException.MustBeValid(
+					okapiIllegalFilterOperationException);
+			}
+			finally {
+				filter.close();
+			}
+
+			return infoItemFieldValues;
 		}
 		catch (InvalidParameterException invalidParameterException) {
 			throw new XLIFFFileException.MustHaveValidParameter(
@@ -117,6 +209,92 @@ public class XLIFFInfoFormTranslationImporter
 		}
 		catch (XLIFFException xliffException) {
 			throw new XLIFFFileException.MustBeValid(xliffException);
+		}
+	}
+
+	private List<InfoFieldValue<Object>> _getInfoItemValuesXLIFF20(
+			long groupId, InfoItemClassPKReference infoItemClassPKReference,
+			File tempFile)
+		throws XLIFFFileException {
+
+		XLIFFDocument xliffDocument = new XLIFFDocument();
+
+		xliffDocument.load(tempFile);
+
+		_validateXLIFFFile(groupId, infoItemClassPKReference, xliffDocument);
+
+		StartXliffData startXliffData = xliffDocument.getStartXliffData();
+
+		Locale targetLocale = LocaleUtil.fromLanguageId(
+			startXliffData.getTargetLanguage(), true, false);
+
+		return InfoItemFieldValues.builder(
+		).<XLIFFFileException>infoFieldValue(
+			consumer -> {
+				for (Unit unit : xliffDocument.getUnits()) {
+					if (unit.getPartCount() != 1) {
+						throw new XLIFFFileException.MustNotHaveMoreThanOne(
+							"The file only can have one unit");
+					}
+
+					Part valuePart = unit.getPart(0);
+
+					Fragment value = valuePart.getTarget();
+
+					if (value == null) {
+						throw new XLIFFFileException.MustBeWellFormed(
+							"There is no translation target");
+					}
+
+					InfoField infoField = new InfoField(
+						TextInfoFieldType.INSTANCE,
+						InfoLocalizedValue.<String>builder(
+						).value(
+							targetLocale, unit.getId()
+						).build(),
+						true, unit.getId());
+
+					consumer.accept(
+						new InfoFieldValue<>(
+							infoField, value.getPlainText()));
+				}
+			}
+		).infoItemClassPKReference(
+			infoItemClassPKReference
+		).build();
+	}
+
+	private void _validateWellFormedXLIFF12(
+			Locale targetLocale, ITextUnit textUnit)
+		throws XLIFFFileException.MustBeWellFormed {
+
+		TextContainer source = textUnit.getSource();
+		Set<LocaleId> targetLocales = textUnit.getTargetLocales();
+
+		if (!source.isEmpty() && targetLocales.isEmpty()) {
+			throw new XLIFFFileException.MustBeWellFormed(
+				"There is no translation target");
+		}
+
+		if (targetLocales.size() > 1) {
+			throw new XLIFFFileException.MustBeWellFormed(
+				"Only one translation language per file is permitted");
+		}
+
+		for (LocaleId targetLocaleId : targetLocales) {
+			if ((targetLocale != null) &&
+				!Objects.equals(targetLocale, targetLocaleId.toJavaLocale())) {
+
+				throw new XLIFFFileException.MustBeWellFormed(
+					"Only one translation language per file is permitted");
+			}
+
+			TextContainer value = textUnit.getTarget(targetLocaleId);
+
+			if (!source.isEmpty() && value.isEmpty()) {
+				throw new XLIFFFileException.MustBeWellFormed(
+					"There is no translation target");
+			}
 		}
 	}
 

--- a/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/importer/XLIFFInfoFormTranslationImporter.java
+++ b/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/importer/XLIFFInfoFormTranslationImporter.java
@@ -197,13 +197,14 @@ public class XLIFFInfoFormTranslationImporter
 
 							TextFragment firstContent = value.getFirstContent();
 
-							InfoField infoField = new InfoField(
-								TextInfoFieldType.INSTANCE,
-								InfoLocalizedValue.<String>builder(
-								).value(
-									targetLocale, textUnit.getId()
-								).build(),
-								true, textUnit.getId());
+							InfoField<TextInfoFieldType> infoField =
+								new InfoField<>(
+									TextInfoFieldType.INSTANCE,
+									InfoLocalizedValue.<String>builder(
+									).value(
+										targetLocale, textUnit.getId()
+									).build(),
+									true, textUnit.getId());
 
 							consumer.accept(
 								new InfoFieldValue<>(
@@ -251,7 +252,7 @@ public class XLIFFInfoFormTranslationImporter
 							"There is no translation target");
 					}
 
-					InfoField infoField = new InfoField(
+					InfoField<TextInfoFieldType> infoField = new InfoField<>(
 						TextInfoFieldType.INSTANCE,
 						InfoLocalizedValue.<String>builder(
 						).value(

--- a/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/importer/XLIFFInfoFormTranslationImporter.java
+++ b/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/importer/XLIFFInfoFormTranslationImporter.java
@@ -42,7 +42,9 @@ import java.io.InputStream;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -89,46 +91,27 @@ public class XLIFFInfoFormTranslationImporter
 		try (AutoXLIFFFilter filter = new AutoXLIFFFilter()) {
 			File tempFile = FileUtil.createTempFile(inputStream);
 
-			String encoding = StringPool.UTF8;
-
-			LocaleId sourceLocaleId = LocaleId.fromString(
-				LocaleUtil.toLanguageId(LocaleUtil.getDefault()));
-
-			LocaleId targetLocaleId = LocaleId.fromString(
-				LocaleUtil.toLanguageId(LocaleUtil.getDefault()));
-
 			Document document = SAXReaderUtil.read(tempFile);
 
 			Element rootElement = document.getRootElement();
 
-			Attribute encodingAttribute = rootElement.attribute("encoding");
-
-			if (encodingAttribute != null) {
-				encoding = encodingAttribute.getValue();
-			}
+			Optional<String> encodingOptional = _getAttributeValueOptional(
+				rootElement, "encoding", string -> string);
 
 			Element fileElement = rootElement.element("file");
 
-			if (fileElement != null) {
-				Attribute sourceLanguageAttribute = fileElement.attribute(
-					"source-language");
+			Optional<LocaleId> sourceLocaleIdOptional =
+				_getAttributeValueOptional(
+					fileElement, "source-language", LocaleId::fromString);
 
-				if (sourceLanguageAttribute != null) {
-					sourceLocaleId = LocaleId.fromString(
-						sourceLanguageAttribute.getValue());
-				}
-
-				Attribute targetLanguageAttribute = fileElement.attribute(
-					"target-language");
-
-				if (targetLanguageAttribute != null) {
-					targetLocaleId = LocaleId.fromString(
-						targetLanguageAttribute.getValue());
-				}
-			}
+			Optional<LocaleId> targetLocaleIdOptional =
+				_getAttributeValueOptional(
+					fileElement, "target-language", LocaleId::fromString);
 
 			RawDocument rawDocument = new RawDocument(
-				tempFile.toURI(), encoding, sourceLocaleId, targetLocaleId);
+				tempFile.toURI(), encodingOptional.orElse(StringPool.UTF8),
+				sourceLocaleIdOptional.orElse(_defaultLocaleId),
+				targetLocaleIdOptional.orElse(_defaultLocaleId));
 
 			filter.open(rawDocument);
 
@@ -153,6 +136,22 @@ public class XLIFFInfoFormTranslationImporter
 			throw new XLIFFFileException.MustHaveValidParameter(
 				invalidParameterException);
 		}
+	}
+
+	private <T> Optional<T> _getAttributeValueOptional(
+		Element element, String attributeName, Function<String, T> function) {
+
+		if (element == null) {
+			return Optional.empty();
+		}
+
+		Attribute attribute = element.attribute(attributeName);
+
+		if (attribute == null) {
+			return Optional.empty();
+		}
+
+		return Optional.of(function.apply(attribute.getValue()));
 	}
 
 	private InfoItemFieldValues _getInfoItemFieldValuesXLIFFv12(
@@ -465,6 +464,9 @@ public class XLIFFInfoFormTranslationImporter
 				"There is no translation target");
 		}
 	}
+
+	private static final LocaleId _defaultLocaleId = LocaleId.fromString(
+		LocaleUtil.toLanguageId(LocaleUtil.getDefault()));
 
 	@Reference
 	private Language _language;

--- a/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/importer/XLIFFInfoFormTranslationImporter.java
+++ b/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/importer/XLIFFInfoFormTranslationImporter.java
@@ -159,9 +159,9 @@ public class XLIFFInfoFormTranslationImporter
 			InfoItemClassPKReference infoItemClassPKReference)
 		throws XLIFFFileException {
 
-		StartSubDocument startSubDocument = _getStartSubDocument(events);
-
 		_validateDocumentPartVersion(events);
+
+		StartSubDocument startSubDocument = _getStartSubDocument(events);
 
 		_validateXLIFFStartSubDocument(
 			infoItemClassPKReference, startSubDocument);

--- a/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/importer/XLIFFInfoFormTranslationImporter.java
+++ b/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/importer/XLIFFInfoFormTranslationImporter.java
@@ -39,7 +39,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;

--- a/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/importer/XLIFFInfoFormTranslationImporter.java
+++ b/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/importer/XLIFFInfoFormTranslationImporter.java
@@ -86,7 +86,7 @@ public class XLIFFInfoFormTranslationImporter
 			InputStream inputStream)
 		throws IOException, XLIFFFileException {
 
-		try {
+		try (AutoXLIFFFilter filter = new AutoXLIFFFilter()) {
 			File tempFile = FileUtil.createTempFile(inputStream);
 
 			String encoding = StringPool.UTF8;
@@ -97,72 +97,61 @@ public class XLIFFInfoFormTranslationImporter
 			LocaleId targetLocaleId = LocaleId.fromString(
 				LocaleUtil.toLanguageId(LocaleUtil.getDefault()));
 
-			try {
-				Document document = SAXReaderUtil.read(tempFile);
+			Document document = SAXReaderUtil.read(tempFile);
 
-				Element rootElement = document.getRootElement();
+			Element rootElement = document.getRootElement();
 
-				Attribute encodingAttribute = rootElement.attribute("encoding");
+			Attribute encodingAttribute = rootElement.attribute("encoding");
 
-				if (encodingAttribute != null) {
-					encoding = encodingAttribute.getValue();
-				}
-
-				Element fileElement = rootElement.element("file");
-
-				if (fileElement != null) {
-					Attribute sourceLanguageAttribute = fileElement.attribute(
-						"source-language");
-
-					if (sourceLanguageAttribute != null) {
-						sourceLocaleId = LocaleId.fromString(
-							sourceLanguageAttribute.getValue());
-					}
-
-					Attribute targetLanguageAttribute = fileElement.attribute(
-						"target-language");
-
-					if (targetLanguageAttribute != null) {
-						targetLocaleId = LocaleId.fromString(
-							targetLanguageAttribute.getValue());
-					}
-				}
+			if (encodingAttribute != null) {
+				encoding = encodingAttribute.getValue();
 			}
-			catch (DocumentException documentException) {
-				throw new XLIFFFileException.MustBeValid(documentException);
+
+			Element fileElement = rootElement.element("file");
+
+			if (fileElement != null) {
+				Attribute sourceLanguageAttribute = fileElement.attribute(
+					"source-language");
+
+				if (sourceLanguageAttribute != null) {
+					sourceLocaleId = LocaleId.fromString(
+						sourceLanguageAttribute.getValue());
+				}
+
+				Attribute targetLanguageAttribute = fileElement.attribute(
+					"target-language");
+
+				if (targetLanguageAttribute != null) {
+					targetLocaleId = LocaleId.fromString(
+						targetLanguageAttribute.getValue());
+				}
 			}
 
 			RawDocument rawDocument = new RawDocument(
 				tempFile.toURI(), encoding, sourceLocaleId, targetLocaleId);
 
-			try (AutoXLIFFFilter filter = new AutoXLIFFFilter()) {
-				filter.open(rawDocument);
+			filter.open(rawDocument);
 
-				Stream<Event> stream = filter.stream();
+			Stream<Event> stream = filter.stream();
 
-				List<Event> events = stream.collect(Collectors.toList());
+			List<Event> events = stream.collect(Collectors.toList());
 
-				if (_isVersion20(events)) {
-					return _getInfoItemFieldValuesXLIFFv20(
-						groupId, infoItemClassPKReference, tempFile);
-				}
-
-				return _getInfoItemFieldValuesXLIFFv12(
-					events, infoItemClassPKReference);
+			if (_isVersion20(events)) {
+				return _getInfoItemFieldValuesXLIFFv20(
+					groupId, infoItemClassPKReference, tempFile);
 			}
-			catch (OkapiIllegalFilterOperationException
-						okapiIllegalFilterOperationException) {
 
-				throw new XLIFFFileException.MustBeValid(
-					okapiIllegalFilterOperationException);
-			}
+			return _getInfoItemFieldValuesXLIFFv12(
+				events, infoItemClassPKReference);
+		}
+		catch (DocumentException | OkapiIllegalFilterOperationException |
+			   XLIFFException exception) {
+
+			throw new XLIFFFileException.MustBeValid(exception);
 		}
 		catch (InvalidParameterException invalidParameterException) {
 			throw new XLIFFFileException.MustHaveValidParameter(
 				invalidParameterException);
-		}
-		catch (XLIFFException xliffException) {
-			throw new XLIFFFileException.MustBeValid(xliffException);
 		}
 	}
 

--- a/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/importer/XLIFFInfoFormTranslationImporter.java
+++ b/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/importer/XLIFFInfoFormTranslationImporter.java
@@ -26,6 +26,12 @@ import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.xml.Attribute;
+import com.liferay.portal.kernel.xml.Document;
+import com.liferay.portal.kernel.xml.DocumentException;
+import com.liferay.portal.kernel.xml.Element;
+import com.liferay.portal.kernel.xml.SAXReader;
+import com.liferay.portal.kernel.xml.SAXReaderUtil;
 import com.liferay.translation.exception.XLIFFFileException;
 import com.liferay.translation.importer.TranslationInfoItemFieldValuesImporter;
 
@@ -84,17 +90,56 @@ public class XLIFFInfoFormTranslationImporter
 		try {
 			File tempFile = FileUtil.createTempFile(inputStream);
 
-			RawDocument document = new RawDocument(
-				tempFile.toURI(), StringPool.UTF8,
-				LocaleId.fromString(
-					LocaleUtil.toLanguageId(LocaleUtil.getDefault())),
-				LocaleId.fromString(
-					LocaleUtil.toLanguageId(LocaleUtil.getDefault())));
+			String encoding = StringPool.UTF8;
+
+			LocaleId sourceLocaleId = LocaleId.fromString(
+				LocaleUtil.toLanguageId(LocaleUtil.getDefault()));
+
+			LocaleId targetLocaleId = LocaleId.fromString(
+				LocaleUtil.toLanguageId(LocaleUtil.getDefault()));
+
+			try {
+				Document document = SAXReaderUtil.read(tempFile);
+
+				Element rootElement = document.getRootElement();
+
+				Attribute encodingAttribute = rootElement.attribute("encoding");
+
+				if (encodingAttribute != null) {
+					encoding = encodingAttribute.getValue();
+				}
+
+				Element fileElement = rootElement.element("file");
+
+				if (fileElement != null) {
+					Attribute sourceLanguageAttribute = fileElement.attribute(
+						"source-language");
+
+					if (sourceLanguageAttribute != null) {
+						sourceLocaleId = LocaleId.fromString(
+							sourceLanguageAttribute.getValue());
+					}
+
+					Attribute targetLanguageAttribute = fileElement.attribute(
+						"target-language");
+
+					if (targetLanguageAttribute != null) {
+						targetLocaleId = LocaleId.fromString(
+							targetLanguageAttribute.getValue());
+					}
+				}
+			}
+			catch (DocumentException documentException) {
+				throw new XLIFFFileException.MustBeValid(documentException);
+			}
+
+			RawDocument rawDocument = new RawDocument(
+				tempFile.toURI(), encoding, sourceLocaleId, targetLocaleId);
 
 			AutoXLIFFFilter filter = new AutoXLIFFFilter();
 
 			try {
-				filter.open(document);
+				filter.open(rawDocument);
 
 				Stream<Event> stream = filter.stream();
 
@@ -132,9 +177,9 @@ public class XLIFFInfoFormTranslationImporter
 			InfoItemClassPKReference infoItemClassPKReference)
 		throws XLIFFFileException {
 
-		_validateDocumentPartVersion(events);
-
 		StartSubDocument startSubDocument = _getStartSubDocument(events);
+
+		_validateDocumentPartVersion(events);
 
 		_validateXLIFFStartSubDocument(
 			infoItemClassPKReference, startSubDocument);
@@ -439,5 +484,8 @@ public class XLIFFInfoFormTranslationImporter
 
 	@Reference
 	private Language _language;
+
+	@Reference
+	private SAXReader _saxReader;
 
 }


### PR DESCRIPTION
Hey @brianchandotcom, @hhuijser

We found an issue with AutoSF that AFAIK can only be fixed with an SF exclusion. The XLIFF library we're using has a class named `StartSubDocument`; this causes two SF rules to conflict with each other anywhere this is used in a variable/method name:

1. The name of the variable should match its type name; e.g. `StartSubDocument startSubDocument = ...;`
2. When adding the "sub" prefix to a word, it has to be camel cased as a whole word (e.g. Document -> Subdocument).

So, if we try to satisfy rule 1, SF will complain about rule 2 and viceversa. As a workaround, we've added a file exclusion, but we wonder if there's anything we can do to solve this kind of issue.

Thanks!