### PR TITLE
LPS-137042 ComparisonFailure in FileEntryInfoDisplayContributorTest because now depends of the value of LOCALE_PREPEND_FRIENDLY_URL_STYLE and the default locale

### DIFF
--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/info/display/contributor/test/FileEntryInfoDisplayContributorTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/info/display/contributor/test/FileEntryInfoDisplayContributorTest.java
@@ -47,6 +47,7 @@ import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.util.PropsValues;
 
 import java.util.Locale;
 
@@ -76,31 +77,157 @@ public class FileEntryInfoDisplayContributorTest {
 	}
 
 	@Test
-	public void testDisplayPageURL() throws Exception {
-		_withAndWithoutAssetEntry(
-			fileEntry -> {
-				_addAssetDisplayPageEntry(fileEntry);
+	public void testDisplayPageURLCustomLocaleAlgorithm1() throws Exception {
+		int originalLocalePrependFriendlyURLStyle =
+			PropsValues.LOCALE_PREPEND_FRIENDLY_URL_STYLE;
 
-				Locale locale = LocaleUtil.getDefault();
+		try {
+			PropsValues.LOCALE_PREPEND_FRIENDLY_URL_STYLE = 1;
 
-				String expectedURL = StringBundler.concat(
-					"/", locale.getLanguage(), "/web/",
-					StringUtil.lowerCase(_group.getGroupKey()), "/d/",
-					fileEntry.getFileEntryId());
+			_withAndWithoutAssetEntry(
+				fileEntry -> {
+					_addAssetDisplayPageEntry(fileEntry);
 
-				ThemeDisplay themeDisplay = new ThemeDisplay();
+					Locale locale = LocaleUtil.FRANCE;
 
-				themeDisplay.setLocale(locale);
-				themeDisplay.setScopeGroupId(_group.getGroupId());
-				themeDisplay.setServerName("localhost");
-				themeDisplay.setSiteGroupId(_group.getGroupId());
+					String expectedURL = StringBundler.concat(
+						"/", locale.getLanguage(), "/web/",
+						StringUtil.lowerCase(_group.getGroupKey()), "/d/",
+						fileEntry.getFileEntryId());
 
-				Assert.assertEquals(
-					expectedURL,
-					_assetDisplayPageFriendlyURLProvider.getFriendlyURL(
-						FileEntry.class.getName(), fileEntry.getFileEntryId(),
-						themeDisplay));
-			});
+					ThemeDisplay themeDisplay = new ThemeDisplay();
+
+					themeDisplay.setLocale(locale);
+					themeDisplay.setScopeGroupId(_group.getGroupId());
+					themeDisplay.setServerName("localhost");
+					themeDisplay.setSiteGroupId(_group.getGroupId());
+
+					Assert.assertEquals(
+						expectedURL,
+						_assetDisplayPageFriendlyURLProvider.getFriendlyURL(
+							FileEntry.class.getName(),
+							fileEntry.getFileEntryId(), themeDisplay));
+				});
+		}
+		finally {
+			PropsValues.LOCALE_PREPEND_FRIENDLY_URL_STYLE =
+				originalLocalePrependFriendlyURLStyle;
+		}
+	}
+
+	@Test
+	public void testDisplayPageURLCustomLocaleAlgorithm1DefaultLocale()
+		throws Exception {
+
+		int originalLocalePrependFriendlyURLStyle =
+			PropsValues.LOCALE_PREPEND_FRIENDLY_URL_STYLE;
+
+		try {
+			_withAndWithoutAssetEntry(
+				fileEntry -> {
+					_addAssetDisplayPageEntry(fileEntry);
+
+					Locale locale = LocaleUtil.getDefault();
+
+					String expectedURL = StringBundler.concat(
+						"/web/", StringUtil.lowerCase(_group.getGroupKey()),
+						"/d/", fileEntry.getFileEntryId());
+
+					ThemeDisplay themeDisplay = new ThemeDisplay();
+
+					themeDisplay.setLocale(locale);
+					themeDisplay.setScopeGroupId(_group.getGroupId());
+					themeDisplay.setServerName("localhost");
+					themeDisplay.setSiteGroupId(_group.getGroupId());
+
+					Assert.assertEquals(
+						expectedURL,
+						_assetDisplayPageFriendlyURLProvider.getFriendlyURL(
+							FileEntry.class.getName(),
+							fileEntry.getFileEntryId(), themeDisplay));
+				});
+		}
+		finally {
+			PropsValues.LOCALE_PREPEND_FRIENDLY_URL_STYLE =
+				originalLocalePrependFriendlyURLStyle;
+		}
+	}
+
+	@Test
+	public void testDisplayPageURLCustomLocaleAlgorithm2() throws Exception {
+		int originalLocalePrependFriendlyURLStyle =
+			PropsValues.LOCALE_PREPEND_FRIENDLY_URL_STYLE;
+
+		try {
+			PropsValues.LOCALE_PREPEND_FRIENDLY_URL_STYLE = 2;
+
+			_withAndWithoutAssetEntry(
+				fileEntry -> {
+					_addAssetDisplayPageEntry(fileEntry);
+
+					Locale locale = LocaleUtil.getDefault();
+
+					String expectedURL = StringBundler.concat(
+						"/", locale.getLanguage(), "/web/",
+						StringUtil.lowerCase(_group.getGroupKey()), "/d/",
+						fileEntry.getFileEntryId());
+
+					ThemeDisplay themeDisplay = new ThemeDisplay();
+
+					themeDisplay.setLocale(locale);
+					themeDisplay.setScopeGroupId(_group.getGroupId());
+					themeDisplay.setServerName("localhost");
+					themeDisplay.setSiteGroupId(_group.getGroupId());
+
+					Assert.assertEquals(
+						expectedURL,
+						_assetDisplayPageFriendlyURLProvider.getFriendlyURL(
+							FileEntry.class.getName(),
+							fileEntry.getFileEntryId(), themeDisplay));
+				});
+		}
+		finally {
+			PropsValues.LOCALE_PREPEND_FRIENDLY_URL_STYLE =
+				originalLocalePrependFriendlyURLStyle;
+		}
+	}
+
+	@Test
+	public void testDisplayPageURLCustomLocaleAlgorithmDefault()
+		throws Exception {
+
+		int originalLocalePrependFriendlyURLStyle =
+			PropsValues.LOCALE_PREPEND_FRIENDLY_URL_STYLE;
+
+		try {
+			_withAndWithoutAssetEntry(
+				fileEntry -> {
+					_addAssetDisplayPageEntry(fileEntry);
+
+					Locale locale = LocaleUtil.getDefault();
+
+					String expectedURL = StringBundler.concat(
+						"/web/", StringUtil.lowerCase(_group.getGroupKey()),
+						"/d/", fileEntry.getFileEntryId());
+
+					ThemeDisplay themeDisplay = new ThemeDisplay();
+
+					themeDisplay.setLocale(locale);
+					themeDisplay.setScopeGroupId(_group.getGroupId());
+					themeDisplay.setServerName("localhost");
+					themeDisplay.setSiteGroupId(_group.getGroupId());
+
+					Assert.assertEquals(
+						expectedURL,
+						_assetDisplayPageFriendlyURLProvider.getFriendlyURL(
+							FileEntry.class.getName(),
+							fileEntry.getFileEntryId(), themeDisplay));
+				});
+		}
+		finally {
+			PropsValues.LOCALE_PREPEND_FRIENDLY_URL_STYLE =
+				originalLocalePrependFriendlyURLStyle;
+		}
 	}
 
 	private void _addAssetDisplayPageEntry(FileEntry dlFileEntry)


### PR DESCRIPTION
ComparisonFailure in FileEntryInfoDisplayContributorTest : https://issues.liferay.com/browse/LPS-137042

Is caused by https://issues.liferay.com/browse/LPS-135692