### PR TITLE
LPS-143559 When replying to a thread with a user name with parentheses, they are displayed as escaped HTML code

### DIFF
--- a/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/util/MBUtil.java
+++ b/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/util/MBUtil.java
@@ -57,8 +57,8 @@ public class MBUtil {
 		return StringBundler.concat(
 			"[quote=",
 			StringUtil.replace(
-				parentAuthor, new String[] {"[", "]", "(", ")"},
-				new String[] {"&#91;", "&#93;", "&#40;", "&#41;"}),
+				parentAuthor, new String[] {"[", "]"},
+				new String[] {"&#91;", "&#93;"}),
 			"]\n", parentMessage.getBody(false), "[/quote]\n\n\n");
 	}
 


### PR DESCRIPTION
Dear Team,

Could you please review this pull request?

Thank you and best regards,
István