### PR TITLE
LPS-135277 Use message creator instead of reviewer for notification information when message is approved

### DIFF
--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBMessageLocalServiceImpl.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBMessageLocalServiceImpl.java
@@ -1761,7 +1761,10 @@ public class MBMessageLocalServiceImpl extends MBMessageLocalServiceBaseImpl {
 			MBMessage.class);
 
 		if (status == WorkflowConstants.STATUS_APPROVED) {
+			long currentUserId = userId;
+
 			if (oldStatus != WorkflowConstants.STATUS_APPROVED) {
+				currentUserId = message.getUserId();
 
 				// Asset
 
@@ -1798,7 +1801,7 @@ public class MBMessageLocalServiceImpl extends MBMessageLocalServiceBaseImpl {
 			// Subscriptions
 
 			notifySubscribers(
-				userId, (MBMessage)message.clone(),
+				currentUserId, (MBMessage)message.clone(),
 				(String)workflowContext.get(WorkflowConstants.CONTEXT_URL),
 				serviceContext);
 


### PR DESCRIPTION
If a MB is approved, the notification to subscribers should still refer to the creator's name, instead of the reviewer's name as author of the message. In other cases (e.g., someone else edits the message), the previous behavior is maintained.

@sammonsjl

