### PR TITLE
LPS-118195 Uses new icon defined by Lexicon

### DIFF
--- a/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/display/context/DepotAdminViewDepotDashboardDisplayContext.java
+++ b/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/display/context/DepotAdminViewDepotDashboardDisplayContext.java
@@ -20,6 +20,7 @@ import com.liferay.application.list.PanelCategory;
 import com.liferay.application.list.PanelCategoryRegistry;
 import com.liferay.application.list.constants.PanelCategoryKeys;
 import com.liferay.asset.categories.admin.web.constants.AssetCategoriesAdminPortletKeys;
+import com.liferay.asset.list.constants.AssetListPortletKeys;
 import com.liferay.asset.tags.constants.AssetTagsAdminPortletKeys;
 import com.liferay.depot.web.internal.constants.DepotPortletKeys;
 import com.liferay.depot.web.internal.servlet.taglib.clay.DepotDashboardApplicationNavigationCard;
@@ -142,6 +143,8 @@ public class DepotAdminViewDepotDashboardDisplayContext {
 	private static final Map<String, String> _panelAppIcons =
 		HashMapBuilder.put(
 			AssetCategoriesAdminPortletKeys.ASSET_CATEGORIES_ADMIN, "categories"
+		).put(
+			AssetListPortletKeys.ASSET_LIST, "closed-book"
 		).put(
 			AssetTagsAdminPortletKeys.ASSET_TAGS_ADMIN, "tag"
 		).put(


### PR DESCRIPTION
Motivation
=======
Replace the default icon for collections in Asset Libraries with the new icon defined by Lexicon: https://github.com/liferay/clay/pull/3549

![](https://issues.liferay.com/secure/attachment/366982/366982_Screen+Shot+2020-07-30+at+10.45.01+AM.png)

Proposed Solution
========
Adds new entry in _panelAppIcons Map with the new icon "closed-book" for Collections Panel App (In code it is Asset List Entry portlet)