### PR TITLE
LPS-133355 Show audio icon shows in CKeditor after enabling FFmpeg

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorConfigContributor.java
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorConfigContributor.java
@@ -14,6 +14,7 @@
 
 package com.liferay.frontend.editor.ckeditor.web.internal.editor.configuration;
 
+import com.liferay.document.library.kernel.util.AudioProcessorUtil;
 import com.liferay.frontend.editor.ckeditor.web.internal.constants.CKEditorConstants;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.editor.configuration.EditorConfigContributor;
@@ -214,7 +215,7 @@ public class CKEditorConfigContributor extends BaseCKEditorConfigContributor {
 			toJSONArray("['Link', Unlink]"),
 			toJSONArray("['Table', 'ImageSelector', 'VideoSelector']"));
 
-		if (XugglerUtil.isEnabled()) {
+		if (XugglerUtil.isEnabled() || AudioProcessorUtil.isEnabled()) {
 			jsonArray.put(toJSONArray("['AudioSelector']"));
 		}
 

--- a/modules/apps/item-selector/item-selector-editor-configuration/src/main/java/com/liferay/item/selector/editor/configuration/internal/AudioEditorConfigContributor.java
+++ b/modules/apps/item-selector/item-selector-editor-configuration/src/main/java/com/liferay/item/selector/editor/configuration/internal/AudioEditorConfigContributor.java
@@ -14,6 +14,7 @@
 
 package com.liferay.item.selector.editor.configuration.internal;
 
+import com.liferay.document.library.kernel.util.AudioProcessorUtil;
 import com.liferay.item.selector.ItemSelector;
 import com.liferay.item.selector.ItemSelectorCriterion;
 import com.liferay.item.selector.criteria.audio.criterion.AudioItemSelectorCriterion;
@@ -46,7 +47,7 @@ public class AudioEditorConfigContributor extends BaseEditorConfigContributor {
 		ThemeDisplay themeDisplay,
 		RequestBackedPortletURLFactory requestBackedPortletURLFactory) {
 
-		if (!XugglerUtil.isEnabled()) {
+		if (!XugglerUtil.isEnabled() && !AudioProcessorUtil.isEnabled()) {
 			return;
 		}
 

--- a/modules/apps/journal/journal-editor-configuration/src/main/java/com/liferay/journal/editor/configuration/internal/JournalMediaEditorConfigContributor.java
+++ b/modules/apps/journal/journal-editor-configuration/src/main/java/com/liferay/journal/editor/configuration/internal/JournalMediaEditorConfigContributor.java
@@ -14,6 +14,7 @@
 
 package com.liferay.journal.editor.configuration.internal;
 
+import com.liferay.document.library.kernel.util.AudioProcessorUtil;
 import com.liferay.journal.constants.JournalPortletKeys;
 import com.liferay.portal.kernel.editor.configuration.BaseEditorConfigContributor;
 import com.liferay.portal.kernel.editor.configuration.EditorConfigContributor;
@@ -48,7 +49,7 @@ public class JournalMediaEditorConfigContributor
 		ThemeDisplay themeDisplay,
 		RequestBackedPortletURLFactory requestBackedPortletURLFactory) {
 
-		if (!XugglerUtil.isEnabled()) {
+		if (!XugglerUtil.isEnabled() && !AudioProcessorUtil.isEnabled()) {
 			return;
 		}
 

--- a/portal-impl/bnd.bnd
+++ b/portal-impl/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 7.6.1
+Bundle-Version: 8.0.0
 Export-Package:\
 	com.liferay.portal.asm,\
 	com.liferay.portal.bean,\

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/util/AudioProcessorImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/util/AudioProcessorImpl.java
@@ -146,6 +146,11 @@ public class AudioProcessorImpl
 	}
 
 	@Override
+	public boolean isEnabled() {
+		return _audioConverter.isEnabled();
+	}
+
+	@Override
 	public boolean isSupported(String mimeType) {
 		if (_audioMimeTypes.contains(mimeType) && _audioConverter.isEnabled()) {
 			return true;

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/util/packageinfo
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/util/packageinfo
@@ -1,1 +1,1 @@
-version 2.2.0
+version 2.3.0

--- a/portal-kernel/src/com/liferay/document/library/kernel/util/AudioProcessor.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/util/AudioProcessor.java
@@ -58,6 +58,10 @@ public interface AudioProcessor {
 
 	public boolean isAudioSupported(String mimeType);
 
+	public default boolean isEnabled() {
+		return false;
+	}
+
 	public boolean isSupported(String mimeType);
 
 	public void trigger(

--- a/portal-kernel/src/com/liferay/document/library/kernel/util/AudioProcessorUtil.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/util/AudioProcessorUtil.java
@@ -108,6 +108,16 @@ public class AudioProcessorUtil {
 		return audioProcessor.isAudioSupported(mimeType);
 	}
 
+	public static boolean isEnabled() {
+		AudioProcessor audioProcessor = getAudioProcessor();
+
+		if (audioProcessor == null) {
+			return false;
+		}
+
+		return audioProcessor.isEnabled();
+	}
+
 	public static boolean isSupported(String mimeType) {
 		AudioProcessor audioProcessor = getAudioProcessor();
 

--- a/portal-kernel/src/com/liferay/document/library/kernel/util/packageinfo
+++ b/portal-kernel/src/com/liferay/document/library/kernel/util/packageinfo
@@ -1,1 +1,1 @@
-version 2.3.0
+version 2.4.0


### PR DESCRIPTION
When enabling FFMpeg for audios, we want to show the audio icon to show the audios on DL in an item selector, as we were doing when we enabled xuggler.
So now we not only check if xuggler is enabled but if the audio processor is enabled.

I decided not to mix xuggler and audio processor for the future deletion of xuggler.