### PR TITLE
[PoC] LPS-124383 Workflow-based moderation for Message Boards

### DIFF
--- a/modules/apps/message-boards/message-boards-moderation/bnd.bnd
+++ b/modules/apps/message-boards/message-boards-moderation/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Liferay Message Boards Moderation
+Bundle-SymbolicName: com.liferay.message.boards.moderation
+Bundle-Version: 1.0.0

--- a/modules/apps/message-boards/message-boards-moderation/build.gradle
+++ b/modules/apps/message-boards/message-boards-moderation/build.gradle
@@ -1,0 +1,19 @@
+dependencies {
+	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "3.1.0"
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.1"
+	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
+	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
+	compileOnly project(":apps:comment:comment-api")
+	compileOnly project(":apps:message-boards:message-boards-api")
+	compileOnly project(":apps:message-boards:message-boards-service")
+	compileOnly project(":apps:portal-workflow:portal-workflow-api")
+	compileOnly project(":apps:portal-workflow:portal-workflow-kaleo-api")
+	compileOnly project(":apps:portal-workflow:portal-workflow-kaleo-runtime-api")
+	compileOnly project(":apps:portal:portal-instance-lifecycle-api")
+	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
+	compileOnly project(":apps:static:portal-configuration:portal-configuration-persistence-api")
+	compileOnly project(":apps:xstream:xstream-configurator-api")
+	compileOnly project(":core:petra:petra-string")
+}

--- a/modules/apps/message-boards/message-boards-moderation/src/main/java/com/liferay/message/boards/moderation/internal/condition/evaluator/MBModerationConditionEvaluator.java
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/java/com/liferay/message/boards/moderation/internal/condition/evaluator/MBModerationConditionEvaluator.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.message.boards.moderation.internal.condition.evaluator;
+
+import com.liferay.message.boards.moderation.internal.configuration.MBModerationGroupConfiguration;
+import com.liferay.message.boards.service.MBStatsUserLocalService;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.module.configuration.ConfigurationProvider;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.workflow.kaleo.model.KaleoCondition;
+import com.liferay.portal.workflow.kaleo.runtime.ExecutionContext;
+import com.liferay.portal.workflow.kaleo.runtime.condition.ConditionEvaluator;
+
+import java.io.Serializable;
+
+import java.util.Map;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Eduardo García
+ */
+@Component(
+	immediate = true, property = "scripting.language=java",
+	service = ConditionEvaluator.class
+)
+public class MBModerationConditionEvaluator implements ConditionEvaluator {
+
+	@Override
+	public String evaluate(
+			KaleoCondition kaleoCondition, ExecutionContext executionContext)
+		throws PortalException {
+
+		Map<String, Serializable> workflowContext =
+			executionContext.getWorkflowContext();
+
+		long groupId = GetterUtil.getLong(
+			workflowContext.get(WorkflowConstants.CONTEXT_GROUP_ID));
+
+		long userId = GetterUtil.getLong(
+			workflowContext.get(WorkflowConstants.CONTEXT_USER_ID));
+
+		MBModerationGroupConfiguration mbModerationGroupConfiguration =
+			_configurationProvider.getGroupConfiguration(
+				MBModerationGroupConfiguration.class, groupId);
+
+		if (_mbStatsUserLocalService.getMessageCountByUserId(userId) >=
+				mbModerationGroupConfiguration.minimumContributedMessages()) {
+
+			return "approve";
+		}
+
+		return "review";
+	}
+
+	@Reference
+	private ConfigurationProvider _configurationProvider;
+
+	@Reference
+	private MBStatsUserLocalService _mbStatsUserLocalService;
+
+}

--- a/modules/apps/message-boards/message-boards-moderation/src/main/java/com/liferay/message/boards/moderation/internal/configuration/MBModerationGroupConfiguration.java
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/java/com/liferay/message/boards/moderation/internal/configuration/MBModerationGroupConfiguration.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.message.boards.moderation.internal.configuration;
+
+import aQute.bnd.annotation.metatype.Meta;
+
+import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
+
+/**
+ * @author Eduardo García
+ */
+@ExtendedObjectClassDefinition(
+	category = "message-boards",
+	scope = ExtendedObjectClassDefinition.Scope.GROUP
+)
+@Meta.OCD(
+	id = "com.liferay.message.boards.moderation.internal.configuration.MBModerationGroupConfiguration",
+	localization = "content/Language",
+	name = "message-boards-moderation-workflow-group-configuration-name"
+)
+public interface MBModerationGroupConfiguration {
+
+	@Meta.AD(
+		deflt = "false", description = "enable-message-boards-moderation-help",
+		name = "enable-message-boards-moderation", required = false
+	)
+	public boolean enableMessageBoardsModeration();
+
+	@Meta.AD(
+		deflt = "1", description = "minimum-contributed-messages-help",
+		min = "1", name = "minimum-contributed-messages", required = false
+	)
+	public int minimumContributedMessages();
+
+}

--- a/modules/apps/message-boards/message-boards-moderation/src/main/java/com/liferay/message/boards/moderation/internal/configuration/persistence/listener/MBModerationGroupConfigurationModelListener.java
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/java/com/liferay/message/boards/moderation/internal/configuration/persistence/listener/MBModerationGroupConfigurationModelListener.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.message.boards.moderation.internal.configuration.persistence.listener;
+
+import com.liferay.message.boards.model.MBMessage;
+import com.liferay.message.boards.moderation.internal.configuration.MBModerationGroupConfiguration;
+import com.liferay.message.boards.moderation.internal.constants.MBModerationConstants;
+import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
+import com.liferay.portal.configuration.persistence.listener.ConfigurationModelListener;
+import com.liferay.portal.configuration.persistence.listener.ConfigurationModelListenerException;
+import com.liferay.portal.kernel.model.WorkflowDefinitionLink;
+import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalService;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HashMapDictionary;
+import com.liferay.portal.kernel.workflow.WorkflowDefinition;
+import com.liferay.portal.kernel.workflow.WorkflowDefinitionManager;
+
+import java.util.Dictionary;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Eduardo García
+ */
+@Component(
+	immediate = true,
+	property = "model.class.name=com.liferay.message.boards.moderation.internal.configuration.MBModerationGroupConfiguration",
+	service = ConfigurationModelListener.class
+)
+public class MBModerationGroupConfigurationModelListener
+	implements ConfigurationModelListener {
+
+	@Override
+	public void onAfterSave(String pid, Dictionary<String, Object> properties)
+		throws ConfigurationModelListenerException {
+
+		MBModerationGroupConfiguration mbModerationGroupConfiguration =
+			ConfigurableUtil.createConfigurable(
+				MBModerationGroupConfiguration.class,
+				new HashMapDictionary<>());
+
+		try {
+			_updateMBModerationWorkflow(
+				GetterUtil.getLong(properties.get("companyId")),
+				GetterUtil.getBoolean(
+					properties.get("enableMessageBoardsModeration"),
+					mbModerationGroupConfiguration.
+						enableMessageBoardsModeration()));
+		}
+		catch (Exception exception) {
+			throw new ConfigurationModelListenerException(
+				exception.getMessage(), MBModerationGroupConfiguration.class,
+				getClass(), properties);
+		}
+	}
+
+	private void _updateMBModerationWorkflow(
+			long companyId, boolean enableMessageBoardsModeration)
+		throws Exception {
+
+		if (!enableMessageBoardsModeration) {
+			WorkflowDefinitionLink workflowDefinitionLink =
+				_workflowDefinitionLinkLocalService.fetchWorkflowDefinitionLink(
+					companyId, 0, MBMessage.class.getName(), 0, 0);
+
+			if (workflowDefinitionLink != null) {
+				_workflowDefinitionLinkLocalService.
+					deleteWorkflowDefinitionLink(workflowDefinitionLink);
+			}
+
+			return;
+		}
+
+		WorkflowDefinition workflowDefinition =
+			_workflowDefinitionManager.getLatestWorkflowDefinition(
+				companyId, MBModerationConstants.WORKFLOW_DEFINITION_NAME);
+
+		_workflowDefinitionLinkLocalService.addWorkflowDefinitionLink(
+			workflowDefinition.getUserId(), companyId, 0,
+			MBMessage.class.getName(), 0, 0,
+			MBModerationConstants.WORKFLOW_DEFINITION_NAME,
+			workflowDefinition.getVersion());
+	}
+
+	@Reference
+	private WorkflowDefinitionLinkLocalService
+		_workflowDefinitionLinkLocalService;
+
+	@Reference(target = "(proxy.bean=false)")
+	private WorkflowDefinitionManager _workflowDefinitionManager;
+
+}

--- a/modules/apps/message-boards/message-boards-moderation/src/main/java/com/liferay/message/boards/moderation/internal/constants/MBModerationConstants.java
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/java/com/liferay/message/boards/moderation/internal/constants/MBModerationConstants.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.message.boards.moderation.internal.constants;
+
+/**
+ * @author Eduardo García
+ */
+public class MBModerationConstants {
+
+	public static final String WORKFLOW_DEFINITION_NAME =
+		"user-stats-moderation";
+
+}

--- a/modules/apps/message-boards/message-boards-moderation/src/main/java/com/liferay/message/boards/moderation/internal/instance/lifecycle/AddMBModerationWorkflowDefinitionPortalInstanceLifecycleListener.java
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/java/com/liferay/message/boards/moderation/internal/instance/lifecycle/AddMBModerationWorkflowDefinitionPortalInstanceLifecycleListener.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.message.boards.moderation.internal.instance.lifecycle;
+
+import com.liferay.message.boards.model.MBMessage;
+import com.liferay.message.boards.moderation.internal.constants.MBModerationConstants;
+import com.liferay.portal.instance.lifecycle.BasePortalInstanceLifecycleListener;
+import com.liferay.portal.instance.lifecycle.PortalInstanceLifecycleListener;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.workflow.WorkflowDefinitionManager;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Eduardo García
+ */
+@Component(
+	immediate = true, property = "service.ranking:Integer=100",
+	service = PortalInstanceLifecycleListener.class
+)
+public class AddMBModerationWorkflowDefinitionPortalInstanceLifecycleListener
+	extends BasePortalInstanceLifecycleListener {
+
+	@Override
+	public void portalInstanceRegistered(Company company) throws Exception {
+		int workflowDefinitionsCount =
+			_workflowDefinitionManager.getWorkflowDefinitionsCount(
+				company.getCompanyId(),
+				MBModerationConstants.WORKFLOW_DEFINITION_NAME);
+
+		if (workflowDefinitionsCount > 0) {
+			return;
+		}
+
+		long defaultUserId = _userLocalService.getDefaultUserId(
+			company.getCompanyId());
+
+		String content = StringUtil.read(
+			AddMBModerationWorkflowDefinitionPortalInstanceLifecycleListener.
+				class,
+			"dependencies/message-boards-moderation-definition.xml");
+
+		_workflowDefinitionManager.deployWorkflowDefinition(
+			company.getCompanyId(), defaultUserId,
+			MBModerationConstants.WORKFLOW_DEFINITION_NAME,
+			MBModerationConstants.WORKFLOW_DEFINITION_NAME,
+			MBMessage.class.getName(), content.getBytes());
+	}
+
+	@Reference
+	private UserLocalService _userLocalService;
+
+	@Reference(target = "(proxy.bean=false)")
+	private WorkflowDefinitionManager _workflowDefinitionManager;
+
+}

--- a/modules/apps/message-boards/message-boards-moderation/src/main/java/com/liferay/message/boards/moderation/internal/settings/definition/MBModerationGroupConfigurationBeanDeclaration.java
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/java/com/liferay/message/boards/moderation/internal/settings/definition/MBModerationGroupConfigurationBeanDeclaration.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.message.boards.moderation.internal.settings.definition;
+
+import com.liferay.message.boards.moderation.internal.configuration.MBModerationGroupConfiguration;
+import com.liferay.portal.kernel.settings.definition.ConfigurationBeanDeclaration;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Eduardo García
+ */
+@Component(service = ConfigurationBeanDeclaration.class)
+public class MBModerationGroupConfigurationBeanDeclaration
+	implements ConfigurationBeanDeclaration {
+
+	@Override
+	public Class<?> getConfigurationBeanClass() {
+		return MBModerationGroupConfiguration.class;
+	}
+
+}

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/com/liferay/message/boards/moderation/internal/instance/lifecycle/dependencies/message-boards-moderation-definition.xml
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/com/liferay/message/boards/moderation/internal/instance/lifecycle/dependencies/message-boards-moderation-definition.xml
@@ -1,0 +1,252 @@
+<?xml version="1.0"?>
+
+<workflow-definition
+	xmlns="urn:liferay.com:liferay-workflow_7.3.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="urn:liferay.com:liferay-workflow_7.3.0 http://www.liferay.com/dtd/liferay-workflow-definition_7_3_0.xsd"
+>
+	<name>Message Board Threads and Comments Reputation Approver</name>
+	<description>Users with a reputation over the threshold get their threads and comments approved automatically.</description>
+	<version>1</version>
+	<condition>
+		<name>check-reputation</name>
+		<metadata>
+			<![CDATA[
+				{
+					"xy": [
+						199,
+						43
+					]
+				}
+			]]>
+		</metadata>
+		<script>
+			<![CDATA[com.liferay.message.boards.moderation.internal.condition.evaluator.MBModerationConditionEvaluator]]>
+		</script>
+		<script-language>java</script-language>
+		<transitions>
+			<transition>
+				<name>approve</name>
+				<target>approved</target>
+				<default>true</default>
+			</transition>
+			<transition>
+				<name>review</name>
+				<target>review</target>
+				<default>false</default>
+			</transition>
+		</transitions>
+	</condition>
+	<state>
+		<name>created</name>
+		<metadata>
+			<![CDATA[
+				{
+					"xy": [
+						36,
+						51
+					]
+				}
+			]]>
+		</metadata>
+		<initial>true</initial>
+		<transitions>
+			<transition>
+				<name>check-reputation</name>
+				<target>check-reputation</target>
+				<default>true</default>
+			</transition>
+		</transitions>
+	</state>
+	<state>
+		<name>approved</name>
+		<metadata>
+			<![CDATA[
+				{
+					"terminal": true,
+					"xy": [
+						648,
+						50
+					]
+				}
+			]]>
+		</metadata>
+		<actions>
+			<action>
+				<name>approve</name>
+				<script>
+					<![CDATA[
+						import com.liferay.portal.kernel.workflow.WorkflowStatusManagerUtil;
+						import com.liferay.portal.kernel.workflow.WorkflowConstants;
+
+						WorkflowStatusManagerUtil.updateStatus(WorkflowConstants.getLabelStatus("approved"), workflowContext);
+					]]>
+				</script>
+				<script-language>groovy</script-language>
+				<execution-type>onEntry</execution-type>
+			</action>
+		</actions>
+	</state>
+	<task>
+		<name>update</name>
+		<metadata>
+			<![CDATA[
+				{
+					"transitions": {
+						"resubmit": {
+							"bendpoints": [
+								[
+									303,
+									140
+								]
+							]
+						}
+					},
+					"xy": [
+						636,
+						245
+					]
+				}
+			]]>
+		</metadata>
+		<actions>
+			<action>
+				<name>reject</name>
+				<script>
+					<![CDATA[
+						import com.liferay.portal.kernel.workflow.WorkflowStatusManagerUtil;
+						import com.liferay.portal.kernel.workflow.WorkflowConstants;
+
+						WorkflowStatusManagerUtil.updateStatus(WorkflowConstants.getLabelStatus("denied"), workflowContext);
+						WorkflowStatusManagerUtil.updateStatus(WorkflowConstants.getLabelStatus("pending"), workflowContext);
+					]]>
+				</script>
+				<script-language>groovy</script-language>
+				<execution-type>onAssignment</execution-type>
+			</action>
+			<notification>
+				<name>Creator Modification Notification</name>
+				<template>
+					<![CDATA[Your submission was rejected by ${userName}, please modify and resubmit.]]>
+				</template>
+				<template-language>freemarker</template-language>
+				<notification-type>email</notification-type>
+				<notification-type>user-notification</notification-type>
+				<recipients receptionType="to">
+					<user />
+				</recipients>
+				<execution-type>onAssignment</execution-type>
+			</notification>
+		</actions>
+		<assignments>
+			<user />
+		</assignments>
+		<transitions>
+			<transition>
+				<name>resubmit</name>
+				<target>review</target>
+				<default>true</default>
+			</transition>
+		</transitions>
+	</task>
+	<task>
+		<name>review</name>
+		<metadata>
+			<![CDATA[
+				{
+					"xy": [
+						285,
+						186
+					]
+				}
+			]]>
+		</metadata>
+		<actions>
+			<notification>
+				<name>Review Notification</name>
+				<template>
+					<![CDATA[${userName} sent you a ${entryType} for review in the workflow.]]>
+				</template>
+				<template-language>freemarker</template-language>
+				<notification-type>email</notification-type>
+				<notification-type>user-notification</notification-type>
+				<recipients receptionType="to">
+					<assignees />
+				</recipients>
+				<execution-type>onAssignment</execution-type>
+			</notification>
+			<notification>
+				<name>Review Completion Notification</name>
+				<template>
+					<![CDATA[Your submission was reviewed<#if taskComments?has_content> and the reviewer applied the following ${taskComments}</#if>.]]>
+				</template>
+				<template-language>freemarker</template-language>
+				<notification-type>email</notification-type>
+				<recipients receptionType="to">
+					<user />
+				</recipients>
+				<execution-type>onExit</execution-type>
+			</notification>
+		</actions>
+		<assignments>
+			<roles>
+				<role>
+					<role-type>depot</role-type>
+					<name>Asset Library Administrator</name>
+				</role>
+				<role>
+					<role-type>depot</role-type>
+					<name>Asset Library Content Reviewer</name>
+				</role>
+				<role>
+					<role-type>depot</role-type>
+					<name>Asset Library Owner</name>
+				</role>
+				<role>
+					<role-type>organization</role-type>
+					<name>Organization Administrator</name>
+				</role>
+				<role>
+					<role-type>organization</role-type>
+					<name>Organization Content Reviewer</name>
+				</role>
+				<role>
+					<role-type>organization</role-type>
+					<name>Organization Owner</name>
+				</role>
+				<role>
+					<role-type>regular</role-type>
+					<name>Administrator</name>
+				</role>
+				<role>
+					<role-type>regular</role-type>
+					<name>Portal Content Reviewer</name>
+				</role>
+				<role>
+					<role-type>site</role-type>
+					<name>Site Administrator</name>
+				</role>
+				<role>
+					<role-type>site</role-type>
+					<name>Site Content Reviewer</name>
+				</role>
+				<role>
+					<role-type>site</role-type>
+					<name>Site Owner</name>
+				</role>
+			</roles>
+		</assignments>
+		<transitions>
+			<transition>
+				<name>approve</name>
+				<target>approved</target>
+				<default>true</default>
+			</transition>
+			<transition>
+				<name>reject</name>
+				<target>update</target>
+				<default>false</default>
+			</transition>
+		</transitions>
+	</task>
+</workflow-definition>

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language.properties
@@ -1,0 +1,5 @@
+enable-message-boards-moderation=Enable Message Boards Moderation
+enable-message-boards-moderation-help=Enables a reputation-based approval workflow for Message Boards messages. This option is incompatible with other workflow definitions for Message Boards messages.
+message-boards-moderation-workflow-group-configuration-name=Message Boards Moderation Workflow
+minimum-contributed-messages=Minimum Contributed Messages
+minimum-contributed-messages-help=Number of contributed Message Boards that skips manual review of Message Board messages.

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_ar.properties
@@ -1,0 +1,5 @@
+enable-message-boards-moderation=Enable Message Boards Moderation (Automatic Copy)
+enable-message-boards-moderation-help=Enables a reputation-based approval workflow for Message Boards messages. This option is incompatible with other workflow definitions for Message Boards messages. (Automatic Copy)
+message-boards-moderation-workflow-group-configuration-name=Message Boards Moderation Workflow (Automatic Copy)
+minimum-contributed-messages=Minimum Contributed Messages (Automatic Copy)
+minimum-contributed-messages-help=Number of contributed Message Boards that skips manual review of Message Board messages. (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_bg.properties
@@ -1,0 +1,5 @@
+enable-message-boards-moderation=Enable Message Boards Moderation (Automatic Copy)
+enable-message-boards-moderation-help=Enables a reputation-based approval workflow for Message Boards messages. This option is incompatible with other workflow definitions for Message Boards messages. (Automatic Copy)
+message-boards-moderation-workflow-group-configuration-name=Message Boards Moderation Workflow (Automatic Copy)
+minimum-contributed-messages=Minimum Contributed Messages (Automatic Copy)
+minimum-contributed-messages-help=Number of contributed Message Boards that skips manual review of Message Board messages. (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_ca.properties
@@ -1,0 +1,5 @@
+enable-message-boards-moderation=Enable Message Boards Moderation (Automatic Copy)
+enable-message-boards-moderation-help=Enables a reputation-based approval workflow for Message Boards messages. This option is incompatible with other workflow definitions for Message Boards messages. (Automatic Copy)
+message-boards-moderation-workflow-group-configuration-name=Message Boards Moderation Workflow (Automatic Copy)
+minimum-contributed-messages=Minimum Contributed Messages (Automatic Copy)
+minimum-contributed-messages-help=Number of contributed Message Boards that skips manual review of Message Board messages. (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_cs.properties
@@ -1,0 +1,5 @@
+enable-message-boards-moderation=Enable Message Boards Moderation (Automatic Copy)
+enable-message-boards-moderation-help=Enables a reputation-based approval workflow for Message Boards messages. This option is incompatible with other workflow definitions for Message Boards messages. (Automatic Copy)
+message-boards-moderation-workflow-group-configuration-name=Message Boards Moderation Workflow (Automatic Copy)
+minimum-contributed-messages=Minimum Contributed Messages (Automatic Copy)
+minimum-contributed-messages-help=Number of contributed Message Boards that skips manual review of Message Board messages. (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_da.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_da.properties
@@ -1,0 +1,5 @@
+enable-message-boards-moderation=Enable Message Boards Moderation (Automatic Copy)
+enable-message-boards-moderation-help=Enables a reputation-based approval workflow for Message Boards messages. This option is incompatible with other workflow definitions for Message Boards messages. (Automatic Copy)
+message-boards-moderation-workflow-group-configuration-name=Message Boards Moderation Workflow (Automatic Copy)
+minimum-contributed-messages=Minimum Contributed Messages (Automatic Copy)
+minimum-contributed-messages-help=Number of contributed Message Boards that skips manual review of Message Board messages. (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_de.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_de.properties
@@ -1,0 +1,5 @@
+enable-message-boards-moderation=Enable Message Boards Moderation (Automatic Copy)
+enable-message-boards-moderation-help=Enables a reputation-based approval workflow for Message Boards messages. This option is incompatible with other workflow definitions for Message Boards messages. (Automatic Copy)
+message-boards-moderation-workflow-group-configuration-name=Message Boards Moderation Workflow (Automatic Copy)
+minimum-contributed-messages=Minimum Contributed Messages (Automatic Copy)
+minimum-contributed-messages-help=Number of contributed Message Boards that skips manual review of Message Board messages. (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_el.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_el.properties
@@ -1,0 +1,5 @@
+enable-message-boards-moderation=Enable Message Boards Moderation (Automatic Copy)
+enable-message-boards-moderation-help=Enables a reputation-based approval workflow for Message Boards messages. This option is incompatible with other workflow definitions for Message Boards messages. (Automatic Copy)
+message-boards-moderation-workflow-group-configuration-name=Message Boards Moderation Workflow (Automatic Copy)
+minimum-contributed-messages=Minimum Contributed Messages (Automatic Copy)
+minimum-contributed-messages-help=Number of contributed Message Boards that skips manual review of Message Board messages. (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_en.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_en.properties
@@ -1,0 +1,5 @@
+enable-message-boards-moderation=Enable Message Boards Moderation
+enable-message-boards-moderation-help=Enables a reputation-based approval workflow for Message Boards messages. This option is incompatible with other workflow definitions for Message Boards messages.
+message-boards-moderation-workflow-group-configuration-name=Message Boards Moderation Workflow
+minimum-contributed-messages=Minimum Contributed Messages
+minimum-contributed-messages-help=Number of contributed Message Boards that skips manual review of Message Board messages.

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_en_AU.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_en_AU.properties
@@ -1,0 +1,5 @@
+enable-message-boards-moderation=Enable Message Boards Moderation (Automatic Copy)
+enable-message-boards-moderation-help=Enables a reputation-based approval workflow for Message Boards messages. This option is incompatible with other workflow definitions for Message Boards messages. (Automatic Copy)
+message-boards-moderation-workflow-group-configuration-name=Message Boards Moderation Workflow (Automatic Copy)
+minimum-contributed-messages=Minimum Contributed Messages (Automatic Copy)
+minimum-contributed-messages-help=Number of contributed Message Boards that skips manual review of Message Board messages. (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_en_GB.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_en_GB.properties
@@ -1,0 +1,5 @@
+enable-message-boards-moderation=Enable Message Boards Moderation (Automatic Copy)
+enable-message-boards-moderation-help=Enables a reputation-based approval workflow for Message Boards messages. This option is incompatible with other workflow definitions for Message Boards messages. (Automatic Copy)
+message-boards-moderation-workflow-group-configuration-name=Message Boards Moderation Workflow (Automatic Copy)
+minimum-contributed-messages=Minimum Contributed Messages (Automatic Copy)
+minimum-contributed-messages-help=Number of contributed Message Boards that skips manual review of Message Board messages. (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_es.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_es.properties
@@ -1,0 +1,5 @@
+enable-message-boards-moderation=Enable Message Boards Moderation (Automatic Copy)
+enable-message-boards-moderation-help=Enables a reputation-based approval workflow for Message Boards messages. This option is incompatible with other workflow definitions for Message Boards messages. (Automatic Copy)
+message-boards-moderation-workflow-group-configuration-name=Message Boards Moderation Workflow (Automatic Copy)
+minimum-contributed-messages=Minimum Contributed Messages (Automatic Copy)
+minimum-contributed-messages-help=Number of contributed Message Boards that skips manual review of Message Board messages. (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_et.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_et.properties
@@ -1,0 +1,5 @@
+enable-message-boards-moderation=Enable Message Boards Moderation (Automatic Copy)
+enable-message-boards-moderation-help=Enables a reputation-based approval workflow for Message Boards messages. This option is incompatible with other workflow definitions for Message Boards messages. (Automatic Copy)
+message-boards-moderation-workflow-group-configuration-name=Message Boards Moderation Workflow (Automatic Copy)
+minimum-contributed-messages=Minimum Contributed Messages (Automatic Copy)
+minimum-contributed-messages-help=Number of contributed Message Boards that skips manual review of Message Board messages. (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_eu.properties
@@ -1,0 +1,5 @@
+enable-message-boards-moderation=Enable Message Boards Moderation (Automatic Copy)
+enable-message-boards-moderation-help=Enables a reputation-based approval workflow for Message Boards messages. This option is incompatible with other workflow definitions for Message Boards messages. (Automatic Copy)
+message-boards-moderation-workflow-group-configuration-name=Message Boards Moderation Workflow (Automatic Copy)
+minimum-contributed-messages=Minimum Contributed Messages (Automatic Copy)
+minimum-contributed-messages-help=Number of contributed Message Boards that skips manual review of Message Board messages. (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_fa.properties
@@ -1,0 +1,5 @@
+enable-message-boards-moderation=Enable Message Boards Moderation (Automatic Copy)
+enable-message-boards-moderation-help=Enables a reputation-based approval workflow for Message Boards messages. This option is incompatible with other workflow definitions for Message Boards messages. (Automatic Copy)
+message-boards-moderation-workflow-group-configuration-name=Message Boards Moderation Workflow (Automatic Copy)
+minimum-contributed-messages=Minimum Contributed Messages (Automatic Copy)
+minimum-contributed-messages-help=Number of contributed Message Boards that skips manual review of Message Board messages. (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_fi.properties
@@ -1,0 +1,5 @@
+enable-message-boards-moderation=Enable Message Boards Moderation (Automatic Copy)
+enable-message-boards-moderation-help=Enables a reputation-based approval workflow for Message Boards messages. This option is incompatible with other workflow definitions for Message Boards messages. (Automatic Copy)
+message-boards-moderation-workflow-group-configuration-name=Message Boards Moderation Workflow (Automatic Copy)
+minimum-contributed-messages=Minimum Contributed Messages (Automatic Copy)
+minimum-contributed-messages-help=Number of contributed Message Boards that skips manual review of Message Board messages. (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_fr.properties
@@ -1,0 +1,5 @@
+enable-message-boards-moderation=Enable Message Boards Moderation (Automatic Copy)
+enable-message-boards-moderation-help=Enables a reputation-based approval workflow for Message Boards messages. This option is incompatible with other workflow definitions for Message Boards messages. (Automatic Copy)
+message-boards-moderation-workflow-group-configuration-name=Message Boards Moderation Workflow (Automatic Copy)
+minimum-contributed-messages=Minimum Contributed Messages (Automatic Copy)
+minimum-contributed-messages-help=Number of contributed Message Boards that skips manual review of Message Board messages. (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_fr_CA.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_fr_CA.properties
@@ -1,0 +1,5 @@
+enable-message-boards-moderation=Enable Message Boards Moderation (Automatic Copy)
+enable-message-boards-moderation-help=Enables a reputation-based approval workflow for Message Boards messages. This option is incompatible with other workflow definitions for Message Boards messages. (Automatic Copy)
+message-boards-moderation-workflow-group-configuration-name=Message Boards Moderation Workflow (Automatic Copy)
+minimum-contributed-messages=Minimum Contributed Messages (Automatic Copy)
+minimum-contributed-messages-help=Number of contributed Message Boards that skips manual review of Message Board messages. (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_gl.properties
@@ -1,0 +1,5 @@
+enable-message-boards-moderation=Enable Message Boards Moderation (Automatic Copy)
+enable-message-boards-moderation-help=Enables a reputation-based approval workflow for Message Boards messages. This option is incompatible with other workflow definitions for Message Boards messages. (Automatic Copy)
+message-boards-moderation-workflow-group-configuration-name=Message Boards Moderation Workflow (Automatic Copy)
+minimum-contributed-messages=Minimum Contributed Messages (Automatic Copy)
+minimum-contributed-messages-help=Number of contributed Message Boards that skips manual review of Message Board messages. (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_hi_IN.properties
@@ -1,0 +1,5 @@
+enable-message-boards-moderation=Enable Message Boards Moderation (Automatic Copy)
+enable-message-boards-moderation-help=Enables a reputation-based approval workflow for Message Boards messages. This option is incompatible with other workflow definitions for Message Boards messages. (Automatic Copy)
+message-boards-moderation-workflow-group-configuration-name=Message Boards Moderation Workflow (Automatic Copy)
+minimum-contributed-messages=Minimum Contributed Messages (Automatic Copy)
+minimum-contributed-messages-help=Number of contributed Message Boards that skips manual review of Message Board messages. (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_hr.properties
@@ -1,0 +1,5 @@
+enable-message-boards-moderation=Enable Message Boards Moderation (Automatic Copy)
+enable-message-boards-moderation-help=Enables a reputation-based approval workflow for Message Boards messages. This option is incompatible with other workflow definitions for Message Boards messages. (Automatic Copy)
+message-boards-moderation-workflow-group-configuration-name=Message Boards Moderation Workflow (Automatic Copy)
+minimum-contributed-messages=Minimum Contributed Messages (Automatic Copy)
+minimum-contributed-messages-help=Number of contributed Message Boards that skips manual review of Message Board messages. (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_hu.properties
@@ -1,0 +1,5 @@
+enable-message-boards-moderation=Enable Message Boards Moderation (Automatic Copy)
+enable-message-boards-moderation-help=Enables a reputation-based approval workflow for Message Boards messages. This option is incompatible with other workflow definitions for Message Boards messages. (Automatic Copy)
+message-boards-moderation-workflow-group-configuration-name=Message Boards Moderation Workflow (Automatic Copy)
+minimum-contributed-messages=Minimum Contributed Messages (Automatic Copy)
+minimum-contributed-messages-help=Number of contributed Message Boards that skips manual review of Message Board messages. (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_in.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_in.properties
@@ -1,0 +1,5 @@
+enable-message-boards-moderation=Enable Message Boards Moderation (Automatic Copy)
+enable-message-boards-moderation-help=Enables a reputation-based approval workflow for Message Boards messages. This option is incompatible with other workflow definitions for Message Boards messages. (Automatic Copy)
+message-boards-moderation-workflow-group-configuration-name=Message Boards Moderation Workflow (Automatic Copy)
+minimum-contributed-messages=Minimum Contributed Messages (Automatic Copy)
+minimum-contributed-messages-help=Number of contributed Message Boards that skips manual review of Message Board messages. (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_it.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_it.properties
@@ -1,0 +1,5 @@
+enable-message-boards-moderation=Enable Message Boards Moderation (Automatic Copy)
+enable-message-boards-moderation-help=Enables a reputation-based approval workflow for Message Boards messages. This option is incompatible with other workflow definitions for Message Boards messages. (Automatic Copy)
+message-boards-moderation-workflow-group-configuration-name=Message Boards Moderation Workflow (Automatic Copy)
+minimum-contributed-messages=Minimum Contributed Messages (Automatic Copy)
+minimum-contributed-messages-help=Number of contributed Message Boards that skips manual review of Message Board messages. (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_iw.properties
@@ -1,0 +1,5 @@
+enable-message-boards-moderation=Enable Message Boards Moderation (Automatic Copy)
+enable-message-boards-moderation-help=Enables a reputation-based approval workflow for Message Boards messages. This option is incompatible with other workflow definitions for Message Boards messages. (Automatic Copy)
+message-boards-moderation-workflow-group-configuration-name=Message Boards Moderation Workflow (Automatic Copy)
+minimum-contributed-messages=Minimum Contributed Messages (Automatic Copy)
+minimum-contributed-messages-help=Number of contributed Message Boards that skips manual review of Message Board messages. (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_ja.properties
@@ -1,0 +1,5 @@
+enable-message-boards-moderation=Enable Message Boards Moderation (Automatic Copy)
+enable-message-boards-moderation-help=Enables a reputation-based approval workflow for Message Boards messages. This option is incompatible with other workflow definitions for Message Boards messages. (Automatic Copy)
+message-boards-moderation-workflow-group-configuration-name=Message Boards Moderation Workflow (Automatic Copy)
+minimum-contributed-messages=Minimum Contributed Messages (Automatic Copy)
+minimum-contributed-messages-help=Number of contributed Message Boards that skips manual review of Message Board messages. (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_kk.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_kk.properties
@@ -1,0 +1,5 @@
+enable-message-boards-moderation=Enable Message Boards Moderation (Automatic Copy)
+enable-message-boards-moderation-help=Enables a reputation-based approval workflow for Message Boards messages. This option is incompatible with other workflow definitions for Message Boards messages. (Automatic Copy)
+message-boards-moderation-workflow-group-configuration-name=Message Boards Moderation Workflow (Automatic Copy)
+minimum-contributed-messages=Minimum Contributed Messages (Automatic Copy)
+minimum-contributed-messages-help=Number of contributed Message Boards that skips manual review of Message Board messages. (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_ko.properties
@@ -1,0 +1,5 @@
+enable-message-boards-moderation=Enable Message Boards Moderation (Automatic Copy)
+enable-message-boards-moderation-help=Enables a reputation-based approval workflow for Message Boards messages. This option is incompatible with other workflow definitions for Message Boards messages. (Automatic Copy)
+message-boards-moderation-workflow-group-configuration-name=Message Boards Moderation Workflow (Automatic Copy)
+minimum-contributed-messages=Minimum Contributed Messages (Automatic Copy)
+minimum-contributed-messages-help=Number of contributed Message Boards that skips manual review of Message Board messages. (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_lo.properties
@@ -1,0 +1,5 @@
+enable-message-boards-moderation=Enable Message Boards Moderation (Automatic Copy)
+enable-message-boards-moderation-help=Enables a reputation-based approval workflow for Message Boards messages. This option is incompatible with other workflow definitions for Message Boards messages. (Automatic Copy)
+message-boards-moderation-workflow-group-configuration-name=Message Boards Moderation Workflow (Automatic Copy)
+minimum-contributed-messages=Minimum Contributed Messages (Automatic Copy)
+minimum-contributed-messages-help=Number of contributed Message Boards that skips manual review of Message Board messages. (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_lt.properties
@@ -1,0 +1,5 @@
+enable-message-boards-moderation=Enable Message Boards Moderation (Automatic Copy)
+enable-message-boards-moderation-help=Enables a reputation-based approval workflow for Message Boards messages. This option is incompatible with other workflow definitions for Message Boards messages. (Automatic Copy)
+message-boards-moderation-workflow-group-configuration-name=Message Boards Moderation Workflow (Automatic Copy)
+minimum-contributed-messages=Minimum Contributed Messages (Automatic Copy)
+minimum-contributed-messages-help=Number of contributed Message Boards that skips manual review of Message Board messages. (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_ms.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_ms.properties
@@ -1,0 +1,5 @@
+enable-message-boards-moderation=Enable Message Boards Moderation (Automatic Copy)
+enable-message-boards-moderation-help=Enables a reputation-based approval workflow for Message Boards messages. This option is incompatible with other workflow definitions for Message Boards messages. (Automatic Copy)
+message-boards-moderation-workflow-group-configuration-name=Message Boards Moderation Workflow (Automatic Copy)
+minimum-contributed-messages=Minimum Contributed Messages (Automatic Copy)
+minimum-contributed-messages-help=Number of contributed Message Boards that skips manual review of Message Board messages. (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_nb.properties
@@ -1,0 +1,5 @@
+enable-message-boards-moderation=Enable Message Boards Moderation (Automatic Copy)
+enable-message-boards-moderation-help=Enables a reputation-based approval workflow for Message Boards messages. This option is incompatible with other workflow definitions for Message Boards messages. (Automatic Copy)
+message-boards-moderation-workflow-group-configuration-name=Message Boards Moderation Workflow (Automatic Copy)
+minimum-contributed-messages=Minimum Contributed Messages (Automatic Copy)
+minimum-contributed-messages-help=Number of contributed Message Boards that skips manual review of Message Board messages. (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_nl.properties
@@ -1,0 +1,5 @@
+enable-message-boards-moderation=Enable Message Boards Moderation (Automatic Copy)
+enable-message-boards-moderation-help=Enables a reputation-based approval workflow for Message Boards messages. This option is incompatible with other workflow definitions for Message Boards messages. (Automatic Copy)
+message-boards-moderation-workflow-group-configuration-name=Message Boards Moderation Workflow (Automatic Copy)
+minimum-contributed-messages=Minimum Contributed Messages (Automatic Copy)
+minimum-contributed-messages-help=Number of contributed Message Boards that skips manual review of Message Board messages. (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_nl_BE.properties
@@ -1,0 +1,5 @@
+enable-message-boards-moderation=Enable Message Boards Moderation (Automatic Copy)
+enable-message-boards-moderation-help=Enables a reputation-based approval workflow for Message Boards messages. This option is incompatible with other workflow definitions for Message Boards messages. (Automatic Copy)
+message-boards-moderation-workflow-group-configuration-name=Message Boards Moderation Workflow (Automatic Copy)
+minimum-contributed-messages=Minimum Contributed Messages (Automatic Copy)
+minimum-contributed-messages-help=Number of contributed Message Boards that skips manual review of Message Board messages. (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_pl.properties
@@ -1,0 +1,5 @@
+enable-message-boards-moderation=Enable Message Boards Moderation (Automatic Copy)
+enable-message-boards-moderation-help=Enables a reputation-based approval workflow for Message Boards messages. This option is incompatible with other workflow definitions for Message Boards messages. (Automatic Copy)
+message-boards-moderation-workflow-group-configuration-name=Message Boards Moderation Workflow (Automatic Copy)
+minimum-contributed-messages=Minimum Contributed Messages (Automatic Copy)
+minimum-contributed-messages-help=Number of contributed Message Boards that skips manual review of Message Board messages. (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_pt_BR.properties
@@ -1,0 +1,5 @@
+enable-message-boards-moderation=Enable Message Boards Moderation (Automatic Copy)
+enable-message-boards-moderation-help=Enables a reputation-based approval workflow for Message Boards messages. This option is incompatible with other workflow definitions for Message Boards messages. (Automatic Copy)
+message-boards-moderation-workflow-group-configuration-name=Message Boards Moderation Workflow (Automatic Copy)
+minimum-contributed-messages=Minimum Contributed Messages (Automatic Copy)
+minimum-contributed-messages-help=Number of contributed Message Boards that skips manual review of Message Board messages. (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_pt_PT.properties
@@ -1,0 +1,5 @@
+enable-message-boards-moderation=Enable Message Boards Moderation (Automatic Copy)
+enable-message-boards-moderation-help=Enables a reputation-based approval workflow for Message Boards messages. This option is incompatible with other workflow definitions for Message Boards messages. (Automatic Copy)
+message-boards-moderation-workflow-group-configuration-name=Message Boards Moderation Workflow (Automatic Copy)
+minimum-contributed-messages=Minimum Contributed Messages (Automatic Copy)
+minimum-contributed-messages-help=Number of contributed Message Boards that skips manual review of Message Board messages. (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_ro.properties
@@ -1,0 +1,5 @@
+enable-message-boards-moderation=Enable Message Boards Moderation (Automatic Copy)
+enable-message-boards-moderation-help=Enables a reputation-based approval workflow for Message Boards messages. This option is incompatible with other workflow definitions for Message Boards messages. (Automatic Copy)
+message-boards-moderation-workflow-group-configuration-name=Message Boards Moderation Workflow (Automatic Copy)
+minimum-contributed-messages=Minimum Contributed Messages (Automatic Copy)
+minimum-contributed-messages-help=Number of contributed Message Boards that skips manual review of Message Board messages. (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_ru.properties
@@ -1,0 +1,5 @@
+enable-message-boards-moderation=Enable Message Boards Moderation (Automatic Copy)
+enable-message-boards-moderation-help=Enables a reputation-based approval workflow for Message Boards messages. This option is incompatible with other workflow definitions for Message Boards messages. (Automatic Copy)
+message-boards-moderation-workflow-group-configuration-name=Message Boards Moderation Workflow (Automatic Copy)
+minimum-contributed-messages=Minimum Contributed Messages (Automatic Copy)
+minimum-contributed-messages-help=Number of contributed Message Boards that skips manual review of Message Board messages. (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_sk.properties
@@ -1,0 +1,5 @@
+enable-message-boards-moderation=Enable Message Boards Moderation (Automatic Copy)
+enable-message-boards-moderation-help=Enables a reputation-based approval workflow for Message Boards messages. This option is incompatible with other workflow definitions for Message Boards messages. (Automatic Copy)
+message-boards-moderation-workflow-group-configuration-name=Message Boards Moderation Workflow (Automatic Copy)
+minimum-contributed-messages=Minimum Contributed Messages (Automatic Copy)
+minimum-contributed-messages-help=Number of contributed Message Boards that skips manual review of Message Board messages. (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_sl.properties
@@ -1,0 +1,5 @@
+enable-message-boards-moderation=Enable Message Boards Moderation (Automatic Copy)
+enable-message-boards-moderation-help=Enables a reputation-based approval workflow for Message Boards messages. This option is incompatible with other workflow definitions for Message Boards messages. (Automatic Copy)
+message-boards-moderation-workflow-group-configuration-name=Message Boards Moderation Workflow (Automatic Copy)
+minimum-contributed-messages=Minimum Contributed Messages (Automatic Copy)
+minimum-contributed-messages-help=Number of contributed Message Boards that skips manual review of Message Board messages. (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_sr_RS.properties
@@ -1,0 +1,5 @@
+enable-message-boards-moderation=Enable Message Boards Moderation (Automatic Copy)
+enable-message-boards-moderation-help=Enables a reputation-based approval workflow for Message Boards messages. This option is incompatible with other workflow definitions for Message Boards messages. (Automatic Copy)
+message-boards-moderation-workflow-group-configuration-name=Message Boards Moderation Workflow (Automatic Copy)
+minimum-contributed-messages=Minimum Contributed Messages (Automatic Copy)
+minimum-contributed-messages-help=Number of contributed Message Boards that skips manual review of Message Board messages. (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_sr_RS_latin.properties
@@ -1,0 +1,5 @@
+enable-message-boards-moderation=Enable Message Boards Moderation (Automatic Copy)
+enable-message-boards-moderation-help=Enables a reputation-based approval workflow for Message Boards messages. This option is incompatible with other workflow definitions for Message Boards messages. (Automatic Copy)
+message-boards-moderation-workflow-group-configuration-name=Message Boards Moderation Workflow (Automatic Copy)
+minimum-contributed-messages=Minimum Contributed Messages (Automatic Copy)
+minimum-contributed-messages-help=Number of contributed Message Boards that skips manual review of Message Board messages. (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_sv.properties
@@ -1,0 +1,5 @@
+enable-message-boards-moderation=Enable Message Boards Moderation (Automatic Copy)
+enable-message-boards-moderation-help=Enables a reputation-based approval workflow for Message Boards messages. This option is incompatible with other workflow definitions for Message Boards messages. (Automatic Copy)
+message-boards-moderation-workflow-group-configuration-name=Message Boards Moderation Workflow (Automatic Copy)
+minimum-contributed-messages=Minimum Contributed Messages (Automatic Copy)
+minimum-contributed-messages-help=Number of contributed Message Boards that skips manual review of Message Board messages. (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_ta_IN.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_ta_IN.properties
@@ -1,0 +1,5 @@
+enable-message-boards-moderation=Enable Message Boards Moderation (Automatic Copy)
+enable-message-boards-moderation-help=Enables a reputation-based approval workflow for Message Boards messages. This option is incompatible with other workflow definitions for Message Boards messages. (Automatic Copy)
+message-boards-moderation-workflow-group-configuration-name=Message Boards Moderation Workflow (Automatic Copy)
+minimum-contributed-messages=Minimum Contributed Messages (Automatic Copy)
+minimum-contributed-messages-help=Number of contributed Message Boards that skips manual review of Message Board messages. (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_th.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_th.properties
@@ -1,0 +1,5 @@
+enable-message-boards-moderation=Enable Message Boards Moderation (Automatic Copy)
+enable-message-boards-moderation-help=Enables a reputation-based approval workflow for Message Boards messages. This option is incompatible with other workflow definitions for Message Boards messages. (Automatic Copy)
+message-boards-moderation-workflow-group-configuration-name=Message Boards Moderation Workflow (Automatic Copy)
+minimum-contributed-messages=Minimum Contributed Messages (Automatic Copy)
+minimum-contributed-messages-help=Number of contributed Message Boards that skips manual review of Message Board messages. (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_tr.properties
@@ -1,0 +1,5 @@
+enable-message-boards-moderation=Enable Message Boards Moderation (Automatic Copy)
+enable-message-boards-moderation-help=Enables a reputation-based approval workflow for Message Boards messages. This option is incompatible with other workflow definitions for Message Boards messages. (Automatic Copy)
+message-boards-moderation-workflow-group-configuration-name=Message Boards Moderation Workflow (Automatic Copy)
+minimum-contributed-messages=Minimum Contributed Messages (Automatic Copy)
+minimum-contributed-messages-help=Number of contributed Message Boards that skips manual review of Message Board messages. (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_uk.properties
@@ -1,0 +1,5 @@
+enable-message-boards-moderation=Enable Message Boards Moderation (Automatic Copy)
+enable-message-boards-moderation-help=Enables a reputation-based approval workflow for Message Boards messages. This option is incompatible with other workflow definitions for Message Boards messages. (Automatic Copy)
+message-boards-moderation-workflow-group-configuration-name=Message Boards Moderation Workflow (Automatic Copy)
+minimum-contributed-messages=Minimum Contributed Messages (Automatic Copy)
+minimum-contributed-messages-help=Number of contributed Message Boards that skips manual review of Message Board messages. (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_vi.properties
@@ -1,0 +1,5 @@
+enable-message-boards-moderation=Enable Message Boards Moderation (Automatic Copy)
+enable-message-boards-moderation-help=Enables a reputation-based approval workflow for Message Boards messages. This option is incompatible with other workflow definitions for Message Boards messages. (Automatic Copy)
+message-boards-moderation-workflow-group-configuration-name=Message Boards Moderation Workflow (Automatic Copy)
+minimum-contributed-messages=Minimum Contributed Messages (Automatic Copy)
+minimum-contributed-messages-help=Number of contributed Message Boards that skips manual review of Message Board messages. (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_zh_CN.properties
@@ -1,0 +1,5 @@
+enable-message-boards-moderation=Enable Message Boards Moderation (Automatic Copy)
+enable-message-boards-moderation-help=Enables a reputation-based approval workflow for Message Boards messages. This option is incompatible with other workflow definitions for Message Boards messages. (Automatic Copy)
+message-boards-moderation-workflow-group-configuration-name=Message Boards Moderation Workflow (Automatic Copy)
+minimum-contributed-messages=Minimum Contributed Messages (Automatic Copy)
+minimum-contributed-messages-help=Number of contributed Message Boards that skips manual review of Message Board messages. (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/message-boards/message-boards-moderation/src/main/resources/content/Language_zh_TW.properties
@@ -1,0 +1,5 @@
+enable-message-boards-moderation=Enable Message Boards Moderation (Automatic Copy)
+enable-message-boards-moderation-help=Enables a reputation-based approval workflow for Message Boards messages. This option is incompatible with other workflow definitions for Message Boards messages. (Automatic Copy)
+message-boards-moderation-workflow-group-configuration-name=Message Boards Moderation Workflow (Automatic Copy)
+minimum-contributed-messages=Minimum Contributed Messages (Automatic Copy)
+minimum-contributed-messages-help=Number of contributed Message Boards that skips manual review of Message Board messages. (Automatic Copy)

--- a/modules/apps/message-boards/message-boards-test/build.gradle
+++ b/modules/apps/message-boards/message-boards-test/build.gradle
@@ -10,6 +10,7 @@ dependencies {
 	testIntegrationCompile project(":apps:layout:layout-test-util")
 	testIntegrationCompile project(":apps:message-boards:message-boards-api")
 	testIntegrationCompile project(":apps:message-boards:message-boards-test-util")
+	testIntegrationCompile project(":apps:portal-configuration:portal-configuration-test-util")
 	testIntegrationCompile project(":apps:portal-search:portal-search-api")
 	testIntegrationCompile project(":apps:portal-search:portal-search-test-util")
 	testIntegrationCompile project(":apps:portal-security:portal-security-permission-test-util")

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/internal/moderation/test/MBModerationTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/internal/moderation/test/MBModerationTest.java
@@ -1,0 +1,145 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.message.boards.internal.moderation.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.message.boards.service.MBMessageLocalService;
+import com.liferay.message.boards.test.util.MBTestUtil;
+import com.liferay.petra.function.UnsafeRunnable;
+import com.liferay.portal.configuration.test.util.ConfigurationTemporarySwapper;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.HashMapDictionary;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.Dictionary;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Eduardo García
+ */
+@RunWith(Arquillian.class)
+public class MBModerationTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+		_user = TestPropsValues.getUser();
+	}
+
+	@Test
+	public void testAddMessageWithModerationDisabled() throws Exception {
+		MBTestUtil.addMessage(
+			_group.getGroupId(), _user.getUserId(),
+			RandomTestUtil.randomString(50), RandomTestUtil.randomString(50));
+
+		int groupMessagesCount = _mbMessageLocalService.getGroupMessagesCount(
+			_group.getGroupId(), _user.getUserId(),
+			WorkflowConstants.STATUS_APPROVED);
+
+		Assert.assertEquals(1, groupMessagesCount);
+	}
+
+	@Test
+	public void testAddMessageWithModerationEnabledAndEnoughPublishedMessages()
+		throws Exception {
+
+		MBTestUtil.addMessage(
+			_group.getGroupId(), _user.getUserId(),
+			RandomTestUtil.randomString(50), RandomTestUtil.randomString(50));
+
+		_withModerationEnabled(
+			() -> {
+				MBTestUtil.addMessage(
+					_group.getGroupId(), _user.getUserId(),
+					RandomTestUtil.randomString(50),
+					RandomTestUtil.randomString(50));
+
+				int groupMessagesCount =
+					_mbMessageLocalService.getGroupMessagesCount(
+						_group.getGroupId(), _user.getUserId(),
+						WorkflowConstants.STATUS_APPROVED);
+
+				Assert.assertEquals(2, groupMessagesCount);
+			});
+	}
+
+	@Test
+	public void testAddMessageWithModerationEnabledAndNotEnoughPublishedMessages()
+		throws Exception {
+
+		_withModerationEnabled(
+			() -> {
+				MBTestUtil.addMessage(
+					_group.getGroupId(), _user.getUserId(),
+					RandomTestUtil.randomString(50),
+					RandomTestUtil.randomString(50));
+
+				int groupMessagesCount =
+					_mbMessageLocalService.getGroupMessagesCount(
+						_group.getGroupId(), _user.getUserId(),
+						WorkflowConstants.STATUS_APPROVED);
+
+				Assert.assertEquals(0, groupMessagesCount);
+			});
+	}
+
+	private void _withModerationEnabled(
+			UnsafeRunnable<Exception> unsafeRunnable)
+		throws Exception {
+
+		Dictionary<String, Object> dictionary = new HashMapDictionary<>();
+
+		dictionary.put("companyId", _group.getCompanyId());
+		dictionary.put("enableMessageBoardsModeration", true);
+		dictionary.put("minimumContributedMessages", 1);
+
+		try (ConfigurationTemporarySwapper configurationTemporarySwapper =
+				new ConfigurationTemporarySwapper(
+					"com.liferay.message.boards.moderation.internal." +
+						"configuration.MBModerationGroupConfiguration",
+					dictionary)) {
+
+			unsafeRunnable.run();
+		}
+	}
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private MBMessageLocalService _mbMessageLocalService;
+
+	private User _user;
+
+}


### PR DESCRIPTION
@liferay-lima Please label it as "on hold".

These changes introduce a workflow-based moderation for message boards. In particular, message board messages are assigned a workflow definition that enables automatic approval when the user has a certain number of already approved messages (defined by configuration). Otherwise, messages have to be reviewed and approved by a reviewer.

I included a test to illustrate and validate the expected behavior.

@liferay-headless: if we follow this path, then the Questions portlet needs to be adapted, so that it shows non-approved questions/answers to their owners, with a "pending" label (as already occurs with messages in message boards). I can take care of it in a separate story.

The workflow definition approach was previously validated with @liferay-workflow team @rafaprax. See PTR-2309.

@sammonsjl 
@pablo-agulla