### PR TITLE
LPS-128003 Message Boards quick reply doesn't work

### DIFF
--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/edit_message_quick.jspf
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/edit_message_quick.jspf
@@ -17,6 +17,6 @@
 <div class="card-tab message-container reply-container" id="<portlet:namespace />addReplyToMessage<%= replyToMessageId %>">
 	<span aria-hidden="true" class="hide loading-animation loading-animation-sm"></span>
 
-	<div class="card hide list-group-card panel">
+	<div class="card hide panel">
 	</div>
 </div>

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/edit_message_quick_resource.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/edit_message_quick_resource.jsp
@@ -188,7 +188,7 @@ String redirect = ParamUtil.getString(request, "redirect");
 				/>
 			</liferay-expando:custom-attributes-available>
 
-			<aui:button-row>
+			<div class="sheet-footer">
 
 				<%
 				String publishButtonLabel = "publish";
@@ -205,7 +205,7 @@ String redirect = ParamUtil.getString(request, "redirect");
 				%>
 
 				<aui:button onClick="<%= taglibCancelReply %>" type="cancel" />
-			</aui:button-row>
+			</div>
 		</aui:form>
 
 		<portlet:renderURL var="advancedReplyURL">


### PR DESCRIPTION
In this task https://issues.liferay.com/browse/LPS-126737 the commit https://github.com/liferay/liferay-portal/commit/bc85ae13a80e75fabd80e363e2f61f442e1858a2 updates the selector but not all the cases are updated in the markup.

**Steps to reproduce**

1. Go to Content and Data > Message Boards
2. Add a message boards thread
3. Click in reply button
4. Write something and Publish

**Expected result:**
The reply is published and added to the thread

**Actual result:**
Nothing happens

---

**After the fix:**

https://user-images.githubusercontent.com/67901/108201938-b553eb00-7120-11eb-97d0-a28ba58d71c4.mp4

