### PR TITLE
LPS-130384 Remove usage of "path" in DM queries/indexers

### DIFF
--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/spi/model/index/contributor/DLFileEntryModelDocumentContributor.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/spi/model/index/contributor/DLFileEntryModelDocumentContributor.java
@@ -164,7 +164,6 @@ public class DLFileEntryModelDocumentContributor
 				StringUtil.replace(
 					dlFileEntry.getMimeType(), CharPool.FORWARD_SLASH,
 					CharPool.UNDERLINE));
-			document.addKeyword("path", dlFileEntry.getTitle());
 			document.addKeyword("readCount", dlFileEntry.getReadCount());
 			document.addNumber("size", dlFileEntry.getSize());
 

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/spi/model/query/contributor/DLFileEntryKeywordQueryContributor.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/spi/model/query/contributor/DLFileEntryKeywordQueryContributor.java
@@ -61,8 +61,6 @@ public class DLFileEntryKeywordQueryContributor
 		queryHelper.addSearchTerm(
 			booleanQuery, searchContext, "ddmContent", false);
 		queryHelper.addSearchTerm(
-			booleanQuery, searchContext, "extension", false);
-		queryHelper.addSearchTerm(
 			booleanQuery, searchContext, "fileEntryTypeId", false);
 		queryHelper.addSearchLocalizedTerm(
 			booleanQuery, searchContext, Field.CONTENT, false);
@@ -81,7 +79,8 @@ public class DLFileEntryKeywordQueryContributor
 						StringPool.QUOTE + exactMatch + StringPool.QUOTE, "");
 
 					fileNameBooleanQuery.add(
-						_getMatchQuery(exactMatch, MatchQuery.Type.PHRASE),
+						_getMatchQuery(
+							"fileName", exactMatch, MatchQuery.Type.PHRASE),
 						BooleanClauseOccur.MUST);
 
 					if (Validator.isNotNull(notExactKeyword)) {
@@ -96,11 +95,14 @@ public class DLFileEntryKeywordQueryContributor
 						BooleanClauseOccur.MUST);
 				}
 
-				MatchQuery matchPhraseQuery = _getMatchQuery(
-					keywords, MatchQuery.Type.PHRASE);
-
+				booleanQuery.add(
+					_getMatchQuery(
+						"extension", keywords, MatchQuery.Type.PHRASE_PREFIX),
+					BooleanClauseOccur.SHOULD);
 				fileNameBooleanQuery.add(
-					matchPhraseQuery, BooleanClauseOccur.SHOULD);
+					_getMatchQuery(
+						"fileName", keywords, MatchQuery.Type.PHRASE),
+					BooleanClauseOccur.SHOULD);
 
 				booleanQuery.add(
 					fileNameBooleanQuery, BooleanClauseOccur.SHOULD);
@@ -114,8 +116,10 @@ public class DLFileEntryKeywordQueryContributor
 	@Reference
 	protected QueryHelper queryHelper;
 
-	private MatchQuery _getMatchQuery(String keywords, MatchQuery.Type phrase) {
-		MatchQuery matchPhraseQuery = new MatchQuery("fileName", keywords);
+	private MatchQuery _getMatchQuery(
+		String field, String keywords, MatchQuery.Type phrase) {
+
+		MatchQuery matchPhraseQuery = new MatchQuery(field, keywords);
 
 		matchPhraseQuery.setType(phrase);
 
@@ -130,10 +134,9 @@ public class DLFileEntryKeywordQueryContributor
 		booleanQuery.add(
 			new MatchQuery("fileName", keyword), BooleanClauseOccur.SHOULD);
 
-		MatchQuery matchPhrasePrefixQuery = _getMatchQuery(
-			keyword, MatchQuery.Type.PHRASE_PREFIX);
-
-		booleanQuery.add(matchPhrasePrefixQuery, BooleanClauseOccur.SHOULD);
+		booleanQuery.add(
+			_getMatchQuery("fileName", keyword, MatchQuery.Type.PHRASE_PREFIX),
+			BooleanClauseOccur.SHOULD);
 
 		return booleanQuery;
 	}

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/spi/model/query/contributor/DLFileEntryKeywordQueryContributor.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/spi/model/query/contributor/DLFileEntryKeywordQueryContributor.java
@@ -55,8 +55,6 @@ public class DLFileEntryKeywordQueryContributor
 			queryHelper.addSearchTerm(
 				booleanQuery, searchContext, Field.DESCRIPTION, false);
 			queryHelper.addSearchTerm(
-				booleanQuery, searchContext, Field.TITLE, false);
-			queryHelper.addSearchTerm(
 				booleanQuery, searchContext, Field.USER_NAME, false);
 		}
 
@@ -66,9 +64,10 @@ public class DLFileEntryKeywordQueryContributor
 			booleanQuery, searchContext, "extension", false);
 		queryHelper.addSearchTerm(
 			booleanQuery, searchContext, "fileEntryTypeId", false);
-		queryHelper.addSearchTerm(booleanQuery, searchContext, "path", false);
 		queryHelper.addSearchLocalizedTerm(
 			booleanQuery, searchContext, Field.CONTENT, false);
+		queryHelper.addSearchTerm(
+			booleanQuery, searchContext, Field.TITLE, false);
 
 		if (Validator.isNotNull(keywords)) {
 			try {

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFileEntryFileNameSearchTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFileEntryFileNameSearchTest.java
@@ -103,7 +103,7 @@ public class DLFileEntryFileNameSearchTest {
 
 		addFileEntriesWithTitleSameAsFileName("One.jpg", "Two.JPG");
 
-		assertSearch("jp", Arrays.asList("One.jpg"));
+		assertSearch("jp", Arrays.asList("One.jpg", "Two.JPG"));
 	}
 
 	@Test

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/resources/META-INF/mappings/liferay-type-mappings.json
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/resources/META-INF/mappings/liferay-type-mappings.json
@@ -660,7 +660,7 @@
 			},
 			"extension": {
 				"store": true,
-				"type": "keyword"
+				"type": "text"
 			},
 			"fileEntryTypeId": {
 				"store": true,

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/resources/com/liferay/portal/search/elasticsearch7/internal/index/ElasticsearchIndexInformationTest-testGetFieldMappings.json
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/resources/com/liferay/portal/search/elasticsearch7/internal/index/ElasticsearchIndexInformationTest-testGetFieldMappings.json
@@ -671,7 +671,7 @@
 				},
 				"extension": {
 					"store": true,
-					"type": "keyword"
+					"type": "text"
 				},
 				"fileEntryTypeId": {
 					"store": true,

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web-test/src/testIntegration/resources/com/liferay/portal/search/tuning/synonyms/web/test/SynonymSearchTest-overrideTypeMappings.json
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web-test/src/testIntegration/resources/com/liferay/portal/search/tuning/synonyms/web/test/SynonymSearchTest-overrideTypeMappings.json
@@ -660,7 +660,7 @@
 			},
 			"extension": {
 				"store": true,
-				"type": "keyword"
+				"type": "text"
 			},
 			"fileEntryTypeId": {
 				"store": true,


### PR DESCRIPTION
All tests green; no appreciable difference in the number of results returned.