### PR TITLE
[TS] LPS-144830 When requesting a image thumbnail, If it doesn't exists, WebServerServlet returns a empty image instead of a 404 error

### DIFF
--- a/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
+++ b/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
@@ -1114,6 +1114,11 @@ public class WebServerServlet extends HttpServlet {
 			}
 		}
 
+		if (converted && (contentLength == 0)) {
+			throw new NoSuchFileException(
+				"The converted file was not correctly created");
+		}
+
 		// Determine proper content type
 
 		String contentType = null;


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-144830

When requesting a image thumbnail, If it doesn't exists, WebServerServlet returns a empty image with 200 code instead of a 404 error
The customer complains that returning 200 code can cause problems to the CDN and other elements, as they are caching them unless an error code is returned.
It can also cause problems to the user browsers, as we send a wrong image that cannot be rendered.