### PR TITLE
LPS-127467 Cannot link page in the parent site from a subsite using the item selector

### DIFF
--- a/modules/apps/layout/layout-item-selector-web/build.gradle
+++ b/modules/apps/layout/layout-item-selector-web/build.gradle
@@ -13,6 +13,8 @@ dependencies {
 	compileOnly project(":apps:item-selector:item-selector-criteria-api")
 	compileOnly project(":apps:layout:layout-item-selector-api")
 	compileOnly project(":apps:layout:layout-taglib")
+	compileOnly project(":apps:petra:petra-portlet-url-builder")
+	compileOnly project(":apps:site-navigation:site-navigation-taglib")
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-sql-dsl-api")
 	compileOnly project(":core:petra:petra-string")

--- a/modules/apps/layout/layout-item-selector-web/src/main/java/com/liferay/layout/item/selector/web/internal/BaseLayoutsItemSelectorView.java
+++ b/modules/apps/layout/layout-item-selector-web/src/main/java/com/liferay/layout/item/selector/web/internal/BaseLayoutsItemSelectorView.java
@@ -36,6 +36,7 @@ import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
 
 /**
  * @author Roberto Díaz
@@ -72,8 +73,9 @@ public abstract class BaseLayoutsItemSelectorView
 		LayoutItemSelectorViewDisplayContext
 			layoutItemSelectorViewDisplayContext =
 				new LayoutItemSelectorViewDisplayContext(
-					layoutItemSelectorCriterion, itemSelectedEventName,
-					isPrivateLayout());
+					(HttpServletRequest)servletRequest,
+					layoutItemSelectorCriterion, portletURL,
+					itemSelectedEventName, isPrivateLayout());
 
 		servletRequest.setAttribute(
 			LayoutsItemSelectorWebKeys.

--- a/modules/apps/layout/layout-item-selector-web/src/main/java/com/liferay/layout/item/selector/web/internal/display/context/LayoutItemSelectorViewDisplayContext.java
+++ b/modules/apps/layout/layout-item-selector-web/src/main/java/com/liferay/layout/item/selector/web/internal/display/context/LayoutItemSelectorViewDisplayContext.java
@@ -14,7 +14,29 @@
 
 package com.liferay.layout.item.selector.web.internal.display.context;
 
+import com.liferay.item.selector.constants.ItemSelectorPortletKeys;
 import com.liferay.layout.item.selector.criterion.LayoutItemSelectorCriterion;
+import com.liferay.petra.portlet.url.builder.PortletURLBuilder;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.portlet.PortletURLUtil;
+import com.liferay.portal.kernel.servlet.taglib.ui.BreadcrumbEntry;
+import com.liferay.portal.kernel.theme.PortletDisplay;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.JavaConstants;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+import javax.portlet.PortletException;
+import javax.portlet.PortletURL;
+import javax.portlet.RenderResponse;
+
+import javax.servlet.http.HttpServletRequest;
 
 /**
  * @author Roberto Díaz
@@ -22,16 +44,30 @@ import com.liferay.layout.item.selector.criterion.LayoutItemSelectorCriterion;
 public class LayoutItemSelectorViewDisplayContext {
 
 	public LayoutItemSelectorViewDisplayContext(
+		HttpServletRequest httpServletRequest,
 		LayoutItemSelectorCriterion layoutItemSelectorCriterion,
-		String itemSelectedEventName, boolean privateLayout) {
+		PortletURL portletURL, String itemSelectedEventName,
+		boolean privateLayout) {
 
+		_httpServletRequest = httpServletRequest;
 		_layoutItemSelectorCriterion = layoutItemSelectorCriterion;
+		_portletURL = portletURL;
 		_itemSelectedEventName = itemSelectedEventName;
 		_privateLayout = privateLayout;
+
+		_renderResponse = (RenderResponse)httpServletRequest.getAttribute(
+			JavaConstants.JAVAX_PORTLET_RESPONSE);
 	}
 
 	public String getItemSelectedEventName() {
 		return _itemSelectedEventName;
+	}
+
+	public List<BreadcrumbEntry> getPortletBreadcrumbEntries()
+		throws PortalException, PortletException {
+
+		return Arrays.asList(
+			_getSitesAndLibrariesBreadcrumb(), _getHomeBreadcrumb());
 	}
 
 	public boolean isCheckDisplayPage() {
@@ -54,12 +90,70 @@ public class LayoutItemSelectorViewDisplayContext {
 		return _privateLayout;
 	}
 
+	public boolean isShowBreadcrumb() {
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)_httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		PortletDisplay portletDisplay = themeDisplay.getPortletDisplay();
+
+		boolean showBreadcrumb = ParamUtil.getBoolean(
+			_httpServletRequest, "showBreadcrumb");
+
+		if (Objects.equals(
+				ItemSelectorPortletKeys.ITEM_SELECTOR,
+				portletDisplay.getPortletName()) ||
+			showBreadcrumb) {
+
+			return true;
+		}
+
+		return false;
+	}
+
 	public boolean isShowHiddenPages() {
 		return _layoutItemSelectorCriterion.isShowHiddenPages();
 	}
 
+	private BreadcrumbEntry _getHomeBreadcrumb() throws PortalException {
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)_httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		BreadcrumbEntry breadcrumbEntry = new BreadcrumbEntry();
+
+		breadcrumbEntry.setTitle(themeDisplay.getSiteGroupName());
+
+		return breadcrumbEntry;
+	}
+
+	private BreadcrumbEntry _getSitesAndLibrariesBreadcrumb()
+		throws PortletException {
+
+		BreadcrumbEntry breadcrumbEntry = new BreadcrumbEntry();
+
+		breadcrumbEntry.setTitle(
+			LanguageUtil.get(_httpServletRequest, "sites-and-libraries"));
+
+		breadcrumbEntry.setURL(
+			PortletURLBuilder.create(
+				PortletURLUtil.clone(
+					_portletURL,
+					PortalUtil.getLiferayPortletResponse(_renderResponse))
+			).setParameter(
+				"groupType", "site"
+			).setParameter(
+				"showGroupSelector", Boolean.TRUE.toString()
+			).buildString());
+
+		return breadcrumbEntry;
+	}
+
+	private final HttpServletRequest _httpServletRequest;
 	private final String _itemSelectedEventName;
 	private final LayoutItemSelectorCriterion _layoutItemSelectorCriterion;
+	private final PortletURL _portletURL;
 	private final boolean _privateLayout;
+	private final RenderResponse _renderResponse;
 
 }

--- a/modules/apps/layout/layout-item-selector-web/src/main/java/com/liferay/layout/item/selector/web/internal/display/context/LayoutItemSelectorViewDisplayContext.java
+++ b/modules/apps/layout/layout-item-selector-web/src/main/java/com/liferay/layout/item/selector/web/internal/display/context/LayoutItemSelectorViewDisplayContext.java
@@ -67,7 +67,8 @@ public class LayoutItemSelectorViewDisplayContext {
 		throws PortalException, PortletException {
 
 		return Arrays.asList(
-			_getSitesAndLibrariesBreadcrumb(), _getHomeBreadcrumb());
+			_getSitesAndAssetLibrariesBreadcrumbEntry(),
+			_getHomeBreadcrumbEntry());
 	}
 
 	public boolean isCheckDisplayPage() {
@@ -115,7 +116,7 @@ public class LayoutItemSelectorViewDisplayContext {
 		return _layoutItemSelectorCriterion.isShowHiddenPages();
 	}
 
-	private BreadcrumbEntry _getHomeBreadcrumb() throws PortalException {
+	private BreadcrumbEntry _getHomeBreadcrumbEntry() throws PortalException {
 		ThemeDisplay themeDisplay =
 			(ThemeDisplay)_httpServletRequest.getAttribute(
 				WebKeys.THEME_DISPLAY);
@@ -127,7 +128,7 @@ public class LayoutItemSelectorViewDisplayContext {
 		return breadcrumbEntry;
 	}
 
-	private BreadcrumbEntry _getSitesAndLibrariesBreadcrumb()
+	private BreadcrumbEntry _getSitesAndAssetLibrariesBreadcrumbEntry()
 		throws PortletException {
 
 		BreadcrumbEntry breadcrumbEntry = new BreadcrumbEntry();

--- a/modules/apps/layout/layout-item-selector-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/layout/layout-item-selector-web/src/main/resources/META-INF/resources/init.jsp
@@ -14,10 +14,13 @@
  */
 --%>
 
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
 <%@ taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/layout" prefix="liferay-layout" %><%@
+taglib uri="http://liferay.com/tld/site-navigation" prefix="liferay-site-navigation" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
 
 <%@ page import="com.liferay.layout.item.selector.web.internal.constants.LayoutsItemSelectorWebKeys" %><%@

--- a/modules/apps/layout/layout-item-selector-web/src/main/resources/META-INF/resources/layouts.jsp
+++ b/modules/apps/layout/layout-item-selector-web/src/main/resources/META-INF/resources/layouts.jsp
@@ -20,6 +20,12 @@
 LayoutItemSelectorViewDisplayContext layoutItemSelectorViewDisplayContext = (LayoutItemSelectorViewDisplayContext)request.getAttribute(LayoutsItemSelectorWebKeys.LAYOUT_ITEM_SELECTOR_VIEW_DISPLAY_CONTEXT);
 %>
 
+<c:if test="<%= layoutItemSelectorViewDisplayContext.isShowBreadcrumb() %>">
+	<liferay-site-navigation:breadcrumb
+		breadcrumbEntries="<%= layoutItemSelectorViewDisplayContext.getPortletBreadcrumbEntries() %>"
+	/>
+</c:if>
+
 <liferay-layout:select-layout
 	checkDisplayPage="<%= layoutItemSelectorViewDisplayContext.isCheckDisplayPage() %>"
 	enableCurrentPage="<%= layoutItemSelectorViewDisplayContext.isEnableCurrentPage() %>"


### PR DESCRIPTION
Dear Team,

Could you please review this pull request?

I added the ability for the layout selector to display the group selector breadcrumb so that the listed pages will belong to the selected site. I modeled the behavior from [AssetBrowserDisplayContext](https://github.com/liferay/liferay-portal/blob/master/modules/apps/asset/asset-browser-web/src/main/java/com/liferay/asset/browser/web/internal/display/context/AssetBrowserDisplayContext.java).

@robertoDiaz suggested passing the information in `LayoutItemSelectorCriterion` whether the site selector should be displayed, but I wasn't able to find a pattern for that yet.
In the current solution, `isShowBreadcrumb()` checks for the "showBreadcrumb" parameter in the request, and, if the layout selector is displayed in the item selector portlet. If either of these conditions is met (similar to `AssetBrowserDisplayContext`) the breadcrumbs will be shown.

Thank you and best regards,
István