### PR TITLE
LPS-133688 Do not escape title in the card views

### DIFF
--- a/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/servlet/taglib/clay/DepotEntryVerticalCard.java
+++ b/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/servlet/taglib/clay/DepotEntryVerticalCard.java
@@ -33,7 +33,6 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -138,8 +137,7 @@ public class DepotEntryVerticalCard
 	@Override
 	public String getTitle() {
 		try {
-			return HtmlUtil.escape(
-				_group.getDescriptiveName(_themeDisplay.getLocale()));
+			return _group.getDescriptiveName(_themeDisplay.getLocale());
 		}
 		catch (Exception exception) {
 			_log.error(exception, exception);


### PR DESCRIPTION
**Issue**: on card's view the title was escaped. Not happening in table or list view. 

**Before the fix:** 

<img width="1262" alt="Screenshot 2021-06-15 at 13 34 50" src="https://user-images.githubusercontent.com/8373764/122046854-b4397e80-cddf-11eb-9e86-29cef1bea89a.png">

**After the fix:**

<img width="1273" alt="Screenshot 2021-06-15 at 13 36 52" src="https://user-images.githubusercontent.com/8373764/122046871-bac7f600-cddf-11eb-8343-c3cf786a1a60.png">

