### PR TITLE
LPS-132481 - Cannot add Google Drive Shortcut

### DIFF
--- a/modules/apps/document-library-google-docs/document-library-google-docs/src/main/resources/com/liferay/document/library/google/docs/internal/display/context/dependencies/google_file_picker.ftl
+++ b/modules/apps/document-library-google-docs/document-library-google-docs/src/main/resources/com/liferay/document/library/google/docs/internal/display/context/dependencies/google_file_picker.ftl
@@ -46,15 +46,9 @@ GoogleFilePicker.prototype = {
 			groupDocuments.addView(viewId.SPREADSHEETS);
 			groupDocuments.addView(viewId.PRESENTATIONS);
 
-			var groupPhotos = new google.picker.ViewGroup(viewId.PHOTOS);
-
-			groupPhotos.addView(viewId.PHOTO_UPLOAD);
-			groupPhotos.addView(viewId.WEBCAM);
-
 			var picker = new google.picker.PickerBuilder();
 
 			picker.addViewGroup(groupDocuments);
-			picker.addViewGroup(groupPhotos);
 
 			picker.addView(viewId.RECENTLY_PICKED);
 
@@ -120,8 +114,7 @@ GoogleFilePicker.API_KEY = '${htmlUtil.escapeJS(googleAppsAPIKey)}';
 GoogleFilePicker.CLIENT_ID = '${htmlUtil.escapeJS(googleClientId)}';
 
 GoogleFilePicker.SCOPE = [
-	'https://www.googleapis.com/auth/drive.readonly',
-	'https://www.googleapis.com/auth/photos.upload'
+	'https://www.googleapis.com/auth/drive.readonly'
 ];
 
 window.onGoogleAPILoad = function() {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-132481

I have to remove deprecated groupPhotos (PHOTO_UPLOAD and WEBCAM): https://developers.google.com/picker/docs/reference#view-id

I guess with this fix we are losing

![image](https://user-images.githubusercontent.com/67901/125073395-2b4ef380-e0bc-11eb-859d-d06a0e5f6403.png)
 
![image](https://user-images.githubusercontent.com/67901/125073449-40c41d80-e0bc-11eb-8d7f-2ff985407ca8.png)

and I think that doesn't exist directed replacement.

**Before this PR**
Not working

**After this PR**
![image](https://user-images.githubusercontent.com/67901/125077174-158ffd00-e0c1-11eb-8637-52e5272922d9.png)
![image](https://user-images.githubusercontent.com/67901/125077188-19bc1a80-e0c1-11eb-9e65-f06e0054a08b.png)
