### PR TITLE
[TS] LPS-127143

### DIFF
--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
@@ -179,14 +179,6 @@ public class FriendlyURLServlet extends HttpServlet {
 
 			httpServletRequest.setAttribute(WebKeys.LAYOUT, layout);
 
-			if (Objects.equals(
-					httpServletRequest.getRequestURI(),
-					PropsValues.LAYOUT_FRIENDLY_URL_PAGE_NOT_FOUND)) {
-
-				SessionErrors.remove(
-					httpServletRequest, NoSuchLayoutException.class);
-			}
-
 			String layoutFriendlyURLSeparatorCompositeFriendlyURL =
 				layoutFriendlyURLSeparatorComposite.getFriendlyURL();
 

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -6714,18 +6714,21 @@ public class PortalImpl implements Portal {
 			}
 		}
 
+		boolean addSessionError = true;
 		String redirect = null;
 
 		if ((exception instanceof NoSuchGroupException) &&
 			Validator.isNotNull(
 				PropsValues.SITES_FRIENDLY_URL_PAGE_NOT_FOUND)) {
 
+			addSessionError = false;
 			redirect = PropsValues.SITES_FRIENDLY_URL_PAGE_NOT_FOUND;
 		}
 		else if ((exception instanceof NoSuchLayoutException) &&
 				 Validator.isNotNull(
 					 PropsValues.LAYOUT_FRIENDLY_URL_PAGE_NOT_FOUND)) {
 
+			addSessionError = false;
 			redirect = PropsValues.LAYOUT_FRIENDLY_URL_PAGE_NOT_FOUND;
 		}
 		else if (PropsValues.LAYOUT_SHOW_HTTP_STATUS) {
@@ -6762,7 +6765,9 @@ public class PortalImpl implements Portal {
 
 			httpServletResponse.setStatus(status);
 
-			SessionErrors.add(session, exception.getClass(), exception);
+			if (addSessionError) {
+				SessionErrors.add(session, exception.getClass(), exception);
+			}
 
 			ServletContext servletContext = session.getServletContext();
 


### PR DESCRIPTION
[LPS-127143](https://issues.liferay.com/browse/LPS-127143)

From @jesseyeh-liferay:

> After being redirected to a custom 404 .jsp page, a `NoSuchLayoutException`/`NoSuchGroupException` session error is added. As a result, when navigating back to a previous page, a corresponding error is shown.
> 
> Instead of removing the session error after the 404 resolves (see [LPS-123054](https://github.com/liferay-lima/liferay-portal/pull/1133/commits/ab5aa5a4a7757d0909bd7e406d762ed30df612f7)), this solution avoids adding the session error to begin with in the event of a redirect to a custom 404 page.