### PR TITLE
LPS-131646 Hide autotranslate button when no configuration is present

### DIFF
--- a/modules/apps/translation/translation-api/src/main/java/com/liferay/translation/translator/Translator.java
+++ b/modules/apps/translation/translation-api/src/main/java/com/liferay/translation/translator/Translator.java
@@ -19,6 +19,8 @@ package com.liferay.translation.translator;
  */
 public interface Translator {
 
+	public boolean isEnabled();
+
 	public TranslatorPacket translate(TranslatorPacket translatorPacket);
 
 }

--- a/modules/apps/translation/translation-google-cloud-translator/build.gradle
+++ b/modules/apps/translation/translation-google-cloud-translator/build.gradle
@@ -8,6 +8,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
+	compileOnly project(":apps:static:portal-configuration:portal-configuration-persistence-api")
 	compileOnly project(":apps:translation:translation-api")
 	compileOnly project(":core:petra:petra-string")
 }

--- a/modules/apps/translation/translation-google-cloud-translator/src/main/java/com/liferay/translation/google/cloud/translator/internal/configuration/persistence/listener/GoogleCloudTranslatorConfigurationModelListener.java
+++ b/modules/apps/translation/translation-google-cloud-translator/src/main/java/com/liferay/translation/google/cloud/translator/internal/configuration/persistence/listener/GoogleCloudTranslatorConfigurationModelListener.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.translation.google.cloud.translator.internal.configuration.persistence.listener;
+
+import com.liferay.portal.configuration.persistence.listener.ConfigurationModelListener;
+import com.liferay.portal.configuration.persistence.listener.ConfigurationModelListenerException;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.resource.bundle.ResourceBundleLoader;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.LocaleThreadLocal;
+import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.translation.google.cloud.translator.internal.configuration.GoogleCloudTranslatorConfiguration;
+
+import java.util.Dictionary;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Adolfo Pérez
+ */
+@Component(
+	immediate = true,
+	property = "model.class.name=com.liferay.translation.google.cloud.translator.internal.configuration.GoogleCloudTranslatorConfiguration",
+	service = ConfigurationModelListener.class
+)
+public class GoogleCloudTranslatorConfigurationModelListener
+	implements ConfigurationModelListener {
+
+	@Override
+	public void onBeforeSave(String pid, Dictionary<String, Object> properties)
+		throws ConfigurationModelListenerException {
+
+		boolean enabled = GetterUtil.getBoolean(properties.get("enabled"));
+		String serviceAccountPrivateKey = GetterUtil.getString(
+			properties.get("serviceAccountPrivateKey"));
+
+		if (enabled && !_isValid(serviceAccountPrivateKey)) {
+			throw new ConfigurationModelListenerException(
+				ResourceBundleUtil.getString(
+					_resourceBundleLoader.loadResourceBundle(
+						LocaleThreadLocal.getThemeDisplayLocale()),
+					"service-account-private-key-must-be-in-json-format"),
+				GoogleCloudTranslatorConfiguration.class, getClass(),
+				properties);
+		}
+	}
+
+	private boolean _isValid(String serviceAccountPrivateKey) {
+		try {
+			JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
+				serviceAccountPrivateKey);
+
+			if (jsonObject.length() > 0) {
+				return true;
+			}
+
+			return false;
+		}
+		catch (Exception exception) {
+			return false;
+		}
+	}
+
+	@Reference(
+		target = "(bundle.symbolic.name=com.liferay.translation.google.cloud.translator)"
+	)
+	private ResourceBundleLoader _resourceBundleLoader;
+
+}

--- a/modules/apps/translation/translation-google-cloud-translator/src/main/java/com/liferay/translation/google/cloud/translator/internal/translator/GoogleCloudTranslator.java
+++ b/modules/apps/translation/translation-google-cloud-translator/src/main/java/com/liferay/translation/google/cloud/translator/internal/translator/GoogleCloudTranslator.java
@@ -50,13 +50,21 @@ import org.osgi.service.component.annotations.Component;
 )
 public class GoogleCloudTranslator implements Translator {
 
-	@Override
-	public TranslatorPacket translate(TranslatorPacket translatorPacket) {
-		if (!_googleCloudTranslatorConfiguration.enabled() ||
-			Validator.isBlank(
+	public boolean isEnabled() {
+		if (_googleCloudTranslatorConfiguration.enabled() &&
+			!Validator.isBlank(
 				_googleCloudTranslatorConfiguration.
 					serviceAccountPrivateKey())) {
 
+			return true;
+		}
+
+		return false;
+	}
+
+	@Override
+	public TranslatorPacket translate(TranslatorPacket translatorPacket) {
+		if (!isEnabled()) {
 			return translatorPacket;
 		}
 
@@ -105,11 +113,7 @@ public class GoogleCloudTranslator implements Translator {
 			ConfigurableUtil.createConfigurable(
 				GoogleCloudTranslatorConfiguration.class, properties);
 
-		if (!_googleCloudTranslatorConfiguration.enabled() ||
-			Validator.isBlank(
-				_googleCloudTranslatorConfiguration.
-					serviceAccountPrivateKey())) {
-
+		if (!isEnabled()) {
 			return;
 		}
 

--- a/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language.properties
+++ b/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language.properties
@@ -3,3 +3,4 @@ enabled-description=Enable or disable the integration with Google Cloud Translat
 google-cloud-translator-configuration-name=Google Cloud Translator
 service-account-private-key=Service Account Private Key
 service-account-private-key-description=Your project service account private key in JSON format.
+service-account-private-key-must-be-in-json-format=Service Account Private Key must be in JSON format.

--- a/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_ar.properties
@@ -3,3 +3,4 @@ enabled-description=تمكين أو تعطيل التكامل مع واجهة ب
 google-cloud-translator-configuration-name=مترجم Google Cloud
 service-account-private-key=مفتاح خاص لحساب الخدمة
 service-account-private-key-description=المفتاح الخاص لحساب خدمة مشروعك بتنسيق JSON.
+service-account-private-key-must-be-in-json-format=Service Account Private Key must be in JSON format. (Automatic Copy)

--- a/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_bg.properties
@@ -3,3 +3,4 @@ enabled-description=Enable or disable the integration with Google Cloud Translat
 google-cloud-translator-configuration-name=Google Cloud Translator (Automatic Copy)
 service-account-private-key=Service Account Private Key (Automatic Copy)
 service-account-private-key-description=Your project service account private key in JSON format. (Automatic Copy)
+service-account-private-key-must-be-in-json-format=Service Account Private Key must be in JSON format. (Automatic Copy)

--- a/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_ca.properties
@@ -3,3 +3,4 @@ enabled-description=Activeu o desactiveu la integració amb l'API de Google Clou
 google-cloud-translator-configuration-name=Google Cloud Translation
 service-account-private-key=Clau privada del compte de servei
 service-account-private-key-description=La clau privada del compte de servei del projecte té el format JSON.
+service-account-private-key-must-be-in-json-format=Service Account Private Key must be in JSON format. (Automatic Copy)

--- a/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_cs.properties
@@ -3,3 +3,4 @@ enabled-description=Enable or disable the integration with Google Cloud Translat
 google-cloud-translator-configuration-name=Google Cloud Translator (Automatic Copy)
 service-account-private-key=Service Account Private Key (Automatic Copy)
 service-account-private-key-description=Your project service account private key in JSON format. (Automatic Copy)
+service-account-private-key-must-be-in-json-format=Service Account Private Key must be in JSON format. (Automatic Copy)

--- a/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_da.properties
+++ b/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_da.properties
@@ -3,3 +3,4 @@ enabled-description=Enable or disable the integration with Google Cloud Translat
 google-cloud-translator-configuration-name=Google Cloud Translator (Automatic Copy)
 service-account-private-key=Service Account Private Key (Automatic Copy)
 service-account-private-key-description=Your project service account private key in JSON format. (Automatic Copy)
+service-account-private-key-must-be-in-json-format=Service Account Private Key must be in JSON format. (Automatic Copy)

--- a/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_de.properties
+++ b/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_de.properties
@@ -3,3 +3,4 @@ enabled-description=Aktivieren oder deaktivieren Sie die Integration in die Goog
 google-cloud-translator-configuration-name=Google Cloud Translator
 service-account-private-key=Privater Dienstkontoschlüssel
 service-account-private-key-description=Ihr privater Dienstkontoschlüssel für das Projekt hat das JSON-Format.
+service-account-private-key-must-be-in-json-format=Service Account Private Key must be in JSON format. (Automatic Copy)

--- a/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_el.properties
+++ b/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_el.properties
@@ -3,3 +3,4 @@ enabled-description=Enable or disable the integration with Google Cloud Translat
 google-cloud-translator-configuration-name=Google Cloud Translator (Automatic Copy)
 service-account-private-key=Service Account Private Key (Automatic Copy)
 service-account-private-key-description=Your project service account private key in JSON format. (Automatic Copy)
+service-account-private-key-must-be-in-json-format=Service Account Private Key must be in JSON format. (Automatic Copy)

--- a/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_en.properties
+++ b/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_en.properties
@@ -3,3 +3,4 @@ enabled-description=Enable or disable the integration with Google Cloud Translat
 google-cloud-translator-configuration-name=Google Cloud Translator
 service-account-private-key=Service Account Private Key
 service-account-private-key-description=Your project service account private key in JSON format.
+service-account-private-key-must-be-in-json-format=Service Account Private Key must be in JSON format.

--- a/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_en_AU.properties
+++ b/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_en_AU.properties
@@ -3,3 +3,4 @@ enabled-description=Enable or disable the integration with Google Cloud Translat
 google-cloud-translator-configuration-name=Google Cloud Translator (Automatic Copy)
 service-account-private-key=Service Account Private Key (Automatic Copy)
 service-account-private-key-description=Your project service account private key in JSON format. (Automatic Copy)
+service-account-private-key-must-be-in-json-format=Service Account Private Key must be in JSON format. (Automatic Copy)

--- a/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_en_GB.properties
+++ b/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_en_GB.properties
@@ -3,3 +3,4 @@ enabled-description=Enable or disable the integration with Google Cloud Translat
 google-cloud-translator-configuration-name=Google Cloud Translator (Automatic Copy)
 service-account-private-key=Service Account Private Key (Automatic Copy)
 service-account-private-key-description=Your project service account private key in JSON format. (Automatic Copy)
+service-account-private-key-must-be-in-json-format=Service Account Private Key must be in JSON format. (Automatic Copy)

--- a/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_es.properties
+++ b/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_es.properties
@@ -3,3 +3,4 @@ enabled-description=Habilite o deshabilite la integración con la API de Google 
 google-cloud-translator-configuration-name=Google Cloud Translation
 service-account-private-key=Clave privada de cuenta de servicio
 service-account-private-key-description=La clave privada de la cuenta de servicio del proyecto tiene el formato JSON.
+service-account-private-key-must-be-in-json-format=Service Account Private Key must be in JSON format. (Automatic Copy)

--- a/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_et.properties
+++ b/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_et.properties
@@ -3,3 +3,4 @@ enabled-description=Enable or disable the integration with Google Cloud Translat
 google-cloud-translator-configuration-name=Google Cloud Translator (Automatic Copy)
 service-account-private-key=Service Account Private Key (Automatic Copy)
 service-account-private-key-description=Your project service account private key in JSON format. (Automatic Copy)
+service-account-private-key-must-be-in-json-format=Service Account Private Key must be in JSON format. (Automatic Copy)

--- a/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_eu.properties
@@ -3,3 +3,4 @@ enabled-description=Enable or disable the integration with Google Cloud Translat
 google-cloud-translator-configuration-name=Google Cloud Translator (Automatic Copy)
 service-account-private-key=Service Account Private Key (Automatic Copy)
 service-account-private-key-description=Your project service account private key in JSON format. (Automatic Copy)
+service-account-private-key-must-be-in-json-format=Service Account Private Key must be in JSON format. (Automatic Copy)

--- a/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_fa.properties
@@ -3,3 +3,4 @@ enabled-description=Enable or disable the integration with Google Cloud Translat
 google-cloud-translator-configuration-name=Google Cloud Translator (Automatic Copy)
 service-account-private-key=Service Account Private Key (Automatic Copy)
 service-account-private-key-description=Your project service account private key in JSON format. (Automatic Copy)
+service-account-private-key-must-be-in-json-format=Service Account Private Key must be in JSON format. (Automatic Copy)

--- a/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_fi.properties
@@ -3,3 +3,4 @@ enabled-description=Ota käyttöön tai poista käytöstä integraatio Google Cl
 google-cloud-translator-configuration-name=Google Cloud Kääntäjä
 service-account-private-key=Palvelutilin Yksityinen Avain
 service-account-private-key-description=Projektisi palvelutilisi yksityinen avain JSON-muodossa.
+service-account-private-key-must-be-in-json-format=Service Account Private Key must be in JSON format. (Automatic Copy)

--- a/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_fr.properties
@@ -3,3 +3,4 @@ enabled-description=Activez ou désactivez l'intégration avec l'API Google Clou
 google-cloud-translator-configuration-name=Google Cloud Translator
 service-account-private-key=Clé privée du compte de service
 service-account-private-key-description=La clé privée de votre compte de service de projet au format JSON.
+service-account-private-key-must-be-in-json-format=Service Account Private Key must be in JSON format. (Automatic Copy)

--- a/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_fr_CA.properties
+++ b/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_fr_CA.properties
@@ -3,3 +3,4 @@ enabled-description=Enable or disable the integration with Google Cloud Translat
 google-cloud-translator-configuration-name=Google Cloud Translator (Automatic Copy)
 service-account-private-key=Service Account Private Key (Automatic Copy)
 service-account-private-key-description=Your project service account private key in JSON format. (Automatic Copy)
+service-account-private-key-must-be-in-json-format=Service Account Private Key must be in JSON format. (Automatic Copy)

--- a/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_gl.properties
@@ -3,3 +3,4 @@ enabled-description=Enable or disable the integration with Google Cloud Translat
 google-cloud-translator-configuration-name=Google Cloud Translator (Automatic Copy)
 service-account-private-key=Service Account Private Key (Automatic Copy)
 service-account-private-key-description=Your project service account private key in JSON format. (Automatic Copy)
+service-account-private-key-must-be-in-json-format=Service Account Private Key must be in JSON format. (Automatic Copy)

--- a/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_hi_IN.properties
@@ -3,3 +3,4 @@ enabled-description=Enable or disable the integration with Google Cloud Translat
 google-cloud-translator-configuration-name=Google Cloud Translator (Automatic Copy)
 service-account-private-key=Service Account Private Key (Automatic Copy)
 service-account-private-key-description=Your project service account private key in JSON format. (Automatic Copy)
+service-account-private-key-must-be-in-json-format=Service Account Private Key must be in JSON format. (Automatic Copy)

--- a/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_hr.properties
@@ -3,3 +3,4 @@ enabled-description=Enable or disable the integration with Google Cloud Translat
 google-cloud-translator-configuration-name=Google Cloud Translator (Automatic Copy)
 service-account-private-key=Service Account Private Key (Automatic Copy)
 service-account-private-key-description=Your project service account private key in JSON format. (Automatic Copy)
+service-account-private-key-must-be-in-json-format=Service Account Private Key must be in JSON format. (Automatic Copy)

--- a/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_hu.properties
@@ -3,3 +3,4 @@ enabled-description=A Google Cloud Translation API integrációjának az engedé
 google-cloud-translator-configuration-name=Google Cloud Translator
 service-account-private-key=Szolgáltatási fiók privát kulcsa
 service-account-private-key-description=Projektje szolgáltatási fiókjának a privát kulcsa JSON formátumban.
+service-account-private-key-must-be-in-json-format=Service Account Private Key must be in JSON format. (Automatic Copy)

--- a/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_in.properties
+++ b/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_in.properties
@@ -3,3 +3,4 @@ enabled-description=Enable or disable the integration with Google Cloud Translat
 google-cloud-translator-configuration-name=Google Cloud Translator (Automatic Copy)
 service-account-private-key=Service Account Private Key (Automatic Copy)
 service-account-private-key-description=Your project service account private key in JSON format. (Automatic Copy)
+service-account-private-key-must-be-in-json-format=Service Account Private Key must be in JSON format. (Automatic Copy)

--- a/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_it.properties
+++ b/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_it.properties
@@ -3,3 +3,4 @@ enabled-description=Enable or disable the integration with Google Cloud Translat
 google-cloud-translator-configuration-name=Google Cloud Translator (Automatic Copy)
 service-account-private-key=Service Account Private Key (Automatic Copy)
 service-account-private-key-description=Your project service account private key in JSON format. (Automatic Copy)
+service-account-private-key-must-be-in-json-format=Service Account Private Key must be in JSON format. (Automatic Copy)

--- a/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_iw.properties
@@ -3,3 +3,4 @@ enabled-description=Enable or disable the integration with Google Cloud Translat
 google-cloud-translator-configuration-name=Google Cloud Translator (Automatic Copy)
 service-account-private-key=Service Account Private Key (Automatic Copy)
 service-account-private-key-description=Your project service account private key in JSON format. (Automatic Copy)
+service-account-private-key-must-be-in-json-format=Service Account Private Key must be in JSON format. (Automatic Copy)

--- a/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_ja.properties
@@ -3,3 +3,4 @@ enabled-description=自動翻訳に使用するGoogle Cloud Translation APIと�
 google-cloud-translator-configuration-name=Google Cloud Translator
 service-account-private-key=サービスアカウントの秘密鍵
 service-account-private-key-description=プロジェクトのサービスアカウントに対応するJSON形式の秘密鍵です。
+service-account-private-key-must-be-in-json-format=Service Account Private Key must be in JSON format. (Automatic Copy)

--- a/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_kk.properties
+++ b/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_kk.properties
@@ -3,3 +3,4 @@ enabled-description=Enable or disable the integration with Google Cloud Translat
 google-cloud-translator-configuration-name=Google Cloud Translator (Automatic Copy)
 service-account-private-key=Service Account Private Key (Automatic Copy)
 service-account-private-key-description=Your project service account private key in JSON format. (Automatic Copy)
+service-account-private-key-must-be-in-json-format=Service Account Private Key must be in JSON format. (Automatic Copy)

--- a/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_ko.properties
@@ -3,3 +3,4 @@ enabled-description=Enable or disable the integration with Google Cloud Translat
 google-cloud-translator-configuration-name=Google Cloud Translator (Automatic Copy)
 service-account-private-key=Service Account Private Key (Automatic Copy)
 service-account-private-key-description=Your project service account private key in JSON format. (Automatic Copy)
+service-account-private-key-must-be-in-json-format=Service Account Private Key must be in JSON format. (Automatic Copy)

--- a/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_lo.properties
@@ -3,3 +3,4 @@ enabled-description=Enable or disable the integration with Google Cloud Translat
 google-cloud-translator-configuration-name=Google Cloud Translator (Automatic Copy)
 service-account-private-key=Service Account Private Key (Automatic Copy)
 service-account-private-key-description=Your project service account private key in JSON format. (Automatic Copy)
+service-account-private-key-must-be-in-json-format=Service Account Private Key must be in JSON format. (Automatic Copy)

--- a/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_lt.properties
@@ -3,3 +3,4 @@ enabled-description=Enable or disable the integration with Google Cloud Translat
 google-cloud-translator-configuration-name=Google Cloud Translator (Automatic Copy)
 service-account-private-key=Service Account Private Key (Automatic Copy)
 service-account-private-key-description=Your project service account private key in JSON format. (Automatic Copy)
+service-account-private-key-must-be-in-json-format=Service Account Private Key must be in JSON format. (Automatic Copy)

--- a/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_ms.properties
+++ b/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_ms.properties
@@ -3,3 +3,4 @@ enabled-description=Enable or disable the integration with Google Cloud Translat
 google-cloud-translator-configuration-name=Google Cloud Translator (Automatic Copy)
 service-account-private-key=Service Account Private Key (Automatic Copy)
 service-account-private-key-description=Your project service account private key in JSON format. (Automatic Copy)
+service-account-private-key-must-be-in-json-format=Service Account Private Key must be in JSON format. (Automatic Copy)

--- a/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_nb.properties
@@ -3,3 +3,4 @@ enabled-description=Enable or disable the integration with Google Cloud Translat
 google-cloud-translator-configuration-name=Google Cloud Translator (Automatic Copy)
 service-account-private-key=Service Account Private Key (Automatic Copy)
 service-account-private-key-description=Your project service account private key in JSON format. (Automatic Copy)
+service-account-private-key-must-be-in-json-format=Service Account Private Key must be in JSON format. (Automatic Copy)

--- a/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_nl.properties
@@ -3,3 +3,4 @@ enabled-description=Schakel de integratie met de API Google Cloud Translation vo
 google-cloud-translator-configuration-name=Google Cloud Translator
 service-account-private-key=Persoonlijke serviceaccountcode
 service-account-private-key-description=De persoonlijke code voor uw projectservice-account in JSON-formaat.
+service-account-private-key-must-be-in-json-format=Service Account Private Key must be in JSON format. (Automatic Copy)

--- a/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_nl_BE.properties
@@ -3,3 +3,4 @@ enabled-description=Enable or disable the integration with Google Cloud Translat
 google-cloud-translator-configuration-name=Google Cloud Translator (Automatic Copy)
 service-account-private-key=Service Account Private Key (Automatic Copy)
 service-account-private-key-description=Your project service account private key in JSON format. (Automatic Copy)
+service-account-private-key-must-be-in-json-format=Service Account Private Key must be in JSON format. (Automatic Copy)

--- a/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_pl.properties
@@ -3,3 +3,4 @@ enabled-description=Enable or disable the integration with Google Cloud Translat
 google-cloud-translator-configuration-name=Google Cloud Translator (Automatic Copy)
 service-account-private-key=Service Account Private Key (Automatic Copy)
 service-account-private-key-description=Your project service account private key in JSON format. (Automatic Copy)
+service-account-private-key-must-be-in-json-format=Service Account Private Key must be in JSON format. (Automatic Copy)

--- a/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_pt_BR.properties
@@ -3,3 +3,4 @@ enabled-description=Habilitar ou desabilitar a integração com a API do Google 
 google-cloud-translator-configuration-name=Google Cloud Translator
 service-account-private-key=Chave privada da conta de serviço
 service-account-private-key-description=Chave privada da conta de serviço de seu projeto no formato JSON.
+service-account-private-key-must-be-in-json-format=Service Account Private Key must be in JSON format. (Automatic Copy)

--- a/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_pt_PT.properties
@@ -3,3 +3,4 @@ enabled-description=Enable or disable the integration with Google Cloud Translat
 google-cloud-translator-configuration-name=Google Cloud Translator (Automatic Copy)
 service-account-private-key=Service Account Private Key (Automatic Copy)
 service-account-private-key-description=Your project service account private key in JSON format. (Automatic Copy)
+service-account-private-key-must-be-in-json-format=Service Account Private Key must be in JSON format. (Automatic Copy)

--- a/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_ro.properties
@@ -3,3 +3,4 @@ enabled-description=Enable or disable the integration with Google Cloud Translat
 google-cloud-translator-configuration-name=Google Cloud Translator (Automatic Copy)
 service-account-private-key=Service Account Private Key (Automatic Copy)
 service-account-private-key-description=Your project service account private key in JSON format. (Automatic Copy)
+service-account-private-key-must-be-in-json-format=Service Account Private Key must be in JSON format. (Automatic Copy)

--- a/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_ru.properties
@@ -3,3 +3,4 @@ enabled-description=Enable or disable the integration with Google Cloud Translat
 google-cloud-translator-configuration-name=Google Cloud Translator (Automatic Copy)
 service-account-private-key=Service Account Private Key (Automatic Copy)
 service-account-private-key-description=Your project service account private key in JSON format. (Automatic Copy)
+service-account-private-key-must-be-in-json-format=Service Account Private Key must be in JSON format. (Automatic Copy)

--- a/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_sk.properties
@@ -3,3 +3,4 @@ enabled-description=Enable or disable the integration with Google Cloud Translat
 google-cloud-translator-configuration-name=Google Cloud Translator (Automatic Copy)
 service-account-private-key=Service Account Private Key (Automatic Copy)
 service-account-private-key-description=Your project service account private key in JSON format. (Automatic Copy)
+service-account-private-key-must-be-in-json-format=Service Account Private Key must be in JSON format. (Automatic Copy)

--- a/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_sl.properties
@@ -3,3 +3,4 @@ enabled-description=Enable or disable the integration with Google Cloud Translat
 google-cloud-translator-configuration-name=Google Cloud Translator (Automatic Copy)
 service-account-private-key=Service Account Private Key (Automatic Copy)
 service-account-private-key-description=Your project service account private key in JSON format. (Automatic Copy)
+service-account-private-key-must-be-in-json-format=Service Account Private Key must be in JSON format. (Automatic Copy)

--- a/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_sr_RS.properties
@@ -3,3 +3,4 @@ enabled-description=Enable or disable the integration with Google Cloud Translat
 google-cloud-translator-configuration-name=Google Cloud Translator (Automatic Copy)
 service-account-private-key=Service Account Private Key (Automatic Copy)
 service-account-private-key-description=Your project service account private key in JSON format. (Automatic Copy)
+service-account-private-key-must-be-in-json-format=Service Account Private Key must be in JSON format. (Automatic Copy)

--- a/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_sr_RS_latin.properties
@@ -3,3 +3,4 @@ enabled-description=Enable or disable the integration with Google Cloud Translat
 google-cloud-translator-configuration-name=Google Cloud Translator (Automatic Copy)
 service-account-private-key=Service Account Private Key (Automatic Copy)
 service-account-private-key-description=Your project service account private key in JSON format. (Automatic Copy)
+service-account-private-key-must-be-in-json-format=Service Account Private Key must be in JSON format. (Automatic Copy)

--- a/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_sv.properties
@@ -3,3 +3,4 @@ enabled-description=Aktivera eller inaktivera integrationen med Google Cloud Tra
 google-cloud-translator-configuration-name=Google Cloud Translator
 service-account-private-key=Privat nyckel för tjänstkonto
 service-account-private-key-description=Din privata nyckel i projektets tjänstkonto är i JSON-format.
+service-account-private-key-must-be-in-json-format=Service Account Private Key must be in JSON format. (Automatic Copy)

--- a/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_ta_IN.properties
+++ b/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_ta_IN.properties
@@ -3,3 +3,4 @@ enabled-description=Enable or disable the integration with Google Cloud Translat
 google-cloud-translator-configuration-name=Google Cloud Translator (Automatic Copy)
 service-account-private-key=Service Account Private Key (Automatic Copy)
 service-account-private-key-description=Your project service account private key in JSON format. (Automatic Copy)
+service-account-private-key-must-be-in-json-format=Service Account Private Key must be in JSON format. (Automatic Copy)

--- a/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_th.properties
+++ b/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_th.properties
@@ -3,3 +3,4 @@ enabled-description=Enable or disable the integration with Google Cloud Translat
 google-cloud-translator-configuration-name=Google Cloud Translator (Automatic Copy)
 service-account-private-key=Service Account Private Key (Automatic Copy)
 service-account-private-key-description=Your project service account private key in JSON format. (Automatic Copy)
+service-account-private-key-must-be-in-json-format=Service Account Private Key must be in JSON format. (Automatic Copy)

--- a/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_tr.properties
@@ -3,3 +3,4 @@ enabled-description=Enable or disable the integration with Google Cloud Translat
 google-cloud-translator-configuration-name=Google Cloud Translator (Automatic Copy)
 service-account-private-key=Service Account Private Key (Automatic Copy)
 service-account-private-key-description=Your project service account private key in JSON format. (Automatic Copy)
+service-account-private-key-must-be-in-json-format=Service Account Private Key must be in JSON format. (Automatic Copy)

--- a/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_uk.properties
@@ -3,3 +3,4 @@ enabled-description=Enable or disable the integration with Google Cloud Translat
 google-cloud-translator-configuration-name=Google Cloud Translator (Automatic Copy)
 service-account-private-key=Service Account Private Key (Automatic Copy)
 service-account-private-key-description=Your project service account private key in JSON format. (Automatic Copy)
+service-account-private-key-must-be-in-json-format=Service Account Private Key must be in JSON format. (Automatic Copy)

--- a/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_vi.properties
@@ -3,3 +3,4 @@ enabled-description=Enable or disable the integration with Google Cloud Translat
 google-cloud-translator-configuration-name=Google Cloud Translator (Automatic Copy)
 service-account-private-key=Service Account Private Key (Automatic Copy)
 service-account-private-key-description=Your project service account private key in JSON format. (Automatic Copy)
+service-account-private-key-must-be-in-json-format=Service Account Private Key must be in JSON format. (Automatic Copy)

--- a/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_zh_CN.properties
@@ -3,3 +3,4 @@ enabled-description=启用或禁用与用于自动翻译的 Google Cloud Transla
 google-cloud-translator-configuration-name=Google Cloud Translator
 service-account-private-key=服务帐户私钥
 service-account-private-key-description=您的 JSON 格式的项目服务帐户私钥。
+service-account-private-key-must-be-in-json-format=Service Account Private Key must be in JSON format. (Automatic Copy)

--- a/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/translation/translation-google-cloud-translator/src/main/resources/content/Language_zh_TW.properties
@@ -3,3 +3,4 @@ enabled-description=啟用或停用與 Google Cloud Translation API 的整合以
 google-cloud-translator-configuration-name=Google Cloud Translator
 service-account-private-key=服務帳戶私鑰
 service-account-private-key-description=您的專案服務帳戶私鑰為 JSON 格式。
+service-account-private-key-must-be-in-json-format=Service Account Private Key must be in JSON format. (Automatic Copy)

--- a/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/display/context/TranslateDisplayContext.java
+++ b/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/display/context/TranslateDisplayContext.java
@@ -48,7 +48,6 @@ import com.liferay.translation.constants.TranslationPortletKeys;
 import com.liferay.translation.info.field.TranslationInfoFieldChecker;
 import com.liferay.translation.model.TranslationEntry;
 import com.liferay.translation.service.TranslationEntryLocalServiceUtil;
-import com.liferay.translation.web.internal.configuration.FFAutoTranslateConfiguration;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -58,6 +57,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.BooleanSupplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -72,8 +72,8 @@ public class TranslateDisplayContext {
 
 	public TranslateDisplayContext(
 		List<String> availableSourceLanguageIds,
-		List<String> availableTargetLanguageIds, String className, long classPK,
-		FFAutoTranslateConfiguration ffAutoTranslateConfiguration,
+		List<String> availableTargetLanguageIds,
+		BooleanSupplier booleanSupplier, String className, long classPK,
 		InfoForm infoForm, LiferayPortletRequest liferayPortletRequest,
 		LiferayPortletResponse liferayPortletResponse, Object object,
 		InfoItemFieldValues sourceInfoItemFieldValues, String sourceLanguageId,
@@ -82,9 +82,9 @@ public class TranslateDisplayContext {
 
 		_availableSourceLanguageIds = availableSourceLanguageIds;
 		_availableTargetLanguageIds = availableTargetLanguageIds;
+		_booleanSupplier = booleanSupplier;
 		_className = className;
 		_classPK = classPK;
-		_ffAutoTranslateConfiguration = ffAutoTranslateConfiguration;
 		_infoForm = infoForm;
 		_liferayPortletResponse = liferayPortletResponse;
 		_object = object;
@@ -404,9 +404,7 @@ public class TranslateDisplayContext {
 	}
 
 	public boolean isAutoTranslateEnabled() {
-		if (_ffAutoTranslateConfiguration.enabled() &&
-			hasTranslationPermission()) {
-
+		if (_booleanSupplier.getAsBoolean() && hasTranslationPermission()) {
 			return true;
 		}
 
@@ -485,9 +483,9 @@ public class TranslateDisplayContext {
 
 	private final List<String> _availableSourceLanguageIds;
 	private final List<String> _availableTargetLanguageIds;
+	private final BooleanSupplier _booleanSupplier;
 	private final String _className;
 	private final long _classPK;
-	private final FFAutoTranslateConfiguration _ffAutoTranslateConfiguration;
 	private Long _groupId;
 	private final HttpServletRequest _httpServletRequest;
 	private final InfoForm _infoForm;

--- a/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/portlet/action/TranslateMVCRenderCommand.java
+++ b/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/portlet/action/TranslateMVCRenderCommand.java
@@ -46,6 +46,7 @@ import com.liferay.translation.info.field.TranslationInfoFieldChecker;
 import com.liferay.translation.info.item.provider.InfoItemLanguagesProvider;
 import com.liferay.translation.model.TranslationEntry;
 import com.liferay.translation.service.TranslationEntryLocalService;
+import com.liferay.translation.translator.Translator;
 import com.liferay.translation.web.internal.configuration.FFAutoTranslateConfiguration;
 import com.liferay.translation.web.internal.display.context.TranslateDisplayContext;
 
@@ -67,6 +68,9 @@ import javax.portlet.RenderResponse;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Ambrín Chaudhary
@@ -104,7 +108,10 @@ public class TranslateMVCRenderCommand implements MVCRenderCommand {
 					TranslateDisplayContext.class.getName(),
 					new TranslateDisplayContext(
 						Collections.emptyList(), Collections.emptyList(),
-						className, classPK, _ffAutoTranslateConfiguration, null,
+						() ->
+							_ffAutoTranslateConfiguration.enabled() &&
+							(_translator != null) && _translator.isEnabled(),
+						className, classPK, null,
 						_portal.getLiferayPortletRequest(renderRequest),
 						_portal.getLiferayPortletResponse(renderResponse), null,
 						null, null, null, null, _translationInfoFieldChecker));
@@ -148,7 +155,10 @@ public class TranslateMVCRenderCommand implements MVCRenderCommand {
 				TranslateDisplayContext.class.getName(),
 				new TranslateDisplayContext(
 					availableSourceLanguageIds, availableTargetLanguageIds,
-					className, classPK, _ffAutoTranslateConfiguration, infoForm,
+					() ->
+						_ffAutoTranslateConfiguration.enabled() &&
+						(_translator != null) && _translator.isEnabled(),
+					className, classPK, infoForm,
 					_portal.getLiferayPortletRequest(renderRequest),
 					_portal.getLiferayPortletResponse(renderResponse), object,
 					sourceInfoItemFieldValues, sourceLanguageId,
@@ -320,5 +330,12 @@ public class TranslateMVCRenderCommand implements MVCRenderCommand {
 
 	@Reference
 	private TranslationInfoFieldChecker _translationInfoFieldChecker;
+
+	@Reference(
+		cardinality = ReferenceCardinality.OPTIONAL,
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY
+	)
+	private volatile Translator _translator;
 
 }


### PR DESCRIPTION
Enable the Auto-translate button only when the configuration is valid (and the feature flag is enabled).

To test this, simply try to enable/disable the Google Cloud configuration is System Settings, and observe that the button in the side by side goes away/shows up as appropriate. The validation checks that the key is a valid, non empty, JSON object.

![translation-validation](https://user-images.githubusercontent.com/729897/117971387-22df7400-b32a-11eb-96eb-7ca18f259ee8.png)