### PR TITLE
LPS 134731 display templates SEO metatags template input

### DIFF
--- a/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/js/seo/display_page_templates/components/MappingFields.js
+++ b/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/js/seo/display_page_templates/components/MappingFields.js
@@ -15,6 +15,7 @@
 import {PropTypes} from 'prop-types';
 import React from 'react';
 
+import {FIELD_TYPES} from '../constants';
 import MappingContext from './MappingContext';
 import MappingInput from './MappingInput';
 import MappingSelector from './MappingSelector';
@@ -33,7 +34,7 @@ function MappingFields({
 				);
 
 				return ffSEOInlineFieldMappingEnabled &&
-					props.fieldType === 'text' ? (
+					props.fieldType === FIELD_TYPES.TEXT ? (
 					<MappingInput
 						fields={filteredFields}
 						key={props.name}

--- a/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/js/seo/display_page_templates/components/MappingFields.js
+++ b/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/js/seo/display_page_templates/components/MappingFields.js
@@ -27,23 +27,28 @@ function MappingFields({
 }) {
 	return (
 		<MappingContext.Provider value={{ffSEOInlineFieldMappingEnabled}}>
-			{inputs.map((props) =>
-				ffSEOInlineFieldMappingEnabled && props.fieldType === 'text' ? (
+			{inputs.map((props) => {
+				const filteredFields = fields.filter(
+					({type}) => type === props.fieldType
+				);
+
+				return ffSEOInlineFieldMappingEnabled &&
+					props.fieldType === 'text' ? (
 					<MappingInput
-						initialFields={fields}
+						fields={filteredFields}
 						key={props.name}
 						selectedSource={selectedSource}
 						{...props}
 					/>
 				) : (
 					<MappingSelector
-						initialFields={fields}
+						fields={filteredFields}
 						key={props.name}
 						selectedSource={selectedSource}
 						{...props}
 					/>
-				)
-			)}
+				);
+			})}
 		</MappingContext.Provider>
 	);
 }

--- a/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/js/seo/display_page_templates/components/MappingInput.js
+++ b/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/js/seo/display_page_templates/components/MappingInput.js
@@ -19,11 +19,6 @@ import React, {useRef, useState} from 'react';
 
 import MappingPanel from './MappingPanel';
 
-const UNMAPPED_OPTION = {
-	key: 'unmapped',
-	label: `-- ${Liferay.Language.get('unmapped')} --`,
-};
-
 const fieldTemplate = (key) => ` $\{${key}} `;
 
 function MappingInput({
@@ -36,12 +31,9 @@ function MappingInput({
 	selectedSource,
 	value: initialValue,
 }) {
-	const fields = [
-		UNMAPPED_OPTION,
-		...initialFields.filter(({type}) => type === fieldType),
-	];
+	const fields = initialFields.filter(({type}) => type === fieldType);
 	const [source, setSource] = useState(selectedSource);
-	const [field, setField] = useState(UNMAPPED_OPTION);
+	const [field, setField] = useState('');
 	const [value, setValue] = useState(initialValue || '');
 	const inputEl = useRef(null);
 	const isMounted = useIsMounted();
@@ -59,10 +51,6 @@ function MappingInput({
 	};
 
 	const addNewVar = ({key}) => {
-		if (key === UNMAPPED_OPTION.key) {
-			return;
-		}
-
 		const selectionStart = inputEl.current.selectionStart;
 		const selectionEnd = inputEl.current.selectionEnd;
 		const fieldVariable = fieldTemplate(key);

--- a/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/js/seo/display_page_templates/components/MappingInput.js
+++ b/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/js/seo/display_page_templates/components/MappingInput.js
@@ -23,15 +23,13 @@ const fieldTemplate = (key) => ` $\{${key}} `;
 
 function MappingInput({
 	component,
-	fieldType,
+	fields,
 	helpMessage,
-	initialFields,
 	label,
 	name,
 	selectedSource,
 	value: initialValue,
 }) {
-	const fields = initialFields.filter(({type}) => type === fieldType);
 	const [source, setSource] = useState(selectedSource);
 	const [field, setField] = useState('');
 	const [value, setValue] = useState(initialValue || '');

--- a/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/js/seo/display_page_templates/components/MappingInput.js
+++ b/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/js/seo/display_page_templates/components/MappingInput.js
@@ -24,7 +24,7 @@ const UNMAPPED_OPTION = {
 	label: `-- ${Liferay.Language.get('unmapped')} --`,
 };
 
-const FIELD_TEMPLATE = (key) => ` $\{${key}} `;
+const fieldTemplate = (key) => ` $\{${key}} `;
 
 function MappingInput({
 	component,
@@ -65,7 +65,7 @@ function MappingInput({
 
 		const selectionStart = inputEl.current.selectionStart;
 		const selectionEnd = inputEl.current.selectionEnd;
-		const fieldVariable = FIELD_TEMPLATE(key);
+		const fieldVariable = fieldTemplate(key);
 
 		setValue(
 			(value) =>

--- a/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/js/seo/display_page_templates/components/MappingInput.js
+++ b/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/js/seo/display_page_templates/components/MappingInput.js
@@ -23,6 +23,7 @@ const fieldTemplate = (key) => ` $\{${key}} `;
 
 function MappingInput({
 	component,
+	fieldType,
 	fields,
 	helpMessage,
 	label,
@@ -88,6 +89,7 @@ function MappingInput({
 				<ClayInput.GroupItem shrink>
 					<MappingPanel
 						clearSelectionOnClose
+						fieldType={fieldType}
 						fields={fields}
 						isActive={isActive}
 						name={name}

--- a/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/js/seo/display_page_templates/components/MappingInput.js
+++ b/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/js/seo/display_page_templates/components/MappingInput.js
@@ -31,7 +31,6 @@ function MappingInput({
 	value: initialValue,
 }) {
 	const [source, setSource] = useState(selectedSource);
-	const [field, setField] = useState('');
 	const [value, setValue] = useState(initialValue || '');
 	const inputEl = useRef(null);
 	const isMounted = useIsMounted();
@@ -44,7 +43,6 @@ function MappingInput({
 
 	const handleOnSelect = ({field, source}) => {
 		setSource(source);
-		setField(field);
 		addNewVar(field);
 	};
 
@@ -89,7 +87,7 @@ function MappingInput({
 				</ClayInput.GroupItem>
 				<ClayInput.GroupItem shrink>
 					<MappingPanel
-						field={field}
+						clearSelectionOnClose
 						fields={fields}
 						isActive={isActive}
 						name={name}

--- a/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/js/seo/display_page_templates/components/MappingPanel.js
+++ b/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/js/seo/display_page_templates/components/MappingPanel.js
@@ -19,6 +19,7 @@ import classNames from 'classnames';
 import {PropTypes} from 'prop-types';
 import React, {useContext, useRef, useState} from 'react';
 
+import {FIELD_TYPES} from '../constants';
 import useOnClickOutside from '../hooks/useOnClickOutside';
 import MappingContext from './MappingContext';
 
@@ -34,6 +35,7 @@ function MappingPanel({
 	name,
 	fields,
 	field: initialField,
+	fieldType,
 	source,
 	onSelect = noop,
 	clearSelectionOnClose = false,
@@ -130,7 +132,9 @@ function MappingPanel({
 								displayType="primary"
 								onClick={handleOnSelect}
 							>
-								{Liferay.Language.get('map-content')}
+								{fieldType === FIELD_TYPES.TEXT
+									? Liferay.Language.get('add-field')
+									: Liferay.Language.get('map-content')}
 							</ClayButton>
 						)}
 					</div>
@@ -146,6 +150,7 @@ MappingPanel.propTypes = {
 		key: PropTypes.string,
 		label: PropTypes.string,
 	}),
+	fieldType: PropTypes.string,
 	fields: PropTypes.arrayOf(
 		PropTypes.shape({
 			key: PropTypes.string,

--- a/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/js/seo/display_page_templates/components/MappingPanel.js
+++ b/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/js/seo/display_page_templates/components/MappingPanel.js
@@ -36,13 +36,26 @@ function MappingPanel({
 	field: initialField,
 	source,
 	onSelect = noop,
+	clearSelectionOnClose = false,
 }) {
 	const [isPanelOpen, setIsPanelOpen] = useState(false);
-	const [fieldValue, setFieldValue] = useState(initialField.key);
+	const [fieldValue, setFieldValue] = useState(
+		initialField?.key || fields[0].key
+	);
 	const {ffSEOInlineFieldMappingEnabled} = useContext(MappingContext);
 	const wrapperRef = useRef(null);
 
-	useOnClickOutside([wrapperRef.current], () => setIsPanelOpen(false));
+	const handleOnClose = () => {
+		if (isPanelOpen) {
+			setIsPanelOpen(false);
+
+			if (clearSelectionOnClose) {
+				setFieldValue(fields[0].key);
+			}
+		}
+	};
+
+	useOnClickOutside([wrapperRef.current], handleOnClose);
 
 	const handleChangeField = (event) => {
 		const {value} = event.target;
@@ -128,10 +141,11 @@ function MappingPanel({
 }
 
 MappingPanel.propTypes = {
+	clearSelectionOnClose: PropTypes.bool,
 	field: PropTypes.shape({
 		key: PropTypes.string,
 		label: PropTypes.string,
-	}).isRequired,
+	}),
 	fields: PropTypes.arrayOf(
 		PropTypes.shape({
 			key: PropTypes.string,

--- a/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/js/seo/display_page_templates/components/MappingSelector.js
+++ b/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/js/seo/display_page_templates/components/MappingSelector.js
@@ -16,12 +16,8 @@ import ClayForm, {ClayInput} from '@clayui/form';
 import {PropTypes} from 'prop-types';
 import React, {useState} from 'react';
 
+import {UNMAPPED_OPTION} from '../constants';
 import MappingPanel from './MappingPanel';
-
-const UNMAPPED_OPTION = {
-	key: 'unmapped',
-	label: `-- ${Liferay.Language.get('unmapped')} --`,
-};
 
 function MappingSelector({
 	fields: initialFields,

--- a/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/js/seo/display_page_templates/components/MappingSelector.js
+++ b/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/js/seo/display_page_templates/components/MappingSelector.js
@@ -24,18 +24,14 @@ const UNMAPPED_OPTION = {
 };
 
 function MappingSelector({
-	fieldType,
+	fields: initialFields,
 	helpMessage,
-	initialFields,
 	label,
 	name,
 	selectedFieldKey,
 	selectedSource,
 }) {
-	const fields = [
-		UNMAPPED_OPTION,
-		...initialFields.filter(({type}) => type === fieldType),
-	];
+	const fields = [UNMAPPED_OPTION, ...initialFields];
 	const [source, setSource] = useState(selectedSource);
 	const [field, setField] = useState(
 		fields.find(({key}) => key === selectedFieldKey) || UNMAPPED_OPTION

--- a/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/js/seo/display_page_templates/constants.js
+++ b/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/js/seo/display_page_templates/constants.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+export const FIELD_TYPES = {
+	TEXT: 'text',
+};
+
+export const UNMAPPED_OPTION = {
+	key: 'unmapped',
+	label: `-- ${Liferay.Language.get('unmapped')} --`,
+};

--- a/modules/apps/layout/layout-seo-web/test/seo/display_page_templates/components/MappingFields.js
+++ b/modules/apps/layout/layout-seo-web/test/seo/display_page_templates/components/MappingFields.js
@@ -13,7 +13,7 @@
  */
 
 import '@testing-library/jest-dom/extend-expect';
-import {cleanup, render} from '@testing-library/react';
+import {cleanup, fireEvent, render} from '@testing-library/react';
 import React from 'react';
 
 import MappingFields from '../../../../src/main/resources/META-INF/resources/js/seo/display_page_templates/components/MappingFields';
@@ -97,6 +97,29 @@ describe('MappingFields', () => {
 			expect(hiddenImageInput.type).toBe('hidden');
 			expect(hiddenImageInput.name).toBe(baseProps.inputs[1].name);
 			expect(hiddenImageInput.value).toBe('unmapped');
+		});
+	});
+
+	describe('when rendered with filtered fieldType image', () => {
+		let result;
+		let fieldSelect;
+		let options;
+
+		beforeEach(() => {
+			result = renderComponent();
+
+			fireEvent.click(result.getAllByTitle('map')[1]);
+
+			fieldSelect = result.getByLabelText('field');
+			options = fieldSelect.querySelectorAll('option');
+		});
+
+		it('only has two filtered options', () => {
+			expect(options.length).toBe(2);
+		});
+
+		it('has the image field in the second position', () => {
+			expect(options[1].value).toBe(baseProps.fields[2].key);
 		});
 	});
 });

--- a/modules/apps/layout/layout-seo-web/test/seo/display_page_templates/components/MappingSelector.js
+++ b/modules/apps/layout/layout-seo-web/test/seo/display_page_templates/components/MappingSelector.js
@@ -20,14 +20,14 @@ import MappingSelector from '../../../../src/main/resources/META-INF/resources/j
 
 const baseProps = {
 	fieldType: 'text',
-	helpMessage: 'Map a text field, it will be used as Title.',
-	initialFields: [
+	fields: [
 		{key: 'field-1', label: 'Field 1', type: 'text'},
 		{key: 'field-2', label: 'Field 2', type: 'text'},
 		{key: 'field-3', label: 'Field 3', type: 'image'},
 		{key: 'field-4', label: 'Field 4', type: 'text'},
 		{key: 'field-5', label: 'Field 5', type: 'text'},
 	],
+	helpMessage: 'Map a text field, it will be used as Title.',
 	label: 'Label test mapping field',
 	name: 'testMappingSelector',
 	selectedFieldKey: 'field-2',
@@ -105,14 +105,12 @@ describe('MappingSelector', () => {
 			describe('and the user selects another field', () => {
 				beforeEach(() => {
 					fireEvent.change(fieldSelect, {
-						target: {value: baseProps.initialFields[0].key},
+						target: {value: baseProps.fields[0].key},
 					});
 				});
 
 				it('sets the new field key in the hidden input', () => {
-					expect(inputValue.value).toBe(
-						baseProps.initialFields[0].key
-					);
+					expect(inputValue.value).toBe(baseProps.fields[0].key);
 				});
 
 				it('sets the new field name in the user feedback input', () => {
@@ -187,7 +185,7 @@ describe('MappingSelector', () => {
 		});
 	});
 
-	describe('when rendered filtred with fieldType image', () => {
+	describe('when rendered with fieldType image', () => {
 		let result;
 		let fieldSelect;
 		let options;
@@ -205,10 +203,6 @@ describe('MappingSelector', () => {
 			options = fieldSelect.querySelectorAll('option');
 		});
 
-		it('only has two filtered options', () => {
-			expect(options.length).toBe(2);
-		});
-
 		it('has the first option unmapped', () => {
 			expect(options[0].value).toBe('unmapped');
 			expect(fieldSelect.value).toBe('unmapped');
@@ -217,10 +211,6 @@ describe('MappingSelector', () => {
 		it('has the selected field unmapped', () => {
 			expect(options[0].value).toBe('unmapped');
 			expect(fieldSelect.value).toBe('unmapped');
-		});
-
-		it('has the image field in the second position', () => {
-			expect(options[1].value).toBe(baseProps.initialFields[2].key);
 		});
 	});
 });


### PR DESCRIPTION
I've updated the code and the test to affecting only to new  MappingInput:

- Remove the unmapped option
- Clear the selected option when the mapping panel is closed
- Change the `Map content` literal of the mapping panel action button to `Add field`, leave the `Map content` on MappingSelector

**How to test it:**
1. Create a config file to enable the feature flag
```sh
cd ${LF_PORTAL_PATH} && echo "enabled=B\"true\"" > ../bundles/osgi/configs/com.liferay.layout.seo.web.internal.configuration.FFSEOInlineFieldMapping.config
```
2. Go to the Site menu > Design > Page Templates > Display Page Templates > [ + ] (create a new one)
3. **Blank**, add **Name:** whatever, **Content Type:** Web Content Article, **Subtype:** Basic Web Content
4. Click on the kebap menu of the new `Display Page Template` and select **configure**