### PR TITLE
LPS-141202 Custom field values of Documents Folders not saved

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/EditFolderMVCActionCommand.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/EditFolderMVCActionCommand.java
@@ -221,7 +221,7 @@ public class EditFolderMVCActionCommand extends BaseMVCActionCommand {
 		String description = ParamUtil.getString(actionRequest, "description");
 
 		ServiceContext serviceContext = ServiceContextFactory.getInstance(
-			actionRequest);
+			DLFolder.class.getName(), actionRequest);
 
 		if (folderId <= 0) {
 


### PR DESCRIPTION
Dear Team,

Could you please review this pull request?

The cause of the issue was that the `EditFolderMVCActionCommand._updateFolder()` doesn't call the version of `ServiceContextFactory.getInstance()` that sets the `serviceContext`'s expand bridge attributes.
This fix corrects that.

Thank you and best regards,
István