### PR TITLE
LPS-136123 add test to check the deletion of the depot after the deletion of the company

### DIFF
--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/company/service/test/CompanyLocalServiceTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/company/service/test/CompanyLocalServiceTest.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.depot.company.service.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.CompanyTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Alicia García
+ */
+@RunWith(Arquillian.class)
+public class CompanyLocalServiceTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_company = CompanyTestUtil.addCompany();
+
+		_user = UserTestUtil.addUser(_company);
+	}
+
+	@Test
+	public void testCleanUpDepotEntries() throws Exception {
+		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), "name"
+			).build(),
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), "description"
+			).build(),
+			_getServiceContext());
+
+		Assert.assertEquals(_company.getCompanyId(), depotEntry.getCompanyId());
+
+		_deleteCompany();
+
+		Assert.assertNull(
+			_depotEntryLocalService.fetchDepotEntry(
+				depotEntry.getDepotEntryId()));
+	}
+
+	private void _deleteCompany() throws Exception {
+		_companyLocalService.deleteCompany(_company);
+
+		_company = null;
+	}
+
+	private ServiceContext _getServiceContext() throws Exception {
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext();
+
+		serviceContext.setCompanyId(_company.getCompanyId());
+		serviceContext.setUserId(_user.getUserId());
+
+		return serviceContext;
+	}
+
+	@DeleteAfterTestRun
+	private Company _company;
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
+
+	@Inject
+	private DepotEntryLocalService _depotEntryLocalService;
+
+	private User _user;
+
+}

--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -25,9 +25,11 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.db.partition.DBPartitionUtil;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
+import com.liferay.portal.kernel.dao.orm.Disjunction;
 import com.liferay.portal.kernel.dao.orm.EntityCacheUtil;
 import com.liferay.portal.kernel.dao.orm.Property;
 import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
+import com.liferay.portal.kernel.dao.orm.RestrictionsFactoryUtil;
 import com.liferay.portal.kernel.exception.AccountNameException;
 import com.liferay.portal.kernel.exception.CompanyMxException;
 import com.liferay.portal.kernel.exception.CompanyVirtualHostException;
@@ -1708,7 +1710,15 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 
 					Property siteProperty = PropertyFactoryUtil.forName("site");
 
-					dynamicQuery.add(siteProperty.eq(Boolean.TRUE));
+					Property typeProperty = PropertyFactoryUtil.forName("type");
+
+					Disjunction disjunction =
+						RestrictionsFactoryUtil.disjunction();
+
+					disjunction.add(siteProperty.eq(Boolean.TRUE));
+					disjunction.add(typeProperty.eq(GroupConstants.TYPE_DEPOT));
+
+					dynamicQuery.add(disjunction);
 				});
 			_actionableDynamicQuery.setPerformActionMethod(
 				(Group group) -> {


### PR DESCRIPTION
 https://issues.liferay.com/browse/LPS-136123

It seems that deleting the virtual instance it’s not deleting the elements of the asset library, nor the groups nor nothing.

related:https://issues.liferay.com/browse/LPS-136408