### PR TITLE
LPS-133539 Can not upload an image to cover image from blog images tab

### DIFF
--- a/modules/apps/item-selector/item-selector-taglib/src/main/java/com/liferay/item/selector/taglib/internal/display/context/ItemSelectorRepositoryEntryManagementToolbarDisplayContext.java
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/java/com/liferay/item/selector/taglib/internal/display/context/ItemSelectorRepositoryEntryManagementToolbarDisplayContext.java
@@ -277,6 +277,19 @@ public class ItemSelectorRepositoryEntryManagementToolbarDisplayContext {
 		return false;
 	}
 
+	public boolean isShowCreationMenu() {
+		Set<String> allowedCreationMenuUIItemKeys =
+			_getAllowedCreationMenuUIItemKeys();
+
+		if ((allowedCreationMenuUIItemKeys == null) ||
+			!allowedCreationMenuUIItemKeys.isEmpty()) {
+
+			return true;
+		}
+
+		return false;
+	}
+
 	private Set<String> _getAllowedCreationMenuUIItemKeys() {
 		Set<String> allowedCreationMenuUIItemKeys =
 			(Set)_httpServletRequest.getAttribute(

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/page.jsp
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/page.jsp
@@ -68,7 +68,7 @@ SearchContainer<?> searchContainer = new SearchContainer(renderRequest, itemSele
 	searchFormMethod="POST"
 	searchFormName="searchFm"
 	selectable="<%= false %>"
-	showCreationMenu="<%= true %>"
+	showCreationMenu="<%= itemSelectorRepositoryEntryManagementToolbarDisplayContext.isShowCreationMenu() %>"
 	showInfoButton="<%= false %>"
 	showSearch="<%= showSearch %>"
 	sortingOrder="<%= itemSelectorRepositoryEntryManagementToolbarDisplayContext.getOrderByType() %>"


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-133539

The real cause of this bug is that the [ManagementToolbar](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.js) is throwing an error because we are passing always the `showCreationMenu` with `true` and the uploader crash.