### PR TITLE
[TS] LPS-128366

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/EditFolderMVCActionCommand.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/EditFolderMVCActionCommand.java
@@ -221,7 +221,7 @@ public class EditFolderMVCActionCommand extends BaseMVCActionCommand {
 		String description = ParamUtil.getString(actionRequest, "description");
 
 		ServiceContext serviceContext = ServiceContextFactory.getInstance(
-			DLFolder.class.getName(), actionRequest);
+			actionRequest);
 
 		if (folderId <= 0) {
 


### PR DESCRIPTION
[LPS-128366](https://issues.liferay.com/browse/LPS-128366)

From @jesseyeh-liferay:

> When creating a new Documents and Media folder with empty permissions, the folder will instead fall back to using the default permissions. Per acfc614447494afffb6e435da0751e61d579c422, this can be resolved by not specifying a `className` parameter in `ServiceContextFactory.getInstance`.