### PR TITLE
LPS-132393 fix tests that were not properly migrated to the new signature

### DIFF
--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenAddingAFileEntryTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenAddingAFileEntryTest.java
@@ -103,7 +103,7 @@ public class DLAppServiceWhenAddingAFileEntryTest extends BaseDLAppTestCase {
 
 		FileEntry fileEntry = DLAppServiceTestUtil.addFileEntry(
 			externalReferenceCode, group.getGroupId(),
-			parentFolder.getFolderId(), fileName, fileName, null);
+			parentFolder.getFolderId(), fileName, fileName, null, null, null);
 
 		Assert.assertEquals(
 			externalReferenceCode, fileEntry.getExternalReferenceCode());
@@ -123,7 +123,7 @@ public class DLAppServiceWhenAddingAFileEntryTest extends BaseDLAppTestCase {
 
 		FileEntry fileEntry = DLAppServiceTestUtil.addFileEntry(
 			null, group.getGroupId(), parentFolder.getFolderId(), fileName,
-			fileName, null);
+			fileName, null, null, null);
 
 		String externalReferenceCode = String.valueOf(
 			fileEntry.getFileEntryId());
@@ -146,7 +146,8 @@ public class DLAppServiceWhenAddingAFileEntryTest extends BaseDLAppTestCase {
 
 		FileEntry fileEntry = DLAppServiceTestUtil.addFileEntry(
 			RandomTestUtil.randomString(), group.getGroupId(),
-			parentFolder.getFolderId(), fileName, fileName, assetTagNames);
+			parentFolder.getFolderId(), fileName, fileName, null, null,
+			assetTagNames);
 
 		AssetEntry assetEntry = AssetEntryLocalServiceUtil.fetchEntry(
 			DLFileEntryConstants.getClassName(), fileEntry.getFileEntryId());
@@ -207,11 +208,11 @@ public class DLAppServiceWhenAddingAFileEntryTest extends BaseDLAppTestCase {
 		DLAppServiceTestUtil.addFileEntry(
 			externalReferenceCode, group.getGroupId(),
 			parentFolder.getFolderId(), DLAppServiceTestUtil.FILE_NAME,
-			DLAppServiceTestUtil.STRIPPED_FILE_NAME, null);
+			DLAppServiceTestUtil.STRIPPED_FILE_NAME, null, null, null);
 		DLAppServiceTestUtil.addFileEntry(
 			externalReferenceCode, group.getGroupId(),
 			parentFolder.getFolderId(), DLAppServiceTestUtil.FILE_NAME,
-			DLAppServiceTestUtil.FILE_NAME, null);
+			DLAppServiceTestUtil.FILE_NAME, null, null, null);
 	}
 
 	@Test(expected = DuplicateFileEntryException.class)
@@ -221,11 +222,11 @@ public class DLAppServiceWhenAddingAFileEntryTest extends BaseDLAppTestCase {
 		DLAppServiceTestUtil.addFileEntry(
 			RandomTestUtil.randomString(), group.getGroupId(),
 			parentFolder.getFolderId(), DLAppServiceTestUtil.FILE_NAME,
-			DLAppServiceTestUtil.STRIPPED_FILE_NAME, null);
+			DLAppServiceTestUtil.STRIPPED_FILE_NAME, null, null, null);
 		DLAppServiceTestUtil.addFileEntry(
 			RandomTestUtil.randomString(), group.getGroupId(),
 			parentFolder.getFolderId(), DLAppServiceTestUtil.FILE_NAME,
-			DLAppServiceTestUtil.FILE_NAME, null);
+			DLAppServiceTestUtil.FILE_NAME, null, null, null);
 	}
 
 	@Test(expected = DuplicateFileEntryException.class)
@@ -235,11 +236,11 @@ public class DLAppServiceWhenAddingAFileEntryTest extends BaseDLAppTestCase {
 		DLAppServiceTestUtil.addFileEntry(
 			RandomTestUtil.randomString(), group.getGroupId(),
 			parentFolder.getFolderId(), DLAppServiceTestUtil.FILE_NAME,
-			DLAppServiceTestUtil.FILE_NAME, null);
+			DLAppServiceTestUtil.FILE_NAME, null, null, null);
 		DLAppServiceTestUtil.addFileEntry(
 			RandomTestUtil.randomString(), group.getGroupId(),
 			parentFolder.getFolderId(), DLAppServiceTestUtil.FILE_NAME,
-			DLAppServiceTestUtil.STRIPPED_FILE_NAME, null);
+			DLAppServiceTestUtil.STRIPPED_FILE_NAME, null, null, null);
 	}
 
 	@Test(expected = DuplicateFileEntryException.class)

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenCheckingInAFileEntryTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenCheckingInAFileEntryTest.java
@@ -192,7 +192,7 @@ public class DLAppServiceWhenCheckingInAFileEntryTest
 		FileEntry fileEntry = DLAppServiceTestUtil.addFileEntry(
 			RandomTestUtil.randomString(), group.getGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-			StringUtil.randomString(), StringUtil.randomString(),
+			StringUtil.randomString(), StringUtil.randomString(), null, null,
 			new String[] {"tag1", "tag2"});
 
 		ServiceContext serviceContext =

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenMovingAFileEntryTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenMovingAFileEntryTest.java
@@ -67,7 +67,7 @@ public class DLAppServiceWhenMovingAFileEntryTest extends BaseDLAppTestCase {
 		FileEntry fileEntry = DLAppServiceTestUtil.addFileEntry(
 			RandomTestUtil.randomString(), group.getGroupId(),
 			parentFolder.getFolderId(), DLAppServiceTestUtil.FILE_NAME,
-			DLAppServiceTestUtil.STRIPPED_FILE_NAME, null);
+			DLAppServiceTestUtil.STRIPPED_FILE_NAME, null, null, null);
 
 		FileEntry copiedFileEntry = DLAppServiceUtil.moveFileEntry(
 			fileEntry.getFileEntryId(),

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenSearchingFileEntriesTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenSearchingFileEntriesTest.java
@@ -52,7 +52,7 @@ public class DLAppServiceWhenSearchingFileEntriesTest
 
 		FileEntry fileEntry = DLAppServiceTestUtil.addFileEntry(
 			RandomTestUtil.randomString(), group.getGroupId(),
-			parentFolder.getFolderId(), fileName, fileName,
+			parentFolder.getFolderId(), fileName, fileName, null, null,
 			new String[] {"hello", "world"});
 
 		DLAppServiceTestUtil.search(fileEntry, "hello", true);
@@ -73,7 +73,8 @@ public class DLAppServiceWhenSearchingFileEntriesTest
 
 		FileEntry fileEntry = DLAppServiceTestUtil.addFileEntry(
 			RandomTestUtil.randomString(), group.getGroupId(),
-			parentFolder.getFolderId(), fileName, fileName, assetTagNames);
+			parentFolder.getFolderId(), fileName, fileName, null, null,
+			assetTagNames);
 
 		assetTagNames = new String[] {"hello", "world", "liferay"};
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenUpdatingAFileEntryTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenUpdatingAFileEntryTest.java
@@ -71,7 +71,8 @@ public class DLAppServiceWhenUpdatingAFileEntryTest extends BaseDLAppTestCase {
 
 		FileEntry fileEntry = DLAppServiceTestUtil.addFileEntry(
 			RandomTestUtil.randomString(), group.getGroupId(),
-			parentFolder.getFolderId(), fileName, fileName, assetTagNames);
+			parentFolder.getFolderId(), fileName, fileName, null, null,
+			assetTagNames);
 
 		assetTagNames = new String[] {"hello", "world"};
 
@@ -117,7 +118,8 @@ public class DLAppServiceWhenUpdatingAFileEntryTest extends BaseDLAppTestCase {
 
 		FileEntry fileEntry = DLAppServiceTestUtil.addFileEntry(
 			RandomTestUtil.randomString(), group.getGroupId(),
-			parentFolder.getFolderId(), fileName, fileName, assetTagNames);
+			parentFolder.getFolderId(), fileName, fileName, null, null,
+			assetTagNames);
 
 		assetTagNames = new String[] {"hello", "world"};
 


### PR DESCRIPTION
On the last PR sent to https://issues.liferay.com/browse/LPS-122267 on the commit when we changed the calls for the deprecated methods, some of the calls were missed.

this PR solves this issues