### PR TITLE
LPS-139069 Count global group on getGroupsCount and add isCompany check to the _filterGroups

### DIFF
--- a/modules/apps/item-selector/item-selector-impl/src/main/java/com/liferay/item/selector/internal/provider/GroupItemSelectorProviderImpl.java
+++ b/modules/apps/item-selector/item-selector-impl/src/main/java/com/liferay/item/selector/internal/provider/GroupItemSelectorProviderImpl.java
@@ -130,6 +130,7 @@ public class GroupItemSelectorProviderImpl
 
 		for (Group group : groups) {
 			if (group.isCompany() ||
+				permissionChecker.isGroupAdmin(group.getGroupId()) ||
 				GroupPermissionUtil.contains(
 					permissionChecker, group, ActionKeys.VIEW)) {
 

--- a/modules/apps/item-selector/item-selector-impl/src/main/java/com/liferay/item/selector/internal/provider/GroupItemSelectorProviderImpl.java
+++ b/modules/apps/item-selector/item-selector-impl/src/main/java/com/liferay/item/selector/internal/provider/GroupItemSelectorProviderImpl.java
@@ -90,6 +90,8 @@ public class GroupItemSelectorProviderImpl
 		return _groupService.searchCount(
 			companyId, _classNameIds, keywords,
 			LinkedHashMapBuilder.<String, Object>put(
+				"actionId", ActionKeys.VIEW
+			).put(
 				"site", Boolean.TRUE
 			).build());
 	}
@@ -128,7 +130,6 @@ public class GroupItemSelectorProviderImpl
 
 		for (Group group : groups) {
 			if (group.isCompany() ||
-				permissionChecker.isGroupAdmin(group.getGroupId()) ||
 				GroupPermissionUtil.contains(
 					permissionChecker, group, ActionKeys.VIEW)) {
 

--- a/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
@@ -5202,7 +5202,8 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 
 		for (Group group : groups) {
 			try {
-				if (permissionChecker.isGroupAdmin(group.getGroupId()) ||
+				if (group.isCompany() ||
+					permissionChecker.isGroupAdmin(group.getGroupId()) ||
 					GroupPermissionUtil.contains(
 						permissionChecker, group.getGroupId(), actionId)) {
 

--- a/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
@@ -5202,8 +5202,7 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 
 		for (Group group : groups) {
 			try {
-				if (group.isCompany() ||
-					permissionChecker.isGroupAdmin(group.getGroupId()) ||
+				if (permissionChecker.isGroupAdmin(group.getGroupId()) ||
 					GroupPermissionUtil.contains(
 						permissionChecker, group.getGroupId(), actionId)) {
 


### PR DESCRIPTION
Hi Team,

could you pleae review my fix?

Description
If a non admin user wants to select images from documents and media, the Global site is visible but the pagination total shows one less

Expected Result:

The pagination will show the number of pages where the user has access - including the Global site

Actual Result:

The Global site is visible, but it does not counts at the pagination total

Thanks, Roland

https://issues.liferay.com/browse/LPS-139069