### PR TITLE
[TS] LPS-130154 Handle the org.apache.tika.sax.WriteOutContentHandler exception. We have to get the parsed text in that case.

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/FileImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/FileImpl.java
@@ -1157,7 +1157,7 @@ public class FileImpl implements com.liferay.portal.kernel.util.File {
 
 	private static String _parseToString(
 			Tika tika, TikaInputStream tikaInputStream)
-		throws IOException, SAXException, TikaException {
+		throws IOException, TikaException {
 
 		UniversalEncodingDetector universalEncodingDetector =
 			new UniversalEncodingDetector();
@@ -1214,6 +1214,12 @@ public class FileImpl implements com.liferay.portal.kernel.util.File {
 			parser.parse(
 				tikaInputStream, new BodyContentHandler(writeOutContentHandler),
 				metadata, parseContext);
+		}
+		catch (SAXException saxException) {
+			if (!writeOutContentHandler.isWriteLimitReached(saxException)) {
+				throw new TikaException(
+					"Unexpected SAX processing failure", saxException);
+			}
 		}
 		finally {
 			tikaInputStream.close();


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-130154

This is a regression caused by the [LPS-112649](https://issues.liferay.com/browse/LPS-112649) changes

In that LPS, we have removed the tika.parseToString(tikaInputStream, metadata) method call and replicated part of the tika.parseToString code to set an EmbeddedDocumentExtractor, but we are not handling the `WriteOutContentHandler$WriteLimitReachedException` exception
- **LPS-112649 changes:** [`302b01c38a...feed27c410`#diff-e9676c4087](https://github.com/brianchandotcom/liferay-portal/compare/302b01c38a...feed27c410#diff-e9676c408769c6359ccec965883bf8570f5fa1c21dc0b2396568425a0da0e6f4R1120-R1185)
- **Original tika.parseToString code:** https://github.com/apache/tika/blob/0090ebac8e4ff4083a9c0c5d3dc55f545ad6f951/tika-core/src/main/java/org/apache/tika/Tika.java#L520-L538

So it is necessary to add following Tika code to the Liferay code:

        catch (SAXException e) {
            if (!handler.isWriteLimitReached(e)) {
                // This should never happen with BodyContentHandler...
                throw new TikaException("Unexpected SAX processing failure", e);
            }
        }

That will avoid this regression.