### PR TITLE
LPS-129698 Remove usage of Liferay.Util.selectEntityHandler in message-boards

### DIFF
--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/select_category.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/select_category.jsp
@@ -22,7 +22,6 @@ MBCategory category = (MBCategory)request.getAttribute(WebKeys.MESSAGE_BOARDS_CA
 long categoryId = MBUtil.getCategoryId(request, category);
 
 long excludedCategoryId = ParamUtil.getLong(request, "excludedMBCategoryId");
-String eventName = ParamUtil.getString(request, "eventName", liferayPortletResponse.getNamespace() + "selectCategory");
 
 MBCategoryDisplay categoryDisplay = new MBCategoryDisplay(scopeGroupId, categoryId);
 
@@ -144,10 +143,3 @@ else {
 		</liferay-ui:search-container>
 	</aui:form>
 </clay:container-fluid>
-
-<aui:script>
-	Liferay.Util.selectEntityHandler(
-		'#<portlet:namespace />selectCategoryFm',
-		'<%= HtmlUtil.escapeJS(eventName) %>'
-	);
-</aui:script>


### PR DESCRIPTION
Fixes [LPS-129698](https://issues.liferay.com/browse/LPS-129698).

I've manually tested if this works, and indeed it does!
The reason just removing it works is because we handle that functionality in our modern implementation of [Modal.js](https://github.com/liferay-frontend/liferay-portal/blob/master/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js#L410-L420).

## Testing

1. Go to Content & Data > Message Boards
2. Create a Thread
3. Create a Category
4. In the ellipsis menu of the Thread, click on `Move`
5. Click on `Select` button in the opened page
6. A modal should open, Select the category to move the thread into
7. Profit!

https://user-images.githubusercontent.com/24564752/112968611-c1ce5900-914c-11eb-9fa0-598208898740.mp4

