### PR TITLE
LPS-146237

### DIFF
--- a/modules/apps/document-library/document-library-preview-document/src/main/resources/META-INF/resources/preview/js/DocumentPreviewer.es.js
+++ b/modules/apps/document-library/document-library-preview-document/src/main/resources/META-INF/resources/preview/js/DocumentPreviewer.es.js
@@ -95,11 +95,19 @@ const DocumentPreviewer = ({baseImageURL, initialPage, totalPages}) => {
 		}, 100);
 	}
 
+	const createImageURL = (page) => {
+		const pos = baseImageURL.search('previewFileIndex=') + 17;
+		const imageURL =
+			baseImageURL.slice(0, pos) + page + baseImageURL.slice(pos);
+
+		return imageURL;
+	};
+
 	const loadPage = (page) => {
 		let pagePromise = loadedPages[page] && loadedPages[page].pagePromise;
 
 		if (!pagePromise) {
-			pagePromise = imagePromise(`${baseImageURL}${page}`).then(() => {
+			pagePromise = imagePromise(`${createImageURL(page)}`).then(() => {
 				loadedPages[page].loaded = true;
 			});
 
@@ -214,7 +222,7 @@ const DocumentPreviewer = ({baseImageURL, initialPage, totalPages}) => {
 						className={`preview-file-document ${
 							!expanded && 'preview-file-document-fit'
 						}`}
-						src={`${baseImageURL}${currentPage}`}
+						src={`${createImageURL(currentPage)}`}
 					/>
 				)}
 			</div>

--- a/modules/apps/document-library/document-library-preview-document/test/__snapshots__/DocumentPreviewer.es.js.snap
+++ b/modules/apps/document-library/document-library-preview-document/test/__snapshots__/DocumentPreviewer.es.js.snap
@@ -10,7 +10,7 @@ exports[`document-library-preview-document renders a document previewer with nin
     >
       <img
         class="preview-file-document preview-file-document-fit"
-        src="/document-images/5"
+        src="/document-images5/"
       />
     </div>
     <div
@@ -93,7 +93,7 @@ exports[`document-library-preview-document renders a document previewer with ten
     >
       <img
         class="preview-file-document preview-file-document-fit"
-        src="/document-images/1"
+        src="/document-images1/"
       />
     </div>
     <div


### PR DESCRIPTION
Original notes from @javalosjr96:

> Ticket:
> https://issues.liferay.com/browse/LPS-146237
> 
> Issue:
> PDF's cannot be view in the recycle bin.
> 
> Cause:
> When a PDF is previewed normally in Documents and Media, the source URL(baseImageURL)
>  (e.g. http://localhost:8080/documents/20121/0/Test.pdf/a25f2a25-ae2d-aaa9-ee47-4208f5b07001?version=1.0&t=1643171833892&previewFileIndex=)
> has an HTTP parameter for the page index that is appended when the preview is viewed in DocumentPreview.es.js.  
> 
> ```
> 					<img
> 						className={`preview-file-document ${
> 							!expanded && 'preview-file-document-fit'
> 						}`}
> 						src={`${baseImageURL}${currentPage}`}
> 					/>
> ```
>  When the PDF is moved to the recycle bin, the baseImageURL changes. (e.g.http://localhost:8080/documents/20121/0/Test.pdf/a25f2a25-ae2d-aaa9-ee47-4208f5b07001?version=1.0&t=1643171833892&previewFileIndex=&status=8) and a status parameter is added.  
> However, the logic remains the same and the page index is appended incorrectly to the end of the baseImageURL causing the 404 error.
>  
>  Solution:
>  Created a method that inserts the page index in the correct position. 


> There was also promise errors that were thrown due to the method call ` loadPage` having similar logic which is also resolved. 