### PR TITLE
LPS-123651 use the method with the extension to provide an unique title to googleDrive files

### DIFF
--- a/modules/apps/document-library-opener/document-library-opener-api/src/main/java/com/liferay/document/library/opener/upload/UniqueFileEntryTitleProvider.java
+++ b/modules/apps/document-library-opener/document-library-opener-api/src/main/java/com/liferay/document/library/opener/upload/UniqueFileEntryTitleProvider.java
@@ -26,6 +26,11 @@ public interface UniqueFileEntryTitleProvider {
 	public String provide(long groupId, long folderId, Locale locale)
 		throws PortalException;
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #provide(long
+	 *             groupId, long folderId, String extension, String title)}
+	 */
+	@Deprecated
 	public String provide(long groupId, long folderId, String title)
 		throws PortalException;
 

--- a/modules/apps/document-library-opener/document-library-opener-api/src/main/java/com/liferay/document/library/opener/upload/UniqueFileEntryTitleProvider.java
+++ b/modules/apps/document-library-opener/document-library-opener-api/src/main/java/com/liferay/document/library/opener/upload/UniqueFileEntryTitleProvider.java
@@ -26,7 +26,11 @@ public interface UniqueFileEntryTitleProvider {
 	public String provide(long groupId, long folderId, Locale locale)
 		throws PortalException;
 
-	public String provide(long groupId, long folderId, String fileName)
+	public String provide(long groupId, long folderId, String title)
+		throws PortalException;
+
+	public String provide(
+			long groupId, long folderId, String extension, String title)
 		throws PortalException;
 
 }

--- a/modules/apps/document-library-opener/document-library-opener-api/src/main/resources/com/liferay/document/library/opener/upload/packageinfo
+++ b/modules/apps/document-library-opener/document-library-opener-api/src/main/resources/com/liferay/document/library/opener/upload/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 2.0.0

--- a/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/main/java/com/liferay/document/library/opener/google/drive/web/internal/service/DLOpenerGoogleDriveDLAppServiceWrapper.java
+++ b/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/main/java/com/liferay/document/library/opener/google/drive/web/internal/service/DLOpenerGoogleDriveDLAppServiceWrapper.java
@@ -169,18 +169,19 @@ public class DLOpenerGoogleDriveDLAppServiceWrapper
 
 		String title = fileEntry.getTitle();
 
+		String mimeTypeExtension = DLOpenerMimeTypes.getMimeTypeExtension(
+			fileEntry.getMimeType());
+
 		if (!title.equals(dlOpenerGoogleDriveFileReference.getTitle())) {
 			title = _uniqueFileEntryTitleProvider.provide(
 				fileEntry.getGroupId(), fileEntry.getFolderId(),
+				mimeTypeExtension,
 				_dlValidator.fixName(
 					dlOpenerGoogleDriveFileReference.getTitle()));
 		}
 
 		try {
-			String sourceFileName = title;
-
-			sourceFileName += DLOpenerMimeTypes.getMimeTypeExtension(
-				fileEntry.getMimeType());
+			String sourceFileName = title.concat(mimeTypeExtension);
 
 			updateFileEntry(
 				fileEntry.getFileEntryId(), sourceFileName,

--- a/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/main/java/com/liferay/document/library/opener/google/drive/web/internal/upload/UniqueFileEntryTitleProviderImpl.java
+++ b/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/main/java/com/liferay/document/library/opener/google/drive/web/internal/upload/UniqueFileEntryTitleProviderImpl.java
@@ -36,6 +36,10 @@ public class UniqueFileEntryTitleProviderImpl
 		return _uniqueFileEntryTitleProvider.provide(groupId, folderId, locale);
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x)
+	 */
+	@Deprecated
 	@Override
 	public String provide(long groupId, long folderId, String fileName)
 		throws PortalException {

--- a/modules/apps/document-library-opener/document-library-opener-service/src/main/java/com/liferay/document/library/opener/internal/upload/UniqueFileEntryTitleProviderImpl.java
+++ b/modules/apps/document-library-opener/document-library-opener-service/src/main/java/com/liferay/document/library/opener/internal/upload/UniqueFileEntryTitleProviderImpl.java
@@ -17,6 +17,7 @@ package com.liferay.document.library.opener.internal.upload;
 import com.liferay.document.library.kernel.exception.NoSuchFileEntryException;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.opener.upload.UniqueFileEntryTitleProvider;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.language.Language;
@@ -46,7 +47,8 @@ public class UniqueFileEntryTitleProviderImpl
 			locale, UniqueFileEntryTitleProviderImpl.class);
 
 		return _provide(
-			groupId, folderId, _language.get(resourceBundle, "untitled"));
+			groupId, folderId, StringPool.BLANK,
+			_language.get(resourceBundle, "untitled"));
 	}
 
 	@Override

--- a/modules/apps/document-library-opener/document-library-opener-service/src/main/java/com/liferay/document/library/opener/internal/upload/UniqueFileEntryTitleProviderImpl.java
+++ b/modules/apps/document-library-opener/document-library-opener-service/src/main/java/com/liferay/document/library/opener/internal/upload/UniqueFileEntryTitleProviderImpl.java
@@ -51,6 +51,11 @@ public class UniqueFileEntryTitleProviderImpl
 			_language.get(resourceBundle, "untitled"));
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #provide(long
+	 *             groupId, long folderId, String extension, String title)}
+	 */
+	@Deprecated
 	@Override
 	public String provide(long groupId, long folderId, String title)
 		throws PortalException {

--- a/modules/apps/document-library-opener/document-library-opener-service/src/main/java/com/liferay/document/library/opener/internal/upload/UniqueFileEntryTitleProviderImpl.java
+++ b/modules/apps/document-library-opener/document-library-opener-service/src/main/java/com/liferay/document/library/opener/internal/upload/UniqueFileEntryTitleProviderImpl.java
@@ -56,6 +56,35 @@ public class UniqueFileEntryTitleProviderImpl
 		return _provide(groupId, folderId, fileName);
 	}
 
+	@Override
+	public String provide(
+			long groupId, long folderId, String extension, String title)
+		throws PortalException {
+
+		return _provide(groupId, folderId, extension, title);
+	}
+
+	private boolean _existsFileName(
+		long groupId, long folderId, String fileName) {
+
+		try {
+			_dlAppLocalService.getFileEntryByFileName(
+				groupId, folderId, fileName);
+
+			return true;
+		}
+		catch (NoSuchFileEntryException noSuchFileEntryException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(noSuchFileEntryException, noSuchFileEntryException);
+			}
+		}
+		catch (PortalException portalException) {
+			throw new SystemException(portalException);
+		}
+
+		return false;
+	}
+
 	private boolean _exists(long groupId, long folderId, String fileName) {
 		try {
 			_dlAppLocalService.getFileEntry(groupId, folderId, fileName);
@@ -80,6 +109,18 @@ public class UniqueFileEntryTitleProviderImpl
 		return _uniqueFileNameProvider.provide(
 			fileName,
 			generatedFileName -> _exists(groupId, folderId, generatedFileName));
+	}
+
+	private String _provide(
+			long groupId, long folderId, String extension, String title)
+		throws PortalException {
+
+		return _uniqueFileNameProvider.provide(
+			title,
+			generatedTitle ->
+				_existsFileName(
+					groupId, folderId, generatedTitle.concat(extension)) ||
+				_exists(groupId, folderId, generatedTitle));
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/document-library-opener/document-library-opener-service/src/main/java/com/liferay/document/library/opener/internal/upload/UniqueFileEntryTitleProviderImpl.java
+++ b/modules/apps/document-library-opener/document-library-opener-service/src/main/java/com/liferay/document/library/opener/internal/upload/UniqueFileEntryTitleProviderImpl.java
@@ -50,10 +50,10 @@ public class UniqueFileEntryTitleProviderImpl
 	}
 
 	@Override
-	public String provide(long groupId, long folderId, String fileName)
+	public String provide(long groupId, long folderId, String title)
 		throws PortalException {
 
-		return _provide(groupId, folderId, fileName);
+		return _provide(groupId, folderId, title);
 	}
 
 	@Override
@@ -85,9 +85,9 @@ public class UniqueFileEntryTitleProviderImpl
 		return false;
 	}
 
-	private boolean _exists(long groupId, long folderId, String fileName) {
+	private boolean _existsTitle(long groupId, long folderId, String title) {
 		try {
-			_dlAppLocalService.getFileEntry(groupId, folderId, fileName);
+			_dlAppLocalService.getFileEntry(groupId, folderId, title);
 
 			return true;
 		}
@@ -103,12 +103,12 @@ public class UniqueFileEntryTitleProviderImpl
 		return false;
 	}
 
-	private String _provide(long groupId, long folderId, String fileName)
+	private String _provide(long groupId, long folderId, String title)
 		throws PortalException {
 
 		return _uniqueFileNameProvider.provide(
-			fileName,
-			generatedFileName -> _exists(groupId, folderId, generatedFileName));
+			title,
+			generatedTitle -> _existsTitle(groupId, folderId, generatedTitle));
 	}
 
 	private String _provide(
@@ -120,7 +120,7 @@ public class UniqueFileEntryTitleProviderImpl
 			generatedTitle ->
 				_existsFileName(
 					groupId, folderId, generatedTitle.concat(extension)) ||
-				_exists(groupId, folderId, generatedTitle));
+				_existsTitle(groupId, folderId, generatedTitle));
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/document-library-opener/document-library-opener-test/src/testIntegration/java/com/liferay/document/library/opener/upload/test/UniqueFileEntryTitleProviderTest.java
+++ b/modules/apps/document-library-opener/document-library-opener-test/src/testIntegration/java/com/liferay/document/library/opener/upload/test/UniqueFileEntryTitleProviderTest.java
@@ -18,6 +18,7 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.opener.upload.UniqueFileEntryTitleProvider;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.repository.model.Folder;
@@ -27,7 +28,9 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
@@ -61,6 +64,36 @@ public class UniqueFileEntryTitleProviderTest {
 	}
 
 	@Test
+	public void testProvideWithExistingFileName() throws PortalException {
+		_dlAppLocalService.addFileEntry(
+			TestPropsValues.getUserId(), _group.getGroupId(),
+			_folder.getFolderId(), "someTitle.jpg", ContentTypes.IMAGE_JPEG,
+			StringUtil.randomString(), StringUtil.randomString(),
+			StringPool.BLANK, "test".getBytes(),
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		String uniqueEntryFileName = _uniqueFileEntryTitleProvider.provide(
+			_group.getGroupId(), _folder.getFolderId(), ".jpg", "someTitle");
+
+		Assert.assertEquals("someTitle (1)", uniqueEntryFileName);
+	}
+
+	@Test
+	public void testProvideWithExistingName() throws PortalException {
+		_dlAppLocalService.addFileEntry(
+			TestPropsValues.getUserId(), _group.getGroupId(),
+			_folder.getFolderId(), null, ContentTypes.IMAGE_JPEG, "someTitle",
+			StringUtil.randomString(), StringPool.BLANK, "test".getBytes(),
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		String uniqueEntryFileName = _uniqueFileEntryTitleProvider.provide(
+			_group.getGroupId(), _folder.getFolderId(), StringPool.BLANK,
+			"someTitle");
+
+		Assert.assertEquals("someTitle (1)", uniqueEntryFileName);
+	}
+
+	@Test
 	public void testProvideWithLocale() throws PortalException {
 		String uniqueEntryFileName = _uniqueFileEntryTitleProvider.provide(
 			_group.getGroupId(), _folder.getFolderId(), LocaleUtil.US);
@@ -69,9 +102,43 @@ public class UniqueFileEntryTitleProviderTest {
 	}
 
 	@Test
+	public void testProvideWithLocaleWithExistingFileName()
+		throws PortalException {
+
+		_dlAppLocalService.addFileEntry(
+			TestPropsValues.getUserId(), _group.getGroupId(),
+			_folder.getFolderId(), "Untitled", ContentTypes.IMAGE_JPEG,
+			StringUtil.randomString(), StringUtil.randomString(),
+			StringPool.BLANK, "test".getBytes(),
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		String uniqueEntryFileName = _uniqueFileEntryTitleProvider.provide(
+			_group.getGroupId(), _folder.getFolderId(), LocaleUtil.US);
+
+		Assert.assertEquals("Untitled (1)", uniqueEntryFileName);
+	}
+
+	@Test
+	public void testProvideWithLocaleWithExistingTitle()
+		throws PortalException {
+
+		_dlAppLocalService.addFileEntry(
+			TestPropsValues.getUserId(), _group.getGroupId(),
+			_folder.getFolderId(), null, ContentTypes.IMAGE_JPEG, "Untitled",
+			StringUtil.randomString(), StringPool.BLANK, "test".getBytes(),
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		String uniqueEntryFileName = _uniqueFileEntryTitleProvider.provide(
+			_group.getGroupId(), _folder.getFolderId(), LocaleUtil.US);
+
+		Assert.assertEquals("Untitled (1)", uniqueEntryFileName);
+	}
+
+	@Test
 	public void testProvideWithName() throws PortalException {
 		String uniqueEntryFileName = _uniqueFileEntryTitleProvider.provide(
-			_group.getGroupId(), _folder.getFolderId(), "someTitle");
+			_group.getGroupId(), _folder.getFolderId(), StringPool.BLANK,
+			"someTitle");
 
 		Assert.assertEquals("someTitle", uniqueEntryFileName);
 	}

--- a/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/src/main/java/com/liferay/document/library/opener/onedrive/web/internal/portlet/action/CreateInOneDriveMVCActionCommand.java
+++ b/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/src/main/java/com/liferay/document/library/opener/onedrive/web/internal/portlet/action/CreateInOneDriveMVCActionCommand.java
@@ -115,11 +115,12 @@ public class CreateInOneDriveMVCActionCommand extends BaseMVCActionCommand {
 			String title, ServiceContext serviceContext)
 		throws PortalException {
 
-		String uniqueTitle = uniqueFileEntryTitleProvider.provide(
-			serviceContext.getScopeGroupId(), folderId, title);
-
 		String mimeTypeExtension =
 			DLOpenerOneDriveMimeTypes.getMimeTypeExtension(mimeType);
+
+		String uniqueTitle = uniqueFileEntryTitleProvider.provide(
+			serviceContext.getScopeGroupId(), folderId, mimeTypeExtension,
+			title);
 
 		String sourceFileName = uniqueTitle + mimeTypeExtension;
 

--- a/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/src/main/java/com/liferay/document/library/opener/onedrive/web/internal/service/DLOpenerOneDriveDLAppServiceWrapper.java
+++ b/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/src/main/java/com/liferay/document/library/opener/onedrive/web/internal/service/DLOpenerOneDriveDLAppServiceWrapper.java
@@ -193,16 +193,18 @@ public class DLOpenerOneDriveDLAppServiceWrapper extends DLAppServiceWrapper {
 		if (!Objects.equals(
 				sourceFileName, dLOpenerOneDriveFileReference.getTitle())) {
 
+			String mimeTypeExtension =
+				DLOpenerOneDriveMimeTypes.getMimeTypeExtension(
+					fileEntry.getMimeType());
+
 			title = _uniqueFileEntryTitleProvider.provide(
 				fileEntry.getGroupId(), fileEntry.getFolderId(),
+				mimeTypeExtension,
 				_dlValidator.fixName(
 					_removeExtension(
 						dLOpenerOneDriveFileReference.getTitle())));
 
-			sourceFileName = title;
-
-			sourceFileName += DLOpenerOneDriveMimeTypes.getMimeTypeExtension(
-				fileEntry.getMimeType());
+			sourceFileName = title.concat(mimeTypeExtension);
 		}
 
 		try {

--- a/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/src/main/java/com/liferay/document/library/opener/onedrive/web/internal/service/DLOpenerOneDriveDLAppServiceWrapper.java
+++ b/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/src/main/java/com/liferay/document/library/opener/onedrive/web/internal/service/DLOpenerOneDriveDLAppServiceWrapper.java
@@ -28,7 +28,6 @@ import com.liferay.document.library.opener.onedrive.web.internal.constants.DLOpe
 import com.liferay.document.library.opener.onedrive.web.internal.exception.GraphServicePortalException;
 import com.liferay.document.library.opener.service.DLOpenerFileEntryReferenceLocalService;
 import com.liferay.document.library.opener.upload.UniqueFileEntryTitleProvider;
-import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
@@ -37,6 +36,7 @@ import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceWrapper;
+import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 
 import java.io.File;
@@ -166,16 +166,6 @@ public class DLOpenerOneDriveDLAppServiceWrapper extends DLAppServiceWrapper {
 		return GetterUtil.getLong(PrincipalThreadLocal.getName());
 	}
 
-	private String _removeExtension(String string) {
-		int i = string.lastIndexOf(CharPool.PERIOD);
-
-		if (i == -1) {
-			return string;
-		}
-
-		return string.substring(0, i);
-	}
-
 	private void _updateFileEntryFromOneDrive(
 			FileEntry fileEntry, ServiceContext serviceContext)
 		throws PortalException {
@@ -201,7 +191,7 @@ public class DLOpenerOneDriveDLAppServiceWrapper extends DLAppServiceWrapper {
 				fileEntry.getGroupId(), fileEntry.getFolderId(),
 				mimeTypeExtension,
 				_dlValidator.fixName(
-					_removeExtension(
+					FileUtil.stripExtension(
 						dLOpenerOneDriveFileReference.getTitle())));
 
 			sourceFileName = title.concat(mimeTypeExtension);


### PR DESCRIPTION
When you are providing a unique title, you should take in consideration that the final filename (the title plus the extension) should be unique too or an error will be thrown, so now the extension is provided to check the title and the title plus the extension.