### PR TITLE
LPS-145649 Use servlet instead of resource action

### DIFF
--- a/modules/apps/translation/translation-web/build.gradle
+++ b/modules/apps/translation/translation-web/build.gradle
@@ -16,6 +16,7 @@ dependencies {
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-react")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-soy")
 	compileOnly project(":apps:info:info-api")
+	compileOnly project(":apps:petra:petra-apache-http-components")
 	compileOnly project(":apps:petra:petra-portlet-url-builder")
 	compileOnly project(":apps:segments:segments-api")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")

--- a/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/helper/TranslationRequestHelper.java
+++ b/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/helper/TranslationRequestHelper.java
@@ -27,6 +27,8 @@ import com.liferay.segments.model.SegmentsExperience;
 
 import javax.portlet.PortletRequest;
 
+import javax.servlet.http.HttpServletRequest;
+
 /**
  * @author Adolfo Pérez
  */
@@ -34,10 +36,19 @@ public class TranslationRequestHelper {
 
 	public TranslationRequestHelper(
 		InfoItemServiceTracker infoItemServiceTracker,
-		PortletRequest portletRequest) {
+		HttpServletRequest httpServletRequest) {
 
 		_infoItemServiceTracker = infoItemServiceTracker;
-		_portletRequest = portletRequest;
+		_httpServletRequest = httpServletRequest;
+	}
+
+	public TranslationRequestHelper(
+		InfoItemServiceTracker infoItemServiceTracker,
+		PortletRequest portletRequest) {
+
+		this(
+			infoItemServiceTracker,
+			PortalUtil.getHttpServletRequest(portletRequest));
 	}
 
 	public String getClassName(long segmentsExperienceId) {
@@ -65,7 +76,7 @@ public class TranslationRequestHelper {
 			return _classNameId;
 		}
 
-		_classNameId = ParamUtil.getLong(_portletRequest, "classNameId");
+		_classNameId = ParamUtil.getLong(_httpServletRequest, "classNameId");
 
 		return _classNameId;
 	}
@@ -97,7 +108,7 @@ public class TranslationRequestHelper {
 			return _groupId;
 		}
 
-		_groupId = ParamUtil.getLong(_portletRequest, "groupId");
+		_groupId = ParamUtil.getLong(_httpServletRequest, "groupId");
 
 		return _groupId;
 	}
@@ -127,7 +138,8 @@ public class TranslationRequestHelper {
 			return _modelClassPKs;
 		}
 
-		_modelClassPKs = ParamUtil.getLongValues(_portletRequest, "classPK");
+		_modelClassPKs = ParamUtil.getLongValues(
+			_httpServletRequest, "classPK");
 
 		if (_modelClassPKs.length != 0) {
 			return _modelClassPKs;
@@ -137,7 +149,7 @@ public class TranslationRequestHelper {
 			_infoItemServiceTracker.getFirstInfoItemService(
 				InfoItemIdentifierTranslator.class, getModelClassName());
 
-		String[] keys = ParamUtil.getStringValues(_portletRequest, "key");
+		String[] keys = ParamUtil.getStringValues(_httpServletRequest, "key");
 
 		long[] modelClassPKs = new long[keys.length];
 
@@ -158,9 +170,9 @@ public class TranslationRequestHelper {
 
 	private Long _classNameId;
 	private Long _groupId;
+	private final HttpServletRequest _httpServletRequest;
 	private final InfoItemServiceTracker _infoItemServiceTracker;
 	private String _modelClassName;
 	private long[] _modelClassPKs;
-	private final PortletRequest _portletRequest;
 
 }

--- a/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/ExportTranslation.js
+++ b/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/ExportTranslation.js
@@ -17,7 +17,7 @@ import ClayForm, {ClayCheckbox, ClayInput, ClaySelect} from '@clayui/form';
 import ClayLayout from '@clayui/layout';
 import ClayLink from '@clayui/link';
 import ClayList from '@clayui/list';
-import {addParams, createPortletURL} from 'frontend-js-web';
+import {addParams} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useState} from 'react';
 
@@ -247,7 +247,7 @@ const ExportTranslation = ({
 					);
 				}
 
-				location.href = createPortletURL(exportTranslationURL, params);
+				location.href = addParams(params, exportTranslationURL);
 			}}
 		>
 			<ClayForm.Group className="w-50">


### PR DESCRIPTION
Resource actions need to propagate all request parameters (by the
specification, they must depend only on the original view state). This
is counterproductive in our case, as we need to specify which
className/classPKs to translate manually (ignoring previously existing
values if any).