### PR TITLE
LPS-132088 Migrate selection modals in depot-web

### DIFF
--- a/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/display/context/DepotAdminRolesDisplayContext.java
+++ b/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/display/context/DepotAdminRolesDisplayContext.java
@@ -103,11 +103,11 @@ public class DepotAdminRolesDisplayContext {
 		return portletNamespace + "selectDepotRole";
 	}
 
-	public PortletURL getSelectDepotRolesURL() throws WindowStateException {
+	public String getSelectDepotRolesURL() throws WindowStateException {
 		RequestBackedPortletURLFactory requestBackedPortletURLFactory =
 			RequestBackedPortletURLFactoryUtil.create(_liferayPortletRequest);
 
-		return PortletURLBuilder.create(
+		PortletURL portletURL = PortletURLBuilder.create(
 			requestBackedPortletURLFactory.createRenderURL(
 				DepotPortletKeys.DEPOT_ADMIN)
 		).setMVCRenderCommandName(
@@ -128,6 +128,8 @@ public class DepotAdminRolesDisplayContext {
 		).setWindowState(
 			LiferayWindowState.POP_UP
 		).build();
+
+		return portletURL.toString();
 	}
 
 	public List<UserGroupRole> getUserGroupRoles(int start, int end)

--- a/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/display/context/DepotAdminSelectRoleDisplayContext.java
+++ b/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/display/context/DepotAdminSelectRoleDisplayContext.java
@@ -18,6 +18,7 @@ import com.liferay.depot.constants.DepotRolesConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.petra.portlet.url.builder.PortletURLBuilder;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -294,12 +295,11 @@ public class DepotAdminSelectRoleDisplayContext {
 
 		public Map<String, Object> getData(Role role) throws PortalException {
 			return HashMapBuilder.<String, Object>put(
-				"entityid", role.getRoleId()
+				"entityid",
+				_group.getGroupId() + StringPool.DASH + role.getRoleId()
 			).put(
 				"groupdescriptivename",
 				_group.getDescriptiveName(_themeDisplay.getLocale())
-			).put(
-				"groupid", _group.getGroupId()
 			).put(
 				"iconcssclass", RolesAdminUtil.getIconCssClass(role)
 			).put(

--- a/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/dynamic_include/com.liferay.users.admin.web/user/roles/depot_roles.jsp
+++ b/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/dynamic_include/com.liferay.users.admin.web/user/roles/depot_roles.jsp
@@ -18,6 +18,8 @@
 
 <%
 DepotAdminRolesDisplayContext depotAdminRolesDisplayContext = (DepotAdminRolesDisplayContext)request.getAttribute(DepotAdminRolesDisplayContext.class.getName());
+
+String searchContainerId = "depotRolesSearchContainer";
 %>
 
 <aui:input name="<%= ActionRequest.ACTION_NAME %>" type="hidden" value="/depot/update_roles" />
@@ -70,7 +72,7 @@ DepotAdminRolesDisplayContext depotAdminRolesDisplayContext = (DepotAdminRolesDi
 	curParam="depotRolesCur"
 	emptyResultsMessage="this-user-is-not-assigned-any-asset-library-roles"
 	headerNames="title,asset-library,null"
-	id="depotRolesSearchContainer"
+	id="<%= searchContainerId %>"
 	iteratorURL="<%= currentURLObj %>"
 	total="<%= depotAdminRolesDisplayContext.getUserGroupRolesCount() %>"
 >
@@ -106,7 +108,7 @@ DepotAdminRolesDisplayContext depotAdminRolesDisplayContext = (DepotAdminRolesDi
 
 		<c:if test="<%= depotAdminRolesDisplayContext.isDeletable() %>">
 			<liferay-ui:search-container-column-text>
-				<a class="modify-link" data-groupId="<%= userGroupRole.getGroupId() %>" data-rowId="<%= userGroupRole.getRoleId() %>" href="javascript:;"><%= removeDepotRoleIcon %></a>
+				<a class="modify-link" data-entityId="<%= userGroupRole.getGroupId() %>-<%= userGroupRole.getRoleId() %>" href="javascript:;"><%= removeDepotRoleIcon %></a>
 			</liferay-ui:search-container-column-text>
 		</c:if>
 	</liferay-ui:search-container-row>
@@ -117,175 +119,20 @@ DepotAdminRolesDisplayContext depotAdminRolesDisplayContext = (DepotAdminRolesDi
 </liferay-ui:search-container>
 
 <c:if test="<%= depotAdminRolesDisplayContext.isSelectable() %>">
-	<aui:script use="liferay-search-container">
-		var Util = Liferay.Util;
-
-		var searchContainer = Liferay.SearchContainer.get(
-			'<portlet:namespace />depotRolesSearchContainer'
-		);
-
-		var searchContainerContentBox = searchContainer.get('contentBox');
-
-		searchContainer.updateDataStore(
-			searchContainerContentBox
-				.all('.modify-link')
-				.getData()
-				.map((data) => {
-					return data.groupid + '-' + data.rowid;
-				})
-		);
-
-		searchContainerContentBox.delegate(
-			'click',
-			(event) => {
-				var link = event.currentTarget;
-				var tr = link.ancestor('tr');
-
-				var groupId = link.getAttribute('data-groupId');
-				var rowId = link.getAttribute('data-rowId');
-				var id = groupId + '-' + rowId;
-
-				var selectDepotRole = Util.getWindow(
-					'<portlet:namespace />selectDepotRole'
-				);
-
-				if (selectDepotRole) {
-					var selectButton = selectDepotRole.iframe.node
-						.get('contentWindow.document')
-						.one(
-							'.selector-button[data-groupid="' +
-								groupId +
-								'"][data-entityid="' +
-								rowId +
-								'"]'
-						);
-
-					Util.toggleDisabled(selectButton, false);
-				}
-
-				searchContainer.deleteRow(tr, id);
-
-				<portlet:namespace />deleteDepotGroupRole(rowId, groupId);
-			},
-			'.modify-link'
-		);
-
-		var <portlet:namespace />addDepotGroupRolesGroupIds = [];
-		var <portlet:namespace />addDepotGroupRolesRoleIds = [];
-		var <portlet:namespace />deleteDepotGroupRolesGroupIds = [];
-		var <portlet:namespace />deleteDepotGroupRolesRoleIds = [];
-
-		function <portlet:namespace />deleteDepotGroupRole(roleId, groupId) {
-			for (
-				var i = 0;
-				i < <portlet:namespace />addDepotGroupRolesRoleIds.length;
-				i++
-			) {
-				if (
-					<portlet:namespace />addDepotGroupRolesGroupIds[i] == groupId &&
-					<portlet:namespace />addDepotGroupRolesRoleIds[i] == roleId
-				) {
-					<portlet:namespace />addDepotGroupRolesGroupIds.splice(i, 1);
-					<portlet:namespace />addDepotGroupRolesRoleIds.splice(i, 1);
-
-					break;
-				}
-			}
-
-			<portlet:namespace />deleteDepotGroupRolesGroupIds.push(groupId);
-			<portlet:namespace />deleteDepotGroupRolesRoleIds.push(roleId);
-
-			document.<portlet:namespace />fm.<portlet:namespace />addDepotGroupRolesGroupIds.value = <portlet:namespace />addDepotGroupRolesGroupIds.join(
-				','
-			);
-			document.<portlet:namespace />fm.<portlet:namespace />addDepotGroupRolesRoleIds.value = <portlet:namespace />addDepotGroupRolesRoleIds.join(
-				','
-			);
-			document.<portlet:namespace />fm.<portlet:namespace />deleteDepotGroupRolesGroupIds.value = <portlet:namespace />deleteDepotGroupRolesGroupIds.join(
-				','
-			);
-			document.<portlet:namespace />fm.<portlet:namespace />deleteDepotGroupRolesRoleIds.value = <portlet:namespace />deleteDepotGroupRolesRoleIds.join(
-				','
-			);
-		}
-
-		A.one('#<portlet:namespace />selectDepotRoleLink').on('click', (event) => {
-			Util.openSelectionModal({
-				onSelect: function (event) {
-					var A = AUI();
-					var LString = A.Lang.String;
-
-					var id = event.groupid + '-' + event.entityid;
-
-					var rowColumns = [];
-
-					rowColumns.push(
-						'<i class="' +
-							event.iconcssclass +
-							'"></i> ' +
-							Liferay.Util.escapeHTML(event.rolename)
-					);
-
-					rowColumns.push(event.groupdescriptivename);
-
-					rowColumns.push(
-						'<a class="modify-link" data-groupId="' +
-							event.groupid +
-							'" data-rowId="' +
-							event.entityid +
-							'" href="javascript:;"><%= UnicodeFormatter.toString(removeDepotRoleIcon) %></a>'
-					);
-
-					for (
-						var i = 0;
-						i < <portlet:namespace />deleteDepotGroupRolesRoleIds.length;
-						i++
-					) {
-						if (
-							<portlet:namespace />deleteDepotGroupRolesGroupIds[i] ==
-								event.groupid &&
-							<portlet:namespace />deleteDepotGroupRolesRoleIds[i] ==
-								event.entityid
-						) {
-							<portlet:namespace />deleteDepotGroupRolesGroupIds.splice(
-								i,
-								1
-							);
-							<portlet:namespace />deleteDepotGroupRolesRoleIds.splice(
-								i,
-								1
-							);
-
-							break;
-						}
-					}
-
-					<portlet:namespace />addDepotGroupRolesGroupIds.push(event.groupid);
-					<portlet:namespace />addDepotGroupRolesRoleIds.push(event.entityid);
-
-					document.<portlet:namespace />fm.<portlet:namespace />addDepotGroupRolesGroupIds.value = <portlet:namespace />addDepotGroupRolesGroupIds.join(
-						','
-					);
-					document.<portlet:namespace />fm.<portlet:namespace />addDepotGroupRolesRoleIds.value = <portlet:namespace />addDepotGroupRolesRoleIds.join(
-						','
-					);
-					document.<portlet:namespace />fm.<portlet:namespace />deleteDepotGroupRolesGroupIds.value = <portlet:namespace />deleteDepotGroupRolesGroupIds.join(
-						','
-					);
-					document.<portlet:namespace />fm.<portlet:namespace />deleteDepotGroupRolesRoleIds.value = <portlet:namespace />deleteDepotGroupRolesRoleIds.join(
-						','
-					);
-
-					searchContainer.addRow(rowColumns, id);
-
-					searchContainer.updateDataStore();
-				},
-				selectedData: searchContainer.getData(true),
-				selectEventName:
-					'<%= depotAdminRolesDisplayContext.getSelectDepotRolesEventName() %>',
-				title: '<liferay-ui:message arguments="role" key="select-x" />',
-				url: '<%= depotAdminRolesDisplayContext.getSelectDepotRolesURL() %>',
-			});
-		});
-	</aui:script>
+	<liferay-frontend:component
+		context='<%=
+			HashMapBuilder.<String, Object>put(
+				"portletNamespace", liferayPortletResponse.getNamespace()
+			).put(
+				"removeDepotRoleIcon", removeDepotRoleIcon
+			).put(
+				"searchContainerId", searchContainerId
+			).put(
+				"selectDepotRolesURL", depotAdminRolesDisplayContext.getSelectDepotRolesURL()
+			).put(
+				"selectEventName", depotAdminRolesDisplayContext.getSelectDepotRolesEventName()
+			).build()
+		%>'
+		module="js/DepotRoles"
+	/>
 </c:if>

--- a/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/js/DepotRoles.js
+++ b/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/js/DepotRoles.js
@@ -1,0 +1,190 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {delegate, openSelectionModal} from 'frontend-js-web';
+
+export default function ({
+	portletNamespace,
+	removeDepotRoleIcon,
+	searchContainerId,
+	selectDepotRolesURL,
+	selectEventName,
+}) {
+	const addGroupIds = [];
+	const addRoleIds = [];
+	const deleteGroupIds = [];
+	const deleteRoleIds = [];
+
+	const deleteDepotGroupRole = (groupId, roleId) => {
+		for (let i = 0; i < addGroupIds.length; i++) {
+			if (addGroupIds[i] === groupId && addRoleIds[i] === roleId) {
+				addGroupIds.splice(i, 1);
+				addRoleIds.splice(i, 1);
+
+				break;
+			}
+		}
+
+		deleteGroupIds.push(groupId);
+		deleteRoleIds.push(roleId);
+
+		const form = document.getElementById(`${portletNamespace}fm`);
+
+		if (!form) {
+			return;
+		}
+
+		form[
+			`${portletNamespace}addDepotGroupRolesGroupIds`
+		].value = addGroupIds.join(',');
+
+		form[
+			`${portletNamespace}addDepotGroupRolesRoleIds`
+		].value = addRoleIds.join(',');
+
+		form[
+			`${portletNamespace}deleteDepotGroupRolesGroupIds`
+		].value = deleteGroupIds.join(',');
+
+		form[
+			`${portletNamespace}deleteDepotGroupRolesRoleIds`
+		].value = deleteRoleIds.join(',');
+	};
+
+	Liferay.componentReady(`${portletNamespace}${searchContainerId}`).then(
+		(searchContainer) => {
+			const searchContainerContentBox = searchContainer.get('contentBox');
+
+			searchContainer.updateDataStore(
+				searchContainerContentBox
+					.all('.modify-link')
+					.getData()
+					.map((data) => {
+						return data.entityid;
+					})
+			);
+
+			const selectDepotRoleLink = document.getElementById(
+				`${portletNamespace}selectDepotRoleLink`
+			);
+
+			if (selectDepotRoleLink) {
+				selectDepotRoleLink.addEventListener('click', (event) => {
+					event.preventDefault();
+
+					openSelectionModal({
+						onSelect: (selectedItem) => {
+							if (!selectedItem) {
+								return;
+							}
+
+							var rowColumns = [];
+
+							rowColumns.push(
+								`<i class="${
+									selectedItem.iconcssclass
+								}"></i>${Liferay.Util.escapeHTML(
+									selectedItem.rolename
+								)}`
+							);
+
+							rowColumns.push(selectedItem.groupdescriptivename);
+
+							rowColumns.push(
+								`<a class="modify-link" data-entityid="${selectedItem.entityid}" href="javascript:;">${removeDepotRoleIcon}</a>`
+							);
+
+							searchContainer.addRow(
+								rowColumns,
+								selectedItem.entityid
+							);
+
+							searchContainer.updateDataStore();
+
+							const [
+								groupId,
+								roleId,
+							] = selectedItem.entityid.split('-');
+
+							for (let i = 0; i < deleteRoleIds.length; i++) {
+								if (
+									deleteGroupIds[i] === groupId &&
+									deleteRoleIds[i] === roleId
+								) {
+									deleteGroupIds.splice(i, 1);
+									deleteRoleIds.splice(i, 1);
+
+									break;
+								}
+							}
+
+							addGroupIds.push(groupId);
+							addRoleIds.push(roleId);
+
+							const form = document.getElementById(
+								`${portletNamespace}fm`
+							);
+
+							if (!form) {
+								return;
+							}
+
+							form[
+								`${portletNamespace}addDepotGroupRolesGroupIds`
+							].value = addGroupIds.join(',');
+
+							form[
+								`${portletNamespace}addDepotGroupRolesRoleIds`
+							].value = addRoleIds.join(',');
+
+							form[
+								`${portletNamespace}deleteDepotGroupRolesGroupIds`
+							].value = deleteGroupIds.join(',');
+
+							form[
+								`${portletNamespace}deleteDepotGroupRolesRoleIds`
+							].value = deleteRoleIds.join(',');
+						},
+						selectEventName,
+						selectedData: searchContainer.getData(true),
+						title: Liferay.Util.sub(
+							Liferay.Language.get('select-x'),
+							Liferay.Language.get('role')
+						),
+						url: selectDepotRolesURL,
+					});
+				});
+			}
+
+			delegate(
+				searchContainerContentBox.getDOMNode(),
+				'click',
+				'.modify-link',
+				(event) => {
+					const link = event.delegateTarget;
+
+					const row = link.closest('tr');
+
+					const entityId = link.dataset.entityid;
+
+					searchContainer.deleteRow(row, entityId);
+
+					const [groupId, roleId] = entityId.split('-');
+
+					deleteDepotGroupRole(groupId, roleId);
+				}
+			);
+		}
+	);
+}

--- a/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/select_depot_role.jsp
+++ b/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/select_depot_role.jsp
@@ -120,24 +120,6 @@ DepotAdminSelectRoleDisplayContext depotAdminSelectRoleDisplayContext = (DepotAd
 					markupView="lexicon"
 				/>
 			</liferay-ui:search-container>
-
-			<aui:script use="aui-base">
-				var Util = Liferay.Util;
-
-				var openingLiferay = Util.getOpener().Liferay;
-
-				openingLiferay.fire(
-					'<%= HtmlUtil.escape(step2.getSyncEntitiesEventName()) %>',
-					{
-						selectors: A.all('.selector-button'),
-					}
-				);
-
-				Util.selectEntityHandler(
-					'#<portlet:namespace />selectDepotRoleFm',
-					'<%= HtmlUtil.escapeJS(step2.getEventName()) %>'
-				);
-			</aui:script>
 		</c:when>
 	</c:choose>
 </aui:form>

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
@@ -436,6 +436,11 @@ const openSelectionModal = ({
 
 					if (selectedDataSet.has(itemId)) {
 						itemElement.disabled = true;
+						itemElement.classList.add('disabled');
+					}
+					else {
+						itemElement.disabled = false;
+						itemElement.classList.remove('disabled');
 					}
 				});
 			}


### PR DESCRIPTION
Hey @liferay-lima ,

This is a part of [an ongoing epic](https://issues.liferay.com/browse/LPS-129246) to replace legacy AUI-based modals with Clay/React-based `openSelectionModal`. In this PR, we are fixing previous migration of a modal in depot-web.

Notes:
- We migrated the select depot role modal to `openSelectionModal` [a while back](https://github.com/liferay/liferay-portal/commit/0cef31651c89f4f260dc34b8379c6dc2774a262f). What got my attention now is the usage of `Util.selectEntityHandler` in `select_depot_role.jsp `. That entire block can be safely deleted after that migration, and we are doing this in this PR.
- While testing to doublecheck modal is ok, I noticed buggy behavior (see the 'before' gif). As this was likely caused by the original migration, I set out to fix the behavior.
- The root cause of the bug is the fact that in `openSelectionModal` we are [checking `dataset.entityid`](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js#L434) to determine if an item should be disabled. In `depot-web` modal, different ids got mixed up. We are inconsistently dealing with `groupId`, `roleId`, `rowId` and `entityId`. In this PR, we are setting `entityId = groupId + '-' + roleId` and consistently use this everywhere.
- Since I was already making a lot of changes, I moved all JS to separate `liferay-frontend:component`, to use modern syntax, imports, etc.
- I needed to tweak URL getter a bit, as `liferay-frontend:component` does not auto-convert to string 
- We are adding support for toggling instead of just setting disabled. Currently, if you delete an item, you cannot re-select it, button stays disabled.
- A second of delay before disable toggle cannot be fixed in modal utility, as this is delay between server-side rendering and hydration. To improve this behavior, we may do something like modify url that opens modal, add selected items as param. This is beyond the scope of this task.

/cc @kresimir-coko @jonmak08

Test plan:
1. Users and Organizations > Open a user > Asset Library Roles > Select

Before:
![before](https://user-images.githubusercontent.com/5435511/118132788-61dff900-b400-11eb-9756-5557366ec876.gif)

After:
![after](https://user-images.githubusercontent.com/5435511/118132728-4f65bf80-b400-11eb-901f-3b028cd1b5ef.gif)
