### PR TITLE
LPS-122391 Remove RSS button to users who have no permission to see its content

### DIFF
--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/dynamic_include/init.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/dynamic_include/init.jsp
@@ -38,6 +38,7 @@ page import="com.liferay.petra.string.StringBundler" %><%@
 page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
 page import="com.liferay.portal.kernel.module.configuration.ConfigurationProviderUtil" %><%@
 page import="com.liferay.portal.kernel.security.permission.ActionKeys" %><%@
+page import="com.liferay.portal.kernel.service.permission.GroupPermissionUtil" %><%@
 page import="com.liferay.portal.kernel.settings.GroupServiceSettingsLocator" %><%@
 page import="com.liferay.portal.kernel.util.Constants" %><%@
 page import="com.liferay.portal.kernel.util.GetterUtil" %><%@

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/dynamic_include/portlet_header.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/dynamic_include/portlet_header.jsp
@@ -18,10 +18,14 @@
 
 <%
 BlogsGroupServiceOverriddenConfiguration blogsGroupServiceOverriddenConfiguration = ConfigurationProviderUtil.getConfiguration(BlogsGroupServiceOverriddenConfiguration.class, new GroupServiceSettingsLocator(themeDisplay.getSiteGroupId(), BlogsConstants.SERVICE_NAME));
+
+long groupId = themeDisplay.getScopeGroupId();
+
+boolean hasViewPermission = (groupId == 0) || GroupPermissionUtil.contains(themeDisplay.getPermissionChecker(), groupId, ActionKeys.VIEW);
 %>
 
 <div class="btn-group">
-	<c:if test="<%= blogsGroupServiceOverriddenConfiguration.enableRss() %>">
+	<c:if test="<%= blogsGroupServiceOverriddenConfiguration.enableRss() && hasViewPermission %>">
 
 		<%
 		String rssURL = RSSUtil.getURL(StringBundler.concat(themeDisplay.getPathMain(), "/blogs/rss?plid=", String.valueOf(themeDisplay.getPlid()), "&groupId=", String.valueOf(themeDisplay.getScopeGroupId())), GetterUtil.getInteger(blogsGroupServiceOverriddenConfiguration.rssDelta()), blogsGroupServiceOverriddenConfiguration.rssDisplayStyle(), blogsGroupServiceOverriddenConfiguration.rssFeedType(), null);


### PR DESCRIPTION
Hi guys,

Can you review this pull request, please?

This issue is coming from [LPS-97483](https://issues.liferay.com/browse/LPS-97483) where we introduced some restrictions related to permissions. The current situation is that 'Guest' users can see the 'RSS' button but it is totally useless, because they have no permission to see their content.

I've discussed it with @robertoDiaz and we agreed this could be addressed in a different way, something more globally applying to all RSS buttons, but after a further investigation I realised RSS button is not standardized in Liferay since we are using two different taglibs (clay:link or liferay-rss:rss), sometimes we carry out permission check (like in blogs) but other times we don't do it, and even sometimes the button is directly not working, as I reported in [LPS-122390](https://issues.liferay.com/browse/LPS-122390). 

Based on that situation, we agreed to solve this specific case for Blogs instead of fixing the issue within the taglibs.

Let me know if you have further questions.

Thanks.

Regards.