### PR TITLE
LPS-131435 Optimize UrlSubject upgrade process

### DIFF
--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/upgrade/v3_1_0/UrlSubjectUpgradeProcess.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/upgrade/v3_1_0/UrlSubjectUpgradeProcess.java
@@ -38,7 +38,13 @@ public class UrlSubjectUpgradeProcess extends UpgradeProcess {
 				new AlterTableAddColumn("urlSubject", "VARCHAR(255) null"));
 		}
 
+		runSQL(
+			"create index IX_TEMP on MBMessage (subject[$COLUMN_LENGTH:75$]," +
+				"messageId)");
+
 		_populateUrlSubject();
+
+		runSQL("drop index IX_TEMP on MBMessage");
 	}
 
 	private String _getUrlSubject(long id, String subject) {

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/upgrade/v3_1_0/UrlSubjectUpgradeProcess.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/upgrade/v3_1_0/UrlSubjectUpgradeProcess.java
@@ -79,24 +79,28 @@ public class UrlSubjectUpgradeProcess extends UpgradeProcess {
 							"= ?"))) {
 
 			int count = 0;
-			String currUrlSubject;
-			String prevUrlSubject = null;
+			String curUrlSubject = null;
+			String previousURLSubject = null;
 
 			while (resultSet.next()) {
 				long messageId = resultSet.getLong(1);
 				String subject = resultSet.getString(2);
 
-				currUrlSubject = _getUrlSubject(messageId, subject);
+				curUrlSubject = _getUrlSubject(messageId, subject);
 
-				if (StringUtil.equals(prevUrlSubject, currUrlSubject)) {
-					preparedStatement2.setString(
-						1, currUrlSubject + StringPool.DASH + ++count);
+				String suffix = null;
+
+				if (StringUtil.equals(previousURLSubject, curUrlSubject)) {
+					count++;
+					suffix = StringPool.DASH + count;
 				}
 				else {
 					count = 0;
-					prevUrlSubject = currUrlSubject;
-					preparedStatement2.setString(1, currUrlSubject);
+					previousURLSubject = curUrlSubject;
+					suffix = StringPool.BLANK;
 				}
+
+				preparedStatement2.setString(1, curUrlSubject + suffix);
 
 				preparedStatement2.setLong(2, messageId);
 


### PR DESCRIPTION
[LPS-131435](https://issues.liferay.com/browse/LPS-131435) improves the performance of the UrlSubject upgrade process. While iterating through each message of the database, instead of querying for the number of previously-seen subjects each iteration, we first sort the messages by their subject and messageId, then maintain a count as we iterate. Adding indexes to the subject and messageId columns improves this further. In a local testing environment with 15k messages, an average 45% improvement in the time taken to complete this process was observed compared to the current implementation in master.

cc @SamZiemer