### PR TITLE
LPS-122502 Fix share link only in default language for Twitter Facebook LinkedIn social bookmarks   

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -1416,13 +1416,14 @@ public class PortalImpl implements Portal {
 
 		Locale siteDefaultLocale = getSiteDefaultLocale(layout.getGroupId());
 
-		if (siteDefaultLocale.equals(themeDisplay.getLocale())) {
+		Locale themeDisplayLocale = themeDisplay.getLocale();
+
+		if (!siteDefaultLocale.equals(themeDisplayLocale)) {
 			defaultLayoutFriendlyURL = themeDisplay.getLayoutFriendlyURL(
 				layout);
 		}
 		else {
-			defaultLayoutFriendlyURL = layout.getFriendlyURL(
-				getSiteDefaultLocale(layout.getGroupId()));
+			defaultLayoutFriendlyURL = layout.getFriendlyURL(siteDefaultLocale);
 		}
 
 		Group siteGroup = themeDisplay.getSiteGroup();
@@ -1462,7 +1463,8 @@ public class PortalImpl implements Portal {
 
 			if ((pos <= 0) || (pos >= groupFriendlyURL.length())) {
 				sb.append(groupFriendlyURL);
-				sb.append(_buildI18NPath(siteDefaultLocale, layout.getGroup()));
+				sb.append(
+					_buildI18NPath(themeDisplayLocale, layout.getGroup()));
 
 				if (!canonicalLayoutFriendlyURL.startsWith(StringPool.SLASH)) {
 					sb.append(StringPool.SLASH);
@@ -1475,7 +1477,8 @@ public class PortalImpl implements Portal {
 				String groupFriendlyURLSuffix = groupFriendlyURL.substring(pos);
 
 				sb.append(groupFriendlyURLPrefix);
-				sb.append(_buildI18NPath(siteDefaultLocale, layout.getGroup()));
+				sb.append(
+					_buildI18NPath(themeDisplayLocale, layout.getGroup()));
 				sb.append(groupFriendlyURLSuffix);
 			}
 


### PR DESCRIPTION
LPS-122502 Fix Twitter and Facebook social bookmarks only share articles with the default locale if URL style = 2

Steps to reproduce:
1. Define the following property: locale.prepend.friendly.url.style=2
2. Create a site with English as default language and other available languages, for this example, Spanish
3. Create an English journal article and the Spanish translation.
4. Create a page with an asset publisher
5. Configure the asset publisher:
    - Asset publisher -> Configuration -> Display Settings -> Set and Enable -> Social Bookmark.
    - Select Facebook and Twitter
6. At the asset publisher, click on Facebook or Twitter icon to share the created content (the link is shared with the default language)
7. Switch to Spanish. 
8. At the asset publisher, click on Facebook or Twitter icon to share the created content, the link to be shared is in English but the title in Spanish. Same thing for Twitter or LinkedIn. 
