### PR TITLE
LPS-136772 | Master

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/Blogs.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Blogs.macro
@@ -236,8 +236,17 @@ definition {
 
 		Pause(locator1 = "3000");
 
+		SelectFrame(value1 = "relative-top");
+
 		if (isSet(captionField)) {
 			AssertElementPresent(locator1 = "BlogsEntry#ENTRY_COVER_IMAGE_CAPTION");
+
+			if (!("${captionField}" == "true")) {
+				Type(
+					key_editor = "coverImageCaption",
+					locator1 = "AlloyEditor#EDITOR",
+					value1 = "${captionField}");
+			}
 		}
 
 		BlogsEntry.addEntryContent(

--- a/portal-web/test/functional/com/liferay/portalweb/macros/Blogs.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Blogs.macro
@@ -492,15 +492,6 @@ definition {
 		IFrame.saveConfiguration();
 	}
 
-	macro editCoverImageCaption {
-		Type(
-			key_editor = "coverImageCaption",
-			locator1 = "AlloyEditor#EDITOR",
-			value1 = "${captionField}");
-
-		Button.clickPublish();
-	}
-
 	macro editDraftPG {
 		BlogsNavigator.gotoEditPG(entryTitle = "${entryTitle}");
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/Blogs.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Blogs.macro
@@ -492,6 +492,15 @@ definition {
 		IFrame.saveConfiguration();
 	}
 
+	macro editCoverImageCaption {
+		Type(
+			key_editor = "coverImageCaption",
+			locator1 = "AlloyEditor#EDITOR",
+			value1 = "${captionField}");
+
+		Button.clickPublish();
+	}
+
 	macro editDraftPG {
 		BlogsNavigator.gotoEditPG(entryTitle = "${entryTitle}");
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/BlogsEntry.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/BlogsEntry.macro
@@ -355,8 +355,6 @@ definition {
 			key_editor = "coverImageCaption",
 			locator1 = "AlloyEditor#EDITOR",
 			value1 = "${captionField}");
-
-		Button.clickPublish();
 	}
 
 	macro editCustomURL {

--- a/portal-web/test/functional/com/liferay/portalweb/macros/BlogsEntry.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/BlogsEntry.macro
@@ -350,6 +350,15 @@ definition {
 			locator1 = "BlogsEntry#ENTRY_COVER_IMAGE_UNPUBLISHED");
 	}
 
+	macro editCoverImageCaption {
+		Type(
+			key_editor = "coverImageCaption",
+			locator1 = "AlloyEditor#EDITOR",
+			value1 = "${captionField}");
+
+		Button.clickPublish();
+	}
+
 	macro editCustomURL {
 		if (isSet(automatic)) {
 			Click(locator1 = "Radio#AUTOMATIC_URL");

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/BlogsEntry.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/BlogsEntry.testcase
@@ -591,10 +591,6 @@ definition {
 			locator1 = "BlogsEntry#ENTRY_COVER_IMAGE_CAPTION",
 			value1 = "Cover Image Caption");
 
-		Navigator.gotoPage(pageName = "Blogs Page");
-
-		BlogsNavigator.gotoEditPG(entryTitle = "Blogs Entry Title");
-
 		Blogs.editCoverImageCaption(captionField = "");
 
 		BlogsNavigator.openToEditEntryInSite(

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/BlogsEntry.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/BlogsEntry.testcase
@@ -559,13 +559,52 @@ definition {
 	}
 
 	@description = "This is a test for LPS-136772. It checks that the cover image caption can be deleted."
-	@ignore = "true"
 	@priority = "3"
 	test CanDeleteCoverImageCaption {
-		property portal.acceptance = "false";
+		JSONLayout.addPublicLayout(
+			groupName = "Guest",
+			layoutName = "Blogs Page");
 
-		// TODO LPS-136772 CanDeleteCoverImageCaption pending implementation
+		JSONLayout.addWidgetToPublicLayout(
+			groupName = "Guest",
+			layoutName = "Blogs Page",
+			widgetName = "Blogs");
 
+		Navigator.gotoPage(pageName = "Blogs Page");
+
+		Blogs.addEntryWithUploadedCoverImage(
+			captionField = "Cover Image Caption",
+			coverImageName = "Document_1",
+			entryContent = "Blogs Entry Content",
+			entryTitle = "Blogs Entry Title",
+			navTab = "Blog Images",
+			uploadFileName = "Document_1.jpg");
+
+		Button.clickPublish();
+
+		Navigator.gotoPage(pageName = "Blogs Page");
+
+		BlogsNavigator.gotoEntryPG(
+			entryContent = "Blogs Entry Content",
+			entryTitle = "Blogs Entry Title");
+
+		AssertTextEquals(
+			locator1 = "BlogsEntry#ENTRY_COVER_IMAGE_CAPTION",
+			value1 = "Cover Image Caption");
+
+		Navigator.gotoPage(pageName = "Blogs Page");
+
+		BlogsNavigator.gotoEditPG(entryTitle = "Blogs Entry Title");
+
+		Blogs.editCoverImageCaption(captionField = "");
+
+		Navigator.gotoPage(pageName = "Blogs Page");
+
+		BlogsNavigator.gotoEntryPG(
+			entryContent = "Blogs Entry Content",
+			entryTitle = "Blogs Entry Title");
+
+		AssertElementNotPresent(locator1 = "BlogsEntry#ENTRY_COVER_IMAGE_CAPTION");
 	}
 
 	@description = "This checks that a blog entry can saved as a draft and then deleted."

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/BlogsEntry.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/BlogsEntry.testcase
@@ -591,7 +591,7 @@ definition {
 			locator1 = "BlogsEntry#ENTRY_COVER_IMAGE_CAPTION",
 			value1 = "Cover Image Caption");
 
-		Blogs.editCoverImageCaption(captionField = "");
+		BlogsEntry.editCoverImageCaption(captionField = "");
 
 		BlogsNavigator.openToEditEntryInSite(
 			entryTitle = "Blogs Entry Title",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/BlogsEntry.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/BlogsEntry.testcase
@@ -879,13 +879,36 @@ definition {
 	}
 
 	@description = "This is a test for LPS-136773. It checks that XSS cannot be executed in the cover image caption."
-	@ignore = "true"
 	@priority = "3"
 	test CannotExecuteXSSInCoverImageCaption {
-		property portal.acceptance = "false";
+		JSONLayout.addPublicLayout(
+			groupName = "Guest",
+			layoutName = "Blogs Page");
 
-		// TODO LPS-136773 CannotExecuteXSSInCoverImageCaption pending implementation
+		JSONLayout.addWidgetToPublicLayout(
+			groupName = "Guest",
+			layoutName = "Blogs Page",
+			widgetName = "Blogs");
 
+		Navigator.gotoPage(pageName = "Blogs Page");
+
+		Blogs.addEntryWithUploadedCoverImage(
+			captionField = '''<script>alert(123);</script>''',
+			coverImageName = "Document_1",
+			entryContent = "Blogs Entry Content",
+			entryTitle = "Blogs Entry Title",
+			navTab = "Blog Images",
+			uploadFileName = "Document_1.jpg");
+
+		Button.clickPublish();
+
+		Navigator.gotoPage(pageName = "Blogs Page");
+
+		BlogsNavigator.gotoEntryPG(
+			entryContent = "Blogs Entry Content",
+			entryTitle = "Blogs Entry Title");
+
+		AssertAlertNotPresent();
 	}
 
 	@description = "This is a test for LPS-136765. It checks that Javascript cannot be executed in the custom abstract."

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/BlogsEntry.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/BlogsEntry.testcase
@@ -582,11 +582,10 @@ definition {
 
 		Button.clickPublish();
 
-		Navigator.gotoPage(pageName = "Blogs Page");
-
-		BlogsNavigator.gotoEntryPG(
-			entryContent = "Blogs Entry Content",
-			entryTitle = "Blogs Entry Title");
+		BlogsNavigator.openToEditEntryInSite(
+			entryTitle = "Blogs Entry Title",
+			groupName = "Guest",
+			siteURLKey = "blogs-page");
 
 		AssertTextEquals(
 			locator1 = "BlogsEntry#ENTRY_COVER_IMAGE_CAPTION",
@@ -598,11 +597,10 @@ definition {
 
 		Blogs.editCoverImageCaption(captionField = "");
 
-		Navigator.gotoPage(pageName = "Blogs Page");
-
-		BlogsNavigator.gotoEntryPG(
-			entryContent = "Blogs Entry Content",
-			entryTitle = "Blogs Entry Title");
+		BlogsNavigator.openToEditEntryInSite(
+			entryTitle = "Blogs Entry Title",
+			groupName = "Guest",
+			siteURLKey = "blogs-page");
 
 		AssertElementNotPresent(locator1 = "BlogsEntry#ENTRY_COVER_IMAGE_CAPTION");
 	}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/BlogsEntry.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/BlogsEntry.testcase
@@ -593,6 +593,8 @@ definition {
 
 		BlogsEntry.editCoverImageCaption(captionField = "");
 
+		Button.clickPublish();
+
 		BlogsNavigator.openToEditEntryInSite(
 			entryTitle = "Blogs Entry Title",
 			groupName = "Guest",


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-136772

@LeandroTravassos BlogsEntry.macro is used to performing any kind of action inside a blog entry so I moved the edit caption macro there. I removed the publish action from it so we can reuse that macro in the future (see BlogsEntry.addTitle, BlogsEntry.addSubtitle, etc.)