### PR TITLE
LPS-146727 add the group id to the group by

### DIFF
--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/impl/BlogsStatsUserLocalServiceImpl.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/impl/BlogsStatsUserLocalServiceImpl.java
@@ -156,7 +156,7 @@ public class BlogsStatsUserLocalServiceImpl
 		).where(
 			predicate
 		).groupBy(
-			BlogsEntryTable.INSTANCE.userId
+			BlogsEntryTable.INSTANCE.groupId, BlogsEntryTable.INSTANCE.userId
 		);
 
 		LimitStep limitStep = orderByStep;


### PR DESCRIPTION
LPS-146727 add the group id to the group by because it is failing on Oracle, PostgreSQL and SQL Server Databases so it needs to be added