### PR TITLE
LPS-133904 add breadcrumb to translation processes at asset libraries

### DIFF
--- a/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/view.jsp
@@ -27,6 +27,10 @@ ViewDisplayContext viewDisplayContext = (ViewDisplayContext)request.getAttribute
 
 <clay:container-fluid>
 	<aui:form action="<%= viewDisplayContext.getActionURL() %>" name="fm">
+		<liferay-ui:breadcrumb
+			showLayout="<%= false %>"
+		/>
+
 		<liferay-ui:search-container
 			id="searchContainer"
 			searchContainer="<%= viewDisplayContext.getSearchContainer() %>"

--- a/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/view.jsp
@@ -25,7 +25,9 @@ ViewDisplayContext viewDisplayContext = (ViewDisplayContext)request.getAttribute
 	propsTransformer="js/TranslationManagementToolbarPropsTransformer"
 />
 
-<clay:container-fluid>
+<clay:container-fluid
+	cssClass="container-view"
+>
 	<aui:form action="<%= viewDisplayContext.getActionURL() %>" name="fm">
 		<liferay-ui:breadcrumb
 			showLayout="<%= false %>"


### PR DESCRIPTION
There is a need to add the liferay-ui:breadcrumb to show the breadcrumbs for the Asset Libraries pages.

This must not  affect the Site pages