### PR TITLE
LPS-134653 Rename "Documents & media" tab to "files" to clarify users

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminNavigationDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminNavigationDisplayContext.java
@@ -94,8 +94,7 @@ public class DLAdminNavigationDisplayContext {
 
 		navigationItem.setLabel(
 			LanguageUtil.get(
-				_liferayPortletRequest.getHttpServletRequest(),
-				"documents-and-media"));
+				_liferayPortletRequest.getHttpServletRequest(), "files"));
 	}
 
 	private void _populateFileEntryTypesNavigationItem(


### PR DESCRIPTION
Tab renamed following the PTR https://issues.liferay.com/browse/PTR-2462

**Before:** 
<img width="1300" alt="Screenshot 2021-07-06 at 15 40 38" src="https://user-images.githubusercontent.com/8373764/124610166-8d1b1d80-de70-11eb-91db-174ccb06fe8a.png">


**After:** 
<img width="1312" alt="Screenshot 2021-07-06 at 15 37 21" src="https://user-images.githubusercontent.com/8373764/124609964-652bba00-de70-11eb-8aef-420e47ae2c9a.png">
