### PR TITLE
LPS-121870 Migrate v2 usages in depot/depot-web

### DIFF
--- a/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/select_depot_role.jsp
+++ b/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/select_depot_role.jsp
@@ -20,8 +20,8 @@
 DepotAdminSelectRoleDisplayContext depotAdminSelectRoleDisplayContext = (DepotAdminSelectRoleDisplayContext)request.getAttribute(DepotAdminWebKeys.DEPOT_ADMIN_SELECT_ROLE_DISPLAY_CONTEXT);
 %>
 
-<clay:management-toolbar-v2
-	displayContext="<%= (DepotAdminSelectRoleManagementToolbarDisplayContext)request.getAttribute(DepotAdminWebKeys.DEPOT_ADMIN_SELECT_ROLE_MANAGEMENT_TOOLBAL_DISPLAY_CONTEXT) %>"
+<clay:management-toolbar
+	managementToolbarDisplayContext="<%= (DepotAdminSelectRoleManagementToolbarDisplayContext)request.getAttribute(DepotAdminWebKeys.DEPOT_ADMIN_SELECT_ROLE_MANAGEMENT_TOOLBAL_DISPLAY_CONTEXT) %>"
 />
 
 <aui:form action="<%= depotAdminSelectRoleDisplayContext.getPortletURL() %>" cssClass="container-fluid container-fluid-max-xl container-form-lg" method="post" name="selectDepotRoleFm">


### PR DESCRIPTION
Hey @liferay-lima,

Attached is an update for http://issues.liferay.com/browse/LPS-121870.

**Test plan:**

1. From the global menu, select the **Applications** tab
2. Navigate to **Asset Libraries**
3. Create a new Asset Library
4. Set the **Sites** tab
5. In the **Connected Sites** section click on the **Add** button
6. Select a site
7. From the global menu, select the **Control Panel** tab
8. Navigate to **Users and Organizations**
9. Select the **Test Test** user
10. In the **Roles** tab, scroll down to **Asset Library Roles**
11. Click on the **Select** button

**Additional Notes:**

Currently it seems that filtering is not working properly in master,
so this has the same issue.  See https://issues.liferay.com/browse/LPS-128902