### PR TITLE
LPS-134125 Decouple export modal from journal-web

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/export_translation/ExportTranslation.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/export_translation/ExportTranslation.es.js
@@ -20,7 +20,7 @@ import ExportTranslationContext from './ExportTranslationContext.es';
 import ExportTranslationModal from './ExportTranslationModal.es';
 
 function ExportTranslation(props) {
-	const [articleIds, setArticleIds] = useState();
+	const [keys, setKeys] = useState();
 	const [showModal, setShowModal] = useState();
 	const {namespace} = useContext(ExportTranslationContext);
 	const bridgeComponentId = `${namespace}ExportForTranslationComponent`;
@@ -41,11 +41,11 @@ function ExportTranslation(props) {
 		Liferay.component(
 			bridgeComponentId,
 			{
-				open: (articleIds) => {
+				open: (keys) => {
 					const getExportTranslationAvailableLocalesURL = Liferay.Util.PortletURL.createPortletURL(
 						props.getExportTranslationAvailableLocalesURL,
 						{
-							key: articleIds[0],
+							key: keys[0],
 						}
 					);
 
@@ -53,7 +53,7 @@ function ExportTranslation(props) {
 						.then((res) => res.json())
 						.then(({availableLocales, defaultLanguageId}) => {
 							setAvailableSourceLocales(availableLocales);
-							setArticleIds(articleIds);
+							setKeys(keys);
 							setDefaultSourceLanguageId(defaultLanguageId);
 							setShowModal(true);
 						});
@@ -70,7 +70,7 @@ function ExportTranslation(props) {
 			{showModal && (
 				<ExportTranslationModal
 					{...props}
-					articleIds={articleIds}
+					keys={keys}
 					availableSourceLocales={availableSourceLocales}
 					defaultSourceLanguageId={defaultSourceLanguageId}
 					observer={observer}

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/export_translation/ExportTranslation.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/export_translation/ExportTranslation.es.js
@@ -70,9 +70,9 @@ function ExportTranslation(props) {
 			{showModal && (
 				<ExportTranslationModal
 					{...props}
-					keys={keys}
 					availableSourceLocales={availableSourceLocales}
 					defaultSourceLanguageId={defaultSourceLanguageId}
+					keys={keys}
 					observer={observer}
 					onModalClose={onClose}
 				/>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/export_translation/ExportTranslationModal.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/export_translation/ExportTranslationModal.es.js
@@ -191,12 +191,6 @@ const ExportTranslationModal = ({
 							/>
 						))}
 					</ClayForm.Group>
-
-					<ClayInput
-						name={`_${namespace}_articleIdsIds`}
-						type="hidden"
-						value={keys}
-					/>
 				</ClayModal.Body>
 
 				<ClayModal.Footer

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/export_translation/ExportTranslationModal.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/export_translation/ExportTranslationModal.es.js
@@ -23,7 +23,7 @@ import ExportTranslationContext from './ExportTranslationContext.es';
 const noop = () => {};
 
 const ExportTranslationModal = ({
-	articleIds,
+	keys,
 	availableExportFileFormats,
 	availableSourceLocales,
 	availableTargetLocales,
@@ -50,7 +50,7 @@ const ExportTranslationModal = ({
 		exportTranslationURL,
 		{
 			exportMimeType,
-			key: articleIds[0],
+			key: keys[0],
 			sourceLanguageId,
 			targetLanguageIds: selectedTargetLanguageIds.join(','),
 		}
@@ -195,7 +195,7 @@ const ExportTranslationModal = ({
 					<ClayInput
 						name={`_${namespace}_articleIdsIds`}
 						type="hidden"
-						value={articleIds}
+						value={keys}
 					/>
 				</ClayModal.Body>
 
@@ -227,7 +227,7 @@ const ExportTranslationModal = ({
 };
 
 ExportTranslationModal.propTypes = {
-	articleIds: PropTypes.array,
+	keys: PropTypes.array,
 	availableExportFileFormats: PropTypes.arrayOf(
 		PropTypes.shape({
 			displayName: PropTypes.string,

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/export_translation/ExportTranslationModal.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/export_translation/ExportTranslationModal.es.js
@@ -23,12 +23,12 @@ import ExportTranslationContext from './ExportTranslationContext.es';
 const noop = () => {};
 
 const ExportTranslationModal = ({
-	keys,
 	availableExportFileFormats,
 	availableSourceLocales,
 	availableTargetLocales,
 	defaultSourceLanguageId,
 	exportTranslationURL,
+	keys,
 	observer,
 	onModalClose = noop,
 }) => {
@@ -227,7 +227,6 @@ const ExportTranslationModal = ({
 };
 
 ExportTranslationModal.propTypes = {
-	keys: PropTypes.array,
 	availableExportFileFormats: PropTypes.arrayOf(
 		PropTypes.shape({
 			displayName: PropTypes.string,
@@ -247,6 +246,7 @@ ExportTranslationModal.propTypes = {
 		})
 	).isRequired,
 	defaultSourceLanguageId: PropTypes.string.isRequired,
+	keys: PropTypes.array,
 };
 
 export default ExportTranslationModal;


### PR DESCRIPTION
As continuation of https://github.com/liferay-lima/liferay-portal/pull/1937/ and to keep consistency with it, I removed all the journal `article` references in the Export modal and replaced them by `key`. 