### PR TITLE
LPS-143623 Allow selecting content stored in an Asset Library from the documents and media widget

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminDisplayContext.java
@@ -245,14 +245,6 @@ public class DLAdminDisplayContext {
 			return _repositoryId;
 		}
 
-		long repositoryId = _dlPortletInstanceSettings.getRepositoryId();
-
-		if (repositoryId != 0) {
-			_repositoryId = repositoryId;
-
-			return _repositoryId;
-		}
-
 		Folder folder = getFolder();
 
 		if (folder != null) {
@@ -306,6 +298,25 @@ public class DLAdminDisplayContext {
 			"searchFolderId",
 			ParamUtil.getLong(_httpServletRequest, "searchFolderId")
 		).buildPortletURL();
+	}
+
+	public long getSelectedRepositoryId() {
+		if (_selectedRepositoryId != 0) {
+			return _selectedRepositoryId;
+		}
+
+		long repositoryId =
+			_dlPortletInstanceSettings.getSelectedRepositoryId();
+
+		if (repositoryId != 0) {
+			_selectedRepositoryId = repositoryId;
+
+			return _selectedRepositoryId;
+		}
+
+		_selectedRepositoryId = getRepositoryId();
+
+		return _selectedRepositoryId;
 	}
 
 	public boolean isDefaultFolderView() {
@@ -385,11 +396,6 @@ public class DLAdminDisplayContext {
 			Folder rootFolder = DLAppLocalServiceUtil.getFolder(_rootFolderId);
 
 			_rootFolderName = rootFolder.getName();
-
-			if (rootFolder.getGroupId() != _themeDisplay.getScopeGroupId()) {
-				_rootFolderId = DLFolderConstants.DEFAULT_PARENT_FOLDER_ID;
-				_rootFolderName = StringPool.BLANK;
-			}
 
 			if (rootFolder.isRepositoryCapabilityProvided(
 					TrashCapability.class)) {
@@ -821,6 +827,7 @@ public class DLAdminDisplayContext {
 	private String _rootFolderName;
 	private boolean _rootFolderNotFound;
 	private SearchContainer<RepositoryEntry> _searchContainer;
+	private long _selectedRepositoryId;
 	private final ThemeDisplay _themeDisplay;
 	private final TrashHelper _trashHelper;
 	private final VersioningStrategy _versioningStrategy;

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLViewDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLViewDisplayContext.java
@@ -216,7 +216,8 @@ public class DLViewDisplayContext {
 			new FolderItemSelectorReturnType());
 		folderItemSelectorCriterion.setFolderId(getFolderId());
 		folderItemSelectorCriterion.setSelectedFolderId(getFolderId());
-		folderItemSelectorCriterion.setSelectedRepositoryId(getRepositoryId());
+		folderItemSelectorCriterion.setSelectedRepositoryId(
+			_dlAdminDisplayContext.getSelectedRepositoryId());
 
 		PortletURL portletURL = itemSelector.getItemSelectorURL(
 			RequestBackedPortletURLFactoryUtil.create(_renderRequest),

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/IGConfigurationDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/IGConfigurationDisplayContext.java
@@ -256,7 +256,9 @@ public class IGConfigurationDisplayContext {
 			return;
 		}
 
-		if (_folder == null) {
+		if ((_folder == null) &&
+			(_folderId != DLFolderConstants.DEFAULT_PARENT_FOLDER_ID)) {
+
 			_folder = _getFolder();
 		}
 

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/IGConfigurationDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/IGConfigurationDisplayContext.java
@@ -37,6 +37,7 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.KeyValuePair;
+import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.trash.TrashHelper;
@@ -263,7 +264,9 @@ public class IGConfigurationDisplayContext {
 			_selectedRepositoryId = _folder.getRepositoryId();
 		}
 		else {
-			_selectedRepositoryId = _themeDisplay.getScopeGroupId();
+			_selectedRepositoryId = ParamUtil.getLong(
+				_httpServletRequest, "repositoryId",
+				_themeDisplay.getScopeGroupId());
 		}
 
 		try {

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/IGConfigurationDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/IGConfigurationDisplayContext.java
@@ -109,12 +109,6 @@ public class IGConfigurationDisplayContext {
 		return portletDisplay.getNamespace() + "folderSelected";
 	}
 
-	public long getRepositoryId() throws PortalException {
-		_initRepository();
-
-		return _repositoryId;
-	}
-
 	public long getRootFolderId() throws PortalException {
 		_initFolder();
 
@@ -125,6 +119,12 @@ public class IGConfigurationDisplayContext {
 		_initFolder();
 
 		return _folderName;
+	}
+
+	public long getSelectedRepositoryId() throws PortalException {
+		_initRepository();
+
+		return _selectedRepositoryId;
 	}
 
 	public PortletURL getSelectFolderURL() throws PortalException {
@@ -140,7 +140,8 @@ public class IGConfigurationDisplayContext {
 
 		folderItemSelectorCriterion.setIgnoreRootFolder(true);
 		folderItemSelectorCriterion.setSelectedFolderId(getRootFolderId());
-		folderItemSelectorCriterion.setSelectedRepositoryId(getRepositoryId());
+		folderItemSelectorCriterion.setSelectedRepositoryId(
+			getSelectedRepositoryId());
 		folderItemSelectorCriterion.setShowGroupSelector(true);
 
 		return _itemSelector.getItemSelectorURL(
@@ -239,16 +240,17 @@ public class IGConfigurationDisplayContext {
 	}
 
 	private void _initRepository() {
-		if (_repositoryId != 0) {
+		if (_selectedRepositoryId != 0) {
 			return;
 		}
 
 		DLPortletInstanceSettings dlPortletInstanceSettings =
 			_igRequestHelper.getDLPortletInstanceSettings();
 
-		_repositoryId = dlPortletInstanceSettings.getRepositoryId();
+		_selectedRepositoryId =
+			dlPortletInstanceSettings.getSelectedRepositoryId();
 
-		if (_repositoryId != 0) {
+		if (_selectedRepositoryId != 0) {
 			return;
 		}
 
@@ -257,14 +259,15 @@ public class IGConfigurationDisplayContext {
 		}
 
 		if (_folder != null) {
-			_repositoryId = _folder.getRepositoryId();
+			_selectedRepositoryId = _folder.getRepositoryId();
 		}
 		else {
-			_repositoryId = _themeDisplay.getScopeGroupId();
+			_selectedRepositoryId = _themeDisplay.getScopeGroupId();
 		}
 
 		try {
-			_repository = _repositoryLocalService.getRepository(_repositoryId);
+			_repository = _repositoryLocalService.getRepository(
+				_selectedRepositoryId);
 
 			_repositoryNotFound = false;
 		}
@@ -290,9 +293,9 @@ public class IGConfigurationDisplayContext {
 		_portletPreferencesLocalService;
 	private final RenderRequest _renderRequest;
 	private Repository _repository;
-	private long _repositoryId;
 	private final RepositoryLocalService _repositoryLocalService;
 	private boolean _repositoryNotFound;
+	private long _selectedRepositoryId;
 	private final ThemeDisplay _themeDisplay;
 	private final TrashHelper _trashHelper;
 

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/IGConfigurationDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/IGConfigurationDisplayContext.java
@@ -226,6 +226,7 @@ public class IGConfigurationDisplayContext {
 		}
 
 		_folder = folder;
+		_folderName = folder.getName();
 
 		if (_folder.isRepositoryCapabilityProvided(TrashCapability.class)) {
 			TrashCapability trashCapability = _folder.getRepositoryCapability(

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/settings/DLPortletInstanceSettings.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/settings/DLPortletInstanceSettings.java
@@ -105,13 +105,13 @@ public class DLPortletInstanceSettings {
 		return _typedSettings.getValues("mimeTypes", _MIME_TYPES_DEFAULT);
 	}
 
-	public long getRepositoryId() {
-		return _typedSettings.getLongValue("repositoryId");
-	}
-
 	public long getRootFolderId() {
 		return _typedSettings.getLongValue(
 			"rootFolderId", DLFolderConstants.DEFAULT_PARENT_FOLDER_ID);
+	}
+
+	public long getSelectedRepositoryId() {
+		return _typedSettings.getLongValue("selectedRepositoryId");
 	}
 
 	public boolean isEnableCommentRatings() {

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/configuration.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/configuration.jsp
@@ -42,8 +42,8 @@ DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper = new DLPortletI
 
 	<liferay-frontend:edit-form-body>
 		<liferay-frontend:fieldset-group>
-			<aui:input name="preferences--repositoryId--" type="hidden" value="<%= dlAdminDisplayContext.getRepositoryId() %>" />
 			<aui:input name="preferences--rootFolderId--" type="hidden" value="<%= dlAdminDisplayContext.getRootFolderId() %>" />
+			<aui:input name="preferences--selectedRepositoryId--" type="hidden" value="<%= dlAdminDisplayContext.getSelectedRepositoryId() %>" />
 			<aui:input name="preferences--displayViews--" type="hidden" />
 			<aui:input name="preferences--entryColumns--" type="hidden" />
 

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/configuration.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/configuration.jsp
@@ -42,6 +42,7 @@ DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper = new DLPortletI
 
 	<liferay-frontend:edit-form-body>
 		<liferay-frontend:fieldset-group>
+			<aui:input name="preferences--repositoryId--" type="hidden" value="<%= dlAdminDisplayContext.getRepositoryId() %>" />
 			<aui:input name="preferences--rootFolderId--" type="hidden" value="<%= dlAdminDisplayContext.getRootFolderId() %>" />
 			<aui:input name="preferences--displayViews--" type="hidden" />
 			<aui:input name="preferences--entryColumns--" type="hidden" />

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/configuration.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/configuration.jsp
@@ -164,6 +164,14 @@ DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper = new DLPortletI
 
 								Liferay.Util.selectFolder(folderData, '<portlet:namespace />');
 
+								var repositoryIdElement = document.querySelector(
+									'#<portlet:namespace />selectedRepositoryId'
+								);
+
+								if (repositoryIdElement != null) {
+									repositoryIdElement.value = selectedItem.repositoryid;
+								}
+
 								var rootFolderInTrashWarning = document.querySelector(
 									'#<portlet:namespace />rootFolderInTrash'
 								);

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/image_gallery_display/configuration.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/image_gallery_display/configuration.jsp
@@ -33,8 +33,8 @@ IGConfigurationDisplayContext igConfigurationDisplayContext = (IGConfigurationDi
 	<aui:input name="<%= Constants.CMD %>" type="hidden" value="<%= Constants.UPDATE %>" />
 	<aui:input name="redirect" type="hidden" value="<%= configurationRenderURL %>" />
 	<aui:input name="preferences--mimeTypes--" type="hidden" />
-	<aui:input name="preferences--repositoryId--" type="hidden" value="<%= igConfigurationDisplayContext.getRepositoryId() %>" />
 	<aui:input name="preferences--rootFolderId--" type="hidden" value="<%= igConfigurationDisplayContext.getRootFolderId() %>" />
+	<aui:input name="preferences--selectedRepositoryId--" type="hidden" value="<%= igConfigurationDisplayContext.getSelectedRepositoryId() %>" />
 
 	<liferay-frontend:edit-form-body>
 		<liferay-ui:error key="rootFolderIdInvalid" message="please-enter-a-valid-root-folder" />
@@ -133,7 +133,7 @@ IGConfigurationDisplayContext igConfigurationDisplayContext = (IGConfigurationDi
 					Liferay.Util.selectFolder(folderData, '<portlet:namespace />');
 
 					var repositoryIdElement = document.querySelector(
-						'#<portlet:namespace />repositoryId'
+						'#<portlet:namespace />selectedRepositoryId'
 					);
 
 					if (repositoryIdElement != null) {

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/image_gallery_display/view.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/image_gallery_display/view.jsp
@@ -56,7 +56,7 @@ if (defaultFolderView) {
 	}
 }
 
-long repositoryId = dlPortletInstanceSettings.getRepositoryId();
+long repositoryId = dlPortletInstanceSettings.getSelectedRepositoryId();
 
 if (repositoryId == 0) {
 	if (folder != null) {


### PR DESCRIPTION
- LPS-143623 add the setting to the configuration of the documents and media
- LPS-143623 we are using the same method dlAdminDisplayContext.getRepositoryId() for two different purposes so change the name of the setting to selectedRepositoryId and change the old method and create a new for this selected repository id
- LPS-143623 rename the setting for the media gallery to have the same name for the same purpose
- LPS-143623 change the folder name with the folder
- LPS-143623 fallback value for the repository id can come from the request
- LPS-143623 if folder id is DLFolderConstants.DEFAULT_PARENT_FOLDER_ID will be no folder

FFFolderItemSelectorGroupSelectorConfiguration needs to be active to see
