### PR TITLE
LPS-119701 Custom description with long special characters display out of the preview

### DIFF
--- a/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/css/main.scss
@@ -16,6 +16,10 @@
 		min-height: $line-height-base * 1em;
 	}
 
+	&-description {
+		word-break: break-all;
+	}
+
 	&-title {
 		font-size: 1rem;
 	}


### PR DESCRIPTION
**Steps to reproduce:**

1. Add a new site page
2. Go to page configuration > Open Graph
3. Check on the checkbox of Use Custom Description, type a custom description with long special characters
  ```
Loremipsumdolorsitametconsecteturadipisicingelit.Totam,excepturiautem.Modiexcepturiofficiasolutanostrumvoluptatum.Iureea,aspernaturodioquoscorporis,sitconsecteturdoloremqueesseatquefacereveritatis!
  ```

**Before the fix:**
![image](https://user-images.githubusercontent.com/67901/91305083-ca237780-e7aa-11ea-92a9-02963d1392cf.png)


**After the fix:**
![image](https://user-images.githubusercontent.com/67901/91305132-de677480-e7aa-11ea-9597-f13c297ff378.png)
