### PR TITLE
LPS-135621 put redirect parameter to the parent folder of the file to unify the behavior if the cases notification or mail

### DIFF
--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -2744,6 +2744,9 @@ public class DLFileEntryLocalServiceImpl
 		entryURL = HttpUtil.addParameter(
 			entryURL, namespace + "fileEntryId",
 			String.valueOf(fileVersion.getFileEntryId()));
+		entryURL = HttpUtil.addParameter(
+			entryURL, namespace + "redirect",
+			_getRedirectURL(fileVersion, namespace, portletId));
 
 		return entryURL;
 	}
@@ -3098,6 +3101,17 @@ public class DLFileEntryLocalServiceImpl
 					DLFileEntryTable.INSTANCE.reviewDate.lte(reviewDateLT)
 				)
 			));
+	}
+
+	private String _getRedirectURL(
+			DLFileVersion fileVersion, String namespace, String portletId)
+		throws PortalException {
+
+		String redirectURL = PortalUtil.getControlPanelFullURL(
+			fileVersion.getGroupId(), portletId, null);
+
+		return HttpUtil.addParameter(
+			redirectURL, namespace + "folderId", fileVersion.getFolderId());
 	}
 
 	private boolean _isValidFileVersionNumber(String version) {

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -2732,13 +2732,11 @@ public class DLFileEntryLocalServiceImpl
 		String entryURL = PortalUtil.getControlPanelFullURL(
 			fileVersion.getGroupId(), portletId, null);
 
-		entryURL = HttpUtil.addParameter(
-			entryURL,
-			PortalUtil.getPortletNamespace(portletId) + "mvcRenderCommandName",
-			"/document_library/edit_file_entry");
-
 		String namespace = PortalUtil.getPortletNamespace(portletId);
 
+		entryURL = HttpUtil.addParameter(
+			entryURL, namespace + "mvcRenderCommandName",
+			"/document_library/edit_file_entry");
 		entryURL = HttpUtil.addParameter(
 			entryURL, namespace + "groupId", fileVersion.getGroupId());
 		entryURL = HttpUtil.addParameter(


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-135621

The link to mails and inline notification (or other methods) is the same. We can not be sure if the "back"/"publish" is to the notifications page or a new page or is from different user, so I think is better to unify the behavior, that the redirect is to the DM (folder) of the file.