### PR TITLE
Lps 137263

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/CopyLayoutMVCActionCommand.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/CopyLayoutMVCActionCommand.java
@@ -121,14 +121,15 @@ public class CopyLayoutMVCActionCommand extends BaseMVCActionCommand {
 				new HashMap<>(), sourceLayout.getMasterLayoutPlid(),
 				serviceContext);
 
+			targetLayout = _layoutCopyHelper.copyLayout(
+				sourceLayout, targetLayout);
+
 			Layout draftLayout = targetLayout.fetchDraftLayout();
 
 			if (draftLayout != null) {
-				targetLayout = draftLayout;
+				targetLayout = _layoutCopyHelper.copyLayout(
+					sourceLayout, draftLayout);
 			}
-
-			targetLayout = _layoutCopyHelper.copyLayout(
-				sourceLayout, targetLayout);
 
 			targetLayout.setNameMap(nameMap);
 

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/util/LayoutCopyHelperImpl.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/util/LayoutCopyHelperImpl.java
@@ -808,6 +808,7 @@ public class LayoutCopyHelperImpl implements LayoutCopyHelper {
 					_targetLayout.getUserId(), _targetLayout.getGroupId(),
 					_targetLayout.isPrivateLayout(),
 					_targetLayout.getLayoutId(),
+					layoutSEOEntry.getDDMStorageId(),
 					layoutSEOEntry.isCanonicalURLEnabled(),
 					layoutSEOEntry.getCanonicalURLMap(),
 					layoutSEOEntry.isOpenGraphDescriptionEnabled(),

--- a/modules/apps/layout/layout-seo-api/src/main/java/com/liferay/layout/seo/service/LayoutSEOEntryLocalService.java
+++ b/modules/apps/layout/layout-seo-api/src/main/java/com/liferay/layout/seo/service/LayoutSEOEntryLocalService.java
@@ -366,6 +366,18 @@ public interface LayoutSEOEntryLocalService
 			ServiceContext serviceContext)
 		throws PortalException;
 
+	public LayoutSEOEntry updateLayoutSEOEntry(
+			long userId, long groupId, boolean privateLayout, long layoutId,
+			long parentDDMStorageId, boolean canonicalURLEnabled,
+			Map<Locale, String> canonicalURLMap,
+			boolean openGraphDescriptionEnabled,
+			Map<Locale, String> openGraphDescriptionMap,
+			Map<Locale, String> openGraphImageAltMap,
+			long openGraphImageFileEntryId, boolean openGraphTitleEnabled,
+			Map<Locale, String> openGraphTitleMap,
+			ServiceContext serviceContext)
+		throws PortalException;
+
 	@Override
 	@Transactional(enabled = false)
 	public CTPersistence<LayoutSEOEntry> getCTPersistence();

--- a/modules/apps/layout/layout-seo-api/src/main/java/com/liferay/layout/seo/service/LayoutSEOEntryLocalServiceUtil.java
+++ b/modules/apps/layout/layout-seo-api/src/main/java/com/liferay/layout/seo/service/LayoutSEOEntryLocalServiceUtil.java
@@ -427,6 +427,26 @@ public class LayoutSEOEntryLocalServiceUtil {
 			canonicalURLMap, serviceContext);
 	}
 
+	public static LayoutSEOEntry updateLayoutSEOEntry(
+			long userId, long groupId, boolean privateLayout, long layoutId,
+			long parentDDMStorageId, boolean canonicalURLEnabled,
+			Map<java.util.Locale, String> canonicalURLMap,
+			boolean openGraphDescriptionEnabled,
+			Map<java.util.Locale, String> openGraphDescriptionMap,
+			Map<java.util.Locale, String> openGraphImageAltMap,
+			long openGraphImageFileEntryId, boolean openGraphTitleEnabled,
+			Map<java.util.Locale, String> openGraphTitleMap,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws PortalException {
+
+		return getService().updateLayoutSEOEntry(
+			userId, groupId, privateLayout, layoutId, parentDDMStorageId,
+			canonicalURLEnabled, canonicalURLMap, openGraphDescriptionEnabled,
+			openGraphDescriptionMap, openGraphImageAltMap,
+			openGraphImageFileEntryId, openGraphTitleEnabled, openGraphTitleMap,
+			serviceContext);
+	}
+
 	public static LayoutSEOEntryLocalService getService() {
 		return _service;
 	}

--- a/modules/apps/layout/layout-seo-api/src/main/java/com/liferay/layout/seo/service/LayoutSEOEntryLocalServiceWrapper.java
+++ b/modules/apps/layout/layout-seo-api/src/main/java/com/liferay/layout/seo/service/LayoutSEOEntryLocalServiceWrapper.java
@@ -467,6 +467,27 @@ public class LayoutSEOEntryLocalServiceWrapper
 	}
 
 	@Override
+	public LayoutSEOEntry updateLayoutSEOEntry(
+			long userId, long groupId, boolean privateLayout, long layoutId,
+			long parentDDMStorageId, boolean canonicalURLEnabled,
+			java.util.Map<java.util.Locale, String> canonicalURLMap,
+			boolean openGraphDescriptionEnabled,
+			java.util.Map<java.util.Locale, String> openGraphDescriptionMap,
+			java.util.Map<java.util.Locale, String> openGraphImageAltMap,
+			long openGraphImageFileEntryId, boolean openGraphTitleEnabled,
+			java.util.Map<java.util.Locale, String> openGraphTitleMap,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _layoutSEOEntryLocalService.updateLayoutSEOEntry(
+			userId, groupId, privateLayout, layoutId, parentDDMStorageId,
+			canonicalURLEnabled, canonicalURLMap, openGraphDescriptionEnabled,
+			openGraphDescriptionMap, openGraphImageAltMap,
+			openGraphImageFileEntryId, openGraphTitleEnabled, openGraphTitleMap,
+			serviceContext);
+	}
+
+	@Override
 	public CTPersistence<LayoutSEOEntry> getCTPersistence() {
 		return _layoutSEOEntryLocalService.getCTPersistence();
 	}

--- a/modules/apps/layout/layout-seo-api/src/main/java/com/liferay/layout/seo/service/LayoutSEOEntryService.java
+++ b/modules/apps/layout/layout-seo-api/src/main/java/com/liferay/layout/seo/service/LayoutSEOEntryService.java
@@ -84,4 +84,16 @@ public interface LayoutSEOEntryService extends BaseService {
 			ServiceContext serviceContext)
 		throws PortalException;
 
+	public LayoutSEOEntry updateLayoutSEOEntry(
+			long groupId, boolean privateLayout, long layoutId,
+			long parentDDMStructureId, boolean canonicalURLEnabled,
+			Map<Locale, String> canonicalURLMap,
+			boolean openGraphDescriptionEnabled,
+			Map<Locale, String> openGraphDescriptionMap,
+			Map<Locale, String> openGraphImageAltMap,
+			long openGraphImageFileEntryId, boolean openGraphTitleEnabled,
+			Map<Locale, String> openGraphTitleMap,
+			ServiceContext serviceContext)
+		throws PortalException;
+
 }

--- a/modules/apps/layout/layout-seo-api/src/main/java/com/liferay/layout/seo/service/LayoutSEOEntryServiceUtil.java
+++ b/modules/apps/layout/layout-seo-api/src/main/java/com/liferay/layout/seo/service/LayoutSEOEntryServiceUtil.java
@@ -89,6 +89,26 @@ public class LayoutSEOEntryServiceUtil {
 			canonicalURLMap, serviceContext);
 	}
 
+	public static LayoutSEOEntry updateLayoutSEOEntry(
+			long groupId, boolean privateLayout, long layoutId,
+			long parentDDMStructureId, boolean canonicalURLEnabled,
+			Map<java.util.Locale, String> canonicalURLMap,
+			boolean openGraphDescriptionEnabled,
+			Map<java.util.Locale, String> openGraphDescriptionMap,
+			Map<java.util.Locale, String> openGraphImageAltMap,
+			long openGraphImageFileEntryId, boolean openGraphTitleEnabled,
+			Map<java.util.Locale, String> openGraphTitleMap,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws PortalException {
+
+		return getService().updateLayoutSEOEntry(
+			groupId, privateLayout, layoutId, parentDDMStructureId,
+			canonicalURLEnabled, canonicalURLMap, openGraphDescriptionEnabled,
+			openGraphDescriptionMap, openGraphImageAltMap,
+			openGraphImageFileEntryId, openGraphTitleEnabled, openGraphTitleMap,
+			serviceContext);
+	}
+
 	public static LayoutSEOEntryService getService() {
 		return _service;
 	}

--- a/modules/apps/layout/layout-seo-api/src/main/java/com/liferay/layout/seo/service/LayoutSEOEntryServiceWrapper.java
+++ b/modules/apps/layout/layout-seo-api/src/main/java/com/liferay/layout/seo/service/LayoutSEOEntryServiceWrapper.java
@@ -88,6 +88,27 @@ public class LayoutSEOEntryServiceWrapper
 	}
 
 	@Override
+	public LayoutSEOEntry updateLayoutSEOEntry(
+			long groupId, boolean privateLayout, long layoutId,
+			long parentDDMStructureId, boolean canonicalURLEnabled,
+			java.util.Map<java.util.Locale, String> canonicalURLMap,
+			boolean openGraphDescriptionEnabled,
+			java.util.Map<java.util.Locale, String> openGraphDescriptionMap,
+			java.util.Map<java.util.Locale, String> openGraphImageAltMap,
+			long openGraphImageFileEntryId, boolean openGraphTitleEnabled,
+			java.util.Map<java.util.Locale, String> openGraphTitleMap,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _layoutSEOEntryService.updateLayoutSEOEntry(
+			groupId, privateLayout, layoutId, parentDDMStructureId,
+			canonicalURLEnabled, canonicalURLMap, openGraphDescriptionEnabled,
+			openGraphDescriptionMap, openGraphImageAltMap,
+			openGraphImageFileEntryId, openGraphTitleEnabled, openGraphTitleMap,
+			serviceContext);
+	}
+
+	@Override
 	public LayoutSEOEntryService getWrappedService() {
 		return _layoutSEOEntryService;
 	}

--- a/modules/apps/layout/layout-seo-api/src/main/resources/com/liferay/layout/seo/service/packageinfo
+++ b/modules/apps/layout/layout-seo-api/src/main/resources/com/liferay/layout/seo/service/packageinfo
@@ -1,1 +1,1 @@
-version 1.5.0
+version 1.6.0

--- a/modules/apps/layout/layout-seo-service/src/main/java/com/liferay/layout/seo/service/http/LayoutSEOEntryServiceHttp.java
+++ b/modules/apps/layout/layout-seo-service/src/main/java/com/liferay/layout/seo/service/http/LayoutSEOEntryServiceHttp.java
@@ -194,6 +194,60 @@ public class LayoutSEOEntryServiceHttp {
 		}
 	}
 
+	public static com.liferay.layout.seo.model.LayoutSEOEntry
+			updateLayoutSEOEntry(
+				HttpPrincipal httpPrincipal, long groupId,
+				boolean privateLayout, long layoutId, long parentDDMStructureId,
+				boolean canonicalURLEnabled,
+				java.util.Map<java.util.Locale, String> canonicalURLMap,
+				boolean openGraphDescriptionEnabled,
+				java.util.Map<java.util.Locale, String> openGraphDescriptionMap,
+				java.util.Map<java.util.Locale, String> openGraphImageAltMap,
+				long openGraphImageFileEntryId, boolean openGraphTitleEnabled,
+				java.util.Map<java.util.Locale, String> openGraphTitleMap,
+				com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				LayoutSEOEntryServiceUtil.class, "updateLayoutSEOEntry",
+				_updateLayoutSEOEntryParameterTypes3);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, groupId, privateLayout, layoutId,
+				parentDDMStructureId, canonicalURLEnabled, canonicalURLMap,
+				openGraphDescriptionEnabled, openGraphDescriptionMap,
+				openGraphImageAltMap, openGraphImageFileEntryId,
+				openGraphTitleEnabled, openGraphTitleMap, serviceContext);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.layout.seo.model.LayoutSEOEntry)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
 	private static Log _log = LogFactoryUtil.getLog(
 		LayoutSEOEntryServiceHttp.class);
 
@@ -213,6 +267,13 @@ public class LayoutSEOEntryServiceHttp {
 		new Class[] {
 			long.class, boolean.class, long.class, boolean.class,
 			java.util.Map.class,
+			com.liferay.portal.kernel.service.ServiceContext.class
+		};
+	private static final Class<?>[] _updateLayoutSEOEntryParameterTypes3 =
+		new Class[] {
+			long.class, boolean.class, long.class, long.class, boolean.class,
+			java.util.Map.class, boolean.class, java.util.Map.class,
+			java.util.Map.class, long.class, boolean.class, java.util.Map.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
 

--- a/modules/apps/layout/layout-seo-service/src/main/java/com/liferay/layout/seo/service/http/LayoutSEOEntryServiceSoap.java
+++ b/modules/apps/layout/layout-seo-service/src/main/java/com/liferay/layout/seo/service/http/LayoutSEOEntryServiceSoap.java
@@ -168,6 +168,57 @@ public class LayoutSEOEntryServiceSoap {
 		}
 	}
 
+	public static com.liferay.layout.seo.model.LayoutSEOEntrySoap
+			updateLayoutSEOEntry(
+				long groupId, boolean privateLayout, long layoutId,
+				long parentDDMStructureId, boolean canonicalURLEnabled,
+				String[] canonicalURLMapLanguageIds,
+				String[] canonicalURLMapValues,
+				boolean openGraphDescriptionEnabled,
+				String[] openGraphDescriptionMapLanguageIds,
+				String[] openGraphDescriptionMapValues,
+				String[] openGraphImageAltMapLanguageIds,
+				String[] openGraphImageAltMapValues,
+				long openGraphImageFileEntryId, boolean openGraphTitleEnabled,
+				String[] openGraphTitleMapLanguageIds,
+				String[] openGraphTitleMapValues,
+				com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws RemoteException {
+
+		try {
+			Map<Locale, String> canonicalURLMap =
+				LocalizationUtil.getLocalizationMap(
+					canonicalURLMapLanguageIds, canonicalURLMapValues);
+			Map<Locale, String> openGraphDescriptionMap =
+				LocalizationUtil.getLocalizationMap(
+					openGraphDescriptionMapLanguageIds,
+					openGraphDescriptionMapValues);
+			Map<Locale, String> openGraphImageAltMap =
+				LocalizationUtil.getLocalizationMap(
+					openGraphImageAltMapLanguageIds,
+					openGraphImageAltMapValues);
+			Map<Locale, String> openGraphTitleMap =
+				LocalizationUtil.getLocalizationMap(
+					openGraphTitleMapLanguageIds, openGraphTitleMapValues);
+
+			com.liferay.layout.seo.model.LayoutSEOEntry returnValue =
+				LayoutSEOEntryServiceUtil.updateLayoutSEOEntry(
+					groupId, privateLayout, layoutId, parentDDMStructureId,
+					canonicalURLEnabled, canonicalURLMap,
+					openGraphDescriptionEnabled, openGraphDescriptionMap,
+					openGraphImageAltMap, openGraphImageFileEntryId,
+					openGraphTitleEnabled, openGraphTitleMap, serviceContext);
+
+			return com.liferay.layout.seo.model.LayoutSEOEntrySoap.toSoapModel(
+				returnValue);
+		}
+		catch (Exception exception) {
+			_log.error(exception, exception);
+
+			throw new RemoteException(exception.getMessage());
+		}
+	}
+
 	private static Log _log = LogFactoryUtil.getLog(
 		LayoutSEOEntryServiceSoap.class);
 

--- a/modules/apps/layout/layout-seo-service/src/main/java/com/liferay/layout/seo/service/impl/LayoutSEOEntryLocalServiceImpl.java
+++ b/modules/apps/layout/layout-seo-service/src/main/java/com/liferay/layout/seo/service/impl/LayoutSEOEntryLocalServiceImpl.java
@@ -123,12 +123,58 @@ public class LayoutSEOEntryLocalServiceImpl
 			ServiceContext serviceContext)
 		throws PortalException {
 
+		return updateLayoutSEOEntry(
+			userId, groupId, privateLayout, layoutId, 0, canonicalURLEnabled,
+			canonicalURLMap, openGraphDescriptionEnabled,
+			openGraphDescriptionMap, openGraphImageAltMap,
+			openGraphImageFileEntryId, openGraphTitleEnabled, openGraphTitleMap,
+			serviceContext);
+	}
+
+	@Override
+	public LayoutSEOEntry updateLayoutSEOEntry(
+			long userId, long groupId, boolean privateLayout, long layoutId,
+			boolean canonicalURLEnabled, Map<Locale, String> canonicalURLMap,
+			ServiceContext serviceContext)
+		throws PortalException {
+
 		LayoutSEOEntry layoutSEOEntry = layoutSEOEntryPersistence.fetchByG_P_L(
 			groupId, privateLayout, layoutId);
 
 		if (layoutSEOEntry == null) {
 			return _addLayoutSEOEntry(
 				userId, groupId, privateLayout, layoutId, 0,
+				canonicalURLEnabled, canonicalURLMap, false,
+				Collections.emptyMap(), Collections.emptyMap(), 0, false,
+				Collections.emptyMap(), serviceContext);
+		}
+
+		layoutSEOEntry.setModifiedDate(DateUtil.newDate());
+		layoutSEOEntry.setCanonicalURLEnabled(canonicalURLEnabled);
+		layoutSEOEntry.setCanonicalURLMap(canonicalURLMap);
+
+		return layoutSEOEntryPersistence.update(layoutSEOEntry);
+	}
+
+	@Override
+	public LayoutSEOEntry updateLayoutSEOEntry(
+			long userId, long groupId, boolean privateLayout, long layoutId,
+			long parentDDMStorageId, boolean canonicalURLEnabled,
+			Map<Locale, String> canonicalURLMap,
+			boolean openGraphDescriptionEnabled,
+			Map<Locale, String> openGraphDescriptionMap,
+			Map<Locale, String> openGraphImageAltMap,
+			long openGraphImageFileEntryId, boolean openGraphTitleEnabled,
+			Map<Locale, String> openGraphTitleMap,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		LayoutSEOEntry layoutSEOEntry = layoutSEOEntryPersistence.fetchByG_P_L(
+			groupId, privateLayout, layoutId);
+
+		if (layoutSEOEntry == null) {
+			return _addLayoutSEOEntry(
+				userId, groupId, privateLayout, layoutId, parentDDMStorageId,
 				canonicalURLEnabled, canonicalURLMap,
 				openGraphDescriptionEnabled, openGraphDescriptionMap,
 				openGraphImageAltMap, openGraphImageFileEntryId,
@@ -153,31 +199,6 @@ public class LayoutSEOEntryLocalServiceImpl
 		layoutSEOEntry.setOpenGraphImageFileEntryId(openGraphImageFileEntryId);
 		layoutSEOEntry.setOpenGraphTitleEnabled(openGraphTitleEnabled);
 		layoutSEOEntry.setOpenGraphTitleMap(openGraphTitleMap);
-
-		return layoutSEOEntryPersistence.update(layoutSEOEntry);
-	}
-
-	@Override
-	public LayoutSEOEntry updateLayoutSEOEntry(
-			long userId, long groupId, boolean privateLayout, long layoutId,
-			boolean canonicalURLEnabled, Map<Locale, String> canonicalURLMap,
-			ServiceContext serviceContext)
-		throws PortalException {
-
-		LayoutSEOEntry layoutSEOEntry = layoutSEOEntryPersistence.fetchByG_P_L(
-			groupId, privateLayout, layoutId);
-
-		if (layoutSEOEntry == null) {
-			return _addLayoutSEOEntry(
-				userId, groupId, privateLayout, layoutId, 0,
-				canonicalURLEnabled, canonicalURLMap, false,
-				Collections.emptyMap(), Collections.emptyMap(), 0, false,
-				Collections.emptyMap(), serviceContext);
-		}
-
-		layoutSEOEntry.setModifiedDate(DateUtil.newDate());
-		layoutSEOEntry.setCanonicalURLEnabled(canonicalURLEnabled);
-		layoutSEOEntry.setCanonicalURLMap(canonicalURLMap);
 
 		return layoutSEOEntryPersistence.update(layoutSEOEntry);
 	}
@@ -312,7 +333,6 @@ public class LayoutSEOEntryLocalServiceImpl
 				LayoutSEOEntry.class.getName()),
 			"custom-meta-tags");
 	}
-
 
 	private long _updateDDMStorage(
 			long companyId, long ddmStorageId, long structureId,

--- a/modules/apps/layout/layout-seo-service/src/main/java/com/liferay/layout/seo/service/impl/LayoutSEOEntryLocalServiceImpl.java
+++ b/modules/apps/layout/layout-seo-service/src/main/java/com/liferay/layout/seo/service/impl/LayoutSEOEntryLocalServiceImpl.java
@@ -91,7 +91,7 @@ public class LayoutSEOEntryLocalServiceImpl
 
 		if (layoutSEOEntry == null) {
 			return _addLayoutSEOEntry(
-				userId, groupId, privateLayout, layoutId, false,
+				userId, groupId, privateLayout, layoutId, 0, false,
 				Collections.emptyMap(), false, Collections.emptyMap(),
 				Collections.emptyMap(), 0, false, Collections.emptyMap(),
 				serviceContext);
@@ -104,7 +104,7 @@ public class LayoutSEOEntryLocalServiceImpl
 
 		long ddmStorageId = _updateDDMStorage(
 			layoutSEOEntry.getCompanyId(), layoutSEOEntry.getDDMStorageId(),
-			ddmStructure.getStructureId(), serviceContext);
+			ddmStructure.getStructureId(), 0, serviceContext);
 
 		layoutSEOEntry.setDDMStorageId(ddmStorageId);
 
@@ -128,11 +128,11 @@ public class LayoutSEOEntryLocalServiceImpl
 
 		if (layoutSEOEntry == null) {
 			return _addLayoutSEOEntry(
-				userId, groupId, privateLayout, layoutId, canonicalURLEnabled,
-				canonicalURLMap, openGraphDescriptionEnabled,
-				openGraphDescriptionMap, openGraphImageAltMap,
-				openGraphImageFileEntryId, openGraphTitleEnabled,
-				openGraphTitleMap, serviceContext);
+				userId, groupId, privateLayout, layoutId, 0,
+				canonicalURLEnabled, canonicalURLMap,
+				openGraphDescriptionEnabled, openGraphDescriptionMap,
+				openGraphImageAltMap, openGraphImageFileEntryId,
+				openGraphTitleEnabled, openGraphTitleMap, serviceContext);
 		}
 
 		layoutSEOEntry.setModifiedDate(DateUtil.newDate());
@@ -169,10 +169,10 @@ public class LayoutSEOEntryLocalServiceImpl
 
 		if (layoutSEOEntry == null) {
 			return _addLayoutSEOEntry(
-				userId, groupId, privateLayout, layoutId, canonicalURLEnabled,
-				canonicalURLMap, false, Collections.emptyMap(),
-				Collections.emptyMap(), 0, false, Collections.emptyMap(),
-				serviceContext);
+				userId, groupId, privateLayout, layoutId, 0,
+				canonicalURLEnabled, canonicalURLMap, false,
+				Collections.emptyMap(), Collections.emptyMap(), 0, false,
+				Collections.emptyMap(), serviceContext);
 		}
 
 		layoutSEOEntry.setModifiedDate(DateUtil.newDate());
@@ -184,7 +184,8 @@ public class LayoutSEOEntryLocalServiceImpl
 
 	private LayoutSEOEntry _addLayoutSEOEntry(
 			long userId, long groupId, boolean privateLayout, long layoutId,
-			boolean canonicalURLEnabled, Map<Locale, String> canonicalURLMap,
+			long parentDDMStorageId, boolean canonicalURLEnabled,
+			Map<Locale, String> canonicalURLMap,
 			boolean openGraphDescriptionEnabled,
 			Map<Locale, String> openGraphDescriptionMap,
 			Map<Locale, String> openGraphImageAltMap,
@@ -220,7 +221,7 @@ public class LayoutSEOEntryLocalServiceImpl
 
 		long ddmStorageId = _updateDDMStorage(
 			layoutSEOEntry.getCompanyId(), layoutSEOEntry.getDDMStorageId(),
-			ddmStructure.getStructureId(), serviceContext);
+			ddmStructure.getStructureId(), parentDDMStorageId, serviceContext);
 
 		layoutSEOEntry.setDDMStorageId(ddmStorageId);
 
@@ -240,11 +241,19 @@ public class LayoutSEOEntryLocalServiceImpl
 	}
 
 	private DDMFormValues _getDDMFormValues(
-			long structureId, ServiceContext serviceContext)
+			long structureId, long parentDDMStorageId,
+			ServiceContext serviceContext)
 		throws PortalException {
 
-		DDMFormValues ddmFormValues = _ddm.getDDMFormValues(
-			structureId, String.valueOf(structureId), serviceContext);
+		DDMFormValues ddmFormValues = null;
+
+		if (parentDDMStorageId != 0) {
+			ddmFormValues = _storageEngine.getDDMFormValues(parentDDMStorageId);
+		}
+		else {
+			ddmFormValues = _ddm.getDDMFormValues(
+				structureId, String.valueOf(structureId), serviceContext);
+		}
 
 		Set<Locale> availableLocales = new HashSet<>();
 		Set<DDMFormFieldValue> ddmFormFieldValues = new LinkedHashSet<>();
@@ -304,13 +313,14 @@ public class LayoutSEOEntryLocalServiceImpl
 			"custom-meta-tags");
 	}
 
+
 	private long _updateDDMStorage(
 			long companyId, long ddmStorageId, long structureId,
-			ServiceContext serviceContext)
+			long parentDDMStorageId, ServiceContext serviceContext)
 		throws PortalException {
 
 		DDMFormValues ddmFormValues = _getDDMFormValues(
-			structureId, serviceContext);
+			structureId, parentDDMStorageId, serviceContext);
 
 		if (ListUtil.isEmpty(ddmFormValues.getDDMFormFieldValues())) {
 			if (ddmStorageId != 0) {

--- a/modules/apps/layout/layout-seo-service/src/main/java/com/liferay/layout/seo/service/impl/LayoutSEOEntryServiceImpl.java
+++ b/modules/apps/layout/layout-seo-service/src/main/java/com/liferay/layout/seo/service/impl/LayoutSEOEntryServiceImpl.java
@@ -100,4 +100,31 @@ public class LayoutSEOEntryServiceImpl extends LayoutSEOEntryServiceBaseImpl {
 			enabledCanonicalURLMap, canonicalURLMap, serviceContext);
 	}
 
+	@Override
+	public LayoutSEOEntry updateLayoutSEOEntry(
+			long groupId, boolean privateLayout, long layoutId,
+			long parentDDMStructureId, boolean canonicalURLEnabled,
+			Map<Locale, String> canonicalURLMap,
+			boolean openGraphDescriptionEnabled,
+			Map<Locale, String> openGraphDescriptionMap,
+			Map<Locale, String> openGraphImageAltMap,
+			long openGraphImageFileEntryId, boolean openGraphTitleEnabled,
+			Map<Locale, String> openGraphTitleMap,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		Layout layout = layoutLocalService.getLayout(
+			groupId, privateLayout, layoutId);
+
+		LayoutPermissionUtil.check(
+			getPermissionChecker(), layout, ActionKeys.UPDATE);
+
+		return layoutSEOEntryLocalService.updateLayoutSEOEntry(
+			getUserId(), groupId, privateLayout, layoutId, parentDDMStructureId,
+			canonicalURLEnabled, canonicalURLMap, openGraphDescriptionEnabled,
+			openGraphDescriptionMap, openGraphImageAltMap,
+			openGraphImageFileEntryId, openGraphTitleEnabled, openGraphTitleMap,
+			serviceContext);
+	}
+
 }


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-137263

Resend of https://github.com/liferay-lima/liferay-portal/pull/2238 with a fix to `LayoutSEOEntryServiceImpl.java`.

* **old**: https://github.com/liferay-lima/liferay-portal/pull/2238/commits/911ed37cc2ceecb73ba74d82bf5654434c48b93d#diff-d0411f60dd631545df3e949b4b9a3b04764a050ee1806e5dcfe825ca79874160
* **new**: https://github.com/liferay-lima/liferay-portal/pull/2241/commits/6f4ad530d06c97b02bf5bd249e5e6cb15a592858#diff-d0411f60dd631545df3e949b4b9a3b04764a050ee1806e5dcfe825ca79874160

## Notes from the TSE

From @thuycao-gs:

> It resolved the issue for cases.
>
> * Custom meta tags are saved after copying the page.
> * Custom meta tags are saved after copying the page and publish the page.
> * Update the custom meta tags on the child page and do not affect the parent page and vice versa.

## Additional notes

In theory, the pattern in LayoutCopyHelperImpl is repeated in the staging code.

* [LayoutCopyHelperImpl.java#L807](https://github.com/holatuwol/liferay-portal/blob/LPS-137263/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/util/LayoutCopyHelperImpl.java#L807)
* [LayoutSEOEntryStagedModelDataHandler.java#L178](https://github.com/holatuwol/liferay-portal/blob/LPS-137263/modules/apps/layout/layout-seo-service/src/main/java/com/liferay/layout/seo/internal/exportimport/data/handler/LayoutSEOEntryStagedModelDataHandler.java#L178)

However, the issue isn't reproducible with staging, just with copied pages. Therefore, the new method only needs to be called from the copied pages code.