### PR TITLE
LPS-148095 blogs more entries card layout stacked

### DIFF
--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/css/main.scss
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/css/main.scss
@@ -397,17 +397,11 @@ html#{$cadmin-selector} {
 
 	.widget-mode-card {
 		.card-page-item {
-			max-width: 20rem;
+			max-width: 40rem;
+			min-width: 20rem;
 			padding-left: $grid-gutter-width / 2;
 			padding-right: $grid-gutter-width / 2;
-			width: 100%;
-
-			@include media-breakpoint-up(lg) {
-				max-width: 26rem;
-			}
-			@include media-breakpoint-up(xl) {
-				max-width: 33.25rem;
-			}
+			width: 50%;
 		}
 	}
 

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/css/main.scss
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/css/main.scss
@@ -300,17 +300,25 @@ html#{$cadmin-selector} {
 		padding: 30px 0;
 	}
 
-	.entry-navigation h2 {
-		margin-bottom: 15px;
-		margin-top: 0;
-	}
-
 	.entry-navigation {
 		padding: 60px 0;
 		width: 100%;
 
+		h2 {
+			margin-bottom: 15px;
+			margin-top: 0;
+		}
+
 		.small-image {
 			height: 140px;
+		}
+
+		.widget-mode-card .card-page-item {
+			max-width: 40rem;
+			min-width: 20rem;
+			padding-left: $grid-gutter-width / 2;
+			padding-right: $grid-gutter-width / 2;
+			width: 50%;
 		}
 	}
 
@@ -392,16 +400,6 @@ html#{$cadmin-selector} {
 
 		.autofit-col + .autofit-col {
 			padding-left: 0.5rem;
-		}
-	}
-
-	.widget-mode-card {
-		.card-page-item {
-			max-width: 40rem;
-			min-width: 20rem;
-			padding-left: $grid-gutter-width / 2;
-			padding-right: $grid-gutter-width / 2;
-			width: 50%;
 		}
 	}
 


### PR DESCRIPTION
Issue: https://issues.liferay.com/browse/LPS-148095

We want to recover the old layout (50/50 layout) in blogs more entries.

In the past, we applied some CSS in this fix http://issues.liferay.com/browse/LPS-132211 maintaining this layout but [the limits](https://github.com/liferay-lima/liferay-portal/pull/1899/commits/a67ea1a2cfe0056fbe48d56818a57a8f23e05d91) are hardcoded and some changes I don't know which ones break it.

With this PR, instead of trying to fit all space and break when the spacing changes, we want to fit 50% and put min and max limits, but without causing a regression on http://issues.liferay.com/browse/LPS-132211

@fortunatomaldonado Can you please check if this solution works for you? Also, I'm checked but Can you please double-check that this PR does not cause a regression on http://issues.liferay.com/browse/LPS-132211?

## Before this PR
### 1 col (full width)
![image](https://user-images.githubusercontent.com/67901/155591900-848b139c-4d51-4cdb-b444-e02cfe72b85a.png)


### 2 cols (70%)
![image](https://user-images.githubusercontent.com/67901/155591974-e2a5ab0a-8158-49d4-a469-2803c413ca50.png)


### 2 cols (30%)
![image](https://user-images.githubusercontent.com/67901/155592082-c1af633a-e29f-4c2b-9b04-5bd99ae41b88.png)


## After this PR

### 1 col (full width)
![image](https://user-images.githubusercontent.com/67901/155590663-e5b8d484-6e4b-4e7a-b5d0-83f11a3c6d04.png)

### 2 cols (70%)
![image](https://user-images.githubusercontent.com/67901/155591175-d9bbf2fe-8ef2-4e4c-b113-91b933f8b5a5.png)

### 2 cols (30%) we need to mantain entries stacked with this little space
![image](https://user-images.githubusercontent.com/67901/155591340-2101819b-2297-42b7-a85f-8066740fcdec.png)


