### PR TITLE
LPS-145967 Move previewURL calculation to D&M info API

### DIFF
--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/item/ContentDashboardItem.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/item/ContentDashboardItem.java
@@ -21,7 +21,6 @@ import com.liferay.content.dashboard.web.internal.item.type.ContentDashboardItem
 import com.liferay.info.item.InfoItemReference;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
-import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 
 import java.util.Date;
 import java.util.List;
@@ -68,10 +67,7 @@ public interface ContentDashboardItem<T> {
 
 	public String getScopeName(Locale locale);
 
-	public default JSONObject getSpecificInformationJSONObject(
-		String backURL, LiferayPortletResponse liferayPortletResponse,
-		Locale locale) {
-
+	public default JSONObject getSpecificInformationJSONObject(Locale locale) {
 		return null;
 	}
 

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/item/ContentDashboardItem.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/item/ContentDashboardItem.java
@@ -22,7 +22,6 @@ import com.liferay.info.item.InfoItemReference;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
-import com.liferay.portal.kernel.theme.ThemeDisplay;
 
 import java.util.Date;
 import java.util.List;
@@ -71,7 +70,7 @@ public interface ContentDashboardItem<T> {
 
 	public default JSONObject getSpecificInformationJSONObject(
 		String backURL, LiferayPortletResponse liferayPortletResponse,
-		Locale locale, ThemeDisplay themeDisplay) {
+		Locale locale) {
 
 		return null;
 	}

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/item/FileEntryContentDashboardItem.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/item/FileEntryContentDashboardItem.java
@@ -332,7 +332,7 @@ public class FileEntryContentDashboardItem
 		).put(
 			"previewImageURL", _getPreviewImageURL()
 		).put(
-			"previewURL", _getPreviewURL(themeDisplay)
+			"previewURL", _getPreviewURL()
 		).put(
 			"size", _getSize(locale)
 		).put(
@@ -480,17 +480,18 @@ public class FileEntryContentDashboardItem
 		return String.valueOf(infoFieldValue.getValue());
 	}
 
-	private String _getPreviewURL(ThemeDisplay themeDisplay) {
-		try {
-			return DLURLHelperUtil.getPreviewURL(
-				_fileEntry, _fileEntry.getFileVersion(), themeDisplay,
-				StringPool.BLANK, false, true);
-		}
-		catch (PortalException portalException) {
-			_log.error(portalException, portalException);
+	private String _getPreviewURL() {
+		InfoItemFieldValues infoItemFieldValues =
+			_infoItemFieldValuesProvider.getInfoItemFieldValues(_fileEntry);
 
-			return null;
+		InfoFieldValue<Object> infoFieldValue =
+			infoItemFieldValues.getInfoFieldValue("previewURL");
+
+		if (infoFieldValue == null) {
+			return StringPool.BLANK;
 		}
+
+		return String.valueOf(infoFieldValue.getValue());
 	}
 
 	private String _getSize(Locale locale) {

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/item/FileEntryContentDashboardItem.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/item/FileEntryContentDashboardItem.java
@@ -23,7 +23,6 @@ import com.liferay.content.dashboard.web.internal.item.action.ContentDashboardIt
 import com.liferay.content.dashboard.web.internal.item.type.ContentDashboardItemSubtype;
 import com.liferay.content.dashboard.web.internal.util.ContentDashboardGroupUtil;
 import com.liferay.document.library.constants.DLPortletKeys;
-import com.liferay.document.library.util.DLURLHelperUtil;
 import com.liferay.info.field.InfoFieldValue;
 import com.liferay.info.item.InfoItemClassDetails;
 import com.liferay.info.item.InfoItemFieldValues;
@@ -42,7 +41,6 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.FileVersion;
-import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -319,7 +317,7 @@ public class FileEntryContentDashboardItem
 	@Override
 	public JSONObject getSpecificInformationJSONObject(
 		String backURL, LiferayPortletResponse liferayPortletResponse,
-		Locale locale, ThemeDisplay themeDisplay) {
+		Locale locale) {
 
 		return JSONUtil.put(
 			"description", getDescription(locale)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/item/FileEntryContentDashboardItemFactory.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/item/FileEntryContentDashboardItemFactory.java
@@ -22,6 +22,7 @@ import com.liferay.content.dashboard.web.internal.item.type.ContentDashboardItem
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFileEntryType;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
+import com.liferay.document.library.util.DLURLHelper;
 import com.liferay.info.item.InfoItemServiceTracker;
 import com.liferay.info.item.provider.InfoItemFieldValuesProvider;
 import com.liferay.portal.kernel.exception.NoSuchModelException;
@@ -30,6 +31,7 @@ import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.Portal;
 
 import java.util.Optional;
@@ -78,7 +80,8 @@ public class FileEntryContentDashboardItemFactory
 			_contentDashboardItemActionProviderTracker,
 			contentDashboardItemSubtypeFactory.create(
 				dlFileEntry.getFileEntryTypeId()),
-			fileEntry, _groupLocalService.fetchGroup(fileEntry.getGroupId()),
+			_dlURLHelper, fileEntry,
+			_groupLocalService.fetchGroup(fileEntry.getGroupId()), _http,
 			infoItemFieldValuesProvider, _language, _portal);
 	}
 
@@ -109,7 +112,13 @@ public class FileEntryContentDashboardItemFactory
 	private DLAppLocalService _dlAppLocalService;
 
 	@Reference
+	private DLURLHelper _dlURLHelper;
+
+	@Reference
 	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private Http _http;
 
 	@Reference
 	private Language _language;

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/item/JournalArticleContentDashboardItem.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/item/JournalArticleContentDashboardItem.java
@@ -34,7 +34,6 @@ import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -314,10 +313,7 @@ public class JournalArticleContentDashboardItem
 	}
 
 	@Override
-	public JSONObject getSpecificInformationJSONObject(
-		String backURL, LiferayPortletResponse liferayPortletResponse,
-		Locale locale) {
-
+	public JSONObject getSpecificInformationJSONObject(Locale locale) {
 		return JSONUtil.put(
 			"creationDate", _journalArticle.getCreateDate()
 		).put(

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/item/JournalArticleContentDashboardItem.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/item/JournalArticleContentDashboardItem.java
@@ -35,7 +35,6 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
-import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -317,7 +316,7 @@ public class JournalArticleContentDashboardItem
 	@Override
 	public JSONObject getSpecificInformationJSONObject(
 		String backURL, LiferayPortletResponse liferayPortletResponse,
-		Locale locale, ThemeDisplay themeDisplay) {
+		Locale locale) {
 
 		return JSONUtil.put(
 			"creationDate", _journalArticle.getCreateDate()

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/portlet/action/GetContentDashboardItemInfoMVCResourceCommand.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/portlet/action/GetContentDashboardItemInfoMVCResourceCommand.java
@@ -140,7 +140,7 @@ public class GetContentDashboardItemInfoMVCResourceCommand
 					contentDashboardItem.getSpecificInformationJSONObject(
 						ParamUtil.getString(resourceRequest, "backURL"),
 						_portal.getLiferayPortletResponse(resourceResponse),
-						locale, themeDisplay)
+						locale)
 				).put(
 					"subType", _getSubtype(contentDashboardItem, locale)
 				).put(

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/portlet/action/GetContentDashboardItemInfoMVCResourceCommand.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/portlet/action/GetContentDashboardItemInfoMVCResourceCommand.java
@@ -138,8 +138,6 @@ public class GetContentDashboardItemInfoMVCResourceCommand
 				).put(
 					"specificFields",
 					contentDashboardItem.getSpecificInformationJSONObject(
-						ParamUtil.getString(resourceRequest, "backURL"),
-						_portal.getLiferayPortletResponse(resourceResponse),
 						locale)
 				).put(
 					"subType", _getSubtype(contentDashboardItem, locale)

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/portlet/action/GetContentDashboardItemsXlsMVCResourceCommand.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/portlet/action/GetContentDashboardItemsXlsMVCResourceCommand.java
@@ -34,7 +34,6 @@ import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.ListUtil;
-import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -183,8 +182,6 @@ public class GetContentDashboardItemsXlsMVCResourceCommand
 			if (contentDashboardItem instanceof FileEntryContentDashboardItem) {
 				JSONObject jsonObject =
 					contentDashboardItem.getSpecificInformationJSONObject(
-						ParamUtil.getString(resourceRequest, "backURL"),
-						_portal.getLiferayPortletResponse(resourceResponse),
 						locale);
 
 				if (jsonObject != null) {
@@ -205,8 +202,6 @@ public class GetContentDashboardItemsXlsMVCResourceCommand
 
 				JSONObject jsonObject =
 					contentDashboardItem.getSpecificInformationJSONObject(
-						ParamUtil.getString(resourceRequest, "backURL"),
-						_portal.getLiferayPortletResponse(resourceResponse),
 						locale);
 
 				if (jsonObject != null) {

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/portlet/action/GetContentDashboardItemsXlsMVCResourceCommand.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/portlet/action/GetContentDashboardItemsXlsMVCResourceCommand.java
@@ -185,7 +185,7 @@ public class GetContentDashboardItemsXlsMVCResourceCommand
 					contentDashboardItem.getSpecificInformationJSONObject(
 						ParamUtil.getString(resourceRequest, "backURL"),
 						_portal.getLiferayPortletResponse(resourceResponse),
-						locale, themeDisplay);
+						locale);
 
 				if (jsonObject != null) {
 					workbookBuilder.cell(
@@ -207,7 +207,7 @@ public class GetContentDashboardItemsXlsMVCResourceCommand
 					contentDashboardItem.getSpecificInformationJSONObject(
 						ParamUtil.getString(resourceRequest, "backURL"),
 						_portal.getLiferayPortletResponse(resourceResponse),
-						locale, themeDisplay);
+						locale);
 
 				if (jsonObject != null) {
 					workbookBuilder.cellIndexIncrement(

--- a/modules/apps/content-dashboard/content-dashboard-web/src/test/java/com/liferay/content/dashboard/web/internal/item/FileEntryContentDashboardItemTest.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/test/java/com/liferay/content/dashboard/web/internal/item/FileEntryContentDashboardItemTest.java
@@ -95,7 +95,7 @@ public class FileEntryContentDashboardItemTest {
 		FileEntryContentDashboardItem fileEntryContentDashboardItem =
 			new FileEntryContentDashboardItem(
 				Collections.singletonList(assetCategory), null, null, null,
-				fileEntry, null, null, null, null);
+				null, fileEntry, null, null, null, null, null);
 
 		Assert.assertEquals(
 			Collections.singletonList(assetCategory),
@@ -117,7 +117,7 @@ public class FileEntryContentDashboardItemTest {
 		FileEntryContentDashboardItem fileEntryContentDashboardItem =
 			new FileEntryContentDashboardItem(
 				Collections.singletonList(assetCategory), null, null, null,
-				fileEntry, null, null, null, null);
+				null, fileEntry, null, null, null, null, null);
 
 		Assert.assertEquals(
 			Collections.singletonList(assetCategory),
@@ -131,7 +131,8 @@ public class FileEntryContentDashboardItemTest {
 
 		FileEntryContentDashboardItem fileEntryContentDashboardItem =
 			new FileEntryContentDashboardItem(
-				null, null, null, null, fileEntry, null, null, null, null);
+				null, null, null, null, null, fileEntry, null, null, null, null,
+				null);
 
 		Assert.assertEquals(
 			Collections.emptyList(),
@@ -153,7 +154,7 @@ public class FileEntryContentDashboardItemTest {
 		FileEntryContentDashboardItem fileEntryContentDashboardItem =
 			new FileEntryContentDashboardItem(
 				Collections.singletonList(assetCategory), null, null, null,
-				fileEntry, null, null, null, null);
+				null, fileEntry, null, null, null, null, null);
 
 		Assert.assertEquals(
 			Collections.emptyList(),
@@ -169,8 +170,8 @@ public class FileEntryContentDashboardItemTest {
 
 		FileEntryContentDashboardItem fileEntryContentDashboardItem =
 			new FileEntryContentDashboardItem(
-				null, Collections.singletonList(assetTag), null, null,
-				fileEntry, null, null, null, null);
+				null, Collections.singletonList(assetTag), null, null, null,
+				fileEntry, null, null, null, null, null);
 
 		Assert.assertEquals(
 			Collections.singletonList(assetTag),
@@ -210,7 +211,7 @@ public class FileEntryContentDashboardItemTest {
 
 		FileEntryContentDashboardItem fileEntryContentDashboardItem =
 			new FileEntryContentDashboardItem(
-				null, null, null, null, fileEntry, null,
+				null, null, null, null, null, fileEntry, null, null,
 				infoItemFieldValuesProvider, null, null);
 
 		Assert.assertEquals(
@@ -224,7 +225,8 @@ public class FileEntryContentDashboardItemTest {
 
 		FileEntryContentDashboardItem fileEntryContentDashboardItem =
 			new FileEntryContentDashboardItem(
-				null, null, null, null, fileEntry, null, null, null, null);
+				null, null, null, null, null, fileEntry, null, null, null, null,
+				null);
 
 		Assert.assertEquals(
 			fileEntry.getModifiedDate(),
@@ -245,7 +247,8 @@ public class FileEntryContentDashboardItemTest {
 
 		FileEntryContentDashboardItem fileEntryContentDashboardItem =
 			new FileEntryContentDashboardItem(
-				null, null, null, null, fileEntry, group, null, null, null);
+				null, null, null, null, null, fileEntry, group, null, null,
+				null, null);
 
 		Assert.assertEquals(
 			"scopeName",
@@ -292,7 +295,7 @@ public class FileEntryContentDashboardItemTest {
 					}
 
 				},
-				fileEntry, null, null, null, null);
+				null, fileEntry, null, null, null, null, null);
 
 		ContentDashboardItemSubtype contentDashboardItemType =
 			fileEntryContentDashboardItem.getContentDashboardItemSubtype();
@@ -307,7 +310,8 @@ public class FileEntryContentDashboardItemTest {
 
 		FileEntryContentDashboardItem fileEntryContentDashboardItem =
 			new FileEntryContentDashboardItem(
-				null, null, null, null, fileEntry, null, null, null, null);
+				null, null, null, null, null, fileEntry, null, null, null, null,
+				null);
 
 		Assert.assertEquals(
 			fileEntry.getTitle(),
@@ -326,7 +330,8 @@ public class FileEntryContentDashboardItemTest {
 
 		FileEntryContentDashboardItem fileEntryContentDashboardItem =
 			new FileEntryContentDashboardItem(
-				null, null, null, null, fileEntry, null, null, null, null);
+				null, null, null, null, null, fileEntry, null, null, null, null,
+				null);
 
 		Assert.assertEquals(
 			fileEntry.getUserId(), fileEntryContentDashboardItem.getUserId());
@@ -344,7 +349,8 @@ public class FileEntryContentDashboardItemTest {
 
 		FileEntryContentDashboardItem fileEntryContentDashboardItem =
 			new FileEntryContentDashboardItem(
-				null, null, null, null, fileEntry, null, null, null, null);
+				null, null, null, null, null, fileEntry, null, null, null, null,
+				null);
 
 		Assert.assertEquals(
 			fileEntry.getUserId(), fileEntryContentDashboardItem.getUserId());
@@ -372,7 +378,7 @@ public class FileEntryContentDashboardItemTest {
 					_getContentDashboardItemActionProvider(
 						ContentDashboardItemAction.Type.VIEW,
 						"http://localhost:8080/view")),
-				null, fileEntry, null, null, _getLanguage(), null);
+				null, null, fileEntry, null, null, null, _getLanguage(), null);
 
 		Assert.assertTrue(
 			fileEntryContentDashboardItem.isViewable(

--- a/modules/apps/content-dashboard/content-dashboard-web/src/test/java/com/liferay/content/dashboard/web/internal/portlet/action/GetContentDashboardItemInfoMVCResourceCommandTest.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/test/java/com/liferay/content/dashboard/web/internal/portlet/action/GetContentDashboardItemInfoMVCResourceCommandTest.java
@@ -166,9 +166,7 @@ public class GetContentDashboardItemInfoMVCResourceCommandTest {
 			contentDashboardItem.getSpecificInformationJSONObject(
 				"backURL",
 				portal.getLiferayPortletResponse(mockLiferayResourceResponse),
-				LocaleUtil.US,
-				(ThemeDisplay)mockLiferayResourceRequest.getAttribute(
-					WebKeys.THEME_DISPLAY));
+				LocaleUtil.US);
 
 		Assert.assertEquals(
 			getSpecificInformationJSONObject.toString(),
@@ -357,7 +355,7 @@ public class GetContentDashboardItemInfoMVCResourceCommandTest {
 			@Override
 			public JSONObject getSpecificInformationJSONObject(
 				String backURL, LiferayPortletResponse liferayPortletResponse,
-				Locale locale, ThemeDisplay themeDisplay) {
+				Locale locale) {
 
 				JSONObject jsonObject = new JSONObjectImpl();
 

--- a/modules/apps/content-dashboard/content-dashboard-web/src/test/java/com/liferay/content/dashboard/web/internal/portlet/action/GetContentDashboardItemInfoMVCResourceCommandTest.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/test/java/com/liferay/content/dashboard/web/internal/portlet/action/GetContentDashboardItemInfoMVCResourceCommandTest.java
@@ -30,7 +30,6 @@ import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.User;
-import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.servlet.BrowserSnifferUtil;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
@@ -39,7 +38,6 @@ import com.liferay.portal.kernel.test.portlet.MockLiferayResourceResponse;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.LocaleUtil;
-import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.servlet.BrowserSnifferImpl;
@@ -160,12 +158,8 @@ public class GetContentDashboardItemInfoMVCResourceCommandTest {
 			contentDashboardItemSubtype.getLabel(LocaleUtil.US),
 			jsonObject.getString("subType"));
 
-		Portal portal = PortalUtil.getPortal();
-
 		JSONObject getSpecificInformationJSONObject =
 			contentDashboardItem.getSpecificInformationJSONObject(
-				"backURL",
-				portal.getLiferayPortletResponse(mockLiferayResourceResponse),
 				LocaleUtil.US);
 
 		Assert.assertEquals(
@@ -353,10 +347,7 @@ public class GetContentDashboardItemInfoMVCResourceCommandTest {
 			}
 
 			@Override
-			public JSONObject getSpecificInformationJSONObject(
-				String backURL, LiferayPortletResponse liferayPortletResponse,
-				Locale locale) {
-
+			public JSONObject getSpecificInformationJSONObject(Locale locale) {
 				JSONObject jsonObject = new JSONObjectImpl();
 
 				jsonObject.put(

--- a/modules/apps/content-dashboard/content-dashboard-web/src/test/java/com/liferay/content/dashboard/web/internal/servlet/taglib/util/ContentDashboardDropdownItemsProviderTest.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/test/java/com/liferay/content/dashboard/web/internal/servlet/taglib/util/ContentDashboardDropdownItemsProviderTest.java
@@ -30,7 +30,6 @@ import com.liferay.portal.kernel.test.portlet.MockLiferayPortletRenderRequest;
 import com.liferay.portal.kernel.test.portlet.MockLiferayPortletRenderResponse;
 import com.liferay.portal.kernel.test.portlet.MockLiferayPortletURL;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
-import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -322,7 +321,7 @@ public class ContentDashboardDropdownItemsProviderTest {
 			@Override
 			public JSONObject getSpecificInformationJSONObject(
 				String backURL, LiferayPortletResponse liferayPortletResponse,
-				Locale locale, ThemeDisplay themeDisplay) {
+				Locale locale) {
 
 				return null;
 			}

--- a/modules/apps/content-dashboard/content-dashboard-web/src/test/java/com/liferay/content/dashboard/web/internal/servlet/taglib/util/ContentDashboardDropdownItemsProviderTest.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/test/java/com/liferay/content/dashboard/web/internal/servlet/taglib/util/ContentDashboardDropdownItemsProviderTest.java
@@ -25,7 +25,6 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.language.LanguageUtil;
-import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.test.portlet.MockLiferayPortletRenderRequest;
 import com.liferay.portal.kernel.test.portlet.MockLiferayPortletRenderResponse;
 import com.liferay.portal.kernel.test.portlet.MockLiferayPortletURL;
@@ -319,10 +318,7 @@ public class ContentDashboardDropdownItemsProviderTest {
 			}
 
 			@Override
-			public JSONObject getSpecificInformationJSONObject(
-				String backURL, LiferayPortletResponse liferayPortletResponse,
-				Locale locale) {
-
+			public JSONObject getSpecificInformationJSONObject(Locale locale) {
 				return null;
 			}
 

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/info/item/FileEntryInfoItemFields.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/info/item/FileEntryInfoItemFields.java
@@ -137,6 +137,16 @@ public class FileEntryInfoItemFields {
 			InfoLocalizedValue.localize(
 				FileEntryInfoItemFields.class, "preview-image")
 		).build();
+	public static final InfoField<URLInfoFieldType> previewURL =
+		InfoField.builder(
+		).infoFieldType(
+			URLInfoFieldType.INSTANCE
+		).name(
+			"previewURL"
+		).labelInfoLocalizedValue(
+			InfoLocalizedValue.localize(
+				FileEntryInfoItemFields.class, "preview-url")
+		).build();
 	public static final InfoField<DateInfoFieldType> publishDateInfoField =
 		InfoField.builder(
 		).infoFieldType(

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/info/item/provider/FileEntryInfoItemFieldValuesProvider.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/info/item/provider/FileEntryInfoItemFieldValuesProvider.java
@@ -276,6 +276,16 @@ public class FileEntryInfoItemFieldValuesProvider
 						FileEntryInfoItemFields.downloadURL, downloadURL));
 			}
 
+			String previewURL = _dlURLHelper.getPreviewURL(
+				fileEntry, fileEntry.getFileVersion(), themeDisplay,
+				StringPool.BLANK, false, true);
+
+			if (Validator.isNotNull(previewURL)) {
+				fileEntryFieldValues.add(
+					new InfoFieldValue<>(
+						FileEntryInfoItemFields.previewURL, previewURL));
+			}
+
 			WebImage imagePreviewURLWebImage = new WebImage(
 				_dlURLHelper.getImagePreviewURL(fileEntry, null),
 				new InfoItemReference(


### PR DESCRIPTION
Motivation
=======
We are using themeDisplay and LiferayPortletURL in Content Dashboard API (these are not correct parameters for an API)
[LPS-145967](https://issues.liferay.com/browse/LPS-145967)

Proposed Solution
========
Move previewURL code to the Document&Media Info API and remove LiferayPortletRequest and ThemeDisplay as parameters

Steps to Verify:
----------------
1.This is not a change with funtional impact so all Content Dashboard Info Panel tests should work as in the previous versions.