### PR TITLE
[TS] LPS-148758 Set extension based on file's mimeType if extension is empty

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/ServletResponseUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/ServletResponseUtil.java
@@ -481,6 +481,11 @@ public class ServletResponseUtil {
 			String extension = GetterUtil.getString(
 				FileUtil.getExtension(fileName));
 
+			if (extension.isEmpty()) {
+				extension = MimeTypesUtil.getExtensions(contentType)
+					.iterator().next().substring(1);
+			}
+
 			extension = StringUtil.toLowerCase(extension);
 
 			String[] mimeTypesContentDispositionInline = null;


### PR DESCRIPTION
Hi Team,
@robertoDiaz

LPS: https://issues.liferay.com/browse/LPS-148758

When we open a link (Latest Version URL) of a file that has no extension in its filename (ex.: "test", instead "test.pdf"), the logic sets the disposition type to “attachment” so it gets downloaded.
Fix: When the file has no extension in its name we use the contentType as a fallback to determine the extension. Result: the file is displayed correctly when opening its URL.

Could you please review it?
Thank you!