### PR TITLE
LPS-121081 Publish button disabled on Blog entry page after a few seconds

### DIFF
--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/js/blogs.js
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/js/blogs.js
@@ -471,9 +471,6 @@ AUI.add(
 								body,
 								method: 'POST',
 							})
-								.then((response) => {
-									return response.json();
-								})
 								.then((data) => {
 									instance._oldContent = content;
 									instance._oldSubtitle = subtitle;


### PR DESCRIPTION
Hi @robertoDiaz

could you please check my changes?
The blogs.js::_saveEntry function was rewritten on the LPS-100101 which is causing this regression issue.
https://github.com/brianchandotcom/liferay-portal/pull/77387/files

Fix: remove the first then branch which returns response.json(); and exiting from the function.

https://issues.liferay.com/browse/LPS-121081

Thanks, Roland