### PR TITLE
LPS-139069 Filter Global site by ActionKeys.VIEW actionId

### DIFF
--- a/modules/apps/item-selector/item-selector-impl/src/main/java/com/liferay/item/selector/internal/provider/GroupItemSelectorProviderImpl.java
+++ b/modules/apps/item-selector/item-selector-impl/src/main/java/com/liferay/item/selector/internal/provider/GroupItemSelectorProviderImpl.java
@@ -69,6 +69,8 @@ public class GroupItemSelectorProviderImpl
 
 		LinkedHashMap<String, Object> groupParams =
 			LinkedHashMapBuilder.<String, Object>put(
+				"actionId", ActionKeys.VIEW
+			).put(
 				"site", Boolean.TRUE
 			).build();
 


### PR DESCRIPTION
Hi Team,

could you pleae review my fix?

**Description**
If a non admin user wants to select images from documents and media, the Global site is visible as well where the user does not have membership. Although the user does not see or has access to this site.

**Expected Result:**
The Global site is not visible and the pagination will show the number of pages where the user has access

**Actual Result:**
 The Global site is visible, although the user does not see or has access to this site.

Thanks, Roland

https://issues.liferay.com/browse/LPS-139069