### PR TITLE
LPS-144839 add test to LPS-135678 and LPS-135679

### DIFF
--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenViewingFolderContentsTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenViewingFolderContentsTest.java
@@ -16,6 +16,7 @@ package com.liferay.document.library.app.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLAppService;
 import com.liferay.document.library.kernel.util.DLUtil;
 import com.liferay.document.library.kernel.util.comparator.RepositoryModelReadCountComparator;
@@ -25,6 +26,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
@@ -43,8 +45,6 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import jodd.net.MimeTypes;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -71,7 +71,7 @@ public class DLAppServiceWhenViewingFolderContentsTest
 
 		_dlAppService.addFileEntry(
 			null, group.getGroupId(), parentFolder.getFolderId(),
-			StringUtil.randomString(), MimeTypes.MIME_APPLICATION_OCTET_STREAM,
+			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
 			StringUtil.randomString(), StringUtil.randomString(),
 			StringPool.BLANK, (byte[])null, null, null, serviceContext);
 
@@ -79,7 +79,7 @@ public class DLAppServiceWhenViewingFolderContentsTest
 
 		_dlAppService.addFileEntry(
 			null, group.getGroupId(), parentFolder.getFolderId(),
-			StringUtil.randomString(), MimeTypes.MIME_APPLICATION_OCTET_STREAM,
+			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
 			StringUtil.randomString(), StringUtil.randomString(),
 			StringPool.BLANK, (byte[])null, null, null, serviceContext);
 
@@ -98,7 +98,7 @@ public class DLAppServiceWhenViewingFolderContentsTest
 
 		_dlAppService.addFileEntry(
 			null, group.getGroupId(), parentFolder.getFolderId(),
-			StringUtil.randomString(), MimeTypes.MIME_APPLICATION_OCTET_STREAM,
+			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
 			StringUtil.randomString(), StringUtil.randomString(),
 			StringPool.BLANK, (byte[])null, null, null, serviceContext);
 
@@ -106,7 +106,7 @@ public class DLAppServiceWhenViewingFolderContentsTest
 
 		_dlAppService.addFileEntry(
 			null, group.getGroupId(), parentFolder.getFolderId(),
-			StringUtil.randomString(), MimeTypes.MIME_APPLICATION_OCTET_STREAM,
+			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
 			StringUtil.randomString(), StringUtil.randomString(),
 			StringPool.BLANK, (byte[])null, null, null, serviceContext);
 
@@ -128,13 +128,47 @@ public class DLAppServiceWhenViewingFolderContentsTest
 	}
 
 	@Test
+	public void testShouldNotReturnContentOfFolderNotInGroup()
+		throws Exception {
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(group.getGroupId());
+
+		Folder targetGroupFolder = _dlAppService.addFolder(
+			targetGroup.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			ServiceContextTestUtil.getServiceContext(targetGroup.getGroupId()));
+
+		_dlAppService.addFileEntry(
+			null, targetGroup.getGroupId(), targetGroupFolder.getFolderId(),
+			StringUtil.randomString() + ".jpg", ContentTypes.IMAGE_JPEG,
+			"title1", StringUtil.randomString(), StringPool.BLANK, (byte[])null,
+			null, null, serviceContext);
+
+		_dlAppService.addFileEntry(
+			null, targetGroup.getGroupId(), targetGroupFolder.getFolderId(),
+			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
+			"title2", StringUtil.randomString(), StringPool.BLANK, (byte[])null,
+			null, null, serviceContext);
+
+		Assert.assertEquals(
+			0,
+			_dlAppService.getFoldersAndFileEntriesAndFileShortcutsCount(
+				group.getGroupId(), targetGroupFolder.getFolderId(),
+				WorkflowConstants.STATUS_APPROVED,
+				ArrayUtil.toStringArray(DLUtil.getAllMediaGalleryMimeTypes()),
+				false));
+	}
+
+	@Test
 	public void testShouldNotReturnDraftsIfNotOwner() throws Exception {
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(group.getGroupId());
 
 		_dlAppService.addFileEntry(
 			null, group.getGroupId(), parentFolder.getFolderId(),
-			StringUtil.randomString(), MimeTypes.MIME_APPLICATION_OCTET_STREAM,
+			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
 			StringUtil.randomString(), StringUtil.randomString(),
 			StringPool.BLANK, (byte[])null, null, null, serviceContext);
 
@@ -142,7 +176,7 @@ public class DLAppServiceWhenViewingFolderContentsTest
 
 		_dlAppService.addFileEntry(
 			null, group.getGroupId(), parentFolder.getFolderId(),
-			StringUtil.randomString(), MimeTypes.MIME_APPLICATION_OCTET_STREAM,
+			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
 			StringUtil.randomString(), StringUtil.randomString(),
 			StringPool.BLANK, (byte[])null, null, null, serviceContext);
 
@@ -184,7 +218,7 @@ public class DLAppServiceWhenViewingFolderContentsTest
 
 		_dlAppService.addFileEntry(
 			null, group.getGroupId(), parentFolder.getFolderId(),
-			StringUtil.randomString(), MimeTypes.MIME_APPLICATION_OCTET_STREAM,
+			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
 			"title2", StringUtil.randomString(), StringPool.BLANK, (byte[])null,
 			null, null, serviceContext);
 
@@ -204,7 +238,7 @@ public class DLAppServiceWhenViewingFolderContentsTest
 
 		_dlAppService.addFileEntry(
 			null, group.getGroupId(), parentFolder.getFolderId(),
-			StringUtil.randomString(), MimeTypes.MIME_APPLICATION_OCTET_STREAM,
+			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
 			StringUtil.randomString(), StringUtil.randomString(),
 			StringPool.BLANK, (byte[])null, null, null, serviceContext);
 
@@ -212,7 +246,7 @@ public class DLAppServiceWhenViewingFolderContentsTest
 
 		_dlAppService.addFileEntry(
 			null, group.getGroupId(), parentFolder.getFolderId(),
-			StringUtil.randomString(), MimeTypes.MIME_APPLICATION_OCTET_STREAM,
+			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
 			StringUtil.randomString(), StringUtil.randomString(),
 			StringPool.BLANK, (byte[])null, null, null, serviceContext);
 
@@ -236,7 +270,7 @@ public class DLAppServiceWhenViewingFolderContentsTest
 
 		FileEntry fileEntry1 = _dlAppService.addFileEntry(
 			null, group.getGroupId(), parentFolder.getFolderId(),
-			StringUtil.randomString(), MimeTypes.MIME_APPLICATION_OCTET_STREAM,
+			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
 			"title1", StringUtil.randomString(), StringPool.BLANK, (byte[])null,
 			null, null, serviceContext);
 
@@ -247,7 +281,7 @@ public class DLAppServiceWhenViewingFolderContentsTest
 
 		FileEntry fileEntry2 = _dlAppService.addFileEntry(
 			null, group.getGroupId(), parentFolder.getFolderId(),
-			StringUtil.randomString(), MimeTypes.MIME_APPLICATION_OCTET_STREAM,
+			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
 			"title2", StringUtil.randomString(), StringPool.BLANK, (byte[])null,
 			null, null, serviceContext);
 
@@ -258,7 +292,7 @@ public class DLAppServiceWhenViewingFolderContentsTest
 
 		FileEntry fileEntry3 = _dlAppService.addFileEntry(
 			null, group.getGroupId(), parentFolder.getFolderId(),
-			StringUtil.randomString(), MimeTypes.MIME_APPLICATION_OCTET_STREAM,
+			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
 			"title3", StringUtil.randomString(), StringPool.BLANK, (byte[])null,
 			null, null, serviceContext);
 
@@ -302,19 +336,19 @@ public class DLAppServiceWhenViewingFolderContentsTest
 
 		FileEntry fileEntry1 = _dlAppService.addFileEntry(
 			null, group.getGroupId(), parentFolder.getFolderId(),
-			StringUtil.randomString(), MimeTypes.MIME_APPLICATION_OCTET_STREAM,
+			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
 			"title2", StringUtil.randomString(), StringPool.BLANK, (byte[])null,
 			null, null, serviceContext);
 
 		FileEntry fileEntry2 = _dlAppService.addFileEntry(
 			null, group.getGroupId(), parentFolder.getFolderId(),
-			StringUtil.randomString(), MimeTypes.MIME_APPLICATION_OCTET_STREAM,
+			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
 			"title1", StringUtil.randomString(), StringPool.BLANK, (byte[])null,
 			null, null, serviceContext);
 
 		FileEntry fileEntry3 = _dlAppService.addFileEntry(
 			null, group.getGroupId(), parentFolder.getFolderId(),
-			StringUtil.randomString(), MimeTypes.MIME_APPLICATION_OCTET_STREAM,
+			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
 			"title3", StringUtil.randomString(), StringPool.BLANK, (byte[])null,
 			null, null, serviceContext);
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenViewingFolderContentsTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenViewingFolderContentsTest.java
@@ -17,6 +17,7 @@ package com.liferay.document.library.app.service.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.service.DLAppService;
+import com.liferay.document.library.kernel.util.DLUtil;
 import com.liferay.document.library.kernel.util.comparator.RepositoryModelReadCountComparator;
 import com.liferay.document.library.kernel.util.comparator.RepositoryModelTitleComparator;
 import com.liferay.document.library.test.util.BaseDLAppTestCase;
@@ -29,8 +30,11 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.context.ContextUserReplace;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.view.count.ViewCountManager;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
@@ -160,6 +164,37 @@ public class DLAppServiceWhenViewingFolderContentsTest
 		finally {
 			_userLocalService.deleteUser(user.getUserId());
 		}
+	}
+
+	@Test
+	public void testShouldNotReturnNotAcceptedMimeTypes() throws Exception {
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(group.getGroupId());
+
+		_dlAppService.addFolder(
+			group.getGroupId(), parentFolder.getFolderId(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
+
+		_dlAppService.addFileEntry(
+			null, group.getGroupId(), parentFolder.getFolderId(),
+			StringUtil.randomString() + ".jpg", ContentTypes.IMAGE_JPEG,
+			"title1", StringUtil.randomString(), StringPool.BLANK, (byte[])null,
+			null, null, serviceContext);
+
+		_dlAppService.addFileEntry(
+			null, group.getGroupId(), parentFolder.getFolderId(),
+			StringUtil.randomString(), MimeTypes.MIME_APPLICATION_OCTET_STREAM,
+			"title2", StringUtil.randomString(), StringPool.BLANK, (byte[])null,
+			null, null, serviceContext);
+
+		Assert.assertEquals(
+			2,
+			_dlAppService.getFoldersAndFileEntriesAndFileShortcutsCount(
+				group.getGroupId(), parentFolder.getFolderId(),
+				WorkflowConstants.STATUS_APPROVED,
+				ArrayUtil.toStringArray(DLUtil.getAllMediaGalleryMimeTypes()),
+				false));
 	}
 
 	@Test

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFolderServiceTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFolderServiceTest.java
@@ -238,8 +238,8 @@ public class DLFolderServiceTest {
 			actualFoldersAndFileEntriesAndFileShortcuts.toString(), 2,
 			actualFoldersAndFileEntriesAndFileShortcuts.size());
 
-		List<DLFileEntry> actualFileEntries = new ArrayList<>();
-		int actualFolders = 0;
+		List<DLFileEntry> actualDLFileEntries = new ArrayList<>();
+		int actualDLFoldersCount = 0;
 
 		for (Object actualFoldersAndFileEntriesAndFileShortcut :
 				actualFoldersAndFileEntriesAndFileShortcuts) {
@@ -247,31 +247,31 @@ public class DLFolderServiceTest {
 			if (actualFoldersAndFileEntriesAndFileShortcut instanceof
 					DLFileEntry) {
 
-				actualFileEntries.add(
+				actualDLFileEntries.add(
 					(DLFileEntry)actualFoldersAndFileEntriesAndFileShortcut);
 			}
 			else if (actualFoldersAndFileEntriesAndFileShortcut instanceof
 						DLFolder) {
 
-				actualFolders++;
+				actualDLFoldersCount++;
 			}
 		}
 
-		Assert.assertEquals(actualFolders, 1, actualFolders);
+		Assert.assertEquals(actualDLFoldersCount, 1, actualDLFoldersCount);
 
 		Assert.assertEquals(
-			actualFileEntries.size(), 1, actualFileEntries.size());
+			actualDLFileEntries.size(), 1, actualDLFileEntries.size());
 
 		Assert.assertEquals(
 			expectedFileEntries.toString(), expectedFileEntries.size(),
-			actualFileEntries.size());
+			actualDLFileEntries.size());
 
 		FileEntry expectedFileEntry = expectedFileEntries.get(0);
-		DLFileEntry actualFileEntry = actualFileEntries.get(0);
+		DLFileEntry actualDLFileEntry = actualDLFileEntries.get(0);
 
 		Assert.assertEquals(
 			expectedFileEntry.getFileEntryId(),
-			actualFileEntry.getFileEntryId());
+			actualDLFileEntry.getFileEntryId());
 	}
 
 	@Test
@@ -379,16 +379,16 @@ public class DLFolderServiceTest {
 				FileEntry expectedFileEntry =
 					(FileEntry)
 						expectedFoldersAndFileEntriesAndFileShortcuts.get(i);
-				DLFileEntry actualFileEntry =
+				DLFileEntry actualDLFileEntry =
 					(DLFileEntry)
 						actualFoldersAndFileEntriesAndFileShortcuts.get(i);
 
 				Assert.assertEquals(
 					expectedFileEntry.getFileEntryId(),
-					actualFileEntry.getFileEntryId());
+					actualDLFileEntry.getFileEntryId());
 			}
 			else {
-				DLFileShortcut actualFileShortcut =
+				DLFileShortcut actualDLFileShortcut =
 					(DLFileShortcut)
 						actualFoldersAndFileEntriesAndFileShortcuts.get(i);
 				FileShortcut expectedFileShortcut =
@@ -397,7 +397,7 @@ public class DLFolderServiceTest {
 
 				Assert.assertEquals(
 					expectedFileShortcut.getFileShortcutId(),
-					actualFileShortcut.getFileShortcutId());
+					actualDLFileShortcut.getFileShortcutId());
 			}
 		}
 	}
@@ -448,12 +448,12 @@ public class DLFolderServiceTest {
 
 		for (int i = 0; i < 3; i++) {
 			FileEntry expectedFileEntry = expectedFileEntries.get(i);
-			DLFileEntry actualFileEntry =
+			DLFileEntry actualDLFileEntry =
 				(DLFileEntry)actualFoldersAndFileEntriesAndFileShortcuts.get(i);
 
 			Assert.assertEquals(
 				expectedFileEntry.getFileEntryId(),
-				actualFileEntry.getFileEntryId());
+				actualDLFileEntry.getFileEntryId());
 		}
 	}
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFolderServiceTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFolderServiceTest.java
@@ -93,6 +93,39 @@ public class DLFolderServiceTest {
 			StringUtil.randomString(),
 			new long[] {_ddmStructure.getStructureId()},
 			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		_alternativeGroup = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	public void testShouldNotReturnContentOfFolderNotInGroup()
+		throws Exception {
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId());
+
+		serviceContext.setAttribute(
+			"fileEntryTypeId", _dlFileEntryType.getFileEntryTypeId());
+
+		_dlAppService.addFileEntry(
+			null, _group.getGroupId(), _parentFolder.getFolderId(),
+			StringUtil.randomString() + ".jpg", ContentTypes.IMAGE_JPEG,
+			"title1", StringUtil.randomString(), StringPool.BLANK, (byte[])null,
+			null, null, serviceContext);
+
+		_dlAppService.addFileEntry(
+			null, _group.getGroupId(), _parentFolder.getFolderId(),
+			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
+			"title2", StringUtil.randomString(), StringPool.BLANK, (byte[])null,
+			null, null, serviceContext);
+
+		Assert.assertEquals(
+			0,
+			_dlFolderService.getFoldersAndFileEntriesAndFileShortcutsCount(
+				_alternativeGroup.getGroupId(), _parentFolder.getFolderId(),
+				WorkflowConstants.STATUS_APPROVED,
+				ArrayUtil.toStringArray(DLUtil.getAllMediaGalleryMimeTypes()),
+				false));
 	}
 
 	@Test
@@ -438,6 +471,9 @@ public class DLFolderServiceTest {
 
 	@Inject
 	private static ViewCountManager _viewCountManager;
+
+	@DeleteAfterTestRun
+	private Group _alternativeGroup;
 
 	@DeleteAfterTestRun
 	private DDMStructure _ddmStructure;

--- a/modules/apps/document-library/document-library-web/src/test/java/com/liferay/document/library/web/internal/util/DLFolderUtilTest.java
+++ b/modules/apps/document-library/document-library-web/src/test/java/com/liferay/document/library/web/internal/util/DLFolderUtilTest.java
@@ -1,0 +1,148 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.document.library.web.internal.util;
+
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryServiceUtil;
+import com.liferay.document.library.kernel.exception.NoSuchFolderException;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.List;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.mockito.Matchers;
+
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+/**
+ * @author Alicia García
+ */
+@PrepareForTest({GroupLocalServiceUtil.class, DepotEntryServiceUtil.class})
+@RunWith(PowerMockRunner.class)
+public class DLFolderUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testValidateDepotFolder() throws PortalException {
+		PowerMockito.mockStatic(GroupLocalServiceUtil.class);
+
+		long depotGroupId = RandomTestUtil.randomLong();
+
+		Group depotGroup = _getDepotGroup(depotGroupId);
+
+		PowerMockito.when(
+			GroupLocalServiceUtil.getGroup(Matchers.anyLong())
+		).thenReturn(
+			depotGroup
+		);
+
+		PowerMockito.mockStatic(DepotEntryServiceUtil.class);
+
+		List<DepotEntry> depotEntries = _getGroupConnectedDepotEntries(
+			depotGroupId);
+
+		PowerMockito.when(
+			DepotEntryServiceUtil.getGroupConnectedDepotEntries(
+				Matchers.anyLong(), Matchers.anyInt(), Matchers.anyInt())
+		).thenReturn(
+			depotEntries
+		);
+
+		DLFolderUtil.validateDepotFolder(
+			RandomTestUtil.randomLong(), depotGroup.getGroupId(),
+			RandomTestUtil.randomLong());
+	}
+
+	@Test(expected = NoSuchFolderException.class)
+	public void testValidateDepotFolderNotConnected() throws PortalException {
+		PowerMockito.mockStatic(GroupLocalServiceUtil.class);
+
+		long depotGroupId = RandomTestUtil.randomLong();
+
+		Group depotGroup = _getDepotGroup(depotGroupId);
+
+		PowerMockito.when(
+			GroupLocalServiceUtil.getGroup(Matchers.anyLong())
+		).thenReturn(
+			depotGroup
+		);
+
+		PowerMockito.mockStatic(DepotEntryServiceUtil.class);
+
+		List<DepotEntry> depotEntries = _getGroupConnectedDepotEntries(
+			RandomTestUtil.randomLong());
+
+		PowerMockito.when(
+			DepotEntryServiceUtil.getGroupConnectedDepotEntries(
+				Matchers.anyLong(), Matchers.anyInt(), Matchers.anyInt())
+		).thenReturn(
+			depotEntries
+		);
+
+		DLFolderUtil.validateDepotFolder(
+			RandomTestUtil.randomLong(), depotGroup.getGroupId(),
+			RandomTestUtil.randomLong());
+	}
+
+	private DepotEntry _addDepotEntry(long depotGroupId) {
+		DepotEntry depotEntry = PowerMockito.mock(DepotEntry.class);
+
+		PowerMockito.doReturn(
+			depotGroupId
+		).when(
+			depotEntry
+		).getGroupId();
+
+		return depotEntry;
+	}
+
+	private Group _getDepotGroup(long groupId) {
+		Group group = PowerMockito.mock(Group.class);
+
+		PowerMockito.doReturn(
+			true
+		).when(
+			group
+		).isDepot();
+
+		PowerMockito.doReturn(
+			groupId
+		).when(
+			group
+		).getGroupId();
+
+		return group;
+	}
+
+	private List<DepotEntry> _getGroupConnectedDepotEntries(long depotGroupId) {
+		return ListUtil.fromArray(_addDepotEntry(depotGroupId));
+	}
+
+}


### PR DESCRIPTION
- LPS-144839 add test with the mimeType when returning folder content
- LPS-144839 add test to check DLFolderUtil new method
- LPS-144839 add test to check th return the folder in the results of the search
- LPS-144839 add test to check if the folder is no contained on the group do not return values
