### PR TITLE
LPS-121802 Message Boards fix overlapping issues with `social-interac…

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/compat/components/_basic_search.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/compat/components/_basic_search.scss
@@ -168,4 +168,18 @@
 			z-index: 1;
 		}
 	}
+
+	.basic-search-no-collapse {
+		.basic-search-slider {
+			@include media-breakpoint-down($scaling-breakpoint-down) {
+				left: 0;
+			}
+
+			.basic-search-close {
+				@include media-breakpoint-down($scaling-breakpoint-down) {
+					display: none;
+				}
+			}
+		}
+	}
 }

--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/portlet/_app_components.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/portlet/_app_components.scss
@@ -88,6 +88,21 @@
 	}
 }
 
+// ---------- liferay-ui:icon-menu Taglib ----------
+
+.lfr-icon-menu {
+	.dropdown-toggle {
+		font-size: $dropdown-action-toggle-font-size;
+
+		> span {
+			display: inherit;
+			height: inherit;
+			line-height: inherit;
+			width: inherit;
+		}
+	}
+}
+
 // ---------- Navbar form search ----------
 
 .navbar form {

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/dynamic_include/portlet_header.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/dynamic_include/portlet_header.jsp
@@ -35,6 +35,7 @@ long categoryId = MBUtil.getCategoryId(request, category);
 	<aui:input name="searchCategoryId" type="hidden" value="<%= categoryId %>" />
 
 	<liferay-ui:input-search
+		cssClass="basic-search-no-collapse"
 		id='<%= (PortalUtil.getLiferayPortletResponse(portletResponse)).getNamespace() + "keywords1" %>'
 		markupView="lexicon"
 		name='<%= (PortalUtil.getLiferayPortletResponse(portletResponse)).getNamespace() + "keywords" %>'

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/css/main.scss
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/css/main.scss
@@ -162,20 +162,51 @@
 		}
 	}
 
+	h3.component-title {
+		font-size: $h3-font-size;
+
+		@include media-breakpoint-down(sm) {
+			font-size: $h3-font-size-mobile;
+		}
+	}
+
+	.message-user-display {
+		margin-bottom: 0.5rem;
+		margin-top: 0.5rem;
+	}
+
+	.social-interaction {
+		display: flex;
+		margin-left: -0.5rem;
+
+		> div {
+			margin-right: 0.5rem;
+		}
+	}
+
 	@include media-breakpoint-up(sm) {
 		.message-user-display {
-			width: 50%;
+			width: calc(100% - 198px);
 		}
 
 		.social-interaction {
+			margin-left: 0;
 			position: absolute;
 			right: 0;
-			top: 0;
-			width: 50%;
+			top: 0.25rem;
 
-			& > div {
-				float: right;
-				margin-right: 12px;
+			> div {
+				float: left;
+			}
+
+			.ratings-thumbs .btn {
+				padding-bottom: 0.21875rem;
+				padding-top: 0.21875rem;
+
+				.c-inner {
+					margin-bottom: -0.21875rem;
+					margin-top: -0.21875rem;
+				}
 			}
 		}
 	}

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view.jsp
@@ -207,7 +207,7 @@ request.setAttribute("view.jsp-viewCategory", Boolean.TRUE.toString());
 						>
 							<c:choose>
 								<c:when test="<%= category != null %>">
-									<h3><%= HtmlUtil.escape(category.getName()) %></h3>
+									<h3 class="component-title"><%= HtmlUtil.escape(category.getName()) %></h3>
 								</c:when>
 								<c:otherwise>
 
@@ -449,7 +449,7 @@ request.setAttribute("view.jsp-viewCategory", Boolean.TRUE.toString());
 								<clay:content-col
 									expand="<%= true %>"
 								>
-									<h3><liferay-ui:message key="recent-posts" /></h3>
+									<h3 class="component-title"><liferay-ui:message key="recent-posts" /></h3>
 								</clay:content-col>
 
 								<clay:content-col>
@@ -495,7 +495,7 @@ request.setAttribute("view.jsp-viewCategory", Boolean.TRUE.toString());
 								<clay:content-col
 									expand="<%= true %>"
 								>
-									<h3><liferay-ui:message key="my-posts" /></h3>
+									<h3 class="component-title"><liferay-ui:message key="my-posts" /></h3>
 								</clay:content-col>
 
 								<clay:content-col>

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_message_content.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_message_content.jsp
@@ -64,7 +64,7 @@ if (portletTitleBasedNavigation) {
 		<clay:content-col
 			expand="<%= true %>"
 		>
-			<h3><%= HtmlUtil.escape(message.getSubject()) %></h3>
+			<h3 class="component-title"><%= HtmlUtil.escape(message.getSubject()) %></h3>
 		</clay:content-col>
 
 		<clay:content-col>


### PR DESCRIPTION
…tion` icons

LPS-121802 Message Boards `lfr-icon-menu` ellipsis not vertically aligned with other icons and text

LPS-121802 Compat Layer the tag `liferay-ui:icon-menu` ellipsis icon should be 16px and focus border shouldn't be jagged

LPS-121801 Compat Layer add class `basic-search-no-collapse` for the tag `liferay-ui:input-search` to force no collapsing in smaller screens

https://issues.liferay.com/browse/LPS-121802

This might fix:
https://issues.liferay.com/browse/LPS-118972
https://issues.liferay.com/browse/LPS-107452

/cc @brianikim 