### PR TITLE
LPS-121858 Migrate v2 usages in announcements/announcements-web

### DIFF
--- a/modules/apps/announcements/announcements-web/package.json
+++ b/modules/apps/announcements/announcements-web/package.json
@@ -1,0 +1,13 @@
+{
+	"dependencies": {
+		"frontend-js-web": "*"
+	},
+	"name": "announcements-web",
+	"private": true,
+	"scripts": {
+		"build": "liferay-npm-scripts build",
+		"checkFormat": "liferay-npm-scripts check",
+		"format": "liferay-npm-scripts fix"
+	},
+	"version": "6.0.0"
+}

--- a/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/announcements_admin/js/AnnouncementsManagementToolbarPropsTransformer.js
+++ b/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/announcements_admin/js/AnnouncementsManagementToolbarPropsTransformer.js
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+export default function propsTransformer({
+	additionalProps: {deleteEntriesURL, inputId, inputValue},
+	portletNamespace,
+	...props
+}) {
+	return {
+		...props,
+		onActionButtonClick(event, {item}) {
+			if (item.data?.action === 'deleteEntries') {
+				if (
+					confirm(
+						Liferay.Language.get(
+							'are-you-sure-you-want-to-delete-the-selected-entries'
+						)
+					)
+				) {
+					const form = document.getElementById(
+						`${portletNamespace}fm`
+					);
+
+					if (!form) {
+						return;
+					}
+
+					form.setAttribute('method', 'post');
+
+					const inputElement = document.getElementById(
+						`${portletNamespace}${inputId}`
+					);
+
+					if (inputElement) {
+						inputElement.setAttribute('value', inputValue);
+					}
+
+					submitForm(form, deleteEntriesURL);
+				}
+			}
+		},
+	};
+}

--- a/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/announcements_admin/view.jsp
+++ b/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/announcements_admin/view.jsp
@@ -66,15 +66,26 @@ AnnouncementsAdminViewManagementToolbarDisplayContext announcementsAdminViewMana
 	%>'
 />
 
-<clay:management-toolbar-v2
+<portlet:actionURL name="/announcements/edit_entry" var="deleteEntriesURL" />
+
+<clay:management-toolbar
 	actionDropdownItems="<%= announcementsAdminViewManagementToolbarDisplayContext.getActionDropdownItems() %>"
+	additionalProps='<%=
+		HashMapBuilder.<String, Object>put(
+			"deleteEntriesURL", deleteEntriesURL.toString()
+		).put(
+			"inputId", Constants.CMD
+		).put(
+			"inputValue", Constants.DELETE
+		).build()
+	%>'
 	clearResultsURL="<%= announcementsAdminViewManagementToolbarDisplayContext.getClearResultsURL() %>"
-	componentId="announcementsAdminViewManagementToolbar"
 	creationMenu="<%= announcementsAdminViewManagementToolbarDisplayContext.getCreationMenu() %>"
 	disabled="<%= announcementsAdminViewManagementToolbarDisplayContext.isDisabled() %>"
 	filterDropdownItems="<%= announcementsAdminViewManagementToolbarDisplayContext.getFilterDropdownItems() %>"
 	filterLabelItems="<%= announcementsAdminViewManagementToolbarDisplayContext.getFilterLabelItems() %>"
 	itemsTotal="<%= announcementsAdminViewManagementToolbarDisplayContext.getTotal() %>"
+	propsTransformer="announcements_admin/js/AnnouncementsManagementToolbarPropsTransformer"
 	searchContainerId="announcementsEntries"
 	selectable="<%= true %>"
 	showSearch="<%= false %>"
@@ -152,48 +163,3 @@ AnnouncementsAdminViewManagementToolbarDisplayContext announcementsAdminViewMana
 		</liferay-ui:search-container>
 	</aui:form>
 </clay:container-fluid>
-
-<aui:script>
-	var deleteEntries = function () {
-		if (
-			confirm(
-				'<liferay-ui:message key="are-you-sure-you-want-to-delete-the-selected-entries" />'
-			)
-		) {
-			var form = document.getElementById('<portlet:namespace />fm');
-
-			if (form) {
-				form.setAttribute('method', 'post');
-
-				var cmd = form.querySelector(
-					'#<portlet:namespace /><%= Constants.CMD %>'
-				);
-
-				if (cmd) {
-					cmd.setAttribute('value', '<%= Constants.DELETE %>');
-				}
-
-				submitForm(
-					form,
-					'<portlet:actionURL name="/announcements/edit_entry" />'
-				);
-			}
-		}
-	};
-
-	var ACTIONS = {
-		deleteEntries: deleteEntries,
-	};
-
-	Liferay.componentReady('announcementsAdminViewManagementToolbar').then(
-		function (managementToolbar) {
-			managementToolbar.on('actionItemClicked', function (event) {
-				var itemData = event.data.item.data;
-
-				if (itemData && itemData.action && ACTIONS[itemData.action]) {
-					ACTIONS[itemData.action]();
-				}
-			});
-		}
-	);
-</aui:script>


### PR DESCRIPTION
The `<clay:management-toolbar-v2 />` tag has been replaced with the
`<clay:management-toolbar />` tag (which uses clay v3).

Creating announcements and alerts as well a deleting them works as
expected.

![](https://user-images.githubusercontent.com/5572/107023005-54cec080-67a6-11eb-97e2-c06fdee80f23.gif)

**Test plan**:
- From the global menu, navigate to "Communication > Announcement and Alerts"
- Create a new Announcement
- From the management toolbar, select it and delete it.
- Select the **Alerts** tab
- Create one or several alerts
- From the management toolbar, selecting and deleting should work as expected.

Additionally, I've created [this LPS](https://issues.liferay.com/browse/LPS-127443) to warn the Lima team about a bug (also happening with `<clay:management-toolbar-v2 />`, [discussed on Slack](https://liferay.slack.com/archives/CLD39UKM5/p1612519927036100))

**Orignally reviewed [here](https://github.com/liferay-frontend/liferay-portal/pull/761)**