### PR TITLE
LPS-124408 Auto translations: dummy resource command

### DIFF
--- a/modules/apps/translation/translation-web/build.gradle
+++ b/modules/apps/translation/translation-web/build.gradle
@@ -17,6 +17,7 @@ dependencies {
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-soy")
 	compileOnly project(":apps:info:info-api")
 	compileOnly project(":apps:petra:petra-portlet-url-builder")
+	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	compileOnly project(":apps:translation:translation-api")
 	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-lang")

--- a/modules/apps/translation/translation-web/build.gradle
+++ b/modules/apps/translation/translation-web/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bnd.annotation", version: "4.2.0"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.util.taglib", version: "default"

--- a/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/configuration/FFAutoTranslateConfiguration.java
+++ b/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/configuration/FFAutoTranslateConfiguration.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.translation.web.internal.configuration;
+
+import aQute.bnd.annotation.metatype.Meta;
+
+import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
+
+/**
+ * @author Adolfo Pérez
+ */
+@ExtendedObjectClassDefinition(generateUI = false)
+@Meta.OCD(
+	id = "com.liferay.translation.web.internal.configuration.FFAutoTranslateConfiguration"
+)
+public interface FFAutoTranslateConfiguration {
+
+	@Meta.AD(deflt = "false", required = false)
+	public boolean enabled();
+
+}

--- a/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/display/context/TranslateDisplayContext.java
+++ b/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/display/context/TranslateDisplayContext.java
@@ -52,6 +52,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import javax.portlet.PortletURL;
+import javax.portlet.ResourceURL;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -93,6 +94,15 @@ public class TranslateDisplayContext {
 
 		_themeDisplay = (ThemeDisplay)_httpServletRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
+	}
+
+	public ResourceURL getAutoTranslatePortletURL(String content) {
+		ResourceURL resourceURL = _liferayPortletResponse.createResourceURL();
+
+		resourceURL.setParameter("content", content);
+		resourceURL.setResourceID("/translation/auto_translate");
+
+		return resourceURL;
 	}
 
 	public boolean getBooleanValue(

--- a/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/display/context/TranslateDisplayContext.java
+++ b/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/display/context/TranslateDisplayContext.java
@@ -42,6 +42,7 @@ import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.translation.info.field.TranslationInfoFieldChecker;
 import com.liferay.translation.model.TranslationEntry;
 import com.liferay.translation.service.TranslationEntryLocalServiceUtil;
+import com.liferay.translation.web.internal.configuration.FFAutoTranslateConfiguration;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -62,6 +63,7 @@ public class TranslateDisplayContext {
 	public TranslateDisplayContext(
 		List<String> availableSourceLanguageIds,
 		List<String> availableTargetLanguageIds, String className, long classPK,
+		FFAutoTranslateConfiguration ffAutoTranslateConfiguration,
 		InfoForm infoForm, LiferayPortletRequest liferayPortletRequest,
 		LiferayPortletResponse liferayPortletResponse, Object object,
 		InfoItemFieldValues sourceInfoItemFieldValues, String sourceLanguageId,
@@ -72,6 +74,7 @@ public class TranslateDisplayContext {
 		_availableTargetLanguageIds = availableTargetLanguageIds;
 		_className = className;
 		_classPK = classPK;
+		_ffAutoTranslateConfiguration = ffAutoTranslateConfiguration;
 		_infoForm = infoForm;
 		_liferayPortletResponse = liferayPortletResponse;
 		_object = object;
@@ -259,6 +262,16 @@ public class TranslateDisplayContext {
 		return true;
 	}
 
+	public boolean isAutoTranslateButtonVisible() {
+		if (_ffAutoTranslateConfiguration.enabled() &&
+			hasTranslationPermission()) {
+
+			return true;
+		}
+
+		return false;
+	}
+
 	public boolean isPublishButtonDisabled() {
 		if (_isAvailableTargetLanguageIdsEmpty()) {
 			return true;
@@ -317,6 +330,7 @@ public class TranslateDisplayContext {
 	private final List<String> _availableTargetLanguageIds;
 	private final String _className;
 	private final long _classPK;
+	private final FFAutoTranslateConfiguration _ffAutoTranslateConfiguration;
 	private Long _groupId;
 	private final HttpServletRequest _httpServletRequest;
 	private final InfoForm _infoForm;

--- a/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/portlet/action/AutoTranslateMVCResourceCommand.java
+++ b/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/portlet/action/AutoTranslateMVCResourceCommand.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.translation.web.internal.portlet.action;
+
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.portlet.JSONPortletResponseUtil;
+import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCResourceCommand;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.translation.constants.TranslationPortletKeys;
+
+import javax.portlet.ResourceRequest;
+import javax.portlet.ResourceResponse;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Adolfo Pérez
+ */
+@Component(
+	property = {
+		"javax.portlet.name=" + TranslationPortletKeys.TRANSLATION,
+		"mvc.command.name=/translation/auto_translate"
+	},
+	service = MVCResourceCommand.class
+)
+public class AutoTranslateMVCResourceCommand extends BaseMVCResourceCommand {
+
+	@Override
+	protected void doServeResource(
+			ResourceRequest resourceRequest, ResourceResponse resourceResponse)
+		throws Exception {
+
+		JSONPortletResponseUtil.writeJSON(
+			resourceRequest, resourceResponse,
+			JSONFactoryUtil.createJSONObject(
+				ParamUtil.getString(resourceRequest, "content")));
+	}
+
+}

--- a/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/portlet/action/TranslateMVCRenderCommand.java
+++ b/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/portlet/action/TranslateMVCRenderCommand.java
@@ -25,6 +25,7 @@ import com.liferay.info.item.provider.InfoItemFormProvider;
 import com.liferay.info.item.provider.InfoItemObjectProvider;
 import com.liferay.info.item.provider.InfoItemPermissionProvider;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
@@ -45,6 +46,7 @@ import com.liferay.translation.info.field.TranslationInfoFieldChecker;
 import com.liferay.translation.info.item.provider.InfoItemLanguagesProvider;
 import com.liferay.translation.model.TranslationEntry;
 import com.liferay.translation.service.TranslationEntryLocalService;
+import com.liferay.translation.web.internal.configuration.FFAutoTranslateConfiguration;
 import com.liferay.translation.web.internal.display.context.TranslateDisplayContext;
 
 import java.util.Arrays;
@@ -52,6 +54,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -61,6 +64,7 @@ import javax.portlet.PortletException;
 import javax.portlet.RenderRequest;
 import javax.portlet.RenderResponse;
 
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
@@ -68,7 +72,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Ambrín Chaudhary
  */
 @Component(
-	immediate = true,
+	configurationPid = "com.liferay.translation.web.internal.configuration.FFAutoTranslateConfiguration",
 	property = {
 		"javax.portlet.name=" + TranslationPortletKeys.TRANSLATION,
 		"mvc.command.name=/translation/translate"
@@ -100,7 +104,7 @@ public class TranslateMVCRenderCommand implements MVCRenderCommand {
 					TranslateDisplayContext.class.getName(),
 					new TranslateDisplayContext(
 						Collections.emptyList(), Collections.emptyList(),
-						className, classPK, null,
+						className, classPK, _ffAutoTranslateConfiguration, null,
 						_portal.getLiferayPortletRequest(renderRequest),
 						_portal.getLiferayPortletResponse(renderResponse), null,
 						null, null, null, null, _translationInfoFieldChecker));
@@ -144,7 +148,7 @@ public class TranslateMVCRenderCommand implements MVCRenderCommand {
 				TranslateDisplayContext.class.getName(),
 				new TranslateDisplayContext(
 					availableSourceLanguageIds, availableTargetLanguageIds,
-					className, classPK, infoForm,
+					className, classPK, _ffAutoTranslateConfiguration, infoForm,
 					_portal.getLiferayPortletRequest(renderRequest),
 					_portal.getLiferayPortletResponse(renderResponse), object,
 					sourceInfoItemFieldValues, sourceLanguageId,
@@ -156,6 +160,12 @@ public class TranslateMVCRenderCommand implements MVCRenderCommand {
 		catch (Exception exception) {
 			throw new PortletException(exception);
 		}
+	}
+
+	@Activate
+	protected void activate(Map<String, Object> properties) {
+		_ffAutoTranslateConfiguration = ConfigurableUtil.createConfigurable(
+			FFAutoTranslateConfiguration.class, properties);
 	}
 
 	private <T> List<String> _getAvailableTargetLanguageIds(
@@ -296,6 +306,8 @@ public class TranslateMVCRenderCommand implements MVCRenderCommand {
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		TranslateMVCRenderCommand.class);
+
+	private FFAutoTranslateConfiguration _ffAutoTranslateConfiguration;
 
 	@Reference
 	private InfoItemServiceTracker _infoItemServiceTracker;

--- a/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/translate.jsp
+++ b/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/translate.jsp
@@ -47,6 +47,15 @@ renderResponse.setTitle(translateDisplayContext.getTitle());
 							</div>
 						</c:if>
 					</li>
+
+					<c:if test="<%= translateDisplayContext.isAutoTranslateButtonVisible() %>">
+						<li class="tbar-item">
+							<div class="tbar-section text-left">
+								<aui:button cssClass="btn-sm mr-3" id="autoTranslateBtn" primary="<%= false %>" value="auto-translate" />
+							</div>
+						</li>
+					</c:if>
+
 					<li class="tbar-item">
 						<div class="metadata-type-button-row tbar-section text-right">
 							<aui:button cssClass="btn-sm mr-3" href="<%= redirect %>" type="cancel" />

--- a/modules/apps/translation/translation-web/src/main/resources/content/Language.properties
+++ b/modules/apps/translation/translation-web/src/main/resources/content/Language.properties
@@ -1,5 +1,6 @@
 are-you-sure-you-want-to-delete-the-selected-translations=Are you sure you want to delete the selected translations?
 are-you-sure-you-want-to-leave-the-page-you-may-lose-your-changes=Are you sure you want to leave the page? You will lose your changes if they have not been saved.
+auto-translate=Auto-translate
 javax.portlet.title.com_liferay_translation_web_internal_portlet_TranslationPortlet=Translation Processes
 model.resource.com.liferay.translation.model.TranslationEntry=Translation
 translate-from=Translate From


### PR DESCRIPTION
@ambrinchaudhary @boton This contains the minimum infrastructure necessary to implement the frontend side of Auto-translation:
- Feature flag.
- Auto translate button (will be enabled/disabled depending on the value of the feature flag).
- Dummy backend resource action to translate content.

What needs to be done is:
- Wire the button and the backend action together.
- Auto translation progress indicator.
- Define the format we'll use to send content to the backend.
- Make the side by side top bar look decent (the button is misaligned right now).
- Fill in the form with the data sent back from the resource action.

About the format, I think the easiest thing would be to use a JSON object of the following shape:
```
{
    "sourceLanguageId": "...",
    "targetLanguageId": "...",
    "content": [{"id": "field1", "content": "text 1"}, {"id": "field2", "content": "..."}, ... ]
}
```
but you're free to choose the format you like the most/is the most convenient for you. Right now, the backend includes a bit of parsing code to enforce it is a JSON object; you can simply remove that call if you change things.

Let me know if you need more info about this.

Thanks!