### PR TITLE
[TS] LPS-129863 | Cannot show preview for video with only audio

### DIFF
--- a/portal-impl/src/com/liferay/portlet/documentlibrary/util/LiferayVideoThumbnailConverter.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/util/LiferayVideoThumbnailConverter.java
@@ -131,8 +131,8 @@ public class LiferayVideoThumbnailConverter extends LiferayConverter {
 			if (!thumbnailGenerated) {
 				if (_log.isWarnEnabled()) {
 					_log.warn(
-						"Unable to create thumbnail from specified frame. Will " +
-							"generate thumbnail from the beginning.");
+						"Unable to create thumbnail from specified frame. " +
+							"Will generate thumbnail from the beginning.");
 				}
 
 				rewind();


### PR DESCRIPTION
Hi @liferay-lima,

This is a solution for the issue [LPS-129863](https://issues.liferay.com/browse/LPS-129863). 

It's not a very common situation but not completely unusual either. It happens whenever one tries to preview a document whose _mimetype_ is a video but has no frames: it's actually audio only. See [LPS-129863](https://issues.liferay.com/browse/LPS-129863) for reproducing steps and an example file.

The problem is not actually on the creation of the preview, since although no frame exist, the audio is processed correctly; it comes only when trying to create the thumbnail for the video. Here it will check for streams with codec of type video but it won't find any. Nevertheless it will try to save the (nonexistent!) thumbnail picture in the Document Library and it will crash. 

The solution simply generates a black image thumbnail whenever it can't find any streams with codec of type video and it will save that. An alternative would have been avoiding the thumbnail creation but Liferay will try every time since the file is an actual video, so I think this is better. 

I've chosen a black image as the default because it seems a common choice, but I haven't checked if it's culturally universal. White might be another reasonable choice? 

Please let me know if you have any questions. Thanks!

