### PR TITLE
LPS-144085

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminDisplayContext.java
@@ -730,6 +730,8 @@ public class DLAdminDisplayContext {
 		searchContext.setKeywords(
 			ParamUtil.getString(_httpServletRequest, "keywords"));
 
+		searchContext.setLocale(_themeDisplay.getSiteDefaultLocale());
+
 		QueryConfig queryConfig = searchContext.getQueryConfig();
 
 		queryConfig.setSearchSubfolders(true);


### PR DESCRIPTION
Hi @liferay-lima,

This is a solution to [LPS-144085](https://issues.liferay.com/browse/LPS-144085). The discussion about this issue together with the solution approach can be found in [PTR-2794](https://issues.liferay.com/browse/PTR-2794).

The idea is to align how the text content of a file entry is index and search by: they should both use the site default locale, instead of the site default locale for indexing but the current locale for searching. 

Please let me know if you have any questions. 

Thanks!

