### PR TITLE
LPS-121925 Migrate management toolbar v2 usages in wiki/wiki-web

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ManagementToolbarTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ManagementToolbarTag.java
@@ -26,6 +26,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.HttpUtil;
+import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.taglib.util.TagResourceBundleUtil;
@@ -34,6 +35,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.ResourceBundle;
+
+import javax.portlet.PortletResponse;
 
 import javax.servlet.jsp.JspException;
 import javax.servlet.jsp.JspWriter;
@@ -169,10 +172,19 @@ public class ManagementToolbarTag extends BaseContainerTag {
 	}
 
 	public String getNamespace() {
-		if ((_namespace == null) &&
-			(_managementToolbarDisplayContext != null)) {
+		if (_namespace != null) {
+			return _namespace;
+		}
 
+		if (_managementToolbarDisplayContext != null) {
 			return _managementToolbarDisplayContext.getNamespace();
+		}
+
+		PortletResponse portletResponse = (PortletResponse)request.getAttribute(
+			JavaConstants.JAVAX_PORTLET_RESPONSE);
+
+		if (portletResponse != null) {
+			_namespace = portletResponse.getNamespace();
 		}
 
 		return _namespace;

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/DataSetDisplay.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/data_set_display/DataSetDisplay.js
@@ -493,7 +493,9 @@ function DataSetDisplay({
 				}));
 
 				return refreshData({
-					message: Liferay.Language.get('item-was-successfully-created'),
+					message: Liferay.Language.get(
+						'item-was-successfully-created'
+					),
 					showSuccessNotification: true,
 				});
 			})
@@ -542,7 +544,9 @@ function DataSetDisplay({
 				toggleItemInlineEdit(itemKey);
 
 				return refreshData({
-					message: Liferay.Language.get('item-was-successfully-updated'),
+					message: Liferay.Language.get(
+						'item-was-successfully-updated'
+					),
 					showSuccessNotification: true,
 				});
 			})

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ActionControls.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ActionControls.js
@@ -29,7 +29,7 @@ const ActionControls = ({
 	return (
 		<>
 			{actionDropdownItems && (
-				<ClayManagementToolbar.ItemList>
+				<>
 					{actionDropdownItems
 						.filter((item) => item.quickAction && item.icon)
 						.map((item, index) => (
@@ -52,7 +52,9 @@ const ActionControls = ({
 										disabled={disabled}
 										displayType="unstyled"
 										onClick={(event) => {
-											onActionButtonClick(event, {item});
+											onActionButtonClick(event, {
+												item,
+											});
 										}}
 										symbol={item.icon}
 										title={item.label}
@@ -90,7 +92,7 @@ const ActionControls = ({
 							}
 						/>
 					</ClayManagementToolbar.Item>
-				</ClayManagementToolbar.ItemList>
+				</>
 			)}
 		</>
 	);

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.js
@@ -102,44 +102,43 @@ function ManagementToolbar({
 						/>
 					)}
 				</ClayManagementToolbar.ItemList>
-				{active ? (
-					<ActionControls
-						actionDropdownItems={actionDropdownItems}
+				{!active && showSearch && (
+					<SearchControls
 						disabled={disabled}
-						onActionButtonClick={onActionButtonClick}
+						searchActionURL={searchActionURL}
+						searchData={searchData}
+						searchFormMethod={searchFormMethod}
+						searchFormName={searchFormName}
+						searchInputName={searchInputName}
+						searchMobile={searchMobile}
+						searchValue={searchValue}
+						setSearchMobile={setSearchMobile}
 					/>
-				) : (
-					<>
-						{showSearch && (
-							<SearchControls
+				)}
+				<ClayManagementToolbar.ItemList>
+					{!active && showSearch && (
+						<SearchControls.ShowMobileButton
+							disabled={disabled}
+							setSearchMobile={setSearchMobile}
+						/>
+					)}
+					{showInfoButton && (
+						<InfoPanelControl
+							disabled={disabled}
+							infoPanelId={infoPanelId}
+							onInfoButtonClick={onInfoButtonClick}
+						/>
+					)}
+					{active ? (
+						<>
+							<ActionControls
+								actionDropdownItems={actionDropdownItems}
 								disabled={disabled}
-								searchActionURL={searchActionURL}
-								searchData={searchData}
-								searchFormMethod={searchFormMethod}
-								searchFormName={searchFormName}
-								searchInputName={searchInputName}
-								searchMobile={searchMobile}
-								searchValue={searchValue}
-								setSearchMobile={setSearchMobile}
+								onActionButtonClick={onActionButtonClick}
 							/>
-						)}
-
-						<ClayManagementToolbar.ItemList>
-							{showSearch && (
-								<SearchControls.ShowMobileButton
-									disabled={disabled}
-									setSearchMobile={setSearchMobile}
-								/>
-							)}
-
-							{showInfoButton && (
-								<InfoPanelControl
-									disabled={disabled}
-									infoPanelId={infoPanelId}
-									onInfoButtonClick={onInfoButtonClick}
-								/>
-							)}
-
+						</>
+					) : (
+						<>
 							{viewTypeItems && (
 								<ClayManagementToolbar.Item>
 									<ClayDropDownWithItems
@@ -170,9 +169,9 @@ function ManagementToolbar({
 									/>
 								</ClayManagementToolbar.Item>
 							)}
-						</ClayManagementToolbar.ItemList>
-					</>
-				)}
+						</>
+					)}
+				</ClayManagementToolbar.ItemList>
 			</ClayManagementToolbar>
 
 			{showResultsBar && (

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/init.jsp
@@ -53,7 +53,6 @@ page import="com.liferay.portal.kernel.exception.PortalException" %><%@
 page import="com.liferay.portal.kernel.json.JSONFactoryUtil" %><%@
 page import="com.liferay.portal.kernel.json.JSONObject" %><%@
 page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
-page import="com.liferay.portal.kernel.language.UnicodeLanguageUtil" %><%@
 page import="com.liferay.portal.kernel.log.Log" %><%@
 page import="com.liferay.portal.kernel.log.LogFactoryUtil" %><%@
 page import="com.liferay.portal.kernel.model.User" %><%@

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/item/selector/wiki_pages.jsp
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/item/selector/wiki_pages.jsp
@@ -72,7 +72,7 @@ searchBaseURL.setParameter("resetCur", Boolean.TRUE.toString());
 String searchURL = HttpUtil.removeParameter(searchBaseURL.toString(), liferayPortletResponse.getNamespace() + "keywords");
 %>
 
-<clay:management-toolbar-v2
+<clay:management-toolbar
 	clearResultsURL="<%= searchURL %>"
 	itemsTotal="<%= wikiPagesSearchContainer.getTotal() %>"
 	searchActionURL="<%= searchURL %>"

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki_admin/js/WikiNodesManagementToolbarPropsTransformer.js
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki_admin/js/WikiNodesManagementToolbarPropsTransformer.js
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {postForm} from 'frontend-js-web';
+
+export default function propsTransformer({
+	additionalProps: {deleteNodesCmd, deleteNodesURL, trashEnabled},
+	portletNamespace,
+	...otherProps
+}) {
+	const deleteNodes = () => {
+		if (
+			trashEnabled ||
+			confirm(
+				Liferay.Language.get(
+					'are-you-sure-you-want-to-delete-the-selected-entries'
+				)
+			)
+		) {
+			postForm(document[`${portletNamespace}fm`], {
+				data: {
+					cmd: deleteNodesCmd,
+				},
+				url: deleteNodesURL,
+			});
+		}
+	};
+
+	return {
+		...otherProps,
+		onActionButtonClick: (event, {item}) => {
+			if (item?.data?.action === 'deleteNodes') {
+				deleteNodes();
+			}
+		},
+	};
+}

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki_admin/js/WikiPagesManagementToolbarPropsTransformer.js
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki_admin/js/WikiPagesManagementToolbarPropsTransformer.js
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {postForm} from 'frontend-js-web';
+
+export default function propsTransformer({
+	additionalProps: {deletePagesCmd, deletePagesURL, trashEnabled},
+	portletNamespace,
+	...otherProps
+}) {
+	const deletePages = () => {
+		if (
+			trashEnabled ||
+			confirm(
+				Liferay.Language.get(
+					'are-you-sure-you-want-to-delete-the-selected-entries'
+				)
+			)
+		) {
+			postForm(document[`${portletNamespace}fm`], {
+				data: {
+					cmd: deletePagesCmd,
+				},
+				url: deletePagesURL,
+			});
+		}
+	};
+
+	return {
+		...otherProps,
+		onActionButtonClick: (event, {item}) => {
+			if (item?.data?.action === 'deletePages') {
+				deletePages();
+			}
+		},
+	};
+}

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki_admin/view.jsp
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki_admin/view.jsp
@@ -76,14 +76,15 @@ wikiNodesSearchContainer.setResults(WikiNodeServiceUtil.getNodes(scopeGroupId, W
 WikiNodesManagementToolbarDisplayContext wikiNodesManagementToolbarDisplayContext = new WikiNodesManagementToolbarDisplayContext(liferayPortletRequest, liferayPortletResponse, displayStyle, wikiNodesSearchContainer, trashHelper);
 %>
 
-<clay:management-toolbar-v2
+<clay:management-toolbar
 	actionDropdownItems="<%= wikiNodesManagementToolbarDisplayContext.getActionDropdownItems() %>"
-	componentId="wikiNodesManagementToolbar"
+	additionalProps="<%= wikiNodesManagementToolbarDisplayContext.getAdditionalProps() %>"
 	creationMenu="<%= wikiNodesManagementToolbarDisplayContext.getCreationMenu() %>"
 	disabled="<%= wikiNodesManagementToolbarDisplayContext.isDisabled() %>"
 	filterDropdownItems="<%= wikiNodesManagementToolbarDisplayContext.getFilterDropdownItems() %>"
 	infoPanelId="infoPanelId"
 	itemsTotal="<%= wikiNodesManagementToolbarDisplayContext.getTotalItems() %>"
+	propsTransformer="wiki_admin/js/WikiNodesManagementToolbarPropsTransformer"
 	searchContainerId="wikiNodes"
 	selectable="<%= wikiNodesManagementToolbarDisplayContext.isSelectable() %>"
 	showInfoButton="<%= true %>"
@@ -230,40 +231,3 @@ WikiNodesManagementToolbarDisplayContext wikiNodesManagementToolbarDisplayContex
 		</clay:container-fluid>
 	</div>
 </div>
-
-<script>
-	var deleteNodes = function () {
-		if (
-			<%= trashHelper.isTrashEnabled(scopeGroupId) %> ||
-			confirm(
-				' <%= UnicodeLanguageUtil.get(request, "are-you-sure-you-want-to-delete-the-selected-entries") %>'
-			)
-		) {
-			var form = document.<portlet:namespace />fm;
-
-			Liferay.Util.postForm(form, {
-				data: {
-					<%= Constants.CMD %>:
-						'<%= trashHelper.isTrashEnabled(scopeGroupId) ? Constants.MOVE_TO_TRASH : Constants.DELETE %>',
-				},
-				url: '<portlet:actionURL name="/wiki/edit_node" />',
-			});
-		}
-	};
-
-	var ACTIONS = {
-		deleteNodes: deleteNodes,
-	};
-
-	Liferay.componentReady('wikiNodesManagementToolbar').then(function (
-		managementToolbar
-	) {
-		managementToolbar.on('actionItemClicked', function (event) {
-			var itemData = event.data.item.data;
-
-			if (itemData && itemData.action && ACTIONS[itemData.action]) {
-				ACTIONS[itemData.action]();
-			}
-		});
-	});
-</script>

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki_admin/view_pages.jsp
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki_admin/view_pages.jsp
@@ -82,16 +82,17 @@ WikiPagesManagementToolbarDisplayContext wikiPagesManagementToolbarDisplayContex
 
 <liferay-util:include page="/wiki_admin/pages_navigation.jsp" servletContext="<%= application %>" />
 
-<clay:management-toolbar-v2
+<clay:management-toolbar
 	actionDropdownItems="<%= wikiPagesManagementToolbarDisplayContext.getActionDropdownItems() %>"
+	additionalProps="<%= wikiPagesManagementToolbarDisplayContext.getAdditionalProps() %>"
 	clearResultsURL="<%= String.valueOf(wikiPagesManagementToolbarDisplayContext.getClearResultsURL()) %>"
-	componentId="wikiPagesManagementToolbar"
 	creationMenu="<%= wikiPagesManagementToolbarDisplayContext.getCreationMenu() %>"
 	disabled="<%= wikiPagesManagementToolbarDisplayContext.isDisabled() %>"
 	filterDropdownItems="<%= wikiPagesManagementToolbarDisplayContext.getFilterDropdownItems() %>"
 	filterLabelItems="<%= wikiPagesManagementToolbarDisplayContext.getFilterLabelItems() %>"
 	infoPanelId="infoPanelId"
 	itemsTotal="<%= wikiPagesManagementToolbarDisplayContext.getTotalItems() %>"
+	propsTransformer="wiki_admin/js/WikiPagesManagementToolbarPropsTransformer"
 	searchActionURL="<%= String.valueOf(wikiPagesManagementToolbarDisplayContext.getSearchActionURL()) %>"
 	searchContainerId="wikiPages"
 	selectable="<%= wikiPagesManagementToolbarDisplayContext.isSelectable() %>"
@@ -296,40 +297,3 @@ WikiPagesManagementToolbarDisplayContext wikiPagesManagementToolbarDisplayContex
 		</clay:container-fluid>
 	</div>
 </div>
-
-<script>
-	var deletePages = function () {
-		if (
-			<%= trashHelper.isTrashEnabled(scopeGroupId) %> ||
-			confirm(
-				' <%= UnicodeLanguageUtil.get(request, "are-you-sure-you-want-to-delete-the-selected-entries") %>'
-			)
-		) {
-			var form = document.<portlet:namespace />fm;
-
-			Liferay.Util.postForm(form, {
-				data: {
-					<%= Constants.CMD %>:
-						'<%= trashHelper.isTrashEnabled(scopeGroupId) ? Constants.MOVE_TO_TRASH : Constants.DELETE %>',
-				},
-				url: '<portlet:actionURL name="/wiki/edit_page" />',
-			});
-		}
-	};
-
-	var ACTIONS = {
-		deletePages: deletePages,
-	};
-
-	Liferay.componentReady('wikiPagesManagementToolbar').then(function (
-		managementToolbar
-	) {
-		managementToolbar.on('actionItemClicked', function (event) {
-			var itemData = event.data.item.data;
-
-			if (itemData && itemData.action && ACTIONS[itemData.action]) {
-				ACTIONS[itemData.action]();
-			}
-		});
-	});
-</script>


### PR DESCRIPTION
Fixes https://issues.liferay.com/browse/LPS-121925

In this PR, we are replacing the three management toolbar usages in wiki-web. In addition, we are fixing default namespace handling in the tag.

Test plan (see in gif):
1. The first management toolbar (nodes) is on Content & Data > Wiki
2. The second management toolbar (pages) is on Content & Data > Wiki > Select a node
3. The third management toolbar:
   1. Create a wiki page sample
   2. Change markup to HTML
   3. Add a link
   4. Right click on link -> Edit Link
   5. Browse Server

Notes:
- Namespace handling follows similar pattern as [v2 implementation](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/soy/base/BaseClayTag.java#L91-L104), with the addition of display context setting overriding default.

@julien @jonmak08 @ambrinchaudhary 

![after](https://user-images.githubusercontent.com/5435511/106606964-07164600-6563-11eb-94ad-ee81d4ca0706.gif)
