### PR TITLE
LPS-146764 Export depot connecitons between staging and live

### DIFF
--- a/modules/apps/depot/depot-api/bnd.bnd
+++ b/modules/apps/depot/depot-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Depot API
 Bundle-SymbolicName: com.liferay.depot.api
-Bundle-Version: 3.3.1
+Bundle-Version: 3.4.0
 Export-Package:\
 	com.liferay.depot.application,\
 	com.liferay.depot.configuration,\

--- a/modules/apps/depot/depot-api/build.gradle
+++ b/modules/apps/depot/depot-api/build.gradle
@@ -3,6 +3,7 @@ dependencies {
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	compileOnly group: "org.osgi", name: "org.osgi.annotation.versioning", version: "1.1.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
+	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-sql-dsl-api")
 	compileOnly project(":core:petra:petra-string")
 }

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/model/DepotAppCustomizationModel.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/model/DepotAppCustomizationModel.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
+import com.liferay.portal.kernel.model.change.tracking.CTModel;
 
 import org.osgi.annotation.versioning.ProviderType;
 
@@ -34,7 +35,8 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface DepotAppCustomizationModel
-	extends BaseModel<DepotAppCustomization>, MVCCModel, ShardedModel {
+	extends BaseModel<DepotAppCustomization>, CTModel<DepotAppCustomization>,
+			MVCCModel, ShardedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -47,6 +49,7 @@ public interface DepotAppCustomizationModel
 	 *
 	 * @return the primary key of this depot app customization
 	 */
+	@Override
 	public long getPrimaryKey();
 
 	/**
@@ -54,6 +57,7 @@ public interface DepotAppCustomizationModel
 	 *
 	 * @param primaryKey the primary key of this depot app customization
 	 */
+	@Override
 	public void setPrimaryKey(long primaryKey);
 
 	/**
@@ -71,6 +75,22 @@ public interface DepotAppCustomizationModel
 	 */
 	@Override
 	public void setMvccVersion(long mvccVersion);
+
+	/**
+	 * Returns the ct collection ID of this depot app customization.
+	 *
+	 * @return the ct collection ID of this depot app customization
+	 */
+	@Override
+	public long getCtCollectionId();
+
+	/**
+	 * Sets the ct collection ID of this depot app customization.
+	 *
+	 * @param ctCollectionId the ct collection ID of this depot app customization
+	 */
+	@Override
+	public void setCtCollectionId(long ctCollectionId);
 
 	/**
 	 * Returns the depot app customization ID of this depot app customization.

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/model/DepotAppCustomizationSoap.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/model/DepotAppCustomizationSoap.java
@@ -35,6 +35,7 @@ public class DepotAppCustomizationSoap implements Serializable {
 		DepotAppCustomizationSoap soapModel = new DepotAppCustomizationSoap();
 
 		soapModel.setMvccVersion(model.getMvccVersion());
+		soapModel.setCtCollectionId(model.getCtCollectionId());
 		soapModel.setDepotAppCustomizationId(
 			model.getDepotAppCustomizationId());
 		soapModel.setCompanyId(model.getCompanyId());
@@ -111,6 +112,14 @@ public class DepotAppCustomizationSoap implements Serializable {
 		_mvccVersion = mvccVersion;
 	}
 
+	public long getCtCollectionId() {
+		return _ctCollectionId;
+	}
+
+	public void setCtCollectionId(long ctCollectionId) {
+		_ctCollectionId = ctCollectionId;
+	}
+
 	public long getDepotAppCustomizationId() {
 		return _depotAppCustomizationId;
 	}
@@ -156,6 +165,7 @@ public class DepotAppCustomizationSoap implements Serializable {
 	}
 
 	private long _mvccVersion;
+	private long _ctCollectionId;
 	private long _depotAppCustomizationId;
 	private long _companyId;
 	private long _depotEntryId;

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/model/DepotAppCustomizationTable.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/model/DepotAppCustomizationTable.java
@@ -35,6 +35,9 @@ public class DepotAppCustomizationTable
 	public final Column<DepotAppCustomizationTable, Long> mvccVersion =
 		createColumn(
 			"mvccVersion", Long.class, Types.BIGINT, Column.FLAG_NULLITY);
+	public final Column<DepotAppCustomizationTable, Long> ctCollectionId =
+		createColumn(
+			"ctCollectionId", Long.class, Types.BIGINT, Column.FLAG_PRIMARY);
 	public final Column<DepotAppCustomizationTable, Long>
 		depotAppCustomizationId = createColumn(
 			"depotAppCustomizationId", Long.class, Types.BIGINT,

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/model/DepotAppCustomizationWrapper.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/model/DepotAppCustomizationWrapper.java
@@ -19,6 +19,8 @@ import com.liferay.portal.kernel.model.wrapper.BaseModelWrapper;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
 
 /**
  * <p>
@@ -44,6 +46,7 @@ public class DepotAppCustomizationWrapper
 		Map<String, Object> attributes = new HashMap<String, Object>();
 
 		attributes.put("mvccVersion", getMvccVersion());
+		attributes.put("ctCollectionId", getCtCollectionId());
 		attributes.put("depotAppCustomizationId", getDepotAppCustomizationId());
 		attributes.put("companyId", getCompanyId());
 		attributes.put("depotEntryId", getDepotEntryId());
@@ -59,6 +62,12 @@ public class DepotAppCustomizationWrapper
 
 		if (mvccVersion != null) {
 			setMvccVersion(mvccVersion);
+		}
+
+		Long ctCollectionId = (Long)attributes.get("ctCollectionId");
+
+		if (ctCollectionId != null) {
+			setCtCollectionId(ctCollectionId);
 		}
 
 		Long depotAppCustomizationId = (Long)attributes.get(
@@ -106,6 +115,16 @@ public class DepotAppCustomizationWrapper
 	@Override
 	public long getCompanyId() {
 		return model.getCompanyId();
+	}
+
+	/**
+	 * Returns the ct collection ID of this depot app customization.
+	 *
+	 * @return the ct collection ID of this depot app customization
+	 */
+	@Override
+	public long getCtCollectionId() {
+		return model.getCtCollectionId();
 	}
 
 	/**
@@ -194,6 +213,16 @@ public class DepotAppCustomizationWrapper
 	}
 
 	/**
+	 * Sets the ct collection ID of this depot app customization.
+	 *
+	 * @param ctCollectionId the ct collection ID of this depot app customization
+	 */
+	@Override
+	public void setCtCollectionId(long ctCollectionId) {
+		model.setCtCollectionId(ctCollectionId);
+	}
+
+	/**
 	 * Sets the depot app customization ID of this depot app customization.
 	 *
 	 * @param depotAppCustomizationId the depot app customization ID of this depot app customization
@@ -251,6 +280,20 @@ public class DepotAppCustomizationWrapper
 	@Override
 	public void setPrimaryKey(long primaryKey) {
 		model.setPrimaryKey(primaryKey);
+	}
+
+	@Override
+	public Map<String, Function<DepotAppCustomization, Object>>
+		getAttributeGetterFunctions() {
+
+		return model.getAttributeGetterFunctions();
+	}
+
+	@Override
+	public Map<String, BiConsumer<DepotAppCustomization, Object>>
+		getAttributeSetterBiConsumers() {
+
+		return model.getAttributeSetterBiConsumers();
 	}
 
 	@Override

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/model/DepotEntryGroupRelModel.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/model/DepotEntryGroupRelModel.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
 import com.liferay.portal.kernel.model.StagedGroupedModel;
+import com.liferay.portal.kernel.model.change.tracking.CTModel;
 
 import java.util.Date;
 
@@ -37,8 +38,8 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface DepotEntryGroupRelModel
-	extends BaseModel<DepotEntryGroupRel>, MVCCModel, ShardedModel,
-			StagedGroupedModel {
+	extends BaseModel<DepotEntryGroupRel>, CTModel<DepotEntryGroupRel>,
+			MVCCModel, ShardedModel, StagedGroupedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -51,6 +52,7 @@ public interface DepotEntryGroupRelModel
 	 *
 	 * @return the primary key of this depot entry group rel
 	 */
+	@Override
 	public long getPrimaryKey();
 
 	/**
@@ -58,6 +60,7 @@ public interface DepotEntryGroupRelModel
 	 *
 	 * @param primaryKey the primary key of this depot entry group rel
 	 */
+	@Override
 	public void setPrimaryKey(long primaryKey);
 
 	/**
@@ -75,6 +78,22 @@ public interface DepotEntryGroupRelModel
 	 */
 	@Override
 	public void setMvccVersion(long mvccVersion);
+
+	/**
+	 * Returns the ct collection ID of this depot entry group rel.
+	 *
+	 * @return the ct collection ID of this depot entry group rel
+	 */
+	@Override
+	public long getCtCollectionId();
+
+	/**
+	 * Sets the ct collection ID of this depot entry group rel.
+	 *
+	 * @param ctCollectionId the ct collection ID of this depot entry group rel
+	 */
+	@Override
+	public void setCtCollectionId(long ctCollectionId);
 
 	/**
 	 * Returns the uuid of this depot entry group rel.

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/model/DepotEntryGroupRelSoap.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/model/DepotEntryGroupRelSoap.java
@@ -34,6 +34,7 @@ public class DepotEntryGroupRelSoap implements Serializable {
 		DepotEntryGroupRelSoap soapModel = new DepotEntryGroupRelSoap();
 
 		soapModel.setMvccVersion(model.getMvccVersion());
+		soapModel.setCtCollectionId(model.getCtCollectionId());
 		soapModel.setUuid(model.getUuid());
 		soapModel.setDepotEntryGroupRelId(model.getDepotEntryGroupRelId());
 		soapModel.setGroupId(model.getGroupId());
@@ -115,6 +116,14 @@ public class DepotEntryGroupRelSoap implements Serializable {
 
 	public void setMvccVersion(long mvccVersion) {
 		_mvccVersion = mvccVersion;
+	}
+
+	public long getCtCollectionId() {
+		return _ctCollectionId;
+	}
+
+	public void setCtCollectionId(long ctCollectionId) {
+		_ctCollectionId = ctCollectionId;
 	}
 
 	public String getUuid() {
@@ -230,6 +239,7 @@ public class DepotEntryGroupRelSoap implements Serializable {
 	}
 
 	private long _mvccVersion;
+	private long _ctCollectionId;
 	private String _uuid;
 	private long _depotEntryGroupRelId;
 	private long _groupId;

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/model/DepotEntryGroupRelTable.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/model/DepotEntryGroupRelTable.java
@@ -37,6 +37,9 @@ public class DepotEntryGroupRelTable
 	public final Column<DepotEntryGroupRelTable, Long> mvccVersion =
 		createColumn(
 			"mvccVersion", Long.class, Types.BIGINT, Column.FLAG_NULLITY);
+	public final Column<DepotEntryGroupRelTable, Long> ctCollectionId =
+		createColumn(
+			"ctCollectionId", Long.class, Types.BIGINT, Column.FLAG_PRIMARY);
 	public final Column<DepotEntryGroupRelTable, String> uuid = createColumn(
 		"uuid_", String.class, Types.VARCHAR, Column.FLAG_DEFAULT);
 	public final Column<DepotEntryGroupRelTable, Long> depotEntryGroupRelId =

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/model/DepotEntryGroupRelWrapper.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/model/DepotEntryGroupRelWrapper.java
@@ -21,6 +21,8 @@ import com.liferay.portal.kernel.model.wrapper.BaseModelWrapper;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
 
 /**
  * <p>
@@ -44,6 +46,7 @@ public class DepotEntryGroupRelWrapper
 		Map<String, Object> attributes = new HashMap<String, Object>();
 
 		attributes.put("mvccVersion", getMvccVersion());
+		attributes.put("ctCollectionId", getCtCollectionId());
 		attributes.put("uuid", getUuid());
 		attributes.put("depotEntryGroupRelId", getDepotEntryGroupRelId());
 		attributes.put("groupId", getGroupId());
@@ -67,6 +70,12 @@ public class DepotEntryGroupRelWrapper
 
 		if (mvccVersion != null) {
 			setMvccVersion(mvccVersion);
+		}
+
+		Long ctCollectionId = (Long)attributes.get("ctCollectionId");
+
+		if (ctCollectionId != null) {
+			setCtCollectionId(ctCollectionId);
 		}
 
 		String uuid = (String)attributes.get("uuid");
@@ -173,6 +182,16 @@ public class DepotEntryGroupRelWrapper
 	@Override
 	public Date getCreateDate() {
 		return model.getCreateDate();
+	}
+
+	/**
+	 * Returns the ct collection ID of this depot entry group rel.
+	 *
+	 * @return the ct collection ID of this depot entry group rel
+	 */
+	@Override
+	public long getCtCollectionId() {
+		return model.getCtCollectionId();
 	}
 
 	/**
@@ -361,6 +380,16 @@ public class DepotEntryGroupRelWrapper
 	}
 
 	/**
+	 * Sets the ct collection ID of this depot entry group rel.
+	 *
+	 * @param ctCollectionId the ct collection ID of this depot entry group rel
+	 */
+	@Override
+	public void setCtCollectionId(long ctCollectionId) {
+		model.setCtCollectionId(ctCollectionId);
+	}
+
+	/**
 	 * Sets whether this depot entry group rel is ddm structures available.
 	 *
 	 * @param ddmStructuresAvailable the ddm structures available of this depot entry group rel
@@ -498,6 +527,20 @@ public class DepotEntryGroupRelWrapper
 	@Override
 	public void setUuid(String uuid) {
 		model.setUuid(uuid);
+	}
+
+	@Override
+	public Map<String, Function<DepotEntryGroupRel, Object>>
+		getAttributeGetterFunctions() {
+
+		return model.getAttributeGetterFunctions();
+	}
+
+	@Override
+	public Map<String, BiConsumer<DepotEntryGroupRel, Object>>
+		getAttributeSetterBiConsumers() {
+
+		return model.getAttributeSetterBiConsumers();
 	}
 
 	@Override

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/model/DepotEntryModel.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/model/DepotEntryModel.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
 import com.liferay.portal.kernel.model.StagedAuditedModel;
+import com.liferay.portal.kernel.model.change.tracking.CTModel;
 
 import java.util.Date;
 
@@ -38,8 +39,8 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface DepotEntryModel
-	extends BaseModel<DepotEntry>, GroupedModel, MVCCModel, ShardedModel,
-			StagedAuditedModel {
+	extends BaseModel<DepotEntry>, CTModel<DepotEntry>, GroupedModel, MVCCModel,
+			ShardedModel, StagedAuditedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -52,6 +53,7 @@ public interface DepotEntryModel
 	 *
 	 * @return the primary key of this depot entry
 	 */
+	@Override
 	public long getPrimaryKey();
 
 	/**
@@ -59,6 +61,7 @@ public interface DepotEntryModel
 	 *
 	 * @param primaryKey the primary key of this depot entry
 	 */
+	@Override
 	public void setPrimaryKey(long primaryKey);
 
 	/**
@@ -76,6 +79,22 @@ public interface DepotEntryModel
 	 */
 	@Override
 	public void setMvccVersion(long mvccVersion);
+
+	/**
+	 * Returns the ct collection ID of this depot entry.
+	 *
+	 * @return the ct collection ID of this depot entry
+	 */
+	@Override
+	public long getCtCollectionId();
+
+	/**
+	 * Sets the ct collection ID of this depot entry.
+	 *
+	 * @param ctCollectionId the ct collection ID of this depot entry
+	 */
+	@Override
+	public void setCtCollectionId(long ctCollectionId);
 
 	/**
 	 * Returns the uuid of this depot entry.

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/model/DepotEntrySoap.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/model/DepotEntrySoap.java
@@ -34,6 +34,7 @@ public class DepotEntrySoap implements Serializable {
 		DepotEntrySoap soapModel = new DepotEntrySoap();
 
 		soapModel.setMvccVersion(model.getMvccVersion());
+		soapModel.setCtCollectionId(model.getCtCollectionId());
 		soapModel.setUuid(model.getUuid());
 		soapModel.setDepotEntryId(model.getDepotEntryId());
 		soapModel.setGroupId(model.getGroupId());
@@ -103,6 +104,14 @@ public class DepotEntrySoap implements Serializable {
 		_mvccVersion = mvccVersion;
 	}
 
+	public long getCtCollectionId() {
+		return _ctCollectionId;
+	}
+
+	public void setCtCollectionId(long ctCollectionId) {
+		_ctCollectionId = ctCollectionId;
+	}
+
 	public String getUuid() {
 		return _uuid;
 	}
@@ -168,6 +177,7 @@ public class DepotEntrySoap implements Serializable {
 	}
 
 	private long _mvccVersion;
+	private long _ctCollectionId;
 	private String _uuid;
 	private long _depotEntryId;
 	private long _groupId;

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/model/DepotEntryTable.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/model/DepotEntryTable.java
@@ -34,6 +34,8 @@ public class DepotEntryTable extends BaseTable<DepotEntryTable> {
 
 	public final Column<DepotEntryTable, Long> mvccVersion = createColumn(
 		"mvccVersion", Long.class, Types.BIGINT, Column.FLAG_NULLITY);
+	public final Column<DepotEntryTable, Long> ctCollectionId = createColumn(
+		"ctCollectionId", Long.class, Types.BIGINT, Column.FLAG_PRIMARY);
 	public final Column<DepotEntryTable, String> uuid = createColumn(
 		"uuid_", String.class, Types.VARCHAR, Column.FLAG_DEFAULT);
 	public final Column<DepotEntryTable, Long> depotEntryId = createColumn(

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/model/DepotEntryWrapper.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/model/DepotEntryWrapper.java
@@ -21,6 +21,8 @@ import com.liferay.portal.kernel.model.wrapper.BaseModelWrapper;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
 
 /**
  * <p>
@@ -44,6 +46,7 @@ public class DepotEntryWrapper
 		Map<String, Object> attributes = new HashMap<String, Object>();
 
 		attributes.put("mvccVersion", getMvccVersion());
+		attributes.put("ctCollectionId", getCtCollectionId());
 		attributes.put("uuid", getUuid());
 		attributes.put("depotEntryId", getDepotEntryId());
 		attributes.put("groupId", getGroupId());
@@ -62,6 +65,12 @@ public class DepotEntryWrapper
 
 		if (mvccVersion != null) {
 			setMvccVersion(mvccVersion);
+		}
+
+		Long ctCollectionId = (Long)attributes.get("ctCollectionId");
+
+		if (ctCollectionId != null) {
+			setCtCollectionId(ctCollectionId);
 		}
 
 		String uuid = (String)attributes.get("uuid");
@@ -136,6 +145,16 @@ public class DepotEntryWrapper
 	@Override
 	public Date getCreateDate() {
 		return model.getCreateDate();
+	}
+
+	/**
+	 * Returns the ct collection ID of this depot entry.
+	 *
+	 * @return the ct collection ID of this depot entry
+	 */
+	@Override
+	public long getCtCollectionId() {
+		return model.getCtCollectionId();
 	}
 
 	/**
@@ -261,6 +280,16 @@ public class DepotEntryWrapper
 	}
 
 	/**
+	 * Sets the ct collection ID of this depot entry.
+	 *
+	 * @param ctCollectionId the ct collection ID of this depot entry
+	 */
+	@Override
+	public void setCtCollectionId(long ctCollectionId) {
+		model.setCtCollectionId(ctCollectionId);
+	}
+
+	/**
 	 * Sets the depot entry ID of this depot entry.
 	 *
 	 * @param depotEntryId the depot entry ID of this depot entry
@@ -348,6 +377,20 @@ public class DepotEntryWrapper
 	@Override
 	public void setUuid(String uuid) {
 		model.setUuid(uuid);
+	}
+
+	@Override
+	public Map<String, Function<DepotEntry, Object>>
+		getAttributeGetterFunctions() {
+
+		return model.getAttributeGetterFunctions();
+	}
+
+	@Override
+	public Map<String, BiConsumer<DepotEntry, Object>>
+		getAttributeSetterBiConsumers() {
+
+		return model.getAttributeSetterBiConsumers();
 	}
 
 	@Override

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotAppCustomizationLocalService.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotAppCustomizationLocalService.java
@@ -15,7 +15,9 @@
 package com.liferay.depot.service;
 
 import com.liferay.depot.model.DepotAppCustomization;
+import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.sql.dsl.query.DSLQuery;
+import com.liferay.portal.kernel.change.tracking.CTAware;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.dao.orm.IndexableActionableDynamicQuery;
@@ -27,6 +29,8 @@ import com.liferay.portal.kernel.search.Indexable;
 import com.liferay.portal.kernel.search.IndexableType;
 import com.liferay.portal.kernel.service.BaseLocalService;
 import com.liferay.portal.kernel.service.PersistedModelLocalService;
+import com.liferay.portal.kernel.service.change.tracking.CTService;
+import com.liferay.portal.kernel.service.persistence.change.tracking.CTPersistence;
 import com.liferay.portal.kernel.transaction.Isolation;
 import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.Transactional;
@@ -48,13 +52,15 @@ import org.osgi.annotation.versioning.ProviderType;
  * @see DepotAppCustomizationLocalServiceUtil
  * @generated
  */
+@CTAware
 @ProviderType
 @Transactional(
 	isolation = Isolation.PORTAL,
 	rollbackFor = {PortalException.class, SystemException.class}
 )
 public interface DepotAppCustomizationLocalService
-	extends BaseLocalService, PersistedModelLocalService {
+	extends BaseLocalService, CTService<DepotAppCustomization>,
+			PersistedModelLocalService {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -286,5 +292,20 @@ public interface DepotAppCustomizationLocalService
 	public DepotAppCustomization updateDepotAppCustomization(
 			long depotEntryId, boolean enabled, String portletId)
 		throws PortalException;
+
+	@Override
+	@Transactional(enabled = false)
+	public CTPersistence<DepotAppCustomization> getCTPersistence();
+
+	@Override
+	@Transactional(enabled = false)
+	public Class<DepotAppCustomization> getModelClass();
+
+	@Override
+	@Transactional(rollbackFor = Throwable.class)
+	public <R, E extends Throwable> R updateWithUnsafeFunction(
+			UnsafeFunction<CTPersistence<DepotAppCustomization>, R, E>
+				updateUnsafeFunction)
+		throws E;
 
 }

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotAppCustomizationLocalServiceWrapper.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotAppCustomizationLocalServiceWrapper.java
@@ -14,7 +14,10 @@
 
 package com.liferay.depot.service;
 
+import com.liferay.depot.model.DepotAppCustomization;
+import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.portal.kernel.service.ServiceWrapper;
+import com.liferay.portal.kernel.service.persistence.change.tracking.CTPersistence;
 
 /**
  * Provides a wrapper for {@link DepotAppCustomizationLocalService}.
@@ -48,10 +51,8 @@ public class DepotAppCustomizationLocalServiceWrapper
 	 * @return the depot app customization that was added
 	 */
 	@Override
-	public com.liferay.depot.model.DepotAppCustomization
-		addDepotAppCustomization(
-			com.liferay.depot.model.DepotAppCustomization
-				depotAppCustomization) {
+	public DepotAppCustomization addDepotAppCustomization(
+		DepotAppCustomization depotAppCustomization) {
 
 		return _depotAppCustomizationLocalService.addDepotAppCustomization(
 			depotAppCustomization);
@@ -64,8 +65,8 @@ public class DepotAppCustomizationLocalServiceWrapper
 	 * @return the new depot app customization
 	 */
 	@Override
-	public com.liferay.depot.model.DepotAppCustomization
-		createDepotAppCustomization(long depotAppCustomizationId) {
+	public DepotAppCustomization createDepotAppCustomization(
+		long depotAppCustomizationId) {
 
 		return _depotAppCustomizationLocalService.createDepotAppCustomization(
 			depotAppCustomizationId);
@@ -94,10 +95,8 @@ public class DepotAppCustomizationLocalServiceWrapper
 	 * @return the depot app customization that was removed
 	 */
 	@Override
-	public com.liferay.depot.model.DepotAppCustomization
-		deleteDepotAppCustomization(
-			com.liferay.depot.model.DepotAppCustomization
-				depotAppCustomization) {
+	public DepotAppCustomization deleteDepotAppCustomization(
+		DepotAppCustomization depotAppCustomization) {
 
 		return _depotAppCustomizationLocalService.deleteDepotAppCustomization(
 			depotAppCustomization);
@@ -115,8 +114,8 @@ public class DepotAppCustomizationLocalServiceWrapper
 	 * @throws PortalException if a depot app customization with the primary key could not be found
 	 */
 	@Override
-	public com.liferay.depot.model.DepotAppCustomization
-			deleteDepotAppCustomization(long depotAppCustomizationId)
+	public DepotAppCustomization deleteDepotAppCustomization(
+			long depotAppCustomizationId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _depotAppCustomizationLocalService.deleteDepotAppCustomization(
@@ -240,16 +239,16 @@ public class DepotAppCustomizationLocalServiceWrapper
 	}
 
 	@Override
-	public com.liferay.depot.model.DepotAppCustomization
-		fetchDepotAppCustomization(long depotAppCustomizationId) {
+	public DepotAppCustomization fetchDepotAppCustomization(
+		long depotAppCustomizationId) {
 
 		return _depotAppCustomizationLocalService.fetchDepotAppCustomization(
 			depotAppCustomizationId);
 	}
 
 	@Override
-	public com.liferay.depot.model.DepotAppCustomization
-		fetchDepotAppCustomization(long depotEntryId, String portletId) {
+	public DepotAppCustomization fetchDepotAppCustomization(
+		long depotEntryId, String portletId) {
 
 		return _depotAppCustomizationLocalService.fetchDepotAppCustomization(
 			depotEntryId, portletId);
@@ -270,8 +269,8 @@ public class DepotAppCustomizationLocalServiceWrapper
 	 * @throws PortalException if a depot app customization with the primary key could not be found
 	 */
 	@Override
-	public com.liferay.depot.model.DepotAppCustomization
-			getDepotAppCustomization(long depotAppCustomizationId)
+	public DepotAppCustomization getDepotAppCustomization(
+			long depotAppCustomizationId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _depotAppCustomizationLocalService.getDepotAppCustomization(
@@ -290,8 +289,8 @@ public class DepotAppCustomizationLocalServiceWrapper
 	 * @return the range of depot app customizations
 	 */
 	@Override
-	public java.util.List<com.liferay.depot.model.DepotAppCustomization>
-		getDepotAppCustomizations(int start, int end) {
+	public java.util.List<DepotAppCustomization> getDepotAppCustomizations(
+		int start, int end) {
 
 		return _depotAppCustomizationLocalService.getDepotAppCustomizations(
 			start, end);
@@ -357,23 +356,40 @@ public class DepotAppCustomizationLocalServiceWrapper
 	 * @return the depot app customization that was updated
 	 */
 	@Override
-	public com.liferay.depot.model.DepotAppCustomization
-		updateDepotAppCustomization(
-			com.liferay.depot.model.DepotAppCustomization
-				depotAppCustomization) {
+	public DepotAppCustomization updateDepotAppCustomization(
+		DepotAppCustomization depotAppCustomization) {
 
 		return _depotAppCustomizationLocalService.updateDepotAppCustomization(
 			depotAppCustomization);
 	}
 
 	@Override
-	public com.liferay.depot.model.DepotAppCustomization
-			updateDepotAppCustomization(
-				long depotEntryId, boolean enabled, String portletId)
+	public DepotAppCustomization updateDepotAppCustomization(
+			long depotEntryId, boolean enabled, String portletId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _depotAppCustomizationLocalService.updateDepotAppCustomization(
 			depotEntryId, enabled, portletId);
+	}
+
+	@Override
+	public CTPersistence<DepotAppCustomization> getCTPersistence() {
+		return _depotAppCustomizationLocalService.getCTPersistence();
+	}
+
+	@Override
+	public Class<DepotAppCustomization> getModelClass() {
+		return _depotAppCustomizationLocalService.getModelClass();
+	}
+
+	@Override
+	public <R, E extends Throwable> R updateWithUnsafeFunction(
+			UnsafeFunction<CTPersistence<DepotAppCustomization>, R, E>
+				updateUnsafeFunction)
+		throws E {
+
+		return _depotAppCustomizationLocalService.updateWithUnsafeFunction(
+			updateUnsafeFunction);
 	}
 
 	@Override

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryGroupRelLocalService.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryGroupRelLocalService.java
@@ -17,7 +17,9 @@ package com.liferay.depot.service;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.model.DepotEntryGroupRel;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
+import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.sql.dsl.query.DSLQuery;
+import com.liferay.portal.kernel.change.tracking.CTAware;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.dao.orm.ExportActionableDynamicQuery;
@@ -31,6 +33,8 @@ import com.liferay.portal.kernel.search.Indexable;
 import com.liferay.portal.kernel.search.IndexableType;
 import com.liferay.portal.kernel.service.BaseLocalService;
 import com.liferay.portal.kernel.service.PersistedModelLocalService;
+import com.liferay.portal.kernel.service.change.tracking.CTService;
+import com.liferay.portal.kernel.service.persistence.change.tracking.CTPersistence;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
 import com.liferay.portal.kernel.transaction.Isolation;
 import com.liferay.portal.kernel.transaction.Propagation;
@@ -53,13 +57,15 @@ import org.osgi.annotation.versioning.ProviderType;
  * @see DepotEntryGroupRelLocalServiceUtil
  * @generated
  */
+@CTAware
 @ProviderType
 @Transactional(
 	isolation = Isolation.PORTAL,
 	rollbackFor = {PortalException.class, SystemException.class}
 )
 public interface DepotEntryGroupRelLocalService
-	extends BaseLocalService, PersistedModelLocalService {
+	extends BaseLocalService, CTService<DepotEntryGroupRel>,
+			PersistedModelLocalService {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -376,5 +382,20 @@ public interface DepotEntryGroupRelLocalService
 	public DepotEntryGroupRel updateSearchable(
 			long depotEntryGroupRelId, boolean searchable)
 		throws PortalException;
+
+	@Override
+	@Transactional(enabled = false)
+	public CTPersistence<DepotEntryGroupRel> getCTPersistence();
+
+	@Override
+	@Transactional(enabled = false)
+	public Class<DepotEntryGroupRel> getModelClass();
+
+	@Override
+	@Transactional(rollbackFor = Throwable.class)
+	public <R, E extends Throwable> R updateWithUnsafeFunction(
+			UnsafeFunction<CTPersistence<DepotEntryGroupRel>, R, E>
+				updateUnsafeFunction)
+		throws E;
 
 }

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryGroupRelLocalServiceWrapper.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryGroupRelLocalServiceWrapper.java
@@ -14,7 +14,10 @@
 
 package com.liferay.depot.service;
 
+import com.liferay.depot.model.DepotEntryGroupRel;
+import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.portal.kernel.service.ServiceWrapper;
+import com.liferay.portal.kernel.service.persistence.change.tracking.CTPersistence;
 
 /**
  * Provides a wrapper for {@link DepotEntryGroupRelLocalService}.
@@ -38,7 +41,7 @@ public class DepotEntryGroupRelLocalServiceWrapper
 	}
 
 	@Override
-	public com.liferay.depot.model.DepotEntryGroupRel addDepotEntryGroupRel(
+	public DepotEntryGroupRel addDepotEntryGroupRel(
 		boolean ddmStructuresAvailable, long depotEntryId, long toGroupId,
 		boolean searchable) {
 
@@ -57,15 +60,15 @@ public class DepotEntryGroupRelLocalServiceWrapper
 	 * @return the depot entry group rel that was added
 	 */
 	@Override
-	public com.liferay.depot.model.DepotEntryGroupRel addDepotEntryGroupRel(
-		com.liferay.depot.model.DepotEntryGroupRel depotEntryGroupRel) {
+	public DepotEntryGroupRel addDepotEntryGroupRel(
+		DepotEntryGroupRel depotEntryGroupRel) {
 
 		return _depotEntryGroupRelLocalService.addDepotEntryGroupRel(
 			depotEntryGroupRel);
 	}
 
 	@Override
-	public com.liferay.depot.model.DepotEntryGroupRel addDepotEntryGroupRel(
+	public DepotEntryGroupRel addDepotEntryGroupRel(
 		long depotEntryId, long toGroupId) {
 
 		return _depotEntryGroupRelLocalService.addDepotEntryGroupRel(
@@ -73,7 +76,7 @@ public class DepotEntryGroupRelLocalServiceWrapper
 	}
 
 	@Override
-	public com.liferay.depot.model.DepotEntryGroupRel addDepotEntryGroupRel(
+	public DepotEntryGroupRel addDepotEntryGroupRel(
 		long depotEntryId, long toGroupId, boolean searchable) {
 
 		return _depotEntryGroupRelLocalService.addDepotEntryGroupRel(
@@ -87,7 +90,7 @@ public class DepotEntryGroupRelLocalServiceWrapper
 	 * @return the new depot entry group rel
 	 */
 	@Override
-	public com.liferay.depot.model.DepotEntryGroupRel createDepotEntryGroupRel(
+	public DepotEntryGroupRel createDepotEntryGroupRel(
 		long depotEntryGroupRelId) {
 
 		return _depotEntryGroupRelLocalService.createDepotEntryGroupRel(
@@ -117,8 +120,8 @@ public class DepotEntryGroupRelLocalServiceWrapper
 	 * @return the depot entry group rel that was removed
 	 */
 	@Override
-	public com.liferay.depot.model.DepotEntryGroupRel deleteDepotEntryGroupRel(
-		com.liferay.depot.model.DepotEntryGroupRel depotEntryGroupRel) {
+	public DepotEntryGroupRel deleteDepotEntryGroupRel(
+		DepotEntryGroupRel depotEntryGroupRel) {
 
 		return _depotEntryGroupRelLocalService.deleteDepotEntryGroupRel(
 			depotEntryGroupRel);
@@ -136,7 +139,7 @@ public class DepotEntryGroupRelLocalServiceWrapper
 	 * @throws PortalException if a depot entry group rel with the primary key could not be found
 	 */
 	@Override
-	public com.liferay.depot.model.DepotEntryGroupRel deleteDepotEntryGroupRel(
+	public DepotEntryGroupRel deleteDepotEntryGroupRel(
 			long depotEntryGroupRelId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
@@ -266,7 +269,7 @@ public class DepotEntryGroupRelLocalServiceWrapper
 	}
 
 	@Override
-	public com.liferay.depot.model.DepotEntryGroupRel fetchDepotEntryGroupRel(
+	public DepotEntryGroupRel fetchDepotEntryGroupRel(
 		long depotEntryGroupRelId) {
 
 		return _depotEntryGroupRelLocalService.fetchDepotEntryGroupRel(
@@ -274,9 +277,8 @@ public class DepotEntryGroupRelLocalServiceWrapper
 	}
 
 	@Override
-	public com.liferay.depot.model.DepotEntryGroupRel
-		fetchDepotEntryGroupRelByDepotEntryIdToGroupId(
-			long depotEntryId, long toGroupId) {
+	public DepotEntryGroupRel fetchDepotEntryGroupRelByDepotEntryIdToGroupId(
+		long depotEntryId, long toGroupId) {
 
 		return _depotEntryGroupRelLocalService.
 			fetchDepotEntryGroupRelByDepotEntryIdToGroupId(
@@ -291,8 +293,8 @@ public class DepotEntryGroupRelLocalServiceWrapper
 	 * @return the matching depot entry group rel, or <code>null</code> if a matching depot entry group rel could not be found
 	 */
 	@Override
-	public com.liferay.depot.model.DepotEntryGroupRel
-		fetchDepotEntryGroupRelByUuidAndGroupId(String uuid, long groupId) {
+	public DepotEntryGroupRel fetchDepotEntryGroupRelByUuidAndGroupId(
+		String uuid, long groupId) {
 
 		return _depotEntryGroupRelLocalService.
 			fetchDepotEntryGroupRelByUuidAndGroupId(uuid, groupId);
@@ -313,8 +315,7 @@ public class DepotEntryGroupRelLocalServiceWrapper
 	 * @throws PortalException if a depot entry group rel with the primary key could not be found
 	 */
 	@Override
-	public com.liferay.depot.model.DepotEntryGroupRel getDepotEntryGroupRel(
-			long depotEntryGroupRelId)
+	public DepotEntryGroupRel getDepotEntryGroupRel(long depotEntryGroupRelId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _depotEntryGroupRelLocalService.getDepotEntryGroupRel(
@@ -330,8 +331,8 @@ public class DepotEntryGroupRelLocalServiceWrapper
 	 * @throws PortalException if a matching depot entry group rel could not be found
 	 */
 	@Override
-	public com.liferay.depot.model.DepotEntryGroupRel
-			getDepotEntryGroupRelByUuidAndGroupId(String uuid, long groupId)
+	public DepotEntryGroupRel getDepotEntryGroupRelByUuidAndGroupId(
+			String uuid, long groupId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _depotEntryGroupRelLocalService.
@@ -339,8 +340,8 @@ public class DepotEntryGroupRelLocalServiceWrapper
 	}
 
 	@Override
-	public java.util.List<com.liferay.depot.model.DepotEntryGroupRel>
-		getDepotEntryGroupRels(com.liferay.depot.model.DepotEntry depotEntry) {
+	public java.util.List<DepotEntryGroupRel> getDepotEntryGroupRels(
+		com.liferay.depot.model.DepotEntry depotEntry) {
 
 		return _depotEntryGroupRelLocalService.getDepotEntryGroupRels(
 			depotEntry);
@@ -358,16 +359,16 @@ public class DepotEntryGroupRelLocalServiceWrapper
 	 * @return the range of depot entry group rels
 	 */
 	@Override
-	public java.util.List<com.liferay.depot.model.DepotEntryGroupRel>
-		getDepotEntryGroupRels(int start, int end) {
+	public java.util.List<DepotEntryGroupRel> getDepotEntryGroupRels(
+		int start, int end) {
 
 		return _depotEntryGroupRelLocalService.getDepotEntryGroupRels(
 			start, end);
 	}
 
 	@Override
-	public java.util.List<com.liferay.depot.model.DepotEntryGroupRel>
-		getDepotEntryGroupRels(long groupId, int start, int end) {
+	public java.util.List<DepotEntryGroupRel> getDepotEntryGroupRels(
+		long groupId, int start, int end) {
 
 		return _depotEntryGroupRelLocalService.getDepotEntryGroupRels(
 			groupId, start, end);
@@ -381,7 +382,7 @@ public class DepotEntryGroupRelLocalServiceWrapper
 	 * @return the matching depot entry group rels, or an empty list if no matches were found
 	 */
 	@Override
-	public java.util.List<com.liferay.depot.model.DepotEntryGroupRel>
+	public java.util.List<DepotEntryGroupRel>
 		getDepotEntryGroupRelsByUuidAndCompanyId(String uuid, long companyId) {
 
 		return _depotEntryGroupRelLocalService.
@@ -399,12 +400,11 @@ public class DepotEntryGroupRelLocalServiceWrapper
 	 * @return the range of matching depot entry group rels, or an empty list if no matches were found
 	 */
 	@Override
-	public java.util.List<com.liferay.depot.model.DepotEntryGroupRel>
+	public java.util.List<DepotEntryGroupRel>
 		getDepotEntryGroupRelsByUuidAndCompanyId(
 			String uuid, long companyId, int start, int end,
-			com.liferay.portal.kernel.util.OrderByComparator
-				<com.liferay.depot.model.DepotEntryGroupRel>
-					orderByComparator) {
+			com.liferay.portal.kernel.util.OrderByComparator<DepotEntryGroupRel>
+				orderByComparator) {
 
 		return _depotEntryGroupRelLocalService.
 			getDepotEntryGroupRelsByUuidAndCompanyId(
@@ -475,8 +475,8 @@ public class DepotEntryGroupRelLocalServiceWrapper
 	}
 
 	@Override
-	public java.util.List<com.liferay.depot.model.DepotEntryGroupRel>
-		getSearchableDepotEntryGroupRels(long groupId, int start, int end) {
+	public java.util.List<DepotEntryGroupRel> getSearchableDepotEntryGroupRels(
+		long groupId, int start, int end) {
 
 		return _depotEntryGroupRelLocalService.getSearchableDepotEntryGroupRels(
 			groupId, start, end);
@@ -489,9 +489,8 @@ public class DepotEntryGroupRelLocalServiceWrapper
 	}
 
 	@Override
-	public com.liferay.depot.model.DepotEntryGroupRel
-			updateDDMStructuresAvailable(
-				long depotEntryGroupRelId, boolean ddmStructuresAvailable)
+	public DepotEntryGroupRel updateDDMStructuresAvailable(
+			long depotEntryGroupRelId, boolean ddmStructuresAvailable)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _depotEntryGroupRelLocalService.updateDDMStructuresAvailable(
@@ -509,20 +508,40 @@ public class DepotEntryGroupRelLocalServiceWrapper
 	 * @return the depot entry group rel that was updated
 	 */
 	@Override
-	public com.liferay.depot.model.DepotEntryGroupRel updateDepotEntryGroupRel(
-		com.liferay.depot.model.DepotEntryGroupRel depotEntryGroupRel) {
+	public DepotEntryGroupRel updateDepotEntryGroupRel(
+		DepotEntryGroupRel depotEntryGroupRel) {
 
 		return _depotEntryGroupRelLocalService.updateDepotEntryGroupRel(
 			depotEntryGroupRel);
 	}
 
 	@Override
-	public com.liferay.depot.model.DepotEntryGroupRel updateSearchable(
+	public DepotEntryGroupRel updateSearchable(
 			long depotEntryGroupRelId, boolean searchable)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _depotEntryGroupRelLocalService.updateSearchable(
 			depotEntryGroupRelId, searchable);
+	}
+
+	@Override
+	public CTPersistence<DepotEntryGroupRel> getCTPersistence() {
+		return _depotEntryGroupRelLocalService.getCTPersistence();
+	}
+
+	@Override
+	public Class<DepotEntryGroupRel> getModelClass() {
+		return _depotEntryGroupRelLocalService.getModelClass();
+	}
+
+	@Override
+	public <R, E extends Throwable> R updateWithUnsafeFunction(
+			UnsafeFunction<CTPersistence<DepotEntryGroupRel>, R, E>
+				updateUnsafeFunction)
+		throws E {
+
+		return _depotEntryGroupRelLocalService.updateWithUnsafeFunction(
+			updateUnsafeFunction);
 	}
 
 	@Override

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryGroupRelService.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryGroupRelService.java
@@ -16,6 +16,7 @@ package com.liferay.depot.service;
 
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.model.DepotEntryGroupRel;
+import com.liferay.portal.kernel.change.tracking.CTAware;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.jsonwebservice.JSONWebService;
@@ -39,6 +40,7 @@ import org.osgi.annotation.versioning.ProviderType;
  * @generated
  */
 @AccessControlled
+@CTAware
 @JSONWebService
 @ProviderType
 @Transactional(

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryGroupRelServiceWrapper.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryGroupRelServiceWrapper.java
@@ -14,6 +14,7 @@
 
 package com.liferay.depot.service;
 
+import com.liferay.depot.model.DepotEntryGroupRel;
 import com.liferay.portal.kernel.service.ServiceWrapper;
 
 /**
@@ -38,7 +39,7 @@ public class DepotEntryGroupRelServiceWrapper
 	}
 
 	@Override
-	public com.liferay.depot.model.DepotEntryGroupRel addDepotEntryGroupRel(
+	public DepotEntryGroupRel addDepotEntryGroupRel(
 			long depotEntryId, long toGroupId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
@@ -47,7 +48,7 @@ public class DepotEntryGroupRelServiceWrapper
 	}
 
 	@Override
-	public com.liferay.depot.model.DepotEntryGroupRel deleteDepotEntryGroupRel(
+	public DepotEntryGroupRel deleteDepotEntryGroupRel(
 			long depotEntryGroupRelId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
@@ -56,8 +57,8 @@ public class DepotEntryGroupRelServiceWrapper
 	}
 
 	@Override
-	public java.util.List<com.liferay.depot.model.DepotEntryGroupRel>
-			getDepotEntryGroupRels(long groupId, int start, int end)
+	public java.util.List<DepotEntryGroupRel> getDepotEntryGroupRels(
+			long groupId, int start, int end)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _depotEntryGroupRelService.getDepotEntryGroupRels(
@@ -91,9 +92,8 @@ public class DepotEntryGroupRelServiceWrapper
 	}
 
 	@Override
-	public com.liferay.depot.model.DepotEntryGroupRel
-			updateDDMStructuresAvailable(
-				long depotEntryGroupRelId, boolean ddmStructuresAvailable)
+	public DepotEntryGroupRel updateDDMStructuresAvailable(
+			long depotEntryGroupRelId, boolean ddmStructuresAvailable)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _depotEntryGroupRelService.updateDDMStructuresAvailable(
@@ -101,7 +101,7 @@ public class DepotEntryGroupRelServiceWrapper
 	}
 
 	@Override
-	public com.liferay.depot.model.DepotEntryGroupRel updateSearchable(
+	public DepotEntryGroupRel updateSearchable(
 			long depotEntryGroupRelId, boolean searchable)
 		throws com.liferay.portal.kernel.exception.PortalException {
 

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryLocalService.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryLocalService.java
@@ -16,7 +16,9 @@ package com.liferay.depot.service;
 
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
+import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.sql.dsl.query.DSLQuery;
+import com.liferay.portal.kernel.change.tracking.CTAware;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.dao.orm.ExportActionableDynamicQuery;
@@ -31,6 +33,8 @@ import com.liferay.portal.kernel.search.IndexableType;
 import com.liferay.portal.kernel.service.BaseLocalService;
 import com.liferay.portal.kernel.service.PersistedModelLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.change.tracking.CTService;
+import com.liferay.portal.kernel.service.persistence.change.tracking.CTPersistence;
 import com.liferay.portal.kernel.transaction.Isolation;
 import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.Transactional;
@@ -55,13 +59,15 @@ import org.osgi.annotation.versioning.ProviderType;
  * @see DepotEntryLocalServiceUtil
  * @generated
  */
+@CTAware
 @ProviderType
 @Transactional(
 	isolation = Isolation.PORTAL,
 	rollbackFor = {PortalException.class, SystemException.class}
 )
 public interface DepotEntryLocalService
-	extends BaseLocalService, PersistedModelLocalService {
+	extends BaseLocalService, CTService<DepotEntry>,
+			PersistedModelLocalService {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -368,5 +374,20 @@ public interface DepotEntryLocalService
 			UnicodeProperties typeSettingsUnicodeProperties,
 			ServiceContext serviceContext)
 		throws PortalException;
+
+	@Override
+	@Transactional(enabled = false)
+	public CTPersistence<DepotEntry> getCTPersistence();
+
+	@Override
+	@Transactional(enabled = false)
+	public Class<DepotEntry> getModelClass();
+
+	@Override
+	@Transactional(rollbackFor = Throwable.class)
+	public <R, E extends Throwable> R updateWithUnsafeFunction(
+			UnsafeFunction<CTPersistence<DepotEntry>, R, E>
+				updateUnsafeFunction)
+		throws E;
 
 }

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryLocalServiceWrapper.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryLocalServiceWrapper.java
@@ -14,7 +14,10 @@
 
 package com.liferay.depot.service;
 
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.portal.kernel.service.ServiceWrapper;
+import com.liferay.portal.kernel.service.persistence.change.tracking.CTPersistence;
 
 /**
  * Provides a wrapper for {@link DepotEntryLocalService}.
@@ -47,14 +50,12 @@ public class DepotEntryLocalServiceWrapper
 	 * @return the depot entry that was added
 	 */
 	@Override
-	public com.liferay.depot.model.DepotEntry addDepotEntry(
-		com.liferay.depot.model.DepotEntry depotEntry) {
-
+	public DepotEntry addDepotEntry(DepotEntry depotEntry) {
 		return _depotEntryLocalService.addDepotEntry(depotEntry);
 	}
 
 	@Override
-	public com.liferay.depot.model.DepotEntry addDepotEntry(
+	public DepotEntry addDepotEntry(
 			com.liferay.portal.kernel.model.Group group,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
@@ -63,7 +64,7 @@ public class DepotEntryLocalServiceWrapper
 	}
 
 	@Override
-	public com.liferay.depot.model.DepotEntry addDepotEntry(
+	public DepotEntry addDepotEntry(
 			java.util.Map<java.util.Locale, String> nameMap,
 			java.util.Map<java.util.Locale, String> descriptionMap,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
@@ -80,9 +81,7 @@ public class DepotEntryLocalServiceWrapper
 	 * @return the new depot entry
 	 */
 	@Override
-	public com.liferay.depot.model.DepotEntry createDepotEntry(
-		long depotEntryId) {
-
+	public DepotEntry createDepotEntry(long depotEntryId) {
 		return _depotEntryLocalService.createDepotEntry(depotEntryId);
 	}
 
@@ -108,9 +107,7 @@ public class DepotEntryLocalServiceWrapper
 	 * @return the depot entry that was removed
 	 */
 	@Override
-	public com.liferay.depot.model.DepotEntry deleteDepotEntry(
-		com.liferay.depot.model.DepotEntry depotEntry) {
-
+	public DepotEntry deleteDepotEntry(DepotEntry depotEntry) {
 		return _depotEntryLocalService.deleteDepotEntry(depotEntry);
 	}
 
@@ -126,8 +123,7 @@ public class DepotEntryLocalServiceWrapper
 	 * @throws PortalException if a depot entry with the primary key could not be found
 	 */
 	@Override
-	public com.liferay.depot.model.DepotEntry deleteDepotEntry(
-			long depotEntryId)
+	public DepotEntry deleteDepotEntry(long depotEntryId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _depotEntryLocalService.deleteDepotEntry(depotEntryId);
@@ -247,9 +243,7 @@ public class DepotEntryLocalServiceWrapper
 	}
 
 	@Override
-	public com.liferay.depot.model.DepotEntry fetchDepotEntry(
-		long depotEntryId) {
-
+	public DepotEntry fetchDepotEntry(long depotEntryId) {
 		return _depotEntryLocalService.fetchDepotEntry(depotEntryId);
 	}
 
@@ -261,7 +255,7 @@ public class DepotEntryLocalServiceWrapper
 	 * @return the matching depot entry, or <code>null</code> if a matching depot entry could not be found
 	 */
 	@Override
-	public com.liferay.depot.model.DepotEntry fetchDepotEntryByUuidAndGroupId(
+	public DepotEntry fetchDepotEntryByUuidAndGroupId(
 		String uuid, long groupId) {
 
 		return _depotEntryLocalService.fetchDepotEntryByUuidAndGroupId(
@@ -269,9 +263,7 @@ public class DepotEntryLocalServiceWrapper
 	}
 
 	@Override
-	public com.liferay.depot.model.DepotEntry fetchGroupDepotEntry(
-		long groupId) {
-
+	public DepotEntry fetchGroupDepotEntry(long groupId) {
 		return _depotEntryLocalService.fetchGroupDepotEntry(groupId);
 	}
 
@@ -294,9 +286,7 @@ public class DepotEntryLocalServiceWrapper
 	 * @return the range of depot entries
 	 */
 	@Override
-	public java.util.List<com.liferay.depot.model.DepotEntry> getDepotEntries(
-		int start, int end) {
-
+	public java.util.List<DepotEntry> getDepotEntries(int start, int end) {
 		return _depotEntryLocalService.getDepotEntries(start, end);
 	}
 
@@ -308,8 +298,8 @@ public class DepotEntryLocalServiceWrapper
 	 * @return the matching depot entries, or an empty list if no matches were found
 	 */
 	@Override
-	public java.util.List<com.liferay.depot.model.DepotEntry>
-		getDepotEntriesByUuidAndCompanyId(String uuid, long companyId) {
+	public java.util.List<DepotEntry> getDepotEntriesByUuidAndCompanyId(
+		String uuid, long companyId) {
 
 		return _depotEntryLocalService.getDepotEntriesByUuidAndCompanyId(
 			uuid, companyId);
@@ -326,11 +316,10 @@ public class DepotEntryLocalServiceWrapper
 	 * @return the range of matching depot entries, or an empty list if no matches were found
 	 */
 	@Override
-	public java.util.List<com.liferay.depot.model.DepotEntry>
-		getDepotEntriesByUuidAndCompanyId(
-			String uuid, long companyId, int start, int end,
-			com.liferay.portal.kernel.util.OrderByComparator
-				<com.liferay.depot.model.DepotEntry> orderByComparator) {
+	public java.util.List<DepotEntry> getDepotEntriesByUuidAndCompanyId(
+		String uuid, long companyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<DepotEntry>
+			orderByComparator) {
 
 		return _depotEntryLocalService.getDepotEntriesByUuidAndCompanyId(
 			uuid, companyId, start, end, orderByComparator);
@@ -354,7 +343,7 @@ public class DepotEntryLocalServiceWrapper
 	 * @throws PortalException if a depot entry with the primary key could not be found
 	 */
 	@Override
-	public com.liferay.depot.model.DepotEntry getDepotEntry(long depotEntryId)
+	public DepotEntry getDepotEntry(long depotEntryId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _depotEntryLocalService.getDepotEntry(depotEntryId);
@@ -369,8 +358,7 @@ public class DepotEntryLocalServiceWrapper
 	 * @throws PortalException if a matching depot entry could not be found
 	 */
 	@Override
-	public com.liferay.depot.model.DepotEntry getDepotEntryByUuidAndGroupId(
-			String uuid, long groupId)
+	public DepotEntry getDepotEntryByUuidAndGroupId(String uuid, long groupId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _depotEntryLocalService.getDepotEntryByUuidAndGroupId(
@@ -382,8 +370,8 @@ public class DepotEntryLocalServiceWrapper
 	 */
 	@Deprecated
 	@Override
-	public java.util.List<com.liferay.depot.model.DepotEntry>
-		getDepotEntryGroupRelsByUuidAndCompanyId(String uuid, long companyId) {
+	public java.util.List<DepotEntry> getDepotEntryGroupRelsByUuidAndCompanyId(
+		String uuid, long companyId) {
 
 		return _depotEntryLocalService.getDepotEntryGroupRelsByUuidAndCompanyId(
 			uuid, companyId);
@@ -400,10 +388,8 @@ public class DepotEntryLocalServiceWrapper
 	}
 
 	@Override
-	public java.util.List<com.liferay.depot.model.DepotEntry>
-			getGroupConnectedDepotEntries(
-				long groupId, boolean ddmStructuresAvailable, int start,
-				int end)
+	public java.util.List<DepotEntry> getGroupConnectedDepotEntries(
+			long groupId, boolean ddmStructuresAvailable, int start, int end)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _depotEntryLocalService.getGroupConnectedDepotEntries(
@@ -411,8 +397,8 @@ public class DepotEntryLocalServiceWrapper
 	}
 
 	@Override
-	public java.util.List<com.liferay.depot.model.DepotEntry>
-			getGroupConnectedDepotEntries(long groupId, int start, int end)
+	public java.util.List<DepotEntry> getGroupConnectedDepotEntries(
+			long groupId, int start, int end)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _depotEntryLocalService.getGroupConnectedDepotEntries(
@@ -426,7 +412,7 @@ public class DepotEntryLocalServiceWrapper
 	}
 
 	@Override
-	public com.liferay.depot.model.DepotEntry getGroupDepotEntry(long groupId)
+	public DepotEntry getGroupDepotEntry(long groupId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _depotEntryLocalService.getGroupDepotEntry(groupId);
@@ -471,14 +457,12 @@ public class DepotEntryLocalServiceWrapper
 	 * @return the depot entry that was updated
 	 */
 	@Override
-	public com.liferay.depot.model.DepotEntry updateDepotEntry(
-		com.liferay.depot.model.DepotEntry depotEntry) {
-
+	public DepotEntry updateDepotEntry(DepotEntry depotEntry) {
 		return _depotEntryLocalService.updateDepotEntry(depotEntry);
 	}
 
 	@Override
-	public com.liferay.depot.model.DepotEntry updateDepotEntry(
+	public DepotEntry updateDepotEntry(
 			long depotEntryId, java.util.Map<java.util.Locale, String> nameMap,
 			java.util.Map<java.util.Locale, String> descriptionMap,
 			java.util.Map<String, Boolean> depotAppCustomizationMap,
@@ -490,6 +474,26 @@ public class DepotEntryLocalServiceWrapper
 		return _depotEntryLocalService.updateDepotEntry(
 			depotEntryId, nameMap, descriptionMap, depotAppCustomizationMap,
 			typeSettingsUnicodeProperties, serviceContext);
+	}
+
+	@Override
+	public CTPersistence<DepotEntry> getCTPersistence() {
+		return _depotEntryLocalService.getCTPersistence();
+	}
+
+	@Override
+	public Class<DepotEntry> getModelClass() {
+		return _depotEntryLocalService.getModelClass();
+	}
+
+	@Override
+	public <R, E extends Throwable> R updateWithUnsafeFunction(
+			UnsafeFunction<CTPersistence<DepotEntry>, R, E>
+				updateUnsafeFunction)
+		throws E {
+
+		return _depotEntryLocalService.updateWithUnsafeFunction(
+			updateUnsafeFunction);
 	}
 
 	@Override

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryService.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryService.java
@@ -15,6 +15,7 @@
 package com.liferay.depot.service;
 
 import com.liferay.depot.model.DepotEntry;
+import com.liferay.portal.kernel.change.tracking.CTAware;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.jsonwebservice.JSONWebService;
@@ -42,6 +43,7 @@ import org.osgi.annotation.versioning.ProviderType;
  * @generated
  */
 @AccessControlled
+@CTAware
 @JSONWebService
 @ProviderType
 @Transactional(

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryServiceWrapper.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryServiceWrapper.java
@@ -14,6 +14,7 @@
 
 package com.liferay.depot.service;
 
+import com.liferay.depot.model.DepotEntry;
 import com.liferay.portal.kernel.service.ServiceWrapper;
 
 /**
@@ -35,7 +36,7 @@ public class DepotEntryServiceWrapper
 	}
 
 	@Override
-	public com.liferay.depot.model.DepotEntry addDepotEntry(
+	public DepotEntry addDepotEntry(
 			java.util.Map<java.util.Locale, String> nameMap,
 			java.util.Map<java.util.Locale, String> descriptionMap,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
@@ -46,25 +47,22 @@ public class DepotEntryServiceWrapper
 	}
 
 	@Override
-	public com.liferay.depot.model.DepotEntry deleteDepotEntry(
-			long depotEntryId)
+	public DepotEntry deleteDepotEntry(long depotEntryId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _depotEntryService.deleteDepotEntry(depotEntryId);
 	}
 
 	@Override
-	public com.liferay.depot.model.DepotEntry getDepotEntry(long depotEntryId)
+	public DepotEntry getDepotEntry(long depotEntryId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _depotEntryService.getDepotEntry(depotEntryId);
 	}
 
 	@Override
-	public java.util.List<com.liferay.depot.model.DepotEntry>
-			getGroupConnectedDepotEntries(
-				long groupId, boolean ddmStructuresAvailable, int start,
-				int end)
+	public java.util.List<DepotEntry> getGroupConnectedDepotEntries(
+			long groupId, boolean ddmStructuresAvailable, int start, int end)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _depotEntryService.getGroupConnectedDepotEntries(
@@ -72,8 +70,8 @@ public class DepotEntryServiceWrapper
 	}
 
 	@Override
-	public java.util.List<com.liferay.depot.model.DepotEntry>
-			getGroupConnectedDepotEntries(long groupId, int start, int end)
+	public java.util.List<DepotEntry> getGroupConnectedDepotEntries(
+			long groupId, int start, int end)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _depotEntryService.getGroupConnectedDepotEntries(
@@ -88,7 +86,7 @@ public class DepotEntryServiceWrapper
 	}
 
 	@Override
-	public com.liferay.depot.model.DepotEntry getGroupDepotEntry(long groupId)
+	public DepotEntry getGroupDepotEntry(long groupId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _depotEntryService.getGroupDepotEntry(groupId);
@@ -105,7 +103,7 @@ public class DepotEntryServiceWrapper
 	}
 
 	@Override
-	public com.liferay.depot.model.DepotEntry updateDepotEntry(
+	public DepotEntry updateDepotEntry(
 			long depotEntryId, java.util.Map<java.util.Locale, String> nameMap,
 			java.util.Map<java.util.Locale, String> descriptionMap,
 			java.util.Map<String, Boolean> depotAppCustomizationMap,

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/persistence/DepotAppCustomizationPersistence.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/persistence/DepotAppCustomizationPersistence.java
@@ -17,6 +17,7 @@ package com.liferay.depot.service.persistence;
 import com.liferay.depot.exception.NoSuchAppCustomizationException;
 import com.liferay.depot.model.DepotAppCustomization;
 import com.liferay.portal.kernel.service.persistence.BasePersistence;
+import com.liferay.portal.kernel.service.persistence.change.tracking.CTPersistence;
 
 import org.osgi.annotation.versioning.ProviderType;
 
@@ -33,7 +34,8 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface DepotAppCustomizationPersistence
-	extends BasePersistence<DepotAppCustomization> {
+	extends BasePersistence<DepotAppCustomization>,
+			CTPersistence<DepotAppCustomization> {
 
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/persistence/DepotEntryGroupRelPersistence.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/persistence/DepotEntryGroupRelPersistence.java
@@ -17,6 +17,7 @@ package com.liferay.depot.service.persistence;
 import com.liferay.depot.exception.NoSuchEntryGroupRelException;
 import com.liferay.depot.model.DepotEntryGroupRel;
 import com.liferay.portal.kernel.service.persistence.BasePersistence;
+import com.liferay.portal.kernel.service.persistence.change.tracking.CTPersistence;
 
 import org.osgi.annotation.versioning.ProviderType;
 
@@ -33,7 +34,8 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface DepotEntryGroupRelPersistence
-	extends BasePersistence<DepotEntryGroupRel> {
+	extends BasePersistence<DepotEntryGroupRel>,
+			CTPersistence<DepotEntryGroupRel> {
 
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/persistence/DepotEntryPersistence.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/persistence/DepotEntryPersistence.java
@@ -17,6 +17,7 @@ package com.liferay.depot.service.persistence;
 import com.liferay.depot.exception.NoSuchEntryException;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.portal.kernel.service.persistence.BasePersistence;
+import com.liferay.portal.kernel.service.persistence.change.tracking.CTPersistence;
 
 import org.osgi.annotation.versioning.ProviderType;
 
@@ -32,7 +33,8 @@ import org.osgi.annotation.versioning.ProviderType;
  * @generated
  */
 @ProviderType
-public interface DepotEntryPersistence extends BasePersistence<DepotEntry> {
+public interface DepotEntryPersistence
+	extends BasePersistence<DepotEntry>, CTPersistence<DepotEntry> {
 
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/modules/apps/depot/depot-api/src/main/resources/com/liferay/depot/model/packageinfo
+++ b/modules/apps/depot/depot-api/src/main/resources/com/liferay/depot/model/packageinfo
@@ -1,1 +1,1 @@
-version 2.1.0
+version 2.2.0

--- a/modules/apps/depot/depot-api/src/main/resources/com/liferay/depot/service/packageinfo
+++ b/modules/apps/depot/depot-api/src/main/resources/com/liferay/depot/service/packageinfo
@@ -1,1 +1,1 @@
-version 1.8.0
+version 1.9.0

--- a/modules/apps/depot/depot-api/src/main/resources/com/liferay/depot/service/persistence/packageinfo
+++ b/modules/apps/depot/depot-api/src/main/resources/com/liferay/depot/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 1.3.0
+version 1.4.0

--- a/modules/apps/depot/depot-service/bnd.bnd
+++ b/modules/apps/depot/depot-service/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Depot Service
 Bundle-SymbolicName: com.liferay.depot.service
 Bundle-Version: 3.0.17
-Liferay-Require-SchemaVersion: 2.0.0
+Liferay-Require-SchemaVersion: 2.1.0
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/depot/depot-service/build.gradle
+++ b/modules/apps/depot/depot-service/build.gradle
@@ -24,6 +24,7 @@ dependencies {
 	compileOnly project(":core:osgi-service-tracker-collections")
 	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-lang")
+	compileOnly project(":core:petra:petra-reflect")
 	compileOnly project(":core:petra:petra-sql-dsl-api")
 	compileOnly project(":core:petra:petra-string")
 }

--- a/modules/apps/depot/depot-service/service.xml
+++ b/modules/apps/depot/depot-service/service.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE service-builder PUBLIC "-//Liferay//DTD Service Builder 7.4.0//EN" "http://www.liferay.com/dtd/liferay-service-builder_7_4_0.dtd">
 
-<service-builder auto-import-default-references="false" auto-namespace-tables="false" dependency-injector="ds" mvcc-enabled="true" package-path="com.liferay.depot">
+<service-builder auto-import-default-references="false" auto-namespace-tables="false" change-tracking-enabled="true" dependency-injector="ds" mvcc-enabled="true" package-path="com.liferay.depot">
 	<namespace>Depot</namespace>
 	<entity local-service="true" name="DepotAppCustomization" remote-service="false">
 

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/upgrade/DepotServiceUpgrade.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/upgrade/DepotServiceUpgrade.java
@@ -45,7 +45,9 @@ public class DepotServiceUpgrade implements UpgradeStepRegistrator {
 		registry.register(
 			"2.0.0", "2.1.0",
 			new CTModelUpgradeProcess(
-				"DepotAppCustomization", "DepotEntry", "DepotEntryGroupRel"));
+				"DepotAppCustomization", "DepotEntry", "DepotEntryGroupRel"),
+			new com.liferay.depot.internal.upgrade.v2_1_0.
+				DepotEntryGroupRelUpgradeProcess());
 	}
 
 }

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/upgrade/DepotServiceUpgrade.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/upgrade/DepotServiceUpgrade.java
@@ -14,6 +14,7 @@
 
 package com.liferay.depot.internal.upgrade;
 
+import com.liferay.portal.kernel.upgrade.CTModelUpgradeProcess;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 
 import org.osgi.service.component.annotations.Component;
@@ -40,6 +41,11 @@ public class DepotServiceUpgrade implements UpgradeStepRegistrator {
 			"1.2.0", "2.0.0",
 			new com.liferay.depot.internal.upgrade.v2_0_0.
 				DepotEntryGroupRelUpgradeProcess());
+
+		registry.register(
+			"2.0.0", "2.1.0",
+			new CTModelUpgradeProcess(
+				"DepotAppCustomization", "DepotEntry", "DepotEntryGroupRel"));
 	}
 
 }

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/upgrade/v2_1_0/DepotEntryGroupRelUpgradeProcess.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/upgrade/v2_1_0/DepotEntryGroupRelUpgradeProcess.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.depot.internal.upgrade.v2_1_0;
+
+import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.LoggingTimer;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+/**
+ * @author Adolfo Pérez
+ */
+public class DepotEntryGroupRelUpgradeProcess extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		try (LoggingTimer loggingTimer = new LoggingTimer()) {
+			try (PreparedStatement preparedStatement1 =
+					connection.prepareStatement(
+						"select depotEntryGroupRelId, depotEntryId from " +
+							"DepotEntryGroupRel");
+				PreparedStatement preparedStatement2 =
+					AutoBatchPreparedStatementUtil.autoBatch(
+						connection.prepareStatement(
+							"update DepotEntryGroupRel set groupId = ? where " +
+								"depotEntryGroupRelId = ?"));
+				ResultSet resultSet1 = preparedStatement1.executeQuery()) {
+
+				while (resultSet1.next()) {
+					try (PreparedStatement preparedStatement3 =
+							connection.prepareStatement(
+								"select groupId from DepotEntry where " +
+									"depotEntryId = ?")) {
+
+						preparedStatement3.setLong(1, resultSet1.getLong(2));
+
+						ResultSet resultSet2 =
+							preparedStatement3.executeQuery();
+
+						if (resultSet2.next()) {
+							preparedStatement2.setLong(
+								1, resultSet2.getLong(1));
+							preparedStatement2.setLong(
+								2, resultSet1.getLong(1));
+
+							preparedStatement2.addBatch();
+						}
+					}
+				}
+
+				preparedStatement2.executeBatch();
+			}
+		}
+	}
+
+}

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/model/impl/DepotAppCustomizationCacheModel.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/model/impl/DepotAppCustomizationCacheModel.java
@@ -76,10 +76,12 @@ public class DepotAppCustomizationCacheModel
 
 	@Override
 	public String toString() {
-		StringBundler sb = new StringBundler(13);
+		StringBundler sb = new StringBundler(15);
 
 		sb.append("{mvccVersion=");
 		sb.append(mvccVersion);
+		sb.append(", ctCollectionId=");
+		sb.append(ctCollectionId);
 		sb.append(", depotAppCustomizationId=");
 		sb.append(depotAppCustomizationId);
 		sb.append(", companyId=");
@@ -101,6 +103,7 @@ public class DepotAppCustomizationCacheModel
 			new DepotAppCustomizationImpl();
 
 		depotAppCustomizationImpl.setMvccVersion(mvccVersion);
+		depotAppCustomizationImpl.setCtCollectionId(ctCollectionId);
 		depotAppCustomizationImpl.setDepotAppCustomizationId(
 			depotAppCustomizationId);
 		depotAppCustomizationImpl.setCompanyId(companyId);
@@ -123,6 +126,8 @@ public class DepotAppCustomizationCacheModel
 	public void readExternal(ObjectInput objectInput) throws IOException {
 		mvccVersion = objectInput.readLong();
 
+		ctCollectionId = objectInput.readLong();
+
 		depotAppCustomizationId = objectInput.readLong();
 
 		companyId = objectInput.readLong();
@@ -136,6 +141,8 @@ public class DepotAppCustomizationCacheModel
 	@Override
 	public void writeExternal(ObjectOutput objectOutput) throws IOException {
 		objectOutput.writeLong(mvccVersion);
+
+		objectOutput.writeLong(ctCollectionId);
 
 		objectOutput.writeLong(depotAppCustomizationId);
 
@@ -154,6 +161,7 @@ public class DepotAppCustomizationCacheModel
 	}
 
 	public long mvccVersion;
+	public long ctCollectionId;
 	public long depotAppCustomizationId;
 	public long companyId;
 	public long depotEntryId;

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/model/impl/DepotAppCustomizationModelImpl.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/model/impl/DepotAppCustomizationModelImpl.java
@@ -68,7 +68,7 @@ public class DepotAppCustomizationModelImpl
 	public static final String TABLE_NAME = "DepotAppCustomization";
 
 	public static final Object[][] TABLE_COLUMNS = {
-		{"mvccVersion", Types.BIGINT},
+		{"mvccVersion", Types.BIGINT}, {"ctCollectionId", Types.BIGINT},
 		{"depotAppCustomizationId", Types.BIGINT}, {"companyId", Types.BIGINT},
 		{"depotEntryId", Types.BIGINT}, {"enabled", Types.BOOLEAN},
 		{"portletId", Types.VARCHAR}
@@ -79,6 +79,7 @@ public class DepotAppCustomizationModelImpl
 
 	static {
 		TABLE_COLUMNS_MAP.put("mvccVersion", Types.BIGINT);
+		TABLE_COLUMNS_MAP.put("ctCollectionId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("depotAppCustomizationId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("depotEntryId", Types.BIGINT);
@@ -87,7 +88,7 @@ public class DepotAppCustomizationModelImpl
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table DepotAppCustomization (mvccVersion LONG default 0 not null,depotAppCustomizationId LONG not null primary key,companyId LONG,depotEntryId LONG,enabled BOOLEAN,portletId VARCHAR(75) null)";
+		"create table DepotAppCustomization (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,depotAppCustomizationId LONG not null,companyId LONG,depotEntryId LONG,enabled BOOLEAN,portletId VARCHAR(75) null,primary key (depotAppCustomizationId, ctCollectionId))";
 
 	public static final String TABLE_SQL_DROP =
 		"drop table DepotAppCustomization";
@@ -279,6 +280,12 @@ public class DepotAppCustomizationModelImpl
 			(BiConsumer<DepotAppCustomization, Long>)
 				DepotAppCustomization::setMvccVersion);
 		attributeGetterFunctions.put(
+			"ctCollectionId", DepotAppCustomization::getCtCollectionId);
+		attributeSetterBiConsumers.put(
+			"ctCollectionId",
+			(BiConsumer<DepotAppCustomization, Long>)
+				DepotAppCustomization::setCtCollectionId);
+		attributeGetterFunctions.put(
 			"depotAppCustomizationId",
 			DepotAppCustomization::getDepotAppCustomizationId);
 		attributeSetterBiConsumers.put(
@@ -328,6 +335,20 @@ public class DepotAppCustomizationModelImpl
 		}
 
 		_mvccVersion = mvccVersion;
+	}
+
+	@Override
+	public long getCtCollectionId() {
+		return _ctCollectionId;
+	}
+
+	@Override
+	public void setCtCollectionId(long ctCollectionId) {
+		if (_columnOriginalValues == Collections.EMPTY_MAP) {
+			_setColumnOriginalValues();
+		}
+
+		_ctCollectionId = ctCollectionId;
 	}
 
 	@Override
@@ -498,6 +519,7 @@ public class DepotAppCustomizationModelImpl
 			new DepotAppCustomizationImpl();
 
 		depotAppCustomizationImpl.setMvccVersion(getMvccVersion());
+		depotAppCustomizationImpl.setCtCollectionId(getCtCollectionId());
 		depotAppCustomizationImpl.setDepotAppCustomizationId(
 			getDepotAppCustomizationId());
 		depotAppCustomizationImpl.setCompanyId(getCompanyId());
@@ -517,6 +539,8 @@ public class DepotAppCustomizationModelImpl
 
 		depotAppCustomizationImpl.setMvccVersion(
 			this.<Long>getColumnOriginalValue("mvccVersion"));
+		depotAppCustomizationImpl.setCtCollectionId(
+			this.<Long>getColumnOriginalValue("ctCollectionId"));
 		depotAppCustomizationImpl.setDepotAppCustomizationId(
 			this.<Long>getColumnOriginalValue("depotAppCustomizationId"));
 		depotAppCustomizationImpl.setCompanyId(
@@ -605,6 +629,8 @@ public class DepotAppCustomizationModelImpl
 			new DepotAppCustomizationCacheModel();
 
 		depotAppCustomizationCacheModel.mvccVersion = getMvccVersion();
+
+		depotAppCustomizationCacheModel.ctCollectionId = getCtCollectionId();
 
 		depotAppCustomizationCacheModel.depotAppCustomizationId =
 			getDepotAppCustomizationId();
@@ -716,6 +742,7 @@ public class DepotAppCustomizationModelImpl
 	}
 
 	private long _mvccVersion;
+	private long _ctCollectionId;
 	private long _depotAppCustomizationId;
 	private long _companyId;
 	private long _depotEntryId;
@@ -750,6 +777,7 @@ public class DepotAppCustomizationModelImpl
 		_columnOriginalValues = new HashMap<String, Object>();
 
 		_columnOriginalValues.put("mvccVersion", _mvccVersion);
+		_columnOriginalValues.put("ctCollectionId", _ctCollectionId);
 		_columnOriginalValues.put(
 			"depotAppCustomizationId", _depotAppCustomizationId);
 		_columnOriginalValues.put("companyId", _companyId);
@@ -771,15 +799,17 @@ public class DepotAppCustomizationModelImpl
 
 		columnBitmasks.put("mvccVersion", 1L);
 
-		columnBitmasks.put("depotAppCustomizationId", 2L);
+		columnBitmasks.put("ctCollectionId", 2L);
 
-		columnBitmasks.put("companyId", 4L);
+		columnBitmasks.put("depotAppCustomizationId", 4L);
 
-		columnBitmasks.put("depotEntryId", 8L);
+		columnBitmasks.put("companyId", 8L);
 
-		columnBitmasks.put("enabled", 16L);
+		columnBitmasks.put("depotEntryId", 16L);
 
-		columnBitmasks.put("portletId", 32L);
+		columnBitmasks.put("enabled", 32L);
+
+		columnBitmasks.put("portletId", 64L);
 
 		_columnBitmasks = Collections.unmodifiableMap(columnBitmasks);
 	}

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/model/impl/DepotEntryCacheModel.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/model/impl/DepotEntryCacheModel.java
@@ -77,10 +77,12 @@ public class DepotEntryCacheModel
 
 	@Override
 	public String toString() {
-		StringBundler sb = new StringBundler(19);
+		StringBundler sb = new StringBundler(21);
 
 		sb.append("{mvccVersion=");
 		sb.append(mvccVersion);
+		sb.append(", ctCollectionId=");
+		sb.append(ctCollectionId);
 		sb.append(", uuid=");
 		sb.append(uuid);
 		sb.append(", depotEntryId=");
@@ -107,6 +109,7 @@ public class DepotEntryCacheModel
 		DepotEntryImpl depotEntryImpl = new DepotEntryImpl();
 
 		depotEntryImpl.setMvccVersion(mvccVersion);
+		depotEntryImpl.setCtCollectionId(ctCollectionId);
 
 		if (uuid == null) {
 			depotEntryImpl.setUuid("");
@@ -149,6 +152,8 @@ public class DepotEntryCacheModel
 	@Override
 	public void readExternal(ObjectInput objectInput) throws IOException {
 		mvccVersion = objectInput.readLong();
+
+		ctCollectionId = objectInput.readLong();
 		uuid = objectInput.readUTF();
 
 		depotEntryId = objectInput.readLong();
@@ -166,6 +171,8 @@ public class DepotEntryCacheModel
 	@Override
 	public void writeExternal(ObjectOutput objectOutput) throws IOException {
 		objectOutput.writeLong(mvccVersion);
+
+		objectOutput.writeLong(ctCollectionId);
 
 		if (uuid == null) {
 			objectOutput.writeUTF("");
@@ -194,6 +201,7 @@ public class DepotEntryCacheModel
 	}
 
 	public long mvccVersion;
+	public long ctCollectionId;
 	public String uuid;
 	public long depotEntryId;
 	public long groupId;

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/model/impl/DepotEntryGroupRelCacheModel.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/model/impl/DepotEntryGroupRelCacheModel.java
@@ -78,10 +78,12 @@ public class DepotEntryGroupRelCacheModel
 
 	@Override
 	public String toString() {
-		StringBundler sb = new StringBundler(29);
+		StringBundler sb = new StringBundler(31);
 
 		sb.append("{mvccVersion=");
 		sb.append(mvccVersion);
+		sb.append(", ctCollectionId=");
+		sb.append(ctCollectionId);
 		sb.append(", uuid=");
 		sb.append(uuid);
 		sb.append(", depotEntryGroupRelId=");
@@ -119,6 +121,7 @@ public class DepotEntryGroupRelCacheModel
 			new DepotEntryGroupRelImpl();
 
 		depotEntryGroupRelImpl.setMvccVersion(mvccVersion);
+		depotEntryGroupRelImpl.setCtCollectionId(ctCollectionId);
 
 		if (uuid == null) {
 			depotEntryGroupRelImpl.setUuid("");
@@ -175,6 +178,8 @@ public class DepotEntryGroupRelCacheModel
 	@Override
 	public void readExternal(ObjectInput objectInput) throws IOException {
 		mvccVersion = objectInput.readLong();
+
+		ctCollectionId = objectInput.readLong();
 		uuid = objectInput.readUTF();
 
 		depotEntryGroupRelId = objectInput.readLong();
@@ -201,6 +206,8 @@ public class DepotEntryGroupRelCacheModel
 	@Override
 	public void writeExternal(ObjectOutput objectOutput) throws IOException {
 		objectOutput.writeLong(mvccVersion);
+
+		objectOutput.writeLong(ctCollectionId);
 
 		if (uuid == null) {
 			objectOutput.writeUTF("");
@@ -238,6 +245,7 @@ public class DepotEntryGroupRelCacheModel
 	}
 
 	public long mvccVersion;
+	public long ctCollectionId;
 	public String uuid;
 	public long depotEntryGroupRelId;
 	public long groupId;

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/model/impl/DepotEntryGroupRelModelImpl.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/model/impl/DepotEntryGroupRelModelImpl.java
@@ -78,11 +78,11 @@ public class DepotEntryGroupRelModelImpl
 	public static final String TABLE_NAME = "DepotEntryGroupRel";
 
 	public static final Object[][] TABLE_COLUMNS = {
-		{"mvccVersion", Types.BIGINT}, {"uuid_", Types.VARCHAR},
-		{"depotEntryGroupRelId", Types.BIGINT}, {"groupId", Types.BIGINT},
-		{"companyId", Types.BIGINT}, {"userId", Types.BIGINT},
-		{"userName", Types.VARCHAR}, {"createDate", Types.TIMESTAMP},
-		{"modifiedDate", Types.TIMESTAMP},
+		{"mvccVersion", Types.BIGINT}, {"ctCollectionId", Types.BIGINT},
+		{"uuid_", Types.VARCHAR}, {"depotEntryGroupRelId", Types.BIGINT},
+		{"groupId", Types.BIGINT}, {"companyId", Types.BIGINT},
+		{"userId", Types.BIGINT}, {"userName", Types.VARCHAR},
+		{"createDate", Types.TIMESTAMP}, {"modifiedDate", Types.TIMESTAMP},
 		{"ddmStructuresAvailable", Types.BOOLEAN},
 		{"depotEntryId", Types.BIGINT}, {"searchable", Types.BOOLEAN},
 		{"toGroupId", Types.BIGINT}, {"lastPublishDate", Types.TIMESTAMP}
@@ -93,6 +93,7 @@ public class DepotEntryGroupRelModelImpl
 
 	static {
 		TABLE_COLUMNS_MAP.put("mvccVersion", Types.BIGINT);
+		TABLE_COLUMNS_MAP.put("ctCollectionId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("uuid_", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("depotEntryGroupRelId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
@@ -109,7 +110,7 @@ public class DepotEntryGroupRelModelImpl
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table DepotEntryGroupRel (mvccVersion LONG default 0 not null,uuid_ VARCHAR(75) null,depotEntryGroupRelId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,ddmStructuresAvailable BOOLEAN,depotEntryId LONG,searchable BOOLEAN,toGroupId LONG,lastPublishDate DATE null)";
+		"create table DepotEntryGroupRel (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,uuid_ VARCHAR(75) null,depotEntryGroupRelId LONG not null,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,ddmStructuresAvailable BOOLEAN,depotEntryId LONG,searchable BOOLEAN,toGroupId LONG,lastPublishDate DATE null,primary key (depotEntryGroupRelId, ctCollectionId))";
 
 	public static final String TABLE_SQL_DROP = "drop table DepotEntryGroupRel";
 
@@ -204,6 +205,7 @@ public class DepotEntryGroupRelModelImpl
 		DepotEntryGroupRel model = new DepotEntryGroupRelImpl();
 
 		model.setMvccVersion(soapModel.getMvccVersion());
+		model.setCtCollectionId(soapModel.getCtCollectionId());
 		model.setUuid(soapModel.getUuid());
 		model.setDepotEntryGroupRelId(soapModel.getDepotEntryGroupRelId());
 		model.setGroupId(soapModel.getGroupId());
@@ -379,6 +381,12 @@ public class DepotEntryGroupRelModelImpl
 			"mvccVersion",
 			(BiConsumer<DepotEntryGroupRel, Long>)
 				DepotEntryGroupRel::setMvccVersion);
+		attributeGetterFunctions.put(
+			"ctCollectionId", DepotEntryGroupRel::getCtCollectionId);
+		attributeSetterBiConsumers.put(
+			"ctCollectionId",
+			(BiConsumer<DepotEntryGroupRel, Long>)
+				DepotEntryGroupRel::setCtCollectionId);
 		attributeGetterFunctions.put("uuid", DepotEntryGroupRel::getUuid);
 		attributeSetterBiConsumers.put(
 			"uuid",
@@ -476,6 +484,21 @@ public class DepotEntryGroupRelModelImpl
 		}
 
 		_mvccVersion = mvccVersion;
+	}
+
+	@JSON
+	@Override
+	public long getCtCollectionId() {
+		return _ctCollectionId;
+	}
+
+	@Override
+	public void setCtCollectionId(long ctCollectionId) {
+		if (_columnOriginalValues == Collections.EMPTY_MAP) {
+			_setColumnOriginalValues();
+		}
+
+		_ctCollectionId = ctCollectionId;
 	}
 
 	@JSON
@@ -850,6 +873,7 @@ public class DepotEntryGroupRelModelImpl
 			new DepotEntryGroupRelImpl();
 
 		depotEntryGroupRelImpl.setMvccVersion(getMvccVersion());
+		depotEntryGroupRelImpl.setCtCollectionId(getCtCollectionId());
 		depotEntryGroupRelImpl.setUuid(getUuid());
 		depotEntryGroupRelImpl.setDepotEntryGroupRelId(
 			getDepotEntryGroupRelId());
@@ -878,6 +902,8 @@ public class DepotEntryGroupRelModelImpl
 
 		depotEntryGroupRelImpl.setMvccVersion(
 			this.<Long>getColumnOriginalValue("mvccVersion"));
+		depotEntryGroupRelImpl.setCtCollectionId(
+			this.<Long>getColumnOriginalValue("ctCollectionId"));
 		depotEntryGroupRelImpl.setUuid(
 			this.<String>getColumnOriginalValue("uuid_"));
 		depotEntryGroupRelImpl.setDepotEntryGroupRelId(
@@ -983,6 +1009,8 @@ public class DepotEntryGroupRelModelImpl
 			new DepotEntryGroupRelCacheModel();
 
 		depotEntryGroupRelCacheModel.mvccVersion = getMvccVersion();
+
+		depotEntryGroupRelCacheModel.ctCollectionId = getCtCollectionId();
 
 		depotEntryGroupRelCacheModel.uuid = getUuid();
 
@@ -1138,6 +1166,7 @@ public class DepotEntryGroupRelModelImpl
 	}
 
 	private long _mvccVersion;
+	private long _ctCollectionId;
 	private String _uuid;
 	private long _depotEntryGroupRelId;
 	private long _groupId;
@@ -1183,6 +1212,7 @@ public class DepotEntryGroupRelModelImpl
 		_columnOriginalValues = new HashMap<String, Object>();
 
 		_columnOriginalValues.put("mvccVersion", _mvccVersion);
+		_columnOriginalValues.put("ctCollectionId", _ctCollectionId);
 		_columnOriginalValues.put("uuid_", _uuid);
 		_columnOriginalValues.put(
 			"depotEntryGroupRelId", _depotEntryGroupRelId);
@@ -1223,31 +1253,33 @@ public class DepotEntryGroupRelModelImpl
 
 		columnBitmasks.put("mvccVersion", 1L);
 
-		columnBitmasks.put("uuid_", 2L);
+		columnBitmasks.put("ctCollectionId", 2L);
 
-		columnBitmasks.put("depotEntryGroupRelId", 4L);
+		columnBitmasks.put("uuid_", 4L);
 
-		columnBitmasks.put("groupId", 8L);
+		columnBitmasks.put("depotEntryGroupRelId", 8L);
 
-		columnBitmasks.put("companyId", 16L);
+		columnBitmasks.put("groupId", 16L);
 
-		columnBitmasks.put("userId", 32L);
+		columnBitmasks.put("companyId", 32L);
 
-		columnBitmasks.put("userName", 64L);
+		columnBitmasks.put("userId", 64L);
 
-		columnBitmasks.put("createDate", 128L);
+		columnBitmasks.put("userName", 128L);
 
-		columnBitmasks.put("modifiedDate", 256L);
+		columnBitmasks.put("createDate", 256L);
 
-		columnBitmasks.put("ddmStructuresAvailable", 512L);
+		columnBitmasks.put("modifiedDate", 512L);
 
-		columnBitmasks.put("depotEntryId", 1024L);
+		columnBitmasks.put("ddmStructuresAvailable", 1024L);
 
-		columnBitmasks.put("searchable", 2048L);
+		columnBitmasks.put("depotEntryId", 2048L);
 
-		columnBitmasks.put("toGroupId", 4096L);
+		columnBitmasks.put("searchable", 4096L);
 
-		columnBitmasks.put("lastPublishDate", 8192L);
+		columnBitmasks.put("toGroupId", 8192L);
+
+		columnBitmasks.put("lastPublishDate", 16384L);
 
 		_columnBitmasks = Collections.unmodifiableMap(columnBitmasks);
 	}

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/model/impl/DepotEntryModelImpl.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/model/impl/DepotEntryModelImpl.java
@@ -77,11 +77,11 @@ public class DepotEntryModelImpl
 	public static final String TABLE_NAME = "DepotEntry";
 
 	public static final Object[][] TABLE_COLUMNS = {
-		{"mvccVersion", Types.BIGINT}, {"uuid_", Types.VARCHAR},
-		{"depotEntryId", Types.BIGINT}, {"groupId", Types.BIGINT},
-		{"companyId", Types.BIGINT}, {"userId", Types.BIGINT},
-		{"userName", Types.VARCHAR}, {"createDate", Types.TIMESTAMP},
-		{"modifiedDate", Types.TIMESTAMP}
+		{"mvccVersion", Types.BIGINT}, {"ctCollectionId", Types.BIGINT},
+		{"uuid_", Types.VARCHAR}, {"depotEntryId", Types.BIGINT},
+		{"groupId", Types.BIGINT}, {"companyId", Types.BIGINT},
+		{"userId", Types.BIGINT}, {"userName", Types.VARCHAR},
+		{"createDate", Types.TIMESTAMP}, {"modifiedDate", Types.TIMESTAMP}
 	};
 
 	public static final Map<String, Integer> TABLE_COLUMNS_MAP =
@@ -89,6 +89,7 @@ public class DepotEntryModelImpl
 
 	static {
 		TABLE_COLUMNS_MAP.put("mvccVersion", Types.BIGINT);
+		TABLE_COLUMNS_MAP.put("ctCollectionId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("uuid_", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("depotEntryId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
@@ -100,7 +101,7 @@ public class DepotEntryModelImpl
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table DepotEntry (mvccVersion LONG default 0 not null,uuid_ VARCHAR(75) null,depotEntryId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null)";
+		"create table DepotEntry (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,uuid_ VARCHAR(75) null,depotEntryId LONG not null,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,primary key (depotEntryId, ctCollectionId))";
 
 	public static final String TABLE_SQL_DROP = "drop table DepotEntry";
 
@@ -171,6 +172,7 @@ public class DepotEntryModelImpl
 		DepotEntry model = new DepotEntryImpl();
 
 		model.setMvccVersion(soapModel.getMvccVersion());
+		model.setCtCollectionId(soapModel.getCtCollectionId());
 		model.setUuid(soapModel.getUuid());
 		model.setDepotEntryId(soapModel.getDepotEntryId());
 		model.setGroupId(soapModel.getGroupId());
@@ -332,6 +334,11 @@ public class DepotEntryModelImpl
 		attributeSetterBiConsumers.put(
 			"mvccVersion",
 			(BiConsumer<DepotEntry, Long>)DepotEntry::setMvccVersion);
+		attributeGetterFunctions.put(
+			"ctCollectionId", DepotEntry::getCtCollectionId);
+		attributeSetterBiConsumers.put(
+			"ctCollectionId",
+			(BiConsumer<DepotEntry, Long>)DepotEntry::setCtCollectionId);
 		attributeGetterFunctions.put("uuid", DepotEntry::getUuid);
 		attributeSetterBiConsumers.put(
 			"uuid", (BiConsumer<DepotEntry, String>)DepotEntry::setUuid);
@@ -383,6 +390,21 @@ public class DepotEntryModelImpl
 		}
 
 		_mvccVersion = mvccVersion;
+	}
+
+	@JSON
+	@Override
+	public long getCtCollectionId() {
+		return _ctCollectionId;
+	}
+
+	@Override
+	public void setCtCollectionId(long ctCollectionId) {
+		if (_columnOriginalValues == Collections.EMPTY_MAP) {
+			_setColumnOriginalValues();
+		}
+
+		_ctCollectionId = ctCollectionId;
 	}
 
 	@JSON
@@ -628,6 +650,7 @@ public class DepotEntryModelImpl
 		DepotEntryImpl depotEntryImpl = new DepotEntryImpl();
 
 		depotEntryImpl.setMvccVersion(getMvccVersion());
+		depotEntryImpl.setCtCollectionId(getCtCollectionId());
 		depotEntryImpl.setUuid(getUuid());
 		depotEntryImpl.setDepotEntryId(getDepotEntryId());
 		depotEntryImpl.setGroupId(getGroupId());
@@ -648,6 +671,8 @@ public class DepotEntryModelImpl
 
 		depotEntryImpl.setMvccVersion(
 			this.<Long>getColumnOriginalValue("mvccVersion"));
+		depotEntryImpl.setCtCollectionId(
+			this.<Long>getColumnOriginalValue("ctCollectionId"));
 		depotEntryImpl.setUuid(this.<String>getColumnOriginalValue("uuid_"));
 		depotEntryImpl.setDepotEntryId(
 			this.<Long>getColumnOriginalValue("depotEntryId"));
@@ -739,6 +764,8 @@ public class DepotEntryModelImpl
 		DepotEntryCacheModel depotEntryCacheModel = new DepotEntryCacheModel();
 
 		depotEntryCacheModel.mvccVersion = getMvccVersion();
+
+		depotEntryCacheModel.ctCollectionId = getCtCollectionId();
 
 		depotEntryCacheModel.uuid = getUuid();
 
@@ -873,6 +900,7 @@ public class DepotEntryModelImpl
 	}
 
 	private long _mvccVersion;
+	private long _ctCollectionId;
 	private String _uuid;
 	private long _depotEntryId;
 	private long _groupId;
@@ -913,6 +941,7 @@ public class DepotEntryModelImpl
 		_columnOriginalValues = new HashMap<String, Object>();
 
 		_columnOriginalValues.put("mvccVersion", _mvccVersion);
+		_columnOriginalValues.put("ctCollectionId", _ctCollectionId);
 		_columnOriginalValues.put("uuid_", _uuid);
 		_columnOriginalValues.put("depotEntryId", _depotEntryId);
 		_columnOriginalValues.put("groupId", _groupId);
@@ -946,21 +975,23 @@ public class DepotEntryModelImpl
 
 		columnBitmasks.put("mvccVersion", 1L);
 
-		columnBitmasks.put("uuid_", 2L);
+		columnBitmasks.put("ctCollectionId", 2L);
 
-		columnBitmasks.put("depotEntryId", 4L);
+		columnBitmasks.put("uuid_", 4L);
 
-		columnBitmasks.put("groupId", 8L);
+		columnBitmasks.put("depotEntryId", 8L);
 
-		columnBitmasks.put("companyId", 16L);
+		columnBitmasks.put("groupId", 16L);
 
-		columnBitmasks.put("userId", 32L);
+		columnBitmasks.put("companyId", 32L);
 
-		columnBitmasks.put("userName", 64L);
+		columnBitmasks.put("userId", 64L);
 
-		columnBitmasks.put("createDate", 128L);
+		columnBitmasks.put("userName", 128L);
 
-		columnBitmasks.put("modifiedDate", 256L);
+		columnBitmasks.put("createDate", 256L);
+
+		columnBitmasks.put("modifiedDate", 512L);
 
 		_columnBitmasks = Collections.unmodifiableMap(columnBitmasks);
 	}

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/base/DepotAppCustomizationLocalServiceBaseImpl.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/base/DepotAppCustomizationLocalServiceBaseImpl.java
@@ -18,6 +18,7 @@ import com.liferay.depot.model.DepotAppCustomization;
 import com.liferay.depot.service.DepotAppCustomizationLocalService;
 import com.liferay.depot.service.DepotAppCustomizationLocalServiceUtil;
 import com.liferay.depot.service.persistence.DepotAppCustomizationPersistence;
+import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.sql.dsl.query.DSLQuery;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.dao.db.DB;
@@ -38,7 +39,9 @@ import com.liferay.portal.kernel.search.Indexable;
 import com.liferay.portal.kernel.search.IndexableType;
 import com.liferay.portal.kernel.service.BaseLocalServiceImpl;
 import com.liferay.portal.kernel.service.PersistedModelLocalService;
+import com.liferay.portal.kernel.service.change.tracking.CTService;
 import com.liferay.portal.kernel.service.persistence.BasePersistence;
+import com.liferay.portal.kernel.service.persistence.change.tracking.CTPersistence;
 import com.liferay.portal.kernel.transaction.Transactional;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.PortalUtil;
@@ -412,7 +415,8 @@ public abstract class DepotAppCustomizationLocalServiceBaseImpl
 	public Class<?>[] getAopInterfaces() {
 		return new Class<?>[] {
 			DepotAppCustomizationLocalService.class,
-			IdentifiableOSGiService.class, PersistedModelLocalService.class
+			IdentifiableOSGiService.class, CTService.class,
+			PersistedModelLocalService.class
 		};
 	}
 
@@ -434,8 +438,23 @@ public abstract class DepotAppCustomizationLocalServiceBaseImpl
 		return DepotAppCustomizationLocalService.class.getName();
 	}
 
-	protected Class<?> getModelClass() {
+	@Override
+	public CTPersistence<DepotAppCustomization> getCTPersistence() {
+		return depotAppCustomizationPersistence;
+	}
+
+	@Override
+	public Class<DepotAppCustomization> getModelClass() {
 		return DepotAppCustomization.class;
+	}
+
+	@Override
+	public <R, E extends Throwable> R updateWithUnsafeFunction(
+			UnsafeFunction<CTPersistence<DepotAppCustomization>, R, E>
+				updateUnsafeFunction)
+		throws E {
+
+		return updateUnsafeFunction.apply(depotAppCustomizationPersistence);
 	}
 
 	protected String getModelClassName() {

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/base/DepotEntryGroupRelLocalServiceBaseImpl.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/base/DepotEntryGroupRelLocalServiceBaseImpl.java
@@ -23,6 +23,7 @@ import com.liferay.exportimport.kernel.lar.ManifestSummary;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.exportimport.kernel.lar.StagedModelDataHandlerUtil;
 import com.liferay.exportimport.kernel.lar.StagedModelType;
+import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.sql.dsl.query.DSLQuery;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.dao.db.DB;
@@ -44,7 +45,9 @@ import com.liferay.portal.kernel.search.Indexable;
 import com.liferay.portal.kernel.search.IndexableType;
 import com.liferay.portal.kernel.service.BaseLocalServiceImpl;
 import com.liferay.portal.kernel.service.PersistedModelLocalService;
+import com.liferay.portal.kernel.service.change.tracking.CTService;
 import com.liferay.portal.kernel.service.persistence.BasePersistence;
+import com.liferay.portal.kernel.service.persistence.change.tracking.CTPersistence;
 import com.liferay.portal.kernel.transaction.Transactional;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.PortalUtil;
@@ -546,7 +549,7 @@ public abstract class DepotEntryGroupRelLocalServiceBaseImpl
 	public Class<?>[] getAopInterfaces() {
 		return new Class<?>[] {
 			DepotEntryGroupRelLocalService.class, IdentifiableOSGiService.class,
-			PersistedModelLocalService.class
+			CTService.class, PersistedModelLocalService.class
 		};
 	}
 
@@ -568,8 +571,23 @@ public abstract class DepotEntryGroupRelLocalServiceBaseImpl
 		return DepotEntryGroupRelLocalService.class.getName();
 	}
 
-	protected Class<?> getModelClass() {
+	@Override
+	public CTPersistence<DepotEntryGroupRel> getCTPersistence() {
+		return depotEntryGroupRelPersistence;
+	}
+
+	@Override
+	public Class<DepotEntryGroupRel> getModelClass() {
 		return DepotEntryGroupRel.class;
+	}
+
+	@Override
+	public <R, E extends Throwable> R updateWithUnsafeFunction(
+			UnsafeFunction<CTPersistence<DepotEntryGroupRel>, R, E>
+				updateUnsafeFunction)
+		throws E {
+
+		return updateUnsafeFunction.apply(depotEntryGroupRelPersistence);
 	}
 
 	protected String getModelClassName() {

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/base/DepotEntryLocalServiceBaseImpl.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/base/DepotEntryLocalServiceBaseImpl.java
@@ -23,6 +23,7 @@ import com.liferay.exportimport.kernel.lar.ManifestSummary;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.exportimport.kernel.lar.StagedModelDataHandlerUtil;
 import com.liferay.exportimport.kernel.lar.StagedModelType;
+import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.sql.dsl.query.DSLQuery;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.dao.db.DB;
@@ -44,7 +45,9 @@ import com.liferay.portal.kernel.search.Indexable;
 import com.liferay.portal.kernel.search.IndexableType;
 import com.liferay.portal.kernel.service.BaseLocalServiceImpl;
 import com.liferay.portal.kernel.service.PersistedModelLocalService;
+import com.liferay.portal.kernel.service.change.tracking.CTService;
 import com.liferay.portal.kernel.service.persistence.BasePersistence;
+import com.liferay.portal.kernel.service.persistence.change.tracking.CTPersistence;
 import com.liferay.portal.kernel.transaction.Transactional;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.PortalUtil;
@@ -519,7 +522,7 @@ public abstract class DepotEntryLocalServiceBaseImpl
 	public Class<?>[] getAopInterfaces() {
 		return new Class<?>[] {
 			DepotEntryLocalService.class, IdentifiableOSGiService.class,
-			PersistedModelLocalService.class
+			CTService.class, PersistedModelLocalService.class
 		};
 	}
 
@@ -540,8 +543,23 @@ public abstract class DepotEntryLocalServiceBaseImpl
 		return DepotEntryLocalService.class.getName();
 	}
 
-	protected Class<?> getModelClass() {
+	@Override
+	public CTPersistence<DepotEntry> getCTPersistence() {
+		return depotEntryPersistence;
+	}
+
+	@Override
+	public Class<DepotEntry> getModelClass() {
 		return DepotEntry.class;
+	}
+
+	@Override
+	public <R, E extends Throwable> R updateWithUnsafeFunction(
+			UnsafeFunction<CTPersistence<DepotEntry>, R, E>
+				updateUnsafeFunction)
+		throws E {
+
+		return updateUnsafeFunction.apply(depotEntryPersistence);
 	}
 
 	protected String getModelClassName() {

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/impl/DepotEntryGroupRelLocalServiceImpl.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/impl/DepotEntryGroupRelLocalServiceImpl.java
@@ -16,7 +16,9 @@ package com.liferay.depot.service.impl;
 
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.model.DepotEntryGroupRel;
+import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.depot.service.base.DepotEntryGroupRelLocalServiceBaseImpl;
+import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.SystemEventConstants;
@@ -27,6 +29,7 @@ import com.liferay.portal.kernel.systemevent.SystemEvent;
 import java.util.List;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Brian Wing Shun Chan
@@ -53,7 +56,7 @@ public class DepotEntryGroupRelLocalServiceImpl
 		depotEntryGroupRel = depotEntryGroupRelPersistence.create(
 			counterLocalService.increment());
 
-		depotEntryGroupRel.setGroupId(toGroupId);
+		depotEntryGroupRel.setGroupId(_getDepotGroupId(depotEntryId));
 		depotEntryGroupRel.setDdmStructuresAvailable(ddmStructuresAvailable);
 		depotEntryGroupRel.setDepotEntryId(depotEntryId);
 		depotEntryGroupRel.setSearchable(searchable);
@@ -170,5 +173,20 @@ public class DepotEntryGroupRelLocalServiceImpl
 
 		return depotEntryGroupRelPersistence.update(depotEntryGroupRel);
 	}
+
+	private long _getDepotGroupId(long depotEntryId) {
+		try {
+			DepotEntry depotEntry = _depotEntryLocalService.getDepotEntry(
+				depotEntryId);
+
+			return depotEntry.getGroupId();
+		}
+		catch (PortalException portalException) {
+			return ReflectionUtil.throwException(portalException);
+		}
+	}
+
+	@Reference
+	private DepotEntryLocalService _depotEntryLocalService;
 
 }

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/persistence/impl/DepotAppCustomizationPersistenceImpl.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/persistence/impl/DepotAppCustomizationPersistenceImpl.java
@@ -23,6 +23,7 @@ import com.liferay.depot.service.persistence.DepotAppCustomizationPersistence;
 import com.liferay.depot.service.persistence.DepotAppCustomizationUtil;
 import com.liferay.depot.service.persistence.impl.constants.DepotPersistenceConstants;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.change.tracking.CTColumnResolutionType;
 import com.liferay.portal.kernel.configuration.Configuration;
 import com.liferay.portal.kernel.dao.orm.EntityCache;
 import com.liferay.portal.kernel.dao.orm.FinderCache;
@@ -36,6 +37,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.persistence.BasePersistence;
+import com.liferay.portal.kernel.service.persistence.change.tracking.helper.CTPersistenceHelper;
 import com.liferay.portal.kernel.service.persistence.impl.BasePersistenceImpl;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
@@ -49,7 +51,12 @@ import java.io.Serializable;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationHandler;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -173,18 +180,21 @@ public class DepotAppCustomizationPersistenceImpl
 		OrderByComparator<DepotAppCustomization> orderByComparator,
 		boolean useFinderCache) {
 
+		boolean productionMode = ctPersistenceHelper.isProductionMode(
+			DepotAppCustomization.class);
+
 		FinderPath finderPath = null;
 		Object[] finderArgs = null;
 
 		if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) &&
 			(orderByComparator == null)) {
 
-			if (useFinderCache) {
+			if (useFinderCache && productionMode) {
 				finderPath = _finderPathWithoutPaginationFindByDepotEntryId;
 				finderArgs = new Object[] {depotEntryId};
 			}
 		}
-		else if (useFinderCache) {
+		else if (useFinderCache && productionMode) {
 			finderPath = _finderPathWithPaginationFindByDepotEntryId;
 			finderArgs = new Object[] {
 				depotEntryId, start, end, orderByComparator
@@ -193,7 +203,7 @@ public class DepotAppCustomizationPersistenceImpl
 
 		List<DepotAppCustomization> list = null;
 
-		if (useFinderCache) {
+		if (useFinderCache && productionMode) {
 			list = (List<DepotAppCustomization>)finderCache.getResult(
 				finderPath, finderArgs);
 
@@ -251,7 +261,7 @@ public class DepotAppCustomizationPersistenceImpl
 
 				cacheResult(list);
 
-				if (useFinderCache) {
+				if (useFinderCache && productionMode) {
 					finderCache.putResult(finderPath, finderArgs, list);
 				}
 			}
@@ -561,11 +571,21 @@ public class DepotAppCustomizationPersistenceImpl
 	 */
 	@Override
 	public int countByDepotEntryId(long depotEntryId) {
-		FinderPath finderPath = _finderPathCountByDepotEntryId;
+		boolean productionMode = ctPersistenceHelper.isProductionMode(
+			DepotAppCustomization.class);
 
-		Object[] finderArgs = new Object[] {depotEntryId};
+		FinderPath finderPath = null;
+		Object[] finderArgs = null;
 
-		Long count = (Long)finderCache.getResult(finderPath, finderArgs);
+		Long count = null;
+
+		if (productionMode) {
+			finderPath = _finderPathCountByDepotEntryId;
+
+			finderArgs = new Object[] {depotEntryId};
+
+			count = (Long)finderCache.getResult(finderPath, finderArgs);
+		}
 
 		if (count == null) {
 			StringBundler sb = new StringBundler(2);
@@ -589,7 +609,9 @@ public class DepotAppCustomizationPersistenceImpl
 
 				count = (Long)query.uniqueResult();
 
-				finderCache.putResult(finderPath, finderArgs, count);
+				if (productionMode) {
+					finderCache.putResult(finderPath, finderArgs, count);
+				}
 			}
 			catch (Exception exception) {
 				throw processException(exception);
@@ -672,15 +694,18 @@ public class DepotAppCustomizationPersistenceImpl
 	public DepotAppCustomization fetchByD_E(
 		long depotEntryId, boolean enabled, boolean useFinderCache) {
 
+		boolean productionMode = ctPersistenceHelper.isProductionMode(
+			DepotAppCustomization.class);
+
 		Object[] finderArgs = null;
 
-		if (useFinderCache) {
+		if (useFinderCache && productionMode) {
 			finderArgs = new Object[] {depotEntryId, enabled};
 		}
 
 		Object result = null;
 
-		if (useFinderCache) {
+		if (useFinderCache && productionMode) {
 			result = finderCache.getResult(_finderPathFetchByD_E, finderArgs);
 		}
 
@@ -722,7 +747,7 @@ public class DepotAppCustomizationPersistenceImpl
 				List<DepotAppCustomization> list = query.list();
 
 				if (list.isEmpty()) {
-					if (useFinderCache) {
+					if (useFinderCache && productionMode) {
 						finderCache.putResult(
 							_finderPathFetchByD_E, finderArgs, list);
 					}
@@ -732,7 +757,7 @@ public class DepotAppCustomizationPersistenceImpl
 						Collections.sort(list, Collections.reverseOrder());
 
 						if (_log.isWarnEnabled()) {
-							if (!useFinderCache) {
+							if (!productionMode || !useFinderCache) {
 								finderArgs = new Object[] {
 									depotEntryId, enabled
 								};
@@ -794,11 +819,21 @@ public class DepotAppCustomizationPersistenceImpl
 	 */
 	@Override
 	public int countByD_E(long depotEntryId, boolean enabled) {
-		FinderPath finderPath = _finderPathCountByD_E;
+		boolean productionMode = ctPersistenceHelper.isProductionMode(
+			DepotAppCustomization.class);
 
-		Object[] finderArgs = new Object[] {depotEntryId, enabled};
+		FinderPath finderPath = null;
+		Object[] finderArgs = null;
 
-		Long count = (Long)finderCache.getResult(finderPath, finderArgs);
+		Long count = null;
+
+		if (productionMode) {
+			finderPath = _finderPathCountByD_E;
+
+			finderArgs = new Object[] {depotEntryId, enabled};
+
+			count = (Long)finderCache.getResult(finderPath, finderArgs);
+		}
 
 		if (count == null) {
 			StringBundler sb = new StringBundler(3);
@@ -826,7 +861,9 @@ public class DepotAppCustomizationPersistenceImpl
 
 				count = (Long)query.uniqueResult();
 
-				finderCache.putResult(finderPath, finderArgs, count);
+				if (productionMode) {
+					finderCache.putResult(finderPath, finderArgs, count);
+				}
 			}
 			catch (Exception exception) {
 				throw processException(exception);
@@ -914,15 +951,18 @@ public class DepotAppCustomizationPersistenceImpl
 
 		portletId = Objects.toString(portletId, "");
 
+		boolean productionMode = ctPersistenceHelper.isProductionMode(
+			DepotAppCustomization.class);
+
 		Object[] finderArgs = null;
 
-		if (useFinderCache) {
+		if (useFinderCache && productionMode) {
 			finderArgs = new Object[] {depotEntryId, portletId};
 		}
 
 		Object result = null;
 
-		if (useFinderCache) {
+		if (useFinderCache && productionMode) {
 			result = finderCache.getResult(_finderPathFetchByD_P, finderArgs);
 		}
 
@@ -976,7 +1016,7 @@ public class DepotAppCustomizationPersistenceImpl
 				List<DepotAppCustomization> list = query.list();
 
 				if (list.isEmpty()) {
-					if (useFinderCache) {
+					if (useFinderCache && productionMode) {
 						finderCache.putResult(
 							_finderPathFetchByD_P, finderArgs, list);
 					}
@@ -1034,11 +1074,21 @@ public class DepotAppCustomizationPersistenceImpl
 	public int countByD_P(long depotEntryId, String portletId) {
 		portletId = Objects.toString(portletId, "");
 
-		FinderPath finderPath = _finderPathCountByD_P;
+		boolean productionMode = ctPersistenceHelper.isProductionMode(
+			DepotAppCustomization.class);
 
-		Object[] finderArgs = new Object[] {depotEntryId, portletId};
+		FinderPath finderPath = null;
+		Object[] finderArgs = null;
 
-		Long count = (Long)finderCache.getResult(finderPath, finderArgs);
+		Long count = null;
+
+		if (productionMode) {
+			finderPath = _finderPathCountByD_P;
+
+			finderArgs = new Object[] {depotEntryId, portletId};
+
+			count = (Long)finderCache.getResult(finderPath, finderArgs);
+		}
 
 		if (count == null) {
 			StringBundler sb = new StringBundler(3);
@@ -1077,7 +1127,9 @@ public class DepotAppCustomizationPersistenceImpl
 
 				count = (Long)query.uniqueResult();
 
-				finderCache.putResult(finderPath, finderArgs, count);
+				if (productionMode) {
+					finderCache.putResult(finderPath, finderArgs, count);
+				}
 			}
 			catch (Exception exception) {
 				throw processException(exception);
@@ -1115,6 +1167,10 @@ public class DepotAppCustomizationPersistenceImpl
 	 */
 	@Override
 	public void cacheResult(DepotAppCustomization depotAppCustomization) {
+		if (depotAppCustomization.getCtCollectionId() != 0) {
+			return;
+		}
+
 		entityCache.putResult(
 			DepotAppCustomizationImpl.class,
 			depotAppCustomization.getPrimaryKey(), depotAppCustomization);
@@ -1157,6 +1213,10 @@ public class DepotAppCustomizationPersistenceImpl
 
 		for (DepotAppCustomization depotAppCustomization :
 				depotAppCustomizations) {
+
+			if (depotAppCustomization.getCtCollectionId() != 0) {
+				continue;
+			}
 
 			if (entityCache.getResult(
 					DepotAppCustomizationImpl.class,
@@ -1326,7 +1386,9 @@ public class DepotAppCustomizationPersistenceImpl
 					depotAppCustomization.getPrimaryKeyObj());
 			}
 
-			if (depotAppCustomization != null) {
+			if ((depotAppCustomization != null) &&
+				ctPersistenceHelper.isRemove(depotAppCustomization)) {
+
 				session.delete(depotAppCustomization);
 			}
 		}
@@ -1377,7 +1439,13 @@ public class DepotAppCustomizationPersistenceImpl
 		try {
 			session = openSession();
 
-			if (isNew) {
+			if (ctPersistenceHelper.isInsert(depotAppCustomization)) {
+				if (!isNew) {
+					session.evict(
+						DepotAppCustomizationImpl.class,
+						depotAppCustomization.getPrimaryKeyObj());
+				}
+
 				session.save(depotAppCustomization);
 			}
 			else {
@@ -1390,6 +1458,16 @@ public class DepotAppCustomizationPersistenceImpl
 		}
 		finally {
 			closeSession(session);
+		}
+
+		if (depotAppCustomization.getCtCollectionId() != 0) {
+			if (isNew) {
+				depotAppCustomization.setNew(false);
+			}
+
+			depotAppCustomization.resetOriginalValues();
+
+			return depotAppCustomization;
 		}
 
 		entityCache.putResult(
@@ -1450,6 +1528,42 @@ public class DepotAppCustomizationPersistenceImpl
 	/**
 	 * Returns the depot app customization with the primary key or returns <code>null</code> if it could not be found.
 	 *
+	 * @param primaryKey the primary key of the depot app customization
+	 * @return the depot app customization, or <code>null</code> if a depot app customization with the primary key could not be found
+	 */
+	@Override
+	public DepotAppCustomization fetchByPrimaryKey(Serializable primaryKey) {
+		if (ctPersistenceHelper.isProductionMode(DepotAppCustomization.class)) {
+			return super.fetchByPrimaryKey(primaryKey);
+		}
+
+		DepotAppCustomization depotAppCustomization = null;
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			depotAppCustomization = (DepotAppCustomization)session.get(
+				DepotAppCustomizationImpl.class, primaryKey);
+
+			if (depotAppCustomization != null) {
+				cacheResult(depotAppCustomization);
+			}
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+
+		return depotAppCustomization;
+	}
+
+	/**
+	 * Returns the depot app customization with the primary key or returns <code>null</code> if it could not be found.
+	 *
 	 * @param depotAppCustomizationId the primary key of the depot app customization
 	 * @return the depot app customization, or <code>null</code> if a depot app customization with the primary key could not be found
 	 */
@@ -1458,6 +1572,102 @@ public class DepotAppCustomizationPersistenceImpl
 		long depotAppCustomizationId) {
 
 		return fetchByPrimaryKey((Serializable)depotAppCustomizationId);
+	}
+
+	@Override
+	public Map<Serializable, DepotAppCustomization> fetchByPrimaryKeys(
+		Set<Serializable> primaryKeys) {
+
+		if (ctPersistenceHelper.isProductionMode(DepotAppCustomization.class)) {
+			return super.fetchByPrimaryKeys(primaryKeys);
+		}
+
+		if (primaryKeys.isEmpty()) {
+			return Collections.emptyMap();
+		}
+
+		Map<Serializable, DepotAppCustomization> map =
+			new HashMap<Serializable, DepotAppCustomization>();
+
+		if (primaryKeys.size() == 1) {
+			Iterator<Serializable> iterator = primaryKeys.iterator();
+
+			Serializable primaryKey = iterator.next();
+
+			DepotAppCustomization depotAppCustomization = fetchByPrimaryKey(
+				primaryKey);
+
+			if (depotAppCustomization != null) {
+				map.put(primaryKey, depotAppCustomization);
+			}
+
+			return map;
+		}
+
+		if ((databaseInMaxParameters > 0) &&
+			(primaryKeys.size() > databaseInMaxParameters)) {
+
+			Iterator<Serializable> iterator = primaryKeys.iterator();
+
+			while (iterator.hasNext()) {
+				Set<Serializable> page = new HashSet<>();
+
+				for (int i = 0;
+					 (i < databaseInMaxParameters) && iterator.hasNext(); i++) {
+
+					page.add(iterator.next());
+				}
+
+				map.putAll(fetchByPrimaryKeys(page));
+			}
+
+			return map;
+		}
+
+		StringBundler sb = new StringBundler((primaryKeys.size() * 2) + 1);
+
+		sb.append(getSelectSQL());
+		sb.append(" WHERE ");
+		sb.append(getPKDBName());
+		sb.append(" IN (");
+
+		for (Serializable primaryKey : primaryKeys) {
+			sb.append((long)primaryKey);
+
+			sb.append(",");
+		}
+
+		sb.setIndex(sb.index() - 1);
+
+		sb.append(")");
+
+		String sql = sb.toString();
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			Query query = session.createQuery(sql);
+
+			for (DepotAppCustomization depotAppCustomization :
+					(List<DepotAppCustomization>)query.list()) {
+
+				map.put(
+					depotAppCustomization.getPrimaryKeyObj(),
+					depotAppCustomization);
+
+				cacheResult(depotAppCustomization);
+			}
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+
+		return map;
 	}
 
 	/**
@@ -1525,25 +1735,28 @@ public class DepotAppCustomizationPersistenceImpl
 		OrderByComparator<DepotAppCustomization> orderByComparator,
 		boolean useFinderCache) {
 
+		boolean productionMode = ctPersistenceHelper.isProductionMode(
+			DepotAppCustomization.class);
+
 		FinderPath finderPath = null;
 		Object[] finderArgs = null;
 
 		if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) &&
 			(orderByComparator == null)) {
 
-			if (useFinderCache) {
+			if (useFinderCache && productionMode) {
 				finderPath = _finderPathWithoutPaginationFindAll;
 				finderArgs = FINDER_ARGS_EMPTY;
 			}
 		}
-		else if (useFinderCache) {
+		else if (useFinderCache && productionMode) {
 			finderPath = _finderPathWithPaginationFindAll;
 			finderArgs = new Object[] {start, end, orderByComparator};
 		}
 
 		List<DepotAppCustomization> list = null;
 
-		if (useFinderCache) {
+		if (useFinderCache && productionMode) {
 			list = (List<DepotAppCustomization>)finderCache.getResult(
 				finderPath, finderArgs);
 		}
@@ -1581,7 +1794,7 @@ public class DepotAppCustomizationPersistenceImpl
 
 				cacheResult(list);
 
-				if (useFinderCache) {
+				if (useFinderCache && productionMode) {
 					finderCache.putResult(finderPath, finderArgs, list);
 				}
 			}
@@ -1614,8 +1827,15 @@ public class DepotAppCustomizationPersistenceImpl
 	 */
 	@Override
 	public int countAll() {
-		Long count = (Long)finderCache.getResult(
-			_finderPathCountAll, FINDER_ARGS_EMPTY);
+		boolean productionMode = ctPersistenceHelper.isProductionMode(
+			DepotAppCustomization.class);
+
+		Long count = null;
+
+		if (productionMode) {
+			count = (Long)finderCache.getResult(
+				_finderPathCountAll, FINDER_ARGS_EMPTY);
+		}
 
 		if (count == null) {
 			Session session = null;
@@ -1628,8 +1848,10 @@ public class DepotAppCustomizationPersistenceImpl
 
 				count = (Long)query.uniqueResult();
 
-				finderCache.putResult(
-					_finderPathCountAll, FINDER_ARGS_EMPTY, count);
+				if (productionMode) {
+					finderCache.putResult(
+						_finderPathCountAll, FINDER_ARGS_EMPTY, count);
+				}
 			}
 			catch (Exception exception) {
 				throw processException(exception);
@@ -1658,8 +1880,61 @@ public class DepotAppCustomizationPersistenceImpl
 	}
 
 	@Override
-	protected Map<String, Integer> getTableColumnsMap() {
+	public Set<String> getCTColumnNames(
+		CTColumnResolutionType ctColumnResolutionType) {
+
+		return _ctColumnNamesMap.getOrDefault(
+			ctColumnResolutionType, Collections.emptySet());
+	}
+
+	@Override
+	public List<String> getMappingTableNames() {
+		return _mappingTableNames;
+	}
+
+	@Override
+	public Map<String, Integer> getTableColumnsMap() {
 		return DepotAppCustomizationModelImpl.TABLE_COLUMNS_MAP;
+	}
+
+	@Override
+	public String getTableName() {
+		return "DepotAppCustomization";
+	}
+
+	@Override
+	public List<String[]> getUniqueIndexColumnNames() {
+		return _uniqueIndexColumnNames;
+	}
+
+	private static final Map<CTColumnResolutionType, Set<String>>
+		_ctColumnNamesMap = new EnumMap<CTColumnResolutionType, Set<String>>(
+			CTColumnResolutionType.class);
+	private static final List<String> _mappingTableNames =
+		new ArrayList<String>();
+	private static final List<String[]> _uniqueIndexColumnNames =
+		new ArrayList<String[]>();
+
+	static {
+		Set<String> ctControlColumnNames = new HashSet<String>();
+		Set<String> ctStrictColumnNames = new HashSet<String>();
+
+		ctControlColumnNames.add("mvccVersion");
+		ctControlColumnNames.add("ctCollectionId");
+		ctStrictColumnNames.add("companyId");
+		ctStrictColumnNames.add("depotEntryId");
+		ctStrictColumnNames.add("enabled");
+		ctStrictColumnNames.add("portletId");
+
+		_ctColumnNamesMap.put(
+			CTColumnResolutionType.CONTROL, ctControlColumnNames);
+		_ctColumnNamesMap.put(
+			CTColumnResolutionType.PK,
+			Collections.singleton("depotAppCustomizationId"));
+		_ctColumnNamesMap.put(
+			CTColumnResolutionType.STRICT, ctStrictColumnNames);
+
+		_uniqueIndexColumnNames.add(new String[] {"depotEntryId", "portletId"});
 	}
 
 	/**
@@ -1771,6 +2046,9 @@ public class DepotAppCustomizationPersistenceImpl
 	public void setSessionFactory(SessionFactory sessionFactory) {
 		super.setSessionFactory(sessionFactory);
 	}
+
+	@Reference
+	protected CTPersistenceHelper ctPersistenceHelper;
 
 	@Reference
 	protected EntityCache entityCache;

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/persistence/impl/DepotEntryGroupRelPersistenceImpl.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/persistence/impl/DepotEntryGroupRelPersistenceImpl.java
@@ -23,6 +23,7 @@ import com.liferay.depot.service.persistence.DepotEntryGroupRelPersistence;
 import com.liferay.depot.service.persistence.DepotEntryGroupRelUtil;
 import com.liferay.depot.service.persistence.impl.constants.DepotPersistenceConstants;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.change.tracking.CTColumnResolutionType;
 import com.liferay.portal.kernel.configuration.Configuration;
 import com.liferay.portal.kernel.dao.orm.EntityCache;
 import com.liferay.portal.kernel.dao.orm.FinderCache;
@@ -38,6 +39,7 @@ import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.service.persistence.BasePersistence;
+import com.liferay.portal.kernel.service.persistence.change.tracking.helper.CTPersistenceHelper;
 import com.liferay.portal.kernel.service.persistence.impl.BasePersistenceImpl;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
@@ -53,8 +55,13 @@ import java.io.Serializable;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationHandler;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
+import java.util.EnumMap;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -178,25 +185,28 @@ public class DepotEntryGroupRelPersistenceImpl
 
 		uuid = Objects.toString(uuid, "");
 
+		boolean productionMode = ctPersistenceHelper.isProductionMode(
+			DepotEntryGroupRel.class);
+
 		FinderPath finderPath = null;
 		Object[] finderArgs = null;
 
 		if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) &&
 			(orderByComparator == null)) {
 
-			if (useFinderCache) {
+			if (useFinderCache && productionMode) {
 				finderPath = _finderPathWithoutPaginationFindByUuid;
 				finderArgs = new Object[] {uuid};
 			}
 		}
-		else if (useFinderCache) {
+		else if (useFinderCache && productionMode) {
 			finderPath = _finderPathWithPaginationFindByUuid;
 			finderArgs = new Object[] {uuid, start, end, orderByComparator};
 		}
 
 		List<DepotEntryGroupRel> list = null;
 
-		if (useFinderCache) {
+		if (useFinderCache && productionMode) {
 			list = (List<DepotEntryGroupRel>)finderCache.getResult(
 				finderPath, finderArgs);
 
@@ -263,7 +273,7 @@ public class DepotEntryGroupRelPersistenceImpl
 
 				cacheResult(list);
 
-				if (useFinderCache) {
+				if (useFinderCache && productionMode) {
 					finderCache.putResult(finderPath, finderArgs, list);
 				}
 			}
@@ -582,11 +592,21 @@ public class DepotEntryGroupRelPersistenceImpl
 	public int countByUuid(String uuid) {
 		uuid = Objects.toString(uuid, "");
 
-		FinderPath finderPath = _finderPathCountByUuid;
+		boolean productionMode = ctPersistenceHelper.isProductionMode(
+			DepotEntryGroupRel.class);
 
-		Object[] finderArgs = new Object[] {uuid};
+		FinderPath finderPath = null;
+		Object[] finderArgs = null;
 
-		Long count = (Long)finderCache.getResult(finderPath, finderArgs);
+		Long count = null;
+
+		if (productionMode) {
+			finderPath = _finderPathCountByUuid;
+
+			finderArgs = new Object[] {uuid};
+
+			count = (Long)finderCache.getResult(finderPath, finderArgs);
+		}
 
 		if (count == null) {
 			StringBundler sb = new StringBundler(2);
@@ -621,7 +641,9 @@ public class DepotEntryGroupRelPersistenceImpl
 
 				count = (Long)query.uniqueResult();
 
-				finderCache.putResult(finderPath, finderArgs, count);
+				if (productionMode) {
+					finderCache.putResult(finderPath, finderArgs, count);
+				}
 			}
 			catch (Exception exception) {
 				throw processException(exception);
@@ -706,15 +728,18 @@ public class DepotEntryGroupRelPersistenceImpl
 
 		uuid = Objects.toString(uuid, "");
 
+		boolean productionMode = ctPersistenceHelper.isProductionMode(
+			DepotEntryGroupRel.class);
+
 		Object[] finderArgs = null;
 
-		if (useFinderCache) {
+		if (useFinderCache && productionMode) {
 			finderArgs = new Object[] {uuid, groupId};
 		}
 
 		Object result = null;
 
-		if (useFinderCache) {
+		if (useFinderCache && productionMode) {
 			result = finderCache.getResult(
 				_finderPathFetchByUUID_G, finderArgs);
 		}
@@ -767,7 +792,7 @@ public class DepotEntryGroupRelPersistenceImpl
 				List<DepotEntryGroupRel> list = query.list();
 
 				if (list.isEmpty()) {
-					if (useFinderCache) {
+					if (useFinderCache && productionMode) {
 						finderCache.putResult(
 							_finderPathFetchByUUID_G, finderArgs, list);
 					}
@@ -823,11 +848,21 @@ public class DepotEntryGroupRelPersistenceImpl
 	public int countByUUID_G(String uuid, long groupId) {
 		uuid = Objects.toString(uuid, "");
 
-		FinderPath finderPath = _finderPathCountByUUID_G;
+		boolean productionMode = ctPersistenceHelper.isProductionMode(
+			DepotEntryGroupRel.class);
 
-		Object[] finderArgs = new Object[] {uuid, groupId};
+		FinderPath finderPath = null;
+		Object[] finderArgs = null;
 
-		Long count = (Long)finderCache.getResult(finderPath, finderArgs);
+		Long count = null;
+
+		if (productionMode) {
+			finderPath = _finderPathCountByUUID_G;
+
+			finderArgs = new Object[] {uuid, groupId};
+
+			count = (Long)finderCache.getResult(finderPath, finderArgs);
+		}
 
 		if (count == null) {
 			StringBundler sb = new StringBundler(3);
@@ -866,7 +901,9 @@ public class DepotEntryGroupRelPersistenceImpl
 
 				count = (Long)query.uniqueResult();
 
-				finderCache.putResult(finderPath, finderArgs, count);
+				if (productionMode) {
+					finderCache.putResult(finderPath, finderArgs, count);
+				}
 			}
 			catch (Exception exception) {
 				throw processException(exception);
@@ -971,18 +1008,21 @@ public class DepotEntryGroupRelPersistenceImpl
 
 		uuid = Objects.toString(uuid, "");
 
+		boolean productionMode = ctPersistenceHelper.isProductionMode(
+			DepotEntryGroupRel.class);
+
 		FinderPath finderPath = null;
 		Object[] finderArgs = null;
 
 		if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) &&
 			(orderByComparator == null)) {
 
-			if (useFinderCache) {
+			if (useFinderCache && productionMode) {
 				finderPath = _finderPathWithoutPaginationFindByUuid_C;
 				finderArgs = new Object[] {uuid, companyId};
 			}
 		}
-		else if (useFinderCache) {
+		else if (useFinderCache && productionMode) {
 			finderPath = _finderPathWithPaginationFindByUuid_C;
 			finderArgs = new Object[] {
 				uuid, companyId, start, end, orderByComparator
@@ -991,7 +1031,7 @@ public class DepotEntryGroupRelPersistenceImpl
 
 		List<DepotEntryGroupRel> list = null;
 
-		if (useFinderCache) {
+		if (useFinderCache && productionMode) {
 			list = (List<DepotEntryGroupRel>)finderCache.getResult(
 				finderPath, finderArgs);
 
@@ -1064,7 +1104,7 @@ public class DepotEntryGroupRelPersistenceImpl
 
 				cacheResult(list);
 
-				if (useFinderCache) {
+				if (useFinderCache && productionMode) {
 					finderCache.putResult(finderPath, finderArgs, list);
 				}
 			}
@@ -1406,11 +1446,21 @@ public class DepotEntryGroupRelPersistenceImpl
 	public int countByUuid_C(String uuid, long companyId) {
 		uuid = Objects.toString(uuid, "");
 
-		FinderPath finderPath = _finderPathCountByUuid_C;
+		boolean productionMode = ctPersistenceHelper.isProductionMode(
+			DepotEntryGroupRel.class);
 
-		Object[] finderArgs = new Object[] {uuid, companyId};
+		FinderPath finderPath = null;
+		Object[] finderArgs = null;
 
-		Long count = (Long)finderCache.getResult(finderPath, finderArgs);
+		Long count = null;
+
+		if (productionMode) {
+			finderPath = _finderPathCountByUuid_C;
+
+			finderArgs = new Object[] {uuid, companyId};
+
+			count = (Long)finderCache.getResult(finderPath, finderArgs);
+		}
 
 		if (count == null) {
 			StringBundler sb = new StringBundler(3);
@@ -1449,7 +1499,9 @@ public class DepotEntryGroupRelPersistenceImpl
 
 				count = (Long)query.uniqueResult();
 
-				finderCache.putResult(finderPath, finderArgs, count);
+				if (productionMode) {
+					finderCache.putResult(finderPath, finderArgs, count);
+				}
 			}
 			catch (Exception exception) {
 				throw processException(exception);
@@ -1548,18 +1600,21 @@ public class DepotEntryGroupRelPersistenceImpl
 		OrderByComparator<DepotEntryGroupRel> orderByComparator,
 		boolean useFinderCache) {
 
+		boolean productionMode = ctPersistenceHelper.isProductionMode(
+			DepotEntryGroupRel.class);
+
 		FinderPath finderPath = null;
 		Object[] finderArgs = null;
 
 		if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) &&
 			(orderByComparator == null)) {
 
-			if (useFinderCache) {
+			if (useFinderCache && productionMode) {
 				finderPath = _finderPathWithoutPaginationFindByDepotEntryId;
 				finderArgs = new Object[] {depotEntryId};
 			}
 		}
-		else if (useFinderCache) {
+		else if (useFinderCache && productionMode) {
 			finderPath = _finderPathWithPaginationFindByDepotEntryId;
 			finderArgs = new Object[] {
 				depotEntryId, start, end, orderByComparator
@@ -1568,7 +1623,7 @@ public class DepotEntryGroupRelPersistenceImpl
 
 		List<DepotEntryGroupRel> list = null;
 
-		if (useFinderCache) {
+		if (useFinderCache && productionMode) {
 			list = (List<DepotEntryGroupRel>)finderCache.getResult(
 				finderPath, finderArgs);
 
@@ -1624,7 +1679,7 @@ public class DepotEntryGroupRelPersistenceImpl
 
 				cacheResult(list);
 
-				if (useFinderCache) {
+				if (useFinderCache && productionMode) {
 					finderCache.putResult(finderPath, finderArgs, list);
 				}
 			}
@@ -1934,11 +1989,21 @@ public class DepotEntryGroupRelPersistenceImpl
 	 */
 	@Override
 	public int countByDepotEntryId(long depotEntryId) {
-		FinderPath finderPath = _finderPathCountByDepotEntryId;
+		boolean productionMode = ctPersistenceHelper.isProductionMode(
+			DepotEntryGroupRel.class);
 
-		Object[] finderArgs = new Object[] {depotEntryId};
+		FinderPath finderPath = null;
+		Object[] finderArgs = null;
 
-		Long count = (Long)finderCache.getResult(finderPath, finderArgs);
+		Long count = null;
+
+		if (productionMode) {
+			finderPath = _finderPathCountByDepotEntryId;
+
+			finderArgs = new Object[] {depotEntryId};
+
+			count = (Long)finderCache.getResult(finderPath, finderArgs);
+		}
 
 		if (count == null) {
 			StringBundler sb = new StringBundler(2);
@@ -1962,7 +2027,9 @@ public class DepotEntryGroupRelPersistenceImpl
 
 				count = (Long)query.uniqueResult();
 
-				finderCache.putResult(finderPath, finderArgs, count);
+				if (productionMode) {
+					finderCache.putResult(finderPath, finderArgs, count);
+				}
 			}
 			catch (Exception exception) {
 				throw processException(exception);
@@ -2054,18 +2121,21 @@ public class DepotEntryGroupRelPersistenceImpl
 		OrderByComparator<DepotEntryGroupRel> orderByComparator,
 		boolean useFinderCache) {
 
+		boolean productionMode = ctPersistenceHelper.isProductionMode(
+			DepotEntryGroupRel.class);
+
 		FinderPath finderPath = null;
 		Object[] finderArgs = null;
 
 		if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) &&
 			(orderByComparator == null)) {
 
-			if (useFinderCache) {
+			if (useFinderCache && productionMode) {
 				finderPath = _finderPathWithoutPaginationFindByToGroupId;
 				finderArgs = new Object[] {toGroupId};
 			}
 		}
-		else if (useFinderCache) {
+		else if (useFinderCache && productionMode) {
 			finderPath = _finderPathWithPaginationFindByToGroupId;
 			finderArgs = new Object[] {
 				toGroupId, start, end, orderByComparator
@@ -2074,7 +2144,7 @@ public class DepotEntryGroupRelPersistenceImpl
 
 		List<DepotEntryGroupRel> list = null;
 
-		if (useFinderCache) {
+		if (useFinderCache && productionMode) {
 			list = (List<DepotEntryGroupRel>)finderCache.getResult(
 				finderPath, finderArgs);
 
@@ -2130,7 +2200,7 @@ public class DepotEntryGroupRelPersistenceImpl
 
 				cacheResult(list);
 
-				if (useFinderCache) {
+				if (useFinderCache && productionMode) {
 					finderCache.putResult(finderPath, finderArgs, list);
 				}
 			}
@@ -2439,11 +2509,21 @@ public class DepotEntryGroupRelPersistenceImpl
 	 */
 	@Override
 	public int countByToGroupId(long toGroupId) {
-		FinderPath finderPath = _finderPathCountByToGroupId;
+		boolean productionMode = ctPersistenceHelper.isProductionMode(
+			DepotEntryGroupRel.class);
 
-		Object[] finderArgs = new Object[] {toGroupId};
+		FinderPath finderPath = null;
+		Object[] finderArgs = null;
 
-		Long count = (Long)finderCache.getResult(finderPath, finderArgs);
+		Long count = null;
+
+		if (productionMode) {
+			finderPath = _finderPathCountByToGroupId;
+
+			finderArgs = new Object[] {toGroupId};
+
+			count = (Long)finderCache.getResult(finderPath, finderArgs);
+		}
 
 		if (count == null) {
 			StringBundler sb = new StringBundler(2);
@@ -2467,7 +2547,9 @@ public class DepotEntryGroupRelPersistenceImpl
 
 				count = (Long)query.uniqueResult();
 
-				finderCache.putResult(finderPath, finderArgs, count);
+				if (productionMode) {
+					finderCache.putResult(finderPath, finderArgs, count);
+				}
 			}
 			catch (Exception exception) {
 				throw processException(exception);
@@ -2569,18 +2651,21 @@ public class DepotEntryGroupRelPersistenceImpl
 		OrderByComparator<DepotEntryGroupRel> orderByComparator,
 		boolean useFinderCache) {
 
+		boolean productionMode = ctPersistenceHelper.isProductionMode(
+			DepotEntryGroupRel.class);
+
 		FinderPath finderPath = null;
 		Object[] finderArgs = null;
 
 		if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) &&
 			(orderByComparator == null)) {
 
-			if (useFinderCache) {
+			if (useFinderCache && productionMode) {
 				finderPath = _finderPathWithoutPaginationFindByDDMSA_TGI;
 				finderArgs = new Object[] {ddmStructuresAvailable, toGroupId};
 			}
 		}
-		else if (useFinderCache) {
+		else if (useFinderCache && productionMode) {
 			finderPath = _finderPathWithPaginationFindByDDMSA_TGI;
 			finderArgs = new Object[] {
 				ddmStructuresAvailable, toGroupId, start, end, orderByComparator
@@ -2589,7 +2674,7 @@ public class DepotEntryGroupRelPersistenceImpl
 
 		List<DepotEntryGroupRel> list = null;
 
-		if (useFinderCache) {
+		if (useFinderCache && productionMode) {
 			list = (List<DepotEntryGroupRel>)finderCache.getResult(
 				finderPath, finderArgs);
 
@@ -2652,7 +2737,7 @@ public class DepotEntryGroupRelPersistenceImpl
 
 				cacheResult(list);
 
-				if (useFinderCache) {
+				if (useFinderCache && productionMode) {
 					finderCache.putResult(finderPath, finderArgs, list);
 				}
 			}
@@ -2986,11 +3071,21 @@ public class DepotEntryGroupRelPersistenceImpl
 	public int countByDDMSA_TGI(
 		boolean ddmStructuresAvailable, long toGroupId) {
 
-		FinderPath finderPath = _finderPathCountByDDMSA_TGI;
+		boolean productionMode = ctPersistenceHelper.isProductionMode(
+			DepotEntryGroupRel.class);
 
-		Object[] finderArgs = new Object[] {ddmStructuresAvailable, toGroupId};
+		FinderPath finderPath = null;
+		Object[] finderArgs = null;
 
-		Long count = (Long)finderCache.getResult(finderPath, finderArgs);
+		Long count = null;
+
+		if (productionMode) {
+			finderPath = _finderPathCountByDDMSA_TGI;
+
+			finderArgs = new Object[] {ddmStructuresAvailable, toGroupId};
+
+			count = (Long)finderCache.getResult(finderPath, finderArgs);
+		}
 
 		if (count == null) {
 			StringBundler sb = new StringBundler(3);
@@ -3018,7 +3113,9 @@ public class DepotEntryGroupRelPersistenceImpl
 
 				count = (Long)query.uniqueResult();
 
-				finderCache.putResult(finderPath, finderArgs, count);
+				if (productionMode) {
+					finderCache.putResult(finderPath, finderArgs, count);
+				}
 			}
 			catch (Exception exception) {
 				throw processException(exception);
@@ -3103,15 +3200,18 @@ public class DepotEntryGroupRelPersistenceImpl
 	public DepotEntryGroupRel fetchByD_TGI(
 		long depotEntryId, long toGroupId, boolean useFinderCache) {
 
+		boolean productionMode = ctPersistenceHelper.isProductionMode(
+			DepotEntryGroupRel.class);
+
 		Object[] finderArgs = null;
 
-		if (useFinderCache) {
+		if (useFinderCache && productionMode) {
 			finderArgs = new Object[] {depotEntryId, toGroupId};
 		}
 
 		Object result = null;
 
-		if (useFinderCache) {
+		if (useFinderCache && productionMode) {
 			result = finderCache.getResult(_finderPathFetchByD_TGI, finderArgs);
 		}
 
@@ -3152,7 +3252,7 @@ public class DepotEntryGroupRelPersistenceImpl
 				List<DepotEntryGroupRel> list = query.list();
 
 				if (list.isEmpty()) {
-					if (useFinderCache) {
+					if (useFinderCache && productionMode) {
 						finderCache.putResult(
 							_finderPathFetchByD_TGI, finderArgs, list);
 					}
@@ -3207,11 +3307,21 @@ public class DepotEntryGroupRelPersistenceImpl
 	 */
 	@Override
 	public int countByD_TGI(long depotEntryId, long toGroupId) {
-		FinderPath finderPath = _finderPathCountByD_TGI;
+		boolean productionMode = ctPersistenceHelper.isProductionMode(
+			DepotEntryGroupRel.class);
 
-		Object[] finderArgs = new Object[] {depotEntryId, toGroupId};
+		FinderPath finderPath = null;
+		Object[] finderArgs = null;
 
-		Long count = (Long)finderCache.getResult(finderPath, finderArgs);
+		Long count = null;
+
+		if (productionMode) {
+			finderPath = _finderPathCountByD_TGI;
+
+			finderArgs = new Object[] {depotEntryId, toGroupId};
+
+			count = (Long)finderCache.getResult(finderPath, finderArgs);
+		}
 
 		if (count == null) {
 			StringBundler sb = new StringBundler(3);
@@ -3239,7 +3349,9 @@ public class DepotEntryGroupRelPersistenceImpl
 
 				count = (Long)query.uniqueResult();
 
-				finderCache.putResult(finderPath, finderArgs, count);
+				if (productionMode) {
+					finderCache.putResult(finderPath, finderArgs, count);
+				}
 			}
 			catch (Exception exception) {
 				throw processException(exception);
@@ -3341,18 +3453,21 @@ public class DepotEntryGroupRelPersistenceImpl
 		OrderByComparator<DepotEntryGroupRel> orderByComparator,
 		boolean useFinderCache) {
 
+		boolean productionMode = ctPersistenceHelper.isProductionMode(
+			DepotEntryGroupRel.class);
+
 		FinderPath finderPath = null;
 		Object[] finderArgs = null;
 
 		if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) &&
 			(orderByComparator == null)) {
 
-			if (useFinderCache) {
+			if (useFinderCache && productionMode) {
 				finderPath = _finderPathWithoutPaginationFindByS_TGI;
 				finderArgs = new Object[] {searchable, toGroupId};
 			}
 		}
-		else if (useFinderCache) {
+		else if (useFinderCache && productionMode) {
 			finderPath = _finderPathWithPaginationFindByS_TGI;
 			finderArgs = new Object[] {
 				searchable, toGroupId, start, end, orderByComparator
@@ -3361,7 +3476,7 @@ public class DepotEntryGroupRelPersistenceImpl
 
 		List<DepotEntryGroupRel> list = null;
 
-		if (useFinderCache) {
+		if (useFinderCache && productionMode) {
 			list = (List<DepotEntryGroupRel>)finderCache.getResult(
 				finderPath, finderArgs);
 
@@ -3423,7 +3538,7 @@ public class DepotEntryGroupRelPersistenceImpl
 
 				cacheResult(list);
 
-				if (useFinderCache) {
+				if (useFinderCache && productionMode) {
 					finderCache.putResult(finderPath, finderArgs, list);
 				}
 			}
@@ -3751,11 +3866,21 @@ public class DepotEntryGroupRelPersistenceImpl
 	 */
 	@Override
 	public int countByS_TGI(boolean searchable, long toGroupId) {
-		FinderPath finderPath = _finderPathCountByS_TGI;
+		boolean productionMode = ctPersistenceHelper.isProductionMode(
+			DepotEntryGroupRel.class);
 
-		Object[] finderArgs = new Object[] {searchable, toGroupId};
+		FinderPath finderPath = null;
+		Object[] finderArgs = null;
 
-		Long count = (Long)finderCache.getResult(finderPath, finderArgs);
+		Long count = null;
+
+		if (productionMode) {
+			finderPath = _finderPathCountByS_TGI;
+
+			finderArgs = new Object[] {searchable, toGroupId};
+
+			count = (Long)finderCache.getResult(finderPath, finderArgs);
+		}
 
 		if (count == null) {
 			StringBundler sb = new StringBundler(3);
@@ -3783,7 +3908,9 @@ public class DepotEntryGroupRelPersistenceImpl
 
 				count = (Long)query.uniqueResult();
 
-				finderCache.putResult(finderPath, finderArgs, count);
+				if (productionMode) {
+					finderCache.putResult(finderPath, finderArgs, count);
+				}
 			}
 			catch (Exception exception) {
 				throw processException(exception);
@@ -3824,6 +3951,10 @@ public class DepotEntryGroupRelPersistenceImpl
 	 */
 	@Override
 	public void cacheResult(DepotEntryGroupRel depotEntryGroupRel) {
+		if (depotEntryGroupRel.getCtCollectionId() != 0) {
+			return;
+		}
+
 		entityCache.putResult(
 			DepotEntryGroupRelImpl.class, depotEntryGroupRel.getPrimaryKey(),
 			depotEntryGroupRel);
@@ -3862,6 +3993,10 @@ public class DepotEntryGroupRelPersistenceImpl
 		}
 
 		for (DepotEntryGroupRel depotEntryGroupRel : depotEntryGroupRels) {
+			if (depotEntryGroupRel.getCtCollectionId() != 0) {
+				continue;
+			}
+
 			if (entityCache.getResult(
 					DepotEntryGroupRelImpl.class,
 					depotEntryGroupRel.getPrimaryKey()) == null) {
@@ -4030,7 +4165,9 @@ public class DepotEntryGroupRelPersistenceImpl
 					depotEntryGroupRel.getPrimaryKeyObj());
 			}
 
-			if (depotEntryGroupRel != null) {
+			if ((depotEntryGroupRel != null) &&
+				ctPersistenceHelper.isRemove(depotEntryGroupRel)) {
+
 				session.delete(depotEntryGroupRel);
 			}
 		}
@@ -4110,7 +4247,13 @@ public class DepotEntryGroupRelPersistenceImpl
 		try {
 			session = openSession();
 
-			if (isNew) {
+			if (ctPersistenceHelper.isInsert(depotEntryGroupRel)) {
+				if (!isNew) {
+					session.evict(
+						DepotEntryGroupRelImpl.class,
+						depotEntryGroupRel.getPrimaryKeyObj());
+				}
+
 				session.save(depotEntryGroupRel);
 			}
 			else {
@@ -4123,6 +4266,16 @@ public class DepotEntryGroupRelPersistenceImpl
 		}
 		finally {
 			closeSession(session);
+		}
+
+		if (depotEntryGroupRel.getCtCollectionId() != 0) {
+			if (isNew) {
+				depotEntryGroupRel.setNew(false);
+			}
+
+			depotEntryGroupRel.resetOriginalValues();
+
+			return depotEntryGroupRel;
 		}
 
 		entityCache.putResult(
@@ -4182,12 +4335,143 @@ public class DepotEntryGroupRelPersistenceImpl
 	/**
 	 * Returns the depot entry group rel with the primary key or returns <code>null</code> if it could not be found.
 	 *
+	 * @param primaryKey the primary key of the depot entry group rel
+	 * @return the depot entry group rel, or <code>null</code> if a depot entry group rel with the primary key could not be found
+	 */
+	@Override
+	public DepotEntryGroupRel fetchByPrimaryKey(Serializable primaryKey) {
+		if (ctPersistenceHelper.isProductionMode(DepotEntryGroupRel.class)) {
+			return super.fetchByPrimaryKey(primaryKey);
+		}
+
+		DepotEntryGroupRel depotEntryGroupRel = null;
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			depotEntryGroupRel = (DepotEntryGroupRel)session.get(
+				DepotEntryGroupRelImpl.class, primaryKey);
+
+			if (depotEntryGroupRel != null) {
+				cacheResult(depotEntryGroupRel);
+			}
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+
+		return depotEntryGroupRel;
+	}
+
+	/**
+	 * Returns the depot entry group rel with the primary key or returns <code>null</code> if it could not be found.
+	 *
 	 * @param depotEntryGroupRelId the primary key of the depot entry group rel
 	 * @return the depot entry group rel, or <code>null</code> if a depot entry group rel with the primary key could not be found
 	 */
 	@Override
 	public DepotEntryGroupRel fetchByPrimaryKey(long depotEntryGroupRelId) {
 		return fetchByPrimaryKey((Serializable)depotEntryGroupRelId);
+	}
+
+	@Override
+	public Map<Serializable, DepotEntryGroupRel> fetchByPrimaryKeys(
+		Set<Serializable> primaryKeys) {
+
+		if (ctPersistenceHelper.isProductionMode(DepotEntryGroupRel.class)) {
+			return super.fetchByPrimaryKeys(primaryKeys);
+		}
+
+		if (primaryKeys.isEmpty()) {
+			return Collections.emptyMap();
+		}
+
+		Map<Serializable, DepotEntryGroupRel> map =
+			new HashMap<Serializable, DepotEntryGroupRel>();
+
+		if (primaryKeys.size() == 1) {
+			Iterator<Serializable> iterator = primaryKeys.iterator();
+
+			Serializable primaryKey = iterator.next();
+
+			DepotEntryGroupRel depotEntryGroupRel = fetchByPrimaryKey(
+				primaryKey);
+
+			if (depotEntryGroupRel != null) {
+				map.put(primaryKey, depotEntryGroupRel);
+			}
+
+			return map;
+		}
+
+		if ((databaseInMaxParameters > 0) &&
+			(primaryKeys.size() > databaseInMaxParameters)) {
+
+			Iterator<Serializable> iterator = primaryKeys.iterator();
+
+			while (iterator.hasNext()) {
+				Set<Serializable> page = new HashSet<>();
+
+				for (int i = 0;
+					 (i < databaseInMaxParameters) && iterator.hasNext(); i++) {
+
+					page.add(iterator.next());
+				}
+
+				map.putAll(fetchByPrimaryKeys(page));
+			}
+
+			return map;
+		}
+
+		StringBundler sb = new StringBundler((primaryKeys.size() * 2) + 1);
+
+		sb.append(getSelectSQL());
+		sb.append(" WHERE ");
+		sb.append(getPKDBName());
+		sb.append(" IN (");
+
+		for (Serializable primaryKey : primaryKeys) {
+			sb.append((long)primaryKey);
+
+			sb.append(",");
+		}
+
+		sb.setIndex(sb.index() - 1);
+
+		sb.append(")");
+
+		String sql = sb.toString();
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			Query query = session.createQuery(sql);
+
+			for (DepotEntryGroupRel depotEntryGroupRel :
+					(List<DepotEntryGroupRel>)query.list()) {
+
+				map.put(
+					depotEntryGroupRel.getPrimaryKeyObj(), depotEntryGroupRel);
+
+				cacheResult(depotEntryGroupRel);
+			}
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+
+		return map;
 	}
 
 	/**
@@ -4255,25 +4539,28 @@ public class DepotEntryGroupRelPersistenceImpl
 		OrderByComparator<DepotEntryGroupRel> orderByComparator,
 		boolean useFinderCache) {
 
+		boolean productionMode = ctPersistenceHelper.isProductionMode(
+			DepotEntryGroupRel.class);
+
 		FinderPath finderPath = null;
 		Object[] finderArgs = null;
 
 		if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) &&
 			(orderByComparator == null)) {
 
-			if (useFinderCache) {
+			if (useFinderCache && productionMode) {
 				finderPath = _finderPathWithoutPaginationFindAll;
 				finderArgs = FINDER_ARGS_EMPTY;
 			}
 		}
-		else if (useFinderCache) {
+		else if (useFinderCache && productionMode) {
 			finderPath = _finderPathWithPaginationFindAll;
 			finderArgs = new Object[] {start, end, orderByComparator};
 		}
 
 		List<DepotEntryGroupRel> list = null;
 
-		if (useFinderCache) {
+		if (useFinderCache && productionMode) {
 			list = (List<DepotEntryGroupRel>)finderCache.getResult(
 				finderPath, finderArgs);
 		}
@@ -4311,7 +4598,7 @@ public class DepotEntryGroupRelPersistenceImpl
 
 				cacheResult(list);
 
-				if (useFinderCache) {
+				if (useFinderCache && productionMode) {
 					finderCache.putResult(finderPath, finderArgs, list);
 				}
 			}
@@ -4344,8 +4631,15 @@ public class DepotEntryGroupRelPersistenceImpl
 	 */
 	@Override
 	public int countAll() {
-		Long count = (Long)finderCache.getResult(
-			_finderPathCountAll, FINDER_ARGS_EMPTY);
+		boolean productionMode = ctPersistenceHelper.isProductionMode(
+			DepotEntryGroupRel.class);
+
+		Long count = null;
+
+		if (productionMode) {
+			count = (Long)finderCache.getResult(
+				_finderPathCountAll, FINDER_ARGS_EMPTY);
+		}
 
 		if (count == null) {
 			Session session = null;
@@ -4358,8 +4652,10 @@ public class DepotEntryGroupRelPersistenceImpl
 
 				count = (Long)query.uniqueResult();
 
-				finderCache.putResult(
-					_finderPathCountAll, FINDER_ARGS_EMPTY, count);
+				if (productionMode) {
+					finderCache.putResult(
+						_finderPathCountAll, FINDER_ARGS_EMPTY, count);
+				}
 			}
 			catch (Exception exception) {
 				throw processException(exception);
@@ -4393,8 +4689,74 @@ public class DepotEntryGroupRelPersistenceImpl
 	}
 
 	@Override
-	protected Map<String, Integer> getTableColumnsMap() {
+	public Set<String> getCTColumnNames(
+		CTColumnResolutionType ctColumnResolutionType) {
+
+		return _ctColumnNamesMap.getOrDefault(
+			ctColumnResolutionType, Collections.emptySet());
+	}
+
+	@Override
+	public List<String> getMappingTableNames() {
+		return _mappingTableNames;
+	}
+
+	@Override
+	public Map<String, Integer> getTableColumnsMap() {
 		return DepotEntryGroupRelModelImpl.TABLE_COLUMNS_MAP;
+	}
+
+	@Override
+	public String getTableName() {
+		return "DepotEntryGroupRel";
+	}
+
+	@Override
+	public List<String[]> getUniqueIndexColumnNames() {
+		return _uniqueIndexColumnNames;
+	}
+
+	private static final Map<CTColumnResolutionType, Set<String>>
+		_ctColumnNamesMap = new EnumMap<CTColumnResolutionType, Set<String>>(
+			CTColumnResolutionType.class);
+	private static final List<String> _mappingTableNames =
+		new ArrayList<String>();
+	private static final List<String[]> _uniqueIndexColumnNames =
+		new ArrayList<String[]>();
+
+	static {
+		Set<String> ctControlColumnNames = new HashSet<String>();
+		Set<String> ctIgnoreColumnNames = new HashSet<String>();
+		Set<String> ctStrictColumnNames = new HashSet<String>();
+
+		ctControlColumnNames.add("mvccVersion");
+		ctControlColumnNames.add("ctCollectionId");
+		ctStrictColumnNames.add("uuid_");
+		ctStrictColumnNames.add("groupId");
+		ctStrictColumnNames.add("companyId");
+		ctStrictColumnNames.add("userId");
+		ctStrictColumnNames.add("userName");
+		ctStrictColumnNames.add("createDate");
+		ctIgnoreColumnNames.add("modifiedDate");
+		ctStrictColumnNames.add("ddmStructuresAvailable");
+		ctStrictColumnNames.add("depotEntryId");
+		ctStrictColumnNames.add("searchable");
+		ctStrictColumnNames.add("toGroupId");
+		ctStrictColumnNames.add("lastPublishDate");
+
+		_ctColumnNamesMap.put(
+			CTColumnResolutionType.CONTROL, ctControlColumnNames);
+		_ctColumnNamesMap.put(
+			CTColumnResolutionType.IGNORE, ctIgnoreColumnNames);
+		_ctColumnNamesMap.put(
+			CTColumnResolutionType.PK,
+			Collections.singleton("depotEntryGroupRelId"));
+		_ctColumnNamesMap.put(
+			CTColumnResolutionType.STRICT, ctStrictColumnNames);
+
+		_uniqueIndexColumnNames.add(new String[] {"uuid_", "groupId"});
+
+		_uniqueIndexColumnNames.add(new String[] {"depotEntryId", "toGroupId"});
 	}
 
 	/**
@@ -4599,6 +4961,9 @@ public class DepotEntryGroupRelPersistenceImpl
 	public void setSessionFactory(SessionFactory sessionFactory) {
 		super.setSessionFactory(sessionFactory);
 	}
+
+	@Reference
+	protected CTPersistenceHelper ctPersistenceHelper;
 
 	@Reference
 	protected EntityCache entityCache;

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/persistence/impl/DepotEntryPersistenceImpl.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/persistence/impl/DepotEntryPersistenceImpl.java
@@ -23,6 +23,7 @@ import com.liferay.depot.service.persistence.DepotEntryPersistence;
 import com.liferay.depot.service.persistence.DepotEntryUtil;
 import com.liferay.depot.service.persistence.impl.constants.DepotPersistenceConstants;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.change.tracking.CTColumnResolutionType;
 import com.liferay.portal.kernel.configuration.Configuration;
 import com.liferay.portal.kernel.dao.orm.EntityCache;
 import com.liferay.portal.kernel.dao.orm.FinderCache;
@@ -38,6 +39,7 @@ import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.service.persistence.BasePersistence;
+import com.liferay.portal.kernel.service.persistence.change.tracking.helper.CTPersistenceHelper;
 import com.liferay.portal.kernel.service.persistence.impl.BasePersistenceImpl;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
@@ -53,8 +55,13 @@ import java.io.Serializable;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationHandler;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
+import java.util.EnumMap;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -173,25 +180,28 @@ public class DepotEntryPersistenceImpl
 
 		uuid = Objects.toString(uuid, "");
 
+		boolean productionMode = ctPersistenceHelper.isProductionMode(
+			DepotEntry.class);
+
 		FinderPath finderPath = null;
 		Object[] finderArgs = null;
 
 		if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) &&
 			(orderByComparator == null)) {
 
-			if (useFinderCache) {
+			if (useFinderCache && productionMode) {
 				finderPath = _finderPathWithoutPaginationFindByUuid;
 				finderArgs = new Object[] {uuid};
 			}
 		}
-		else if (useFinderCache) {
+		else if (useFinderCache && productionMode) {
 			finderPath = _finderPathWithPaginationFindByUuid;
 			finderArgs = new Object[] {uuid, start, end, orderByComparator};
 		}
 
 		List<DepotEntry> list = null;
 
-		if (useFinderCache) {
+		if (useFinderCache && productionMode) {
 			list = (List<DepotEntry>)finderCache.getResult(
 				finderPath, finderArgs);
 
@@ -258,7 +268,7 @@ public class DepotEntryPersistenceImpl
 
 				cacheResult(list);
 
-				if (useFinderCache) {
+				if (useFinderCache && productionMode) {
 					finderCache.putResult(finderPath, finderArgs, list);
 				}
 			}
@@ -569,11 +579,21 @@ public class DepotEntryPersistenceImpl
 	public int countByUuid(String uuid) {
 		uuid = Objects.toString(uuid, "");
 
-		FinderPath finderPath = _finderPathCountByUuid;
+		boolean productionMode = ctPersistenceHelper.isProductionMode(
+			DepotEntry.class);
 
-		Object[] finderArgs = new Object[] {uuid};
+		FinderPath finderPath = null;
+		Object[] finderArgs = null;
 
-		Long count = (Long)finderCache.getResult(finderPath, finderArgs);
+		Long count = null;
+
+		if (productionMode) {
+			finderPath = _finderPathCountByUuid;
+
+			finderArgs = new Object[] {uuid};
+
+			count = (Long)finderCache.getResult(finderPath, finderArgs);
+		}
 
 		if (count == null) {
 			StringBundler sb = new StringBundler(2);
@@ -608,7 +628,9 @@ public class DepotEntryPersistenceImpl
 
 				count = (Long)query.uniqueResult();
 
-				finderCache.putResult(finderPath, finderArgs, count);
+				if (productionMode) {
+					finderCache.putResult(finderPath, finderArgs, count);
+				}
 			}
 			catch (Exception exception) {
 				throw processException(exception);
@@ -693,15 +715,18 @@ public class DepotEntryPersistenceImpl
 
 		uuid = Objects.toString(uuid, "");
 
+		boolean productionMode = ctPersistenceHelper.isProductionMode(
+			DepotEntry.class);
+
 		Object[] finderArgs = null;
 
-		if (useFinderCache) {
+		if (useFinderCache && productionMode) {
 			finderArgs = new Object[] {uuid, groupId};
 		}
 
 		Object result = null;
 
-		if (useFinderCache) {
+		if (useFinderCache && productionMode) {
 			result = finderCache.getResult(
 				_finderPathFetchByUUID_G, finderArgs);
 		}
@@ -754,7 +779,7 @@ public class DepotEntryPersistenceImpl
 				List<DepotEntry> list = query.list();
 
 				if (list.isEmpty()) {
-					if (useFinderCache) {
+					if (useFinderCache && productionMode) {
 						finderCache.putResult(
 							_finderPathFetchByUUID_G, finderArgs, list);
 					}
@@ -810,11 +835,21 @@ public class DepotEntryPersistenceImpl
 	public int countByUUID_G(String uuid, long groupId) {
 		uuid = Objects.toString(uuid, "");
 
-		FinderPath finderPath = _finderPathCountByUUID_G;
+		boolean productionMode = ctPersistenceHelper.isProductionMode(
+			DepotEntry.class);
 
-		Object[] finderArgs = new Object[] {uuid, groupId};
+		FinderPath finderPath = null;
+		Object[] finderArgs = null;
 
-		Long count = (Long)finderCache.getResult(finderPath, finderArgs);
+		Long count = null;
+
+		if (productionMode) {
+			finderPath = _finderPathCountByUUID_G;
+
+			finderArgs = new Object[] {uuid, groupId};
+
+			count = (Long)finderCache.getResult(finderPath, finderArgs);
+		}
 
 		if (count == null) {
 			StringBundler sb = new StringBundler(3);
@@ -853,7 +888,9 @@ public class DepotEntryPersistenceImpl
 
 				count = (Long)query.uniqueResult();
 
-				finderCache.putResult(finderPath, finderArgs, count);
+				if (productionMode) {
+					finderCache.putResult(finderPath, finderArgs, count);
+				}
 			}
 			catch (Exception exception) {
 				throw processException(exception);
@@ -958,18 +995,21 @@ public class DepotEntryPersistenceImpl
 
 		uuid = Objects.toString(uuid, "");
 
+		boolean productionMode = ctPersistenceHelper.isProductionMode(
+			DepotEntry.class);
+
 		FinderPath finderPath = null;
 		Object[] finderArgs = null;
 
 		if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) &&
 			(orderByComparator == null)) {
 
-			if (useFinderCache) {
+			if (useFinderCache && productionMode) {
 				finderPath = _finderPathWithoutPaginationFindByUuid_C;
 				finderArgs = new Object[] {uuid, companyId};
 			}
 		}
-		else if (useFinderCache) {
+		else if (useFinderCache && productionMode) {
 			finderPath = _finderPathWithPaginationFindByUuid_C;
 			finderArgs = new Object[] {
 				uuid, companyId, start, end, orderByComparator
@@ -978,7 +1018,7 @@ public class DepotEntryPersistenceImpl
 
 		List<DepotEntry> list = null;
 
-		if (useFinderCache) {
+		if (useFinderCache && productionMode) {
 			list = (List<DepotEntry>)finderCache.getResult(
 				finderPath, finderArgs);
 
@@ -1051,7 +1091,7 @@ public class DepotEntryPersistenceImpl
 
 				cacheResult(list);
 
-				if (useFinderCache) {
+				if (useFinderCache && productionMode) {
 					finderCache.putResult(finderPath, finderArgs, list);
 				}
 			}
@@ -1388,11 +1428,21 @@ public class DepotEntryPersistenceImpl
 	public int countByUuid_C(String uuid, long companyId) {
 		uuid = Objects.toString(uuid, "");
 
-		FinderPath finderPath = _finderPathCountByUuid_C;
+		boolean productionMode = ctPersistenceHelper.isProductionMode(
+			DepotEntry.class);
 
-		Object[] finderArgs = new Object[] {uuid, companyId};
+		FinderPath finderPath = null;
+		Object[] finderArgs = null;
 
-		Long count = (Long)finderCache.getResult(finderPath, finderArgs);
+		Long count = null;
+
+		if (productionMode) {
+			finderPath = _finderPathCountByUuid_C;
+
+			finderArgs = new Object[] {uuid, companyId};
+
+			count = (Long)finderCache.getResult(finderPath, finderArgs);
+		}
 
 		if (count == null) {
 			StringBundler sb = new StringBundler(3);
@@ -1431,7 +1481,9 @@ public class DepotEntryPersistenceImpl
 
 				count = (Long)query.uniqueResult();
 
-				finderCache.putResult(finderPath, finderArgs, count);
+				if (productionMode) {
+					finderCache.putResult(finderPath, finderArgs, count);
+				}
 			}
 			catch (Exception exception) {
 				throw processException(exception);
@@ -1507,15 +1559,18 @@ public class DepotEntryPersistenceImpl
 	 */
 	@Override
 	public DepotEntry fetchByGroupId(long groupId, boolean useFinderCache) {
+		boolean productionMode = ctPersistenceHelper.isProductionMode(
+			DepotEntry.class);
+
 		Object[] finderArgs = null;
 
-		if (useFinderCache) {
+		if (useFinderCache && productionMode) {
 			finderArgs = new Object[] {groupId};
 		}
 
 		Object result = null;
 
-		if (useFinderCache) {
+		if (useFinderCache && productionMode) {
 			result = finderCache.getResult(
 				_finderPathFetchByGroupId, finderArgs);
 		}
@@ -1551,7 +1606,7 @@ public class DepotEntryPersistenceImpl
 				List<DepotEntry> list = query.list();
 
 				if (list.isEmpty()) {
-					if (useFinderCache) {
+					if (useFinderCache && productionMode) {
 						finderCache.putResult(
 							_finderPathFetchByGroupId, finderArgs, list);
 					}
@@ -1603,11 +1658,21 @@ public class DepotEntryPersistenceImpl
 	 */
 	@Override
 	public int countByGroupId(long groupId) {
-		FinderPath finderPath = _finderPathCountByGroupId;
+		boolean productionMode = ctPersistenceHelper.isProductionMode(
+			DepotEntry.class);
 
-		Object[] finderArgs = new Object[] {groupId};
+		FinderPath finderPath = null;
+		Object[] finderArgs = null;
 
-		Long count = (Long)finderCache.getResult(finderPath, finderArgs);
+		Long count = null;
+
+		if (productionMode) {
+			finderPath = _finderPathCountByGroupId;
+
+			finderArgs = new Object[] {groupId};
+
+			count = (Long)finderCache.getResult(finderPath, finderArgs);
+		}
 
 		if (count == null) {
 			StringBundler sb = new StringBundler(2);
@@ -1631,7 +1696,9 @@ public class DepotEntryPersistenceImpl
 
 				count = (Long)query.uniqueResult();
 
-				finderCache.putResult(finderPath, finderArgs, count);
+				if (productionMode) {
+					finderCache.putResult(finderPath, finderArgs, count);
+				}
 			}
 			catch (Exception exception) {
 				throw processException(exception);
@@ -1669,6 +1736,10 @@ public class DepotEntryPersistenceImpl
 	 */
 	@Override
 	public void cacheResult(DepotEntry depotEntry) {
+		if (depotEntry.getCtCollectionId() != 0) {
+			return;
+		}
+
 		entityCache.putResult(
 			DepotEntryImpl.class, depotEntry.getPrimaryKey(), depotEntry);
 
@@ -1699,6 +1770,10 @@ public class DepotEntryPersistenceImpl
 		}
 
 		for (DepotEntry depotEntry : depotEntries) {
+			if (depotEntry.getCtCollectionId() != 0) {
+				continue;
+			}
+
 			if (entityCache.getResult(
 					DepotEntryImpl.class, depotEntry.getPrimaryKey()) == null) {
 
@@ -1854,7 +1929,9 @@ public class DepotEntryPersistenceImpl
 					DepotEntryImpl.class, depotEntry.getPrimaryKeyObj());
 			}
 
-			if (depotEntry != null) {
+			if ((depotEntry != null) &&
+				ctPersistenceHelper.isRemove(depotEntry)) {
+
 				session.delete(depotEntry);
 			}
 		}
@@ -1930,7 +2007,12 @@ public class DepotEntryPersistenceImpl
 		try {
 			session = openSession();
 
-			if (isNew) {
+			if (ctPersistenceHelper.isInsert(depotEntry)) {
+				if (!isNew) {
+					session.evict(
+						DepotEntryImpl.class, depotEntry.getPrimaryKeyObj());
+				}
+
 				session.save(depotEntry);
 			}
 			else {
@@ -1942,6 +2024,16 @@ public class DepotEntryPersistenceImpl
 		}
 		finally {
 			closeSession(session);
+		}
+
+		if (depotEntry.getCtCollectionId() != 0) {
+			if (isNew) {
+				depotEntry.setNew(false);
+			}
+
+			depotEntry.resetOriginalValues();
+
+			return depotEntry;
 		}
 
 		entityCache.putResult(
@@ -2000,12 +2092,139 @@ public class DepotEntryPersistenceImpl
 	/**
 	 * Returns the depot entry with the primary key or returns <code>null</code> if it could not be found.
 	 *
+	 * @param primaryKey the primary key of the depot entry
+	 * @return the depot entry, or <code>null</code> if a depot entry with the primary key could not be found
+	 */
+	@Override
+	public DepotEntry fetchByPrimaryKey(Serializable primaryKey) {
+		if (ctPersistenceHelper.isProductionMode(DepotEntry.class)) {
+			return super.fetchByPrimaryKey(primaryKey);
+		}
+
+		DepotEntry depotEntry = null;
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			depotEntry = (DepotEntry)session.get(
+				DepotEntryImpl.class, primaryKey);
+
+			if (depotEntry != null) {
+				cacheResult(depotEntry);
+			}
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+
+		return depotEntry;
+	}
+
+	/**
+	 * Returns the depot entry with the primary key or returns <code>null</code> if it could not be found.
+	 *
 	 * @param depotEntryId the primary key of the depot entry
 	 * @return the depot entry, or <code>null</code> if a depot entry with the primary key could not be found
 	 */
 	@Override
 	public DepotEntry fetchByPrimaryKey(long depotEntryId) {
 		return fetchByPrimaryKey((Serializable)depotEntryId);
+	}
+
+	@Override
+	public Map<Serializable, DepotEntry> fetchByPrimaryKeys(
+		Set<Serializable> primaryKeys) {
+
+		if (ctPersistenceHelper.isProductionMode(DepotEntry.class)) {
+			return super.fetchByPrimaryKeys(primaryKeys);
+		}
+
+		if (primaryKeys.isEmpty()) {
+			return Collections.emptyMap();
+		}
+
+		Map<Serializable, DepotEntry> map =
+			new HashMap<Serializable, DepotEntry>();
+
+		if (primaryKeys.size() == 1) {
+			Iterator<Serializable> iterator = primaryKeys.iterator();
+
+			Serializable primaryKey = iterator.next();
+
+			DepotEntry depotEntry = fetchByPrimaryKey(primaryKey);
+
+			if (depotEntry != null) {
+				map.put(primaryKey, depotEntry);
+			}
+
+			return map;
+		}
+
+		if ((databaseInMaxParameters > 0) &&
+			(primaryKeys.size() > databaseInMaxParameters)) {
+
+			Iterator<Serializable> iterator = primaryKeys.iterator();
+
+			while (iterator.hasNext()) {
+				Set<Serializable> page = new HashSet<>();
+
+				for (int i = 0;
+					 (i < databaseInMaxParameters) && iterator.hasNext(); i++) {
+
+					page.add(iterator.next());
+				}
+
+				map.putAll(fetchByPrimaryKeys(page));
+			}
+
+			return map;
+		}
+
+		StringBundler sb = new StringBundler((primaryKeys.size() * 2) + 1);
+
+		sb.append(getSelectSQL());
+		sb.append(" WHERE ");
+		sb.append(getPKDBName());
+		sb.append(" IN (");
+
+		for (Serializable primaryKey : primaryKeys) {
+			sb.append((long)primaryKey);
+
+			sb.append(",");
+		}
+
+		sb.setIndex(sb.index() - 1);
+
+		sb.append(")");
+
+		String sql = sb.toString();
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			Query query = session.createQuery(sql);
+
+			for (DepotEntry depotEntry : (List<DepotEntry>)query.list()) {
+				map.put(depotEntry.getPrimaryKeyObj(), depotEntry);
+
+				cacheResult(depotEntry);
+			}
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+
+		return map;
 	}
 
 	/**
@@ -2071,25 +2290,28 @@ public class DepotEntryPersistenceImpl
 		int start, int end, OrderByComparator<DepotEntry> orderByComparator,
 		boolean useFinderCache) {
 
+		boolean productionMode = ctPersistenceHelper.isProductionMode(
+			DepotEntry.class);
+
 		FinderPath finderPath = null;
 		Object[] finderArgs = null;
 
 		if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) &&
 			(orderByComparator == null)) {
 
-			if (useFinderCache) {
+			if (useFinderCache && productionMode) {
 				finderPath = _finderPathWithoutPaginationFindAll;
 				finderArgs = FINDER_ARGS_EMPTY;
 			}
 		}
-		else if (useFinderCache) {
+		else if (useFinderCache && productionMode) {
 			finderPath = _finderPathWithPaginationFindAll;
 			finderArgs = new Object[] {start, end, orderByComparator};
 		}
 
 		List<DepotEntry> list = null;
 
-		if (useFinderCache) {
+		if (useFinderCache && productionMode) {
 			list = (List<DepotEntry>)finderCache.getResult(
 				finderPath, finderArgs);
 		}
@@ -2127,7 +2349,7 @@ public class DepotEntryPersistenceImpl
 
 				cacheResult(list);
 
-				if (useFinderCache) {
+				if (useFinderCache && productionMode) {
 					finderCache.putResult(finderPath, finderArgs, list);
 				}
 			}
@@ -2160,8 +2382,15 @@ public class DepotEntryPersistenceImpl
 	 */
 	@Override
 	public int countAll() {
-		Long count = (Long)finderCache.getResult(
-			_finderPathCountAll, FINDER_ARGS_EMPTY);
+		boolean productionMode = ctPersistenceHelper.isProductionMode(
+			DepotEntry.class);
+
+		Long count = null;
+
+		if (productionMode) {
+			count = (Long)finderCache.getResult(
+				_finderPathCountAll, FINDER_ARGS_EMPTY);
+		}
 
 		if (count == null) {
 			Session session = null;
@@ -2173,8 +2402,10 @@ public class DepotEntryPersistenceImpl
 
 				count = (Long)query.uniqueResult();
 
-				finderCache.putResult(
-					_finderPathCountAll, FINDER_ARGS_EMPTY, count);
+				if (productionMode) {
+					finderCache.putResult(
+						_finderPathCountAll, FINDER_ARGS_EMPTY, count);
+				}
 			}
 			catch (Exception exception) {
 				throw processException(exception);
@@ -2208,8 +2439,68 @@ public class DepotEntryPersistenceImpl
 	}
 
 	@Override
-	protected Map<String, Integer> getTableColumnsMap() {
+	public Set<String> getCTColumnNames(
+		CTColumnResolutionType ctColumnResolutionType) {
+
+		return _ctColumnNamesMap.getOrDefault(
+			ctColumnResolutionType, Collections.emptySet());
+	}
+
+	@Override
+	public List<String> getMappingTableNames() {
+		return _mappingTableNames;
+	}
+
+	@Override
+	public Map<String, Integer> getTableColumnsMap() {
 		return DepotEntryModelImpl.TABLE_COLUMNS_MAP;
+	}
+
+	@Override
+	public String getTableName() {
+		return "DepotEntry";
+	}
+
+	@Override
+	public List<String[]> getUniqueIndexColumnNames() {
+		return _uniqueIndexColumnNames;
+	}
+
+	private static final Map<CTColumnResolutionType, Set<String>>
+		_ctColumnNamesMap = new EnumMap<CTColumnResolutionType, Set<String>>(
+			CTColumnResolutionType.class);
+	private static final List<String> _mappingTableNames =
+		new ArrayList<String>();
+	private static final List<String[]> _uniqueIndexColumnNames =
+		new ArrayList<String[]>();
+
+	static {
+		Set<String> ctControlColumnNames = new HashSet<String>();
+		Set<String> ctIgnoreColumnNames = new HashSet<String>();
+		Set<String> ctStrictColumnNames = new HashSet<String>();
+
+		ctControlColumnNames.add("mvccVersion");
+		ctControlColumnNames.add("ctCollectionId");
+		ctStrictColumnNames.add("uuid_");
+		ctStrictColumnNames.add("groupId");
+		ctStrictColumnNames.add("companyId");
+		ctStrictColumnNames.add("userId");
+		ctStrictColumnNames.add("userName");
+		ctStrictColumnNames.add("createDate");
+		ctIgnoreColumnNames.add("modifiedDate");
+
+		_ctColumnNamesMap.put(
+			CTColumnResolutionType.CONTROL, ctControlColumnNames);
+		_ctColumnNamesMap.put(
+			CTColumnResolutionType.IGNORE, ctIgnoreColumnNames);
+		_ctColumnNamesMap.put(
+			CTColumnResolutionType.PK, Collections.singleton("depotEntryId"));
+		_ctColumnNamesMap.put(
+			CTColumnResolutionType.STRICT, ctStrictColumnNames);
+
+		_uniqueIndexColumnNames.add(new String[] {"uuid_", "groupId"});
+
+		_uniqueIndexColumnNames.add(new String[] {"groupId"});
 	}
 
 	/**
@@ -2339,6 +2630,9 @@ public class DepotEntryPersistenceImpl
 	public void setSessionFactory(SessionFactory sessionFactory) {
 		super.setSessionFactory(sessionFactory);
 	}
+
+	@Reference
+	protected CTPersistenceHelper ctPersistenceHelper;
 
 	@Reference
 	protected EntityCache entityCache;

--- a/modules/apps/depot/depot-service/src/main/resources/META-INF/module-hbm.xml
+++ b/modules/apps/depot/depot-service/src/main/resources/META-INF/module-hbm.xml
@@ -10,6 +10,7 @@
 			<generator class="assigned" />
 		</id>
 		<version access="com.liferay.portal.dao.orm.hibernate.PrivatePropertyAccessor" name="mvccVersion" type="long" />
+		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="ctCollectionId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="companyId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="depotEntryId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="enabled" type="com.liferay.portal.dao.orm.hibernate.BooleanType" />
@@ -20,6 +21,7 @@
 			<generator class="assigned" />
 		</id>
 		<version access="com.liferay.portal.dao.orm.hibernate.PrivatePropertyAccessor" name="mvccVersion" type="long" />
+		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="ctCollectionId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" column="uuid_" name="uuid" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="groupId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="companyId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
@@ -33,6 +35,7 @@
 			<generator class="assigned" />
 		</id>
 		<version access="com.liferay.portal.dao.orm.hibernate.PrivatePropertyAccessor" name="mvccVersion" type="long" />
+		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="ctCollectionId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" column="uuid_" name="uuid" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="groupId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="companyId" type="com.liferay.portal.dao.orm.hibernate.LongType" />

--- a/modules/apps/depot/depot-service/src/main/resources/META-INF/portlet-model-hints.xml
+++ b/modules/apps/depot/depot-service/src/main/resources/META-INF/portlet-model-hints.xml
@@ -3,6 +3,7 @@
 <model-hints>
 	<model name="com.liferay.depot.model.DepotAppCustomization">
 		<field name="mvccVersion" type="long" />
+		<field name="ctCollectionId" type="long" />
 		<field name="depotAppCustomizationId" type="long" />
 		<field name="companyId" type="long" />
 		<field name="depotEntryId" type="long" />
@@ -11,6 +12,7 @@
 	</model>
 	<model name="com.liferay.depot.model.DepotEntry">
 		<field name="mvccVersion" type="long" />
+		<field name="ctCollectionId" type="long" />
 		<field name="uuid" type="String" />
 		<field name="depotEntryId" type="long" />
 		<field name="groupId" type="long" />
@@ -22,6 +24,7 @@
 	</model>
 	<model name="com.liferay.depot.model.DepotEntryGroupRel">
 		<field name="mvccVersion" type="long" />
+		<field name="ctCollectionId" type="long" />
 		<field name="uuid" type="String" />
 		<field name="depotEntryGroupRelId" type="long" />
 		<field name="groupId" type="long" />

--- a/modules/apps/depot/depot-service/src/main/resources/META-INF/sql/indexes.sql
+++ b/modules/apps/depot/depot-service/src/main/resources/META-INF/sql/indexes.sql
@@ -1,12 +1,16 @@
-create index IX_5B76D798 on DepotAppCustomization (depotEntryId, enabled);
-create unique index IX_DA8D9ACC on DepotAppCustomization (depotEntryId, portletId[$COLUMN_LENGTH:75$]);
+create index IX_F00DDB17 on DepotAppCustomization (depotEntryId, ctCollectionId);
+create index IX_D32F7DF6 on DepotAppCustomization (depotEntryId, enabled, ctCollectionId);
+create unique index IX_2CE1592A on DepotAppCustomization (depotEntryId, portletId[$COLUMN_LENGTH:75$], ctCollectionId);
 
-create unique index IX_884D6226 on DepotEntry (groupId);
-create index IX_FBDFFFF8 on DepotEntry (uuid_[$COLUMN_LENGTH:75$], companyId);
+create unique index IX_E3EB2C84 on DepotEntry (groupId, ctCollectionId);
+create index IX_4BFBE656 on DepotEntry (uuid_[$COLUMN_LENGTH:75$], companyId, ctCollectionId);
+create index IX_6179BC8E on DepotEntry (uuid_[$COLUMN_LENGTH:75$], ctCollectionId);
 
-create index IX_F329B161 on DepotEntryGroupRel (ddmStructuresAvailable, toGroupId);
-create unique index IX_65D34444 on DepotEntryGroupRel (depotEntryId, toGroupId);
-create index IX_C61C803B on DepotEntryGroupRel (searchable, toGroupId);
-create index IX_DB75E9F1 on DepotEntryGroupRel (toGroupId);
-create index IX_7ED7EAB2 on DepotEntryGroupRel (uuid_[$COLUMN_LENGTH:75$], companyId);
-create unique index IX_D25F75B4 on DepotEntryGroupRel (uuid_[$COLUMN_LENGTH:75$], groupId);
+create index IX_196FA5BF on DepotEntryGroupRel (ddmStructuresAvailable, toGroupId, ctCollectionId);
+create index IX_8A747829 on DepotEntryGroupRel (depotEntryId, ctCollectionId);
+create unique index IX_815512A2 on DepotEntryGroupRel (depotEntryId, toGroupId, ctCollectionId);
+create index IX_29AD8099 on DepotEntryGroupRel (searchable, toGroupId, ctCollectionId);
+create index IX_71D8BE4F on DepotEntryGroupRel (toGroupId, ctCollectionId);
+create index IX_E14B1D10 on DepotEntryGroupRel (uuid_[$COLUMN_LENGTH:75$], companyId, ctCollectionId);
+create index IX_AC497614 on DepotEntryGroupRel (uuid_[$COLUMN_LENGTH:75$], ctCollectionId);
+create unique index IX_23B06412 on DepotEntryGroupRel (uuid_[$COLUMN_LENGTH:75$], groupId, ctCollectionId);

--- a/modules/apps/depot/depot-service/src/main/resources/META-INF/sql/tables.sql
+++ b/modules/apps/depot/depot-service/src/main/resources/META-INF/sql/tables.sql
@@ -1,28 +1,33 @@
 create table DepotAppCustomization (
 	mvccVersion LONG default 0 not null,
-	depotAppCustomizationId LONG not null primary key,
+	ctCollectionId LONG default 0 not null,
+	depotAppCustomizationId LONG not null,
 	companyId LONG,
 	depotEntryId LONG,
 	enabled BOOLEAN,
-	portletId VARCHAR(75) null
+	portletId VARCHAR(75) null,
+	primary key (depotAppCustomizationId, ctCollectionId)
 );
 
 create table DepotEntry (
 	mvccVersion LONG default 0 not null,
+	ctCollectionId LONG default 0 not null,
 	uuid_ VARCHAR(75) null,
-	depotEntryId LONG not null primary key,
+	depotEntryId LONG not null,
 	groupId LONG,
 	companyId LONG,
 	userId LONG,
 	userName VARCHAR(75) null,
 	createDate DATE null,
-	modifiedDate DATE null
+	modifiedDate DATE null,
+	primary key (depotEntryId, ctCollectionId)
 );
 
 create table DepotEntryGroupRel (
 	mvccVersion LONG default 0 not null,
+	ctCollectionId LONG default 0 not null,
 	uuid_ VARCHAR(75) null,
-	depotEntryGroupRelId LONG not null primary key,
+	depotEntryGroupRelId LONG not null,
 	groupId LONG,
 	companyId LONG,
 	userId LONG,
@@ -33,5 +38,6 @@ create table DepotEntryGroupRel (
 	depotEntryId LONG,
 	searchable BOOLEAN,
 	toGroupId LONG,
-	lastPublishDate DATE null
+	lastPublishDate DATE null,
+	primary key (depotEntryGroupRelId, ctCollectionId)
 );

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/persistence/test/DepotAppCustomizationPersistenceTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/persistence/test/DepotAppCustomizationPersistenceTest.java
@@ -129,6 +129,8 @@ public class DepotAppCustomizationPersistenceTest {
 
 		newDepotAppCustomization.setMvccVersion(RandomTestUtil.nextLong());
 
+		newDepotAppCustomization.setCtCollectionId(RandomTestUtil.nextLong());
+
 		newDepotAppCustomization.setCompanyId(RandomTestUtil.nextLong());
 
 		newDepotAppCustomization.setDepotEntryId(RandomTestUtil.nextLong());
@@ -147,6 +149,9 @@ public class DepotAppCustomizationPersistenceTest {
 		Assert.assertEquals(
 			existingDepotAppCustomization.getMvccVersion(),
 			newDepotAppCustomization.getMvccVersion());
+		Assert.assertEquals(
+			existingDepotAppCustomization.getCtCollectionId(),
+			newDepotAppCustomization.getCtCollectionId());
 		Assert.assertEquals(
 			existingDepotAppCustomization.getDepotAppCustomizationId(),
 			newDepotAppCustomization.getDepotAppCustomizationId());
@@ -216,9 +221,9 @@ public class DepotAppCustomizationPersistenceTest {
 
 	protected OrderByComparator<DepotAppCustomization> getOrderByComparator() {
 		return OrderByComparatorFactoryUtil.create(
-			"DepotAppCustomization", "mvccVersion", true,
-			"depotAppCustomizationId", true, "companyId", true, "depotEntryId",
-			true, "enabled", true, "portletId", true);
+			"DepotAppCustomization", "mvccVersion", true, "ctCollectionId",
+			true, "depotAppCustomizationId", true, "companyId", true,
+			"depotEntryId", true, "enabled", true, "portletId", true);
 	}
 
 	@Test
@@ -545,6 +550,8 @@ public class DepotAppCustomizationPersistenceTest {
 		DepotAppCustomization depotAppCustomization = _persistence.create(pk);
 
 		depotAppCustomization.setMvccVersion(RandomTestUtil.nextLong());
+
+		depotAppCustomization.setCtCollectionId(RandomTestUtil.nextLong());
 
 		depotAppCustomization.setCompanyId(RandomTestUtil.nextLong());
 

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/persistence/test/DepotEntryGroupRelPersistenceTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/persistence/test/DepotEntryGroupRelPersistenceTest.java
@@ -127,6 +127,8 @@ public class DepotEntryGroupRelPersistenceTest {
 
 		newDepotEntryGroupRel.setMvccVersion(RandomTestUtil.nextLong());
 
+		newDepotEntryGroupRel.setCtCollectionId(RandomTestUtil.nextLong());
+
 		newDepotEntryGroupRel.setUuid(RandomTestUtil.randomString());
 
 		newDepotEntryGroupRel.setGroupId(RandomTestUtil.nextLong());
@@ -161,6 +163,9 @@ public class DepotEntryGroupRelPersistenceTest {
 		Assert.assertEquals(
 			existingDepotEntryGroupRel.getMvccVersion(),
 			newDepotEntryGroupRel.getMvccVersion());
+		Assert.assertEquals(
+			existingDepotEntryGroupRel.getCtCollectionId(),
+			newDepotEntryGroupRel.getCtCollectionId());
 		Assert.assertEquals(
 			existingDepotEntryGroupRel.getUuid(),
 			newDepotEntryGroupRel.getUuid());
@@ -295,10 +300,10 @@ public class DepotEntryGroupRelPersistenceTest {
 
 	protected OrderByComparator<DepotEntryGroupRel> getOrderByComparator() {
 		return OrderByComparatorFactoryUtil.create(
-			"DepotEntryGroupRel", "mvccVersion", true, "uuid", true,
-			"depotEntryGroupRelId", true, "groupId", true, "companyId", true,
-			"userId", true, "userName", true, "createDate", true,
-			"modifiedDate", true, "ddmStructuresAvailable", true,
+			"DepotEntryGroupRel", "mvccVersion", true, "ctCollectionId", true,
+			"uuid", true, "depotEntryGroupRelId", true, "groupId", true,
+			"companyId", true, "userId", true, "userName", true, "createDate",
+			true, "modifiedDate", true, "ddmStructuresAvailable", true,
 			"depotEntryId", true, "searchable", true, "toGroupId", true,
 			"lastPublishDate", true);
 	}
@@ -608,6 +613,8 @@ public class DepotEntryGroupRelPersistenceTest {
 		DepotEntryGroupRel depotEntryGroupRel = _persistence.create(pk);
 
 		depotEntryGroupRel.setMvccVersion(RandomTestUtil.nextLong());
+
+		depotEntryGroupRel.setCtCollectionId(RandomTestUtil.nextLong());
 
 		depotEntryGroupRel.setUuid(RandomTestUtil.randomString());
 

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/persistence/test/DepotEntryPersistenceTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/persistence/test/DepotEntryPersistenceTest.java
@@ -126,6 +126,8 @@ public class DepotEntryPersistenceTest {
 
 		newDepotEntry.setMvccVersion(RandomTestUtil.nextLong());
 
+		newDepotEntry.setCtCollectionId(RandomTestUtil.nextLong());
+
 		newDepotEntry.setUuid(RandomTestUtil.randomString());
 
 		newDepotEntry.setGroupId(RandomTestUtil.nextLong());
@@ -148,6 +150,9 @@ public class DepotEntryPersistenceTest {
 		Assert.assertEquals(
 			existingDepotEntry.getMvccVersion(),
 			newDepotEntry.getMvccVersion());
+		Assert.assertEquals(
+			existingDepotEntry.getCtCollectionId(),
+			newDepotEntry.getCtCollectionId());
 		Assert.assertEquals(
 			existingDepotEntry.getUuid(), newDepotEntry.getUuid());
 		Assert.assertEquals(
@@ -228,9 +233,10 @@ public class DepotEntryPersistenceTest {
 
 	protected OrderByComparator<DepotEntry> getOrderByComparator() {
 		return OrderByComparatorFactoryUtil.create(
-			"DepotEntry", "mvccVersion", true, "uuid", true, "depotEntryId",
-			true, "groupId", true, "companyId", true, "userId", true,
-			"userName", true, "createDate", true, "modifiedDate", true);
+			"DepotEntry", "mvccVersion", true, "ctCollectionId", true, "uuid",
+			true, "depotEntryId", true, "groupId", true, "companyId", true,
+			"userId", true, "userName", true, "createDate", true,
+			"modifiedDate", true);
 	}
 
 	@Test
@@ -517,6 +523,8 @@ public class DepotEntryPersistenceTest {
 		DepotEntry depotEntry = _persistence.create(pk);
 
 		depotEntry.setMvccVersion(RandomTestUtil.nextLong());
+
+		depotEntry.setCtCollectionId(RandomTestUtil.nextLong());
 
 		depotEntry.setUuid(RandomTestUtil.randomString());
 


### PR DESCRIPTION
The column `groupId` in the group rels pointed to the site group ID, not the depot group ID. When staging/ct looks for changes to export/import, it will look for models that have a group ID equal to the group ID of the exporting/importing group. Originally, the group ID column contained the group of the site, so staging/ct interpreted that as if the group rel belonged to the site, and not the depot (in other words, the rel would be exported/imported when you tried to export/import the site).

This PR adds change tracking support for completeness (looks like an oversight not to support that), and fixes the values of the group ID column so that it points to the depot group.