### PR TITLE
[TS] LPS-127707 message-boards-service: Refactor finder to make it compatible with oracle

### DIFF
--- a/modules/apps/message-boards/message-boards-service/src/main/resources/custom-sql/default.xml
+++ b/modules/apps/message-boards/message-boards-service/src/main/resources/custom-sql/default.xml
@@ -59,29 +59,38 @@
 			SELECT
 				{MBCategory.*}
 			FROM
-				MBCategory
+				(
+					SELECT
+						MBCategory.categoryId, MBCategory.ctCollectionId, MAX(MBMessage.modifiedDate) AS lastPostDate
+					FROM
+						MBCategory
+					INNER JOIN
+						Subscription ON
+							(Subscription.companyId = MBCategory.companyId) AND
+							(Subscription.classNameId = ?) AND
+							(Subscription.classPK = MBCategory.categoryId)
+					LEFT JOIN
+						MBMessage ON
+							MBMessage.categoryId = MBCategory.categoryId
+					WHERE
+						(MBCategory.groupId = ?) AND
+						(MBCategory.parentCategoryId = ?) AND
+						(Subscription.userId = ?)
+					GROUP BY
+						MBCategory.ctCollectionId, MBCategory.categoryId
+				) TEMP_TABLE
 			INNER JOIN
-				Subscription ON
-					(Subscription.companyId = MBCategory.companyId) AND
-					(Subscription.classNameId = ?) AND
-					(Subscription.classPK = MBCategory.categoryId)
-			LEFT JOIN
-				MBMessage ON
-					MBMessage.categoryId = MBCategory.categoryId
-			WHERE
-				(MBCategory.groupId = ?) AND
-				(MBCategory.parentCategoryId = ?) AND
-				(Subscription.userId = ?)
-			GROUP BY
-				MBCategory.ctCollectionId, MBCategory.categoryId
+				MBCategory ON
+					(TEMP_TABLE.categoryId = MBCategory.categoryId) AND
+					(TEMP_TABLE.ctCollectionId = MBCategory.ctCollectionId)
 			ORDER BY
 				(
 					CASE WHEN
-						MAX(MBMessage.modifiedDate) IS NULL
+						TEMP_TABLE.lastPostDate IS NULL
 					THEN
 						MBCategory.modifiedDate
 					ELSE
-						MAX(MBMessage.modifiedDate)
+						TEMP_TABLE.lastPostDate
 					END
 				) DESC
 		]]>


### PR DESCRIPTION
/cc @robertoDiaz @adolfopa 

Hi Team Lima,

**Previous PR:** https://github.com/brianchandotcom/liferay-portal/pull/98844

After discussing with Brian, I decided to try this approach instead. 

This approach would:
- Retain the current finder implementation
- Avoid re-fetching for each retrieved MBCategory

This approach utilizes a subquery to allow us to retrieve the **MAX(MBMessage.modifiedDate)**, while still returning all the MBCategory fields in the final result set.

Please let me know if you have any questions or if there's anything you would like me to change.

Thanks!