### PR TITLE
LPS-132503 Only try to reload the iframe if have a valid contentWindow

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/progress.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/progress.js
@@ -81,7 +81,9 @@ AUI.add(
 					var instance = this;
 
 					setTimeout(() => {
-						instance._frame.get('contentWindow.location').reload();
+						instance._frame
+							.get('contentWindow')
+							?.location?.reload();
 					}, instance.get(STR_UPDATE_PERIOD));
 				},
 


### PR DESCRIPTION
**Description:** https://issues.liferay.com/browse/LPS-132503

If the iframe isn't loaded because of a submit or navigation the contentWindow is null.

https://html.spec.whatwg.org/multipage/iframe-embed-object.html#dom-iframe-contentwindow
> The contentWindow IDL attribute must return the WindowProxy object of the iframe element's nested browsing context, if its nested browsing context is non-null, or null otherwise.

In this case, trying to access to iframe.contentWindow.location throws an error.

**Note:** Don´t forward directly forward to FI.