### PR TITLE
LPS-142835 Use getAttribute instead of dataset since it is an AUI instance

### DIFF
--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/js/MBPortlet.es.js
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/js/MBPortlet.es.js
@@ -170,14 +170,14 @@ class MBPortlet {
 	_removeAttachment(event) {
 		const link = event.currentTarget;
 
-		const deleteURL = link.dataset.url;
+		const deleteURL = link.getAttribute('data-url');
 
 		fetch(deleteURL).then(() => {
 			Liferay.componentReady(this.searchContainerId).then(
 				(searchContainer) => {
 					searchContainer.deleteRow(
 						link.ancestor('tr'),
-						link.dataset.rowid
+						link.getAttribute('data-rowid')
 					);
 					searchContainer.updateDataStore();
 				}

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/js/WikiPortlet.es.js
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/js/WikiPortlet.es.js
@@ -159,14 +159,14 @@ class WikiPortlet {
 	_removeAttachment(event) {
 		const link = event.currentTarget;
 
-		const deleteURL = link.dataset.url;
+		const deleteURL = link.getAttribute('data-url');
 
 		fetch(deleteURL).then(() => {
 			Liferay.componentReady(this.searchContainerId).then(
 				(searchContainer) => {
 					searchContainer.deleteRow(
 						link.ancestor('tr'),
-						link.dataset.rowid
+						link.getAttribute('data-rowid')
 					);
 					searchContainer.updateDataStore();
 				}


### PR DESCRIPTION
This is a partial revert of https://issues.liferay.com/browse/LPS-142100 that caused this bug 

In this case link is an AUI instance so we cannot replace `getAttribute('data-` with `.dataset`