### PR TITLE
LPS-129271 Consume input stream before S3 object is closed

### DIFF
--- a/modules/apps/portal-store/portal-store-s3/build.gradle
+++ b/modules/apps/portal-store/portal-store-s3/build.gradle
@@ -80,5 +80,6 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
+	compileOnly project(":core:petra:petra-io")
 	compileOnly project(":core:petra:petra-string")
 }

--- a/modules/apps/portal-store/portal-store-s3/src/main/java/com/liferay/portal/store/s3/IBMS3Store.java
+++ b/modules/apps/portal-store/portal-store-s3/src/main/java/com/liferay/portal/store/s3/IBMS3Store.java
@@ -45,6 +45,7 @@ import com.liferay.document.library.kernel.exception.AccessDeniedException;
 import com.liferay.document.library.kernel.exception.NoSuchFileException;
 import com.liferay.document.library.kernel.store.Store;
 import com.liferay.document.library.kernel.util.DLUtil;
+import com.liferay.petra.io.StreamUtil;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -58,6 +59,7 @@ import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.store.s3.configuration.S3StoreConfiguration;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -165,9 +167,11 @@ public class IBMS3Store implements Store {
 
 			ObjectMetadata objectMetadata = s3Object.getObjectMetadata();
 
+			InputStream inputStream = new ByteArrayInputStream(
+				StreamUtil.toByteArray(s3Object.getObjectContent()));
+
 			return _s3FileCache.getCacheFileInputStream(
-				fileName, s3Object::getObjectContent,
-				objectMetadata.getLastModified());
+				fileName, () -> inputStream, objectMetadata.getLastModified());
 		}
 		catch (IOException ioException) {
 			throw new SystemException(ioException);

--- a/modules/apps/portal-store/portal-store-s3/src/main/java/com/liferay/portal/store/s3/S3Store.java
+++ b/modules/apps/portal-store/portal-store-s3/src/main/java/com/liferay/portal/store/s3/S3Store.java
@@ -45,6 +45,7 @@ import com.liferay.document.library.kernel.exception.AccessDeniedException;
 import com.liferay.document.library.kernel.exception.NoSuchFileException;
 import com.liferay.document.library.kernel.store.Store;
 import com.liferay.document.library.kernel.util.DLUtil;
+import com.liferay.petra.io.StreamUtil;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -58,6 +59,7 @@ import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.store.s3.configuration.S3StoreConfiguration;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -162,9 +164,11 @@ public class S3Store implements Store {
 
 			ObjectMetadata objectMetadata = s3Object.getObjectMetadata();
 
+			InputStream inputStream = new ByteArrayInputStream(
+				StreamUtil.toByteArray(s3Object.getObjectContent()));
+
 			return _s3FileCache.getCacheFileInputStream(
-				fileName, s3Object::getObjectContent,
-				objectMetadata.getLastModified());
+				fileName, () -> inputStream, objectMetadata.getLastModified());
 		}
 		catch (IOException ioException) {
 			throw new SystemException(ioException);


### PR DESCRIPTION
**Ticket:**
<https://issues.liferay.com/browse/LPS-129271>

tests passed here: https://github.com/SamZiemer/liferay-portal/pull/793

Notes from @kevhlee:
> The issue is that the S3 object where the file input stream comes from is being closed before the input stream is consumed. Hence, the portal throws the exception `java.io.IOException: Attempted read on closed stream`. We still need to close the S3 object to avoid leaking HTTP connections ([LPS-127589](https://issues.liferay.com/browse/LPS-127589)). Thus, my solution is to consume the input stream and create a new one from it before the S3 object is closed. This may not be ideal, but at least this allows us to not worry about closing the S3 object too early.
> 
> Let me know if you have any questions or thoughts.