### PR TITLE
[TS] LPS-137143

### DIFF
--- a/modules/apps/asset/asset-browser-web/src/main/java/com/liferay/asset/browser/web/internal/display/context/AssetBrowserDisplayContext.java
+++ b/modules/apps/asset/asset-browser-web/src/main/java/com/liferay/asset/browser/web/internal/display/context/AssetBrowserDisplayContext.java
@@ -422,6 +422,15 @@ public class AssetBrowserDisplayContext {
 	}
 
 	public boolean isShowBreadcrumb() {
+		String scopeGroupType = ParamUtil.getString(
+			_httpServletRequest, "scopeGroupType");
+
+		if (Validator.isNotNull(scopeGroupType) &&
+			scopeGroupType.equals("page")) {
+
+			return false;
+		}
+
 		ThemeDisplay themeDisplay =
 			(ThemeDisplay)_httpServletRequest.getAttribute(
 				WebKeys.THEME_DISPLAY);
@@ -578,6 +587,9 @@ public class AssetBrowserDisplayContext {
 					PortalUtil.getLiferayPortletResponse(_renderResponse))
 			).setParameter(
 				"groupType", "site"
+			).setParameter(
+				"scopeGroupType",
+				ParamUtil.getString(_httpServletRequest, "scopeGroupType", "")
 			).setParameter(
 				"showGroupSelector", true
 			).buildString());

--- a/modules/apps/asset/asset-browser-web/src/main/java/com/liferay/asset/browser/web/internal/item/selector/AssetEntryItemSelectorView.java
+++ b/modules/apps/asset/asset-browser-web/src/main/java/com/liferay/asset/browser/web/internal/item/selector/AssetEntryItemSelectorView.java
@@ -120,6 +120,10 @@ public class AssetEntryItemSelectorView
 				_toStringArray(
 					!assetEntryItemSelectorCriterion.isSingleSelect())
 			).put(
+				"scopeGroupType",
+				_toStringArray(
+					assetEntryItemSelectorCriterion.getScopeGroupType())
+			).put(
 				"selectedGroupIds",
 				_toStringArray(
 					StringUtil.merge(

--- a/modules/apps/item-selector/item-selector-criteria-api/bnd.bnd
+++ b/modules/apps/item-selector/item-selector-criteria-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Item Selector Criteria API
 Bundle-SymbolicName: com.liferay.item.selector.criteria.api
-Bundle-Version: 6.0.3
+Bundle-Version: 6.1.0
 Export-Package:\
 	com.liferay.item.selector.criteria,\
 	com.liferay.item.selector.criteria.asset.criterion,\

--- a/modules/apps/item-selector/item-selector-criteria-api/src/main/java/com/liferay/item/selector/criteria/asset/criterion/AssetEntryItemSelectorCriterion.java
+++ b/modules/apps/item-selector/item-selector-criteria-api/src/main/java/com/liferay/item/selector/criteria/asset/criterion/AssetEntryItemSelectorCriterion.java
@@ -25,6 +25,10 @@ public class AssetEntryItemSelectorCriterion extends BaseItemSelectorCriterion {
 		return _groupId;
 	}
 
+	public String getScopeGroupType() {
+		return _scopeGroupType;
+	}
+
 	public long[] getSelectedGroupIds() {
 		return _selectedGroupIds;
 	}
@@ -53,6 +57,10 @@ public class AssetEntryItemSelectorCriterion extends BaseItemSelectorCriterion {
 		_groupId = groupId;
 	}
 
+	public void setScopeGroupType(String scopeGroupType) {
+		_scopeGroupType = scopeGroupType;
+	}
+
 	public void setSelectedGroupIds(long[] selectedGroupIds) {
 		_selectedGroupIds = selectedGroupIds;
 	}
@@ -78,6 +86,7 @@ public class AssetEntryItemSelectorCriterion extends BaseItemSelectorCriterion {
 	}
 
 	private long _groupId;
+	private String _scopeGroupType;
 	private long[] _selectedGroupIds;
 	private boolean _showNonindexable;
 	private boolean _showScheduled;

--- a/modules/apps/item-selector/item-selector-criteria-api/src/main/resources/com/liferay/item/selector/criteria/asset/criterion/packageinfo
+++ b/modules/apps/item-selector/item-selector-criteria-api/src/main/resources/com/liferay/item/selector/criteria/asset/criterion/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 1.2.0

--- a/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/display/context/JournalContentDisplayContext.java
+++ b/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/display/context/JournalContentDisplayContext.java
@@ -525,6 +525,7 @@ public class JournalContentDisplayContext {
 			new AssetEntryItemSelectorReturnType());
 
 		assetEntryItemSelectorCriterion.setGroupId(getGroupId());
+		assetEntryItemSelectorCriterion.setScopeGroupType(getScopeGroupType());
 		assetEntryItemSelectorCriterion.setShowNonindexable(true);
 		assetEntryItemSelectorCriterion.setShowScheduled(true);
 		assetEntryItemSelectorCriterion.setSingleSelect(true);
@@ -564,6 +565,24 @@ public class JournalContentDisplayContext {
 			_portletRequest, "portletResource");
 
 		return _portletResource;
+	}
+
+	public String getScopeGroupType() {
+		Group scopeGroup = _themeDisplay.getScopeGroup();
+
+		if (scopeGroup.isDepot()) {
+			return "asset-library";
+		}
+
+		if (scopeGroup.getGroupId() == _themeDisplay.getCompanyGroupId()) {
+			return "global";
+		}
+
+		if (scopeGroup.isLayout()) {
+			return "page";
+		}
+
+		return "site";
 	}
 
 	public JournalArticle getSelectedArticle() {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/journal/webcontentdisplay/WebContentDisplay.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/journal/webcontentdisplay/WebContentDisplay.testcase
@@ -730,33 +730,6 @@ Welcome to Liferay Community Edition Portal 7.4.0 CE GA1''';
 		}
 	}
 
-	@description = "This is a use case for LPS-118702. Display web content article from other site."
-	@priority = "5"
-	test DisplayWebContentFromOtherSite {
-		property portal.acceptance = "true";
-
-		task ("Add a web content article in Site Name") {
-			JSONWebcontent.addWebContent(
-				content = "Web Content Content",
-				groupName = "Site Name",
-				title = "Web Content Title");
-		}
-
-		task ("Select the web content article in Web Content Display in Test Site Name") {
-			Navigator.gotoSitePage(
-				pageName = "Web Content Display Page",
-				siteName = "Test Site Name");
-
-			WebContentDisplayPortlet.selectOtherSiteWebContent(
-				otherSiteName = "Site Name",
-				webContentTitle = "Web Content Title");
-		}
-
-		task ("Assert the web content article is shown in Web Content Display") {
-			WebContent.viewPGViaWCD(webContentContent = "Web Content Content");
-		}
-	}
-
 	@description = "This is a use case for LPS-130033. Display web content with Geolocation field in Web Content Display."
 	@priority = "4"
 	test DisplayWebContentWithGeolocationField {


### PR DESCRIPTION
[LPS-137143](https://issues.liferay.com/browse/LPS-137143)

From @jesseyeh-liferay 

> **Issue**
> Web Content Displays have a scope setting in their configuration that allows for users to limit the scope of selectable Web Content. However, as of 7.3, WCDs now display the Sites and Libraries breadcrumb, which allows users to select content from any site (thus ignoring the portlet-configured scope). This has since been determined to be unintended behavior.
> 
> **Solution**
> Per PTR-2570, this solution makes it so that the Sites and Libraries breadcrumb behaves as follows:
> |Portlet Scope|Behavior|
> |---|---|
> |Page|Hide the breadcrumb|
> |Site|Show the breadcrumb. In the breadcrumb, if the user navigates to "Sites," only the current site will be displayed. If the user navigates to "Asset Libraries," only the Asset Libraries connected to the current site will be displayed.|
> |Global|Show the breadcrumb. In the breadcrumb, if the user navigates to "Sites,", only the global site will be displayed. If the user navigates to "Asset Libraries", only the Asset Libraries connected to the global site will be displayed.|
> 
> This is achieved with the following steps:
> 1. [Determine the `scopeGroupType` and pass it into the `assetEntryItemSelectorCriterion`](https://github.com/jesseyeh-liferay/liferay-portal/blob/1d521242120160b752a2443a65a763f986c7821c/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/display/context/JournalContentDisplayContext.java#L528)
> 2. [Pass the `scopeGroupType` into the request](https://github.com/jesseyeh-liferay/liferay-portal/blob/1d521242120160b752a2443a65a763f986c7821c/modules/apps/asset/asset-browser-web/src/main/java/com/liferay/asset/browser/web/internal/item/selector/AssetEntryItemSelectorView.java#L122-L125) and [forward it to the Sites and Libraries breadcrumb link](https://github.com/ChrisKian/liferay-portal/blob/1d521242120160b752a2443a65a763f986c7821c/modules/apps/asset/asset-browser-web/src/main/java/com/liferay/asset/browser/web/internal/display/context/AssetBrowserDisplayContext.java#L590-L592)
> 3. Depending on the value of `scopeGroupType`, the breadcrumb behavior will be in accordance to the table outlined above. In the absence of a value, the behavior will default to the implementation prior to these changes (refer to changes in AssetBrowserDisplayContext.java and GroupSelectorTag.java). 