### PR TITLE
LPS-137331 the order of the calls is relevant

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/lar/DLAdminPortletDataHandler.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/lar/DLAdminPortletDataHandler.java
@@ -171,6 +171,7 @@ public class DLAdminPortletDataHandler extends BasePortletDataHandler {
 		_dlAppLocalService.deleteAll(portletDataContext.getScopeGroupId());
 		_dlFileEntryTypeLocalService.deleteFileEntryTypes(
 			portletDataContext.getScopeGroupId());
+
 		_ddmStructureLocalService.deleteStructures(
 			portletDataContext.getScopeGroupId(),
 			_portal.getClassNameId(DLFileEntryMetadata.class));

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/lar/DLAdminPortletDataHandler.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/lar/DLAdminPortletDataHandler.java
@@ -168,12 +168,12 @@ public class DLAdminPortletDataHandler extends BasePortletDataHandler {
 			return portletPreferences;
 		}
 
-		_ddmStructureLocalService.deleteStructures(
-			portletDataContext.getScopeGroupId(),
-			_portal.getClassNameId(DLFileEntryMetadata.class));
 		_dlAppLocalService.deleteAll(portletDataContext.getScopeGroupId());
 		_dlFileEntryTypeLocalService.deleteFileEntryTypes(
 			portletDataContext.getScopeGroupId());
+		_ddmStructureLocalService.deleteStructures(
+			portletDataContext.getScopeGroupId(),
+			_portal.getClassNameId(DLFileEntryMetadata.class));
 
 		if (portletPreferences == null) {
 			return portletPreferences;


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-137331

The order of the calls is relevant. You must delete the file entries types before delete the metadata sets (ddmStructures)