### PR TITLE
LPS-136280

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-image-content-transformer-backwards-compatibility/src/main/java/com/liferay/adaptive/media/image/content/transformer/backwards/compatibility/internal/AMBackwardsCompatibilityHtmlContentTransformer.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-content-transformer-backwards-compatibility/src/main/java/com/liferay/adaptive/media/image/content/transformer/backwards/compatibility/internal/AMBackwardsCompatibilityHtmlContentTransformer.java
@@ -20,6 +20,7 @@ import com.liferay.adaptive.media.content.transformer.ContentTransformerContentT
 import com.liferay.adaptive.media.content.transformer.constants.ContentTransformerContentTypes;
 import com.liferay.adaptive.media.image.html.AMImageHTMLTagFactory;
 import com.liferay.adaptive.media.image.html.constants.AMImageHTMLConstants;
+import com.liferay.document.library.kernel.exception.NoSuchFileEntryException;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.repository.model.FileEntry;
@@ -83,7 +84,13 @@ public class AMBackwardsCompatibilityHtmlContentTransformer
 		long folderId = Long.valueOf(matcher.group(2));
 		String title = matcher.group(3);
 
-		return _dlAppLocalService.getFileEntry(groupId, folderId, title);
+		try {
+			return _dlAppLocalService.getFileEntry(groupId, folderId, title);
+		}
+		catch (NoSuchFileEntryException noSuchFileEntryException) {
+			return _dlAppLocalService.getFileEntryByFileName(
+				groupId, folderId, title);
+		}
 	}
 
 	@Override
@@ -103,8 +110,8 @@ public class AMBackwardsCompatibilityHtmlContentTransformer
 	}
 
 	private static final Pattern _pattern = Pattern.compile(
-		"<img\\s+src=['\"]/documents/(\\d+)/(\\d+)/([^/?]+)" +
-			"(?:/([-0-9a-fA-F]+))?(?:\\?t=\\d+)?['\"]\\s*/>");
+		"<img\\s+(?:[^>]*\\s)*src=['\"]/documents/(\\d+)/(\\d+)/([^/?]+)" +
+			"(?:/([-0-9a-fA-F]+))?(?:\\?t=\\d+)?['\"][^>]*/>");
 
 	@Reference
 	private AMImageHTMLTagFactory _amImageHTMLTagFactory;

--- a/modules/apps/adaptive-media/adaptive-media-image-content-transformer-backwards-compatibility/src/main/java/com/liferay/adaptive/media/image/content/transformer/backwards/compatibility/internal/AMBackwardsCompatibilityHtmlContentTransformer.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-content-transformer-backwards-compatibility/src/main/java/com/liferay/adaptive/media/image/content/transformer/backwards/compatibility/internal/AMBackwardsCompatibilityHtmlContentTransformer.java
@@ -24,7 +24,6 @@ import com.liferay.document.library.kernel.exception.NoSuchFileEntryException;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.repository.model.FileEntry;
-import com.liferay.portal.kernel.util.StringUtil;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -64,8 +63,9 @@ public class AMBackwardsCompatibilityHtmlContentTransformer
 
 	@Override
 	protected FileEntry getFileEntry(Matcher matcher) throws PortalException {
-		if (StringUtil.containsIgnoreCase(
-				matcher.group(0),
+		String imgTag = matcher.group(0);
+
+		if (imgTag.contains(
 				AMImageHTMLConstants.ATTRIBUTE_NAME_FILE_ENTRY_ID)) {
 
 			return null;


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-136280

Re-send of https://github.com/liferay-lima/liferay-portal/pull/2109

From @tototrinh:

> I noticed that when an image has an alt attribute (this is the default when adding an Image on WC) or some other attribute, the image won't be able to display as an image tag.
> * https://github.com/liferay/liferay-portal/blob/7.4.0-ga1/modules/apps/adaptive-media/adaptive-media-content-transformer-api/src/main/java/com/liferay/adaptive/media/content/transformer/BaseRegexStringContentTransformer.java#L40-L56
> * https://github.com/liferay/liferay-portal/blob/7.4.0-ga1/modules/apps/adaptive-media/adaptive-media-image-content-transformer-backwards-compatibility/src/main/java/com/liferay/adaptive/media/image/content/transformer/backwards/compatibility/internal/AMBackwardsCompatibilityHtmlContentTransformer.java#L105-L107
>
> I noticed that changing the pattern caused the issue as mentioned at [LPS-79815](https://issues.liferay.com/browse/LPS-79815). So I added a commit to fix it.