### PR TITLE
LPS-123392 Add servlet context to get the correct module name when using Asset Publisher

### DIFF
--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/edit_message.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/edit_message.jsp
@@ -466,4 +466,5 @@ MBEditMessageDisplayContext mbEditMessageDisplayContext = new MBEditMessageDispl
 <liferay-frontend:component
 	context="<%= mbEditMessageDisplayContext.getMBPortletComponentContext() %>"
 	module="message_boards/js/MBPortlet.es"
+	servletContext="<%= application %>"
 />


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-123392

We are unable to edit a message thread through an Asset Publisher because the module name was not rendering correctly.
To fix this issue, I followed the proposed solution from previous PR [comment](https://github.com/liferay-frontend/liferay-portal/pull/513#pullrequestreview-534392187)