### PR TITLE
LPS-136652 urlTitle may not be unique

### DIFF
--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/upgrade/BlogsServiceUpgrade.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/upgrade/BlogsServiceUpgrade.java
@@ -59,7 +59,8 @@ public class BlogsServiceUpgrade implements UpgradeStepRegistrator {
 		registry.register(
 			"1.0.0", "1.1.0",
 			new com.liferay.blogs.internal.upgrade.v1_1_0.
-				BlogsEntryUpgradeProcess(_friendlyURLEntryLocalService));
+				BlogsEntryUpgradeProcess(
+					_classNameLocalService, _friendlyURLEntryLocalService));
 
 		registry.register(
 			"1.1.0", "1.1.1",


### PR DESCRIPTION
Dear Team,

Could you please review this pull request?

I added this correction because it realized (and also verified with tests) that `FriendlyURLNormalizerUtil.normalizeWithPeriodsAndSlashes(urlTitle)` returns a Friendly URL that may no be unique, and adding it with `_friendlyURLEntryLocalService.addFriendlyURLEntry()` could fail with a `DuplicateFriendlyURLEntryException`.

Thank you and best regards,
István