### PR TITLE
LPS-144080 Home folder display in select root folder iframe when configuring MG

### DIFF
--- a/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/folder/DLFolderItemSelectorView.java
+++ b/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/folder/DLFolderItemSelectorView.java
@@ -26,11 +26,13 @@ import com.liferay.item.selector.PortletItemSelectorView;
 import com.liferay.item.selector.criteria.FolderItemSelectorReturnType;
 import com.liferay.item.selector.criteria.folder.criterion.FolderItemSelectorCriterion;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
-import com.liferay.portal.kernel.bean.BeanParamUtil;
 import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.resource.bundle.ResourceBundleLoader;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.language.LanguageResources;
 
 import java.io.IOException;
@@ -105,12 +107,19 @@ public class DLFolderItemSelectorView
 		RequestDispatcher requestDispatcher =
 			_servletContext.getRequestDispatcher("/select_folder.jsp");
 
-		long repositoryId = BeanParamUtil.getLong(
-			itemSelectorCriterion, (HttpServletRequest)servletRequest,
-			"repositoryId");
-		long folderId = BeanParamUtil.getLong(
-			itemSelectorCriterion, (HttpServletRequest)servletRequest,
-			"folderId");
+		ThemeDisplay themeDisplay = (ThemeDisplay)servletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		long repositoryId = themeDisplay.getScopeGroupId();
+
+		long folderId = ParamUtil.getLong(
+			(HttpServletRequest)servletRequest, "folderId",
+			itemSelectorCriterion.getFolderId());
+
+		if (repositoryId != itemSelectorCriterion.getRepositoryId()) {
+			folderId = ParamUtil.getLong(
+				(HttpServletRequest)servletRequest, "folderId");
+		}
 
 		servletRequest.setAttribute(
 			DLSelectFolderDisplayContext.class.getName(),

--- a/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/folder/DLFolderItemSelectorView.java
+++ b/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/folder/DLFolderItemSelectorView.java
@@ -125,14 +125,10 @@ public class DLFolderItemSelectorView
 			DLSelectFolderDisplayContext.class.getName(),
 			new DLSelectFolderDisplayContext(
 				_dlAppService, _fetchFolder(folderId),
-				(HttpServletRequest)servletRequest, portletURL,
-				BeanParamUtil.getLong(
-					itemSelectorCriterion, (HttpServletRequest)servletRequest,
-					"selectedRepositoryId"),
-				BeanParamUtil.getLong(
-					itemSelectorCriterion, (HttpServletRequest)servletRequest,
-					"selectedFolderId", folderId),
-				repositoryId, _isShowGroupSelector(itemSelectorCriterion)));
+				(HttpServletRequest)servletRequest, portletURL, repositoryId,
+				itemSelectorCriterion.getSelectedFolderId(),
+				itemSelectorCriterion.getSelectedRepositoryId(),
+				_isShowGroupSelector(itemSelectorCriterion)));
 
 		requestDispatcher.include(servletRequest, servletResponse);
 	}

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/IGConfigurationDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/IGConfigurationDisplayContext.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.model.Repository;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactoryUtil;
 import com.liferay.portal.kernel.repository.capabilities.TrashCapability;
 import com.liferay.portal.kernel.repository.model.Folder;
+import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.PortletPreferencesLocalService;
 import com.liferay.portal.kernel.service.RepositoryLocalService;
 import com.liferay.portal.kernel.theme.PortletDisplay;
@@ -150,7 +151,12 @@ public class IGConfigurationDisplayContext {
 
 		return _itemSelector.getItemSelectorURL(
 			RequestBackedPortletURLFactoryUtil.create(_httpServletRequest),
-			getItemSelectedEventName(), folderItemSelectorCriterion);
+			GroupLocalServiceUtil.getGroup(
+				GetterUtil.getLong(
+					getSelectedRepositoryId(),
+					_themeDisplay.getScopeGroupId())),
+			_themeDisplay.getScopeGroupId(), getItemSelectedEventName(),
+			folderItemSelectorCriterion);
 	}
 
 	public boolean isRootFolderInTrash() throws PortalException {

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/IGConfigurationDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/IGConfigurationDisplayContext.java
@@ -140,10 +140,9 @@ public class IGConfigurationDisplayContext {
 		folderItemSelectorCriterion.setDesiredItemSelectorReturnTypes(
 			new FolderItemSelectorReturnType());
 
-		folderItemSelectorCriterion.setFolderId(
-			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID);
+		folderItemSelectorCriterion.setFolderId(getRootFolderId());
 		folderItemSelectorCriterion.setIgnoreRootFolder(true);
-		folderItemSelectorCriterion.setRepositoryId(0);
+		folderItemSelectorCriterion.setRepositoryId(getSelectedRepositoryId());
 		folderItemSelectorCriterion.setSelectedFolderId(getRootFolderId());
 		folderItemSelectorCriterion.setSelectedRepositoryId(
 			getSelectedRepositoryId());

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/configuration.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/configuration.jsp
@@ -200,7 +200,7 @@ DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper = new DLPortletI
 							folderItemSelectorCriterion.setShowGroupSelector(true);
 							folderItemSelectorCriterion.setShowMountFolder(false);
 
-							PortletURL selectFolderURL = itemSelector.getItemSelectorURL(RequestBackedPortletURLFactoryUtil.create(request), portletDisplay.getNamespace() + "folderSelected", folderItemSelectorCriterion);
+							PortletURL selectFolderURL = itemSelector.getItemSelectorURL(RequestBackedPortletURLFactoryUtil.create(request), GroupLocalServiceUtil.getGroup(GetterUtil.getLong(dlAdminDisplayContext.getSelectedRepositoryId(), themeDisplay.getScopeGroupId())), themeDisplay.getScopeGroupId(), portletDisplay.getNamespace() + "folderSelected", folderItemSelectorCriterion);
 							%>
 
 							url: '<%= HtmlUtil.escapeJS(selectFolderURL.toString()) %>',

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/configuration.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/configuration.jsp
@@ -192,11 +192,11 @@ DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper = new DLPortletI
 							FolderItemSelectorCriterion folderItemSelectorCriterion = new FolderItemSelectorCriterion();
 
 							folderItemSelectorCriterion.setDesiredItemSelectorReturnTypes(new FolderItemSelectorReturnType());
-							folderItemSelectorCriterion.setFolderId(DLFolderConstants.DEFAULT_PARENT_FOLDER_ID);
+							folderItemSelectorCriterion.setFolderId(dlAdminDisplayContext.getRootFolderId());
 							folderItemSelectorCriterion.setIgnoreRootFolder(true);
-							folderItemSelectorCriterion.setRepositoryId(0);
+							folderItemSelectorCriterion.setRepositoryId(dlAdminDisplayContext.getSelectedRepositoryId());
 							folderItemSelectorCriterion.setSelectedFolderId(dlAdminDisplayContext.getRootFolderId());
-							folderItemSelectorCriterion.setSelectedRepositoryId(dlAdminDisplayContext.getRepositoryId());
+							folderItemSelectorCriterion.setSelectedRepositoryId(dlAdminDisplayContext.getSelectedRepositoryId());
 							folderItemSelectorCriterion.setShowGroupSelector(true);
 							folderItemSelectorCriterion.setShowMountFolder(false);
 


### PR DESCRIPTION
- LPS-144080 put the data on the folder cirterion to know where the selected data is
- LPS-144080 get the repository from the scope if that is changed we can restore the folder from the request
- LPS-144080 put the selected repository and the actual repository on order to match the DLSelectFolderDisplayContext
