### PR TITLE
LPS-129597 Remove obsolete usages of Liferay.Util.selectEntityHandler in document-library

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/select_file_version.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/select_file_version.jsp
@@ -20,8 +20,6 @@
 FileEntry fileEntry = (FileEntry)request.getAttribute(WebKeys.DOCUMENT_LIBRARY_FILE_ENTRY);
 FileVersion fileVersion = (FileVersion)request.getAttribute(WebKeys.DOCUMENT_LIBRARY_FILE_VERSION);
 
-String eventName = ParamUtil.getString(request, "eventName", liferayPortletResponse.getNamespace() + "selectFileVersionFm");
-
 int status = WorkflowConstants.STATUS_APPROVED;
 
 if ((user.getUserId() == fileEntry.getUserId()) || permissionChecker.isContentReviewer(user.getCompanyId(), scopeGroupId)) {
@@ -94,10 +92,3 @@ if ((user.getUserId() == fileEntry.getUserId()) || permissionChecker.isContentRe
 		</liferay-ui:search-container>
 	</aui:form>
 </clay:container-fluid>
-
-<aui:script>
-	Liferay.Util.selectEntityHandler(
-		'#<portlet:namespace />selectFileVersionFm',
-		'<%= HtmlUtil.escapeJS(eventName) %>'
-	);
-</aui:script>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/select_restricted_file_entry_type.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/select_restricted_file_entry_type.jsp
@@ -18,8 +18,6 @@
 
 <%
 DLSelectRestrictedFileEntryTypesDisplayContext selectRestrictedFileEntryTypesDisplayContext = new DLSelectRestrictedFileEntryTypesDisplayContext(request, renderRequest, renderResponse);
-
-String eventName = ParamUtil.getString(request, "eventName", liferayPortletResponse.getNamespace() + "selectFileEntryType");
 %>
 
 <clay:navigation-bar
@@ -80,10 +78,3 @@ String eventName = ParamUtil.getString(request, "eventName", liferayPortletRespo
 		/>
 	</liferay-ui:search-container>
 </aui:form>
-
-<aui:script>
-	Liferay.Util.selectEntityHandler(
-		'#<portlet:namespace />selectFileEntryTypeFm',
-		'<%= HtmlUtil.escapeJS(eventName) %>'
-	);
-</aui:script>


### PR DESCRIPTION
Part 1 of [LPS-129597](https://issues.liferay.com/browse/LPS-129597).

This PR removes usages of `Liferay.Util.selectEntityHandler` that are no longer necessary as they're included in the implementation of `openSelectionModal`.

I've tested both these removals with the help of @adolfopa.

# 🧪 Test scenarios
For both of these files you need to go to `Content & Data > Documents and Media`

## `select_file_version.jsp`
1. Upload a simple `*.txt` file, any other format won't work
2. Edit the file inside the DXP UI to create an another version
3. Select the uploaded file, click on the `i` button to show Information about the file
4. Go to the `Versions` tab, Click `Compare to...` and choose a version to compare with
5. This opens a modal that has been changed with this PR

![image](https://user-images.githubusercontent.com/24564752/114521129-6a4ae580-9c42-11eb-84c7-5178f542829f.png)

## `select_restricted_file_entry_type.jsp` 
1. Make a Folder
2. Edit the Folder
3. Under the Name & Description there's a `DOCUMENT TYPE RESTRICTIONS AND WORKFLOW` tab
4. Select `Define Specific Document Type Restrictions and Workflow for This Folder (The Folder)`
5. Click on `Select Document Type`
6. A modal opened is changed in this PR

![image](https://user-images.githubusercontent.com/24564752/114522158-6075b200-9c43-11eb-930a-ed59c1a454da.png)


Part 2 of the LPS will be done (sent as a separate PR) once https://github.com/brianchandotcom/liferay-portal/pull/100629 is merged.