### PR TITLE
LPS-135868 Discussion adds wrong username when adding a comment while impersonating someone

### DIFF
--- a/modules/apps/comment/comment-taglib/src/main/java/com/liferay/comment/taglib/servlet/taglib/DiscussionTag.java
+++ b/modules/apps/comment/comment-taglib/src/main/java/com/liferay/comment/taglib/servlet/taglib/DiscussionTag.java
@@ -19,6 +19,7 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.comment.Discussion;
 import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.URLCodec;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.taglib.util.IncludeTag;
 
@@ -141,8 +142,8 @@ public class DiscussionTag extends IncludeTag {
 		return StringBundler.concat(
 			themeDisplay.getPathMain(),
 			"/portal/comment/discussion/get_editor?p_p_isolated=1&",
-			"doAsUserId=", themeDisplay.getDoAsUserId(), "&portletId=",
-			portletId);
+			"doAsUserId=", URLCodec.encodeURL(themeDisplay.getDoAsUserId()),
+			"&portletId=", portletId);
 	}
 
 	protected String getFormAction(HttpServletRequest httpServletRequest) {
@@ -157,7 +158,7 @@ public class DiscussionTag extends IncludeTag {
 		return StringBundler.concat(
 			themeDisplay.getPathMain(),
 			"/portal/comment/discussion/edit?doAsUserId=",
-			themeDisplay.getDoAsUserId());
+			URLCodec.encodeURL(themeDisplay.getDoAsUserId()));
 	}
 
 	@Override
@@ -177,8 +178,8 @@ public class DiscussionTag extends IncludeTag {
 		return StringBundler.concat(
 			themeDisplay.getPathMain(),
 			"/portal/comment/discussion/get_comments?p_p_isolated=1&",
-			"doAsUserId=", themeDisplay.getDoAsUserId(), "&portletId=",
-			portletId);
+			"doAsUserId=", URLCodec.encodeURL(themeDisplay.getDoAsUserId()),
+			"&portletId=", portletId);
 	}
 
 	@Override


### PR DESCRIPTION
Dear Team,

Could you please review this pull request?

When an URL parameter contains plus signs, the signs are automatically getting replaced with spaces when the request is submitted.
This can lead to problems when impersonating a user, as this replacement can alter the `doAsUserId` parameter if it contains plus signs.

A particular case is when an impersonated user wants to submit a comment. For example, if `doAsUserId` is `jtP9LViCzpjvR+ip/Dr1Ng==` this may lead to an EncryptorException.

```
2021-07-21 07:27:53.709 WARN  [http-nio-8080-exec-2][PortalImpl:7661] Unable to impersonate jtP9LViCzpjvR ip/Dr1Ng== because the string cannot be decrypted
com.liferay.petra.encryptor.EncryptorException: com.liferay.petra.encryptor.EncryptorException: javax.crypto.BadPaddingException: Given final block not properly padded. Such issues can arise if a bad key is used during decryption.

```

Please note that `jtP9LViCzpjvR+ip/Dr1Ng==` has been replaced to `jtP9LViCzpjvR ip/Dr1Ng==` (plus sign to space).

I'm employing a solution that is encoding the plus signs. I'm found the solution here:
https://stackoverflow.com/questions/7842547/request-parameter-losing-plus-sign

Thank you and best regards,
István