### PR TITLE
LPS-139932 | master

### DIFF
--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_category_entries.jspf
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_category_entries.jspf
@@ -45,19 +45,17 @@ MBCategoryDisplay categoryDisplay = new MBCategoryDisplay(scopeGroupId, category
 		<liferay-ui:search-container-column-text
 			colspan="<%= 2 %>"
 		>
-			<h4>
-				<aui:a href="<%= rowURL.toString() %>">
-					<%= curCategory.getName() %>
-				</aui:a>
+			<aui:a href="<%= rowURL.toString() %>">
+				<%= curCategory.getName() %>
+			</aui:a>
 
-				<c:if test='<%= Objects.equals(curCategory.getDisplayStyle(), "question") %>'>
-					<aui:icon cssClass="icon-monospaced" image="question-circle" markupView="lexicon" message="question" />
-				</c:if>
-			</h4>
+			<c:if test='<%= Objects.equals(curCategory.getDisplayStyle(), "question") %>'>
+				<aui:icon cssClass="icon-monospaced" image="question-circle" markupView="lexicon" message="question" />
+			</c:if>
 
-			<h5 class="text-default">
+			<span class="text-default">
 				<%= curCategory.getDescription() %>
-			</h5>
+			</span>
 
 			<%
 			int subcategoriesCount = categoryDisplay.getSubcategoriesCount(curCategory);

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_thread_entries.jspf
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_thread_entries.jspf
@@ -60,7 +60,7 @@
 		<liferay-ui:search-container-column-text
 			colspan="<%= 2 %>"
 		>
-			<h2 class="h5">
+			<div class="h5">
 				<aui:a href="<%= rowURL.toString() %>">
 					<c:if test="<%= message != null %>">
 						<c:choose>
@@ -87,7 +87,7 @@
 				<c:if test="<%= thread.isQuestion() %>">
 					<aui:icon cssClass="icon-monospaced" image="question-circle" markupView="lexicon" message="question" />
 				</c:if>
-			</h2>
+			</div>
 
 			<c:choose>
 				<c:when test="<%= (message != null) && (thread.getMessageCount() == 1) %>">

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_thread_message.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_thread_message.jsp
@@ -67,9 +67,9 @@ User messageUser = UserLocalServiceUtil.fetchUser(message.getUserId());
 				String userDisplayText = LanguageUtil.format(request, "x-modified-x-ago", new Object[] {messageUserName, modifiedDateDescription});
 				%>
 
-				<h5 class="message-user-display text-default" title="<%= HtmlUtil.escapeAttribute(userDisplayText) %>">
+				<span class="message-user-display text-default" title="<%= HtmlUtil.escapeAttribute(userDisplayText) %>">
 					<%= HtmlUtil.escape(userDisplayText) %>
-				</h5>
+				</span>
 
 				<h4 title="<%= HtmlUtil.escape(message.getSubject()) %>">
 					<c:choose>

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_thread_message.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_thread_message.jsp
@@ -445,7 +445,7 @@ User messageUser = UserLocalServiceUtil.fetchUser(message.getUserId());
 
 			<c:if test="<%= attachmentsFileEntriesCount > 0 %>">
 				<div class="card-body message-attachments">
-					<h3><liferay-ui:message key="attachments" />:</h3>
+					<p class="h3"><liferay-ui:message key="attachments" />:</p>
 
 					<ul>
 

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/messageboards/MessageBoardsThread.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/messageboards/MessageBoardsThread.path
@@ -68,12 +68,12 @@
 </tr>
 <tr>
 	<td>THREAD_USERNAME</td>
-	<td>//div[@class='panel-heading' and contains(.,'${key_threadSubject}')]//h5[contains(.,'${key_userName}')]</td>
+	<td>//div[@class='panel-heading' and contains(.,'${key_threadSubject}')]//span[contains(.,'${key_userName}')]</td>
 	<td></td>
 </tr>
 <tr>
 	<td>THREAD_USERNAME_2</td>
-	<td>xpath=(//div[@class='panel-heading' and contains(.,'${key_threadSubject}')]//h5[contains(.,'${key_userName}')])[2]</td>
+	<td>xpath=(//div[@class='panel-heading' and contains(.,'${key_threadSubject}')]//span[contains(.,'${key_userName}')])[2]</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-139932

We are not following heading hierarchy in Message Boards and it is mostly because we are adding unnecessary headers.

- In view_categories_entries.jspf we are already inside a structured list, so we don't need them.
- In view_thread_entries.jspf and view_thread_message.jsp we are adding a header to something it shouldn't be a header (description and user's name)

Thanks.

Regards.