### PR TITLE
LPS-137761 Use ballooneditor on contentEditor

### DIFF
--- a/modules/apps/blogs/blogs-editor-configuration/src/main/java/com/liferay/blogs/editor/configuration/internal/BlogsContentEditorConfigContributor.java
+++ b/modules/apps/blogs/blogs-editor-configuration/src/main/java/com/liferay/blogs/editor/configuration/internal/BlogsContentEditorConfigContributor.java
@@ -95,9 +95,15 @@ public class BlogsContentEditorConfigContributor
 				).buildString());
 		}
 
-		jsonObject.put("toolbarText", "Styles,Bold,Italic,Underline,BulletedList,NumberedList,TextLink,SourceEditor");
-
-		jsonObject.put("extraPlugins", "itemselector,stylescombo,ballooneditor,videoembed,insertbutton,codemirror");
+		jsonObject.put(
+			"extraPlugins",
+			"itemselector,stylescombo,ballooneditor," +
+				"videoembed,insertbutton,codemirror"
+		).put(
+			"toolbarText",
+			"Styles,Bold,Italic,Underline,BulletedList" +
+				",NumberedList,TextLink,SourceEditor"
+		);
 	}
 
 	private String _getAllowedContentLists() {

--- a/modules/apps/blogs/blogs-editor-configuration/src/main/java/com/liferay/blogs/editor/configuration/internal/BlogsContentEditorConfigContributor.java
+++ b/modules/apps/blogs/blogs-editor-configuration/src/main/java/com/liferay/blogs/editor/configuration/internal/BlogsContentEditorConfigContributor.java
@@ -94,6 +94,10 @@ public class BlogsContentEditorConfigContributor
 					"/blogs/upload_temp_image"
 				).buildString());
 		}
+
+		jsonObject.put("toolbarText", "Styles,Bold,Italic,Underline,BulletedList,NumberedList,TextLink,SourceEditor");
+
+		jsonObject.put("extraPlugins", "itemselector,stylescombo,ballooneditor,videoembed,insertbutton,codemirror");
 	}
 
 	private String _getAllowedContentLists() {

--- a/modules/apps/blogs/blogs-editor-configuration/src/main/java/com/liferay/blogs/editor/configuration/internal/BlogsContentEditorConfigContributor.java
+++ b/modules/apps/blogs/blogs-editor-configuration/src/main/java/com/liferay/blogs/editor/configuration/internal/BlogsContentEditorConfigContributor.java
@@ -75,6 +75,9 @@ public class BlogsContentEditorConfigContributor
 				"liferay-ui:input-editor:namespace"));
 		String name = GetterUtil.getString(
 			inputEditorTaglibAttributes.get("liferay-ui:input-editor:name"));
+		String editorName = GetterUtil.getString(
+			inputEditorTaglibAttributes.get(
+				"liferay-ui:input-editor:editorName"));
 
 		_populateFileBrowserURL(
 			jsonObject, requestBackedPortletURLFactory,
@@ -95,15 +98,17 @@ public class BlogsContentEditorConfigContributor
 				).buildString());
 		}
 
-		jsonObject.put(
-			"extraPlugins",
-			"itemselector,stylescombo,ballooneditor," +
-				"videoembed,insertbutton,codemirror"
-		).put(
-			"toolbarText",
-			"Styles,Bold,Italic,Underline,BulletedList" +
-				",NumberedList,TextLink,SourceEditor"
-		);
+		if (editorName.equals("ballooneditor")) {
+			jsonObject.put(
+				"extraPlugins",
+				"itemselector,stylescombo,ballooneditor," +
+					"videoembed,insertbutton,codemirror"
+			).put(
+				"toolbarText",
+				"Styles,Bold,Italic,Underline,BulletedList" +
+					",NumberedList,TextLink,SourceEditor"
+			);
+		}
 	}
 
 	private String _getAllowedContentLists() {

--- a/modules/apps/blogs/blogs-editor-configuration/src/main/java/com/liferay/blogs/editor/configuration/internal/BlogsCoverImageCaptionEditorConfigContributor.java
+++ b/modules/apps/blogs/blogs-editor-configuration/src/main/java/com/liferay/blogs/editor/configuration/internal/BlogsCoverImageCaptionEditorConfigContributor.java
@@ -54,6 +54,8 @@ public class BlogsCoverImageCaptionEditorConfigContributor
 		jsonObject.put(
 			"allowedContent", "a[*](*)"
 		).put(
+			"balloonEditorEnabled", true
+		).put(
 			"disallowedContent", "br"
 		);
 

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/build.gradle
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/build.gradle
@@ -59,6 +59,7 @@ clean {
 }
 
 dependencies {
+	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bnd.annotation", version: "4.2.0"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.util.taglib", version: "default"
 	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.1"
@@ -71,6 +72,7 @@ dependencies {
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-react")
 	compileOnly project(":apps:message-boards:message-boards-api")
+	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	compileOnly project(":core:osgi-service-tracker-collections")
 	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-lang")

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/configuration/FFBalloonEditorConfiguration.java
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/configuration/FFBalloonEditorConfiguration.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.editor.ckeditor.web.internal.configuration;
+
+import aQute.bnd.annotation.metatype.Meta;
+
+import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
+
+/**
+ * @author Diego Nascimento
+ */
+@ExtendedObjectClassDefinition(generateUI = false)
+@Meta.OCD(
+	id = "com.liferay.frontend.editor.ckeditor.web.internal.configuration.FFBalloonEditorConfiguration"
+)
+public interface FFBalloonEditorConfiguration {
+
+	@Meta.AD(deflt = "false", required = false)
+	public boolean enable();
+
+}

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/configuration/FFBalloonEditorConfigurationUtil.java
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/configuration/FFBalloonEditorConfigurationUtil.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.editor.ckeditor.web.internal.configuration;
+
+import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
+
+import java.util.Map;
+
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Modified;
+
+/**
+ * @author Diego Nascimento
+ */
+@Component(
+	configurationPid = "com.liferay.frontend.editor.ckeditor.web.internal.configuration.FFBalloonEditorConfiguration",
+	immediate = true, service = {}
+)
+public class FFBalloonEditorConfigurationUtil {
+
+	public static boolean enable() {
+		return _ffBalloonEditorConfiguration.enable();
+	}
+
+	@Activate
+	@Modified
+	protected void activate(Map<String, Object> properties) {
+		_ffBalloonEditorConfiguration = ConfigurableUtil.createConfigurable(
+			FFBalloonEditorConfiguration.class, properties);
+	}
+
+	private static volatile FFBalloonEditorConfiguration
+		_ffBalloonEditorConfiguration;
+
+}

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/BaseCKEditorConfigContributor.java
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/BaseCKEditorConfigContributor.java
@@ -14,7 +14,6 @@
 
 package com.liferay.frontend.editor.ckeditor.web.internal.editor.configuration;
 
-import com.liferay.frontend.editor.ckeditor.web.internal.configuration.FFBalloonEditorConfigurationUtil;
 import com.liferay.frontend.editor.ckeditor.web.internal.constants.CKEditorConstants;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -123,11 +122,7 @@ public class BaseCKEditorConfigContributor extends BaseEditorConfigContributor {
 			jsonObject.put("resize_dir", "vertical");
 		}
 
-		jsonObject.put(
-			"enableBalloonEditor", FFBalloonEditorConfigurationUtil.enable()
-		).put(
-			"resize_enabled", resizable
-		);
+		jsonObject.put("resize_enabled", resizable);
 	}
 
 	protected boolean isShowSource(

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/BaseCKEditorConfigContributor.java
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/BaseCKEditorConfigContributor.java
@@ -14,6 +14,7 @@
 
 package com.liferay.frontend.editor.ckeditor.web.internal.editor.configuration;
 
+import com.liferay.frontend.editor.ckeditor.web.internal.configuration.FFBalloonEditorConfigurationUtil;
 import com.liferay.frontend.editor.ckeditor.web.internal.constants.CKEditorConstants;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -122,7 +123,11 @@ public class BaseCKEditorConfigContributor extends BaseEditorConfigContributor {
 			jsonObject.put("resize_dir", "vertical");
 		}
 
-		jsonObject.put("resize_enabled", resizable);
+		jsonObject.put(
+			"enableBalloonEditor", FFBalloonEditorConfigurationUtil.enable()
+		).put(
+			"resize_enabled", resizable
+		);
 	}
 
 	protected boolean isShowSource(

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorBalloonEditorConfigContributor.java
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorBalloonEditorConfigContributor.java
@@ -14,7 +14,13 @@
 
 package com.liferay.frontend.editor.ckeditor.web.internal.editor.configuration;
 
+import com.liferay.frontend.editor.ckeditor.web.internal.configuration.FFBalloonEditorConfigurationUtil;
 import com.liferay.portal.kernel.editor.configuration.EditorConfigContributor;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactory;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+
+import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -27,4 +33,19 @@ import org.osgi.service.component.annotations.Component;
 )
 public class CKEditorBalloonEditorConfigContributor
 	extends BaseCKEditorConfigContributor {
+
+	@Override
+	public void populateConfigJSONObject(
+		JSONObject jsonObject, Map<String, Object> inputEditorTaglibAttributes,
+		ThemeDisplay themeDisplay,
+		RequestBackedPortletURLFactory requestBackedPortletURLFactory) {
+
+		super.populateConfigJSONObject(
+			jsonObject, inputEditorTaglibAttributes, themeDisplay,
+			requestBackedPortletURLFactory);
+
+		jsonObject.put(
+			"balloonEditorEnabled", FFBalloonEditorConfigurationUtil.enable());
+	}
+
 }

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor_balloon.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor_balloon.jsp
@@ -20,6 +20,12 @@
 String contents = (String)request.getAttribute(CKEditorConstants.ATTRIBUTE_NAMESPACE + ":contents");
 Map<String, Object> editorData = (Map<String, Object>)request.getAttribute(CKEditorConstants.ATTRIBUTE_NAMESPACE + ":data");
 String name = namespace + GetterUtil.getString((String)request.getAttribute(CKEditorConstants.ATTRIBUTE_NAMESPACE + ":name"));
+
+String onChangeMethod = (String)request.getAttribute(CKEditorConstants.ATTRIBUTE_NAMESPACE + ":onChangeMethod");
+
+if (Validator.isNotNull(onChangeMethod)) {
+	onChangeMethod = namespace + onChangeMethod;
+}
 %>
 
 <div>
@@ -32,6 +38,8 @@ String name = namespace + GetterUtil.getString((String)request.getAttribute(CKEd
 				"contents", contents
 			).put(
 				"name", HtmlUtil.escapeAttribute(name)
+			).put(
+				"onChangeMethodName", HtmlUtil.escapeJS(onChangeMethod)
 			).build()
 		%>'
 	/>

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/css/main.scss
@@ -138,6 +138,7 @@
 
 .liferay-editable {
 	overflow: auto;
+	position: inherit !important;
 }
 
 .cke_toolbar {

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BalloonEditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BalloonEditor.js
@@ -33,6 +33,10 @@ const BalloonEditor = ({
 		...config,
 	};
 
+	if (!editorConfig.enableBalloonEditor) {
+		return null;
+	}
+
 	return (
 		<Editor
 			config={editorConfig}

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BalloonEditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BalloonEditor.js
@@ -33,7 +33,7 @@ const BalloonEditor = ({
 		...config,
 	};
 
-	if (!editorConfig.enableBalloonEditor) {
+	if (!editorConfig.balloonEditorEnabled) {
 		return null;
 	}
 

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BalloonEditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BalloonEditor.js
@@ -13,96 +13,176 @@
  */
 
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, {useCallback, useEffect, useRef} from 'react';
 
 import {Editor} from './Editor';
 import DEFAULT_BALLOON_EDITOR_CONFIG from './config/DefaultBalloonEditorConfiguration';
 
 import '../css/main.scss';
 
-const BalloonEditor = ({config = {}, contents, name, ...otherProps}) => {
-	const editorConfig = {
-		...DEFAULT_BALLOON_EDITOR_CONFIG,
-		...config,
-	};
+const EMPTY_OBJECT = {};
 
-	return (
-		<Editor
-			config={editorConfig}
-			data={contents}
-			name={name}
-			onBeforeLoad={(CKEDITOR) => {
-				CKEDITOR.ADDITIONAL_RESOURCE_PARAMS = {
-					languageId: themeDisplay.getLanguageId(),
-				};
+const BalloonEditor = React.forwardRef(
+	(
+		{
+			config = EMPTY_OBJECT,
+			contents,
+			name,
+			onChange,
+			onChangeMethodName,
+			...otherProps
+		},
+		ref
+	) => {
+		const editorConfig = {
+			...DEFAULT_BALLOON_EDITOR_CONFIG,
+			...config,
+		};
 
-				CKEDITOR.disableAutoInline = true;
+		const editorRef = useRef();
 
-				CKEDITOR.getNextZIndex = function () {
-					return CKEDITOR.dialog._.currentZIndex
-						? CKEDITOR.dialog._.currentZIndex + 10
-						: Liferay.zIndex.WINDOW + 10;
-				};
-			}}
-			onInstanceReady={(event) => {
-				const editor = event.editor;
+		const getHTML = useCallback(() => {
+			let data = contents;
 
-				const editable = editor.editable();
+			const editor = editorRef.current.editor;
 
-				// `floatPanel` plugin requires `id` to be `cke_${editor.name}`
+			if (editor && editor.instanceReady) {
+				data = editor.getData();
 
-				editable.setAttribute('id', `cke_${editor.name}`);
-
-				editable.attachClass('liferay-editable');
-
-				const balloonToolbars = editor.balloonToolbars;
-
-				if (editorConfig.toolbarText) {
-					balloonToolbars.create({
-						buttons: editorConfig.toolbarText,
-						cssSelector: '*',
-					});
+				if (
+					CKEDITOR.env.gecko &&
+					CKEDITOR.tools.trim(data) === '<br />'
+				) {
+					data = '';
 				}
 
-				if (editorConfig.toolbarImage) {
-					balloonToolbars.create({
-						buttons: editorConfig.toolbarImage,
-						priority:
-							window.CKEDITOR.plugins.balloontoolbar.PRIORITY
-								.HIGH,
-						widgets: 'image,image2',
-					});
+				data = data.replace(/(\u200B){7}/, '');
+			}
+
+			return data;
+		}, [contents]);
+
+		const editorRefsCallback = useCallback(
+			(element) => {
+				if (ref) {
+					ref.current = element;
+				}
+				editorRef.current = element;
+			},
+			[ref, editorRef]
+		);
+
+		const onChangeCallback = () => {
+			if (!onChangeMethodName && !onChange) {
+				return;
+			}
+
+			const editor = editorRef.current.editor;
+
+			if (editor.checkDirty()) {
+				if (onChangeMethodName) {
+					window[onChangeMethodName](getHTML());
+				}
+				else {
+					onChange(getHTML());
 				}
 
-				if (editorConfig.toolbarTable) {
-					balloonToolbars.create({
-						buttons: editorConfig.toolbarTable,
-						cssSelector: 'td',
-						priority:
-							window.CKEDITOR.plugins.balloontoolbar.PRIORITY
-								.HIGH,
-					});
-				}
+				editor.resetDirty();
+			}
+		};
 
-				if (editorConfig.toolbarVideo) {
-					balloonToolbars.create({
-						buttons: editorConfig.toolbarVideo,
-						priority:
-							window.CKEDITOR.plugins.balloontoolbar.PRIORITY
-								.HIGH,
-						widgets: 'videoembed',
-					});
-				}
-			}}
-			type="inline"
-			{...otherProps}
-		/>
-	);
-};
+		useEffect(() => {
+			window[name] = {
+				getHTML,
+				getText() {
+					return contents;
+				},
+			};
+		}, [name, contents, getHTML]);
+
+		return (
+			<Editor
+				config={editorConfig}
+				data={contents}
+				name={name}
+				onBeforeLoad={(CKEDITOR) => {
+					CKEDITOR.ADDITIONAL_RESOURCE_PARAMS = {
+						languageId: themeDisplay.getLanguageId(),
+					};
+
+					CKEDITOR.disableAutoInline = true;
+
+					CKEDITOR.getNextZIndex = function () {
+						return CKEDITOR.dialog._.currentZIndex
+							? CKEDITOR.dialog._.currentZIndex + 10
+							: Liferay.zIndex.WINDOW + 10;
+					};
+				}}
+				onChange={onChangeCallback}
+				onInstanceReady={(event) => {
+					const editor = event.editor;
+
+					const editable = editor.editable();
+
+					// `floatPanel` plugin requires `id` to be `cke_${editor.name}`
+
+					editable.setAttribute('id', `cke_${editor.name}`);
+
+					editable.attachClass('liferay-editable');
+
+					const balloonToolbars = editor.balloonToolbars;
+
+					if (editorConfig.toolbarText) {
+						balloonToolbars.create({
+							buttons: editorConfig.toolbarText,
+							cssSelector: '*',
+						});
+					}
+
+					if (editorConfig.toolbarImage) {
+						balloonToolbars.create({
+							buttons: editorConfig.toolbarImage,
+							priority:
+								window.CKEDITOR.plugins.balloontoolbar.PRIORITY
+									.HIGH,
+							widgets: 'image,image2',
+						});
+					}
+
+					if (editorConfig.toolbarTable) {
+						balloonToolbars.create({
+							buttons: editorConfig.toolbarTable,
+							cssSelector: 'td',
+							priority:
+								window.CKEDITOR.plugins.balloontoolbar.PRIORITY
+									.HIGH,
+						});
+					}
+
+					if (editorConfig.toolbarVideo) {
+						balloonToolbars.create({
+							buttons: editorConfig.toolbarVideo,
+							priority:
+								window.CKEDITOR.plugins.balloontoolbar.PRIORITY
+									.HIGH,
+							widgets: 'videoembed',
+						});
+					}
+				}}
+				ref={editorRefsCallback}
+				type="inline"
+				{...otherProps}
+			/>
+		);
+	}
+);
 
 BalloonEditor.propTypes = {
 	config: PropTypes.object,
+	contents: PropTypes.string,
 	name: PropTypes.string,
+	onChange: PropTypes.func,
+	onChangeMethodName: PropTypes.string,
 };
 
 export default BalloonEditor;

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/Editor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/Editor.js
@@ -13,26 +13,105 @@
  */
 
 import CKEditor from 'ckeditor4-react';
-import React, {useEffect} from 'react';
+import PropTypes from 'prop-types';
+import React, {forwardRef, useCallback, useEffect, useRef} from 'react';
 
 const BASEPATH = '/o/frontend-editor-ckeditor-web/ckeditor/';
 
-const Editor = React.forwardRef((props, ref) => {
-	useEffect(() => {
-		Liferay.once('beforeScreenFlip', () => {
-			if (
-				window.CKEDITOR &&
-				Object.keys(window.CKEDITOR.instances).length === 0
-			) {
-				delete window.CKEDITOR;
-			}
-		});
-	}, []);
+const Editor = forwardRef(
+	({contents = '', name, onChange, onChangeMethodName, ...props}, ref) => {
+		const editorRef = useRef();
 
-	return <CKEditor ref={ref} {...props} />;
-});
+		useEffect(() => {
+			Liferay.once('beforeScreenFlip', () => {
+				if (
+					window.CKEDITOR &&
+					Object.keys(window.CKEDITOR.instances).length === 0
+				) {
+					delete window.CKEDITOR;
+				}
+			});
+		}, []);
+
+		const getHTML = useCallback(() => {
+			let data = contents;
+
+			const editor = editorRef.current.editor;
+
+			if (editor && editor.instanceReady) {
+				data = editor.getData();
+
+				if (
+					CKEDITOR.env.gecko &&
+					CKEDITOR.tools.trim(data) === '<br />'
+				) {
+					data = '';
+				}
+
+				data = data.replace(/(\u200B){7}/, '');
+			}
+
+			return data;
+		}, [contents]);
+
+		const onChangeCallback = () => {
+			if (!onChangeMethodName && !onChange) {
+				return;
+			}
+
+			const editor = editorRef.current.editor;
+
+			if (editor.checkDirty()) {
+				if (onChangeMethodName) {
+					window[onChangeMethodName](getHTML());
+				}
+				else {
+					onChange(getHTML());
+				}
+
+				editor.resetDirty();
+			}
+		};
+
+		const editorRefsCallback = useCallback(
+			(element) => {
+				if (ref) {
+					ref.current = element;
+				}
+				editorRef.current = element;
+			},
+			[ref, editorRef]
+		);
+
+		useEffect(() => {
+			window[name] = {
+				getHTML,
+				getText() {
+					return contents;
+				},
+			};
+		}, [contents, getHTML, name]);
+
+		return (
+			<CKEditor
+				contents={contents}
+				name={name}
+				onChange={onChangeCallback}
+				ref={editorRefsCallback}
+				{...props}
+			/>
+		);
+	}
+);
 
 CKEditor.editorUrl = `${BASEPATH}ckeditor.js`;
 window.CKEDITOR_BASEPATH = BASEPATH;
+
+Editor.propTypes = {
+	contents: PropTypes.string,
+	name: PropTypes.string,
+	onChange: PropTypes.func,
+	onChangeMethodName: PropTypes.string,
+};
 
 export {Editor};


### PR DESCRIPTION
Forwarded from https://github.com/liferay-frontend/liferay-portal/pull/1663

## How to reproduce my changes:

1. Inside your `portal-ext.properties`, set ballooneditor as a default editor:

`editor.wysiwyg.portal-web.docroot.html.portlet.blogs.edit_entry.jsp=ballooneditor`

2. Create a file named `com.liferay.frontend.editor.ckeditor.web.internal.configuration.FFBalloonEditorConfiguration.config` on osgi/configs folder

3. Inside the content, set `enable="true"` and then start catalina again

4. Be sure you already have [liferay-ckeditor@4.16.2-liferay.4 ](https://github.com/brianchandotcom/liferay-portal/pull/110392) installed

5. Go to Blogs -> New Blogs Entry and 🎉 

## Do you want to see in action? 📹

Open https://drive.google.com/file/d/1Uk236EPvrMTVfmRRQYEF2Cy0WnA6mX10/view?usp=sharing 

<img width="393" alt="Screen Shot 2021-11-25 at 17 11 07" src="https://user-images.githubusercontent.com/7663513/143496131-66209763-adab-4cbf-b192-5ed93d92f8e7.png"> 😭 

