### PR TITLE
LPS-141019

### DIFF
--- a/modules/apps/mentions/mentions-service/src/main/java/com/liferay/mentions/internal/util/DefaultMentionsNotifier.java
+++ b/modules/apps/mentions/mentions-service/src/main/java/com/liferay/mentions/internal/util/DefaultMentionsNotifier.java
@@ -123,19 +123,21 @@ public class DefaultMentionsNotifier implements MentionsNotifier {
 
 			ThemeDisplay themeDisplay = serviceContext.getThemeDisplay();
 
-			Layout layout = themeDisplay.getLayout();
+			if (themeDisplay != null) {
+				Layout layout = themeDisplay.getLayout();
 
-			if (layout != null) {
-				PermissionChecker permissionChecker =
-					PermissionCheckerFactoryUtil.create(mentionedUser);
+				if (layout != null) {
+					PermissionChecker permissionChecker =
+						PermissionCheckerFactoryUtil.create(mentionedUser);
 
-				if (!LayoutPermissionUtil.contains(
-						permissionChecker, layout, true, ActionKeys.VIEW) ||
-					!PortletPermissionUtil.contains(
-						permissionChecker, layout, themeDisplay.getPpid(),
-						ActionKeys.VIEW)) {
+					if (!LayoutPermissionUtil.contains(
+							permissionChecker, layout, true, ActionKeys.VIEW) ||
+						!PortletPermissionUtil.contains(
+							permissionChecker, layout, themeDisplay.getPpid(),
+							ActionKeys.VIEW)) {
 
-					continue;
+						continue;
+					}
 				}
 			}
 

--- a/modules/apps/mentions/mentions-service/src/main/java/com/liferay/mentions/internal/util/DefaultMentionsNotifier.java
+++ b/modules/apps/mentions/mentions-service/src/main/java/com/liferay/mentions/internal/util/DefaultMentionsNotifier.java
@@ -27,11 +27,11 @@ import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
-import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
-import com.liferay.portal.kernel.service.permission.LayoutPermissionUtil;
-import com.liferay.portal.kernel.service.permission.PortletPermissionUtil;
+import com.liferay.portal.kernel.service.permission.LayoutPermission;
+import com.liferay.portal.kernel.service.permission.PortletPermission;
 import com.liferay.portal.kernel.settings.LocalizedValuesMap;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
@@ -128,11 +128,11 @@ public class DefaultMentionsNotifier implements MentionsNotifier {
 
 				if (layout != null) {
 					PermissionChecker permissionChecker =
-						PermissionCheckerFactoryUtil.create(mentionedUser);
+						_permissionCheckerFactory.create(mentionedUser);
 
-					if (!LayoutPermissionUtil.contains(
+					if (!_layoutPermission.contains(
 							permissionChecker, layout, true, ActionKeys.VIEW) ||
-						!PortletPermissionUtil.contains(
+						!_portletPermission.contains(
 							permissionChecker, layout, themeDisplay.getPpid(),
 							ActionKeys.VIEW)) {
 
@@ -212,11 +212,20 @@ public class DefaultMentionsNotifier implements MentionsNotifier {
 		_userLocalService = userLocalService;
 	}
 
+	@Reference
+	private LayoutPermission _layoutPermission;
+
 	private MentionsMatcherRegistry _mentionsMatcherRegistry;
 	private MentionsUserFinder _mentionsUserFinder;
 
 	@Reference
+	private PermissionCheckerFactory _permissionCheckerFactory;
+
+	@Reference
 	private Portal _portal;
+
+	@Reference
+	private PortletPermission _portletPermission;
 
 	private UserLocalService _userLocalService;
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-141019

/cc @tototrinh

Follow-up to https://github.com/brianchandotcom/liferay-portal/pull/110323 that moves the null check to the right place, along with some source formatting issues I noticed on the second review.

### Steps to reproduce

1. Create a blog entry with the content `@test`, scheduled for display 1-2 minutes in the future
2. Wait 1-2 minutes
3. Run the following Groovy script to force it to check for scheduled entries
```
import com.liferay.portal.template.ServiceLocator

def serviceLocator = ServiceLocator.getInstance()

def blogsEntryLocalService = serviceLocator.findService("com.liferay.blogs.service.BlogsEntryLocalService")

try {
  blogsEntryLocalService.checkEntries()
}
catch (Exception e) {
  e.printStackTrace(out)
}
```

Expected behavior is that there are no errors.
Actual behavior is that you get a `NullPointerException` due to a null `ThemeDisplay`.