### PR TITLE
LPS-127252 Add external reference code to MBMessage

### DIFF
--- a/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/exception/DuplicateExternalReferenceCodeException.java
+++ b/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/exception/DuplicateExternalReferenceCodeException.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.message.boards.exception;
+
+import com.liferay.portal.kernel.exception.PortalException;
+
+/**
+ * @author Javier de Arcos
+ */
+public class DuplicateExternalReferenceCodeException extends PortalException {
+
+	public DuplicateExternalReferenceCodeException() {
+	}
+
+	public DuplicateExternalReferenceCodeException(String msg) {
+		super(msg);
+	}
+
+	public DuplicateExternalReferenceCodeException(
+		String msg, Throwable throwable) {
+
+		super(msg, throwable);
+	}
+
+	public DuplicateExternalReferenceCodeException(Throwable throwable) {
+		super(throwable);
+	}
+
+}

--- a/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/model/MBMessageModel.java
+++ b/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/model/MBMessageModel.java
@@ -117,6 +117,21 @@ public interface MBMessageModel
 	public void setUuid(String uuid);
 
 	/**
+	 * Returns the external reference code of this message-boards message.
+	 *
+	 * @return the external reference code of this message-boards message
+	 */
+	@AutoEscape
+	public String getExternalReferenceCode();
+
+	/**
+	 * Sets the external reference code of this message-boards message.
+	 *
+	 * @param externalReferenceCode the external reference code of this message-boards message
+	 */
+	public void setExternalReferenceCode(String externalReferenceCode);
+
+	/**
 	 * Returns the message ID of this message-boards message.
 	 *
 	 * @return the message ID of this message-boards message

--- a/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/model/MBMessageSoap.java
+++ b/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/model/MBMessageSoap.java
@@ -36,6 +36,7 @@ public class MBMessageSoap implements Serializable {
 		soapModel.setMvccVersion(model.getMvccVersion());
 		soapModel.setCtCollectionId(model.getCtCollectionId());
 		soapModel.setUuid(model.getUuid());
+		soapModel.setExternalReferenceCode(model.getExternalReferenceCode());
 		soapModel.setMessageId(model.getMessageId());
 		soapModel.setGroupId(model.getGroupId());
 		soapModel.setCompanyId(model.getCompanyId());
@@ -138,6 +139,14 @@ public class MBMessageSoap implements Serializable {
 
 	public void setUuid(String uuid) {
 		_uuid = uuid;
+	}
+
+	public String getExternalReferenceCode() {
+		return _externalReferenceCode;
+	}
+
+	public void setExternalReferenceCode(String externalReferenceCode) {
+		_externalReferenceCode = externalReferenceCode;
 	}
 
 	public long getMessageId() {
@@ -371,6 +380,7 @@ public class MBMessageSoap implements Serializable {
 	private long _mvccVersion;
 	private long _ctCollectionId;
 	private String _uuid;
+	private String _externalReferenceCode;
 	private long _messageId;
 	private long _groupId;
 	private long _companyId;

--- a/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/model/MBMessageTable.java
+++ b/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/model/MBMessageTable.java
@@ -39,6 +39,10 @@ public class MBMessageTable extends BaseTable<MBMessageTable> {
 		"ctCollectionId", Long.class, Types.BIGINT, Column.FLAG_PRIMARY);
 	public final Column<MBMessageTable, String> uuid = createColumn(
 		"uuid_", String.class, Types.VARCHAR, Column.FLAG_DEFAULT);
+	public final Column<MBMessageTable, String> externalReferenceCode =
+		createColumn(
+			"externalReferenceCode", String.class, Types.VARCHAR,
+			Column.FLAG_DEFAULT);
 	public final Column<MBMessageTable, Long> messageId = createColumn(
 		"messageId", Long.class, Types.BIGINT, Column.FLAG_PRIMARY);
 	public final Column<MBMessageTable, Long> groupId = createColumn(

--- a/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/model/MBMessageWrapper.java
+++ b/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/model/MBMessageWrapper.java
@@ -48,6 +48,7 @@ public class MBMessageWrapper
 		attributes.put("mvccVersion", getMvccVersion());
 		attributes.put("ctCollectionId", getCtCollectionId());
 		attributes.put("uuid", getUuid());
+		attributes.put("externalReferenceCode", getExternalReferenceCode());
 		attributes.put("messageId", getMessageId());
 		attributes.put("groupId", getGroupId());
 		attributes.put("companyId", getCompanyId());
@@ -97,6 +98,13 @@ public class MBMessageWrapper
 
 		if (uuid != null) {
 			setUuid(uuid);
+		}
+
+		String externalReferenceCode = (String)attributes.get(
+			"externalReferenceCode");
+
+		if (externalReferenceCode != null) {
+			setExternalReferenceCode(externalReferenceCode);
 		}
 
 		Long messageId = (Long)attributes.get("messageId");
@@ -455,6 +463,16 @@ public class MBMessageWrapper
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return model.getDeletedAttachmentsFileEntriesCount();
+	}
+
+	/**
+	 * Returns the external reference code of this message-boards message.
+	 *
+	 * @return the external reference code of this message-boards message
+	 */
+	@Override
+	public String getExternalReferenceCode() {
+		return model.getExternalReferenceCode();
 	}
 
 	/**
@@ -1013,6 +1031,16 @@ public class MBMessageWrapper
 	@Override
 	public void setCtCollectionId(long ctCollectionId) {
 		model.setCtCollectionId(ctCollectionId);
+	}
+
+	/**
+	 * Sets the external reference code of this message-boards message.
+	 *
+	 * @param externalReferenceCode the external reference code of this message-boards message
+	 */
+	@Override
+	public void setExternalReferenceCode(String externalReferenceCode) {
+		model.setExternalReferenceCode(externalReferenceCode);
 	}
 
 	/**

--- a/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/service/MBMessageLocalService.java
+++ b/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/service/MBMessageLocalService.java
@@ -316,6 +316,17 @@ public interface MBMessageLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public MBMessage fetchMBMessage(long messageId);
 
+	/**
+	 * Returns the message-boards message with the matching external reference code and group.
+	 *
+	 * @param groupId the primary key of the group
+	 * @param externalReferenceCode the message-boards message's external reference code
+	 * @return the matching message-boards message, or <code>null</code> if a matching message-boards message could not be found
+	 */
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public MBMessage fetchMBMessageByReferenceCode(
+		long groupId, String externalReferenceCode);
+
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public MBMessage fetchMBMessageByUrlSubject(
 		long groupId, String urlSubject);

--- a/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/service/MBMessageLocalServiceUtil.java
+++ b/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/service/MBMessageLocalServiceUtil.java
@@ -421,6 +421,21 @@ public class MBMessageLocalServiceUtil {
 		return getService().fetchMBMessage(messageId);
 	}
 
+	/**
+	 * Returns the message-boards message with the matching external reference code and group.
+	 *
+	 * @param groupId the primary key of the group
+	 * @param externalReferenceCode the message-boards message's external reference code
+	 * @return the matching message-boards message, or <code>null</code> if a matching message-boards message could not be found
+	 */
+	public static com.liferay.message.boards.model.MBMessage
+		fetchMBMessageByReferenceCode(
+			long groupId, String externalReferenceCode) {
+
+		return getService().fetchMBMessageByReferenceCode(
+			groupId, externalReferenceCode);
+	}
+
 	public static com.liferay.message.boards.model.MBMessage
 		fetchMBMessageByUrlSubject(long groupId, String urlSubject) {
 

--- a/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/service/MBMessageLocalServiceWrapper.java
+++ b/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/service/MBMessageLocalServiceWrapper.java
@@ -436,6 +436,21 @@ public class MBMessageLocalServiceWrapper
 		return _mbMessageLocalService.fetchMBMessage(messageId);
 	}
 
+	/**
+	 * Returns the message-boards message with the matching external reference code and group.
+	 *
+	 * @param groupId the primary key of the group
+	 * @param externalReferenceCode the message-boards message's external reference code
+	 * @return the matching message-boards message, or <code>null</code> if a matching message-boards message could not be found
+	 */
+	@Override
+	public MBMessage fetchMBMessageByReferenceCode(
+		long groupId, String externalReferenceCode) {
+
+		return _mbMessageLocalService.fetchMBMessageByReferenceCode(
+			groupId, externalReferenceCode);
+	}
+
 	@Override
 	public MBMessage fetchMBMessageByUrlSubject(
 		long groupId, String urlSubject) {

--- a/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/service/persistence/MBMessagePersistence.java
+++ b/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/service/persistence/MBMessagePersistence.java
@@ -5522,6 +5522,56 @@ public interface MBMessagePersistence
 		long userId, long classNameId, long classPK, int status);
 
 	/**
+	 * Returns the message-boards message where groupId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchMessageException</code> if it could not be found.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the matching message-boards message
+	 * @throws NoSuchMessageException if a matching message-boards message could not be found
+	 */
+	public MBMessage findByG_ERC(long groupId, String externalReferenceCode)
+		throws NoSuchMessageException;
+
+	/**
+	 * Returns the message-boards message where groupId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the matching message-boards message, or <code>null</code> if a matching message-boards message could not be found
+	 */
+	public MBMessage fetchByG_ERC(long groupId, String externalReferenceCode);
+
+	/**
+	 * Returns the message-boards message where groupId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the matching message-boards message, or <code>null</code> if a matching message-boards message could not be found
+	 */
+	public MBMessage fetchByG_ERC(
+		long groupId, String externalReferenceCode, boolean useFinderCache);
+
+	/**
+	 * Removes the message-boards message where groupId = &#63; and externalReferenceCode = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the message-boards message that was removed
+	 */
+	public MBMessage removeByG_ERC(long groupId, String externalReferenceCode)
+		throws NoSuchMessageException;
+
+	/**
+	 * Returns the number of message-boards messages where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the number of matching message-boards messages
+	 */
+	public int countByG_ERC(long groupId, String externalReferenceCode);
+
+	/**
 	 * Caches the message-boards message in the entity cache if it is enabled.
 	 *
 	 * @param mbMessage the message-boards message

--- a/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/service/persistence/MBMessageUtil.java
+++ b/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/service/persistence/MBMessageUtil.java
@@ -6687,6 +6687,74 @@ public class MBMessageUtil {
 	}
 
 	/**
+	 * Returns the message-boards message where groupId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchMessageException</code> if it could not be found.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the matching message-boards message
+	 * @throws NoSuchMessageException if a matching message-boards message could not be found
+	 */
+	public static MBMessage findByG_ERC(
+			long groupId, String externalReferenceCode)
+		throws com.liferay.message.boards.exception.NoSuchMessageException {
+
+		return getPersistence().findByG_ERC(groupId, externalReferenceCode);
+	}
+
+	/**
+	 * Returns the message-boards message where groupId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the matching message-boards message, or <code>null</code> if a matching message-boards message could not be found
+	 */
+	public static MBMessage fetchByG_ERC(
+		long groupId, String externalReferenceCode) {
+
+		return getPersistence().fetchByG_ERC(groupId, externalReferenceCode);
+	}
+
+	/**
+	 * Returns the message-boards message where groupId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the matching message-boards message, or <code>null</code> if a matching message-boards message could not be found
+	 */
+	public static MBMessage fetchByG_ERC(
+		long groupId, String externalReferenceCode, boolean useFinderCache) {
+
+		return getPersistence().fetchByG_ERC(
+			groupId, externalReferenceCode, useFinderCache);
+	}
+
+	/**
+	 * Removes the message-boards message where groupId = &#63; and externalReferenceCode = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the message-boards message that was removed
+	 */
+	public static MBMessage removeByG_ERC(
+			long groupId, String externalReferenceCode)
+		throws com.liferay.message.boards.exception.NoSuchMessageException {
+
+		return getPersistence().removeByG_ERC(groupId, externalReferenceCode);
+	}
+
+	/**
+	 * Returns the number of message-boards messages where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the number of matching message-boards messages
+	 */
+	public static int countByG_ERC(long groupId, String externalReferenceCode) {
+		return getPersistence().countByG_ERC(groupId, externalReferenceCode);
+	}
+
+	/**
 	 * Caches the message-boards message in the entity cache if it is enabled.
 	 *
 	 * @param mbMessage the message-boards message

--- a/modules/apps/message-boards/message-boards-api/src/main/resources/com/liferay/message/boards/exception/packageinfo
+++ b/modules/apps/message-boards/message-boards-api/src/main/resources/com/liferay/message/boards/exception/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.2
+version 1.1.0

--- a/modules/apps/message-boards/message-boards-api/src/main/resources/com/liferay/message/boards/model/packageinfo
+++ b/modules/apps/message-boards/message-boards-api/src/main/resources/com/liferay/message/boards/model/packageinfo
@@ -1,1 +1,1 @@
-version 5.0.0
+version 5.1.0

--- a/modules/apps/message-boards/message-boards-api/src/main/resources/com/liferay/message/boards/service/packageinfo
+++ b/modules/apps/message-boards/message-boards-api/src/main/resources/com/liferay/message/boards/service/packageinfo
@@ -1,1 +1,1 @@
-version 4.0.0
+version 4.1.0

--- a/modules/apps/message-boards/message-boards-api/src/main/resources/com/liferay/message/boards/service/persistence/packageinfo
+++ b/modules/apps/message-boards/message-boards-api/src/main/resources/com/liferay/message/boards/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 4.0.0
+version 4.1.0

--- a/modules/apps/message-boards/message-boards-service/bnd.bnd
+++ b/modules/apps/message-boards/message-boards-service/bnd.bnd
@@ -5,6 +5,6 @@ Import-Package:\
 	com.liferay.portal.kernel.search;version="[8.1.0,9.5.0)",\
 	\
 	*
-Liferay-Require-SchemaVersion: 5.1.0
+Liferay-Require-SchemaVersion: 5.2.0
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/message-boards/message-boards-service/service.xml
+++ b/modules/apps/message-boards/message-boards-service/service.xml
@@ -218,7 +218,7 @@
 			<finder-column name="categoryId" />
 		</finder>
 	</entity>
-	<entity human-name="message-boards message" local-service="true" name="MBMessage" remote-service="true" trash-enabled="true" uuid="true">
+	<entity external-reference-code="group" human-name="message-boards message" local-service="true" name="MBMessage" remote-service="true" trash-enabled="true" uuid="true">
 
 		<!-- PK fields -->
 

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/exportimport/data/handler/MBMessageStagedModelDataHandler.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/exportimport/data/handler/MBMessageStagedModelDataHandler.java
@@ -290,6 +290,9 @@ public class MBMessageStagedModelDataHandler
 			ServiceContext serviceContext =
 				portletDataContext.createServiceContext(message);
 
+			serviceContext.setAttribute(
+				"externalReferenceCode", message.getExternalReferenceCode());
+
 			MBMessage importedMessage = null;
 
 			if (portletDataContext.isDataStrategyMirror()) {

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/upgrade/MBServiceUpgrade.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/upgrade/MBServiceUpgrade.java
@@ -31,6 +31,7 @@ import com.liferay.message.boards.internal.upgrade.v4_0_0.UpgradeMBCategoryLastP
 import com.liferay.message.boards.internal.upgrade.v4_0_0.UpgradeMBCategoryMessageCount;
 import com.liferay.message.boards.internal.upgrade.v4_0_0.UpgradeMBCategoryThreadCount;
 import com.liferay.message.boards.internal.upgrade.v5_0_0.UpgradeMBThreadMessageCount;
+import com.liferay.message.boards.internal.upgrade.v5_2_0.UpgradeMBMessageExternalReferenceCode;
 import com.liferay.message.boards.model.MBThread;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
@@ -105,6 +106,9 @@ public class MBServiceUpgrade implements UpgradeStepRegistrator {
 			new UpgradeCTModel(
 				"MBBan", "MBCategory", "MBDiscussion", "MBMailingList",
 				"MBMessage", "MBStatsUser", "MBThread", "MBThreadFlag"));
+
+		registry.register(
+			"5.1.0", "5.2.0", new UpgradeMBMessageExternalReferenceCode());
 	}
 
 	@Reference

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/upgrade/v5_2_0/UpgradeMBMessageExternalReferenceCode.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/upgrade/v5_2_0/UpgradeMBMessageExternalReferenceCode.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.message.boards.internal.upgrade.v5_2_0;
+
+import com.liferay.message.boards.internal.upgrade.v5_2_0.util.MBMessageTable;
+import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+/**
+ * @author Javier de Arcos
+ */
+public class UpgradeMBMessageExternalReferenceCode extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		if (!hasColumn("MBMessage", "externalReferenceCode")) {
+			alter(
+				MBMessageTable.class,
+				new AlterTableAddColumn(
+					"externalReferenceCode", "VARCHAR(75)"));
+		}
+
+		_populateExternalReferenceCode();
+	}
+
+	private void _populateExternalReferenceCode() throws Exception {
+		try (PreparedStatement ps1 = connection.prepareStatement(
+				"select messageId, externalReferenceCode from MBMessage " +
+					"where (externalReferenceCode is null) or " +
+						"(externalReferenceCode = '')");
+			ResultSet rs = ps1.executeQuery();
+			PreparedStatement ps2 = AutoBatchPreparedStatementUtil.autoBatch(
+				connection.prepareStatement(
+					"update MBMessage set externalReferenceCode = ? where " +
+						"messageId = ?"))) {
+
+			while (rs.next()) {
+				long messageId = rs.getLong(1);
+
+				ps2.setString(1, String.valueOf(messageId));
+
+				ps2.setLong(2, messageId);
+
+				ps2.addBatch();
+			}
+
+			ps2.executeBatch();
+		}
+	}
+
+}

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/upgrade/v5_2_0/util/MBMessageTable.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/upgrade/v5_2_0/util/MBMessageTable.java
@@ -1,0 +1,153 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.message.boards.internal.upgrade.v5_2_0.util;
+
+import java.sql.Types;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author	  Javier de Arcos
+ * @generated
+ */
+public class MBMessageTable {
+
+	public static final String TABLE_NAME = "MBMessage";
+
+	public static final Object[][] TABLE_COLUMNS = {
+		{"mvccVersion", Types.BIGINT}, {"ctCollectionId", Types.BIGINT},
+		{"uuid_", Types.VARCHAR}, {"externalReferenceCode", Types.VARCHAR},
+		{"messageId", Types.BIGINT}, {"groupId", Types.BIGINT},
+		{"companyId", Types.BIGINT}, {"userId", Types.BIGINT},
+		{"userName", Types.VARCHAR}, {"createDate", Types.TIMESTAMP},
+		{"modifiedDate", Types.TIMESTAMP}, {"classNameId", Types.BIGINT},
+		{"classPK", Types.BIGINT}, {"categoryId", Types.BIGINT},
+		{"threadId", Types.BIGINT}, {"rootMessageId", Types.BIGINT},
+		{"parentMessageId", Types.BIGINT}, {"treePath", Types.VARCHAR},
+		{"subject", Types.VARCHAR}, {"urlSubject", Types.VARCHAR},
+		{"body", Types.CLOB}, {"format", Types.VARCHAR},
+		{"anonymous", Types.BOOLEAN}, {"priority", Types.DOUBLE},
+		{"allowPingbacks", Types.BOOLEAN}, {"answer", Types.BOOLEAN},
+		{"lastPublishDate", Types.TIMESTAMP}, {"status", Types.INTEGER},
+		{"statusByUserId", Types.BIGINT}, {"statusByUserName", Types.VARCHAR},
+		{"statusDate", Types.TIMESTAMP}
+	};
+
+	public static final Map<String, Integer> TABLE_COLUMNS_MAP =
+new HashMap<String, Integer>();
+
+static {
+TABLE_COLUMNS_MAP.put("mvccVersion", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("ctCollectionId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("uuid_", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("externalReferenceCode", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("messageId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("createDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("modifiedDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("classNameId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("classPK", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("categoryId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("threadId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("rootMessageId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("parentMessageId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("treePath", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("subject", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("urlSubject", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("body", Types.CLOB);
+
+TABLE_COLUMNS_MAP.put("format", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("anonymous", Types.BOOLEAN);
+
+TABLE_COLUMNS_MAP.put("priority", Types.DOUBLE);
+
+TABLE_COLUMNS_MAP.put("allowPingbacks", Types.BOOLEAN);
+
+TABLE_COLUMNS_MAP.put("answer", Types.BOOLEAN);
+
+TABLE_COLUMNS_MAP.put("lastPublishDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("status", Types.INTEGER);
+
+TABLE_COLUMNS_MAP.put("statusByUserId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("statusByUserName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("statusDate", Types.TIMESTAMP);
+
+}
+	public static final String TABLE_SQL_CREATE =
+"create table MBMessage (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,messageId LONG not null,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,classNameId LONG,classPK LONG,categoryId LONG,threadId LONG,rootMessageId LONG,parentMessageId LONG,treePath STRING null,subject VARCHAR(75) null,urlSubject VARCHAR(255) null,body TEXT null,format VARCHAR(75) null,anonymous BOOLEAN,priority DOUBLE,allowPingbacks BOOLEAN,answer BOOLEAN,lastPublishDate DATE null,status INTEGER,statusByUserId LONG,statusByUserName VARCHAR(75) null,statusDate DATE null,primary key (messageId, ctCollectionId))";
+
+	public static final String TABLE_SQL_DROP = "drop table MBMessage";
+
+	public static final String[] TABLE_SQL_ADD_INDEXES = {
+		"create index IX_860370AB on MBMessage (classNameId, classPK, ctCollectionId)",
+		"create index IX_19FE8691 on MBMessage (classNameId, classPK, status, ctCollectionId)",
+		"create index IX_5C8DA38E on MBMessage (companyId, ctCollectionId)",
+		"create index IX_9CE52674 on MBMessage (companyId, status, ctCollectionId)",
+		"create index IX_F0A963FD on MBMessage (groupId, categoryId, ctCollectionId)",
+		"create index IX_82ED07E3 on MBMessage (groupId, categoryId, status, ctCollectionId)",
+		"create index IX_AAAD4168 on MBMessage (groupId, categoryId, threadId, answer, ctCollectionId)",
+		"create index IX_158DD1B6 on MBMessage (groupId, categoryId, threadId, ctCollectionId)",
+		"create index IX_CC88AC9C on MBMessage (groupId, categoryId, threadId, status, ctCollectionId)",
+		"create index IX_A3E7210 on MBMessage (groupId, ctCollectionId)",
+		"create index IX_7BEA05A9 on MBMessage (groupId, externalReferenceCode[$COLUMN_LENGTH:75$], ctCollectionId)",
+		"create index IX_F6A852F6 on MBMessage (groupId, status, ctCollectionId)",
+		"create unique index IX_8813E901 on MBMessage (groupId, urlSubject[$COLUMN_LENGTH:255$], ctCollectionId)",
+		"create index IX_C892444A on MBMessage (groupId, userId, ctCollectionId)",
+		"create index IX_6C8B4B30 on MBMessage (groupId, userId, status, ctCollectionId)",
+		"create index IX_D6EAC68E on MBMessage (parentMessageId, ctCollectionId)",
+		"create index IX_C56F4974 on MBMessage (parentMessageId, status, ctCollectionId)",
+		"create index IX_E84A6B81 on MBMessage (threadId, answer, ctCollectionId)",
+		"create index IX_297F24CF on MBMessage (threadId, ctCollectionId)",
+		"create index IX_7A7FD535 on MBMessage (threadId, parentMessageId, ctCollectionId)",
+		"create index IX_A25D6B5 on MBMessage (threadId, status, ctCollectionId)",
+		"create index IX_93815565 on MBMessage (userId, classNameId, classPK, ctCollectionId)",
+		"create index IX_711114B on MBMessage (userId, classNameId, classPK, status, ctCollectionId)",
+		"create index IX_8B146CBA on MBMessage (userId, classNameId, ctCollectionId)",
+		"create index IX_1C5603A0 on MBMessage (userId, classNameId, status, ctCollectionId)",
+		"create index IX_3F043E90 on MBMessage (userId, ctCollectionId)",
+		"create index IX_F6B01E4A on MBMessage (uuid_[$COLUMN_LENGTH:75$], companyId, ctCollectionId)",
+		"create index IX_DAB8F51A on MBMessage (uuid_[$COLUMN_LENGTH:75$], ctCollectionId)",
+		"create unique index IX_EAF86BCC on MBMessage (uuid_[$COLUMN_LENGTH:75$], groupId, ctCollectionId)"
+	};
+
+}

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/model/impl/MBMessageCacheModel.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/model/impl/MBMessageCacheModel.java
@@ -76,7 +76,7 @@ public class MBMessageCacheModel
 
 	@Override
 	public String toString() {
-		StringBundler sb = new StringBundler(61);
+		StringBundler sb = new StringBundler(63);
 
 		sb.append("{mvccVersion=");
 		sb.append(mvccVersion);
@@ -84,6 +84,8 @@ public class MBMessageCacheModel
 		sb.append(ctCollectionId);
 		sb.append(", uuid=");
 		sb.append(uuid);
+		sb.append(", externalReferenceCode=");
+		sb.append(externalReferenceCode);
 		sb.append(", messageId=");
 		sb.append(messageId);
 		sb.append(", groupId=");
@@ -155,6 +157,13 @@ public class MBMessageCacheModel
 		}
 		else {
 			mbMessageImpl.setUuid(uuid);
+		}
+
+		if (externalReferenceCode == null) {
+			mbMessageImpl.setExternalReferenceCode("");
+		}
+		else {
+			mbMessageImpl.setExternalReferenceCode(externalReferenceCode);
 		}
 
 		mbMessageImpl.setMessageId(messageId);
@@ -267,6 +276,7 @@ public class MBMessageCacheModel
 
 		ctCollectionId = objectInput.readLong();
 		uuid = objectInput.readUTF();
+		externalReferenceCode = objectInput.readUTF();
 
 		messageId = objectInput.readLong();
 
@@ -323,6 +333,13 @@ public class MBMessageCacheModel
 		}
 		else {
 			objectOutput.writeUTF(uuid);
+		}
+
+		if (externalReferenceCode == null) {
+			objectOutput.writeUTF("");
+		}
+		else {
+			objectOutput.writeUTF(externalReferenceCode);
 		}
 
 		objectOutput.writeLong(messageId);
@@ -416,6 +433,7 @@ public class MBMessageCacheModel
 	public long mvccVersion;
 	public long ctCollectionId;
 	public String uuid;
+	public String externalReferenceCode;
 	public long messageId;
 	public long groupId;
 	public long companyId;

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/model/impl/MBMessageModelImpl.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/model/impl/MBMessageModelImpl.java
@@ -81,20 +81,21 @@ public class MBMessageModelImpl
 
 	public static final Object[][] TABLE_COLUMNS = {
 		{"mvccVersion", Types.BIGINT}, {"ctCollectionId", Types.BIGINT},
-		{"uuid_", Types.VARCHAR}, {"messageId", Types.BIGINT},
-		{"groupId", Types.BIGINT}, {"companyId", Types.BIGINT},
-		{"userId", Types.BIGINT}, {"userName", Types.VARCHAR},
-		{"createDate", Types.TIMESTAMP}, {"modifiedDate", Types.TIMESTAMP},
-		{"classNameId", Types.BIGINT}, {"classPK", Types.BIGINT},
-		{"categoryId", Types.BIGINT}, {"threadId", Types.BIGINT},
-		{"rootMessageId", Types.BIGINT}, {"parentMessageId", Types.BIGINT},
-		{"treePath", Types.VARCHAR}, {"subject", Types.VARCHAR},
-		{"urlSubject", Types.VARCHAR}, {"body", Types.CLOB},
-		{"format", Types.VARCHAR}, {"anonymous", Types.BOOLEAN},
-		{"priority", Types.DOUBLE}, {"allowPingbacks", Types.BOOLEAN},
-		{"answer", Types.BOOLEAN}, {"lastPublishDate", Types.TIMESTAMP},
-		{"status", Types.INTEGER}, {"statusByUserId", Types.BIGINT},
-		{"statusByUserName", Types.VARCHAR}, {"statusDate", Types.TIMESTAMP}
+		{"uuid_", Types.VARCHAR}, {"externalReferenceCode", Types.VARCHAR},
+		{"messageId", Types.BIGINT}, {"groupId", Types.BIGINT},
+		{"companyId", Types.BIGINT}, {"userId", Types.BIGINT},
+		{"userName", Types.VARCHAR}, {"createDate", Types.TIMESTAMP},
+		{"modifiedDate", Types.TIMESTAMP}, {"classNameId", Types.BIGINT},
+		{"classPK", Types.BIGINT}, {"categoryId", Types.BIGINT},
+		{"threadId", Types.BIGINT}, {"rootMessageId", Types.BIGINT},
+		{"parentMessageId", Types.BIGINT}, {"treePath", Types.VARCHAR},
+		{"subject", Types.VARCHAR}, {"urlSubject", Types.VARCHAR},
+		{"body", Types.CLOB}, {"format", Types.VARCHAR},
+		{"anonymous", Types.BOOLEAN}, {"priority", Types.DOUBLE},
+		{"allowPingbacks", Types.BOOLEAN}, {"answer", Types.BOOLEAN},
+		{"lastPublishDate", Types.TIMESTAMP}, {"status", Types.INTEGER},
+		{"statusByUserId", Types.BIGINT}, {"statusByUserName", Types.VARCHAR},
+		{"statusDate", Types.TIMESTAMP}
 	};
 
 	public static final Map<String, Integer> TABLE_COLUMNS_MAP =
@@ -104,6 +105,7 @@ public class MBMessageModelImpl
 		TABLE_COLUMNS_MAP.put("mvccVersion", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("ctCollectionId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("uuid_", Types.VARCHAR);
+		TABLE_COLUMNS_MAP.put("externalReferenceCode", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("messageId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
@@ -134,7 +136,7 @@ public class MBMessageModelImpl
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table MBMessage (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,uuid_ VARCHAR(75) null,messageId LONG not null,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,classNameId LONG,classPK LONG,categoryId LONG,threadId LONG,rootMessageId LONG,parentMessageId LONG,treePath STRING null,subject VARCHAR(75) null,urlSubject VARCHAR(255) null,body TEXT null,format VARCHAR(75) null,anonymous BOOLEAN,priority DOUBLE,allowPingbacks BOOLEAN,answer BOOLEAN,lastPublishDate DATE null,status INTEGER,statusByUserId LONG,statusByUserName VARCHAR(75) null,statusDate DATE null,primary key (messageId, ctCollectionId))";
+		"create table MBMessage (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,messageId LONG not null,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,classNameId LONG,classPK LONG,categoryId LONG,threadId LONG,rootMessageId LONG,parentMessageId LONG,treePath STRING null,subject VARCHAR(75) null,urlSubject VARCHAR(255) null,body TEXT null,format VARCHAR(75) null,anonymous BOOLEAN,priority DOUBLE,allowPingbacks BOOLEAN,answer BOOLEAN,lastPublishDate DATE null,status INTEGER,statusByUserId LONG,statusByUserName VARCHAR(75) null,statusDate DATE null,primary key (messageId, ctCollectionId))";
 
 	public static final String TABLE_SQL_DROP = "drop table MBMessage";
 
@@ -184,57 +186,63 @@ public class MBMessageModelImpl
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)
 	 */
 	@Deprecated
-	public static final long GROUPID_COLUMN_BITMASK = 32L;
+	public static final long EXTERNALREFERENCECODE_COLUMN_BITMASK = 32L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)
 	 */
 	@Deprecated
-	public static final long PARENTMESSAGEID_COLUMN_BITMASK = 64L;
+	public static final long GROUPID_COLUMN_BITMASK = 64L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)
 	 */
 	@Deprecated
-	public static final long STATUS_COLUMN_BITMASK = 128L;
+	public static final long PARENTMESSAGEID_COLUMN_BITMASK = 128L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)
 	 */
 	@Deprecated
-	public static final long THREADID_COLUMN_BITMASK = 256L;
+	public static final long STATUS_COLUMN_BITMASK = 256L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)
 	 */
 	@Deprecated
-	public static final long URLSUBJECT_COLUMN_BITMASK = 512L;
+	public static final long THREADID_COLUMN_BITMASK = 512L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)
 	 */
 	@Deprecated
-	public static final long USERID_COLUMN_BITMASK = 1024L;
+	public static final long URLSUBJECT_COLUMN_BITMASK = 1024L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)
 	 */
 	@Deprecated
-	public static final long UUID_COLUMN_BITMASK = 2048L;
+	public static final long USERID_COLUMN_BITMASK = 2048L;
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)
+	 */
+	@Deprecated
+	public static final long UUID_COLUMN_BITMASK = 4096L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
 	 *		#getColumnBitmask(String)
 	 */
 	@Deprecated
-	public static final long CREATEDATE_COLUMN_BITMASK = 4096L;
+	public static final long CREATEDATE_COLUMN_BITMASK = 8192L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
 	 *		#getColumnBitmask(String)
 	 */
 	@Deprecated
-	public static final long MESSAGEID_COLUMN_BITMASK = 8192L;
+	public static final long MESSAGEID_COLUMN_BITMASK = 16384L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
@@ -268,6 +276,7 @@ public class MBMessageModelImpl
 		model.setMvccVersion(soapModel.getMvccVersion());
 		model.setCtCollectionId(soapModel.getCtCollectionId());
 		model.setUuid(soapModel.getUuid());
+		model.setExternalReferenceCode(soapModel.getExternalReferenceCode());
 		model.setMessageId(soapModel.getMessageId());
 		model.setGroupId(soapModel.getGroupId());
 		model.setCompanyId(soapModel.getCompanyId());
@@ -456,6 +465,11 @@ public class MBMessageModelImpl
 		attributeGetterFunctions.put("uuid", MBMessage::getUuid);
 		attributeSetterBiConsumers.put(
 			"uuid", (BiConsumer<MBMessage, String>)MBMessage::setUuid);
+		attributeGetterFunctions.put(
+			"externalReferenceCode", MBMessage::getExternalReferenceCode);
+		attributeSetterBiConsumers.put(
+			"externalReferenceCode",
+			(BiConsumer<MBMessage, String>)MBMessage::setExternalReferenceCode);
 		attributeGetterFunctions.put("messageId", MBMessage::getMessageId);
 		attributeSetterBiConsumers.put(
 			"messageId", (BiConsumer<MBMessage, Long>)MBMessage::setMessageId);
@@ -621,6 +635,35 @@ public class MBMessageModelImpl
 	@Deprecated
 	public String getOriginalUuid() {
 		return getColumnOriginalValue("uuid_");
+	}
+
+	@JSON
+	@Override
+	public String getExternalReferenceCode() {
+		if (_externalReferenceCode == null) {
+			return "";
+		}
+		else {
+			return _externalReferenceCode;
+		}
+	}
+
+	@Override
+	public void setExternalReferenceCode(String externalReferenceCode) {
+		if (_columnOriginalValues == Collections.EMPTY_MAP) {
+			_setColumnOriginalValues();
+		}
+
+		_externalReferenceCode = externalReferenceCode;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #getColumnOriginalValue(String)}
+	 */
+	@Deprecated
+	public String getOriginalExternalReferenceCode() {
+		return getColumnOriginalValue("externalReferenceCode");
 	}
 
 	@JSON
@@ -1534,6 +1577,7 @@ public class MBMessageModelImpl
 		mbMessageImpl.setMvccVersion(getMvccVersion());
 		mbMessageImpl.setCtCollectionId(getCtCollectionId());
 		mbMessageImpl.setUuid(getUuid());
+		mbMessageImpl.setExternalReferenceCode(getExternalReferenceCode());
 		mbMessageImpl.setMessageId(getMessageId());
 		mbMessageImpl.setGroupId(getGroupId());
 		mbMessageImpl.setCompanyId(getCompanyId());
@@ -1662,6 +1706,17 @@ public class MBMessageModelImpl
 
 		if ((uuid != null) && (uuid.length() == 0)) {
 			mbMessageCacheModel.uuid = null;
+		}
+
+		mbMessageCacheModel.externalReferenceCode = getExternalReferenceCode();
+
+		String externalReferenceCode =
+			mbMessageCacheModel.externalReferenceCode;
+
+		if ((externalReferenceCode != null) &&
+			(externalReferenceCode.length() == 0)) {
+
+			mbMessageCacheModel.externalReferenceCode = null;
 		}
 
 		mbMessageCacheModel.messageId = getMessageId();
@@ -1864,6 +1919,7 @@ public class MBMessageModelImpl
 	private long _mvccVersion;
 	private long _ctCollectionId;
 	private String _uuid;
+	private String _externalReferenceCode;
 	private long _messageId;
 	private long _groupId;
 	private long _companyId;
@@ -1925,6 +1981,8 @@ public class MBMessageModelImpl
 		_columnOriginalValues.put("mvccVersion", _mvccVersion);
 		_columnOriginalValues.put("ctCollectionId", _ctCollectionId);
 		_columnOriginalValues.put("uuid_", _uuid);
+		_columnOriginalValues.put(
+			"externalReferenceCode", _externalReferenceCode);
 		_columnOriginalValues.put("messageId", _messageId);
 		_columnOriginalValues.put("groupId", _groupId);
 		_columnOriginalValues.put("companyId", _companyId);
@@ -1981,59 +2039,61 @@ public class MBMessageModelImpl
 
 		columnBitmasks.put("uuid_", 4L);
 
-		columnBitmasks.put("messageId", 8L);
+		columnBitmasks.put("externalReferenceCode", 8L);
 
-		columnBitmasks.put("groupId", 16L);
+		columnBitmasks.put("messageId", 16L);
 
-		columnBitmasks.put("companyId", 32L);
+		columnBitmasks.put("groupId", 32L);
 
-		columnBitmasks.put("userId", 64L);
+		columnBitmasks.put("companyId", 64L);
 
-		columnBitmasks.put("userName", 128L);
+		columnBitmasks.put("userId", 128L);
 
-		columnBitmasks.put("createDate", 256L);
+		columnBitmasks.put("userName", 256L);
 
-		columnBitmasks.put("modifiedDate", 512L);
+		columnBitmasks.put("createDate", 512L);
 
-		columnBitmasks.put("classNameId", 1024L);
+		columnBitmasks.put("modifiedDate", 1024L);
 
-		columnBitmasks.put("classPK", 2048L);
+		columnBitmasks.put("classNameId", 2048L);
 
-		columnBitmasks.put("categoryId", 4096L);
+		columnBitmasks.put("classPK", 4096L);
 
-		columnBitmasks.put("threadId", 8192L);
+		columnBitmasks.put("categoryId", 8192L);
 
-		columnBitmasks.put("rootMessageId", 16384L);
+		columnBitmasks.put("threadId", 16384L);
 
-		columnBitmasks.put("parentMessageId", 32768L);
+		columnBitmasks.put("rootMessageId", 32768L);
 
-		columnBitmasks.put("treePath", 65536L);
+		columnBitmasks.put("parentMessageId", 65536L);
 
-		columnBitmasks.put("subject", 131072L);
+		columnBitmasks.put("treePath", 131072L);
 
-		columnBitmasks.put("urlSubject", 262144L);
+		columnBitmasks.put("subject", 262144L);
 
-		columnBitmasks.put("body", 524288L);
+		columnBitmasks.put("urlSubject", 524288L);
 
-		columnBitmasks.put("format", 1048576L);
+		columnBitmasks.put("body", 1048576L);
 
-		columnBitmasks.put("anonymous", 2097152L);
+		columnBitmasks.put("format", 2097152L);
 
-		columnBitmasks.put("priority", 4194304L);
+		columnBitmasks.put("anonymous", 4194304L);
 
-		columnBitmasks.put("allowPingbacks", 8388608L);
+		columnBitmasks.put("priority", 8388608L);
 
-		columnBitmasks.put("answer", 16777216L);
+		columnBitmasks.put("allowPingbacks", 16777216L);
 
-		columnBitmasks.put("lastPublishDate", 33554432L);
+		columnBitmasks.put("answer", 33554432L);
 
-		columnBitmasks.put("status", 67108864L);
+		columnBitmasks.put("lastPublishDate", 67108864L);
 
-		columnBitmasks.put("statusByUserId", 134217728L);
+		columnBitmasks.put("status", 134217728L);
 
-		columnBitmasks.put("statusByUserName", 268435456L);
+		columnBitmasks.put("statusByUserId", 268435456L);
 
-		columnBitmasks.put("statusDate", 536870912L);
+		columnBitmasks.put("statusByUserName", 536870912L);
+
+		columnBitmasks.put("statusDate", 1073741824L);
 
 		_columnBitmasks = Collections.unmodifiableMap(columnBitmasks);
 	}

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/base/MBMessageLocalServiceBaseImpl.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/base/MBMessageLocalServiceBaseImpl.java
@@ -265,6 +265,21 @@ public abstract class MBMessageLocalServiceBaseImpl
 	}
 
 	/**
+	 * Returns the message-boards message with the matching external reference code and group.
+	 *
+	 * @param groupId the primary key of the group
+	 * @param externalReferenceCode the message-boards message's external reference code
+	 * @return the matching message-boards message, or <code>null</code> if a matching message-boards message could not be found
+	 */
+	@Override
+	public MBMessage fetchMBMessageByReferenceCode(
+		long groupId, String externalReferenceCode) {
+
+		return mbMessagePersistence.fetchByG_ERC(
+			groupId, externalReferenceCode);
+	}
+
+	/**
 	 * Returns the message-boards message with the primary key.
 	 *
 	 * @param messageId the primary key of the message-boards message

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBMessageLocalServiceImpl.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBMessageLocalServiceImpl.java
@@ -26,6 +26,7 @@ import com.liferay.message.boards.constants.MBConstants;
 import com.liferay.message.boards.constants.MBMessageConstants;
 import com.liferay.message.boards.constants.MBThreadConstants;
 import com.liferay.message.boards.exception.DiscussionMaxCommentsException;
+import com.liferay.message.boards.exception.DuplicateExternalReferenceCodeException;
 import com.liferay.message.boards.exception.MessageBodyException;
 import com.liferay.message.boards.exception.MessageSubjectException;
 import com.liferay.message.boards.exception.NoSuchThreadException;
@@ -136,6 +137,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 import javax.portlet.PortletRequest;
 import javax.portlet.PortletURL;
@@ -306,6 +308,11 @@ public class MBMessageLocalServiceImpl extends MBMessageLocalServiceBaseImpl {
 
 		long messageId = counterLocalService.increment();
 
+		String externalReferenceCode = _getExternalReferenceCode(
+			messageId, serviceContext);
+
+		_validateExternalReferenceCode(externalReferenceCode, groupId);
+
 		subject = getSubject(subject, body);
 
 		body = getBody(subject, body, format);
@@ -327,6 +334,7 @@ public class MBMessageLocalServiceImpl extends MBMessageLocalServiceBaseImpl {
 
 		MBMessage message = mbMessagePersistence.create(messageId);
 
+		message.setExternalReferenceCode(externalReferenceCode);
 		message.setUuid(serviceContext.getUuid());
 		message.setGroupId(groupId);
 		message.setCompanyId(user.getCompanyId());
@@ -2479,6 +2487,16 @@ public class MBMessageLocalServiceImpl extends MBMessageLocalServiceBaseImpl {
 			new GroupServiceSettingsLocator(groupId, MBConstants.SERVICE_NAME));
 	}
 
+	private String _getExternalReferenceCode(
+		long messageId, ServiceContext serviceContext) {
+
+		return Optional.ofNullable(
+			(String)serviceContext.getAttribute("externalReferenceCode")
+		).orElse(
+			String.valueOf(messageId)
+		);
+	}
+
 	private long _getFileEntryMessageId(long fileEntryId)
 		throws PortalException {
 
@@ -2569,6 +2587,18 @@ public class MBMessageLocalServiceImpl extends MBMessageLocalServiceBaseImpl {
 		throws PortalException {
 
 		MBMessage message = mbMessagePersistence.findByPrimaryKey(messageId);
+
+		String externalReferenceCode = (String)serviceContext.getAttribute(
+			"externalReferenceCode");
+
+		if ((externalReferenceCode != null) &&
+			!StringUtil.equals(
+				externalReferenceCode, message.getExternalReferenceCode())) {
+
+			_validateExternalReferenceCode(externalReferenceCode, messageId);
+
+			message.setExternalReferenceCode(externalReferenceCode);
+		}
 
 		int oldStatus = message.getStatus();
 		String oldSubject = message.getSubject();
@@ -2745,6 +2775,21 @@ public class MBMessageLocalServiceImpl extends MBMessageLocalServiceBaseImpl {
 						extraDataJSONObject.toString(), assetEntry.getUserId());
 				}
 			}
+		}
+	}
+
+	private void _validateExternalReferenceCode(
+			String externalReferenceCode, long groupId)
+		throws PortalException {
+
+		MBMessage messageWithERC = mbMessagePersistence.fetchByG_ERC(
+			groupId, externalReferenceCode);
+
+		if (messageWithERC != null) {
+			throw new DuplicateExternalReferenceCodeException(
+				StringBundler.concat(
+					"Duplicate external reference code ", externalReferenceCode,
+					" in group ", groupId));
 		}
 	}
 

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/persistence/impl/MBMessagePersistenceImpl.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/persistence/impl/MBMessagePersistenceImpl.java
@@ -21128,6 +21128,287 @@ public class MBMessagePersistenceImpl
 	private static final String _FINDER_COLUMN_U_C_C_S_STATUS_2 =
 		"mbMessage.status = ?";
 
+	private FinderPath _finderPathFetchByG_ERC;
+	private FinderPath _finderPathCountByG_ERC;
+
+	/**
+	 * Returns the message-boards message where groupId = &#63; and externalReferenceCode = &#63; or throws a <code>NoSuchMessageException</code> if it could not be found.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the matching message-boards message
+	 * @throws NoSuchMessageException if a matching message-boards message could not be found
+	 */
+	@Override
+	public MBMessage findByG_ERC(long groupId, String externalReferenceCode)
+		throws NoSuchMessageException {
+
+		MBMessage mbMessage = fetchByG_ERC(groupId, externalReferenceCode);
+
+		if (mbMessage == null) {
+			StringBundler sb = new StringBundler(6);
+
+			sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+			sb.append("groupId=");
+			sb.append(groupId);
+
+			sb.append(", externalReferenceCode=");
+			sb.append(externalReferenceCode);
+
+			sb.append("}");
+
+			if (_log.isDebugEnabled()) {
+				_log.debug(sb.toString());
+			}
+
+			throw new NoSuchMessageException(sb.toString());
+		}
+
+		return mbMessage;
+	}
+
+	/**
+	 * Returns the message-boards message where groupId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the matching message-boards message, or <code>null</code> if a matching message-boards message could not be found
+	 */
+	@Override
+	public MBMessage fetchByG_ERC(long groupId, String externalReferenceCode) {
+		return fetchByG_ERC(groupId, externalReferenceCode, true);
+	}
+
+	/**
+	 * Returns the message-boards message where groupId = &#63; and externalReferenceCode = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the matching message-boards message, or <code>null</code> if a matching message-boards message could not be found
+	 */
+	@Override
+	public MBMessage fetchByG_ERC(
+		long groupId, String externalReferenceCode, boolean useFinderCache) {
+
+		externalReferenceCode = Objects.toString(externalReferenceCode, "");
+
+		boolean productionMode = ctPersistenceHelper.isProductionMode(
+			MBMessage.class);
+
+		Object[] finderArgs = null;
+
+		if (useFinderCache && productionMode) {
+			finderArgs = new Object[] {groupId, externalReferenceCode};
+		}
+
+		Object result = null;
+
+		if (useFinderCache && productionMode) {
+			result = finderCache.getResult(_finderPathFetchByG_ERC, finderArgs);
+		}
+
+		if (result instanceof MBMessage) {
+			MBMessage mbMessage = (MBMessage)result;
+
+			if ((groupId != mbMessage.getGroupId()) ||
+				!Objects.equals(
+					externalReferenceCode,
+					mbMessage.getExternalReferenceCode())) {
+
+				result = null;
+			}
+		}
+
+		if (result == null) {
+			StringBundler sb = new StringBundler(4);
+
+			sb.append(_SQL_SELECT_MBMESSAGE_WHERE);
+
+			sb.append(_FINDER_COLUMN_G_ERC_GROUPID_2);
+
+			boolean bindExternalReferenceCode = false;
+
+			if (externalReferenceCode.isEmpty()) {
+				sb.append(_FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_3);
+			}
+			else {
+				bindExternalReferenceCode = true;
+
+				sb.append(_FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_2);
+			}
+
+			String sql = sb.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query query = session.createQuery(sql);
+
+				QueryPos queryPos = QueryPos.getInstance(query);
+
+				queryPos.add(groupId);
+
+				if (bindExternalReferenceCode) {
+					queryPos.add(externalReferenceCode);
+				}
+
+				List<MBMessage> list = query.list();
+
+				if (list.isEmpty()) {
+					if (useFinderCache && productionMode) {
+						finderCache.putResult(
+							_finderPathFetchByG_ERC, finderArgs, list);
+					}
+				}
+				else {
+					if (list.size() > 1) {
+						Collections.sort(list, Collections.reverseOrder());
+
+						if (_log.isWarnEnabled()) {
+							if (!productionMode || !useFinderCache) {
+								finderArgs = new Object[] {
+									groupId, externalReferenceCode
+								};
+							}
+
+							_log.warn(
+								"MBMessagePersistenceImpl.fetchByG_ERC(long, String, boolean) with parameters (" +
+									StringUtil.merge(finderArgs) +
+										") yields a result set with more than 1 result. This violates the logical unique restriction. There is no order guarantee on which result is returned by this finder.");
+						}
+					}
+
+					MBMessage mbMessage = list.get(0);
+
+					result = mbMessage;
+
+					cacheResult(mbMessage);
+				}
+			}
+			catch (Exception exception) {
+				throw processException(exception);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		if (result instanceof List<?>) {
+			return null;
+		}
+		else {
+			return (MBMessage)result;
+		}
+	}
+
+	/**
+	 * Removes the message-boards message where groupId = &#63; and externalReferenceCode = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the message-boards message that was removed
+	 */
+	@Override
+	public MBMessage removeByG_ERC(long groupId, String externalReferenceCode)
+		throws NoSuchMessageException {
+
+		MBMessage mbMessage = findByG_ERC(groupId, externalReferenceCode);
+
+		return remove(mbMessage);
+	}
+
+	/**
+	 * Returns the number of message-boards messages where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the number of matching message-boards messages
+	 */
+	@Override
+	public int countByG_ERC(long groupId, String externalReferenceCode) {
+		externalReferenceCode = Objects.toString(externalReferenceCode, "");
+
+		boolean productionMode = ctPersistenceHelper.isProductionMode(
+			MBMessage.class);
+
+		FinderPath finderPath = null;
+		Object[] finderArgs = null;
+
+		Long count = null;
+
+		if (productionMode) {
+			finderPath = _finderPathCountByG_ERC;
+
+			finderArgs = new Object[] {groupId, externalReferenceCode};
+
+			count = (Long)finderCache.getResult(finderPath, finderArgs);
+		}
+
+		if (count == null) {
+			StringBundler sb = new StringBundler(3);
+
+			sb.append(_SQL_COUNT_MBMESSAGE_WHERE);
+
+			sb.append(_FINDER_COLUMN_G_ERC_GROUPID_2);
+
+			boolean bindExternalReferenceCode = false;
+
+			if (externalReferenceCode.isEmpty()) {
+				sb.append(_FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_3);
+			}
+			else {
+				bindExternalReferenceCode = true;
+
+				sb.append(_FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_2);
+			}
+
+			String sql = sb.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query query = session.createQuery(sql);
+
+				QueryPos queryPos = QueryPos.getInstance(query);
+
+				queryPos.add(groupId);
+
+				if (bindExternalReferenceCode) {
+					queryPos.add(externalReferenceCode);
+				}
+
+				count = (Long)query.uniqueResult();
+
+				if (productionMode) {
+					finderCache.putResult(finderPath, finderArgs, count);
+				}
+			}
+			catch (Exception exception) {
+				throw processException(exception);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return count.intValue();
+	}
+
+	private static final String _FINDER_COLUMN_G_ERC_GROUPID_2 =
+		"mbMessage.groupId = ? AND ";
+
+	private static final String _FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_2 =
+		"mbMessage.externalReferenceCode = ?";
+
+	private static final String _FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_3 =
+		"(mbMessage.externalReferenceCode IS NULL OR mbMessage.externalReferenceCode = '')";
+
 	public MBMessagePersistenceImpl() {
 		Map<String, String> dbColumnNames = new HashMap<String, String>();
 
@@ -21165,6 +21446,13 @@ public class MBMessagePersistenceImpl
 		finderCache.putResult(
 			_finderPathFetchByG_US,
 			new Object[] {mbMessage.getGroupId(), mbMessage.getUrlSubject()},
+			mbMessage);
+
+		finderCache.putResult(
+			_finderPathFetchByG_ERC,
+			new Object[] {
+				mbMessage.getGroupId(), mbMessage.getExternalReferenceCode()
+			},
 			mbMessage);
 	}
 
@@ -21247,6 +21535,15 @@ public class MBMessagePersistenceImpl
 
 		finderCache.putResult(_finderPathCountByG_US, args, Long.valueOf(1));
 		finderCache.putResult(_finderPathFetchByG_US, args, mbMessageModelImpl);
+
+		args = new Object[] {
+			mbMessageModelImpl.getGroupId(),
+			mbMessageModelImpl.getExternalReferenceCode()
+		};
+
+		finderCache.putResult(_finderPathCountByG_ERC, args, Long.valueOf(1));
+		finderCache.putResult(
+			_finderPathFetchByG_ERC, args, mbMessageModelImpl);
 	}
 
 	/**
@@ -21891,6 +22188,7 @@ public class MBMessagePersistenceImpl
 		ctControlColumnNames.add("mvccVersion");
 		ctControlColumnNames.add("ctCollectionId");
 		ctStrictColumnNames.add("uuid_");
+		ctStrictColumnNames.add("externalReferenceCode");
 		ctStrictColumnNames.add("groupId");
 		ctStrictColumnNames.add("companyId");
 		ctStrictColumnNames.add("userId");
@@ -22581,6 +22879,16 @@ public class MBMessagePersistenceImpl
 				Long.class.getName(), Integer.class.getName()
 			},
 			new String[] {"userId", "classNameId", "classPK", "status"}, false);
+
+		_finderPathFetchByG_ERC = new FinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByG_ERC",
+			new String[] {Long.class.getName(), String.class.getName()},
+			new String[] {"groupId", "externalReferenceCode"}, true);
+
+		_finderPathCountByG_ERC = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_ERC",
+			new String[] {Long.class.getName(), String.class.getName()},
+			new String[] {"groupId", "externalReferenceCode"}, false);
 	}
 
 	@Deactivate

--- a/modules/apps/message-boards/message-boards-service/src/main/resources/META-INF/module-hbm.xml
+++ b/modules/apps/message-boards/message-boards-service/src/main/resources/META-INF/module-hbm.xml
@@ -106,6 +106,7 @@
 		<version access="com.liferay.portal.dao.orm.hibernate.PrivatePropertyAccessor" name="mvccVersion" type="long" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="ctCollectionId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" column="uuid_" name="uuid" type="com.liferay.portal.dao.orm.hibernate.StringType" />
+		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="externalReferenceCode" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="groupId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="companyId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="userId" type="com.liferay.portal.dao.orm.hibernate.LongType" />

--- a/modules/apps/message-boards/message-boards-service/src/main/resources/META-INF/portlet-model-hints.xml
+++ b/modules/apps/message-boards/message-boards-service/src/main/resources/META-INF/portlet-model-hints.xml
@@ -98,6 +98,7 @@
 		<field name="mvccVersion" type="long" />
 		<field name="ctCollectionId" type="long" />
 		<field name="uuid" type="String" />
+		<field name="externalReferenceCode" type="String" />
 		<field name="messageId" type="long" />
 		<field name="groupId" type="long" />
 		<field name="companyId" type="long" />

--- a/modules/apps/message-boards/message-boards-service/src/main/resources/META-INF/sql/indexes.sql
+++ b/modules/apps/message-boards/message-boards-service/src/main/resources/META-INF/sql/indexes.sql
@@ -40,6 +40,7 @@ create index IX_AAAD4168 on MBMessage (groupId, categoryId, threadId, answer, ct
 create index IX_158DD1B6 on MBMessage (groupId, categoryId, threadId, ctCollectionId);
 create index IX_CC88AC9C on MBMessage (groupId, categoryId, threadId, status, ctCollectionId);
 create index IX_A3E7210 on MBMessage (groupId, ctCollectionId);
+create index IX_7BEA05A9 on MBMessage (groupId, externalReferenceCode[$COLUMN_LENGTH:75$], ctCollectionId);
 create index IX_F6A852F6 on MBMessage (groupId, status, ctCollectionId);
 create unique index IX_8813E901 on MBMessage (groupId, urlSubject[$COLUMN_LENGTH:255$], ctCollectionId);
 create index IX_C892444A on MBMessage (groupId, userId, ctCollectionId);

--- a/modules/apps/message-boards/message-boards-service/src/main/resources/META-INF/sql/tables.sql
+++ b/modules/apps/message-boards/message-boards-service/src/main/resources/META-INF/sql/tables.sql
@@ -91,6 +91,7 @@ create table MBMessage (
 	mvccVersion LONG default 0 not null,
 	ctCollectionId LONG default 0 not null,
 	uuid_ VARCHAR(75) null,
+	externalReferenceCode VARCHAR(75) null,
 	messageId LONG not null,
 	groupId LONG,
 	companyId LONG,

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/persistence/test/MBMessagePersistenceTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/persistence/test/MBMessagePersistenceTest.java
@@ -131,6 +131,8 @@ public class MBMessagePersistenceTest {
 
 		newMBMessage.setUuid(RandomTestUtil.randomString());
 
+		newMBMessage.setExternalReferenceCode(RandomTestUtil.randomString());
+
 		newMBMessage.setGroupId(RandomTestUtil.nextLong());
 
 		newMBMessage.setCompanyId(RandomTestUtil.nextLong());
@@ -195,6 +197,9 @@ public class MBMessagePersistenceTest {
 			newMBMessage.getCtCollectionId());
 		Assert.assertEquals(
 			existingMBMessage.getUuid(), newMBMessage.getUuid());
+		Assert.assertEquals(
+			existingMBMessage.getExternalReferenceCode(),
+			newMBMessage.getExternalReferenceCode());
 		Assert.assertEquals(
 			existingMBMessage.getMessageId(), newMBMessage.getMessageId());
 		Assert.assertEquals(
@@ -531,6 +536,15 @@ public class MBMessagePersistenceTest {
 	}
 
 	@Test
+	public void testCountByG_ERC() throws Exception {
+		_persistence.countByG_ERC(RandomTestUtil.nextLong(), "");
+
+		_persistence.countByG_ERC(0L, "null");
+
+		_persistence.countByG_ERC(0L, (String)null);
+	}
+
+	@Test
 	public void testFindByPrimaryKeyExisting() throws Exception {
 		MBMessage newMBMessage = addMBMessage();
 
@@ -562,15 +576,15 @@ public class MBMessagePersistenceTest {
 	protected OrderByComparator<MBMessage> getOrderByComparator() {
 		return OrderByComparatorFactoryUtil.create(
 			"MBMessage", "mvccVersion", true, "ctCollectionId", true, "uuid",
-			true, "messageId", true, "groupId", true, "companyId", true,
-			"userId", true, "userName", true, "createDate", true,
-			"modifiedDate", true, "classNameId", true, "classPK", true,
-			"categoryId", true, "threadId", true, "rootMessageId", true,
-			"parentMessageId", true, "treePath", true, "subject", true,
-			"urlSubject", true, "format", true, "anonymous", true, "priority",
-			true, "allowPingbacks", true, "answer", true, "lastPublishDate",
-			true, "status", true, "statusByUserId", true, "statusByUserName",
-			true, "statusDate", true);
+			true, "externalReferenceCode", true, "messageId", true, "groupId",
+			true, "companyId", true, "userId", true, "userName", true,
+			"createDate", true, "modifiedDate", true, "classNameId", true,
+			"classPK", true, "categoryId", true, "threadId", true,
+			"rootMessageId", true, "parentMessageId", true, "treePath", true,
+			"subject", true, "urlSubject", true, "format", true, "anonymous",
+			true, "priority", true, "allowPingbacks", true, "answer", true,
+			"lastPublishDate", true, "status", true, "statusByUserId", true,
+			"statusByUserName", true, "statusDate", true);
 	}
 
 	@Test
@@ -851,6 +865,17 @@ public class MBMessagePersistenceTest {
 			ReflectionTestUtil.invoke(
 				mbMessage, "getColumnOriginalValue",
 				new Class<?>[] {String.class}, "urlSubject"));
+
+		Assert.assertEquals(
+			Long.valueOf(mbMessage.getGroupId()),
+			ReflectionTestUtil.<Long>invoke(
+				mbMessage, "getColumnOriginalValue",
+				new Class<?>[] {String.class}, "groupId"));
+		Assert.assertEquals(
+			mbMessage.getExternalReferenceCode(),
+			ReflectionTestUtil.invoke(
+				mbMessage, "getColumnOriginalValue",
+				new Class<?>[] {String.class}, "externalReferenceCode"));
 	}
 
 	protected MBMessage addMBMessage() throws Exception {
@@ -863,6 +888,8 @@ public class MBMessagePersistenceTest {
 		mbMessage.setCtCollectionId(RandomTestUtil.nextLong());
 
 		mbMessage.setUuid(RandomTestUtil.randomString());
+
+		mbMessage.setExternalReferenceCode(RandomTestUtil.randomString());
 
 		mbMessage.setGroupId(RandomTestUtil.nextLong());
 

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/test/MBMessageLocalServiceTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/test/MBMessageLocalServiceTest.java
@@ -17,6 +17,7 @@ package com.liferay.message.boards.service.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.message.boards.constants.MBCategoryConstants;
 import com.liferay.message.boards.constants.MBMessageConstants;
+import com.liferay.message.boards.exception.DuplicateExternalReferenceCodeException;
 import com.liferay.message.boards.model.MBMessage;
 import com.liferay.message.boards.model.MBThread;
 import com.liferay.message.boards.service.MBMessageLocalServiceUtil;
@@ -171,6 +172,48 @@ public class MBMessageLocalServiceTest {
 		Assert.assertEquals(subject, mbMessage.getBody());
 	}
 
+	@Test(expected = DuplicateExternalReferenceCodeException.class)
+	public void testAddMessageWithExistingExternalReferenceCode()
+		throws Exception {
+
+		User user = TestPropsValues.getUser();
+
+		MBMessage message = addMessage();
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext();
+
+		serviceContext.setAttribute(
+			"externalReferenceCode", message.getExternalReferenceCode());
+
+		MBMessageLocalServiceUtil.addMessage(
+			user.getUserId(), user.getFullName(), _group.getGroupId(),
+			MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			serviceContext);
+	}
+
+	@Test
+	public void testAddMessageWithExternalReferenceCode() throws Exception {
+		String externalReferenceCode = RandomTestUtil.randomString();
+		User user = TestPropsValues.getUser();
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext();
+
+		serviceContext.setAttribute(
+			"externalReferenceCode", externalReferenceCode);
+
+		MBMessage mbMessage = MBMessageLocalServiceUtil.addMessage(
+			user.getUserId(), user.getFullName(), _group.getGroupId(),
+			MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			serviceContext);
+
+		Assert.assertEquals(
+			externalReferenceCode, mbMessage.getExternalReferenceCode());
+	}
+
 	@Test
 	public void testAddMessageWithNullBody() throws Exception {
 		User user = TestPropsValues.getUser();
@@ -196,6 +239,21 @@ public class MBMessageLocalServiceTest {
 			ServiceContextTestUtil.getServiceContext());
 
 		Assert.assertEquals(body, mbMessage.getBody());
+	}
+
+	@Test
+	public void testAddMessageWithoutExternalReferenceCode() throws Exception {
+		User user = TestPropsValues.getUser();
+
+		MBMessage mbMessage = MBMessageLocalServiceUtil.addMessage(
+			user.getUserId(), user.getFullName(), _group.getGroupId(),
+			MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			ServiceContextTestUtil.getServiceContext());
+
+		Assert.assertEquals(
+			String.valueOf(mbMessage.getMessageId()),
+			mbMessage.getExternalReferenceCode());
 	}
 
 	@Test


### PR DESCRIPTION
Hello team,

In the APIs we need to get and manage entities by an external reference code (ERC) so we need to add this new fields to all portal entities.

This issue come after a long discussion about reusing a existing field or creating a new one and the decision was creating a new one to be more confident that the new code does not interfere with any existing feature.

To be able to used the Service Builder generated code with the external-reference-code attribute we have made some modifications on Service Builder to specify if the scope of the ERC is Company (as it always has been) or Group. After this modification this is the first entity where we are using it to create a ERC scoped by group for MBMessage.

To try to make the least code modifications possible I've passed the externalReferenceCode as a Service Context attribute to get it in the addMessage and updateMessage methods in the MBMessageLocalServiceImpl. I've thought a lot about doing it this way instead overloading the methods. Please, check if this approach is desirable and tell me if you feel it is better to overload this methods passing the new externalReferenceCode parameter. In case there is no ERC, the messageId will be used as a String.

I've also modified the datahandler for import/export, made the database upgrade process populating the new externalReferenceCode column with the messageId, and made some tests to be sure the code is working.

Please, take a look at this PR when you can and let me know if you require any change or there is something you don't understand.

Thank you very much!