### PR TITLE
LPS-142516 upgrade lib version because current has the following known vulnerabilities: CVE-2021-42575

### DIFF
--- a/lib/versions-complete.xml
+++ b/lib/versions-complete.xml
@@ -243,13 +243,13 @@
 			</library>
 			<library>
 				<file-name>com.liferay.comment.sanitizer.jar!owasp-java-html-sanitizer.jar</file-name>
-				<version>r239</version>
+				<version>20211018.2</version>
 				<project-name>OWASP Java HTML Sanitizer</project-name>
-				<project-url>http://code.google.com/p/owasp-java-html-sanitizer</project-url>
+				<project-url>https://owasp.org</project-url>
 				<licenses>
 					<license>
-						<license-name>New BSD License</license-name>
-						<license-url>http://www.opensource.org/licenses/bsd-license.php</license-url>
+						<license-name>Apache License, Version 2.0</license-name>
+						<license-url>http://www.apache.org/licenses/LICENSE-2.0.txt</license-url>
 					</license>
 				</licenses>
 			</library>
@@ -2782,7 +2782,7 @@
 			</library>
 			<library>
 				<file-name>com.liferay.portal.security.antisamy.jar!antisamy.jar</file-name>
-				<version>1.5.9</version>
+				<version>1.6.4</version>
 				<project-name>OWASP AntiSamy</project-name>
 				<project-url>https://github.com/nahsra/antisamy</project-url>
 				<licenses>
@@ -2794,7 +2794,7 @@
 			</library>
 			<library>
 				<file-name>com.liferay.portal.security.antisamy.jar!batik-constants.jar</file-name>
-				<version>1.13</version>
+				<version>1.14</version>
 				<project-name>org.apache.xmlgraphics:batik-constants</project-name>
 				<licenses>
 					<license>
@@ -2805,7 +2805,7 @@
 			</library>
 			<library>
 				<file-name>com.liferay.portal.security.antisamy.jar!batik-css.jar</file-name>
-				<version>1.13</version>
+				<version>1.14</version>
 				<project-name>org.apache.xmlgraphics:batik-css</project-name>
 				<licenses>
 					<license>
@@ -2816,7 +2816,7 @@
 			</library>
 			<library>
 				<file-name>com.liferay.portal.security.antisamy.jar!batik-i18n.jar</file-name>
-				<version>1.13</version>
+				<version>1.14</version>
 				<project-name>org.apache.xmlgraphics:batik-i18n</project-name>
 				<licenses>
 					<license>
@@ -2827,7 +2827,7 @@
 			</library>
 			<library>
 				<file-name>com.liferay.portal.security.antisamy.jar!batik-util.jar</file-name>
-				<version>1.13</version>
+				<version>1.14</version>
 				<project-name>org.apache.xmlgraphics:batik-util</project-name>
 				<licenses>
 					<license>
@@ -2837,26 +2837,14 @@
 				</licenses>
 			</library>
 			<library>
-				<file-name>com.liferay.portal.security.antisamy.jar!commons-io.jar</file-name>
-				<version>2.8.0</version>
-				<project-name>Apache Commons IO</project-name>
-				<project-url>https://commons.apache.org/proper/commons-io/</project-url>
+				<file-name>com.liferay.portal.security.antisamy.jar!commons-codec.jar</file-name>
+				<version>1.15</version>
+				<project-name>Apache Commons Codec</project-name>
+				<project-url>https://commons.apache.org/proper/commons-codec/</project-url>
 				<licenses>
 					<license>
 						<license-name>Apache License, Version 2.0</license-name>
 						<license-url>https://www.apache.org/licenses/LICENSE-2.0.txt</license-url>
-					</license>
-				</licenses>
-			</library>
-			<library>
-				<file-name>com.liferay.portal.security.antisamy.jar!commons-logging.jar</file-name>
-				<version>1.0.4</version>
-				<project-name>Logging</project-name>
-				<project-url>http://jakarta.apache.org/commons/logging/</project-url>
-				<licenses>
-					<license>
-						<license-name>The Apache Software License, Version 2.0</license-name>
-						<license-url>/LICENSE.txt</license-url>
 					</license>
 				</licenses>
 			</library>
@@ -2886,7 +2874,7 @@
 			</library>
 			<library>
 				<file-name>com.liferay.portal.security.antisamy.jar!nekohtml.jar</file-name>
-				<version>1.9.16</version>
+				<version>1.9.22</version>
 				<project-name>Neko HTML</project-name>
 				<project-url>http://nekohtml.sourceforge.net/</project-url>
 				<licenses>
@@ -2910,7 +2898,7 @@
 			</library>
 			<library>
 				<file-name>com.liferay.portal.security.antisamy.jar!xmlgraphics-commons.jar</file-name>
-				<version>2.2</version>
+				<version>2.6</version>
 				<project-name>Apache XML Graphics Commons</project-name>
 				<project-url>http://xmlgraphics.apache.org/commons/</project-url>
 				<licenses>

--- a/lib/versions.html
+++ b/lib/versions.html
@@ -142,7 +142,7 @@
 </td><td></td>
 </tr>
 <tr>
-<td nowrap>com.liferay.comment.sanitizer.jar!owasp-java-html-sanitizer.jar</td><td nowrap>r239</td><td nowrap><a href="http://code.google.com/p/owasp-java-html-sanitizer">OWASP Java HTML Sanitizer</a></td><td nowrap><a href="http://www.opensource.org/licenses/bsd-license.php">New BSD License</a>
+<td nowrap>com.liferay.comment.sanitizer.jar!owasp-java-html-sanitizer.jar</td><td nowrap>20211018.2</td><td nowrap><a href="https://owasp.org">OWASP Java HTML Sanitizer</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.txt">Apache License, Version 2.0</a>
 <br>
 </td><td></td>
 </tr>
@@ -1227,37 +1227,32 @@
 </td><td></td>
 </tr>
 <tr>
-<td nowrap>com.liferay.portal.security.antisamy.jar!antisamy.jar</td><td nowrap>1.5.9</td><td nowrap><a href="https://github.com/nahsra/antisamy">OWASP AntiSamy</a></td><td nowrap><a href="https://opensource.org/licenses/BSD-3-Clause">BSD 3</a>
+<td nowrap>com.liferay.portal.security.antisamy.jar!antisamy.jar</td><td nowrap>1.6.4</td><td nowrap><a href="https://github.com/nahsra/antisamy">OWASP AntiSamy</a></td><td nowrap><a href="https://opensource.org/licenses/BSD-3-Clause">BSD 3</a>
 <br>
 </td><td></td>
 </tr>
 <tr>
-<td nowrap>com.liferay.portal.security.antisamy.jar!batik-constants.jar</td><td nowrap>1.13</td><td nowrap>org.apache.xmlgraphics:batik-constants</td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a>
+<td nowrap>com.liferay.portal.security.antisamy.jar!batik-constants.jar</td><td nowrap>1.14</td><td nowrap>org.apache.xmlgraphics:batik-constants</td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a>
 <br>
 </td><td></td>
 </tr>
 <tr>
-<td nowrap>com.liferay.portal.security.antisamy.jar!batik-css.jar</td><td nowrap>1.13</td><td nowrap>org.apache.xmlgraphics:batik-css</td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a>
+<td nowrap>com.liferay.portal.security.antisamy.jar!batik-css.jar</td><td nowrap>1.14</td><td nowrap>org.apache.xmlgraphics:batik-css</td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a>
 <br>
 </td><td></td>
 </tr>
 <tr>
-<td nowrap>com.liferay.portal.security.antisamy.jar!batik-i18n.jar</td><td nowrap>1.13</td><td nowrap>org.apache.xmlgraphics:batik-i18n</td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a>
+<td nowrap>com.liferay.portal.security.antisamy.jar!batik-i18n.jar</td><td nowrap>1.14</td><td nowrap>org.apache.xmlgraphics:batik-i18n</td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a>
 <br>
 </td><td></td>
 </tr>
 <tr>
-<td nowrap>com.liferay.portal.security.antisamy.jar!batik-util.jar</td><td nowrap>1.13</td><td nowrap>org.apache.xmlgraphics:batik-util</td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a>
+<td nowrap>com.liferay.portal.security.antisamy.jar!batik-util.jar</td><td nowrap>1.14</td><td nowrap>org.apache.xmlgraphics:batik-util</td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a>
 <br>
 </td><td></td>
 </tr>
 <tr>
-<td nowrap>com.liferay.portal.security.antisamy.jar!commons-io.jar</td><td nowrap>2.8.0</td><td nowrap><a href="https://commons.apache.org/proper/commons-io/">Apache Commons IO</a></td><td nowrap><a href="https://www.apache.org/licenses/LICENSE-2.0.txt">Apache License, Version 2.0</a>
-<br>
-</td><td></td>
-</tr>
-<tr>
-<td nowrap>com.liferay.portal.security.antisamy.jar!commons-logging.jar</td><td nowrap>1.0.4</td><td nowrap><a href="http://jakarta.apache.org/commons/logging/">Logging</a></td><td nowrap><a href="/LICENSE.txt">The Apache Software License, Version 2.0</a>
+<td nowrap>com.liferay.portal.security.antisamy.jar!commons-codec.jar</td><td nowrap>1.15</td><td nowrap><a href="https://commons.apache.org/proper/commons-codec/">Apache Commons Codec</a></td><td nowrap><a href="https://www.apache.org/licenses/LICENSE-2.0.txt">Apache License, Version 2.0</a>
 <br>
 </td><td></td>
 </tr>
@@ -1272,7 +1267,7 @@
 </td><td></td>
 </tr>
 <tr>
-<td nowrap>com.liferay.portal.security.antisamy.jar!nekohtml.jar</td><td nowrap>1.9.16</td><td nowrap><a href="http://nekohtml.sourceforge.net/">Neko HTML</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a>
+<td nowrap>com.liferay.portal.security.antisamy.jar!nekohtml.jar</td><td nowrap>1.9.22</td><td nowrap><a href="http://nekohtml.sourceforge.net/">Neko HTML</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a>
 <br>
 </td><td></td>
 </tr>
@@ -1282,7 +1277,7 @@
 </td><td></td>
 </tr>
 <tr>
-<td nowrap>com.liferay.portal.security.antisamy.jar!xmlgraphics-commons.jar</td><td nowrap>2.2</td><td nowrap><a href="http://xmlgraphics.apache.org/commons/">Apache XML Graphics Commons</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a>
+<td nowrap>com.liferay.portal.security.antisamy.jar!xmlgraphics-commons.jar</td><td nowrap>2.6</td><td nowrap><a href="http://xmlgraphics.apache.org/commons/">Apache XML Graphics Commons</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a>
 <br>
 </td><td></td>
 </tr>

--- a/modules/apps/comment/comment-sanitizer/build.gradle
+++ b/modules/apps/comment/comment-sanitizer/build.gradle
@@ -4,7 +4,7 @@ dependencies {
 	compileInclude group: "com.google.guava", name: "guava", version: "30.1.1-jre"
 	compileInclude group: "com.google.guava", name: "listenablefuture", version: "9999.0-empty-to-avoid-conflict-with-guava"
 	compileInclude group: "com.google.j2objc", name: "j2objc-annotations", version: "1.3"
-	compileInclude group: "com.googlecode.owasp-java-html-sanitizer", name: "owasp-java-html-sanitizer", version: "r239"
+	compileInclude group: "com.googlecode.owasp-java-html-sanitizer", name: "owasp-java-html-sanitizer", version: "20211018.2"
 	compileInclude group: "org.checkerframework", name: "checker-qual", version: "3.11.0"
 
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"


### PR DESCRIPTION
- LPS-142516 upgrade lib version because current has the following known vulnerabilities: CVE-2021-42575
- LPS-142516 lib Versions
