### PR TITLE
LPS-130359, LPS-130615 Port cover image events to use Liferay.State API

### DIFF
--- a/modules/apps/blogs/blogs-web/package.json
+++ b/modules/apps/blogs/blogs-web/package.json
@@ -1,6 +1,8 @@
 {
 	"dependencies": {
+		"@liferay/frontend-js-state-web": "*",
 		"frontend-js-web": "*",
+		"item-selector-taglib": "*",
 		"metal-state": "2.16.8"
 	},
 	"name": "blogs-web",

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/js/blogs.js
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/js/blogs.js
@@ -12,6 +12,12 @@
  * details.
  */
 
+import {State} from '@liferay/frontend-js-state-web';
+import {
+	STR_NULL_IMAGE_FILE_ENTRY_ID,
+	imageSelectorCoverImageAtom,
+} from 'item-selector-taglib';
+
 const CSS_INVISIBLE = 'invisible';
 const STR_BLANK = '';
 const STR_CHANGE = 'change';
@@ -128,11 +134,9 @@ export default class Blogs {
 			'.cover-image-caption'
 		);
 
-		Liferay.on('coverImageDeleted', this._removeCaption, this);
-		Liferay.on(
-			['coverImageUploaded', 'coverImageSelected'],
-			this._showCaption,
-			this
+		this._imageSelectorCoverImageSubscription = State.subscribe(
+			imageSelectorCoverImageAtom,
+			(data) => this._updateCaption(data)
 		);
 
 		const publishButton = this._getElementById('publishButton');
@@ -509,6 +513,15 @@ export default class Blogs {
 		}
 	}
 
+	_updateCaption(imageData) {
+		if (imageData.fileEntryId !== STR_NULL_IMAGE_FILE_ENTRY_ID) {
+			this._showCaption();
+		}
+		else {
+			this._removeCaption();
+		}
+	}
+
 	_updateContentImages(finalContent, attributeDataImageId) {
 		const originalContent = window[
 			`${this._config.namespace}contentEditor`
@@ -570,11 +583,8 @@ export default class Blogs {
 		this._eventsHandles.forEach((removeListener) => removeListener());
 		this._eventsHandles = [];
 
-		Liferay.detach('coverImageDeleted', this._removeCaption);
-		Liferay.detach(
-			['coverImageUploaded', 'coverImageSelected'],
-			this._showCaption
-		);
+		this._imageSelectorCoverImageSubscription.dispose();
+		this._imageSelectorCoverImageSubscription = null;
 	}
 
 	setCustomDescription(text) {

--- a/modules/apps/frontend-js/frontend-js-state-web/src/main/resources/META-INF/resources/State.ts
+++ b/modules/apps/frontend-js/frontend-js-state-web/src/main/resources/META-INF/resources/State.ts
@@ -17,8 +17,11 @@ import deepFreeze from './deepFreeze';
 
 import type {Immutable} from './types';
 
-const ATOM = Symbol('Liferay.State.ATOM');
-const SELECTOR = Symbol('Liferay.State.SELECTOR');
+// In the future, these should be Symbol(); see:
+// https://github.com/microsoft/TypeScript/issues/37888
+
+const ATOM = 'Liferay.State.ATOM';
+const SELECTOR = 'Liferay.State.SELECTOR';
 
 interface Getter {
 	<T>(atomOrSelector: Atom<T> | Selector<T>): Immutable<T>;

--- a/modules/apps/frontend-js/frontend-js-state-web/types/src/main/resources/META-INF/resources/State.d.ts
+++ b/modules/apps/frontend-js/frontend-js-state-web/types/src/main/resources/META-INF/resources/State.d.ts
@@ -13,8 +13,8 @@
  */
 
 import type {Immutable} from './types';
-declare const ATOM: unique symbol;
-declare const SELECTOR: unique symbol;
+declare const ATOM = 'Liferay.State.ATOM';
+declare const SELECTOR = 'Liferay.State.SELECTOR';
 interface Getter {
 	<T>(atomOrSelector: Atom<T> | Selector<T>): Immutable<T>;
 }
@@ -34,12 +34,12 @@ declare const State: {
 			readonly atoms: {
 				readonly default: Readonly<unknown>;
 				readonly key: string;
-				readonly [ATOM]: true;
+				readonly 'Liferay.State.ATOM': true;
 			}[];
 			readonly selectors: {
 				readonly deriveValue: (get: Getter) => unknown;
 				readonly key: string;
-				readonly [SELECTOR]: true;
+				readonly 'Liferay.State.SELECTOR': true;
 			}[];
 		};
 		reset(): void;
@@ -81,7 +81,7 @@ declare const State: {
 		selector: {
 			readonly deriveValue: (get: Getter) => T_2;
 			readonly key: string;
-			readonly [SELECTOR]: true;
+			readonly 'Liferay.State.SELECTOR': true;
 		},
 		seen: Set<Selector<unknown>>
 	): Immutable<T_2>;
@@ -106,7 +106,7 @@ declare const State: {
 	): {
 		readonly default: Immutable<T_3>;
 		readonly key: string;
-		readonly [ATOM]: true;
+		readonly 'Liferay.State.ATOM': true;
 	};
 
 	/**
@@ -119,12 +119,12 @@ declare const State: {
 			| {
 					readonly default: Immutable<T_4>;
 					readonly key: string;
-					readonly [ATOM]: true;
+					readonly 'Liferay.State.ATOM': true;
 			  }
 			| {
 					readonly deriveValue: (get: Getter) => T_4;
 					readonly key: string;
-					readonly [SELECTOR]: true;
+					readonly 'Liferay.State.SELECTOR': true;
 			  }
 	): Immutable<T_4>;
 
@@ -134,7 +134,7 @@ declare const State: {
 	readAtom<T_5>(atom: {
 		readonly default: Immutable<T_5>;
 		readonly key: string;
-		readonly [ATOM]: true;
+		readonly 'Liferay.State.ATOM': true;
 	}): Immutable<T_5>;
 
 	/**
@@ -143,7 +143,7 @@ declare const State: {
 	readSelector<T_6>(selector: {
 		readonly deriveValue: (get: Getter) => T_6;
 		readonly key: string;
-		readonly [SELECTOR]: true;
+		readonly 'Liferay.State.SELECTOR': true;
 	}): Immutable<T_6>;
 
 	/**
@@ -169,7 +169,7 @@ declare const State: {
 		key: string,
 		deriveValue: (get: Getter) => T_7
 	): {
-		readonly [SELECTOR]: true;
+		readonly 'Liferay.State.SELECTOR': true;
 		readonly deriveValue: (get: Getter) => T_7;
 		readonly key: string;
 	};
@@ -190,12 +190,12 @@ declare const State: {
 			| {
 					readonly default: Immutable<T_8>;
 					readonly key: string;
-					readonly [ATOM]: true;
+					readonly 'Liferay.State.ATOM': true;
 			  }
 			| {
 					readonly deriveValue: (get: Getter) => T_8;
 					readonly key: string;
-					readonly [SELECTOR]: true;
+					readonly 'Liferay.State.SELECTOR': true;
 			  },
 		callback: (value: Immutable<T_8>) => void
 	): {
@@ -217,12 +217,12 @@ declare const State: {
 			| {
 					readonly default: Immutable<T_9>;
 					readonly key: string;
-					readonly [ATOM]: true;
+					readonly 'Liferay.State.ATOM': true;
 			  }
 			| {
 					readonly deriveValue: (get: Getter) => T_9;
 					readonly key: string;
-					readonly [SELECTOR]: true;
+					readonly 'Liferay.State.SELECTOR': true;
 			  },
 		value: T_9
 	): void;
@@ -236,7 +236,7 @@ declare const State: {
 		atom: {
 			readonly default: Immutable<T_10>;
 			readonly key: string;
-			readonly [ATOM]: true;
+			readonly 'Liferay.State.ATOM': true;
 		},
 		value: T_10
 	): void;

--- a/modules/apps/item-selector/item-selector-taglib/package.json
+++ b/modules/apps/item-selector/item-selector-taglib/package.json
@@ -7,6 +7,8 @@
 		"@clayui/navigation-bar": "3.3.5",
 		"@clayui/progress-bar": "3.2.0",
 		"@clayui/tabs": "3.3.5",
+		"@liferay/frontend-js-react-web": "*",
+		"@liferay/frontend-js-state-web": "*",
 		"frontend-js-web": "*",
 		"metal-state": "2.16.8",
 		"prop-types": "15.7.2",

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/atoms/imageSelectorCoverImageAtom.ts
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/atoms/imageSelectorCoverImageAtom.ts
@@ -16,10 +16,7 @@ import {State} from '@liferay/frontend-js-state-web';
 
 export const STR_NULL_IMAGE_FILE_ENTRY_ID = '0';
 
-const imageSelectorCoverImageAtom = State.atom<{
-	fileEntryId: string;
-	src: string;
-}>('imageSelectorCoverImage', {
+const imageSelectorCoverImageAtom = State.atom('imageSelectorCoverImage', {
 	fileEntryId: STR_NULL_IMAGE_FILE_ENTRY_ID,
 	src: '',
 });

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/atoms/imageSelectorCoverImageAtom.ts
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/atoms/imageSelectorCoverImageAtom.ts
@@ -12,9 +12,16 @@
  * details.
  */
 
-export {default as ItemSelectorRepositoryEntryBrowser} from './repository_entry_browser/js/ItemSelectorRepositoryEntryBrowser.es';
+import {State} from '@liferay/frontend-js-state-web';
 
-export {
-	STR_NULL_IMAGE_FILE_ENTRY_ID,
-	default as imageSelectorCoverImageAtom,
-} from './atoms/imageSelectorCoverImageAtom';
+export const STR_NULL_IMAGE_FILE_ENTRY_ID = '0';
+
+const imageSelectorCoverImageAtom = State.atom<{
+	fileEntryId: string;
+	src: string;
+}>('imageSelectorCoverImage', {
+	fileEntryId: STR_NULL_IMAGE_FILE_ENTRY_ID,
+	src: '',
+});
+
+export default imageSelectorCoverImageAtom;

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/image_selector/js/ImageSelector.js
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/image_selector/js/ImageSelector.js
@@ -13,7 +13,7 @@
  */
 
 import ClayIcon from '@clayui/icon';
-import {useLiferayState} from '@liferay/frontend-js-react-web';
+import {State} from '@liferay/frontend-js-state-web';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, {useEffect, useRef, useState} from 'react';
@@ -59,14 +59,15 @@ const ImageSelector = ({
 	const [progressData, setProgressData] = useState();
 	const [progressValue, setProgressValue] = useState(0);
 
-	const [image, setImage] = useLiferayState(imageSelectorCoverImageAtom);
+	const [image, setImage] = useState({fileEntryId, src: imageURL});
 
 	useEffect(() => {
-		setImage({
-			fileEntryId,
-			src: imageURL,
-		});
-	}, [fileEntryId, imageURL, setImage]);
+		const isCoverImageSelector = paramName === 'coverImageFileEntry';
+
+		if (isCoverImageSelector) {
+			State.write(imageSelectorCoverImageAtom, image);
+		}
+	}, [image, paramName]);
 
 	const rootNodeRef = useRef(null);
 	const uploaderRef = useRef(null);

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/image_selector/js/ImageSelector.js
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/image_selector/js/ImageSelector.js
@@ -53,21 +53,15 @@ const ImageSelector = ({
 }) => {
 	const [errorMessage, setErrorMessage] = useState('');
 	const [fileName, setFileName] = useState('');
+	const [image, setImage] = useState({
+		fileEntryId,
+		src: imageURL,
+	});
 	const [imageCropRegion, setImageCropRegion] = useState(
 		initialImageCropRegion
 	);
 	const [progressData, setProgressData] = useState();
 	const [progressValue, setProgressValue] = useState(0);
-
-	const [image, setImage] = useState({fileEntryId, src: imageURL});
-
-	useEffect(() => {
-		const isCoverImageSelector = paramName === 'coverImageFileEntry';
-
-		if (isCoverImageSelector) {
-			State.write(imageSelectorCoverImageAtom, image);
-		}
-	}, [image, paramName]);
 
 	const rootNodeRef = useRef(null);
 	const uploaderRef = useRef(null);
@@ -129,27 +123,6 @@ const ImageSelector = ({
 		}
 
 		return message;
-	};
-
-	const showImagePreview = (file) => {
-		const reader = new FileReader();
-
-		reader.addEventListener('loadend', () => {
-			if (progressValue < 100) {
-				setImage({
-					fileEntryId: '-1',
-					src: reader.result,
-				});
-			}
-		});
-
-		reader.readAsDataURL(file);
-	};
-
-	const stopProgress = () => {
-		rootNodeRef.current.classList.remove(CSS_PROGRESS_ACTIVE);
-
-		setProgressValue(0);
 	};
 
 	const handleDeleteImageClick = () => {
@@ -254,6 +227,35 @@ const ImageSelector = ({
 			)
 		);
 	};
+
+	const showImagePreview = (file) => {
+		const reader = new FileReader();
+
+		reader.addEventListener('loadend', () => {
+			if (progressValue < 100) {
+				setImage({
+					fileEntryId: '-1',
+					src: reader.result,
+				});
+			}
+		});
+
+		reader.readAsDataURL(file);
+	};
+
+	const stopProgress = () => {
+		rootNodeRef.current.classList.remove(CSS_PROGRESS_ACTIVE);
+
+		setProgressValue(0);
+	};
+
+	useEffect(() => {
+		const isCoverImageSelector = paramName === 'coverImageFileEntry';
+
+		if (isCoverImageSelector) {
+			State.write(imageSelectorCoverImageAtom, image);
+		}
+	}, [image, paramName]);
 
 	useEffect(() => {
 		AUI().use('uploader', (A) => {

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/image_selector/js/image_selector.js
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/image_selector/js/image_selector.js
@@ -12,6 +12,9 @@
  * details.
  */
 
+/**
+ * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+ */
 AUI.add(
 	'liferay-image-selector',
 	(A) => {

--- a/modules/apps/item-selector/item-selector-taglib/tsconfig.json
+++ b/modules/apps/item-selector/item-selector-taglib/tsconfig.json
@@ -1,0 +1,44 @@
+{
+	"@generated": "34c740cd2f79b8647ad871f9f5fba449f27dbb4a",
+	"@overrides": {
+	},
+	"@readonly": "** AUTO-GENERATED: DO NOT EDIT OUTSIDE @overrides **",
+	"@see": "https://git.io/JY2EA",
+	"compilerOptions": {
+		"allowSyntheticDefaultImports": true,
+		"baseUrl": ".",
+		"composite": true,
+		"jsx": "react",
+		"module": "es6",
+		"moduleResolution": "node",
+		"outDir": "./types",
+		"paths": {
+			"@liferay/frontend-js-react-web": [
+				"../../frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/index.ts"
+			],
+			"@liferay/frontend-js-state-web": [
+				"../../frontend-js/frontend-js-state-web/src/main/resources/META-INF/resources/index.ts"
+			]
+		},
+		"sourceMap": false,
+		"strict": true,
+		"target": "es6",
+		"tsBuildInfoFile": "tmp/tsconfig.tsbuildinfo",
+		"typeRoots": [
+			"../../../node_modules/@types",
+			"./node_modules/@types"
+		]
+	},
+	"include": [
+		"src/**/*",
+		"test/**/*"
+	],
+	"references": [
+		{
+			"path": "../../frontend-js/frontend-js-react-web"
+		},
+		{
+			"path": "../../frontend-js/frontend-js-state-web"
+		}
+	]
+}

--- a/modules/apps/item-selector/item-selector-taglib/types/src/main/resources/META-INF/resources/atoms/imageSelectorCoverImageAtom.d.ts
+++ b/modules/apps/item-selector/item-selector-taglib/types/src/main/resources/META-INF/resources/atoms/imageSelectorCoverImageAtom.d.ts
@@ -12,9 +12,13 @@
  * details.
  */
 
-export {default as ItemSelectorRepositoryEntryBrowser} from './repository_entry_browser/js/ItemSelectorRepositoryEntryBrowser.es';
-
-export {
-	STR_NULL_IMAGE_FILE_ENTRY_ID,
-	default as imageSelectorCoverImageAtom,
-} from './atoms/imageSelectorCoverImageAtom';
+export declare const STR_NULL_IMAGE_FILE_ENTRY_ID = '0';
+declare const imageSelectorCoverImageAtom: {
+	readonly default: {
+		readonly fileEntryId: string;
+		readonly src: string;
+	};
+	readonly key: string;
+	readonly 'Liferay.State.ATOM': true;
+};
+export default imageSelectorCoverImageAtom;

--- a/modules/npmscripts.config.js
+++ b/modules/npmscripts.config.js
@@ -194,6 +194,9 @@ module.exports = {
 						'clay-table': '>=2.9.0',
 						'clay-tooltip': '>=2.9.0',
 					},
+					'item-selector-taglib': {
+						'/': '>=1.0.0',
+					},
 				},
 			},
 			exclude: {

--- a/readme/BREAKING_CHANGES.markdown
+++ b/readme/BREAKING_CHANGES.markdown
@@ -547,3 +547,37 @@ If your markup is based on Boostrap 3, you can update it with new Boostrap 4 mar
 #### Why was this change made?
 
 We included a "small" configurable CSS compatibility layer to simplify the migration from Liferay 7.0 to 7.1. Now it has been removed in order to fix conflicts with new styles and improve general CSS weight.
+
+---------------------------------------
+
+### item-selector-taglib no longer fires coverImage-related events
+- **Date:** 2021-Apr-15
+- **JIRA Ticket:** [LPS-130359](https://issues.liferay.com/browse/LPS-130359)
+
+#### What changed?
+
+The `ImageSelector` JS module no longer fires the `coverImageDeleted`,
+`coverImageSelected`, and `coverImageUploaded` events using the `Liferay.fire()`
+API. These events were used for internal communication between the
+`item-selector-taglib` and the `blogs-web` module, but now state is synchronized
+between the two modules via the `Liferay.State` mechanism instead, using
+`imageSelectorCoverImageAtom`.
+
+#### Who is affected?
+
+Anybody listening for the removed events with `Liferay.on()` or similar
+functions.
+
+#### How should I update my code?
+
+In practice, you should not be observing the interaction between these two
+modules, but if you must, you could instead use the `Liferay.State.subscribe()`
+API to subscribe to `imageSelectorCoverImageAtom`.
+
+#### Why was this change made?
+
+`Liferay.fire()` and `Liferay.on()` publish globally visible events on a shared
+channel. The `Liferay.State` API is a better fit for modules that wish to
+coordinate at a distance in this way, and it does so in a type-safe manner.
+
+---------------------------------------


### PR DESCRIPTION
~In case this is hard to read (because it is showing commits from upstream that haven't synced over to `liferay-lima/liferay-portal` yet), you can see the actual changes of interest (the last 3 commits) over at [the draft version of this PR on `liferay-frontend`](https://github.com/liferay-frontend/liferay-portal/pull/970).~

For [LPS-130359](https://issues.liferay.com/browse/LPS-130359), we wanted to find a simple candidate for migration from `Liferay.fire()`/`Liferay.on()` to the new global state API, `Liferay.State` ~(and the related React hook, `useLiferayState()`)~. We found `item-selector-taglib`'s `ImageSelector.js` (firing events related to cover images) and `blogs-web` (listening to those events). So here's the PR.

- "LPS-130615 Deprecate AUI liferay-image-selector": Seeing as we noticed along the way that the old `image_selector.js` was still hanging around, unused, and decided to deprecate it ([LPS-130615](https://issues.liferay.com/browse/LPS-130615)).
- "LPS-130359 Work around value visibility issue": We had to tweak our state implementation because this first attempt at usage from another module revealed a limitation in the TypeScript compiler.
- "LPS-130359 Port cover image events to use Liferay.State API": This is the actual meat 🥩 of the PR.
- "LPS-130359 Refactor to fix shared state bug": Fixes a pre-existing bug in `master` that was made obvious (and made worse) by the preceding commit.

The commit messages go into the details, but the main points are:

- Some refactoring to clean up the types (we had `propTypes` that said the `fileEntryId` was a required `string`, but we were using `0` (the number) with special meaning in a few places.
- Global state is synchronized via an "atom", called `imageSelectorCoverImageAtom`. What atoms are is described [in these docs](https://github.com/liferay/liferay-frontend-projects/blob/master/guidelines/dxp/react_state_management.md).
- The core idea of the atom design is that atoms are a type-safe API (a useful property to have when you are talking about global synchronization), so I took the opportunity to define the atom in a TypeScript file. This is The Right Way™ to define atoms. So that means turning on TypeScript in `item-selector-taglib`. Note that a partial migration like this is fine: it's literally just a single file that is TS and all the rest is left untouched.
- Breaking changes updated to note that we are no longer firing some globally-visible events that somebody could, in theory, be watching.

**Test plan:**

1. In blogs, add a cover image via drag an drop. Delete it. Change it and select a new file. Try this over and over again in different orders with the JS console open and see no errors. See the caption show/hide when changing the cover image.
2. Verify that the "small image" selector that appears under configuration still works as before (adding/removing/changing). Verify that changes to the "small image" do not affect the cover image or its caption in any way.
3. Create a commerce catalog and add a product to it. Add an image using the image selector there and see it work as before.

cc @ambrinchaudhary @boton