### PR TITLE
LPS-129643 Buttons are overlapping the pagination in DM move modal

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/select_folder.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/select_folder.jsp
@@ -77,6 +77,7 @@ DLVisualizationHelper dlVisualizationHelper = new DLVisualizationHelper(dlReques
 		</aui:button-row>
 
 		<liferay-ui:search-container
+			cssClass="pb-6"
 			iteratorURL='<%=
 				PortletURLBuilder.createRenderURL(
 					renderResponse


### PR DESCRIPTION
**Steps to reproduce:**

1. Go to documents and media
2. Create 21 folders
3. Upload a file
4. Select the file and use the dropdown menu to move the file

**Before the fix** 
A dialog opens showing the first 20 folders, but the pagination has covered by the frame at the bottom.

![image](https://user-images.githubusercontent.com/67901/113846595-ee125700-9796-11eb-8f8d-3f7312eba4f0.png)
![image](https://user-images.githubusercontent.com/67901/113846614-f2d70b00-9796-11eb-8baf-212e3571ddad.png)


**After the fix**  
The pagination display normally.

![image](https://user-images.githubusercontent.com/67901/113846625-f79bbf00-9796-11eb-8e80-8695e56f3db7.png)
