### PR TITLE
add the id group to the group by clause

### DIFF
--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/impl/BlogsStatsUserLocalServiceImpl.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/impl/BlogsStatsUserLocalServiceImpl.java
@@ -106,7 +106,7 @@ public class BlogsStatsUserLocalServiceImpl
 			).and(
 				BlogsEntryTable.INSTANCE.userId.eq(userId)
 			),
-			null, 0, 1);
+			_groupIdExpression.descending(), 0, 1);
 
 		if (blogsStatsUsers.isEmpty()) {
 			return new BlogsStatsUserImpl(0, groupId, null, 0, 0, 0, userId);
@@ -195,6 +195,12 @@ public class BlogsStatsUserLocalServiceImpl
 			BlogsEntryTable.INSTANCE.entryId
 		).as(
 			"entryCount"
+		);
+	private final Expression<Long> _groupIdExpression =
+		DSLFunctionFactoryUtil.max(
+			BlogsEntryTable.INSTANCE.groupId
+		).as(
+			"groupId"
 		);
 	private final Expression<Date> _lastPostDateExpression =
 		DSLFunctionFactoryUtil.max(


### PR DESCRIPTION
LPS-146727 Adding the group Id to the group by sentence
It seems that all the calls to getStatsUser(BlogsStatsUserLocalServiceImpl.java:102) with the error :
`Column 'BlogsEntry.groupId' is invalid in the select list because it is not contained in either an aggregate function or the GROUP BY clause,`
This function is only called by the test are failing on not MySql database.
 Theoretically this must solve the issue adding the missing column to the group by sentence.
