### PR TITLE
LPS-143751 Solve several problems about select folder to move  and select folders from another sites/asset libs

### DIFF
--- a/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/display/context/DLSelectFolderDisplayContext.java
+++ b/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/display/context/DLSelectFolderDisplayContext.java
@@ -59,13 +59,14 @@ public class DLSelectFolderDisplayContext {
 	public DLSelectFolderDisplayContext(
 		DLAppService dlAppService, Folder folder,
 		HttpServletRequest httpServletRequest, PortletURL portletURL,
-		long selectedFolderId, long selectedRepositoryId,
+		long repositoryId, long selectedFolderId, long selectedRepositoryId,
 		boolean showGroupSelector) {
 
 		_dlAppService = dlAppService;
 		_folder = folder;
 		_httpServletRequest = httpServletRequest;
 		_portletURL = portletURL;
+		_repositoryId = repositoryId;
 		_selectedFolderId = selectedFolderId;
 		_selectedRepositoryId = selectedRepositoryId;
 		_showGroupSelector = showGroupSelector;
@@ -166,6 +167,10 @@ public class DLSelectFolderDisplayContext {
 	}
 
 	public long getRepositoryId() {
+		if (_repositoryId != 0) {
+			return _repositoryId;
+		}
+
 		if (_folder != null) {
 			return _folder.getRepositoryId();
 		}
@@ -317,6 +322,7 @@ public class DLSelectFolderDisplayContext {
 	private final Folder _folder;
 	private final HttpServletRequest _httpServletRequest;
 	private final PortletURL _portletURL;
+	private final long _repositoryId;
 	private final long _selectedFolderId;
 	private final long _selectedRepositoryId;
 	private final boolean _showGroupSelector;

--- a/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/folder/DLFolderItemSelectorView.java
+++ b/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/folder/DLFolderItemSelectorView.java
@@ -29,7 +29,6 @@ import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.bean.BeanParamUtil;
 import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.resource.bundle.ResourceBundleLoader;
-import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.language.LanguageResources;
@@ -106,10 +105,12 @@ public class DLFolderItemSelectorView
 		RequestDispatcher requestDispatcher =
 			_servletContext.getRequestDispatcher("/select_folder.jsp");
 
-		long repositoryId = ParamUtil.getLong(
-			(HttpServletRequest)servletRequest, "repositoryId");
-		long folderId = ParamUtil.getLong(
-			(HttpServletRequest)servletRequest, "folderId");
+		long folderId = BeanParamUtil.getLong(
+			itemSelectorCriterion, (HttpServletRequest)servletRequest,
+			"folderId");
+		long selectedRepositoryId = BeanParamUtil.getLong(
+			itemSelectorCriterion, (HttpServletRequest)servletRequest,
+			"selectedRepositoryId");
 
 		servletRequest.setAttribute(
 			DLSelectFolderDisplayContext.class.getName(),
@@ -118,11 +119,9 @@ public class DLFolderItemSelectorView
 				(HttpServletRequest)servletRequest, portletURL,
 				BeanParamUtil.getLong(
 					itemSelectorCriterion, (HttpServletRequest)servletRequest,
-					"selectedFolderId",
-					BeanParamUtil.getLong(
-						itemSelectorCriterion,
-						(HttpServletRequest)servletRequest, "folderId")),
-				repositoryId, _isShowGroupSelector(itemSelectorCriterion)));
+					"selectedFolderId", folderId),
+				selectedRepositoryId,
+				_isShowGroupSelector(itemSelectorCriterion)));
 
 		requestDispatcher.include(servletRequest, servletResponse);
 	}

--- a/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/folder/DLFolderItemSelectorView.java
+++ b/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/folder/DLFolderItemSelectorView.java
@@ -105,12 +105,12 @@ public class DLFolderItemSelectorView
 		RequestDispatcher requestDispatcher =
 			_servletContext.getRequestDispatcher("/select_folder.jsp");
 
+		long repositoryId = BeanParamUtil.getLong(
+			itemSelectorCriterion, (HttpServletRequest)servletRequest,
+			"repositoryId");
 		long folderId = BeanParamUtil.getLong(
 			itemSelectorCriterion, (HttpServletRequest)servletRequest,
 			"folderId");
-		long selectedRepositoryId = BeanParamUtil.getLong(
-			itemSelectorCriterion, (HttpServletRequest)servletRequest,
-			"selectedRepositoryId");
 
 		servletRequest.setAttribute(
 			DLSelectFolderDisplayContext.class.getName(),
@@ -119,9 +119,11 @@ public class DLFolderItemSelectorView
 				(HttpServletRequest)servletRequest, portletURL,
 				BeanParamUtil.getLong(
 					itemSelectorCriterion, (HttpServletRequest)servletRequest,
+					"selectedRepositoryId"),
+				BeanParamUtil.getLong(
+					itemSelectorCriterion, (HttpServletRequest)servletRequest,
 					"selectedFolderId", folderId),
-				selectedRepositoryId,
-				_isShowGroupSelector(itemSelectorCriterion)));
+				repositoryId, _isShowGroupSelector(itemSelectorCriterion)));
 
 		requestDispatcher.include(servletRequest, servletResponse);
 	}

--- a/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/util/DLBreadcrumbUtil.java
+++ b/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/util/DLBreadcrumbUtil.java
@@ -57,7 +57,7 @@ public class DLBreadcrumbUtil {
 			portletURL,
 			_getRepositoryId(folder, httpServletRequest, repositoryId),
 			_getRootFolderName(
-				httpServletRequest,
+				folder, httpServletRequest,
 				_getRepositoryId(folder, httpServletRequest, repositoryId),
 				showGroupSelector));
 
@@ -112,12 +112,12 @@ public class DLBreadcrumbUtil {
 		Folder folder, HttpServletRequest httpServletRequest,
 		long repositoryId) {
 
-		if (repositoryId != 0) {
-			return repositoryId;
-		}
-
 		if (folder != null) {
 			return folder.getRepositoryId();
+		}
+
+		if (repositoryId != 0) {
+			return repositoryId;
 		}
 
 		ThemeDisplay themeDisplay =
@@ -128,8 +128,8 @@ public class DLBreadcrumbUtil {
 	}
 
 	private static String _getRootFolderName(
-			HttpServletRequest httpServletRequest, long repositoryId,
-			boolean showGroupSelector)
+			Folder folder, HttpServletRequest httpServletRequest,
+			long repositoryId, boolean showGroupSelector)
 		throws Exception {
 
 		if (!showGroupSelector) {
@@ -144,6 +144,9 @@ public class DLBreadcrumbUtil {
 
 		if (repositoryId != 0) {
 			group = GroupServiceUtil.getGroup(repositoryId);
+		}
+		else if (folder != null) {
+			group = GroupServiceUtil.getGroup(folder.getGroupId());
 		}
 
 		return group.getDescriptiveName(themeDisplay.getLocale());

--- a/modules/apps/document-library/document-library-item-selector-web/src/main/resources/META-INF/resources/select_folder.jsp
+++ b/modules/apps/document-library/document-library-item-selector-web/src/main/resources/META-INF/resources/select_folder.jsp
@@ -19,7 +19,7 @@
 <%
 DLSelectFolderDisplayContext dlSelectFolderDisplayContext = (DLSelectFolderDisplayContext)request.getAttribute(DLSelectFolderDisplayContext.class.getName());
 
-DLBreadcrumbUtil.addPortletBreadcrumbEntries(ParamUtil.getString(request, "displayStyle"), dlSelectFolderDisplayContext.getFolder(), request, liferayPortletResponse, dlSelectFolderDisplayContext.getIteratorPortletURL(liferayPortletResponse), dlSelectFolderDisplayContext.getSelectedRepositoryId(), dlSelectFolderDisplayContext.isShowGroupSelector());
+DLBreadcrumbUtil.addPortletBreadcrumbEntries(ParamUtil.getString(request, "displayStyle"), dlSelectFolderDisplayContext.getFolder(), request, liferayPortletResponse, dlSelectFolderDisplayContext.getIteratorPortletURL(liferayPortletResponse), dlSelectFolderDisplayContext.getRepositoryId(), dlSelectFolderDisplayContext.isShowGroupSelector());
 %>
 
 <clay:container-fluid>

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLViewDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLViewDisplayContext.java
@@ -215,6 +215,8 @@ public class DLViewDisplayContext {
 		folderItemSelectorCriterion.setDesiredItemSelectorReturnTypes(
 			new FolderItemSelectorReturnType());
 		folderItemSelectorCriterion.setFolderId(getFolderId());
+		folderItemSelectorCriterion.setRepositoryId(
+			_dlAdminDisplayContext.getSelectedRepositoryId());
 		folderItemSelectorCriterion.setSelectedFolderId(getFolderId());
 		folderItemSelectorCriterion.setSelectedRepositoryId(
 			_dlAdminDisplayContext.getSelectedRepositoryId());

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/IGConfigurationDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/IGConfigurationDisplayContext.java
@@ -43,6 +43,7 @@ import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.trash.TrashHelper;
 
 import java.util.List;
+import java.util.Objects;
 
 import javax.portlet.PortletPreferences;
 import javax.portlet.PortletURL;
@@ -119,6 +120,10 @@ public class IGConfigurationDisplayContext {
 	public String getRootFolderName() throws PortalException {
 		_initFolder();
 
+		if (Objects.equals(_folderName, StringPool.BLANK)) {
+			_getFolderName();
+		}
+
 		return _folderName;
 	}
 
@@ -177,6 +182,26 @@ public class IGConfigurationDisplayContext {
 		}
 	}
 
+	private void _getFolderName() {
+		if ((_folderId == null) ||
+			(_folderId == DLFolderConstants.DEFAULT_PARENT_FOLDER_ID)) {
+
+			return;
+		}
+
+		Folder folder = _getFolder();
+
+		if (folder == null) {
+			return;
+		}
+
+		_folderName = folder.getName();
+
+		if (_folderInTrash) {
+			_folderName = _trashHelper.getOriginalTitle(_folder.getName());
+		}
+	}
+
 	private PortletPreferences _getPortletPreferences() {
 		if (_portletPreferences != null) {
 			return _portletPreferences;
@@ -220,9 +245,7 @@ public class IGConfigurationDisplayContext {
 
 		Folder folder = _getFolder();
 
-		if ((folder == null) ||
-			(folder.getGroupId() != _themeDisplay.getScopeGroupId())) {
-
+		if (folder == null) {
 			return;
 		}
 

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/IGConfigurationDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/IGConfigurationDisplayContext.java
@@ -140,12 +140,11 @@ public class IGConfigurationDisplayContext {
 		folderItemSelectorCriterion.setDesiredItemSelectorReturnTypes(
 			new FolderItemSelectorReturnType());
 
-		if (!isRootFolderInTrash()) {
-			folderItemSelectorCriterion.setFolderId(getRootFolderId());
-		}
-
+		folderItemSelectorCriterion.setFolderId(
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID);
 		folderItemSelectorCriterion.setIgnoreRootFolder(true);
 		folderItemSelectorCriterion.setSelectedFolderId(getRootFolderId());
+		folderItemSelectorCriterion.setRepositoryId(0);
 		folderItemSelectorCriterion.setSelectedRepositoryId(
 			getSelectedRepositoryId());
 		folderItemSelectorCriterion.setShowGroupSelector(true);

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/configuration.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/configuration.jsp
@@ -192,10 +192,11 @@ DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper = new DLPortletI
 							FolderItemSelectorCriterion folderItemSelectorCriterion = new FolderItemSelectorCriterion();
 
 							folderItemSelectorCriterion.setDesiredItemSelectorReturnTypes(new FolderItemSelectorReturnType());
-							folderItemSelectorCriterion.setFolderId((dlAdminDisplayContext.isRootFolderInTrash() || dlAdminDisplayContext.isRootFolderNotFound()) ? DLFolderConstants.DEFAULT_PARENT_FOLDER_ID : dlAdminDisplayContext.getRootFolderId());
+							folderItemSelectorCriterion.setFolderId(DLFolderConstants.DEFAULT_PARENT_FOLDER_ID);
 							folderItemSelectorCriterion.setIgnoreRootFolder(true);
 							folderItemSelectorCriterion.setSelectedFolderId(dlAdminDisplayContext.getRootFolderId());
 							folderItemSelectorCriterion.setSelectedRepositoryId(dlAdminDisplayContext.getRepositoryId());
+							folderItemSelectorCriterion.setRepositoryId(0);
 							folderItemSelectorCriterion.setShowGroupSelector(true);
 							folderItemSelectorCriterion.setShowMountFolder(false);
 

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry.jsp
@@ -179,6 +179,7 @@ FolderItemSelectorCriterion folderItemSelectorCriterion = new FolderItemSelector
 
 folderItemSelectorCriterion.setDesiredItemSelectorReturnTypes(new FolderItemSelectorReturnType());
 folderItemSelectorCriterion.setFolderId(fileEntry.getFolderId());
+folderItemSelectorCriterion.setRepositoryId(fileEntry.getRepositoryId());
 folderItemSelectorCriterion.setSelectedFolderId(fileEntry.getFolderId());
 folderItemSelectorCriterion.setSelectedRepositoryId(fileEntry.getRepositoryId());
 

--- a/modules/apps/item-selector/item-selector-criteria-api/bnd.bnd
+++ b/modules/apps/item-selector/item-selector-criteria-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Item Selector Criteria API
 Bundle-SymbolicName: com.liferay.item.selector.criteria.api
-Bundle-Version: 7.2.1
+Bundle-Version: 7.3.0
 Export-Package:\
 	com.liferay.item.selector.criteria,\
 	com.liferay.item.selector.criteria.asset.criterion,\

--- a/modules/apps/item-selector/item-selector-criteria-api/src/main/java/com/liferay/item/selector/criteria/folder/criterion/FolderItemSelectorCriterion.java
+++ b/modules/apps/item-selector/item-selector-criteria-api/src/main/java/com/liferay/item/selector/criteria/folder/criterion/FolderItemSelectorCriterion.java
@@ -25,6 +25,10 @@ public class FolderItemSelectorCriterion extends BaseItemSelectorCriterion {
 		return _folderId;
 	}
 
+	public long getRepositoryId() {
+		return _repositoryId;
+	}
+
 	public long getSelectedFolderId() {
 		return _selectedFolderId;
 	}
@@ -53,6 +57,10 @@ public class FolderItemSelectorCriterion extends BaseItemSelectorCriterion {
 		_ignoreRootFolder = ignoreRootFolder;
 	}
 
+	public void setRepositoryId(long repositoryId) {
+		_repositoryId = repositoryId;
+	}
+
 	public void setSelectedFolderId(long selectedFolderId) {
 		_selectedFolderId = selectedFolderId;
 	}
@@ -71,6 +79,7 @@ public class FolderItemSelectorCriterion extends BaseItemSelectorCriterion {
 
 	private long _folderId;
 	private boolean _ignoreRootFolder;
+	private long _repositoryId;
 	private long _selectedFolderId;
 	private long _selectedRepositoryId;
 	private boolean _showGroupSelector;

--- a/modules/apps/item-selector/item-selector-criteria-api/src/main/resources/com/liferay/item/selector/criteria/folder/criterion/packageinfo
+++ b/modules/apps/item-selector/item-selector-criteria-api/src/main/resources/com/liferay/item/selector/criteria/folder/criterion/packageinfo
@@ -1,1 +1,1 @@
-version 2.1.0
+version 2.2.0


### PR DESCRIPTION
- LPS-143751 get the folder name from the folder if blank and delete the restriction of the group same as the themeDisplay
- LPS-143751 use the FolderItemSelectorCriterion values to show the selected breadcrumbs
- LPS-143751 generate repository id on folder criteriua to separate the behavior of the selected with the actual
- LPS-143751 baseline
- LPS-143751 add the new parameter of the folder criteria
- LPS-143751 for the widgets the preffered repository and folder is the defaul
- LPS-143751 the selector now pass both repositories selected and actual
- LPS-143751 we want the actual repository to show the breadcrumb



The problems I am trying to solve are 2:
[The icon "select this folder" is clickable when moving file from current Home Folder](https://issues.liferay.com/browse/LPS-143751 )

https://user-images.githubusercontent.com/47524751/145996795-3087235a-dfbd-47e5-bac3-7531e0ef702d.mp4



and the issue found by beck :


https://user-images.githubusercontent.com/47524751/145996579-97bb0f48-3135-4351-bcc8-ed1488642bfa.mp4




With this PR achieved to "solve" the issues BUT I break the `themeDisplay.getScopeGroup();` issue that was fixed previously:

You can see how without the FF the things work smoothly

https://user-images.githubusercontent.com/47524751/145995479-6bb1736d-288a-48bc-9bb2-b30a45e78acc.mp4


but with the FF and selecting other groups/repositories the things goes wrong


https://user-images.githubusercontent.com/47524751/145995491-f6c2226e-ff58-44e9-939a-ab19f1358c0d.mp4
