### PR TITLE
[TS] LPS-139790 | Error when selecting a new root folder if current one is in trash

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminDisplayContext.java
@@ -48,6 +48,7 @@ import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.PortalPreferences;
 import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
+import com.liferay.portal.kernel.repository.capabilities.TrashCapability;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.repository.model.RepositoryEntry;
@@ -322,6 +323,10 @@ public class DLAdminDisplayContext {
 		return _versioningStrategy.isOverridable();
 	}
 
+	public boolean rootFolderInTrash() {
+		return _rootFolderInTrash;
+	}
+
 	private void _computeFolders() {
 		try {
 			_computeRootFolder();
@@ -381,6 +386,11 @@ public class DLAdminDisplayContext {
 				_rootFolderId = DLFolderConstants.DEFAULT_PARENT_FOLDER_ID;
 				_rootFolderName = StringPool.BLANK;
 			}
+
+			TrashCapability trashCapability =
+				rootFolder.getRepositoryCapability(TrashCapability.class);
+
+			_rootFolderInTrash = trashCapability.isInTrash(rootFolder);
 		}
 		catch (NoSuchFolderException noSuchFolderException) {
 			_rootFolderId = DLFolderConstants.DEFAULT_PARENT_FOLDER_ID;
@@ -794,6 +804,7 @@ public class DLAdminDisplayContext {
 	private final PortalPreferences _portalPreferences;
 	private Long _repositoryId;
 	private long _rootFolderId;
+	private boolean _rootFolderInTrash;
 	private String _rootFolderName;
 	private SearchContainer<RepositoryEntry> _searchContainer;
 	private final ThemeDisplay _themeDisplay;

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/configuration.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/configuration.jsp
@@ -92,6 +92,12 @@ DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper = new DLPortletI
 				<div class="form-group">
 					<aui:input label="root-folder" name="rootFolderName" type="resource" value="<%= dlAdminDisplayContext.getRootFolderName() %>" />
 
+					<c:if test="<%= dlAdminDisplayContext.rootFolderInTrash() %>">
+						<div class="alert alert-warning">
+							<liferay-ui:message key="the-selected-root-folder-is-in-the-recycle-bin-please-remove-it-or-select-another-one" />
+						</div>
+					</c:if>
+
 					<aui:button name="selectFolderButton" value="select" />
 
 					<%

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/configuration.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/configuration.jsp
@@ -157,7 +157,7 @@ DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper = new DLPortletI
 
 							<liferay-portlet:renderURL portletName="<%= dlRequestHelper.getPortletResource() %>" var="selectFolderURL" windowState="<%= LiferayWindowState.POP_UP.toString() %>">
 								<portlet:param name="mvcRenderCommandName" value="/document_library/select_folder" />
-								<portlet:param name="folderId" value="<%= String.valueOf(dlAdminDisplayContext.getRootFolderId()) %>" />
+								<portlet:param name="folderId" value="<%= dlAdminDisplayContext.rootFolderInTrash() ? String.valueOf(DLFolderConstants.DEFAULT_PARENT_FOLDER_ID) : String.valueOf(dlAdminDisplayContext.getRootFolderId()) %>" />
 								<portlet:param name="ignoreRootFolder" value="<%= Boolean.TRUE.toString() %>" />
 								<portlet:param name="showMountFolder" value="<%= Boolean.FALSE.toString() %>" />
 							</liferay-portlet:renderURL>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/image_gallery_display/configuration.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/image_gallery_display/configuration.jsp
@@ -78,6 +78,12 @@ DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper = new DLPortletI
 					<div class="form-group">
 						<aui:input label="root-folder" name="rootFolderName" type="resource" value="<%= rootFolderName %>" />
 
+						<c:if test="<%= rootFolderInTrash %>">
+							<div class="alert alert-warning">
+								<liferay-ui:message key="the-selected-root-folder-is-in-the-recycle-bin-please-remove-it-or-select-another-one" />
+							</div>
+						</c:if>
+
 						<aui:button name="openFolderSelectorButton" value="select" />
 
 						<%

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/image_gallery_display/configuration.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/image_gallery_display/configuration.jsp
@@ -124,7 +124,7 @@ DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper = new DLPortletI
 
 				<liferay-portlet:renderURL portletName="<%= igRequestHelper.getPortletResource() %>" var="selectFolderURL" windowState="<%= LiferayWindowState.POP_UP.toString() %>">
 					<portlet:param name="mvcRenderCommandName" value="/document_library/select_folder" />
-					<portlet:param name="folderId" value="<%= String.valueOf(rootFolderId) %>" />
+					<portlet:param name="folderId" value="<%= rootFolderInTrash ? String.valueOf(DLFolderConstants.DEFAULT_PARENT_FOLDER_ID): String.valueOf(rootFolderId) %>" />
 					<portlet:param name="ignoreRootFolder" value="<%= Boolean.TRUE.toString() %>" />
 				</liferay-portlet:renderURL>
 

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/image_gallery_display/init.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/image_gallery_display/init.jsp
@@ -29,6 +29,8 @@ long rootFolderId = dlPortletInstanceSettings.getRootFolderId();
 
 String rootFolderName = StringPool.BLANK;
 
+boolean rootFolderInTrash = false;
+
 if (rootFolderId != DLFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
 	try {
 		Folder rootFolder = DLAppLocalServiceUtil.getFolder(rootFolderId);
@@ -39,6 +41,10 @@ if (rootFolderId != DLFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
 			rootFolderId = DLFolderConstants.DEFAULT_PARENT_FOLDER_ID;
 			rootFolderName = StringPool.BLANK;
 		}
+
+		TrashCapability trashCapability = rootFolder.getRepositoryCapability(TrashCapability.class);
+
+		rootFolderInTrash = trashCapability.isInTrash(rootFolder);
 	}
 	catch (NoSuchFolderException nsfe) {
 		rootFolderId = DLFolderConstants.DEFAULT_PARENT_FOLDER_ID;

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/init.jsp
@@ -167,6 +167,7 @@ page import="com.liferay.portal.kernel.portlet.PortletURLUtil" %><%@
 page import="com.liferay.portal.kernel.repository.AuthenticationRepositoryException" %><%@
 page import="com.liferay.portal.kernel.repository.RepositoryConfiguration" %><%@
 page import="com.liferay.portal.kernel.repository.RepositoryException" %><%@
+page import="com.liferay.portal.kernel.repository.capabilities.TrashCapability" %><%@
 page import="com.liferay.portal.kernel.repository.model.FileEntry" %><%@
 page import="com.liferay.portal.kernel.repository.model.FileShortcut" %><%@
 page import="com.liferay.portal.kernel.repository.model.FileVersion" %><%@

--- a/portal-impl/src/content/Language.properties
+++ b/portal-impl/src/content/Language.properties
@@ -5041,6 +5041,7 @@ the-selected-entry-has-been-deleted=The selected entry has been deleted.
 the-selected-license-is-used-by-at-least-one-product=The selected license is used by at least one product.
 the-selected-list-no-longer-exists=The selected list no longer exists.
 the-selected-role-cannot-be-deleted-because-it-is-a-required-system-role=The selected role cannot be deleted because it is a required system role.
+the-selected-root-folder-is-in-the-recycle-bin-please-remove-it-or-select-another-one=The selected Root Folder is in the Recycle Bin. Please remove it or select another one.
 the-selected-web-content-no-longer-exists=The selected web content no longer exists.
 the-sign-in-process-is-temporarily-disabled-because-the-portal-is-undergoing-a-routine-maintenance-upgrade=The sign in process is temporarily disabled because the portal is undergoing a routine maintenance upgrade. The sign in process will be reenabled once the upgrade process is complete. Thank you for your patience.
 the-signature-below-will-be-added-to-each-outgoing-message=The signature below will be added to each outgoing message.

--- a/portal-impl/src/content/Language_ar.properties
+++ b/portal-impl/src/content/Language_ar.properties
@@ -5035,6 +5035,7 @@ the-selected-entry-has-been-deleted=.تم حذف المدخلات المختار
 the-selected-license-is-used-by-at-least-one-product=يتم استخدام الترخيص المحدد من قبل منتج واحد على الأقل.
 the-selected-list-no-longer-exists=القائمة التي تم اختيارها لم تعد موجودة.
 the-selected-role-cannot-be-deleted-because-it-is-a-required-system-role=لا يمكن حذف الدور المختار كونه مطلوب تابع للنظام.
+the-selected-root-folder-is-in-the-recycle-bin-please-remove-it-or-select-another-one=The selected Root Folder is in the Recycle Bin. Please remove it or select another one. (Automatic Copy)
 the-selected-web-content-no-longer-exists=محتوى الويب الذي تم اختياره لم يعد موجودا.
 the-sign-in-process-is-temporarily-disabled-because-the-portal-is-undergoing-a-routine-maintenance-upgrade=عملية تسجيل الدخول معطلة مؤقتا للقيام بالصيانة التحديثية الدورية للبوابة. سيتم إعادة تفعيل عملية تسجيل الدخول عند الإنتهاء من التحديث. نشكر لكم تفهمكم.
 the-signature-below-will-be-added-to-each-outgoing-message=سيتم إضافة التوقيع التالي على كل رسالة صادرة.

--- a/portal-impl/src/content/Language_bg.properties
+++ b/portal-impl/src/content/Language_bg.properties
@@ -5035,6 +5035,7 @@ the-selected-entry-has-been-deleted=The Избраните записи са и�
 the-selected-license-is-used-by-at-least-one-product=Избраният лиценз се използва от поне един продукт. (Automatic Translation)
 the-selected-list-no-longer-exists=Избраният списък вече не съществува. (Automatic Translation)
 the-selected-role-cannot-be-deleted-because-it-is-a-required-system-role=Избраната роля не може да бъде изтрита защото е задължителна системна роля.
+the-selected-root-folder-is-in-the-recycle-bin-please-remove-it-or-select-another-one=The selected Root Folder is in the Recycle Bin. Please remove it or select another one. (Automatic Copy)
 the-selected-web-content-no-longer-exists=Избраното уеб съдържание вече не съществува. (Automatic Translation)
 the-sign-in-process-is-temporarily-disabled-because-the-portal-is-undergoing-a-routine-maintenance-upgrade=Процесът на влизане е временно забранен, защото порталът е в процес на рутинна поддръжка надстройка. Процесът на влизане ще бъде отново достъпен след завършване на процеса на надстройване. Благодаря ви за търпението. (Automatic Translation)
 the-signature-below-will-be-added-to-each-outgoing-message=Подписът по-долу ще бъде добавен към всяко изходящо съобщение.

--- a/portal-impl/src/content/Language_ca.properties
+++ b/portal-impl/src/content/Language_ca.properties
@@ -5037,6 +5037,7 @@ the-selected-entry-has-been-deleted=S'ha esborrat l'entrada que heu seleccionat.
 the-selected-license-is-used-by-at-least-one-product=La llicència seleccionada és utilitzada per almenys un producte.
 the-selected-list-no-longer-exists=La llista seleccionada ja no existeix.
 the-selected-role-cannot-be-deleted-because-it-is-a-required-system-role=No es pot eliminar el rol que heu seleccionat perquè és un rol obligatòria del sistema.
+the-selected-root-folder-is-in-the-recycle-bin-please-remove-it-or-select-another-one=The selected Root Folder is in the Recycle Bin. Please remove it or select another one. (Automatic Copy)
 the-selected-web-content-no-longer-exists=Ja no existeix el contingut web seleccionat.
 the-sign-in-process-is-temporarily-disabled-because-the-portal-is-undergoing-a-routine-maintenance-upgrade=L'inici de sessió s'ha desactivat temporalment perquè el portal està experimentant una actualització rutinària de manteniment. L'inici de sessió es tornarà a habilitar un cop l'actualització s'hagi completat. Gràcies per la seva paciència.
 the-signature-below-will-be-added-to-each-outgoing-message=La signatura següent s'afegirà a cada missatge de sortida.

--- a/portal-impl/src/content/Language_cs.properties
+++ b/portal-impl/src/content/Language_cs.properties
@@ -5035,6 +5035,7 @@ the-selected-entry-has-been-deleted=Vybraný příspěvek byl smazán.
 the-selected-license-is-used-by-at-least-one-product=Zvolená licence je využívána alespoň jedním produktem.
 the-selected-list-no-longer-exists=Zvolený seznam již neexistuje.
 the-selected-role-cannot-be-deleted-because-it-is-a-required-system-role=Zvolená role nemůže být smazána, protože jde o nezbytnou systémovou roli.
+the-selected-root-folder-is-in-the-recycle-bin-please-remove-it-or-select-another-one=The selected Root Folder is in the Recycle Bin. Please remove it or select another one. (Automatic Copy)
 the-selected-web-content-no-longer-exists=Zvolený webový obsah již neexistuje.
 the-sign-in-process-is-temporarily-disabled-because-the-portal-is-undergoing-a-routine-maintenance-upgrade=Přihlašování je dočasně nedostupné, protože se provádí aktualizace. Po dokončení všech nezbytných operací bude opět možné se přihlásit. Děkujeme za pochopení.
 the-signature-below-will-be-added-to-each-outgoing-message=Následující podpis bude přidán do každé odchozí zprávy.

--- a/portal-impl/src/content/Language_da.properties
+++ b/portal-impl/src/content/Language_da.properties
@@ -5035,6 +5035,7 @@ the-selected-entry-has-been-deleted=The selected entry has been deleted. (Automa
 the-selected-license-is-used-by-at-least-one-product=The selected license is used by at least one product. (Automatic Copy)
 the-selected-list-no-longer-exists=The selected list no longer exists. (Automatic Copy)
 the-selected-role-cannot-be-deleted-because-it-is-a-required-system-role=The selected role cannot be deleted because it is a required system role. (Automatic Copy)
+the-selected-root-folder-is-in-the-recycle-bin-please-remove-it-or-select-another-one=The selected Root Folder is in the Recycle Bin. Please remove it or select another one. (Automatic Copy)
 the-selected-web-content-no-longer-exists=The selected web content no longer exists. (Automatic Copy)
 the-sign-in-process-is-temporarily-disabled-because-the-portal-is-undergoing-a-routine-maintenance-upgrade=The sign in process is temporarily disabled because the portal is undergoing a routine maintenance upgrade. The sign in process will be reenabled once the upgrade process is complete. Thank you for your patience. (Automatic Copy)
 the-signature-below-will-be-added-to-each-outgoing-message=The signature below will be added to each outgoing message. (Automatic Copy)

--- a/portal-impl/src/content/Language_de.properties
+++ b/portal-impl/src/content/Language_de.properties
@@ -5037,6 +5037,7 @@ the-selected-entry-has-been-deleted=Der gewählte Eintrag wurde gelöscht.
 the-selected-license-is-used-by-at-least-one-product=Die gewählte Lizenz wird von mindestens einem Produkt verwendet.
 the-selected-list-no-longer-exists=Die ausgewählte Liste gibt es nicht mehr.
 the-selected-role-cannot-be-deleted-because-it-is-a-required-system-role=Die ausgewählte Rolle konnte nicht gelöscht werden, da sie eine erforderliche Systemrolle ist.
+the-selected-root-folder-is-in-the-recycle-bin-please-remove-it-or-select-another-one=The selected Root Folder is in the Recycle Bin. Please remove it or select another one. (Automatic Copy)
 the-selected-web-content-no-longer-exists=Der ausgewählte Webcontent existiert nicht mehr.
 the-sign-in-process-is-temporarily-disabled-because-the-portal-is-undergoing-a-routine-maintenance-upgrade=Der Anmeldeprozess ist temporär deaktiviert, weil am Portal Wartungsarbeiten stattfinden. Der Anmeldeprozess wird wieder verfügbar sein, wenn dieser Vorgang abgeschlossen ist. Vielen Dank für Ihre Geduld.
 the-signature-below-will-be-added-to-each-outgoing-message=Die unten stehende Signatur wird an jede ausgehende Nachricht angehängt.

--- a/portal-impl/src/content/Language_el.properties
+++ b/portal-impl/src/content/Language_el.properties
@@ -5035,6 +5035,7 @@ the-selected-entry-has-been-deleted=Η επιλεγμένη καταχώρηση
 the-selected-license-is-used-by-at-least-one-product=Η επιλεγμένη άδεια χρησιμοποιείται από τουλάχιστον ένα προϊόν.
 the-selected-list-no-longer-exists=Ο επιλεγμένος κατάλογος δεν υπάρχει πλέον.
 the-selected-role-cannot-be-deleted-because-it-is-a-required-system-role=Ο επιλεγμένος ρόλος δεν μπορεί να διαγραφεί διότι είναι ένας απαιτούμενος ρόλος του συστήματος.
+the-selected-root-folder-is-in-the-recycle-bin-please-remove-it-or-select-another-one=The selected Root Folder is in the Recycle Bin. Please remove it or select another one. (Automatic Copy)
 the-selected-web-content-no-longer-exists=Το επιλεγμένο περιεχόμενο Web δεν υπάρχει πλέον.
 the-sign-in-process-is-temporarily-disabled-because-the-portal-is-undergoing-a-routine-maintenance-upgrade=Η δυνατότητα σύνδεσης είναι προσωρινά απενεργοποιημένη επειδή το portal είναι σε κατάσταση αναβάθμισης στο πλαίσιο τυπικής συντήρησης. Η δυνατότητα σύνδεσης θα επενενεργοποιηθεί μόλις τελειώσει η αναβάθμιση. Ευχαριστούμε για την κατανόησή σας.
 the-signature-below-will-be-added-to-each-outgoing-message=Η παρακάτω υπογραφή θα προστίθεται σε κάθε εξερχόμενο μήνυμα.

--- a/portal-impl/src/content/Language_en.properties
+++ b/portal-impl/src/content/Language_en.properties
@@ -5041,6 +5041,7 @@ the-selected-entry-has-been-deleted=The selected entry has been deleted.
 the-selected-license-is-used-by-at-least-one-product=The selected license is used by at least one product.
 the-selected-list-no-longer-exists=The selected list no longer exists.
 the-selected-role-cannot-be-deleted-because-it-is-a-required-system-role=The selected role cannot be deleted because it is a required system role.
+the-selected-root-folder-is-in-the-recycle-bin-please-remove-it-or-select-another-one=The selected Root Folder is in the Recycle Bin. Please remove it or select another one.
 the-selected-web-content-no-longer-exists=The selected web content no longer exists.
 the-sign-in-process-is-temporarily-disabled-because-the-portal-is-undergoing-a-routine-maintenance-upgrade=The sign in process is temporarily disabled because the portal is undergoing a routine maintenance upgrade. The sign in process will be reenabled once the upgrade process is complete. Thank you for your patience.
 the-signature-below-will-be-added-to-each-outgoing-message=The signature below will be added to each outgoing message.

--- a/portal-impl/src/content/Language_en_AU.properties
+++ b/portal-impl/src/content/Language_en_AU.properties
@@ -5035,6 +5035,7 @@ the-selected-entry-has-been-deleted=The selected entry has been deleted. (Automa
 the-selected-license-is-used-by-at-least-one-product=The selected license is used by at least one product. (Automatic Copy)
 the-selected-list-no-longer-exists=The selected list no longer exists. (Automatic Copy)
 the-selected-role-cannot-be-deleted-because-it-is-a-required-system-role=The selected role cannot be deleted because it is a required system role. (Automatic Copy)
+the-selected-root-folder-is-in-the-recycle-bin-please-remove-it-or-select-another-one=The selected Root Folder is in the Recycle Bin. Please remove it or select another one. (Automatic Copy)
 the-selected-web-content-no-longer-exists=The selected web content no longer exists. (Automatic Copy)
 the-sign-in-process-is-temporarily-disabled-because-the-portal-is-undergoing-a-routine-maintenance-upgrade=The sign in process is temporarily disabled because the portal is undergoing a routine maintenance upgrade. The sign in process will be reenabled once the upgrade process is complete. Thank you for your patience. (Automatic Copy)
 the-signature-below-will-be-added-to-each-outgoing-message=The signature below will be added to each outgoing message. (Automatic Copy)

--- a/portal-impl/src/content/Language_en_GB.properties
+++ b/portal-impl/src/content/Language_en_GB.properties
@@ -5035,6 +5035,7 @@ the-selected-entry-has-been-deleted=The selected entry has been deleted. (Automa
 the-selected-license-is-used-by-at-least-one-product=The selected license is used by at least one product. (Automatic Copy)
 the-selected-list-no-longer-exists=The selected list no longer exists. (Automatic Copy)
 the-selected-role-cannot-be-deleted-because-it-is-a-required-system-role=The selected role cannot be deleted because it is a required system role. (Automatic Copy)
+the-selected-root-folder-is-in-the-recycle-bin-please-remove-it-or-select-another-one=The selected Root Folder is in the Recycle Bin. Please remove it or select another one. (Automatic Copy)
 the-selected-web-content-no-longer-exists=The selected web content no longer exists. (Automatic Copy)
 the-sign-in-process-is-temporarily-disabled-because-the-portal-is-undergoing-a-routine-maintenance-upgrade=The sign in process is temporarily disabled because the portal is undergoing a routine maintenance upgrade. The sign in process will be reenabled once the upgrade process is complete. Thank you for your patience. (Automatic Copy)
 the-signature-below-will-be-added-to-each-outgoing-message=The signature below will be added to each outgoing message. (Automatic Copy)

--- a/portal-impl/src/content/Language_es.properties
+++ b/portal-impl/src/content/Language_es.properties
@@ -5037,6 +5037,7 @@ the-selected-entry-has-been-deleted=La entrada seleccionada ha sido eliminada.
 the-selected-license-is-used-by-at-least-one-product=La licencia seleccionada es utilizada por al menos un producto.
 the-selected-list-no-longer-exists=El contenido web seleccionado ya no existe.
 the-selected-role-cannot-be-deleted-because-it-is-a-required-system-role=El rol seleccionado no puede ser eliminado porque es un rol de sistema.
+the-selected-root-folder-is-in-the-recycle-bin-please-remove-it-or-select-another-one=La Carpeta raíz seleccionada está en la Papelera de reciclaje. Elimínela o seleccione una nueva.
 the-selected-web-content-no-longer-exists=El contenido web seleccionado ya no existe.
 the-sign-in-process-is-temporarily-disabled-because-the-portal-is-undergoing-a-routine-maintenance-upgrade=El portal no permite logarse temporalmente porque está bajo una rutina de actualizaciones de mantenimiento. El portal volverá a permitir logarse una vez termine el proceso de actualización. Gracias por tu paciencia.
 the-signature-below-will-be-added-to-each-outgoing-message=La firma mostrada abajo se añadirá a cada mensaje de salida.

--- a/portal-impl/src/content/Language_et.properties
+++ b/portal-impl/src/content/Language_et.properties
@@ -5035,6 +5035,7 @@ the-selected-entry-has-been-deleted=Valitud kirje on kustutatud.
 the-selected-license-is-used-by-at-least-one-product=Valitud litsentsi kasutab vähemalt üks toode. (Automatic Translation)
 the-selected-list-no-longer-exists=Valitud loendit pole enam olemas. (Automatic Translation)
 the-selected-role-cannot-be-deleted-because-it-is-a-required-system-role=Valitud rolli ei saa kustutada, kuna see on kohustuslik süsteemiroll.
+the-selected-root-folder-is-in-the-recycle-bin-please-remove-it-or-select-another-one=The selected Root Folder is in the Recycle Bin. Please remove it or select another one. (Automatic Copy)
 the-selected-web-content-no-longer-exists=Valitud veebisisu pole enam olemas. (Automatic Translation)
 the-sign-in-process-is-temporarily-disabled-because-the-portal-is-undergoing-a-routine-maintenance-upgrade=Sisselogimisprotsess on ajutiselt keelatud, kuna portaal on läbimas rutiinset hooldustäiendust. Kui versiooniuuendusprotsess on lõpule jõudnud, lubatakse sisselogimisprotsess uuesti. Tänan kannatlikkuse eest. (Automatic Translation)
 the-signature-below-will-be-added-to-each-outgoing-message=Allolev allkiri lisatakse kõigile väljaminevatele sõnumitele.

--- a/portal-impl/src/content/Language_eu.properties
+++ b/portal-impl/src/content/Language_eu.properties
@@ -5035,6 +5035,7 @@ the-selected-entry-has-been-deleted=Aukeratutako sarrera ezabatu da.
 the-selected-license-is-used-by-at-least-one-product=Aukeratutako lizentzia gutxienez produktu batetan erabilia da.
 the-selected-list-no-longer-exists=Hautatutako zerrenda jadanik ez da existitzen.
 the-selected-role-cannot-be-deleted-because-it-is-a-required-system-role=Aukeratutako rola ezin da ezabatu sistemaren beharrezko rola delako.
+the-selected-root-folder-is-in-the-recycle-bin-please-remove-it-or-select-another-one=The selected Root Folder is in the Recycle Bin. Please remove it or select another one. (Automatic Copy)
 the-selected-web-content-no-longer-exists=Aukeratutako web edukia jada ez da existitzen.
 the-sign-in-process-is-temporarily-disabled-because-the-portal-is-undergoing-a-routine-maintenance-upgrade=Saio hasiera prozesua momentuz desgaituta dago, portalaren ohiko mantentze lanak direla eta. Behin eguneratze lanak bukatuta, saio hasiera prozesua berriro martxan jarriko da. Mila esker zure pazientziagatik.
 the-signature-below-will-be-added-to-each-outgoing-message=Behean erakutsitako sinadura ateratzen den mezu bakoitzean gehituko da.

--- a/portal-impl/src/content/Language_fa.properties
+++ b/portal-impl/src/content/Language_fa.properties
@@ -5035,6 +5035,7 @@ the-selected-entry-has-been-deleted=پست انتخاب شده حذف شد
 the-selected-license-is-used-by-at-least-one-product=لیسانس اتتخاب شده حداقل توسط یک محصول استفاده می‌شود
 the-selected-list-no-longer-exists=فهرست انتخابی ووجود ندارد.
 the-selected-role-cannot-be-deleted-because-it-is-a-required-system-role=نقش انتخاب شده را نمی‌توان حذف کرد زیرا یک نقش سیستمی است
+the-selected-root-folder-is-in-the-recycle-bin-please-remove-it-or-select-another-one=The selected Root Folder is in the Recycle Bin. Please remove it or select another one. (Automatic Copy)
 the-selected-web-content-no-longer-exists=محتوای سایت انتخاب شده دیگر وجود ندارد.
 the-sign-in-process-is-temporarily-disabled-because-the-portal-is-undergoing-a-routine-maintenance-upgrade=ورود موقتا غیر فعال است زیرا پورتال در حال تعمیر و نگهداری است. پس از اتمام عملیات تعمیر ورود مجددا فعال می‌شود. از شکیبایی شما سپاسگذاریم.
 the-signature-below-will-be-added-to-each-outgoing-message=امضای پایین به هر پیام اضافه می‌شود

--- a/portal-impl/src/content/Language_fi.properties
+++ b/portal-impl/src/content/Language_fi.properties
@@ -5033,6 +5033,7 @@ the-selected-entry-has-been-deleted=Valitty merkintä on poistettu.
 the-selected-license-is-used-by-at-least-one-product=Valittua lisenssiä käyttää ainakin yksi tuote.
 the-selected-list-no-longer-exists=Valittulista ei ole enää olemassa.
 the-selected-role-cannot-be-deleted-because-it-is-a-required-system-role=Valittua roolia ei voida poistaa, sillä se on vaadittu systeemi rooli.
+the-selected-root-folder-is-in-the-recycle-bin-please-remove-it-or-select-another-one=The selected Root Folder is in the Recycle Bin. Please remove it or select another one. (Automatic Copy)
 the-selected-web-content-no-longer-exists=Valittu web-sisältö ei ole enää olemassa.
 the-sign-in-process-is-temporarily-disabled-because-the-portal-is-undergoing-a-routine-maintenance-upgrade=Sisäänkirjautumisprosessi on väliaikaisesti poistettu käytöstä, koska tekemässä huoltopäivitystä. Sisäänkirjautumisprosessi tullaan ottamaan käyttöön prosessin valmistuessa. Kiitos kärsivällisyydestä.
 the-signature-below-will-be-added-to-each-outgoing-message=Alla oleva allekirjoitus lisätään jokaiseen lähetevään sähköpostiin.

--- a/portal-impl/src/content/Language_fr.properties
+++ b/portal-impl/src/content/Language_fr.properties
@@ -5037,6 +5037,7 @@ the-selected-entry-has-been-deleted=L'entrée choisie a été supprimée.
 the-selected-license-is-used-by-at-least-one-product=La licence sélectionnée est utilisée par au moins un produit.
 the-selected-list-no-longer-exists=La liste sélectionnée n'existe plus.
 the-selected-role-cannot-be-deleted-because-it-is-a-required-system-role=Le rôle choisi ne peut pas être supprimé car c'est un rôle requis par le système.
+the-selected-root-folder-is-in-the-recycle-bin-please-remove-it-or-select-another-one=The selected Root Folder is in the Recycle Bin. Please remove it or select another one. (Automatic Copy)
 the-selected-web-content-no-longer-exists=Le contenu de Web choisi n'existe plus.
 the-sign-in-process-is-temporarily-disabled-because-the-portal-is-undergoing-a-routine-maintenance-upgrade=Le processus d'authentification est temporairement désactivé parce que le portail est en cours de maintenance. Le processus d'authentification sera réactivé une fois que la mise-à-jour sera complétée. Merci de votre patience.
 the-signature-below-will-be-added-to-each-outgoing-message=La signature ci-dessous sera ajoutée à chaque message envoyé.

--- a/portal-impl/src/content/Language_fr_CA.properties
+++ b/portal-impl/src/content/Language_fr_CA.properties
@@ -5035,6 +5035,7 @@ the-selected-entry-has-been-deleted=L'entrée choisie a été supprimée.
 the-selected-license-is-used-by-at-least-one-product=La licence sélectionnée est utilisée par au moins un produit.
 the-selected-list-no-longer-exists=La liste sélectionnée n'existe plus.
 the-selected-role-cannot-be-deleted-because-it-is-a-required-system-role=Le rôle choisi ne peut pas être supprimé car c'est un rôle requis par le système.
+the-selected-root-folder-is-in-the-recycle-bin-please-remove-it-or-select-another-one=The selected Root Folder is in the Recycle Bin. Please remove it or select another one. (Automatic Copy)
 the-selected-web-content-no-longer-exists=Le contenu de Web choisi n'existe plus.
 the-sign-in-process-is-temporarily-disabled-because-the-portal-is-undergoing-a-routine-maintenance-upgrade=Le processus d'authentification est temporairement désactivé parce que le portail est en cours de maintenance. Le processus d'authentification sera réactivé une fois que la mise-à-jour sera complétée. Merci de votre patience.
 the-signature-below-will-be-added-to-each-outgoing-message=La signature ci-dessous sera ajoutée à chaque message envoyé.

--- a/portal-impl/src/content/Language_gl.properties
+++ b/portal-impl/src/content/Language_gl.properties
@@ -5035,6 +5035,7 @@ the-selected-entry-has-been-deleted=A entrada seleccionada foi eliminada.
 the-selected-license-is-used-by-at-least-one-product=The selected license is used by at least one product. (Automatic Copy)
 the-selected-list-no-longer-exists=A lista seleccionada non existe.
 the-selected-role-cannot-be-deleted-because-it-is-a-required-system-role=O rol seleccionado non pode ser eliminado porque é un rol de sistema.
+the-selected-root-folder-is-in-the-recycle-bin-please-remove-it-or-select-another-one=The selected Root Folder is in the Recycle Bin. Please remove it or select another one. (Automatic Copy)
 the-selected-web-content-no-longer-exists=O contido web seleccionado non existirá máis.
 the-sign-in-process-is-temporarily-disabled-because-the-portal-is-undergoing-a-routine-maintenance-upgrade=O proceso de identificación esta temporalmente desactivado porque o portal está baixo un mantemento de actualización. O proceso de identificación estará activo en canto se termine o mantemento. Grazas pola túa paciencia.
 the-signature-below-will-be-added-to-each-outgoing-message=A firma mostrada abaixo engadirase a cada mensaxe de saída.

--- a/portal-impl/src/content/Language_hi_IN.properties
+++ b/portal-impl/src/content/Language_hi_IN.properties
@@ -5035,6 +5035,7 @@ the-selected-entry-has-been-deleted=Selected entry delete कर दी गय�
 the-selected-license-is-used-by-at-least-one-product=चयनित लाइसेंस का उपयोग कम से कम एक उत्पाद द्वारा किया जाता है। (Automatic Translation)
 the-selected-list-no-longer-exists=चयनित सूची अब मौजूद नहीं है। (Automatic Translation)
 the-selected-role-cannot-be-deleted-because-it-is-a-required-system-role=Selected रोल delete नही हो सकता क्योकि System रोल की आवश्यकता है|
+the-selected-root-folder-is-in-the-recycle-bin-please-remove-it-or-select-another-one=The selected Root Folder is in the Recycle Bin. Please remove it or select another one. (Automatic Copy)
 the-selected-web-content-no-longer-exists=चयनित वेब सामग्री अब मौजूद नहीं है। (Automatic Translation)
 the-sign-in-process-is-temporarily-disabled-because-the-portal-is-undergoing-a-routine-maintenance-upgrade=प्रक्रिया में साइन अस्थायी रूप से अक्षम है क्योंकि पोर्टल एक नियमित रखरखाव उन्नयन के दौर से गुजर रहा है। अपग्रेड प्रक्रिया पूरी होने के बाद साइन इन प्रोसेस को रीटेबल किया जाएगा । आपके धैर्य के लिए धन्यवाद। (Automatic Translation)
 the-signature-below-will-be-added-to-each-outgoing-message=नीचे दिए गए हस्ताक्षर प्रत्येक आउटगोइंग संदेश में जोड़े जाएंगे। (Automatic Translation)

--- a/portal-impl/src/content/Language_hr.properties
+++ b/portal-impl/src/content/Language_hr.properties
@@ -5035,6 +5035,7 @@ the-selected-entry-has-been-deleted=Odabrani unos je obrisan.
 the-selected-license-is-used-by-at-least-one-product=The selected license is used by at least one product. (Automatic Copy)
 the-selected-list-no-longer-exists=Odabranog popisa više ne postoji.
 the-selected-role-cannot-be-deleted-because-it-is-a-required-system-role=Odabrane uloga se ne može izbrisati jer je to zahtjevana sistemska uloga.
+the-selected-root-folder-is-in-the-recycle-bin-please-remove-it-or-select-another-one=The selected Root Folder is in the Recycle Bin. Please remove it or select another one. (Automatic Copy)
 the-selected-web-content-no-longer-exists=Odabranih web sadržaja više ne postoji.
 the-sign-in-process-is-temporarily-disabled-because-the-portal-is-undergoing-a-routine-maintenance-upgrade=Prijava je privremeno onemogućena zbog postupka nadogradnje portala koji je u tijeku. Prijava će biti moguća nakon postupka nadogradnje. Hvala na strpljenju.
 the-signature-below-will-be-added-to-each-outgoing-message=Donji potpis će se dodati svakoj izlaznoj poruci.

--- a/portal-impl/src/content/Language_hu.properties
+++ b/portal-impl/src/content/Language_hu.properties
@@ -5038,6 +5038,7 @@ the-selected-entry-has-been-deleted=A kijelölt tétel törölve.
 the-selected-license-is-used-by-at-least-one-product=A választott licenc már használva van legalább egy termékhez.
 the-selected-list-no-longer-exists=A kijelölt lista már nem létezik.
 the-selected-role-cannot-be-deleted-because-it-is-a-required-system-role=A kijelölt szerepkör nem törölhető, mert szükséges rendszerszerepkör.
+the-selected-root-folder-is-in-the-recycle-bin-please-remove-it-or-select-another-one=The selected Root Folder is in the Recycle Bin. Please remove it or select another one. (Automatic Copy)
 the-selected-web-content-no-longer-exists=A kiválasztott webtartalom nem létezik.
 the-sign-in-process-is-temporarily-disabled-because-the-portal-is-undergoing-a-routine-maintenance-upgrade=A bejelentkezés átmenetileg szünetel, mert a portál a szokásos karbantartását végzik. A bejelentkezés akkor lesz lehetséges, ha a karbantartásnak vége. A türelmet köszönjük.
 the-signature-below-will-be-added-to-each-outgoing-message=Az alábbi aláírás minden kimenő üzenet végére odakerül.

--- a/portal-impl/src/content/Language_in.properties
+++ b/portal-impl/src/content/Language_in.properties
@@ -5035,6 +5035,7 @@ the-selected-entry-has-been-deleted=Catatan yang dipilih telah dihapus.
 the-selected-license-is-used-by-at-least-one-product=Lisensi yang dipilih digunakan oleh setidaknya satu produk. (Automatic Translation)
 the-selected-list-no-longer-exists=Konten web yang dipilih tidak ada lagi.
 the-selected-role-cannot-be-deleted-because-it-is-a-required-system-role=Peran yang dipilih tidak dapat dihapus karena peran sistem yang diperlukan.
+the-selected-root-folder-is-in-the-recycle-bin-please-remove-it-or-select-another-one=The selected Root Folder is in the Recycle Bin. Please remove it or select another one. (Automatic Copy)
 the-selected-web-content-no-longer-exists=Konten web yang dipilih tidak ada lagi.
 the-sign-in-process-is-temporarily-disabled-because-the-portal-is-undergoing-a-routine-maintenance-upgrade=Tanda dalam proses untuk sementara dinonaktifkan karena portal sedang mengalami upgrade perawatan rutin. Tanda dalam proses akan diaktifkan kembali setelah proses upgrade selesai. Terima kasih atas kesabaran Anda.
 the-signature-below-will-be-added-to-each-outgoing-message=Tanda tangan di bawah ini akan ditambahkan ke setiap pesan keluar.

--- a/portal-impl/src/content/Language_it.properties
+++ b/portal-impl/src/content/Language_it.properties
@@ -5036,6 +5036,7 @@ the-selected-entry-has-been-deleted=L'elemento selezionato è stato cancellato.
 the-selected-license-is-used-by-at-least-one-product=La licenza selezionata è usata da almeno un prodotto.
 the-selected-list-no-longer-exists=Il contenuto selezionato non esiste più.
 the-selected-role-cannot-be-deleted-because-it-is-a-required-system-role=Il ruolo selezionato non può essere cancellato perché è un ruolo richiesto dal sistema.
+the-selected-root-folder-is-in-the-recycle-bin-please-remove-it-or-select-another-one=The selected Root Folder is in the Recycle Bin. Please remove it or select another one. (Automatic Copy)
 the-selected-web-content-no-longer-exists=Il contenuto selezionato non esiste più.
 the-sign-in-process-is-temporarily-disabled-because-the-portal-is-undergoing-a-routine-maintenance-upgrade=Il processo di autenticazione è momentaneamente sospeso perché si sta effettuando un aggiornamento di manutenzione. Il processo di autenticazione sarà ripristinato una volta che il processo di aggiornamento sarà completato. Grazie per la pazienza.
 the-signature-below-will-be-added-to-each-outgoing-message=La firma qui sotto sarà aggiunta a ogni messaggio in uscita.

--- a/portal-impl/src/content/Language_iw.properties
+++ b/portal-impl/src/content/Language_iw.properties
@@ -5035,6 +5035,7 @@ the-selected-entry-has-been-deleted=הרשומה שנבחרה נמחקה
 the-selected-license-is-used-by-at-least-one-product=הרישיון שנבחר נמצא בשימוש מוצר אחד לפחות.
 the-selected-list-no-longer-exists=הרשימה שנבחרה לא קיימת עוד.
 the-selected-role-cannot-be-deleted-because-it-is-a-required-system-role=לא ניתן למחוק את התפקיד שנבחר מפני שהוא תפקיד מערכת נדרש.
+the-selected-root-folder-is-in-the-recycle-bin-please-remove-it-or-select-another-one=The selected Root Folder is in the Recycle Bin. Please remove it or select another one. (Automatic Copy)
 the-selected-web-content-no-longer-exists=התוכן האינטרנטי שנבחר לא קיים עוד.
 the-sign-in-process-is-temporarily-disabled-because-the-portal-is-undergoing-a-routine-maintenance-upgrade=תהליך הכניסה מושבת באופן זמני משום שהפורטל נמצא בהליך עדכון תחזוקתי שגרתי. תהליך הכניסה יהא זמין עם השלמת העדכון. תודה על הסבלנות.
 the-signature-below-will-be-added-to-each-outgoing-message=החתימה להל"ן תצורף לכל הודעה יוצאת

--- a/portal-impl/src/content/Language_ja.properties
+++ b/portal-impl/src/content/Language_ja.properties
@@ -5037,6 +5037,7 @@ the-selected-entry-has-been-deleted=選択したエントリはすでに削除�
 the-selected-license-is-used-by-at-least-one-product=選択されたライセンスは、少なくとも１つのプロダクトに使用されています。
 the-selected-list-no-longer-exists=選択されたリストは存在しません。
 the-selected-role-cannot-be-deleted-because-it-is-a-required-system-role=選択したロールは標準ロールのため削除できません。
+the-selected-root-folder-is-in-the-recycle-bin-please-remove-it-or-select-another-one=The selected Root Folder is in the Recycle Bin. Please remove it or select another one. (Automatic Copy)
 the-selected-web-content-no-longer-exists=選択されたWebページは存在しません。
 the-sign-in-process-is-temporarily-disabled-because-the-portal-is-undergoing-a-routine-maintenance-upgrade=ポータルはアップグレードのための定期メインテナンスを行っているためログインが一時的に利用できません。アップグレードが完了した後ご利用できますので少々お待ちください。
 the-signature-below-will-be-added-to-each-outgoing-message=送信メールに追加する署名を入力します。

--- a/portal-impl/src/content/Language_kk.properties
+++ b/portal-impl/src/content/Language_kk.properties
@@ -5035,6 +5035,7 @@ the-selected-entry-has-been-deleted=The selected entry has been deleted. (Automa
 the-selected-license-is-used-by-at-least-one-product=The selected license is used by at least one product. (Automatic Copy)
 the-selected-list-no-longer-exists=The selected list no longer exists. (Automatic Copy)
 the-selected-role-cannot-be-deleted-because-it-is-a-required-system-role=The selected role cannot be deleted because it is a required system role. (Automatic Copy)
+the-selected-root-folder-is-in-the-recycle-bin-please-remove-it-or-select-another-one=The selected Root Folder is in the Recycle Bin. Please remove it or select another one. (Automatic Copy)
 the-selected-web-content-no-longer-exists=The selected web content no longer exists. (Automatic Copy)
 the-sign-in-process-is-temporarily-disabled-because-the-portal-is-undergoing-a-routine-maintenance-upgrade=The sign in process is temporarily disabled because the portal is undergoing a routine maintenance upgrade. The sign in process will be reenabled once the upgrade process is complete. Thank you for your patience. (Automatic Copy)
 the-signature-below-will-be-added-to-each-outgoing-message=The signature below will be added to each outgoing message. (Automatic Copy)

--- a/portal-impl/src/content/Language_ko.properties
+++ b/portal-impl/src/content/Language_ko.properties
@@ -5034,6 +5034,7 @@ the-selected-entry-has-been-deleted=선정된 입장은 삭제되었다.
 the-selected-license-is-used-by-at-least-one-product=선택한 라이선스는 하나 이상의 제품에 사용됩니다. (Automatic Translation)
 the-selected-list-no-longer-exists=선택한 목록이 더 이상 존재하지 않습니다. (Automatic Translation)
 the-selected-role-cannot-be-deleted-because-it-is-a-required-system-role=요구하기 체계 역할 이기 때문에 선정한 역할은 삭제될 수 없다
+the-selected-root-folder-is-in-the-recycle-bin-please-remove-it-or-select-another-one=The selected Root Folder is in the Recycle Bin. Please remove it or select another one. (Automatic Copy)
 the-selected-web-content-no-longer-exists=선택한 웹 콘텐츠가 더 이상 존재하지 않습니다. (Automatic Translation)
 the-sign-in-process-is-temporarily-disabled-because-the-portal-is-undergoing-a-routine-maintenance-upgrade=포털에서 일상적인 유지 관리 업그레이드를 진행 중이므로 로그인 프로세스가 일시적으로 비활성화됩니다. 업그레이드 프로세스가 완료되면 로그인 프로세스가 다시 활성화됩니다. 인내심을 가져 주셔서 감사합니다. (Automatic Translation)
 the-signature-below-will-be-added-to-each-outgoing-message=아래에의 서명은 각 outgoing 메시지에 추가될 것이다.

--- a/portal-impl/src/content/Language_lo.properties
+++ b/portal-impl/src/content/Language_lo.properties
@@ -5035,6 +5035,7 @@ the-selected-entry-has-been-deleted=ການປ້ອນທີ່ທ່ານ�
 the-selected-license-is-used-by-at-least-one-product=The selected license is used by at least one product. (Automatic Copy)
 the-selected-list-no-longer-exists=ລາຍການທີ່ເລືອກແມ່ນບໍ່ມີແລ້ວ
 the-selected-role-cannot-be-deleted-because-it-is-a-required-system-role=ຫຼັກການທີ່ເລືອກບໍ່ສາມາດລຶບເພາະຕ້ອງການຫຼັການຂອງລະບົບພ້ອມ
+the-selected-root-folder-is-in-the-recycle-bin-please-remove-it-or-select-another-one=The selected Root Folder is in the Recycle Bin. Please remove it or select another one. (Automatic Copy)
 the-selected-web-content-no-longer-exists=ລາຍການທີ່ເລືອກແມ່ນບໍ່ມີແລ້ວ
 the-sign-in-process-is-temporarily-disabled-because-the-portal-is-undergoing-a-routine-maintenance-upgrade=The sign in process is temporarily disabled because the portal is undergoing a routine maintenance upgrade. The sign in process will be reenabled once the upgrade process is complete. Thank you for your patience. (Automatic Copy)
 the-signature-below-will-be-added-to-each-outgoing-message=The signature below will be added to each outgoing message. (Automatic Copy)

--- a/portal-impl/src/content/Language_lt.properties
+++ b/portal-impl/src/content/Language_lt.properties
@@ -5035,6 +5035,7 @@ the-selected-entry-has-been-deleted=Pasirinktas įrašas panaikintas. (Automatic
 the-selected-license-is-used-by-at-least-one-product=Pasirinktą licenciją naudoja bent vienas produktas. (Automatic Translation)
 the-selected-list-no-longer-exists=Pasirinkto sąrašo nebėra. (Automatic Translation)
 the-selected-role-cannot-be-deleted-because-it-is-a-required-system-role=Pasirinkto vaidmens panaikinti negalima, nes jis yra būtinas sistemos vaidmuo. (Automatic Translation)
+the-selected-root-folder-is-in-the-recycle-bin-please-remove-it-or-select-another-one=The selected Root Folder is in the Recycle Bin. Please remove it or select another one. (Automatic Copy)
 the-selected-web-content-no-longer-exists=Pasirinkto žiniatinklio turinio nebėra. (Automatic Translation)
 the-sign-in-process-is-temporarily-disabled-because-the-portal-is-undergoing-a-routine-maintenance-upgrade=Prisijungimo procesas laikinai išjungtas, nes portale atliekamas įprastas priežiūros atnaujinimas. Pasibaigus atnaujinimo procesui, prisijungimo procesas bus įgalintas iš naujo. Ačiū už kantrybę. (Automatic Translation)
 the-signature-below-will-be-added-to-each-outgoing-message=Žemiau esantis parašas bus pridėtas prie kiekvieno siunčiamo pranešimo. (Automatic Translation)

--- a/portal-impl/src/content/Language_ms.properties
+++ b/portal-impl/src/content/Language_ms.properties
@@ -5035,6 +5035,7 @@ the-selected-entry-has-been-deleted=Entri terpilih telah dihapuskan. (Automatic 
 the-selected-license-is-used-by-at-least-one-product=Lesen terpilih digunakan oleh sekurang-kurangnya satu produk. (Automatic Translation)
 the-selected-list-no-longer-exists=Senarai terpilih tidak lagi wujud. (Automatic Translation)
 the-selected-role-cannot-be-deleted-because-it-is-a-required-system-role=Peranan yang dipilih tidak dapat dihapuskan kerana ia adalah peranan sistem yang diperlukan. (Automatic Translation)
+the-selected-root-folder-is-in-the-recycle-bin-please-remove-it-or-select-another-one=The selected Root Folder is in the Recycle Bin. Please remove it or select another one. (Automatic Copy)
 the-selected-web-content-no-longer-exists=Kandungan web terpilih tidak lagi wujud. (Automatic Translation)
 the-sign-in-process-is-temporarily-disabled-because-the-portal-is-undergoing-a-routine-maintenance-upgrade=Proses daftar masuk dilumpuhkan buat sementara waktu kerana portal itu sedang menjalani naik taraf penyelenggaraan rutin. Proses daftar masuk akan dikembalikan sebaik sahaja proses naik taraf selesai. Terima kasih atas kesabaran anda. (Automatic Translation)
 the-signature-below-will-be-added-to-each-outgoing-message=Tandatangan di bawah akan ditambah pada setiap mesej keluar. (Automatic Translation)

--- a/portal-impl/src/content/Language_nb.properties
+++ b/portal-impl/src/content/Language_nb.properties
@@ -5035,6 +5035,7 @@ the-selected-entry-has-been-deleted=Det valgte innlegget har blitt slettet.
 the-selected-license-is-used-by-at-least-one-product=Den valgte lisensen brukes av minst ett produkt.
 the-selected-list-no-longer-exists=Den valgte listen eksisterer ikke lenger.
 the-selected-role-cannot-be-deleted-because-it-is-a-required-system-role=Den valgte rollen kan ikke slettes fordi den er en nødvendig systemrolle.
+the-selected-root-folder-is-in-the-recycle-bin-please-remove-it-or-select-another-one=The selected Root Folder is in the Recycle Bin. Please remove it or select another one. (Automatic Copy)
 the-selected-web-content-no-longer-exists=Det valge webinnholdet eksisterer ikke lenger.
 the-sign-in-process-is-temporarily-disabled-because-the-portal-is-undergoing-a-routine-maintenance-upgrade=Innloggingsprosessen er midlertidig deaktivert da portalen undergår en rutinemessig oppdatering. Innloggingsprosessen vil reaktiveres når oppdateringsprosessen er ferdig. Takk for din tålmodighet.
 the-signature-below-will-be-added-to-each-outgoing-message=Signaturen nedenfor vil bli lagt til hver utgående beskjed.

--- a/portal-impl/src/content/Language_nl.properties
+++ b/portal-impl/src/content/Language_nl.properties
@@ -5038,6 +5038,7 @@ the-selected-entry-has-been-deleted=De geselecteerde invoer is verwijderd.
 the-selected-license-is-used-by-at-least-one-product=De geselecteerde licentie is in gebruik voor minstens één product.
 the-selected-list-no-longer-exists=De geselecteerde lijst bestaat niet meer.
 the-selected-role-cannot-be-deleted-because-it-is-a-required-system-role=Verwijderen van de geselecteerde rol is niet mogelijk omdat het een vereiste systeemrol is.
+the-selected-root-folder-is-in-the-recycle-bin-please-remove-it-or-select-another-one=The selected Root Folder is in the Recycle Bin. Please remove it or select another one. (Automatic Copy)
 the-selected-web-content-no-longer-exists=De geselecteerde webcontent bestaat niet meer.
 the-sign-in-process-is-temporarily-disabled-because-the-portal-is-undergoing-a-routine-maintenance-upgrade=U kunt zich tijdelijk niet aanmelden omdat er onderhoud aan de portal plaatsvindt. Het aanmeldproces is weer beschikbaar zodra het onderhoud is voltooid. Dank voor uw begrip.
 the-signature-below-will-be-added-to-each-outgoing-message=Onderstaande handtekening wordt toegevoegd aan elk uitgaand bericht.

--- a/portal-impl/src/content/Language_nl_BE.properties
+++ b/portal-impl/src/content/Language_nl_BE.properties
@@ -5038,6 +5038,7 @@ the-selected-entry-has-been-deleted=De geselecteerde regel is verwijderd.
 the-selected-license-is-used-by-at-least-one-product=The selected license is used by at least one product. (Automatic Copy)
 the-selected-list-no-longer-exists=De geselecteerde Web Content bestaat niet meer.
 the-selected-role-cannot-be-deleted-because-it-is-a-required-system-role=De geselecteerde rol kan niet worden verwijderd omdat het een vereiste systeemrol is.
+the-selected-root-folder-is-in-the-recycle-bin-please-remove-it-or-select-another-one=The selected Root Folder is in the Recycle Bin. Please remove it or select another one. (Automatic Copy)
 the-selected-web-content-no-longer-exists=De geselecteerde Web Content bestaat niet meer.
 the-sign-in-process-is-temporarily-disabled-because-the-portal-is-undergoing-a-routine-maintenance-upgrade=U kunt zich tijdelijk niet aanmelden omdat er onderhoud aan de portal plaatsvindt. Het aanmeldproces is weer beschikbaar zodra het onderhoud is voltooid. Dank voor uw begrip.
 the-signature-below-will-be-added-to-each-outgoing-message=Onderstaande handtekening zal aan elk uitgaand bericht worden toegevoegd.

--- a/portal-impl/src/content/Language_pl.properties
+++ b/portal-impl/src/content/Language_pl.properties
@@ -5035,6 +5035,7 @@ the-selected-entry-has-been-deleted=Wybrany wpis został usunięty.
 the-selected-license-is-used-by-at-least-one-product=Wybrana licencja jest używana co najmniej przez jeden produkt.
 the-selected-list-no-longer-exists=Wybrana lista już nie istnieje.
 the-selected-role-cannot-be-deleted-because-it-is-a-required-system-role=Wybrana rola nie może zostać usunięta, ponieważ jest to wymagana rola systemowa.
+the-selected-root-folder-is-in-the-recycle-bin-please-remove-it-or-select-another-one=The selected Root Folder is in the Recycle Bin. Please remove it or select another one. (Automatic Copy)
 the-selected-web-content-no-longer-exists=Wybrana zawartość stron już nie istnieje.
 the-sign-in-process-is-temporarily-disabled-because-the-portal-is-undergoing-a-routine-maintenance-upgrade=Portal przechodzi standardową aktualizację, dlatego proces logowania został chwilowo wyłączony. Proces logowania zostanie włączony po zakończeniu aktualizacji. Dziękujemy za cierpliwość.
 the-signature-below-will-be-added-to-each-outgoing-message=Poniższy podpis zostanie dodany do każdej wiadomości wychodzącej.

--- a/portal-impl/src/content/Language_pt_BR.properties
+++ b/portal-impl/src/content/Language_pt_BR.properties
@@ -5035,6 +5035,7 @@ the-selected-entry-has-been-deleted=O item selecionado foi excluído.
 the-selected-license-is-used-by-at-least-one-product=A licença selecionada é usada por pelo menos um produto.
 the-selected-list-no-longer-exists=A lista selecionada não existe mais.
 the-selected-role-cannot-be-deleted-because-it-is-a-required-system-role=O papel selecionado não pode ser excluído porque é requerido do sistema.
+the-selected-root-folder-is-in-the-recycle-bin-please-remove-it-or-select-another-one=The selected Root Folder is in the Recycle Bin. Please remove it or select another one. (Automatic Copy)
 the-selected-web-content-no-longer-exists=O conteúdo web selecionado não existe mais.
 the-sign-in-process-is-temporarily-disabled-because-the-portal-is-undergoing-a-routine-maintenance-upgrade=As autenticações serão desabilitadas temporariamente porque o portal está entrando em uma manutenção programada. O acesso será reabilitado assim que o processo de atualização do portal estiver completo. Obrigado por sua paciência.
 the-signature-below-will-be-added-to-each-outgoing-message=A assinatura abaixo será adicionada a cada mensagem enviada.

--- a/portal-impl/src/content/Language_pt_PT.properties
+++ b/portal-impl/src/content/Language_pt_PT.properties
@@ -5037,6 +5037,7 @@ the-selected-entry-has-been-deleted=O item selecionado foi removido.
 the-selected-license-is-used-by-at-least-one-product=A licença selecionada é utilizada por pelo menos um produto.
 the-selected-list-no-longer-exists=A lista selecionada já não existe.
 the-selected-role-cannot-be-deleted-because-it-is-a-required-system-role=O role selecionado não pode ser removido porque é um role obrigatório de sistema.
+the-selected-root-folder-is-in-the-recycle-bin-please-remove-it-or-select-another-one=The selected Root Folder is in the Recycle Bin. Please remove it or select another one. (Automatic Copy)
 the-selected-web-content-no-longer-exists=O conteúdo web selecionado já não existe.
 the-sign-in-process-is-temporarily-disabled-because-the-portal-is-undergoing-a-routine-maintenance-upgrade=O processo de autenticação está desabilitado temporariamente porque o portal está a iniciar um processo de manutenção de rotina. O acesso será reposto assim que o processo de atualização do portal estiver concluído. Obrigado pela sua paciência.
 the-signature-below-will-be-added-to-each-outgoing-message=A assinatura abaixo será adicionada a cada mensagem enviada.

--- a/portal-impl/src/content/Language_ro.properties
+++ b/portal-impl/src/content/Language_ro.properties
@@ -5035,6 +5035,7 @@ the-selected-entry-has-been-deleted=Intrarea selectata a fost stearsa.
 the-selected-license-is-used-by-at-least-one-product=Licența selectată este utilizată de cel puțin un produs. (Automatic Translation)
 the-selected-list-no-longer-exists=Continutul web selectat nu mai exista.
 the-selected-role-cannot-be-deleted-because-it-is-a-required-system-role=Roluriele selectate nu pot fi stersa pentru ca este necesar un rol de sistem.
+the-selected-root-folder-is-in-the-recycle-bin-please-remove-it-or-select-another-one=The selected Root Folder is in the Recycle Bin. Please remove it or select another one. (Automatic Copy)
 the-selected-web-content-no-longer-exists=Continutul web selectat nu mai exista.
 the-sign-in-process-is-temporarily-disabled-because-the-portal-is-undergoing-a-routine-maintenance-upgrade=Procesul de conectare este dezactivat temporar, deoarece portalul este supus unui upgrade de întreținere de rutină. Procesul de conectare va fi reactivat după finalizarea procesului de upgrade. Mulțumesc pentru răbdare. (Automatic Translation)
 the-signature-below-will-be-added-to-each-outgoing-message=Semantura de mai jos va fi adaugata la fiecare mesaj trimis.

--- a/portal-impl/src/content/Language_ru.properties
+++ b/portal-impl/src/content/Language_ru.properties
@@ -5035,6 +5035,7 @@ the-selected-entry-has-been-deleted=Выбранная запись будет �
 the-selected-license-is-used-by-at-least-one-product=Выбранная лицензия используется как минимум одним продуктом.
 the-selected-list-no-longer-exists=Выбранный список больше не существует.
 the-selected-role-cannot-be-deleted-because-it-is-a-required-system-role=Выбранная роль не может быть удалена, так как она является необходимой системной ролью.
+the-selected-root-folder-is-in-the-recycle-bin-please-remove-it-or-select-another-one=The selected Root Folder is in the Recycle Bin. Please remove it or select another one. (Automatic Copy)
 the-selected-web-content-no-longer-exists=Выбранный сетевой контент больше не существует.
 the-sign-in-process-is-temporarily-disabled-because-the-portal-is-undergoing-a-routine-maintenance-upgrade=Вход временно отключен, поскольку на портале ведутся профилактические работы. Процесс входа будет включен, когда профилактика закончится. Спасибо за ваше терпение.
 the-signature-below-will-be-added-to-each-outgoing-message=Сигнатура, приведенная ниже, будет добавляться к каждому исходящему сообщению.

--- a/portal-impl/src/content/Language_sk.properties
+++ b/portal-impl/src/content/Language_sk.properties
@@ -5035,6 +5035,7 @@ the-selected-entry-has-been-deleted=Vybraná položka bola vymazaná.
 the-selected-license-is-used-by-at-least-one-product=Vybraná licencia je použitá s najmenej jedným produktom.
 the-selected-list-no-longer-exists=Zvolený zoznam už neexistuje.
 the-selected-role-cannot-be-deleted-because-it-is-a-required-system-role=Vybraná rola nemôže byť zmazaná, lebo sa jedná o systémovú rolu.
+the-selected-root-folder-is-in-the-recycle-bin-please-remove-it-or-select-another-one=The selected Root Folder is in the Recycle Bin. Please remove it or select another one. (Automatic Copy)
 the-selected-web-content-no-longer-exists=Vybraný webový obsah už neexistuje.
 the-sign-in-process-is-temporarily-disabled-because-the-portal-is-undergoing-a-routine-maintenance-upgrade=Prihlasovací proces je práve nedostupný, pretože na portáli vykonávame rutinnú údržbu. Prihlasovanie bude sprístupnené hneď, ako proces skončí. Ďakujeme vám za trpezlivosť.
 the-signature-below-will-be-added-to-each-outgoing-message=Podpis uvedený nižšie bude pridaný ku každej odoslanej správe.

--- a/portal-impl/src/content/Language_sl.properties
+++ b/portal-impl/src/content/Language_sl.properties
@@ -5035,6 +5035,7 @@ the-selected-entry-has-been-deleted=Izbrani vnos je izbrisan.
 the-selected-license-is-used-by-at-least-one-product=Izbrano licenco uporablja vsaj en izdelek. (Automatic Translation)
 the-selected-list-no-longer-exists=Izbrani seznam ne obstaja več. (Automatic Translation)
 the-selected-role-cannot-be-deleted-because-it-is-a-required-system-role=Izbrana vloga ne more biti izbrisana, ker je to obvezna sistemska vloga.
+the-selected-root-folder-is-in-the-recycle-bin-please-remove-it-or-select-another-one=The selected Root Folder is in the Recycle Bin. Please remove it or select another one. (Automatic Copy)
 the-selected-web-content-no-longer-exists=Izbrana spletna vsebina ne obstaja več. (Automatic Translation)
 the-sign-in-process-is-temporarily-disabled-because-the-portal-is-undergoing-a-routine-maintenance-upgrade=Vpis v postopku je začasno onemogočen, ker je portal v rutinski nadgradnji vzdrževanja. Postopek vpisa bo po končanem postopku nadgradnje omogočen. Hvala za potrpljenje. (Automatic Translation)
 the-signature-below-will-be-added-to-each-outgoing-message=Spodnji podpis bo dodan vsem odhajajočim sporočilom.

--- a/portal-impl/src/content/Language_sr_RS.properties
+++ b/portal-impl/src/content/Language_sr_RS.properties
@@ -5035,6 +5035,7 @@ the-selected-entry-has-been-deleted=Изабрани унос је избрис�
 the-selected-license-is-used-by-at-least-one-product=The selected license is used by at least one product. (Automatic Copy)
 the-selected-list-no-longer-exists=Изабрана листа више не постоји.
 the-selected-role-cannot-be-deleted-because-it-is-a-required-system-role=Изабрана улогу не може бити обрисана зато што је захтевана системска улога.
+the-selected-root-folder-is-in-the-recycle-bin-please-remove-it-or-select-another-one=The selected Root Folder is in the Recycle Bin. Please remove it or select another one. (Automatic Copy)
 the-selected-web-content-no-longer-exists=Одабрани веб садржај више не постоји.
 the-sign-in-process-is-temporarily-disabled-because-the-portal-is-undergoing-a-routine-maintenance-upgrade=Процес пријаве је привремено укинут јер портал пролази рутинско одржавање и надоградњу. Процес пријаве ће бити поново омогућен када се процес надоградње заврши. Хвала на стрпљењу.
 the-signature-below-will-be-added-to-each-outgoing-message=Потпис испод ће бити додат свакој одлазној поруци.

--- a/portal-impl/src/content/Language_sr_RS_latin.properties
+++ b/portal-impl/src/content/Language_sr_RS_latin.properties
@@ -5035,6 +5035,7 @@ the-selected-entry-has-been-deleted=Izabrani unos je izbrisan.
 the-selected-license-is-used-by-at-least-one-product=The selected license is used by at least one product. (Automatic Copy)
 the-selected-list-no-longer-exists=Izabrana lista više ne postoji.
 the-selected-role-cannot-be-deleted-because-it-is-a-required-system-role=Izabrana ulogu ne može biti obrisana zato što je zahtevana sistemska uloga.
+the-selected-root-folder-is-in-the-recycle-bin-please-remove-it-or-select-another-one=The selected Root Folder is in the Recycle Bin. Please remove it or select another one. (Automatic Copy)
 the-selected-web-content-no-longer-exists=Odabrani veb sadržaj više ne postoji.
 the-sign-in-process-is-temporarily-disabled-because-the-portal-is-undergoing-a-routine-maintenance-upgrade=Proces prijave je privremeno ukinut jer portal prolazi rutinsko održavanje i nadogradnju. Proces prijave će biti ponovo omogućen kada se proces nadogradnje završi. Hvala na strpljenju.
 the-signature-below-will-be-added-to-each-outgoing-message=Potpis ispod će biti dodat svakoj odlaznoj poruci.

--- a/portal-impl/src/content/Language_sv.properties
+++ b/portal-impl/src/content/Language_sv.properties
@@ -5035,6 +5035,7 @@ the-selected-entry-has-been-deleted=Datan är redan raderad.
 the-selected-license-is-used-by-at-least-one-product=Den valda licensen används av minst en produkt.
 the-selected-list-no-longer-exists=Den valda listan existerar inte längre.
 the-selected-role-cannot-be-deleted-because-it-is-a-required-system-role=Den valda rollen kan inte raderas för att den är en nödvändig systemroll.
+the-selected-root-folder-is-in-the-recycle-bin-please-remove-it-or-select-another-one=The selected Root Folder is in the Recycle Bin. Please remove it or select another one. (Automatic Copy)
 the-selected-web-content-no-longer-exists=Det valda innehållet existerar inte längre.
 the-sign-in-process-is-temporarily-disabled-because-the-portal-is-undergoing-a-routine-maintenance-upgrade=Inloggningsprocessen är tillfälligt inaktiverad eftersom portalen genomgår en underhållsuppgradering. Inloggningsprocessen återaktiveras när uppgraderingen är slutförd. Tack för ditt tålamod.
 the-signature-below-will-be-added-to-each-outgoing-message=Signaturen kommer läggas till på varje utgående meddelande.

--- a/portal-impl/src/content/Language_ta_IN.properties
+++ b/portal-impl/src/content/Language_ta_IN.properties
@@ -5035,6 +5035,7 @@ the-selected-entry-has-been-deleted=தேர்ந்தெடுக்கப�
 the-selected-license-is-used-by-at-least-one-product=தேர்ந்தெடுக்கப்பட்ட உரிமம் குறைந்தபட்சம் ஒரு தயாரிப்பு மூலம் பயன்படுத்தப்படுகிறது.
 the-selected-list-no-longer-exists=தேர்ந்தெடுத்த பட்டியல் இனி இருக்காது.
 the-selected-role-cannot-be-deleted-because-it-is-a-required-system-role=தேர்ந்தெடுக்கப்பட்ட பாத்திரம் நீக்கப்படமுடியாது, ஏனெனில் இது ஒரு சிஸ்டம் அமைப்பு பாத்திரம்.
+the-selected-root-folder-is-in-the-recycle-bin-please-remove-it-or-select-another-one=The selected Root Folder is in the Recycle Bin. Please remove it or select another one. (Automatic Copy)
 the-selected-web-content-no-longer-exists=தேர்ந்தெடுக்கப்பட்ட வலை உள்ளடக்கம் இனி இல்லை.
 the-sign-in-process-is-temporarily-disabled-because-the-portal-is-undergoing-a-routine-maintenance-upgrade=உள்நுழைவு செயல்முறை தற்காலிகமாக முடக்கப்பட்டதால், ஒரு வழக்கமான பராமரிப்பு மேம்படுத்தலுக்கு போர்டல் தொடர்கிறது. மேம்படுத்தல் செயற்பாடு முடிந்தவுடன் உள்நுழைவு செயலாக்கம் மீண்டும் செயல்படுத்தப்படும். பொறுமை காத்தமைக்கு நன்றி.
 the-signature-below-will-be-added-to-each-outgoing-message=ஒவ்வொரு வெளிச்செல்லும் செய்திக்கு கீழே உள்ள கையொப்பம் சேர்க்கப்படும்.

--- a/portal-impl/src/content/Language_th.properties
+++ b/portal-impl/src/content/Language_th.properties
@@ -5035,6 +5035,7 @@ the-selected-entry-has-been-deleted=รายการที่เลือก�
 the-selected-license-is-used-by-at-least-one-product=สิทธิ์การใช้งานที่เลือกถูกใช้โดยผลิตภัณฑ์อย่างน้อยหนึ่งผลิตภัณฑ์ (Automatic Translation)
 the-selected-list-no-longer-exists=ไม่มีรายการที่เลือกอยู่อีกต่อไป (Automatic Translation)
 the-selected-role-cannot-be-deleted-because-it-is-a-required-system-role=ไม่สามารถลบบทบาทที่เลือกได้ เนื่องจากบทบาทนี้เป็นบทบาทระบบที่จําเป็น (Automatic Translation)
+the-selected-root-folder-is-in-the-recycle-bin-please-remove-it-or-select-another-one=The selected Root Folder is in the Recycle Bin. Please remove it or select another one. (Automatic Copy)
 the-selected-web-content-no-longer-exists=ไม่มีเนื้อหาเว็บที่เลือกอยู่อีกต่อไป (Automatic Translation)
 the-sign-in-process-is-temporarily-disabled-because-the-portal-is-undergoing-a-routine-maintenance-upgrade=กระบวนการลงชื่อเข้าใช้ถูกปิดใช้งานชั่วคราว เนื่องจากพอร์ทัลกําลังอยู่ระหว่างการปรับรุ่นการบํารุงรักษาตามปกติ กระบวนการลงชื่อเข้าใช้จะสามารถเปิดใช้งานอีกครั้งเมื่อกระบวนการอัพเกรดเสร็จสมบูรณ์ ขอบคุณสําหรับความอดทนของคุณ (Automatic Translation)
 the-signature-below-will-be-added-to-each-outgoing-message=ลายเซ็นด้านล่างจะถูกเพิ่มลงในแต่ละข้อความขาออก (Automatic Translation)

--- a/portal-impl/src/content/Language_tr.properties
+++ b/portal-impl/src/content/Language_tr.properties
@@ -5035,6 +5035,7 @@ the-selected-entry-has-been-deleted=Seçili giriş silinmiştir.
 the-selected-license-is-used-by-at-least-one-product=Seçilen lisans en az bir ürün tarafından kullanılır. (Automatic Translation)
 the-selected-list-no-longer-exists=Seçili liste artık yok. (Automatic Translation)
 the-selected-role-cannot-be-deleted-because-it-is-a-required-system-role=Seçilen rol sistem gereksinimi olduğundan silinememektedir.
+the-selected-root-folder-is-in-the-recycle-bin-please-remove-it-or-select-another-one=The selected Root Folder is in the Recycle Bin. Please remove it or select another one. (Automatic Copy)
 the-selected-web-content-no-longer-exists=Seçili web içeriği artık yok. (Automatic Translation)
 the-sign-in-process-is-temporarily-disabled-because-the-portal-is-undergoing-a-routine-maintenance-upgrade=Portal rutin bir bakım yükseltmesi geçirdiğinden oturum açma işlemi geçici olarak devre dışı bırakıldı. Yükseltme işlemi tamamlandıktan sonra oturum açma işlemi yeniden kullanılabilir. Sabrınız için teşekkür ederim. (Automatic Translation)
 the-signature-below-will-be-added-to-each-outgoing-message=Aşağıdaki imza bütün giden mesajlara eklenecektir.

--- a/portal-impl/src/content/Language_uk.properties
+++ b/portal-impl/src/content/Language_uk.properties
@@ -5035,6 +5035,7 @@ the-selected-entry-has-been-deleted=Вибраний запис буде вид�
 the-selected-license-is-used-by-at-least-one-product=Вибрана ліцензія використовується принаймні одним продуктом. (Automatic Translation)
 the-selected-list-no-longer-exists=Вибраний список більше не існує. (Automatic Translation)
 the-selected-role-cannot-be-deleted-because-it-is-a-required-system-role=Вибрана роль не може бути видалена, адже вона є необходною системною роллю.
+the-selected-root-folder-is-in-the-recycle-bin-please-remove-it-or-select-another-one=The selected Root Folder is in the Recycle Bin. Please remove it or select another one. (Automatic Copy)
 the-selected-web-content-no-longer-exists=Вибраний веб-вміст більше не існує. (Automatic Translation)
 the-sign-in-process-is-temporarily-disabled-because-the-portal-is-undergoing-a-routine-maintenance-upgrade=Процес входу тимчасово вимкнуто, оскільки на порталі відбувається планове оновлення обслуговування. Процес входу буде повторно ввійдіть після завершення процесу оновлення. Дякую за терпіння. (Automatic Translation)
 the-signature-below-will-be-added-to-each-outgoing-message=Сігнатура, що показана нижче, буде додаватись до кожного вихідного повідомлення.

--- a/portal-impl/src/content/Language_vi.properties
+++ b/portal-impl/src/content/Language_vi.properties
@@ -5035,6 +5035,7 @@ the-selected-entry-has-been-deleted=Điểm lưu trữ lựa chọn đã bị x�
 the-selected-license-is-used-by-at-least-one-product=Bản quyền đã chọn được sử dụng bởi ít nhất một sản phẩm.
 the-selected-list-no-longer-exists=Danh sách đã chọn không còn tồn tại.
 the-selected-role-cannot-be-deleted-because-it-is-a-required-system-role=Không thể xóa quyền hệ thống.
+the-selected-root-folder-is-in-the-recycle-bin-please-remove-it-or-select-another-one=The selected Root Folder is in the Recycle Bin. Please remove it or select another one. (Automatic Copy)
 the-selected-web-content-no-longer-exists=Nội dung web đã chọn không còn tồn tại.
 the-sign-in-process-is-temporarily-disabled-because-the-portal-is-undergoing-a-routine-maintenance-upgrade=Dấu hiệu trong tiến trình đã tạm thời được khóa vì cổng TTĐT đang trong quá trình cập nhật hệ thống. Dấu hiệu sẽ tiếp tục được bật lên sau khi quá trình này hoàn thành. Cảm ơn sự kiên nhẫn của quý vị.
 the-signature-below-will-be-added-to-each-outgoing-message=Chữ ký thêm vào mỗi email gửi đi.

--- a/portal-impl/src/content/Language_zh_CN.properties
+++ b/portal-impl/src/content/Language_zh_CN.properties
@@ -5037,6 +5037,7 @@ the-selected-entry-has-been-deleted=选定的条目已被删除。
 the-selected-license-is-used-by-at-least-one-product=所选license已经至少被用于一个产品。
 the-selected-list-no-longer-exists=所选列表已不再存在。
 the-selected-role-cannot-be-deleted-because-it-is-a-required-system-role=无法删除所选角色，因为它是一个必需的系统角色。
+the-selected-root-folder-is-in-the-recycle-bin-please-remove-it-or-select-another-one=The selected Root Folder is in the Recycle Bin. Please remove it or select another one. (Automatic Copy)
 the-selected-web-content-no-longer-exists=选定的 web 内容不再存在。
 the-sign-in-process-is-temporarily-disabled-because-the-portal-is-undergoing-a-routine-maintenance-upgrade=登录过程临时禁用因为portal正在进行例行维护升级。一旦升级完成，登录过程会重新开启。感谢您的耐心等待。
 the-signature-below-will-be-added-to-each-outgoing-message=以下签名将添加到每一封已发送邮件的末尾。

--- a/portal-impl/src/content/Language_zh_TW.properties
+++ b/portal-impl/src/content/Language_zh_TW.properties
@@ -5036,6 +5036,7 @@ the-selected-entry-has-been-deleted=選擇的項目已被刪除。
 the-selected-license-is-used-by-at-least-one-product=選擇的授權被使用在至少一個產品。
 the-selected-list-no-longer-exists=選擇的名單不再存在。
 the-selected-role-cannot-be-deleted-because-it-is-a-required-system-role=選擇的角色不能刪除，因為這是一個必須的系統角色。
+the-selected-root-folder-is-in-the-recycle-bin-please-remove-it-or-select-another-one=The selected Root Folder is in the Recycle Bin. Please remove it or select another one. (Automatic Copy)
 the-selected-web-content-no-longer-exists=選擇的網站內容不再存在。
 the-sign-in-process-is-temporarily-disabled-because-the-portal-is-undergoing-a-routine-maintenance-upgrade=登入流程暫時停用因為入口網正在進行一個定期的維護升級。一旦升級流程完成，登入流程將會再度可用。謝謝您的耐心。
 the-signature-below-will-be-added-to-each-outgoing-message=以下簽名將加於每個外寄郵件。


### PR DESCRIPTION
Hi @liferay-lima,

This fix improves usability of the Documents & Media and the Image Gallery portlets when the selected Root Folder is in the trash and another one needs to be selected. With this solution it's not necessary to remove the current root folder to select the new one. Also, a message explaining the situation is shown in the configuration view.

Please let me know if you need any questions. 

Thanks!