### PR TITLE
LPS-138708 reverting the previous changes of the LPS-138409 and escaping HTMl only of the sharing body notification

### DIFF
--- a/modules/apps/notifications/notifications-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/notifications/notifications-web/src/main/resources/META-INF/resources/init.jsp
@@ -48,7 +48,6 @@ page import="com.liferay.portal.kernel.service.UserNotificationDeliveryLocalServ
 page import="com.liferay.portal.kernel.service.UserNotificationEventLocalServiceUtil" %><%@
 page import="com.liferay.portal.kernel.util.FastDateFormatFactoryUtil" %><%@
 page import="com.liferay.portal.kernel.util.HashMapBuilder" %><%@
-page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
 page import="com.liferay.portal.kernel.util.ParamUtil" %><%@
 page import="com.liferay.portal.kernel.util.PortalUtil" %><%@
 page import="com.liferay.portal.kernel.util.StringUtil" %><%@

--- a/modules/apps/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/user_notification_entry.jspf
+++ b/modules/apps/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/user_notification_entry.jspf
@@ -82,7 +82,7 @@ if (notificationUnread) {
 						<h4>
 					</c:if>
 						<a data-senna-off="true" href="<%= markNotificationAsReadURL.toString() %>">
-							<%= HtmlUtil.escape(userNotificationFeedEntry.getBody()) %>
+							<%= userNotificationFeedEntry.getBody() %>
 						</a>
 					<c:if test="<%= notificationUnread %>">
 						</h4>

--- a/modules/apps/sharing/sharing-notifications/src/main/java/com/liferay/sharing/notifications/internal/notifications/SharingUserNotificationHandler.java
+++ b/modules/apps/sharing/sharing-notifications/src/main/java/com/liferay/sharing/notifications/internal/notifications/SharingUserNotificationHandler.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserNotificationEventLocalService;
 import com.liferay.portal.kernel.trash.TrashHandler;
 import com.liferay.portal.kernel.trash.TrashHandlerRegistryUtil;
+import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.sharing.constants.SharingPortletKeys;
 import com.liferay.sharing.model.SharingEntry;
@@ -88,7 +89,7 @@ public class SharingUserNotificationHandler
 				userNotificationEvent);
 		}
 
-		return message;
+		return HtmlUtil.escape(message);
 	}
 
 	private boolean _isInTrash(String className, long classPK)


### PR DESCRIPTION
- Revert "LPS-138409 escape message body to prevent XSS on all the assets"
- LPS-138708 add the html escape only to the creation of the body of the sharing notification to prevent the html on the others notifications. This solves too the LPS-138409


![image](https://user-images.githubusercontent.com/47524751/132189192-208ec901-492a-4bf6-a8ab-783d72a5f4c7.png)
