### PR TITLE
LPS-121871 Migrate v2 usages in document-library/document-library-web

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/ddm/select_ddm_structure.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/ddm/select_ddm_structure.jsp
@@ -22,8 +22,8 @@ DLSelectDDMStructureDisplayContext dlSelectDDMStructureDisplayContext = new DLSe
 SearchContainer<com.liferay.dynamic.data.mapping.model.DDMStructure> ddmStructureSearch = dlSelectDDMStructureDisplayContext.getDDMStructureSearch();
 %>
 
-<clay:management-toolbar-v2
-	displayContext="<%= new DLSelectDDMStructureManagementToolbarDisplayContext(request, liferayPortletRequest, liferayPortletResponse, dlSelectDDMStructureDisplayContext) %>"
+<clay:management-toolbar
+	managementToolbarDisplayContext="<%= new DLSelectDDMStructureManagementToolbarDisplayContext(request, liferayPortletRequest, liferayPortletResponse, dlSelectDDMStructureDisplayContext) %>"
 />
 
 <aui:form cssClass="container-fluid container-fluid-max-xl" method="post" name="selectDDMStructureFm">

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/DLManagementToolbarPropsTransformer.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/DLManagementToolbarPropsTransformer.js
@@ -116,6 +116,28 @@ export default function propsTransformer({
 		processAction(action, editEntryURL);
 	};
 
+	const editCategories = () => {
+		const searchContainer = Liferay.SearchContainer.get(
+			otherProps.searchContainerId
+		);
+
+		Liferay.componentReady(
+			`${portletNamespace}EditCategoriesComponent`
+		).then((editCategoriesComponent) => {
+			const bulkSelection = searchContainer.select?.get('bulkSelection');
+
+			const selectedFileEntries = searchContainer.select
+				.getAllSelectedElements()
+				.get('value');
+
+			editCategoriesComponent.open(
+				selectedFileEntries,
+				bulkSelection,
+				folderConfiguration.defaultParentFolderId
+			);
+		});
+	};
+
 	const editTags = () => {
 		const searchContainer = Liferay.SearchContainer.get(
 			otherProps.searchContainerId
@@ -214,6 +236,9 @@ export default function propsTransformer({
 			}
 			else if (action === 'download') {
 				processAction('download', downloadEntryURL);
+			}
+			else if (action === 'editCategories') {
+				editCategories();
 			}
 			else if (action === 'editTags') {
 				editTags();

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/DLManagementToolbarPropsTransformer.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/DLManagementToolbarPropsTransformer.js
@@ -206,7 +206,7 @@ export default function propsTransformer({
 			if (action === 'checkin') {
 				checkIn();
 			}
-			if (action === 'checkout') {
+			else if (action === 'checkout') {
 				processAction('checkout', editEntryURL);
 			}
 			else if (action === 'deleteEntries') {

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/DLManagementToolbarPropsTransformer.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/DLManagementToolbarPropsTransformer.js
@@ -1,0 +1,252 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {
+	addParams,
+	navigate,
+	openModal,
+	openSelectionModal,
+} from 'frontend-js-web';
+
+export default function propsTransformer({
+	additionalProps: {
+		downloadEntryURL,
+		editEntryURL,
+		folderConfiguration,
+		openViewMoreFileEntryTypesURL,
+		selectFileEntryTypeURL,
+		selectFolderURL,
+		trashEnabled,
+		viewFileEntryTypeURL,
+	},
+	portletNamespace,
+	...otherProps
+}) {
+	const processAction = (action, url) => {
+		if (!action) {
+			return;
+		}
+
+		const form = document.getElementById(`${portletNamespace}fm2`);
+
+		if (!form) {
+			return;
+		}
+
+		form.setAttribute('method', 'post');
+
+		const actionInputElement = form.querySelector(
+			`#${portletNamespace}javax-portlet-action`
+		);
+
+		if (actionInputElement) {
+			actionInputElement.setAttribute('value', action);
+		}
+
+		const commandInputElement = form.querySelector(
+			`#${portletNamespace}cmd`
+		);
+
+		if (commandInputElement) {
+			commandInputElement.setAttribute('value', action);
+		}
+
+		submitForm(form, url, false);
+	};
+
+	const checkIn = () => {
+		Liferay.componentReady(
+			`${portletNamespace}DocumentLibraryCheckinModal`
+		).then((documentLibraryCheckinModal) => {
+			documentLibraryCheckinModal.open((versionIncrease, changeLog) => {
+				const form = document.getElementById(`${portletNamespace}fm2`);
+
+				if (!form) {
+					return;
+				}
+
+				const changeLogInput = form.querySelector(
+					`#${portletNamespace}changeLog`
+				);
+
+				if (changeLogInput) {
+					changeLogInput.setAttribute('value', changeLog);
+				}
+
+				const versionIncreaseInput = form.querySelector(
+					`#${portletNamespace}versionIncrease`
+				);
+
+				if (versionIncreaseInput) {
+					versionIncreaseInput.setAttribute('value', versionIncrease);
+				}
+
+				processAction('checkin', editEntryURL);
+			});
+		});
+	};
+
+	const deleteEntries = () => {
+		let action;
+
+		if (trashEnabled) {
+			action = 'move_to_trash';
+		}
+		else if (
+			confirm(
+				Liferay.Language.get(
+					'are-you-sure-you-want-to-delete-the-selected-entries'
+				)
+			)
+		) {
+			action = 'delete';
+		}
+
+		processAction(action, editEntryURL);
+	};
+
+	const editTags = () => {
+		const searchContainer = Liferay.SearchContainer.get(
+			otherProps.searchContainerId
+		);
+
+		Liferay.componentReady(`${portletNamespace}EditTagsComponent`).then(
+			(editTagsComponent) => {
+				const bulkSelection = searchContainer.select?.get(
+					'bulkSelection'
+				);
+
+				const selectedFileEntries = searchContainer.select
+					.getAllSelectedElements()
+					.get('value');
+
+				editTagsComponent.open(
+					selectedFileEntries,
+					bulkSelection,
+					folderConfiguration.defaultParentFolderId
+				);
+			}
+		);
+	};
+
+	const move = () => {
+		const searchContainer = Liferay.SearchContainer.get(
+			otherProps.searchContainerId
+		);
+
+		let selectedItems = 0;
+
+		if (searchContainer.select) {
+			selectedItems = searchContainer.select
+				.getAllSelectedElements()
+				.filter(':enabled')
+				.size();
+		}
+
+		const dialogTitle =
+			selectedItems === 1
+				? Liferay.Language.get('select-destination-folder-for-x-item')
+				: Liferay.Language.get('select-destination-folder-for-x-items');
+
+		openSelectionModal({
+			height: '480px',
+			id: `${portletNamespace}selectFolder`,
+			onSelect(selectedItem) {
+				const newFolderId = selectedItem.folderid;
+
+				const form = document.getElementById(`${portletNamespace}fm2`);
+
+				if (!form) {
+					return;
+				}
+
+				form.setAttribute('action', editEntryURL);
+				form.setAttribute('enctype', 'multipart/form-data');
+				form.setAttribute('method', 'post');
+
+				const cmdInput = form.querySelector(`#${portletNamespace}cmd`);
+
+				if (cmdInput) {
+					cmdInput.setAttribute('value', 'move');
+				}
+
+				const newFolderIdInput = form.querySelector(
+					`#${portletNamespace}newFolderId`
+				);
+
+				if (newFolderIdInput) {
+					newFolderIdInput.setAttribute('value', newFolderId);
+				}
+
+				submitForm(form, editEntryURL, false);
+			},
+			selectEventName: `${portletNamespace}selectFolder`,
+			size: 'lg',
+			title: Liferay.Util.sub(dialogTitle, [selectedItems]),
+			url: selectFolderURL,
+		});
+	};
+
+	return {
+		...otherProps,
+		onActionButtonClick(event, {item}) {
+			const action = item.data?.action;
+
+			if (action === 'checkin') {
+				checkIn();
+			}
+			if (action === 'checkout') {
+				processAction('checkout', editEntryURL);
+			}
+			else if (action === 'deleteEntries') {
+				deleteEntries();
+			}
+			else if (action === 'download') {
+				processAction('download', downloadEntryURL);
+			}
+			else if (action === 'editTags') {
+				editTags();
+			}
+			else if (action === 'move') {
+				move();
+			}
+		},
+		onFilterDropdownItemClick(event, {item}) {
+			const action = item.data?.action;
+
+			if (action === 'openDocumentTypesSelector') {
+				openSelectionModal({
+					onSelect(selectedItem) {
+						if (selectedItem) {
+							const url = addParams(
+								`${portletNamespace}fileEntryTypeId=${selectedItem.value}`,
+								viewFileEntryTypeURL
+							);
+							navigate(url);
+						}
+					},
+					selectEventName: `${portletNamespace}selectFileEntryType`,
+					title: Liferay.Language.get('select-document-type'),
+					url: selectFileEntryTypeURL,
+				});
+			}
+		},
+		onShowMoreButtonClick() {
+			openModal({
+				title: Liferay.Language.get('more'),
+				url: openViewMoreFileEntryTypesURL,
+			});
+		},
+	};
+}

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/legacy/main.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/legacy/main.js
@@ -145,36 +145,6 @@ AUI.add(
 					submitForm(formNode, actionUrl, false);
 				},
 
-				_moveToFolder(obj) {
-					var instance = this;
-
-					var dropTarget = obj.targetItem;
-
-					var selectedItems = obj.selectedItems;
-
-					var folderId = dropTarget.attr('data-folder-id');
-
-					if (folderId) {
-						if (
-							!instance._searchContainer.select ||
-							selectedItems.indexOf(
-								dropTarget.one('input[type=checkbox]')
-							)
-						) {
-							instance._moveCurrentSelection(folderId);
-						}
-					}
-				},
-
-				_moveToTrash() {
-					var instance = this;
-
-					instance._processAction(
-						'move_to_trash',
-						instance.get('editEntryUrl')
-					);
-				},
-
 				_openDocument(event) {
 					var instance = this;
 
@@ -202,61 +172,6 @@ AUI.add(
 					);
 				},
 
-				_openModalCategories() {
-					var instance = this;
-
-					Liferay.componentReady(
-						instance.NS + 'EditCategoriesComponent'
-					).then((editCategoriesComponent) => {
-						var bulkSelection =
-							instance._searchContainer.select &&
-							instance._searchContainer.select.get(
-								'bulkSelection'
-							);
-
-						editCategoriesComponent.open(
-							instance._selectedFileEntries,
-							bulkSelection,
-							instance.getFolderId()
-						);
-					});
-				},
-
-				_openModalMove() {
-					var instance = this;
-
-					var selectedItems = 0;
-
-					if (instance._searchContainer.select) {
-						selectedItems = instance._searchContainer.select
-							.getAllSelectedElements()
-							.filter(':enabled')
-							.size();
-					}
-
-					this.showFolderDialog(selectedItems);
-				},
-
-				_openModalTags() {
-					var instance = this;
-
-					Liferay.componentReady(
-						instance.NS + 'EditTagsComponent'
-					).then((editTagsComponent) => {
-						var bulkSelection =
-							instance._searchContainer.select &&
-							instance._searchContainer.select.get(
-								'bulkSelection'
-							);
-
-						editTagsComponent.open(
-							instance._selectedFileEntries,
-							bulkSelection,
-							instance.getFolderId()
-						);
-					});
-				},
-
 				_plugUpload(event, config) {
 					var instance = this;
 
@@ -275,31 +190,6 @@ AUI.add(
 					});
 				},
 
-				_processAction(action, url, redirectUrl) {
-					var instance = this;
-
-					var namespace = instance.NS;
-
-					var form = instance.get('form').node;
-
-					redirectUrl = redirectUrl || location.href;
-
-					form.attr('method', instance.get('form').method);
-
-					if (form.get(namespace + 'javax-portlet-action')) {
-						form.get(namespace + 'javax-portlet-action').val(
-							action
-						);
-					}
-					else {
-						form.get(namespace + 'cmd').val(action);
-					}
-
-					form.get(namespace + 'redirect').val(redirectUrl);
-
-					submitForm(form, url, false);
-				},
-
 				destructor() {
 					var instance = this;
 
@@ -312,117 +202,6 @@ AUI.add(
 					var instance = this;
 
 					return instance._folderId;
-				},
-
-				handleActionItemClicked(event) {
-					var instance = this;
-
-					var action = event.data.item.data.action;
-
-					var namespace = instance.NS;
-
-					var url = instance.get('editEntryUrl');
-
-					if (action === 'editTags') {
-						instance._openModalTags();
-
-						action = null;
-					}
-					else if (action === 'editCategories') {
-						instance._openModalCategories();
-
-						action = null;
-					}
-					else if (action === 'move' || action === 'moveEntries') {
-						instance._openModalMove();
-
-						action = null;
-					}
-					else if (action === 'download') {
-						url = instance.get('downloadEntryUrl');
-					}
-					else if (action === 'deleteEntries') {
-						if (instance.get('trashEnabled')) {
-							action = 'move_to_trash';
-						}
-						else if (
-							confirm(
-								Liferay.Language.get(
-									'are-you-sure-you-want-to-delete-the-selected-entries'
-								)
-							)
-						) {
-							action = 'delete';
-						}
-						else {
-							action = null;
-						}
-					}
-					else if (action === 'checkin') {
-						Liferay.componentReady(
-							instance.ns('DocumentLibraryCheckinModal')
-						).then((documentLibraryCheckinModal) => {
-							documentLibraryCheckinModal.open(
-								(versionIncrease, changeLog) => {
-									var form = instance.get('form').node;
-
-									form.get(namespace + 'changeLog').val(
-										changeLog
-									);
-									form.get(namespace + 'versionIncrease').val(
-										versionIncrease
-									);
-
-									instance._processAction('checkin', url);
-								}
-							);
-						});
-						action = null;
-					}
-
-					if (action) {
-						instance._processAction(action, url);
-					}
-				},
-
-				handleCreationMenuMoreButtonClicked(event) {
-					var instance = this;
-
-					event.preventDefault();
-
-					Liferay.Util.openModal({
-						title: Liferay.Language.get('more'),
-						url: instance.get('openViewMoreFileEntryTypesURL'),
-					});
-				},
-
-				handleFilterItemClicked(event) {
-					var instance = this;
-
-					var itemData = event.data.item.data;
-
-					if (itemData.action === 'openDocumentTypesSelector') {
-						Liferay.Util.openSelectionModal({
-							onSelect: (selectedItem) => {
-								if (selectedItem) {
-									var uri = instance.get(
-										'viewFileEntryTypeURL'
-									);
-
-									uri = Liferay.Util.addParams(
-										instance.ns('fileEntryTypeId=') +
-											selectedItem.value,
-										uri
-									);
-
-									Liferay.Util.navigate(uri);
-								}
-							},
-							selectEventName: instance.ns('selectFileEntryType'),
-							title: Liferay.Language.get('select-document-type'),
-							url: instance.get('selectFileEntryTypeURL'),
-						});
-					}
 				},
 
 				initializer(config) {
@@ -447,14 +226,6 @@ AUI.add(
 						namespace + instance.get('searchContainerId')
 					);
 
-					searchContainer.registerAction(
-						'move-to-folder',
-						A.bind('_moveToFolder', instance)
-					);
-					searchContainer.registerAction(
-						'move-to-trash',
-						A.bind('_moveToTrash', instance)
-					);
 					eventHandles.push(
 						searchContainer.on(
 							'rowToggled',

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view.jsp
@@ -46,8 +46,40 @@ DLViewDisplayContext dlViewDisplayContext = new DLViewDisplayContext(dlAdminDisp
 
 		<liferay-util:include page="/document_library/navigation.jsp" servletContext="<%= application %>" />
 
-		<clay:management-toolbar-v2
-			displayContext="<%= (DLAdminManagementToolbarDisplayContext)request.getAttribute(DLAdminManagementToolbarDisplayContext.class.getName()) %>"
+		<clay:management-toolbar
+			additionalProps='<%=
+				HashMapBuilder.<String, Object>put(
+					"downloadEntryURL", dlViewDisplayContext.getDownloadEntryURL()
+				).put(
+					"editEntryURL", dlViewDisplayContext.getEditEntryURL()
+				).put(
+					"folderConfiguration",
+					HashMapBuilder.<String, Object>put(
+						"defaultParentFolderId", dlViewDisplayContext.getFolderId()
+					).put(
+						"dimensions",
+						HashMapBuilder.<String, Object>put(
+							"height", PrefsPropsUtil.getLong(PropsKeys.DL_FILE_ENTRY_THUMBNAIL_MAX_HEIGHT)
+						).put(
+							"width", PrefsPropsUtil.getLong(PropsKeys.DL_FILE_ENTRY_THUMBNAIL_MAX_WIDTH)
+						).build()
+					).build()
+				).put(
+					"openViewMoreFileEntryTypesURL", dlViewDisplayContext.getViewMoreFileEntryTypesURL()
+				).put(
+					"selectFileEntryTypeURL", dlViewDisplayContext.getSelectFileEntryTypeURL()
+				).put(
+					"selectFolderURL", dlViewDisplayContext.getSelectFolderURL()
+				).put(
+					"trashEnabled", dlTrashHelper.isTrashEnabled(scopeGroupId, dlViewDisplayContext.getRepositoryId())
+				).put(
+					"viewFileEntryTypeURL", dlViewDisplayContext.getViewFileEntryTypeURL()
+				).put(
+					"viewFileEntryURL", dlViewDisplayContext.getViewFileEntryURL()
+				).build()
+			%>'
+			managementToolbarDisplayContext="<%= (DLAdminManagementToolbarDisplayContext)request.getAttribute(DLAdminManagementToolbarDisplayContext.class.getName()) %>"
+			propsTransformer="document_library/js/DLManagementToolbarPropsTransformer"
 		/>
 
 		<%

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry_metadata_sets.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry_metadata_sets.jsp
@@ -24,8 +24,8 @@ DLViewFileEntryMetadataSetsManagementToolbarDisplayContext dlViewFileEntryMetada
 
 <liferay-util:include page="/document_library/navigation.jsp" servletContext="<%= application %>" />
 
-<clay:management-toolbar-v2
-	displayContext="<%= dlViewFileEntryMetadataSetsManagementToolbarDisplayContext %>"
+<clay:management-toolbar
+	managementToolbarDisplayContext="<%= dlViewFileEntryMetadataSetsManagementToolbarDisplayContext %>"
 />
 
 <portlet:actionURL copyCurrentRenderParameters="<%= true %>" name="/document_library/delete_data_definition" var="deleteDataDefinitionURL">

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry_types.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry_types.jsp
@@ -22,7 +22,7 @@ DLViewFileEntryTypesDisplayContext dlViewFileEntryTypesDisplayContext = new DLVi
 
 <liferay-util:include page="/document_library/navigation.jsp" servletContext="<%= application %>" />
 
-<clay:management-toolbar-v2
+<clay:management-toolbar
 	clearResultsURL="<%= dlViewFileEntryTypesDisplayContext.getClearResultsURL() %>"
 	creationMenu="<%= dlViewFileEntryTypesDisplayContext.getCreationMenu() %>"
 	disabled="<%= dlViewFileEntryTypesDisplayContext.getTotalItems() == 0 %>"

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_more_menu_items.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_more_menu_items.jsp
@@ -26,7 +26,7 @@ DLViewMoreMenuItemsDisplayContext dlViewMoreMenuItemsDisplayContext = new DLView
 	navigationItems="<%= dlViewMoreMenuItemsDisplayContext.getNavigationItems() %>"
 />
 
-<clay:management-toolbar-v2
+<clay:management-toolbar
 	clearResultsURL="<%= dlViewMoreMenuItemsDisplayContext.getClearResultsURL() %>"
 	componentId="dlViewMoreMenuItemsManagementToolbar"
 	disabled="<%= dlViewMoreMenuItemsDisplayContext.getTotalItems() == 0 %>"

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/CreationMenu.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/CreationMenu.js
@@ -14,6 +14,7 @@
 
 import {ClayButtonWithIcon} from '@clayui/button';
 import ClayDropDown from '@clayui/drop-down';
+import classNames from 'classnames';
 import React, {useRef, useState} from 'react';
 
 import LinkOrButton from './LinkOrButton';
@@ -102,7 +103,13 @@ const CreationMenu = ({
 		let currentItemCount = 0;
 
 		return (
-			<ClayDropDown.ItemList>
+			<ClayDropDown.ItemList
+				className={classNames({
+					'dropdown-menu-indicator-start': primaryItems.some(
+						(item) => item.icon
+					),
+				})}
+			>
 				{primaryItems?.map((item, index) => {
 					currentItemCount++;
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/FilterOrderControls.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/FilterOrderControls.js
@@ -20,13 +20,32 @@ import React from 'react';
 
 import LinkOrButton from './LinkOrButton';
 
-const FilterOrderControls = ({disabled, filterDropdownItems, sortingURL}) => {
+const FilterOrderControls = ({
+	disabled,
+	filterDropdownItems,
+	onFilterDropdownItemClick,
+	sortingURL,
+}) => {
 	return (
 		<>
 			{filterDropdownItems && (
 				<ClayManagementToolbar.Item>
 					<ClayDropDownWithItems
-						items={filterDropdownItems}
+						items={filterDropdownItems.map((item) => {
+							return {
+								...item,
+								items: item.items.map((childItem) => {
+									return {
+										...childItem,
+										onClick(event) {
+											onFilterDropdownItemClick(event, {
+												item: childItem,
+											});
+										},
+									};
+								}),
+							};
+						})}
 						trigger={
 							<ClayButton
 								className="nav-link"

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/InfoPanelControl.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/InfoPanelControl.js
@@ -16,7 +16,7 @@ import {ClayButtonWithIcon} from '@clayui/button';
 import ClayManagementToolbar from '@clayui/management-toolbar';
 import React, {useEffect, useRef} from 'react';
 
-const InfoPanelControl = ({disabled, infoPanelId, onInfoButtonClick}) => {
+const InfoPanelControl = ({infoPanelId, onInfoButtonClick}) => {
 	const infoButtonRef = useRef();
 
 	useEffect(() => {
@@ -45,7 +45,6 @@ const InfoPanelControl = ({disabled, infoPanelId, onInfoButtonClick}) => {
 		<ClayManagementToolbar.Item>
 			<ClayButtonWithIcon
 				className="nav-link nav-link-monospaced"
-				disabled={disabled}
 				displayType="unstyled"
 				id={infoPanelId && `${infoPanelId}_trigger`}
 				onClick={onInfoButtonClick}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.js
@@ -45,6 +45,7 @@ function ManagementToolbar({
 	onCreateButtonClick = () => {},
 	onCreationMenuItemClick = () => {},
 	onInfoButtonClick = () => {},
+	onFilterDropdownItemClick = () => {},
 	onSelectAllButtonClick = () => {},
 	onShowMoreButtonClick,
 	searchActionURL,
@@ -101,6 +102,9 @@ function ManagementToolbar({
 						<FilterOrderControls
 							disabled={disabled}
 							filterDropdownItems={filterDropdownItems}
+							onFilterDropdownItemClick={
+								onFilterDropdownItemClick
+							}
 							sortingURL={sortingURL}
 						/>
 					)}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.js
@@ -131,7 +131,6 @@ function ManagementToolbar({
 					)}
 					{showInfoButton && (
 						<InfoPanelControl
-							disabled={disabled}
 							infoPanelId={infoPanelId}
 							onInfoButtonClick={onInfoButtonClick}
 						/>
@@ -153,7 +152,6 @@ function ManagementToolbar({
 										trigger={
 											<ClayButtonWithIcon
 												className="nav-link nav-link-monospaced"
-												disabled={disabled}
 												displayType="unstyled"
 												symbol={
 													viewTypeItems.find(


### PR DESCRIPTION
The <clay:management-toolbar-v2 /> tag has been replaced with the
<clay:management-toolbar /> tag (which uses clay v3).

**Test plan**:
- Navigate to **Content & Data** > **Documents and Media**
- Uploading new files should work as expected
- Editing tags should work as expected
- Deleting items should work as expected
- Moving items to a new folder should work as expected
- Creating Document Types should work as expected
- Creating Metadata Sets should work as expected

**Test plan to test edit Categories**

- Navigate to Categorization > Categories
- Add New vocabulary
- Add new categories
- Navigate to Content & Data > Documents and Media
- New icon edit categories

**Additional notes**
Originally reviewed [here](https://github.com/liferay-frontend/liferay-portal/pull/805)

**[EDIT]**
In order to test this properly, navigate to **Content & Data** > **Documents and Media**, you'll see three tabs: 
**Documents and Media**, **Document Types** and **Metadata Sets**. 

Each of these tabs has a management toolbar that is affected by these changes, and they should work as they previously used to.

You'll also have to go to the **Documents and Media** tab, create a folder (via the management toolbar), and then click on that folder's name to view and test if the management toolbar works there.

The last thing to do, is to go to the **Document Types**  tab, create a lot of document types (>20) at which point the clicking on the "More" button of the creation menu should open a modal window that has another management toolbar.

Since it seems that it's not possible to create document types right now (changes in DDM), I'm putting this on hold, but feel free to review when DDM is working again.
