### PR TITLE
LPS-129537 Message Board links to pages

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorBBCodeConfigContributor.java
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorBBCodeConfigContributor.java
@@ -54,7 +54,7 @@ public class CKEditorBBCodeConfigContributor
 			"enterMode", 2
 		).put(
 			"extraPlugins",
-			"a11yhelpbtn,bbcode,itemselector,sourcearea,wikilink"
+			"a11yhelpbtn,bbcode,itemselector,sourcearea"
 		).put(
 			"fontSize_defaultLabel", "14"
 		).put(

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorBBCodeConfigContributor.java
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorBBCodeConfigContributor.java
@@ -54,7 +54,7 @@ public class CKEditorBBCodeConfigContributor
 			"enterMode", 2
 		).put(
 			"extraPlugins",
-			"a11yhelpbtn,bbcode,itemselector,sourcearea"
+			"a11yhelpbtn,bbcode,filebrowser,itemselector,sourcearea"
 		).put(
 			"fontSize_defaultLabel", "14"
 		).put(
@@ -73,7 +73,7 @@ public class CKEditorBBCodeConfigContributor
 		).put(
 			"removePlugins",
 			"bidi,codemirror,div,elementspath,forms,indentblock,keystrokes," +
-				"link,maximize,newpage,pagebreak,preview,print,save," +
+				"maximize,newpage,pagebreak,preview,print,save," +
 					"showblocks,templates,video"
 		).put(
 			"smiley_descriptions",


### PR DESCRIPTION
Hey @liferay-lima team, this is a fix for https://issues.liferay.com/browse/LPS-129537. Message Boards was wrongly using the `wikilink` plugin, which must be used only for wiki and for the Creole format. I removed it and replaced by the default link plugin. 

**Steps to Reproduce:**
1. Go to Site Builder > Pages > Create a new Widget page name CKEditor Page
2. Go to Content & Data > Message Board > Create a new thread name MBThread Message Subject
3. On the Editor, type "Link to Page" and link the newly create page "CKEditor Page"
4. Publish the thread
5. Go to newly create thread MBThread Message Subject and click on "Link to Page"

**Expected Result**
This link should bring user to CKEditor page (Widget page)

**Actual Result:**
The link does not take user anywhere


In addition, I checked wiki and it is not rendering the dialog that `wikilink` plugin provides, although the plugin is included in the config. In Creole, link to pages are formed with the title of the page, not the url, just like it is done [here](https://github.com/liferay/liferay-portal/blame/master/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/wikilink/dialogs/link.js#L119-L119) (this was causing the current bug in MB). So  I highly recommend you to check why this is happening because I guess this could cause another bug. 

/cc @adolfopa 
