### PR TITLE
LPS-146518 Editing Geolocation value of an existing Web Contents is not possible

### DIFF
--- a/modules/apps/map/map-google-maps/src/main/resources/META-INF/resources/js/MapGoogleMaps.es.js
+++ b/modules/apps/map/map-google-maps/src/main/resources/META-INF/resources/js/MapGoogleMaps.es.js
@@ -32,13 +32,13 @@ class MapGoogleMaps extends MapBase {
 	 * @review
 	 */
 	constructor(...args) {
-		super(...args);
-
 		MapBase.DialogImpl = GoogleMapsDialog;
 		MapBase.GeocoderImpl = GoogleMapsGeocoder;
 		MapBase.GeoJSONImpl = GoogleMapsGeoJSON;
 		MapBase.MarkerImpl = GoogleMapsMarker;
 		MapBase.SearchImpl = GoogleMapsSearch;
+
+		super(...args);
 
 		this._bounds = null;
 	}

--- a/modules/apps/map/map-openstreetmap/src/main/resources/META-INF/resources/js/MapOpenStreetMap.es.js
+++ b/modules/apps/map/map-openstreetmap/src/main/resources/META-INF/resources/js/MapOpenStreetMap.es.js
@@ -32,13 +32,13 @@ class MapOpenStreetMap extends MapBase {
 	 * @review
 	 */
 	constructor(...args) {
-		super(...args);
-
 		MapBase.DialogImpl = OpenStreetMapDialog;
 		MapBase.GeocoderImpl = OpenStreetMapGeocoder;
 		MapBase.GeoJSONImpl = OpenStreetMapGeoJSON;
 		MapBase.MarkerImpl = OpenStreetMapMarker;
 		MapBase.SearchImpl = null;
+
+		super(...args);
 
 		this._map = null;
 	}


### PR DESCRIPTION
Issue: https://issues.liferay.com/browse/LPS-146518

@boton

**What's going on?**
The `MapBase` constructor is being executed before the initialization of the `MapBase.MarkerImpl`, which is in the constructors of `MapOpenStreetMap.es.js` and `MapGoogleMaps.es.js`. The method in charge of adding the marker (`addMarker` in `MapBase.es.js`) is being run before the `MarkerImpl` is initialized with the corresponding value, so [this condition](https://github.com/liferay/liferay-portal/blob/3fe4354c47df856b15bccd54f64d52595f22e178/modules/apps/map/map-common/src/main/resources/META-INF/resources/js/MapBase.es.js#L557) is not met. This causes the marker is not painted when editing web content.

**The fix**
I have moved the initialization of the MapBase implementations to their constructor, receiving the values as arguments.

**UPDATE**
I've set the implementations on the constructor of `Google/OpenStreeMaps` just before calling `super(...args)`. In this way, we aren't changing how MapBase works now.