### PR TITLE
LPS-143549

### DIFF
--- a/portal-impl/src/com/liferay/portal/security/permission/UserBagFactoryImpl.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/UserBagFactoryImpl.java
@@ -76,30 +76,29 @@ public class UserBagFactoryImpl implements UserBagFactory {
 			allGroupIds.add(groupId);
 		}
 
-		long[] userGroupIds = null;
+		long[] userGroupIds = UserLocalServiceUtil.getGroupPrimaryKeys(userId);
 
-		if (userOrgs.isEmpty() && userUserGroups.isEmpty()) {
-			userGroupIds = UserLocalServiceUtil.getGroupPrimaryKeys(userId);
+		Set<Long> userGroupIdsSet = new HashSet<>();
 
-			for (long userGroupId : userGroupIds) {
-				allGroupIds.add(userGroupId);
-			}
+		for (long userGroupId : userGroupIds) {
+			userGroupIdsSet.add(userGroupId);
+
+			allGroupIds.add(userGroupId);
 		}
-		else {
+
+		if (!userOrgs.isEmpty() || !userUserGroups.isEmpty()) {
 			List<Group> userGroups = GroupLocalServiceUtil.getUserGroups(
 				userId, true);
 
-			userGroupIds = new long[userGroups.size()];
-
-			for (int i = 0; i < userGroups.size(); i++) {
-				Group userGroup = userGroups.get(i);
-
+			for (Group userGroup : userGroups) {
 				long groupId = userGroup.getGroupId();
 
-				userGroupIds[i] = groupId;
+				userGroupIdsSet.add(groupId);
 
 				allGroupIds.add(groupId);
 			}
+
+			userGroupIds = ArrayUtil.toLongArray(userGroupIdsSet);
 		}
 
 		if (allGroupIds.isEmpty()) {


### PR DESCRIPTION
Hi Lima Team,

The original fix got reverted because it caused a regression ([LPS-143834](https://issues.liferay.com/browse/LPS-143834)). I added a [new commit](https://github.com/liferay-lima/liferay-portal/commit/1149cf7bbaf1efcdadfa888e283ea3c207a4614f) on top of this which fixes the regression, and should fix any other potential regressions as well).

The reason for the regression is that the new API that we used, omits several types of groups that the old API returned (all of which deal with UserGroups or Organizations in some way):

- Groups that the user's UserGroup is a member of
- Groups that represent an Organization that the user is _directly_ a member of
- Groups that the user's _direct_ Organization is a member of

By studying the SQL query that was generated by the old API, I was able to gain confidence that this is a comprehensive List of groups that were returned by the old API but not the new one. You can see that query here: https://gist.github.com/mbowerman/45ef6b0218f3f9c05b181a8547a596e1

The new commit adds all of those Groups back in.

Feel free to forward this to the USM team if you think it would be more appropriate to send it to them.

https://issues.liferay.com/browse/LPS-143549