### PR TITLE
LPS-127613 field geolocation google maps

### DIFF
--- a/modules/apps/map/map-google-maps/src/main/resources/META-INF/resources/js/GoogleMapsGeocoder.es.js
+++ b/modules/apps/map/map-google-maps/src/main/resources/META-INF/resources/js/GoogleMapsGeocoder.es.js
@@ -46,7 +46,7 @@ class GoogleMapsGeocoder extends State {
 			error: status === google.maps.GeocoderStatus.OK ? null : status,
 		};
 
-		if (!result.err) {
+		if (!result.error) {
 			const geocoderResult = response[0];
 			const geolocation = geocoderResult.geometry.location;
 

--- a/modules/apps/map/map-google-maps/src/main/resources/META-INF/resources/js/MapGoogleMaps.es.js
+++ b/modules/apps/map/map-google-maps/src/main/resources/META-INF/resources/js/MapGoogleMaps.es.js
@@ -34,6 +34,12 @@ class MapGoogleMaps extends MapBase {
 	constructor(...args) {
 		super(...args);
 
+		MapBase.DialogImpl = GoogleMapsDialog;
+		MapBase.GeocoderImpl = GoogleMapsGeocoder;
+		MapBase.GeoJSONImpl = GoogleMapsGeoJSON;
+		MapBase.MarkerImpl = GoogleMapsMarker;
+		MapBase.SearchImpl = GoogleMapsSearch;
+
 		this._bounds = null;
 	}
 
@@ -111,16 +117,6 @@ class MapGoogleMaps extends MapBase {
 		}
 	}
 }
-
-MapBase.DialogImpl = GoogleMapsDialog;
-
-MapBase.GeocoderImpl = GoogleMapsGeocoder;
-
-MapBase.GeoJSONImpl = GoogleMapsGeoJSON;
-
-MapBase.MarkerImpl = GoogleMapsMarker;
-
-MapBase.SearchImpl = GoogleMapsSearch;
 
 MapGoogleMaps.CONTROLS_MAP = {
 	[MapBase.CONTROLS.OVERVIEW]: 'overviewMapControl',

--- a/modules/apps/map/map-openstreetmap/src/main/resources/META-INF/resources/js/MapOpenStreetMap.es.js
+++ b/modules/apps/map/map-openstreetmap/src/main/resources/META-INF/resources/js/MapOpenStreetMap.es.js
@@ -34,6 +34,12 @@ class MapOpenStreetMap extends MapBase {
 	constructor(...args) {
 		super(...args);
 
+		MapBase.DialogImpl = OpenStreetMapDialog;
+		MapBase.GeocoderImpl = OpenStreetMapGeocoder;
+		MapBase.GeoJSONImpl = OpenStreetMapGeoJSON;
+		MapBase.MarkerImpl = OpenStreetMapMarker;
+		MapBase.SearchImpl = null;
+
 		this._map = null;
 	}
 
@@ -115,16 +121,6 @@ class MapOpenStreetMap extends MapBase {
 		}
 	}
 }
-
-MapBase.DialogImpl = OpenStreetMapDialog;
-
-MapBase.GeocoderImpl = OpenStreetMapGeocoder;
-
-MapBase.GeoJSONImpl = OpenStreetMapGeoJSON;
-
-MapBase.MarkerImpl = OpenStreetMapMarker;
-
-MapBase.SearchImpl = null;
 
 MapOpenStreetMap.CONTROLS_MAP = {
 	[MapBase.CONTROLS.ATTRIBUTION]: 'attributionControl',


### PR DESCRIPTION
Issue: https://issues.liferay.com/browse/LPS-127613

---

**What's going on?**

In [useGeolocation](https://github.com/liferay/liferay-portal/blob/4acc81de59b202db303fd9c54b136694ceb23523/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Geolocation/useGeolocation.es.js#L15-L16) we are importing the two maps providers and only the last imported provider is well constructed in our [global MapBase](https://github.com/liferay/liferay-portal/blob/master/modules/apps/map/map-common/src/main/resources/META-INF/resources/js/MapBase.es.js#L836). 

When we import `MapGoogleMaps` the [MapBase implementations are updated](https://github.com/liferay/liferay-portal/blob/32f72ae28ccb9ba240d9a7902bde08d7e6854cd9/modules/apps/map/map-google-maps/src/main/resources/META-INF/resources/js/MapGoogleMaps.es.js#L97-L105).

When is loaded our `Liferay.MapBase.*Impl` are pointing to the [MapGoogleMaps](https://github.com/liferay/liferay-portal/blob/7c437a02cbc5f6a77c798076691961b702b2e21f/modules/apps/map/map-google-maps/src/main/resources/META-INF/resources/js/MapGoogleMaps.es.js#L115-L123) implementations.

Later we import `MapOpenStreetMap` and `Liferay.MapBase.*Impl` are updated another time leaving the `Liferay.MapBase.*Impl` pointing to [MapOpenStreetMap](https://github.com/liferay/liferay-portal/blob/master/modules/apps/map/map-openstreetmap/src/main/resources/META-INF/resources/js/MapOpenStreetMap.es.js#L119-L127) implementations and overwetting the [MapGoogleMaps](https://github.com/liferay/liferay-portal/blob/7c437a02cbc5f6a77c798076691961b702b2e21f/modules/apps/map/map-google-maps/src/main/resources/META-INF/resources/js/MapGoogleMaps.es.js#L115-L123).

When we try to use the `MapGoogleMaps` provider fails because the MapBase implementations are pointing to `MapOpenStreetMap`.

---

**The fix**

I move the global MapBase implementations initialization to the constructors. Instead of relying on the order of execution, we will only update MapBase implementations when a new `Map*` provider is created.