### PR TITLE
LPS-141919 Video cannot be previewed correctly on MediaGallery

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/image_gallery_display/css/main.scss
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/image_gallery_display/css/main.scss
@@ -55,8 +55,18 @@
 	}
 
 	.image-link {
-		text-align: center;
-		text-decoration: none;
+		border-radius: $card-border-radius;
+		margin-bottom: $card-margin-bottom;
+
+		&:focus {
+			border-color: transparent;
+			box-shadow: 0 0 0 2px #719aff;
+			outline: 0;
+		}
+
+		.card {
+			margin-bottom: 0;
+		}
 	}
 
 	.image-thumbnail {

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/image_gallery_display/view_images.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/image_gallery_display/view_images.jsp
@@ -96,7 +96,7 @@ DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper = new DLPortletI
 				%>
 
 				<liferay-ui:search-container-column-text>
-					<a class="image-link preview" <%= (hasAudio || hasVideo) ? "data-options=\"height=" + playerHeight + "&thumbnailURL=" + HtmlUtil.escapeURL(DLURLHelperUtil.getPreviewURL(fileEntry, fileVersion, themeDisplay, "&videoThumbnail=1")) + "&width=640" + dataOptions + "\"" : StringPool.BLANK %> href="<%= imageURL %>" thumbnailId="<%= thumbnailId %>" title="<%= title %>">
+					<div class="image-link preview" <%= (hasAudio || hasVideo) ? "data-options=\"height=" + playerHeight + "&thumbnailURL=" + HtmlUtil.escapeURL(DLURLHelperUtil.getPreviewURL(fileEntry, fileVersion, themeDisplay, "&videoThumbnail=1")) + "&width=640" + dataOptions + "\"" : StringPool.BLANK %> href="<%= imageURL %>" thumbnailId="<%= thumbnailId %>" title="<%= title %>">
 						<c:choose>
 							<c:when test="<%= Validator.isNull(imagePreviewURL) %>">
 								<liferay-frontend:icon-vertical-card
@@ -121,7 +121,7 @@ DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper = new DLPortletI
 								/>
 							</c:otherwise>
 						</c:choose>
-					</a>
+					</div>
 				</liferay-ui:search-container-column-text>
 			</c:when>
 			<c:otherwise>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/image_gallery_display/view_images.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/image_gallery_display/view_images.jsp
@@ -275,6 +275,24 @@ PortletURL embeddedPlayerURL = PortletURLBuilder.createRenderURL(
 		}
 	};
 
+	// LPS-141384
+
+	var onKeydownDefaultFn = imageViewer._onKeydown;
+	imageViewer._onKeydown = function (event) {
+		onKeydownDefaultFn.call(this, event);
+
+		var target = document.activeElement;
+
+		if (
+			!this.get('visible') &&
+			event.isKey('ENTER') &&
+			target.classList.contains('image-link')
+		) {
+			this.show();
+			this.set('currentIndex', this.get('links').indexOf(target));
+		}
+	};
+
 	imageViewer.render();
 
 	Liferay.on('<portlet:namespace />Video:play', function () {

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/image_gallery_display/view_images.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/image_gallery_display/view_images.jsp
@@ -96,7 +96,7 @@ DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper = new DLPortletI
 				%>
 
 				<liferay-ui:search-container-column-text>
-					<div class="image-link preview" <%= (hasAudio || hasVideo) ? "data-options=\"height=" + playerHeight + "&thumbnailURL=" + HtmlUtil.escapeURL(DLURLHelperUtil.getPreviewURL(fileEntry, fileVersion, themeDisplay, "&videoThumbnail=1")) + "&width=640" + dataOptions + "\"" : StringPool.BLANK %> href="<%= imageURL %>" thumbnailId="<%= thumbnailId %>" title="<%= title %>">
+					<div class="image-link preview" <%= (hasAudio || hasVideo) ? "data-options=\"height=" + playerHeight + "&thumbnailURL=" + HtmlUtil.escapeURL(DLURLHelperUtil.getPreviewURL(fileEntry, fileVersion, themeDisplay, "&videoThumbnail=1")) + "&width=640" + dataOptions + "\"" : StringPool.BLANK %> href="<%= imageURL %>" tabindex="0" thumbnailId="<%= thumbnailId %>" title="<%= title %>">
 						<c:choose>
 							<c:when test="<%= Validator.isNull(imagePreviewURL) %>">
 								<liferay-frontend:icon-vertical-card


### PR DESCRIPTION
BUG: https://issues.liferay.com/browse/LPS-141919

This bug is caused by #2419 but only when the Show Actions are enabled.

The first commit is a revert of #2419 this would be going to reopen [LPS-141384 Media Gallery images are skipped by TAB](https://issues.liferay.com/browse/LPS-141384).

The rest of the commits is a workaround fix for this bug [LPS-141384](https://issues.liferay.com/browse/LPS-141384). 

This fix does not use a proper `a` tag but opens the image gallery when the item is focused and the user press ENTER key.
