### PR TITLE
LPS-121870 Migrate v2 usages in depot/depot-web

### DIFF
--- a/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/select_depot_role.jsp
+++ b/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/select_depot_role.jsp
@@ -20,8 +20,8 @@
 DepotAdminSelectRoleDisplayContext depotAdminSelectRoleDisplayContext = (DepotAdminSelectRoleDisplayContext)request.getAttribute(DepotAdminWebKeys.DEPOT_ADMIN_SELECT_ROLE_DISPLAY_CONTEXT);
 %>
 
-<clay:management-toolbar-v2
-	displayContext="<%= (DepotAdminSelectRoleManagementToolbarDisplayContext)request.getAttribute(DepotAdminWebKeys.DEPOT_ADMIN_SELECT_ROLE_MANAGEMENT_TOOLBAL_DISPLAY_CONTEXT) %>"
+<clay:management-toolbar
+	managementToolbarDisplayContext="<%= (DepotAdminSelectRoleManagementToolbarDisplayContext)request.getAttribute(DepotAdminWebKeys.DEPOT_ADMIN_SELECT_ROLE_MANAGEMENT_TOOLBAL_DISPLAY_CONTEXT) %>"
 />
 
 <aui:form action="<%= depotAdminSelectRoleDisplayContext.getPortletURL() %>" cssClass="container-fluid container-fluid-max-xl container-form-lg" method="post" name="selectDepotRoleFm">


### PR DESCRIPTION
When we sent [https://github.com/liferay-lima/liferay-portal/pull/1478](https://github.com/liferay-lima/liferay-portal/pull/1478), we forgot to migrate one of the usages.

**Test plan**:
- From the global menu, select the **Applications** tab
- Navigate to **Asset Libraries**
- Create a new Asset Library
- Set the **Sites** tab
- In the **Connected Sites** section click on the **Add** button
- Select a site
- From the global menu, select the **Control Panel** tab
- Navigate to **Users and Organizations**
- Select the **Test Test** user
- In the **Roles** tab, scroll down to **Asset Library Roles**
- Click on the **Select** button

**Additional Notes**:

Currently it seems that filtering is not working properly in `master`,
so this has the same issue, so I created a [Jira Ticket](https://issues.liferay.com/browse/LPS-128902)