### PR TITLE
Lps 131302

### DIFF
--- a/modules/.releng/test/jenkins-results-parser/artifact.properties
+++ b/modules/.releng/test/jenkins-results-parser/artifact.properties
@@ -1,4 +1,4 @@
-artifact.git.id=428bcbb13861f074831c4fd919a1d13aeaaa1b09
-artifact.sources-commercial.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.jenkins.results.parser/1.0.831/com.liferay.jenkins.results.parser-1.0.831-sources-commercial.jar
-artifact.sources.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.jenkins.results.parser/1.0.831/com.liferay.jenkins.results.parser-1.0.831-sources.jar
-artifact.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.jenkins.results.parser/1.0.831/com.liferay.jenkins.results.parser-1.0.831.jar
+artifact.git.id=970192ea1a6d6f571961950a3aaf36a128bffaf0
+artifact.sources-commercial.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.jenkins.results.parser/1.0.832/com.liferay.jenkins.results.parser-1.0.832-sources-commercial.jar
+artifact.sources.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.jenkins.results.parser/1.0.832/com.liferay.jenkins.results.parser-1.0.832-sources.jar
+artifact.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.jenkins.results.parser/1.0.832/com.liferay.jenkins.results.parser-1.0.832.jar

--- a/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/helper/AccountRoleRequestHelper.java
+++ b/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/helper/AccountRoleRequestHelper.java
@@ -19,9 +19,12 @@ import com.liferay.application.list.PanelCategoryRegistry;
 import com.liferay.application.list.constants.ApplicationListWebKeys;
 import com.liferay.application.list.display.context.logic.PanelCategoryHelper;
 import com.liferay.application.list.display.context.logic.PersonalMenuEntryHelper;
+import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.product.navigation.personal.menu.PersonalMenuEntry;
 import com.liferay.roles.admin.constants.RolesAdminWebKeys;
+import com.liferay.roles.admin.panel.category.role.type.mapper.PanelCategoryRoleTypeMapper;
 import com.liferay.roles.admin.role.type.contributor.RoleTypeContributor;
 
 import java.util.List;
@@ -48,6 +51,9 @@ public class AccountRoleRequestHelper {
 			ApplicationListWebKeys.PANEL_APP_REGISTRY, _panelAppRegistry);
 		httpServletRequest.setAttribute(
 			RolesAdminWebKeys.CURRENT_ROLE_TYPE, _accountRoleTypeContributor);
+		httpServletRequest.setAttribute(
+			RolesAdminWebKeys.PANEL_CATEGORY_KEYS,
+			ArrayUtil.toStringArray(_panelCategoryKeys));
 		httpServletRequest.setAttribute(
 			RolesAdminWebKeys.SHOW_NAV_TABS, Boolean.FALSE);
 
@@ -77,10 +83,35 @@ public class AccountRoleRequestHelper {
 		cardinality = ReferenceCardinality.MULTIPLE,
 		policy = ReferencePolicy.DYNAMIC,
 		policyOption = ReferencePolicyOption.GREEDY,
+		unbind = "_removePanelCategoryRoleTypeMapper"
+	)
+	private void _addPanelCategoryRoleTypeMapper(
+		PanelCategoryRoleTypeMapper panelCategoryRoleTypeMapper) {
+
+		if (ArrayUtil.contains(
+				panelCategoryRoleTypeMapper.getRoleTypes(),
+				RoleConstants.TYPE_ACCOUNT)) {
+
+			_panelCategoryKeys.add(
+				panelCategoryRoleTypeMapper.getPanelCategoryKey());
+		}
+	}
+
+	@Reference(
+		cardinality = ReferenceCardinality.MULTIPLE,
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
 		unbind = "_removePersonalMenuEntry"
 	)
 	private void _addPersonalMenuEntry(PersonalMenuEntry personalMenuEntry) {
 		_personalMenuEntries.add(personalMenuEntry);
+	}
+
+	private void _removePanelCategoryRoleTypeMapper(
+		PanelCategoryRoleTypeMapper panelCategoryRoleTypeMapper) {
+
+		_panelCategoryKeys.remove(
+			panelCategoryRoleTypeMapper.getPanelCategoryKey());
 	}
 
 	private void _removePersonalMenuEntry(PersonalMenuEntry personalMenuEntry) {
@@ -92,6 +123,9 @@ public class AccountRoleRequestHelper {
 
 	@Reference
 	private PanelAppRegistry _panelAppRegistry;
+
+	private final List<String> _panelCategoryKeys =
+		new CopyOnWriteArrayList<>();
 
 	@Reference
 	private PanelCategoryRegistry _panelCategoryRegistry;

--- a/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/helper/AccountRoleRequestHelper.java
+++ b/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/helper/AccountRoleRequestHelper.java
@@ -50,29 +50,21 @@ public class AccountRoleRequestHelper {
 		httpServletRequest.setAttribute(
 			ApplicationListWebKeys.PANEL_APP_REGISTRY, _panelAppRegistry);
 		httpServletRequest.setAttribute(
+			ApplicationListWebKeys.PANEL_CATEGORY_HELPER,
+			new PanelCategoryHelper(_panelAppRegistry, _panelCategoryRegistry));
+		httpServletRequest.setAttribute(
+			ApplicationListWebKeys.PANEL_CATEGORY_REGISTRY,
+			_panelCategoryRegistry);
+		httpServletRequest.setAttribute(
+			ApplicationListWebKeys.PERSONAL_MENU_ENTRY_HELPER,
+			new PersonalMenuEntryHelper(_personalMenuEntries));
+		httpServletRequest.setAttribute(
 			RolesAdminWebKeys.CURRENT_ROLE_TYPE, _accountRoleTypeContributor);
 		httpServletRequest.setAttribute(
 			RolesAdminWebKeys.PANEL_CATEGORY_KEYS,
 			ArrayUtil.toStringArray(_panelCategoryKeys));
 		httpServletRequest.setAttribute(
 			RolesAdminWebKeys.SHOW_NAV_TABS, Boolean.FALSE);
-
-		PanelCategoryHelper panelCategoryHelper = new PanelCategoryHelper(
-			_panelAppRegistry, _panelCategoryRegistry);
-
-		httpServletRequest.setAttribute(
-			ApplicationListWebKeys.PANEL_CATEGORY_HELPER, panelCategoryHelper);
-
-		httpServletRequest.setAttribute(
-			ApplicationListWebKeys.PANEL_CATEGORY_REGISTRY,
-			_panelCategoryRegistry);
-
-		PersonalMenuEntryHelper personalMenuEntryHelper =
-			new PersonalMenuEntryHelper(_personalMenuEntries);
-
-		httpServletRequest.setAttribute(
-			ApplicationListWebKeys.PERSONAL_MENU_ENTRY_HELPER,
-			personalMenuEntryHelper);
 	}
 
 	public void setRequestAttributes(PortletRequest portletRequest) {

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/account_role_action.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/account_role_action.jsp
@@ -45,7 +45,7 @@ Role role = accountRoleDisplay.getRole();
 		url="<%= editAccountRoleURL %>"
 	/>
 
-	<c:if test="<%= role.getType() != RoleConstants.TYPE_ACCOUNT %>">
+	<c:if test="<%= !AccountRoleConstants.isSharedRole(role) %>">
 		<portlet:actionURL name="/account_admin/delete_account_roles" var="deleteAccountRolesURL">
 			<portlet:param name="redirect" value="<%= currentURL %>" />
 			<portlet:param name="accountRoleIds" value="<%= String.valueOf(accountRoleDisplay.getAccountRoleId()) %>" />

--- a/modules/apps/account/account-api/src/main/java/com/liferay/account/constants/AccountRoleConstants.java
+++ b/modules/apps/account/account-api/src/main/java/com/liferay/account/constants/AccountRoleConstants.java
@@ -14,8 +14,9 @@
 
 package com.liferay.account.constants;
 
+import com.liferay.account.model.AccountRole;
+import com.liferay.account.service.AccountRoleLocalServiceUtil;
 import com.liferay.portal.kernel.model.Role;
-import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.util.ArrayUtil;
 
 import java.util.Objects;
@@ -75,7 +76,14 @@ public class AccountRoleConstants {
 	}
 
 	public static boolean isSharedRole(Role role) {
-		if (role.getType() == RoleConstants.TYPE_ACCOUNT) {
+		AccountRole accountRole =
+			AccountRoleLocalServiceUtil.fetchAccountRoleByRoleId(
+				role.getRoleId());
+
+		if (Objects.equals(
+				accountRole.getAccountEntryId(),
+				AccountConstants.ACCOUNT_ENTRY_ID_DEFAULT)) {
+
 			return true;
 		}
 

--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/service/impl/AccountRoleLocalServiceImpl.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/service/impl/AccountRoleLocalServiceImpl.java
@@ -348,22 +348,9 @@ public class AccountRoleLocalServiceImpl
 
 		User defaultUser = company.getDefaultUser();
 
-		AccountRole accountRole = createAccountRole(
-			counterLocalService.increment());
-
-		role = roleLocalService.addRole(
-			defaultUser.getUserId(), AccountRole.class.getName(),
-			accountRole.getAccountRoleId(), roleName, null,
-			_roleDescriptionsMaps.get(roleName), RoleConstants.TYPE_ACCOUNT,
-			null, null);
-
-		accountRole.setCompanyId(role.getCompanyId());
-
-		accountRole.setAccountEntryId(
-			AccountConstants.ACCOUNT_ENTRY_ID_DEFAULT);
-		accountRole.setRoleId(role.getRoleId());
-
-		addAccountRole(accountRole);
+		addAccountRole(
+			defaultUser.getUserId(), AccountConstants.ACCOUNT_ENTRY_ID_DEFAULT,
+			roleName, null, _roleDescriptionsMaps.get(roleName));
 	}
 
 	private DynamicQuery _getRoleDynamicQuery(

--- a/modules/apps/alloy/alloy-mvc/src/main/java/com/liferay/alloy/mvc/AlloyPermission.java
+++ b/modules/apps/alloy/alloy-mvc/src/main/java/com/liferay/alloy/mvc/AlloyPermission.java
@@ -15,6 +15,7 @@
 package com.liferay.alloy.mvc;
 
 import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.bean.BeanPropertiesUtil;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -173,7 +174,7 @@ public class AlloyPermission {
 	}
 
 	protected static String formatActionId(String controller, String action) {
-		StringBuilder sb = new StringBuilder(formatAction(action));
+		StringBundler sb = new StringBundler(formatAction(action));
 
 		sb.append(StringPool.POUND);
 		sb.append(StringUtil.toUpperCase(controller));

--- a/modules/apps/asset/asset-publisher-test/src/testIntegration/java/com/liferay/asset/publisher/test/util/AssetPublisherTestUtil.java
+++ b/modules/apps/asset/asset-publisher-test/src/testIntegration/java/com/liferay/asset/publisher/test/util/AssetPublisherTestUtil.java
@@ -15,6 +15,7 @@
 package com.liferay.asset.publisher.test.util;
 
 import com.liferay.asset.kernel.model.AssetEntry;
+import com.liferay.petra.string.StringBundler;
 
 /**
  * Provides a utility method to convert an asset entry to XML format so it can
@@ -25,7 +26,7 @@ import com.liferay.asset.kernel.model.AssetEntry;
 public class AssetPublisherTestUtil {
 
 	public static String getAssetEntryXml(AssetEntry assetEntry) {
-		StringBuilder sb = new StringBuilder(6);
+		StringBundler sb = new StringBundler(6);
 
 		sb.append("<?xml version=\"1.0\"?><asset-entry>");
 		sb.append("<asset-entry-type>");

--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/closure/CTClosureImpl.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/closure/CTClosureImpl.java
@@ -112,7 +112,7 @@ public class CTClosureImpl implements CTClosure {
 
 			int indent = indentEntry.getValue();
 
-			StringBuilder stringBuilder = new StringBuilder(indent);
+			StringBundler stringBuilder = new StringBundler(indent);
 
 			for (int i = 0; i < indent; i++) {
 				stringBuilder.append(CharPool.TAB);

--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/closure/CTClosureImpl.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/closure/CTClosureImpl.java
@@ -86,9 +86,9 @@ public class CTClosureImpl implements CTClosure {
 
 	@Override
 	public String toString() {
-		StringBundler sb = new StringBundler();
+		StringBundler sb1 = new StringBundler();
 
-		sb.append("{\n");
+		sb1.append("{\n");
 
 		Map<Long, List<Long>> pksMap = getRootPKsMap();
 
@@ -112,21 +112,21 @@ public class CTClosureImpl implements CTClosure {
 
 			int indent = indentEntry.getValue();
 
-			StringBundler stringBuilder = new StringBundler(indent);
+			StringBundler sb2 = new StringBundler(indent);
 
 			for (int i = 0; i < indent; i++) {
-				stringBuilder.append(CharPool.TAB);
+				sb2.append(CharPool.TAB);
 			}
 
-			String indentString = stringBuilder.toString();
+			String indentString = sb2.toString();
 
 			for (long classPK : entry.getValue()) {
-				sb.append(indentString);
-				sb.append("(classNameId=");
-				sb.append(classNameId);
-				sb.append(", classPK=");
-				sb.append(classPK);
-				sb.append(")\n");
+				sb1.append(indentString);
+				sb1.append("(classNameId=");
+				sb1.append(classNameId);
+				sb1.append(", classPK=");
+				sb1.append(classPK);
+				sb1.append(")\n");
 
 				Map<Long, ? extends Collection<Long>> childPKsMap =
 					getChildPKsMap(classNameId, classPK);
@@ -141,9 +141,9 @@ public class CTClosureImpl implements CTClosure {
 			}
 		}
 
-		sb.append("}");
+		sb1.append("}");
 
-		return sb.toString();
+		return sb1.toString();
 	}
 
 	private Map<Long, List<Long>> _getPrimaryKeysMap(

--- a/modules/apps/commerce/headless/headless-commerce-core-api/src/main/java/com/liferay/headless/commerce/core/exception/mapper/BaseExceptionMapper.java
+++ b/modules/apps/commerce/headless/headless-commerce-core-api/src/main/java/com/liferay/headless/commerce/core/exception/mapper/BaseExceptionMapper.java
@@ -74,9 +74,7 @@ public abstract class BaseExceptionMapper<E extends Throwable>
 		for (int i = 0; i < (args.length - 1); i = i + 2) {
 			sb.append("\"");
 			sb.append(args[i]);
-			sb.append("\"");
-			sb.append(":");
-			sb.append("\"");
+			sb.append("\":\"");
 			sb.append(args[i + 1]);
 			sb.append("\"");
 

--- a/modules/apps/commerce/headless/headless-commerce-core-api/src/main/java/com/liferay/headless/commerce/core/exception/mapper/BaseExceptionMapper.java
+++ b/modules/apps/commerce/headless/headless-commerce-core-api/src/main/java/com/liferay/headless/commerce/core/exception/mapper/BaseExceptionMapper.java
@@ -14,6 +14,7 @@
 
 package com.liferay.headless.commerce.core.exception.mapper;
 
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 
@@ -53,7 +54,7 @@ public abstract class BaseExceptionMapper<E extends Throwable>
 	}
 
 	protected String toJSON(String message, int status, Object... args) {
-		StringBuilder sb = new StringBuilder();
+		StringBundler sb = new StringBundler();
 
 		sb.append("{\"errorDescription\": \"");
 		sb.append(getErrorDescription());

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/util/test/DLDirectoryNameAndFileNameTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/util/test/DLDirectoryNameAndFileNameTest.java
@@ -22,6 +22,7 @@ import com.liferay.document.library.kernel.model.DLVersionNumberIncrease;
 import com.liferay.document.library.kernel.service.DLAppLocalServiceUtil;
 import com.liferay.document.library.kernel.service.DLAppServiceUtil;
 import com.liferay.document.library.kernel.util.DLValidatorUtil;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.repository.model.FileEntry;
@@ -155,7 +156,7 @@ public class DLDirectoryNameAndFileNameTest {
 	@Test
 	public void testFixNameRandom() throws Exception {
 		for (String blacklistChar : PropsValues.DL_CHAR_BLACKLIST) {
-			StringBuilder sb = new StringBuilder(4);
+			StringBundler sb = new StringBundler(4);
 
 			sb.append(StringUtil.randomString(10));
 			sb.append(blacklistChar);
@@ -242,7 +243,7 @@ public class DLDirectoryNameAndFileNameTest {
 		}
 
 		for (String blacklistChar : PropsValues.DL_CHAR_BLACKLIST) {
-			StringBuilder sb = new StringBuilder(4);
+			StringBundler sb = new StringBundler(4);
 
 			sb.append(StringUtil.randomString(10));
 			sb.append(blacklistChar);

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/asset/file_entry_full_content.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/asset/file_entry_full_content.jsp
@@ -16,34 +16,18 @@
 
 <%@ include file="/document_library/init.jsp" %>
 
-<%
-FileEntry fileEntry = (FileEntry)request.getAttribute(WebKeys.DOCUMENT_LIBRARY_FILE_ENTRY);
-
-boolean showExtraInfo = ParamUtil.getBoolean(request, "showExtraInfo");
-
-DLViewFileVersionDisplayContext dlViewFileVersionDisplayContext = dlDisplayContextProvider.getDLViewFileVersionDisplayContext(request, response, fileEntry.getFileVersion());
-%>
-
 <liferay-util:html-top
 	outputKey="document_library_preview_css"
 >
 	<link href="<%= PortalUtil.getStaticResourceURL(request, application.getContextPath() + "/document_library/css/document_library_preview.css") %>" rel="stylesheet" type="text/css" />
 </liferay-util:html-top>
 
-<c:choose>
-	<c:when test="<%= PropsValues.DL_FILE_ENTRY_PREVIEW_ENABLED && !showExtraInfo && (fileEntry.getSize() > 0) && dlViewFileVersionDisplayContext.hasPreview() %>">
-		<liferay-util:include page="/document_library/view_file_entry_simple_view.jsp" servletContext="<%= application %>" />
-	</c:when>
-	<c:otherwise>
+<%
+DLAdminDisplayContextProvider dlAdminDisplayContextProvider = dlWebComponentProvider.getDlAdminDisplayContextProvider();
 
-		<%
-		DLAdminDisplayContextProvider dlAdminDisplayContextProvider = dlWebComponentProvider.getDlAdminDisplayContextProvider();
+renderRequest.setAttribute(DLViewFileEntryDisplayContext.class.getName(), new DLViewFileEntryDisplayContext(dlAdminDisplayContextProvider.getDLAdminDisplayContext(request, response), dlDisplayContextProvider, HtmlUtil.getHtml(), LanguageUtil.getLanguage(), PortalUtil.getPortal(), renderRequest, renderResponse));
+%>
 
-		renderRequest.setAttribute(DLViewFileEntryDisplayContext.class.getName(), new DLViewFileEntryDisplayContext(dlAdminDisplayContextProvider.getDLAdminDisplayContext(request, response), dlDisplayContextProvider, HtmlUtil.getHtml(), LanguageUtil.getLanguage(), PortalUtil.getPortal(), renderRequest, renderResponse));
-		%>
-
-		<liferay-util:include page="/document_library/view_file_entry.jsp" servletContext="<%= application %>">
-			<liferay-util:param name="addPortletBreadcrumbEntries" value="<%= Boolean.FALSE.toString() %>" />
-		</liferay-util:include>
-	</c:otherwise>
-</c:choose>
+<liferay-util:include page="/document_library/view_file_entry.jsp" servletContext="<%= application %>">
+	<liferay-util:param name="addPortletBreadcrumbEntries" value="<%= Boolean.FALSE.toString() %>" />
+</liferay-util:include>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/java/com/liferay/dynamic/data/mapping/form/builder/internal/converter/serializer/CalculateDDMFormRuleActionSerializer.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/java/com/liferay/dynamic/data/mapping/form/builder/internal/converter/serializer/CalculateDDMFormRuleActionSerializer.java
@@ -20,6 +20,7 @@ import com.liferay.dynamic.data.mapping.model.DDMFormField;
 import com.liferay.dynamic.data.mapping.spi.converter.serializer.SPIDDMFormRuleActionSerializer;
 import com.liferay.dynamic.data.mapping.spi.converter.serializer.SPIDDMFormRuleSerializerContext;
 import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -81,7 +82,7 @@ public class CalculateDDMFormRuleActionSerializer
 
 		StringBuilder newExpressionSB = new StringBuilder();
 
-		StringBuilder sb = new StringBuilder();
+		StringBundler sb = new StringBundler();
 
 		for (int i = 0; i < expression.length(); i++) {
 			char token = expression.charAt(i);
@@ -110,7 +111,7 @@ public class CalculateDDMFormRuleActionSerializer
 
 				newExpressionSB.append(token);
 
-				sb = new StringBuilder();
+				sb = new StringBundler();
 
 				start = Integer.MAX_VALUE;
 				end = Integer.MIN_VALUE;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/test/java/com/liferay/dynamic/data/mapping/form/renderer/internal/DDMFormTemplateContextFactoryHelperTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/test/java/com/liferay/dynamic/data/mapping/form/renderer/internal/DDMFormTemplateContextFactoryHelperTest.java
@@ -23,6 +23,7 @@ import com.liferay.dynamic.data.mapping.model.DDMFormLayout;
 import com.liferay.dynamic.data.mapping.model.DDMFormRule;
 import com.liferay.dynamic.data.mapping.service.DDMDataProviderInstanceService;
 import com.liferay.dynamic.data.mapping.test.util.DDMFormTestUtil;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.util.SetUtil;
 
@@ -133,7 +134,7 @@ public class DDMFormTemplateContextFactoryHelperTest extends PowerMockito {
 	}
 
 	protected DDMFormRule createAutoFillDDMFormRule() {
-		StringBuilder sb = new StringBuilder();
+		StringBundler sb = new StringBundler();
 
 		sb.append("call(");
 		sb.append(StringPool.APOSTROPHE);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/test/java/com/liferay/dynamic/data/mapping/form/renderer/internal/DDMFormTemplateContextFactoryHelperTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/test/java/com/liferay/dynamic/data/mapping/form/renderer/internal/DDMFormTemplateContextFactoryHelperTest.java
@@ -134,7 +134,7 @@ public class DDMFormTemplateContextFactoryHelperTest extends PowerMockito {
 	}
 
 	protected DDMFormRule createAutoFillDDMFormRule() {
-		StringBundler sb = new StringBundler();
+		StringBundler sb = new StringBundler(5);
 
 		sb.append("call(");
 		sb.append(StringPool.APOSTROPHE);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v4_3_0/DLFileEntryTypeDDMFieldAttributeUpgradeProcess.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v4_3_0/DLFileEntryTypeDDMFieldAttributeUpgradeProcess.java
@@ -32,7 +32,7 @@ public class DLFileEntryTypeDDMFieldAttributeUpgradeProcess
 
 	@Override
 	protected void doUpgrade() throws Exception {
-		StringBundler sb = new StringBundler(8);
+		StringBundler sb = new StringBundler(6);
 
 		sb.append("select DDMField.storageId, DDMField.fieldName from ");
 		sb.append("DLFileEntryType inner join DDMStructureVersion on ");

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v4_3_0/DLFileEntryTypeDDMFieldAttributeUpgradeProcess.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v4_3_0/DLFileEntryTypeDDMFieldAttributeUpgradeProcess.java
@@ -14,6 +14,7 @@
 
 package com.liferay.dynamic.data.mapping.internal.upgrade.v4_3_0;
 
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 
@@ -31,7 +32,7 @@ public class DLFileEntryTypeDDMFieldAttributeUpgradeProcess
 
 	@Override
 	protected void doUpgrade() throws Exception {
-		StringBuilder sb = new StringBuilder(8);
+		StringBundler sb = new StringBundler(8);
 
 		sb.append("select DDMField.storageId, DDMField.fieldName ");
 		sb.append("from DLFileEntryType inner join DDMStructureVersion on ");

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v4_3_0/DLFileEntryTypeDDMFieldAttributeUpgradeProcess.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v4_3_0/DLFileEntryTypeDDMFieldAttributeUpgradeProcess.java
@@ -34,14 +34,12 @@ public class DLFileEntryTypeDDMFieldAttributeUpgradeProcess
 	protected void doUpgrade() throws Exception {
 		StringBundler sb = new StringBundler(8);
 
-		sb.append("select DDMField.storageId, DDMField.fieldName ");
-		sb.append("from DLFileEntryType inner join DDMStructureVersion on ");
+		sb.append("select DDMField.storageId, DDMField.fieldName from ");
+		sb.append("DLFileEntryType inner join DDMStructureVersion on ");
 		sb.append("DDMStructureVersion.structureId = ");
-		sb.append("DLFileEntryType.dataDefinitionId ");
-		sb.append("inner join DDMField on ");
+		sb.append("DLFileEntryType.dataDefinitionId inner join DDMField on ");
 		sb.append("DDMStructureVersion.structureVersionId = ");
-		sb.append("DDMField.structureVersionId and ");
-		sb.append("DDMField.fieldType like ? ");
+		sb.append("DDMField.structureVersionId and DDMField.fieldType like ? ");
 
 		try (PreparedStatement ps1 = connection.prepareStatement(
 				sb.toString())) {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v4_3_1/DDMFormInstanceUpgradeProcess.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v4_3_1/DDMFormInstanceUpgradeProcess.java
@@ -14,6 +14,7 @@
 
 package com.liferay.dynamic.data.mapping.internal.upgrade.v4_3_1;
 
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
 import com.liferay.portal.kernel.json.JSONArray;
@@ -38,7 +39,7 @@ public class DDMFormInstanceUpgradeProcess extends UpgradeProcess {
 
 	@Override
 	protected void doUpgrade() throws Exception {
-		StringBuilder sb = new StringBuilder(4);
+		StringBundler sb = new StringBundler(4);
 
 		sb.append("where settings_ not like '%workflowDefinition\\\",\\\"");
 		sb.append("value\\\":\\\"[\\\\\\\\\"no-workflow\\\\\\\\\"]\\\"%' and ");

--- a/modules/apps/flags/flags-service/src/main/java/com/liferay/flags/internal/messaging/FlagsRequest.java
+++ b/modules/apps/flags/flags-service/src/main/java/com/liferay/flags/internal/messaging/FlagsRequest.java
@@ -117,7 +117,7 @@ public class FlagsRequest implements Serializable {
 
 	@Override
 	public String toString() {
-		StringBundler sb = new StringBundler();
+		StringBundler sb = new StringBundler(19);
 
 		sb.append("{className=");
 		sb.append(_className);

--- a/modules/apps/flags/flags-service/src/main/java/com/liferay/flags/internal/messaging/FlagsRequest.java
+++ b/modules/apps/flags/flags-service/src/main/java/com/liferay/flags/internal/messaging/FlagsRequest.java
@@ -14,6 +14,7 @@
 
 package com.liferay.flags.internal.messaging;
 
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.service.ServiceContext;
 
 import java.io.Serializable;
@@ -116,7 +117,7 @@ public class FlagsRequest implements Serializable {
 
 	@Override
 	public String toString() {
-		StringBuilder sb = new StringBuilder();
+		StringBundler sb = new StringBundler();
 
 		sb.append("{className=");
 		sb.append(_className);

--- a/modules/apps/frontend-taglib/frontend-taglib-chart-sample-web/src/main/java/com/liferay/frontend/taglib/chart/sample/web/internal/display/context/ChartSampleDisplayContext.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-chart-sample-web/src/main/java/com/liferay/frontend/taglib/chart/sample/web/internal/display/context/ChartSampleDisplayContext.java
@@ -193,7 +193,7 @@ public class ChartSampleDisplayContext {
 
 		_geomapConfig2.setColor(geomapColor);
 
-		StringBundler sb = new StringBundler();
+		StringBundler sb = new StringBundler(3);
 
 		sb.append(_portletRequest.getContextPath());
 		sb.append(StringPool.SLASH);

--- a/modules/apps/frontend-taglib/frontend-taglib-chart-sample-web/src/main/java/com/liferay/frontend/taglib/chart/sample/web/internal/display/context/ChartSampleDisplayContext.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-chart-sample-web/src/main/java/com/liferay/frontend/taglib/chart/sample/web/internal/display/context/ChartSampleDisplayContext.java
@@ -33,6 +33,7 @@ import com.liferay.frontend.taglib.chart.model.point.scatter.ScatterChartConfig;
 import com.liferay.frontend.taglib.chart.model.point.spline.SplineChartConfig;
 import com.liferay.frontend.taglib.chart.model.point.step.StepChartConfig;
 import com.liferay.frontend.taglib.chart.model.predictive.PredictiveChartConfig;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 
 import java.util.ArrayList;
@@ -192,7 +193,7 @@ public class ChartSampleDisplayContext {
 
 		_geomapConfig2.setColor(geomapColor);
 
-		StringBuilder sb = new StringBuilder();
+		StringBundler sb = new StringBundler();
 
 		sb.append(_portletRequest.getContextPath());
 		sb.append(StringPool.SLASH);

--- a/modules/apps/frontend-theme/frontend-theme-browser-support/src/main/java/com/liferay/frontend/theme/browser/support/internal/template/BrowserTemplateContextContributor.java
+++ b/modules/apps/frontend-theme/frontend-theme-browser-support/src/main/java/com/liferay/frontend/theme/browser/support/internal/template/BrowserTemplateContextContributor.java
@@ -42,7 +42,7 @@ public class BrowserTemplateContextContributor
 		Map<String, Object> contextObjects,
 		HttpServletRequest httpServletRequest) {
 
-		StringBundler sb = new StringBundler();
+		StringBundler sb = new StringBundler(5);
 
 		sb.append(GetterUtil.getString(contextObjects.get("bodyCssClass")));
 		sb.append(StringPool.SPACE);

--- a/modules/apps/frontend-theme/frontend-theme-browser-support/src/main/java/com/liferay/frontend/theme/browser/support/internal/template/BrowserTemplateContextContributor.java
+++ b/modules/apps/frontend-theme/frontend-theme-browser-support/src/main/java/com/liferay/frontend/theme/browser/support/internal/template/BrowserTemplateContextContributor.java
@@ -14,6 +14,7 @@
 
 package com.liferay.frontend.theme.browser.support.internal.template;
 
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.servlet.BrowserSnifferUtil;
 import com.liferay.portal.kernel.template.TemplateContextContributor;
@@ -41,7 +42,7 @@ public class BrowserTemplateContextContributor
 		Map<String, Object> contextObjects,
 		HttpServletRequest httpServletRequest) {
 
-		StringBuilder sb = new StringBuilder();
+		StringBundler sb = new StringBundler();
 
 		sb.append(GetterUtil.getString(contextObjects.get("bodyCssClass")));
 		sb.append(StringPool.SPACE);

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_1_6/AssetDisplayPageEntryUpgradeProcess.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_1_6/AssetDisplayPageEntryUpgradeProcess.java
@@ -180,9 +180,9 @@ public class AssetDisplayPageEntryUpgradeProcess extends UpgradeProcess {
 
 		StringBundler sb = new StringBundler(3);
 
-		sb.append("select groupId, liveGroupId from Group_ where ");
-		sb.append("companyId = ? and liveGroupId is not null and ");
-		sb.append("liveGroupId != 0 and remoteStagingGroupCount = 0");
+		sb.append("select groupId, liveGroupId from Group_ where companyId = ");
+		sb.append("? and liveGroupId is not null and liveGroupId != 0 and ");
+		sb.append("remoteStagingGroupCount = 0");
 
 		try (LoggingTimer loggingTimer = new LoggingTimer();
 			PreparedStatement ps = connection.prepareStatement(

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_1_6/AssetDisplayPageEntryUpgradeProcess.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_1_6/AssetDisplayPageEntryUpgradeProcess.java
@@ -17,6 +17,7 @@ package com.liferay.journal.internal.upgrade.v1_1_6;
 import com.liferay.asset.display.page.constants.AssetDisplayPageConstants;
 import com.liferay.asset.display.page.service.AssetDisplayPageEntryLocalService;
 import com.liferay.journal.model.JournalArticle;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.dao.orm.common.SQLTransformer;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -69,7 +70,7 @@ public class AssetDisplayPageEntryUpgradeProcess extends UpgradeProcess {
 
 		_init(company.getCompanyId());
 
-		StringBuilder sb = new StringBuilder(17);
+		StringBundler sb = new StringBundler(17);
 
 		sb.append("select JournalArticle.groupId, ");
 		sb.append("JournalArticle.resourcePrimKey, AssetEntry.classUuid from ");
@@ -177,7 +178,7 @@ public class AssetDisplayPageEntryUpgradeProcess extends UpgradeProcess {
 		_stagedGroupIds.clear();
 		_uuidsMaps.clear();
 
-		StringBuilder sb = new StringBuilder(3);
+		StringBundler sb = new StringBundler(3);
 
 		sb.append("select groupId, liveGroupId from Group_ where ");
 		sb.append("companyId = ? and liveGroupId is not null and ");

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/importer/util/KBArticleImporterUtil.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/importer/util/KBArticleImporterUtil.java
@@ -20,6 +20,7 @@ import com.liferay.knowledge.base.constants.KBConstants;
 import com.liferay.knowledge.base.constants.KBPortletKeys;
 import com.liferay.knowledge.base.exception.KBArticleImportException;
 import com.liferay.knowledge.base.model.KBArticle;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
@@ -80,7 +81,7 @@ public class KBArticleImporterUtil {
 				fileEntriesMap);
 		}
 		catch (Exception exception) {
-			StringBuilder sb = new StringBuilder(4);
+			StringBundler sb = new StringBundler(4);
 
 			sb.append("Unable to import image file ");
 			sb.append(imageFileName);

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/template/LayoutEditModeTemplateContextContributor.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/template/LayoutEditModeTemplateContextContributor.java
@@ -14,6 +14,7 @@
 
 package com.liferay.layout.admin.web.internal.template;
 
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.template.TemplateContextContributor;
 import com.liferay.portal.kernel.util.Constants;
@@ -48,7 +49,7 @@ public class LayoutEditModeTemplateContextContributor
 		if (layoutMode.equals(Constants.EDIT) ||
 			layoutMode.equals(Constants.PREVIEW)) {
 
-			StringBuilder sb = new StringBuilder(3);
+			StringBundler sb = new StringBundler(3);
 
 			sb.append(GetterUtil.getString(contextObjects.get("bodyCssClass")));
 			sb.append(StringPool.SPACE);

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/java/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/ImportExportLayoutPageTemplateEntriesTest.java
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/java/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/ImportExportLayoutPageTemplateEntriesTest.java
@@ -601,7 +601,7 @@ public class ImportExportLayoutPageTemplateEntriesTest {
 
 		ZipWriter zipWriter = ZipWriterFactoryUtil.getZipWriter();
 
-		StringBuilder sb = new StringBuilder(3);
+		StringBundler sb = new StringBundler(3);
 
 		sb.append(_LAYOUT_PATE_TEMPLATES_PATH + testPath);
 		sb.append(StringPool.FORWARD_SLASH + _ROOT_FOLDER);

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v1_1_0/LayoutPrototypeUpgradeProcess.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v1_1_0/LayoutPrototypeUpgradeProcess.java
@@ -62,7 +62,7 @@ public class LayoutPrototypeUpgradeProcess extends UpgradeProcess {
 	}
 
 	protected void upgradeLayoutPrototype() throws Exception {
-		StringBundler sb = new StringBundler();
+		StringBundler sb = new StringBundler(6);
 
 		sb.append("insert into LayoutPageTemplateEntry (uuid_, ");
 		sb.append("layoutPageTemplateEntryId, groupId, companyId, userId, ");

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v1_1_0/LayoutPrototypeUpgradeProcess.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v1_1_0/LayoutPrototypeUpgradeProcess.java
@@ -62,7 +62,7 @@ public class LayoutPrototypeUpgradeProcess extends UpgradeProcess {
 	}
 
 	protected void upgradeLayoutPrototype() throws Exception {
-		StringBuilder sb = new StringBuilder();
+		StringBundler sb = new StringBundler();
 
 		sb.append("insert into LayoutPageTemplateEntry (uuid_, ");
 		sb.append("layoutPageTemplateEntryId, groupId, companyId, userId, ");

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/internal/importer/test/DisplayPagesImporterTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/internal/importer/test/DisplayPagesImporterTest.java
@@ -24,6 +24,7 @@ import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalServ
 import com.liferay.layout.page.template.service.LayoutPageTemplateStructureLocalService;
 import com.liferay.layout.util.structure.LayoutStructure;
 import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
@@ -176,7 +177,7 @@ public class DisplayPagesImporterTest {
 	private File _generateZipFile(String testCaseName) throws Exception {
 		ZipWriter zipWriter = ZipWriterFactoryUtil.getZipWriter();
 
-		StringBuilder sb = new StringBuilder(3);
+		StringBundler sb = new StringBundler(3);
 
 		sb.append(_BASE_PATH + testCaseName);
 		sb.append(StringPool.FORWARD_SLASH + _ROOT_FOLDER);

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/internal/importer/test/LayoutPageTemplatesImporterTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/internal/importer/test/LayoutPageTemplatesImporterTest.java
@@ -38,6 +38,7 @@ import com.liferay.layout.util.structure.LayoutStructure;
 import com.liferay.layout.util.structure.LayoutStructureItem;
 import com.liferay.layout.util.structure.RowStyledLayoutStructureItem;
 import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
@@ -652,7 +653,7 @@ public class LayoutPageTemplatesImporterTest {
 
 		ZipWriter zipWriter = ZipWriterFactoryUtil.getZipWriter();
 
-		StringBuilder sb = new StringBuilder(3);
+		StringBundler sb = new StringBundler(3);
 
 		sb.append(_LAYOUT_PATE_TEMPLATES_PATH + type);
 		sb.append(StringPool.FORWARD_SLASH + _ROOT_FOLDER);

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/internal/importer/test/MasterLayoutsImporterTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/internal/importer/test/MasterLayoutsImporterTest.java
@@ -29,6 +29,7 @@ import com.liferay.layout.util.structure.DropZoneLayoutStructureItem;
 import com.liferay.layout.util.structure.LayoutStructure;
 import com.liferay.layout.util.structure.LayoutStructureItem;
 import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
@@ -256,7 +257,7 @@ public class MasterLayoutsImporterTest {
 	private File _generateZipFile(String testCaseName) throws Exception {
 		ZipWriter zipWriter = ZipWriterFactoryUtil.getZipWriter();
 
-		StringBuilder sb = new StringBuilder(3);
+		StringBundler sb = new StringBundler(3);
 
 		sb.append(_BASE_PATH + testCaseName);
 		sb.append(StringPool.FORWARD_SLASH + _ROOT_FOLDER);

--- a/modules/apps/layout/layout-seo-web/src/main/java/com/liferay/layout/seo/web/internal/servlet/taglib/OpenGraphTopHeadDynamicInclude.java
+++ b/modules/apps/layout/layout-seo-web/src/main/java/com/liferay/layout/seo/web/internal/servlet/taglib/OpenGraphTopHeadDynamicInclude.java
@@ -277,7 +277,7 @@ public class OpenGraphTopHeadDynamicInclude extends BaseDynamicInclude {
 	}
 
 	private String _addLinkTag(LayoutSEOLink layoutSEOLink) {
-		StringBuilder sb = new StringBuilder(10);
+		StringBundler sb = new StringBundler(10);
 
 		sb.append("<link data-senna-track=\"temporary\" ");
 		sb.append("href=\"");

--- a/modules/apps/message-boards/message-boards-parser-bbcode/src/main/java/com/liferay/message/boards/parser/bbcode/internal/HtmlBBCodeTranslatorImpl.java
+++ b/modules/apps/message-boards/message-boards-parser-bbcode/src/main/java/com/liferay/message/boards/parser/bbcode/internal/HtmlBBCodeTranslatorImpl.java
@@ -82,7 +82,7 @@ public class HtmlBBCodeTranslatorImpl implements BBCodeTranslator {
 
 			String image = emoticon[0];
 
-			StringBuilder sb = new StringBuilder(6);
+			StringBundler sb = new StringBundler(6);
 
 			sb.append("<img alt=\"emoticon\" src=\"");
 			sb.append(ThemeConstants.TOKEN_THEME_IMAGES_PATH);
@@ -196,7 +196,7 @@ public class HtmlBBCodeTranslatorImpl implements BBCodeTranslator {
 	}
 
 	protected String escapeQuote(String quote) {
-		StringBuilder sb = new StringBuilder();
+		StringBundler sb = new StringBundler();
 
 		int index = 0;
 

--- a/modules/apps/message-boards/message-boards-web/src/test/java/com/liferay/message/boards/web/internal/upload/format/handlers/MBMessageBBCodeFormatUploadHandlerTest.java
+++ b/modules/apps/message-boards/message-boards-web/src/test/java/com/liferay/message/boards/web/internal/upload/format/handlers/MBMessageBBCodeFormatUploadHandlerTest.java
@@ -15,6 +15,7 @@
 package com.liferay.message.boards.web.internal.upload.format.handlers;
 
 import com.liferay.message.boards.web.internal.util.MBAttachmentFileEntryReference;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.portletfilerepository.PortletFileRepository;
 import com.liferay.portal.kernel.repository.model.FileEntry;
@@ -122,8 +123,8 @@ public class MBMessageBBCodeFormatUploadHandlerTest {
 		List<MBAttachmentFileEntryReference> fileEntryReferences =
 			new ArrayList<>();
 
-		StringBuilder originalContent = new StringBuilder();
-		StringBuilder expectedContent = new StringBuilder();
+		StringBundler originalContent = new StringBundler();
+		StringBundler expectedContent = new StringBundler();
 
 		for (int tempFileId = 0; tempFileId < 3; tempFileId++) {
 			FileEntry fileEntry = Mockito.mock(FileEntry.class);

--- a/modules/apps/message-boards/message-boards-web/src/test/java/com/liferay/message/boards/web/internal/upload/format/handlers/MBMessageBBCodeFormatUploadHandlerTest.java
+++ b/modules/apps/message-boards/message-boards-web/src/test/java/com/liferay/message/boards/web/internal/upload/format/handlers/MBMessageBBCodeFormatUploadHandlerTest.java
@@ -149,7 +149,9 @@ public class MBMessageBBCodeFormatUploadHandlerTest {
 
 			originalContent.append(curOriginalContent);
 
-			expectedContent.append("[img]" + finalURL + "[/img]");
+			expectedContent.append("[img]");
+			expectedContent.append(finalURL);
+			expectedContent.append("[/img]");
 		}
 
 		String finalContent =

--- a/modules/apps/message-boards/message-boards-web/src/test/java/com/liferay/message/boards/web/internal/upload/format/handlers/MBMessageBBCodeFormatUploadHandlerTest.java
+++ b/modules/apps/message-boards/message-boards-web/src/test/java/com/liferay/message/boards/web/internal/upload/format/handlers/MBMessageBBCodeFormatUploadHandlerTest.java
@@ -123,8 +123,8 @@ public class MBMessageBBCodeFormatUploadHandlerTest {
 		List<MBAttachmentFileEntryReference> fileEntryReferences =
 			new ArrayList<>();
 
-		StringBundler originalContent = new StringBundler();
-		StringBundler expectedContent = new StringBundler();
+		StringBundler originalContentSB = new StringBundler();
+		StringBundler expectedContentSB = new StringBundler();
 
 		for (int tempFileId = 0; tempFileId < 3; tempFileId++) {
 			FileEntry fileEntry = Mockito.mock(FileEntry.class);
@@ -147,18 +147,18 @@ public class MBMessageBBCodeFormatUploadHandlerTest {
 			fileEntryReferences.add(
 				new MBAttachmentFileEntryReference(tempFileId, fileEntry));
 
-			originalContent.append(curOriginalContent);
+			originalContentSB.append(curOriginalContent);
 
-			expectedContent.append("[img]");
-			expectedContent.append(finalURL);
-			expectedContent.append("[/img]");
+			expectedContentSB.append("[img]");
+			expectedContentSB.append(finalURL);
+			expectedContentSB.append("[/img]");
 		}
 
 		String finalContent =
 			_mbMessageBBCodeFormatUploadHandler.replaceImageReferences(
-				originalContent.toString(), fileEntryReferences);
+				originalContentSB.toString(), fileEntryReferences);
 
-		Assert.assertEquals(expectedContent.toString(), finalContent);
+		Assert.assertEquals(expectedContentSB.toString(), finalContent);
 	}
 
 	private final MBMessageBBCodeFormatUploadHandler

--- a/modules/apps/message-boards/message-boards-web/src/test/java/com/liferay/message/boards/web/internal/upload/format/handlers/MBMessageHTMLFormatUploadHandlerTest.java
+++ b/modules/apps/message-boards/message-boards-web/src/test/java/com/liferay/message/boards/web/internal/upload/format/handlers/MBMessageHTMLFormatUploadHandlerTest.java
@@ -15,6 +15,7 @@
 package com.liferay.message.boards.web.internal.upload.format.handlers;
 
 import com.liferay.message.boards.web.internal.util.MBAttachmentFileEntryReference;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.portletfilerepository.PortletFileRepository;
 import com.liferay.portal.kernel.repository.model.FileEntry;
@@ -122,8 +123,8 @@ public class MBMessageHTMLFormatUploadHandlerTest {
 		List<MBAttachmentFileEntryReference> fileEntryReferences =
 			new ArrayList<>();
 
-		StringBuilder originalContent = new StringBuilder();
-		StringBuilder expectedContent = new StringBuilder();
+		StringBundler originalContent = new StringBundler();
+		StringBundler expectedContent = new StringBundler();
 
 		for (int tempFileId = 0; tempFileId < 3; tempFileId++) {
 			FileEntry fileEntry = Mockito.mock(FileEntry.class);

--- a/modules/apps/message-boards/message-boards-web/src/test/java/com/liferay/message/boards/web/internal/upload/format/handlers/MBMessageHTMLFormatUploadHandlerTest.java
+++ b/modules/apps/message-boards/message-boards-web/src/test/java/com/liferay/message/boards/web/internal/upload/format/handlers/MBMessageHTMLFormatUploadHandlerTest.java
@@ -149,7 +149,9 @@ public class MBMessageHTMLFormatUploadHandlerTest {
 
 			originalContent.append(curOriginalContent);
 
-			expectedContent.append("<img src=\"" + finalURL + "\" />");
+			expectedContent.append("<img src=\"");
+			expectedContent.append(finalURL);
+			expectedContent.append("\" />");
 		}
 
 		String finalContent =

--- a/modules/apps/message-boards/message-boards-web/src/test/java/com/liferay/message/boards/web/internal/upload/format/handlers/MBMessageHTMLFormatUploadHandlerTest.java
+++ b/modules/apps/message-boards/message-boards-web/src/test/java/com/liferay/message/boards/web/internal/upload/format/handlers/MBMessageHTMLFormatUploadHandlerTest.java
@@ -123,8 +123,8 @@ public class MBMessageHTMLFormatUploadHandlerTest {
 		List<MBAttachmentFileEntryReference> fileEntryReferences =
 			new ArrayList<>();
 
-		StringBundler originalContent = new StringBundler();
-		StringBundler expectedContent = new StringBundler();
+		StringBundler originalContentSB = new StringBundler();
+		StringBundler expectedContentSB = new StringBundler();
 
 		for (int tempFileId = 0; tempFileId < 3; tempFileId++) {
 			FileEntry fileEntry = Mockito.mock(FileEntry.class);
@@ -147,18 +147,18 @@ public class MBMessageHTMLFormatUploadHandlerTest {
 			fileEntryReferences.add(
 				new MBAttachmentFileEntryReference(tempFileId, fileEntry));
 
-			originalContent.append(curOriginalContent);
+			originalContentSB.append(curOriginalContent);
 
-			expectedContent.append("<img src=\"");
-			expectedContent.append(finalURL);
-			expectedContent.append("\" />");
+			expectedContentSB.append("<img src=\"");
+			expectedContentSB.append(finalURL);
+			expectedContentSB.append("\" />");
 		}
 
 		String finalContent =
 			_mbMessageHTMLFormatUploadHandler.replaceImageReferences(
-				originalContent.toString(), fileEntryReferences);
+				originalContentSB.toString(), fileEntryReferences);
 
-		Assert.assertEquals(expectedContent.toString(), finalContent);
+		Assert.assertEquals(expectedContentSB.toString(), finalContent);
 	}
 
 	private final MBMessageHTMLFormatUploadHandler

--- a/modules/apps/microblogs/microblogs-service/src/main/java/com/liferay/microblogs/internal/util/MicroblogsUtil.java
+++ b/modules/apps/microblogs/microblogs-service/src/main/java/com/liferay/microblogs/internal/util/MicroblogsUtil.java
@@ -18,6 +18,7 @@ import com.liferay.microblogs.constants.MicroblogsEntryConstants;
 import com.liferay.microblogs.constants.MicroblogsPortletKeys;
 import com.liferay.microblogs.model.MicroblogsEntry;
 import com.liferay.microblogs.service.MicroblogsEntryLocalServiceUtil;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.NoSuchUserException;
@@ -334,7 +335,7 @@ public class MicroblogsUtil {
 		while (matcher.find()) {
 			String result = matcher.group();
 
-			StringBuilder sb = new StringBuilder(6);
+			StringBundler sb = new StringBundler(6);
 
 			sb.append("<span class=\"hashtag\">#</span>");
 			sb.append("<a class=\"hashtag-link\" href=\"");
@@ -411,7 +412,7 @@ public class MicroblogsUtil {
 			String result = matcher.group();
 
 			try {
-				StringBuilder sb = new StringBuilder(5);
+				StringBundler sb = new StringBundler(5);
 
 				sb.append("<a href=\"");
 

--- a/modules/apps/microblogs/microblogs-web/src/main/java/com/liferay/microblogs/web/internal/util/MicroblogsWebUtil.java
+++ b/modules/apps/microblogs/microblogs-web/src/main/java/com/liferay/microblogs/web/internal/util/MicroblogsWebUtil.java
@@ -16,6 +16,7 @@ package com.liferay.microblogs.web.internal.util;
 
 import com.liferay.microblogs.constants.MicroblogsPortletKeys;
 import com.liferay.microblogs.model.MicroblogsEntry;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.NoSuchUserException;
@@ -155,7 +156,7 @@ public class MicroblogsWebUtil {
 		while (matcher.find()) {
 			String result = matcher.group();
 
-			StringBuilder sb = new StringBuilder(6);
+			StringBundler sb = new StringBundler(6);
 
 			sb.append("<span class=\"hashtag\">#</span>");
 			sb.append("<a class=\"hashtag-link\" href=\"");
@@ -232,7 +233,7 @@ public class MicroblogsWebUtil {
 			String result = matcher.group();
 
 			try {
-				StringBuilder sb = new StringBuilder(5);
+				StringBundler sb = new StringBundler(5);
 
 				sb.append("<a href=\"");
 

--- a/modules/apps/portal-cache/portal-cache-api/src/test/java/com/liferay/portal/cache/io/SerializableObjectWrapperTest.java
+++ b/modules/apps/portal-cache/portal-cache-api/src/test/java/com/liferay/portal/cache/io/SerializableObjectWrapperTest.java
@@ -167,19 +167,24 @@ public class SerializableObjectWrapperTest {
 			SerializableObjectWrapper serializableObjectWrapper)
 		throws Exception {
 
-		try (UnsyncByteArrayOutputStream ubaos =
+		try (UnsyncByteArrayOutputStream unsyncByteArrayOutputStream =
 				new UnsyncByteArrayOutputStream()) {
 
-			try (ObjectOutputStream oos = new ObjectOutputStream(ubaos)) {
-				oos.writeObject(serializableObjectWrapper);
+			try (ObjectOutputStream objectOutputStream = new ObjectOutputStream(
+					unsyncByteArrayOutputStream)) {
+
+				objectOutputStream.writeObject(serializableObjectWrapper);
 			}
 
-			try (UnsyncByteArrayInputStream ubais =
+			try (UnsyncByteArrayInputStream unsyncByteArrayInputStream =
 					new UnsyncByteArrayInputStream(
-						ubaos.unsafeGetByteArray(), 0, ubaos.size());
-				ObjectInputStream ois = new ObjectInputStream(ubais)) {
+						unsyncByteArrayOutputStream.unsafeGetByteArray(), 0,
+						unsyncByteArrayOutputStream.size());
+				ObjectInputStream objectInputStream = new ObjectInputStream(
+					unsyncByteArrayInputStream)) {
 
-				return (SerializableObjectWrapper)ois.readObject();
+				return (SerializableObjectWrapper)
+					objectInputStream.readObject();
 			}
 		}
 	}

--- a/modules/apps/portal-configuration/portal-configuration-metatype-definitions-annotations/src/main/java/com/liferay/portal/configuration/metatype/definitions/annotations/internal/AnnotationsExtendedObjectClassDefinition.java
+++ b/modules/apps/portal-configuration/portal-configuration-metatype-definitions-annotations/src/main/java/com/liferay/portal/configuration/metatype/definitions/annotations/internal/AnnotationsExtendedObjectClassDefinition.java
@@ -127,8 +127,9 @@ public class AnnotationsExtendedObjectClassDefinition
 		URL url = bundle.getResource(resourcePath);
 
 		if (url != null) {
-			try (InputStream is = url.openStream()) {
-				return JSONFactoryUtil.createJSONObject(StringUtil.read(is));
+			try (InputStream inputStream = url.openStream()) {
+				return JSONFactoryUtil.createJSONObject(
+					StringUtil.read(inputStream));
 			}
 			catch (Exception exception) {
 				_log.error(

--- a/modules/apps/portal-odata/portal-odata-api/src/main/java/com/liferay/portal/odata/filter/Filter.java
+++ b/modules/apps/portal-odata/portal-odata-api/src/main/java/com/liferay/portal/odata/filter/Filter.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.odata.filter;
 
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.odata.filter.expression.Expression;
 
 /**
@@ -65,7 +66,7 @@ public class Filter {
 
 	@Override
 	public String toString() {
-		StringBuilder sb = new StringBuilder(3);
+		StringBundler sb = new StringBundler(3);
 
 		sb.append("{_expression=");
 		sb.append(_expression);

--- a/modules/apps/portal-security/portal-security-antisamy/src/main/java/com/liferay/portal/security/antisamy/internal/AntiSamySanitizerImpl.java
+++ b/modules/apps/portal-security/portal-security-antisamy/src/main/java/com/liferay/portal/security/antisamy/internal/AntiSamySanitizerImpl.java
@@ -46,8 +46,8 @@ public class AntiSamySanitizerImpl implements Sanitizer {
 	public AntiSamySanitizerImpl(
 		String[] blacklist, URL url, String[] whitelist) {
 
-		try (InputStream inputstream = url.openStream()) {
-			_policy = Policy.getInstance(inputstream);
+		try (InputStream inputStream = url.openStream()) {
+			_policy = Policy.getInstance(inputStream);
 		}
 		catch (Exception exception) {
 			throw new IllegalStateException(
@@ -80,8 +80,8 @@ public class AntiSamySanitizerImpl implements Sanitizer {
 	}
 
 	public void addPolicy(String className, URL url) {
-		try (InputStream inputstream = url.openStream()) {
-			Policy policy = Policy.getInstance(inputstream);
+		try (InputStream inputStream = url.openStream()) {
+			Policy policy = Policy.getInstance(inputStream);
 
 			_policies.put(className, policy);
 		}

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/param/converter/provider/SiteParamConverterProvider.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/param/converter/provider/SiteParamConverterProvider.java
@@ -16,6 +16,7 @@ package com.liferay.portal.vulcan.internal.jaxrs.param.converter.provider;
 
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -71,7 +72,7 @@ public class SiteParamConverterProvider
 			return siteId;
 		}
 
-		StringBuilder sb = new StringBuilder(4);
+		StringBundler sb = new StringBundler(4);
 
 		sb.append("Unable to get a valid ");
 

--- a/modules/apps/portal/portal-dao-orm-custom-sql-impl/src/main/java/com/liferay/portal/dao/orm/custom/sql/internal/CustomSQLImpl.java
+++ b/modules/apps/portal/portal-dao-orm-custom-sql-impl/src/main/java/com/liferay/portal/dao/orm/custom/sql/internal/CustomSQLImpl.java
@@ -921,12 +921,12 @@ public class CustomSQLImpl implements CustomSQL {
 			ClassLoader classLoader, URL sourceURL, Map<String, String> sqls)
 		throws Exception {
 
-		try (InputStream is = sourceURL.openStream()) {
+		try (InputStream inputStream = sourceURL.openStream()) {
 			if (_log.isDebugEnabled()) {
 				_log.debug("Loading " + sourceURL);
 			}
 
-			Document document = UnsecureSAXReaderUtil.read(is);
+			Document document = UnsecureSAXReaderUtil.read(inputStream);
 
 			Element rootElement = document.getRootElement();
 

--- a/modules/apps/portal/portal-monitoring/src/main/java/com/liferay/portal/monitoring/internal/MonitoringGateKeeper.java
+++ b/modules/apps/portal/portal-monitoring/src/main/java/com/liferay/portal/monitoring/internal/MonitoringGateKeeper.java
@@ -90,8 +90,8 @@ public class MonitoringGateKeeper {
 		while (enumeration.hasMoreElements()) {
 			URL url = enumeration.nextElement();
 
-			try (InputStream is = url.openStream()) {
-				Document document = documentBuilder.parse(is);
+			try (InputStream inputStream = url.openStream()) {
+				Document document = documentBuilder.parse(inputStream);
 
 				Element element = document.getDocumentElement();
 

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeDBColumnSizeTestCase.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeDBColumnSizeTestCase.java
@@ -85,21 +85,22 @@ public abstract class BaseUpgradeDBColumnSizeTestCase {
 			String tableName = dbInspector.normalizeName("TestTable");
 			String columnName = dbInspector.normalizeName("testValue");
 
-			try (ResultSet columnRS = databaseMetaData.getColumns(
+			try (ResultSet columnResultSet = databaseMetaData.getColumns(
 					catalog, schema, tableName, columnName)) {
 
-				Assert.assertTrue(columnRS.next());
+				Assert.assertTrue(columnResultSet.next());
 
 				Assert.assertEquals(
-					columnName, columnRS.getString("COLUMN_NAME"));
+					columnName, columnResultSet.getString("COLUMN_NAME"));
 
 				Assert.assertEquals(
 					dbInspector.normalizeName(getTypeName()),
-					columnRS.getString("TYPE_NAME"));
+					columnResultSet.getString("TYPE_NAME"));
 
-				Assert.assertEquals(size, columnRS.getInt("COLUMN_SIZE"));
+				Assert.assertEquals(
+					size, columnResultSet.getInt("COLUMN_SIZE"));
 
-				Assert.assertFalse(columnRS.next());
+				Assert.assertFalse(columnResultSet.next());
 			}
 		}
 	}

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/ModuleBuildAutoUpgradeTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/ModuleBuildAutoUpgradeTest.java
@@ -70,10 +70,10 @@ public class ModuleBuildAutoUpgradeTest extends BaseBuildAutoUpgradeTestCase {
 	private byte[] _createBundleBytes(Object[][] tableColumns, int version)
 		throws Exception {
 
-		try (UnsyncByteArrayOutputStream unsyncbyteArrayOutputStream =
+		try (UnsyncByteArrayOutputStream unsyncByteArrayOutputStream =
 				new UnsyncByteArrayOutputStream();
 			JarOutputStream jarOutputStream = new JarOutputStream(
-				unsyncbyteArrayOutputStream)) {
+				unsyncByteArrayOutputStream)) {
 
 			Manifest manifest = new Manifest();
 
@@ -115,7 +115,7 @@ public class ModuleBuildAutoUpgradeTest extends BaseBuildAutoUpgradeTestCase {
 
 			jarOutputStream.finish();
 
-			return unsyncbyteArrayOutputStream.toByteArray();
+			return unsyncByteArrayOutputStream.toByteArray();
 		}
 	}
 

--- a/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalImplControlPanelFullURLTest.java
+++ b/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalImplControlPanelFullURLTest.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.util.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
@@ -60,7 +61,7 @@ public class PortalImplControlPanelFullURLTest {
 
 	@Test
 	public void testControlPanelPortlet() throws Exception {
-		StringBuilder sb = new StringBuilder(5);
+		StringBundler sb = new StringBundler(5);
 
 		sb.append(_getPortalURL());
 		sb.append(_portalImpl.getPathFriendlyURLPrivateGroup());
@@ -79,7 +80,7 @@ public class PortalImplControlPanelFullURLTest {
 
 	@Test
 	public void testMyAccountPortlet() throws Exception {
-		StringBuilder sb = new StringBuilder(5);
+		StringBundler sb = new StringBundler(5);
 
 		sb.append(_getPortalURL());
 
@@ -104,7 +105,7 @@ public class PortalImplControlPanelFullURLTest {
 
 	@Test
 	public void testSiteAdministrationPortlet() throws Exception {
-		StringBuilder sb = new StringBuilder(7);
+		StringBundler sb = new StringBundler(7);
 
 		sb.append(_getPortalURL());
 		sb.append(_portalImpl.getPathFriendlyURLPrivateGroup());
@@ -133,7 +134,7 @@ public class PortalImplControlPanelFullURLTest {
 	}
 
 	private String _getQueryString(String portletId) {
-		StringBuilder sb = new StringBuilder(6);
+		StringBundler sb = new StringBundler(6);
 
 		sb.append("?p_p_id=");
 		sb.append(portletId);

--- a/modules/apps/push-notifications/push-notifications-sender/push-notifications-sender-microsoft/src/main/java/com/liferay/push/notifications/sender/microsoft/internal/MicrosoftPushNotificationsSender.java
+++ b/modules/apps/push-notifications/push-notifications-sender/push-notifications-sender-microsoft/src/main/java/com/liferay/push/notifications/sender/microsoft/internal/MicrosoftPushNotificationsSender.java
@@ -15,6 +15,7 @@
 package com.liferay.push.notifications.sender.microsoft.internal;
 
 import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
@@ -135,7 +136,7 @@ public class MicrosoftPushNotificationsSender
 	}
 
 	protected String getAttributes(JSONObject payloadJSONObject) {
-		StringBuilder sb = new StringBuilder();
+		StringBundler sb = new StringBundler();
 
 		Iterator<String> iterator = payloadJSONObject.keys();
 

--- a/modules/apps/sharing/sharing-document-library/src/main/java/com/liferay/sharing/document/library/internal/frontend/taglib/dynamic/section/DLInfoPanelFileEntryOwnerDynamicSection.java
+++ b/modules/apps/sharing/sharing-document-library/src/main/java/com/liferay/sharing/document/library/internal/frontend/taglib/dynamic/section/DLInfoPanelFileEntryOwnerDynamicSection.java
@@ -65,14 +65,18 @@ public class DLInfoPanelFileEntryOwnerDynamicSection implements DynamicSection {
 				"/META-INF/resources/dynamic_section" +
 					"/info_panel_file_entry.jsp");
 
-		try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+		try (ByteArrayOutputStream byteArrayOutputStream =
+				new ByteArrayOutputStream()) {
+
 			HttpServletResponse httpServletResponse = new PipingServletResponse(
-				(HttpServletResponse)pageContext.getResponse(), outputStream);
+				(HttpServletResponse)pageContext.getResponse(),
+				byteArrayOutputStream);
 
 			requestDispatcher.include(
 				pageContext.getRequest(), httpServletResponse);
 
-			return new StringBundler(new String(outputStream.toByteArray()));
+			return new StringBundler(
+				new String(byteArrayOutputStream.toByteArray()));
 		}
 		catch (Exception exception) {
 			throw new RuntimeException(exception);

--- a/modules/apps/site-navigation/site-navigation-menu-item-layout/src/main/java/com/liferay/site/navigation/menu/item/layout/internal/type/LayoutSiteNavigationMenuItemType.java
+++ b/modules/apps/site-navigation/site-navigation-menu-item-layout/src/main/java/com/liferay/site/navigation/menu/item/layout/internal/type/LayoutSiteNavigationMenuItemType.java
@@ -401,7 +401,7 @@ public class LayoutSiteNavigationMenuItemType
 		DynamicQuery dynamicQuery =
 			_siteNavigationMenuItemLocalService.dynamicQuery();
 
-		StringBuilder sb = new StringBuilder(5);
+		StringBundler sb = new StringBundler(5);
 
 		sb.append(StringPool.PERCENT);
 		sb.append("layoutUuid");

--- a/modules/apps/site/site-insurance-site-initializer/src/main/java/com/liferay/site/insurance/site/initializer/internal/InsuranceSiteInitializer.java
+++ b/modules/apps/site/site-insurance-site-initializer/src/main/java/com/liferay/site/insurance/site/initializer/internal/InsuranceSiteInitializer.java
@@ -655,7 +655,7 @@ public class InsuranceSiteInitializer implements SiteInitializer {
 		ZipWriter zipWriter = ZipWriterFactoryUtil.getZipWriter();
 
 		for (KeyValuePair pathKeyValuePair : pathKeyValuePairs) {
-			StringBundler sb = new StringBundler(3);
+			StringBundler sb = new StringBundler(2);
 
 			sb.append(
 				_PATH + StringPool.FORWARD_SLASH + pathKeyValuePair.getKey());

--- a/modules/apps/site/site-insurance-site-initializer/src/main/java/com/liferay/site/insurance/site/initializer/internal/InsuranceSiteInitializer.java
+++ b/modules/apps/site/site-insurance-site-initializer/src/main/java/com/liferay/site/insurance/site/initializer/internal/InsuranceSiteInitializer.java
@@ -655,7 +655,7 @@ public class InsuranceSiteInitializer implements SiteInitializer {
 		ZipWriter zipWriter = ZipWriterFactoryUtil.getZipWriter();
 
 		for (KeyValuePair pathKeyValuePair : pathKeyValuePairs) {
-			StringBuilder sb = new StringBuilder(3);
+			StringBundler sb = new StringBundler(3);
 
 			sb.append(
 				_PATH + StringPool.FORWARD_SLASH + pathKeyValuePair.getKey());

--- a/modules/apps/site/site-insurance-site-initializer/src/main/java/com/liferay/site/insurance/site/initializer/internal/util/ImagesImporterUtil.java
+++ b/modules/apps/site/site-insurance-site-initializer/src/main/java/com/liferay/site/insurance/site/initializer/internal/util/ImagesImporterUtil.java
@@ -56,8 +56,8 @@ public class ImagesImporterUtil {
 
 			byte[] bytes = null;
 
-			try (InputStream is = zipFile.getInputStream(zipEntry)) {
-				bytes = FileUtil.getBytes(is);
+			try (InputStream inputStream = zipFile.getInputStream(zipEntry)) {
+				bytes = FileUtil.getBytes(inputStream);
 			}
 
 			FileEntry fileEntry = DLAppLocalServiceUtil.addFileEntry(

--- a/modules/apps/staging/staging-bar-web/src/main/java/com/liferay/staging/bar/web/internal/template/StagingBarTemplateContextContributor.java
+++ b/modules/apps/staging/staging-bar-web/src/main/java/com/liferay/staging/bar/web/internal/template/StagingBarTemplateContextContributor.java
@@ -61,7 +61,7 @@ public class StagingBarTemplateContextContributor
 			if (_stagingBarControlMenuJSPDynamicInclude.isShow(
 					httpServletRequest)) {
 
-				StringBundler sb = new StringBundler();
+				StringBundler sb = new StringBundler(5);
 
 				sb.append(
 					GetterUtil.getString(contextObjects.get("bodyCssClass")));

--- a/modules/apps/staging/staging-bar-web/src/main/java/com/liferay/staging/bar/web/internal/template/StagingBarTemplateContextContributor.java
+++ b/modules/apps/staging/staging-bar-web/src/main/java/com/liferay/staging/bar/web/internal/template/StagingBarTemplateContextContributor.java
@@ -14,6 +14,7 @@
 
 package com.liferay.staging.bar.web.internal.template;
 
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
@@ -60,7 +61,7 @@ public class StagingBarTemplateContextContributor
 			if (_stagingBarControlMenuJSPDynamicInclude.isShow(
 					httpServletRequest)) {
 
-				StringBuilder sb = new StringBuilder();
+				StringBundler sb = new StringBundler();
 
 				sb.append(
 					GetterUtil.getString(contextObjects.get("bodyCssClass")));

--- a/modules/apps/static/osgi/osgi-log-service-extender/src/main/java/com/liferay/osgi/log/service/extender/internal/OSGiLogServiceExtenderBundleActivator.java
+++ b/modules/apps/static/osgi/osgi-log-service-extender/src/main/java/com/liferay/osgi/log/service/extender/internal/OSGiLogServiceExtenderBundleActivator.java
@@ -95,8 +95,8 @@ public class OSGiLogServiceExtenderBundleActivator implements BundleActivator {
 
 				Properties properties = new Properties();
 
-				try (InputStream is = url.openStream()) {
-					properties.load(is);
+				try (InputStream inputStream = url.openStream()) {
+					properties.load(inputStream);
 				}
 
 				for (String name : properties.stringPropertyNames()) {

--- a/modules/apps/static/portal-configuration/portal-configuration-metatype-api/src/test/java/com/liferay/portal/configuration/metatype/bnd/util/ConfigurableUtilTest.java
+++ b/modules/apps/static/portal-configuration/portal-configuration-metatype-api/src/test/java/com/liferay/portal/configuration/metatype/bnd/util/ConfigurableUtilTest.java
@@ -276,13 +276,13 @@ public class ConfigurableUtilTest {
 	}
 
 	private void _testBigString(int length) {
-		StringBundler stringBuilder = new StringBundler(length);
+		StringBundler sb = new StringBundler(length);
 
 		for (int i = 0; i < length; i++) {
-			stringBuilder.append(CharPool.LOWER_CASE_A);
+			sb.append(CharPool.LOWER_CASE_A);
 		}
 
-		String bigString = stringBuilder.toString();
+		String bigString = sb.toString();
 
 		_assertTestConfiguration(
 			ConfigurableUtil.createConfigurable(

--- a/modules/apps/static/portal-configuration/portal-configuration-metatype-api/src/test/java/com/liferay/portal/configuration/metatype/bnd/util/ConfigurableUtilTest.java
+++ b/modules/apps/static/portal-configuration/portal-configuration-metatype-api/src/test/java/com/liferay/portal/configuration/metatype/bnd/util/ConfigurableUtilTest.java
@@ -17,6 +17,7 @@ package com.liferay.portal.configuration.metatype.bnd.util;
 import aQute.bnd.annotation.metatype.Meta;
 
 import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.CodeCoverageAssertor;
 import com.liferay.portal.kernel.test.rule.NewEnv;
@@ -275,7 +276,7 @@ public class ConfigurableUtilTest {
 	}
 
 	private void _testBigString(int length) {
-		StringBuilder stringBuilder = new StringBuilder(length);
+		StringBundler stringBuilder = new StringBundler(length);
 
 		for (int i = 0; i < length; i++) {
 			stringBuilder.append(CharPool.LOWER_CASE_A);

--- a/modules/apps/static/portal-file-install/portal-file-install-impl/src/main/java/com/liferay/portal/file/install/internal/DirectoryWatcher.java
+++ b/modules/apps/static/portal-file-install/portal-file-install-impl/src/main/java/com/liferay/portal/file/install/internal/DirectoryWatcher.java
@@ -670,11 +670,11 @@ public class DirectoryWatcher extends Thread implements BundleListener {
 			if (url != null) {
 				String location = url.toString();
 
-				try (BufferedInputStream inputStream = new BufferedInputStream(
-						url.openStream())) {
+				try (BufferedInputStream bufferedInputStream =
+						new BufferedInputStream(url.openStream())) {
 
 					bundle = _installOrUpdateBundle(
-						location, inputStream, checksum, modified);
+						location, bufferedInputStream, checksum, modified);
 
 					artifact.setBundleId(bundle.getBundleId());
 				}

--- a/modules/apps/static/portal-lpkg-deployer/portal-lpkg-deployer-impl/src/main/java/com/liferay/portal/lpkg/deployer/internal/LPKGArtifactInstaller.java
+++ b/modules/apps/static/portal-lpkg-deployer/portal-lpkg-deployer-impl/src/main/java/com/liferay/portal/lpkg/deployer/internal/LPKGArtifactInstaller.java
@@ -92,7 +92,7 @@ public class LPKGArtifactInstaller implements FileInstaller {
 			return null;
 		}
 
-		try (SafeClosable safeCloseable =
+		try (SafeClosable safeClosable =
 				LPKGBatchInstallThreadLocal.setBatchInstallInProcess(true)) {
 
 			_batchInstall(lpkgFiles);

--- a/modules/apps/static/portal-lpkg-deployer/portal-lpkg-deployer-test/src/test/java/com/liferay/portal/lpkg/deployer/override/LPKGOverrideTest.java
+++ b/modules/apps/static/portal-lpkg-deployer/portal-lpkg-deployer-test/src/test/java/com/liferay/portal/lpkg/deployer/override/LPKGOverrideTest.java
@@ -207,7 +207,7 @@ public class LPKGOverrideTest {
 			Path manifestPath = fileSystem.getPath("META-INF/MANIFEST.MF");
 
 			try (InputStream inputStream = Files.newInputStream(manifestPath);
-				UnsyncByteArrayOutputStream outputStream =
+				UnsyncByteArrayOutputStream unsyncByteArrayOutputStream =
 					new UnsyncByteArrayOutputStream()) {
 
 				Manifest manifest = new Manifest(inputStream);
@@ -232,10 +232,10 @@ public class LPKGOverrideTest {
 						versionString);
 				}
 
-				manifest.write(outputStream);
+				manifest.write(unsyncByteArrayOutputStream);
 
 				Files.write(
-					manifestPath, outputStream.toByteArray(),
+					manifestPath, unsyncByteArrayOutputStream.toByteArray(),
 					StandardOpenOption.TRUNCATE_EXISTING,
 					StandardOpenOption.WRITE);
 			}

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-generator-impl/src/main/java/com/liferay/portal/osgi/web/wab/generator/internal/artifact/ArtifactURLUtil.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-generator-impl/src/main/java/com/liferay/portal/osgi/web/wab/generator/internal/artifact/ArtifactURLUtil.java
@@ -17,6 +17,7 @@ package com.liferay.portal.osgi.web.wab.generator.internal.artifact;
 import aQute.bnd.osgi.Jar;
 import aQute.bnd.osgi.Resource;
 
+import com.liferay.petra.string.StringBundler;
 import com.liferay.whip.util.ReflectionUtil;
 
 import java.io.IOException;
@@ -67,7 +68,7 @@ public class ArtifactURLUtil {
 			contextName = symbolicName;
 		}
 
-		StringBuilder sb = new StringBuilder();
+		StringBundler sb = new StringBundler();
 
 		sb.append(artifact.getPath());
 		sb.append("?");

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-generator-impl/src/main/java/com/liferay/portal/osgi/web/wab/generator/internal/artifact/ArtifactURLUtil.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-generator-impl/src/main/java/com/liferay/portal/osgi/web/wab/generator/internal/artifact/ArtifactURLUtil.java
@@ -68,7 +68,7 @@ public class ArtifactURLUtil {
 			contextName = symbolicName;
 		}
 
-		StringBundler sb = new StringBundler();
+		StringBundler sb = new StringBundler(8);
 
 		sb.append(artifact.getPath());
 		sb.append("?");

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-generator-impl/src/main/java/com/liferay/portal/osgi/web/wab/generator/internal/processor/WabProcessor.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-generator-impl/src/main/java/com/liferay/portal/osgi/web/wab/generator/internal/processor/WabProcessor.java
@@ -501,7 +501,7 @@ public class WabProcessor {
 			Matcher matcher = _versionMavenPattern.matcher(_bundleVersion);
 
 			if (matcher.matches()) {
-				StringBuilder sb = new StringBuilder();
+				StringBundler sb = new StringBundler();
 
 				sb.append(matcher.group(1));
 				sb.append(".");

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-generator-impl/src/main/java/com/liferay/portal/osgi/web/wab/generator/internal/processor/WabProcessor.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-generator-impl/src/main/java/com/liferay/portal/osgi/web/wab/generator/internal/processor/WabProcessor.java
@@ -501,7 +501,7 @@ public class WabProcessor {
 			Matcher matcher = _versionMavenPattern.matcher(_bundleVersion);
 
 			if (matcher.matches()) {
-				StringBundler sb = new StringBundler();
+				StringBundler sb = new StringBundler(7);
 
 				sb.append(matcher.group(1));
 				sb.append(".");

--- a/modules/apps/subscription/subscription-web/src/main/java/com/liferay/subscription/web/internal/util/UnsubscribeHooks.java
+++ b/modules/apps/subscription/subscription-web/src/main/java/com/liferay/subscription/web/internal/util/UnsubscribeHooks.java
@@ -19,6 +19,7 @@ import com.liferay.mail.kernel.template.MailTemplate;
 import com.liferay.mail.kernel.template.MailTemplateContext;
 import com.liferay.mail.kernel.template.MailTemplateContextBuilder;
 import com.liferay.mail.kernel.template.MailTemplateFactoryUtil;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Ticket;
@@ -177,7 +178,7 @@ public class UnsubscribeHooks {
 	}
 
 	private String _getUnsubscribeURL(User user, Ticket ticket) {
-		StringBuilder sb = new StringBuilder();
+		StringBundler sb = new StringBundler();
 
 		sb.append(_subscriptionSender.getContextAttribute("[$PORTAL_URL$]"));
 		sb.append(PortalUtil.getPathMain());

--- a/modules/apps/subscription/subscription-web/src/main/java/com/liferay/subscription/web/internal/util/UnsubscribeHooks.java
+++ b/modules/apps/subscription/subscription-web/src/main/java/com/liferay/subscription/web/internal/util/UnsubscribeHooks.java
@@ -178,7 +178,7 @@ public class UnsubscribeHooks {
 	}
 
 	private String _getUnsubscribeURL(User user, Ticket ticket) {
-		StringBundler sb = new StringBundler();
+		StringBundler sb = new StringBundler(6);
 
 		sb.append(_subscriptionSender.getContextAttribute("[$PORTAL_URL$]"));
 		sb.append(PortalUtil.getPathMain());

--- a/modules/apps/users-admin/users-admin-demo-data-creator-impl/src/main/java/com/liferay/users/admin/demo/data/creator/internal/BaseUserDemoDataCreator.java
+++ b/modules/apps/users-admin/users-admin-demo-data-creator-impl/src/main/java/com/liferay/users/admin/demo/data/creator/internal/BaseUserDemoDataCreator.java
@@ -78,8 +78,8 @@ public abstract class BaseUserDemoDataCreator implements UserDemoDataCreator {
 		try {
 			URL url = new URL(_RANDOM_USER_API);
 
-			try (InputStream is = url.openStream()) {
-				String json = StringUtil.read(is);
+			try (InputStream inputStream = url.openStream()) {
+				String json = StringUtil.read(inputStream);
 
 				JSONObject rootJSONObject = JSONFactoryUtil.createJSONObject(
 					json);
@@ -253,8 +253,8 @@ public abstract class BaseUserDemoDataCreator implements UserDemoDataCreator {
 	}
 
 	private byte[] _getBytes(URL url) throws IOException {
-		try (InputStream is = url.openStream()) {
-			return FileUtil.getBytes(is);
+		try (InputStream inputStream = url.openStream()) {
+			return FileUtil.getBytes(inputStream);
 		}
 	}
 

--- a/modules/dxp/apps/commerce/commerce-machine-learning-impl/src/main/java/com/liferay/commerce/machine/learning/internal/forecast/BaseCommerceMLForecastServiceImpl.java
+++ b/modules/dxp/apps/commerce/commerce-machine-learning-impl/src/main/java/com/liferay/commerce/machine/learning/internal/forecast/BaseCommerceMLForecastServiceImpl.java
@@ -19,6 +19,7 @@ import com.liferay.commerce.machine.learning.internal.forecast.constants.Commerc
 import com.liferay.commerce.machine.learning.internal.forecast.constants.CommerceMLForecastPeriod;
 import com.liferay.commerce.machine.learning.internal.search.api.CommerceMLIndexer;
 import com.liferay.petra.lang.HashUtil;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -283,7 +284,7 @@ public abstract class BaseCommerceMLForecastServiceImpl
 	}
 
 	protected long getHash(Object... values) {
-		StringBuilder sb = new StringBuilder(values.length);
+		StringBundler sb = new StringBundler(values.length);
 
 		for (Object value : values) {
 			sb.append(value);

--- a/modules/dxp/apps/commerce/commerce-machine-learning-impl/src/main/java/com/liferay/commerce/machine/learning/internal/recommendation/BaseCommerceMLRecommendationServiceImpl.java
+++ b/modules/dxp/apps/commerce/commerce-machine-learning-impl/src/main/java/com/liferay/commerce/machine/learning/internal/recommendation/BaseCommerceMLRecommendationServiceImpl.java
@@ -17,6 +17,7 @@ package com.liferay.commerce.machine.learning.internal.recommendation;
 import com.liferay.commerce.machine.learning.internal.recommendation.constants.CommerceMLRecommendationField;
 import com.liferay.commerce.machine.learning.recommendation.CommerceMLRecommendation;
 import com.liferay.petra.lang.HashUtil;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -122,7 +123,7 @@ public abstract class BaseCommerceMLRecommendationServiceImpl
 	}
 
 	protected long getHash(Object... values) {
-		StringBuilder sb = new StringBuilder(values.length);
+		StringBundler sb = new StringBundler(values.length);
 
 		for (Object value : values) {
 			sb.append(value);

--- a/modules/dxp/apps/commerce/commerce-machine-learning-impl/src/main/java/com/liferay/commerce/machine/learning/internal/recommendation/data/source/FrequentPatternCommerceMLRecommendationCPDataSourceImpl.java
+++ b/modules/dxp/apps/commerce/commerce-machine-learning-impl/src/main/java/com/liferay/commerce/machine/learning/internal/recommendation/data/source/FrequentPatternCommerceMLRecommendationCPDataSourceImpl.java
@@ -109,7 +109,7 @@ public class FrequentPatternCommerceMLRecommendationCPDataSourceImpl
 					getRecommendedEntryClassPK();
 
 			if (_log.isTraceEnabled()) {
-				StringBundler sb = new StringBundler();
+				StringBundler sb = new StringBundler(4);
 
 				sb.append("Recommended entry ");
 				sb.append(recommendedEntryClassPK);

--- a/modules/dxp/apps/commerce/commerce-machine-learning-impl/src/main/java/com/liferay/commerce/machine/learning/internal/recommendation/data/source/FrequentPatternCommerceMLRecommendationCPDataSourceImpl.java
+++ b/modules/dxp/apps/commerce/commerce-machine-learning-impl/src/main/java/com/liferay/commerce/machine/learning/internal/recommendation/data/source/FrequentPatternCommerceMLRecommendationCPDataSourceImpl.java
@@ -21,6 +21,7 @@ import com.liferay.commerce.product.catalog.CPCatalogEntry;
 import com.liferay.commerce.product.constants.CPWebKeys;
 import com.liferay.commerce.product.data.source.CPDataSource;
 import com.liferay.commerce.product.data.source.CPDataSourceResult;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
@@ -108,7 +109,7 @@ public class FrequentPatternCommerceMLRecommendationCPDataSourceImpl
 					getRecommendedEntryClassPK();
 
 			if (_log.isTraceEnabled()) {
-				StringBuilder sb = new StringBuilder();
+				StringBundler sb = new StringBundler();
 
 				sb.append("Recommended entry ");
 				sb.append(recommendedEntryClassPK);

--- a/modules/dxp/apps/commerce/commerce-machine-learning-impl/src/main/java/com/liferay/commerce/machine/learning/internal/recommendation/data/source/ProductContentCommerceMLRecommendationCPDataSourceImpl.java
+++ b/modules/dxp/apps/commerce/commerce-machine-learning-impl/src/main/java/com/liferay/commerce/machine/learning/internal/recommendation/data/source/ProductContentCommerceMLRecommendationCPDataSourceImpl.java
@@ -111,7 +111,7 @@ public class ProductContentCommerceMLRecommendationCPDataSourceImpl
 					getRecommendedEntryClassPK();
 
 			if (_log.isTraceEnabled()) {
-				StringBundler sb = new StringBundler();
+				StringBundler sb = new StringBundler(6);
 
 				sb.append("Recommended item: ");
 				sb.append(recommendedEntryClassPK);

--- a/modules/dxp/apps/commerce/commerce-machine-learning-impl/src/main/java/com/liferay/commerce/machine/learning/internal/recommendation/data/source/ProductContentCommerceMLRecommendationCPDataSourceImpl.java
+++ b/modules/dxp/apps/commerce/commerce-machine-learning-impl/src/main/java/com/liferay/commerce/machine/learning/internal/recommendation/data/source/ProductContentCommerceMLRecommendationCPDataSourceImpl.java
@@ -21,6 +21,7 @@ import com.liferay.commerce.product.catalog.CPCatalogEntry;
 import com.liferay.commerce.product.constants.CPWebKeys;
 import com.liferay.commerce.product.data.source.CPDataSource;
 import com.liferay.commerce.product.data.source.CPDataSourceResult;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
@@ -110,7 +111,7 @@ public class ProductContentCommerceMLRecommendationCPDataSourceImpl
 					getRecommendedEntryClassPK();
 
 			if (_log.isTraceEnabled()) {
-				StringBuilder sb = new StringBuilder();
+				StringBundler sb = new StringBundler();
 
 				sb.append("Recommended item: ");
 				sb.append(recommendedEntryClassPK);

--- a/modules/dxp/apps/commerce/commerce-machine-learning-impl/src/main/java/com/liferay/commerce/machine/learning/internal/recommendation/data/source/ProductInteractionCommerceMLRecommendationCPDataSourceImpl.java
+++ b/modules/dxp/apps/commerce/commerce-machine-learning-impl/src/main/java/com/liferay/commerce/machine/learning/internal/recommendation/data/source/ProductInteractionCommerceMLRecommendationCPDataSourceImpl.java
@@ -112,7 +112,7 @@ public class ProductInteractionCommerceMLRecommendationCPDataSourceImpl
 					getRecommendedEntryClassPK();
 
 			if (_log.isTraceEnabled()) {
-				StringBundler sb = new StringBundler();
+				StringBundler sb = new StringBundler(6);
 
 				sb.append("Recommended item: ");
 				sb.append(recommendedEntryClassPK);

--- a/modules/dxp/apps/commerce/commerce-machine-learning-impl/src/main/java/com/liferay/commerce/machine/learning/internal/recommendation/data/source/ProductInteractionCommerceMLRecommendationCPDataSourceImpl.java
+++ b/modules/dxp/apps/commerce/commerce-machine-learning-impl/src/main/java/com/liferay/commerce/machine/learning/internal/recommendation/data/source/ProductInteractionCommerceMLRecommendationCPDataSourceImpl.java
@@ -21,6 +21,7 @@ import com.liferay.commerce.product.catalog.CPCatalogEntry;
 import com.liferay.commerce.product.constants.CPWebKeys;
 import com.liferay.commerce.product.data.source.CPDataSource;
 import com.liferay.commerce.product.data.source.CPDataSourceResult;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
@@ -111,7 +112,7 @@ public class ProductInteractionCommerceMLRecommendationCPDataSourceImpl
 					getRecommendedEntryClassPK();
 
 			if (_log.isTraceEnabled()) {
-				StringBuilder sb = new StringBuilder();
+				StringBundler sb = new StringBundler();
 
 				sb.append("Recommended item: ");
 				sb.append(recommendedEntryClassPK);

--- a/modules/dxp/apps/commerce/commerce-machine-learning-impl/src/main/java/com/liferay/commerce/machine/learning/internal/recommendation/data/source/UserCommerceMLRecommendationCPDataSourceImpl.java
+++ b/modules/dxp/apps/commerce/commerce-machine-learning-impl/src/main/java/com/liferay/commerce/machine/learning/internal/recommendation/data/source/UserCommerceMLRecommendationCPDataSourceImpl.java
@@ -116,7 +116,7 @@ public class UserCommerceMLRecommendationCPDataSourceImpl
 				userCommerceMLRecommendation.getRecommendedEntryClassPK();
 
 			if (_log.isTraceEnabled()) {
-				StringBundler sb = new StringBundler();
+				StringBundler sb = new StringBundler(4);
 
 				sb.append("Recommended item: ");
 				sb.append(recommendedEntryClassPK);

--- a/modules/dxp/apps/commerce/commerce-machine-learning-impl/src/main/java/com/liferay/commerce/machine/learning/internal/recommendation/data/source/UserCommerceMLRecommendationCPDataSourceImpl.java
+++ b/modules/dxp/apps/commerce/commerce-machine-learning-impl/src/main/java/com/liferay/commerce/machine/learning/internal/recommendation/data/source/UserCommerceMLRecommendationCPDataSourceImpl.java
@@ -24,6 +24,7 @@ import com.liferay.commerce.product.constants.CPWebKeys;
 import com.liferay.commerce.product.data.source.CPDataSource;
 import com.liferay.commerce.product.data.source.CPDataSourceResult;
 import com.liferay.commerce.product.model.CPDefinition;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
@@ -115,7 +116,7 @@ public class UserCommerceMLRecommendationCPDataSourceImpl
 				userCommerceMLRecommendation.getRecommendedEntryClassPK();
 
 			if (_log.isTraceEnabled()) {
-				StringBuilder sb = new StringBuilder();
+				StringBundler sb = new StringBundler();
 
 				sb.append("Recommended item: ");
 				sb.append(recommendedEntryClassPK);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/helper/WorkflowMetricsRESTTestHelper.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/helper/WorkflowMetricsRESTTestHelper.java
@@ -16,6 +16,7 @@ package com.liferay.portal.workflow.metrics.rest.resource.v1_0.test.helper;
 
 import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.reflect.ReflectionUtil;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
@@ -940,7 +941,7 @@ public class WorkflowMetricsRESTTestHelper {
 	}
 
 	private String _digest(String indexNamePrefix, Serializable... parts) {
-		StringBuilder sb = new StringBuilder();
+		StringBundler sb = new StringBundler();
 
 		for (Serializable part : parts) {
 			sb.append(part);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/util/WorkflowMetricsIndexerUtil.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/util/WorkflowMetricsIndexerUtil.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.workflow.metrics.internal.search.index.util;
 
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.util.StringUtil;
 
 import java.io.Serializable;
@@ -26,7 +27,7 @@ import org.apache.commons.codec.digest.DigestUtils;
 public class WorkflowMetricsIndexerUtil {
 
 	public static String digest(String indexType, Serializable... parts) {
-		StringBuilder sb = new StringBuilder();
+		StringBundler sb = new StringBundler();
 
 		for (Serializable part : parts) {
 			sb.append(part);

--- a/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/client/model/Individual.java
+++ b/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/client/model/Individual.java
@@ -82,7 +82,7 @@ public class Individual {
 
 	@Override
 	public String toString() {
-		StringBundler sb = new StringBundler(11);
+		StringBundler sb = new StringBundler(13);
 
 		sb.append("{dataSourceIndividualPKs=");
 		sb.append(_dataSourceIndividualPKs);

--- a/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/client/model/Individual.java
+++ b/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/client/model/Individual.java
@@ -14,6 +14,8 @@
 
 package com.liferay.segments.asah.connector.internal.client.model;
 
+import com.liferay.petra.string.StringBundler;
+
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -80,7 +82,7 @@ public class Individual {
 
 	@Override
 	public String toString() {
-		StringBuilder sb = new StringBuilder(11);
+		StringBundler sb = new StringBundler(11);
 
 		sb.append("{dataSourceIndividualPKs=");
 		sb.append(_dataSourceIndividualPKs);

--- a/modules/test/jenkins-results-parser/bnd.bnd
+++ b/modules/test/jenkins-results-parser/bnd.bnd
@@ -1,3 +1,3 @@
 Bundle-Name: Liferay Jenkins Results Parser
 Bundle-SymbolicName: com.liferay.jenkins.results.parser
-Bundle-Version: 1.0.832
+Bundle-Version: 1.0.833

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/AppServer.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/AppServer.java
@@ -36,16 +36,9 @@ public class AppServer {
 	}
 
 	public void startService() {
-		if (JenkinsResultsParserUtil.isWindows()) {
-			JenkinsResultsParserUtil.executeBatchCommandService(
-				_getStartCommand(), _getBinDir(), _getEnvironments(),
-				_getMaxLogSize());
-		}
-		else {
-			JenkinsResultsParserUtil.executeBashCommandService(
-				_getStartCommand(), _getBinDir(), _getEnvironments(),
-				_getMaxLogSize());
-		}
+		JenkinsResultsParserUtil.executeBashCommandService(
+			_getStartCommand(), _getBinDir(), _getEnvironments(),
+			_getMaxLogSize());
 
 		String type = getType();
 
@@ -57,14 +50,6 @@ public class AppServer {
 	}
 
 	public void stopService() {
-		if (JenkinsResultsParserUtil.isWindows()) {
-			JenkinsResultsParserUtil.executeBatchCommandService(
-				_getStopCommand(), _getBinDir(), _getEnvironments(),
-				_getMaxLogSize());
-
-			return;
-		}
-
 		JenkinsResultsParserUtil.executeBashCommandService(
 			_getStopCommand(), _getBinDir(), _getEnvironments(),
 			_getMaxLogSize());
@@ -171,7 +156,7 @@ public class AppServer {
 		if (JenkinsResultsParserUtil.isWindows()) {
 			return path.replaceAll(
 				"[^;]+\\\\jdk[^\\\\]*\\\\[^;]*bin",
-				javaHome.replaceAll("\\\\", "\\\\") + "\\\\bin");
+				javaHome.replaceAll("\\\\", "\\\\\\\\") + "\\\\bin");
 		}
 
 		return path.replaceAll("[^:]+/jdk[^/]*/[^:]*bin", javaHome + "/bin");
@@ -216,7 +201,7 @@ public class AppServer {
 					"app.server.", getType(), ".start.executable"));
 		}
 
-		return startExecutable;
+		return startExecutable.replace(".bat", ".sh");
 	}
 
 	private String _getStartExecutableArgLine() {
@@ -249,7 +234,7 @@ public class AppServer {
 					"app.server.", getType(), ".stop.executable"));
 		}
 
-		return stopExecutable;
+		return stopExecutable.replace(".bat", ".sh");
 	}
 
 	private String _getStopExecutableArgLine() {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/RsyncTestrayAttachmentUploader.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/RsyncTestrayAttachmentUploader.java
@@ -105,7 +105,7 @@ public class RsyncTestrayAttachmentUploader
 	}
 
 	protected void rsync() {
-		String[] commands;
+		String[] commands = null;
 
 		if (JenkinsResultsParserUtil.isWindows()) {
 			commands = new String[2];
@@ -114,7 +114,6 @@ public class RsyncTestrayAttachmentUploader
 				"cd ",
 				JenkinsResultsParserUtil.getCanonicalPath(
 					_getSourceTestrayLogsDir()));
-
 			commands[1] = JenkinsResultsParserUtil.combine(
 				"rsync -aqz --chmod=go=rx ./* \"root@", _getMasterHostname(),
 				"::testray-results/production/logs/\"");

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/RESTBuilder.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/RESTBuilder.java
@@ -452,7 +452,7 @@ public class RESTBuilder {
 	private void _createApplicationFile(Map<String, Object> context)
 		throws Exception {
 
-		StringBundler sb = new StringBundler();
+		StringBundler sb = new StringBundler(6);
 
 		sb.append(_configYAML.getImplDir());
 		sb.append("/");
@@ -481,7 +481,7 @@ public class RESTBuilder {
 			String schemaName)
 		throws Exception {
 
-		StringBundler sb = new StringBundler();
+		StringBundler sb = new StringBundler(8);
 
 		sb.append(_configYAML.getImplDir());
 		sb.append("/");
@@ -508,7 +508,7 @@ public class RESTBuilder {
 			String schemaName)
 		throws Exception {
 
-		StringBundler sb = new StringBundler();
+		StringBundler sb = new StringBundler(8);
 
 		sb.append(_configYAML.getTestDir());
 		sb.append("/");
@@ -533,7 +533,7 @@ public class RESTBuilder {
 	private void _createClientAggregationFile(Map<String, Object> context)
 		throws Exception {
 
-		StringBundler sb = new StringBundler();
+		StringBundler sb = new StringBundler(4);
 
 		sb.append(_configYAML.getClientDir());
 		sb.append("/");
@@ -554,7 +554,7 @@ public class RESTBuilder {
 	private void _createClientBaseJSONParserFile(Map<String, Object> context)
 		throws Exception {
 
-		StringBundler sb = new StringBundler();
+		StringBundler sb = new StringBundler(4);
 
 		sb.append(_configYAML.getClientDir());
 		sb.append("/");
@@ -577,7 +577,7 @@ public class RESTBuilder {
 			String schemaName)
 		throws Exception {
 
-		StringBundler sb = new StringBundler();
+		StringBundler sb = new StringBundler(8);
 
 		sb.append(_configYAML.getClientDir());
 		sb.append("/");
@@ -604,7 +604,7 @@ public class RESTBuilder {
 			String schemaName)
 		throws Exception {
 
-		StringBundler sb = new StringBundler();
+		StringBundler sb = new StringBundler(8);
 
 		sb.append(_configYAML.getClientDir());
 		sb.append("/");
@@ -629,7 +629,7 @@ public class RESTBuilder {
 	private void _createClientFacetFile(Map<String, Object> context)
 		throws Exception {
 
-		StringBundler sb = new StringBundler();
+		StringBundler sb = new StringBundler(4);
 
 		sb.append(_configYAML.getClientDir());
 		sb.append("/");
@@ -650,7 +650,7 @@ public class RESTBuilder {
 	private void _createClientHttpInvokerFile(Map<String, Object> context)
 		throws Exception {
 
-		StringBundler sb = new StringBundler();
+		StringBundler sb = new StringBundler(4);
 
 		sb.append(_configYAML.getClientDir());
 		sb.append("/");
@@ -671,7 +671,7 @@ public class RESTBuilder {
 	private void _createClientPageFile(Map<String, Object> context)
 		throws Exception {
 
-		StringBundler sb = new StringBundler();
+		StringBundler sb = new StringBundler(4);
 
 		sb.append(_configYAML.getClientDir());
 		sb.append("/");
@@ -692,7 +692,7 @@ public class RESTBuilder {
 	private void _createClientPaginationFile(Map<String, Object> context)
 		throws Exception {
 
-		StringBundler sb = new StringBundler();
+		StringBundler sb = new StringBundler(4);
 
 		sb.append(_configYAML.getClientDir());
 		sb.append("/");
@@ -713,7 +713,7 @@ public class RESTBuilder {
 	private void _createClientPermissionFile(Map<String, Object> context)
 		throws Exception {
 
-		StringBundler sb = new StringBundler();
+		StringBundler sb = new StringBundler(4);
 
 		sb.append(_configYAML.getClientDir());
 		sb.append("/");
@@ -734,7 +734,7 @@ public class RESTBuilder {
 	private void _createClientProblemFile(Map<String, Object> context)
 		throws Exception {
 
-		StringBundler sb = new StringBundler();
+		StringBundler sb = new StringBundler(4);
 
 		sb.append(_configYAML.getClientDir());
 		sb.append("/");
@@ -757,7 +757,7 @@ public class RESTBuilder {
 			String schemaName)
 		throws Exception {
 
-		StringBundler sb = new StringBundler();
+		StringBundler sb = new StringBundler(8);
 
 		sb.append(_configYAML.getClientDir());
 		sb.append("/");
@@ -784,7 +784,7 @@ public class RESTBuilder {
 			String schemaName)
 		throws Exception {
 
-		StringBundler sb = new StringBundler();
+		StringBundler sb = new StringBundler(8);
 
 		sb.append(_configYAML.getClientDir());
 		sb.append("/");
@@ -809,7 +809,7 @@ public class RESTBuilder {
 	private void _createClientUnsafeSupplierFile(Map<String, Object> context)
 		throws Exception {
 
-		StringBundler sb = new StringBundler();
+		StringBundler sb = new StringBundler(4);
 
 		sb.append(_configYAML.getClientDir());
 		sb.append("/");
@@ -832,7 +832,7 @@ public class RESTBuilder {
 			String schemaName)
 		throws Exception {
 
-		StringBundler sb = new StringBundler();
+		StringBundler sb = new StringBundler(8);
 
 		sb.append(_configYAML.getApiDir());
 		sb.append("/");
@@ -858,7 +858,7 @@ public class RESTBuilder {
 			String schemaName)
 		throws Exception {
 
-		StringBundler sb = new StringBundler();
+		StringBundler sb = new StringBundler(8);
 
 		sb.append(_configYAML.getApiDir());
 		sb.append("/");
@@ -900,7 +900,7 @@ public class RESTBuilder {
 			Map<String, Object> context, String escapedVersion)
 		throws Exception {
 
-		StringBundler sb = new StringBundler();
+		StringBundler sb = new StringBundler(6);
 
 		sb.append(_configYAML.getImplDir());
 		sb.append("/");
@@ -924,7 +924,7 @@ public class RESTBuilder {
 			Map<String, Object> context, String escapedVersion)
 		throws Exception {
 
-		StringBundler sb = new StringBundler();
+		StringBundler sb = new StringBundler(6);
 
 		sb.append(_configYAML.getImplDir());
 		sb.append("/");
@@ -948,7 +948,7 @@ public class RESTBuilder {
 			Map<String, Object> context, String escapedVersion)
 		throws Exception {
 
-		StringBundler sb = new StringBundler();
+		StringBundler sb = new StringBundler(6);
 
 		sb.append(_configYAML.getImplDir());
 		sb.append("/");
@@ -972,7 +972,7 @@ public class RESTBuilder {
 			Map<String, Object> context, String escapedVersion)
 		throws Exception {
 
-		StringBundler sb = new StringBundler();
+		StringBundler sb = new StringBundler(6);
 
 		sb.append(_configYAML.getImplDir());
 		sb.append("/");
@@ -997,7 +997,7 @@ public class RESTBuilder {
 			String schemaPath)
 		throws Exception {
 
-		StringBundler sb = new StringBundler();
+		StringBundler sb = new StringBundler(6);
 
 		sb.append(_configYAML.getImplDir());
 		sb.append("/../resources/OSGI-INF/liferay/rest/");
@@ -1019,7 +1019,7 @@ public class RESTBuilder {
 			String schemaName)
 		throws Exception {
 
-		StringBundler sb = new StringBundler();
+		StringBundler sb = new StringBundler(8);
 
 		sb.append(_configYAML.getImplDir());
 		sb.append("/");
@@ -1046,7 +1046,7 @@ public class RESTBuilder {
 			String schemaName)
 		throws Exception {
 
-		StringBundler sb = new StringBundler();
+		StringBundler sb = new StringBundler(8);
 
 		sb.append(_configYAML.getApiDir());
 		sb.append("/");
@@ -1073,7 +1073,7 @@ public class RESTBuilder {
 			String schemaName)
 		throws Exception {
 
-		StringBundler sb = new StringBundler();
+		StringBundler sb = new StringBundler(8);
 
 		sb.append(_configYAML.getImplDir());
 		sb.append("/");
@@ -1104,7 +1104,7 @@ public class RESTBuilder {
 			String schemaName)
 		throws Exception {
 
-		StringBundler sb = new StringBundler();
+		StringBundler sb = new StringBundler(8);
 
 		sb.append(_configYAML.getTestDir());
 		sb.append("/");
@@ -1241,7 +1241,7 @@ public class RESTBuilder {
 		String licenseName = _configYAML.getLicenseName();
 		String licenseURL = _configYAML.getLicenseURL();
 
-		StringBundler licenseSB = new StringBundler();
+		StringBundler licenseSB = new StringBundler(6);
 
 		licenseSB.append("        name: \"");
 		licenseSB.append(licenseName);
@@ -1253,7 +1253,7 @@ public class RESTBuilder {
 		Info info = openAPIYAML.getInfo();
 
 		if (info == null) {
-			StringBundler sb = new StringBundler();
+			StringBundler sb = new StringBundler(4);
 
 			sb.append("info:\n");
 			sb.append(licenseSB.toString());
@@ -1429,7 +1429,7 @@ public class RESTBuilder {
 						z + 1, yamlString.indexOf("\n", z + 1));
 				}
 
-				StringBundler sb = new StringBundler();
+				StringBundler sb = new StringBundler(6);
 
 				sb.append(yamlString.substring(0, z + 1));
 				sb.append(leadingWhiteSpace);
@@ -1486,7 +1486,7 @@ public class RESTBuilder {
 						int z = yamlString.indexOf(
 							" " + parameterName + "\n", y);
 
-						StringBundler sb = new StringBundler();
+						StringBundler sb = new StringBundler(4);
 
 						sb.append(yamlString.substring(0, z + 1));
 						sb.append(newParameterName);
@@ -1954,7 +1954,7 @@ public class RESTBuilder {
 					!Objects.equals(propertySchema.getFormat(), "double") &&
 					!Objects.equals(propertySchema.getFormat(), "float")) {
 
-					StringBundler sb = new StringBundler();
+					StringBundler sb = new StringBundler(6);
 
 					sb.append("The property \"");
 					sb.append(entry1.getKey());
@@ -1980,7 +1980,7 @@ public class RESTBuilder {
 					requiredPropertySchemaNames) {
 
 				if (!propertySchemaNames.contains(requiredPropertySchemaName)) {
-					StringBundler sb = new StringBundler();
+					StringBundler sb = new StringBundler(4);
 
 					sb.append("The required property \"");
 					sb.append(requiredPropertySchemaName);

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/RESTBuilder.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/RESTBuilder.java
@@ -1960,9 +1960,8 @@ public class RESTBuilder {
 					sb.append(entry1.getKey());
 					sb.append('.');
 					sb.append(entry2.getKey());
-					sb.append(
-						"\" should use \"type: integer\" instead of \"type: " +
-							"number\"");
+					sb.append("\" should use \"type: integer\" instead of ");
+					sb.append("\"type: number\"");
 
 					System.out.println(sb.toString());
 				}

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/RESTBuilder.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/RESTBuilder.java
@@ -452,7 +452,7 @@ public class RESTBuilder {
 	private void _createApplicationFile(Map<String, Object> context)
 		throws Exception {
 
-		StringBuilder sb = new StringBuilder();
+		StringBundler sb = new StringBundler();
 
 		sb.append(_configYAML.getImplDir());
 		sb.append("/");
@@ -481,7 +481,7 @@ public class RESTBuilder {
 			String schemaName)
 		throws Exception {
 
-		StringBuilder sb = new StringBuilder();
+		StringBundler sb = new StringBundler();
 
 		sb.append(_configYAML.getImplDir());
 		sb.append("/");
@@ -508,7 +508,7 @@ public class RESTBuilder {
 			String schemaName)
 		throws Exception {
 
-		StringBuilder sb = new StringBuilder();
+		StringBundler sb = new StringBundler();
 
 		sb.append(_configYAML.getTestDir());
 		sb.append("/");
@@ -533,7 +533,7 @@ public class RESTBuilder {
 	private void _createClientAggregationFile(Map<String, Object> context)
 		throws Exception {
 
-		StringBuilder sb = new StringBuilder();
+		StringBundler sb = new StringBundler();
 
 		sb.append(_configYAML.getClientDir());
 		sb.append("/");
@@ -554,7 +554,7 @@ public class RESTBuilder {
 	private void _createClientBaseJSONParserFile(Map<String, Object> context)
 		throws Exception {
 
-		StringBuilder sb = new StringBuilder();
+		StringBundler sb = new StringBundler();
 
 		sb.append(_configYAML.getClientDir());
 		sb.append("/");
@@ -577,7 +577,7 @@ public class RESTBuilder {
 			String schemaName)
 		throws Exception {
 
-		StringBuilder sb = new StringBuilder();
+		StringBundler sb = new StringBundler();
 
 		sb.append(_configYAML.getClientDir());
 		sb.append("/");
@@ -604,7 +604,7 @@ public class RESTBuilder {
 			String schemaName)
 		throws Exception {
 
-		StringBuilder sb = new StringBuilder();
+		StringBundler sb = new StringBundler();
 
 		sb.append(_configYAML.getClientDir());
 		sb.append("/");
@@ -629,7 +629,7 @@ public class RESTBuilder {
 	private void _createClientFacetFile(Map<String, Object> context)
 		throws Exception {
 
-		StringBuilder sb = new StringBuilder();
+		StringBundler sb = new StringBundler();
 
 		sb.append(_configYAML.getClientDir());
 		sb.append("/");
@@ -650,7 +650,7 @@ public class RESTBuilder {
 	private void _createClientHttpInvokerFile(Map<String, Object> context)
 		throws Exception {
 
-		StringBuilder sb = new StringBuilder();
+		StringBundler sb = new StringBundler();
 
 		sb.append(_configYAML.getClientDir());
 		sb.append("/");
@@ -671,7 +671,7 @@ public class RESTBuilder {
 	private void _createClientPageFile(Map<String, Object> context)
 		throws Exception {
 
-		StringBuilder sb = new StringBuilder();
+		StringBundler sb = new StringBundler();
 
 		sb.append(_configYAML.getClientDir());
 		sb.append("/");
@@ -692,7 +692,7 @@ public class RESTBuilder {
 	private void _createClientPaginationFile(Map<String, Object> context)
 		throws Exception {
 
-		StringBuilder sb = new StringBuilder();
+		StringBundler sb = new StringBundler();
 
 		sb.append(_configYAML.getClientDir());
 		sb.append("/");
@@ -713,7 +713,7 @@ public class RESTBuilder {
 	private void _createClientPermissionFile(Map<String, Object> context)
 		throws Exception {
 
-		StringBuilder sb = new StringBuilder();
+		StringBundler sb = new StringBundler();
 
 		sb.append(_configYAML.getClientDir());
 		sb.append("/");
@@ -734,7 +734,7 @@ public class RESTBuilder {
 	private void _createClientProblemFile(Map<String, Object> context)
 		throws Exception {
 
-		StringBuilder sb = new StringBuilder();
+		StringBundler sb = new StringBundler();
 
 		sb.append(_configYAML.getClientDir());
 		sb.append("/");
@@ -757,7 +757,7 @@ public class RESTBuilder {
 			String schemaName)
 		throws Exception {
 
-		StringBuilder sb = new StringBuilder();
+		StringBundler sb = new StringBundler();
 
 		sb.append(_configYAML.getClientDir());
 		sb.append("/");
@@ -784,7 +784,7 @@ public class RESTBuilder {
 			String schemaName)
 		throws Exception {
 
-		StringBuilder sb = new StringBuilder();
+		StringBundler sb = new StringBundler();
 
 		sb.append(_configYAML.getClientDir());
 		sb.append("/");
@@ -809,7 +809,7 @@ public class RESTBuilder {
 	private void _createClientUnsafeSupplierFile(Map<String, Object> context)
 		throws Exception {
 
-		StringBuilder sb = new StringBuilder();
+		StringBundler sb = new StringBundler();
 
 		sb.append(_configYAML.getClientDir());
 		sb.append("/");
@@ -832,7 +832,7 @@ public class RESTBuilder {
 			String schemaName)
 		throws Exception {
 
-		StringBuilder sb = new StringBuilder();
+		StringBundler sb = new StringBundler();
 
 		sb.append(_configYAML.getApiDir());
 		sb.append("/");
@@ -858,7 +858,7 @@ public class RESTBuilder {
 			String schemaName)
 		throws Exception {
 
-		StringBuilder sb = new StringBuilder();
+		StringBundler sb = new StringBundler();
 
 		sb.append(_configYAML.getApiDir());
 		sb.append("/");
@@ -900,7 +900,7 @@ public class RESTBuilder {
 			Map<String, Object> context, String escapedVersion)
 		throws Exception {
 
-		StringBuilder sb = new StringBuilder();
+		StringBundler sb = new StringBundler();
 
 		sb.append(_configYAML.getImplDir());
 		sb.append("/");
@@ -924,7 +924,7 @@ public class RESTBuilder {
 			Map<String, Object> context, String escapedVersion)
 		throws Exception {
 
-		StringBuilder sb = new StringBuilder();
+		StringBundler sb = new StringBundler();
 
 		sb.append(_configYAML.getImplDir());
 		sb.append("/");
@@ -948,7 +948,7 @@ public class RESTBuilder {
 			Map<String, Object> context, String escapedVersion)
 		throws Exception {
 
-		StringBuilder sb = new StringBuilder();
+		StringBundler sb = new StringBundler();
 
 		sb.append(_configYAML.getImplDir());
 		sb.append("/");
@@ -972,7 +972,7 @@ public class RESTBuilder {
 			Map<String, Object> context, String escapedVersion)
 		throws Exception {
 
-		StringBuilder sb = new StringBuilder();
+		StringBundler sb = new StringBundler();
 
 		sb.append(_configYAML.getImplDir());
 		sb.append("/");
@@ -997,7 +997,7 @@ public class RESTBuilder {
 			String schemaPath)
 		throws Exception {
 
-		StringBuilder sb = new StringBuilder();
+		StringBundler sb = new StringBundler();
 
 		sb.append(_configYAML.getImplDir());
 		sb.append("/../resources/OSGI-INF/liferay/rest/");
@@ -1019,7 +1019,7 @@ public class RESTBuilder {
 			String schemaName)
 		throws Exception {
 
-		StringBuilder sb = new StringBuilder();
+		StringBundler sb = new StringBundler();
 
 		sb.append(_configYAML.getImplDir());
 		sb.append("/");
@@ -1046,7 +1046,7 @@ public class RESTBuilder {
 			String schemaName)
 		throws Exception {
 
-		StringBuilder sb = new StringBuilder();
+		StringBundler sb = new StringBundler();
 
 		sb.append(_configYAML.getApiDir());
 		sb.append("/");
@@ -1073,7 +1073,7 @@ public class RESTBuilder {
 			String schemaName)
 		throws Exception {
 
-		StringBuilder sb = new StringBuilder();
+		StringBundler sb = new StringBundler();
 
 		sb.append(_configYAML.getImplDir());
 		sb.append("/");
@@ -1104,7 +1104,7 @@ public class RESTBuilder {
 			String schemaName)
 		throws Exception {
 
-		StringBuilder sb = new StringBuilder();
+		StringBundler sb = new StringBundler();
 
 		sb.append(_configYAML.getTestDir());
 		sb.append("/");
@@ -1241,7 +1241,7 @@ public class RESTBuilder {
 		String licenseName = _configYAML.getLicenseName();
 		String licenseURL = _configYAML.getLicenseURL();
 
-		StringBuilder licenseSB = new StringBuilder();
+		StringBundler licenseSB = new StringBundler();
 
 		licenseSB.append("        name: \"");
 		licenseSB.append(licenseName);
@@ -1253,7 +1253,7 @@ public class RESTBuilder {
 		Info info = openAPIYAML.getInfo();
 
 		if (info == null) {
-			StringBuilder sb = new StringBuilder();
+			StringBundler sb = new StringBundler();
 
 			sb.append("info:\n");
 			sb.append(licenseSB.toString());
@@ -1322,7 +1322,7 @@ public class RESTBuilder {
 
 		fieldMap.put("license", licenseSB.toString());
 
-		StringBuilder sb = new StringBuilder();
+		StringBundler sb = new StringBundler();
 
 		sb.append(yamlString.substring(0, yamlString.indexOf('\n', x + 1) + 1));
 
@@ -1429,7 +1429,7 @@ public class RESTBuilder {
 						z + 1, yamlString.indexOf("\n", z + 1));
 				}
 
-				StringBuilder sb = new StringBuilder();
+				StringBundler sb = new StringBundler();
 
 				sb.append(yamlString.substring(0, z + 1));
 				sb.append(leadingWhiteSpace);
@@ -1486,7 +1486,7 @@ public class RESTBuilder {
 						int z = yamlString.indexOf(
 							" " + parameterName + "\n", y);
 
-						StringBuilder sb = new StringBuilder();
+						StringBundler sb = new StringBundler();
 
 						sb.append(yamlString.substring(0, z + 1));
 						sb.append(newParameterName);
@@ -1954,7 +1954,7 @@ public class RESTBuilder {
 					!Objects.equals(propertySchema.getFormat(), "double") &&
 					!Objects.equals(propertySchema.getFormat(), "float")) {
 
-					StringBuilder sb = new StringBuilder();
+					StringBundler sb = new StringBundler();
 
 					sb.append("The property \"");
 					sb.append(entry1.getKey());
@@ -1981,7 +1981,7 @@ public class RESTBuilder {
 					requiredPropertySchemaNames) {
 
 				if (!propertySchemaNames.contains(requiredPropertySchemaName)) {
-					StringBuilder sb = new StringBuilder();
+					StringBundler sb = new StringBundler();
 
 					sb.append("The required property \"");
 					sb.append(requiredPropertySchemaName);

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
@@ -320,7 +320,7 @@ public class FreeMarkerTool {
 		List<JavaMethodSignature> javaMethodSignatures,
 		OpenAPIYAML openAPIYAML) {
 
-		StringBuilder sb = new StringBuilder();
+		StringBundler sb = new StringBundler();
 
 		sb.append("Invoke this method with the command line:\n*\n* ");
 		sb.append("curl -H 'Content-Type: text/plain; charset=utf-8' ");
@@ -579,7 +579,7 @@ public class FreeMarkerTool {
 				continue;
 			}
 
-			StringBuilder sb = new StringBuilder();
+			StringBundler sb = new StringBundler();
 
 			sb.append(getHTTPMethod(operation));
 
@@ -670,7 +670,7 @@ public class FreeMarkerTool {
 		ConfigYAML configYAML, JavaMethodSignature javaMethodSignature,
 		OpenAPIYAML openAPIYAML) {
 
-		StringBuilder sb = new StringBuilder();
+		StringBundler sb = new StringBundler();
 
 		sb.append("Invoke this method with the command line:\n*\n* ");
 		sb.append("curl -X '");
@@ -877,7 +877,7 @@ public class FreeMarkerTool {
 		List<JavaMethodSignature> javaMethodSignatures,
 		OpenAPIYAML openAPIYAML) {
 
-		StringBuilder sb = new StringBuilder("{\"query\": \"query {");
+		StringBundler sb = new StringBundler("{\"query\": \"query {");
 
 		sb.append(
 			getGraphQLPropertyName(javaMethodSignature, javaMethodSignatures));
@@ -1075,7 +1075,7 @@ public class FreeMarkerTool {
 	private String _getRESTBody(
 		JavaMethodSignature javaMethodSignature, OpenAPIYAML openAPIYAML) {
 
-		StringBuilder sb = new StringBuilder();
+		StringBundler sb = new StringBundler();
 
 		Set<String> properties = new TreeSet<>();
 

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
@@ -320,7 +320,7 @@ public class FreeMarkerTool {
 		List<JavaMethodSignature> javaMethodSignatures,
 		OpenAPIYAML openAPIYAML) {
 
-		StringBundler sb = new StringBundler();
+		StringBundler sb = new StringBundler(5);
 
 		sb.append("Invoke this method with the command line:\n*\n* curl -H ");
 		sb.append("'Content-Type: text/plain; charset=utf-8' -X 'POST' ");
@@ -578,7 +578,7 @@ public class FreeMarkerTool {
 				continue;
 			}
 
-			StringBundler sb = new StringBundler();
+			StringBundler sb = new StringBundler(3);
 
 			sb.append(getHTTPMethod(operation));
 
@@ -669,7 +669,7 @@ public class FreeMarkerTool {
 		ConfigYAML configYAML, JavaMethodSignature javaMethodSignature,
 		OpenAPIYAML openAPIYAML) {
 
-		StringBundler sb = new StringBundler();
+		StringBundler sb = new StringBundler(10);
 
 		sb.append("Invoke this method with the command line:\n*\n* curl -X '");
 		sb.append(

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
@@ -322,10 +322,9 @@ public class FreeMarkerTool {
 
 		StringBundler sb = new StringBundler();
 
-		sb.append("Invoke this method with the command line:\n*\n* ");
-		sb.append("curl -H 'Content-Type: text/plain; charset=utf-8' ");
-		sb.append("-X 'POST' 'http://localhost:8080/o/graphql' ");
-		sb.append("-d $'");
+		sb.append("Invoke this method with the command line:\n*\n* curl -H ");
+		sb.append("'Content-Type: text/plain; charset=utf-8' -X 'POST' ");
+		sb.append("'http://localhost:8080/o/graphql' -d $'");
 		sb.append(
 			_getGraphQLBody(
 				javaMethodSignature, javaMethodSignatures, openAPIYAML));
@@ -672,8 +671,7 @@ public class FreeMarkerTool {
 
 		StringBundler sb = new StringBundler();
 
-		sb.append("Invoke this method with the command line:\n*\n* ");
-		sb.append("curl -X '");
+		sb.append("Invoke this method with the command line:\n*\n* curl -X '");
 		sb.append(
 			StringUtil.toUpperCase(
 				OpenAPIParserUtil.getHTTPMethod(
@@ -919,10 +917,7 @@ public class FreeMarkerTool {
 		String returnType = javaMethodSignature.getReturnType();
 
 		if (returnType.startsWith("java.util.Collection<")) {
-			sb.append("items {__}, ");
-			sb.append("page, ");
-			sb.append("pageSize, ");
-			sb.append("totalCount");
+			sb.append("items {__}, page, pageSize, totalCount");
 		}
 		else {
 			Map<String, Schema> schemas = getSchemas(openAPIYAML);

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/util/OpenAPIParserUtil.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/util/OpenAPIParserUtil.java
@@ -370,7 +370,7 @@ public class OpenAPIParserUtil {
 			OpenAPIUtil.getGlobalEnumSchemas(openAPIYAML);
 
 		for (String schemaName : globalEnumSchemas.keySet()) {
-			StringBuilder sb = new StringBuilder();
+			StringBundler sb = new StringBundler();
 
 			sb.append(configYAML.getApiPackagePath());
 			sb.append(".constant.");
@@ -421,7 +421,7 @@ public class OpenAPIParserUtil {
 	public static String getParameter(
 		JavaMethodParameter javaMethodParameter, String parameterAnnotation) {
 
-		StringBuilder sb = new StringBuilder();
+		StringBundler sb = new StringBundler();
 
 		if (Validator.isNotNull(parameterAnnotation)) {
 			sb.append(parameterAnnotation);

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/util/OpenAPIParserUtil.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/util/OpenAPIParserUtil.java
@@ -370,7 +370,7 @@ public class OpenAPIParserUtil {
 			OpenAPIUtil.getGlobalEnumSchemas(openAPIYAML);
 
 		for (String schemaName : globalEnumSchemas.keySet()) {
-			StringBundler sb = new StringBundler();
+			StringBundler sb = new StringBundler(5);
 
 			sb.append(configYAML.getApiPackagePath());
 			sb.append(".constant.");
@@ -421,7 +421,7 @@ public class OpenAPIParserUtil {
 	public static String getParameter(
 		JavaMethodParameter javaMethodParameter, String parameterAnnotation) {
 
-		StringBundler sb = new StringBundler();
+		StringBundler sb = new StringBundler(6);
 
 		if (Validator.isNotNull(parameterAnnotation)) {
 			sb.append(parameterAnnotation);

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/GradleIndentationCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/GradleIndentationCheck.java
@@ -106,7 +106,7 @@ public class GradleIndentationCheck extends BaseFileCheck {
 			return line;
 		}
 
-		StringBuilder sb = new StringBuilder();
+		StringBundler sb = new StringBundler();
 
 		for (int i = 0; i < expectedTabCount; i++) {
 			sb.append(StringPool.TAB);

--- a/portal-impl/src/com/liferay/portal/dao/sql/transformer/BaseSQLTransformerLogic.java
+++ b/portal-impl/src/com/liferay/portal/dao/sql/transformer/BaseSQLTransformerLogic.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.dao.sql.transformer;
 
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.internal.dao.sql.transformer.SQLFunctionTransformer;
 import com.liferay.portal.kernel.dao.db.DB;
@@ -142,7 +143,7 @@ public abstract class BaseSQLTransformerLogic implements SQLTransformerLogic {
 				return sql;
 			}
 
-			StringBuilder sb = new StringBuilder(sql.length());
+			StringBundler sb = new StringBundler(sql.length());
 
 			int y = 0;
 

--- a/portal-impl/src/com/liferay/portal/javadoc/JavadocUtil.java
+++ b/portal-impl/src/com/liferay/portal/javadoc/JavadocUtil.java
@@ -76,7 +76,7 @@ public class JavadocUtil {
 			return className;
 		}
 
-		StringBuilder sb = new StringBuilder(bracketCount);
+		StringBundler sb = new StringBundler(bracketCount);
 
 		for (int i = 0; i < bracketCount; i++) {
 			sb.append('[');

--- a/portal-impl/src/com/liferay/portal/servlet/filters/dynamiccss/DynamicCSSUtil.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/dynamiccss/DynamicCSSUtil.java
@@ -93,7 +93,7 @@ public class DynamicCSSUtil {
 	protected static String propagateQueryString(
 		String content, String queryString) {
 
-		StringBuilder sb = new StringBuilder(content.length());
+		StringBundler sb = new StringBundler(content.length());
 
 		int pos = 0;
 

--- a/portal-impl/src/com/liferay/portal/tools/JavadocBuilder.java
+++ b/portal-impl/src/com/liferay/portal/tools/JavadocBuilder.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.tools;
 
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.petra.xml.DocUtil;
 import com.liferay.portal.kernel.io.unsync.UnsyncStringReader;
@@ -526,7 +527,7 @@ public class JavadocBuilder {
 	}
 
 	private String _getMethodKey(Element methodElement) {
-		StringBuilder sb = new StringBuilder();
+		StringBundler sb = new StringBundler();
 
 		sb.append(methodElement.elementText("name"));
 		sb.append(StringPool.OPEN_PARENTHESIS);
@@ -546,7 +547,7 @@ public class JavadocBuilder {
 	}
 
 	private String _getMethodKey(JavaMethod javaMethod) {
-		StringBuilder sb = new StringBuilder();
+		StringBundler sb = new StringBundler();
 
 		sb.append(javaMethod.getName());
 		sb.append(StringPool.OPEN_PARENTHESIS);
@@ -720,7 +721,7 @@ public class JavadocBuilder {
 			}
 		}
 
-		StringBuilder sb = new StringBuilder(oldContent.length());
+		StringBundler sb = new StringBundler(oldContent.length());
 
 		for (String line : lines) {
 			if (line != null) {
@@ -832,7 +833,7 @@ public class JavadocBuilder {
 				_getJavaFieldComment(lines, fieldElementsMap, javaField));
 		}
 
-		StringBuilder sb = new StringBuilder(oldContent.length());
+		StringBundler sb = new StringBundler(oldContent.length());
 
 		for (int lineNumber = 1; lineNumber <= lines.length; lineNumber++) {
 			String line = lines[lineNumber - 1];

--- a/portal-impl/src/com/liferay/portal/tools/SPDXBuilder.java
+++ b/portal-impl/src/com/liferay/portal/tools/SPDXBuilder.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.tools;
 
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.petra.xml.Dom4jUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
@@ -307,7 +308,7 @@ public class SPDXBuilder {
 	}
 
 	private String _getKey(String type, Element libraryElement) {
-		StringBuilder sb = new StringBuilder();
+		StringBundler sb = new StringBundler();
 
 		sb.append(StringUtil.upperCase(type));
 		sb.append(StringPool.COLON);
@@ -394,7 +395,7 @@ public class SPDXBuilder {
 
 	@SuppressWarnings("unchecked")
 	private String _toCSV(Document document) {
-		StringBuilder sb = new StringBuilder();
+		StringBundler sb = new StringBundler();
 
 		sb.append("File Name,Version,Project,License,Comments");
 

--- a/portal-impl/src/com/liferay/portal/tools/SPDXBuilder.java
+++ b/portal-impl/src/com/liferay/portal/tools/SPDXBuilder.java
@@ -308,7 +308,7 @@ public class SPDXBuilder {
 	}
 
 	private String _getKey(String type, Element libraryElement) {
-		StringBundler sb = new StringBundler();
+		StringBundler sb = new StringBundler(5);
 
 		sb.append(StringUtil.upperCase(type));
 		sb.append(StringPool.COLON);

--- a/portal-impl/src/com/liferay/portal/util/HtmlImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/HtmlImpl.java
@@ -535,7 +535,7 @@ public class HtmlImpl implements Html {
 			return xPath;
 		}
 
-		StringBuilder sb = new StringBuilder(xPath.length());
+		StringBundler sb = new StringBundler(xPath.length());
 
 		for (int i = 0; i < xPath.length(); i++) {
 			char c = xPath.charAt(i);
@@ -754,7 +754,7 @@ public class HtmlImpl implements Html {
 
 		text = stripComments(text);
 
-		StringBuilder sb = new StringBuilder(text.length());
+		StringBundler sb = new StringBundler(text.length());
 
 		int x = 0;
 		int y = text.indexOf("<");

--- a/portal-impl/src/com/liferay/portal/util/LicenseUtil.java
+++ b/portal-impl/src/com/liferay/portal/util/LicenseUtil.java
@@ -573,7 +573,7 @@ public class LicenseUtil {
 					continue;
 				}
 
-				StringBuilder sb = new StringBuilder(
+				StringBundler sb = new StringBundler(
 					(hardwareAddress.length * 3) - 1);
 
 				String hexString = StringUtil.bytesToHexString(hardwareAddress);

--- a/portal-impl/test/unit/com/liferay/portal/util/HtmlImplTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/util/HtmlImplTest.java
@@ -81,7 +81,7 @@ public class HtmlImplTest {
 
 	@Test
 	public void testEscapeExtendedASCIICharacters() {
-		StringBuilder sb = new StringBuilder(256);
+		StringBundler sb = new StringBundler(256);
 
 		for (int i = 0; i < 256; i++) {
 			if (Character.isLetterOrDigit(i)) {

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/search/RowChecker.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/search/RowChecker.java
@@ -200,7 +200,7 @@ public class RowChecker {
 			return StringPool.BLANK;
 		}
 
-		StringBuilder sb = new StringBuilder(10);
+		StringBundler sb = new StringBundler(10);
 
 		sb.append("<label><input name=\"");
 		sb.append(name);

--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/taglib/aui/VariableUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/taglib/aui/VariableUtil.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.kernel.servlet.taglib.aui;
 
 import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 
 import java.util.Arrays;
@@ -33,7 +34,7 @@ public class VariableUtil {
 	public static String generateVariable(
 		String module, Set<String> usedVariables) {
 
-		StringBuilder sb = new StringBuilder(module.length());
+		StringBundler sb = new StringBundler(module.length());
 
 		char c = module.charAt(0);
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/Base64.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/Base64.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.kernel.util;
 
 import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.io.ProtectedObjectInputStream;
 import com.liferay.portal.kernel.io.unsync.UnsyncByteArrayInputStream;
 import com.liferay.portal.kernel.io.unsync.UnsyncByteArrayOutputStream;
@@ -120,7 +121,7 @@ public class Base64 {
 
 		int lastIndex = Math.min(raw.length, offset + length);
 
-		StringBuilder sb = new StringBuilder(
+		StringBundler sb = new StringBundler(
 			(((lastIndex - offset) / 3) + 1) * 4);
 
 		for (int i = offset; i < lastIndex; i += 3) {

--- a/portal-kernel/src/com/liferay/portal/kernel/util/CamelCaseUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/CamelCaseUtil.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.kernel.util;
 
 import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringBundler;
 
 /**
  * @author Igor Spasic
@@ -27,7 +28,7 @@ public class CamelCaseUtil {
 	}
 
 	public static String fromCamelCase(String s, char delimiter) {
-		StringBuilder sb = new StringBuilder();
+		StringBundler sb = new StringBundler();
 
 		boolean upperCase = false;
 
@@ -106,7 +107,7 @@ public class CamelCaseUtil {
 	}
 
 	public static String toCamelCase(String s, char delimiter) {
-		StringBuilder sb = new StringBuilder(s.length());
+		StringBundler sb = new StringBundler(s.length());
 
 		boolean upperCase = false;
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/DeterminateKeyGenerator.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/DeterminateKeyGenerator.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.kernel.util;
 
 import com.liferay.petra.lang.CentralizedThreadLocal;
+import com.liferay.petra.string.StringBundler;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -56,7 +57,7 @@ public class DeterminateKeyGenerator {
 			seed = previousSeed;
 		}
 
-		StringBuilder sb = new StringBuilder(length);
+		StringBundler sb = new StringBundler(length);
 
 		for (int i = 0; i < length; i++) {
 			int index = 0;

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PwdGenerator.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PwdGenerator.java
@@ -53,7 +53,7 @@ public class PwdGenerator {
 
 		long secureLong = 0;
 
-		StringBuilder sb = new StringBuilder(length);
+		StringBundler sb = new StringBundler(length);
 
 		for (int i = 0; i < length; i++) {
 			if ((i % refreshPeriod) == 0) {

--- a/portal-kernel/src/com/liferay/portal/kernel/util/StringUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/StringUtil.java
@@ -2280,7 +2280,7 @@ public class StringUtil {
 			return s;
 		}
 
-		StringBuilder sb = new StringBuilder(s.length());
+		StringBundler sb = new StringBundler(s.length());
 
 		iterate:
 		for (int i = 0; i < s.length(); i++) {

--- a/portal-kernel/src/com/liferay/portal/kernel/util/TextFormatter.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/TextFormatter.java
@@ -285,7 +285,7 @@ public class TextFormatter {
 	}
 
 	private static String _formatH(String s) {
-		StringBuilder sb = new StringBuilder(s.length() * 2);
+		StringBundler sb = new StringBundler(s.length() * 2);
 
 		for (int i = 0; i < s.length(); i++) {
 			char c = s.charAt(i);
@@ -384,7 +384,7 @@ public class TextFormatter {
 	}
 
 	private static String _formatM(String s) {
-		StringBuilder sb = new StringBuilder(s.length());
+		StringBundler sb = new StringBundler(s.length());
 
 		for (int i = 0; i < s.length(); i++) {
 			char c = s.charAt(i);

--- a/portal-kernel/src/com/liferay/portal/kernel/util/UnicodeFormatter.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/UnicodeFormatter.java
@@ -102,7 +102,7 @@ public class UnicodeFormatter {
 			return hexString;
 		}
 
-		StringBuilder sb = new StringBuilder();
+		StringBundler sb = new StringBundler();
 
 		for (int i = 2; i < hexString.length(); i = i + 6) {
 			String s = hexString.substring(i, i + 4);
@@ -123,7 +123,7 @@ public class UnicodeFormatter {
 	}
 
 	public static String toString(char[] array) {
-		StringBuilder sb = new StringBuilder(array.length * 6);
+		StringBundler sb = new StringBundler(array.length * 6);
 
 		char[] hexes = new char[4];
 
@@ -140,7 +140,7 @@ public class UnicodeFormatter {
 			return null;
 		}
 
-		StringBuilder sb = new StringBuilder(s.length() * 6);
+		StringBundler sb = new StringBundler(s.length() * 6);
 
 		char[] hexes = new char[4];
 

--- a/portal-kernel/src/com/liferay/social/kernel/model/BaseSocialAchievement.java
+++ b/portal-kernel/src/com/liferay/social/kernel/model/BaseSocialAchievement.java
@@ -17,6 +17,7 @@ package com.liferay.social.kernel.model;
 import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.asset.kernel.service.AssetEntryLocalServiceUtil;
 import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.bean.BeanPropertiesUtil;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -167,7 +168,7 @@ public class BaseSocialAchievement implements SocialAchievement {
 			return;
 		}
 
-		StringBuilder sb = new StringBuilder(name.length());
+		StringBundler sb = new StringBundler(name.length());
 
 		for (int i = 0; i < name.length(); i++) {
 			char c = name.charAt(i);

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/internal/servlet/RestrictedByteArrayCacheOutputStreamTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/internal/servlet/RestrictedByteArrayCacheOutputStreamTest.java
@@ -225,7 +225,7 @@ public class RestrictedByteArrayCacheOutputStreamTest {
 				new RestrictedByteArrayCacheOutputStream(
 					unsyncByteArrayOutputStream, 10, 27, flushPreAction);
 
-		StringBuilder sb = new StringBuilder(26);
+		StringBundler sb = new StringBundler(26);
 
 		for (int i = 'a'; i <= 'z'; i++) {
 			restrictedByteArrayCacheOutputStream.write(i);

--- a/test.properties
+++ b/test.properties
@@ -5268,7 +5268,11 @@
     #
 
     search.engine[workflow-es7-remote]=remote-elasticsearch7
-    test.batch.class.names.includes[workflow-es7-remote]=${test.batch.class.names.includes[workflow]}
+
+    test.batch.class.names.includes[workflow-es7-remote]=\
+        **/apps/portal-workflow/**/*Test.java,\
+        **/dxp/apps/portal-workflow/**/*Test.java
+
     test.batch.dist.app.servers[workflow-es7-remote]=tomcat
 
     test.batch.names[workflow-es7-remote]=\
@@ -5277,10 +5281,18 @@
         modules-integration-mysql57-jdk8
 
     test.batch.run.property.query[functional-tomcat90-mysql57-jdk8][workflow-es7-remote]=\
-        ${test.batch.run.property.query[functional-tomcat90-mysql57-jdk8][workflow]}
+        (portal.acceptance != quarantine AND portal.upstream != quarantine) AND \
+        (\
+            (testray.main.component.name == "Kaleo Designer") OR \
+            (testray.main.component.name == "Workflow Metrics") OR \
+            (testray.main.component.name == "Workflow")\
+        )
 
     test.batch.run.property.query[functional-upgrade-tomcat90-mysql57-jdk8][workflow-es7-remote]=\
-        ${test.batch.run.property.query[functional-upgrade-tomcat90-mysql57-jdk8][workflow]}
+        (portal.acceptance != quarantine AND portal.upstream != quarantine) AND \
+        (\
+            (testray.main.component.name == "Upgrades Workflow")\
+        )
 
     #
     # Workflow Metrics

--- a/util-java/src/com/liferay/util/transport/MulticastClientTool.java
+++ b/util-java/src/com/liferay/util/transport/MulticastClientTool.java
@@ -14,6 +14,8 @@
 
 package com.liferay.util.transport;
 
+import com.liferay.petra.string.StringBundler;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -35,7 +37,7 @@ public class MulticastClientTool {
 		catch (Exception exception) {
 			exception.printStackTrace();
 
-			StringBuilder sb = new StringBuilder(3);
+			StringBundler sb = new StringBundler(3);
 
 			sb.append("Usage: java -classpath util-java.jar ");
 			sb.append(MulticastClientTool.class.getName());

--- a/util-taglib/src/com/liferay/taglib/search/ButtonSearchEntry.java
+++ b/util-taglib/src/com/liferay/taglib/search/ButtonSearchEntry.java
@@ -14,6 +14,7 @@
 
 package com.liferay.taglib.search;
 
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.bean.BeanPropertiesUtil;
 
 import java.io.Writer;
@@ -41,7 +42,7 @@ public class ButtonSearchEntry extends TextSearchEntry {
 			HttpServletResponse httpServletResponse)
 		throws Exception {
 
-		StringBuilder sb = new StringBuilder();
+		StringBundler sb = new StringBundler();
 
 		sb.append("<input type=\"button\" value=\"");
 		sb.append(getName());

--- a/util-taglib/src/com/liferay/taglib/search/ButtonSearchEntry.java
+++ b/util-taglib/src/com/liferay/taglib/search/ButtonSearchEntry.java
@@ -42,7 +42,7 @@ public class ButtonSearchEntry extends TextSearchEntry {
 			HttpServletResponse httpServletResponse)
 		throws Exception {
 
-		StringBundler sb = new StringBundler();
+		StringBundler sb = new StringBundler(5);
 
 		sb.append("<input type=\"button\" value=\"");
 		sb.append(getName());


### PR DESCRIPTION
From @noornajj :

> https://issues.liferay.com/browse/LPS-131302
> 
> The issue here is that the info button does not appear for searched documents that have a preview. This was occurring because all documents with a preview were being viewed by view_file_entry_simple_view.jsp. There is a condition to skip this view if showExtraInfo is equal to true, but this value was always set to false.
> To fix this, I removed the use of view_file_entry_simple_view.jsp and had all file entries be viewed by view_file_entry.jsp. I saw that view_file_entry_simple_view.jsp was introduced in LPS-42026 and tested the issue reported in this ticket and was not able to reproduce it with this change.
> After this change, there is no use for view_file_entry_simple_view.jsp. I will leave the decision on whether this fix is appropriate and if view_file_entry_simple_view.jsp should be deleted to the product team.
