### PR TITLE
LPS-132565 Show status message consistently

### DIFF
--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_thread_entries.jspf
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_thread_entries.jspf
@@ -136,7 +136,7 @@
 
 			<c:if test="<%= (message != null) && !message.isApproved() %>">
 				<span class="h6">
-					<aui:workflow-status bean="<%= message %>" markupView="lexicon" model="<%= MBMessage.class %>" showIcon="<%= false %>" showLabel="<%= false %>" status="<%= message.getStatus() %>" />
+					<aui:workflow-status markupView="lexicon" showIcon="<%= false %>" showLabel="<%= false %>" status="<%= message.getStatus() %>" />
 				</span>
 			</c:if>
 

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards_admin/view_entries.jspf
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards_admin/view_entries.jspf
@@ -271,7 +271,7 @@ MBCategoryDisplay categoryDisplay = new MBCategoryDisplay(scopeGroupId, category
 							</c:if>
 
 							<div>
-								<aui:workflow-status bean="<%= message %>" markupView="lexicon" model="<%= MBMessage.class %>" showIcon="<%= false %>" showLabel="<%= false %>" status="<%= message.getStatus() %>" />
+								<aui:workflow-status markupView="lexicon" showIcon="<%= false %>" showLabel="<%= false %>" status="<%= message.getStatus() %>" />
 
 								<c:if test="<%= thread.isLocked() %>">
 									<aui:icon image="lock" markupView="lexicon" />


### PR DESCRIPTION
Render the status message the same way everywhere. For consistency with other apps, keep the shortest version (see Jira ticket for the details.)