### PR TITLE
LPS-128746 Use modified date as publish date in FileEntryInfoItemFieldValuesProvider

### DIFF
--- a/modules/apps/blogs/blogs-web-test/build.gradle
+++ b/modules/apps/blogs/blogs-web-test/build.gradle
@@ -4,6 +4,7 @@ dependencies {
 	testIntegrationCompile group: "javax.portlet", name: "portlet-api", version: "3.0.1"
 	testIntegrationCompile group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	testIntegrationCompile project(":apps:blogs:blogs-api")
+	testIntegrationCompile project(":apps:info:info-api")
 	testIntegrationCompile project(":apps:layout:layout-test-util")
 	testIntegrationCompile project(":apps:trash:trash-api")
 	testIntegrationCompile project(":core:registry-api")

--- a/modules/apps/blogs/blogs-web-test/src/testIntegration/java/com/liferay/blogs/web/internal/info/item/provider/test/BlogsEntryInfoItemFieldValuesProviderTest.java
+++ b/modules/apps/blogs/blogs-web-test/src/testIntegration/java/com/liferay/blogs/web/internal/info/item/provider/test/BlogsEntryInfoItemFieldValuesProviderTest.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.blogs.web.internal.info.item.provider.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.blogs.model.BlogsEntry;
+import com.liferay.blogs.service.BlogsEntryLocalService;
+import com.liferay.info.field.InfoFieldValue;
+import com.liferay.info.item.InfoItemFieldValues;
+import com.liferay.info.item.provider.InfoItemFieldValuesProvider;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Cristina González
+ */
+@RunWith(Arquillian.class)
+public class BlogsEntryInfoItemFieldValuesProviderTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	public void testGetInfoItemFieldValues() throws PortalException {
+		BlogsEntry blogsEntry = _blogsEntryLocalService.addEntry(
+			TestPropsValues.getUserId(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(),
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		InfoItemFieldValues infoItemFieldValues =
+			_infoItemFieldValuesProvider.getInfoItemFieldValues(blogsEntry);
+
+		InfoFieldValue<Object> createDateInfoFieldValue =
+			infoItemFieldValues.getInfoFieldValue("createDate");
+
+		Assert.assertEquals(
+			blogsEntry.getCreateDate(), createDateInfoFieldValue.getValue());
+
+		InfoFieldValue<Object> modifiedDateInfoFieldValue =
+			infoItemFieldValues.getInfoFieldValue("modifiedDate");
+
+		Assert.assertEquals(
+			blogsEntry.getModifiedDate(),
+			modifiedDateInfoFieldValue.getValue());
+
+		InfoFieldValue<Object> publishDateInfoFieldValue =
+			infoItemFieldValues.getInfoFieldValue("publishDate");
+
+		Assert.assertEquals(
+			blogsEntry.getDisplayDate(), publishDateInfoFieldValue.getValue());
+	}
+
+	@Inject
+	private BlogsEntryLocalService _blogsEntryLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject(filter = "component.name=*.BlogsEntryInfoItemFieldValuesProvider")
+	private InfoItemFieldValuesProvider _infoItemFieldValuesProvider;
+
+}

--- a/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/info/item/BlogsEntryInfoItemFields.java
+++ b/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/info/item/BlogsEntryInfoItemFields.java
@@ -76,6 +76,16 @@ public interface BlogsEntryInfoItemFields {
 			InfoLocalizedValue.localize(
 				BlogsEntryInfoItemFields.class, "cover-image")
 		).build();
+	public static final InfoField<TextInfoFieldType> createDateInfoField =
+		InfoField.builder(
+		).infoFieldType(
+			TextInfoFieldType.INSTANCE
+		).name(
+			"createDate"
+		).labelInfoLocalizedValue(
+			InfoLocalizedValue.localize(
+				BlogsEntryInfoItemFields.class, "create-date")
+		).build();
 	public static final InfoField<TextInfoFieldType> descriptionInfoField =
 		InfoField.builder(
 		).infoFieldType(
@@ -105,6 +115,16 @@ public interface BlogsEntryInfoItemFields {
 		).labelInfoLocalizedValue(
 			InfoLocalizedValue.localize(
 				"com.liferay.asset.info.display.impl", "display-page-url")
+		).build();
+	public static final InfoField<TextInfoFieldType> modifiedDateInfoField =
+		InfoField.builder(
+		).infoFieldType(
+			TextInfoFieldType.INSTANCE
+		).name(
+			"modifiedDate"
+		).labelInfoLocalizedValue(
+			InfoLocalizedValue.localize(
+				BlogsEntryInfoItemFields.class, "modified-date")
 		).build();
 	public static final InfoField<DateInfoFieldType> publishDateInfoField =
 		InfoField.builder(

--- a/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/info/item/BlogsEntryInfoItemFields.java
+++ b/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/info/item/BlogsEntryInfoItemFields.java
@@ -106,6 +106,16 @@ public interface BlogsEntryInfoItemFields {
 			InfoLocalizedValue.localize(
 				"com.liferay.asset.info.display.impl", "display-page-url")
 		).build();
+	public static final InfoField<DateInfoFieldType> publishDateInfoField =
+		InfoField.builder(
+		).infoFieldType(
+			DateInfoFieldType.INSTANCE
+		).name(
+			"publishDate"
+		).labelInfoLocalizedValue(
+			InfoLocalizedValue.localize(
+				BlogsEntryInfoItemFields.class, "publish-date")
+		).build();
 	public static final InfoField<ImageInfoFieldType> smallImageInfoField =
 		InfoField.builder(
 		).infoFieldType(

--- a/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/info/item/provider/BlogsEntryInfoItemFieldValuesProvider.java
+++ b/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/info/item/provider/BlogsEntryInfoItemFieldValuesProvider.java
@@ -102,6 +102,15 @@ public class BlogsEntryInfoItemFieldValuesProvider
 					BlogsEntryInfoItemFields.descriptionInfoField,
 					blogsEntry.getDescription()));
 
+			blogsEntryFieldValues.add(
+				new InfoFieldValue<>(
+					BlogsEntryInfoItemFields.createDateInfoField,
+					blogsEntry.getCreateDate()));
+			blogsEntryFieldValues.add(
+				new InfoFieldValue<>(
+					BlogsEntryInfoItemFields.modifiedDateInfoField,
+					blogsEntry.getModifiedDate()));
+
 			if (themeDisplay != null) {
 				WebImage smallWebImage = new WebImage(
 					blogsEntry.getSmallImageURL(themeDisplay),

--- a/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/info/item/provider/BlogsEntryInfoItemFieldValuesProvider.java
+++ b/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/info/item/provider/BlogsEntryInfoItemFieldValuesProvider.java
@@ -163,6 +163,10 @@ public class BlogsEntryInfoItemFieldValuesProvider
 				new InfoFieldValue<>(
 					BlogsEntryInfoItemFields.displayDateInfoField,
 					blogsEntry.getDisplayDate()));
+			blogsEntryFieldValues.add(
+				new InfoFieldValue<>(
+					BlogsEntryInfoItemFields.publishDateInfoField,
+					blogsEntry.getDisplayDate()));
 
 			if (themeDisplay != null) {
 				blogsEntryFieldValues.add(

--- a/modules/apps/document-library/document-library-web-test/build.gradle
+++ b/modules/apps/document-library/document-library-web-test/build.gradle
@@ -6,6 +6,7 @@ dependencies {
 	testIntegrationCompile project(":apps:document-library:document-library-api")
 	testIntegrationCompile project(":apps:export-import:export-import-api")
 	testIntegrationCompile project(":apps:export-import:export-import-test-util")
+	testIntegrationCompile project(":apps:info:info-api")
 	testIntegrationCompile project(":apps:layout:layout-test-util")
 	testIntegrationCompile project(":apps:ratings:ratings-test-util")
 	testIntegrationCompile project(":test:arquillian-extension-junit-bridge")

--- a/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/info/item/provider/test/FileEntryInfoItemFieldValuesProviderTest.java
+++ b/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/info/item/provider/test/FileEntryInfoItemFieldValuesProviderTest.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.document.library.web.internal.info.item.provider.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.document.library.kernel.model.DLFolderConstants;
+import com.liferay.document.library.kernel.service.DLAppService;
+import com.liferay.info.field.InfoFieldValue;
+import com.liferay.info.item.InfoItemFieldValues;
+import com.liferay.info.item.provider.InfoItemFieldValuesProvider;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import jodd.util.MimeTypes;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Cristina González
+ */
+@RunWith(Arquillian.class)
+public class FileEntryInfoItemFieldValuesProviderTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	public void testGetInfoItemFieldValues() throws PortalException {
+		FileEntry fileEntry = _dlAppService.addFileEntry(
+			_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			RandomTestUtil.randomString(),
+			MimeTypes.MIME_APPLICATION_OCTET_STREAM,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			StringPool.BLANK, (byte[])null,
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		InfoItemFieldValues infoItemFieldValues =
+			_infoItemFieldValuesProvider.getInfoItemFieldValues(fileEntry);
+
+		InfoFieldValue<Object> createDateInfoFieldValue =
+			infoItemFieldValues.getInfoFieldValue("createDate");
+
+		Assert.assertEquals(
+			fileEntry.getCreateDate(), createDateInfoFieldValue.getValue());
+
+		InfoFieldValue<Object> modifiedDateInfoFieldValue =
+			infoItemFieldValues.getInfoFieldValue("modifiedDate");
+
+		Assert.assertEquals(
+			fileEntry.getModifiedDate(), modifiedDateInfoFieldValue.getValue());
+
+		InfoFieldValue<Object> publishDateInfoFieldValue =
+			infoItemFieldValues.getInfoFieldValue("publishDate");
+
+		Assert.assertEquals(
+			fileEntry.getModifiedDate(), publishDateInfoFieldValue.getValue());
+	}
+
+	@Inject
+	private DLAppService _dlAppService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject(filter = "component.name=*.FileEntryInfoItemFieldValuesProvider")
+	private InfoItemFieldValuesProvider _infoItemFieldValuesProvider;
+
+}

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/info/item/FileEntryInfoItemFields.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/info/item/FileEntryInfoItemFields.java
@@ -47,6 +47,16 @@ public class FileEntryInfoItemFields {
 			InfoLocalizedValue.localize(
 				"com.liferay.journal.lang", "author-profile-image")
 		).build();
+	public static final InfoField<TextInfoFieldType> createDateInfoField =
+		InfoField.builder(
+		).infoFieldType(
+			TextInfoFieldType.INSTANCE
+		).name(
+			"createDate"
+		).labelInfoLocalizedValue(
+			InfoLocalizedValue.localize(
+				FileEntryInfoItemFields.class, "create-date")
+		).build();
 	public static final InfoField<TextInfoFieldType> descriptionInfoField =
 		InfoField.builder(
 		).infoFieldType(
@@ -106,6 +116,16 @@ public class FileEntryInfoItemFields {
 		).labelInfoLocalizedValue(
 			InfoLocalizedValue.localize(
 				FileEntryInfoItemFields.class, "mime-type")
+		).build();
+	public static final InfoField<TextInfoFieldType> modifiedDateInfoField =
+		InfoField.builder(
+		).infoFieldType(
+			TextInfoFieldType.INSTANCE
+		).name(
+			"modifiedDate"
+		).labelInfoLocalizedValue(
+			InfoLocalizedValue.localize(
+				FileEntryInfoItemFields.class, "modified-date")
 		).build();
 	public static final InfoField<ImageInfoFieldType> previewImage =
 		InfoField.builder(

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/info/item/provider/FileEntryInfoItemFieldValuesProvider.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/info/item/provider/FileEntryInfoItemFieldValuesProvider.java
@@ -200,6 +200,15 @@ public class FileEntryInfoItemFieldValuesProvider
 				new InfoFieldValue<>(
 					FileEntryInfoItemFields.size, fileEntry.getSize()));
 
+			fileEntryFieldValues.add(
+				new InfoFieldValue<>(
+					FileEntryInfoItemFields.createDateInfoField,
+					fileEntry.getCreateDate()));
+			fileEntryFieldValues.add(
+				new InfoFieldValue<>(
+					FileEntryInfoItemFields.modifiedDateInfoField,
+					fileEntry.getModifiedDate()));
+
 			User user = _userLocalService.fetchUser(fileEntry.getUserId());
 
 			if (user != null) {

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/info/item/provider/FileEntryInfoItemFieldValuesProvider.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/info/item/provider/FileEntryInfoItemFieldValuesProvider.java
@@ -224,7 +224,7 @@ public class FileEntryInfoItemFieldValuesProvider
 			fileEntryFieldValues.add(
 				new InfoFieldValue<>(
 					FileEntryInfoItemFields.publishDateInfoField,
-					fileEntry.getLastPublishDate()));
+					fileEntry.getModifiedDate()));
 
 			String downloadURL = _dlURLHelper.getDownloadURL(
 				fileEntry, fileEntry.getFileVersion(), null, StringPool.BLANK);

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/info/item/provider/test/JournalArticleInfoItemFormProviderTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/info/item/provider/test/JournalArticleInfoItemFormProviderTest.java
@@ -306,7 +306,7 @@ public class JournalArticleInfoItemFormProviderTest {
 			infoItemFieldValues.getInfoFieldValues();
 
 		Assert.assertEquals(
-			infoFieldValues.toString(), 17, infoFieldValues.size());
+			infoFieldValues.toString(), 19, infoFieldValues.size());
 
 		InfoFieldValue<Object> descriptionInfoFieldValue =
 			infoItemFieldValues.getInfoFieldValue("description");

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/web/internal/info/item/provider/test/JournalArticleInfoItemFieldValuesProviderTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/web/internal/info/item/provider/test/JournalArticleInfoItemFieldValuesProviderTest.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.journal.web.internal.info.item.provider.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.dynamic.data.mapping.model.DDMTemplate;
+import com.liferay.dynamic.data.mapping.test.util.DDMStructureTestUtil;
+import com.liferay.dynamic.data.mapping.test.util.DDMTemplateTestUtil;
+import com.liferay.info.field.InfoFieldValue;
+import com.liferay.info.item.InfoItemFieldValues;
+import com.liferay.info.item.provider.InfoItemFieldValuesProvider;
+import com.liferay.journal.constants.JournalArticleConstants;
+import com.liferay.journal.constants.JournalFolderConstants;
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.journal.service.JournalArticleLocalServiceUtil;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Cristina González
+ */
+@RunWith(Arquillian.class)
+public class JournalArticleInfoItemFieldValuesProviderTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	public void testGetInfoItemFieldValues() throws Exception {
+		String content = DDMStructureTestUtil.getSampleStructuredContent();
+
+		DDMStructure ddmStructure = DDMStructureTestUtil.addStructure(
+			_group.getGroupId(), JournalArticle.class.getName());
+
+		DDMTemplate ddmTemplate = DDMTemplateTestUtil.addTemplate(
+			_group.getGroupId(), ddmStructure.getStructureId(),
+			PortalUtil.getClassNameId(JournalArticle.class));
+
+		Calendar displayDateCalendar = new GregorianCalendar();
+
+		displayDateCalendar.setTime(new Date());
+
+		JournalArticle journalArticle =
+			JournalArticleLocalServiceUtil.addArticle(
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+				JournalArticleConstants.CLASS_NAME_ID_DEFAULT, 0,
+				StringPool.BLANK, true, JournalArticleConstants.VERSION_DEFAULT,
+				RandomTestUtil.randomLocaleStringMap(),
+				RandomTestUtil.randomLocaleStringMap(), content,
+				ddmStructure.getStructureKey(), ddmTemplate.getTemplateKey(),
+				null, displayDateCalendar.get(Calendar.MONTH),
+				displayDateCalendar.get(Calendar.DAY_OF_MONTH),
+				displayDateCalendar.get(Calendar.YEAR),
+				displayDateCalendar.get(Calendar.HOUR_OF_DAY),
+				displayDateCalendar.get(Calendar.MINUTE), 0, 0, 0, 0, 0, true,
+				0, 0, 0, 0, 0, true, true, false, null, null, null, null,
+				ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		InfoItemFieldValues infoItemFieldValues =
+			_infoItemFieldValuesProvider.getInfoItemFieldValues(journalArticle);
+
+		InfoFieldValue<Object> createDateInfoFieldValue =
+			infoItemFieldValues.getInfoFieldValue("createDate");
+
+		Assert.assertEquals(
+			journalArticle.getCreateDate(),
+			createDateInfoFieldValue.getValue());
+
+		InfoFieldValue<Object> modifiedDateInfoFieldValue =
+			infoItemFieldValues.getInfoFieldValue("modifiedDate");
+
+		Assert.assertEquals(
+			journalArticle.getModifiedDate(),
+			modifiedDateInfoFieldValue.getValue());
+
+		InfoFieldValue<Object> publishDateInfoFieldValue =
+			infoItemFieldValues.getInfoFieldValue("publishDate");
+
+		Assert.assertEquals(
+			journalArticle.getDisplayDate(),
+			publishDateInfoFieldValue.getValue());
+	}
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject(
+		filter = "component.name=*.JournalArticleInfoItemFieldValuesProvider"
+	)
+	private InfoItemFieldValuesProvider _infoItemFieldValuesProvider;
+
+}

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/info/item/JournalArticleInfoItemFields.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/info/item/JournalArticleInfoItemFields.java
@@ -46,6 +46,16 @@ public interface JournalArticleInfoItemFields {
 			InfoLocalizedValue.localize(
 				"com.liferay.journal.lang", "author-profile-image")
 		).build();
+	public static final InfoField<TextInfoFieldType> createDateInfoField =
+		InfoField.builder(
+		).infoFieldType(
+			TextInfoFieldType.INSTANCE
+		).name(
+			"createDate"
+		).labelInfoLocalizedValue(
+			InfoLocalizedValue.localize(
+				JournalArticleInfoItemFields.class, "create-date")
+		).build();
 	public static final InfoField<TextInfoFieldType> descriptionInfoField =
 		InfoField.builder(
 		).infoFieldType(
@@ -109,6 +119,16 @@ public interface JournalArticleInfoItemFields {
 		).labelInfoLocalizedValue(
 			InfoLocalizedValue.localize(
 				JournalArticleInfoItemFields.class, "last-editor-profile-image")
+		).build();
+	public static final InfoField<TextInfoFieldType> modifiedDateInfoField =
+		InfoField.builder(
+		).infoFieldType(
+			TextInfoFieldType.INSTANCE
+		).name(
+			"modifiedDate"
+		).labelInfoLocalizedValue(
+			InfoLocalizedValue.localize(
+				JournalArticleInfoItemFields.class, "modified-date")
 		).build();
 	public static final InfoField<DateInfoFieldType> publishDateInfoField =
 		InfoField.builder(

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/info/item/provider/JournalArticleInfoItemFieldValuesProvider.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/info/item/provider/JournalArticleInfoItemFieldValuesProvider.java
@@ -280,6 +280,15 @@ public class JournalArticleInfoItemFieldValuesProvider
 						journalArticle.getDescriptionMap()
 					).build()));
 
+			journalArticleFieldValues.add(
+				new InfoFieldValue<>(
+					JournalArticleInfoItemFields.createDateInfoField,
+					journalArticle.getCreateDate()));
+			journalArticleFieldValues.add(
+				new InfoFieldValue<>(
+					JournalArticleInfoItemFields.modifiedDateInfoField,
+					journalArticle.getModifiedDate()));
+
 			if (themeDisplay != null) {
 				String articleImageURL = journalArticle.getArticleImageURL(
 					themeDisplay);


### PR DESCRIPTION
**Motivation**

Currently the publish date of a given document is set as lastPublishDate, this is not a real publish date, since this field is related with Staging only.

I have updated this field, so we will use the modifiedDate as the publishDate of a document.

Also I have updated BlogsEntryInfoItemFieldValuesProvider, FileEntryInfoItemFieldValuesProvider and JournalArticleInfoItemFieldValuesProviderto add create and modified date.

**How to test it**

I have added integration tests for the changes.

/cc @4lejandrito I think you worked a lot with the info framework, so maybe you can take a look to the changes (maybe this doesn't make sense)

/cc @adolfopa this is the pull I promise to you in our Slack conversation.

/cc @AliciaGarciaGarcia I don't have any particular comment to you, but, how are you doing? 