### PR TITLE
Revert "LPS-135678"

### DIFF
--- a/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/display/context/DLSelectFolderDisplayContext.java
+++ b/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/display/context/DLSelectFolderDisplayContext.java
@@ -224,15 +224,6 @@ public class DLSelectFolderDisplayContext {
 
 				return getFolderName();
 			}
-		).put(
-			"repositoryid",
-			() -> {
-				if (folder != null) {
-					return folder.getRepositoryId();
-				}
-
-				return getRepositoryId();
-			}
 		).build();
 	}
 

--- a/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/display/context/DLSelectFolderDisplayContext.java
+++ b/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/display/context/DLSelectFolderDisplayContext.java
@@ -59,15 +59,13 @@ public class DLSelectFolderDisplayContext {
 	public DLSelectFolderDisplayContext(
 		DLAppService dlAppService, Folder folder,
 		HttpServletRequest httpServletRequest, PortletURL portletURL,
-		long selectedFolderId, long selectedRepositoryId,
-		boolean showGroupSelector) {
+		long selectedFolderId, boolean showGroupSelector) {
 
 		_dlAppService = dlAppService;
 		_folder = folder;
 		_httpServletRequest = httpServletRequest;
 		_portletURL = portletURL;
 		_selectedFolderId = selectedFolderId;
-		_selectedRepositoryId = selectedRepositoryId;
 		_showGroupSelector = showGroupSelector;
 
 		_themeDisplay = (ThemeDisplay)httpServletRequest.getAttribute(
@@ -185,10 +183,6 @@ public class DLSelectFolderDisplayContext {
 		return _selectedFolderId;
 	}
 
-	public long getSelectedRepositoryId() {
-		return _selectedRepositoryId;
-	}
-
 	public Map<String, Object> getSelectorButtonData() {
 		return getSelectorButtonData(_folder);
 	}
@@ -255,13 +249,11 @@ public class DLSelectFolderDisplayContext {
 	}
 
 	public boolean isSelectButtonDisabled() {
-		return isSelectButtonDisabled(getFolderId(), getRepositoryId());
+		return isSelectButtonDisabled(getFolderId());
 	}
 
-	public boolean isSelectButtonDisabled(long folderId, long repositoryId) {
-		if ((folderId == getSelectedFolderId()) &&
-			(repositoryId == getSelectedRepositoryId())) {
-
+	public boolean isSelectButtonDisabled(long folderId) {
+		if (folderId == getSelectedFolderId()) {
 			return true;
 		}
 
@@ -282,8 +274,6 @@ public class DLSelectFolderDisplayContext {
 			"folderId", folderId
 		).setParameter(
 			"ignoreRootFolder", true
-		).setParameter(
-			"repositoryId", getRepositoryId()
 		).setParameter(
 			"selectedFolderId", getSelectedFolderId()
 		).setParameter(
@@ -318,7 +308,6 @@ public class DLSelectFolderDisplayContext {
 	private final HttpServletRequest _httpServletRequest;
 	private final PortletURL _portletURL;
 	private final long _selectedFolderId;
-	private final long _selectedRepositoryId;
 	private final boolean _showGroupSelector;
 	private final ThemeDisplay _themeDisplay;
 

--- a/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/folder/DLFolderItemSelectorView.java
+++ b/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/folder/DLFolderItemSelectorView.java
@@ -105,12 +105,13 @@ public class DLFolderItemSelectorView
 		RequestDispatcher requestDispatcher =
 			_servletContext.getRequestDispatcher("/select_folder.jsp");
 
-		long repositoryId = BeanParamUtil.getLong(
-			itemSelectorCriterion, (HttpServletRequest)servletRequest,
-			"repositoryId");
 		long folderId = BeanParamUtil.getLong(
 			itemSelectorCriterion, (HttpServletRequest)servletRequest,
 			"folderId");
+
+		long repositoryId = BeanParamUtil.getLong(
+			itemSelectorCriterion, (HttpServletRequest)servletRequest,
+			"repositoryId");
 
 		servletRequest.setAttribute(
 			DLSelectFolderDisplayContext.class.getName(),

--- a/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/folder/DLFolderItemSelectorView.java
+++ b/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/folder/DLFolderItemSelectorView.java
@@ -109,10 +109,6 @@ public class DLFolderItemSelectorView
 			itemSelectorCriterion, (HttpServletRequest)servletRequest,
 			"folderId");
 
-		long repositoryId = BeanParamUtil.getLong(
-			itemSelectorCriterion, (HttpServletRequest)servletRequest,
-			"repositoryId");
-
 		servletRequest.setAttribute(
 			DLSelectFolderDisplayContext.class.getName(),
 			new DLSelectFolderDisplayContext(
@@ -121,7 +117,7 @@ public class DLFolderItemSelectorView
 				BeanParamUtil.getLong(
 					itemSelectorCriterion, (HttpServletRequest)servletRequest,
 					"selectedFolderId", folderId),
-				repositoryId, _isShowGroupSelector(itemSelectorCriterion)));
+				_isShowGroupSelector(itemSelectorCriterion)));
 
 		requestDispatcher.include(servletRequest, servletResponse);
 	}

--- a/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/util/DLBreadcrumbUtil.java
+++ b/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/util/DLBreadcrumbUtil.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.PortletURLUtil;
 import com.liferay.portal.kernel.repository.model.Folder;
+import com.liferay.portal.kernel.service.GroupServiceUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -41,7 +42,7 @@ public class DLBreadcrumbUtil {
 			String displayStyle, Folder folder,
 			HttpServletRequest httpServletRequest,
 			LiferayPortletResponse liferayPortletResponse,
-			PortletURL portletURL, boolean showGroupSelector)
+			PortletURL portletURL, long repositoryId, boolean showGroupSelector)
 		throws Exception {
 
 		if (showGroupSelector) {
@@ -51,14 +52,10 @@ public class DLBreadcrumbUtil {
 
 		portletURL.setParameter("displayStyle", displayStyle);
 
-		ThemeDisplay themeDisplay =
-			(ThemeDisplay)httpServletRequest.getAttribute(
-				WebKeys.THEME_DISPLAY);
-
 		_addPortletBreadcrumbEntry(
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, httpServletRequest,
-			portletURL, themeDisplay.getScopeGroupId(),
-			_getRootFolderName(httpServletRequest, showGroupSelector));
+			portletURL, _getRepositoryId(httpServletRequest, repositoryId),
+			_getRootFolderName(folder, httpServletRequest, showGroupSelector));
 
 		if (folder != null) {
 			List<Folder> ancestorFolders = folder.getAncestors();
@@ -107,8 +104,23 @@ public class DLBreadcrumbUtil {
 			httpServletRequest, title, portletURL.toString());
 	}
 
+	private static long _getRepositoryId(
+		HttpServletRequest httpServletRequest, long repositoryId) {
+
+		if (repositoryId == 0) {
+			ThemeDisplay themeDisplay =
+				(ThemeDisplay)httpServletRequest.getAttribute(
+					WebKeys.THEME_DISPLAY);
+
+			repositoryId = themeDisplay.getScopeGroupId();
+		}
+
+		return repositoryId;
+	}
+
 	private static String _getRootFolderName(
-			HttpServletRequest httpServletRequest, boolean showGroupSelector)
+			Folder folder, HttpServletRequest httpServletRequest,
+			boolean showGroupSelector)
 		throws Exception {
 
 		if (!showGroupSelector) {
@@ -120,6 +132,10 @@ public class DLBreadcrumbUtil {
 				WebKeys.THEME_DISPLAY);
 
 		Group group = themeDisplay.getScopeGroup();
+
+		if (folder != null) {
+			group = GroupServiceUtil.getGroup(folder.getGroupId());
+		}
 
 		return group.getDescriptiveName(themeDisplay.getLocale());
 	}

--- a/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/util/DLBreadcrumbUtil.java
+++ b/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/util/DLBreadcrumbUtil.java
@@ -100,8 +100,8 @@ public class DLBreadcrumbUtil {
 		long folderId, HttpServletRequest httpServletRequest,
 		PortletURL portletURL, long repositoryId, String title) {
 
-		portletURL.setParameter("repositoryId", String.valueOf(repositoryId));
 		portletURL.setParameter("folderId", String.valueOf(folderId));
+		portletURL.setParameter("repositoryId", String.valueOf(repositoryId));
 
 		PortalUtil.addPortletBreadcrumbEntry(
 			httpServletRequest, title, portletURL.toString());

--- a/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/util/DLBreadcrumbUtil.java
+++ b/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/util/DLBreadcrumbUtil.java
@@ -39,10 +39,10 @@ import javax.servlet.http.HttpServletRequest;
 public class DLBreadcrumbUtil {
 
 	public static void addPortletBreadcrumbEntries(
-			String displayStyle, Folder folder,
+			Folder folder, String displayStyle,
 			HttpServletRequest httpServletRequest,
 			LiferayPortletResponse liferayPortletResponse,
-			PortletURL portletURL, long repositoryId, boolean showGroupSelector)
+			PortletURL portletURL, boolean showGroupSelector)
 		throws Exception {
 
 		if (showGroupSelector) {
@@ -54,8 +54,8 @@ public class DLBreadcrumbUtil {
 
 		_addPortletBreadcrumbEntry(
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, httpServletRequest,
-			portletURL, _getRepositoryId(httpServletRequest, repositoryId),
-			_getRootFolderName(folder, httpServletRequest, showGroupSelector));
+			_getRootFolderName(folder, httpServletRequest, showGroupSelector),
+			portletURL);
 
 		if (folder != null) {
 			List<Folder> ancestorFolders = folder.getAncestors();
@@ -65,13 +65,12 @@ public class DLBreadcrumbUtil {
 			for (Folder ancestorFolder : ancestorFolders) {
 				_addPortletBreadcrumbEntry(
 					ancestorFolder.getFolderId(), httpServletRequest,
-					portletURL, ancestorFolder.getRepositoryId(),
-					ancestorFolder.getName());
+					ancestorFolder.getName(), portletURL);
 			}
 
 			_addPortletBreadcrumbEntry(
-				folder.getFolderId(), httpServletRequest, portletURL,
-				folder.getRepositoryId(), folder.getName());
+				folder.getFolderId(), httpServletRequest, folder.getName(),
+				portletURL);
 		}
 	}
 
@@ -94,28 +93,13 @@ public class DLBreadcrumbUtil {
 	}
 
 	private static void _addPortletBreadcrumbEntry(
-		long folderId, HttpServletRequest httpServletRequest,
-		PortletURL portletURL, long repositoryId, String title) {
+		long folderId, HttpServletRequest httpServletRequest, String title,
+		PortletURL portletURL) {
 
 		portletURL.setParameter("folderId", String.valueOf(folderId));
-		portletURL.setParameter("repositoryId", String.valueOf(repositoryId));
 
 		PortalUtil.addPortletBreadcrumbEntry(
 			httpServletRequest, title, portletURL.toString());
-	}
-
-	private static long _getRepositoryId(
-		HttpServletRequest httpServletRequest, long repositoryId) {
-
-		if (repositoryId == 0) {
-			ThemeDisplay themeDisplay =
-				(ThemeDisplay)httpServletRequest.getAttribute(
-					WebKeys.THEME_DISPLAY);
-
-			repositoryId = themeDisplay.getScopeGroupId();
-		}
-
-		return repositoryId;
 	}
 
 	private static String _getRootFolderName(

--- a/modules/apps/document-library/document-library-item-selector-web/src/main/resources/META-INF/resources/select_folder.jsp
+++ b/modules/apps/document-library/document-library-item-selector-web/src/main/resources/META-INF/resources/select_folder.jsp
@@ -19,7 +19,7 @@
 <%
 DLSelectFolderDisplayContext dlSelectFolderDisplayContext = (DLSelectFolderDisplayContext)request.getAttribute(DLSelectFolderDisplayContext.class.getName());
 
-DLBreadcrumbUtil.addPortletBreadcrumbEntries(ParamUtil.getString(request, "displayStyle"), dlSelectFolderDisplayContext.getFolder(), request, liferayPortletResponse, dlSelectFolderDisplayContext.getIteratorPortletURL(liferayPortletResponse), dlSelectFolderDisplayContext.isShowGroupSelector());
+DLBreadcrumbUtil.addPortletBreadcrumbEntries(ParamUtil.getString(request, "displayStyle"), dlSelectFolderDisplayContext.getFolder(), request, liferayPortletResponse, dlSelectFolderDisplayContext.getIteratorPortletURL(liferayPortletResponse), dlSelectFolderDisplayContext.getRepositoryId(), dlSelectFolderDisplayContext.isShowGroupSelector());
 %>
 
 <clay:container-fluid>

--- a/modules/apps/document-library/document-library-item-selector-web/src/main/resources/META-INF/resources/select_folder.jsp
+++ b/modules/apps/document-library/document-library-item-selector-web/src/main/resources/META-INF/resources/select_folder.jsp
@@ -19,7 +19,7 @@
 <%
 DLSelectFolderDisplayContext dlSelectFolderDisplayContext = (DLSelectFolderDisplayContext)request.getAttribute(DLSelectFolderDisplayContext.class.getName());
 
-DLBreadcrumbUtil.addPortletBreadcrumbEntries(ParamUtil.getString(request, "displayStyle"), dlSelectFolderDisplayContext.getFolder(), request, liferayPortletResponse, dlSelectFolderDisplayContext.getIteratorPortletURL(liferayPortletResponse), dlSelectFolderDisplayContext.getRepositoryId(), dlSelectFolderDisplayContext.isShowGroupSelector());
+DLBreadcrumbUtil.addPortletBreadcrumbEntries(dlSelectFolderDisplayContext.getFolder(), ParamUtil.getString(request, "displayStyle"), request, liferayPortletResponse, dlSelectFolderDisplayContext.getIteratorPortletURL(liferayPortletResponse), dlSelectFolderDisplayContext.isShowGroupSelector());
 %>
 
 <clay:container-fluid>
@@ -89,7 +89,7 @@ DLBreadcrumbUtil.addPortletBreadcrumbEntries(ParamUtil.getString(request, "displ
 				/>
 
 				<liferay-ui:search-container-column-text>
-					<aui:button cssClass="selector-button" data="<%= dlSelectFolderDisplayContext.getSelectorButtonData(curFolder) %>" disabled="<%= dlSelectFolderDisplayContext.isSelectButtonDisabled(curFolder.getFolderId(), curFolder.getRepositoryId()) %>" value="select" />
+					<aui:button cssClass="selector-button" data="<%= dlSelectFolderDisplayContext.getSelectorButtonData(curFolder) %>" disabled="<%= dlSelectFolderDisplayContext.isSelectButtonDisabled(curFolder.getFolderId()) %>" value="select" />
 				</liferay-ui:search-container-column-text>
 			</liferay-ui:search-container-row>
 

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLViewDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLViewDisplayContext.java
@@ -215,7 +215,6 @@ public class DLViewDisplayContext {
 		folderItemSelectorCriterion.setDesiredItemSelectorReturnTypes(
 			new FolderItemSelectorReturnType());
 		folderItemSelectorCriterion.setFolderId(getFolderId());
-		folderItemSelectorCriterion.setRepositoryId(getRepositoryId());
 		folderItemSelectorCriterion.setSelectedFolderId(getFolderId());
 
 		PortletURL portletURL = itemSelector.getItemSelectorURL(

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/IGConfigurationDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/IGConfigurationDisplayContext.java
@@ -110,6 +110,7 @@ public class IGConfigurationDisplayContext {
 	}
 
 	public long getRepositoryId() throws PortalException {
+		_initFolder();
 		_initRepository();
 
 		return _repositoryId;
@@ -140,7 +141,6 @@ public class IGConfigurationDisplayContext {
 
 		folderItemSelectorCriterion.setIgnoreRootFolder(true);
 		folderItemSelectorCriterion.setSelectedFolderId(getRootFolderId());
-		folderItemSelectorCriterion.setRepositoryId(getRepositoryId());
 		folderItemSelectorCriterion.setShowGroupSelector(true);
 
 		return _itemSelector.getItemSelectorURL(
@@ -226,6 +226,8 @@ public class IGConfigurationDisplayContext {
 
 		_folder = folder;
 
+		_initRepository();
+
 		if (_folder.isRepositoryCapabilityProvided(TrashCapability.class)) {
 			TrashCapability trashCapability = _folder.getRepositoryCapability(
 				TrashCapability.class);
@@ -250,10 +252,6 @@ public class IGConfigurationDisplayContext {
 
 		if (_repositoryId != 0) {
 			return;
-		}
-
-		if (_folder == null) {
-			_folder = _getFolder();
 		}
 
 		if (_folder != null) {

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/lar/DLAdminPortletDataHandler.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/lar/DLAdminPortletDataHandler.java
@@ -186,7 +186,6 @@ public class DLAdminPortletDataHandler extends BasePortletDataHandler {
 		portletPreferences.setValue("fileEntryColumns", StringPool.BLANK);
 		portletPreferences.setValue("folderColumns", StringPool.BLANK);
 		portletPreferences.setValue("foldersPerPage", StringPool.BLANK);
-		portletPreferences.setValue("repositoryId", StringPool.BLANK);
 		portletPreferences.setValue("rootFolderId", StringPool.BLANK);
 		portletPreferences.setValue("showFoldersSearch", StringPool.BLANK);
 		portletPreferences.setValue("showSubfolders", StringPool.BLANK);

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/lar/IGDisplayPortletDataHandler.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/lar/IGDisplayPortletDataHandler.java
@@ -66,7 +66,6 @@ public class IGDisplayPortletDataHandler extends BasePortletDataHandler {
 		portletPreferences.setValue("fileEntryColumns", StringPool.BLANK);
 		portletPreferences.setValue("folderColumns", StringPool.BLANK);
 		portletPreferences.setValue("foldersPerPage", StringPool.BLANK);
-		portletPreferences.setValue("repositoryId", StringPool.BLANK);
 		portletPreferences.setValue("rootFolderId", StringPool.BLANK);
 		portletPreferences.setValue("showSubfolders", StringPool.BLANK);
 

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/util/IGUtil.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/util/IGUtil.java
@@ -50,6 +50,8 @@ public class IGUtil {
 
 		long rootFolderId = getRootFolderId(httpServletRequest);
 
+		long repositoryId = getRepositoryId(folder, httpServletRequest);
+
 		List<Folder> ancestorFolders = Collections.emptyList();
 
 		if ((folder != null) && (folder.getFolderId() != rootFolderId)) {
@@ -72,20 +74,16 @@ public class IGUtil {
 
 		Collections.reverse(new ArrayList<>(ancestorFolders));
 
-		long repositoryId = getRepositoryId(folder, httpServletRequest);
-
 		for (Folder ancestorFolder : ancestorFolders) {
 			portletURL.setParameter(
-				"repositoryId", String.valueOf(repositoryId));
-			portletURL.setParameter(
 				"folderId", String.valueOf(ancestorFolder.getFolderId()));
+			portletURL.setParameter(
+				"repositoryId", String.valueOf(repositoryId));
 
 			PortalUtil.addPortletBreadcrumbEntry(
 				httpServletRequest, ancestorFolder.getName(),
 				portletURL.toString());
 		}
-
-		portletURL.setParameter("repositoryId", String.valueOf(repositoryId));
 
 		long folderId = DLFolderConstants.DEFAULT_PARENT_FOLDER_ID;
 
@@ -94,6 +92,7 @@ public class IGUtil {
 		}
 
 		portletURL.setParameter("folderId", String.valueOf(folderId));
+		portletURL.setParameter("repositoryId", String.valueOf(repositoryId));
 
 		PortalUtil.addPortletBreadcrumbEntry(
 			httpServletRequest, folder.getName(), portletURL.toString());

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/util/IGUtil.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/util/IGUtil.java
@@ -50,8 +50,6 @@ public class IGUtil {
 
 		long rootFolderId = getRootFolderId(httpServletRequest);
 
-		long repositoryId = getRepositoryId(folder, httpServletRequest);
-
 		List<Folder> ancestorFolders = Collections.emptyList();
 
 		if ((folder != null) && (folder.getFolderId() != rootFolderId)) {
@@ -77,8 +75,6 @@ public class IGUtil {
 		for (Folder ancestorFolder : ancestorFolders) {
 			portletURL.setParameter(
 				"folderId", String.valueOf(ancestorFolder.getFolderId()));
-			portletURL.setParameter(
-				"repositoryId", String.valueOf(repositoryId));
 
 			PortalUtil.addPortletBreadcrumbEntry(
 				httpServletRequest, ancestorFolder.getName(),
@@ -92,7 +88,6 @@ public class IGUtil {
 		}
 
 		portletURL.setParameter("folderId", String.valueOf(folderId));
-		portletURL.setParameter("repositoryId", String.valueOf(repositoryId));
 
 		PortalUtil.addPortletBreadcrumbEntry(
 			httpServletRequest, folder.getName(), portletURL.toString());
@@ -110,20 +105,6 @@ public class IGUtil {
 		addPortletBreadcrumbEntries(
 			DLAppLocalServiceUtil.getFolder(folderId), httpServletRequest,
 			renderResponse);
-	}
-
-	protected static long getRepositoryId(
-			Folder folder, HttpServletRequest httpServletRequest)
-		throws Exception {
-
-		PortletPreferences portletPreferences =
-			PortletPreferencesFactoryUtil.getPortletPreferences(
-				httpServletRequest,
-				PortalUtil.getPortletId(httpServletRequest));
-
-		return GetterUtil.getLong(
-			portletPreferences.getValue(
-				"repositoryId", String.valueOf(folder.getRepositoryId())));
 	}
 
 	protected static long getRootFolderId(HttpServletRequest httpServletRequest)

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/configuration.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/configuration.jsp
@@ -42,7 +42,6 @@ DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper = new DLPortletI
 
 	<liferay-frontend:edit-form-body>
 		<liferay-frontend:fieldset-group>
-			<aui:input name="preferences--repositoryId--" type="hidden" value="<%= dlAdminDisplayContext.getRepositoryId() %>" />
 			<aui:input name="preferences--rootFolderId--" type="hidden" value="<%= dlAdminDisplayContext.getRootFolderId() %>" />
 			<aui:input name="preferences--displayViews--" type="hidden" />
 			<aui:input name="preferences--entryColumns--" type="hidden" />
@@ -163,14 +162,6 @@ DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper = new DLPortletI
 								};
 
 								Liferay.Util.selectFolder(folderData, '<portlet:namespace />');
-
-								var repositoryIdElement = document.querySelector(
-									'#<portlet:namespace />repositoryId'
-								);
-
-								if (repositoryIdElement != null) {
-									repositoryIdElement.value = selectedItem.repositoryid;
-								}
 
 								var rootFolderInTrashWarning = document.querySelector(
 									'#<portlet:namespace />rootFolderInTrash'

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/configuration.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/configuration.jsp
@@ -185,7 +185,6 @@ DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper = new DLPortletI
 							folderItemSelectorCriterion.setDesiredItemSelectorReturnTypes(new FolderItemSelectorReturnType());
 							folderItemSelectorCriterion.setFolderId((dlAdminDisplayContext.isRootFolderInTrash() || dlAdminDisplayContext.isRootFolderNotFound()) ? DLFolderConstants.DEFAULT_PARENT_FOLDER_ID : dlAdminDisplayContext.getRootFolderId());
 							folderItemSelectorCriterion.setIgnoreRootFolder(true);
-							folderItemSelectorCriterion.setRepositoryId(dlAdminDisplayContext.getRepositoryId());
 							folderItemSelectorCriterion.setSelectedFolderId(dlAdminDisplayContext.getRootFolderId());
 							folderItemSelectorCriterion.setShowGroupSelector(true);
 							folderItemSelectorCriterion.setShowMountFolder(false);

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry.jsp
@@ -179,7 +179,6 @@ FolderItemSelectorCriterion folderItemSelectorCriterion = new FolderItemSelector
 
 folderItemSelectorCriterion.setDesiredItemSelectorReturnTypes(new FolderItemSelectorReturnType());
 folderItemSelectorCriterion.setFolderId(fileEntry.getFolderId());
-folderItemSelectorCriterion.setRepositoryId(fileEntry.getRepositoryId());
 folderItemSelectorCriterion.setSelectedFolderId(fileEntry.getFolderId());
 
 PortletURL selectFolderURL = itemSelector.getItemSelectorURL(RequestBackedPortletURLFactoryUtil.create(request), portletDisplay.getNamespace() + "folderSelected", folderItemSelectorCriterion);

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/image_gallery_display/configuration.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/image_gallery_display/configuration.jsp
@@ -132,14 +132,6 @@ IGConfigurationDisplayContext igConfigurationDisplayContext = (IGConfigurationDi
 
 					Liferay.Util.selectFolder(folderData, '<portlet:namespace />');
 
-					var repositoryIdElement = document.querySelector(
-						'#<portlet:namespace />repositoryId'
-					);
-
-					if (repositoryIdElement != null) {
-						repositoryIdElement.value = selectedItem.repositoryid;
-					}
-
 					var rootFolderInTrashWarning = document.querySelector(
 						'#<portlet:namespace />rootFolderInTrash'
 					);

--- a/modules/apps/item-selector/item-selector-criteria-api/bnd.bnd
+++ b/modules/apps/item-selector/item-selector-criteria-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Item Selector Criteria API
 Bundle-SymbolicName: com.liferay.item.selector.criteria.api
-Bundle-Version: 6.3.1
+Bundle-Version: 6.3.0
 Export-Package:\
 	com.liferay.item.selector.criteria,\
 	com.liferay.item.selector.criteria.asset.criterion,\

--- a/modules/apps/item-selector/item-selector-criteria-api/src/main/java/com/liferay/item/selector/criteria/folder/criterion/FolderItemSelectorCriterion.java
+++ b/modules/apps/item-selector/item-selector-criteria-api/src/main/java/com/liferay/item/selector/criteria/folder/criterion/FolderItemSelectorCriterion.java
@@ -25,10 +25,6 @@ public class FolderItemSelectorCriterion extends BaseItemSelectorCriterion {
 		return _folderId;
 	}
 
-	public long getRepositoryId() {
-		return _repositoryId;
-	}
-
 	public long getSelectedFolderId() {
 		return _selectedFolderId;
 	}
@@ -53,10 +49,6 @@ public class FolderItemSelectorCriterion extends BaseItemSelectorCriterion {
 		_ignoreRootFolder = ignoreRootFolder;
 	}
 
-	public void setRepositoryId(long repositoryId) {
-		_repositoryId = repositoryId;
-	}
-
 	public void setSelectedFolderId(long selectedFolderId) {
 		_selectedFolderId = selectedFolderId;
 	}
@@ -71,7 +63,6 @@ public class FolderItemSelectorCriterion extends BaseItemSelectorCriterion {
 
 	private long _folderId;
 	private boolean _ignoreRootFolder;
-	private long _repositoryId;
 	private long _selectedFolderId;
 	private boolean _showGroupSelector;
 	private boolean _showMountFolder;

--- a/modules/apps/item-selector/item-selector-criteria-api/src/main/resources/com/liferay/item/selector/criteria/folder/criterion/packageinfo
+++ b/modules/apps/item-selector/item-selector-criteria-api/src/main/resources/com/liferay/item/selector/criteria/folder/criterion/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 1.0.0


### PR DESCRIPTION

- Revert "LPS-135678 SF"
- Revert "LPS-135678 SF"
- Revert "LPS-135678 the first repository on the breadcrumb is always the scopeGroup"
- Revert "LPS-135678 add the selected repository to differentiate the root folders from differents groups to let the user select the folder"
- Revert "LPS-135678 add the repository id to the breadcrumb util to generate the portlets URL"
- Revert "LPS-135678 add the repository setting to the dL configuration settings"
- Revert "LPS-135678 update the get the settings of the repository id when selecting the folder"
- Revert "LPS-135678 clean repository id on portlet preferences"
- Revert "LPS-135678 add the repositoryId to the criteria of folder"
- Revert "LPS-135678 baseline"
- Revert "LPS-135678 add the repositoryId to the FolderSelector criterion"
