### PR TITLE
LPS-130200 | master v2

### DIFF
--- a/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/src/main/java/com/liferay/document/library/opener/onedrive/web/internal/service/DLOpenerOneDriveDLAppServiceWrapper.java
+++ b/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/src/main/java/com/liferay/document/library/opener/onedrive/web/internal/service/DLOpenerOneDriveDLAppServiceWrapper.java
@@ -40,6 +40,7 @@ import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 
 import java.io.File;
+import java.io.InputStream;
 
 import java.util.Objects;
 
@@ -160,6 +161,32 @@ public class DLOpenerOneDriveDLAppServiceWrapper extends DLAppServiceWrapper {
 
 		_dlOpenerOneDriveManager.deleteFile(
 			serviceContext.getUserId(), fileEntry);
+	}
+
+	@Override
+	public FileEntry updateFileEntryAndCheckIn(
+			long fileEntryId, String sourceFileName, String mimeType,
+			String title, String description, String changeLog,
+			DLVersionNumberIncrease dlVersionNumberIncrease,
+			InputStream inputStream, long size, ServiceContext serviceContext)
+		throws PortalException {
+
+		FileEntry fileEntry = getFileEntry(fileEntryId);
+
+		if (!_dlOpenerOneDriveManager.isConfigured(fileEntry.getCompanyId()) ||
+			!_dlOpenerOneDriveManager.isOneDriveFile(fileEntry)) {
+
+			return super.updateFileEntryAndCheckIn(
+				fileEntryId, sourceFileName, mimeType, title, description,
+				changeLog, dlVersionNumberIncrease, null, serviceContext);
+		}
+
+		checkInFileEntry(
+			fileEntryId, dlVersionNumberIncrease, changeLog, serviceContext);
+
+		return super.updateFileEntry(
+			fileEntryId, sourceFileName, mimeType, title, description,
+			changeLog, dlVersionNumberIncrease, null, 0, serviceContext);
 	}
 
 	private long _getUserId() {


### PR DESCRIPTION
Hi @liferay-lima ,

This PR resolves the LPS-130200. The root problem is that the updateFileEntryAndCheckIn method is not implemented in the class DLOpenerOneDriveDLAppServiceWrapper, which produces an inconsistent state in the document.

When an Office 365 document is in a checkout state, there is a row in the "DLOpenerFileEntryReference" table with the open document reference information.

This row is removed when the action "checkin" is done (the code is in the method DLOpenerOneDriveDLAppServiceWrapper.checkInFileEntry).

If the user uses the action "Save and checkin" instead "checkin", because "updateFileEntryAndCheckIn" method is not implemented, the row in the "DLOpenerFileEntryReference" table does not remove. This situation produces an error the next time the users try to "edit in Office 365".

This PR has the changes suggested in the previous PR https://github.com/liferay-lima/liferay-portal/pull/1728.