### PR TITLE
LPS-141975 Clarify the field names for mapping SEO - Modify the LayoutSEOTemplateProcessor to admit labels on the references

### DIFF
--- a/modules/apps/layout/layout-seo-service/src/main/java/com/liferay/layout/seo/internal/template/LayoutSEOTemplateProcessorImpl.java
+++ b/modules/apps/layout/layout-seo-service/src/main/java/com/liferay/layout/seo/internal/template/LayoutSEOTemplateProcessorImpl.java
@@ -68,6 +68,7 @@ public class LayoutSEOTemplateProcessorImpl
 		return sb.toString();
 	}
 
-	private static final Pattern _pattern = Pattern.compile("\\$\\{([^}]+)\\}");
+	private static final Pattern _pattern = Pattern.compile(
+		"\\$\\{([^:}]+)(?::[^}]*)?\\}");
 
 }

--- a/modules/apps/layout/layout-seo-test/build.gradle
+++ b/modules/apps/layout/layout-seo-test/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
 	testIntegrationCompile project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")
+	testIntegrationCompile project(":apps:info:info-api")
 	testIntegrationCompile project(":apps:layout:layout-seo-api")
 	testIntegrationCompile project(":apps:layout:layout-test-util")
 	testIntegrationCompile project(":apps:portal-configuration:portal-configuration-test-util")

--- a/modules/apps/layout/layout-seo-test/src/testIntegration/java/com/liferay/layout/seo/internal/template/test/LayoutSEOTemplateProcessorTest.java
+++ b/modules/apps/layout/layout-seo-test/src/testIntegration/java/com/liferay/layout/seo/internal/template/test/LayoutSEOTemplateProcessorTest.java
@@ -1,0 +1,185 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.layout.seo.internal.template.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.info.field.InfoField;
+import com.liferay.info.field.InfoFieldValue;
+import com.liferay.info.field.type.TextInfoFieldType;
+import com.liferay.info.item.InfoItemFieldValues;
+import com.liferay.info.localized.InfoLocalizedValue;
+import com.liferay.layout.seo.template.LayoutSEOTemplateProcessor;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Alicia García
+ */
+@RunWith(Arquillian.class)
+public class LayoutSEOTemplateProcessorTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Test
+	public void testProcessTemplateDefaultMappedTitleAndDescriptionReferences() {
+		InfoItemFieldValues infoItemFieldValues = _getInfoItemFieldValues();
+
+		Assert.assertEquals(
+			"<p>defaultMappedDescription</p>",
+			_layoutSEOTemplateProcessor.processTemplate(
+				"${description}", infoItemFieldValues, LocaleUtil.US));
+		Assert.assertEquals(
+			"defaultMappedTitle",
+			_layoutSEOTemplateProcessor.processTemplate(
+				"${title}", infoItemFieldValues, LocaleUtil.US));
+	}
+
+	@Test
+	public void testProcessTemplateEmptyLabelReference() {
+		Assert.assertEquals(
+			"This is the text",
+			_layoutSEOTemplateProcessor.processTemplate(
+				"${Text45966564:}", _getInfoItemFieldValues(), LocaleUtil.US));
+	}
+
+	@Test
+	public void testProcessTemplateIncompleteReference() {
+		Assert.assertEquals(
+			"${Text45966564: incomplete tag",
+			_layoutSEOTemplateProcessor.processTemplate(
+				"${Text45966564: incomplete tag", _getInfoItemFieldValues(),
+				LocaleUtil.US));
+	}
+
+	@Test
+	public void testProcessTemplateIncorrectLabeledReference() {
+		Assert.assertEquals(
+			"This is the text",
+			_layoutSEOTemplateProcessor.processTemplate(
+				"${Text45966564:ThisIsNotTheLabel}", _getInfoItemFieldValues(),
+				LocaleUtil.US));
+	}
+
+	@Test
+	public void testProcessTemplateIncorrectReference() {
+		Assert.assertEquals(
+			"This is the text }",
+			_layoutSEOTemplateProcessor.processTemplate(
+				"${Text45966564:This is a bad label ${title} }",
+				_getInfoItemFieldValues(), LocaleUtil.US));
+	}
+
+	@Test
+	public void testProcessTemplateIncorrectReferenceLegacyBehavior() {
+		Assert.assertEquals(
+			"Text85",
+			_layoutSEOTemplateProcessor.processTemplate(
+				"${Text85}", _getInfoItemFieldValues(), LocaleUtil.US));
+	}
+
+	@Test
+	public void testProcessTemplateLabeledReference() {
+		Assert.assertEquals(
+			"This is the text",
+			_layoutSEOTemplateProcessor.processTemplate(
+				"${Text45966564:Text Label}", _getInfoItemFieldValues(),
+				LocaleUtil.US));
+	}
+
+	@Test
+	public void testProcessTemplateReferencesWithMessage() {
+		Assert.assertEquals(
+			"This is the title: defaultMappedTitle",
+			_layoutSEOTemplateProcessor.processTemplate(
+				"This is the title: ${title}", _getInfoItemFieldValues(),
+				LocaleUtil.US));
+	}
+
+	@Test
+	public void testProcessTemplateReferencesWithMessageBreakLines() {
+		Assert.assertEquals(
+			"This is the title: defaultMappedTitle\n" +
+				"<p>defaultMappedDescription</p>\nThis is the text",
+			_layoutSEOTemplateProcessor.processTemplate(
+				"This is the title: ${title}\n${description}\n${Text45966564}",
+				_getInfoItemFieldValues(), LocaleUtil.US));
+	}
+
+	@Test
+	public void testProcessTemplateSeveralReferences() {
+		Assert.assertEquals(
+			"defaultMappedTitle <p>defaultMappedDescription</p> This is the " +
+				"text",
+			_layoutSEOTemplateProcessor.processTemplate(
+				"${title} ${description} ${Text45966564}",
+				_getInfoItemFieldValues(), LocaleUtil.US));
+	}
+
+	private InfoItemFieldValues _getInfoItemFieldValues() {
+		return InfoItemFieldValues.builder(
+		).infoFieldValue(
+			new InfoFieldValue<>(
+				InfoField.builder(
+				).infoFieldType(
+					TextInfoFieldType.INSTANCE
+				).name(
+					"description"
+				).labelInfoLocalizedValue(
+					null
+				).build(),
+				"<p>defaultMappedDescription</p>")
+		).infoFieldValue(
+			new InfoFieldValue<>(
+				InfoField.builder(
+				).infoFieldType(
+					TextInfoFieldType.INSTANCE
+				).name(
+					"Text45966564"
+				).labelInfoLocalizedValue(
+					InfoLocalizedValue.localize(getClass(), "Text Label")
+				).build(),
+				"This is the text")
+		).infoFieldValue(
+			new InfoFieldValue<>(
+				InfoField.builder(
+				).infoFieldType(
+					TextInfoFieldType.INSTANCE
+				).name(
+					"title"
+				).labelInfoLocalizedValue(
+					null
+				).build(),
+				"defaultMappedTitle")
+		).build();
+	}
+
+	@Inject
+	private LayoutSEOTemplateProcessor _layoutSEOTemplateProcessor;
+
+}

--- a/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/js/seo/display_page_templates/components/MappingInput.js
+++ b/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/js/seo/display_page_templates/components/MappingInput.js
@@ -53,11 +53,10 @@ function MappingInput({
 		const selectionEnd = inputEl.current.selectionEnd;
 		const fieldVariable = fieldTemplate(key, label);
 
-		setValue(
-			(value) =>
-				`${value.slice(0, selectionStart)}${fieldVariable}${value.slice(
-					selectionEnd
-				)}`
+		setValue((value) =>
+			`${value.slice(0, selectionStart)}${fieldVariable}${value.slice(
+				selectionEnd
+			)}`.trim()
 		);
 
 		setTimeout(() => {

--- a/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/js/seo/display_page_templates/components/MappingInput.js
+++ b/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/js/seo/display_page_templates/components/MappingInput.js
@@ -19,7 +19,8 @@ import React, {useRef, useState} from 'react';
 
 import MappingPanel from './MappingPanel';
 
-const fieldTemplate = (key) => ` $\{${key}} `;
+const sanitizeLabel = (label) => label.replace(/}|[\r\n]+/gm, '');
+const fieldTemplate = (key, label) => ` $\{${key}:${sanitizeLabel(label)}} `;
 
 function MappingInput({
 	component,
@@ -47,10 +48,10 @@ function MappingInput({
 		addNewVar(field);
 	};
 
-	const addNewVar = ({key}) => {
+	const addNewVar = ({key, label}) => {
 		const selectionStart = inputEl.current.selectionStart;
 		const selectionEnd = inputEl.current.selectionEnd;
-		const fieldVariable = fieldTemplate(key);
+		const fieldVariable = fieldTemplate(key, label);
 
 		setValue(
 			(value) =>

--- a/modules/apps/layout/layout-seo-web/test/seo/display_page_templates/components/MappingInput.js
+++ b/modules/apps/layout/layout-seo-web/test/seo/display_page_templates/components/MappingInput.js
@@ -33,7 +33,7 @@ const baseProps = {
 	selectedSource: {
 		classTypeLabel: 'Label source type',
 	},
-	value: 'field-2',
+	value: '${field-2}',
 };
 
 const renderComponent = (props) =>
@@ -95,16 +95,14 @@ describe('MappingInput', () => {
 			});
 
 			describe('and the user selects another field', () => {
-				beforeEach(() => {
+				it('adds the new field ${key:label} to the input', () => {
 					fireEvent.change(fieldSelect, {
 						target: {value: baseProps.fields[0].key},
 					});
 					fireEvent.click(mappingPanelButton);
-				});
 
-				it('adds the new field key to the input', () => {
 					expect(inputValue.value).toBe(
-						` $\{${baseProps.fields[0].key}} ${baseProps.value}`
+						` $\{${baseProps.fields[0].key}:${baseProps.fields[0].label}} ${baseProps.value}`
 					);
 				});
 			});

--- a/modules/apps/layout/layout-seo-web/test/seo/display_page_templates/components/MappingInput.js
+++ b/modules/apps/layout/layout-seo-web/test/seo/display_page_templates/components/MappingInput.js
@@ -102,7 +102,7 @@ describe('MappingInput', () => {
 					fireEvent.click(mappingPanelButton);
 
 					expect(inputValue.value).toBe(
-						` $\{${baseProps.fields[0].key}:${baseProps.fields[0].label}} ${baseProps.value}`
+						`$\{${baseProps.fields[0].key}:${baseProps.fields[0].label}} ${baseProps.value}`
 					);
 				});
 			});

--- a/modules/apps/layout/layout-seo-web/test/seo/display_page_templates/components/MappingInput.js
+++ b/modules/apps/layout/layout-seo-web/test/seo/display_page_templates/components/MappingInput.js
@@ -23,7 +23,12 @@ const baseProps = {
 	fields: [
 		{key: 'field-1', label: 'Field 1', type: 'text'},
 		{key: 'field-2', label: 'Field 2', type: 'text'},
-		{key: 'field-3', label: 'Field 3', type: 'image'},
+		{
+			key: 'field-3',
+			label:
+				'Field 3: with }right curly brackets}}}}, line breaks by \r\nwin\r\n\r\n\r\n, \nlinux\n and \rold mac\r',
+			type: 'image',
+		},
 		{key: 'field-4', label: 'Field 4', type: 'text'},
 		{key: 'field-5', label: 'Field 5', type: 'text'},
 	],
@@ -103,6 +108,20 @@ describe('MappingInput', () => {
 
 					expect(inputValue.value).toBe(
 						`$\{${baseProps.fields[0].key}:${baseProps.fields[0].label}} ${baseProps.value}`
+					);
+				});
+
+				it('adds the new field ${key:label} sanitized to the input', () => {
+					fireEvent.change(fieldSelect, {
+						target: {value: baseProps.fields[2].key},
+					});
+					fireEvent.click(mappingPanelButton);
+
+					const sanitizedLabel =
+						'Field 3: with right curly brackets, line breaks by win, linux and old mac';
+
+					expect(inputValue.value).toBe(
+						`$\{${baseProps.fields[2].key}:${sanitizedLabel}} ${baseProps.value}`
 					);
 				});
 			});


### PR DESCRIPTION
- LPS-141975 add the possibility of contain the label on the template to the pattern to extract the variable name
- LPS-141975 Add test to check the new behavior on the LayoutSEOTemplateProcessor

I modified the pattern of the LayoutSEOTemplateProcessor to take on consideration that the references can have the label.
