### PR TITLE
LPS-129973 Redirect entry is not aligned

### DIFF
--- a/modules/apps/frontend-js/frontend-js-tooltip-support-web/src/main/resources/META-INF/resources/index.js
+++ b/modules/apps/frontend-js/frontend-js-tooltip-support-web/src/main/resources/META-INF/resources/index.js
@@ -49,7 +49,7 @@ const SELECTOR_TRIGGER = `
 	.preview-toolbar-container [title]:not(.lfr-portal-tooltip),
 	.preview-tooltbar-containter [data-restore-title],
 	.progress-container[data-title],
-	.redirect-entries span[data-title],
+	.redirect-entries [data-title]:not(.lfr-portal-tooltip),
 	.source-editor__fixed-text__help[data-title],
 	.upper-tbar [data-title]:not(.lfr-portal-tooltip),
 	.upper-tbar [title]:not(.lfr-portal-tooltip),

--- a/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/css/main.scss
@@ -42,7 +42,11 @@
 		text-transform: uppercase;
 	}
 
-	.text-truncate-reverse {
+	.table-cell-expand {
 		direction: rtl;
+		overflow: hidden;
+		text-align: left;
+		text-overflow: ellipsis;
+		white-space: nowrap;
 	}
 }

--- a/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/css/main.scss
@@ -42,7 +42,7 @@
 		text-transform: uppercase;
 	}
 
-	.table-cell-expand {
+	.table-cell-text-truncate-reverse {
 		direction: rtl;
 		overflow: hidden;
 		text-align: left;

--- a/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/view_redirect_entries.jsp
+++ b/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/view_redirect_entries.jsp
@@ -86,8 +86,8 @@ RedirectManagementToolbarDisplayContext redirectManagementToolbarDisplayContext 
 							String sourceURL = HtmlUtil.escape(RedirectUtil.getGroupBaseURL(themeDisplay) + StringPool.SLASH + redirectEntry.getSourceURL());
 							%>
 
-							<span class="text-truncate text-truncate-reverse" data-title="<%= HtmlUtil.escapeAttribute(sourceURL) %>">
-								<bdi><%= sourceURL %></bdi>
+							<span data-title="<%= HtmlUtil.escapeAttribute(sourceURL) %>">
+								<%= sourceURL %>
 							</span>
 						</liferay-ui:search-container-column-text>
 
@@ -100,8 +100,8 @@ RedirectManagementToolbarDisplayContext redirectManagementToolbarDisplayContext 
 							String destinationURL = HtmlUtil.escape(redirectEntry.getDestinationURL());
 							%>
 
-							<span class="text-truncate text-truncate-reverse" data-title="<%= HtmlUtil.escapeAttribute(destinationURL) %>">
-								<bdi><%= destinationURL %></bdi>
+							<span data-title="<%= HtmlUtil.escapeAttribute(destinationURL) %>">
+								<%= destinationURL %>
 							</span>
 						</liferay-ui:search-container-column-text>
 

--- a/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/view_redirect_entries.jsp
+++ b/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/view_redirect_entries.jsp
@@ -78,7 +78,7 @@ RedirectManagementToolbarDisplayContext redirectManagementToolbarDisplayContext 
 						%>
 
 						<liferay-ui:search-container-column-text
-							cssClass="table-cell-expand"
+							cssClass="table-cell-expand table-cell-text-truncate-reverse"
 							name="source-url"
 						>
 
@@ -86,13 +86,13 @@ RedirectManagementToolbarDisplayContext redirectManagementToolbarDisplayContext 
 							String sourceURL = HtmlUtil.escape(RedirectUtil.getGroupBaseURL(themeDisplay) + StringPool.SLASH + redirectEntry.getSourceURL());
 							%>
 
-							<span data-title="<%= HtmlUtil.escapeAttribute(sourceURL) %>">
+							<bdi data-title="<%= HtmlUtil.escapeAttribute(sourceURL) %>">
 								<%= sourceURL %>
-							</span>
+							</bdi>
 						</liferay-ui:search-container-column-text>
 
 						<liferay-ui:search-container-column-text
-							cssClass="table-cell-expand"
+							cssClass="table-cell-expand table-cell-text-truncate-reverse"
 							name="destination-url"
 						>
 
@@ -100,9 +100,9 @@ RedirectManagementToolbarDisplayContext redirectManagementToolbarDisplayContext 
 							String destinationURL = HtmlUtil.escape(redirectEntry.getDestinationURL());
 							%>
 
-							<span data-title="<%= HtmlUtil.escapeAttribute(destinationURL) %>">
+							<bdi data-title="<%= HtmlUtil.escapeAttribute(destinationURL) %>">
 								<%= destinationURL %>
-							</span>
+							</bdi>
 						</liferay-ui:search-container-column-text>
 
 						<liferay-ui:search-container-column-text


### PR DESCRIPTION
**Steps to reproduce:**

1. Go to redirection
2. Add an entry

**Before the fix**
Redirect entry is not aligned.

![image](https://user-images.githubusercontent.com/67901/113885072-d26f7680-97bf-11eb-9328-668b9cff48ef.png)


**After the fix**
Redirect entry is aligned.

![image](https://user-images.githubusercontent.com/67901/113885155-e61add00-97bf-11eb-8dcb-a935f02f6e11.png)


I introduce this bug when I fixed https://issues.liferay.com/browse/LPS-113405, the first commit b6d0483c7b4ac200020d27e2f501c0569f95ac57 is a revert of the previous approach.

The second one 426d90170cdcb7775d2d211c82a9dfd07a679b26 is another approach fixing this bug and https://issues.liferay.com/browse/LPS-113405.
