### PR TITLE
LPS-131382 no need to load the react component if do you not have permissions

### DIFF
--- a/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/translate.jsp
+++ b/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/translate.jsp
@@ -198,8 +198,10 @@ renderResponse.setTitle(translateDisplayContext.getTitle());
 		</clay:container-fluid>
 	</aui:form>
 
-	<react:component
-		module="js/translate/Translate"
-		props="<%= translateDisplayContext.getInfoFieldSetEntriesData() %>"
-	/>
+	<c:if test="<%= translateDisplayContext.hasTranslationPermission() %>">
+		<react:component
+			module="js/translate/Translate"
+			props="<%= translateDisplayContext.getInfoFieldSetEntriesData() %>"
+		/>
+	</c:if>
 </div>


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-131382

If there is not permission to the article or the article is unreachable, there is no need to load the react component that was throwing the error of the translation component cause the InfoFieldSetEntriesData was null.

So I decided that there is no need to load it if there is no permission and that shows the message that it expected to be shown.

![image](https://user-images.githubusercontent.com/47524751/116683415-def68180-a9af-11eb-959a-6804ba39eea4.png)


As [said on the ticket,](https://issues.liferay.com/browse/LPS-131382?focusedCommentId=2430258&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-2430258) the error on console is thrown on the previous page and if they do not want it to be shown is another issue