### PR TITLE
LPS-135449 Disable map content button when the selected value is already mapped

### DIFF
--- a/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/js/seo/display_page_templates/components/MappingPanel.js
+++ b/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/js/seo/display_page_templates/components/MappingPanel.js
@@ -129,6 +129,7 @@ function MappingPanel({
 						{ffSEOInlineFieldMappingEnabled && (
 							<ClayButton
 								block
+								disabled={initialField?.key === fieldValue}
 								displayType="primary"
 								onClick={handleOnSelect}
 							>


### PR DESCRIPTION
**Bug:** https://issues.liferay.com/browse/LPS-135449

This PR Disable map content button when the selected value is already mapped

Note that only have an `initialField` value when is called by `MappingSelector.js`

---

**Enable the feature flag**
```sh
cd ${LF_PORTAL_PATH} && echo "enabled=B\"true\"" > ../bundles/osgi/configs/com.liferay.layout.seo.web.internal.configuration.FFSEOInlineFieldMapping.config
```

**Before this PR**
![image](https://user-images.githubusercontent.com/67901/125598210-f19412d7-95bb-4250-974d-d9c94cff6ecb.png)


**After this PR**
![image](https://user-images.githubusercontent.com/67901/125598005-564eefcb-1349-4c49-bf84-7cb6bc091b35.png)


