### PR TITLE
[TS] LPS-138585 

### DIFF
--- a/modules/apps/item-selector/item-selector-impl/src/main/java/com/liferay/item/selector/internal/provider/GroupItemSelectorProviderImpl.java
+++ b/modules/apps/item-selector/item-selector-impl/src/main/java/com/liferay/item/selector/internal/provider/GroupItemSelectorProviderImpl.java
@@ -90,6 +90,8 @@ public class GroupItemSelectorProviderImpl
 		return _groupService.searchCount(
 			companyId, _classNameIds, keywords,
 			LinkedHashMapBuilder.<String, Object>put(
+				"actionId", ActionKeys.VIEW
+			).put(
 				"site", Boolean.TRUE
 			).build());
 	}


### PR DESCRIPTION
Hi Team,

**Description**
If a non admin user wants to select images from documents and media, the pagination is shown wrong as it counts the private/restricted sites as well where the user does not have membership. Although the user does not see or has access to these sites.

**Expected Result:**
The pagination will show the number of pages where the user has access

**Actual Result:**
The pagination is shown wrong as it counts the private/restricted sites as well where the user does not have membership. Although the user does not see or has access to these sites.

**Solution**
Adding actionId ActionKeys.VIEW parameter to the groupParams will filter the groups

Thanks, Roland

https://issues.liferay.com/browse/LPS-138585
