### PR TITLE
[TS] LPS-125082

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/article_action.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/article_action.jsp
@@ -65,7 +65,7 @@ else {
 		/>
 	</c:if>
 
-	<c:if test="<%= kbArticle.isRoot() && KBArticlePermission.contains(permissionChecker, kbArticle, KBActionKeys.PERMISSIONS) %>">
+	<c:if test="<%= KBArticlePermission.contains(permissionChecker, kbArticle, KBActionKeys.PERMISSIONS) %>">
 		<liferay-security:permissionsURL
 			modelResource="<%= KBArticle.class.getName() %>"
 			modelResourceDescription="<%= kbArticle.getTitle() %>"

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_article.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_article.jsp
@@ -248,7 +248,7 @@ if (portletTitleBasedNavigation) {
 				</aui:fieldset>
 
 				<c:if test="<%= kbArticle == null %>">
-					<aui:fieldset collapsed="<%= true %>" collapsible="<%= true %>" cssClass='<%= (parentResourcePrimKey != KBFolderConstants.DEFAULT_PARENT_FOLDER_ID) ? "hide" : StringPool.BLANK %>' label="permissions">
+					<aui:fieldset collapsed="<%= true %>" collapsible="<%= true %>" label="permissions">
 						<liferay-ui:input-permissions
 							modelName="<%= KBArticle.class.getName() %>"
 						/>


### PR DESCRIPTION
[LPS-125082](https://issues.liferay.com/browse/LPS-125082)

From @jesseyeh-liferay: 

> When creating a Knowledge Base article within a subfolder, there is no option to edit the permissions. Furthermore, after publishing the article, the option to edit the permissions of the article is missing. Articles within the root folder do not have this issue. LPS-125082 introduces changes which allow for article permissions to be edited regardless of the article's parent folder.

I also dug a bit and found this change was initially added with [LPS-15659](https://issues.liferay.com/browse/LPS-15659) as a way to improve performance.  I think it's acceptable to add this feature back into the portal now.