### PR TITLE
[TECHNICAL SUPPORT] LPS-146530 Document Does Not Checkin after Edit in Office 365

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/checkin/Checkin.es.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/checkin/Checkin.es.js
@@ -13,7 +13,7 @@
  */
 
 import {useModal} from '@clayui/modal';
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 
 import CheckinModal from './CheckinModal.es';
 
@@ -34,20 +34,26 @@ export default function Checkin({
 		onClose: handleOnClose,
 	});
 
-	if (!Liferay.component(bridgeComponentId)) {
-		Liferay.component(
-			bridgeComponentId,
-			{
-				open: (callback) => {
-					setCallback(() => callback);
-					setShowModal(true);
+	useEffect(() => {
+		if (!Liferay.component(bridgeComponentId)) {
+			Liferay.component(
+				bridgeComponentId,
+				{
+					open: (callback) => {
+						setCallback(() => callback);
+						setShowModal(true);
+					},
 				},
-			},
-			{
-				destroyOnNavigate: true,
-			}
-		);
-	}
+				{
+					destroyOnNavigate: true,
+				}
+			);
+		}
+
+		return () => {
+			Liferay.destroyComponent(bridgeComponentId);
+		};
+	}, []);
 
 	return (
 		<>


### PR DESCRIPTION
This message was written by Norbert:

Hey,

[LPS-146530](https://issues.liferay.com/browse/LPS-146530)

I'd like to start with the requirement to reproduce this issue is you will need a company account at Office 365 with active license to the programs like word. I had to request it trough IS and it took a bit of time.
In case you want just reach out to me and we can schedule a call for reproduction on my machine with my credentials.

About the issue: We are using effects in a functional component in a dangerous way.
When the user edits a document trough office 365, we will open a new tab and reload the documents and media page.
The problem here, is that our Liferay.component registered modal is still alive and its open method will reference setState methods that are not part of the current React component's scope.

As per [the react documentation about useEffect](https://reactjs.org/docs/hooks-effect.html#example-using-hooks-1) I refactored the code to make sure we handle this effect in our component proper lifecycles and also clean up after we unmount the react component.

Please review my change