### PR TITLE
LPS-146058 Instance Settings does not override System Settings for CommentGroupServiceConfiguration

### DIFF
--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBMessageLocalServiceImpl.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBMessageLocalServiceImpl.java
@@ -2566,7 +2566,8 @@ public class MBMessageLocalServiceImpl extends MBMessageLocalServiceBaseImpl {
 		return _configurationProvider.getConfiguration(
 			CommentGroupServiceConfiguration.class,
 			new GroupServiceSettingsLocator(
-				groupId, CommentConstants.SERVICE_NAME));
+				groupId, CommentConstants.SERVICE_NAME,
+				CommentGroupServiceConfiguration.class.getName()));
 	}
 
 	private long _getFileEntryMessageId(long fileEntryId)


### PR DESCRIPTION
Dear Team,

Could you please review this pull request?

`SettingsLocatorHelperImpl._getScopedConfigurationBeanSettings` expects **com.liferay.comment.configuration.CommentGroupServiceConfiguration** as configurationPid but it receives **com.liferay.comment**, so `scopedConfigurationManagedServiceFactory` will be null and the `parentSettings` (which is the System Settings) will be returned.
https://github.com/liferay/liferay-portal/blob/master/modules/apps/portal-configuration/portal-configuration-settings/src/main/java/com/liferay/portal/configuration/settings/internal/SettingsLocatorHelperImpl.java#L308-L315

The issue can be resolved if `CommentGroupServiceConfiguration.class.getName()` is added as a third argument to `GroupServiceSettingsLocator`'s constructor.

See an example here for the same approach:
https://github.com/liferay/liferay-portal/blob/master/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/impl/BlogsEntryLocalServiceImpl.java#L1704-L1708

Thank you and best regards,
István