### PR TITLE
LPS-114635 Set underlying structure type to AUTO

### DIFF
--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/service/DataEngineDLFileEntryTypeLocalServiceWrapper.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/service/DataEngineDLFileEntryTypeLocalServiceWrapper.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.document.library.internal.service;
+
+import com.liferay.document.library.kernel.model.DLFileEntryType;
+import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalService;
+import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalServiceWrapper;
+import com.liferay.dynamic.data.mapping.constants.DDMStructureConstants;
+import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceWrapper;
+
+import java.util.Locale;
+import java.util.Map;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Adolfo Pérez
+ */
+@Component(service = ServiceWrapper.class)
+public class DataEngineDLFileEntryTypeLocalServiceWrapper
+	extends DLFileEntryTypeLocalServiceWrapper {
+
+	public DataEngineDLFileEntryTypeLocalServiceWrapper() {
+		this(null);
+	}
+
+	public DataEngineDLFileEntryTypeLocalServiceWrapper(
+		DLFileEntryTypeLocalService dlFileEntryTypeLocalService) {
+
+		super(dlFileEntryTypeLocalService);
+	}
+
+	@Override
+	public DLFileEntryType addDLFileEntryType(DLFileEntryType dlFileEntryType) {
+		DLFileEntryType fileEntryType = super.addDLFileEntryType(
+			dlFileEntryType);
+
+		_updateDDMStructure(fileEntryType.getDataDefinitionId());
+
+		return fileEntryType;
+	}
+
+	@Override
+	public DLFileEntryType addFileEntryType(
+			long userId, long groupId, long dataDefinitionId,
+			String fileEntryTypeKey, Map<Locale, String> nameMap,
+			Map<Locale, String> descriptionMap, ServiceContext serviceContext)
+		throws PortalException {
+
+		DLFileEntryType fileEntryType = super.addFileEntryType(
+			userId, groupId, dataDefinitionId, fileEntryTypeKey, nameMap,
+			descriptionMap, serviceContext);
+
+		_updateDDMStructure(dataDefinitionId);
+
+		return fileEntryType;
+	}
+
+	private void _updateDDMStructure(long structureId) {
+		DDMStructure ddmStructure = _ddmStructureLocalService.fetchDDMStructure(
+			structureId);
+
+		if (ddmStructure == null) {
+			return;
+		}
+
+		ddmStructure.setType(DDMStructureConstants.TYPE_AUTO);
+
+		_ddmStructureLocalService.updateDDMStructure(ddmStructure);
+	}
+
+	@Reference
+	private DDMStructureLocalService _ddmStructureLocalService;
+
+}


### PR DESCRIPTION
Hey @brianchandotcom 

We cannot update the type column in DLFileEntryTypeLocalServiceImpl (located in portal-impl) because the DDMStructureLocalService is in a module. In core, we have the DDMStructureManager interface, but we cannot update "type" field through it.

As an alternative, I could add a new method to the DDMStructureManager; I didn't do that because I don't want to add  new API (the "type" column is an implementation detail, and AFAIK only DM uses it at the moment).

Thanks!



