### PR TITLE
LPS-146060 Display contents of selected root folder

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminDisplayContext.java
@@ -259,6 +259,11 @@ public class DLAdminDisplayContext {
 			_repositoryId = folder.getRepositoryId();
 		}
 		else {
+			_repositoryId =
+				_dlPortletInstanceSettings.getSelectedRepositoryId();
+		}
+
+		if (_repositoryId == 0) {
 			_repositoryId = ParamUtil.getLong(
 				_httpServletRequest, "repositoryId",
 				_themeDisplay.getScopeGroupId());

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/exportimport/portlet/preferences/processor/DLExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/exportimport/portlet/preferences/processor/DLExportImportPortletPreferencesProcessor.java
@@ -340,6 +340,25 @@ public class DLExportImportPortletPreferencesProcessor
 				}
 			}
 		}
+		else {
+			try {
+				long selectedRepositoryId = GetterUtil.getLong(
+					portletPreferences.getValue("selectedRepositoryId", null));
+
+				if (selectedRepositoryId ==
+						portletDataContext.getSourceGroupId()) {
+
+					portletPreferences.setValue(
+						"selectedRepositoryId",
+						String.valueOf(portletDataContext.getGroupId()));
+				}
+			}
+			catch (ReadOnlyException readOnlyException) {
+				throw new PortletDataException(
+					"Unable to update portlet preferences during import",
+					readOnlyException);
+			}
+		}
 
 		// Root folder is not set, need to import everything
 


### PR DESCRIPTION
This PR fixes two issues:

1. Makes sure we use the configured repository ID when the root folder is selected.

2. When importing the portlet preferences, if the DL portlet is configured to point to itself, translate the group ID so that it refers the correct group (staged or live).

Note that for other cases (e.g. configured to point to Global or anAsset Library) we don't do the translation. The reason is that,  in general, you want Live to look exactly like Staging after a publication. If we showed the staged group, Live would not be the same as Staged until the other group is published as well.