### PR TITLE
LPS-145189 SVG can not be previewed

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/configuration/AMImageAttributeMapping.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/configuration/AMImageAttributeMapping.java
@@ -17,6 +17,7 @@ package com.liferay.adaptive.media.image.internal.configuration;
 import com.liferay.adaptive.media.AMAttribute;
 import com.liferay.adaptive.media.image.processor.AMImageAttribute;
 import com.liferay.adaptive.media.image.processor.AMImageProcessor;
+import com.liferay.portal.kernel.repository.model.FileVersion;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 
 import java.util.Map;
@@ -31,6 +32,22 @@ import java.util.Optional;
  * @author Adolfo Pérez
  */
 public class AMImageAttributeMapping {
+
+	public static AMImageAttributeMapping fromFileVersion(
+		FileVersion fileVersion) {
+
+		return new AMImageAttributeMapping(
+			HashMapBuilder.<AMAttribute<AMImageProcessor, ?>, Optional<?>>put(
+				AMAttribute.getContentLengthAMAttribute(),
+				Optional.of(fileVersion.getSize())
+			).put(
+				AMAttribute.getContentTypeAMAttribute(),
+				Optional.of(fileVersion.getMimeType())
+			).put(
+				AMAttribute.getFileNameAMAttribute(),
+				Optional.of(fileVersion.getFileName())
+			).build());
+	}
 
 	/**
 	 * Returns an {@link AMImageAttributeMapping} that uses the map as the

--- a/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/configuration/AMImageAttributeMapping.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/configuration/AMImageAttributeMapping.java
@@ -38,6 +38,8 @@ public class AMImageAttributeMapping {
 
 		return new AMImageAttributeMapping(
 			HashMapBuilder.<AMAttribute<AMImageProcessor, ?>, Optional<?>>put(
+				AMAttribute.getConfigurationUuidAMAttribute(), Optional.empty()
+			).put(
 				AMAttribute.getContentLengthAMAttribute(),
 				Optional.of(fileVersion.getSize())
 			).put(
@@ -46,6 +48,10 @@ public class AMImageAttributeMapping {
 			).put(
 				AMAttribute.getFileNameAMAttribute(),
 				Optional.of(fileVersion.getFileName())
+			).put(
+				AMImageAttribute.AM_IMAGE_ATTRIBUTE_HEIGHT, Optional.empty()
+			).put(
+				AMImageAttribute.AM_IMAGE_ATTRIBUTE_WIDTH, Optional.empty()
 			).build());
 	}
 

--- a/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/finder/AMImageFinderImpl.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/finder/AMImageFinderImpl.java
@@ -35,14 +35,12 @@ import com.liferay.adaptive.media.image.url.AMImageURLFactory;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.repository.model.FileVersion;
 import com.liferay.portal.kernel.util.ContentTypes;
-
-import java.io.InputStream;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 
 import java.net.URI;
 
 import java.util.Collection;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -95,7 +93,7 @@ public class AMImageFinderImpl implements AMImageFinder {
 		String mimeType = fileVersion.getMimeType();
 
 		if (mimeType.equals(ContentTypes.IMAGE_SVG_XML)) {
-			return Stream.of(new SVGAdaptiveMedia(fileVersion));
+			return Stream.of(_createRawAdaptiveMedia(fileVersion));
 		}
 
 		BiFunction<FileVersion, AMImageConfigurationEntry, URI> uriFactory =
@@ -194,6 +192,48 @@ public class AMImageFinderImpl implements AMImageFinder {
 			uriFactory.apply(fileVersion, amImageConfigurationEntry));
 	}
 
+	private AdaptiveMedia<AMImageProcessor> _createRawAdaptiveMedia(
+			FileVersion fileVersion)
+		throws PortalException {
+
+		Map<String, String> properties = HashMapBuilder.put(
+			() -> {
+				AMAttribute<Object, Long> contentLengthAMAttribute =
+					AMAttribute.getContentLengthAMAttribute();
+
+				return contentLengthAMAttribute.getName();
+			},
+			String.valueOf(fileVersion.getSize())
+		).put(
+			() -> {
+				AMAttribute<Object, String> contentTypeAMAttribute =
+					AMAttribute.getContentTypeAMAttribute();
+
+				return contentTypeAMAttribute.getName();
+			},
+			fileVersion.getMimeType()
+		).put(
+			() -> {
+				AMAttribute<Object, String> fileNameAMAttribute =
+					AMAttribute.getFileNameAMAttribute();
+
+				return fileNameAMAttribute.getName();
+			},
+			fileVersion.getFileName()
+		).build();
+
+		return new AMImage(
+			() -> {
+				try {
+					return fileVersion.getContentStream(false);
+				}
+				catch (PortalException portalException) {
+					throw new AMRuntimeException(portalException);
+				}
+			},
+			AMImageAttributeMapping.fromProperties(properties), null);
+	}
+
 	private BiFunction<FileVersion, AMImageConfigurationEntry, URI>
 		_getURIFactory(AMImageQueryBuilderImpl amImageQueryBuilderImpl) {
 
@@ -230,38 +270,5 @@ public class AMImageFinderImpl implements AMImageFinder {
 
 	@Reference
 	private AMImageURLFactory _amImageURLFactory;
-
-	private static class SVGAdaptiveMedia
-		implements AdaptiveMedia<AMImageProcessor> {
-
-		public SVGAdaptiveMedia(FileVersion fileVersion) {
-			_fileVersion = fileVersion;
-		}
-
-		@Override
-		public InputStream getInputStream() {
-			try {
-				return _fileVersion.getContentStream(false);
-			}
-			catch (PortalException portalException) {
-				throw new AMRuntimeException.IOException(portalException);
-			}
-		}
-
-		@Override
-		public URI getURI() {
-			return null;
-		}
-
-		@Override
-		public <V> Optional<V> getValueOptional(
-			AMAttribute<AMImageProcessor, V> amAttribute) {
-
-			return Optional.empty();
-		}
-
-		private final FileVersion _fileVersion;
-
-	}
 
 }

--- a/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/finder/AMImageFinderImpl.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/finder/AMImageFinderImpl.java
@@ -35,7 +35,6 @@ import com.liferay.adaptive.media.image.url.AMImageURLFactory;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.repository.model.FileVersion;
 import com.liferay.portal.kernel.util.ContentTypes;
-import com.liferay.portal.kernel.util.HashMapBuilder;
 
 import java.net.URI;
 
@@ -193,34 +192,7 @@ public class AMImageFinderImpl implements AMImageFinder {
 	}
 
 	private AdaptiveMedia<AMImageProcessor> _createRawAdaptiveMedia(
-			FileVersion fileVersion)
-		throws PortalException {
-
-		Map<String, String> properties = HashMapBuilder.put(
-			() -> {
-				AMAttribute<Object, Long> contentLengthAMAttribute =
-					AMAttribute.getContentLengthAMAttribute();
-
-				return contentLengthAMAttribute.getName();
-			},
-			String.valueOf(fileVersion.getSize())
-		).put(
-			() -> {
-				AMAttribute<Object, String> contentTypeAMAttribute =
-					AMAttribute.getContentTypeAMAttribute();
-
-				return contentTypeAMAttribute.getName();
-			},
-			fileVersion.getMimeType()
-		).put(
-			() -> {
-				AMAttribute<Object, String> fileNameAMAttribute =
-					AMAttribute.getFileNameAMAttribute();
-
-				return fileNameAMAttribute.getName();
-			},
-			fileVersion.getFileName()
-		).build();
+		FileVersion fileVersion) {
 
 		return new AMImage(
 			() -> {
@@ -231,7 +203,7 @@ public class AMImageFinderImpl implements AMImageFinder {
 					throw new AMRuntimeException(portalException);
 				}
 			},
-			AMImageAttributeMapping.fromProperties(properties), null);
+			AMImageAttributeMapping.fromFileVersion(fileVersion), null);
 	}
 
 	private BiFunction<FileVersion, AMImageConfigurationEntry, URI>

--- a/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/handler/AMImageRequestHandler.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/handler/AMImageRequestHandler.java
@@ -33,7 +33,6 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.repository.model.FileVersion;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
 import java.io.IOException;
@@ -84,34 +83,7 @@ public class AMImageRequestHandler
 	}
 
 	private AdaptiveMedia<AMImageProcessor> _createRawAdaptiveMedia(
-			FileVersion fileVersion)
-		throws PortalException {
-
-		Map<String, String> properties = HashMapBuilder.put(
-			() -> {
-				AMAttribute<Object, Long> contentLengthAMAttribute =
-					AMAttribute.getContentLengthAMAttribute();
-
-				return contentLengthAMAttribute.getName();
-			},
-			String.valueOf(fileVersion.getSize())
-		).put(
-			() -> {
-				AMAttribute<Object, String> contentTypeAMAttribute =
-					AMAttribute.getContentTypeAMAttribute();
-
-				return contentTypeAMAttribute.getName();
-			},
-			fileVersion.getMimeType()
-		).put(
-			() -> {
-				AMAttribute<Object, String> fileNameAMAttribute =
-					AMAttribute.getFileNameAMAttribute();
-
-				return fileNameAMAttribute.getName();
-			},
-			fileVersion.getFileName()
-		).build();
+		FileVersion fileVersion) {
 
 		return new AMImage(
 			() -> {
@@ -122,7 +94,7 @@ public class AMImageRequestHandler
 					throw new AMRuntimeException(portalException);
 				}
 			},
-			AMImageAttributeMapping.fromProperties(properties), null);
+			AMImageAttributeMapping.fromFileVersion(fileVersion), null);
 	}
 
 	private Optional<AdaptiveMedia<AMImageProcessor>> _findAdaptiveMedia(

--- a/modules/apps/adaptive-media/adaptive-media-image-impl/src/test/java/com/liferay/adaptive/media/image/internal/finder/AMImageFinderImplTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-impl/src/test/java/com/liferay/adaptive/media/image/internal/finder/AMImageFinderImplTest.java
@@ -1448,6 +1448,18 @@ public class AMImageFinderImplTest {
 		);
 
 		Mockito.when(
+			_fileVersion.getFileName()
+		).thenReturn(
+			RandomTestUtil.randomString()
+		);
+
+		Mockito.when(
+			_fileVersion.getSize()
+		).thenReturn(
+			RandomTestUtil.randomLong()
+		);
+
+		Mockito.when(
 			_amImageMimeTypeProvider.isMimeTypeSupported(
 				ContentTypes.IMAGE_SVG_XML)
 		).thenReturn(

--- a/modules/apps/adaptive-media/adaptive-media-image-impl/src/test/java/com/liferay/adaptive/media/image/internal/finder/AMImageFinderImplTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-impl/src/test/java/com/liferay/adaptive/media/image/internal/finder/AMImageFinderImplTest.java
@@ -1481,6 +1481,12 @@ public class AMImageFinderImplTest {
 		AdaptiveMedia<AMImageProcessor> adaptiveMedia = adaptiveMedias.get(0);
 
 		Assert.assertSame(inputStream, adaptiveMedia.getInputStream());
+
+		Optional<Long> contentLengthOptional = adaptiveMedia.getValueOptional(
+			AMAttribute.getContentLengthAMAttribute());
+
+		Assert.assertEquals(
+			_fileVersion.getSize(), (long)contentLengthOptional.get());
 	}
 
 	@Test


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-145189

Regression caused by LPS-144830.

The root cause of this issue is:
 - LPS-144830 starts checking the size of converted files
 - But SVG files are not converted, we return a fake SVGAdaptiveMedia that returns the original fileVersion.getContentStream correctly, but it doesn't return the file atributes
 - As it doesn't have any attribute, size zero is returned.

To fix this problem, I am coping the *_createRawAdaptiveMedia* method from AMImageRequestHandler that is correctly handling the FileVersion object

I have move duplicated code to the AMImageAttributeMapping class, let me know if there is a better place to put it.

