### PR TITLE
[TS] LPS 144687 Temporary files created by DownloadEntriesMVCResourceCommand in the _downloadFolder is not deleted either (Additional Commit)

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/DownloadEntriesMVCResourceCommand.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/DownloadEntriesMVCResourceCommand.java
@@ -207,30 +207,28 @@ public class DownloadEntriesMVCResourceCommand implements MVCResourceCommand {
 
 		_checkFolder(folderId);
 
-		File file = null;
+		ZipWriter zipWriter = ZipWriterFactoryUtil.getZipWriter();
 
 		try {
 			String zipFileName = _getZipFileName(folderId, themeDisplay);
-
-			ZipWriter zipWriter = ZipWriterFactoryUtil.getZipWriter();
 
 			long repositoryId = ParamUtil.getLong(
 				resourceRequest, "repositoryId");
 
 			_zipFolder(repositoryId, folderId, StringPool.SLASH, zipWriter);
 
-			file = zipWriter.getFile();
+			try (InputStream inputStream = new FileInputStream(
+					zipWriter.getFile())) {
 
-			try (InputStream inputStream = new FileInputStream(file)) {
 				PortletResponseUtil.sendFile(
 					resourceRequest, resourceResponse, zipFileName, inputStream,
 					ContentTypes.APPLICATION_ZIP);
 			}
 		}
 		finally {
-			if (file != null) {
-				file.delete();
-			}
+			File file = zipWriter.getFile();
+
+			file.delete();
 		}
 	}
 


### PR DESCRIPTION
This is an additional commit for https://issues.liferay.com/browse/LPS-144687

Original PR was sent here: https://github.com/liferay-lima/liferay-portal/pull/2608

I have noticed that the same problem I fixed in previous PR is also happening in the _downloadFolder method of DownloadEntriesMVCResourceCommand
