### PR TITLE
LPS-144290 Preview window shows in Item Selector for non-previewable files

### DIFF
--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/css/item_selector_preview.scss
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/css/item_selector_preview.scss
@@ -86,6 +86,7 @@ html#{$cadmin-selector}:not(._) {
 
 			&:not(.open) {
 				img,
+				.no-preview-container,
 				.video-preview {
 					left: 50%;
 					position: absolute;

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/item_selector_preview/js/Carousel.es.js
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/item_selector_preview/js/Carousel.es.js
@@ -17,6 +17,7 @@ import ClayIcon from '@clayui/icon';
 import ClayTabs from '@clayui/tabs';
 import React, {useState} from 'react';
 
+import NoPreview from './NoPreview.es';
 import PreviewImage from './PreviewImage.es';
 import PreviewVideo from './PreviewVideo.es';
 
@@ -91,6 +92,7 @@ const Carousel = ({
 	currentItem,
 	handleClickNext,
 	handleClickPrevious,
+	isImage,
 	showArrows = true,
 }) => {
 	const isVideo = currentItem.type === 'video';
@@ -111,11 +113,13 @@ const Carousel = ({
 
 				{isVideo ? (
 					<PreviewVideo html={videoHtml} />
-				) : (
+				) : isImage ? (
 					<PreviewImage
 						src={currentItem.url || currentItem.base64}
 						title={currentItem.title}
 					/>
+				) : (
+					<NoPreview />
 				)}
 
 				{showArrows && (

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/item_selector_preview/js/ItemSelectorPreview.es.js
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/item_selector_preview/js/ItemSelectorPreview.es.js
@@ -48,7 +48,7 @@ const ItemSelectorPreview = ({
 }) => {
 	const [currentItemIndex, setCurrentItemIndex] = useState(currentIndex);
 	const [isEditing, setIsEditing] = useState();
-	const [isImage, setIsImage] = useState(false);
+	const [isImage, setIsImage] = useState(itemIsImage(items[currentIndex]));
 	const [itemList, setItemList] = useState(items);
 	const [reloadOnHide, setReloadOnHide] = useState(initialReloadOnHide);
 

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/item_selector_preview/js/ItemSelectorPreview.es.js
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/item_selector_preview/js/ItemSelectorPreview.es.js
@@ -234,7 +234,7 @@ const ItemSelectorPreview = ({
 				handleClickEdit={handleClickEdit}
 				headerTitle={headerTitle}
 				infoButtonRef={infoButtonRef}
-				showEditIcon={true}
+				showEditIcon={isImage}
 				showInfoIcon={!!currentItem.metadata}
 				showNavbar={!isEditing}
 			/>

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/item_selector_preview/js/ItemSelectorPreview.es.js
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/item_selector_preview/js/ItemSelectorPreview.es.js
@@ -32,6 +32,9 @@ const KEY_CODE = {
 
 const noop = () => {};
 
+const itemIsImage = ({mimeType, type}) =>
+	type === 'image' || Boolean(mimeType?.match(/image.*/));
+
 const ItemSelectorPreview = ({
 	container,
 	currentIndex = 0,
@@ -45,6 +48,7 @@ const ItemSelectorPreview = ({
 }) => {
 	const [currentItemIndex, setCurrentItemIndex] = useState(currentIndex);
 	const [isEditing, setIsEditing] = useState();
+	const [isImage, setIsImage] = useState(false);
 	const [itemList, setItemList] = useState(items);
 	const [reloadOnHide, setReloadOnHide] = useState(initialReloadOnHide);
 
@@ -217,6 +221,10 @@ const ItemSelectorPreview = ({
 		}
 	}, [infoButtonRef]);
 
+	useEffect(() => {
+		setIsImage(itemIsImage(currentItem));
+	}, [currentItem]);
+
 	return (
 		<div className="fullscreen item-selector-preview">
 			<Header
@@ -246,6 +254,7 @@ const ItemSelectorPreview = ({
 						currentItem={currentItem}
 						handleClickNext={handleClickNext}
 						handleClickPrevious={handleClickPrevious}
+						isImage={isImage}
 						showArrows={itemList.length > 1}
 					/>
 

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/item_selector_preview/js/ItemSelectorPreview.es.js
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/item_selector_preview/js/ItemSelectorPreview.es.js
@@ -219,6 +219,10 @@ const ItemSelectorPreview = ({
 				width: '320px',
 			});
 		}
+
+		return () => {
+			Liferay.SideNavigation.destroy(sidenavToggle);
+		};
 	}, [infoButtonRef]);
 
 	useEffect(() => {

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/item_selector_preview/js/NoPreview.es.js
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/item_selector_preview/js/NoPreview.es.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import React from 'react';
+
+export default function NoPreview() {
+	return (
+		<div className="no-preview-container text-light">
+			<strong>
+				{Liferay.Language.get('there-is-no-preview-available')}
+			</strong>
+		</div>
+	);
+}

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/item_selector_uploader/js/utils/getPreviewProps.js
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/item_selector_uploader/js/utils/getPreviewProps.js
@@ -76,6 +76,7 @@ function getPreviewProps({
 			{
 				fileEntryId: itemFile.fileEntryId,
 				metadata: JSON.stringify(getUploadFileMetadata(file)),
+				mimeType: itemFile.mimeType,
 				returntype: uploadItemReturnType,
 				title: itemFile.title,
 				url: itemFileUrl,

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/js/ItemSelectorRepositoryEntryBrowser.es.js
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/js/ItemSelectorRepositoryEntryBrowser.es.js
@@ -450,6 +450,7 @@ class ItemSelectorRepositoryEntryBrowser extends PortletBase {
 		const item = {
 			base64: preview,
 			metadata: JSON.stringify(this._getUploadFileMetadata(file)),
+			mimeType: file.type,
 			returntype: this.uploadItemReturnType,
 			title: file.name,
 			value: preview,

--- a/modules/apps/item-selector/item-selector-taglib/test/item_selector_preview/Carousel.es.js
+++ b/modules/apps/item-selector/item-selector-taglib/test/item_selector_preview/Carousel.es.js
@@ -48,6 +48,7 @@ const carouselProps = {
 	},
 	handleClickNext: jest.fn(),
 	handleClickPrevious: jest.fn(),
+	isImage: true,
 };
 
 const renderCarouselComponent = (props) => render(<Carousel {...props} />);

--- a/modules/apps/item-selector/item-selector-taglib/test/item_selector_preview/ItemSelectorPreview.es.js
+++ b/modules/apps/item-selector/item-selector-taglib/test/item_selector_preview/ItemSelectorPreview.es.js
@@ -71,16 +71,21 @@ const renderPreviewComponent = (props) =>
 describe('ItemSelectorPreview', () => {
 	beforeAll(() => {
 		Liferay.component = jest.fn();
-		Liferay.SideNavigation = jest.fn();
-		Liferay.SideNavigation.initialize = jest.fn();
+		Liferay.SideNavigation = {
+			destroy: jest.fn(),
+			initialize: jest.fn(),
+		};
 	});
 
 	afterEach(cleanup);
 
-	it('initialize the sidebar only once', () => {
+	it('initialize/destroy the sidebar properly', () => {
 		renderPreviewComponent(previewProps);
 
-		expect(Liferay.SideNavigation.initialize).toHaveBeenCalledTimes(1);
+		expect(
+			Liferay.SideNavigation.initialize.mock.calls.length -
+				Liferay.SideNavigation.destroy.mock.calls.length
+		).toBe(1);
 	});
 
 	it('renders the ItemSelectorPreview component with the fullscreen class', () => {

--- a/modules/apps/item-selector/item-selector-taglib/test/item_selector_preview/ItemSelectorPreview.es.js
+++ b/modules/apps/item-selector/item-selector-taglib/test/item_selector_preview/ItemSelectorPreview.es.js
@@ -42,6 +42,7 @@ const headerTitle = 'Images';
 const items = [
 	{
 		metadata: JSON.stringify(basicMetadata),
+		mimeType: 'image/jpeg',
 		returntype: 'returntype',
 		title: item1Title,
 		url: itemUrl,
@@ -49,6 +50,7 @@ const items = [
 	},
 	{
 		metadata: JSON.stringify(basicMetadata),
+		mimeType: 'image/jpeg',
 		returntype: 'returntype',
 		title: item2Title,
 		url: itemUrl,


### PR DESCRIPTION
Issue: https://issues.liferay.com/browse/LPS-144290

---

Only enable the preview of the image files based on backed response type and mime-type as a fallback.

When you upload a video file, it is not previewable until the video is processed and transformed. We show the `No Preview` message in videos until is processed.

I'll try to add a more bulletproof approach showing only the image when the image is loaded but is a bit over-engineering, I think that makes sense to go with this simplest approach.


