### PR TITLE
LPS-141339 The error message is incorrect after adding a duplicate site or depot

### DIFF
--- a/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/portlet/action/AddDepotEntryMVCActionCommand.java
+++ b/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/portlet/action/AddDepotEntryMVCActionCommand.java
@@ -108,14 +108,14 @@ public class AddDepotEntryMVCActionCommand extends BaseMVCActionCommand {
 				JSONUtil.put(
 					"error",
 					_getErrorMessage(
-						exception.getCause(),
 						(ThemeDisplay)actionRequest.getAttribute(
-							WebKeys.THEME_DISPLAY))));
+							WebKeys.THEME_DISPLAY),
+						exception.getCause())));
 		}
 	}
 
 	private String _getErrorMessage(
-		Throwable throwable, ThemeDisplay themeDisplay) {
+		ThemeDisplay themeDisplay, Throwable throwable) {
 
 		if (throwable instanceof DepotEntryNameException) {
 			return LanguageUtil.get(


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-141339

- LPS-141339 UnsafeSupplier throws always RuntimeException with the exception on the cause
- LPS-141339 sort

![image](https://user-images.githubusercontent.com/47524751/138669043-a926df8b-93e7-4fdb-b722-3bbef4640c69.png)
