### PR TITLE
LPS-124672 Add translation export to content pages

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/translation/exporter/TranslationInfoItemFieldValuesExporterTrackerUtil.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/translation/exporter/TranslationInfoItemFieldValuesExporterTrackerUtil.java
@@ -32,7 +32,7 @@ public class TranslationInfoItemFieldValuesExporterTrackerUtil {
 		getTranslationInfoItemFieldValuesExporters() {
 
 		return _translationInfoItemFieldValuesExporterTracker.
-			getTranslationInfoItemFieldValueExporters();
+			getTranslationInfoItemFieldValuesExporters();
 	}
 
 	@Reference(unbind = "-")

--- a/modules/apps/layout/layout-admin-web/.npmbundlerrc
+++ b/modules/apps/layout/layout-admin-web/.npmbundlerrc
@@ -1,0 +1,9 @@
+{
+	"config": {
+		"imports": {
+			"translation-web": {
+				"/": ">=2.0.7"
+			}
+		}
+	}
+}

--- a/modules/apps/layout/layout-admin-web/build.gradle
+++ b/modules/apps/layout/layout-admin-web/build.gradle
@@ -52,6 +52,7 @@ dependencies {
 	compileOnly project(":apps:static:portal:portal-upgrade-api")
 	compileOnly project(":apps:style-book:style-book-api")
 	compileOnly project(":apps:translation:translation-api")
+	compileOnly project(":apps:translation:translation-web")
 	compileOnly project(":apps:upload:upload-api")
 	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-lang")

--- a/modules/apps/layout/layout-admin-web/package.json
+++ b/modules/apps/layout/layout-admin-web/package.json
@@ -17,7 +17,8 @@
 		"prop-types": "15.7.2",
 		"react": "16.12.0",
 		"react-dnd": "11.1.1",
-		"react-dnd-html5-backend": "11.1.1"
+		"react-dnd-html5-backend": "11.1.1",
+		"translation-web": "*"
 	},
 	"name": "layout-admin-web",
 	"scripts": {

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/MillerColumnsDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/MillerColumnsDisplayContext.java
@@ -15,6 +15,7 @@
 package com.liferay.layout.admin.web.internal.display.context;
 
 import com.liferay.exportimport.kernel.staging.LayoutStagingUtil;
+import com.liferay.info.localized.InfoLocalizedValue;
 import com.liferay.layout.admin.web.internal.configuration.FFLayoutTranslationConfiguration;
 import com.liferay.petra.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
@@ -23,6 +24,7 @@ import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.model.LayoutRevision;
@@ -42,6 +44,7 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -50,15 +53,23 @@ import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.util.LayoutTypeControllerTracker;
 import com.liferay.translation.constants.TranslationActionKeys;
+import com.liferay.translation.constants.TranslationPortletKeys;
+import com.liferay.translation.exporter.TranslationInfoItemFieldValuesExporter;
+import com.liferay.translation.exporter.TranslationInfoItemFieldValuesExporterTracker;
 import com.liferay.translation.security.permission.TranslationPermission;
 import com.liferay.translation.url.provider.TranslationURLProvider;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.ResourceBundle;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.portlet.ResourceURL;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -72,12 +83,16 @@ public class MillerColumnsDisplayContext {
 		LayoutsAdminDisplayContext layoutsAdminDisplayContext,
 		LiferayPortletRequest liferayPortletRequest,
 		LiferayPortletResponse liferayPortletResponse,
+		TranslationInfoItemFieldValuesExporterTracker
+			translationInfoItemFieldValuesExporterTracker,
 		TranslationPermission translationPermission,
 		TranslationURLProvider translationURLProvider) {
 
 		_ffLayoutTranslationConfiguration = ffLayoutTranslationConfiguration;
 		_layoutsAdminDisplayContext = layoutsAdminDisplayContext;
 		_liferayPortletResponse = liferayPortletResponse;
+		_translationInfoItemFieldValuesExporterTracker =
+			translationInfoItemFieldValuesExporterTracker;
 		_translationPermission = translationPermission;
 		_translationURLProvider = translationURLProvider;
 
@@ -85,6 +100,71 @@ public class MillerColumnsDisplayContext {
 			liferayPortletRequest);
 		_themeDisplay = (ThemeDisplay)liferayPortletRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
+	}
+
+	public Map<String, Object> getExportTranslationData() {
+		ResourceURL exportTranslationURL =
+			_liferayPortletResponse.createResourceURL(
+				TranslationPortletKeys.TRANSLATION);
+
+		exportTranslationURL.setParameter(
+			"groupId", String.valueOf(GroupConstants.DEFAULT_PARENT_GROUP_ID));
+		exportTranslationURL.setParameter(
+			"classNameId",
+			String.valueOf(PortalUtil.getClassNameId(Layout.class.getName())));
+		exportTranslationURL.setResourceID("/translation/export_translation");
+
+		ResourceURL getExportTranslationAvailableLocalesURL =
+			_liferayPortletResponse.createResourceURL(
+				TranslationPortletKeys.TRANSLATION);
+
+		getExportTranslationAvailableLocalesURL.setParameter(
+			"groupId", String.valueOf(_themeDisplay.getScopeGroupId()));
+		getExportTranslationAvailableLocalesURL.setParameter(
+			"classNameId",
+			String.valueOf(PortalUtil.getClassNameId(Layout.class.getName())));
+		getExportTranslationAvailableLocalesURL.setResourceID(
+			"/translation/get_export_translation_available_locales");
+
+		return HashMapBuilder.<String, Object>put(
+			"context",
+			Collections.singletonMap(
+				"namespace", _liferayPortletResponse.getNamespace())
+		).put(
+			"props",
+			HashMapBuilder.<String, Object>put(
+				"availableExportFileFormats",
+				() -> {
+					Collection<TranslationInfoItemFieldValuesExporter>
+						translationInfoItemFieldValuesExporters =
+							_translationInfoItemFieldValuesExporterTracker.
+								getTranslationInfoItemFieldValuesExporters();
+
+					Stream<TranslationInfoItemFieldValuesExporter>
+						translationInfoItemFieldValuesExporterStream =
+							translationInfoItemFieldValuesExporters.stream();
+
+					return translationInfoItemFieldValuesExporterStream.map(
+						this::_getExportFileFormatJSONObject
+					).collect(
+						Collectors.toList()
+					);
+				}
+			).put(
+				"availableTargetLocales",
+				_getLocalesJSONArray(
+					_themeDisplay.getLocale(),
+					LanguageUtil.getAvailableLocales(
+						_themeDisplay.getSiteGroupId()))
+			).put(
+				"exportTranslationURL", exportTranslationURL.toString()
+			).put(
+				"getExportTranslationAvailableLocalesURL",
+				getExportTranslationAvailableLocalesURL.toString()
+			).put(
+				"pathModule", PortalUtil.getPathModule()
+			).build()
+		).build();
 	}
 
 	public String getLayoutChildrenURL() {
@@ -332,6 +412,21 @@ public class MillerColumnsDisplayContext {
 		return breadcrumbEntriesJSONArray;
 	}
 
+	private JSONObject _getExportFileFormatJSONObject(
+		TranslationInfoItemFieldValuesExporter
+			translationInfoItemFieldValuesExporter) {
+
+		InfoLocalizedValue<String> labelInfoLocalizedValue =
+			translationInfoItemFieldValuesExporter.getLabelInfoLocalizedValue();
+
+		return JSONUtil.put(
+			"displayName",
+			labelInfoLocalizedValue.getValue(_themeDisplay.getLocale())
+		).put(
+			"mimeType", translationInfoItemFieldValuesExporter.getMimeType()
+		);
+	}
+
 	private JSONArray _getFirstLayoutColumnActionsJSONArray(
 			boolean privatePages)
 		throws Exception {
@@ -538,6 +633,17 @@ public class MillerColumnsDisplayContext {
 						"label", LanguageUtil.get(_httpServletRequest, "edit")
 					));
 			}
+		}
+
+		if (_ffLayoutTranslationConfiguration.enabled()) {
+			jsonArray.put(
+				JSONUtil.put(
+					"id", "exportTranslation"
+				).put(
+					"label",
+					LanguageUtil.get(
+						_httpServletRequest, "export-for-translation")
+				));
 		}
 
 		if (_isShowTranslateAction()) {
@@ -791,6 +897,22 @@ public class MillerColumnsDisplayContext {
 		return jsonArray;
 	}
 
+	private JSONArray _getLocalesJSONArray(
+		Locale currentLocale, Collection<Locale> locales) {
+
+		JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
+
+		locales.forEach(
+			locale -> jsonArray.put(
+				JSONUtil.put(
+					"displayName", locale.getDisplayName(currentLocale)
+				).put(
+					"languageId", LocaleUtil.toLanguageId(locale)
+				)));
+
+		return jsonArray;
+	}
+
 	private boolean _hasTranslatePermission() {
 		PermissionChecker permissionChecker =
 			_themeDisplay.getPermissionChecker();
@@ -836,6 +958,8 @@ public class MillerColumnsDisplayContext {
 	private final LayoutsAdminDisplayContext _layoutsAdminDisplayContext;
 	private final LiferayPortletResponse _liferayPortletResponse;
 	private final ThemeDisplay _themeDisplay;
+	private final TranslationInfoItemFieldValuesExporterTracker
+		_translationInfoItemFieldValuesExporterTracker;
 	private final TranslationPermission _translationPermission;
 	private final TranslationURLProvider _translationURLProvider;
 

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/info/item/updater/LayoutInfoItemFieldValuesUpdater.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/info/item/updater/LayoutInfoItemFieldValuesUpdater.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.layout.admin.web.internal.info.item.updater;
+
+import com.liferay.info.field.InfoFieldValue;
+import com.liferay.info.item.InfoItemFieldValues;
+import com.liferay.info.item.updater.InfoItemFieldValuesUpdater;
+import com.liferay.info.localized.InfoLocalizedValue;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.service.LayoutLocalService;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Adolfo Pérez
+ */
+@Component(
+	property = "item.class.name=com.liferay.portal.kernel.model.Layout",
+	service = InfoItemFieldValuesUpdater.class
+)
+public class LayoutInfoItemFieldValuesUpdater
+	implements InfoItemFieldValuesUpdater<Layout> {
+
+	@Override
+	public Layout updateFromInfoItemFieldValues(
+		Layout layout, InfoItemFieldValues infoItemFieldValues) {
+
+		layout.setDescriptionMap(
+			_getFieldMap(
+				"description", infoItemFieldValues,
+				layout.getDescriptionMap()));
+		layout.setNameMap(
+			_getFieldMap("name", infoItemFieldValues, layout.getNameMap()));
+		layout.setTitleMap(
+			_getFieldMap("title", infoItemFieldValues, layout.getTitleMap()));
+
+		return _layoutLocalService.updateLayout(layout);
+	}
+
+	private Map<Locale, String> _getFieldMap(
+		String fieldName, InfoItemFieldValues infoItemFieldValues,
+		Map<Locale, String> initialValue) {
+
+		Map<Locale, String> fieldMap = new HashMap<>(initialValue);
+
+		InfoFieldValue<Object> infoFieldValue =
+			infoItemFieldValues.getInfoFieldValue(fieldName);
+
+		InfoLocalizedValue<Object> infoLocalizedValue =
+			(InfoLocalizedValue)infoFieldValue.getValue();
+
+		for (Locale locale : infoLocalizedValue.getAvailableLocales()) {
+			fieldMap.put(locale, (String)infoLocalizedValue.getValue(locale));
+		}
+
+		return fieldMap;
+	}
+
+	@Reference
+	private LayoutLocalService _layoutLocalService;
+
+}

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/GroupPagesPortlet.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/GroupPagesPortlet.java
@@ -64,6 +64,7 @@ import com.liferay.portal.kernel.upload.UploadException;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.staging.StagingGroupHelper;
+import com.liferay.translation.exporter.TranslationInfoItemFieldValuesExporterTracker;
 import com.liferay.translation.security.permission.TranslationPermission;
 import com.liferay.translation.url.provider.TranslationURLProvider;
 
@@ -211,6 +212,7 @@ public class GroupPagesPortlet extends MVCPortlet {
 					layoutsAdminDisplayContext,
 					_portal.getLiferayPortletRequest(renderRequest),
 					_portal.getLiferayPortletResponse(renderResponse),
+					_translationInfoItemFieldValuesExporterTracker,
 					_translationPermission, _translationURLProvider));
 
 			renderRequest.setAttribute(
@@ -292,6 +294,10 @@ public class GroupPagesPortlet extends MVCPortlet {
 
 	@Reference
 	private StagingGroupHelper _stagingGroupHelper;
+
+	@Reference
+	private TranslationInfoItemFieldValuesExporterTracker
+		_translationInfoItemFieldValuesExporterTracker;
 
 	@Reference
 	private TranslationPermission _translationPermission;

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/GetLayoutChildrenMVCActionCommand.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/GetLayoutChildrenMVCActionCommand.java
@@ -32,6 +32,7 @@ import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.staging.StagingGroupHelper;
+import com.liferay.translation.exporter.TranslationInfoItemFieldValuesExporterTracker;
 import com.liferay.translation.security.permission.TranslationPermission;
 import com.liferay.translation.url.provider.TranslationURLProvider;
 
@@ -93,6 +94,7 @@ public class GetLayoutChildrenMVCActionCommand extends BaseMVCActionCommand {
 				_ffLayoutTranslationConfiguration, layoutsAdminDisplayContext,
 				_portal.getLiferayPortletRequest(actionRequest),
 				_portal.getLiferayPortletResponse(actionResponse),
+				_translationInfoItemFieldValuesExporterTracker,
 				_translationPermission, _translationURLProvider);
 
 		JSONArray jsonArray = millerColumnsDisplayContext.getLayoutsJSONArray(
@@ -120,6 +122,10 @@ public class GetLayoutChildrenMVCActionCommand extends BaseMVCActionCommand {
 
 	@Reference
 	private StagingGroupHelper _stagingGroupHelper;
+
+	@Reference
+	private TranslationInfoItemFieldValuesExporterTracker
+		_translationInfoItemFieldValuesExporterTracker;
 
 	@Reference
 	private TranslationPermission _translationPermission;

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/MoveLayoutMVCActionCommand.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/MoveLayoutMVCActionCommand.java
@@ -36,6 +36,7 @@ import com.liferay.portal.kernel.service.LayoutService;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.staging.StagingGroupHelper;
+import com.liferay.translation.exporter.TranslationInfoItemFieldValuesExporterTracker;
 import com.liferay.translation.security.permission.TranslationPermission;
 import com.liferay.translation.url.provider.TranslationURLProvider;
 
@@ -121,6 +122,7 @@ public class MoveLayoutMVCActionCommand extends BaseAddLayoutMVCActionCommand {
 						_layoutCopyHelper, liferayPortletRequest,
 						liferayPortletResponse, _stagingGroupHelper),
 					liferayPortletRequest, liferayPortletResponse,
+					_translationInfoItemFieldValuesExporterTracker,
 					_translationPermission, _translationURLProvider);
 
 			JSONObject jsonObject = JSONUtil.put(
@@ -159,6 +161,10 @@ public class MoveLayoutMVCActionCommand extends BaseAddLayoutMVCActionCommand {
 
 	@Reference
 	private StagingGroupHelper _stagingGroupHelper;
+
+	@Reference
+	private TranslationInfoItemFieldValuesExporterTracker
+		_translationInfoItemFieldValuesExporterTracker;
 
 	@Reference
 	private TranslationPermission _translationPermission;

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/layout/LayoutExportTranslation.js
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/layout/LayoutExportTranslation.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {ExportTranslation} from 'translation-web';
+
+export default ExportTranslation;

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/layout/actionHandlers.js
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/layout/actionHandlers.js
@@ -52,6 +52,14 @@ const actionHandlers = {
 		}
 	},
 
+	exportTranslation({itemData, namespace}) {
+		Liferay.componentReady(
+			`${namespace}ExportForTranslationComponent`
+		).then((exportTranslationComponent) => {
+			exportTranslationComponent.open([itemData.layoutId]);
+		});
+	},
+
 	permissions: ({actionURL}) => {
 		openModal({
 			title: Liferay.Language.get('permissions'),

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -62,6 +62,11 @@ portletDisplay.setShowStagingIcon(false);
 							module="js/layout/Layout"
 							props="<%= millerColumnsDisplayContext.getLayoutData() %>"
 						/>
+
+						<react:component
+							module="js/layout/LayoutExportTranslation"
+							props="<%= millerColumnsDisplayContext.getExportTranslationData() %>"
+						/>
 					</div>
 				</c:otherwise>
 			</c:choose>

--- a/modules/apps/translation/translation-api/src/main/java/com/liferay/translation/exporter/TranslationInfoItemFieldValuesExporterTracker.java
+++ b/modules/apps/translation/translation-api/src/main/java/com/liferay/translation/exporter/TranslationInfoItemFieldValuesExporterTracker.java
@@ -25,10 +25,20 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface TranslationInfoItemFieldValuesExporterTracker {
 
-	public Collection<TranslationInfoItemFieldValuesExporter>
-		getTranslationInfoItemFieldValueExporters();
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #getTranslationInfoItemFieldValuesExporters()}
+	 */
+	@Deprecated
+	public default Collection<TranslationInfoItemFieldValuesExporter>
+		getTranslationInfoItemFieldValueExporters() {
+
+		return getTranslationInfoItemFieldValuesExporters();
+	}
 
 	public Optional<TranslationInfoItemFieldValuesExporter>
 		getTranslationInfoItemFieldValuesExporterOptional(String mimeType);
+
+	public Collection<TranslationInfoItemFieldValuesExporter>
+		getTranslationInfoItemFieldValuesExporters();
 
 }

--- a/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/exporter/TranslationInfoItemFieldValuesExporterTrackerImpl.java
+++ b/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/exporter/TranslationInfoItemFieldValuesExporterTrackerImpl.java
@@ -36,17 +36,17 @@ public class TranslationInfoItemFieldValuesExporterTrackerImpl
 	implements TranslationInfoItemFieldValuesExporterTracker {
 
 	@Override
-	public Collection<TranslationInfoItemFieldValuesExporter>
-		getTranslationInfoItemFieldValueExporters() {
-
-		return _serviceTrackerMap.values();
-	}
-
-	@Override
 	public Optional<TranslationInfoItemFieldValuesExporter>
 		getTranslationInfoItemFieldValuesExporterOptional(String mimeType) {
 
 		return Optional.ofNullable(_serviceTrackerMap.getService(mimeType));
+	}
+
+	@Override
+	public Collection<TranslationInfoItemFieldValuesExporter>
+		getTranslationInfoItemFieldValuesExporters() {
+
+		return _serviceTrackerMap.values();
 	}
 
 	@Activate

--- a/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/service/impl/TranslationEntryServiceImpl.java
+++ b/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/service/impl/TranslationEntryServiceImpl.java
@@ -131,7 +131,7 @@ public class TranslationEntryServiceImpl
 		InfoItemPermissionProvider<JournalArticle> infoItemPermissionProvider =
 			_infoItemServiceTracker.getFirstInfoItemService(
 				InfoItemPermissionProvider.class,
-				JournalArticle.class.getName());
+				infoItemReference.getClassName());
 
 		if (!infoItemPermissionProvider.hasPermission(
 				permissionChecker, infoItemReference, ActionKeys.UPDATE)) {

--- a/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/portlet/action/ExportTranslationMVCResourceCommand.java
+++ b/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/portlet/action/ExportTranslationMVCResourceCommand.java
@@ -15,13 +15,16 @@
 package com.liferay.translation.web.internal.portlet.action;
 
 import com.liferay.info.field.InfoFieldValue;
+import com.liferay.info.item.ClassPKInfoItemIdentifier;
 import com.liferay.info.item.GroupKeyInfoItemIdentifier;
+import com.liferay.info.item.InfoItemIdentifier;
 import com.liferay.info.item.InfoItemServiceTracker;
 import com.liferay.info.item.provider.InfoItemFieldValuesProvider;
 import com.liferay.info.item.provider.InfoItemObjectProvider;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.portlet.PortletResponseUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -87,11 +90,7 @@ public class ExportTranslationMVCResourceCommand implements MVCResourceCommand {
 					InfoItemObjectProvider.class, className);
 
 			Object object = infoItemObjectProvider.getInfoItem(
-				new GroupKeyInfoItemIdentifier(
-					ParamUtil.getLong(
-						resourceRequest, "groupId",
-						themeDisplay.getScopeGroupId()),
-					ParamUtil.getString(resourceRequest, "key")));
+				_getInfoItemIdentifier(resourceRequest));
 
 			InfoFieldValue<Object> infoItemFieldValue =
 				infoItemFieldValuesProvider.getInfoItemFieldValue(
@@ -154,6 +153,20 @@ public class ExportTranslationMVCResourceCommand implements MVCResourceCommand {
 		catch (IOException | PortalException exception) {
 			throw new PortletException(exception);
 		}
+	}
+
+	private InfoItemIdentifier _getInfoItemIdentifier(
+		ResourceRequest resourceRequest) {
+
+		long groupId = ParamUtil.getLong(resourceRequest, "groupId");
+
+		if (groupId == GroupConstants.DEFAULT_PARENT_GROUP_ID) {
+			return new ClassPKInfoItemIdentifier(
+				ParamUtil.getLong(resourceRequest, "key"));
+		}
+
+		return new GroupKeyInfoItemIdentifier(
+			groupId, ParamUtil.getString(resourceRequest, "key"));
 	}
 
 	@Reference


### PR DESCRIPTION
@boton @ambrinchaudhary I need some help with the integration of the export modal; I've tried to duplicate what's in journal as best as I can, but it doesn't work (it doesn't explode either).

If you manage to get that working, don't forward; I need to test the backend changes properly.

To test, do:
- Enable feature flag: `echo 'enabled=B"true"' > ${liferay_home}/osgi/configs/com.liferay.layout.admin.web.internal.configuration.FFLayoutTranslationConfiguration.config`
- Go to Product Menu > Site Builder > Pages
- Open the dropdown in any page, select "Export Translation"