### PR TITLE
LPS-140303 Change HTML fields to be rendered as textareas

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/info/field/converter/DDMFormFieldInfoFieldConverterImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/info/field/converter/DDMFormFieldInfoFieldConverterImpl.java
@@ -104,6 +104,7 @@ public class DDMFormFieldInfoFieldConverterImpl
 
 			finalStep.attribute(TextInfoFieldType.HTML, true);
 			finalStep.attribute(TextInfoFieldType.MULTILINE, true);
+			finalStep.attribute(TextInfoFieldType.RICH_TEXT, true);
 		}
 
 		return finalStep;

--- a/modules/apps/info/info-api/bnd.bnd
+++ b/modules/apps/info/info-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Info API
 Bundle-SymbolicName: com.liferay.info.api
-Bundle-Version: 8.0.2
+Bundle-Version: 8.1.0
 Export-Package:\
 	com.liferay.info.collection.provider,\
 	com.liferay.info.constants,\

--- a/modules/apps/info/info-api/src/main/java/com/liferay/info/display/contributor/InfoDisplayContributor.java
+++ b/modules/apps/info/info-api/src/main/java/com/liferay/info/display/contributor/InfoDisplayContributor.java
@@ -27,10 +27,10 @@ import java.util.Set;
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
- * @author Jürgen Kappler
+ * @author     Jürgen Kappler
  * @deprecated As of Athanasius (7.3.x), replaced by {@link
- * com.liferay.info.item.provider.InfoItemObjectProvider and
- * com.liferay.layout.display.page.LayoutDisplayPageProvider}
+ *             com.liferay.info.item.provider.InfoItemObjectProvider and
+ *             com.liferay.layout.display.page.LayoutDisplayPageProvider}
  */
 @Deprecated
 @ProviderType

--- a/modules/apps/info/info-api/src/main/java/com/liferay/info/display/contributor/InfoDisplayContributorTracker.java
+++ b/modules/apps/info/info-api/src/main/java/com/liferay/info/display/contributor/InfoDisplayContributorTracker.java
@@ -17,7 +17,7 @@ package com.liferay.info.display.contributor;
 import java.util.List;
 
 /**
- * @author Jürgen Kappler
+ * @author     Jürgen Kappler
  * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
  */
 @Deprecated

--- a/modules/apps/info/info-api/src/main/java/com/liferay/info/display/contributor/InfoDisplayField.java
+++ b/modules/apps/info/info-api/src/main/java/com/liferay/info/display/contributor/InfoDisplayField.java
@@ -21,7 +21,7 @@ import com.liferay.portal.kernel.json.JSONUtil;
 import java.util.Objects;
 
 /**
- * @author Jürgen Kappler
+ * @author     Jürgen Kappler
  * @deprecated As of Cavanaugh (7.4.x)
  */
 @Deprecated

--- a/modules/apps/info/info-api/src/main/java/com/liferay/info/display/contributor/InfoDisplayObjectProvider.java
+++ b/modules/apps/info/info-api/src/main/java/com/liferay/info/display/contributor/InfoDisplayObjectProvider.java
@@ -19,7 +19,7 @@ import java.io.Serializable;
 import java.util.Locale;
 
 /**
- * @author Jürgen Kappler
+ * @author     Jürgen Kappler
  * @deprecated As of Cavanaugh (7.4.x)
  */
 @Deprecated

--- a/modules/apps/info/info-api/src/main/java/com/liferay/info/display/field/ClassTypesInfoDisplayFieldProvider.java
+++ b/modules/apps/info/info-api/src/main/java/com/liferay/info/display/field/ClassTypesInfoDisplayFieldProvider.java
@@ -25,7 +25,7 @@ import java.util.Locale;
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
- * @author Jürgen Kappler
+ * @author     Jürgen Kappler
  * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
  */
 @Deprecated

--- a/modules/apps/info/info-api/src/main/java/com/liferay/info/display/field/ExpandoInfoDisplayFieldProvider.java
+++ b/modules/apps/info/info-api/src/main/java/com/liferay/info/display/field/ExpandoInfoDisplayFieldProvider.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
- * @author Jürgen Kappler
+ * @author     Jürgen Kappler
  * @deprecated As of Cavanaugh (7.4.x)
  */
 @Deprecated

--- a/modules/apps/info/info-api/src/main/java/com/liferay/info/display/field/InfoDisplayFieldProvider.java
+++ b/modules/apps/info/info-api/src/main/java/com/liferay/info/display/field/InfoDisplayFieldProvider.java
@@ -24,7 +24,7 @@ import java.util.Set;
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
- * @author Jürgen Kappler
+ * @author     Jürgen Kappler
  * @deprecated As of Cavanaugh (7.4.x)
  */
 @Deprecated

--- a/modules/apps/info/info-api/src/main/java/com/liferay/info/field/type/TextInfoFieldType.java
+++ b/modules/apps/info/info-api/src/main/java/com/liferay/info/field/type/TextInfoFieldType.java
@@ -27,6 +27,9 @@ public class TextInfoFieldType implements InfoFieldType {
 	public static final Attribute<TextInfoFieldType, Boolean> MULTILINE =
 		new Attribute<>();
 
+	public static final Attribute<TextInfoFieldType, Boolean> RICH_TEXT =
+		new Attribute<>();
+
 	@Override
 	public String getName() {
 		return "text";

--- a/modules/apps/info/info-api/src/main/java/com/liferay/info/item/field/reader/InfoItemFieldReader.java
+++ b/modules/apps/info/info-api/src/main/java/com/liferay/info/item/field/reader/InfoItemFieldReader.java
@@ -23,8 +23,7 @@ import com.liferay.info.field.InfoField;
 public interface InfoItemFieldReader<T> {
 
 	/**
-	 *   @deprecated As of Cavanaugh (7.4.x), replaced by {@link
-	 *          #getInfoField()}
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #getInfoField()}
 	 */
 	@Deprecated
 	public InfoField getField();

--- a/modules/apps/info/info-api/src/main/java/com/liferay/info/item/provider/InfoItemFieldValuesProvider.java
+++ b/modules/apps/info/info-api/src/main/java/com/liferay/info/item/provider/InfoItemFieldValuesProvider.java
@@ -31,9 +31,9 @@ public interface InfoItemFieldValuesProvider<T> {
 	}
 
 	/**
-	 *   @deprecated As the method name does not match the interface class
-	 *   that is returned , replaced by {@link
-	 *          #getInfoFieldValue(Object, String)} ()}
+	 * @deprecated As of Cavanaugh (7.4.x), As the method name does not match
+	 *             the interface class that is returned , replaced by {@link
+	 *             #getInfoFieldValue(Object, String)} ()}
 	 */
 	@Deprecated
 	public default InfoFieldValue<Object> getInfoItemFieldValue(

--- a/modules/apps/info/info-api/src/main/java/com/liferay/info/list/provider/InfoListProvider.java
+++ b/modules/apps/info/info-api/src/main/java/com/liferay/info/list/provider/InfoListProvider.java
@@ -22,7 +22,7 @@ import java.util.List;
 import java.util.Locale;
 
 /**
- * @author Jorge Ferrer
+ * @author     Jorge Ferrer
  * @deprecated As of Athanasius (7.3.x), replaced by {@link
  *             com.liferay.info.collection.provider.InfoCollectionProvider}
  */

--- a/modules/apps/info/info-api/src/main/resources/com/liferay/info/field/type/packageinfo
+++ b/modules/apps/info/info-api/src/main/resources/com/liferay/info/field/type/packageinfo
@@ -1,1 +1,1 @@
-version 1.2.0
+version 1.3.0

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/info/item/JournalArticleInfoItemFields.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/info/item/JournalArticleInfoItemFields.java
@@ -64,6 +64,8 @@ public interface JournalArticleInfoItemFields {
 			"description"
 		).attribute(
 			TextInfoFieldType.HTML, true
+		).attribute(
+			TextInfoFieldType.RICH_TEXT, true
 		).labelInfoLocalizedValue(
 			InfoLocalizedValue.localize(
 				JournalArticleInfoItemFields.class, "description")

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/util/InfoFieldUtil.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/util/InfoFieldUtil.java
@@ -149,11 +149,21 @@ public class InfoFieldUtil {
 			true
 		).attribute(
 			TextInfoFieldType.HTML, _isHtml(type)
+		).attribute(
+			TextInfoFieldType.RICH_TEXT, _isRichText(type)
 		).build();
 	}
 
 	private static boolean _isHtml(String type) {
-		if (type.equals("html") || type.equals("rich-text")) {
+		if (type.equals("html") || _isRichText(type)) {
+			return true;
+		}
+
+		return false;
+	}
+
+	private static boolean _isRichText(String type) {
+		if (type.equals("rich-text")) {
 			return true;
 		}
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
@@ -997,7 +997,7 @@ public class ContentPageEditorDisplayContext {
 					EditorConfigurationFactoryUtil.getEditorConfiguration(
 						ContentPageEditorPortletKeys.
 							CONTENT_PAGE_EDITOR_PORTLET,
-						"fragmenEntryLinkRichTextEditor", StringPool.BLANK,
+						"fragmentEntryLinkRichTextEditor", StringPool.BLANK,
 						Collections.emptyMap(), themeDisplay,
 						RequestBackedPortletURLFactoryUtil.create(
 							httpServletRequest));
@@ -1011,7 +1011,7 @@ public class ContentPageEditorDisplayContext {
 					EditorConfigurationFactoryUtil.getEditorConfiguration(
 						ContentPageEditorPortletKeys.
 							CONTENT_PAGE_EDITOR_PORTLET,
-						"fragmenEntryLinkEditor", StringPool.BLANK,
+						"fragmentEntryLinkEditor", StringPool.BLANK,
 						Collections.emptyMap(), themeDisplay,
 						RequestBackedPortletURLFactoryUtil.create(
 							httpServletRequest));

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/editor/configuration/FragmentEntryLinkEditorConfigContributor.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/editor/configuration/FragmentEntryLinkEditorConfigContributor.java
@@ -42,7 +42,7 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	property = {
-		"editor.config.key=fragmenEntryLinkEditor",
+		"editor.config.key=fragmentEntryLinkEditor",
 		"javax.portlet.name=" + ContentPageEditorPortletKeys.CONTENT_PAGE_EDITOR_PORTLET
 	},
 	service = {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/editor/configuration/FragmentEntryLinkRichTextEditorConfigContributor.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/editor/configuration/FragmentEntryLinkRichTextEditorConfigContributor.java
@@ -48,7 +48,7 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	property = {
-		"editor.config.key=fragmenEntryLinkRichTextEditor",
+		"editor.config.key=fragmentEntryLinkRichTextEditor",
 		"javax.portlet.name=" + ContentPageEditorPortletKeys.CONTENT_PAGE_EDITOR_PORTLET
 	},
 	service = EditorConfigContributor.class

--- a/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/display/context/TranslateDisplayContext.java
+++ b/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/display/context/TranslateDisplayContext.java
@@ -216,6 +216,10 @@ public class TranslateDisplayContext {
 									getBooleanValue(
 										infoField, TextInfoFieldType.MULTILINE)
 								).put(
+									"richText",
+									getBooleanValue(
+										infoField, TextInfoFieldType.RICH_TEXT)
+								).put(
 									"sourceContent",
 									getSourceStringValue(
 										infoField, getSourceLocale())


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-140303

Hi @boton :

At this moment the html type should be working as before BUT I created a new attribute only for it 
Summarizing:

The old 

- HTML tag now is named RICH_TEXT
- Only the type equals to "rich-text" will have this tag
- There is a new tag called HTML 
- only the the type equals "html" will have this tag
- I duplicated the code for RICH_TEXT and HTML. This is the point in which you can begin to differentiate the behavior between html and rich text.


please, ping me with any problem that this can have

![image](https://user-images.githubusercontent.com/47524751/137349160-f231e042-caff-4e39-a260-1407ae2bbe69.png)

