### PR TITLE
LPS-139816 Do extra validation against friendlyURLEntry

### DIFF
--- a/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/service/LayoutFriendlyURLValidatorImpl.java
+++ b/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/service/LayoutFriendlyURLValidatorImpl.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.layout.internal.service;
+
+import com.liferay.friendly.url.exception.DuplicateFriendlyURLEntryException;
+import com.liferay.friendly.url.service.FriendlyURLEntryLocalService;
+import com.liferay.layout.friendly.url.LayoutFriendlyURLEntryHelper;
+import com.liferay.portal.kernel.exception.LayoutFriendlyURLException;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.service.LayoutFriendlyURLValidator;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Noor Najjar
+ */
+@Component(service = LayoutFriendlyURLValidator.class)
+public class LayoutFriendlyURLValidatorImpl
+	implements LayoutFriendlyURLValidator {
+
+	@Override
+	public void validateFriendlyURLEntry(
+			long groupId, boolean privateLayout, long classPK, String urlTitle)
+		throws PortalException {
+
+		try {
+			_friendlyURLEntryLocalService.validate(
+				groupId,
+				_layoutFriendlyURLEntryHelper.getClassNameId(privateLayout),
+				classPK, urlTitle);
+		}
+		catch (DuplicateFriendlyURLEntryException
+					duplicateFriendlyURLEntryException) {
+
+			LayoutFriendlyURLException layoutFriendlyURLException =
+				new LayoutFriendlyURLException(
+					LayoutFriendlyURLException.DUPLICATE);
+
+			layoutFriendlyURLException.setDuplicateClassPK(classPK);
+			layoutFriendlyURLException.setDuplicateClassName(
+				Layout.class.getName());
+
+			throw layoutFriendlyURLException;
+		}
+	}
+
+	@Reference
+	private FriendlyURLEntryLocalService _friendlyURLEntryLocalService;
+
+	@Reference
+	private LayoutFriendlyURLEntryHelper _layoutFriendlyURLEntryHelper;
+
+}

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceHelper.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceHelper.java
@@ -41,9 +41,12 @@ import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.module.framework.service.IdentifiableOSGiService;
+import com.liferay.portal.kernel.module.util.SystemBundleUtil;
 import com.liferay.portal.kernel.portlet.FriendlyURLMapper;
 import com.liferay.portal.kernel.portlet.FriendlyURLResolverRegistryUtil;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.service.LayoutFriendlyURLValidator;
+import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.service.LayoutRevisionLocalService;
 import com.liferay.portal.kernel.service.PortletLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
@@ -73,10 +76,24 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.osgi.util.tracker.ServiceTracker;
+
 /**
  * @author Raymond Augé
  */
 public class LayoutLocalServiceHelper implements IdentifiableOSGiService {
+
+	public void afterPropertiesSet() {
+		_serviceTracker = new ServiceTracker(
+			SystemBundleUtil.getBundleContext(),
+			LayoutFriendlyURLValidator.class, null);
+
+		_serviceTracker.open();
+	}
+
+	public void destroy() {
+		_serviceTracker.close();
+	}
 
 	public String getFriendlyURL(
 			long groupId, boolean privateLayout, long layoutId, String name,
@@ -104,8 +121,12 @@ public class LayoutLocalServiceHelper implements IdentifiableOSGiService {
 
 		for (int i = 1;; i++) {
 			try {
+				_layoutFriendlyURLValidator = _serviceTracker.getService();
+
 				validateFriendlyURL(
 					groupId, privateLayout, layoutId, friendlyURL, languageId);
+				_layoutFriendlyURLValidator.validateFriendlyURLEntry(
+					groupId, privateLayout, layoutId, friendlyURL);
 
 				break;
 			}
@@ -113,7 +134,12 @@ public class LayoutLocalServiceHelper implements IdentifiableOSGiService {
 				int type = layoutFriendlyURLException.getType();
 
 				if (type == LayoutFriendlyURLException.DUPLICATE) {
-					friendlyURL = originalFriendlyURL + i;
+					Layout layout = LayoutLocalServiceUtil.fetchLayout(
+						groupId, privateLayout, layoutId);
+
+					if (layout == null) {
+						friendlyURL = originalFriendlyURL + i;
+					}
 				}
 				else {
 					friendlyURL = StringPool.SLASH + layoutId;
@@ -715,5 +741,10 @@ public class LayoutLocalServiceHelper implements IdentifiableOSGiService {
 
 	private static final Pattern _urlSeparatorPattern = Pattern.compile(
 		"/[A-Za-z]");
+
+	private LayoutFriendlyURLValidator _layoutFriendlyURLValidator;
+	private ServiceTracker
+		<LayoutFriendlyURLValidator, LayoutFriendlyURLValidator>
+			_serviceTracker;
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/service/LayoutFriendlyURLValidator.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/LayoutFriendlyURLValidator.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.service;
+
+import com.liferay.portal.kernel.exception.PortalException;
+
+/**
+ * @author Noor Najjar
+ */
+public interface LayoutFriendlyURLValidator {
+
+	public void validateFriendlyURLEntry(
+			long groupId, boolean privateLayout, long classPK, String urlTitle)
+		throws PortalException;
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/service/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/packageinfo
@@ -1,1 +1,1 @@
-version 8.3.0
+version 8.4.0


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-139816

I have been working on this fix with @robertoDiaz and there was a discussion about this issue through PTR-2680

Originally, the issue here was that a new page cannot be created with a name that is the same as an old friendly URL. However, after the changes made by LPS-143165, the page can now successfully be created but the increment of the friendly URL is not consistent with a duplicate FURL that is being currently used. If the duplicated FURL is a currently used one, then the name will be incremented by "i" but if the FURL is an old one, then it's incremented by "-i". (Please see updated ticket steps for clarity)

To fix the issue, I created an extra validation step for layoutFriendlyURLs against the friendlyURLEntry table.