### PR TITLE
LPS 106905

### DIFF
--- a/modules/apps/item-selector/item-selector-impl/src/main/java/com/liferay/item/selector/internal/provider/GroupItemSelectorProviderImpl.java
+++ b/modules/apps/item-selector/item-selector-impl/src/main/java/com/liferay/item/selector/internal/provider/GroupItemSelectorProviderImpl.java
@@ -22,11 +22,17 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Organization;
+import com.liferay.portal.kernel.security.auth.GuestOrUserUtil;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.GroupService;
+import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
 import com.liferay.portlet.usersadmin.search.GroupSearch;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -67,9 +73,10 @@ public class GroupItemSelectorProviderImpl
 			).build();
 
 		try {
-			return _groupService.search(
-				companyId, _classNameIds, keywords, groupParams, start, end,
-				null);
+			return _filterGroups(
+				_groupLocalService.search(
+					companyId, _classNameIds, keywords, groupParams, start, end,
+					null));
 		}
 		catch (PortalException portalException) {
 			_log.error(portalException, portalException);
@@ -111,6 +118,26 @@ public class GroupItemSelectorProviderImpl
 		};
 	}
 
+	private List<Group> _filterGroups(List<Group> groups)
+		throws PortalException {
+
+		List<Group> filteredGroups = new ArrayList<>();
+
+		PermissionChecker permissionChecker =
+			GuestOrUserUtil.getPermissionChecker();
+
+		for (Group group : groups) {
+			if (group.isCompany() ||
+				GroupPermissionUtil.contains(
+					permissionChecker, group, ActionKeys.VIEW)) {
+
+				filteredGroups.add(group);
+			}
+		}
+
+		return filteredGroups;
+	}
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		GroupItemSelectorProviderImpl.class);
 
@@ -118,6 +145,9 @@ public class GroupItemSelectorProviderImpl
 
 	@Reference
 	private ClassNameLocalService _classNameLocalService;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
 
 	@Reference
 	private GroupService _groupService;

--- a/modules/apps/item-selector/item-selector-test/src/testIntegration/java/com/liferay/item/selector/provider/test/GroupItemSelectorProviderImplTest.java
+++ b/modules/apps/item-selector/item-selector-test/src/testIntegration/java/com/liferay/item/selector/provider/test/GroupItemSelectorProviderImplTest.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -75,6 +76,17 @@ public class GroupItemSelectorProviderImplTest {
 
 			Assert.assertTrue(groups.contains(company.getGroup()));
 		}
+	}
+
+	@Test
+	public void testGetIcon() {
+		Assert.assertEquals("sites", _groupItemSelectorProvider.getIcon());
+	}
+
+	@Test
+	public void testGetLabel() {
+		Assert.assertEquals(
+			"Site", _groupItemSelectorProvider.getLabel(LocaleUtil.US));
 	}
 
 	@DeleteAfterTestRun

--- a/modules/apps/item-selector/item-selector-test/src/testIntegration/java/com/liferay/item/selector/provider/test/GroupItemSelectorProviderImplTest.java
+++ b/modules/apps/item-selector/item-selector-test/src/testIntegration/java/com/liferay/item/selector/provider/test/GroupItemSelectorProviderImplTest.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.item.selector.provider.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.item.selector.provider.GroupItemSelectorProvider;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
+import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
+import com.liferay.portal.kernel.test.context.ContextUserReplace;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Alejandro Tardín
+ */
+@RunWith(Arquillian.class)
+public class GroupItemSelectorProviderImplTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+		_user = UserTestUtil.addUser();
+	}
+
+	@Test
+	public void testGetGroupsAlwaysReturnsGlobal() throws Exception {
+		PermissionChecker permissionChecker =
+			PermissionCheckerFactoryUtil.create(_user);
+
+		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
+				_user, permissionChecker)) {
+
+			List<Group> groups = _groupItemSelectorProvider.getGroups(
+				_group.getCompanyId(), _group.getGroupId(), null, 0, 20);
+
+			Company company = CompanyLocalServiceUtil.getCompany(
+				_group.getCompanyId());
+
+			Assert.assertTrue(groups.contains(company.getGroup()));
+		}
+	}
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject(filter = "component.name=*.GroupItemSelectorProviderImpl")
+	private GroupItemSelectorProvider _groupItemSelectorProvider;
+
+	private User _user;
+
+}


### PR DESCRIPTION
Hi @adolfopa,

I discussed this issue with Jorge and he said Global should appear, it was one of the goals of having global. Maybe we should always grant view permissions to the Global group at the GroupPermission level but I have decided to only modify the logic inside the item selector group provider to avoid unintended side effects.
 
