### PR TITLE
Revert "LPS-139497 Fix behavior for Save Draft and Publish button"

### DIFF
--- a/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/translate/components/TranslateActionBar.js
+++ b/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/translate/components/TranslateActionBar.js
@@ -124,6 +124,7 @@ const TransLateActionBar = ({
 								<ClayButton
 									disabled={saveButtonDisabled}
 									displayType="secondary"
+									onClick={onSaveButtonClick}
 									small
 									type="submit"
 								>
@@ -132,7 +133,6 @@ const TransLateActionBar = ({
 								<ClayButton
 									disabled={publishButtonDisabled}
 									displayType="primary"
-									onClick={onSaveButtonClick}
 									small
 									type="submit"
 								>


### PR DESCRIPTION
This reverts this PR #2378

[LPS-139497](https://issues.liferay.com/browse/LPS-139497) is not a bug, that was the intended behavior for pages that @pablo-agulla agreed with @adolfopa. 

`Save as draft` saves the draft of the translation, _**not the draft of the page**_. 

And publishing the translation builds a page draft in order to be consistent with the page flow (which is slightly different from content) so the translations can be reviewed merged with the page before the page is published