### PR TITLE
LPS-134027 Decouple MVC actions from Journal

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
@@ -559,6 +559,13 @@ public class JournalDisplayContext {
 		getExportTranslationAvailableLocalesURL.setResourceID(
 			"/journal/get_export_translation_available_locales");
 
+		getExportTranslationAvailableLocalesURL.setParameter(
+			"groupId", String.valueOf(_themeDisplay.getScopeGroupId()));
+		getExportTranslationAvailableLocalesURL.setParameter(
+			"classNameId",
+			String.valueOf(
+				PortalUtil.getClassNameId(JournalArticle.class.getName())));
+
 		return HashMapBuilder.<String, Object>put(
 			"context",
 			Collections.singletonMap(

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
@@ -553,6 +553,13 @@ public class JournalDisplayContext {
 
 		exportTranslationURL.setResourceID("/journal/export_translation");
 
+		exportTranslationURL.setParameter(
+			"groupId", String.valueOf(_themeDisplay.getScopeGroupId()));
+		exportTranslationURL.setParameter(
+			"classNameId",
+			String.valueOf(
+				PortalUtil.getClassNameId(JournalArticle.class.getName())));
+
 		ResourceURL getExportTranslationAvailableLocalesURL =
 			_liferayPortletResponse.createResourceURL();
 

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/ExportTranslationMVCResourceCommand.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/ExportTranslationMVCResourceCommand.java
@@ -85,8 +85,10 @@ public class ExportTranslationMVCResourceCommand implements MVCResourceCommand {
 
 			Object object = infoItemObjectProvider.getInfoItem(
 				new GroupKeyInfoItemIdentifier(
-					themeDisplay.getScopeGroupId(),
-					ParamUtil.getString(resourceRequest, "articleId")));
+					ParamUtil.getLong(
+						resourceRequest, "groupId",
+						themeDisplay.getScopeGroupId()),
+					ParamUtil.getString(resourceRequest, "key")));
 
 			InfoFieldValue<Object> infoItemFieldValue =
 				infoItemFieldValuesProvider.getInfoItemFieldValue(

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/ExportTranslationMVCResourceCommand.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/ExportTranslationMVCResourceCommand.java
@@ -20,7 +20,6 @@ import com.liferay.info.item.InfoItemServiceTracker;
 import com.liferay.info.item.provider.InfoItemFieldValuesProvider;
 import com.liferay.info.item.provider.InfoItemObjectProvider;
 import com.liferay.journal.constants.JournalPortletKeys;
-import com.liferay.journal.model.JournalArticle;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -30,6 +29,7 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.zip.ZipWriter;
@@ -73,15 +73,18 @@ public class ExportTranslationMVCResourceCommand implements MVCResourceCommand {
 				(ThemeDisplay)resourceRequest.getAttribute(
 					WebKeys.THEME_DISPLAY);
 
+			long classNameId = ParamUtil.getLong(
+				resourceRequest, "classNameId");
+
+			String className = _portal.getClassName(classNameId);
+
 			InfoItemFieldValuesProvider<Object> infoItemFieldValuesProvider =
 				_infoItemServiceTracker.getFirstInfoItemService(
-					InfoItemFieldValuesProvider.class,
-					JournalArticle.class.getName());
+					InfoItemFieldValuesProvider.class, className);
 
 			InfoItemObjectProvider<Object> infoItemObjectProvider =
 				_infoItemServiceTracker.getFirstInfoItemService(
-					InfoItemObjectProvider.class,
-					JournalArticle.class.getName());
+					InfoItemObjectProvider.class, className);
 
 			Object object = infoItemObjectProvider.getInfoItem(
 				new GroupKeyInfoItemIdentifier(
@@ -155,6 +158,9 @@ public class ExportTranslationMVCResourceCommand implements MVCResourceCommand {
 
 	@Reference
 	private InfoItemServiceTracker _infoItemServiceTracker;
+
+	@Reference
+	private Portal _portal;
 
 	@Reference
 	private TranslationInfoItemFieldValuesExporterTracker

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/GetExportTranslationAvailableLocalesMVCResourceCommand.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/GetExportTranslationAvailableLocalesMVCResourceCommand.java
@@ -18,7 +18,6 @@ import com.liferay.info.item.GroupKeyInfoItemIdentifier;
 import com.liferay.info.item.InfoItemServiceTracker;
 import com.liferay.info.item.provider.InfoItemObjectProvider;
 import com.liferay.journal.constants.JournalPortletKeys;
-import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.web.internal.util.ExportTranslationUtil;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.portlet.JSONPortletResponseUtil;
@@ -27,6 +26,7 @@ import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.translation.info.item.provider.InfoItemLanguagesProvider;
 
@@ -62,9 +62,13 @@ public class GetExportTranslationAvailableLocalesMVCResourceCommand
 		ThemeDisplay themeDisplay = (ThemeDisplay)resourceRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
+		long classNameId = ParamUtil.getLong(resourceRequest, "classNameId");
+
+		String className = _portal.getClassName(classNameId);
+
 		InfoItemObjectProvider<Object> infoItemObjectProvider =
 			_infoItemServiceTracker.getFirstInfoItemService(
-				InfoItemObjectProvider.class, JournalArticle.class.getName());
+				InfoItemObjectProvider.class, className);
 
 		long groupId = ParamUtil.getLong(
 			resourceRequest, "groupId", themeDisplay.getScopeGroupId());
@@ -75,8 +79,7 @@ public class GetExportTranslationAvailableLocalesMVCResourceCommand
 
 		InfoItemLanguagesProvider<Object> infoItemLanguagesProvider =
 			_infoItemServiceTracker.getFirstInfoItemService(
-				InfoItemLanguagesProvider.class,
-				JournalArticle.class.getName());
+				InfoItemLanguagesProvider.class, className);
 
 		Stream<String> stream = Arrays.stream(
 			infoItemLanguagesProvider.getAvailableLanguageIds(object));
@@ -100,5 +103,8 @@ public class GetExportTranslationAvailableLocalesMVCResourceCommand
 
 	@Reference
 	private InfoItemServiceTracker _infoItemServiceTracker;
+
+	@Reference
+	private Portal _portal;
 
 }

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/GetExportTranslationAvailableLocalesMVCResourceCommand.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/GetExportTranslationAvailableLocalesMVCResourceCommand.java
@@ -68,10 +68,10 @@ public class GetExportTranslationAvailableLocalesMVCResourceCommand
 
 		long groupId = ParamUtil.getLong(
 			resourceRequest, "groupId", themeDisplay.getScopeGroupId());
-		String articleId = ParamUtil.getString(resourceRequest, "articleId");
+		String key = ParamUtil.getString(resourceRequest, "key");
 
 		Object object = infoItemObjectProvider.getInfoItem(
-			new GroupKeyInfoItemIdentifier(groupId, articleId));
+			new GroupKeyInfoItemIdentifier(groupId, key));
 
 		InfoItemLanguagesProvider<Object> infoItemLanguagesProvider =
 			_infoItemServiceTracker.getFirstInfoItemService(

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/import_translation.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/import_translation.jsp
@@ -23,9 +23,6 @@ JournalArticle article = journalDisplayContext.getArticle();
 
 JournalEditArticleDisplayContext journalEditArticleDisplayContext = new JournalEditArticleDisplayContext(request, liferayPortletResponse, article);
 
-String articleResourcePrimKey = String.valueOf(article.getResourcePrimKey());
-String articleTitle = article.getTitle();
-
 portletDisplay.setShowBackIcon(true);
 portletDisplay.setURLBack(redirect);
 
@@ -37,10 +34,9 @@ renderResponse.setTitle(LanguageUtil.get(resourceBundle, "import-translation"));
 </liferay-util:html-top>
 
 <portlet:actionURL name="/journal/import_translation" var="importTranslationURL">
-	<portlet:param name="articleResourcePrimKey" value="<%= articleResourcePrimKey %>" />
+	<portlet:param name="classNameId" value="<%= String.valueOf(PortalUtil.getClassNameId(JournalArticle.class.getName())) %>" />
+	<portlet:param name="classPK" value="<%= String.valueOf(article.getResourcePrimKey()) %>" />
 	<portlet:param name="groupId" value="<%= String.valueOf(article.getGroupId()) %>" />
-	<portlet:param name="articleId" value="<%= article.getArticleId() %>" />
-	<portlet:param name="version" value="<%= String.valueOf(article.getVersion()) %>" />
 </portlet:actionURL>
 
 <div class="translation">
@@ -53,8 +49,8 @@ renderResponse.setTitle(LanguageUtil.get(resourceBundle, "import-translation"));
 				<ul class="tbar-nav">
 					<li class="tbar-item tbar-item-expand">
 						<div class="pl-2 tbar-section text-left">
-							<h2 class="h4 text-truncate-inline" title="<%= HtmlUtil.escapeAttribute(articleTitle) %>">
-								<span class="text-truncate"><%= HtmlUtil.escape(articleTitle) %></span>
+							<h2 class="h4 text-truncate-inline" title="<%= HtmlUtil.escapeAttribute(article.getTitle()) %>">
+								<span class="text-truncate"><%= HtmlUtil.escape(article.getTitle()) %></span>
 							</h2>
 						</div>
 					</li>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/import_translation.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/import_translation.jsp
@@ -90,7 +90,7 @@ renderResponse.setTitle(LanguageUtil.get(resourceBundle, "import-translation"));
 							).put(
 								"submitBtnId", liferayPortletResponse.getNamespace() + "submitBtnId"
 							).put(
-								"worflowPending", journalEditArticleDisplayContext.isPending()
+								"workflowPending", journalEditArticleDisplayContext.isPending()
 							).build()
 						%>'
 					/>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/ImportTranslation.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/ImportTranslation.es.js
@@ -21,7 +21,7 @@ const VALID_EXTENSIONS = '.xliff,.xlf';
 export default function ImportTranslation({
 	saveDraftBtnId,
 	submitBtnId,
-	worflowPending = false,
+	workflowPending = false,
 }) {
 	const [importFile, setImportFile] = useState();
 
@@ -31,9 +31,9 @@ export default function ImportTranslation({
 		Liferay.Util.toggleDisabled('#' + saveDraftBtnId, !importFile);
 		Liferay.Util.toggleDisabled(
 			'#' + submitBtnId,
-			!importFile || worflowPending
+			!importFile || workflowPending
 		);
-	}, [importFile, saveDraftBtnId, submitBtnId, worflowPending]);
+	}, [importFile, saveDraftBtnId, submitBtnId, workflowPending]);
 
 	return (
 		<div>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/export_translation/ExportTranslation.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/export_translation/ExportTranslation.es.js
@@ -45,7 +45,7 @@ function ExportTranslation(props) {
 					const getExportTranslationAvailableLocalesURL = Liferay.Util.PortletURL.createPortletURL(
 						props.getExportTranslationAvailableLocalesURL,
 						{
-							articleId: articleIds[0],
+							key: articleIds[0],
 						}
 					);
 

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/export_translation/ExportTranslationModal.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/export_translation/ExportTranslationModal.es.js
@@ -49,8 +49,8 @@ const ExportTranslationModal = ({
 	const exportTranslationPortletURL = Liferay.Util.PortletURL.createPortletURL(
 		exportTranslationURL,
 		{
-			articleId: articleIds[0],
 			exportMimeType,
+			key: articleIds[0],
 			sourceLanguageId,
 			targetLanguageIds: selectedTargetLanguageIds.join(','),
 		}


### PR DESCRIPTION
This removes all dependencies on Journal from the backend MVC action. I've also renamed a request parameter, from "articleId" to "key".

Further backend changes are needed (e.g. decouple display contexts), but those will be sent under a different issue.