### PR TITLE
LPS-133166 Order By Modification date for Docs and Media folders will display the Last Post Date

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp
@@ -427,7 +427,7 @@ if (portletTitleBasedNavigation && !dlViewEntriesDisplayContext.isRootFolder() &
 										<liferay-ui:search-container-column-date
 											cssClass="table-cell-expand-smallest table-cell-ws-nowrap"
 											name="modified-date"
-											value="<%= curFolder.getLastPostDate() %>"
+											value="<%= curFolder.getModifiedDate() %>"
 										/>
 									</c:when>
 									<c:when test='<%= curEntryColumn.equals("action") %>'>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_folder_descriptive.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_folder_descriptive.jsp
@@ -23,7 +23,7 @@ Folder folder = (Folder)row.getObject();
 
 folder = folder.toEscapedModel();
 
-Date modifiedDate = folder.getLastPostDate();
+Date modifiedDate = folder.getModifiedDate();
 
 String modifiedDateDescription = LanguageUtil.getTimeDescription(request, System.currentTimeMillis() - modifiedDate.getTime(), true);
 %>


### PR DESCRIPTION
Dear Team,

Could you please review this pull request?

One of the customers finds it confusing that while the folders are sorted by modification date the Modified Date column in shows their Last Post Date.
To be clear, these two fields are updated at different events:

- `modifiedDate` is updated when the folder itself is modified eg. its title is changed or a description is added
- `lastPostDate` is updated when a file or subfolder is created in the folder

The customer would be fine with it when the `modifiedDate` would be shown instead of `lastPostDate`. The changes in the pull achieve exactly that.
But I'm not sure if we should alter the behavior this way. For example, other users would expect to still view the `lastPostDate`.

Maybe we could add an option for sorting by `lastPostDate`? This would be tricky though as all of the sortings for files, folders and shortcuts are done by Repository Model Comparators (for example [RepositoryModelModifiedDateComparator](https://github.com/liferay/liferay-portal/blob/master/portal-kernel/src/com/liferay/document/library/kernel/util/comparator/RepositoryModelModifiedDateComparator.java)), and while all repository entries have a `modifiedDate` field, only folders have a `lastPostDate` field. A Repository Model Comparators thus would not be able to compare base on `lastPostDate`.

Alternatively, should we suggest a workaround/customization for the customer?

Thank you and best regards,
István