### PR TITLE
LPS-127980 use ddm prefix to show relation between ddmFields and their content

### DIFF
--- a/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/info/item/updater/JournalArticleInfoItemFieldValuesUpdaterImpl.java
+++ b/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/info/item/updater/JournalArticleInfoItemFieldValuesUpdaterImpl.java
@@ -159,24 +159,24 @@ public class JournalArticleInfoItemFieldValuesUpdaterImpl
 			translatedContent, latestArticle.getLayoutUuid(), serviceContext);
 	}
 
-	private void _addNewTranslatedField(
-			DDMStructure ddmStructure, Locale targetLocale, Fields ddmFields,
-			String fieldName, String entryValue)
+	private void _addNewTranslatedDDMField(
+			DDMStructure ddmStructure, Locale targetLocale, String ddmFieldName,
+			Fields ddmFields, String ddmFieldValue)
 		throws Exception {
 
-		Field field = new Field(
-			ddmStructure.getStructureId(), fieldName, Collections.emptyList(),
-			ddmFields.getDefaultLocale());
+		Field ddmField = new Field(
+			ddmStructure.getStructureId(), ddmFieldName,
+			Collections.emptyList(), ddmFields.getDefaultLocale());
 
-		field.setValue(
+		ddmField.setValue(
 			targetLocale,
 			FieldConstants.getSerializable(
 				targetLocale, targetLocale,
-				ddmStructure.getFieldType(fieldName), entryValue));
+				ddmStructure.getFieldType(ddmFieldName), ddmFieldValue));
 
-		ddmFields.put(field);
+		ddmFields.put(ddmField);
 
-		_updateFieldsDisplay(ddmFields, fieldName);
+		_updateFieldsDisplay(ddmFields, ddmFieldName);
 	}
 
 	private Optional<InfoLocalizedValue<Object>> _getInfoLocalizedValueOptional(
@@ -218,8 +218,8 @@ public class JournalArticleInfoItemFieldValuesUpdaterImpl
 						entry.getValue()));
 			}
 			else if (ddmStructure.hasField(entry.getKey())) {
-				_addNewTranslatedField(
-					ddmStructure, targetLocale, ddmFields, entry.getKey(),
+				_addNewTranslatedDDMField(
+					ddmStructure, targetLocale, entry.getKey(), ddmFields,
 					entry.getValue());
 			}
 		}

--- a/modules/apps/translation/translation-test/src/testIntegration/java/com/liferay/translation/info/item/updater/test/JournalArticleInfoItemFieldValuesUpdaterTest.java
+++ b/modules/apps/translation/translation-test/src/testIntegration/java/com/liferay/translation/info/item/updater/test/JournalArticleInfoItemFieldValuesUpdaterTest.java
@@ -357,7 +357,7 @@ public class JournalArticleInfoItemFieldValuesUpdaterTest {
 				"name", StringPool.BLANK);
 
 			if (!Objects.equals(attribute, fieldName)) {
-				return StringPool.BLANK;
+				continue;
 			}
 
 			for (Element element :

--- a/modules/apps/translation/translation-test/src/testIntegration/resources/com/liferay/translation/dependencies/test-ddm-structure.json
+++ b/modules/apps/translation/translation-test/src/testIntegration/resources/com/liferay/translation/dependencies/test-ddm-structure.json
@@ -1,0 +1,86 @@
+{
+	"availableLanguageIds": [
+		"en_US"
+	],
+	"defaultLanguageId": "en_US",
+	"definitionSchemaVersion": "2.0",
+	"fields": [
+		{
+			"autocomplete": false,
+			"dataSourceType": "manual",
+			"dataType": "string",
+			"ddmDataProviderInstanceId": "[]",
+			"ddmDataProviderInstanceOutput": "[]",
+			"displayStyle": "singleline",
+			"fieldNamespace": "",
+			"fieldReference": "Text05643854",
+			"indexType": "keyword",
+			"label": {
+				"en_US": "Text"
+			},
+			"localizable": true,
+			"name": "Text05643854",
+			"nativeField": false,
+			"placeholder": {
+				"en_US": ""
+			},
+			"predefinedValue": {
+				"en_US": ""
+			},
+			"readOnly": false,
+			"repeatable": false,
+			"required": false,
+			"showLabel": true,
+			"tip": {
+				"en_US": ""
+			},
+			"tooltip": {
+				"en_US": ""
+			},
+			"type": "text",
+			"visibilityExpression": ""
+		},
+		{
+			"autocomplete": false,
+			"dataSourceType": "manual",
+			"dataType": "string",
+			"ddmDataProviderInstanceId": "[]",
+			"ddmDataProviderInstanceOutput": "[]",
+			"displayStyle": "singleline",
+			"fieldNamespace": "",
+			"fieldReference": "NewText",
+			"indexType": "keyword",
+			"label": {
+				"en_US": "Text"
+			},
+			"localizable": true,
+			"name": "NewText",
+			"nativeField": false,
+			"placeholder": {
+				"en_US": ""
+			},
+			"predefinedValue": {
+				"en_US": ""
+			},
+			"readOnly": false,
+			"repeatable": false,
+			"required": false,
+			"showLabel": true,
+			"tip": {
+				"en_US": ""
+			},
+			"tooltip": {
+				"en_US": ""
+			},
+			"type": "text",
+			"visibilityExpression": ""
+		}
+	],
+	"successPage": {
+		"body": {
+		},
+		"enabled": false,
+		"title": {
+		}
+	}
+}

--- a/modules/apps/translation/translation-test/src/testIntegration/resources/com/liferay/translation/dependencies/test-journal-article-new-field.xlf
+++ b/modules/apps/translation/translation-test/src/testIntegration/resources/com/liferay/translation/dependencies/test-journal-article-new-field.xlf
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-US" trgLang="es-ES" version="2.0">
+	<file id="com.liferay.journal.model.JournalArticle:[$JOURNAL_ARTICLE_ID$]">
+		<unit id="NewText">
+			<segment>
+				<source></source>
+				<target><![CDATA[Este campo es nuevo]]></target>
+			</segment>
+		</unit>
+	</file>
+</xliff>

--- a/modules/apps/translation/translation-test/src/testIntegration/resources/com/liferay/translation/dependencies/test-journal-content-one-field.xml
+++ b/modules/apps/translation/translation-test/src/testIntegration/resources/com/liferay/translation/dependencies/test-journal-content-one-field.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+
+<root available-locales="en_US" default-locale="en_US" version="1.0">
+	<dynamic-element index-type="keyword" instance-id="e54h1Ge1" name="Text05643854" type="text">
+		<dynamic-content language-id="en_US"><![CDATA[text one]]></dynamic-content>
+	</dynamic-element>
+</root>

--- a/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/portlet/action/UpdateTranslationMVCActionCommand.java
+++ b/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/portlet/action/UpdateTranslationMVCActionCommand.java
@@ -148,9 +148,11 @@ public class UpdateTranslationMVCActionCommand extends BaseMVCActionCommand {
 									infoItemFieldValues.getInfoFieldValue(
 										infoField.getName());
 
-								biConsumer.accept(
-									sourceLocale,
-									infoFieldValue.getValue(sourceLocale));
+								if (infoFieldValue != null) {
+									biConsumer.accept(
+										sourceLocale,
+										infoFieldValue.getValue(sourceLocale));
+								}
 							}
 						).build()));
 			}


### PR DESCRIPTION
In reference to : https://github.com/brianchandotcom/liferay-portal/pull/99176#issuecomment-787589032

I add the prefix to the _addNewTranslatedField (method and fields)

On the case of the `testUpdateJournalArticleFromInfoItemFieldValuesUpdatesNewField` the Field that the test makes reference to is a field of the content, modified by the xlf translation file and makes no reference to a ddmField in this case. DDM is just the implementation detail.

Thanks!