### PR TITLE
LPS-136069 Don't assume endpoint/region are defined

### DIFF
--- a/modules/apps/portal-store/portal-store-s3/src/main/java/com/liferay/portal/store/s3/IBMS3Store.java
+++ b/modules/apps/portal-store/portal-store-s3/src/main/java/com/liferay/portal/store/s3/IBMS3Store.java
@@ -437,18 +437,38 @@ public class IBMS3Store implements Store {
 	protected AmazonS3 getAmazonS3(
 		AWSCredentialsProvider awsCredentialsProvider) {
 
-		return AmazonS3ClientBuilder.standard(
-		).withCredentials(
-			awsCredentialsProvider
-		).withClientConfiguration(
-			getClientConfiguration()
-		).withEndpointConfiguration(
-			new AwsClientBuilder.EndpointConfiguration(
-				_s3StoreConfiguration.s3Endpoint(),
-				_s3StoreConfiguration.s3Region())
-		).withPathStyleAccessEnabled(
-			_s3StoreConfiguration.s3PathStyle()
-		).build();
+		if (Validator.isNotNull(_s3StoreConfiguration.s3Endpoint()) &&
+			Validator.isNotNull(_s3StoreConfiguration.s3Region())) {
+
+			return AmazonS3ClientBuilder.standard(
+			).withCredentials(
+				awsCredentialsProvider
+			).withClientConfiguration(
+				getClientConfiguration()
+			).withEndpointConfiguration(
+				new AwsClientBuilder.EndpointConfiguration(
+					_s3StoreConfiguration.s3Endpoint(),
+					_s3StoreConfiguration.s3Region())
+			).withPathStyleAccessEnabled(
+				_s3StoreConfiguration.s3PathStyle()
+			).build();
+		}
+
+		AmazonS3ClientBuilder amazonS3ClientBuilder =
+			AmazonS3ClientBuilder.standard(
+			).withCredentials(
+				awsCredentialsProvider
+			).withClientConfiguration(
+				getClientConfiguration()
+			).withPathStyleAccessEnabled(
+				_s3StoreConfiguration.s3PathStyle()
+			);
+
+		if (Validator.isNotNull(_s3StoreConfiguration.s3Region())) {
+			amazonS3ClientBuilder.setRegion(_s3StoreConfiguration.s3Region());
+		}
+
+		return amazonS3ClientBuilder.build();
 	}
 
 	protected AWSCredentialsProvider getAWSCredentialsProvider() {

--- a/modules/apps/portal-store/portal-store-s3/src/main/java/com/liferay/portal/store/s3/S3Store.java
+++ b/modules/apps/portal-store/portal-store-s3/src/main/java/com/liferay/portal/store/s3/S3Store.java
@@ -434,18 +434,38 @@ public class S3Store implements Store {
 	protected AmazonS3 getAmazonS3(
 		AWSCredentialsProvider awsCredentialsProvider) {
 
-		return AmazonS3ClientBuilder.standard(
-		).withCredentials(
-			awsCredentialsProvider
-		).withClientConfiguration(
-			getClientConfiguration()
-		).withEndpointConfiguration(
-			new AwsClientBuilder.EndpointConfiguration(
-				_s3StoreConfiguration.s3Endpoint(),
-				_s3StoreConfiguration.s3Region())
-		).withPathStyleAccessEnabled(
-			_s3StoreConfiguration.s3PathStyle()
-		).build();
+		if (Validator.isNotNull(_s3StoreConfiguration.s3Endpoint()) &&
+			Validator.isNotNull(_s3StoreConfiguration.s3Region())) {
+
+			return AmazonS3ClientBuilder.standard(
+			).withCredentials(
+				awsCredentialsProvider
+			).withClientConfiguration(
+				getClientConfiguration()
+			).withEndpointConfiguration(
+				new AwsClientBuilder.EndpointConfiguration(
+					_s3StoreConfiguration.s3Endpoint(),
+					_s3StoreConfiguration.s3Region())
+			).withPathStyleAccessEnabled(
+				_s3StoreConfiguration.s3PathStyle()
+			).build();
+		}
+
+		AmazonS3ClientBuilder amazonS3ClientBuilder =
+			AmazonS3ClientBuilder.standard(
+			).withCredentials(
+				awsCredentialsProvider
+			).withClientConfiguration(
+				getClientConfiguration()
+			).withPathStyleAccessEnabled(
+				_s3StoreConfiguration.s3PathStyle()
+			);
+
+		if (Validator.isNotNull(_s3StoreConfiguration.s3Region())) {
+			amazonS3ClientBuilder.setRegion(_s3StoreConfiguration.s3Region());
+		}
+
+		return amazonS3ClientBuilder.build();
 	}
 
 	protected AWSCredentialsProvider getAWSCredentialsProvider() {


### PR DESCRIPTION
@AliciaGarciaGarcia We need to test this with Amazon S3. I've tested it with IBM S3 and it works fine.

Once you got the S3 credentials, you should try to migrate to the store providing only the required fields in S3StoreConfiguration (i.e. region and endpoint empty). If that works, this can be forwarded.

Also, we'll need to backport this to 7.3 and 7.2.