### PR TITLE
[TS] LPS-132358 | Pagination on asset collections not working when selecting from Asset Library

### DIFF
--- a/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/display/context/EditAssetListDisplayContext.java
+++ b/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/display/context/EditAssetListDisplayContext.java
@@ -1156,8 +1156,6 @@ public class EditAssetListDisplayContext {
 			new AssetEntryItemSelectorReturnType());
 		assetEntryItemSelectorCriterion.setGroupId(
 			_themeDisplay.getScopeGroupId());
-		assetEntryItemSelectorCriterion.setSelectedGroupIds(
-			new long[] {_themeDisplay.getScopeGroupId()});
 		assetEntryItemSelectorCriterion.setShowNonindexable(true);
 		assetEntryItemSelectorCriterion.setShowScheduled(true);
 		assetEntryItemSelectorCriterion.setSubtypeSelectionId(


### PR DESCRIPTION
Hi Team,
Could you please review this pull request?
The issue seems to be similar to [LPS-119553](https://issues.liferay.com/browse/LPS-119553) using the same solution from the LPS allowed me to navigate between the pages of the pagination.

https://issues.liferay.com/browse/LPS-132358
Thank you!