### PR TITLE
LPS-129742 / LPS-129743 Add file upload and video options to item selectors

### DIFF
--- a/modules/apps/document-library/document-library-api/src/main/java/com/liferay/document/library/display/context/DLUIItemKeys.java
+++ b/modules/apps/document-library/document-library-api/src/main/java/com/liferay/document/library/display/context/DLUIItemKeys.java
@@ -65,6 +65,9 @@ public class DLUIItemKeys {
 	public static final String REVERT =
 		DLUIItemKeys.class.getName() + "#revert";
 
+	public static final String UPLOAD =
+		DLUIItemKeys.class.getName() + "#upload";
+
 	public static final String VIEW_ORIGINAL_FILE =
 		DLUIItemKeys.class.getName() + "#view-original-file";
 

--- a/modules/apps/document-library/document-library-video/src/main/java/com/liferay/document/library/video/internal/item/selector/criterion/DLVideoItemSelectorCriterionCreationMenuRestriction.java
+++ b/modules/apps/document-library/document-library-video/src/main/java/com/liferay/document/library/video/internal/item/selector/criterion/DLVideoItemSelectorCriterionCreationMenuRestriction.java
@@ -27,7 +27,13 @@ import org.osgi.service.component.annotations.Component;
 /**
  * @author Adolfo Pérez
  */
-@Component(service = DLItemSelectorCriterionCreationMenuRestriction.class)
+@Component(
+	property = {
+		"model.class.name=com.liferay.item.selector.criteria.file.criterion.FileItemSelectorCriterion",
+		"model.class.name=com.liferay.item.selector.criteria.video.criterion.VideoItemSelectorCriterion"
+	},
+	service = DLItemSelectorCriterionCreationMenuRestriction.class
+)
 public class DLVideoItemSelectorCriterionCreationMenuRestriction
 	implements DLItemSelectorCriterionCreationMenuRestriction
 		<VideoItemSelectorCriterion> {

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/toolbar/contributor/helper/MenuItemProvider.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/toolbar/contributor/helper/MenuItemProvider.java
@@ -98,6 +98,7 @@ public class MenuItemProvider {
 		URLMenuItem urlMenuItem = new URLMenuItem();
 
 		urlMenuItem.setIcon("upload");
+		urlMenuItem.setKey(DLUIItemKeys.UPLOAD);
 		urlMenuItem.setLabel(
 			LanguageUtil.get(
 				PortalUtil.getHttpServletRequest(portletRequest),

--- a/modules/apps/item-selector/item-selector-taglib/src/main/java/com/liferay/item/selector/taglib/internal/display/context/ItemSelectorRepositoryEntryManagementToolbarDisplayContext.java
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/java/com/liferay/item/selector/taglib/internal/display/context/ItemSelectorRepositoryEntryManagementToolbarDisplayContext.java
@@ -115,7 +115,8 @@ public class ItemSelectorRepositoryEntryManagementToolbarDisplayContext {
 				(List<URLMenuItem>)(List<?>)menu.getMenuItems();
 
 			for (URLMenuItem urlMenuItem : urlMenuItems) {
-				if (Objects.equals(
+				if (Objects.equals(urlMenuItem.getKey(), DLUIItemKeys.UPLOAD) ||
+					Objects.equals(
 						urlMenuItem.getKey(), DLUIItemKeys.ADD_FOLDER) ||
 					allowedCreationMenuUIItemKeys.contains(
 						urlMenuItem.getKey())) {


### PR DESCRIPTION
- Add "File Upload" option to all item selectors.
- Add "External Video Shortcut" option to generic item selectors.

You can see the first change in any Item Selector (e.g. try to add a cover image to a blogs entry). For the second case, go to message boards, edit/create a thread, and in the body insert a link and choose "Browse Server". The "Documents & Media" tab will display the video shortcut option.