### PR TITLE
LPS-141741 The input mode is incorrect when translating content and description of an article

### DIFF
--- a/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/translate/components/TranslateFieldSetEntries.js
+++ b/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/translate/components/TranslateFieldSetEntries.js
@@ -103,13 +103,16 @@ const TranslateFieldEditor = ({
 	onChange = noop,
 }) => {
 	const [content, setContent] = useState(targetContent);
+
 	const editorRef = useRef();
+	const internalUpdateRef = useRef(true);
 
 	useEffect(() => {
-		if (editorRef.current.editor) {
+		if (editorRef.current.editor && !internalUpdateRef.current) {
 			editorRef.current.editor.setData(targetContent);
 			setContent(targetContent);
 		}
+		internalUpdateRef.current = false;
 	}, [targetContent]);
 
 	return (
@@ -136,6 +139,7 @@ const TranslateFieldEditor = ({
 						onChange={(data) => {
 							setContent(data);
 							onChange(data);
+							internalUpdateRef.current = true;
 						}}
 						onInstanceReady={({editor}) => {
 


### PR DESCRIPTION
BUG 🐛 :  https://issues.liferay.com/browse/LPS-141741

I have differentiated the internal updates from the external ones so that only call at the CKEditorInstance.setData directly when the update is external, avoiding losing focus when the user is typing.