### PR TITLE
LPS-140315 It is not possible to edit the header image alt text on a blog post

### DIFF
--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/asset/abstract.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/asset/abstract.jsp
@@ -27,7 +27,12 @@ BlogsEntry entry = (BlogsEntry)request.getAttribute(WebKeys.BLOGS_ENTRY);
 	%>
 
 	<c:if test="<%= Validator.isNotNull(coverImageURL) %>">
-		<div aria-label="<%= HtmlUtil.escapeAttribute(HtmlUtil.stripHtml(entry.getCoverImageCaption())) %>" class="aspect-ratio aspect-ratio-8-to-3 aspect-ratio-bg-cover cover-image mb-4" role="img" style="background-image: url(<%= coverImageURL %>);"></div>
+
+		<%
+		String coverImageCaption = HtmlUtil.escapeAttribute(HtmlUtil.stripHtml(entry.getCoverImageCaption()));
+		%>
+
+		<div <%= Validator.isNotNull(coverImageCaption) ? "aria-label=\"" + coverImageCaption + "\" role=\"img\"" : StringPool.BLANK %> class="aspect-ratio aspect-ratio-8-to-3 aspect-ratio-bg-cover cover-image mb-4" style="background-image: url(<%= coverImageURL %>);"></div>
 	</c:if>
 
 	<%

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/asset/full_content.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/asset/full_content.jsp
@@ -40,7 +40,12 @@ String entryTitle = BlogsEntryUtil.getDisplayTitle(resourceBundle, entry);
 				%>
 
 				<c:if test="<%= Validator.isNotNull(coverImageURL) %>">
-					<div aria-label="<%= HtmlUtil.escapeAttribute(HtmlUtil.stripHtml(entry.getCoverImageCaption())) %>" class="aspect-ratio aspect-ratio-8-to-3 aspect-ratio-bg-cover cover-image" role="img" style="background-image: url(<%= coverImageURL %>);"></div>
+
+					<%
+					String coverImageCaption = HtmlUtil.escapeAttribute(HtmlUtil.stripHtml(entry.getCoverImageCaption()));
+					%>
+
+					<div <%= Validator.isNotNull(coverImageCaption) ? "aria-label=\"" + coverImageCaption + "\" role=\"img\"" : StringPool.BLANK %> class="aspect-ratio aspect-ratio-8-to-3 aspect-ratio-bg-cover cover-image" style="background-image: url(<%= coverImageURL %>);"></div>
 				</c:if>
 
 				<%= entry.getContent() %>

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/info/item/renderer/full_content.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/info/item/renderer/full_content.jsp
@@ -31,7 +31,12 @@ String entryTitle = BlogsEntryUtil.getDisplayTitle(resourceBundle, entry);
 			%>
 
 			<c:if test="<%= Validator.isNotNull(coverImageURL) %>">
-				<div aria-label="<%= HtmlUtil.escapeAttribute(HtmlUtil.stripHtml(entry.getCoverImageCaption())) %>" class="aspect-ratio aspect-ratio-8-to-3 aspect-ratio-bg-cover cover-image" role="img" style="background-image: url(<%= coverImageURL %>);"></div>
+
+				<%
+				String coverImageCaption = HtmlUtil.escapeAttribute(HtmlUtil.stripHtml(entry.getCoverImageCaption()));
+				%>
+
+				<div <%= Validator.isNotNull(coverImageCaption) ? "aria-label=\"" + coverImageCaption + "\" role=\"img\"" : StringPool.BLANK %> class="aspect-ratio aspect-ratio-8-to-3 aspect-ratio-bg-cover cover-image" style="background-image: url(<%= coverImageURL %>);"></div>
 			</c:if>
 
 			<%= entry.getContent() %>

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/info/item/renderer/init.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/info/item/renderer/init.jsp
@@ -24,6 +24,7 @@ taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
 <%@ page import="com.liferay.asset.kernel.model.AssetRenderer" %><%@
 page import="com.liferay.blogs.model.BlogsEntry" %><%@
 page import="com.liferay.blogs.web.internal.util.BlogsEntryUtil" %><%@
+page import="com.liferay.petra.string.StringPool" %><%@
 page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
 page import="com.liferay.portal.kernel.util.Validator" %><%@
 page import="com.liferay.portal.kernel.util.WebKeys" %>

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/view_entry_content.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/view_entry_content.jsp
@@ -140,7 +140,12 @@ BlogsPortletInstanceConfiguration blogsPortletInstanceConfiguration = BlogsPortl
 
 				<c:if test="<%= Validator.isNotNull(coverImageURL) %>">
 					<a href="<%= viewEntryURL.toString() %>">
-						<div aria-label="<%= HtmlUtil.escapeAttribute(HtmlUtil.stripHtml(entry.getCoverImageCaption())) %>" class="aspect-ratio aspect-ratio-8-to-3 aspect-ratio-bg-cover cover-image" role="img" style="background-image: url(<%= coverImageURL %>);"></div>
+
+						<%
+						String coverImageCaption = HtmlUtil.escapeAttribute(HtmlUtil.stripHtml(entry.getCoverImageCaption()));
+						%>
+
+						<div <%= Validator.isNotNull(coverImageCaption) ? "aria-label=\"" + coverImageCaption + "\" role=\"img\"" : StringPool.BLANK %> class="aspect-ratio aspect-ratio-8-to-3 aspect-ratio-bg-cover cover-image" style="background-image: url(<%= coverImageURL %>);"></div>
 					</a>
 				</c:if>
 

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/view_entry_content_detail.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/view_entry_content_detail.jsp
@@ -178,7 +178,12 @@ BlogsPortletInstanceConfiguration blogsPortletInstanceConfiguration = BlogsPortl
 		%>
 
 		<c:if test="<%= Validator.isNotNull(coverImageURL) %>">
-			<div aria-label="<%= HtmlUtil.escapeAttribute(HtmlUtil.stripHtml(entry.getCoverImageCaption())) %>" class="aspect-ratio aspect-ratio-bg-cover cover-image" role="img" style="background-image: url(<%= coverImageURL %>);"></div>
+
+			<%
+			String coverImageCaption = HtmlUtil.escapeAttribute(HtmlUtil.stripHtml(entry.getCoverImageCaption()));
+			%>
+
+			<div <%= Validator.isNotNull(coverImageCaption) ? "aria-label=\"" + coverImageCaption + "\" role=\"img\"" : StringPool.BLANK %> class="aspect-ratio aspect-ratio-8-to-3 aspect-ratio-bg-cover cover-image" style="background-image: url(<%= coverImageURL %>);"></div>
 		</c:if>
 
 		<!-- text resume -->


### PR DESCRIPTION
Bug: https://issues.liferay.com/browse/LPS-140315

This PR adds a description to the cover background image on a blog entry using the cover image caption. 

We can improve it in the future by using the DM file description (adding Documents 
 & Media file description to blogs images) or adding a field in the blog entry.