### PR TITLE
[TS] LPS-141218 Remove unnecessary heading element and keep headings in sequentially-descending order

### DIFF
--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/edit_message_quick_resource.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/edit_message_quick_resource.jsp
@@ -90,9 +90,9 @@ String redirect = ParamUtil.getString(request, "redirect");
 			String userDisplayText = LanguageUtil.format(request, "x-replying", new Object[] {HtmlUtil.escape(userName)});
 			%>
 
-			<h5 class="message-user-display text-default" title="<%= userDisplayText %>">
+			<span class="message-user-display text-default" title="<%= userDisplayText %>">
 				<%= userDisplayText %>
-			</h5>
+			</span>
 
 			<h4 title="<%= HtmlUtil.escape(message.getSubject()) %>">
 				<c:choose>


### PR DESCRIPTION
Hello,

We have incorrect heading hierarchy in Message Board, **h4** tag is followed by **h5**.
Small fix for removing an unnecessary heading element **h5**. Similarly to [LPS-139932](https://issues.liferay.com/browse/LPS-139932)

LPS ticket: [LPS-141218](https://issues.liferay.com/browse/LPS-141218
)

Can you please review it?

Thank you!
