### PR TITLE
LPS-130402 Generate urlTitle on conflict when saving draft

### DIFF
--- a/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/service/test/BlogsEntryLocalServiceTest.java
+++ b/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/service/test/BlogsEntryLocalServiceTest.java
@@ -215,6 +215,30 @@ public class BlogsEntryLocalServiceTest {
 	}
 
 	@Test
+	public void testAddDraftEntryWithDuplicateURLTitle() throws Exception {
+		String urlTitle = RandomTestUtil.randomString();
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(_group, _user.getUserId());
+
+		BlogsEntryLocalServiceUtil.addEntry(
+			_user.getUserId(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), urlTitle,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			new Date(), false, false, null, null, null, null, serviceContext);
+
+		serviceContext.setWorkflowAction(WorkflowConstants.ACTION_SAVE_DRAFT);
+
+		BlogsEntry entry = BlogsEntryLocalServiceUtil.addEntry(
+			_user.getUserId(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), urlTitle,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			new Date(), false, false, null, null, null, null, serviceContext);
+
+		Assert.assertNotEquals(urlTitle, entry.getUrlTitle());
+	}
+
+	@Test
 	public void testAddDraftEntryWithNullTitle() throws Exception {
 		int initialCount = BlogsEntryLocalServiceUtil.getGroupEntriesCount(
 			_group.getGroupId(), _statusAnyQueryDefinition);
@@ -965,6 +989,36 @@ public class BlogsEntryLocalServiceTest {
 				_user.getUserId());
 
 		Assert.assertEquals(initialCount, actualCount);
+	}
+
+	@Test
+	public void testUpdateDraftEntryWithDuplicateURLTitle() throws Exception {
+		String urlTitle = RandomTestUtil.randomString();
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(_group, _user.getUserId());
+
+		BlogsEntryLocalServiceUtil.addEntry(
+			_user.getUserId(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), urlTitle,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			new Date(), false, false, null, null, null, null, serviceContext);
+
+		serviceContext.setWorkflowAction(WorkflowConstants.ACTION_SAVE_DRAFT);
+
+		BlogsEntry entry = BlogsEntryLocalServiceUtil.addEntry(
+			_user.getUserId(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), urlTitle,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			new Date(), false, false, null, null, null, null, serviceContext);
+
+		entry = BlogsEntryLocalServiceUtil.updateEntry(
+			_user.getUserId(), entry.getEntryId(), entry.getTitle(),
+			entry.getSubtitle(), urlTitle, entry.getDescription(),
+			entry.getContent(), entry.getDisplayDate(), false, false, null,
+			null, null, null, serviceContext);
+
+		Assert.assertNotEquals(urlTitle, entry.getUrlTitle());
 	}
 
 	@Test

--- a/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/portlet/action/EditEntryMVCActionCommand.java
+++ b/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/portlet/action/EditEntryMVCActionCommand.java
@@ -184,6 +184,8 @@ public class EditEntryMVCActionCommand extends BaseMVCActionCommand {
 						entry.getCoverImageFileEntryId()
 					).put(
 						"entryId", entry.getEntryId()
+					).put(
+						"urlTitle", entry.getUrlTitle()
 					));
 
 				return;

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/js/blogs.js
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/js/blogs.js
@@ -443,6 +443,9 @@ export default class Blogs {
 								);
 							}
 
+							this._getElementById('urlTitle').value =
+								message.urlTitle;
+
 							if (saveStatus) {
 								const saveText = entry?.pending
 									? strings.savedAtMessage


### PR DESCRIPTION
When saving or updating a draft, generate a fresh urlTitle if the one provided by the user is already in use.

Note that we only do this when autosaving drafts; if the user saves explicitly, and error should be signalled. Where doing this for drafts to prevent the user from losing the entry's contents.