### PR TITLE
[TS] LPS-146666

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceHelper.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceHelper.java
@@ -120,6 +120,11 @@ public class LayoutLocalServiceHelper implements IdentifiableOSGiService {
 								groupId, privateLayout, layout.getPlid(),
 								friendlyURL);
 					}
+					else {
+						_layoutFriendlyURLEntryValidator.
+							validateFriendlyURLEntry(
+								groupId, privateLayout, 0, friendlyURL);
+					}
 				}
 
 				break;

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceHelper.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceHelper.java
@@ -105,14 +105,21 @@ public class LayoutLocalServiceHelper implements IdentifiableOSGiService {
 
 		String originalFriendlyURL = friendlyURL;
 
+		Layout layout = LayoutLocalServiceUtil.fetchLayout(
+			groupId, privateLayout, layoutId);
+
 		for (int i = 1;; i++) {
 			try {
 				validateFriendlyURL(
 					groupId, privateLayout, layoutId, friendlyURL, languageId);
 
 				if (_layoutFriendlyURLEntryValidator != null) {
-					_layoutFriendlyURLEntryValidator.validateFriendlyURLEntry(
-						groupId, privateLayout, layoutId, friendlyURL);
+					if (layout != null) {
+						_layoutFriendlyURLEntryValidator.
+							validateFriendlyURLEntry(
+								groupId, privateLayout, layout.getPlid(),
+								friendlyURL);
+					}
 				}
 
 				break;
@@ -121,9 +128,6 @@ public class LayoutLocalServiceHelper implements IdentifiableOSGiService {
 				int type = layoutFriendlyURLException.getType();
 
 				if (type == LayoutFriendlyURLException.DUPLICATE) {
-					Layout layout = LayoutLocalServiceUtil.fetchLayout(
-						groupId, privateLayout, layoutId);
-
 					if (layout == null) {
 						friendlyURL = originalFriendlyURL + i;
 					}


### PR DESCRIPTION
Hi @robertoDiaz ,

Can you help review this PR?

Please let us know if you have any questions.
Thanks!

**Notes from @noornajj:**

> https://issues.liferay.com/browse/LPS-146666
> 
> The issue here was an infinite loop was caused when the default friendly URL was left empty. The reason this occurred is because the layoutId was being passed into layoutFriendlyURLEntryValidator.validateFriendlyURLEntry instead of the plid of the layout.
> To fix the issue, I passed the layout's plid when the friendly URL being validated belongs to an already existing layout. However, I also added an else statement to handle the validation when a new layout is being created.