### PR TITLE
LPS-125413 Use new ImageSelector component in image-selector tag and remove old one

### DIFF
--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/liferay-item-selector.tld
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/liferay-item-selector.tld
@@ -34,7 +34,7 @@
 		<tag-class>com.liferay.item.selector.taglib.servlet.taglib.ImageSelectorTag</tag-class>
 		<body-content>JSP</body-content>
 		<attribute>
-			<description>A CSS class to specify the direction of the image drag. Possible values are <![CDATA[<code>vertical</code>]]>, <![CDATA[<code>horizontal</code>]]>, <![CDATA[<code>both</code>]]>, or <![CDATA[<code>none</code>]]>.</description>
+			<description>Deprecated as of 7.4.0, replaced by the attribute <![CDATA[<code>imageCropDirection</code>]]>.</description>
 			<name>draggableImage</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -43,6 +43,12 @@
 			<description>The ID of a previously selected file entry.</description>
 			<name>fileEntryId</name>
 			<required>true</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>The direction of the image drag to crop it. Possible values are <![CDATA[<code>vertical</code>]]>, <![CDATA[<code>horizontal</code>]]>, <![CDATA[<code>both</code>]]>, or <![CDATA[<code>none</code>]]>.</description>
+			<name>imageCropDirection</name>
+			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/image_selector/init.jsp
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/image_selector/init.jsp
@@ -16,5 +16,4 @@
 
 <%@ include file="/init.jsp" %>
 
-<%@ page import="com.liferay.document.library.util.DLURLHelperUtil" %><%@
-page import="com.liferay.portal.kernel.servlet.BrowserSnifferUtil" %>
+<%@ page import="com.liferay.portal.kernel.servlet.BrowserSnifferUtil" %>

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/image_selector/js/ChangeImageControls.js
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/image_selector/js/ChangeImageControls.js
@@ -19,6 +19,7 @@ import React from 'react';
 const ChangeImageControls = ({handleClickDelete, handleClickPicture}) => (
 	<div className="change-image-controls">
 		<ClayButtonWithIcon
+			className="browse-image"
 			displayType="secondary"
 			monospaced
 			onClick={handleClickPicture}

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/image_selector/js/ImageSelector.js
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/image_selector/js/ImageSelector.js
@@ -307,12 +307,14 @@ const ImageSelector = ({
 			ref={rootNodeRef}
 		>
 			<input
+				id={`${portletNamespace}${paramName}Id`}
 				name={`${portletNamespace}${paramName}Id`}
 				type="hidden"
 				value={image.fileEntryId}
 			/>
 
 			<input
+				id={`${portletNamespace}${paramName}CropRegion`}
 				name={`${portletNamespace}${paramName}CropRegion`}
 				type="hidden"
 				value={imageCropRegion}

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/init.jsp
@@ -22,6 +22,7 @@
 taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/document-library" prefix="liferay-document-library" %><%@
 taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
+taglib uri="http://liferay.com/tld/react" prefix="react" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %><%@
 taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/com/liferay/item/selector/taglib/servlet/taglib/packageinfo
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/com/liferay/item/selector/taglib/servlet/taglib/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 2.1.0

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/blogs/BlogsEntry.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/blogs/BlogsEntry.path
@@ -20,7 +20,7 @@
 </tr>
 <tr>
 	<td>ENTRY_COVER_IMAGE_UNPUBLISHED</td>
-	<td>//div[@class='image-wrapper']//img[contains(@src,'${key_coverImageName}')]</td>
+	<td>//div[contains(@class,'image-wrapper')]//img[contains(@src,'${key_coverImageName}')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/blogs/BlogsEntry.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/blogs/BlogsEntry.path
@@ -15,7 +15,7 @@
 </tr>
 <tr>
 	<td>ENTRY_COVER_IMAGE_SELECT_FILE</td>
-	<td>//div[contains(@class,'image-selector')]//a[contains(.,'Select File')]</td>
+	<td>//div[contains(@class,'image-selector')]//button[contains(.,'Select File')]</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
Following up on https://github.com/liferay-lima/liferay-portal/pull/1484

https://issues.liferay.com/browse/LPS-125413

In this pr we're removing the old `image-selector` AUI component in favor of the new React one.

We're adding some missing markup in the React component and removing no needed one for SSR in the JSP

Made also some refactor and renaming in the React Components.

Deprecate `draggableImage` in favor of new `imageCropDirection` attribute in `ImageSelector` tag to improve naming.

![imageselector](https://user-images.githubusercontent.com/5803434/107640553-bd201500-6c72-11eb-8149-bb726d2e0855.gif)

Test Plan 1:
- Go to Content & Data / Blogs
- Create a new Blog
- Select an image bigger than the container
- Click and move vertically the picture to crop it in the desired position
- Publish
- Edit the blog
- Check that the image has been cropped correctly

Test Plan 2:
- Go to Content & Data / Blogs
- Edit an existing Blog with an image
- Check that you can't move the image since it's already cropped
- Remove the image and repeat Test plan 1 from point 3.