### PR TITLE
[TS] LPS-130028 | Figure and figcaption tags are stripped in blogs.

### DIFF
--- a/modules/apps/blogs/blogs-editor-configuration/src/main/java/com/liferay/blogs/editor/configuration/internal/BlogsContentEditorConfigContributor.java
+++ b/modules/apps/blogs/blogs-editor-configuration/src/main/java/com/liferay/blogs/editor/configuration/internal/BlogsContentEditorConfigContributor.java
@@ -66,7 +66,8 @@ public class BlogsContentEditorConfigContributor
 
 		sb.append("a[*](*); ");
 		sb.append(_getAllowedContentText());
-		sb.append(" div[*](*); iframe[*](*); img[*](*){*}; ");
+		sb.append(
+			" div[*](*); figcaption; figure; iframe[*](*); img[*](*){*}; ");
 		sb.append(_getAllowedContentLists());
 		sb.append(" p[*](*){text-align}; ");
 		sb.append(_getAllowedContentTable());


### PR DESCRIPTION
https://issues.liferay.com/browse/LPP-40807
https://issues.liferay.com/browse/LPS-107732

Hi @liferay-lima,

Currently figure and figcaption tags, which were [added as a part of HTML5](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figure) to help provide further native support for sectioning context, are not permitted in blogs posts as they are not a part of the allowedContent in our content contributor. This PR adds them to this permitted list.

Please let me know if you have any questions or concerns about this. Thanks!