### PR TITLE
LPS-131065 Translate automatically specific fields

### DIFF
--- a/modules/apps/translation/translation-api/src/main/java/com/liferay/translation/translator/JSONTranslatorPacket.java
+++ b/modules/apps/translation/translation-api/src/main/java/com/liferay/translation/translator/JSONTranslatorPacket.java
@@ -14,10 +14,8 @@
 
 package com.liferay.translation.translator;
 
-import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONObject;
 
-import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -32,16 +30,10 @@ public class JSONTranslatorPacket implements TranslatorPacket {
 
 		_fieldsMap = new LinkedHashMap<>();
 
-		JSONArray fieldsJSONArray = jsonObject.getJSONArray("fields");
+		JSONObject fieldsJSONObject = jsonObject.getJSONObject("fields");
 
-		for (Object object : fieldsJSONArray) {
-			JSONObject fieldJSONObject = (JSONObject)object;
-
-			Iterator<String> iterator = fieldJSONObject.keys();
-
-			String key = iterator.next();
-
-			_fieldsMap.put(key, fieldJSONObject.getString(key));
+		for (String key : fieldsJSONObject.keySet()) {
+			_fieldsMap.put(key, fieldsJSONObject.getString(key));
 		}
 	}
 

--- a/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/display/context/TranslateDisplayContext.java
+++ b/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/display/context/TranslateDisplayContext.java
@@ -233,7 +233,7 @@ public class TranslateDisplayContext {
 				"targetLanguageId", getTargetLanguageId()
 			).build()
 		).put(
-			"autoTranslateButtonVisible", isAutoTranslateButtonVisible()
+			"autoTranslateEnabled", isAutoTranslateEnabled()
 		).put(
 			"getAutoTranslateURL", getAutoTranslateURL()
 		).put(
@@ -403,7 +403,7 @@ public class TranslateDisplayContext {
 		return true;
 	}
 
-	public boolean isAutoTranslateButtonVisible() {
+	public boolean isAutoTranslateEnabled() {
 		if (_ffAutoTranslateConfiguration.enabled() &&
 			hasTranslationPermission()) {
 

--- a/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/servlet/AutoTranslateServlet.java
+++ b/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/servlet/AutoTranslateServlet.java
@@ -17,8 +17,8 @@ package com.liferay.translation.web.internal.servlet;
 import com.liferay.petra.io.StreamUtil;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
-import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -84,19 +84,19 @@ public class AutoTranslateServlet extends HttpServlet {
 		}
 	}
 
-	private JSONArray _getContentJSONArray(Map<String, String> fieldsMap) {
-		JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
+	private JSONObject _getFieldsJSONObject(Map<String, String> fieldsMap) {
+		JSONObject jsonObject = JSONFactoryUtil.createJSONObject();
 
 		for (Map.Entry<String, String> entry : fieldsMap.entrySet()) {
-			jsonArray.put(JSONUtil.put(entry.getKey(), entry.getValue()));
+			jsonObject.put(entry.getKey(), entry.getValue());
 		}
 
-		return jsonArray;
+		return jsonObject;
 	}
 
 	private String _toJSON(TranslatorPacket translatorPacket) {
 		return JSONUtil.put(
-			"fields", _getContentJSONArray(translatorPacket.getFieldsMap())
+			"fields", _getFieldsJSONObject(translatorPacket.getFieldsMap())
 		).put(
 			"sourceLanguageId", translatorPacket.getSourceLanguageId()
 		).put(

--- a/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/css/main.scss
@@ -106,6 +106,20 @@ $productMenuWidth: 320px;
 			}
 		}
 
+		.col-autotranslate-field {
+			margin-bottom: 1rem;
+			padding-left: 12px;
+			width: 100%;
+
+			@include media-breakpoint-up(md) {
+				margin-bottom: 0;
+				padding-left: 0.25rem;
+				padding-right: 0.75rem;
+				padding-top: 1.625rem;
+				width: auto;
+			}
+		}
+
 		.fieldset-title {
 			font-size: 0.875rem;
 			font-weight: 700;
@@ -115,6 +129,17 @@ $productMenuWidth: 320px;
 
 		.form-control[readonly] {
 			background-color: #fff;
+		}
+
+		.row .row {
+			margin-left: 0;
+			margin-right: 0;
+		}
+
+		.row-autotranslate-title {
+			@include media-breakpoint-up(md) {
+				padding-right: 3.5rem;
+			}
 		}
 
 		.separator {

--- a/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/translate/Translate.js
+++ b/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/translate/Translate.js
@@ -24,6 +24,13 @@ import TranslateFieldSetEntries from './components/TranslateFieldSetEntries';
 import TranslateHeader from './components/TranslateHeader';
 import {FETCH_STATUS} from './constants';
 
+const normalizeFields = (fields) =>
+	fields.reduce((acc, field) => {
+		const [id, content] = Object.entries(field)[0];
+
+		return {...acc, [id]: content};
+	}, {});
+
 const ACTION_TYPES = {
 	UPDATE_FETCH_STATUS: 'UPDATE_FETCH_STATUS',
 	UPDATE_FIELD: 'UPDATE_FIELD',
@@ -148,11 +155,7 @@ const Translate = ({
 
 				if (isMounted()) {
 					dispatch({
-						payload: fields.reduce((acc, field) => {
-							const [id, content] = Object.entries(field)[0];
-
-							return {...acc, [id]: content};
-						}, {}),
+						payload: normalizeFields(fields),
 						type: ACTION_TYPES.UPDATE_FIELDS_BULK,
 					});
 
@@ -198,11 +201,7 @@ const Translate = ({
 
 			if (isMounted()) {
 				dispatch({
-					payload: fields.reduce((acc, field) => {
-						const [id, content] = Object.entries(field)[0];
-
-						return {...acc, [id]: content};
-					}, {}),
+					payload: normalizeFields(fields),
 					type: ACTION_TYPES.UPDATE_FIELD,
 				});
 			}

--- a/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/translate/Translate.js
+++ b/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/translate/Translate.js
@@ -52,14 +52,14 @@ const getInfoFields = (infoFieldSetEntries = []) => {
 	};
 };
 
-const normalizeFields = (fields = []) =>
+const massageResponseFields = (fields = []) =>
 	fields.reduce((acc, field) => {
 		const [id, content] = Object.entries(field)[0];
 
 		return {...acc, [id]: {content}};
 	}, {});
 
-const denormalizeFields = (fields = {}) =>
+const prepareFields = (fields = {}) =>
 	Object.entries(fields).map(([key, value]) => ({[key]: value}));
 
 const reducer = (state, action) => {
@@ -158,7 +158,7 @@ const Translate = ({
 			type: ACTION_TYPES.UPDATE_FETCH_STATUS,
 		});
 
-		fetchAutoTranslation({fields: denormalizeFields(sourceFields)})
+		fetchAutoTranslation({fields: prepareFields(sourceFields)})
 			.then(({error, fields}) => {
 				if (error) {
 					throw error;
@@ -166,7 +166,7 @@ const Translate = ({
 
 				if (isMounted()) {
 					dispatch({
-						payload: normalizeFields(fields),
+						payload: massageResponseFields(fields),
 						type: ACTION_TYPES.UPDATE_FIELDS_BULK,
 					});
 
@@ -207,7 +207,7 @@ const Translate = ({
 		});
 
 		fetchAutoTranslation({
-			fields: denormalizeFields({[fieldId]: sourceFields[fieldId]}),
+			fields: prepareFields({[fieldId]: sourceFields[fieldId]}),
 		})
 			.then(({error, fields}) => {
 				if (error) {
@@ -216,7 +216,7 @@ const Translate = ({
 
 				if (isMounted()) {
 					const [id, {content}] = Object.entries(
-						normalizeFields(fields)
+						massageResponseFields(fields)
 					)[0];
 
 					dispatch({

--- a/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/translate/Translate.js
+++ b/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/translate/Translate.js
@@ -140,7 +140,7 @@ const Translate = ({
 		});
 	};
 
-	const fetchAutoTranslate = ({fields}) =>
+	const fetchAutoTranslation = ({fields}) =>
 		fetch(getAutoTranslateURL, {
 			body: JSON.stringify({
 				fields,
@@ -158,7 +158,7 @@ const Translate = ({
 			type: ACTION_TYPES.UPDATE_FETCH_STATUS,
 		});
 
-		fetchAutoTranslate({fields: denormalizeFields(sourceFields)})
+		fetchAutoTranslation({fields: denormalizeFields(sourceFields)})
 			.then(({error, fields}) => {
 				if (error) {
 					throw error;
@@ -206,7 +206,7 @@ const Translate = ({
 			type: ACTION_TYPES.UPDATE_FIELD,
 		});
 
-		fetchAutoTranslate({
+		fetchAutoTranslation({
 			fields: denormalizeFields({[fieldId]: sourceFields[fieldId]}),
 		})
 			.then(({error, fields}) => {

--- a/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/translate/Translate.js
+++ b/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/translate/Translate.js
@@ -73,7 +73,7 @@ const getInfoFields = (infoFieldSetEntries = []) => {
 
 const Translate = ({
 	aditionalFields,
-	autoTranslateButtonVisible = false,
+	autoTranslateEnabled = false,
 	getAutoTranslateURL,
 	infoFieldSetEntries,
 	portletNamespace,
@@ -206,7 +206,7 @@ const Translate = ({
 			))}
 
 			<TranslateActionBar
-				autoTranslateButtonVisible={autoTranslateButtonVisible}
+				autoTranslateEnabled={autoTranslateEnabled}
 				fetchAutoTranslateFields={fetchAutoTranslateFields}
 				fetchAutoTranslateStatus={state.fetchAutoTranslateStatus}
 				formHasChanges={state.formHasChanges}
@@ -250,7 +250,7 @@ const Translate = ({
 };
 
 Translate.propTypes = {
-	autoTranslateButtonVisible: PropTypes.bool,
+	autoTranslateEnabled: PropTypes.bool,
 	getAutoTranslateURL: PropTypes.string.isRequired,
 	infoFieldSetEntries: PropTypes.arrayOf(
 		PropTypes.shape({

--- a/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/translate/Translate.js
+++ b/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/translate/Translate.js
@@ -261,6 +261,7 @@ const Translate = ({
 							/>
 
 							<TranslateFieldSetEntries
+								autoTranslateEnabled={autoTranslateEnabled}
 								fetchAutoTranslateField={
 									fetchAutoTranslateField
 								}

--- a/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/translate/components/LanguageSelector.js
+++ b/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/translate/components/LanguageSelector.js
@@ -37,7 +37,7 @@ function LanguageSelector({languageIds, onChange, selectedLanguageId}) {
 			active={isDropdownOpen}
 			onActiveChange={setIsDropdownOpen}
 			trigger={
-				<ClayButton displayType="secondary" monospaced>
+				<ClayButton displayType="secondary" monospaced small>
 					<span className="inline-item">
 						<ClayIcon symbol={selectedLanguage.icon} />
 					</span>

--- a/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/translate/components/TranslateActionBar.js
+++ b/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/translate/components/TranslateActionBar.js
@@ -23,7 +23,7 @@ import React from 'react';
 import TranslateLanguagesSelector from './TranslateLanguagesSelector';
 
 const TransLateActionBar = ({
-	autoTranslateButtonVisible,
+	autoTranslateEnabled,
 	fetchAutoTranslateFields,
 	fetchAutoTranslateStatus,
 	formHasChanges,
@@ -45,7 +45,7 @@ const TransLateActionBar = ({
 				<ul className="tbar-nav">
 					<li
 						className={classNames('tbar-item', {
-							'tbar-item-expand': !autoTranslateButtonVisible,
+							'tbar-item-expand': !autoTranslateEnabled,
 						})}
 					>
 						<TranslateLanguagesSelector
@@ -54,7 +54,7 @@ const TransLateActionBar = ({
 							portletNamespace={portletNamespace}
 						/>
 					</li>
-					{autoTranslateButtonVisible && (
+					{autoTranslateEnabled && (
 						<>
 							<li className="tbar-item">
 								<ClayButton

--- a/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/translate/components/TranslateFieldSetEntries.js
+++ b/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/translate/components/TranslateFieldSetEntries.js
@@ -68,27 +68,30 @@ const TranslateAutoTranslateRow = ({
 };
 
 const TranslateFieldFeedback = ({message = '', status = ''}) => {
-	return status === FETCH_STATUS.ERROR || status === FETCH_STATUS.SUCCESS ? (
-		<div
-			className={classNames({
-				'has-error': status === FETCH_STATUS.ERROR,
-				'has-success': status === FETCH_STATUS.SUCCESS,
-			})}
-		>
-			<div className="form-feedback-item">
-				<span className="form-feedback-indicator mr-1">
-					<ClayIcon
-						symbol={
-							status === FETCH_STATUS.SUCCESS
-								? 'check-circle-full'
-								: 'exclamation-full'
-						}
-					/>
-				</span>
-				{message}
+	return (
+		status === FETCH_STATUS.ERROR ||
+		(status === FETCH_STATUS.SUCCESS && (
+			<div
+				className={classNames({
+					'has-error': status === FETCH_STATUS.ERROR,
+					'has-success': status === FETCH_STATUS.SUCCESS,
+				})}
+			>
+				<div className="form-feedback-item">
+					<span className="form-feedback-indicator mr-1">
+						<ClayIcon
+							symbol={
+								status === FETCH_STATUS.SUCCESS
+									? 'check-circle-full'
+									: 'exclamation-full'
+							}
+						/>
+					</span>
+					{message}
+				</div>
 			</div>
-		</div>
-	) : null;
+		))
+	);
 };
 
 const TranslateFieldEditor = ({

--- a/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/translate/components/TranslateFieldSetEntries.js
+++ b/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/translate/components/TranslateFieldSetEntries.js
@@ -16,12 +16,40 @@ import ClayButton from '@clayui/button';
 import ClayForm, {ClayInput} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import ClayLayout from '@clayui/layout';
+import classNames from 'classnames';
 import {ClassicEditor} from 'frontend-editor-ckeditor-web';
 import React from 'react';
 
 const noop = () => {};
 
+const TranslateAutoTranslateRow = ({
+	autoTranslateEnabled,
+	children,
+	handleAutoTranslateClick = noop,
+	label,
+}) =>
+	autoTranslateEnabled ? (
+		<ClayLayout.Row>
+			<ClayLayout.ContentCol expand>{children}</ClayLayout.ContentCol>
+			<ClayLayout.ContentCol className="align-self-top col-autotranslate-field">
+				<ClayButton
+					displayType="secondary"
+					monospaced
+					onClick={handleAutoTranslateClick}
+				>
+					<ClayIcon symbol="automatic-translate" />
+					<span className="sr-only">
+						Auto translate {label} field
+					</span>
+				</ClayButton>
+			</ClayLayout.ContentCol>
+		</ClayLayout.Row>
+	) : (
+		children
+	);
+
 const TranslateFieldEditor = ({
+	autoTranslateEnabled,
 	editorConfiguration,
 	id,
 	label,
@@ -30,41 +58,53 @@ const TranslateFieldEditor = ({
 	targetContent,
 	targetContentDir,
 	onChange = noop,
+	handleAutoTranslateClick,
 }) => (
-	<ClayLayout.Row>
-		<ClayLayout.Col md={6}>
-			<ClayForm.Group>
-				<label className="control-label">{label}</label>
-				<div
-					className="translation-editor-preview"
-					dangerouslySetInnerHTML={{__html: sourceContent}}
-					dir={sourceContentDir}
-				/>
-			</ClayForm.Group>
-		</ClayLayout.Col>
-		<ClayLayout.Col md={6}>
-			<ClayForm.Group>
-				<label className="control-label">{label}</label>
-				<ClassicEditor
-					data={targetContent}
-					editorConfig={{
-						...editorConfiguration.editorConfig,
-						contentsLangDirection: targetContentDir,
-					}}
-					name={id}
-					onChange={(data) => {
-						if (targetContent !== data.trim()) {
-							onChange(data);
-						}
-					}}
-				/>
-				<input defaultValue={targetContent} name={id} type="hidden" />
-			</ClayForm.Group>
-		</ClayLayout.Col>
-	</ClayLayout.Row>
+	<TranslateAutoTranslateRow
+		autoTranslateEnabled={autoTranslateEnabled}
+		handleAutoTranslateClick={handleAutoTranslateClick}
+		label={label}
+	>
+		<ClayLayout.Row>
+			<ClayLayout.Col md={6}>
+				<ClayForm.Group>
+					<label className="control-label">{label}</label>
+					<div
+						className="translation-editor-preview"
+						dangerouslySetInnerHTML={{__html: sourceContent}}
+						dir={sourceContentDir}
+					/>
+				</ClayForm.Group>
+			</ClayLayout.Col>
+			<ClayLayout.Col md={6}>
+				<ClayForm.Group>
+					<label className="control-label">{label}</label>
+					<ClassicEditor
+						data={targetContent}
+						editorConfig={{
+							...editorConfiguration.editorConfig,
+							contentsLangDirection: targetContentDir,
+						}}
+						name={id}
+						onChange={(data) => {
+							if (targetContent !== data.trim()) {
+								onChange(data);
+							}
+						}}
+					/>
+					<input
+						defaultValue={targetContent}
+						name={id}
+						type="hidden"
+					/>
+				</ClayForm.Group>
+			</ClayLayout.Col>
+		</ClayLayout.Row>
+	</TranslateAutoTranslateRow>
 );
 
 const TranslateFieldInput = ({
+	autoTranslateEnabled,
 	id,
 	label,
 	multiline,
@@ -73,58 +113,51 @@ const TranslateFieldInput = ({
 	targetContent,
 	targetContentDir,
 	onChange = noop,
-	handleAutoTranslateClick = noop,
+	handleAutoTranslateClick,
 }) => (
-	<ClayLayout.Row>
-		<ClayLayout.ContentCol expand>
-			<ClayLayout.Row>
-				<ClayLayout.Col md={6}>
-					<ClayForm.Group>
-						<label className="control-label">{label}</label>
-						<ClayInput
-							component={multiline ? 'textarea' : undefined}
-							defaultValue={sourceContent}
-							dir={sourceContentDir}
-							readOnly
-							type="text"
-						/>
-					</ClayForm.Group>
-				</ClayLayout.Col>
-				<ClayLayout.Col md={6}>
-					<ClayForm.Group>
-						<label className="control-label" htmlFor={id}>
-							{label}
-						</label>
-						<ClayInput
-							component={multiline ? 'textarea' : undefined}
-							dir={targetContentDir}
-							id={id}
-							name={id}
-							onChange={(event) => {
-								const data = event.target.value;
-								onChange(data);
-							}}
-							type="text"
-							value={targetContent}
-						/>
-					</ClayForm.Group>
-				</ClayLayout.Col>
-			</ClayLayout.Row>
-		</ClayLayout.ContentCol>
-		<ClayLayout.ContentCol className="align-self-top col-autotranslate-field">
-			<ClayButton
-				displayType="secondary"
-				monospaced
-				onClick={handleAutoTranslateClick}
-			>
-				<ClayIcon symbol="automatic-translate" />
-				<span className="sr-only">Auto translate {label} field</span>
-			</ClayButton>
-		</ClayLayout.ContentCol>
-	</ClayLayout.Row>
+	<TranslateAutoTranslateRow
+		autoTranslateEnabled={autoTranslateEnabled}
+		handleAutoTranslateClick={handleAutoTranslateClick}
+		label={label}
+	>
+		<ClayLayout.Row>
+			<ClayLayout.Col md={6}>
+				<ClayForm.Group>
+					<label className="control-label">{label}</label>
+					<ClayInput
+						component={multiline ? 'textarea' : undefined}
+						defaultValue={sourceContent}
+						dir={sourceContentDir}
+						readOnly
+						type="text"
+					/>
+				</ClayForm.Group>
+			</ClayLayout.Col>
+			<ClayLayout.Col md={6}>
+				<ClayForm.Group>
+					<label className="control-label" htmlFor={id}>
+						{label}
+					</label>
+					<ClayInput
+						component={multiline ? 'textarea' : undefined}
+						dir={targetContentDir}
+						id={id}
+						name={id}
+						onChange={(event) => {
+							const data = event.target.value;
+							onChange(data);
+						}}
+						type="text"
+						value={targetContent}
+					/>
+				</ClayForm.Group>
+			</ClayLayout.Col>
+		</ClayLayout.Row>
+	</TranslateAutoTranslateRow>
 );
 
 const TranslateFieldSetEntries = ({
+	autoTranslateEnabled,
 	fetchAutoTranslateField,
 	infoFieldSetEntries,
 	onChange,
@@ -133,7 +166,11 @@ const TranslateFieldSetEntries = ({
 }) =>
 	infoFieldSetEntries.map(({fields, legend}) => (
 		<React.Fragment key={legend}>
-			<ClayLayout.Row className="row-autotranslate-title">
+			<ClayLayout.Row
+				className={classNames({
+					'row-autotranslate-title': autoTranslateEnabled,
+				})}
+			>
 				<ClayLayout.Col md={6}>
 					<div className="fieldset-title">{legend}</div>
 				</ClayLayout.Col>
@@ -144,6 +181,7 @@ const TranslateFieldSetEntries = ({
 			{fields.map((field) => {
 				const fieldProps = {
 					...field,
+					autoTranslateEnabled,
 					handleAutoTranslateClick: () =>
 						fetchAutoTranslateField(field.id),
 					id: `${portletNamespace}${field.id}`,

--- a/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/translate/components/TranslateFieldSetEntries.js
+++ b/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/translate/components/TranslateFieldSetEntries.js
@@ -73,6 +73,7 @@ const TranslateFieldInput = ({
 	targetContent,
 	targetContentDir,
 	onChange = noop,
+	handleAutoTranslateClick = noop,
 }) => (
 	<ClayLayout.Row>
 		<ClayLayout.ContentCol expand>
@@ -111,7 +112,11 @@ const TranslateFieldInput = ({
 			</ClayLayout.Row>
 		</ClayLayout.ContentCol>
 		<ClayLayout.ContentCol className="align-self-top col-autotranslate-field">
-			<ClayButton displayType="secondary" monospaced>
+			<ClayButton
+				displayType="secondary"
+				monospaced
+				onClick={handleAutoTranslateClick}
+			>
 				<ClayIcon symbol="automatic-translate" />
 				<span className="sr-only">Auto translate {label} field</span>
 			</ClayButton>
@@ -120,6 +125,7 @@ const TranslateFieldInput = ({
 );
 
 const TranslateFieldSetEntries = ({
+	fetchAutoTranslateField,
 	infoFieldSetEntries,
 	onChange,
 	portletNamespace,
@@ -138,6 +144,8 @@ const TranslateFieldSetEntries = ({
 			{fields.map((field) => {
 				const fieldProps = {
 					...field,
+					handleAutoTranslateClick: () =>
+						fetchAutoTranslateField(field.id),
 					id: `${portletNamespace}${field.id}`,
 					onChange: (content) => {
 						onChange({content, id: field.id});

--- a/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/translate/components/TranslateFieldSetEntries.js
+++ b/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/translate/components/TranslateFieldSetEntries.js
@@ -91,7 +91,6 @@ const TranslateFieldFeedback = ({message = '', status = ''}) => {
 };
 
 const TranslateFieldEditor = ({
-	autoTranslateEnabled,
 	editorConfiguration,
 	fieldStatus,
 	id,
@@ -101,60 +100,46 @@ const TranslateFieldEditor = ({
 	targetContent,
 	targetContentDir,
 	onChange = noop,
-	handleAutoTranslateClick,
 }) => (
-	<TranslateAutoTranslateRow
-		autoTranslateEnabled={autoTranslateEnabled}
-		fieldStatus={fieldStatus}
-		handleAutoTranslateClick={handleAutoTranslateClick}
-		label={label}
-	>
-		<ClayLayout.Row>
-			<ClayLayout.Col md={6}>
-				<ClayForm.Group>
-					<label className="control-label">{label}</label>
-					<div
-						className="translation-editor-preview"
-						dangerouslySetInnerHTML={{__html: sourceContent}}
-						dir={sourceContentDir}
-					/>
-				</ClayForm.Group>
-			</ClayLayout.Col>
-			<ClayLayout.Col md={6}>
-				<ClayForm.Group>
-					<label className="control-label">{label}</label>
-					<ClassicEditor
-						data={targetContent}
-						editorConfig={{
-							...editorConfiguration.editorConfig,
-							contentsLangDirection: targetContentDir,
-						}}
-						name={id}
-						onChange={(data) => {
-							if (targetContent !== data.trim()) {
-								onChange(data);
-							}
-						}}
-					/>
-					<input
-						defaultValue={targetContent}
-						name={id}
-						type="hidden"
-					/>
-					<TranslateFieldFeedback
-						message={fieldStatus.message}
-						status={fieldStatus.status}
-					/>
-				</ClayForm.Group>
-			</ClayLayout.Col>
-		</ClayLayout.Row>
-	</TranslateAutoTranslateRow>
+	<ClayLayout.Row>
+		<ClayLayout.Col md={6}>
+			<ClayForm.Group>
+				<label className="control-label">{label}</label>
+				<div
+					className="translation-editor-preview"
+					dangerouslySetInnerHTML={{__html: sourceContent}}
+					dir={sourceContentDir}
+				/>
+			</ClayForm.Group>
+		</ClayLayout.Col>
+		<ClayLayout.Col md={6}>
+			<ClayForm.Group>
+				<label className="control-label">{label}</label>
+				<ClassicEditor
+					data={targetContent}
+					editorConfig={{
+						...editorConfiguration.editorConfig,
+						contentsLangDirection: targetContentDir,
+					}}
+					name={id}
+					onChange={(data) => {
+						if (targetContent !== data.trim()) {
+							onChange(data);
+						}
+					}}
+				/>
+				<input defaultValue={targetContent} name={id} type="hidden" />
+				<TranslateFieldFeedback
+					message={fieldStatus.message}
+					status={fieldStatus.status}
+				/>
+			</ClayForm.Group>
+		</ClayLayout.Col>
+	</ClayLayout.Row>
 );
 
 const TranslateFieldInput = ({
-	autoTranslateEnabled,
 	fieldStatus,
-	handleAutoTranslateClick,
 	id,
 	label,
 	multiline,
@@ -164,54 +149,47 @@ const TranslateFieldInput = ({
 	targetContent,
 	targetContentDir,
 }) => (
-	<TranslateAutoTranslateRow
-		autoTranslateEnabled={autoTranslateEnabled}
-		fieldStatus={fieldStatus}
-		handleAutoTranslateClick={handleAutoTranslateClick}
-		label={label}
-	>
-		<ClayLayout.Row>
-			<ClayLayout.Col md={6}>
-				<ClayForm.Group>
-					<label className="control-label">{label}</label>
-					<ClayInput
-						component={multiline ? 'textarea' : undefined}
-						defaultValue={sourceContent}
-						dir={sourceContentDir}
-						readOnly
-						type="text"
-					/>
-				</ClayForm.Group>
-			</ClayLayout.Col>
-			<ClayLayout.Col md={6}>
-				<ClayForm.Group>
-					<ClayLayout.Row>
-						<ClayLayout.ContentCol expand>
-							<label className="control-label" htmlFor={id}>
-								{label}
-							</label>
-						</ClayLayout.ContentCol>
-					</ClayLayout.Row>
-					<ClayInput
-						component={multiline ? 'textarea' : undefined}
-						dir={targetContentDir}
-						id={id}
-						name={id}
-						onChange={(event) => {
-							const data = event.target.value;
-							onChange(data);
-						}}
-						type="text"
-						value={targetContent}
-					/>
-					<TranslateFieldFeedback
-						message={fieldStatus.message}
-						status={fieldStatus.status}
-					/>
-				</ClayForm.Group>
-			</ClayLayout.Col>
-		</ClayLayout.Row>
-	</TranslateAutoTranslateRow>
+	<ClayLayout.Row>
+		<ClayLayout.Col md={6}>
+			<ClayForm.Group>
+				<label className="control-label">{label}</label>
+				<ClayInput
+					component={multiline ? 'textarea' : undefined}
+					defaultValue={sourceContent}
+					dir={sourceContentDir}
+					readOnly
+					type="text"
+				/>
+			</ClayForm.Group>
+		</ClayLayout.Col>
+		<ClayLayout.Col md={6}>
+			<ClayForm.Group>
+				<ClayLayout.Row>
+					<ClayLayout.ContentCol expand>
+						<label className="control-label" htmlFor={id}>
+							{label}
+						</label>
+					</ClayLayout.ContentCol>
+				</ClayLayout.Row>
+				<ClayInput
+					component={multiline ? 'textarea' : undefined}
+					dir={targetContentDir}
+					id={id}
+					name={id}
+					onChange={(event) => {
+						const data = event.target.value;
+						onChange(data);
+					}}
+					type="text"
+					value={targetContent}
+				/>
+				<TranslateFieldFeedback
+					message={fieldStatus.message}
+					status={fieldStatus.status}
+				/>
+			</ClayForm.Group>
+		</ClayLayout.Col>
+	</ClayLayout.Row>
 );
 
 const TranslateFieldSetEntries = ({
@@ -239,13 +217,10 @@ const TranslateFieldSetEntries = ({
 			{fields.map((field) => {
 				const fieldProps = {
 					...field,
-					autoTranslateEnabled,
 					fieldStatus: {
 						message: targetFieldsContent[field.id].message,
 						status: targetFieldsContent[field.id].status,
 					},
-					handleAutoTranslateClick: () =>
-						fetchAutoTranslateField(field.id),
 					id: `${portletNamespace}${field.id}`,
 					onChange: (content) => {
 						onChange({content, id: field.id});
@@ -253,10 +228,22 @@ const TranslateFieldSetEntries = ({
 					targetContent: targetFieldsContent[field.id].content,
 				};
 
-				return field.html ? (
-					<TranslateFieldEditor key={field.id} {...fieldProps} />
-				) : (
-					<TranslateFieldInput key={field.id} {...fieldProps} />
+				return (
+					<TranslateAutoTranslateRow
+						autoTranslateEnabled={autoTranslateEnabled}
+						fieldStatus={fieldProps.fieldStatus}
+						handleAutoTranslateClick={() =>
+							fetchAutoTranslateField(field.id)
+						}
+						key={field.id}
+						label={fieldProps.label}
+					>
+						{field.html ? (
+							<TranslateFieldEditor {...fieldProps} />
+						) : (
+							<TranslateFieldInput {...fieldProps} />
+						)}
+					</TranslateAutoTranslateRow>
 				);
 			})}
 		</React.Fragment>

--- a/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/translate/components/TranslateFieldSetEntries.js
+++ b/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/translate/components/TranslateFieldSetEntries.js
@@ -12,7 +12,9 @@
  * details.
  */
 
+import ClayButton from '@clayui/button';
 import ClayForm, {ClayInput} from '@clayui/form';
+import ClayIcon from '@clayui/icon';
 import ClayLayout from '@clayui/layout';
 import {ClassicEditor} from 'frontend-editor-ckeditor-web';
 import React from 'react';
@@ -73,37 +75,47 @@ const TranslateFieldInput = ({
 	onChange = noop,
 }) => (
 	<ClayLayout.Row>
-		<ClayLayout.Col md={6}>
-			<ClayForm.Group>
-				<label className="control-label">{label}</label>
-				<ClayInput
-					component={multiline ? 'textarea' : undefined}
-					defaultValue={sourceContent}
-					dir={sourceContentDir}
-					readOnly
-					type="text"
-				/>
-			</ClayForm.Group>
-		</ClayLayout.Col>
-		<ClayLayout.Col md={6}>
-			<ClayForm.Group>
-				<label className="control-label" htmlFor={id}>
-					{label}
-				</label>
-				<ClayInput
-					component={multiline ? 'textarea' : undefined}
-					dir={targetContentDir}
-					id={id}
-					name={id}
-					onChange={(event) => {
-						const data = event.target.value;
-						onChange(data);
-					}}
-					type="text"
-					value={targetContent}
-				/>
-			</ClayForm.Group>
-		</ClayLayout.Col>
+		<ClayLayout.ContentCol expand>
+			<ClayLayout.Row>
+				<ClayLayout.Col md={6}>
+					<ClayForm.Group>
+						<label className="control-label">{label}</label>
+						<ClayInput
+							component={multiline ? 'textarea' : undefined}
+							defaultValue={sourceContent}
+							dir={sourceContentDir}
+							readOnly
+							type="text"
+						/>
+					</ClayForm.Group>
+				</ClayLayout.Col>
+				<ClayLayout.Col md={6}>
+					<ClayForm.Group>
+						<label className="control-label" htmlFor={id}>
+							{label}
+						</label>
+						<ClayInput
+							component={multiline ? 'textarea' : undefined}
+							dir={targetContentDir}
+							id={id}
+							name={id}
+							onChange={(event) => {
+								const data = event.target.value;
+								onChange(data);
+							}}
+							type="text"
+							value={targetContent}
+						/>
+					</ClayForm.Group>
+				</ClayLayout.Col>
+			</ClayLayout.Row>
+		</ClayLayout.ContentCol>
+		<ClayLayout.ContentCol className="align-self-top col-autotranslate-field">
+			<ClayButton displayType="secondary" monospaced>
+				<ClayIcon symbol="automatic-translate" />
+				<span className="sr-only">Auto translate {label} field</span>
+			</ClayButton>
+		</ClayLayout.ContentCol>
 	</ClayLayout.Row>
 );
 
@@ -115,7 +127,7 @@ const TranslateFieldSetEntries = ({
 }) =>
 	infoFieldSetEntries.map(({fields, legend}) => (
 		<React.Fragment key={legend}>
-			<ClayLayout.Row>
+			<ClayLayout.Row className="row-autotranslate-title">
 				<ClayLayout.Col md={6}>
 					<div className="fieldset-title">{legend}</div>
 				</ClayLayout.Col>

--- a/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/translate/components/TranslateFieldSetEntries.js
+++ b/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/translate/components/TranslateFieldSetEntries.js
@@ -31,6 +31,7 @@ const TranslateAutoTranslateRow = ({
 	handleAutoTranslateClick = noop,
 	label,
 	fieldStatus,
+	sourceContent,
 }) => {
 	if (!autoTranslateEnabled) {
 		return children;
@@ -48,7 +49,7 @@ const TranslateAutoTranslateRow = ({
 			<ClayLayout.ContentCol className="align-self-top col-autotranslate-field">
 				<ClayButton
 					className="lfr-portal-tooltip"
-					disabled={isLoading}
+					disabled={isLoading || !sourceContent}
 					displayType="secondary"
 					monospaced
 					onClick={handleAutoTranslateClick}
@@ -237,6 +238,7 @@ const TranslateFieldSetEntries = ({
 						}
 						key={field.id}
 						label={fieldProps.label}
+						sourceContent={fieldProps.sourceContent}
 					>
 						{field.html ? (
 							<TranslateFieldEditor {...fieldProps} />

--- a/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/translate/components/TranslateHeader.js
+++ b/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/translate/components/TranslateHeader.js
@@ -17,7 +17,7 @@ import ClayLayout from '@clayui/layout';
 import React from 'react';
 
 const TranslateHeader = ({sourceLanguageIdTitle, targetLanguageIdTitle}) => (
-	<ClayLayout.Row>
+	<ClayLayout.Row className="row-autotranslate-title">
 		<ClayLayout.Col md={6}>
 			<ClayIcon symbol={sourceLanguageIdTitle.toLowerCase()} />
 			<span className="ml-1">{sourceLanguageIdTitle}</span>

--- a/modules/apps/translation/translation-web/src/main/resources/content/Language.properties
+++ b/modules/apps/translation/translation-web/src/main/resources/content/Language.properties
@@ -1,6 +1,8 @@
 are-you-sure-you-want-to-delete-the-selected-translations=Are you sure you want to delete the selected translations?
 are-you-sure-you-want-to-leave-the-page-you-may-lose-your-changes=Are you sure you want to leave the page? You will lose your changes if they have not been saved.
 auto-translate=Auto Translate
+auto-translate-x-field=Auto translate {0} field
+field-translated=Field translated
 javax.portlet.title.com_liferay_translation_web_internal_portlet_TranslationPortlet=Translation Processes
 model.resource.com.liferay.translation.model.TranslationEntry=Translation
 requesting-translation=Requesting translation.

--- a/modules/apps/translation/translation-web/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/translation/translation-web/src/main/resources/content/Language_ar.properties
@@ -1,6 +1,8 @@
 are-you-sure-you-want-to-delete-the-selected-translations=هل أنت متأكد من أنك تريد حذف الترجمات المحددة؟
 are-you-sure-you-want-to-leave-the-page-you-may-lose-your-changes=هل أنت متأكد من أنك تريد مغادرة الصفحة؟ سوف تفقد تغييراتك إذا لم يتم حفظها.
 auto-translate=ترجمة تلقائية
+auto-translate-x-field=Auto translate {0} field (Automatic Copy)
+field-translated=Field translated (Automatic Copy)
 javax.portlet.title.com_liferay_translation_web_internal_portlet_TranslationPortlet=الترجمة
 model.resource.com.liferay.translation.model.TranslationEntry=الترجمة
 requesting-translation=طلب الترجمة.

--- a/modules/apps/translation/translation-web/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/translation/translation-web/src/main/resources/content/Language_bg.properties
@@ -1,6 +1,8 @@
 are-you-sure-you-want-to-delete-the-selected-translations=Are you sure you want to delete the selected translations? (Automatic Copy)
 are-you-sure-you-want-to-leave-the-page-you-may-lose-your-changes=Наистина ли искате да излезете от страницата? Ще загубите промените си, ако не са записани. (Automatic Translation)
 auto-translate=Auto Translate (Automatic Copy)
+auto-translate-x-field=Auto translate {0} field (Automatic Copy)
+field-translated=Field translated (Automatic Copy)
 javax.portlet.title.com_liferay_translation_web_internal_portlet_TranslationPortlet=Translation Processes (Automatic Copy)
 model.resource.com.liferay.translation.model.TranslationEntry=Превод (Automatic Translation)
 requesting-translation=Requesting translation. (Automatic Copy)

--- a/modules/apps/translation/translation-web/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/translation/translation-web/src/main/resources/content/Language_ca.properties
@@ -1,6 +1,8 @@
 are-you-sure-you-want-to-delete-the-selected-translations=Segur que voleu esborrar les traduccions que heu seleccionat?
 are-you-sure-you-want-to-leave-the-page-you-may-lose-your-changes=Segur que voleu sortir de la pàgina? Perdreu els canvis si no els heu desat.
 auto-translate=Tradueix automàticament
+auto-translate-x-field=Auto translate {0} field (Automatic Copy)
+field-translated=Field translated (Automatic Copy)
 javax.portlet.title.com_liferay_translation_web_internal_portlet_TranslationPortlet=Traducció
 model.resource.com.liferay.translation.model.TranslationEntry=Traducció
 requesting-translation=S'està sol·licitant la traducció.

--- a/modules/apps/translation/translation-web/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/translation/translation-web/src/main/resources/content/Language_cs.properties
@@ -1,6 +1,8 @@
 are-you-sure-you-want-to-delete-the-selected-translations=Are you sure you want to delete the selected translations? (Automatic Copy)
 are-you-sure-you-want-to-leave-the-page-you-may-lose-your-changes=Opravdu chcete stránku opustit? Pokud nebyly uloženy, změny ztratíte. (Automatic Translation)
 auto-translate=Auto Translate (Automatic Copy)
+auto-translate-x-field=Auto translate {0} field (Automatic Copy)
+field-translated=Field translated (Automatic Copy)
 javax.portlet.title.com_liferay_translation_web_internal_portlet_TranslationPortlet=Translation Processes (Automatic Copy)
 model.resource.com.liferay.translation.model.TranslationEntry=Překlad (Automatic Translation)
 requesting-translation=Requesting translation. (Automatic Copy)

--- a/modules/apps/translation/translation-web/src/main/resources/content/Language_da.properties
+++ b/modules/apps/translation/translation-web/src/main/resources/content/Language_da.properties
@@ -1,6 +1,8 @@
 are-you-sure-you-want-to-delete-the-selected-translations=Are you sure you want to delete the selected translations? (Automatic Copy)
 are-you-sure-you-want-to-leave-the-page-you-may-lose-your-changes=Are you sure you want to leave the page? You will lose your changes if they have not been saved. (Automatic Copy)
 auto-translate=Auto Translate (Automatic Copy)
+auto-translate-x-field=Auto translate {0} field (Automatic Copy)
+field-translated=Field translated (Automatic Copy)
 javax.portlet.title.com_liferay_translation_web_internal_portlet_TranslationPortlet=Translation Processes (Automatic Copy)
 model.resource.com.liferay.translation.model.TranslationEntry=Translation (Automatic Copy)
 requesting-translation=Requesting translation. (Automatic Copy)

--- a/modules/apps/translation/translation-web/src/main/resources/content/Language_de.properties
+++ b/modules/apps/translation/translation-web/src/main/resources/content/Language_de.properties
@@ -1,6 +1,8 @@
 are-you-sure-you-want-to-delete-the-selected-translations=Sind Sie sicher, dass Sie die ausgewählten Übersetzungen löschen möchten?
 are-you-sure-you-want-to-leave-the-page-you-may-lose-your-changes=Möchten Sie wirklich die Seite verlassen? Ungespeicherte Änderungen gehen verloren.
 auto-translate=Automatisch übersetzen
+auto-translate-x-field=Auto translate {0} field (Automatic Copy)
+field-translated=Field translated (Automatic Copy)
 javax.portlet.title.com_liferay_translation_web_internal_portlet_TranslationPortlet=Übersetzung
 model.resource.com.liferay.translation.model.TranslationEntry=Übersetzung
 requesting-translation=Übersetzung wird angefordert.

--- a/modules/apps/translation/translation-web/src/main/resources/content/Language_el.properties
+++ b/modules/apps/translation/translation-web/src/main/resources/content/Language_el.properties
@@ -1,6 +1,8 @@
 are-you-sure-you-want-to-delete-the-selected-translations=Are you sure you want to delete the selected translations? (Automatic Copy)
 are-you-sure-you-want-to-leave-the-page-you-may-lose-your-changes=Είστε βέβαιοι ότι θέλετε να φύγετε από τη σελίδα; Θα χάσετε τις αλλαγές σας αν δεν έχουν αποθηκευτεί. (Automatic Translation)
 auto-translate=Auto Translate (Automatic Copy)
+auto-translate-x-field=Auto translate {0} field (Automatic Copy)
+field-translated=Field translated (Automatic Copy)
 javax.portlet.title.com_liferay_translation_web_internal_portlet_TranslationPortlet=Translation Processes (Automatic Copy)
 model.resource.com.liferay.translation.model.TranslationEntry=Μεταφράση (Automatic Translation)
 requesting-translation=Requesting translation. (Automatic Copy)

--- a/modules/apps/translation/translation-web/src/main/resources/content/Language_en.properties
+++ b/modules/apps/translation/translation-web/src/main/resources/content/Language_en.properties
@@ -1,6 +1,8 @@
 are-you-sure-you-want-to-delete-the-selected-translations=Are you sure you want to delete the selected translations?
 are-you-sure-you-want-to-leave-the-page-you-may-lose-your-changes=Are you sure you want to leave the page? You will lose your changes if they have not been saved.
 auto-translate=Auto Translate
+auto-translate-x-field=Auto translate {0} field
+field-translated=Field translated
 javax.portlet.title.com_liferay_translation_web_internal_portlet_TranslationPortlet=Translation Processes
 model.resource.com.liferay.translation.model.TranslationEntry=Translation
 requesting-translation=Requesting translation.

--- a/modules/apps/translation/translation-web/src/main/resources/content/Language_en_AU.properties
+++ b/modules/apps/translation/translation-web/src/main/resources/content/Language_en_AU.properties
@@ -1,6 +1,8 @@
 are-you-sure-you-want-to-delete-the-selected-translations=Are you sure you want to delete the selected translations? (Automatic Copy)
 are-you-sure-you-want-to-leave-the-page-you-may-lose-your-changes=Are you sure you want to leave the page? You will lose your changes if they have not been saved. (Automatic Copy)
 auto-translate=Auto Translate (Automatic Copy)
+auto-translate-x-field=Auto translate {0} field (Automatic Copy)
+field-translated=Field translated (Automatic Copy)
 javax.portlet.title.com_liferay_translation_web_internal_portlet_TranslationPortlet=Translation Processes (Automatic Copy)
 model.resource.com.liferay.translation.model.TranslationEntry=Translation (Automatic Copy)
 requesting-translation=Requesting translation. (Automatic Copy)

--- a/modules/apps/translation/translation-web/src/main/resources/content/Language_en_GB.properties
+++ b/modules/apps/translation/translation-web/src/main/resources/content/Language_en_GB.properties
@@ -1,6 +1,8 @@
 are-you-sure-you-want-to-delete-the-selected-translations=Are you sure you want to delete the selected translations? (Automatic Copy)
 are-you-sure-you-want-to-leave-the-page-you-may-lose-your-changes=Are you sure you want to leave the page? You will lose your changes if they have not been saved. (Automatic Copy)
 auto-translate=Auto Translate (Automatic Copy)
+auto-translate-x-field=Auto translate {0} field (Automatic Copy)
+field-translated=Field translated (Automatic Copy)
 javax.portlet.title.com_liferay_translation_web_internal_portlet_TranslationPortlet=Translation Processes (Automatic Copy)
 model.resource.com.liferay.translation.model.TranslationEntry=Translation (Automatic Copy)
 requesting-translation=Requesting translation. (Automatic Copy)

--- a/modules/apps/translation/translation-web/src/main/resources/content/Language_es.properties
+++ b/modules/apps/translation/translation-web/src/main/resources/content/Language_es.properties
@@ -1,6 +1,8 @@
 are-you-sure-you-want-to-delete-the-selected-translations=¿Seguro que quiere eliminar las traducciones seleccionadas?
 are-you-sure-you-want-to-leave-the-page-you-may-lose-your-changes=¿Seguro que quiere abandonar la página? Si no guarda los cambios, se perderán.
 auto-translate=Traducir automáticamente
+auto-translate-x-field=Auto translate {0} field (Automatic Copy)
+field-translated=Field translated (Automatic Copy)
 javax.portlet.title.com_liferay_translation_web_internal_portlet_TranslationPortlet=Traducción
 model.resource.com.liferay.translation.model.TranslationEntry=Traducción
 requesting-translation=Solicitando la traducción.

--- a/modules/apps/translation/translation-web/src/main/resources/content/Language_et.properties
+++ b/modules/apps/translation/translation-web/src/main/resources/content/Language_et.properties
@@ -1,6 +1,8 @@
 are-you-sure-you-want-to-delete-the-selected-translations=Are you sure you want to delete the selected translations? (Automatic Copy)
 are-you-sure-you-want-to-leave-the-page-you-may-lose-your-changes=Kas soovite kindlasti lehelt lahkuda? Muudatused lähevad kaotsi, kui neid pole salvestatud. (Automatic Translation)
 auto-translate=Auto Translate (Automatic Copy)
+auto-translate-x-field=Auto translate {0} field (Automatic Copy)
+field-translated=Field translated (Automatic Copy)
 javax.portlet.title.com_liferay_translation_web_internal_portlet_TranslationPortlet=Translation Processes (Automatic Copy)
 model.resource.com.liferay.translation.model.TranslationEntry=Tõlge (Automatic Translation)
 requesting-translation=Requesting translation. (Automatic Copy)

--- a/modules/apps/translation/translation-web/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/translation/translation-web/src/main/resources/content/Language_eu.properties
@@ -1,6 +1,8 @@
 are-you-sure-you-want-to-delete-the-selected-translations=Are you sure you want to delete the selected translations? (Automatic Copy)
 are-you-sure-you-want-to-leave-the-page-you-may-lose-your-changes=Are you sure you want to leave the page? You will lose your changes if they have not been saved. (Automatic Copy)
 auto-translate=Auto Translate (Automatic Copy)
+auto-translate-x-field=Auto translate {0} field (Automatic Copy)
+field-translated=Field translated (Automatic Copy)
 javax.portlet.title.com_liferay_translation_web_internal_portlet_TranslationPortlet=Translation Processes (Automatic Copy)
 model.resource.com.liferay.translation.model.TranslationEntry=Translation (Automatic Copy)
 requesting-translation=Requesting translation. (Automatic Copy)

--- a/modules/apps/translation/translation-web/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/translation/translation-web/src/main/resources/content/Language_fa.properties
@@ -1,6 +1,8 @@
 are-you-sure-you-want-to-delete-the-selected-translations=Are you sure you want to delete the selected translations? (Automatic Copy)
 are-you-sure-you-want-to-leave-the-page-you-may-lose-your-changes=آیا مطمئن هستید که می خواهید صفحه را ترک کنید؟ اگر آنها ذخیره نشده اند تغییرات خود را از دست خواهید داد. (Automatic Translation)
 auto-translate=Auto Translate (Automatic Copy)
+auto-translate-x-field=Auto translate {0} field (Automatic Copy)
+field-translated=Field translated (Automatic Copy)
 javax.portlet.title.com_liferay_translation_web_internal_portlet_TranslationPortlet=Translation Processes (Automatic Copy)
 model.resource.com.liferay.translation.model.TranslationEntry=ترجمه (Automatic Translation)
 requesting-translation=Requesting translation. (Automatic Copy)

--- a/modules/apps/translation/translation-web/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/translation/translation-web/src/main/resources/content/Language_fi.properties
@@ -1,6 +1,8 @@
 are-you-sure-you-want-to-delete-the-selected-translations=Oletko varma, että haluat poistaa valitut käännökset?
 are-you-sure-you-want-to-leave-the-page-you-may-lose-your-changes=Haluatko varmasti poistua sivulta? Menetät muutoksesi, jos niitä ei ole tallennettu.
 auto-translate=Automaattinen Käännös
+auto-translate-x-field=Auto translate {0} field (Automatic Copy)
+field-translated=Field translated (Automatic Copy)
 javax.portlet.title.com_liferay_translation_web_internal_portlet_TranslationPortlet=Käännös
 model.resource.com.liferay.translation.model.TranslationEntry=Käännös
 requesting-translation=Pyytää käännöstä.

--- a/modules/apps/translation/translation-web/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/translation/translation-web/src/main/resources/content/Language_fr.properties
@@ -1,6 +1,8 @@
 are-you-sure-you-want-to-delete-the-selected-translations=Voulez-vous vraiment supprimer les traductions sélectionnées ?
 are-you-sure-you-want-to-leave-the-page-you-may-lose-your-changes=Voulez-vous vraiment quitter la page ? Vous perdrez vos modifications si elles n'ont pas été enregistrées.
 auto-translate=Traduire automatiquement
+auto-translate-x-field=Auto translate {0} field (Automatic Copy)
+field-translated=Field translated (Automatic Copy)
 javax.portlet.title.com_liferay_translation_web_internal_portlet_TranslationPortlet=Traduction
 model.resource.com.liferay.translation.model.TranslationEntry=Traduction
 requesting-translation=Demande de traduction.

--- a/modules/apps/translation/translation-web/src/main/resources/content/Language_fr_CA.properties
+++ b/modules/apps/translation/translation-web/src/main/resources/content/Language_fr_CA.properties
@@ -1,6 +1,8 @@
 are-you-sure-you-want-to-delete-the-selected-translations=Are you sure you want to delete the selected translations? (Automatic Copy)
 are-you-sure-you-want-to-leave-the-page-you-may-lose-your-changes=Are you sure you want to leave the page? You will lose your changes if they have not been saved. (Automatic Copy)
 auto-translate=Auto Translate (Automatic Copy)
+auto-translate-x-field=Auto translate {0} field (Automatic Copy)
+field-translated=Field translated (Automatic Copy)
 javax.portlet.title.com_liferay_translation_web_internal_portlet_TranslationPortlet=Translation Processes (Automatic Copy)
 model.resource.com.liferay.translation.model.TranslationEntry=Translation (Automatic Copy)
 requesting-translation=Requesting translation. (Automatic Copy)

--- a/modules/apps/translation/translation-web/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/translation/translation-web/src/main/resources/content/Language_gl.properties
@@ -1,6 +1,8 @@
 are-you-sure-you-want-to-delete-the-selected-translations=Are you sure you want to delete the selected translations? (Automatic Copy)
 are-you-sure-you-want-to-leave-the-page-you-may-lose-your-changes=Are you sure you want to leave the page? You will lose your changes if they have not been saved. (Automatic Copy)
 auto-translate=Auto Translate (Automatic Copy)
+auto-translate-x-field=Auto translate {0} field (Automatic Copy)
+field-translated=Field translated (Automatic Copy)
 javax.portlet.title.com_liferay_translation_web_internal_portlet_TranslationPortlet=Tradución
 model.resource.com.liferay.translation.model.TranslationEntry=Tradución
 requesting-translation=Requesting translation. (Automatic Copy)

--- a/modules/apps/translation/translation-web/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/translation/translation-web/src/main/resources/content/Language_hi_IN.properties
@@ -1,6 +1,8 @@
 are-you-sure-you-want-to-delete-the-selected-translations=Are you sure you want to delete the selected translations? (Automatic Copy)
 are-you-sure-you-want-to-leave-the-page-you-may-lose-your-changes=क्या आप सुनिश्चित हैं कि आप पृष्ठ छोड़ना चाहते हैं? यदि उन्हें बचाया नहीं गया है तो आप अपने परिवर्तन खो देंगे। (Automatic Translation)
 auto-translate=Auto Translate (Automatic Copy)
+auto-translate-x-field=Auto translate {0} field (Automatic Copy)
+field-translated=Field translated (Automatic Copy)
 javax.portlet.title.com_liferay_translation_web_internal_portlet_TranslationPortlet=Translation Processes (Automatic Copy)
 model.resource.com.liferay.translation.model.TranslationEntry=अनुवाद (Automatic Translation)
 requesting-translation=Requesting translation. (Automatic Copy)

--- a/modules/apps/translation/translation-web/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/translation/translation-web/src/main/resources/content/Language_hr.properties
@@ -1,6 +1,8 @@
 are-you-sure-you-want-to-delete-the-selected-translations=Are you sure you want to delete the selected translations? (Automatic Copy)
 are-you-sure-you-want-to-leave-the-page-you-may-lose-your-changes=Are you sure you want to leave the page? You will lose your changes if they have not been saved. (Automatic Copy)
 auto-translate=Auto Translate (Automatic Copy)
+auto-translate-x-field=Auto translate {0} field (Automatic Copy)
+field-translated=Field translated (Automatic Copy)
 javax.portlet.title.com_liferay_translation_web_internal_portlet_TranslationPortlet=Translation Processes (Automatic Copy)
 model.resource.com.liferay.translation.model.TranslationEntry=Translation (Automatic Copy)
 requesting-translation=Requesting translation. (Automatic Copy)

--- a/modules/apps/translation/translation-web/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/translation/translation-web/src/main/resources/content/Language_hu.properties
@@ -1,6 +1,8 @@
 are-you-sure-you-want-to-delete-the-selected-translations=Biztosan törli a kiválasztott fordításokat?
 are-you-sure-you-want-to-leave-the-page-you-may-lose-your-changes=Biztosan elhagyja ezt az oldalt? A változtatásai el fognak veszni, ha nem mentette őket.
 auto-translate=Automatikus fordítás
+auto-translate-x-field=Auto translate {0} field (Automatic Copy)
+field-translated=Field translated (Automatic Copy)
 javax.portlet.title.com_liferay_translation_web_internal_portlet_TranslationPortlet=Fordítás
 model.resource.com.liferay.translation.model.TranslationEntry=Fordítás
 requesting-translation=Fordítás kérelmezése.

--- a/modules/apps/translation/translation-web/src/main/resources/content/Language_in.properties
+++ b/modules/apps/translation/translation-web/src/main/resources/content/Language_in.properties
@@ -1,6 +1,8 @@
 are-you-sure-you-want-to-delete-the-selected-translations=Are you sure you want to delete the selected translations? (Automatic Copy)
 are-you-sure-you-want-to-leave-the-page-you-may-lose-your-changes=Anda yakin ingin meninggalkan halaman? Anda akan kehilangan perubahan jika mereka belum disimpan. (Automatic Translation)
 auto-translate=Auto Translate (Automatic Copy)
+auto-translate-x-field=Auto translate {0} field (Automatic Copy)
+field-translated=Field translated (Automatic Copy)
 javax.portlet.title.com_liferay_translation_web_internal_portlet_TranslationPortlet=Translation Processes (Automatic Copy)
 model.resource.com.liferay.translation.model.TranslationEntry=Terjemahan (Automatic Translation)
 requesting-translation=Requesting translation. (Automatic Copy)

--- a/modules/apps/translation/translation-web/src/main/resources/content/Language_it.properties
+++ b/modules/apps/translation/translation-web/src/main/resources/content/Language_it.properties
@@ -1,6 +1,8 @@
 are-you-sure-you-want-to-delete-the-selected-translations=Are you sure you want to delete the selected translations? (Automatic Copy)
 are-you-sure-you-want-to-leave-the-page-you-may-lose-your-changes=Sei sicuro di voler lasciare la pagina? Le modifiche verranno perd nesse se non sono state salvate. (Automatic Translation)
 auto-translate=Auto Translate (Automatic Copy)
+auto-translate-x-field=Auto translate {0} field (Automatic Copy)
+field-translated=Field translated (Automatic Copy)
 javax.portlet.title.com_liferay_translation_web_internal_portlet_TranslationPortlet=Translation Processes (Automatic Copy)
 model.resource.com.liferay.translation.model.TranslationEntry=Traduzione (Automatic Translation)
 requesting-translation=Requesting translation. (Automatic Copy)

--- a/modules/apps/translation/translation-web/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/translation/translation-web/src/main/resources/content/Language_iw.properties
@@ -1,6 +1,8 @@
 are-you-sure-you-want-to-delete-the-selected-translations=Are you sure you want to delete the selected translations? (Automatic Copy)
 are-you-sure-you-want-to-leave-the-page-you-may-lose-your-changes=האם אתה בטוח שברצונך לעזוב את הדף? תאבד את השינויים שלך אם הם לא נשמרו. (Automatic Translation)
 auto-translate=Auto Translate (Automatic Copy)
+auto-translate-x-field=Auto translate {0} field (Automatic Copy)
+field-translated=Field translated (Automatic Copy)
 javax.portlet.title.com_liferay_translation_web_internal_portlet_TranslationPortlet=Translation Processes (Automatic Copy)
 model.resource.com.liferay.translation.model.TranslationEntry=תרגום ותרגום (Automatic Translation)
 requesting-translation=Requesting translation. (Automatic Copy)

--- a/modules/apps/translation/translation-web/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/translation/translation-web/src/main/resources/content/Language_ja.properties
@@ -1,6 +1,8 @@
 are-you-sure-you-want-to-delete-the-selected-translations=選択した翻訳を削除してもよろしいですか？
 are-you-sure-you-want-to-leave-the-page-you-may-lose-your-changes=ページを離れてもよろしいですか？保存されていない変更は失われます。
 auto-translate=自動翻訳
+auto-translate-x-field=Auto translate {0} field (Automatic Copy)
+field-translated=Field translated (Automatic Copy)
 javax.portlet.title.com_liferay_translation_web_internal_portlet_TranslationPortlet=翻訳
 model.resource.com.liferay.translation.model.TranslationEntry=翻訳
 requesting-translation=翻訳をリクエストしています。

--- a/modules/apps/translation/translation-web/src/main/resources/content/Language_kk.properties
+++ b/modules/apps/translation/translation-web/src/main/resources/content/Language_kk.properties
@@ -1,6 +1,8 @@
 are-you-sure-you-want-to-delete-the-selected-translations=Are you sure you want to delete the selected translations? (Automatic Copy)
 are-you-sure-you-want-to-leave-the-page-you-may-lose-your-changes=Are you sure you want to leave the page? You will lose your changes if they have not been saved. (Automatic Copy)
 auto-translate=Auto Translate (Automatic Copy)
+auto-translate-x-field=Auto translate {0} field (Automatic Copy)
+field-translated=Field translated (Automatic Copy)
 javax.portlet.title.com_liferay_translation_web_internal_portlet_TranslationPortlet=Translation Processes (Automatic Copy)
 model.resource.com.liferay.translation.model.TranslationEntry=Translation (Automatic Copy)
 requesting-translation=Requesting translation. (Automatic Copy)

--- a/modules/apps/translation/translation-web/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/translation/translation-web/src/main/resources/content/Language_ko.properties
@@ -1,6 +1,8 @@
 are-you-sure-you-want-to-delete-the-selected-translations=Are you sure you want to delete the selected translations? (Automatic Copy)
 are-you-sure-you-want-to-leave-the-page-you-may-lose-your-changes=페이지를 떠나시겠습니까? 변경 내용이 저장되지 않으면 변경 내용이 손실됩니다. (Automatic Translation)
 auto-translate=Auto Translate (Automatic Copy)
+auto-translate-x-field=Auto translate {0} field (Automatic Copy)
+field-translated=Field translated (Automatic Copy)
 javax.portlet.title.com_liferay_translation_web_internal_portlet_TranslationPortlet=Translation Processes (Automatic Copy)
 model.resource.com.liferay.translation.model.TranslationEntry=번역 (Automatic Translation)
 requesting-translation=Requesting translation. (Automatic Copy)

--- a/modules/apps/translation/translation-web/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/translation/translation-web/src/main/resources/content/Language_lo.properties
@@ -1,6 +1,8 @@
 are-you-sure-you-want-to-delete-the-selected-translations=Are you sure you want to delete the selected translations? (Automatic Copy)
 are-you-sure-you-want-to-leave-the-page-you-may-lose-your-changes=Are you sure you want to leave the page? You will lose your changes if they have not been saved. (Automatic Copy)
 auto-translate=Auto Translate (Automatic Copy)
+auto-translate-x-field=Auto translate {0} field (Automatic Copy)
+field-translated=Field translated (Automatic Copy)
 javax.portlet.title.com_liferay_translation_web_internal_portlet_TranslationPortlet=Translation Processes (Automatic Copy)
 model.resource.com.liferay.translation.model.TranslationEntry=Translation (Automatic Copy)
 requesting-translation=Requesting translation. (Automatic Copy)

--- a/modules/apps/translation/translation-web/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/translation/translation-web/src/main/resources/content/Language_lt.properties
@@ -1,6 +1,8 @@
 are-you-sure-you-want-to-delete-the-selected-translations=Are you sure you want to delete the selected translations? (Automatic Copy)
 are-you-sure-you-want-to-leave-the-page-you-may-lose-your-changes=Ar tikrai norite išeiti iš puslapio? Jei jie nebus įrašyti, pametėte pakeitimus. (Automatic Translation)
 auto-translate=Auto Translate (Automatic Copy)
+auto-translate-x-field=Auto translate {0} field (Automatic Copy)
+field-translated=Field translated (Automatic Copy)
 javax.portlet.title.com_liferay_translation_web_internal_portlet_TranslationPortlet=Translation Processes (Automatic Copy)
 model.resource.com.liferay.translation.model.TranslationEntry=Vertimas (Automatic Translation)
 requesting-translation=Requesting translation. (Automatic Copy)

--- a/modules/apps/translation/translation-web/src/main/resources/content/Language_ms.properties
+++ b/modules/apps/translation/translation-web/src/main/resources/content/Language_ms.properties
@@ -1,6 +1,8 @@
 are-you-sure-you-want-to-delete-the-selected-translations=Are you sure you want to delete the selected translations? (Automatic Copy)
 are-you-sure-you-want-to-leave-the-page-you-may-lose-your-changes=Adakah awda pasti hendak meninggalkan halaman itu? Anda akan kehilangan perubahan anda jika ia tidak disimpan. (Automatic Translation)
 auto-translate=Auto Translate (Automatic Copy)
+auto-translate-x-field=Auto translate {0} field (Automatic Copy)
+field-translated=Field translated (Automatic Copy)
 javax.portlet.title.com_liferay_translation_web_internal_portlet_TranslationPortlet=Translation Processes (Automatic Copy)
 model.resource.com.liferay.translation.model.TranslationEntry=Translation (Automatic Copy)
 requesting-translation=Requesting translation. (Automatic Copy)

--- a/modules/apps/translation/translation-web/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/translation/translation-web/src/main/resources/content/Language_nb.properties
@@ -1,6 +1,8 @@
 are-you-sure-you-want-to-delete-the-selected-translations=Are you sure you want to delete the selected translations? (Automatic Copy)
 are-you-sure-you-want-to-leave-the-page-you-may-lose-your-changes=Er du sikker på at du vil forlate siden? Du vil miste endringene hvis de ikke har blitt lagret. (Automatic Translation)
 auto-translate=Auto Translate (Automatic Copy)
+auto-translate-x-field=Auto translate {0} field (Automatic Copy)
+field-translated=Field translated (Automatic Copy)
 javax.portlet.title.com_liferay_translation_web_internal_portlet_TranslationPortlet=Translation Processes (Automatic Copy)
 model.resource.com.liferay.translation.model.TranslationEntry=Oversettelse (Automatic Translation)
 requesting-translation=Requesting translation. (Automatic Copy)

--- a/modules/apps/translation/translation-web/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/translation/translation-web/src/main/resources/content/Language_nl.properties
@@ -1,6 +1,8 @@
 are-you-sure-you-want-to-delete-the-selected-translations=Weet u zeker dat u de geselecteerde vertalingen wilt verwijderen?
 are-you-sure-you-want-to-leave-the-page-you-may-lose-your-changes=Weet u zeker dat u de pagina wilt verlaten? Niet-opgeslagen wijzigingen zullen verloren gaan.
 auto-translate=Automatisch vertalen
+auto-translate-x-field=Auto translate {0} field (Automatic Copy)
+field-translated=Field translated (Automatic Copy)
 javax.portlet.title.com_liferay_translation_web_internal_portlet_TranslationPortlet=Vertaling
 model.resource.com.liferay.translation.model.TranslationEntry=Vertaling
 requesting-translation=Vertaling aanvragen ...

--- a/modules/apps/translation/translation-web/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/translation/translation-web/src/main/resources/content/Language_nl_BE.properties
@@ -1,6 +1,8 @@
 are-you-sure-you-want-to-delete-the-selected-translations=Are you sure you want to delete the selected translations? (Automatic Copy)
 are-you-sure-you-want-to-leave-the-page-you-may-lose-your-changes=Are you sure you want to leave the page? You will lose your changes if they have not been saved. (Automatic Copy)
 auto-translate=Auto Translate (Automatic Copy)
+auto-translate-x-field=Auto translate {0} field (Automatic Copy)
+field-translated=Field translated (Automatic Copy)
 javax.portlet.title.com_liferay_translation_web_internal_portlet_TranslationPortlet=Translation Processes (Automatic Copy)
 model.resource.com.liferay.translation.model.TranslationEntry=Translation (Automatic Copy)
 requesting-translation=Requesting translation. (Automatic Copy)

--- a/modules/apps/translation/translation-web/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/translation/translation-web/src/main/resources/content/Language_pl.properties
@@ -1,6 +1,8 @@
 are-you-sure-you-want-to-delete-the-selected-translations=Czy na pewno chcesz usunąć wybrane tłumaczenia? (Automatic Translation)
 are-you-sure-you-want-to-leave-the-page-you-may-lose-your-changes=Czy na pewno chcesz opuścić stronę? Zmiany zostaną wprowadzone, jeśli nie zostały zapisane. (Automatic Translation)
 auto-translate=Auto Translate (Automatic Copy)
+auto-translate-x-field=Auto translate {0} field (Automatic Copy)
+field-translated=Field translated (Automatic Copy)
 javax.portlet.title.com_liferay_translation_web_internal_portlet_TranslationPortlet=Procesy tłumaczeniowe (Automatic Translation)
 model.resource.com.liferay.translation.model.TranslationEntry=Tłumacz (Automatic Translation)
 requesting-translation=Requesting translation. (Automatic Copy)

--- a/modules/apps/translation/translation-web/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/translation/translation-web/src/main/resources/content/Language_pt_BR.properties
@@ -1,6 +1,8 @@
 are-you-sure-you-want-to-delete-the-selected-translations=Tem certeza que deseja excluir as traduções selecionadas?
 are-you-sure-you-want-to-leave-the-page-you-may-lose-your-changes=Tem certeza que deseja sair da página? Você perderá suas modificações se elas não foram salvas.
 auto-translate=Traduzir automaticamente
+auto-translate-x-field=Auto translate {0} field (Automatic Copy)
+field-translated=Field translated (Automatic Copy)
 javax.portlet.title.com_liferay_translation_web_internal_portlet_TranslationPortlet=Tradução
 model.resource.com.liferay.translation.model.TranslationEntry=Tradução
 requesting-translation=Solicitando tradução.

--- a/modules/apps/translation/translation-web/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/translation/translation-web/src/main/resources/content/Language_pt_PT.properties
@@ -1,6 +1,8 @@
 are-you-sure-you-want-to-delete-the-selected-translations=Are you sure you want to delete the selected translations? (Automatic Copy)
 are-you-sure-you-want-to-leave-the-page-you-may-lose-your-changes=Are you sure you want to leave the page? You will lose your changes if they have not been saved. (Automatic Copy)
 auto-translate=Auto Translate (Automatic Copy)
+auto-translate-x-field=Auto translate {0} field (Automatic Copy)
+field-translated=Field translated (Automatic Copy)
 javax.portlet.title.com_liferay_translation_web_internal_portlet_TranslationPortlet=Translation Processes (Automatic Copy)
 model.resource.com.liferay.translation.model.TranslationEntry=Translation (Automatic Copy)
 requesting-translation=Requesting translation. (Automatic Copy)

--- a/modules/apps/translation/translation-web/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/translation/translation-web/src/main/resources/content/Language_ro.properties
@@ -1,6 +1,8 @@
 are-you-sure-you-want-to-delete-the-selected-translations=Are you sure you want to delete the selected translations? (Automatic Copy)
 are-you-sure-you-want-to-leave-the-page-you-may-lose-your-changes=Sigur părăsiți pagina? Veți pierde modificările dacă acestea nu au fost salvate. (Automatic Translation)
 auto-translate=Auto Translate (Automatic Copy)
+auto-translate-x-field=Auto translate {0} field (Automatic Copy)
+field-translated=Field translated (Automatic Copy)
 javax.portlet.title.com_liferay_translation_web_internal_portlet_TranslationPortlet=Translation Processes (Automatic Copy)
 model.resource.com.liferay.translation.model.TranslationEntry=Traducere (Automatic Translation)
 requesting-translation=Requesting translation. (Automatic Copy)

--- a/modules/apps/translation/translation-web/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/translation/translation-web/src/main/resources/content/Language_ru.properties
@@ -1,6 +1,8 @@
 are-you-sure-you-want-to-delete-the-selected-translations=Are you sure you want to delete the selected translations? (Automatic Copy)
 are-you-sure-you-want-to-leave-the-page-you-may-lose-your-changes=Вы уверены, что хотите покинуть страницу? Вы потеряете свои изменения, если они не были сохранены. (Automatic Translation)
 auto-translate=Auto Translate (Automatic Copy)
+auto-translate-x-field=Auto translate {0} field (Automatic Copy)
+field-translated=Field translated (Automatic Copy)
 javax.portlet.title.com_liferay_translation_web_internal_portlet_TranslationPortlet=Translation Processes (Automatic Copy)
 model.resource.com.liferay.translation.model.TranslationEntry=Перевод (Automatic Translation)
 requesting-translation=Requesting translation. (Automatic Copy)

--- a/modules/apps/translation/translation-web/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/translation/translation-web/src/main/resources/content/Language_sk.properties
@@ -1,6 +1,8 @@
 are-you-sure-you-want-to-delete-the-selected-translations=Are you sure you want to delete the selected translations? (Automatic Copy)
 are-you-sure-you-want-to-leave-the-page-you-may-lose-your-changes=Naozaj chcete opustiť stránku? Zmeny stratíte, ak neboli uložené. (Automatic Translation)
 auto-translate=Auto Translate (Automatic Copy)
+auto-translate-x-field=Auto translate {0} field (Automatic Copy)
+field-translated=Field translated (Automatic Copy)
 javax.portlet.title.com_liferay_translation_web_internal_portlet_TranslationPortlet=Translation Processes (Automatic Copy)
 model.resource.com.liferay.translation.model.TranslationEntry=Preklad (Automatic Translation)
 requesting-translation=Requesting translation. (Automatic Copy)

--- a/modules/apps/translation/translation-web/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/translation/translation-web/src/main/resources/content/Language_sl.properties
@@ -1,6 +1,8 @@
 are-you-sure-you-want-to-delete-the-selected-translations=Are you sure you want to delete the selected translations? (Automatic Copy)
 are-you-sure-you-want-to-leave-the-page-you-may-lose-your-changes=Ali ste prepričani, da želite zapustiti stran? Če spremembe niso bile shranjene, boste izgubili spremembe. (Automatic Translation)
 auto-translate=Auto Translate (Automatic Copy)
+auto-translate-x-field=Auto translate {0} field (Automatic Copy)
+field-translated=Field translated (Automatic Copy)
 javax.portlet.title.com_liferay_translation_web_internal_portlet_TranslationPortlet=Translation Processes (Automatic Copy)
 model.resource.com.liferay.translation.model.TranslationEntry=Prevod (Automatic Translation)
 requesting-translation=Requesting translation. (Automatic Copy)

--- a/modules/apps/translation/translation-web/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/translation/translation-web/src/main/resources/content/Language_sr_RS.properties
@@ -1,6 +1,8 @@
 are-you-sure-you-want-to-delete-the-selected-translations=Are you sure you want to delete the selected translations? (Automatic Copy)
 are-you-sure-you-want-to-leave-the-page-you-may-lose-your-changes=Are you sure you want to leave the page? You will lose your changes if they have not been saved. (Automatic Copy)
 auto-translate=Auto Translate (Automatic Copy)
+auto-translate-x-field=Auto translate {0} field (Automatic Copy)
+field-translated=Field translated (Automatic Copy)
 javax.portlet.title.com_liferay_translation_web_internal_portlet_TranslationPortlet=Translation Processes (Automatic Copy)
 model.resource.com.liferay.translation.model.TranslationEntry=Translation (Automatic Copy)
 requesting-translation=Requesting translation. (Automatic Copy)

--- a/modules/apps/translation/translation-web/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/translation/translation-web/src/main/resources/content/Language_sr_RS_latin.properties
@@ -1,6 +1,8 @@
 are-you-sure-you-want-to-delete-the-selected-translations=Are you sure you want to delete the selected translations? (Automatic Copy)
 are-you-sure-you-want-to-leave-the-page-you-may-lose-your-changes=Are you sure you want to leave the page? You will lose your changes if they have not been saved. (Automatic Copy)
 auto-translate=Auto Translate (Automatic Copy)
+auto-translate-x-field=Auto translate {0} field (Automatic Copy)
+field-translated=Field translated (Automatic Copy)
 javax.portlet.title.com_liferay_translation_web_internal_portlet_TranslationPortlet=Translation Processes (Automatic Copy)
 model.resource.com.liferay.translation.model.TranslationEntry=Translation (Automatic Copy)
 requesting-translation=Requesting translation. (Automatic Copy)

--- a/modules/apps/translation/translation-web/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/translation/translation-web/src/main/resources/content/Language_sv.properties
@@ -1,6 +1,8 @@
 are-you-sure-you-want-to-delete-the-selected-translations=Vill du verkligen ta bort de valda översättningarna?
 are-you-sure-you-want-to-leave-the-page-you-may-lose-your-changes=Vill du verkligen lämna sidan? Du förlorar dina ändringar om du inte sparar dem.
-auto-translate=Översätt automatiskt
+auto-translate=Auto Translate (Automatic Copy)
+auto-translate-x-field=Auto translate {0} field (Automatic Copy)
+field-translated=Field translated (Automatic Copy)
 javax.portlet.title.com_liferay_translation_web_internal_portlet_TranslationPortlet=Översättning
 model.resource.com.liferay.translation.model.TranslationEntry=Översättning
 requesting-translation=Begär översättning.

--- a/modules/apps/translation/translation-web/src/main/resources/content/Language_ta_IN.properties
+++ b/modules/apps/translation/translation-web/src/main/resources/content/Language_ta_IN.properties
@@ -1,6 +1,8 @@
 are-you-sure-you-want-to-delete-the-selected-translations=Are you sure you want to delete the selected translations? (Automatic Copy)
 are-you-sure-you-want-to-leave-the-page-you-may-lose-your-changes=Are you sure you want to leave the page? You will lose your changes if they have not been saved. (Automatic Copy)
 auto-translate=Auto Translate (Automatic Copy)
+auto-translate-x-field=Auto translate {0} field (Automatic Copy)
+field-translated=Field translated (Automatic Copy)
 javax.portlet.title.com_liferay_translation_web_internal_portlet_TranslationPortlet=Translation Processes (Automatic Copy)
 model.resource.com.liferay.translation.model.TranslationEntry=Translation (Automatic Copy)
 requesting-translation=Requesting translation. (Automatic Copy)

--- a/modules/apps/translation/translation-web/src/main/resources/content/Language_th.properties
+++ b/modules/apps/translation/translation-web/src/main/resources/content/Language_th.properties
@@ -1,6 +1,8 @@
 are-you-sure-you-want-to-delete-the-selected-translations=Are you sure you want to delete the selected translations? (Automatic Copy)
 are-you-sure-you-want-to-leave-the-page-you-may-lose-your-changes=คุณแน่ใจหรือไม่ว่าคุณต้องการออกจากเพจ คุณจะสูญเสียการเปลี่ยนแปลงของคุณหากยังไม่ได้บันทึก (Automatic Translation)
 auto-translate=Auto Translate (Automatic Copy)
+auto-translate-x-field=Auto translate {0} field (Automatic Copy)
+field-translated=Field translated (Automatic Copy)
 javax.portlet.title.com_liferay_translation_web_internal_portlet_TranslationPortlet=Translation Processes (Automatic Copy)
 model.resource.com.liferay.translation.model.TranslationEntry=แปล (Automatic Translation)
 requesting-translation=Requesting translation. (Automatic Copy)

--- a/modules/apps/translation/translation-web/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/translation/translation-web/src/main/resources/content/Language_tr.properties
@@ -1,6 +1,8 @@
 are-you-sure-you-want-to-delete-the-selected-translations=Are you sure you want to delete the selected translations? (Automatic Copy)
 are-you-sure-you-want-to-leave-the-page-you-may-lose-your-changes=Sayfayı terk etmek istediğinden emin misin? Kaydedilmedilerse değişikliklerinizi kaybedersiniz. (Automatic Translation)
 auto-translate=Auto Translate (Automatic Copy)
+auto-translate-x-field=Auto translate {0} field (Automatic Copy)
+field-translated=Field translated (Automatic Copy)
 javax.portlet.title.com_liferay_translation_web_internal_portlet_TranslationPortlet=Translation Processes (Automatic Copy)
 model.resource.com.liferay.translation.model.TranslationEntry=Çeviri (Automatic Translation)
 requesting-translation=Requesting translation. (Automatic Copy)

--- a/modules/apps/translation/translation-web/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/translation/translation-web/src/main/resources/content/Language_uk.properties
@@ -1,6 +1,8 @@
 are-you-sure-you-want-to-delete-the-selected-translations=Are you sure you want to delete the selected translations? (Automatic Copy)
 are-you-sure-you-want-to-leave-the-page-you-may-lose-your-changes=Ви дійсно бажаєте залишити сторінку? Зміни буде внесемо до втрати, якщо їх не збережено. (Automatic Translation)
 auto-translate=Auto Translate (Automatic Copy)
+auto-translate-x-field=Auto translate {0} field (Automatic Copy)
+field-translated=Field translated (Automatic Copy)
 javax.portlet.title.com_liferay_translation_web_internal_portlet_TranslationPortlet=Translation Processes (Automatic Copy)
 model.resource.com.liferay.translation.model.TranslationEntry=Переклад (Automatic Translation)
 requesting-translation=Requesting translation. (Automatic Copy)

--- a/modules/apps/translation/translation-web/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/translation/translation-web/src/main/resources/content/Language_vi.properties
@@ -1,6 +1,8 @@
 are-you-sure-you-want-to-delete-the-selected-translations=Are you sure you want to delete the selected translations? (Automatic Copy)
 are-you-sure-you-want-to-leave-the-page-you-may-lose-your-changes=Bạn có chắc bạn muốn rời khỏi trang không? Bạn sẽ mất thay đổi của bạn nếu họ đã không được lưu. (Automatic Translation)
 auto-translate=Auto Translate (Automatic Copy)
+auto-translate-x-field=Auto translate {0} field (Automatic Copy)
+field-translated=Field translated (Automatic Copy)
 javax.portlet.title.com_liferay_translation_web_internal_portlet_TranslationPortlet=Translation Processes (Automatic Copy)
 model.resource.com.liferay.translation.model.TranslationEntry=Dịch (Automatic Translation)
 requesting-translation=Requesting translation. (Automatic Copy)

--- a/modules/apps/translation/translation-web/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/translation/translation-web/src/main/resources/content/Language_zh_CN.properties
@@ -1,6 +1,8 @@
 are-you-sure-you-want-to-delete-the-selected-translations=确定要删除选定的翻译吗？
 are-you-sure-you-want-to-leave-the-page-you-may-lose-your-changes=确定要离开此页面吗？如果未保存，您将丢失这些更改。
 auto-translate=自动翻译
+auto-translate-x-field=Auto translate {0} field (Automatic Copy)
+field-translated=Field translated (Automatic Copy)
 javax.portlet.title.com_liferay_translation_web_internal_portlet_TranslationPortlet=翻译
 model.resource.com.liferay.translation.model.TranslationEntry=翻译
 requesting-translation=需要翻译。

--- a/modules/apps/translation/translation-web/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/translation/translation-web/src/main/resources/content/Language_zh_TW.properties
@@ -1,6 +1,8 @@
 are-you-sure-you-want-to-delete-the-selected-translations=確定要刪除選定的翻譯？
 are-you-sure-you-want-to-leave-the-page-you-may-lose-your-changes=確定要離開頁面？如果沒有儲存，您將會遺失相關變更。
 auto-translate=自動翻譯
+auto-translate-x-field=Auto translate {0} field (Automatic Copy)
+field-translated=Field translated (Automatic Copy)
 javax.portlet.title.com_liferay_translation_web_internal_portlet_TranslationPortlet=翻譯
 model.resource.com.liferay.translation.model.TranslationEntry=翻譯
 requesting-translation=請求翻譯。


### PR DESCRIPTION
Hello, I add a link [with the instructions](https://github.com/liferay-lima/liferay-portal/pull/1766) to configure the auto-translate.

This revision includes everything related to auto-translate, a general button to translate all the content, and a button to translate each field.

Migration to React is [already reviewed](https://github.com/liferay-lima/liferay-portal/pull/1641).

**Remains:**
Update the JSP markup to add the column to the auto-translate button in a [separate task](https://issues.liferay.com/browse/LPS-131604)  

**After the PR**

![image](https://user-images.githubusercontent.com/67901/116998048-f13d2c00-acdd-11eb-98e2-108143c10dcc.png)
