### PR TITLE
LPS-130387 Search on properties field: eliminate wildcard usage and use a different type of query

### DIFF
--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/spi/model/index/contributor/DLFileEntryModelDocumentContributor.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/spi/model/index/contributor/DLFileEntryModelDocumentContributor.java
@@ -133,8 +133,6 @@ public class DLFileEntryModelDocumentContributor
 			document.addText(Field.DESCRIPTION, dlFileEntry.getDescription());
 			document.addKeyword(Field.FOLDER_ID, dlFileEntry.getFolderId());
 			document.addKeyword(Field.HIDDEN, dlFileEntry.isInHiddenFolder());
-			document.addText(
-				Field.PROPERTIES, dlFileEntry.getLuceneProperties());
 			document.addKeyword(Field.STATUS, dlFileVersion.getStatus());
 
 			String title = dlFileEntry.getTitle();

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFileEntryIndexerIndexedFieldsTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFileEntryIndexerIndexedFieldsTest.java
@@ -218,8 +218,6 @@ public class DLFileEntryIndexerIndexedFieldsTest extends BaseDLIndexerTestCase {
 			Field.ENTRY_CLASS_PK, String.valueOf(fileEntry.getFileEntryId()));
 		map.put(Field.FOLDER_ID, String.valueOf(fileEntry.getFolderId()));
 		map.put(Field.GROUP_ID, String.valueOf(fileEntry.getGroupId()));
-		map.put(
-			Field.PROPERTIES, FileUtil.stripExtension(fileEntry.getTitle()));
 		map.put(Field.SCOPE_GROUP_ID, String.valueOf(fileEntry.getGroupId()));
 		map.put(Field.STAGING_GROUP, "false");
 		map.put(Field.STATUS, "0");

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/spi/model/query/contributor/AlwaysPresentFieldsKeywordQueryContributor.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/spi/model/query/contributor/AlwaysPresentFieldsKeywordQueryContributor.java
@@ -61,8 +61,8 @@ public class AlwaysPresentFieldsKeywordQueryContributor
 	protected FieldQueryFactory fieldQueryFactory;
 
 	private static final String[] _ALWAYS_PRESENT_FIELDS = {
-		Field.COMMENTS, Field.CONTENT, Field.DESCRIPTION, Field.PROPERTIES,
-		Field.TITLE, Field.URL, Field.USER_NAME
+		Field.COMMENTS, Field.CONTENT, Field.DESCRIPTION, Field.TITLE,
+		Field.URL, Field.USER_NAME
 	};
 
 }

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLFileEntryImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLFileEntryImpl.java
@@ -245,6 +245,10 @@ public class DLFileEntryImpl extends DLFileEntryBaseImpl {
 			DLFileEntry.class.getName(), getFileEntryId());
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x)
+	 */
+	@Deprecated
 	@Override
 	public String getLuceneProperties() {
 		UnicodeProperties extraSettingsUnicodeProperties =

--- a/portal-kernel/src/com/liferay/document/library/kernel/model/DLFileEntry.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/model/DLFileEntry.java
@@ -109,6 +109,10 @@ public interface DLFileEntry
 
 	public com.liferay.portal.kernel.lock.Lock getLock();
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x)
+	 */
+	@Deprecated
 	public String getLuceneProperties();
 
 	public long getReadCount();

--- a/portal-kernel/src/com/liferay/document/library/kernel/model/DLFileEntryWrapper.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/model/DLFileEntryWrapper.java
@@ -562,6 +562,10 @@ public class DLFileEntryWrapper
 		return model.getLock();
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x)
+	 */
+	@Deprecated
 	@Override
 	public String getLuceneProperties() {
 		return model.getLuceneProperties();


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-130387

The properties field is a field that mainly integrates the title and the description, and it insert extra-attributes only if the file has it and in my opinion is without use.

since the properties field is inserted on the query as a wildcard with the double star and we are not effectively using it. I'm deleting it from the search of the documents and media.

You can check the deletion of it on the search field on : 

Adding the search bar on the page
Adding the Search Insights on the page


![image](https://user-images.githubusercontent.com/47524751/117180790-d8637200-add4-11eb-9adc-dc64173269fd.png)

making a search and seeing the result query

Thanks