### PR TITLE
LPS-148012 Truncate text for Table view documents and media

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp
@@ -172,7 +172,7 @@ DLViewEntriesDisplayContext dlViewEntriesDisplayContext = new DLViewEntriesDispl
 
 												<div class="autofit-col autofit-col-expand">
 													<div class="table-title">
-														<aui:a href="<%= dlViewEntriesDisplayContext.getViewFileEntryURL(fileEntry) %>"><%= latestFileVersion.getTitle() %></aui:a>
+														<aui:a cssClass="text-truncate" href="<%= dlViewEntriesDisplayContext.getViewFileEntryURL(fileEntry) %>" title="<%= latestFileVersion.getTitle() %>"><%= latestFileVersion.getTitle() %></aui:a>
 													</div>
 												</div>
 											</div>


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-148012

If a title is too long in Documents and Media, the title is not being truncated and will display the full title. To fix this, I added `text-truncate` as well as a `title` in order to have it truncated and display the full title when hovered over. 

Let me know if there are any questions or comments about this.
Thank you.