### PR TITLE
LPS-135620 Drag & drop for files in documents and media does not work with this enabled

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/EditFileEntryMVCActionCommand.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/EditFileEntryMVCActionCommand.java
@@ -875,7 +875,7 @@ public class EditFileEntryMVCActionCommand extends BaseMVCActionCommand {
 		}
 
 		boolean neverExpire = ParamUtil.getBoolean(
-			uploadPortletRequest, "neverExpire");
+			uploadPortletRequest, "neverExpire", true);
 
 		if (!PropsValues.SCHEDULER_ENABLED || neverExpire) {
 			return null;
@@ -920,7 +920,7 @@ public class EditFileEntryMVCActionCommand extends BaseMVCActionCommand {
 		}
 
 		boolean neverReview = ParamUtil.getBoolean(
-			uploadPortletRequest, "neverReview");
+			uploadPortletRequest, "neverReview", true);
 
 		if (!PropsValues.SCHEDULER_ENABLED || neverReview) {
 			return null;


### PR DESCRIPTION
on this case, the value of the date was incorrect (0/0/0) and throws an exception that is not catch and fails the creation of the file.
so never expire and never review must be true by default for the case of the upload that the fields are not loaded