### PR TITLE
LPS-138272 Workflow should not apply to reviewer comments

### DIFF
--- a/modules/apps/comment/comment-taglib/bnd.bnd
+++ b/modules/apps/comment/comment-taglib/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Comment Taglib
 Bundle-SymbolicName: com.liferay.comment.taglib
-Bundle-Version: 4.0.11
+Bundle-Version: 4.1.0
 Export-Package: com.liferay.comment.taglib.servlet.taglib
 Provide-Capability:\
 	osgi.extender;\

--- a/modules/apps/comment/comment-taglib/package.json
+++ b/modules/apps/comment/comment-taglib/package.json
@@ -15,5 +15,5 @@
 		"checkFormat": "liferay-npm-scripts check",
 		"format": "liferay-npm-scripts fix"
 	},
-	"version": "4.0.11"
+	"version": "4.1.0"
 }

--- a/modules/apps/comment/comment-taglib/src/main/java/com/liferay/comment/taglib/servlet/taglib/DiscussionTag.java
+++ b/modules/apps/comment/comment-taglib/src/main/java/com/liferay/comment/taglib/servlet/taglib/DiscussionTag.java
@@ -67,6 +67,10 @@ public class DiscussionTag extends IncludeTag {
 		return _ratingsEnabled;
 	}
 
+	public boolean isWorkflowReviewComment() {
+		return _workflowReviewComment;
+	}
+
 	public void setAssetEntryVisible(boolean assetEntryVisible) {
 		_assetEntryVisible = assetEntryVisible;
 	}
@@ -114,6 +118,10 @@ public class DiscussionTag extends IncludeTag {
 		_userId = userId;
 	}
 
+	public void setWorkflowReviewComment(boolean workflowReviewComment) {
+		_workflowReviewComment = workflowReviewComment;
+	}
+
 	@Override
 	protected void cleanUp() {
 		super.cleanUp();
@@ -128,6 +136,7 @@ public class DiscussionTag extends IncludeTag {
 		_ratingsEnabled = true;
 		_redirect = null;
 		_userId = 0;
+		_workflowReviewComment = false;
 	}
 
 	protected String getEditorURL(HttpServletRequest httpServletRequest) {
@@ -219,6 +228,9 @@ public class DiscussionTag extends IncludeTag {
 			"liferay-comment:discussion:redirect", _redirect);
 		httpServletRequest.setAttribute(
 			"liferay-comment:discussion:userId", String.valueOf(_userId));
+		httpServletRequest.setAttribute(
+			"liferay-comment:discussion:workflowReviewComment",
+			String.valueOf(_workflowReviewComment));
 	}
 
 	private static final String _PAGE = "/discussion/page.jsp";
@@ -233,5 +245,6 @@ public class DiscussionTag extends IncludeTag {
 	private boolean _ratingsEnabled = true;
 	private String _redirect;
 	private long _userId;
+	private boolean _workflowReviewComment;
 
 }

--- a/modules/apps/comment/comment-taglib/src/main/resources/META-INF/liferay-comment.tld
+++ b/modules/apps/comment/comment-taglib/src/main/resources/META-INF/liferay-comment.tld
@@ -64,5 +64,10 @@
 			<required>true</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
+		<attribute>
+			<name>workflowReviewComment</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
 	</tag>
 </taglib>

--- a/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/page.jsp
+++ b/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/page.jsp
@@ -71,6 +71,7 @@ StagingGroupHelper stagingGroupHelper = StagingGroupHelperUtil.getStagingGroupHe
 				<aui:input name="parentCommentId" type="hidden" />
 				<aui:input name="body" type="hidden" />
 				<aui:input name="workflowAction" type="hidden" value="<%= String.valueOf(WorkflowConstants.ACTION_PUBLISH) %>" />
+				<aui:input name="workflowReviewComment" type="hidden" value='<%= String.valueOf(request.getAttribute("liferay-comment:discussion:workflowReviewComment")) %>' />
 				<aui:input name="ajax" type="hidden" value="<%= true %>" />
 
 				<c:if test="<%= commentSectionDisplayContext.isControlsVisible() %>">

--- a/modules/apps/comment/comment-taglib/src/main/resources/com/liferay/comment/taglib/servlet/taglib/packageinfo
+++ b/modules/apps/comment/comment-taglib/src/main/resources/com/liferay/comment/taglib/servlet/taglib/packageinfo
@@ -1,1 +1,1 @@
-version 1.2.0
+version 1.3.0

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/workflow/MBDiscussionWorkflowHandler.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/workflow/MBDiscussionWorkflowHandler.java
@@ -17,12 +17,20 @@ package com.liferay.message.boards.internal.workflow;
 import com.liferay.asset.kernel.AssetRendererFactoryRegistryUtil;
 import com.liferay.asset.kernel.model.AssetRendererFactory;
 import com.liferay.message.boards.model.MBDiscussion;
+import com.liferay.message.boards.model.MBMessage;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
+import com.liferay.portal.kernel.service.WorkflowInstanceLinkLocalService;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.kernel.workflow.WorkflowHandler;
 
+import java.io.Serializable;
+
 import java.util.Locale;
+import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Jorge Ferrer
@@ -49,5 +57,28 @@ public class MBDiscussionWorkflowHandler extends MBMessageWorkflowHandler {
 	public String getType(Locale locale) {
 		return ResourceActionsUtil.getModelResource(locale, getClassName());
 	}
+
+	@Override
+	public void startWorkflowInstance(
+			long companyId, long groupId, long userId, long classPK,
+			MBMessage model, Map<String, Serializable> workflowContext)
+		throws PortalException {
+
+		boolean workflowReviewComment = (boolean)workflowContext.get(
+			"workflowReviewComment");
+
+		if (workflowReviewComment) {
+			updateStatus(WorkflowConstants.STATUS_APPROVED, workflowContext);
+
+			return;
+		}
+
+		_workflowInstanceLinkLocalService.startWorkflowInstance(
+			companyId, groupId, userId, getClassName(), classPK,
+			workflowContext);
+	}
+
+	@Reference
+	private WorkflowInstanceLinkLocalService _workflowInstanceLinkLocalService;
 
 }

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBMessageLocalServiceImpl.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBMessageLocalServiceImpl.java
@@ -2413,10 +2413,21 @@ public class MBMessageLocalServiceImpl extends MBMessageLocalServiceBaseImpl {
 			long userId, MBMessage message, ServiceContext serviceContext)
 		throws PortalException {
 
+		boolean workflowReviewComment = false;
+
+		HttpServletRequest httpServletRequest = serviceContext.getRequest();
+
+		if (httpServletRequest != null) {
+			workflowReviewComment = ParamUtil.getBoolean(
+				httpServletRequest, "workflowReviewComment");
+		}
+
 		Map<String, Serializable> workflowContext =
 			HashMapBuilder.<String, Serializable>put(
 				WorkflowConstants.CONTEXT_URL,
 				getMessageURL(message, serviceContext)
+			).put(
+				"workflowReviewComment", workflowReviewComment
 			).build();
 
 		return WorkflowHandlerRegistryUtil.startWorkflowInstance(

--- a/modules/apps/portal-workflow/portal-workflow-task-web/src/main/resources/META-INF/resources/edit_workflow_task.jsp
+++ b/modules/apps/portal-workflow/portal-workflow-task-web/src/main/resources/META-INF/resources/edit_workflow_task.jsp
@@ -285,6 +285,7 @@ renderResponse.setTitle(workflowTaskDisplayContext.getHeaderTitle(workflowTask))
 								ratingsEnabled="<%= false %>"
 								redirect="<%= currentURL %>"
 								userId="<%= user.getUserId() %>"
+								workflowReviewComment="<%= true %>"
 							/>
 						</liferay-ui:panel>
 					</c:if>


### PR DESCRIPTION
Dear Team,

Could you please review this pull request?

As the changes affect the **Workflow** component as well, a [pull request with the same content](https://github.com/liferay-workflow/liferay-portal/pull/510) has been sent to the @liferay-workflow team where they approved it and asked me to send it to you as well so you can review the changes in the DiscussionTag.

Currently, when an approval Workflow (eg. Single Approver) is set for Comments, even the Comments made on the Workflow Task are sent for review. The Comments made on that Workflow Task are in turn sent for review as well and so on.

The changes in the pull make the comments on the Workflow Task exempt from the workflow process.
Please let me know if this behavior should be rather made optional by turning it on/off with a configuration.

Thank you and best regards,
István