### PR TITLE
LPS-121864 Migrate management toolbar v2 usages in blogs-web

### DIFF
--- a/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/display/context/BlogImagesManagementToolbarDisplayContext.java
+++ b/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/display/context/BlogImagesManagementToolbarDisplayContext.java
@@ -16,6 +16,7 @@ package com.liferay.blogs.web.internal.display.context;
 
 import com.liferay.blogs.constants.BlogsPortletKeys;
 import com.liferay.blogs.web.internal.security.permission.resource.BlogsImagesFileEntryPermission;
+import com.liferay.frontend.taglib.clay.servlet.taglib.display.context.SearchContainerManagementToolbarDisplayContext;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemListBuilder;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.ViewTypeItemList;
@@ -26,7 +27,6 @@ import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.PortalPreferences;
 import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
-import com.liferay.portal.kernel.portlet.PortletURLUtil;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -38,7 +38,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-import javax.portlet.PortletException;
 import javax.portlet.PortletURL;
 
 import javax.servlet.http.HttpServletRequest;
@@ -46,23 +45,28 @@ import javax.servlet.http.HttpServletRequest;
 /**
  * @author Sergio González
  */
-public class BlogImagesManagementToolbarDisplayContext {
+public class BlogImagesManagementToolbarDisplayContext
+	extends SearchContainerManagementToolbarDisplayContext {
 
 	public BlogImagesManagementToolbarDisplayContext(
 		HttpServletRequest httpServletRequest,
 		LiferayPortletRequest liferayPortletRequest,
 		LiferayPortletResponse liferayPortletResponse,
-		PortletURL currentURLObj) {
+		SearchContainer<FileEntry> searchContainer) {
+
+		super(
+			httpServletRequest, liferayPortletRequest, liferayPortletResponse,
+			searchContainer);
 
 		_httpServletRequest = httpServletRequest;
 		_liferayPortletRequest = liferayPortletRequest;
 		_liferayPortletResponse = liferayPortletResponse;
-		_currentURLObj = currentURLObj;
 
 		_portalPreferences = PortletPreferencesFactoryUtil.getPortalPreferences(
 			liferayPortletRequest);
 	}
 
+	@Override
 	public List<DropdownItem> getActionDropdownItems() {
 		return DropdownItemListBuilder.add(
 			dropdownItem -> {
@@ -94,6 +98,7 @@ public class BlogImagesManagementToolbarDisplayContext {
 		return availableActions;
 	}
 
+	@Override
 	public String getDisplayStyle() {
 		String displayStyle = ParamUtil.getString(
 			_httpServletRequest, "displayStyle");
@@ -114,6 +119,7 @@ public class BlogImagesManagementToolbarDisplayContext {
 		return displayStyle;
 	}
 
+	@Override
 	public List<DropdownItem> getFilterDropdownItems() {
 		return DropdownItemListBuilder.addGroup(
 			dropdownGroupItem -> {
@@ -124,14 +130,17 @@ public class BlogImagesManagementToolbarDisplayContext {
 		).build();
 	}
 
+	@Override
 	public String getOrderByCol() {
 		return ParamUtil.getString(_httpServletRequest, "orderByCol", "title");
 	}
 
+	@Override
 	public String getOrderByType() {
 		return ParamUtil.getString(_httpServletRequest, "orderByType", "desc");
 	}
 
+	@Override
 	public String getSearchActionURL() {
 		PortletURL searchURL = _liferayPortletResponse.createRenderURL();
 
@@ -143,14 +152,15 @@ public class BlogImagesManagementToolbarDisplayContext {
 		return searchURL.toString();
 	}
 
-	public PortletURL getSortingURL() throws PortletException {
+	@Override
+	public String getSortingURL() {
 		PortletURL sortingURL = _getCurrentSortingURL();
 
 		sortingURL.setParameter(
 			"orderByType",
 			Objects.equals(getOrderByType(), "asc") ? "desc" : "asc");
 
-		return sortingURL;
+		return sortingURL.toString();
 	}
 
 	public ViewTypeItemList getViewTypes() {
@@ -191,9 +201,8 @@ public class BlogImagesManagementToolbarDisplayContext {
 		};
 	}
 
-	private PortletURL _getCurrentSortingURL() throws PortletException {
-		PortletURL sortingURL = PortletURLUtil.clone(
-			_currentURLObj, _liferayPortletResponse);
+	private PortletURL _getCurrentSortingURL() {
+		PortletURL sortingURL = getPortletURL();
 
 		sortingURL.setParameter(SearchContainer.DEFAULT_CUR_PARAM, "0");
 
@@ -227,7 +236,6 @@ public class BlogImagesManagementToolbarDisplayContext {
 		).build();
 	}
 
-	private final PortletURL _currentURLObj;
 	private final HttpServletRequest _httpServletRequest;
 	private final LiferayPortletRequest _liferayPortletRequest;
 	private final LiferayPortletResponse _liferayPortletResponse;

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/js/BlogEntriesManagementToolbarPropsTransformer.js
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/js/BlogEntriesManagementToolbarPropsTransformer.js
@@ -12,46 +12,46 @@
  * details.
  */
 
-import {DefaultEventHandler} from 'frontend-js-web';
-import {Config} from 'metal-state';
+import {postForm} from 'frontend-js-web';
 
-class ManagementToolbarDefaultEventHandler extends DefaultEventHandler {
-	deleteEntries() {
+export default function propsTransformer({
+	additionalProps: {deleteEntriesCmd, deleteEntriesURL, trashEnabled},
+	portletNamespace,
+	...otherProps
+}) {
+	const deleteEntries = () => {
 		if (
-			this.trashEnabled ||
+			trashEnabled ||
 			confirm(
 				Liferay.Language.get('are-you-sure-you-want-to-delete-this')
 			)
 		) {
-			const form = this.one('#fm');
+			const form = document.getElementById(`${portletNamespace}fm`);
 
 			const searchContainer = Liferay.SearchContainer.get(
-				this.ns('blogEntries')
+				`${portletNamespace}blogEntries`
 			);
 
-			const bulkSelection =
-				searchContainer.select &&
-				searchContainer.select.get('bulkSelection');
-
-			Liferay.Util.postForm(form, {
+			postForm(form, {
 				data: {
-					cmd: this.deleteEntriesCmd,
+					cmd: deleteEntriesCmd,
 					deleteEntryIds: Liferay.Util.listCheckedExcept(
 						form,
-						this.ns('allRowIds')
+						`${portletNamespace}allRowIds`
 					),
-					selectAll: bulkSelection,
+					selectAll: searchContainer.select?.get('bulkSelection'),
 				},
-				url: this.deleteEntriesURL,
+				url: deleteEntriesURL,
 			});
 		}
-	}
+	};
+
+	return {
+		...otherProps,
+		onActionButtonClick: (event, {item}) => {
+			if (item?.data?.action === 'deleteEntries') {
+				deleteEntries();
+			}
+		},
+	};
 }
-
-ManagementToolbarDefaultEventHandler.STATE = {
-	deleteEntriesCmd: Config.string(),
-	deleteEntriesURL: Config.string(),
-	trashEnabled: Config.bool(),
-};
-
-export default ManagementToolbarDefaultEventHandler;

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/js/BlogImagesManagementToolbarPropsTransformer.js
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/js/BlogImagesManagementToolbarPropsTransformer.js
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+export default function propsTransformer({portletNamespace, ...otherProps}) {
+	const deleteImages = () => {
+		if (
+			confirm(
+				Liferay.Language.get(
+					'are-you-sure-you-want-to-delete-the-selected-images'
+				)
+			)
+		) {
+			const form = document.getElementById(`${portletNamespace}fm`);
+
+			if (form) {
+				var cmd = form.querySelector(`#${portletNamespace}cmd`);
+
+				cmd?.setAttribute('value', 'delete');
+
+				var deleteFileEntryIds = form.querySelector(
+					`#${portletNamespace}deleteFileEntryIds`
+				);
+
+				deleteFileEntryIds?.setAttribute(
+					'value',
+					Liferay.Util.listCheckedExcept(
+						form,
+						`${portletNamespace}allRowIds`
+					)
+				);
+
+				submitForm(form);
+			}
+		}
+	};
+
+	return {
+		...otherProps,
+		onActionButtonClick: (event, {item}) => {
+			if (item?.data?.action === 'deleteImages') {
+				deleteImages();
+			}
+		},
+	};
+}

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/view_entries.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/view_entries.jsp
@@ -31,10 +31,11 @@ PortletURL portletURL = entriesSearchContainer.getIteratorURL();
 BlogEntriesManagementToolbarDisplayContext blogEntriesManagementToolbarDisplayContext = new BlogEntriesManagementToolbarDisplayContext(request, liferayPortletRequest, liferayPortletResponse, entriesSearchContainer, trashHelper, displayStyle);
 %>
 
-<clay:management-toolbar-v2
-	displayContext="<%= blogEntriesManagementToolbarDisplayContext %>"
+<clay:management-toolbar
+	additionalProps="<%= blogEntriesManagementToolbarDisplayContext.getAdditionalProps() %>"
+	managementToolbarDisplayContext="<%= blogEntriesManagementToolbarDisplayContext %>"
+	propsTransformer="blogs_admin/js/BlogEntriesManagementToolbarPropsTransformer"
 	searchContainerId="blogEntries"
-	supportsBulkActions="<%= true %>"
 />
 
 <portlet:actionURL name="/blogs/edit_entry" var="restoreTrashEntriesURL">
@@ -92,12 +93,6 @@ BlogEntriesManagementToolbarDisplayContext blogEntriesManagementToolbarDisplayCo
 		</liferay-ui:search-container>
 	</aui:form>
 </clay:container-fluid>
-
-<liferay-frontend:component
-	componentId="<%= blogEntriesManagementToolbarDisplayContext.getDefaultEventHandler() %>"
-	context="<%= blogEntriesManagementToolbarDisplayContext.getComponentContext() %>"
-	module="blogs_admin/js/ManagementToolbarDefaultEventHandler.es"
-/>
 
 <liferay-frontend:component
 	componentId="<%= BlogsWebConstants.BLOGS_ELEMENTS_DEFAULT_EVENT_HANDLER %>"

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/view_images.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/view_images.jsp
@@ -45,25 +45,26 @@ BlogImagesDisplayContext blogImagesDisplayContext = new BlogImagesDisplayContext
 
 blogImagesDisplayContext.populateResults(blogImagesSearchContainer);
 
-BlogImagesManagementToolbarDisplayContext blogImagesManagementToolbarDisplayContext = new BlogImagesManagementToolbarDisplayContext(request, liferayPortletRequest, liferayPortletResponse, currentURLObj);
+BlogImagesManagementToolbarDisplayContext blogImagesManagementToolbarDisplayContext = new BlogImagesManagementToolbarDisplayContext(request, liferayPortletRequest, liferayPortletResponse, blogImagesSearchContainer);
 
 String displayStyle = blogImagesManagementToolbarDisplayContext.getDisplayStyle();
 %>
 
-<clay:management-toolbar-v2
+<clay:management-toolbar
 	actionDropdownItems="<%= blogImagesManagementToolbarDisplayContext.getActionDropdownItems() %>"
 	clearResultsURL="<%= blogImagesManagementToolbarDisplayContext.getSearchActionURL() %>"
-	componentId="blogImagesManagementToolbar"
 	disabled="<%= blogImagesSearchContainer.getTotal() <= 0 %>"
 	filterDropdownItems="<%= blogImagesManagementToolbarDisplayContext.getFilterDropdownItems() %>"
 	itemsTotal="<%= blogImagesSearchContainer.getTotal() %>"
+	managementToolbarDisplayContext="<%= blogImagesManagementToolbarDisplayContext %>"
+	propsTransformer="blogs_admin/js/BlogImagesManagementToolbarPropsTransformer"
 	searchActionURL="<%= blogImagesManagementToolbarDisplayContext.getSearchActionURL() %>"
 	searchContainerId="images"
 	searchFormName="searchFm"
 	showCreationMenu="<%= false %>"
 	showInfoButton="<%= false %>"
 	sortingOrder="<%= blogImagesManagementToolbarDisplayContext.getOrderByType() %>"
-	sortingURL="<%= String.valueOf(blogImagesManagementToolbarDisplayContext.getSortingURL()) %>"
+	sortingURL="<%= blogImagesManagementToolbarDisplayContext.getSortingURL() %>"
 	viewTypeItems="<%= blogImagesManagementToolbarDisplayContext.getViewTypes() %>"
 />
 
@@ -106,57 +107,3 @@ String displayStyle = blogImagesManagementToolbarDisplayContext.getDisplayStyle(
 		</liferay-ui:search-container>
 	</aui:form>
 </clay:container-fluid>
-
-<aui:script>
-	var deleteImages = function () {
-		if (
-			confirm(
-				'<liferay-ui:message key="are-you-sure-you-want-to-delete-the-selected-images" />'
-			)
-		) {
-			var form = document.getElementById('<portlet:namespace />fm');
-
-			if (form) {
-				var cmd = form.querySelector(
-					'#<portlet:namespace /><%= Constants.CMD %>'
-				);
-
-				if (cmd) {
-					cmd.setAttribute('value', '<%= Constants.DELETE %>');
-				}
-
-				var deleteFileEntryIds = form.querySelector(
-					'#<portlet:namespace />deleteFileEntryIds'
-				);
-
-				if (deleteFileEntryIds) {
-					deleteFileEntryIds.setAttribute(
-						'value',
-						Liferay.Util.listCheckedExcept(
-							form,
-							'<portlet:namespace />allRowIds'
-						)
-					);
-				}
-
-				submitForm(form);
-			}
-		}
-	};
-
-	var ACTIONS = {
-		deleteImages: deleteImages,
-	};
-
-	Liferay.componentReady('blogImagesManagementToolbar').then(function (
-		managementToolbar
-	) {
-		managementToolbar.on('actionItemClicked', function (event) {
-			var itemData = event.data.item.data;
-
-			if (itemData && itemData.action && ACTIONS[itemData.action]) {
-				ACTIONS[itemData.action]();
-			}
-		});
-	});
-</aui:script>

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.es.js
@@ -33,6 +33,7 @@ export {default as delegate} from './liferay/delegate/delegate.es';
 // Form API
 
 export {default as objectToFormData} from './liferay/util/form/object_to_form_data.es';
+export {default as postForm} from './liferay/util/form/post_form.es';
 
 // Liferay API
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/servlet/taglib/display/context/ManagementToolbarDefaults.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/servlet/taglib/display/context/ManagementToolbarDefaults.java
@@ -27,12 +27,28 @@ public class ManagementToolbarDefaults {
 		return "hiddenInputsForm";
 	}
 
+	public static Integer getItemsTotal() {
+		return 0;
+	}
+
 	public static String getSearchFormMethod() {
 		return "GET";
 	}
 
 	public static String getSearchInputName() {
 		return DisplayTerms.KEYWORDS;
+	}
+
+	public static Integer getSelectedItems() {
+		return 0;
+	}
+
+	public static Boolean isDisabled() {
+		return false;
+	}
+
+	public static Boolean isSelectable() {
+		return true;
 	}
 
 	public static Boolean isShowCreationMenu(CreationMenu creationMenu) {
@@ -45,6 +61,14 @@ public class ManagementToolbarDefaults {
 
 	public static Boolean isShowInfoButton(String infoPanelId) {
 		return Validator.isNotNull(infoPanelId);
+	}
+
+	public static Boolean isShowSearch() {
+		return true;
+	}
+
+	public static Boolean isSupportsBulkActions() {
+		return true;
 	}
 
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ManagementToolbarTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ManagementToolbarTag.java
@@ -141,26 +141,22 @@ public class ManagementToolbarTag extends BaseContainerTag {
 	}
 
 	public String getInfoPanelId() {
-		String infoPanelId = _infoPanelId;
+		if ((_infoPanelId == null) &&
+			(_managementToolbarDisplayContext != null)) {
 
-		if (infoPanelId == null) {
-			if (_managementToolbarDisplayContext == null) {
-				return null;
-			}
-
-			infoPanelId = _managementToolbarDisplayContext.getInfoPanelId();
+			return _managementToolbarDisplayContext.getInfoPanelId();
 		}
 
-		return infoPanelId;
+		return _infoPanelId;
 	}
 
 	public Integer getItemsTotal() {
 		if (_itemsTotal == null) {
-			if (_managementToolbarDisplayContext == null) {
-				return 0;
+			if (_managementToolbarDisplayContext != null) {
+				return _managementToolbarDisplayContext.getItemsTotal();
 			}
 
-			return _managementToolbarDisplayContext.getItemsTotal();
+			return ManagementToolbarDefaults.getItemsTotal();
 		}
 
 		return _itemsTotal;
@@ -193,60 +189,47 @@ public class ManagementToolbarTag extends BaseContainerTag {
 	}
 
 	public String getSearchContainerId() {
-		String searchContainerId = _searchContainerId;
+		if ((_searchContainerId == null) &&
+			(_managementToolbarDisplayContext != null)) {
 
-		if (searchContainerId == null) {
-			if (_managementToolbarDisplayContext == null) {
-				return null;
-			}
-
-			searchContainerId =
-				_managementToolbarDisplayContext.getSearchContainerId();
+			return _managementToolbarDisplayContext.getSearchContainerId();
 		}
 
-		return searchContainerId;
+		return _searchContainerId;
 	}
 
 	public String getSearchFormMethod() {
 		if (_searchFormMethod == null) {
-			if (_managementToolbarDisplayContext == null) {
-				return ManagementToolbarDefaults.getSearchFormMethod();
+			if (_managementToolbarDisplayContext != null) {
+				return _managementToolbarDisplayContext.getSearchFormMethod();
 			}
 
-			return _managementToolbarDisplayContext.getSearchFormMethod();
+			return ManagementToolbarDefaults.getSearchFormMethod();
 		}
 
 		return _searchFormMethod;
 	}
 
 	public String getSearchFormName() {
-		String searchFormName = _searchFormName;
+		if ((_searchFormName == null) &&
+			(_managementToolbarDisplayContext != null)) {
 
-		if (searchFormName == null) {
-			if (_managementToolbarDisplayContext == null) {
-				return null;
-			}
-
-			searchFormName =
-				_managementToolbarDisplayContext.getSearchFormName();
+			return _managementToolbarDisplayContext.getSearchFormName();
 		}
 
-		return searchFormName;
+		return _searchFormName;
 	}
 
 	public String getSearchInputName() {
-		String searchInputName = _searchInputName;
-
-		if (searchInputName == null) {
-			if (_managementToolbarDisplayContext == null) {
-				return ManagementToolbarDefaults.getSearchInputName();
+		if (_searchInputName == null) {
+			if (_managementToolbarDisplayContext != null) {
+				_managementToolbarDisplayContext.getSearchInputName();
 			}
 
-			searchInputName =
-				_managementToolbarDisplayContext.getSearchInputName();
+			return ManagementToolbarDefaults.getSearchInputName();
 		}
 
-		return searchInputName;
+		return _searchInputName;
 	}
 
 	public String getSearchValue() {
@@ -265,11 +248,11 @@ public class ManagementToolbarTag extends BaseContainerTag {
 
 	public Integer getSelectedItems() {
 		if (_selectedItems == null) {
-			if (_managementToolbarDisplayContext == null) {
-				return 0;
+			if (_managementToolbarDisplayContext != null) {
+				return _managementToolbarDisplayContext.getSelectedItems();
 			}
 
-			return _managementToolbarDisplayContext.getSelectedItems();
+			return ManagementToolbarDefaults.getSelectedItems();
 		}
 
 		return _selectedItems;
@@ -311,17 +294,19 @@ public class ManagementToolbarTag extends BaseContainerTag {
 				return _managementToolbarDisplayContext.isDisabled();
 			}
 
-			return false;
+			return ManagementToolbarDefaults.isDisabled();
 		}
 
 		return _disabled;
 	}
 
 	public Boolean isSelectable() {
-		if ((_selectable == null) &&
-			(_managementToolbarDisplayContext != null)) {
+		if (_selectable == null) {
+			if (_managementToolbarDisplayContext != null) {
+				return _managementToolbarDisplayContext.isSelectable();
+			}
 
-			return _managementToolbarDisplayContext.isSelectable();
+			return ManagementToolbarDefaults.isSelectable();
 		}
 
 		return _selectable;
@@ -338,19 +323,15 @@ public class ManagementToolbarTag extends BaseContainerTag {
 	}
 
 	public Boolean isShowInfoButton() {
-		Boolean showInfoButton = _showInfoButton;
-
-		if (showInfoButton == null) {
-			if (_managementToolbarDisplayContext == null) {
-				return ManagementToolbarDefaults.isShowInfoButton(
-					getInfoPanelId());
+		if (_showInfoButton == null) {
+			if (_managementToolbarDisplayContext != null) {
+				return _managementToolbarDisplayContext.isShowInfoButton();
 			}
 
-			showInfoButton =
-				_managementToolbarDisplayContext.isShowInfoButton();
+			return ManagementToolbarDefaults.isShowInfoButton(getInfoPanelId());
 		}
 
-		return showInfoButton;
+		return _showInfoButton;
 	}
 
 	public Boolean isShowResultsBar() {
@@ -363,7 +344,7 @@ public class ManagementToolbarTag extends BaseContainerTag {
 				return _managementToolbarDisplayContext.isShowSearch();
 			}
 
-			return true;
+			return ManagementToolbarDefaults.isShowSearch();
 		}
 
 		return _showSearch;
@@ -375,12 +356,12 @@ public class ManagementToolbarTag extends BaseContainerTag {
 
 	public Boolean isSupportsBulkActions() {
 		if (_supportsBulkActions == null) {
-			if (_supportsBulkActions != null) {
+			if (_managementToolbarDisplayContext != null) {
 				return _managementToolbarDisplayContext.
 					getSupportsBulkActions();
 			}
 
-			return true;
+			return ManagementToolbarDefaults.isSupportsBulkActions();
 		}
 
 		return _supportsBulkActions;


### PR DESCRIPTION
Fixes https://issues.liferay.com/browse/LPS-121864

This PR contains the first 'real' usage upgrade to the new management toolbar tag, based on Clay v3. The only existing usage so far is in `frontend-taglib-clay-sample-web`.

Test plan:
1. Open Content & Data > Blogs. There are two tabs, with two management toolbars, 'Entries' and 'Images'
2. To create entry samples, create from (+) button on entries tab.
3. To create image samples, open one entry, add a bunch of images, save.
4. Confirm that all features follow [Lexicon guidelines](https://liferay.design/lexicon/core-components/toolbars/management-bar/). 
See gif on bottom. 

@liferay-lima Please check all the use cases, it is quite possible that I missed some.

Notes:
- I had to make significant changes in the usages, primarily to enable bulk actions, i.e. deletions. For both toolbars we are implementing `*PropsTransformer`, as a part of standard wiring pattern for React-based components. For entries, this meant rewriting a `DefaultEventHandler`. For images, this meant rewriting JS block in JSP. 
- Images implementation looks older than entries, and there are quite a few additional tweaks that can be made to make it consistent. For example, `postForm` can be used in images form, instead of `submitForm`. I only made those changes that enabled component to fully function. Implementing `SearchContainerManagementToolbarDisplayContext` inheritance for display context is strictly speaking not mandatory, but it makes it easier, as it provides ootb attributes required for interaction with search container. The same is true for adding `managementToolbarDisplayContext` attribute to images; it is useful as it to provides ootb attributes like namespace, but it is up to to you if you want to remove it or collapse other attributes into it.
- `_isTrashEnabled` block is a copy from `BlogsEntryActionDropdownItemsProvider`. I made the change to remove the error throwing, as this clashed with super-class method not throwing an error.
- We are setting `selectable` to be `true` by default, to match v2 default. In addition, we are doing a bit of housekeeping on the tag, to make defaults handling consistent. All non-`null` defaults are now in `ManagementToolbarDefaults`, all `null` defaults have a consistent and simplest check.

/cc @carloslancha @julien @jonmak08 @jbalsas

![after](https://user-images.githubusercontent.com/5435511/105717527-8763f800-5f20-11eb-9d1d-45661ed11150.gif)