### PR TITLE
LPS-147438 add error message to exception to audio and video processor

### DIFF
--- a/portal-impl/src/com/liferay/portlet/documentlibrary/util/AudioProcessorImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/util/AudioProcessorImpl.java
@@ -298,7 +298,11 @@ public class AudioProcessorImpl
 			}
 		}
 		catch (Exception exception) {
-			_log.error(exception);
+			_log.error(
+				StringBundler.concat(
+					"Unable to process ", fileVersion.getFileVersionId(), " ",
+					fileVersion.getTitle()),
+				exception);
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/util/VideoProcessorImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/util/VideoProcessorImpl.java
@@ -428,7 +428,11 @@ public class VideoProcessorImpl
 			_fileVersionPreviewEventListener.onFailure(fileVersion);
 		}
 		catch (Exception exception) {
-			_log.error(exception);
+			_log.error(
+				StringBundler.concat(
+					"Unable to process ", fileVersion.getFileVersionId(), " ",
+					fileVersion.getTitle()),
+				exception);
 
 			_fileVersionPreviewEventListener.onFailure(fileVersion);
 		}


### PR DESCRIPTION
- LPS-147438 add error message to exception to audio and video processor to be properly consumed by the test because without message assert can't process it properly


Without message, the ExpectedLog from the tests is "null" so it cannot be processed properly and assert fails but not for the test