### PR TITLE
LPS-143039 If folder is selected and goes to the site/asset lib selector, the folder id is not reset and is the same as the previous selection

### DIFF
--- a/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/folder/DLFolderItemSelectorView.java
+++ b/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/folder/DLFolderItemSelectorView.java
@@ -29,6 +29,7 @@ import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.bean.BeanParamUtil;
 import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.resource.bundle.ResourceBundleLoader;
+import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.language.LanguageResources;
@@ -105,12 +106,10 @@ public class DLFolderItemSelectorView
 		RequestDispatcher requestDispatcher =
 			_servletContext.getRequestDispatcher("/select_folder.jsp");
 
-		long folderId = BeanParamUtil.getLong(
-			itemSelectorCriterion, (HttpServletRequest)servletRequest,
-			"folderId");
-		long selectedRepositoryId = BeanParamUtil.getLong(
-			itemSelectorCriterion, (HttpServletRequest)servletRequest,
-			"selectedRepositoryId");
+		long repositoryId = ParamUtil.getLong(
+			(HttpServletRequest)servletRequest, "repositoryId");
+		long folderId = ParamUtil.getLong(
+			(HttpServletRequest)servletRequest, "folderId");
 
 		servletRequest.setAttribute(
 			DLSelectFolderDisplayContext.class.getName(),
@@ -119,9 +118,11 @@ public class DLFolderItemSelectorView
 				(HttpServletRequest)servletRequest, portletURL,
 				BeanParamUtil.getLong(
 					itemSelectorCriterion, (HttpServletRequest)servletRequest,
-					"selectedFolderId", folderId),
-				selectedRepositoryId,
-				_isShowGroupSelector(itemSelectorCriterion)));
+					"selectedFolderId",
+					BeanParamUtil.getLong(
+						itemSelectorCriterion,
+						(HttpServletRequest)servletRequest, "folderId")),
+				repositoryId, _isShowGroupSelector(itemSelectorCriterion)));
 
 		requestDispatcher.include(servletRequest, servletResponse);
 	}

--- a/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/util/DLBreadcrumbUtil.java
+++ b/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/util/DLBreadcrumbUtil.java
@@ -42,7 +42,7 @@ public class DLBreadcrumbUtil {
 			String displayStyle, Folder folder,
 			HttpServletRequest httpServletRequest,
 			LiferayPortletResponse liferayPortletResponse,
-			PortletURL portletURL, boolean showGroupSelector)
+			PortletURL portletURL, boolean showGroupSelector, long repositoryId)
 		throws Exception {
 
 		if (showGroupSelector) {
@@ -52,14 +52,13 @@ public class DLBreadcrumbUtil {
 
 		portletURL.setParameter("displayStyle", displayStyle);
 
-		ThemeDisplay themeDisplay =
-			(ThemeDisplay)httpServletRequest.getAttribute(
-				WebKeys.THEME_DISPLAY);
-
 		_addPortletBreadcrumbEntry(
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, httpServletRequest,
-			portletURL, themeDisplay.getScopeGroupId(),
-			_getRootFolderName(folder, httpServletRequest, showGroupSelector));
+			portletURL,
+			_getRepositoryId(folder, httpServletRequest, repositoryId),
+			_getRootFolderName(
+				httpServletRequest, showGroupSelector,
+				_getRepositoryId(folder, httpServletRequest, repositoryId)));
 
 		if (folder != null) {
 			List<Folder> ancestorFolders = folder.getAncestors();
@@ -108,9 +107,28 @@ public class DLBreadcrumbUtil {
 			httpServletRequest, title, portletURL.toString());
 	}
 
+	private static long _getRepositoryId(
+		Folder folder, HttpServletRequest httpServletRequest,
+		long repositoryId) {
+
+		if (repositoryId != 0) {
+			return repositoryId;
+		}
+
+		if (folder != null) {
+			return folder.getRepositoryId();
+		}
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		return themeDisplay.getScopeGroupId();
+	}
+
 	private static String _getRootFolderName(
-			Folder folder, HttpServletRequest httpServletRequest,
-			boolean showGroupSelector)
+			HttpServletRequest httpServletRequest, boolean showGroupSelector,
+			long repositoryId)
 		throws Exception {
 
 		if (!showGroupSelector) {
@@ -123,8 +141,8 @@ public class DLBreadcrumbUtil {
 
 		Group group = themeDisplay.getScopeGroup();
 
-		if (folder != null) {
-			group = GroupServiceUtil.getGroup(folder.getGroupId());
+		if (repositoryId != 0) {
+			group = GroupServiceUtil.getGroup(repositoryId);
 		}
 
 		return group.getDescriptiveName(themeDisplay.getLocale());

--- a/modules/apps/document-library/document-library-item-selector-web/src/main/resources/META-INF/resources/select_folder.jsp
+++ b/modules/apps/document-library/document-library-item-selector-web/src/main/resources/META-INF/resources/select_folder.jsp
@@ -19,7 +19,7 @@
 <%
 DLSelectFolderDisplayContext dlSelectFolderDisplayContext = (DLSelectFolderDisplayContext)request.getAttribute(DLSelectFolderDisplayContext.class.getName());
 
-DLBreadcrumbUtil.addPortletBreadcrumbEntries(ParamUtil.getString(request, "displayStyle"), dlSelectFolderDisplayContext.getFolder(), request, liferayPortletResponse, dlSelectFolderDisplayContext.getIteratorPortletURL(liferayPortletResponse), dlSelectFolderDisplayContext.isShowGroupSelector());
+DLBreadcrumbUtil.addPortletBreadcrumbEntries(ParamUtil.getString(request, "displayStyle"), dlSelectFolderDisplayContext.getFolder(), request, liferayPortletResponse, dlSelectFolderDisplayContext.getIteratorPortletURL(liferayPortletResponse), dlSelectFolderDisplayContext.isShowGroupSelector(), dlSelectFolderDisplayContext.getSelectedRepositoryId());
 %>
 
 <clay:container-fluid>


### PR DESCRIPTION

Previously, if a folder was selected. the behavior was erratic cause the themeDisplay.group was the site group till you select the site/asset lib on the group selector
https://user-images.githubusercontent.com/47524751/143580636-19524470-cc39-463b-bdc6-c97b3dd1d443.mp4

After, the behavior is consistent, always, with the initial point on the site root.
https://user-images.githubusercontent.com/47524751/143580649-049b1f6b-98ef-4652-b8f9-c528e5a76f95.mp4



