### PR TITLE
LPS-131302 Set showExtraInfo variable to true to be able to view files with view_file_entry.jsp

### DIFF
--- a/modules/apps/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/servlet/taglib/AssetDisplayTag.java
+++ b/modules/apps/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/servlet/taglib/AssetDisplayTag.java
@@ -22,6 +22,7 @@ import com.liferay.asset.kernel.service.AssetEntryLocalServiceUtil;
 import com.liferay.asset.taglib.internal.servlet.ServletContextUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.taglib.util.IncludeTag;
@@ -266,6 +267,8 @@ public class AssetDisplayTag extends IncludeTag {
 		}
 
 		httpServletRequest.setAttribute(WebKeys.ASSET_ENTRY_VIEW_URL, _viewURL);
+
+		_showExtraInfo = ParamUtil.getBoolean(httpServletRequest, "showExtraInfo");
 
 		addParam("showComments", String.valueOf(_showComments));
 		addParam("showExtraInfo", String.valueOf(_showExtraInfo));

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/util/SearchUtil.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/util/SearchUtil.java
@@ -183,6 +183,10 @@ public class SearchUtil {
 				"assetEntryId", String.valueOf(assetEntry.getEntryId()));
 			viewContentURL.setParameter("type", assetRendererFactory.getType());
 
+			if (assetRendererFactory.getType().equals("document")) {
+				viewContentURL.setParameter("showExtraInfo", "true");
+			}
+
 			if (!viewInContext) {
 				return HttpUtil.setParameter(
 					viewContentURL.toString(), "p_l_back_url", currentURL);


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-131302

Updated PR based on comment [832861622](https://github.com/liferay-lima/liferay-portal/pull/1783#issuecomment-832861622)
The issue here is that the info button does not appear for searched documents that have a preview. This was occurring because all documents with a preview were being viewed by view_file_entry_simple_view.jsp because showExtraInfo is always equal to false.

To fix this, I set showExtraInfo to true. However, I did not know what the condition should be to set to true. Is there a set of certain file entries that should have the showExtraInfo set to true and the rest false; or should all file entry types have that property set to true? I could not find any reference to this.