### PR TITLE
LPS-145132 Return the fileSize of the default image when AMImage is not ready

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-document-library-thumbnails/src/main/java/com/liferay/adaptive/media/document/library/thumbnails/internal/processor/AMImageEntryProcessor.java
+++ b/modules/apps/adaptive-media/adaptive-media-document-library-thumbnails/src/main/java/com/liferay/adaptive/media/document/library/thumbnails/internal/processor/AMImageEntryProcessor.java
@@ -154,6 +154,8 @@ public class AMImageEntryProcessor implements DLProcessor, ImageProcessor {
 
 		if (!adaptiveMediaOptional.isPresent()) {
 			_processAMImage(fileVersion);
+
+			return fileVersion.getSize();
 		}
 
 		return adaptiveMediaOptional.flatMap(

--- a/modules/apps/adaptive-media/adaptive-media-document-library-thumbnails/src/test/java/com/liferay/adaptive/media/document/library/thumbnails/internal/processor/AMImageEntryProcessorTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-document-library-thumbnails/src/test/java/com/liferay/adaptive/media/document/library/thumbnails/internal/processor/AMImageEntryProcessorTest.java
@@ -30,6 +30,7 @@ import com.liferay.portal.test.rule.LiferayUnitTestRule;
 import java.io.InputStream;
 
 import java.util.Optional;
+import java.util.Random;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
@@ -305,6 +306,43 @@ public class AMImageEntryProcessorTest {
 		).triggerProcess(
 			Mockito.any(FileVersion.class), Mockito.anyString()
 		);
+	}
+
+	@Test
+	public void testGetPreviewFileSizeReturnsTheOriginalSizeWhenNoAMImageExists()
+		throws Exception {
+
+		Mockito.when(
+			_amImageFinder.getAdaptiveMediaStream(Mockito.any(Function.class))
+		).thenAnswer(
+			invocation -> Stream.empty()
+		);
+
+		Mockito.when(
+			_amImageMimeTypeProvider.isMimeTypeSupported(Mockito.anyString())
+		).thenReturn(
+			true
+		);
+
+		Mockito.when(
+			_amImageValidator.isValid(_fileVersion)
+		).thenReturn(
+			true
+		);
+
+		Random random = new Random();
+
+		long originalSize = random.nextLong();
+
+		Mockito.when(
+			_fileVersion.getSize()
+		).thenReturn(
+			originalSize
+		);
+
+		Assert.assertEquals(
+			originalSize,
+			_amImageEntryProcessor.getPreviewFileSize(_fileVersion));
 	}
 
 	@Test


### PR DESCRIPTION
Hi lima people! 👋 

Here is a fix for https://issues.liferay.com/browse/LPS-145132. Let me know what do you think :)

The same way we return the default image in the method `getPreviewAsStream` https://github.com/liferay/liferay-portal/blob/636033e171c4eb5e4397575821b38ab900118281/modules/apps/adaptive-media/adaptive-media-document-library-thumbnails/src/main/java/com/liferay/adaptive/media/document/library/thumbnails/internal/processor/AMImageEntryProcessor.java#L132 

This wasn't needed in the past since we didn't check the content length in the `WebServerServlet` so we ended up with a valid inputStream (the default image) but with a contentLength of 0, which now causes an exception due to 
874b5c60a974278f8417c4100d4807f76124638f

Reproduction steps in https://issues.liferay.com/browse/LPS-145132
