### PR TITLE
LPS-137887 escape label to prevent XSS

### DIFF
--- a/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/display/context/TranslateDisplayContext.java
+++ b/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/display/context/TranslateDisplayContext.java
@@ -309,7 +309,7 @@ public class TranslateDisplayContext {
 		if (infoFieldSetEntry instanceof InfoFieldSet) {
 			InfoFieldSet infoFieldSet = (InfoFieldSet)infoFieldSetEntry;
 
-			return infoFieldSet.getLabel(locale);
+			return HtmlUtil.escape(infoFieldSet.getLabel(locale));
 		}
 
 		return null;


### PR DESCRIPTION

After the fix, the name will show up escaped in the label. We'll accept this as a limitation for the moment – better to have some ugliness than some XSS security hole.

![image](https://user-images.githubusercontent.com/47524751/131100167-1e888a16-415b-44c8-a2f8-a4f92622f795.png)
