### PR TITLE
LPS-124970 Apply changes

### DIFF
--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/upgrade/BlogsServiceUpgrade.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/upgrade/BlogsServiceUpgrade.java
@@ -14,7 +14,6 @@
 
 package com.liferay.blogs.internal.upgrade;
 
-import com.liferay.asset.kernel.service.AssetEntryLocalService;
 import com.liferay.blogs.internal.upgrade.v1_1_0.UpgradeClassNames;
 import com.liferay.blogs.internal.upgrade.v1_1_0.UpgradeFriendlyURL;
 import com.liferay.blogs.internal.upgrade.v1_1_1.UpgradeUrlTitle;
@@ -59,8 +58,8 @@ public class BlogsServiceUpgrade implements UpgradeStepRegistrator {
 		registry.register(
 			"1.1.2", "1.1.3",
 			new UpgradeDiscussionSubscriptionClassName(
-				_assetEntryLocalService, _classNameLocalService,
-				_subscriptionLocalService, BlogsEntry.class.getName(),
+				_classNameLocalService, _subscriptionLocalService,
+				BlogsEntry.class.getName(),
 				UpgradeDiscussionSubscriptionClassName.DeletionMode.UPDATE));
 
 		registry.register(
@@ -73,8 +72,8 @@ public class BlogsServiceUpgrade implements UpgradeStepRegistrator {
 		registry.register(
 			"2.0.0", "2.0.1",
 			new UpgradeDiscussionSubscriptionClassName(
-				_assetEntryLocalService, _classNameLocalService,
-				_subscriptionLocalService, BlogsEntry.class.getName(),
+				_classNameLocalService, _subscriptionLocalService,
+				BlogsEntry.class.getName(),
 				UpgradeDiscussionSubscriptionClassName.DeletionMode.
 					DELETE_OLD));
 
@@ -89,9 +88,6 @@ public class BlogsServiceUpgrade implements UpgradeStepRegistrator {
 
 			});
 	}
-
-	@Reference
-	private AssetEntryLocalService _assetEntryLocalService;
 
 	@Reference
 	private ClassNameLocalService _classNameLocalService;

--- a/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/upgrade/CalendarServiceUpgrade.java
+++ b/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/upgrade/CalendarServiceUpgrade.java
@@ -14,7 +14,6 @@
 
 package com.liferay.calendar.internal.upgrade;
 
-import com.liferay.asset.kernel.service.AssetEntryLocalService;
 import com.liferay.calendar.internal.upgrade.v1_0_2.UpgradeCalendar;
 import com.liferay.calendar.internal.upgrade.v1_0_4.UpgradeClassNames;
 import com.liferay.calendar.internal.upgrade.v1_0_5.UpgradeCalendarResource;
@@ -99,8 +98,8 @@ public class CalendarServiceUpgrade implements UpgradeStepRegistrator {
 		registry.register(
 			"3.0.0", "3.0.1",
 			new UpgradeDiscussionSubscriptionClassName(
-				_assetEntryLocalService, _classNameLocalService,
-				_subscriptionLocalService, CalendarBooking.class.getName(),
+				_classNameLocalService, _subscriptionLocalService,
+				CalendarBooking.class.getName(),
 				UpgradeDiscussionSubscriptionClassName.DeletionMode.UPDATE));
 
 		registry.register(
@@ -115,8 +114,8 @@ public class CalendarServiceUpgrade implements UpgradeStepRegistrator {
 		registry.register(
 			"4.0.0", "4.0.1",
 			new UpgradeDiscussionSubscriptionClassName(
-				_assetEntryLocalService, _classNameLocalService,
-				_subscriptionLocalService, CalendarBooking.class.getName(),
+				_classNameLocalService, _subscriptionLocalService,
+				CalendarBooking.class.getName(),
 				UpgradeDiscussionSubscriptionClassName.DeletionMode.
 					DELETE_OLD));
 
@@ -144,9 +143,6 @@ public class CalendarServiceUpgrade implements UpgradeStepRegistrator {
 			new com.liferay.calendar.internal.upgrade.v4_1_2.
 				UpgradeCalendarNotificationTemplate());
 	}
-
-	@Reference
-	private AssetEntryLocalService _assetEntryLocalService;
 
 	@Reference
 	private ClassNameLocalService _classNameLocalService;

--- a/modules/apps/comment/comment-api/src/main/java/com/liferay/comment/upgrade/UpgradeDiscussionSubscriptionClassName.java
+++ b/modules/apps/comment/comment-api/src/main/java/com/liferay/comment/upgrade/UpgradeDiscussionSubscriptionClassName.java
@@ -15,7 +15,6 @@
 package com.liferay.comment.upgrade;
 
 import com.liferay.asset.kernel.service.AssetEntryLocalService;
-import com.liferay.asset.kernel.service.AssetEntryLocalServiceUtil;
 import com.liferay.message.boards.model.MBDiscussion;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -32,13 +31,26 @@ import com.liferay.subscription.service.SubscriptionLocalService;
  */
 public class UpgradeDiscussionSubscriptionClassName extends UpgradeProcess {
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x)
+	 */
+	@Deprecated
 	public UpgradeDiscussionSubscriptionClassName(
 		AssetEntryLocalService assetEntryLocalService,
 		ClassNameLocalService classNameLocalService,
 		SubscriptionLocalService subscriptionLocalService,
 		String oldSubscriptionClassName, DeletionMode deletionMode) {
 
-		_assetEntryLocalService = assetEntryLocalService;
+		this(
+			classNameLocalService, subscriptionLocalService,
+			oldSubscriptionClassName, deletionMode);
+	}
+
+	public UpgradeDiscussionSubscriptionClassName(
+		ClassNameLocalService classNameLocalService,
+		SubscriptionLocalService subscriptionLocalService,
+		String oldSubscriptionClassName, DeletionMode deletionMode) {
+
 		_classNameLocalService = classNameLocalService;
 		_subscriptionLocalService = subscriptionLocalService;
 		_oldSubscriptionClassName = oldSubscriptionClassName;
@@ -50,25 +62,10 @@ public class UpgradeDiscussionSubscriptionClassName extends UpgradeProcess {
 	 */
 	@Deprecated
 	public UpgradeDiscussionSubscriptionClassName(
-		ClassNameLocalService classNameLocalService,
 		SubscriptionLocalService subscriptionLocalService,
 		String oldSubscriptionClassName, DeletionMode deletionMode) {
 
 		this(
-			AssetEntryLocalServiceUtil.getService(), classNameLocalService,
-			subscriptionLocalService, oldSubscriptionClassName, deletionMode);
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x)
-	 */
-	@Deprecated
-	public UpgradeDiscussionSubscriptionClassName(
-		SubscriptionLocalService subscriptionLocalService,
-		String oldSubscriptionClassName, DeletionMode deletionMode) {
-
-		this(
-			AssetEntryLocalServiceUtil.getService(),
 			ClassNameLocalServiceUtil.getService(), subscriptionLocalService,
 			oldSubscriptionClassName, deletionMode);
 	}
@@ -127,7 +124,6 @@ public class UpgradeDiscussionSubscriptionClassName extends UpgradeProcess {
 					_oldSubscriptionClassName)));
 	}
 
-	private final AssetEntryLocalService _assetEntryLocalService;
 	private final ClassNameLocalService _classNameLocalService;
 	private final DeletionMode _deletionMode;
 	private final String _oldSubscriptionClassName;

--- a/modules/apps/comment/comment-api/src/main/java/com/liferay/comment/upgrade/UpgradeDiscussionSubscriptionClassName.java
+++ b/modules/apps/comment/comment-api/src/main/java/com/liferay/comment/upgrade/UpgradeDiscussionSubscriptionClassName.java
@@ -14,7 +14,6 @@
 
 package com.liferay.comment.upgrade;
 
-import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.asset.kernel.service.AssetEntryLocalService;
 import com.liferay.asset.kernel.service.AssetEntryLocalServiceUtil;
 import com.liferay.message.boards.model.MBDiscussion;
@@ -117,34 +116,6 @@ public class UpgradeDiscussionSubscriptionClassName extends UpgradeProcess {
 		String newSubscriptionClassName =
 			MBDiscussion.class.getName() + StringPool.UNDERLINE +
 				_oldSubscriptionClassName;
-
-		ActionableDynamicQuery actionableDynamicQuery =
-			_subscriptionLocalService.getActionableDynamicQuery();
-
-		actionableDynamicQuery.setAddCriteriaMethod(
-			dynamicQuery -> dynamicQuery.add(
-				RestrictionsFactoryUtil.eq(
-					"classNameId",
-					_classNameLocalService.getClassNameId(
-						_oldSubscriptionClassName))));
-		actionableDynamicQuery.setPerformActionMethod(
-			(Subscription subscription) -> {
-				AssetEntry assetEntry = _assetEntryLocalService.fetchEntry(
-					newSubscriptionClassName, subscription.getClassPK());
-
-				if (assetEntry == null) {
-					_assetEntryLocalService.updateEntry(
-						subscription.getUserId(), subscription.getGroupId(),
-						subscription.getCreateDate(),
-						subscription.getModifiedDate(),
-						newSubscriptionClassName, subscription.getClassPK(),
-						null, 0, null, null, true, false, null, null, null,
-						null, null, String.valueOf(subscription.getGroupId()),
-						null, null, null, null, 0, 0, null);
-				}
-			});
-
-		actionableDynamicQuery.performActions();
 
 		runSQL(
 			StringBundler.concat(

--- a/modules/apps/comment/comment-page-comments-web/src/main/java/com/liferay/comment/page/comments/web/internal/upgrade/PageCommentsWebUpgrade.java
+++ b/modules/apps/comment/comment-page-comments-web/src/main/java/com/liferay/comment/page/comments/web/internal/upgrade/PageCommentsWebUpgrade.java
@@ -14,7 +14,6 @@
 
 package com.liferay.comment.page.comments.web.internal.upgrade;
 
-import com.liferay.asset.kernel.service.AssetEntryLocalService;
 import com.liferay.comment.page.comments.web.internal.constants.PageCommentsPortletKeys;
 import com.liferay.comment.upgrade.UpgradeDiscussionSubscriptionClassName;
 import com.liferay.portal.kernel.model.Layout;
@@ -54,21 +53,18 @@ public class PageCommentsWebUpgrade implements UpgradeStepRegistrator {
 		registry.register(
 			"1.0.0", "1.0.1",
 			new UpgradeDiscussionSubscriptionClassName(
-				_assetEntryLocalService, _classNameLocalService,
-				_subscriptionLocalService, Layout.class.getName(),
+				_classNameLocalService, _subscriptionLocalService,
+				Layout.class.getName(),
 				UpgradeDiscussionSubscriptionClassName.DeletionMode.UPDATE));
 
 		registry.register(
 			"1.0.1", "2.0.0",
 			new UpgradeDiscussionSubscriptionClassName(
-				_assetEntryLocalService, _classNameLocalService,
-				_subscriptionLocalService, Layout.class.getName(),
+				_classNameLocalService, _subscriptionLocalService,
+				Layout.class.getName(),
 				UpgradeDiscussionSubscriptionClassName.DeletionMode.
 					DELETE_OLD));
 	}
-
-	@Reference
-	private AssetEntryLocalService _assetEntryLocalService;
 
 	@Reference
 	private ClassNameLocalService _classNameLocalService;

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/DLServiceUpgrade.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/DLServiceUpgrade.java
@@ -14,7 +14,6 @@
 
 package com.liferay.document.library.internal.upgrade;
 
-import com.liferay.asset.kernel.service.AssetEntryLocalService;
 import com.liferay.comment.upgrade.UpgradeDiscussionSubscriptionClassName;
 import com.liferay.document.library.internal.upgrade.v1_0_0.UpgradeDocumentLibrary;
 import com.liferay.document.library.internal.upgrade.v1_0_1.UpgradeDLConfiguration;
@@ -75,8 +74,8 @@ public class DLServiceUpgrade implements UpgradeStepRegistrator {
 		registry.register(
 			"3.0.0", "3.0.1",
 			new UpgradeDiscussionSubscriptionClassName(
-				_assetEntryLocalService, _classNameLocalService,
-				_subscriptionLocalService, DLFileEntry.class.getName(),
+				_classNameLocalService, _subscriptionLocalService,
+				DLFileEntry.class.getName(),
 				UpgradeDiscussionSubscriptionClassName.DeletionMode.UPDATE));
 
 		registry.register(
@@ -91,9 +90,6 @@ public class DLServiceUpgrade implements UpgradeStepRegistrator {
 			},
 			new UpgradeCTModel("DLFileVersionPreview"));
 	}
-
-	@Reference
-	private AssetEntryLocalService _assetEntryLocalService;
 
 	@Reference
 	private ClassNameLocalService _classNameLocalService;

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/JournalServiceUpgrade.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/JournalServiceUpgrade.java
@@ -206,8 +206,8 @@ public class JournalServiceUpgrade implements UpgradeStepRegistrator {
 		registry.register(
 			"1.1.6", "1.1.7",
 			new UpgradeDiscussionSubscriptionClassName(
-				_assetEntryLocalService, _classNameLocalService,
-				_subscriptionLocalService, JournalArticle.class.getName(),
+				_classNameLocalService, _subscriptionLocalService,
+				JournalArticle.class.getName(),
 				UpgradeDiscussionSubscriptionClassName.DeletionMode.UPDATE));
 
 		registry.register("1.1.7", "1.1.8", new UpgradeJournalArticle());

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/upgrade/WikiServiceUpgrade.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/upgrade/WikiServiceUpgrade.java
@@ -14,7 +14,6 @@
 
 package com.liferay.wiki.internal.upgrade;
 
-import com.liferay.asset.kernel.service.AssetEntryLocalService;
 import com.liferay.comment.upgrade.UpgradeDiscussionSubscriptionClassName;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.settings.SettingsFactory;
@@ -63,8 +62,8 @@ public class WikiServiceUpgrade implements UpgradeStepRegistrator {
 		registry.register(
 			"1.1.0", "1.1.1",
 			new UpgradeDiscussionSubscriptionClassName(
-				_assetEntryLocalService, _classNameLocalService,
-				_subscriptionLocalService, WikiPage.class.getName(),
+				_classNameLocalService, _subscriptionLocalService,
+				WikiPage.class.getName(),
 				UpgradeDiscussionSubscriptionClassName.DeletionMode.UPDATE));
 
 		registry.register(
@@ -87,9 +86,6 @@ public class WikiServiceUpgrade implements UpgradeStepRegistrator {
 
 		registry.register("2.1.0", "2.1.1", new DummyUpgradeStep());
 	}
-
-	@Reference
-	private AssetEntryLocalService _assetEntryLocalService;
 
 	@Reference
 	private ClassNameLocalService _classNameLocalService;


### PR DESCRIPTION
Hi @adolfopa @robertoDiaz,

The key question is, is the assetEntry object required for a subscription? Subscriptions tied to objects (JournalArticle, WikiPage, etc.) have it because those objects need it but, what about the others?

@robertoDiaz and I have thought about that and we believe the MBDiscusssion subscriptions shouldn't have an AssetEntry. If that's the case, this is wrong:
https://github.com/liferay/liferay-portal/blob/master/modules/apps/subscription/subscription-service/src/main/java/com/liferay/subscription/service/impl/SubscriptionLocalServiceImpl.java#L147

We can discuss it tomorrow because if we would need an additional to fix that code and an upgrade process to remove the incorrect AssetEntries.

Cheers!

PS: I have tested my code and it's working after an upgrade, the subscription is still valid.