### PR TITLE
LPS-124817 Implement cover cropper in react image selector component

### DIFF
--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/image_selector/js/ImageSelector.js
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/image_selector/js/ImageSelector.js
@@ -20,6 +20,7 @@ import DropHereInfo from '../../drop_here_info/js/DropHereInfo';
 import BrowseImage from './BrowseImage';
 import ChangeImageControls from './ChangeImageControls';
 import ErrorAlert from './ErrorAlert';
+import ImageSelectorImage from './ImageSelectorImage';
 import ProgressWrapper from './ProgressWrapper';
 
 const CSS_DROP_ACTIVE = 'drop-active';
@@ -46,11 +47,14 @@ const ImageSelector = ({
 	uploadURL,
 	validExtensions,
 }) => {
+	const isDraggable = draggableImage !== 'none';
+
 	const [image, setImage] = useState({
 		fileEntryId,
 		src: imageURL,
 	});
 
+	const [imageCropRegion, setImageCropRegion] = useState(cropRegion);
 	const [fileName, setFileName] = useState('');
 	const [progressValue, setProgressValue] = useState(0);
 	const [progressData, setProgressData] = useState();
@@ -124,6 +128,10 @@ const ImageSelector = ({
 		},
 		[maxFileSize, validExtensions]
 	);
+
+	const handleImageCropped = (cropRegion) => {
+		setImageCropRegion(JSON.stringify(cropRegion));
+	};
 
 	const handleSelectFileClick = useCallback(() => {
 		Liferay.Util.openSelectionModal({
@@ -309,7 +317,8 @@ const ImageSelector = ({
 		<div
 			className={classNames(
 				'drop-zone',
-				{'draggable-image': draggableImage !== 'none'},
+				{'draggable-image': isDraggable},
+				{[`${draggableImage}`]: isDraggable},
 				{'drop-enabled': image.fileEntryId == 0},
 				'taglib-image-selector'
 			)}
@@ -323,18 +332,17 @@ const ImageSelector = ({
 			<input
 				name={`${portletNamespace}${paramName}CropRegion`}
 				type="hidden"
-				value={cropRegion}
+				value={imageCropRegion}
 			/>
 
 			{image.src && (
-				<div className="image-wrapper">
-					<img
-						alt={Liferay.Language.get('current-image')}
-						className="current-image"
-						id={`${portletNamespace}image`}
-						src={image.src}
-					/>
-				</div>
+				<ImageSelectorImage
+					direction={draggableImage}
+					imageSrc={image.src}
+					isCroppable={isDraggable}
+					onImageCrop={handleImageCropped}
+					portletNamespace={portletNamespace}
+				/>
 			)}
 
 			{image.fileEntryId == 0 && (
@@ -382,7 +390,7 @@ ImageSelector.propTypes = {
 	imageURL: PropTypes.string,
 	itemSelectorEventName: PropTypes.string,
 	itemSelectorURL: PropTypes.string,
-	maxFileSize: PropTypes.number,
+	maxFileSize: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 	paramName: PropTypes.string.isRequired,
 	portletNamespace: PropTypes.string.isRequired,
 	validExtensions: PropTypes.string,

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/image_selector/js/ImageSelectorImage.js
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/image_selector/js/ImageSelectorImage.js
@@ -1,0 +1,177 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import classNames from 'classnames';
+import PropTypes from 'prop-types';
+import React, {useEffect, useRef, useState} from 'react';
+
+const STR_BOTH = 'both';
+const STR_HORIZONTAL = 'horizontal';
+const STR_VERTICAL = 'vertical';
+
+const noop = () => {};
+
+const ImageSelectorImage = ({
+	direction = STR_VERTICAL,
+	imageSrc,
+	isCroppable,
+	onImageCrop = noop,
+	portletNamespace,
+}) => {
+	const containerRef = useRef();
+	const imageRef = useRef();
+
+	const [imagePosition, setImagePosition] = useState({x: 0, y: 0});
+	const [imageRelativePosition, setImageRelativePosition] = useState();
+	const [isDragging, setIsDragging] = useState();
+
+	const getImageStyle = () => {
+		let imageStyle = {};
+
+		if (isCroppable) {
+			imageStyle = {
+				cursor: isDragging ? 'move' : 'unset',
+				left: imagePosition.x,
+				position: 'relative',
+				top: imagePosition.y,
+			};
+		}
+
+		return imageStyle;
+	};
+
+	const handleMouseDown = (event) => {
+		event.stopPropagation();
+		event.preventDefault();
+
+		const imageContainer = containerRef.current;
+		const position = imageContainer.getBoundingClientRect();
+
+		setImageRelativePosition({
+			x: event.pageX - position.left,
+			y: event.pageY - position.top,
+		});
+
+		setIsDragging(true);
+	};
+
+	const handleMouseMove = (event) => {
+		event.stopPropagation();
+		event.preventDefault();
+
+		const imageContainer = containerRef.current;
+		const image = imageRef.current;
+
+		const imageContainerPosition = imageContainer.getBoundingClientRect();
+
+		let horizontalPos = imagePosition.x;
+		let verticalPos = imagePosition.y;
+
+		if (direction === STR_HORIZONTAL || direction === STR_BOTH) {
+			const horizontalDiff =
+				event.pageX -
+				imageContainerPosition.left -
+				imageRelativePosition.x;
+			horizontalPos = horizontalPos + horizontalDiff;
+
+			if (
+				horizontalPos >= 0 ||
+				horizontalPos < imageContainer.offsetWidth - image.offsetWidth
+			) {
+				event.preventDefault();
+
+				return;
+			}
+		}
+
+		if (direction === STR_VERTICAL || direction === STR_BOTH) {
+			const verticalDiff =
+				event.pageY -
+				imageContainerPosition.top -
+				imageRelativePosition.y;
+			verticalPos = verticalPos + verticalDiff;
+
+			if (
+				verticalPos >= 0 ||
+				verticalPos < imageContainer.offsetHeight - image.offsetHeight
+			) {
+				event.preventDefault();
+
+				return;
+			}
+		}
+
+		setImagePosition({
+			x: horizontalPos,
+			y: verticalPos,
+		});
+	};
+
+	const handleMouseUp = (event) => {
+		event.stopPropagation();
+		event.preventDefault();
+
+		setIsDragging(false);
+
+		const cropRegion = Liferay.Util.getCropRegion(imageRef.current, {
+			height: containerRef.current.offsetHeight,
+			x: Math.abs(imagePosition.x),
+			y: Math.abs(imagePosition.y),
+		});
+
+		onImageCrop(cropRegion);
+	};
+
+	useEffect(() => {
+		if (isDragging) {
+			document.addEventListener('mousemove', handleMouseMove);
+			document.addEventListener('mouseup', handleMouseUp);
+		}
+
+		return () => {
+			document.removeEventListener('mousemove', handleMouseMove);
+			document.removeEventListener('mouseup', handleMouseUp);
+		};
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [isDragging]);
+
+	return (
+		<div
+			className={classNames('image-wrapper', {
+				cropper: isCroppable,
+			})}
+			ref={containerRef}
+		>
+			<img
+				alt={Liferay.Language.get('current-image')}
+				className="current-image"
+				id={`${portletNamespace}image`}
+				onMouseDown={handleMouseDown}
+				ref={imageRef}
+				src={imageSrc}
+				style={getImageStyle()}
+			/>
+		</div>
+	);
+};
+
+ImageSelectorImage.propTypes = {
+	direction: PropTypes.string,
+	imageSrc: PropTypes.string.isRequired,
+	isCroppable: PropTypes.bool,
+	onImageCrop: PropTypes.func,
+	portletNamespace: PropTypes.string.isRequired,
+};
+
+export default ImageSelectorImage;


### PR DESCRIPTION
This is a followup of https://github.com/liferay-lima/liferay-portal/pull/1430

This pr adds the cover cropper capability for image selector.

![imageselector](https://user-images.githubusercontent.com/5803434/106641488-903f7400-6587-11eb-825c-12b385c724c1.gif)


Test Plan:

- Go to Content & Data / Blogs
- Go to Blog creation page
- Select an image bigger than the container using the first item selector
- Move the image