### PR TITLE
LPS-135684

### DIFF
--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBDiscussionLocalServiceImpl.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBDiscussionLocalServiceImpl.java
@@ -60,7 +60,7 @@ public class MBDiscussionLocalServiceImpl
 
 		discussion.setUuid(serviceContext.getUuid());
 		discussion.setGroupId(groupId);
-		discussion.setCompanyId(serviceContext.getCompanyId());
+		discussion.setCompanyId(group.getCompanyId());
 		discussion.setUserId(userId);
 		discussion.setUserName(user.getFullName());
 		discussion.setClassNameId(classNameId);


### PR DESCRIPTION
The `ServiceContext` object is created here but is not populated with a `companyId` - https://github.com/jonathanmccann/liferay-portal/blob/364b540034169360e90c90be00f50406be4c0c8c/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBMessageLocalServiceImpl.java#L1115-L1118

A few lines up from the suggested changes we fetch the user using the company ID from the group so I applied the same logic here.

Please let me know if there are any issues.