### PR TITLE
LPS-131065 Change autotranslate JSON payload format

### DIFF
--- a/modules/apps/translation/translation-api/src/main/java/com/liferay/translation/translator/JSONTranslatorPacket.java
+++ b/modules/apps/translation/translation-api/src/main/java/com/liferay/translation/translator/JSONTranslatorPacket.java
@@ -14,10 +14,8 @@
 
 package com.liferay.translation.translator;
 
-import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONObject;
 
-import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -32,16 +30,10 @@ public class JSONTranslatorPacket implements TranslatorPacket {
 
 		_fieldsMap = new LinkedHashMap<>();
 
-		JSONArray fieldsJSONArray = jsonObject.getJSONArray("fields");
+		JSONObject fieldsJSONObject = jsonObject.getJSONObject("fields");
 
-		for (Object object : fieldsJSONArray) {
-			JSONObject fieldJSONObject = (JSONObject)object;
-
-			Iterator<String> iterator = fieldJSONObject.keys();
-
-			String key = iterator.next();
-
-			_fieldsMap.put(key, fieldJSONObject.getString(key));
+		for (String key : fieldsJSONObject.keySet()) {
+			_fieldsMap.put(key, fieldsJSONObject.getString(key));
 		}
 	}
 

--- a/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/servlet/AutoTranslateServlet.java
+++ b/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/servlet/AutoTranslateServlet.java
@@ -17,8 +17,8 @@ package com.liferay.translation.web.internal.servlet;
 import com.liferay.petra.io.StreamUtil;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
-import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -84,19 +84,19 @@ public class AutoTranslateServlet extends HttpServlet {
 		}
 	}
 
-	private JSONArray _getContentJSONArray(Map<String, String> fieldsMap) {
-		JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
+	private JSONObject _getFieldsJSONObject(Map<String, String> fieldsMap) {
+		JSONObject jsonObject = JSONFactoryUtil.createJSONObject();
 
 		for (Map.Entry<String, String> entry : fieldsMap.entrySet()) {
-			jsonArray.put(JSONUtil.put(entry.getKey(), entry.getValue()));
+			jsonObject.put(entry.getKey(), entry.getValue());
 		}
 
-		return jsonArray;
+		return jsonObject;
 	}
 
 	private String _toJSON(TranslatorPacket translatorPacket) {
 		return JSONUtil.put(
-			"fields", _getContentJSONArray(translatorPacket.getFieldsMap())
+			"fields", _getFieldsJSONObject(translatorPacket.getFieldsMap())
 		).put(
 			"sourceLanguageId", translatorPacket.getSourceLanguageId()
 		).put(


### PR DESCRIPTION
@boton I've updated the payload format. Now it expects a regular JSON object. Where it previously expected:
```
[{"field1": "value1"}, ...]
```
now it assumes the format is:
```
{"field1": "value1", ...}
```

The rest of the JSON hasn't changed, so you should still send:
```
{
	"sourceLanguageId": ...,
	"targetLanguageId": ...,
	"fields": /* The new JSON goes here. /*
}
```

Let me know if you need anything else.