### PR TITLE
[TS] LPS-139535 | Locales are doubled in canonical URLs with multiple virtual hosts and using the property locale.prepend.friendly.url.style=2

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -8249,20 +8249,26 @@ public class PortalImpl implements Portal {
 			Set<Locale> availableLocales)
 		throws PortalException {
 
-		String virtualHostname = getVirtualHostname(
+		TreeMap<String, String> virtualHostnames = getVirtualHostnames(
 			themeDisplay.getLayoutSet());
 
-		if (Validator.isNull(virtualHostname)) {
+		String virtualHostname = "";
+
+		if (virtualHostnames.isEmpty()) {
 			Company company = themeDisplay.getCompany();
 
 			virtualHostname = company.getVirtualHostname();
 		}
+		else {
+			virtualHostname = virtualHostnames.firstKey();
+		}
 
 		String portalDomain = themeDisplay.getPortalDomain();
 
-		if (!Validator.isBlank(portalDomain) &&
-			!StringUtil.equalsIgnoreCase(portalDomain, _LOCALHOST) &&
-			StringUtil.equalsIgnoreCase(virtualHostname, _LOCALHOST)) {
+		if ((!Validator.isBlank(portalDomain) &&
+			 !StringUtil.equalsIgnoreCase(portalDomain, _LOCALHOST) &&
+			 StringUtil.equalsIgnoreCase(virtualHostname, _LOCALHOST)) ||
+			virtualHostnames.containsKey(portalDomain)) {
 
 			virtualHostname = portalDomain;
 		}


### PR DESCRIPTION
Hi Team,
Could you please review this pull request?

https://issues.liferay.com/browse/LPS-139535
Thank you!