### PR TITLE
LPS-136123 add test to check the deletion of the depot after the deletion of the company

### DIFF
--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/test/DepotEntryLocalServiceTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/test/DepotEntryLocalServiceTest.java
@@ -222,7 +222,7 @@ public class DepotEntryLocalServiceTest {
 				typeSettingsUnicodeProperties.getProperty("inheritLocales")));
 		Assert.assertEquals(
 			StringUtil.merge(
-				LocaleUtil.toLanguageIds(_languaje.getAvailableLocales())),
+				LocaleUtil.toLanguageIds(_language.getAvailableLocales())),
 			typeSettingsUnicodeProperties.getProperty("locales"));
 	}
 
@@ -356,7 +356,7 @@ public class DepotEntryLocalServiceTest {
 	private GroupLocalService _groupLocalService;
 
 	@Inject
-	private Language _languaje;
+	private Language _language;
 
 	@Inject
 	private UserGroupRoleLocalService _userGroupRoleLocalService;

--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -25,9 +25,11 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.db.partition.DBPartitionUtil;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
+import com.liferay.portal.kernel.dao.orm.Disjunction;
 import com.liferay.portal.kernel.dao.orm.EntityCacheUtil;
 import com.liferay.portal.kernel.dao.orm.Property;
 import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
+import com.liferay.portal.kernel.dao.orm.RestrictionsFactoryUtil;
 import com.liferay.portal.kernel.exception.AccountNameException;
 import com.liferay.portal.kernel.exception.CompanyMxException;
 import com.liferay.portal.kernel.exception.CompanyVirtualHostException;
@@ -1706,9 +1708,18 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 
 					dynamicQuery.add(parentGroupIdProperty.eq(_parentGroupId));
 
+					Disjunction disjunction =
+						RestrictionsFactoryUtil.disjunction();
+
 					Property siteProperty = PropertyFactoryUtil.forName("site");
 
-					dynamicQuery.add(siteProperty.eq(Boolean.TRUE));
+					disjunction.add(siteProperty.eq(Boolean.TRUE));
+
+					Property typeProperty = PropertyFactoryUtil.forName("type");
+
+					disjunction.add(typeProperty.eq(GroupConstants.TYPE_DEPOT));
+
+					dynamicQuery.add(disjunction);
 				});
 			_actionableDynamicQuery.setPerformActionMethod(
 				(Group group) -> {


### PR DESCRIPTION
 https://issues.liferay.com/browse/LPS-136123

It seems that deleting the virtual instance it’s not deleting the elements of the asset library, nor the groups nor nothing.

related:https://issues.liferay.com/browse/LPS-136408


