### PR TITLE
LPS-130200 | master

### DIFF
--- a/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/src/main/java/com/liferay/document/library/opener/onedrive/web/internal/service/DLOpenerOneDriveDLAppServiceWrapper.java
+++ b/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/src/main/java/com/liferay/document/library/opener/onedrive/web/internal/service/DLOpenerOneDriveDLAppServiceWrapper.java
@@ -40,6 +40,7 @@ import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 
 import java.io.File;
+import java.io.InputStream;
 
 import java.util.Objects;
 
@@ -160,6 +161,21 @@ public class DLOpenerOneDriveDLAppServiceWrapper extends DLAppServiceWrapper {
 
 		_dlOpenerOneDriveManager.deleteFile(
 			serviceContext.getUserId(), fileEntry);
+	}
+
+	@Override
+	public FileEntry updateFileEntryAndCheckIn(
+			long fileEntryId, String sourceFileName, String mimeType,
+			String title, String description, String changeLog,
+			DLVersionNumberIncrease dlVersionNumberIncrease,
+			InputStream inputStream, long size, ServiceContext serviceContext)
+		throws PortalException {
+
+		FileEntry fileEntry = getFileEntry(fileEntryId);
+		checkInFileEntry(
+			fileEntryId, dlVersionNumberIncrease, changeLog, serviceContext);
+
+		return fileEntry;
 	}
 
 	private long _getUserId() {


### PR DESCRIPTION
Hi @liferay-lima ,

This PR resolves the LPS-130200. The root problem is that the updateFileEntryAndCheckIn method is not implemented in the class DLOpenerOneDriveDLAppServiceWrapper, which produces an inconsistent state in the document. 

When an Office 365 document is in a checkout state, there is a row in the "DLOpenerFileEntryReference" table with the open document reference information. 

This row is removed when the action "checkin" is done (the code is in the method DLOpenerOneDriveDLAppServiceWrapper.checkInFileEntry). 

If the user uses the action "Save and checkin" instead "checkin", because "updateFileEntryAndCheckIn" method is not implemented, the row in the "DLOpenerFileEntryReference" table does not remove. This situation produces an error the next time the users try to "edit in Office 365".

This PR is related with this [one](https://github.com/liferay-lima/liferay-portal/pull/1727).