### PR TITLE
LPS-143100 Use new method instead old

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/util/DocumentLibraryDDMFormFieldValueTransformer.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/util/DocumentLibraryDDMFormFieldValueTransformer.java
@@ -67,7 +67,7 @@ public class DocumentLibraryDDMFormFieldValueTransformer
 
 		String fileName = DLUtil.getUniqueFileName(
 			tempFileEntry.getGroupId(), tempFileEntry.getFolderId(),
-			tempFileEntry.getFileName());
+			tempFileEntry.getFileName(), false);
 
 		return DLAppServiceUtil.addFileEntry(
 			null, tempFileEntry.getGroupId(), 0, fileName,

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -6961,7 +6961,7 @@ public class JournalArticleLocalServiceImpl
 
 						String fileEntryName = DLUtil.getUniqueFileName(
 							folder.getGroupId(), folder.getFolderId(),
-							tempFileEntry.getFileName());
+							tempFileEntry.getFileName(), false);
 
 						fileEntry = _portletFileRepository.addPortletFileEntry(
 							folder.getGroupId(), tempFileEntry.getUserId(),
@@ -9171,7 +9171,7 @@ public class JournalArticleLocalServiceImpl
 			fileEntry -> {
 				String fileEntryName = DLUtil.getUniqueFileName(
 					fileEntry.getGroupId(), fileEntry.getFolderId(),
-					fileEntry.getFileName());
+					fileEntry.getFileName(), false);
 
 				Folder folder = article.addImagesFolder();
 

--- a/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/portlet/action/EditMessageMVCActionCommand.java
+++ b/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/portlet/action/EditMessageMVCActionCommand.java
@@ -429,7 +429,8 @@ public class EditMessageMVCActionCommand extends BaseMVCActionCommand {
 
 				uniqueFileName = DLUtil.getUniqueFileName(
 					tempFileEntry.getGroupId(),
-					message.getAttachmentsFolderId(), originalSelectedFileName);
+					message.getAttachmentsFolderId(), originalSelectedFileName,
+					false);
 			}
 
 			ObjectValuePair<String, InputStream> inputStreamOVP =

--- a/modules/apps/wiki/wiki-web/src/main/java/com/liferay/wiki/web/internal/helper/WikiAttachmentsHelper.java
+++ b/modules/apps/wiki/wiki-web/src/main/java/com/liferay/wiki/web/internal/helper/WikiAttachmentsHelper.java
@@ -98,7 +98,8 @@ public class WikiAttachmentsHelper {
 						wikiPage.getGroupId(),
 						wikiPage.getAttachmentsFolderId(),
 						TempFileEntryUtil.getOriginalTempFileName(
-							tempFileEntry.getFileName()));
+							tempFileEntry.getFileName()),
+						false);
 
 					ObjectValuePair<String, InputStream> inputStreamOVP =
 						new ObjectValuePair<>(

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/util/DLImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/util/DLImpl.java
@@ -850,6 +850,10 @@ public class DLImpl implements DL {
 		return title;
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #getUniqueFileName(long, long, String, boolean)}
+	 */
+	@Deprecated
 	@Override
 	public String getUniqueFileName(
 		long groupId, long folderId, String fileName) {

--- a/portal-kernel/src/com/liferay/document/library/kernel/util/DL.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/util/DL.java
@@ -229,6 +229,10 @@ public interface DL {
 
 	public String getTitleWithExtension(String title, String extension);
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #getUniqueFileName(long, long, String, boolean)}
+	 */
+	@Deprecated
 	public String getUniqueFileName(
 		long groupId, long folderId, String fileName);
 

--- a/portal-kernel/src/com/liferay/document/library/kernel/util/DLUtil.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/util/DLUtil.java
@@ -324,6 +324,10 @@ public class DLUtil {
 		return _dl.getTitleWithExtension(title, extension);
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #getUniqueFileName(long, long, String, boolean)}
+	 */
+	@Deprecated
 	public static String getUniqueFileName(
 		long groupId, long folderId, String fileName) {
 


### PR DESCRIPTION
- LPS-143100 use new method with the boolean parameter
- LPS-143100 deprecate the method because deletion makes a breaking change
