### PR TITLE
LPS-144629 Use the new ClayTreeView component

### DIFF
--- a/modules/apps/journal/journal-web/package.json
+++ b/modules/apps/journal/journal-web/package.json
@@ -2,6 +2,7 @@
 	"dependencies": {
 		"@clayui/alert": "3.40.0",
 		"@clayui/button": "3.40.0",
+		"@clayui/core": "3.45.1",
 		"@clayui/drop-down": "3.45.0",
 		"@clayui/form": "3.45.0",
 		"@clayui/icon": "3.40.0",

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/SelectFolderButton.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/SelectFolderButton.es.js
@@ -67,7 +67,7 @@ class SelectFolderButton extends PortletBase {
 	 */
 	_handleSelectFolderButtonClick() {
 		openSelectionModal({
-			iframeBodyCssClass: '',
+			iframeBodyCssClass: 'cadmin',
 			onSelect: (selectedItem) => {
 				if (selectedItem) {
 					var folderData = {


### PR DESCRIPTION
In this change, we're migrating from our previous
[Treeview](https://github.com/liferay/liferay-portal/blob/c5a9a72d3a58a504233e4cc799652fc9f544ba5e/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/treeview/Treeview.js) component to the new [ClayTreeView](https://github.com/liferay/clay/blob/d7340f875372ba7ac11752aedd70f4343100241b/packages/clay-core/src/tree-view/TreeView.tsx) component.

**Test plan**:
- Fetch this branch
- Deploy the journal-web OSGi module
- Navigate to Content & Data > Web Content
- Create a new Folder
- Create a new Basic Web Content
- Click on the ellipsis icon to the right of the Web Content
- Click on the "Move" option
- Click on the "Select" button
- In the modal window, choose a destination Folder