### PR TITLE
LPS-139726 Make it work for anchor tags as well

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/transformer/DLPreviewURLRefreshTimestampTransformerListener.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/transformer/DLPreviewURLRefreshTimestampTransformerListener.java
@@ -105,9 +105,7 @@ public class DLPreviewURLRefreshTimestampTransformerListener
 	}
 
 	private String _replace(String s) {
-		if (Validator.isNull(s) || !s.contains("<img") ||
-			!s.contains("/documents/")) {
-
+		if (Validator.isNull(s) || !s.contains("/documents/")) {
 			return s;
 		}
 
@@ -146,8 +144,9 @@ public class DLPreviewURLRefreshTimestampTransformerListener
 		DLPreviewURLRefreshTimestampTransformerListener.class);
 
 	private static final Pattern _pattern = Pattern.compile(
-		"(<img\\s+(?:[^>]*\\s)*src=['\"](?:/?[^\\s]*)/documents/(\\d+)/(\\d+)" +
-			"/([^/?]+)(?:/([-0-9a-fA-F]+))?)(?:\\?t=\\d+)?(['\"][^>]*/>)");
+		"(<(?:a|img)\\s+(?:[^>]*\\s)*(?:href|src)=['\"](?:/?[^\\s]*)" +
+			"/documents/(\\d+)/(\\d+)/([^/?]+)(?:/([-0-9a-fA-F]+))?)" +
+				"(?:\\?t=\\d+)?(['\"](?:\\s*>.*</a>|[^>]*/>))");
 
 	@Reference
 	private DLAppLocalService _dlAppLocalService;


### PR DESCRIPTION
Dear Team,

Could you please review this pull request?

The customer wanted the listener to work not only for **img** tags, but for **a** tags as well.
I made an update to the pattern accordingly.

This is an additional commit for LPS-139726, which has been already merged to master.
Please let me know if you would prefer for me to send a pull with a new LPS instead of the already existing LPS-139726.

Thank you and best regards,
István