### PR TITLE
LPS-127237  Upload to DM (Drag&Drop) in list view results in unusable UI, requiring reload

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/legacy/upload.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/legacy/upload.js
@@ -532,7 +532,7 @@ AUI.add(
 					}
 					else {
 						var entriesContainerSelector =
-							'ul.tabular-list-group:last-of-type';
+							'ul.list-group:last-of-type';
 
 						if (displayStyle === CSS_ICON) {
 							entriesContainerSelector =

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/legacy/upload.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/legacy/upload.js
@@ -1229,7 +1229,7 @@ AUI.add(
 							instance._updateFileLink(
 								fileNode,
 								response.message,
-								displayStyleList
+								displayStyle
 							);
 
 							instance._updateFileHiddenInput(
@@ -1386,16 +1386,19 @@ AUI.add(
 					}
 				},
 
-				_updateFileLink(node, id, displayStyleList) {
+				_updateFileLink(node, id, displayStyle) {
 					var instance = this;
 
-					var selector = SELECTOR_ENTRY_LINK;
+					var selector = 'a';
 
-					if (displayStyleList) {
+					if (displayStyle === STR_LIST) {
 						selector =
 							SELECTOR_ENTRY_DISPLAY_STYLE +
 							STR_SPACE +
 							SELECTOR_TAGLIB_ICON;
+					}
+					else if (displayStyle === CSS_ICON) {
+						selector = SELECTOR_ENTRY_LINK;
 					}
 
 					var link = node.all(selector);

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/legacy/upload.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/legacy/upload.js
@@ -495,7 +495,7 @@ AUI.add(
 
 				_createEntriesContainer(searchContainer, displayStyle) {
 					var containerClasses =
-						'display-style-descriptive tabular-list-group';
+						'list-group list-group-notification show-quick-actions-on-hover';
 
 					if (displayStyle === CSS_ICON) {
 						containerClasses = 'card-page card-page-equal-height';

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view.jsp
@@ -195,15 +195,15 @@ DLViewDisplayContext dlViewDisplayContext = new DLViewDisplayContext(dlAdminDisp
 										</div>
 
 										<div class="autofit-col autofit-col-expand">
-											<h5 class="text-default">
-												<liferay-ui:message arguments="<%= HtmlUtil.escape(user.getFullName()) %>" key="right-now-by-x" />
-											</h5>
-
-											<h4>
+											<h2 class="h5">
 												<aui:a href="<%= dlViewDisplayContext.getUploadURL() %>">
 													{title}
 												</aui:a>
-											</h4>
+											</h2>
+
+											<span>
+												<liferay-ui:message arguments="<%= HtmlUtil.escape(user.getFullName()) %>" key="right-now-by-x" />
+											</span>
 										</div>
 
 										<div class="autofit-col"></div>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view.jsp
@@ -187,7 +187,7 @@ DLViewDisplayContext dlViewDisplayContext = new DLViewDisplayContext(dlAdminDisp
 										<div class="autofit-col"></div>
 
 										<div class="autofit-col">
-											<div class="click-selector sticker sticker-user-icon sticker-xl">
+											<div class="click-selector sticker">
 												<div class="sticker-overlay">
 													<img alt="thumbnail" class="sticker-img" src="<%= thumbnailSrc %>" />
 												</div>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view.jsp
@@ -183,7 +183,7 @@ DLViewDisplayContext dlViewDisplayContext = new DLViewDisplayContext(dlAdminDisp
 										</liferay-frontend:vertical-card-header>
 									</liferay-frontend:vertical-card>
 
-									<li class="display-descriptive entry-display-style list-group-item">
+									<li class="display-descriptive entry-display-style list-group-item list-group-item-flex">
 										<div class="autofit-col"></div>
 
 										<div class="autofit-col">


### PR DESCRIPTION
We have different bugs here:

**Bug link**: the link of the newly updated document doesn't work and points into a JSON and breaks the UI.
**Bug container**: If the folder isn't empty the uploader creates a new container with outdated markup.
**Bug style**: The UI looks ugly and break.

**Steps to reproduce:**

1. Go to Content & data > Documents and Media
2. Change to list view
3. Drag & Drop a document into the folder
4. View the upload and result document (**bug style**)
5. click the newly uploaded files' name (**bug link**)

If you try to update a document in a not empty folder the upload doesn't detect the current container and create a new one with outdated markup (**bug container**).

Visuals documented on https://youtu.be/xzX29Mda678

the bug link is fixed in 2f6e4831eba5537a11a0c89cdf557428bafaa48d,  the bug container is fixed dfa9e95970b1799321c547b28f154bac08df7950 the rest of commits are for styling.

**Before the fix**

![image](https://user-images.githubusercontent.com/67901/114417041-8d798480-9bb1-11eb-96c3-717cf3dc9f2a.png)
![image](https://user-images.githubusercontent.com/67901/114417094-98341980-9bb1-11eb-815d-d0ad98bef772.png)

**After the fix**

![image](https://user-images.githubusercontent.com/67901/114417174-a71acc00-9bb1-11eb-9d85-11b3c1630c1d.png)
![image](https://user-images.githubusercontent.com/67901/114417210-af730700-9bb1-11eb-839c-eeffbacf5642.png)
