### PR TITLE
[TS] LPS-146269 NullPointerException is thrown if keystore file does not exist

### DIFF
--- a/modules/apps/portal-store/portal-store-gcs/src/main/java/com/liferay/portal/store/gcs/GCSStore.java
+++ b/modules/apps/portal-store/portal-store-gcs/src/main/java/com/liferay/portal/store/gcs/GCSStore.java
@@ -131,14 +131,20 @@ public class GCSStore implements Store {
 
 	@Override
 	public InputStream getFileAsStream(
-		long companyId, long repositoryId, String fileName,
-		String versionLabel) {
+			long companyId, long repositoryId, String fileName,
+			String versionLabel)
+		throws NoSuchFileException {
 
 		Blob blob = _gcsStore.get(
 			BlobId.of(
 				_gcsStoreConfiguration.bucketName(),
 				_getHeadVersionLabel(
 					companyId, repositoryId, fileName, versionLabel)));
+
+		if (blob == null) {
+			throw new NoSuchFileException(
+				companyId, repositoryId, fileName, versionLabel);
+		}
 
 		return Channels.newInputStream(_getReadChannel(blob));
 	}


### PR DESCRIPTION
[LPS-146269](https://issues.liferay.com/browse/LPS-146269)
Dear Lima Team,

I think this change belongs to you. Please let me know if I am wrong and should send it to somewhere else.

Thank you,
Istvan