### PR TITLE
LPS-122233 Use AutoDeleteFileInputStream to delete files created in t…

### DIFF
--- a/modules/apps/portal-store/portal-store-s3/build.gradle
+++ b/modules/apps/portal-store/portal-store-s3/build.gradle
@@ -18,5 +18,6 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
+	compileOnly project(":core:petra:petra-io")
 	compileOnly project(":core:petra:petra-string")
 }

--- a/modules/apps/portal-store/portal-store-s3/src/main/java/com/liferay/portal/store/s3/S3Store.java
+++ b/modules/apps/portal-store/portal-store-s3/src/main/java/com/liferay/portal/store/s3/S3Store.java
@@ -47,6 +47,7 @@ import com.liferay.document.library.kernel.exception.AccessDeniedException;
 import com.liferay.document.library.kernel.exception.NoSuchFileException;
 import com.liferay.document.library.kernel.store.Store;
 import com.liferay.document.library.kernel.util.DLUtil;
+import com.liferay.petra.io.AutoDeleteFileInputStream;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -61,7 +62,6 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.store.s3.configuration.S3StoreConfiguration;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -168,7 +168,7 @@ public class S3Store implements Store {
 
 			File file = _s3FileCache.getCacheFile(s3Object, fileName);
 
-			return new FileInputStream(file);
+			return new AutoDeleteFileInputStream(file);
 		}
 		catch (IOException ioException) {
 			throw new SystemException(ioException);


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-122233

Tests were run here: https://github.com/brianikim/liferay-portal/pull/116#issuecomment-714624196

Notes from @noornajj
> The issue here was that the InputStream created to make a copy of the S3 Store document library in the temp folder and was being closed without deleting the files.
> The solution was to create the file stream using AutoDeleteFileInputStream instead of FileInputStream which will automatically delete the created file when the input stream is closed.