### PR TITLE
LPS-141019 Mentioning a user from a page they cannot access results in a broken link

### DIFF
--- a/modules/apps/comment/comment-taglib/src/main/java/com/liferay/comment/taglib/internal/struts/GetCommentsStrutsAction.java
+++ b/modules/apps/comment/comment-taglib/src/main/java/com/liferay/comment/taglib/internal/struts/GetCommentsStrutsAction.java
@@ -74,7 +74,7 @@ public class GetCommentsStrutsAction implements StrutsAction {
 			"liferay-comment:discussion:index", String.valueOf(index));
 
 		String portletId = ParamUtil.getString(
-			namespacedHttpServletRequest, "portletId");
+			namespacedHttpServletRequest, "p_p_id");
 
 		namespacedHttpServletRequest.setAttribute(
 			WebKeys.PORTLET_ID, portletId);

--- a/modules/apps/comment/comment-taglib/src/main/java/com/liferay/comment/taglib/internal/struts/GetEditorStrutsAction.java
+++ b/modules/apps/comment/comment-taglib/src/main/java/com/liferay/comment/taglib/internal/struts/GetEditorStrutsAction.java
@@ -70,7 +70,7 @@ public class GetEditorStrutsAction implements StrutsAction {
 			"liferay-comment:editor:onChangeMethod", onChangeMethod);
 
 		String portletId = ParamUtil.getString(
-			namespacedHttpServletRequest, "portletId");
+			namespacedHttpServletRequest, "p_p_id");
 
 		namespacedHttpServletRequest.setAttribute(
 			WebKeys.PORTLET_ID, portletId);

--- a/modules/apps/comment/comment-taglib/src/main/java/com/liferay/comment/taglib/servlet/taglib/DiscussionTag.java
+++ b/modules/apps/comment/comment-taglib/src/main/java/com/liferay/comment/taglib/servlet/taglib/DiscussionTag.java
@@ -143,7 +143,7 @@ public class DiscussionTag extends IncludeTag {
 			themeDisplay.getPathMain(),
 			"/portal/comment/discussion/get_editor?p_p_isolated=1&",
 			"doAsUserId=", URLCodec.encodeURL(themeDisplay.getDoAsUserId()),
-			"&portletId=", portletId);
+			"&p_p_id=", portletId, "&p_l_id=", themeDisplay.getPlid());
 	}
 
 	protected String getFormAction(HttpServletRequest httpServletRequest) {
@@ -155,10 +155,15 @@ public class DiscussionTag extends IncludeTag {
 			(ThemeDisplay)httpServletRequest.getAttribute(
 				WebKeys.THEME_DISPLAY);
 
+		PortletDisplay portletDisplay = themeDisplay.getPortletDisplay();
+
+		String portletId = portletDisplay.getId();
+
 		return StringBundler.concat(
 			themeDisplay.getPathMain(),
 			"/portal/comment/discussion/edit?doAsUserId=",
-			URLCodec.encodeURL(themeDisplay.getDoAsUserId()));
+			URLCodec.encodeURL(themeDisplay.getDoAsUserId()), "&p_p_id=",
+			portletId, "&p_l_id=", themeDisplay.getPlid());
 	}
 
 	@Override
@@ -179,7 +184,7 @@ public class DiscussionTag extends IncludeTag {
 			themeDisplay.getPathMain(),
 			"/portal/comment/discussion/get_comments?p_p_isolated=1&",
 			"doAsUserId=", URLCodec.encodeURL(themeDisplay.getDoAsUserId()),
-			"&portletId=", portletId);
+			"&p_p_id=", portletId, "&p_l_id=", themeDisplay.getPlid());
 	}
 
 	@Override

--- a/modules/apps/mentions/mentions-service/src/main/java/com/liferay/mentions/internal/util/DefaultMentionsNotifier.java
+++ b/modules/apps/mentions/mentions-service/src/main/java/com/liferay/mentions/internal/util/DefaultMentionsNotifier.java
@@ -23,10 +23,17 @@ import com.liferay.mentions.util.MentionsNotifier;
 import com.liferay.mentions.util.MentionsUserFinder;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.service.permission.LayoutPermissionUtil;
+import com.liferay.portal.kernel.service.permission.PortletPermissionUtil;
 import com.liferay.portal.kernel.settings.LocalizedValuesMap;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -111,6 +118,22 @@ public class DefaultMentionsNotifier implements MentionsNotifier {
 				user.getCompanyId(), mentionedUserScreenName);
 
 			if (mentionedUser == null) {
+				continue;
+			}
+
+			PermissionChecker permissionChecker =
+				PermissionCheckerFactoryUtil.create(mentionedUser);
+
+			ThemeDisplay themeDisplay = serviceContext.getThemeDisplay();
+
+			Layout layout = themeDisplay.getLayout();
+
+			if (!LayoutPermissionUtil.contains(
+					permissionChecker, layout, true, ActionKeys.VIEW) ||
+				!PortletPermissionUtil.contains(
+					permissionChecker, layout, themeDisplay.getPpid(),
+					ActionKeys.VIEW)) {
+
 				continue;
 			}
 

--- a/modules/apps/mentions/mentions-service/src/main/java/com/liferay/mentions/internal/util/DefaultMentionsNotifier.java
+++ b/modules/apps/mentions/mentions-service/src/main/java/com/liferay/mentions/internal/util/DefaultMentionsNotifier.java
@@ -113,6 +113,10 @@ public class DefaultMentionsNotifier implements MentionsNotifier {
 		subscriptionSender.setLocalizedSubjectMap(
 			LocalizationUtil.getMap(subjectLocalizedValuesMap));
 
+		ThemeDisplay themeDisplay = serviceContext.getThemeDisplay();
+
+		Layout layout = themeDisplay.getLayout();
+
 		for (String mentionedUserScreenName : mentionedUsersScreenNames) {
 			User mentionedUser = _userLocalService.fetchUserByScreenName(
 				user.getCompanyId(), mentionedUserScreenName);
@@ -121,20 +125,18 @@ public class DefaultMentionsNotifier implements MentionsNotifier {
 				continue;
 			}
 
-			PermissionChecker permissionChecker =
-				PermissionCheckerFactoryUtil.create(mentionedUser);
+			if ((themeDisplay != null) && (layout != null)) {
+				PermissionChecker permissionChecker =
+					PermissionCheckerFactoryUtil.create(mentionedUser);
 
-			ThemeDisplay themeDisplay = serviceContext.getThemeDisplay();
+				if (!LayoutPermissionUtil.contains(
+						permissionChecker, layout, true, ActionKeys.VIEW) ||
+					!PortletPermissionUtil.contains(
+						permissionChecker, layout, themeDisplay.getPpid(),
+						ActionKeys.VIEW)) {
 
-			Layout layout = themeDisplay.getLayout();
-
-			if (!LayoutPermissionUtil.contains(
-					permissionChecker, layout, true, ActionKeys.VIEW) ||
-				!PortletPermissionUtil.contains(
-					permissionChecker, layout, themeDisplay.getPpid(),
-					ActionKeys.VIEW)) {
-
-				continue;
+					continue;
+				}
 			}
 
 			subscriptionSender.addRuntimeSubscribers(

--- a/modules/apps/mentions/mentions-web/src/main/java/com/liferay/mentions/web/internal/editor/configuration/BaseMentionsEditorConfigContributor.java
+++ b/modules/apps/mentions/mentions-web/src/main/java/com/liferay/mentions/web/internal/editor/configuration/BaseMentionsEditorConfigContributor.java
@@ -16,11 +16,13 @@ package com.liferay.mentions.web.internal.editor.configuration;
 
 import com.liferay.mentions.constants.MentionsPortletKeys;
 import com.liferay.mentions.matcher.MentionsMatcherUtil;
+import com.liferay.petra.portlet.url.builder.PortletURLBuilder;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.editor.configuration.BaseEditorConfigContributor;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactory;
+import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -106,8 +108,20 @@ public class BaseMentionsEditorConfigContributor
 		ThemeDisplay themeDisplay,
 		RequestBackedPortletURLFactory requestBackedPortletURLFactory) {
 
-		return requestBackedPortletURLFactory.createResourceURL(
-			MentionsPortletKeys.MENTIONS);
+		String discussionPortletId = themeDisplay.getPpid();
+
+		if (Validator.isBlank(discussionPortletId)) {
+			PortletDisplay portletDisplay = themeDisplay.getPortletDisplay();
+
+			discussionPortletId = portletDisplay.getId();
+		}
+
+		return PortletURLBuilder.create(
+			requestBackedPortletURLFactory.createResourceURL(
+				MentionsPortletKeys.MENTIONS)
+		).setParameter(
+			"discussionPortletId", discussionPortletId
+		).buildPortletURL();
 	}
 
 }

--- a/modules/apps/mentions/mentions-web/src/main/java/com/liferay/mentions/web/internal/portlet/MentionsPortlet.java
+++ b/modules/apps/mentions/mentions-web/src/main/java/com/liferay/mentions/web/internal/portlet/MentionsPortlet.java
@@ -34,8 +34,8 @@ import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
-import com.liferay.portal.kernel.service.permission.LayoutPermissionUtil;
-import com.liferay.portal.kernel.service.permission.PortletPermissionUtil;
+import com.liferay.portal.kernel.service.permission.LayoutPermission;
+import com.liferay.portal.kernel.service.permission.PortletPermission;
 import com.liferay.portal.kernel.servlet.ServletResponseUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ContentTypes;
@@ -219,9 +219,10 @@ public class MentionsPortlet extends MVCPortlet {
 					PermissionChecker permissionChecker =
 						PermissionCheckerFactoryUtil.create(user);
 
-					if (LayoutPermissionUtil.contains(
+					if ((layout != null) &&
+						_layoutPermission.contains(
 							permissionChecker, layout, true, ActionKeys.VIEW) &&
-						PortletPermissionUtil.contains(
+						_portletPermission.contains(
 							permissionChecker, layout, discussionPortletId,
 							ActionKeys.VIEW)) {
 
@@ -243,7 +244,13 @@ public class MentionsPortlet extends MVCPortlet {
 		MentionsPortlet.class);
 
 	@Reference
+	private LayoutPermission _layoutPermission;
+
+	@Reference
 	private Portal _portal;
+
+	@Reference
+	private PortletPermission _portletPermission;
 
 	private ServiceTrackerMap<String, MentionsStrategy> _serviceTrackerMap;
 

--- a/modules/apps/mentions/mentions-web/src/main/java/com/liferay/mentions/web/internal/portlet/MentionsPortlet.java
+++ b/modules/apps/mentions/mentions-web/src/main/java/com/liferay/mentions/web/internal/portlet/MentionsPortlet.java
@@ -28,8 +28,14 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
+import com.liferay.portal.kernel.service.permission.LayoutPermissionUtil;
+import com.liferay.portal.kernel.service.permission.PortletPermissionUtil;
 import com.liferay.portal.kernel.servlet.ServletResponseUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ContentTypes;
@@ -39,6 +45,7 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.taglib.ui.UserPortraitTag;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Supplier;
@@ -94,7 +101,9 @@ public class MentionsPortlet extends MVCPortlet {
 				_getSupplier(
 					themeDisplay,
 					ParamUtil.getString(resourceRequest, "strategy"),
-					ParamUtil.getString(resourceRequest, "query")),
+					ParamUtil.getString(resourceRequest, "query"),
+					ParamUtil.getString(
+						resourceRequest, "discussionPortletId")),
 				themeDisplay);
 
 			HttpServletResponse httpServletResponse =
@@ -180,7 +189,8 @@ public class MentionsPortlet extends MVCPortlet {
 	}
 
 	private Supplier<List<User>> _getSupplier(
-			ThemeDisplay themeDisplay, String strategyString, String query)
+			ThemeDisplay themeDisplay, String strategyString, String query,
+			String discussionPortletId)
 		throws PortalException {
 
 		JSONObject jsonObject = _getJSONObject(strategyString);
@@ -197,9 +207,29 @@ public class MentionsPortlet extends MVCPortlet {
 
 		return () -> {
 			try {
-				return mentionsStrategy.getUsers(
+				List<User> users = mentionsStrategy.getUsers(
 					themeDisplay.getCompanyId(), themeDisplay.getUserId(),
 					query, jsonObject);
+
+				Layout layout = themeDisplay.getLayout();
+
+				List<User> filteredUsers = new ArrayList<>();
+
+				for (User user : users) {
+					PermissionChecker permissionChecker =
+						PermissionCheckerFactoryUtil.create(user);
+
+					if (LayoutPermissionUtil.contains(
+							permissionChecker, layout, true, ActionKeys.VIEW) &&
+						PortletPermissionUtil.contains(
+							permissionChecker, layout, discussionPortletId,
+							ActionKeys.VIEW)) {
+
+						filteredUsers.add(user);
+					}
+				}
+
+				return filteredUsers;
 			}
 			catch (PortalException portalException) {
 				_log.error(portalException, portalException);


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-141019

### Issue overview

When mentioning a user in a comment, we don't check to see if the user can access the page and portlet where the comment is made. Since it's related to notifications and discussions, Lima seemed like the best fit based on its current list of key DXP components.

### Steps to reproduce

1. Start a clean bundle
1. Login as admin
1. Go to [Global site > Web Content]
1. Create any random Basic Web Content
1. Go to [CP > Sites > Site Template]
1. Create a new template
1. Add an Asset Publisher to the page and configure it to:
   * Asset Selection > Scope: Global
   * Display Settings > ENABLE > Comments: ON
1. Go to [CP > Users and Organizations]
1. Create 2 users (user1 and user2)
1. For each user, in Profile and Dashboard, set the created template for Dashboard
1. Login as user1
1. Go to [User icon > My Dashboard]
1. Add a new comment to the web content and mention @user2
1. Login as user2
1. Note there is 1 notification
1. Go to [User icon > Notifications]
1. Click on the notification

### Solution overview

To resolve the issue, the fix adds information to the URL so that ServicePreAction will, when processing the request, add information about the page and portlet to the ThemeDisplay. This allows code later on to check the ThemeDisplay for the page and portlet to use for permission checks.
