### PR TITLE
LPS-121880 Migrate v2 usages in item-selector/item-selector-web

### DIFF
--- a/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/view_item_selector_view_descriptor.jsp
+++ b/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/view_item_selector_view_descriptor.jsp
@@ -25,8 +25,8 @@ SearchContainer<Object> searchContainer = itemSelectorViewDescriptorRendererDisp
 %>
 
 <c:if test="<%= itemSelectorViewDescriptor.isShowManagementToolbar() %>">
-	<clay:management-toolbar-v2
-		displayContext="<%= new ItemSelectorViewDescriptorRendererManagementToolbarDisplayContext(itemSelectorViewDescriptor, request, liferayPortletRequest, liferayPortletResponse, searchContainer) %>"
+	<clay:management-toolbar
+		managementToolbarDisplayContext="<%= new ItemSelectorViewDescriptorRendererManagementToolbarDisplayContext(itemSelectorViewDescriptor, request, liferayPortletRequest, liferayPortletResponse, searchContainer) %>"
 	/>
 </c:if>
 


### PR DESCRIPTION
**Depends on** #1525

The <clay:management-toolbar-v2 /> tag has been replaced with the
<clay:management-toolbar /> tag (which uses clay v3).

**Test plan:** 
1. On the home page, edit and add something, like a button. 
2. Double click on the button
3. Go to the mapping section, and in the Content field, click on + button 
4. On the modal, click on "Blogs" tab => here is the management toolbar that we are replacing. 

<img width="1050" alt="Screenshot 2021-02-23 at 13 06 22" src="https://user-images.githubusercontent.com/8373764/108841387-f2fcbc00-75d7-11eb-81c8-64a488157351.png">

If there are no blogs, you will see that the management toolbar is disabled, including the Display Style button when it shouldn't. Well, this is fixed in pull https://github.com/liferay-lima/liferay-portal/pull/1525, in this specific [line](https://github.com/liferay-lima/liferay-portal/pull/1525/commits/bc125ba882fe46e9c4cf321106c6ffc48d474e8c#diff-0472a60df273abf88d70b40c81377e866387a3d0a1564d484dc1b62ee9d8acc2L156). So, once this pull is merged this icon will not get disabled ever (behaviour confirmed with Lexicon). 

<img width="970" alt="MT item-selector-web" src="https://user-images.githubusercontent.com/8373764/108842409-871b5300-75d9-11eb-9a92-09d4c8c6eb83.png">


/cc @julien @markocikos @jonmak08
