### PR TITLE
[TS] LPS-119212 knowledge-base-service:  Retrieve classNameID using service call instead of kbArticle.getClassName

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/exportimport/data/handler/KBArticleStagedModelDataHandler.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/exportimport/data/handler/KBArticleStagedModelDataHandler.java
@@ -128,8 +128,11 @@ public class KBArticleStagedModelDataHandler
 		if (kbArticle.getParentResourcePrimKey() !=
 				KBFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
 
+			long kbArticleClassNameId = _classNameLocalService.getClassNameId(
+				KBArticleConstants.getClassName());
+
 			if (kbArticle.getParentResourceClassNameId() ==
-					kbArticle.getClassNameId()) {
+					kbArticleClassNameId) {
 
 				KBArticle parentKBArticle =
 					_kbArticleLocalService.getLatestKBArticle(
@@ -187,9 +190,10 @@ public class KBArticleStagedModelDataHandler
 			KBFolderConstants.getClassName());
 		long parentResourcePrimKey = KBFolderConstants.DEFAULT_PARENT_FOLDER_ID;
 
-		if (kbArticle.getClassNameId() ==
-				kbArticle.getParentResourceClassNameId()) {
+		long kbArticleClassNameId = _classNameLocalService.getClassNameId(
+			KBArticleConstants.getClassName());
 
+		if (kbArticleClassNameId == kbArticle.getParentResourceClassNameId()) {
 			parentResourceClassNameId = _classNameLocalService.getClassNameId(
 				KBArticleConstants.getClassName());
 			parentResourcePrimKey = MapUtil.getLong(


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-119212

**Notes from @javalosjr96:**

> Retrieve classNameID using service call instead of kbArticle.getClassName
> 
> The issue was that kbAritcle.getClassNameID would retrieve the classNameId from the previous database. Using the service call will ensure that it will always use the classNameID in the current database.

**Additional Notes**
During the export, if **kbArticle.getClassNameId()** is called, the **classNameId** from the origin database would be included in the lar. 

If we avoid this call during export, the **classNameId** would have the default value of 0 in the exported LAR. Looking at the code, this appears to be the value that would be expected during import, in order for the current import logic to work properly. 