### PR TITLE
LPS-130213 | master

### DIFF
--- a/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/build.gradle
+++ b/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/build.gradle
@@ -6,7 +6,7 @@ dependencies {
 	compileInclude group: "com.google.guava", name: "guava", version: "30.1.1-jre"
 	compileInclude group: "com.googlecode.jsontoken", name: "jsontoken", version: "1.1"
 	compileInclude group: "com.microsoft.graph", name: "microsoft-graph", version: "1.5.0"
-	compileInclude group: "com.microsoft.graph", name: "microsoft-graph-core", version: "1.0.0"
+	compileInclude group: "com.microsoft.graph", name: "microsoft-graph-core", version: "1.0.9"
 	compileInclude group: "com.squareup.okhttp3", name: "okhttp", version: "3.12.1"
 	compileInclude group: "com.squareup.okio", name: "okio", version: "1.15.0"
 	compileInclude group: "com.zaxxer", name: "SparseBitSet", version: "1.2"


### PR DESCRIPTION
Hi @liferay-lima ,

This PR resolves the LPS-130213. When you try to execute the action "checkin" in an Office 365 document, you can get an error and the action cannot be finished correctly.

There was a change in the Graph service, and the Graph API client must be updated (as least to 1.0.8). 

I find out information about the problem in [link](https://stackoverflow.com/questions/66075502/graphapi-com-microsoft-graph-core-clientexception-caused-by-java-lang-illegalst) and [link1](https://github.com/microsoftgraph/msgraph-sdk-java-core/pull/141). I tried the API upgrade, and the error disappeared.