### PR TITLE
LPS-130379 Eliminate wildcard usage for the url field and use a different type of query

### DIFF
--- a/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/internal/search/spi/model/index/contributor/RedirectEntryModelDocumentContributor.java
+++ b/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/internal/search/spi/model/index/contributor/RedirectEntryModelDocumentContributor.java
@@ -16,6 +16,7 @@ package com.liferay.redirect.internal.search.spi.model.index.contributor;
 
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.search.spi.model.index.contributor.ModelDocumentContributor;
+import com.liferay.redirect.internal.util.URLUtil;
 import com.liferay.redirect.model.RedirectEntry;
 
 import org.osgi.service.component.annotations.Component;
@@ -37,9 +38,14 @@ public class RedirectEntryModelDocumentContributor
 			new String[] {"destinationURL", "sourceURL"});
 
 		document.addText("destinationURL", redirectEntry.getDestinationURL());
+		document.addText(
+			"destinationURLParts",
+			URLUtil.splitURL(redirectEntry.getDestinationURL()));
 		document.addDateSortable(
 			"lastOccurrenceDate", redirectEntry.getLastOccurrenceDate());
 		document.addText("sourceURL", redirectEntry.getSourceURL());
+		document.addText(
+			"sourceURLParts", URLUtil.splitURL(redirectEntry.getSourceURL()));
 	}
 
 }

--- a/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/internal/search/spi/model/index/contributor/RedirectNotFoundEntryModelDocumentContributor.java
+++ b/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/internal/search/spi/model/index/contributor/RedirectNotFoundEntryModelDocumentContributor.java
@@ -17,6 +17,7 @@ package com.liferay.redirect.internal.search.spi.model.index.contributor;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.search.spi.model.index.contributor.ModelDocumentContributor;
+import com.liferay.redirect.internal.util.URLUtil;
 import com.liferay.redirect.model.RedirectNotFoundEntry;
 
 import org.osgi.service.component.annotations.Component;
@@ -40,6 +41,8 @@ public class RedirectNotFoundEntryModelDocumentContributor
 		document.addKeyword("ignored", redirectNotFoundEntry.isIgnored());
 		document.addNumber(
 			"requestCount", redirectNotFoundEntry.getRequestCount());
+		document.addText(
+			"urlParts", URLUtil.splitURL(redirectNotFoundEntry.getUrl()));
 	}
 
 }

--- a/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/internal/util/URLUtil.java
+++ b/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/internal/util/URLUtil.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.redirect.internal.util;
+
+import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringPool;
+import com.liferay.petra.string.StringUtil;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/**
+ * @author Adolfo Pérez
+ */
+public class URLUtil {
+
+	public static String[] splitURL(String url) {
+		Set<String> terms = new HashSet<>();
+
+		int pos = url.indexOf("://");
+
+		if (pos == -1) {
+			pos = 0;
+		}
+		else {
+			pos += 3;
+		}
+
+		String[] parts = _pattern.split(url.substring(pos));
+
+		Collections.addAll(terms, parts);
+
+		if (terms.isEmpty()) {
+			return new String[0];
+		}
+
+		String domain = parts[0];
+
+		terms.addAll(StringUtil.split(domain, CharPool.PERIOD));
+
+		pos = domain.length();
+
+		while (pos != -1) {
+			pos = domain.lastIndexOf(StringPool.PERIOD, pos - 1);
+
+			if (pos > 0) {
+				terms.add(domain.substring(pos + 1));
+			}
+		}
+
+		return terms.toArray(new String[0]);
+	}
+
+	private static final Pattern _pattern = Pattern.compile("[/?=&]+");
+
+}

--- a/modules/apps/redirect/redirect-test/src/testIntegration/java/com/liferay/redirect/search/test/RedirectNotFoundEntrySearchTest.java
+++ b/modules/apps/redirect/redirect-test/src/testIntegration/java/com/liferay/redirect/search/test/RedirectNotFoundEntrySearchTest.java
@@ -167,26 +167,6 @@ public class RedirectNotFoundEntrySearchTest extends BaseSearchTestCase {
 	}
 
 	@Test
-	public void testSearchByURLSubstring() throws Exception {
-		ServiceContext serviceContext =
-			ServiceContextTestUtil.getServiceContext(group.getGroupId());
-
-		RedirectNotFoundEntry redirectNotFoundEntry =
-			_redirectNotFoundEntryLocalService.addOrUpdateRedirectNotFoundEntry(
-				serviceContext.getScopeGroup(), "/path/page");
-
-		List<SearchResult> searchResults = _getSearchResults("age");
-
-		Assert.assertEquals(searchResults.toString(), 1, searchResults.size());
-
-		SearchResult searchResult = searchResults.get(0);
-
-		Assert.assertEquals(
-			redirectNotFoundEntry.getRedirectNotFoundEntryId(),
-			searchResult.getClassPK());
-	}
-
-	@Test
 	public void testSearchByURLSuffix() throws Exception {
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(group.getGroupId());
@@ -224,6 +204,11 @@ public class RedirectNotFoundEntrySearchTest extends BaseSearchTestCase {
 	@Override
 	@Test
 	public void testSearchExpireLatestVersion() {
+	}
+
+	@Override
+	@Test
+	public void testSearchMixedPhraseKeywords() {
 	}
 
 	@Override


### PR DESCRIPTION
Changes to the URL indexer, so that we match prefixes of the URL component instead of using wilcard matching.