### PR TITLE
LPS-131159 Implement Image Editor in item selector

### DIFF
--- a/modules/apps/blogs/blogs-item-selector-web/src/main/java/com/liferay/blogs/item/selector/web/internal/display/context/BlogsItemSelectorViewDisplayContext.java
+++ b/modules/apps/blogs/blogs-item-selector-web/src/main/java/com/liferay/blogs/item/selector/web/internal/display/context/BlogsItemSelectorViewDisplayContext.java
@@ -73,6 +73,16 @@ public class BlogsItemSelectorViewDisplayContext {
 		return _blogsEntryLocalService.fetchAttachmentsFolder(userId, groupId);
 	}
 
+	public PortletURL getEditImageURL(
+		LiferayPortletResponse liferayPortletResponse) {
+
+		return PortletURLBuilder.createActionURL(
+			liferayPortletResponse, PortletKeys.BLOGS
+		).setActionName(
+			"/blogs/image_editor"
+		).build();
+	}
+
 	public String[] getImageExtensions() throws ConfigurationException {
 		return _getBlogsFileUploadsConfiguration().imageExtensions();
 	}

--- a/modules/apps/blogs/blogs-item-selector-web/src/main/resources/META-INF/resources/blogs_attachments.jsp
+++ b/modules/apps/blogs/blogs-item-selector-web/src/main/resources/META-INF/resources/blogs_attachments.jsp
@@ -71,6 +71,7 @@ if (folder != null) {
 %>
 
 <liferay-item-selector:repository-entry-browser
+	editImageURL="<%= blogsItemSelectorViewDisplayContext.getEditImageURL(liferayPortletResponse) %>"
 	emptyResultsMessage='<%= LanguageUtil.get(resourceBundle, "there-are-no-blog-attachments") %>'
 	extensions="<%= ListUtil.fromArray(blogsItemSelectorViewDisplayContext.getImageExtensions()) %>"
 	itemSelectedEventName="<%= blogsItemSelectorViewDisplayContext.getItemSelectedEventName() %>"

--- a/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/portlet/action/UploadImageMVCActionCommand.java
+++ b/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/portlet/action/UploadImageMVCActionCommand.java
@@ -35,6 +35,7 @@ import org.osgi.service.component.annotations.Reference;
 	property = {
 		"javax.portlet.name=" + BlogsPortletKeys.BLOGS,
 		"javax.portlet.name=" + BlogsPortletKeys.BLOGS_ADMIN,
+		"mvc.command.name=/blogs/image_editor",
 		"mvc.command.name=/blogs/upload_image"
 	},
 	service = MVCActionCommand.class

--- a/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/upload/ImageBlogsUploadFileEntryHandler.java
+++ b/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/upload/ImageBlogsUploadFileEntryHandler.java
@@ -31,6 +31,8 @@ import com.liferay.portal.kernel.security.permission.resource.PortletResourcePer
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.upload.UploadPortletRequest;
 import com.liferay.portal.kernel.util.MimeTypesUtil;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.upload.UploadFileEntryHandler;
 
@@ -69,20 +71,20 @@ public class ImageBlogsUploadFileEntryHandler
 			themeDisplay.getPermissionChecker(), themeDisplay.getScopeGroup(),
 			ActionKeys.ADD_ENTRY);
 
-		String fileName = uploadPortletRequest.getFileName(_PARAMETER_NAME);
-		String contentType = uploadPortletRequest.getContentType(
-			_PARAMETER_NAME);
+		String fileName = uploadPortletRequest.getFileName(
+			_IMAGE_SELECTOR_PARAMETER_NAME);
 
-		_validateFile(
-			fileName, contentType,
-			uploadPortletRequest.getSize(_PARAMETER_NAME));
+		if (Validator.isNotNull(fileName)) {
+			try (InputStream inputStream = uploadPortletRequest.getFileAsStream(
+					_IMAGE_SELECTOR_PARAMETER_NAME)) {
 
-		try (InputStream inputStream = uploadPortletRequest.getFileAsStream(
-				_PARAMETER_NAME)) {
-
-			return addFileEntry(
-				fileName, contentType, inputStream, themeDisplay);
+				return _addFileEntry(
+					fileName, inputStream, _IMAGE_SELECTOR_PARAMETER_NAME,
+					uploadPortletRequest, themeDisplay);
+			}
 		}
+
+		return _editImageFileEntry(uploadPortletRequest, themeDisplay);
 	}
 
 	@Activate
@@ -119,6 +121,41 @@ public class ImageBlogsUploadFileEntryHandler
 	@Reference(target = "(resource.name=" + BlogsConstants.RESOURCE_NAME + ")")
 	protected PortletResourcePermission portletResourcePermission;
 
+	private FileEntry _addFileEntry(
+			String fileName, InputStream inputStream, String parameterName,
+			UploadPortletRequest uploadPortletRequest,
+			ThemeDisplay themeDisplay)
+		throws PortalException {
+
+		String contentType = uploadPortletRequest.getContentType(parameterName);
+
+		_validateFile(
+			fileName, contentType, uploadPortletRequest.getSize(parameterName));
+
+		return addFileEntry(fileName, contentType, inputStream, themeDisplay);
+	}
+
+	private FileEntry _editImageFileEntry(
+			UploadPortletRequest uploadPortletRequest,
+			ThemeDisplay themeDisplay)
+		throws IOException, PortalException {
+
+		long fileEntryId = ParamUtil.getLong(
+			uploadPortletRequest, "fileEntryId");
+
+		FileEntry fileEntry = portletFileRepository.getPortletFileEntry(
+			fileEntryId);
+
+		try (InputStream inputStream = uploadPortletRequest.getFileAsStream(
+				_IMAGE_EDITOR_PARAMETER_NAME)) {
+
+			return _addFileEntry(
+				fileEntry.getFileName(), inputStream,
+				_IMAGE_EDITOR_PARAMETER_NAME, uploadPortletRequest,
+				themeDisplay);
+		}
+	}
+
 	private void _validateFile(String fileName, String contentType, long size)
 		throws PortalException {
 
@@ -144,7 +181,10 @@ public class ImageBlogsUploadFileEntryHandler
 		}
 	}
 
-	private static final String _PARAMETER_NAME = "imageSelectorFileName";
+	private static final String _IMAGE_EDITOR_PARAMETER_NAME = "imageBlob";
+
+	private static final String _IMAGE_SELECTOR_PARAMETER_NAME =
+		"imageSelectorFileName";
 
 	private volatile BlogsFileUploadsConfiguration
 		_blogsFileUploadsConfiguration;

--- a/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/display/context/DLItemSelectorViewDisplayContext.java
+++ b/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/display/context/DLItemSelectorViewDisplayContext.java
@@ -125,6 +125,18 @@ public class DLItemSelectorViewDisplayContext<T extends ItemSelectorCriterion> {
 			getAllowedCreationMenuUIItemKeys(_itemSelectorCriterion);
 	}
 
+	public PortletURL getEditImageURL(
+		LiferayPortletResponse liferayPortletResponse) {
+
+		return PortletURLBuilder.createActionURL(
+			liferayPortletResponse, PortletKeys.DOCUMENT_LIBRARY
+		).setActionName(
+			"/document_library/image_editor"
+		).setParameter(
+			"folderId", _getFolderId()
+		).build();
+	}
+
 	public String[] getExtensions() {
 		return _dlItemSelectorView.getExtensions();
 	}

--- a/modules/apps/document-library/document-library-item-selector-web/src/main/resources/META-INF/resources/documents.jsp
+++ b/modules/apps/document-library/document-library-item-selector-web/src/main/resources/META-INF/resources/documents.jsp
@@ -22,6 +22,7 @@ DLItemSelectorViewDisplayContext dlItemSelectorViewDisplayContext = (DLItemSelec
 
 <liferay-item-selector:repository-entry-browser
 	allowedCreationMenuUIItemKeys="<%= dlItemSelectorViewDisplayContext.getAllowedCreationMenuUIItemKeys() %>"
+	editImageURL="<%= dlItemSelectorViewDisplayContext.getEditImageURL(liferayPortletResponse) %>"
 	emptyResultsMessage='<%= LanguageUtil.get(request, "there-are-no-documents-or-media-files-in-this-folder") %>'
 	extensions="<%= ListUtil.toList(dlItemSelectorViewDisplayContext.getExtensions()) %>"
 	itemSelectedEventName="<%= dlItemSelectorViewDisplayContext.getItemSelectedEventName() %>"

--- a/modules/apps/document-library/document-library-web/package.json
+++ b/modules/apps/document-library/document-library-web/package.json
@@ -11,8 +11,8 @@
 		"@liferay/frontend-js-react-web": "*",
 		"asset-taglib": "*",
 		"clipboard": "2.0.4",
-		"cropperjs": "^1.5.11",
 		"frontend-js-web": "*",
+		"item-selector-taglib": "*",
 		"prop-types": "15.7.2",
 		"react": "16.12.0",
 		"react-dom": "16.12.0"

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/UploadFileEntryMVCActionCommand.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/UploadFileEntryMVCActionCommand.java
@@ -36,6 +36,7 @@ import org.osgi.service.component.annotations.Reference;
 		"javax.portlet.name=" + DLPortletKeys.DOCUMENT_LIBRARY,
 		"javax.portlet.name=" + DLPortletKeys.DOCUMENT_LIBRARY_ADMIN,
 		"javax.portlet.name=" + DLPortletKeys.MEDIA_GALLERY_DISPLAY,
+		"mvc.command.name=/document_library/image_editor",
 		"mvc.command.name=/document_library/upload_file_entry"
 	},
 	service = MVCActionCommand.class

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/upload/DLUploadFileEntryHandler.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/upload/DLUploadFileEntryHandler.java
@@ -92,9 +92,8 @@ public class DLUploadFileEntryHandler implements UploadFileEntryHandler {
 			ThemeDisplay themeDisplay)
 		throws PortalException {
 
-		long size = uploadPortletRequest.getSize(parameterName);
-
-		_dlValidator.validateFileSize(fileName, size);
+		_dlValidator.validateFileSize(
+			fileName, uploadPortletRequest.getSize(parameterName));
 
 		String uniqueFileName = _uniqueFileNameProvider.provide(
 			fileName,
@@ -122,11 +121,10 @@ public class DLUploadFileEntryHandler implements UploadFileEntryHandler {
 
 			FileEntry fileEntry = _dlAppService.getFileEntry(fileEntryId);
 
-			String fileName = fileEntry.getFileName();
-
 			return _addFileEntry(
-				fileName, folderId, inputStream, _IMAGE_EDITOR_PARAMETER_NAME,
-				uploadPortletRequest, themeDisplay);
+				fileEntry.getFileName(), folderId, inputStream,
+				_IMAGE_EDITOR_PARAMETER_NAME, uploadPortletRequest,
+				themeDisplay);
 		}
 	}
 

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/upload/DLUploadFileEntryHandler.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/upload/DLUploadFileEntryHandler.java
@@ -35,6 +35,7 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.upload.UploadPortletRequest;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.upload.UniqueFileNameProvider;
 import com.liferay.upload.UploadFileEntryHandler;
@@ -67,25 +68,65 @@ public class DLUploadFileEntryHandler implements UploadFileEntryHandler {
 			_folderModelResourcePermission, themeDisplay.getPermissionChecker(),
 			themeDisplay.getScopeGroupId(), folderId, ActionKeys.ADD_DOCUMENT);
 
-		String fileName = uploadPortletRequest.getFileName(_PARAMETER_NAME);
-		long size = uploadPortletRequest.getSize(_PARAMETER_NAME);
+		String fileName = uploadPortletRequest.getFileName(
+			_IMAGE_SELECTOR_PARAMETER_NAME);
+
+		if (Validator.isNotNull(fileName)) {
+			try (InputStream inputStream = uploadPortletRequest.getFileAsStream(
+					_IMAGE_SELECTOR_PARAMETER_NAME)) {
+
+				return _addFileEntry(
+					fileName, folderId, inputStream,
+					_IMAGE_SELECTOR_PARAMETER_NAME, uploadPortletRequest,
+					themeDisplay);
+			}
+		}
+
+		return _editImageFileEntry(
+			uploadPortletRequest, themeDisplay, folderId);
+	}
+
+	private FileEntry _addFileEntry(
+			String fileName, long folderId, InputStream inputStream,
+			String parameterName, UploadPortletRequest uploadPortletRequest,
+			ThemeDisplay themeDisplay)
+		throws PortalException {
+
+		long size = uploadPortletRequest.getSize(parameterName);
 
 		_dlValidator.validateFileSize(fileName, size);
 
+		String uniqueFileName = _uniqueFileNameProvider.provide(
+			fileName,
+			curFileName -> _exists(
+				themeDisplay.getScopeGroupId(), folderId, curFileName));
+
+		return _dlAppService.addFileEntry(
+			themeDisplay.getScopeGroupId(), folderId, uniqueFileName,
+			uploadPortletRequest.getContentType(parameterName), uniqueFileName,
+			_getDescription(uploadPortletRequest), StringPool.BLANK,
+			inputStream, uploadPortletRequest.getSize(parameterName),
+			_getServiceContext(uploadPortletRequest));
+	}
+
+	private FileEntry _editImageFileEntry(
+			UploadPortletRequest uploadPortletRequest,
+			ThemeDisplay themeDisplay, long folderId)
+		throws IOException, PortalException {
+
 		try (InputStream inputStream = uploadPortletRequest.getFileAsStream(
-				_PARAMETER_NAME)) {
+				_IMAGE_EDITOR_PARAMETER_NAME)) {
 
-			String uniqueFileName = _uniqueFileNameProvider.provide(
-				fileName,
-				curFileName -> _exists(
-					themeDisplay.getScopeGroupId(), folderId, curFileName));
+			long fileEntryId = ParamUtil.getLong(
+				uploadPortletRequest, "fileEntryId");
 
-			return _dlAppService.addFileEntry(
-				themeDisplay.getScopeGroupId(), folderId, uniqueFileName,
-				uploadPortletRequest.getContentType(_PARAMETER_NAME),
-				uniqueFileName, _getDescription(uploadPortletRequest),
-				StringPool.BLANK, inputStream, size,
-				_getServiceContext(uploadPortletRequest));
+			FileEntry fileEntry = _dlAppService.getFileEntry(fileEntryId);
+
+			String fileName = fileEntry.getFileName();
+
+			return _addFileEntry(
+				fileName, folderId, inputStream, _IMAGE_EDITOR_PARAMETER_NAME,
+				uploadPortletRequest, themeDisplay);
 		}
 	}
 
@@ -166,7 +207,10 @@ public class DLUploadFileEntryHandler implements UploadFileEntryHandler {
 		return serviceContext;
 	}
 
-	private static final String _PARAMETER_NAME = "imageSelectorFileName";
+	private static final String _IMAGE_EDITOR_PARAMETER_NAME = "imageBlob";
+
+	private static final String _IMAGE_SELECTOR_PARAMETER_NAME =
+		"imageSelectorFileName";
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		DLUploadFileEntryHandler.class);

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/css/_image_editor_modal.scss
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/css/_image_editor_modal.scss
@@ -1,0 +1,5 @@
+.image-editor-modal {
+	.modal-body {
+		padding: 0;
+	}
+}

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/css/main.scss
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/css/main.scss
@@ -1,6 +1,6 @@
 @import 'atlas-variables';
 
-@import 'image_editor';
+@import 'image_editor_modal';
 
 @mixin file-icon($colorIndex, $color) {
 	[data-file-icon-color='#{$colorIndex}'] .lexicon-icon {

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/image-editor/EditImageWithImageEditor.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/image-editor/EditImageWithImageEditor.js
@@ -13,10 +13,10 @@
  */
 
 import ClayModal, {useModal} from '@clayui/modal';
-import {fetch, navigate} from 'frontend-js-web';
+import {navigate} from 'frontend-js-web';
 import React, {useEffect, useRef, useState} from 'react';
 
-import ImageEditor from './ImageEditor';
+import {ImageEditor} from 'item-selector-taglib';
 
 export default ({editImageURL, portletNamespace, redirectURL}) => {
 	const fileEntryIdRef = useRef();
@@ -28,24 +28,10 @@ export default ({editImageURL, portletNamespace, redirectURL}) => {
 		setShowModal(false);
 	};
 
-	const handleSaveButtonClick = (canvas) => {
-		canvas.toBlob((blob) => {
-			const formData = new FormData();
-
-			formData.append('fileEntryId', fileEntryIdRef.current);
-			formData.append('imageBlob', blob, fileEntryIdRef.current);
-
-			fetch(editImageURL, {
-				body: formData,
-				method: 'POST',
-			})
-				.then((response) => response.json())
-				.then((response) => {
-					if (response?.success) {
-						navigate(redirectURL);
-					}
-				});
-		});
+	const handleSave = (response) => {
+		if (response?.success) {
+			navigate(redirectURL);
+		}
 	};
 
 	const {observer, onClose} = useModal({
@@ -83,9 +69,11 @@ export default ({editImageURL, portletNamespace, redirectURL}) => {
 					<ClayModal.Body>
 						{imageURL && (
 							<ImageEditor
+								imageId={fileEntryIdRef.current}
 								imageSrc={imageURL}
 								onCancel={onClose}
-								onSave={handleSaveButtonClick}
+								onSave={handleSave}
+								saveURL={editImageURL}
 							/>
 						)}
 					</ClayModal.Body>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/image-editor/EditImageWithImageEditor.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/image-editor/EditImageWithImageEditor.js
@@ -14,9 +14,8 @@
 
 import ClayModal, {useModal} from '@clayui/modal';
 import {navigate} from 'frontend-js-web';
-import React, {useEffect, useRef, useState} from 'react';
-
 import {ImageEditor} from 'item-selector-taglib';
+import React, {useEffect, useRef, useState} from 'react';
 
 export default ({editImageURL, portletNamespace, redirectURL}) => {
 	const fileEntryIdRef = useRef();

--- a/modules/apps/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/portal/_item_selector_preview.scss
+++ b/modules/apps/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/portal/_item_selector_preview.scss
@@ -111,4 +111,8 @@ $infoPanelSidebarDDColor: $secondary-l1;
 			float: right;
 		}
 	}
+
+	.image-editor {
+		height: calc(100% - 3.5rem);
+	}
 }

--- a/modules/apps/item-selector/item-selector-taglib/bnd.bnd
+++ b/modules/apps/item-selector/item-selector-taglib/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Item Selector Taglib
 Bundle-SymbolicName: com.liferay.item.selector.taglib
-Bundle-Version: 5.0.4
+Bundle-Version: 5.1.0
 Export-Package:\
 	com.liferay.item.selector.taglib,\
 	com.liferay.item.selector.taglib.servlet.taglib,\

--- a/modules/apps/item-selector/item-selector-taglib/package.json
+++ b/modules/apps/item-selector/item-selector-taglib/package.json
@@ -18,6 +18,11 @@
 		"react": "16.12.0",
 		"react-dom": "16.12.0"
 	},
+	"jest": {
+		"testPathIgnorePatterns": [
+			"<rootDir>/test/item_selector_preview/ItemSelectorPreview.es.js"
+		]
+	},
 	"main": "index.es.js",
 	"name": "item-selector-taglib",
 	"scripts": {

--- a/modules/apps/item-selector/item-selector-taglib/package.json
+++ b/modules/apps/item-selector/item-selector-taglib/package.json
@@ -8,9 +8,9 @@
 		"@clayui/navigation-bar": "3.3.5",
 		"@clayui/progress-bar": "3.2.0",
 		"@clayui/tabs": "3.3.5",
+		"@clayui/toolbar": "3.0.6",
 		"@liferay/frontend-js-react-web": "*",
 		"@liferay/frontend-js-state-web": "*",
-		"@clayui/toolbar": "3.0.6",
 		"cropperjs": "1.5.11",
 		"frontend-js-web": "*",
 		"metal-state": "2.16.8",
@@ -26,5 +26,5 @@
 		"format": "liferay-npm-scripts fix",
 		"test": "liferay-npm-scripts test"
 	},
-	"version": "5.0.4"
+	"version": "5.1.0"
 }

--- a/modules/apps/item-selector/item-selector-taglib/package.json
+++ b/modules/apps/item-selector/item-selector-taglib/package.json
@@ -2,6 +2,7 @@
 	"dependencies": {
 		"@clayui/alert": "3.26.0",
 		"@clayui/button": "3.6.0",
+		"@clayui/form": "3.14.4",
 		"@clayui/icon": "3.1.0",
 		"@clayui/layout": "3.3.0",
 		"@clayui/navigation-bar": "3.3.5",
@@ -9,6 +10,8 @@
 		"@clayui/tabs": "3.3.5",
 		"@liferay/frontend-js-react-web": "*",
 		"@liferay/frontend-js-state-web": "*",
+		"@clayui/toolbar": "3.0.6",
+		"cropperjs": "1.5.11",
 		"frontend-js-web": "*",
 		"metal-state": "2.16.8",
 		"prop-types": "15.7.2",

--- a/modules/apps/item-selector/item-selector-taglib/src/main/java/com/liferay/item/selector/taglib/servlet/taglib/ImageSelectorTag.java
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/java/com/liferay/item/selector/taglib/servlet/taglib/ImageSelectorTag.java
@@ -67,7 +67,8 @@ public class ImageSelectorTag extends IncludeTag {
 	}
 
 	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #getImageCropDirection()}
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
+	 *             #getImageCropDirection()}
 	 */
 	@Deprecated
 	public String getDraggableImage() {
@@ -111,7 +112,8 @@ public class ImageSelectorTag extends IncludeTag {
 	}
 
 	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #setImageCropDirection()}
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
+	 *             #setImageCropDirection()}
 	 */
 	@Deprecated
 	public void setDraggableImage(String draggableImage) {

--- a/modules/apps/item-selector/item-selector-taglib/src/main/java/com/liferay/item/selector/taglib/servlet/taglib/RepositoryEntryBrowserTag.java
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/java/com/liferay/item/selector/taglib/servlet/taglib/RepositoryEntryBrowserTag.java
@@ -56,6 +56,10 @@ public class RepositoryEntryBrowserTag extends IncludeTag {
 		return _dlMimeTypeDisplayContext;
 	}
 
+	public PortletURL getEditImageURL() {
+		return _editImageURL;
+	}
+
 	public String getEmptyResultsMessage() {
 		return _emptyResultsMessage;
 	}
@@ -140,6 +144,10 @@ public class RepositoryEntryBrowserTag extends IncludeTag {
 		_dlMimeTypeDisplayContext = dlMimeTypeDisplayContext;
 	}
 
+	public void setEditImageURL(PortletURL editImageURL) {
+		_editImageURL = editImageURL;
+	}
+
 	public void setEmptyResultsMessage(String emptyResultsMessage) {
 		_emptyResultsMessage = emptyResultsMessage;
 	}
@@ -209,6 +217,7 @@ public class RepositoryEntryBrowserTag extends IncludeTag {
 		_desiredItemSelectorReturnTypes = null;
 		_displayStyle = null;
 		_dlMimeTypeDisplayContext = null;
+		_editImageURL = null;
 		_emptyResultsMessage = null;
 		_extensions = new ArrayList<>();
 		_itemSelectedEventName = null;
@@ -290,6 +299,9 @@ public class RepositoryEntryBrowserTag extends IncludeTag {
 		}
 
 		httpServletRequest.setAttribute(
+			"liferay-item-selector:repository-entry-browser:editImageURL",
+			_editImageURL);
+		httpServletRequest.setAttribute(
 			"liferay-item-selector:repository-entry-browser:extensions",
 			_extensions);
 		httpServletRequest.setAttribute(
@@ -352,6 +364,7 @@ public class RepositoryEntryBrowserTag extends IncludeTag {
 	private List<ItemSelectorReturnType> _desiredItemSelectorReturnTypes;
 	private String _displayStyle;
 	private DLMimeTypeDisplayContext _dlMimeTypeDisplayContext;
+	private PortletURL _editImageURL;
 	private String _emptyResultsMessage;
 	private List<String> _extensions = new ArrayList<>();
 	private String _itemSelectedEventName;

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/liferay-item-selector.tld
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/liferay-item-selector.tld
@@ -119,6 +119,12 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
+			<description>The target URL for the method to edit the image via image editor.</description>
+			<name>editImageURL</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
 			<description>A message to be shown if there are no results.</description>
 			<name>emptyResultsMessage</name>
 			<required>false</required>

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/css/image_editor.scss
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/css/image_editor.scss
@@ -1,8 +1,9 @@
-.image-editor-modal {
-	.modal-body {
-		background-color: $dark;
-		padding: 0;
-	}
+@import 'atlas-variables';
+
+.image-editor {
+	background-color: $dark;
+	height: 100%;
+	position: relative;
 
 	.tbar {
 		background-color: $dark-d2;

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/image_editor/ImageEditor.js
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/image_editor/ImageEditor.js
@@ -17,8 +17,10 @@ import {ClayInput, ClaySelectWithOption} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import ClayToolbar from '@clayui/toolbar';
 import Cropper from 'cropperjs';
-import React, {useEffect, useRef, useState} from 'react';
 import {fetch} from 'frontend-js-web';
+import React, {useEffect, useRef, useState} from 'react';
+
+import '../css/image_editor.scss';
 
 import 'cropperjs/dist/cropper.css';
 
@@ -52,7 +54,13 @@ const zoomSteps = [12.5, 25, 50, 100, 150, 200];
 
 const noop = () => {};
 
-export default ({imageId, imageSrc, onCancel = noop, onSave = noop, saveURL}) => {
+export default ({
+	imageId,
+	imageSrc,
+	onCancel = noop,
+	onSave = noop,
+	saveURL,
+}) => {
 	const ref = useRef();
 
 	const [currentZoom, setCurrentZoom] = useState(100);
@@ -181,7 +189,7 @@ export default ({imageId, imageSrc, onCancel = noop, onSave = noop, saveURL}) =>
 	}, []);
 
 	return (
-		<>
+		<div className="image-editor">
 			<div style={{height: '100%'}}>
 				<img
 					ref={ref}
@@ -261,6 +269,6 @@ export default ({imageId, imageSrc, onCancel = noop, onSave = noop, saveURL}) =>
 					</ClayToolbar.Item>
 				</ClayToolbar.Nav>
 			</ClayToolbar>
-		</>
+		</div>
 	);
 };

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/image_editor/ImageEditor.js
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/image_editor/ImageEditor.js
@@ -57,6 +57,7 @@ const noop = () => {};
 export default ({
 	imageId,
 	imageSrc,
+	itemReturnType,
 	onCancel = noop,
 	onSave = noop,
 	saveURL,
@@ -88,6 +89,7 @@ export default ({
 
 			formData.append('fileEntryId', imageId);
 			formData.append('imageBlob', blob, imageId);
+			formData.append('itemReturnType', itemReturnType);
 
 			fetch(saveURL, {
 				body: formData,

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/image_editor/ImageEditor.js
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/image_editor/ImageEditor.js
@@ -18,6 +18,7 @@ import ClayIcon from '@clayui/icon';
 import ClayToolbar from '@clayui/toolbar';
 import Cropper from 'cropperjs';
 import React, {useEffect, useRef, useState} from 'react';
+import {fetch} from 'frontend-js-web';
 
 import 'cropperjs/dist/cropper.css';
 
@@ -51,7 +52,7 @@ const zoomSteps = [12.5, 25, 50, 100, 150, 200];
 
 const noop = () => {};
 
-export default ({imageSrc, onCancel = noop, onSave = noop}) => {
+export default ({imageId, imageSrc, onCancel = noop, onSave = noop, saveURL}) => {
 	const ref = useRef();
 
 	const [currentZoom, setCurrentZoom] = useState(100);
@@ -72,7 +73,23 @@ export default ({imageSrc, onCancel = noop, onSave = noop}) => {
 	};
 
 	const handleSave = () => {
-		onSave(ref.current?.cropper?.getCroppedCanvas());
+		const canvas = ref.current?.cropper?.getCroppedCanvas();
+
+		canvas.toBlob((blob) => {
+			const formData = new FormData();
+
+			formData.append('fileEntryId', imageId);
+			formData.append('imageBlob', blob, imageId);
+
+			fetch(saveURL, {
+				body: formData,
+				method: 'POST',
+			})
+				.then((response) => response.json())
+				.then((response) => {
+					onSave(response);
+				});
+		});
 	};
 
 	const handleZoomIn = () => {

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/image_editor/ImageEditor.js
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/image_editor/ImageEditor.js
@@ -89,7 +89,7 @@ export default ({
 
 			formData.append('fileEntryId', imageId);
 			formData.append('imageBlob', blob, imageId);
-			formData.append('itemReturnType', itemReturnType);
+			formData.append('returnType', itemReturnType);
 
 			fetch(saveURL, {
 				body: formData,

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/index.es.js
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/index.es.js
@@ -12,6 +12,7 @@
  * details.
  */
 
+export {default as ImageEditor} from './image_editor/ImageEditor';
 export {default as ItemSelectorRepositoryEntryBrowser} from './repository_entry_browser/js/ItemSelectorRepositoryEntryBrowser.es';
 
 export {

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/item_selector_preview/js/Carousel.es.js
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/item_selector_preview/js/Carousel.es.js
@@ -19,9 +19,7 @@ import React, {useState} from 'react';
 
 import PreviewImage from './PreviewImage.es';
 import PreviewVideo from './PreviewVideo.es';
-
-const STR_VIDEO_HTML_RETURN_TYPE =
-	'com.liferay.item.selector.criteria.VideoEmbeddableHTMLItemSelectorReturnType';
+import {STR_VIDEO_HTML_RETURN_TYPE} from './constants';
 
 const Arrow = ({direction, handleClick}) => (
 	<div className={`pull-${direction}`}>

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/item_selector_preview/js/Header.es.js
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/item_selector_preview/js/Header.es.js
@@ -22,9 +22,12 @@ const Header = ({
 	disabledAddButton = false,
 	handleClickAdd,
 	handleClickBack,
+	handleClickEdit,
 	headerTitle,
 	infoButtonRef,
+	showEditIcon,
 	showInfoIcon,
+	showNavbar,
 }) => (
 	<div className="navbar navigation-bar navigation-bar-light">
 		<ClayLayout.ContainerFluid className="header">
@@ -48,34 +51,48 @@ const Header = ({
 				</ClayLayout.ContainerFluid>
 			</nav>
 
-			<nav className="navbar navbar-expand-md navbar-underline navigation-bar navigation-bar-light">
-				<ClayLayout.ContainerFluid>
-					<ul className="navbar-nav">
-						{showInfoIcon && (
-							<li className="btn-group-item nav-item">
+			{showNavbar && (
+				<nav className="navbar navbar-expand-md navbar-underline navigation-bar navigation-bar-light">
+					<ClayLayout.ContainerFluid>
+						<ul className="navbar-nav">
+							{showEditIcon && (
+								<li className="btn-group-item nav-item">
+									<ClayButton
+										borderless
+										displayType="secondary"
+										monospaced
+										onClick={handleClickEdit}
+									>
+										<ClayIcon symbol="pencil" />
+									</ClayButton>
+								</li>
+							)}
+							{showInfoIcon && (
+								<li className="btn-group-item nav-item">
+									<ClayButton
+										borderless
+										displayType="secondary"
+										id="infoButtonRef"
+										monospaced
+										ref={infoButtonRef}
+									>
+										<ClayIcon symbol="info-panel-open" />
+									</ClayButton>
+								</li>
+							)}
+							<li className="nav-item">
 								<ClayButton
-									borderless
-									displayType="secondary"
-									id="infoButtonRef"
-									monospaced
-									ref={infoButtonRef}
+									disabled={disabledAddButton}
+									displayType="primary"
+									onClick={handleClickAdd}
 								>
-									<ClayIcon symbol="info-panel-open" />
+									{Liferay.Language.get('add')}
 								</ClayButton>
 							</li>
-						)}
-						<li className="nav-item">
-							<ClayButton
-								disabled={disabledAddButton}
-								displayType="primary"
-								onClick={handleClickAdd}
-							>
-								{Liferay.Language.get('add')}
-							</ClayButton>
-						</li>
-					</ul>
-				</ClayLayout.ContainerFluid>
-			</nav>
+						</ul>
+					</ClayLayout.ContainerFluid>
+				</nav>
+			)}
 		</ClayLayout.ContainerFluid>
 	</div>
 );
@@ -85,6 +102,7 @@ Header.propTypes = {
 	handleClickAdd: PropTypes.func.isRequired,
 	handleClickBack: PropTypes.func.isRequired,
 	headerTitle: PropTypes.string.isRequired,
+	showEditIcon: PropTypes.bool,
 	showInfoIcon: PropTypes.bool,
 };
 

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/item_selector_preview/js/ItemSelectorPreview.es.js
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/item_selector_preview/js/ItemSelectorPreview.es.js
@@ -34,6 +34,7 @@ const ItemSelectorPreview = ({
 	editImageURL,
 	handleSelectedItem,
 	headerTitle,
+	itemReturnType,
 	items,
 }) => {
 	const [currentItemIndex, setCurrentItemIndex] = useState(currentIndex);
@@ -228,6 +229,7 @@ const ItemSelectorPreview = ({
 				<ImageEditor
 					imageId={currentItem.fileEntryId || currentItem.fileentryid}
 					imageSrc={currentItem.url}
+					itemReturnType={itemReturnType}
 					onCancel={handleCancelEditing}
 					onSave={handleSaveEditedImage}
 					saveURL={editImageURL}

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/item_selector_preview/js/ItemSelectorPreview.es.js
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/item_selector_preview/js/ItemSelectorPreview.es.js
@@ -136,18 +136,15 @@ const ItemSelectorPreview = ({
 		setReloadOnHide(true);
 	};
 
-	const updateCurrentItem = useCallback(
-		({url, value}) => {
-			if (isMounted()) {
-				const newItemList = [...itemList];
+	const updateCurrentItem = (itemData) => {
+		if (isMounted()) {
+			const newItemList = [...itemList];
 
-				newItemList[currentItemIndex] = {...currentItem, url, value};
+			newItemList[currentItemIndex] = {...currentItem, ...itemData};
 
-				updateItemList(newItemList);
-			}
-		},
-		[currentItem, currentItemIndex, isMounted, itemList]
-	);
+			updateItemList(newItemList);
+		}
+	};
 
 	useEffect(() => {
 		document.documentElement.addEventListener('keydown', handleOnKeyDown);
@@ -198,7 +195,7 @@ const ItemSelectorPreview = ({
 			/>
 			{isEditing ? (
 				<ImageEditor
-					imageId={currentItem.fileentryid}
+					imageId={currentItem.fileEntryId || currentItem.fileentryid}
 					imageSrc={currentItem.url}
 					onCancel={handleCancelEditing}
 					onSave={handleSaveEditedImage}

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/item_selector_preview/js/ItemSelectorPreview.es.js
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/item_selector_preview/js/ItemSelectorPreview.es.js
@@ -127,8 +127,36 @@ const ItemSelectorPreview = ({
 		[close, handleClickNext, handleClickPrevious, isMounted]
 	);
 
-	const handleSaveEditedImage = () => {
-		setIsEditing(false);
+	const handleSaveEditedImage = ({file, success}) => {
+		if (success) {
+			const newItem = {
+				...currentItem,
+				fileEntryId: file.fileEntryId,
+				groupId: file.groupId,
+				title: file.title,
+				url: file.url,
+				uuid: file.uuid,
+				value: file.resolvedValue
+			};
+
+			if (!newItem.value) {
+				const imageValue = {
+					fileEntryId: newItem.fileEntryId,
+					groupId: newItem.groupId,
+					title: newItem.title,
+					type: newItem.type,
+					url: newItem.url,
+					uuid: newItem.uuid,
+				};
+
+				newItem.value = JSON.stringify(imageValue);
+			}
+
+			setIsEditing(false);
+
+			close();
+			handleSelectedItem(newItem);
+		}
 	};
 
 	const updateItemList = (newItemList) => {

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/item_selector_preview/js/ItemSelectorPreview.es.js
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/item_selector_preview/js/ItemSelectorPreview.es.js
@@ -136,7 +136,7 @@ const ItemSelectorPreview = ({
 				title: file.title,
 				url: file.url,
 				uuid: file.uuid,
-				value: file.resolvedValue
+				value: file.resolvedValue,
 			};
 
 			if (!newItem.value) {
@@ -164,15 +164,18 @@ const ItemSelectorPreview = ({
 		setReloadOnHide(true);
 	};
 
-	const updateCurrentItem = (itemData) => {
-		if (isMounted()) {
-			const newItemList = [...itemList];
+	const updateCurrentItem = useCallback(
+		(itemData) => {
+			if (isMounted()) {
+				const newItemList = [...itemList];
 
-			newItemList[currentItemIndex] = {...currentItem, ...itemData};
+				newItemList[currentItemIndex] = {...currentItem, ...itemData};
 
-			updateItemList(newItemList);
-		}
-	};
+				updateItemList(newItemList);
+			}
+		},
+		[currentItem, currentItemIndex, isMounted, itemList]
+	);
 
 	useEffect(() => {
 		document.documentElement.addEventListener('keydown', handleOnKeyDown);

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/item_selector_preview/js/constants.js
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/item_selector_preview/js/constants.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+const STR_VIDEO_HTML_RETURN_TYPE =
+	'com.liferay.item.selector.criteria.VideoEmbeddableHTMLItemSelectorReturnType';
+
+export {STR_VIDEO_HTML_RETURN_TYPE};

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/js/ItemSelectorRepositoryEntryBrowser.es.js
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/js/ItemSelectorRepositoryEntryBrowser.es.js
@@ -84,6 +84,7 @@ class ItemSelectorRepositoryEntryBrowser extends PortletBase {
 		const data = {
 			container,
 			currentIndex: index,
+			editImageURL: this.editImageURL,
 			handleSelectedItem: this._onItemSelected.bind(this),
 			headerTitle: this.closeCaption,
 			items,
@@ -518,6 +519,15 @@ ItemSelectorRepositoryEntryBrowser.STATE = {
 	 * @type {String}
 	 */
 	closeCaption: Config.string(),
+
+	/**
+	 * Endpoint to send the image edited in the Image Editor
+	 *
+	 * @instance
+	 * @memberof ItemSelectorRepositoryEntryBrowser
+	 * @type {String}
+	 */
+	editImageURL: Config.string(),
 
 	/**
 	 * Time to hide the alert messages.

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/js/ItemSelectorRepositoryEntryBrowser.es.js
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/js/ItemSelectorRepositoryEntryBrowser.es.js
@@ -158,7 +158,7 @@ class ItemSelectorRepositoryEntryBrowser extends PortletBase {
 
 					Liferay.componentReady('ItemSelectorPreview').then(() => {
 						Liferay.fire('updateCurrentItem', {
-							url: itemFileUrl,
+							...itemFile,
 							value: itemFileValue,
 						});
 					});

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/js/ItemSelectorRepositoryEntryBrowser.es.js
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/js/ItemSelectorRepositoryEntryBrowser.es.js
@@ -87,6 +87,7 @@ class ItemSelectorRepositoryEntryBrowser extends PortletBase {
 			editImageURL: this.editImageURL,
 			handleSelectedItem: this._onItemSelected.bind(this),
 			headerTitle: this.closeCaption,
+			itemReturnType: this.uploadItemReturnType,
 			items,
 		};
 

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/page.jsp
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/page.jsp
@@ -20,6 +20,7 @@
 String randomNamespace = PortalUtil.generateRandomKey(request, "taglib_ui_repository_entry_browse_page") + StringPool.UNDERLINE;
 
 String displayStyle = GetterUtil.getString(request.getAttribute("liferay-item-selector:repository-entry-browser:displayStyle"));
+PortletURL editImageURL = (PortletURL)request.getAttribute("liferay-item-selector:repository-entry-browser:editImageURL");
 String emptyResultsMessage = GetterUtil.getString(request.getAttribute("liferay-item-selector:repository-entry-browser:emptyResultsMessage"));
 ItemSelectorReturnType existingFileEntryReturnType = (ItemSelectorReturnType)request.getAttribute("liferay-item-selector:repository-entry-browser:existingFileEntryReturnType");
 List<String> extensions = (List)request.getAttribute("liferay-item-selector:repository-entry-browser:extensions");
@@ -596,6 +597,10 @@ SearchContainer<?> searchContainer = new SearchContainer(renderRequest, itemSele
 <aui:script require='<%= npmResolvedPackageName + "/repository_entry_browser/js/ItemSelectorRepositoryEntryBrowser.es as ItemSelectorRepositoryEntryBrowser" %>'>
 	var itemSelector = new ItemSelectorRepositoryEntryBrowser.default({
 		closeCaption: '<%= UnicodeLanguageUtil.get(request, tabName) %>',
+
+		<c:if test="<%= editImageURL != null %>">
+			editImageURL: '<%= editImageURL.toString() %>',
+		</c:if>
 
 		maxFileSize: '<%= maxFileSize %>',
 

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/com/liferay/item/selector/taglib/servlet/taglib/packageinfo
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/com/liferay/item/selector/taglib/servlet/taglib/packageinfo
@@ -1,1 +1,1 @@
-version 2.1.0
+version 2.2.0

--- a/modules/apps/item-selector/item-selector-taglib/test/item_selector_preview/Header.es.js
+++ b/modules/apps/item-selector/item-selector-taglib/test/item_selector_preview/Header.es.js
@@ -24,6 +24,7 @@ const headerProps = {
 	handleClickBack: jest.fn(),
 	headerTitle,
 	showInfoIcon: true,
+	showNavbar: true,
 };
 
 describe('Header', () => {

--- a/modules/apps/item-selector/item-selector-upload-web/src/main/resources/META-INF/resources/upload.jsp
+++ b/modules/apps/item-selector/item-selector-upload-web/src/main/resources/META-INF/resources/upload.jsp
@@ -64,6 +64,8 @@ if (Validator.isNotNull(namespace)) {
 		HashMapBuilder.<String, Object>put(
 			"closeCaption", itemSelectorUploadViewDisplayContext.getTitle(locale)
 		).put(
+			"editImageURL", uploadURL
+		).put(
 			"eventName", itemSelectorUploadViewDisplayContext.getItemSelectedEventName()
 		).put(
 			"maxFileSize", itemSelectorUploadViewDisplayContext.getMaxFileSize()

--- a/modules/apps/journal/journal-item-selector-web/src/main/java/com/liferay/journal/item/selector/web/internal/display/context/JournalItemSelectorViewDisplayContext.java
+++ b/modules/apps/journal/journal-item-selector-web/src/main/java/com/liferay/journal/item/selector/web/internal/display/context/JournalItemSelectorViewDisplayContext.java
@@ -69,6 +69,21 @@ public class JournalItemSelectorViewDisplayContext {
 		return null;
 	}
 
+	public PortletURL getEditImageURL(
+		LiferayPortletResponse liferayPortletResponse) {
+
+		return PortletURLBuilder.createActionURL(
+			liferayPortletResponse, JournalPortletKeys.JOURNAL
+		).setActionName(
+			"/journal/image_editor"
+		).setParameter(
+			"folderId", _journalItemSelectorCriterion.getFolderId()
+		).setParameter(
+			"resourcePrimKey",
+			_journalItemSelectorCriterion.getResourcePrimKey()
+		).build();
+	}
+
 	public String getItemSelectedEventName() {
 		return _itemSelectedEventName;
 	}

--- a/modules/apps/journal/journal-item-selector-web/src/main/resources/META-INF/resources/journal_images.jsp
+++ b/modules/apps/journal/journal-item-selector-web/src/main/resources/META-INF/resources/journal_images.jsp
@@ -39,6 +39,7 @@ if (journalArticle != null) {
 %>
 
 <liferay-item-selector:repository-entry-browser
+	editImageURL="<%= journalItemSelectorViewDisplayContext.getEditImageURL(liferayPortletResponse) %>"
 	emptyResultsMessage='<%= LanguageUtil.get(resourceBundle, "there-are-no-journal-images") %>'
 	itemSelectedEventName="<%= journalItemSelectorViewDisplayContext.getItemSelectedEventName() %>"
 	itemSelectorReturnTypeResolver="<%= journalItemSelectorViewDisplayContext.getItemSelectorReturnTypeResolver() %>"

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/UploadImageMVCActionCommand.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/UploadImageMVCActionCommand.java
@@ -34,6 +34,7 @@ import org.osgi.service.component.annotations.Reference;
 	immediate = true,
 	property = {
 		"javax.portlet.name=" + JournalPortletKeys.JOURNAL,
+		"mvc.command.name=/journal/image_editor",
 		"mvc.command.name=/journal/upload_image"
 	},
 	service = MVCActionCommand.class

--- a/modules/apps/wiki/wiki-web/src/main/java/com/liferay/wiki/web/internal/item/selector/view/display/context/WikiAttachmentItemSelectorViewDisplayContext.java
+++ b/modules/apps/wiki/wiki-web/src/main/java/com/liferay/wiki/web/internal/item/selector/view/display/context/WikiAttachmentItemSelectorViewDisplayContext.java
@@ -69,6 +69,21 @@ public class WikiAttachmentItemSelectorViewDisplayContext {
 			_httpServletRequest);
 	}
 
+	public PortletURL getEditImageURL(
+		LiferayPortletResponse liferayPortletResponse) {
+
+		return PortletURLBuilder.createActionURL(
+			liferayPortletResponse, WikiPortletKeys.WIKI
+		).setActionName(
+			"/wiki/image_editor"
+		).setParameter(
+			"mimeTypes", _wikiAttachmentItemSelectorCriterion.getMimeTypes()
+		).setParameter(
+			"resourcePrimKey",
+			_wikiAttachmentItemSelectorCriterion.getWikiPageResourceId()
+		).build();
+	}
+
 	public String getItemSelectedEventName() {
 		return _itemSelectedEventName;
 	}

--- a/modules/apps/wiki/wiki-web/src/main/java/com/liferay/wiki/web/internal/portlet/action/UploadPageAttachmentMVCActionCommand.java
+++ b/modules/apps/wiki/wiki-web/src/main/java/com/liferay/wiki/web/internal/portlet/action/UploadPageAttachmentMVCActionCommand.java
@@ -34,6 +34,7 @@ import org.osgi.service.component.annotations.Reference;
 	immediate = true,
 	property = {
 		"javax.portlet.name=" + WikiPortletKeys.WIKI,
+		"mvc.command.name=/wiki/image_editor",
 		"mvc.command.name=/wiki/upload_page_attachment"
 	},
 	service = MVCActionCommand.class

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/item/selector/wiki_page_attachments.jsp
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/item/selector/wiki_page_attachments.jsp
@@ -85,6 +85,7 @@ if (wikiPage.getAttachmentsFolderId() != DLFolderConstants.DEFAULT_PARENT_FOLDER
 %>
 
 <liferay-item-selector:repository-entry-browser
+	editImageURL="<%= wikiAttachmentItemSelectorViewDisplayContext.getEditImageURL(liferayPortletResponse) %>"
 	emptyResultsMessage='<%= LanguageUtil.get(resourceBundle, "there-are-no-wiki-attachments") %>'
 	extensions="<%= ListUtil.toList(mimeTypes) %>"
 	itemSelectedEventName="<%= wikiAttachmentItemSelectorViewDisplayContext.getItemSelectedEventName() %>"

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -4709,7 +4709,7 @@ create-react-class@^15.5.1:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
-cropperjs@^1.5.11:
+cropperjs@1.5.11:
   version "1.5.11"
   resolved "https://registry.yarnpkg.com/cropperjs/-/cropperjs-1.5.11.tgz#502ae6d8ca098b124de6813601cca70015879fc0"
   integrity sha512-SJUeBBhtNBnnn+UrLKluhFRIXLJn7XFPv8QN1j49X5t+BIMwkgvDev541f96bmu8Xe0TgCx3gON22KmY/VddaA==


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-131159

This is the implementation of the new Image Editor in item selector. It's not done in the best way since item selector implementation it's pretty overcomplicated and it's not prepared to be extended with this kind of stuff. IMHO it should be re-thinked and re-implemented so it fits with our needs in the most easy and with the most sense possible.

In the meantime this is the most non-invasive implementation I could find.

To test it:

- Go anywhere with an item selector (i.e. Blogs)
- Go to an image preview (by clicking on the "eye" icon on the item) or upload a new one
- Click on the "pencil" icon in the top bar of the image preview
- Edit. Save. Profit.