### PR TITLE
LPS-134773 Using actionURL instead of renderURL

### DIFF
--- a/modules/apps/wiki/wiki-web/src/main/java/com/liferay/wiki/web/internal/asset/model/WikiPageAssetRenderer.java
+++ b/modules/apps/wiki/wiki-web/src/main/java/com/liferay/wiki/web/internal/asset/model/WikiPageAssetRenderer.java
@@ -44,6 +44,7 @@ import com.liferay.wiki.constants.WikiPageConstants;
 import com.liferay.wiki.constants.WikiPortletKeys;
 import com.liferay.wiki.constants.WikiWebKeys;
 import com.liferay.wiki.engine.WikiEngineRenderer;
+import com.liferay.wiki.model.WikiNode;
 import com.liferay.wiki.model.WikiPage;
 import com.liferay.wiki.service.WikiPageLocalServiceUtil;
 import com.liferay.wiki.web.internal.security.permission.resource.WikiPagePermission;
@@ -85,6 +86,8 @@ public class WikiPageAssetRenderer
 		_page = page;
 		_wikiEngineRenderer = wikiEngineRenderer;
 		_trashHelper = trashHelper;
+
+		_node = page.getNode();
 	}
 
 	@Override
@@ -220,16 +223,18 @@ public class WikiPageAssetRenderer
 		LiferayPortletRequest liferayPortletRequest,
 		LiferayPortletResponse liferayPortletResponse) {
 
-		return PortletURLBuilder.create(
-			PortalUtil.getControlPanelPortletURL(
-				liferayPortletRequest, WikiPortletKeys.WIKI,
-				PortletRequest.RENDER_PHASE)
-		).setMVCRenderCommandName(
+		return PortletURLBuilder.createActionURL(
+			liferayPortletResponse, WikiPortletKeys.WIKI
+		).setActionName(
 			"/wiki/export_page"
 		).setParameter(
 			"nodeId", _page.getNodeId()
 		).setParameter(
+			"nodeName", _node.getName()
+		).setParameter(
 			"title", _page.getTitle()
+		).setParameter(
+			"version", _page.getVersion()
 		).build();
 	}
 
@@ -412,6 +417,7 @@ public class WikiPageAssetRenderer
 
 	private AssetDisplayPageFriendlyURLProvider
 		_assetDisplayPageFriendlyURLProvider;
+	private final WikiNode _node;
 	private final WikiPage _page;
 	private final TrashHelper _trashHelper;
 	private final WikiEngineRenderer _wikiEngineRenderer;


### PR DESCRIPTION
Dear Team,

Could you please review this pull request?

`WikiPageAssetRenderer.getURLExport()` creates a **renderURL**, but there is no `ExportPageMVCRenderCommand` class to handle the mapping. The page export will fail because of this.

However, an `ExportPageMVCActionCommand` class exists that is used by the **actionURL** created in https://github.com/liferay/liferay-portal/blob/master/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/view_page_details.jsp#L121

This solution changes the **renderURL** to an **actionURL** in `WikiPageAssetRenderer.getURLExport()` so the can be processed by `ExportPageMVCActionCommand`. 

Thank you and best regards,
István