### PR TITLE
LPS-141978 Edit image from item selector do not work all the times

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/upload/DLUploadFileEntryHandler.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/upload/DLUploadFileEntryHandler.java
@@ -128,9 +128,10 @@ public class DLUploadFileEntryHandler implements UploadFileEntryHandler {
 
 	private boolean _exists(long groupId, long folderId, String fileName) {
 		try {
-			if (_dlAppService.getFileEntry(groupId, folderId, fileName) !=
-					null) {
+			FileEntry fileEntry = _dlAppService.getFileEntryByFileName(
+				groupId, folderId, fileName);
 
+			if (fileEntry != null) {
 				return true;
 			}
 


### PR DESCRIPTION
check the existence of the file by the filename to prevent the try of the creation of a file with the same name when editing an image from the item selector try of the creation of a file with the same name when editing an image from the item selector