### PR TITLE
LPS-135447 No meta tag `og:image:alt` displays on the page source for Web Content

### DIFF
--- a/modules/apps/layout/layout-seo-web/src/main/java/com/liferay/layout/seo/web/internal/servlet/taglib/OpenGraphTopHeadDynamicInclude.java
+++ b/modules/apps/layout/layout-seo-web/src/main/java/com/liferay/layout/seo/web/internal/servlet/taglib/OpenGraphTopHeadDynamicInclude.java
@@ -307,7 +307,8 @@ public class OpenGraphTopHeadDynamicInclude extends BaseDynamicInclude {
 		_openGraphImageProvider = new OpenGraphImageProvider(
 			_ddmStructureLocalService, _dlAppLocalService,
 			_dlFileEntryMetadataLocalService, _dlurlHelper,
-			_layoutSEOSiteLocalService, _portal, _storageEngine);
+			_layoutSEOSiteLocalService, _layoutSEOTemplateProcessor, _portal,
+			_storageEngine);
 		_titleProvider = new TitleProvider(_layoutSEOLinkManager);
 	}
 

--- a/modules/apps/layout/layout-seo-web/src/main/java/com/liferay/layout/seo/web/internal/util/OpenGraphImageProvider.java
+++ b/modules/apps/layout/layout-seo-web/src/main/java/com/liferay/layout/seo/web/internal/util/OpenGraphImageProvider.java
@@ -26,6 +26,7 @@ import com.liferay.info.type.WebImage;
 import com.liferay.layout.seo.model.LayoutSEOEntry;
 import com.liferay.layout.seo.model.LayoutSEOSite;
 import com.liferay.layout.seo.service.LayoutSEOSiteLocalService;
+import com.liferay.layout.seo.template.LayoutSEOTemplateProcessor;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Layout;
@@ -49,12 +50,14 @@ public class OpenGraphImageProvider {
 		DLAppLocalService dlAppLocalService,
 		DLFileEntryMetadataLocalService dlFileEntryMetadataLocalService,
 		DLURLHelper dlurlHelper,
-		LayoutSEOSiteLocalService layoutSEOSiteLocalService, Portal portal,
+		LayoutSEOSiteLocalService layoutSEOSiteLocalService,
+		LayoutSEOTemplateProcessor layoutSEOTemplateProcessor, Portal portal,
 		StorageEngine storageEngine) {
 
 		_dlAppLocalService = dlAppLocalService;
 		_dlurlHelper = dlurlHelper;
 		_layoutSEOSiteLocalService = layoutSEOSiteLocalService;
+		_layoutSEOTemplateProcessor = layoutSEOTemplateProcessor;
 
 		_fileEntryMetadataOpenGraphTagsProvider =
 			new FileEntryMetadataOpenGraphTagsProvider(
@@ -180,6 +183,14 @@ public class OpenGraphImageProvider {
 			(layoutSEOSite.getOpenGraphImageFileEntryId() > 0)) {
 
 			return layoutSEOSite.getOpenGraphImageAlt(locale);
+		}
+
+		String imageAltMappingFieldKey = layout.getTypeSettingsProperty(
+			"mapped-openGraphImageAlt", null);
+
+		if (Validator.isNotNull(imageAltMappingFieldKey)) {
+			return _layoutSEOTemplateProcessor.processTemplate(
+				imageAltMappingFieldKey, infoItemFieldValues, locale);
 		}
 
 		return null;
@@ -308,5 +319,6 @@ public class OpenGraphImageProvider {
 	private final FileEntryMetadataOpenGraphTagsProvider
 		_fileEntryMetadataOpenGraphTagsProvider;
 	private final LayoutSEOSiteLocalService _layoutSEOSiteLocalService;
+	private final LayoutSEOTemplateProcessor _layoutSEOTemplateProcessor;
 
 }


### PR DESCRIPTION
The image is not null and the alt image description is stored on the infovalues from the wc.

i'm not sure if this approximation is the better.

What do you think about it?
