### PR TITLE
[TS] LPS-147324 | master

### DIFF
--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/persistence/impl/DLFolderFinderImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/persistence/impl/DLFolderFinderImpl.java
@@ -945,7 +945,7 @@ public class DLFolderFinderImpl
 			}
 
 			sb.append(sql);
-			sb.append(" UNION ALL ");
+			sb.append(" UNION ");
 
 			sql = getFileEntriesSQL(
 				FIND_FE_BY_G_F_RC, groupId, mimeTypes, queryDefinition,
@@ -953,7 +953,7 @@ public class DLFolderFinderImpl
 
 			sb.append(sql);
 
-			sb.append(" UNION ALL ");
+			sb.append(" UNION ");
 
 			sql = getFileShortcutsSQL(
 				FIND_FS_BY_G_F_A_RC, groupId, mimeTypes, queryDefinition,


### PR DESCRIPTION
### D&M shows duplicated file entries when order by 'Downloads'
#### Description
- When a document is n times edited, the document list shows that document n+1 times instead of only once.

#### Steps to reproduce

- You can use both the Control Panel (_Site Menu -> Content & Data -> Documents and Media_) and also the _D&M widget_ on a site page.
- Use file upload option to add a new document and publish.

- **Checkpoint:**
    Select order by 'Downloads'. The document list shows one document.

- Edit the document: change the title and publish.

#### Expected behavior
The document list shows one document.

#### Observed behavior
The document list shows the document twice.

- Edit the document again: change the title and publish.

#### Expected behavior
The document list shows one document.

#### Observed behavior
The document list shows the document three times.

### Proposed solution
Apply the UNION operator when building the SQL query instead of using UNION ALL. This way UNION operator removes duplicate rows.

References:
https://issues.liferay.com/browse/LPS-147324

/cc @robertoDiaz 