### PR TITLE
LPS-143100 Multiple Files Upload unnecessarily renames files

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/EditFileEntryMVCActionCommand.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/EditFileEntryMVCActionCommand.java
@@ -458,14 +458,19 @@ public class EditFileEntryMVCActionCommand extends BaseMVCActionCommand {
 					tempFileEntry.getFileName());
 
 			String uniqueFileName = DLUtil.getUniqueFileName(
-				tempFileEntry.getGroupId(), folderId, originalSelectedFileName);
+				tempFileEntry.getGroupId(), folderId, originalSelectedFileName,
+				true);
+
+			String uniqueFileTitle = DLUtil.getUniqueTitle(
+				tempFileEntry.getGroupId(), folderId,
+				FileUtil.stripExtension(originalSelectedFileName));
 
 			FileEntry fileEntry = _dlAppService.addFileEntry(
 				null, repositoryId, folderId, uniqueFileName,
-				tempFileEntry.getMimeType(),
-				FileUtil.stripExtension(uniqueFileName), description, changeLog,
-				tempFileEntry.getContentStream(), tempFileEntry.getSize(),
-				expirationDate, reviewDate, serviceContext);
+				tempFileEntry.getMimeType(), uniqueFileTitle, description,
+				changeLog, tempFileEntry.getContentStream(),
+				tempFileEntry.getSize(), expirationDate, reviewDate,
+				serviceContext);
 
 			_assetDisplayPageEntryFormProcessor.process(
 				FileEntry.class.getName(), fileEntry.getFileEntryId(),
@@ -1241,13 +1246,17 @@ public class EditFileEntryMVCActionCommand extends BaseMVCActionCommand {
 				// Add file entry
 
 				String uniqueFileName = DLUtil.getUniqueFileName(
-					themeDisplay.getScopeGroupId(), folderId, sourceFileName);
+					themeDisplay.getScopeGroupId(), folderId, sourceFileName,
+					true);
+
+				String uniqueFileTitle = DLUtil.getUniqueTitle(
+					themeDisplay.getScopeGroupId(), folderId,
+					FileUtil.stripExtension(sourceFileName));
 
 				fileEntry = _dlAppService.addFileEntry(
 					null, repositoryId, folderId, uniqueFileName, contentType,
-					FileUtil.stripExtension(uniqueFileName), description,
-					changeLog, inputStream, size, expirationDate, reviewDate,
-					serviceContext);
+					uniqueFileTitle, description, changeLog, inputStream, size,
+					expirationDate, reviewDate, serviceContext);
 
 				JSONObject jsonObject = JSONUtil.put(
 					"fileEntryId", fileEntry.getFileEntryId());

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/util/DLImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/util/DLImpl.java
@@ -873,6 +873,48 @@ public class DLImpl implements DL {
 		return getTitleWithExtension(uniqueFileTitle, extension);
 	}
 
+	@Override
+	public String getUniqueFileName(
+		long groupId, long folderId, String fileName,
+		boolean ignoreDuplicateTitle) {
+
+		String uniqueFileTitle = FileUtil.stripExtension(fileName);
+
+		String extension = FileUtil.getExtension(fileName);
+
+		for (int i = 1;; i++) {
+			if ((ignoreDuplicateTitle ||
+				 !_existsFileEntryByTitle(
+					 groupId, folderId, uniqueFileTitle)) &&
+				!_existsFileEntryByFileName(
+					groupId, extension, folderId, uniqueFileTitle)) {
+
+				break;
+			}
+
+			uniqueFileTitle = FileUtil.appendParentheticalSuffix(
+				FileUtil.stripExtension(fileName), String.valueOf(i));
+		}
+
+		return getTitleWithExtension(uniqueFileTitle, extension);
+	}
+
+	@Override
+	public String getUniqueTitle(long groupId, long folderId, String title) {
+		String uniqueFileTitle = title;
+
+		int i = 1;
+
+		while (_existsFileEntryByTitle(groupId, folderId, uniqueFileTitle)) {
+			uniqueFileTitle = FileUtil.appendParentheticalSuffix(
+				title, String.valueOf(i));
+
+			i++;
+		}
+
+		return uniqueFileTitle;
+	}
+
 	/**
 	 * @deprecated As of Mueller (7.2.x), replaced by {@link
 	 *             com.liferay.document.library.util.DLURLHelper#getWebDavURL(

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/util/DLImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/util/DLImpl.java
@@ -854,23 +854,7 @@ public class DLImpl implements DL {
 	public String getUniqueFileName(
 		long groupId, long folderId, String fileName) {
 
-		String uniqueFileTitle = FileUtil.stripExtension(fileName);
-
-		String extension = FileUtil.getExtension(fileName);
-
-		for (int i = 1;; i++) {
-			if (!_existsFileEntryByTitle(groupId, folderId, uniqueFileTitle) &&
-				!_existsFileEntryByFileName(
-					groupId, extension, folderId, uniqueFileTitle)) {
-
-				break;
-			}
-
-			uniqueFileTitle = FileUtil.appendParentheticalSuffix(
-				FileUtil.stripExtension(fileName), String.valueOf(i));
-		}
-
-		return getTitleWithExtension(uniqueFileTitle, extension);
+		return getUniqueFileName(groupId, folderId, fileName, false);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/util/packageinfo
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/util/packageinfo
@@ -1,1 +1,1 @@
-version 3.0.0
+version 3.1.0

--- a/portal-kernel/src/com/liferay/document/library/kernel/util/DL.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/util/DL.java
@@ -232,6 +232,12 @@ public interface DL {
 	public String getUniqueFileName(
 		long groupId, long folderId, String fileName);
 
+	public String getUniqueFileName(
+		long groupId, long folderId, String fileName,
+		boolean ignoreDuplicateTitle);
+
+	public String getUniqueTitle(long groupId, long folderId, String title);
+
 	/**
 	 * @deprecated As of Mueller (7.2.x), replaced by {@link
 	 *             com.liferay.document.library.util.DLURLHelper#getWebDavURL(

--- a/portal-kernel/src/com/liferay/document/library/kernel/util/DLUtil.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/util/DLUtil.java
@@ -330,6 +330,20 @@ public class DLUtil {
 		return _dl.getUniqueFileName(groupId, folderId, fileName);
 	}
 
+	public static String getUniqueFileName(
+		long groupId, long folderId, String fileName,
+		boolean ignoreDuplicateTitle) {
+
+		return _dl.getUniqueFileName(
+			groupId, folderId, fileName, ignoreDuplicateTitle);
+	}
+
+	public static String getUniqueTitle(
+		long groupId, long folderId, String title) {
+
+		return _dl.getUniqueTitle(groupId, folderId, title);
+	}
+
 	/**
 	 * @deprecated As of Mueller (7.2.x), replaced by {@link
 	 *             com.liferay.document.library.util.DLURLHelper#getWebDavURL(

--- a/portal-kernel/src/com/liferay/document/library/kernel/util/packageinfo
+++ b/portal-kernel/src/com/liferay/document/library/kernel/util/packageinfo
@@ -1,1 +1,1 @@
-version 2.4.0
+version 2.5.0


### PR DESCRIPTION
- LPS-143100 Create two new methods to return the unique fileName and the unique title ignoring the existence of the title/filename for the same return
- LPS-143100 buildService
- LPS-143100 apply the new methods to get the title and the filename when you use the multiupload or the drag and drop to upload files
- LPS-143100 baseline
- LPS-143100 add test to meet the new behavior and rename old test
