### PR TITLE
LPS-141358 An error will be dispalyed when user view the shared content through notification

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminDisplayContextProvider.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminDisplayContextProvider.java
@@ -17,6 +17,7 @@ package com.liferay.document.library.web.internal.display.context;
 import com.liferay.document.library.kernel.versioning.VersioningStrategy;
 import com.liferay.document.library.web.internal.display.context.util.DLRequestHelper;
 import com.liferay.document.library.web.internal.helper.DLTrashHelper;
+import com.liferay.item.selector.ItemSelector;
 import com.liferay.trash.TrashHelper;
 
 import javax.servlet.http.HttpServletRequest;
@@ -36,6 +37,9 @@ public class DLAdminDisplayContextProvider {
 	public DLAdminDisplayContext getDLAdminDisplayContext(
 		HttpServletRequest httpServletRequest,
 		HttpServletResponse httpServletResponse) {
+
+		httpServletRequest.setAttribute(
+			ItemSelector.class.getName(), _itemSelector);
 
 		DLRequestHelper dlRequestHelper = new DLRequestHelper(
 			httpServletRequest);
@@ -63,6 +67,9 @@ public class DLAdminDisplayContextProvider {
 
 	@Reference
 	private DLTrashHelper _dlTrashHelper;
+
+	@Reference
+	private ItemSelector _itemSelector;
 
 	@Reference
 	private TrashHelper _trashHelper;


### PR DESCRIPTION
I see that there is a lack of ItemSelector attribute on the 

I do not think that it's a permission issue cause I could reproduce this way:

1. Add a new user 
2. Add a document (Not reproduce for image, cause it has a preview and enters by https://github.com/liferay/liferay-portal/blob/d407d1aa715e826f6a2040c3b0a4401926e7a9ce/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/asset/file_entry_full_content.jsp#L35 )
3. Go to user menu > shared content
4. Shared By me
4. Click the message to go to the shared content
8. View the console


To avoid the NPE on https://github.com/liferay/liferay-portal/blob/587cd9e9c994c37c98acf787f79ac95463f394a0/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry.jsp#L184 I added it to the `DLAdminDisplayContextProvider` because I found it the least intromission point to add it. To set a null check it's another way but when you have the correct permission maybe you want to make something with it.

The problem is that when access via notifications, (my shared or shared with me) the item selector it is never filled in because it accesses through the asset renderer and the file_entry_full_content. 

