### PR TITLE
LPS-121882 Migrate v2 usages in knowledge-base/knowledge-base-web

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-web/package.json
+++ b/modules/apps/knowledge-base/knowledge-base-web/package.json
@@ -1,0 +1,13 @@
+{
+	"dependencies": {
+		"frontend-js-web": "*"
+	},
+	"name": "knowledge-base-web",
+	"private": true,
+	"scripts": {
+		"build": "liferay-npm-scripts build",
+		"checkFormat": "liferay-npm-scripts check",
+		"format": "liferay-npm-scripts fix"
+	},
+	"version": "5.0.0"
+}

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/js/ManagementToolbarPropsTransformer.js
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/js/ManagementToolbarPropsTransformer.js
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+export default function propsTransformer({portletNamespace, ...otherProps}) {
+	return {
+		...otherProps,
+		onActionButtonClick(event, {item}) {
+			const action = item.data?.action;
+
+			if (action === 'deleteEntries') {
+				if (
+					confirm(
+						Liferay.Language.get(
+							'are-you-sure-you-want-to-delete-the-selected-entries'
+						)
+					)
+				) {
+					const form = document.getElementById(
+						`${portletNamespace}fm`
+					);
+
+					if (form) {
+						submitForm(form);
+					}
+				}
+			}
+		},
+	};
+}

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/js/SuggestionsManagementToolbarPropsTransformer.js
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/js/SuggestionsManagementToolbarPropsTransformer.js
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+export default function propsTransformer({portletNamespace, ...otherProps}) {
+	return {
+		...otherProps,
+		onActionButtonClick(event, {item}) {
+			const action = item.data?.action;
+
+			if (action === 'deleteKBComments') {
+				if (
+					confirm(
+						Liferay.Language.get(
+							'are-you-sure-you-want-to-delete-this'
+						)
+					)
+				) {
+					const form = document.getElementById(
+						`${portletNamespace}fm`
+					);
+
+					if (!form) {
+						submitForm(form);
+					}
+				}
+			}
+		},
+	};
+}

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/js/TemplatesManagementToolbarPropsTransformer.js
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/js/TemplatesManagementToolbarPropsTransformer.js
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+export default function propsTransformer({
+	additionalProps: {deleteKBTemplatesURL},
+	portletNamespace,
+	...otherProps
+}) {
+	return {
+		...otherProps,
+		onActionButtonClick(event, {item}) {
+			const action = item.data?.action;
+
+			if (action === 'deleteKBTemplates') {
+				if (
+					confirm(
+						Liferay.Language.get(
+							'are-you-sure-you-want-to-delete-the-selected-templates'
+						)
+					)
+				) {
+					const form = document.getElementById(
+						`${portletNamespace}fm`
+					);
+
+					if (!form) {
+						return;
+					}
+
+					form.setAttribute('method', 'post');
+
+					form.querySelector(
+						`#${portletNamespace}kbTemplateIds`
+					).setAttribute(
+						'value',
+						Liferay.Util.listCheckedExcept(
+							form,
+							`${portletNamespace}allRowIds`
+						)
+					);
+
+					submitForm(form, deleteKBTemplatesURL);
+				}
+			}
+		},
+	};
+}

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/view.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/view.jsp
@@ -51,7 +51,7 @@ if (parentResourcePrimKey != KBFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
 
 <liferay-util:include page="/admin/common/top_tabs.jsp" servletContext="<%= application %>" />
 
-<clay:management-toolbar-v2
+<clay:management-toolbar
 	actionDropdownItems="<%= kbAdminManagementToolbarDisplayContext.getActionDropdownItems() %>"
 	clearResultsURL="<%= String.valueOf(kbAdminManagementToolbarDisplayContext.getSearchURL()) %>"
 	componentId="kbAdminManagementToolbar"
@@ -60,6 +60,7 @@ if (parentResourcePrimKey != KBFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
 	filterDropdownItems="<%= kbAdminManagementToolbarDisplayContext.getFilterDropdownItems() %>"
 	infoPanelId="infoPanelId"
 	itemsTotal="<%= kbAdminManagementToolbarDisplayContext.getTotal() %>"
+	propsTransformer="admin/js/ManagementToolbarPropsTransformer"
 	searchActionURL="<%= String.valueOf(kbAdminManagementToolbarDisplayContext.getSearchURL()) %>"
 	searchContainerId="kbObjects"
 	selectable="<%= true %>"
@@ -319,33 +320,3 @@ if (parentResourcePrimKey != KBFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
 		</clay:container-fluid>
 	</div>
 </div>
-
-<script>
-	var deleteEntries = function () {
-		if (
-			confirm(
-				'<liferay-ui:message key="are-you-sure-you-want-to-delete-the-selected-entries" />'
-			)
-		) {
-			var form = document.getElementById('<portlet:namespace />fm');
-
-			if (form) {
-				submitForm(form);
-			}
-		}
-	};
-
-	var ACTIONS = {
-		deleteEntries: deleteEntries,
-	};
-
-	Liferay.componentReady('kbAdminManagementToolbar').then((managementToolbar) => {
-		managementToolbar.on('actionItemClicked', (event) => {
-			var itemData = event.data.item.data;
-
-			if (itemData && itemData.action && ACTIONS[itemData.action]) {
-				ACTIONS[itemData.action]();
-			}
-		});
-	});
-</script>

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/view_suggestions.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/view_suggestions.jsp
@@ -63,7 +63,7 @@ request.setAttribute("view_suggestions.jsp-searchContainer", kbCommentsSearchCon
 
 <liferay-util:include page="/admin/common/top_tabs.jsp" servletContext="<%= application %>" />
 
-<clay:management-toolbar-v2
+<clay:management-toolbar
 	actionDropdownItems="<%= kbSuggestionListManagementToolbarDisplayContext.getActionDropdownItems() %>"
 	clearResultsURL="<%= kbSuggestionListManagementToolbarDisplayContext.getClearResultsURL() %>"
 	componentId="kbSuggestionListManagementToolbar"
@@ -71,6 +71,7 @@ request.setAttribute("view_suggestions.jsp-searchContainer", kbCommentsSearchCon
 	filterDropdownItems="<%= kbSuggestionListManagementToolbarDisplayContext.getFilterDropdownItems() %>"
 	filterLabelItems="<%= kbSuggestionListManagementToolbarDisplayContext.getFilterLabelItems() %>"
 	itemsTotal="<%= kbSuggestionListManagementToolbarDisplayContext.getTotal() %>"
+	propsTransformer="admin/js/SuggestionsManagementToolbarPropsTransformer"
 	searchContainerId="kbComments"
 	selectable="<%= true %>"
 	showSearch="<%= false %>"
@@ -89,35 +90,3 @@ request.setAttribute("view_suggestions.jsp-searchContainer", kbCommentsSearchCon
 
 	<liferay-util:include page="/admin/common/view_suggestions_by_status.jsp" servletContext="<%= application %>" />
 </clay:container-fluid>
-
-<script>
-	var deleteKBComments = function () {
-		if (
-			confirm(
-				'<liferay-ui:message key="are-you-sure-you-want-to-delete-this" />'
-			)
-		) {
-			var form = document.getElementById('<portlet:namespace />fm');
-
-			if (form) {
-				submitForm(form);
-			}
-		}
-	};
-
-	var ACTIONS = {
-		deleteKBComments: deleteKBComments,
-	};
-
-	Liferay.componentReady('kbSuggestionListManagementToolbar').then(
-		(managementToolbar) => {
-			managementToolbar.on('actionItemClicked', (event) => {
-				var itemData = event.data.item.data;
-
-				if (itemData && itemData.action && ACTIONS[itemData.action]) {
-					ACTIONS[itemData.action]();
-				}
-			});
-		}
-	);
-</script>

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/view_templates.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/view_templates.jsp
@@ -22,14 +22,25 @@ KBTemplatesManagementToolbarDisplayContext kbTemplatesManagementToolbarDisplayCo
 
 <liferay-util:include page="/admin/common/top_tabs.jsp" servletContext="<%= application %>" />
 
-<clay:management-toolbar-v2
+<liferay-portlet:actionURL name="deleteKBTemplates" var="deleteKBTemplatesURL">
+	<portlet:param name="mvcPath" value="/admin/view_templates.jsp" />
+	<portlet:param name="redirect" value="<%= currentURL %>" />
+</liferay-portlet:actionURL>
+
+<clay:management-toolbar
 	actionDropdownItems="<%= kbTemplatesManagementToolbarDisplayContext.getActionDropdownItems() %>"
+	additionalProps='<%=
+		HashMapBuilder.<String, Object>put(
+			"deleteKBTemplatesURL", deleteKBTemplatesURL.toString()
+		).build()
+	%>'
 	clearResultsURL="<%= String.valueOf(kbTemplatesManagementToolbarDisplayContext.getSearchURL()) %>"
 	componentId="kbTemplatesManagementToolbar"
 	creationMenu="<%= kbTemplatesManagementToolbarDisplayContext.getCreationMenu() %>"
 	disabled="<%= kbTemplatesManagementToolbarDisplayContext.isDisabled() %>"
 	filterDropdownItems="<%= kbTemplatesManagementToolbarDisplayContext.getFilterDropdownItems() %>"
 	itemsTotal="<%= kbTemplatesManagementToolbarDisplayContext.getTotal() %>"
+	propsTransformer="admin/js/TemplatesManagementToolbarPropsTransformer"
 	searchActionURL="<%= String.valueOf(kbTemplatesManagementToolbarDisplayContext.getSearchURL()) %>"
 	searchContainerId="kbTemplates"
 	selectable="<%= true %>"
@@ -110,47 +121,3 @@ KBTemplatesManagementToolbarDisplayContext kbTemplatesManagementToolbarDisplayCo
 		</aui:fieldset>
 	</aui:form>
 </clay:container-fluid>
-
-<script>
-	var deleteKBTemplates = function () {
-		if (
-			confirm(
-				'<liferay-ui:message key="are-you-sure-you-want-to-delete-the-selected-templates" />'
-			)
-		) {
-			var form = document.querySelector('#<portlet:namespace />fm');
-
-			if (form) {
-				form.setAttribute('method', 'post');
-
-				form.querySelector(
-					'#<portlet:namespace />kbTemplateIds'
-				).value = Liferay.Util.listCheckedExcept(
-					form,
-					'<portlet:namespace />allRowIds'
-				);
-
-				submitForm(
-					form,
-					'<liferay-portlet:actionURL name="deleteKBTemplates"><portlet:param name="mvcPath" value="/admin/view_templates.jsp" /><portlet:param name="redirect" value="<%= currentURL %>" /></liferay-portlet:actionURL>'
-				);
-			}
-		}
-	};
-
-	var ACTIONS = {
-		deleteKBTemplates: deleteKBTemplates,
-	};
-
-	Liferay.componentReady('kbTemplatesManagementToolbar').then(
-		(managementToolbar) => {
-			managementToolbar.on('actionItemClicked', (event) => {
-				var itemData = event.data.item.data;
-
-				if (itemData && itemData.action && ACTIONS[itemData.action]) {
-					ACTIONS[itemData.action]();
-				}
-			});
-		}
-	);
-</script>


### PR DESCRIPTION
In this change we've updated the <clay:management-toolbar-v2 />
to <clay:management-toolbar /> (which uses clay v3).

Creating new knowledge base articles, templates and deleting works as
expected, suggestions can be deleted too.

![](https://user-images.githubusercontent.com/5572/108347229-9157de80-71e0-11eb-8edb-d76d12c080a1.gif)

**Test Plan**:
- Navigate to **Content & Data** > **Knowledge Base**
- Create one or several articles, and delete them
- Create one or several templates and delete them

cc @markocikos, @jonmak08, @ambrinchaudhary 
