### PR TITLE
[TS] LPS-130719 - comments and message boards should not share e-mail settings

### DIFF
--- a/modules/apps/comment/comment-api/bnd.bnd
+++ b/modules/apps/comment/comment-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Comment API
 Bundle-SymbolicName: com.liferay.comment.api
-Bundle-Version: 6.0.2
+Bundle-Version: 6.1.0
 Export-Package:\
 	com.liferay.comment.configuration,\
 	com.liferay.comment.constants,\

--- a/modules/apps/comment/comment-api/src/main/java/com/liferay/comment/constants/CommentConstants.java
+++ b/modules/apps/comment/comment-api/src/main/java/com/liferay/comment/constants/CommentConstants.java
@@ -21,6 +21,8 @@ import com.liferay.message.boards.model.MBDiscussion;
  */
 public class CommentConstants {
 
+	public static final String SERVICE_NAME = "com.liferay.comment";
+
 	public static Class<?> getDiscussionClass() {
 		return MBDiscussion.class;
 	}

--- a/modules/apps/comment/comment-api/src/main/resources/com/liferay/comment/constants/packageinfo
+++ b/modules/apps/comment/comment-api/src/main/resources/com/liferay/comment/constants/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/modules/apps/comment/comment-web/src/main/java/com/liferay/comment/web/internal/configuration/definition/CommentGroupServiceConfigurationPidMapping.java
+++ b/modules/apps/comment/comment-web/src/main/java/com/liferay/comment/web/internal/configuration/definition/CommentGroupServiceConfigurationPidMapping.java
@@ -15,7 +15,7 @@
 package com.liferay.comment.web.internal.configuration.definition;
 
 import com.liferay.comment.configuration.CommentGroupServiceConfiguration;
-import com.liferay.message.boards.constants.MBConstants;
+import com.liferay.comment.constants.CommentConstants;
 import com.liferay.portal.kernel.settings.definition.ConfigurationPidMapping;
 
 import org.osgi.service.component.annotations.Component;
@@ -35,7 +35,7 @@ public class CommentGroupServiceConfigurationPidMapping
 
 	@Override
 	public String getConfigurationPid() {
-		return MBConstants.SERVICE_NAME;
+		return CommentConstants.SERVICE_NAME;
 	}
 
 }

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBMessageLocalServiceImpl.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBMessageLocalServiceImpl.java
@@ -17,6 +17,7 @@ package com.liferay.message.boards.service.impl;
 import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.asset.kernel.model.AssetLinkConstants;
 import com.liferay.comment.configuration.CommentGroupServiceConfiguration;
+import com.liferay.comment.constants.CommentConstants;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFolder;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
@@ -2527,7 +2528,8 @@ public class MBMessageLocalServiceImpl extends MBMessageLocalServiceBaseImpl {
 
 		return _configurationProvider.getConfiguration(
 			CommentGroupServiceConfiguration.class,
-			new GroupServiceSettingsLocator(groupId, MBConstants.SERVICE_NAME));
+			new GroupServiceSettingsLocator(
+				groupId, CommentConstants.SERVICE_NAME));
 	}
 
 	private long _getFileEntryMessageId(long fileEntryId)


### PR DESCRIPTION
Hi @liferay-lima team!

This is a fix for an issue that was declared a bug in [PTR-2371](https://issues.liferay.com/browse/PTR-2371). Currently, due to both sharing the same GroupServiceSettings settingsId of MBConstants.SERVICE_NAME, comments and message boards share the same email from name and address. By setting Comments to its own service name, the comments settings should no longer override message boards settings and visa versa.