### PR TITLE
LPS-147439 There's no space between "Content text" and "This field is required"

### DIFF
--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/css/main.scss
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/css/main.scss
@@ -233,7 +233,7 @@ html#{$cadmin-selector} {
 			width: 100%;
 		}
 
-		.cover-image-caption .cke_editable {
+		.cke_editable {
 			background-color: white;
 		}
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-147439

Instead of adding a margin, the background color was changed in accordance to the rest of the page, and visually there is no need to add a margin. 

**Before**
<img width="939" alt="Blogs before" src="https://user-images.githubusercontent.com/8373764/157858370-66667a6b-7b78-4488-bdd5-705d2444020a.png">


**After**
<img width="941" alt="Blogs after" src="https://user-images.githubusercontent.com/8373764/157858383-4ee99dac-eabc-4947-b478-2acfd4f8b60f.png">
r