### PR TITLE
LPS-131604 translations auto translation by field JSP markup

### DIFF
--- a/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/css/main.scss
@@ -106,7 +106,13 @@ $productMenuWidth: 320px;
 			}
 		}
 
-		.col-autotranslate-field {
+		.col-autotranslate-content {
+			@include media-breakpoint-up(md) {
+				max-width: calc(100% - 3.5rem);
+			}
+		}
+
+		.col-autotranslate-button {
 			margin-bottom: 1rem;
 			padding-left: 12px;
 			width: 100%;

--- a/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/init.jsp
@@ -29,6 +29,7 @@ taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
 <%@ page import="com.liferay.info.field.InfoField" %><%@
 page import="com.liferay.info.field.InfoFieldSetEntry" %><%@
 page import="com.liferay.info.field.type.TextInfoFieldType" %><%@
+page import="com.liferay.petra.string.StringPool" %><%@
 page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
 page import="com.liferay.portal.kernel.util.HashMapBuilder" %><%@
 page import="com.liferay.portal.kernel.util.ListUtil" %><%@

--- a/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/translate/components/TranslateFieldSetEntries.js
+++ b/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/translate/components/TranslateFieldSetEntries.js
@@ -45,8 +45,10 @@ const TranslateAutoTranslateRow = ({
 
 	return (
 		<ClayLayout.Row>
-			<ClayLayout.ContentCol expand>{children}</ClayLayout.ContentCol>
-			<ClayLayout.ContentCol className="align-self-top col-autotranslate-field">
+			<ClayLayout.ContentCol className="col-autotranslate-content" expand>
+				{children}
+			</ClayLayout.ContentCol>
+			<ClayLayout.ContentCol className="align-self-top col-autotranslate-button">
 				<ClayButton
 					className="lfr-portal-tooltip"
 					disabled={isLoading || !sourceContent}

--- a/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/translate/components/TranslateHeader.js
+++ b/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/translate/components/TranslateHeader.js
@@ -20,12 +20,12 @@ const TranslateHeader = ({sourceLanguageIdTitle, targetLanguageIdTitle}) => (
 	<ClayLayout.Row className="row-autotranslate-title">
 		<ClayLayout.Col md={6}>
 			<ClayIcon symbol={sourceLanguageIdTitle.toLowerCase()} />
-			<span className="ml-1">{sourceLanguageIdTitle}</span>
+			<span className="ml-2">{sourceLanguageIdTitle}</span>
 			<div className="separator" />
 		</ClayLayout.Col>
 		<ClayLayout.Col md={6}>
 			<ClayIcon symbol={targetLanguageIdTitle.toLowerCase()} />
-			<span className="ml-1">{targetLanguageIdTitle}</span>
+			<span className="ml-2">{targetLanguageIdTitle}</span>
 			<div className="separator" />
 		</ClayLayout.Col>
 	</ClayLayout.Row>

--- a/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/translate.jsp
+++ b/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/translate.jsp
@@ -62,7 +62,9 @@ renderResponse.setTitle(translateDisplayContext.getTitle());
 						/>
 					</c:when>
 					<c:otherwise>
-						<clay:row>
+						<clay:row
+							cssClass='<%= translateDisplayContext.isAutoTranslateEnabled() ? "row-autotranslate-title" : StringPool.BLANK %>'
+						>
 							<clay:col
 								md="6"
 							>
@@ -110,7 +112,9 @@ renderResponse.setTitle(translateDisplayContext.getTitle());
 						%>
 
 							<c:if test="<%= Validator.isNotNull(infoFieldSetLabel) %>">
-								<clay:row>
+								<clay:row
+									cssClass='<%= translateDisplayContext.isAutoTranslateEnabled() ? "row-autotranslate-title" : StringPool.BLANK %>'
+								>
 									<clay:col
 										md="6"
 									>
@@ -136,56 +140,90 @@ renderResponse.setTitle(translateDisplayContext.getTitle());
 								boolean multiline = translateDisplayContext.getBooleanValue(infoField, TextInfoFieldType.MULTILINE);
 							%>
 
-								<clay:row>
-									<clay:col
-										md="6"
-									>
+								<liferay-util:buffer
+									var="translationContent"
+								>
+									<clay:row>
+										<clay:col
+											md="6"
+										>
 
-										<%
-										String sourceContent = translateDisplayContext.getSourceStringValue(infoField, translateDisplayContext.getSourceLocale());
-										String sourceContentDir = LanguageUtil.get(translateDisplayContext.getSourceLocale(), "lang.dir");
-										%>
+											<%
+											String sourceContent = translateDisplayContext.getSourceStringValue(infoField, translateDisplayContext.getSourceLocale());
+											String sourceContentDir = LanguageUtil.get(translateDisplayContext.getSourceLocale(), "lang.dir");
+											%>
 
-										<c:choose>
-											<c:when test="<%= html %>">
-												<label class="control-label">
-													<%= label %>
-												</label>
+											<c:choose>
+												<c:when test="<%= html %>">
+													<label class="control-label">
+														<%= label %>
+													</label>
 
-												<div class="translation-editor-preview" dir="<%= sourceContentDir %>">
-													<%= sourceContent %>
-												</div>
-											</c:when>
-											<c:otherwise>
-												<aui:input dir="<%= sourceContentDir %>" label="<%= label %>" name="<%= label %>" readonly="true" tabIndex="-1" type='<%= multiline ? "textarea" : "text" %>' value="<%= sourceContent %>" />
-											</c:otherwise>
-										</c:choose>
-									</clay:col>
+													<div class="translation-editor-preview" dir="<%= sourceContentDir %>">
+														<%= sourceContent %>
+													</div>
+												</c:when>
+												<c:otherwise>
+													<aui:input dir="<%= sourceContentDir %>" label="<%= label %>" name="<%= label %>" readonly="true" tabIndex="-1" type='<%= multiline ? "textarea" : "text" %>' value="<%= sourceContent %>" />
+												</c:otherwise>
+											</c:choose>
+										</clay:col>
 
-									<clay:col
-										md="6"
-									>
+										<clay:col
+											md="6"
+										>
 
-										<%
-										String targetContent = translateDisplayContext.getTargetStringValue(infoField, translateDisplayContext.getTargetLocale());
-										%>
+											<%
+											String targetContent = translateDisplayContext.getTargetStringValue(infoField, translateDisplayContext.getTargetLocale());
+											%>
 
-										<c:choose>
-											<c:when test="<%= html %>">
-												<label class="control-label">
-													<%= label %>
-												</label>
+											<c:choose>
+												<c:when test="<%= html %>">
+													<label class="control-label">
+														<%= label %>
+													</label>
 
-												<div class="translation-editor-preview" dir="<%= LanguageUtil.get(translateDisplayContext.getTargetLocale(), "lang.dir") %>">
-													<%= targetContent %>
-												</div>
-											</c:when>
-											<c:otherwise>
-												<aui:input dir='<%= LanguageUtil.get(translateDisplayContext.getTargetLocale(), "lang.dir") %>' disabled="<%= true %>" label="<%= label %>" name='<%= "infoField--" + infoField.getName() + "--" %>' type='<%= multiline ? "textarea" : "text" %>' value="<%= targetContent %>" />
-											</c:otherwise>
-										</c:choose>
-									</clay:col>
-								</clay:row>
+													<div class="translation-editor-preview" dir="<%= LanguageUtil.get(translateDisplayContext.getTargetLocale(), "lang.dir") %>">
+														<%= targetContent %>
+													</div>
+												</c:when>
+												<c:otherwise>
+													<aui:input dir='<%= LanguageUtil.get(translateDisplayContext.getTargetLocale(), "lang.dir") %>' disabled="<%= true %>" label="<%= label %>" name='<%= "infoField--" + infoField.getName() + "--" %>' type='<%= multiline ? "textarea" : "text" %>' value="<%= targetContent %>" />
+												</c:otherwise>
+											</c:choose>
+										</clay:col>
+									</clay:row>
+								</liferay-util:buffer>
+
+								<c:choose>
+									<c:when test="<%= translateDisplayContext.isAutoTranslateEnabled() %>">
+										<clay:row>
+											<clay:content-col
+												cssClass="col-autotranslate-content"
+												expand="<%= true %>"
+											>
+												<%= translationContent %>
+											</clay:content-col>
+
+											<clay:content-col
+												cssClass="col-autotranslate-button"
+											>
+												<clay:button
+													disabled="<%= true %>"
+													displayType="secondary"
+													monospaced="<%= true %>"
+												>
+													<clay:icon
+														symbol="automatic-translate"
+													/>
+
+													<span class="sr-only"><liferay-ui:message key="location" /></span>
+												</clay:button>
+											</clay:content-col>
+										</clay:row>
+									</c:when>
+									<c:otherwise><%= translationContent %></c:otherwise>
+								</c:choose>
 
 						<%
 							}


### PR DESCRIPTION
Add placeholder auto-translation markup on the server render.

**Test Plan:**

- Enable `com.liferay.translation.web.internal.configuration.FFAutoTranslateConfiguration` feature flag.
 
   ```
   cd LIFERAY_PORTAL_PATH
   echo "enabled=B\"true\"" > ../bundles/osgi/configs/com.liferay.translation.web.internal.configuration.FFAutoTranslateConfiguration.config
  ```
  
- Configuration: System settings > Content and Data > category.translations (default cog icon)
- Enable and add well-formed JSON or a valid key
- Disable JS in your browser (in chrome: https://developer.chrome.com/docs/devtools/javascript/disable/) avoiding that placeholder markup being hydrated by the react component.

---

**Server rendering (with js disabled):**

![image](https://user-images.githubusercontent.com/67901/118529685-143af780-b744-11eb-9153-86b43e37722e.png)

**Client rendering:**

![image](https://user-images.githubusercontent.com/67901/118529404-c58d5d80-b743-11eb-8398-b06a42ca492f.png)

