### PR TITLE
LPS-135168 Avatar of comments editor in Blogs isn't vertically alignment

### DIFF
--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/view_entry.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/view_entry.jsp
@@ -121,10 +121,9 @@ BlogsPortletInstanceConfiguration blogsPortletInstanceConfiguration = BlogsPortl
 		</c:if>
 	</c:if>
 
-	<clay:row
-		cssClass="justify-content-center"
-	>
+	<clay:row>
 		<clay:col
+			cssClass="offset-md-2"
 			md="8"
 		>
 			<c:if test="<%= blogsPortletInstanceConfiguration.enableComments() %>">


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-135168

**Before this PR:**
![image](https://user-images.githubusercontent.com/67901/124590507-80d89580-de5b-11eb-9a51-3c83acc84fbd.png)

**After this PR:**
![image](https://user-images.githubusercontent.com/67901/124590326-4969e900-de5b-11eb-838a-36e4b4dbb8e8.png)
