### PR TITLE
LPS-132752 clay:label tag should allow for literal values

### DIFF
--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_summary/page.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_summary/page.jsp
@@ -67,6 +67,7 @@ for (AssetVocabulary vocabulary : vocabularies) {
 									displayType="dark"
 									label="<%= HtmlUtil.escape(category.getTitle(themeDisplay.getLocale())) %>"
 									large="<%= true %>"
+									translateLabel="<%= false %>"
 								/>
 
 							<%

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/LabelTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/LabelTag.java
@@ -56,6 +56,10 @@ public class LabelTag extends BaseContainerTag {
 		return _large;
 	}
 
+	public boolean getTranslateLabel() {
+		return _translateLabel;
+	}
+
 	public void setDismissible(boolean dismissible) {
 		_dismissible = dismissible;
 	}
@@ -72,6 +76,10 @@ public class LabelTag extends BaseContainerTag {
 		_large = large;
 	}
 
+	public void setTranslateLabel(boolean translateLabel) {
+		_translateLabel = translateLabel;
+	}
+
 	@Override
 	protected void cleanUp() {
 		super.cleanUp();
@@ -80,6 +88,7 @@ public class LabelTag extends BaseContainerTag {
 		_displayType = "secondary";
 		_label = null;
 		_large = false;
+		_translateLabel = true;
 	}
 
 	@Override
@@ -107,10 +116,15 @@ public class LabelTag extends BaseContainerTag {
 
 			jspWriter.write("<span class=\"label-item label-item-expand\">");
 
-			jspWriter.write(
-				LanguageUtil.get(
-					TagResourceBundleUtil.getResourceBundle(pageContext),
-					_label));
+			if (_translateLabel) {
+				jspWriter.write(
+					LanguageUtil.get(
+						TagResourceBundleUtil.getResourceBundle(pageContext),
+						_label));
+			}
+			else {
+				jspWriter.write(_label);
+			}
 
 			jspWriter.write("</span>");
 
@@ -141,5 +155,6 @@ public class LabelTag extends BaseContainerTag {
 	private String _displayType = "secondary";
 	private String _label;
 	private boolean _large;
+	private boolean _translateLabel = true;
 
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
@@ -1441,6 +1441,12 @@
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
+		<attribute>
+			<description></description>
+			<name>translateLabel</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
 		<dynamic-attributes>true</dynamic-attributes>
 	</tag>
 	<tag>


### PR DESCRIPTION
Clay:label translates the label by default; this makes it awkward to use any label that happens to have a lang key with the same name.

We cannot change the default behaviour to keep backwards compatibility, so I've added a new "translateLabel" attribute to let callers choose the behaviour they need.

See https://issues.liferay.com/browse/LPS-132752 for the reproduction steps and a description of the issue.