### PR TITLE
LPS-137112 Fix issues with findByExtraSettings and countByExtraSettings in Oracle DB

### DIFF
--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/persistence/impl/DLFileEntryFinderImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/persistence/impl/DLFileEntryFinderImpl.java
@@ -19,6 +19,8 @@ import com.liferay.document.library.kernel.model.DLFileEntryConstants;
 import com.liferay.document.library.kernel.service.persistence.DLFileEntryFinder;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.dao.db.DB;
+import com.liferay.portal.kernel.dao.db.DBType;
 import com.liferay.portal.kernel.dao.orm.QueryDefinition;
 import com.liferay.portal.kernel.dao.orm.QueryPos;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
@@ -94,7 +96,17 @@ public class DLFileEntryFinderImpl
 		try {
 			session = openSession();
 
+			DB db = getDB();
+
+			boolean oracle = false;
+
+			if (db.getDBType() == DBType.ORACLE) {
+				oracle = true;
+			}
+
 			String sql = CustomSQLUtil.get(COUNT_BY_EXTRA_SETTINGS);
+
+			sql = getExtraSettingsSQL(sql, oracle);
 
 			SQLQuery sqlQuery = session.createSynchronizedSQLQuery(sql);
 
@@ -372,7 +384,17 @@ public class DLFileEntryFinderImpl
 		try {
 			session = openSession();
 
+			DB db = getDB();
+
+			boolean oracle = false;
+
+			if (db.getDBType() == DBType.ORACLE) {
+				oracle = true;
+			}
+
 			String sql = CustomSQLUtil.get(FIND_BY_EXTRA_SETTINGS);
+
+			sql = getExtraSettingsSQL(sql, oracle);
 
 			SQLQuery sqlQuery = session.createSynchronizedSQLQuery(sql);
 
@@ -699,6 +721,23 @@ public class DLFileEntryFinderImpl
 		sb.append(StringPool.CLOSE_PARENTHESIS);
 
 		return sb.toString();
+	}
+
+	protected String getExtraSettingsSQL(String sql, boolean oracle) {
+		String replacementSQL = null;
+
+		if (oracle) {
+			replacementSQL =
+				"(LENGTH(DLFileEntry.extraSettings) > 0) OR " +
+					"(LENGTH(DLFileVersion.extraSettings) > 0)";
+		}
+		else {
+			replacementSQL =
+				"(CAST_TEXT(DLFileEntry.extraSettings) != '') OR " +
+					"(CAST_TEXT(DLFileVersion.extraSettings) != '')";
+		}
+
+		return StringUtil.replace(sql, "[$EXTRA_SETTINGS$]", replacementSQL);
 	}
 
 	protected String getFileEntriesSQL(

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/persistence/impl/DLFileEntryFinderImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/persistence/impl/DLFileEntryFinderImpl.java
@@ -39,6 +39,7 @@ import com.liferay.portlet.documentlibrary.model.impl.DLFileEntryImpl;
 import com.liferay.portlet.documentlibrary.model.impl.DLFileVersionImpl;
 import com.liferay.util.dao.orm.CustomSQLUtil;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -394,15 +395,33 @@ public class DLFileEntryFinderImpl
 
 			String sql = CustomSQLUtil.get(FIND_BY_EXTRA_SETTINGS);
 
+			sql = getDLFileEntryColumnsSQL(sql, oracle);
 			sql = getExtraSettingsSQL(sql, oracle);
 
 			SQLQuery sqlQuery = session.createSynchronizedSQLQuery(sql);
 
-			sqlQuery.addEntity(
-				DLFileEntryImpl.TABLE_NAME, DLFileEntryImpl.class);
+			if (!oracle) {
+				sqlQuery.addEntity(
+					DLFileEntryImpl.TABLE_NAME, DLFileEntryImpl.class);
 
-			return (List<DLFileEntry>)QueryUtil.list(
+				return (List<DLFileEntry>)QueryUtil.list(
+					sqlQuery, getDialect(), start, end);
+			}
+
+			sqlQuery.addScalar("fileEntryId", Type.LONG);
+
+			List<Long> fileEntryIds = (List<Long>)QueryUtil.list(
 				sqlQuery, getDialect(), start, end);
+
+			List<DLFileEntry> dlFileEntries = new ArrayList<>(
+				fileEntryIds.size());
+
+			for (long fileEntryId : fileEntryIds) {
+				dlFileEntries.add(
+					dlFileEntryPersistence.findByPrimaryKey(fileEntryId));
+			}
+
+			return Collections.unmodifiableList(dlFileEntries);
 		}
 		catch (Exception exception) {
 			throw new SystemException(exception);
@@ -721,6 +740,21 @@ public class DLFileEntryFinderImpl
 		sb.append(StringPool.CLOSE_PARENTHESIS);
 
 		return sb.toString();
+	}
+
+	protected String getDLFileEntryColumnsSQL(String sql, boolean oracle) {
+		String replacementSQL = null;
+
+		if (oracle) {
+			replacementSQL =
+				"DLFileEntry.fileEntryId, DLFileEntry.modifiedDate";
+		}
+		else {
+			replacementSQL = "{DLFileEntry.*}";
+		}
+
+		return StringUtil.replace(
+			sql, "[$DL_FILE_ENTRY_COLUMNS$]", replacementSQL);
 	}
 
 	protected String getExtraSettingsSQL(String sql, boolean oracle) {

--- a/portal-impl/src/custom-sql/documentlibrary.xml
+++ b/portal-impl/src/custom-sql/documentlibrary.xml
@@ -11,8 +11,7 @@
 				DLFileVersion ON
 					DLFileVersion.fileEntryId = DLFileEntry.fileEntryId
 			WHERE
-				(CAST_TEXT(DLFileEntry.extraSettings) != '') OR
-				(CAST_TEXT(DLFileVersion.extraSettings) != '')
+				[$EXTRA_SETTINGS$]
 		]]>
 	</sql>
 	<sql id="com.liferay.document.library.kernel.service.persistence.DLFileEntryFinder.countByG_F">
@@ -145,8 +144,7 @@
 				DLFileVersion ON
 					DLFileVersion.fileEntryId = DLFileEntry.fileEntryId
 			WHERE
-				(CAST_TEXT(DLFileEntry.extraSettings) != '') OR
-				(CAST_TEXT(DLFileVersion.extraSettings) != '')
+				[$EXTRA_SETTINGS$]
 			ORDER BY
 				DLFileEntry.modifiedDate DESC
 		]]>

--- a/portal-impl/src/custom-sql/documentlibrary.xml
+++ b/portal-impl/src/custom-sql/documentlibrary.xml
@@ -137,7 +137,7 @@
 	<sql id="com.liferay.document.library.kernel.service.persistence.DLFileEntryFinder.findByExtraSettings">
 		<![CDATA[
 			SELECT
-				DISTINCT {DLFileEntry.*}
+				DISTINCT [$DL_FILE_ENTRY_COLUMNS$]
 			FROM
 				DLFileEntry
 			INNER JOIN


### PR DESCRIPTION
The extraSettings column in DLFileEntry and DLFileVersion is a CLOB-type column. Unfortunately, Oracle DB has some weird restrictions surrounding CLOB-type columns:
1. The WHERE clause included a "[clob_column] != ''" operation, which isn't allowed in Oracle.
2. We were SELECTING a DISTINCT set of columns, which isn't allowed when one or more of the columns being DISTINCTED is a CLOB type in Oracle.

I applied the following fixes for problems 1 and 2:
Problem 1: If an Oracle database is in use, change the WHERE clause to use "LENGTH([clob_column]) > 0".
Problem 2: If an Oracle database is in use, separate the query into multiple queries. In the first query, we select the DISTINCT fileEntryIds from the database. Then, we do a separate query(ies) to select all the column values for each fileEntryId. (I know this isn't ideal performance-wise to split it into multiple queries, but I couldn't find any way to do it in a single query.)

https://issues.liferay.com/browse/LPS-137112