### PR TITLE
LPS-134658 Display preview title like how facebook and twitter does

### DIFF
--- a/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/layout/screen/navigation/entries/open_graph.jsp
+++ b/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/layout/screen/navigation/entries/open_graph.jsp
@@ -163,8 +163,6 @@ Layout selLayout = layoutsSEODisplayContext.getSelLayout();
 										).put(
 											"url", Collections.singletonMap("defaultValue", layoutsSEODisplayContext.getDefaultCanonicalURLMap())
 										).build()
-									).put(
-										"titleSuffix", layoutsSEODisplayContext.getPageTitleSuffix()
 									).build()
 								%>'
 								servletContext="<%= application %>"


### PR DESCRIPTION
Hi @liferay-lima ,

I'd like to suggest this improvement so that opengraph previews look more like how facebook or twitter would show them. (They don't display the optional og:site_name)

Can you please review?
https://issues.liferay.com/browse/LPS-134658

Thanks,
Balázs