### PR TITLE
LPS-141436 The Document types and the Metadata Sets should not have guest & site member view permission by default

### DIFF
--- a/portal-impl/src/resource-actions/documentlibrary.xml
+++ b/portal-impl/src/resource-actions/documentlibrary.xml
@@ -99,12 +99,6 @@
 				<action-key>UPDATE</action-key>
 				<action-key>VIEW</action-key>
 			</supports>
-			<site-member-defaults>
-				<action-key>VIEW</action-key>
-			</site-member-defaults>
-			<guest-defaults>
-				<action-key>VIEW</action-key>
-			</guest-defaults>
 			<guest-unsupported>
 				<action-key>DELETE</action-key>
 				<action-key>PERMISSIONS</action-key>


### PR DESCRIPTION
The Document types and the Metadata Sets should not have guest & site member view permission by default

![image](https://user-images.githubusercontent.com/47524751/142037362-1ca9b0f5-096b-4076-af14-1c2da1f9d075.png)

