### PR TITLE
[TS] LPS 144687 Temporary files created by DownloadEntriesMVCResourceCommand are not deleted in case of an Exception

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/DownloadEntriesMVCResourceCommand.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/DownloadEntriesMVCResourceCommand.java
@@ -111,11 +111,6 @@ public class DownloadEntriesMVCResourceCommand implements MVCResourceCommand {
 			ResourceRequest resourceRequest, ResourceResponse resourceResponse)
 		throws IOException, PortalException {
 
-		ThemeDisplay themeDisplay = (ThemeDisplay)resourceRequest.getAttribute(
-			WebKeys.THEME_DISPLAY);
-
-		long folderId = ParamUtil.getLong(resourceRequest, "folderId");
-
 		List<FileEntry> fileEntries = ActionUtil.getFileEntries(
 			resourceRequest);
 
@@ -154,6 +149,12 @@ public class DownloadEntriesMVCResourceCommand implements MVCResourceCommand {
 				HttpHeaders.CONTENT_DISPOSITION_ATTACHMENT);
 		}
 		else {
+			ThemeDisplay themeDisplay =
+				(ThemeDisplay)resourceRequest.getAttribute(
+					WebKeys.THEME_DISPLAY);
+
+			long folderId = ParamUtil.getLong(resourceRequest, "folderId");
+
 			String zipFileName = _getZipFileName(folderId, themeDisplay);
 
 			ZipWriter zipWriter = ZipWriterFactoryUtil.getZipWriter();


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-144687

To correctly remove the temporary file, I have moved the "try...finally" block to inside the last else clause, where we are using ZipWriter and I have change the code to always delete its file