### PR TITLE
[TS] LPS-134601 depend on languageId instead of languageTag

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/I18nServlet.java
+++ b/portal-impl/src/com/liferay/portal/servlet/I18nServlet.java
@@ -254,7 +254,8 @@ public class I18nServlet extends HttpServlet {
 		_setRequestAttributes(
 			httpServletRequest, httpServletResponse, i18nData);
 
-		String languageId = LocaleUtil.toW3cLanguageId(i18nData.getLanguageId());
+		String languageId = LocaleUtil.toW3cLanguageId(
+			i18nData.getLanguageId());
 
 		httpServletResponse.setStatus(HttpServletResponse.SC_MOVED_PERMANENTLY);
 
@@ -263,8 +264,8 @@ public class I18nServlet extends HttpServlet {
 		httpServletResponse.setHeader(
 			"Location",
 			StringBundler.concat(
-				servletContext.getContextPath(), StringPool.SLASH,
-				languageId, i18nData.getPath()));
+				servletContext.getContextPath(), StringPool.SLASH, languageId,
+				i18nData.getPath()));
 	}
 
 	protected class I18nData {


### PR DESCRIPTION
Hi Team Lima,

Can you help review this PR? 

Hopefully this is the right team to review this change, if not can you forward to the proper team or let us know which team?

**Notes from @NemethNorbert:**

> Hey,
> 
> Last PR: https://github.com/ericyanLr/liferay-portal/pull/236
> Ticket: [LPS-134601](https://issues.liferay.com/browse/LPS-134601)
> 
> I red trough your suggestions, and I ended up not depending on the languageTag as we are not supporting the newest languageTags (he,id,yi)
> Instead I modified sendRedirect to create a W3cLanguageId and use that in our redirect url. This resolves the issue without hardcoding the specific use cases for this 3 language and we can switch back to using languageTags once we are prepared to handle them.
> 
> Please review my changes.
> 
> Thanks

I'll also leave a couple links for additional notes below.

Please let us know if you have any questions.
Thanks!


----

Additional Notes:
- https://github.com/ericyanLr/liferay-portal/pull/236#issuecomment-867998846
- PTR-2515 (Has Info on he_IL vs iw_IL)
  - https://issues.liferay.com/browse/PTR-2515?focusedCommentId=2473950&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-2473950