### PR TITLE
LPS-146765 Avoid exporting references that don't belong to the current group

### DIFF
--- a/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/exportimport/portlet/preferences/processor/test/DLExportImportPortletPreferencesProcessorTest.java
+++ b/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/exportimport/portlet/preferences/processor/test/DLExportImportPortletPreferencesProcessorTest.java
@@ -116,7 +116,10 @@ public class DLExportImportPortletPreferencesProcessorTest {
 			RandomTestUtil.randomString(), RandomTestUtil.randomString());
 
 		_portletPreferences.setValue(
-			"fileEntryId", String.valueOf(fileEntry.getFileEntryId()));
+			"rootFolderId", String.valueOf(fileEntry.getFolderId()));
+		_portletPreferences.setValue(
+			"selectedRepositoryId",
+			String.valueOf(fileEntry.getRepositoryId()));
 
 		_portletPreferences.store();
 
@@ -168,7 +171,10 @@ public class DLExportImportPortletPreferencesProcessorTest {
 			RandomTestUtil.randomString(), RandomTestUtil.randomString());
 
 		_portletPreferences.setValue(
-			"fileEntryId", String.valueOf(fileEntry.getFileEntryId()));
+			"rootFolderId", String.valueOf(fileEntry.getFolderId()));
+		_portletPreferences.setValue(
+			"selectedRepositoryId",
+			String.valueOf(fileEntry.getRepositoryId()));
 
 		_portletPreferences.store();
 

--- a/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/exportimport/portlet/preferences/processor/test/DLExportImportPortletPreferencesProcessorTest.java
+++ b/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/exportimport/portlet/preferences/processor/test/DLExportImportPortletPreferencesProcessorTest.java
@@ -216,6 +216,73 @@ public class DLExportImportPortletPreferencesProcessorTest {
 	}
 
 	@Test
+	public void testExportDLFileEntryInDifferentGroup() throws Exception {
+		FileEntry fileEntry = _addDLFileEntry(
+			TestPropsValues.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString());
+
+		_portletPreferences.setValue(
+			"rootFolderId", String.valueOf(fileEntry.getFolderId()));
+		_portletPreferences.setValue(
+			"selectedRepositoryId",
+			String.valueOf(fileEntry.getRepositoryId()));
+
+		_portletPreferences.store();
+
+		Document document = SAXReaderUtil.createDocument();
+
+		Element rootElement = document.addElement("root");
+
+		_portletExportController.exportPortlet(
+			_portletDataContextExport, _layout.getPlid(), rootElement, false,
+			false, true, true, false);
+
+		Set<String> primaryKeys = _portletDataContextExport.getPrimaryKeys();
+
+		Assert.assertFalse(
+			primaryKeys.toString(),
+			primaryKeys.contains(
+				StringBundler.concat(
+					String.class.getName(), StringPool.POUND,
+					DLFileEntry.class.getName(), StringPool.POUND,
+					fileEntry.getFileEntryId())));
+	}
+
+	@Test
+	public void testExportDLFileEntryInSameGroup() throws Exception {
+		FileEntry fileEntry = _addDLFileEntry(
+			_layout.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString());
+
+		_portletPreferences.setValue(
+			"rootFolderId", String.valueOf(fileEntry.getFolderId()));
+		_portletPreferences.setValue(
+			"selectedRepositoryId",
+			String.valueOf(fileEntry.getRepositoryId()));
+
+		_portletPreferences.store();
+
+		Document document = SAXReaderUtil.createDocument();
+
+		Element rootElement = document.addElement("root");
+
+		_portletExportController.exportPortlet(
+			_portletDataContextExport, _layout.getPlid(), rootElement, false,
+			false, true, true, false);
+
+		Set<String> primaryKeys = _portletDataContextExport.getPrimaryKeys();
+
+		Assert.assertTrue(
+			primaryKeys.toString(),
+			primaryKeys.contains(
+				StringBundler.concat(
+					String.class.getName(), StringPool.POUND,
+					DLFileEntry.class.getName(), StringPool.POUND,
+					fileEntry.getFileEntryId())));
+	}
+
+	@Test
 	public void testProcessExportPortletPreferencesDLFileEntryId()
 		throws Exception {
 
@@ -245,18 +312,26 @@ public class DLExportImportPortletPreferencesProcessorTest {
 			GetterUtil.getLong(importedfileEntryId));
 	}
 
-	private FileEntry _addDLFileEntry(String fileName, String content)
+	private FileEntry _addDLFileEntry(
+			long groupId, long folderId, String fileName, String content)
 		throws Exception {
 
 		ServiceContext serviceContext =
-			ServiceContextTestUtil.getServiceContext(_group.getGroupId());
+			ServiceContextTestUtil.getServiceContext(groupId);
 
 		return _dlAppLocalService.addFileEntry(
-			null, TestPropsValues.getUserId(), serviceContext.getScopeGroupId(),
-			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, fileName,
+			null, TestPropsValues.getUserId(), groupId, folderId, fileName,
 			ContentTypes.TEXT_PLAIN, RandomTestUtil.randomString(),
 			StringPool.BLANK, StringPool.BLANK, content.getBytes(), null, null,
 			serviceContext);
+	}
+
+	private FileEntry _addDLFileEntry(String fileName, String content)
+		throws Exception {
+
+		return _addDLFileEntry(
+			_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			fileName, content);
 	}
 
 	@Inject

--- a/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/exportimport/portlet/preferences/processor/test/DLExportImportPortletPreferencesProcessorTest.java
+++ b/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/exportimport/portlet/preferences/processor/test/DLExportImportPortletPreferencesProcessorTest.java
@@ -113,6 +113,7 @@ public class DLExportImportPortletPreferencesProcessorTest {
 	@Test
 	public void testExportDLFileEntryIdWithComments() throws Exception {
 		FileEntry fileEntry = _addDLFileEntry(
+			_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString());
 
 		_portletPreferences.setValue(
@@ -168,6 +169,7 @@ public class DLExportImportPortletPreferencesProcessorTest {
 	@Test
 	public void testExportDLFileEntryIdWithRatings() throws Exception {
 		FileEntry fileEntry = _addDLFileEntry(
+			_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString());
 
 		_portletPreferences.setValue(
@@ -287,6 +289,7 @@ public class DLExportImportPortletPreferencesProcessorTest {
 		throws Exception {
 
 		FileEntry fileEntry = _addDLFileEntry(
+			_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString());
 
 		_portletPreferences.setValue(
@@ -324,14 +327,6 @@ public class DLExportImportPortletPreferencesProcessorTest {
 			ContentTypes.TEXT_PLAIN, RandomTestUtil.randomString(),
 			StringPool.BLANK, StringPool.BLANK, content.getBytes(), null, null,
 			serviceContext);
-	}
-
-	private FileEntry _addDLFileEntry(String fileName, String content)
-		throws Exception {
-
-		return _addDLFileEntry(
-			_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-			fileName, content);
 	}
 
 	@Inject

--- a/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/exportimport/portlet/preferences/processor/test/DLExportImportPortletPreferencesProcessorTest.java
+++ b/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/exportimport/portlet/preferences/processor/test/DLExportImportPortletPreferencesProcessorTest.java
@@ -113,8 +113,7 @@ public class DLExportImportPortletPreferencesProcessorTest {
 	@Test
 	public void testExportDLFileEntryIdWithComments() throws Exception {
 		FileEntry fileEntry = _addDLFileEntry(
-			_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-			RandomTestUtil.randomString(), RandomTestUtil.randomString());
+			_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID);
 
 		_portletPreferences.setValue(
 			"rootFolderId", String.valueOf(fileEntry.getFolderId()));
@@ -169,8 +168,7 @@ public class DLExportImportPortletPreferencesProcessorTest {
 	@Test
 	public void testExportDLFileEntryIdWithRatings() throws Exception {
 		FileEntry fileEntry = _addDLFileEntry(
-			_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-			RandomTestUtil.randomString(), RandomTestUtil.randomString());
+			_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID);
 
 		_portletPreferences.setValue(
 			"rootFolderId", String.valueOf(fileEntry.getFolderId()));
@@ -221,8 +219,7 @@ public class DLExportImportPortletPreferencesProcessorTest {
 	public void testExportDLFileEntryInDifferentGroup() throws Exception {
 		FileEntry fileEntry = _addDLFileEntry(
 			TestPropsValues.getGroupId(),
-			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-			RandomTestUtil.randomString(), RandomTestUtil.randomString());
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID);
 
 		_portletPreferences.setValue(
 			"rootFolderId", String.valueOf(fileEntry.getFolderId()));
@@ -254,8 +251,7 @@ public class DLExportImportPortletPreferencesProcessorTest {
 	@Test
 	public void testExportDLFileEntryInSameGroup() throws Exception {
 		FileEntry fileEntry = _addDLFileEntry(
-			_layout.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-			RandomTestUtil.randomString(), RandomTestUtil.randomString());
+			_layout.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID);
 
 		_portletPreferences.setValue(
 			"rootFolderId", String.valueOf(fileEntry.getFolderId()));
@@ -289,8 +285,7 @@ public class DLExportImportPortletPreferencesProcessorTest {
 		throws Exception {
 
 		FileEntry fileEntry = _addDLFileEntry(
-			_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-			RandomTestUtil.randomString(), RandomTestUtil.randomString());
+			_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID);
 
 		_portletPreferences.setValue(
 			"fileEntryId", String.valueOf(fileEntry.getFileEntryId()));
@@ -315,18 +310,17 @@ public class DLExportImportPortletPreferencesProcessorTest {
 			GetterUtil.getLong(importedfileEntryId));
 	}
 
-	private FileEntry _addDLFileEntry(
-			long groupId, long folderId, String fileName, String content)
+	private FileEntry _addDLFileEntry(long groupId, long folderId)
 		throws Exception {
 
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(groupId);
 
 		return _dlAppLocalService.addFileEntry(
-			null, TestPropsValues.getUserId(), groupId, folderId, fileName,
-			ContentTypes.TEXT_PLAIN, RandomTestUtil.randomString(),
-			StringPool.BLANK, StringPool.BLANK, content.getBytes(), null, null,
-			serviceContext);
+			null, TestPropsValues.getUserId(), groupId, folderId,
+			RandomTestUtil.randomString(), ContentTypes.TEXT_PLAIN,
+			RandomTestUtil.randomString(), StringPool.BLANK, StringPool.BLANK,
+			RandomTestUtil.randomBytes(), null, null, serviceContext);
 	}
 
 	@Inject

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/exportimport/portlet/preferences/processor/DLExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/exportimport/portlet/preferences/processor/DLExportImportPortletPreferencesProcessor.java
@@ -121,7 +121,12 @@ public class DLExportImportPortletPreferencesProcessor
 			}
 		}
 
-		if (!_exportImportHelper.isExportPortletData(portletDataContext)) {
+		long selectedRepositoryId = GetterUtil.getLong(
+			portletPreferences.getValue("selectedRepositoryId", null));
+
+		if (!_exportImportHelper.isExportPortletData(portletDataContext) ||
+			(selectedRepositoryId != portletDataContext.getGroupId())) {
+
 			return portletPreferences;
 		}
 

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/exportimport/portlet/preferences/processor/DLExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/exportimport/portlet/preferences/processor/DLExportImportPortletPreferencesProcessor.java
@@ -295,30 +295,28 @@ public class DLExportImportPortletPreferencesProcessor
 			List<Element> folderElements = foldersElement.elements();
 
 			if (!folderElements.isEmpty()) {
-				StagedModelDataHandlerUtil.importStagedModel(
-					portletDataContext, folderElements.get(0));
-
-				Map<Long, Long> folderIds =
-					(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
-						Folder.class + ".folderIdsAndRepositoryEntryIds");
-
-				rootFolderId = MapUtil.getLong(
-					folderIds, rootFolderId, rootFolderId);
-
 				try {
-					portletPreferences.setValue(
-						"rootFolderId", String.valueOf(rootFolderId));
+					StagedModelDataHandlerUtil.importStagedModel(
+						portletDataContext, folderElements.get(0));
 
-					Folder folder = _dlAppLocalService.getFolder(rootFolderId);
+					Map<Long, Long> folderIds =
+						(Map<Long, Long>)
+							portletDataContext.getNewPrimaryKeysMap(
+								Folder.class +
+									".folderIdsAndRepositoryEntryIds");
+
+					long importedRootFolderId = MapUtil.getLong(
+						folderIds, rootFolderId, rootFolderId);
+
+					portletPreferences.setValue(
+						"rootFolderId", String.valueOf(importedRootFolderId));
+
+					Folder folder = _getFolder(
+						importedRootFolderId, portletDataContext);
 
 					portletPreferences.setValue(
 						"selectedRepositoryId",
 						String.valueOf(folder.getRepositoryId()));
-				}
-				catch (PortalException portalException) {
-					throw new PortletDataException(
-						"Invalid root folder ID " + rootFolderId,
-						portalException);
 				}
 				catch (ReadOnlyException readOnlyException) {
 					throw new PortletDataException(
@@ -364,69 +362,67 @@ public class DLExportImportPortletPreferencesProcessor
 			throw portletDataException;
 		}
 
-		String namespace = _dlPortletDataHandler.getNamespace();
+		if (portletDataContext.getBooleanParameter(
+				_dlPortletDataHandler.getNamespace(), "folders")) {
 
-		if (portletDataContext.getBooleanParameter(namespace, "folders")) {
 			Element foldersElement =
 				portletDataContext.getImportDataGroupElement(DLFolder.class);
 
-			List<Element> folderElements = foldersElement.elements();
-
-			for (Element folderElement : folderElements) {
+			for (Element folderElement : foldersElement.elements()) {
 				StagedModelDataHandlerUtil.importStagedModel(
 					portletDataContext, folderElement);
 			}
 		}
 
-		if (portletDataContext.getBooleanParameter(namespace, "documents")) {
+		if (portletDataContext.getBooleanParameter(
+				_dlPortletDataHandler.getNamespace(), "documents")) {
+
 			Element fileEntriesElement =
 				portletDataContext.getImportDataGroupElement(DLFileEntry.class);
 
-			List<Element> fileEntryElements = fileEntriesElement.elements();
-
-			for (Element fileEntryElement : fileEntryElements) {
+			for (Element fileEntryElement : fileEntriesElement.elements()) {
 				StagedModelDataHandlerUtil.importStagedModel(
 					portletDataContext, fileEntryElement);
 			}
 		}
 
 		if (portletDataContext.getBooleanParameter(
-				namespace, "document-types")) {
+				_dlPortletDataHandler.getNamespace(), "document-types")) {
 
 			Element fileEntryTypesElement =
 				portletDataContext.getImportDataGroupElement(
 					DLFileEntryType.class);
 
-			List<Element> fileEntryTypeElements =
-				fileEntryTypesElement.elements();
+			for (Element fileEntryTypeElement :
+					fileEntryTypesElement.elements()) {
 
-			for (Element fileEntryTypeElement : fileEntryTypeElements) {
 				StagedModelDataHandlerUtil.importStagedModel(
 					portletDataContext, fileEntryTypeElement);
 			}
 		}
 
-		if (portletDataContext.getBooleanParameter(namespace, "repositories")) {
+		if (portletDataContext.getBooleanParameter(
+				_dlPortletDataHandler.getNamespace(), "repositories")) {
+
 			Element repositoriesElement =
 				portletDataContext.getImportDataGroupElement(Repository.class);
 
-			List<Element> repositoryElements = repositoriesElement.elements();
-
-			for (Element repositoryElement : repositoryElements) {
+			for (Element repositoryElement : repositoriesElement.elements()) {
 				StagedModelDataHandlerUtil.importStagedModel(
 					portletDataContext, repositoryElement);
 			}
 		}
 
-		if (portletDataContext.getBooleanParameter(namespace, "shortcuts")) {
+		if (portletDataContext.getBooleanParameter(
+				_dlPortletDataHandler.getNamespace(), "shortcuts")) {
+
 			Element fileShortcutsElement =
 				portletDataContext.getImportDataGroupElement(
 					DLFileShortcut.class);
 
-			List<Element> fileShortcutElements =
-				fileShortcutsElement.elements();
+			for (Element fileShortcutElement :
+					fileShortcutsElement.elements()) {
 
-			for (Element fileShortcutElement : fileShortcutElements) {
 				StagedModelDataHandlerUtil.importStagedModel(
 					portletDataContext, fileShortcutElement);
 			}

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/exportimport/portlet/preferences/processor/DLExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/exportimport/portlet/preferences/processor/DLExportImportPortletPreferencesProcessor.java
@@ -317,6 +317,8 @@ public class DLExportImportPortletPreferencesProcessor
 					portletPreferences.setValue(
 						"selectedRepositoryId",
 						String.valueOf(folder.getRepositoryId()));
+
+					return portletPreferences;
 				}
 				catch (ReadOnlyException readOnlyException) {
 					throw new PortletDataException(
@@ -325,24 +327,21 @@ public class DLExportImportPortletPreferencesProcessor
 				}
 			}
 		}
-		else {
-			try {
-				long selectedRepositoryId = GetterUtil.getLong(
-					portletPreferences.getValue("selectedRepositoryId", null));
 
-				if (selectedRepositoryId ==
-						portletDataContext.getSourceGroupId()) {
+		try {
+			long selectedRepositoryId = GetterUtil.getLong(
+				portletPreferences.getValue("selectedRepositoryId", null));
 
-					portletPreferences.setValue(
-						"selectedRepositoryId",
-						String.valueOf(portletDataContext.getGroupId()));
-				}
+			if (selectedRepositoryId == portletDataContext.getSourceGroupId()) {
+				portletPreferences.setValue(
+					"selectedRepositoryId",
+					String.valueOf(portletDataContext.getGroupId()));
 			}
-			catch (ReadOnlyException readOnlyException) {
-				throw new PortletDataException(
-					"Unable to update portlet preferences during import",
-					readOnlyException);
-			}
+		}
+		catch (ReadOnlyException readOnlyException) {
+			throw new PortletDataException(
+				"Unable to update portlet preferences during import",
+				readOnlyException);
 		}
 
 		// Root folder is not set, need to import everything

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/exportimport/portlet/preferences/processor/DLExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/exportimport/portlet/preferences/processor/DLExportImportPortletPreferencesProcessor.java
@@ -132,8 +132,10 @@ public class DLExportImportPortletPreferencesProcessor
 					readOnlyException);
 			}
 
-			StagedModelDataHandlerUtil.exportReferenceStagedModel(
-				portletDataContext, portletId, folder);
+			if (folder.getGroupId() == portletDataContext.getGroupId()) {
+				StagedModelDataHandlerUtil.exportReferenceStagedModel(
+					portletDataContext, portletId, folder);
+			}
 
 			return portletPreferences;
 		}


### PR DESCRIPTION
Each group is responsible of importing/exporting their own data, so we should avoid trying to import things that don't belong to the group being exported/imported (in the best of cases, it will do nothing).