### PR TITLE
[TS] LPS-143099

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/struts/FindKBArticleStrutsAction.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/struts/FindKBArticleStrutsAction.java
@@ -80,6 +80,8 @@ public class FindKBArticleStrutsAction implements StrutsAction {
 			HttpServletResponse httpServletResponse)
 		throws Exception {
 
+		String backURL = ParamUtil.getString(
+			httpServletRequest, "p_l_back_url");
 		long plid = ParamUtil.getLong(httpServletRequest, "plid");
 		long resourcePrimKey = ParamUtil.getLong(
 			httpServletRequest, "resourcePrimKey");
@@ -118,6 +120,10 @@ public class FindKBArticleStrutsAction implements StrutsAction {
 
 		if (portletURL == null) {
 			portletURL = getDynamicPortletURL(plid, status, httpServletRequest);
+		}
+
+		if (Validator.isNotNull(backURL)) {
+			portletURL.setParameter("backURL", backURL);
 		}
 
 		if (maximized) {

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/view_article.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/view_article.jsp
@@ -19,6 +19,12 @@
 <%
 KBArticle kbArticle = (KBArticle)request.getAttribute(KBWebKeys.KNOWLEDGE_BASE_KB_ARTICLE);
 
+String backURL = ParamUtil.getString(request, "backURL");
+
+if (Validator.isNotNull(backURL)) {
+	portletDisplay.setURLBack(backURL);
+}
+
 if (enableKBArticleViewCountIncrement && kbArticle.isApproved()) {
 	KBArticle latestKBArticle = KBArticleLocalServiceUtil.getLatestKBArticle(kbArticle.getResourcePrimKey(), WorkflowConstants.STATUS_APPROVED);
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/CustomFields.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/CustomFields.macro
@@ -117,6 +117,12 @@ definition {
 		PortletEntry.save();
 	}
 
+	macro openCustomFieldAdmin {
+		Navigator.openWithAppendToBaseURL(
+			baseURL = "${baseURL}",
+			urlAppend = "group/control_panel/manage?p_p_id=com_liferay_expando_web_portlet_ExpandoPortlet");
+	}
+
 	macro openToAddResourceCustomField {
 		Navigator.openWithAppendToBaseURL(
 			baseURL = "${baseURL}",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/usecase/RemoteStaging.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/usecase/RemoteStaging.testcase
@@ -88,21 +88,13 @@ definition {
 	test PublishCustomFieldDeletionviaRemoteStaging {
 		property test.name.skip.portal.instance = "RemoteStaging#PublishCustomFieldDeletionviaRemoteStaging";
 
-		ApplicationsMenu.gotoPortlet(
-			category = "Configuration",
-			panel = "Control Panel",
-			portlet = "Custom Fields");
-
 		CustomFields.addCP(
 			customFieldName = "Text Field",
 			customFieldType = "Input Field",
 			customInputDataType = "Text",
-			resourceName = "Document");
+			modelResource = "com.liferay.document.library.kernel.model.DLFileEntry");
 
-		ApplicationsMenu.gotoPortlet(
-			category = "Configuration",
-			panel = "Control Panel",
-			portlet = "Custom Fields");
+		CustomFields.openCustomFieldAdmin();
 
 		LAR.exportPortlet(
 			larFileName = "custom_fields.portlet.lar",
@@ -115,10 +107,7 @@ definition {
 			specificURL = "http://localhost:9080",
 			userEmailAddress = "test@liferay.com");
 
-		ApplicationsMenu.gotoPortlet(
-			category = "Configuration",
-			panel = "Control Panel",
-			portlet = "Custom Fields");
+		CustomFields.openCustomFieldAdmin(baseURL = "http://localhost:9080");
 
 		LAR.importPortlet(larFileName = "custom_fields.portlet.lar");
 
@@ -130,9 +119,7 @@ definition {
 
 		Navigator.openSiteURL(siteName = "Site Name");
 
-		ProductMenu.gotoPortlet(
-			category = "Content & Data",
-			portlet = "Documents and Media");
+		DMNavigator.openDocumentsAndMediaAdmin(siteURLKey = "site-name");
 
 		DMDocument.addCP(
 			customFieldText = "DM Document Custom Field",
@@ -160,9 +147,9 @@ definition {
 			pageName = "Staging Test Page",
 			siteName = "Remote Site");
 
-		ProductMenu.gotoPortlet(
-			category = "Content & Data",
-			portlet = "Documents and Media");
+		DMNavigator.openDocumentsAndMediaAdmin(
+			baseURL = "http://localhost:9080",
+			siteURLKey = "remote-site");
 
 		DMNavigator.gotoDocumentCP(dmDocumentTitle = "DM Document Title");
 
@@ -177,19 +164,13 @@ definition {
 			password = "test",
 			userEmailAddress = "test@liferay.com");
 
-		ApplicationsMenu.gotoPortlet(
-			category = "Configuration",
-			panel = "Control Panel",
-			portlet = "Custom Fields");
+		CustomFields.openCustomFieldAdmin();
 
 		CustomFields.deleteCP(
 			customFieldName = "Text Field",
 			resourceName = "Document");
 
-		ApplicationsMenu.gotoPortlet(
-			category = "Configuration",
-			panel = "Control Panel",
-			portlet = "Custom Fields");
+		CustomFields.openCustomFieldAdmin();
 
 		LAR.exportPortlet(
 			exportIndividualDeletions = "true",
@@ -203,10 +184,7 @@ definition {
 			specificURL = "http://localhost:9080",
 			userEmailAddress = "test@liferay.com");
 
-		ApplicationsMenu.gotoPortlet(
-			category = "Configuration",
-			panel = "Control Panel",
-			portlet = "Custom Fields");
+		CustomFields.openCustomFieldAdmin(baseURL = "http://localhost:9080");
 
 		LAR.importPortlet(
 			importDeletions = "true",
@@ -220,9 +198,7 @@ definition {
 
 		Navigator.openSiteURL(siteName = "Site Name");
 
-		ProductMenu.gotoPortlet(
-			category = "Content & Data",
-			portlet = "Documents and Media");
+		DMNavigator.openDocumentsAndMediaAdmin(siteURLKey = "site-name");
 
 		DMNavigator.gotoDocumentCP(dmDocumentTitle = "DM Document Title");
 
@@ -251,9 +227,9 @@ definition {
 			pageName = "Staging Test Page",
 			siteName = "Remote Site");
 
-		ProductMenu.gotoPortlet(
-			category = "Content & Data",
-			portlet = "Documents and Media");
+		DMNavigator.openDocumentsAndMediaAdmin(
+			baseURL = "http://localhost:9080",
+			siteURLKey = "remote-site");
 
 		DMNavigator.gotoDocumentCP(dmDocumentTitle = "DM Document Title");
 


### PR DESCRIPTION
Hi Team,

please review the changes of this fix!

It aims to resolve the issue described in [LPS-143099](https://issues.liferay.com/browse/LPS-143099): when opening a KB article search result, the '<' button navigated back to an empty Search page.
The issue was caused by a missing `backURL` parameter.

Thank you!