### PR TITLE
master LPS 120928

### DIFF
--- a/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/util/BlogsEntryAssetEntryUtil.java
+++ b/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/util/BlogsEntryAssetEntryUtil.java
@@ -18,6 +18,7 @@ import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.asset.kernel.service.AssetEntryLocalServiceUtil;
 import com.liferay.blogs.model.BlogsEntry;
 import com.liferay.blogs.web.internal.constants.BlogsWebConstants;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 
 import javax.servlet.http.HttpServletRequest;
@@ -31,15 +32,18 @@ public class BlogsEntryAssetEntryUtil {
 			HttpServletRequest httpServletRequest, BlogsEntry blogsEntry)
 		throws PortalException {
 
+		String key =
+			BlogsWebConstants.BLOGS_ENTRY_ASSET_ENTRY + StringPool.UNDERLINE +
+				blogsEntry.getEntryId();
+
 		AssetEntry assetEntry = (AssetEntry)httpServletRequest.getAttribute(
-			BlogsWebConstants.BLOGS_ENTRY_ASSET_ENTRY);
+			key);
 
 		if (assetEntry == null) {
 			assetEntry = AssetEntryLocalServiceUtil.getEntry(
 				BlogsEntry.class.getName(), blogsEntry.getEntryId());
 
-			httpServletRequest.setAttribute(
-				BlogsWebConstants.BLOGS_ENTRY_ASSET_ENTRY, assetEntry);
+			httpServletRequest.setAttribute(key, assetEntry);
 		}
 
 		return assetEntry;

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/view_entry_content.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/view_entry_content.jsp
@@ -112,7 +112,7 @@ BlogsPortletInstanceConfiguration blogsPortletInstanceConfiguration = BlogsPortl
 								<c:if test="<%= blogsPortletInstanceConfiguration.enableViewCount() %>">
 
 									<%
-									AssetEntry assetEntry = BlogsEntryAssetEntryUtil.getAssetEntry(request, entry);
+									AssetEntry assetEntry = AssetEntryLocalServiceUtil.getEntry(BlogsEntry.class.getName(), entry.getEntryId());
 									%>
 
 									- <liferay-ui:message arguments="<%= assetEntry.getViewCount() %>" key='<%= (assetEntry.getViewCount() == 1) ? "x-view" : "x-views" %>' />

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/view_entry_content.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/view_entry_content.jsp
@@ -112,7 +112,7 @@ BlogsPortletInstanceConfiguration blogsPortletInstanceConfiguration = BlogsPortl
 								<c:if test="<%= blogsPortletInstanceConfiguration.enableViewCount() %>">
 
 									<%
-									AssetEntry assetEntry = AssetEntryLocalServiceUtil.getEntry(BlogsEntry.class.getName(), entry.getEntryId());
+									AssetEntry assetEntry = BlogsEntryAssetEntryUtil.getAssetEntry(request, entry);
 									%>
 
 									- <liferay-ui:message arguments="<%= assetEntry.getViewCount() %>" key='<%= (assetEntry.getViewCount() == 1) ? "x-view" : "x-views" %>' />


### PR DESCRIPTION
Hi @rgusztus,

Thanks for the fix. The reason why we were using a custom util was performance (read https://github.com/liferay-lima/liferay-portal/pull/791/commits/b0bfa6de53d6f0932db10e60dc77cd011eb7fa40).

I've reverted your change and added the entry id to the cache key to make sure different blog entries don't reuse the same asset entry (see https://github.com/liferay-lima/liferay-portal/pull/791/commits/587b8919e8bcb5a2a5ab93b4b96ad203c5a2aaab).