### PR TITLE
LPS-125917 + LPS-124911 - Alloy/ck editor bugs

### DIFF
--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/css/common_main.scss
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/css/common_main.scss
@@ -68,6 +68,7 @@
 
 		img,
 		.cke_widget_embedurl,
+		.cke_widget_videoembed,
 		.cke_widget_image,
 		.embed-responsive {
 			&[style*='float: left;'],

--- a/modules/apps/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/portal/_editor_alloy.scss
+++ b/modules/apps/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/portal/_editor_alloy.scss
@@ -65,57 +65,6 @@
 			}
 		}
 
-		.cke_widget_embedurl,
-		.cke_widget_videoembed {
-			.embed-help-message {
-				color: #fff;
-				font-weight: 600;
-				opacity: 0;
-				position: absolute;
-				text-align: center;
-				top: 50%;
-				transform: translateY(-50%);
-				transition: opacity 0.15s ease-in-out;
-				width: 100%;
-				z-index: 1;
-			}
-
-			.embed-responsive {
-				.embed-responsive-16by9 {
-					iframe {
-						@extend .embed-responsive-item !optional;
-					}
-				}
-			}
-
-			.cke_widget_mask {
-				background-color: #000;
-				cursor: pointer;
-				opacity: 0;
-				transition: opacity 0.15s ease-in-out;
-			}
-
-			&.cke_widget_wrapper {
-				&:hover,
-				&.cke_widget_focused {
-					.cke_widget_element {
-						outline: none;
-					}
-				}
-
-				&.cke_widget_selected {
-					.cke_widget_mask {
-						height: 100%;
-						opacity: 0.6;
-					}
-
-					.embed-help-message {
-						opacity: 1;
-					}
-				}
-			}
-		}
-
 		.cke_widget_wrapper {
 			max-width: 100%;
 		}
@@ -146,6 +95,57 @@
 
 			.lfr-source-editor {
 				display: block;
+			}
+		}
+	}
+}
+
+.cke_widget_embedurl,
+.cke_widget_videoembed {
+	.embed-help-message {
+		color: #fff;
+		font-weight: 600;
+		opacity: 0;
+		position: absolute;
+		text-align: center;
+		top: 50%;
+		transform: translateY(-50%);
+		transition: opacity 0.15s ease-in-out;
+		width: 100%;
+		z-index: 1;
+	}
+
+	.embed-responsive {
+		.embed-responsive-16by9 {
+			iframe {
+				@extend .embed-responsive-item !optional;
+			}
+		}
+	}
+
+	.cke_widget_mask {
+		background-color: #000;
+		cursor: pointer;
+		opacity: 0;
+		transition: opacity 0.15s ease-in-out;
+	}
+
+	&.cke_widget_wrapper {
+		&:hover,
+		&.cke_widget_focused {
+			.cke_widget_element {
+				outline: none;
+			}
+		}
+
+		&.cke_widget_selected {
+			.cke_widget_mask {
+				height: 100%;
+				opacity: 0.6;
+			}
+
+			.embed-help-message {
+				opacity: 1;
 			}
 		}
 	}

--- a/modules/apps/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/portal/_editor_alloy.scss
+++ b/modules/apps/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/portal/_editor_alloy.scss
@@ -65,7 +65,8 @@
 			}
 		}
 
-		.cke_widget_embedurl {
+		.cke_widget_embedurl,
+		.cke_widget_videoembed {
 			.embed-help-message {
 				color: #fff;
 				font-weight: 600;

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/videoembed/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/videoembed/plugin.js
@@ -16,7 +16,7 @@ if (!CKEDITOR.plugins.get('videoembed')) {
 	const REGEX_HTTP = /^https?/;
 
 	CKEDITOR.DEFAULT_LFR_EMBED_WIDGET_TPL =
-		'<div data-embed-url="{url}" class="embed-responsive embed-responsive-16by9"><div data-embed-id="{url}">{content}</div><div class="embed-help-message">{helpMessageIcon}<span> {helpMessage}</span></div></div><br>';
+		'<div data-embed-url="{url}" class="embed-responsive embed-responsive-16by9">{content}<div class="embed-help-message">{helpMessageIcon}<span> {helpMessage}</span></div></div><br>';
 
 	/**
 	 * Enum for supported embed alignments
@@ -740,7 +740,11 @@ if (!CKEDITOR.plugins.get('videoembed')) {
 		},
 
 		onOkVideoHtml(editor, html, url) {
-			const embedContent = this._generateEmbedContent(editor, url, html);
+			const embedContent = this._generateEmbedContent(
+				editor,
+				url,
+				`<div data-embed-id="${url}">${html}</div>`
+			);
 
 			editor.insertHtml(embedContent);
 		},


### PR DESCRIPTION
Hello guys,

I think that the bug is fixed, @ambrinchaudhary @4lejandrito  please if you can check it in case I forget some case. 

I have some questions.

**Do you think it is better to use `%` or `px`?**

Because I was missing logic and it is because it was deleted on purpose https://github.com/brianchandotcom/liferay-portal/pull/89635/commits/3259a99805fd2173828ee8fc63f0d6c157d9cf5e but this part is related to this [LPS-114255](https://issues.liferay.com/browse/LPS-114255) and it doesn't seem to fix it. :(

We have left some of the logic that calculates the `%` https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/videoembed/plugin.js#L503-L517

@julien do you think it is better to rescue the `%` calculation or eliminate it?

~~On the other hand, the use of providers before we pass directly to their template the ID that was then used to fill in a part of the URL. Deleted here https://github.com/liferay/liferay-portal/commit/68f167a826ddc5a758d6d2a63578dcd788477226.~~

~~For example, if someone is using an implementation like the one that existed from youtube https://github.com/liferay/liferay-portal/commit/68f167a826ddc5a758d6d2a63578dcd788477226#diff-8a7f3b2fbfc7b4852c5fb8d5ee634d216a8417bdL.~~

~~Executing it now will return the iframe with an incorrect URL, as far as I understand.~~

~~**Returned:**~~
```
src="https://www.youtube.com/embed/https://www.youtube.com/embed/Mu0LcyOPadQ?rel=0"
```

~~**Expected:**~~
```
src="https://www.youtube.com/embed/Mu0LcyOPadQ?rel=0"
```

~~**Do you think is better to remove providers completely or fix them?**~~


Chat with @ambrinchaudhary @4lejandrito about providers. 
We think that providers should work with these changes in the old way.