### PR TITLE
LPS-149285 Add icons to the actions dropdown of D&M

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/logic/UIItemsBuilder.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/logic/UIItemsBuilder.java
@@ -741,8 +741,8 @@ public class UIItemsBuilder {
 		}
 
 		URLMenuItem urlMenuItem = _addURLUIItem(
-			new URLMenuItem(), menuItems, "password-policies", DLUIItemKeys.PERMISSIONS,
-			"permissions", url);
+			new URLMenuItem(), menuItems, "password-policies",
+			DLUIItemKeys.PERMISSIONS, "permissions", url);
 
 		urlMenuItem.setMethod("get");
 		urlMenuItem.setUseDialog(true);

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/logic/UIItemsBuilder.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/logic/UIItemsBuilder.java
@@ -144,7 +144,7 @@ public class UIItemsBuilder {
 		}
 
 		_addURLUIItem(
-			new URLMenuItem(), menuItems, DLUIItemKeys.CANCEL_CHECKOUT,
+			new URLMenuItem(), menuItems, "", DLUIItemKeys.CANCEL_CHECKOUT,
 			"cancel-checkout[document]",
 			PortletURLBuilder.create(
 				_getActionURL(
@@ -165,7 +165,7 @@ public class UIItemsBuilder {
 		}
 
 		_addJavaScriptUIItem(
-			new JavaScriptToolbarItem(), toolbarItems,
+			new JavaScriptToolbarItem(), toolbarItems, "",
 			DLUIItemKeys.CANCEL_CHECKOUT,
 			LanguageUtil.get(_resourceBundle, "cancel-checkout[document]"),
 			_getSubmitFormJavaScript(Constants.CANCEL_CHECKOUT, null));
@@ -192,7 +192,7 @@ public class UIItemsBuilder {
 
 		JavaScriptToolbarItem javaScriptToolbarItem = _addJavaScriptUIItem(
 			new JavaScriptToolbarItem(), toolbarItems, DLUIItemKeys.CHECKIN,
-			LanguageUtil.get(_resourceBundle, "checkin"),
+			LanguageUtil.get(_resourceBundle, "checkin"), "",
 			StringBundler.concat(
 				_getNamespace(), "showVersionDetailsDialog('",
 				HtmlUtil.escapeJS(
@@ -237,7 +237,7 @@ public class UIItemsBuilder {
 		}
 
 		_addURLUIItem(
-			new URLMenuItem(), menuItems, DLUIItemKeys.CHECKOUT,
+			new URLMenuItem(), menuItems, "", DLUIItemKeys.CHECKOUT,
 			"checkout[document]",
 			PortletURLBuilder.create(
 				_getActionURL(
@@ -257,7 +257,8 @@ public class UIItemsBuilder {
 		}
 
 		_addJavaScriptUIItem(
-			new JavaScriptToolbarItem(), toolbarItems, DLUIItemKeys.CHECKOUT,
+			new JavaScriptToolbarItem(), toolbarItems, "",
+			DLUIItemKeys.CHECKOUT,
 			LanguageUtil.get(_resourceBundle, "checkout[document]"),
 			_getSubmitFormJavaScript(Constants.CHECKOUT, null));
 	}
@@ -279,7 +280,7 @@ public class UIItemsBuilder {
 			RequestBackedPortletURLFactoryUtil.create(_httpServletRequest);
 
 		_addURLUIItem(
-			new URLMenuItem(), menuItems,
+			new URLMenuItem(), menuItems, "",
 			DLUIItemKeys.COLLECT_DIGITAL_SIGNATURE,
 			LanguageUtil.get(_resourceBundle, "collect-digital-signature"),
 			PortletURLBuilder.create(
@@ -297,7 +298,7 @@ public class UIItemsBuilder {
 		throws PortalException {
 
 		_addJavaScriptUIItem(
-			new JavaScriptToolbarItem(), toolbarItems,
+			new JavaScriptToolbarItem(), toolbarItems, "",
 			DLUIItemKeys.COLLECT_DIGITAL_SIGNATURE,
 			LanguageUtil.get(_resourceBundle, "collect-digital-signature"),
 			null);
@@ -335,7 +336,7 @@ public class UIItemsBuilder {
 		String jsNamespace = _getNamespace() + _fileVersion.getFileVersionId();
 
 		JavaScriptMenuItem javaScriptMenuItem = _addJavaScriptUIItem(
-			new JavaScriptMenuItem(), menuItems, DLUIItemKeys.COMPARE_TO,
+			new JavaScriptMenuItem(), menuItems, "", DLUIItemKeys.COMPARE_TO,
 			"compare-to",
 			StringBundler.concat(
 				jsNamespace, "compareVersionDialog('",
@@ -460,7 +461,7 @@ public class UIItemsBuilder {
 		sb.append("}");
 
 		_addJavaScriptUIItem(
-			new JavaScriptToolbarItem(), toolbarItems, DLUIItemKeys.DELETE,
+			new JavaScriptToolbarItem(), toolbarItems, "", DLUIItemKeys.DELETE,
 			LanguageUtil.get(_resourceBundle, "delete"), sb.toString());
 	}
 
@@ -533,7 +534,8 @@ public class UIItemsBuilder {
 			appendVersion, true);
 
 		URLMenuItem urlMenuItem = _addURLUIItem(
-			new URLMenuItem(), menuItems, DLUIItemKeys.DOWNLOAD, label, url);
+			new URLMenuItem(), menuItems, "", DLUIItemKeys.DOWNLOAD, label,
+			url);
 
 		urlMenuItem.setData(
 			HashMapBuilder.<String, Object>put(
@@ -563,7 +565,7 @@ public class UIItemsBuilder {
 			).build());
 
 		_addURLUIItem(
-			urlToolbarItem, toolbarItems, DLUIItemKeys.DOWNLOAD,
+			urlToolbarItem, toolbarItems, "", DLUIItemKeys.DOWNLOAD,
 			StringBundler.concat(
 				LanguageUtil.get(_resourceBundle, "download"), " (", label,
 				")"),
@@ -585,7 +587,7 @@ public class UIItemsBuilder {
 		}
 
 		_addJavaScriptUIItem(
-			new JavaScriptMenuItem(), menuItems, DLUIItemKeys.EDIT_IMAGE,
+			new JavaScriptMenuItem(), menuItems, "", DLUIItemKeys.EDIT_IMAGE,
 			LanguageUtil.get(_resourceBundle, "edit-image"),
 			_getEditImageOnClickJavaScript());
 	}
@@ -615,7 +617,7 @@ public class UIItemsBuilder {
 		portletURL.setParameter("backURL", _getCurrentURL());
 
 		_addURLUIItem(
-			new URLMenuItem(), menuItems, DLUIItemKeys.EDIT, "edit",
+			new URLMenuItem(), menuItems, "", DLUIItemKeys.EDIT, "edit",
 			portletURL.toString());
 	}
 
@@ -630,7 +632,7 @@ public class UIItemsBuilder {
 			"/document_library/edit_file_entry");
 
 		_addURLUIItem(
-			new URLToolbarItem(), toolbarItems, DLUIItemKeys.EDIT,
+			new URLToolbarItem(), toolbarItems, "", DLUIItemKeys.EDIT,
 			LanguageUtil.get(_resourceBundle, "edit"), portletURL.toString());
 	}
 
@@ -646,7 +648,7 @@ public class UIItemsBuilder {
 		}
 
 		_addJavaScriptUIItem(
-			new JavaScriptMenuItem(), menuItems, DLUIItemKeys.MOVE,
+			new JavaScriptMenuItem(), menuItems, "", DLUIItemKeys.MOVE,
 			LanguageUtil.get(_resourceBundle, "move"),
 			_getMoveEntryOnClickJavaScript());
 	}
@@ -659,7 +661,7 @@ public class UIItemsBuilder {
 		}
 
 		_addJavaScriptUIItem(
-			new JavaScriptToolbarItem(), toolbarItems, DLUIItemKeys.MOVE,
+			new JavaScriptToolbarItem(), toolbarItems, "", DLUIItemKeys.MOVE,
 			LanguageUtil.get(_resourceBundle, "move"),
 			_getMoveEntryOnClickJavaScript());
 	}
@@ -693,7 +695,7 @@ public class UIItemsBuilder {
 			"folderId", String.valueOf(_fileEntry.getFolderId()));
 
 		_addJavaScriptUIItem(
-			new JavaScriptToolbarItem(), toolbarItems,
+			new JavaScriptToolbarItem(), toolbarItems, "",
 			DLUIItemKeys.MOVE_TO_THE_RECYCLE_BIN,
 			LanguageUtil.get(_resourceBundle, "move-to-recycle-bin"),
 			_getSubmitFormJavaScript(
@@ -737,7 +739,7 @@ public class UIItemsBuilder {
 		}
 
 		URLMenuItem urlMenuItem = _addURLUIItem(
-			new URLMenuItem(), menuItems, DLUIItemKeys.PERMISSIONS,
+			new URLMenuItem(), menuItems, "", DLUIItemKeys.PERMISSIONS,
 			"permissions", url);
 
 		urlMenuItem.setMethod("get");
@@ -767,7 +769,8 @@ public class UIItemsBuilder {
 		}
 
 		_addJavaScriptUIItem(
-			new JavaScriptToolbarItem(), toolbarItems, DLUIItemKeys.PERMISSIONS,
+			new JavaScriptToolbarItem(), toolbarItems, "",
+			DLUIItemKeys.PERMISSIONS,
 			LanguageUtil.get(_resourceBundle, "permissions"),
 			StringBundler.concat(
 				"Liferay.Util.openModal({title: '",
@@ -845,7 +848,7 @@ public class UIItemsBuilder {
 		sb.append("';}");
 
 		_addURLUIItem(
-			new URLMenuItem(), menuItems, DLUIItemKeys.PUBLISH,
+			new URLMenuItem(), menuItems, "", DLUIItemKeys.PUBLISH,
 			"publish-to-live", sb.toString());
 	}
 
@@ -870,7 +873,7 @@ public class UIItemsBuilder {
 			"/document_library/view_file_entry", _getRedirect());
 
 		_addURLUIItem(
-			new URLMenuItem(), menuItems, DLUIItemKeys.REVERT, "revert",
+			new URLMenuItem(), menuItems, "", DLUIItemKeys.REVERT, "revert",
 			PortletURLBuilder.create(
 				_getActionURL(
 					"/document_library/edit_file_entry", Constants.REVERT,
@@ -888,7 +891,7 @@ public class UIItemsBuilder {
 		}
 
 		_addURLUIItem(
-			new URLMenuItem(), menuItems, DLUIItemKeys.VIEW_ORIGINAL_FILE,
+			new URLMenuItem(), menuItems, "", DLUIItemKeys.VIEW_ORIGINAL_FILE,
 			"view-original-file",
 			PortletURLBuilder.create(
 				_getRenderURL("/document_library/view_file_entry")
@@ -903,7 +906,7 @@ public class UIItemsBuilder {
 		}
 
 		_addURLUIItem(
-			new URLMenuItem(), menuItems, DLUIItemKeys.VIEW_VERSION,
+			new URLMenuItem(), menuItems, "", DLUIItemKeys.VIEW_VERSION,
 			"view[action]",
 			PortletURLBuilder.create(
 				_getRenderURL(
@@ -1006,8 +1009,12 @@ public class UIItemsBuilder {
 	}
 
 	private <T extends JavaScriptUIItem> T _addJavaScriptUIItem(
-		T javascriptUIItem, List<? super T> javascriptUIItems, String key,
-		String label, String onClick) {
+		T javascriptUIItem, List<? super T> javascriptUIItems, String icon,
+		String key, String label, String onClick) {
+
+		if (Validator.isNotNull(icon)) {
+			javascriptUIItem.setIcon(icon);
+		}
 
 		javascriptUIItem.setKey(key);
 		javascriptUIItem.setLabel(label);
@@ -1019,8 +1026,12 @@ public class UIItemsBuilder {
 	}
 
 	private <T extends URLUIItem> T _addURLUIItem(
-		T urlUIItem, List<? super T> urlUIItems, String key, String label,
-		String url) {
+		T urlUIItem, List<? super T> urlUIItems, String icon, String key,
+		String label, String url) {
+
+		if (Validator.isNotNull(icon)) {
+			urlUIItem.setIcon(icon);
+		}
 
 		urlUIItem.setKey(key);
 		urlUIItem.setLabel(label);

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/logic/UIItemsBuilder.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/logic/UIItemsBuilder.java
@@ -146,8 +146,8 @@ public class UIItemsBuilder {
 		}
 
 		_addURLUIItem(
-			new URLMenuItem(), menuItems, "", DLUIItemKeys.CANCEL_CHECKOUT,
-			"cancel-checkout[document]",
+			new URLMenuItem(), menuItems, StringPool.BLANK,
+			DLUIItemKeys.CANCEL_CHECKOUT, "cancel-checkout[document]",
 			PortletURLBuilder.create(
 				_getActionURL(
 					"/document_library/edit_file_entry",
@@ -167,7 +167,7 @@ public class UIItemsBuilder {
 		}
 
 		_addJavaScriptUIItem(
-			new JavaScriptToolbarItem(), toolbarItems, "",
+			new JavaScriptToolbarItem(), toolbarItems, StringPool.BLANK,
 			DLUIItemKeys.CANCEL_CHECKOUT,
 			LanguageUtil.get(_resourceBundle, "cancel-checkout[document]"),
 			_getSubmitFormJavaScript(Constants.CANCEL_CHECKOUT, null));
@@ -193,8 +193,8 @@ public class UIItemsBuilder {
 		}
 
 		JavaScriptToolbarItem javaScriptToolbarItem = _addJavaScriptUIItem(
-			new JavaScriptToolbarItem(), toolbarItems, "", DLUIItemKeys.CHECKIN,
-			LanguageUtil.get(_resourceBundle, "checkin"),
+			new JavaScriptToolbarItem(), toolbarItems, StringPool.BLANK,
+			DLUIItemKeys.CHECKIN, LanguageUtil.get(_resourceBundle, "checkin"),
 			StringBundler.concat(
 				_getNamespace(), "showVersionDetailsDialog('",
 				HtmlUtil.escapeJS(
@@ -239,8 +239,8 @@ public class UIItemsBuilder {
 		}
 
 		_addURLUIItem(
-			new URLMenuItem(), menuItems, "", DLUIItemKeys.CHECKOUT,
-			"checkout[document]",
+			new URLMenuItem(), menuItems, StringPool.BLANK,
+			DLUIItemKeys.CHECKOUT, "checkout[document]",
 			PortletURLBuilder.create(
 				_getActionURL(
 					"/document_library/edit_file_entry", Constants.CHECKOUT)
@@ -259,7 +259,7 @@ public class UIItemsBuilder {
 		}
 
 		_addJavaScriptUIItem(
-			new JavaScriptToolbarItem(), toolbarItems, "",
+			new JavaScriptToolbarItem(), toolbarItems, StringPool.BLANK,
 			DLUIItemKeys.CHECKOUT,
 			LanguageUtil.get(_resourceBundle, "checkout[document]"),
 			_getSubmitFormJavaScript(Constants.CHECKOUT, null));
@@ -282,7 +282,7 @@ public class UIItemsBuilder {
 			RequestBackedPortletURLFactoryUtil.create(_httpServletRequest);
 
 		_addURLUIItem(
-			new URLMenuItem(), menuItems, "",
+			new URLMenuItem(), menuItems, StringPool.BLANK,
 			DLUIItemKeys.COLLECT_DIGITAL_SIGNATURE,
 			LanguageUtil.get(_resourceBundle, "collect-digital-signature"),
 			PortletURLBuilder.create(
@@ -300,7 +300,7 @@ public class UIItemsBuilder {
 		throws PortalException {
 
 		_addJavaScriptUIItem(
-			new JavaScriptToolbarItem(), toolbarItems, "",
+			new JavaScriptToolbarItem(), toolbarItems, StringPool.BLANK,
 			DLUIItemKeys.COLLECT_DIGITAL_SIGNATURE,
 			LanguageUtil.get(_resourceBundle, "collect-digital-signature"),
 			null);
@@ -338,8 +338,8 @@ public class UIItemsBuilder {
 		String jsNamespace = _getNamespace() + _fileVersion.getFileVersionId();
 
 		JavaScriptMenuItem javaScriptMenuItem = _addJavaScriptUIItem(
-			new JavaScriptMenuItem(), menuItems, "", DLUIItemKeys.COMPARE_TO,
-			"compare-to",
+			new JavaScriptMenuItem(), menuItems, StringPool.BLANK,
+			DLUIItemKeys.COMPARE_TO, "compare-to",
 			StringBundler.concat(
 				jsNamespace, "compareVersionDialog('",
 				HtmlUtil.escapeJS(selectFileVersionURL.toString()), "');"));
@@ -463,8 +463,9 @@ public class UIItemsBuilder {
 		sb.append("}");
 
 		_addJavaScriptUIItem(
-			new JavaScriptToolbarItem(), toolbarItems, "", DLUIItemKeys.DELETE,
-			LanguageUtil.get(_resourceBundle, "delete"), sb.toString());
+			new JavaScriptToolbarItem(), toolbarItems, StringPool.BLANK,
+			DLUIItemKeys.DELETE, LanguageUtil.get(_resourceBundle, "delete"),
+			sb.toString());
 	}
 
 	public void addDeleteVersionMenuItem(List<MenuItem> menuItems)
@@ -567,7 +568,8 @@ public class UIItemsBuilder {
 			).build());
 
 		_addURLUIItem(
-			urlToolbarItem, toolbarItems, "", DLUIItemKeys.DOWNLOAD,
+			urlToolbarItem, toolbarItems, StringPool.BLANK,
+			DLUIItemKeys.DOWNLOAD,
 			StringBundler.concat(
 				LanguageUtil.get(_resourceBundle, "download"), " (", label,
 				")"),
@@ -589,7 +591,8 @@ public class UIItemsBuilder {
 		}
 
 		_addJavaScriptUIItem(
-			new JavaScriptMenuItem(), menuItems, "", DLUIItemKeys.EDIT_IMAGE,
+			new JavaScriptMenuItem(), menuItems, StringPool.BLANK,
+			DLUIItemKeys.EDIT_IMAGE,
 			LanguageUtil.get(_resourceBundle, "edit-image"),
 			_getEditImageOnClickJavaScript());
 	}
@@ -634,8 +637,9 @@ public class UIItemsBuilder {
 			"/document_library/edit_file_entry");
 
 		_addURLUIItem(
-			new URLToolbarItem(), toolbarItems, "", DLUIItemKeys.EDIT,
-			LanguageUtil.get(_resourceBundle, "edit"), portletURL.toString());
+			new URLToolbarItem(), toolbarItems, StringPool.BLANK,
+			DLUIItemKeys.EDIT, LanguageUtil.get(_resourceBundle, "edit"),
+			portletURL.toString());
 	}
 
 	public void addMoveMenuItem(List<MenuItem> menuItems)
@@ -663,8 +667,8 @@ public class UIItemsBuilder {
 		}
 
 		_addJavaScriptUIItem(
-			new JavaScriptToolbarItem(), toolbarItems, "", DLUIItemKeys.MOVE,
-			LanguageUtil.get(_resourceBundle, "move"),
+			new JavaScriptToolbarItem(), toolbarItems, StringPool.BLANK,
+			DLUIItemKeys.MOVE, LanguageUtil.get(_resourceBundle, "move"),
 			_getMoveEntryOnClickJavaScript());
 	}
 
@@ -697,7 +701,7 @@ public class UIItemsBuilder {
 			"folderId", String.valueOf(_fileEntry.getFolderId()));
 
 		_addJavaScriptUIItem(
-			new JavaScriptToolbarItem(), toolbarItems, "",
+			new JavaScriptToolbarItem(), toolbarItems, StringPool.BLANK,
 			DLUIItemKeys.MOVE_TO_THE_RECYCLE_BIN,
 			LanguageUtil.get(_resourceBundle, "move-to-recycle-bin"),
 			_getSubmitFormJavaScript(
@@ -771,7 +775,7 @@ public class UIItemsBuilder {
 		}
 
 		_addJavaScriptUIItem(
-			new JavaScriptToolbarItem(), toolbarItems, "",
+			new JavaScriptToolbarItem(), toolbarItems, StringPool.BLANK,
 			DLUIItemKeys.PERMISSIONS,
 			LanguageUtil.get(_resourceBundle, "permissions"),
 			StringBundler.concat(
@@ -850,8 +854,8 @@ public class UIItemsBuilder {
 		sb.append("';}");
 
 		_addURLUIItem(
-			new URLMenuItem(), menuItems, "", DLUIItemKeys.PUBLISH,
-			"publish-to-live", sb.toString());
+			new URLMenuItem(), menuItems, StringPool.BLANK,
+			DLUIItemKeys.PUBLISH, "publish-to-live", sb.toString());
 	}
 
 	public void addRevertToVersionMenuItem(List<MenuItem> menuItems)
@@ -875,7 +879,8 @@ public class UIItemsBuilder {
 			"/document_library/view_file_entry", _getRedirect());
 
 		_addURLUIItem(
-			new URLMenuItem(), menuItems, "", DLUIItemKeys.REVERT, "revert",
+			new URLMenuItem(), menuItems, StringPool.BLANK, DLUIItemKeys.REVERT,
+			"revert",
 			PortletURLBuilder.create(
 				_getActionURL(
 					"/document_library/edit_file_entry", Constants.REVERT,
@@ -893,8 +898,8 @@ public class UIItemsBuilder {
 		}
 
 		_addURLUIItem(
-			new URLMenuItem(), menuItems, "", DLUIItemKeys.VIEW_ORIGINAL_FILE,
-			"view-original-file",
+			new URLMenuItem(), menuItems, StringPool.BLANK,
+			DLUIItemKeys.VIEW_ORIGINAL_FILE, "view-original-file",
 			PortletURLBuilder.create(
 				_getRenderURL("/document_library/view_file_entry")
 			).setParameter(
@@ -908,8 +913,8 @@ public class UIItemsBuilder {
 		}
 
 		_addURLUIItem(
-			new URLMenuItem(), menuItems, "", DLUIItemKeys.VIEW_VERSION,
-			"view[action]",
+			new URLMenuItem(), menuItems, StringPool.BLANK,
+			DLUIItemKeys.VIEW_VERSION, "view[action]",
 			PortletURLBuilder.create(
 				_getRenderURL(
 					"/document_library/view_file_entry", _getRedirect())

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/logic/UIItemsBuilder.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/logic/UIItemsBuilder.java
@@ -70,6 +70,7 @@ import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Constants;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.JavaConstants;
@@ -79,6 +80,7 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.util.PropsUtil;
 import com.liferay.portal.util.PropsValues;
 import com.liferay.staging.StagingGroupHelper;
 import com.liferay.staging.StagingGroupHelperUtil;
@@ -1012,7 +1014,9 @@ public class UIItemsBuilder {
 		T javascriptUIItem, List<? super T> javascriptUIItems, String icon,
 		String key, String label, String onClick) {
 
-		if (Validator.isNotNull(icon)) {
+		if (GetterUtil.getBoolean(PropsUtil.get("feature.flag.LPS-146954")) &&
+			Validator.isNotNull(icon)) {
+
 			javascriptUIItem.setIcon(icon);
 		}
 
@@ -1029,7 +1033,9 @@ public class UIItemsBuilder {
 		T urlUIItem, List<? super T> urlUIItems, String icon, String key,
 		String label, String url) {
 
-		if (Validator.isNotNull(icon)) {
+		if (GetterUtil.getBoolean(PropsUtil.get("feature.flag.LPS-146954")) &&
+			Validator.isNotNull(icon)) {
+
 			urlUIItem.setIcon(icon);
 		}
 

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/logic/UIItemsBuilder.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/logic/UIItemsBuilder.java
@@ -191,8 +191,8 @@ public class UIItemsBuilder {
 		}
 
 		JavaScriptToolbarItem javaScriptToolbarItem = _addJavaScriptUIItem(
-			new JavaScriptToolbarItem(), toolbarItems, DLUIItemKeys.CHECKIN,
-			LanguageUtil.get(_resourceBundle, "checkin"), "",
+			new JavaScriptToolbarItem(), toolbarItems, "", DLUIItemKeys.CHECKIN,
+			LanguageUtil.get(_resourceBundle, "checkin"),
 			StringBundler.concat(
 				_getNamespace(), "showVersionDetailsDialog('",
 				HtmlUtil.escapeJS(
@@ -534,8 +534,8 @@ public class UIItemsBuilder {
 			appendVersion, true);
 
 		URLMenuItem urlMenuItem = _addURLUIItem(
-			new URLMenuItem(), menuItems, "", DLUIItemKeys.DOWNLOAD, label,
-			url);
+			new URLMenuItem(), menuItems, "download", DLUIItemKeys.DOWNLOAD,
+			label, url);
 
 		urlMenuItem.setData(
 			HashMapBuilder.<String, Object>put(
@@ -617,7 +617,7 @@ public class UIItemsBuilder {
 		portletURL.setParameter("backURL", _getCurrentURL());
 
 		_addURLUIItem(
-			new URLMenuItem(), menuItems, "", DLUIItemKeys.EDIT, "edit",
+			new URLMenuItem(), menuItems, "pencil", DLUIItemKeys.EDIT, "edit",
 			portletURL.toString());
 	}
 
@@ -648,8 +648,8 @@ public class UIItemsBuilder {
 		}
 
 		_addJavaScriptUIItem(
-			new JavaScriptMenuItem(), menuItems, "", DLUIItemKeys.MOVE,
-			LanguageUtil.get(_resourceBundle, "move"),
+			new JavaScriptMenuItem(), menuItems, "move-folder",
+			DLUIItemKeys.MOVE, LanguageUtil.get(_resourceBundle, "move"),
 			_getMoveEntryOnClickJavaScript());
 	}
 
@@ -739,7 +739,7 @@ public class UIItemsBuilder {
 		}
 
 		URLMenuItem urlMenuItem = _addURLUIItem(
-			new URLMenuItem(), menuItems, "", DLUIItemKeys.PERMISSIONS,
+			new URLMenuItem(), menuItems, "password-policies", DLUIItemKeys.PERMISSIONS,
 			"permissions", url);
 
 		urlMenuItem.setMethod("get");

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/logic/UIItemsBuilder.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/logic/UIItemsBuilder.java
@@ -401,6 +401,16 @@ public class UIItemsBuilder {
 			deleteMenuItem.setTrash(true);
 		}
 
+		if (GetterUtil.getBoolean(PropsUtil.get("feature.flag.LPS-146954"))) {
+			String icon = "times";
+
+			if (cmd.equals(Constants.MOVE_TO_TRASH)) {
+				icon = "trash";
+			}
+
+			deleteMenuItem.setIcon(icon);
+		}
+
 		String mvcActionCommandName = "/document_library/edit_file_entry";
 
 		if (_fileShortcut != null) {

--- a/modules/apps/sharing/sharing-web/src/main/java/com/liferay/sharing/web/internal/display/context/util/SharingMenuItemFactoryImpl.java
+++ b/modules/apps/sharing/sharing-web/src/main/java/com/liferay/sharing/web/internal/display/context/util/SharingMenuItemFactoryImpl.java
@@ -22,7 +22,9 @@ import com.liferay.portal.kernel.servlet.taglib.ui.JavaScriptMenuItem;
 import com.liferay.portal.kernel.servlet.taglib.ui.JavaScriptToolbarItem;
 import com.liferay.portal.kernel.servlet.taglib.ui.MenuItem;
 import com.liferay.portal.kernel.servlet.taglib.ui.ToolbarItem;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.sharing.display.context.util.SharingDropdownItemFactory;
 import com.liferay.sharing.display.context.util.SharingJavaScriptFactory;
 import com.liferay.sharing.display.context.util.SharingMenuItemFactory;
@@ -130,6 +132,10 @@ public class SharingMenuItemFactoryImpl
 		throws PortalException {
 
 		JavaScriptMenuItem javaScriptMenuItem = new JavaScriptMenuItem();
+
+		if (GetterUtil.getBoolean(PropsUtil.get("feature.flag.LPS-146954"))) {
+			javaScriptMenuItem.setIcon("share");
+		}
 
 		javaScriptMenuItem.setKey("#share");
 		javaScriptMenuItem.setLabel(_getSharingLabel(httpServletRequest));

--- a/portal-web/docroot/html/taglib/ui/icon/link_content.jspf
+++ b/portal-web/docroot/html/taglib/ui/icon/link_content.jspf
@@ -16,7 +16,7 @@
 
 <c:choose>
 	<c:when test="<%= Validator.isNotNull(icon) %>">
-		<aui:icon cssClass="<%= iconCssClass %>" image="<%= icon %>" markupView="<%= markupView %>" />
+		<aui:icon cssClass='<%= iconCssClass + " dropdown-item-indicator-start" %>' image="<%= icon %>" markupView="<%= markupView %>" />
 	</c:when>
 	<c:when test="<%= auiImage %>">
 		<aui:icon image="<%= image.substring(_AUI_PATH.length()) %>" />

--- a/portal-web/docroot/html/taglib/ui/icon_menu/lexicon/start.jsp
+++ b/portal-web/docroot/html/taglib/ui/icon_menu/lexicon/start.jsp
@@ -20,6 +20,7 @@
 String cssClass = GetterUtil.getString((String)request.getAttribute("liferay-ui:icon-menu:cssClass"));
 Map<String, Object> data = (Map<String, Object>)request.getAttribute("liferay-ui:icon-menu:data");
 String direction = (String)request.getAttribute("liferay-ui:icon-menu:direction");
+String dropdownCssClass = (String)request.getAttribute("liferay-ui:icon-menu:dropdownCssClass");
 String icon = GetterUtil.getString((String)request.getAttribute("liferay-ui:icon-menu:icon"));
 String id = GetterUtil.getString((String)request.getAttribute("liferay-ui:icon-menu:id"));
 String message = (String)request.getAttribute("liferay-ui:icon-menu:message");
@@ -57,10 +58,10 @@ if (Validator.isNull(icon)) {
 
 	<c:choose>
 		<c:when test="<%= scroll %>">
-			<div class="dropdown-menu dropdown-menu-<%= direction %>">
+			<div class="dropdown-menu dropdown-menu-<%= direction %> <%= dropdownCssClass %>">
 				<ul class="inline-scroller">
 		</c:when>
 		<c:otherwise>
-			<ul class="dropdown-menu dropdown-menu-<%= direction %>">
+			<ul class="dropdown-menu dropdown-menu-<%= direction %> <%= dropdownCssClass %>">
 		</c:otherwise>
 	</c:choose>

--- a/portal-web/docroot/html/taglib/ui/menu/init.jsp
+++ b/portal-web/docroot/html/taglib/ui/menu/init.jsp
@@ -17,3 +17,5 @@
 <%@ include file="/html/taglib/init.jsp" %>
 
 <%@ page import="com.liferay.portal.kernel.servlet.taglib.ui.Menu" %>
+
+<%@ page import="java.util.Optional" %>

--- a/portal-web/docroot/html/taglib/ui/menu/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/menu/page.jsp
@@ -21,7 +21,7 @@ Menu menu = (Menu)request.getAttribute("liferay-ui:menu:menu");
 
 List<MenuItem> menuItems = menu.getMenuItems();
 
-Optional<MenuItem> itemWithIcon = menuItems.stream(
+Optional<MenuItem> menuItemOptional = menuItems.stream(
 ).filter(
 	menuItem -> menuItem.getIcon() != null
 ).findFirst();
@@ -31,7 +31,7 @@ Optional<MenuItem> itemWithIcon = menuItems.stream(
 	cssClass="<%= menu.getCssClass() %>"
 	data="<%= menu.getData() %>"
 	direction="<%= menu.getDirection() %>"
-	dropdownCssClass='<%= itemWithIcon.isPresent() ? "dropdown-menu-indicator-start" : StringPool.BLANK %>'
+	dropdownCssClass='<%= menuItemOptional.isPresent() ? "dropdown-menu-indicator-start" : StringPool.BLANK %>'
 	extended="<%= menu.isExtended() %>"
 	icon="<%= menu.getIcon() %>"
 	markupView="<%= menu.getMarkupView() %>"

--- a/portal-web/docroot/html/taglib/ui/menu/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/menu/page.jsp
@@ -20,12 +20,18 @@
 Menu menu = (Menu)request.getAttribute("liferay-ui:menu:menu");
 
 List<MenuItem> menuItems = menu.getMenuItems();
+
+Optional<MenuItem> itemWithIcon = menuItems.stream(
+).filter(
+	menuItem -> menuItem.getIcon() != null
+).findFirst();
 %>
 
 <liferay-ui:icon-menu
 	cssClass="<%= menu.getCssClass() %>"
 	data="<%= menu.getData() %>"
 	direction="<%= menu.getDirection() %>"
+	dropdownCssClass='<%= itemWithIcon.isPresent() ? "dropdown-menu-indicator-start" : StringPool.BLANK %>'
 	extended="<%= menu.isExtended() %>"
 	icon="<%= menu.getIcon() %>"
 	markupView="<%= menu.getMarkupView() %>"

--- a/portal-web/docroot/html/taglib/ui/menu_item/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/menu_item/page.jsp
@@ -41,7 +41,9 @@ MenuItem menuItem = (MenuItem)request.getAttribute("liferay-ui:menu_item:menuIte
 
 		<liferay-ui:icon
 			data="<%= javaScriptMenuItem.getData() %>"
+			icon="<%= javaScriptMenuItem.getIcon() %>"
 			iconCssClass="<%= javaScriptMenuItem.getIcon() %>"
+			markupView="lexicon"
 			message="<%= HtmlUtil.escape(javaScriptMenuItem.getLabel()) %>"
 			onClick="<%= javaScriptMenuItem.getOnClick() %>"
 			url="javascript:;"
@@ -61,7 +63,9 @@ MenuItem menuItem = (MenuItem)request.getAttribute("liferay-ui:menu_item:menuIte
 
 		<liferay-ui:icon
 			data="<%= urlMenuItem.getData() %>"
+			icon="<%= urlMenuItem.getIcon() %>"
 			iconCssClass="<%= urlMenuItem.getIcon() %>"
+			markupView="lexicon"
 			message="<%= HtmlUtil.escape(urlMenuItem.getLabel()) %>"
 			method="<%= urlMenuItem.getMethod() %>"
 			target="<%= urlMenuItem.getTarget() %>"

--- a/portal-web/docroot/html/taglib/ui/menu_item/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/menu_item/page.jsp
@@ -29,6 +29,7 @@ MenuItem menuItem = (MenuItem)request.getAttribute("liferay-ui:menu_item:menuIte
 
 		<liferay-ui:icon-delete
 			message="<%= HtmlUtil.escape(deleteMenuItem.getLabel()) %>"
+			showIcon="<%= Validator.isNotNull(deleteMenuItem.getIcon()) %>"
 			trash="<%= deleteMenuItem.isTrash() %>"
 			url="<%= deleteMenuItem.getURL() %>"
 		/>

--- a/util-taglib/bnd.bnd
+++ b/util-taglib/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 8.4.7
+Bundle-Version: 8.5.0
 Export-Package:\
 	com.liferay.alloy.taglib.*;version="3.0.0",\
 	com.liferay.taglib.*

--- a/util-taglib/src/META-INF/liferay-ui.tld
+++ b/util-taglib/src/META-INF/liferay-ui.tld
@@ -657,6 +657,12 @@
 			<type>boolean</type>
 		</attribute>
 		<attribute>
+			<description>A CSS class for styling the dropdown.</description>
+			<name>dropdownCssClass</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
 			<description>Whether to extend the icon menu trigger by wrapping it in a button. The default value is <![CDATA[<code>true</code>]]>.</description>
 			<name>extended</name>
 			<required>false</required>

--- a/util-taglib/src/com/liferay/taglib/ui/IconMenuTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/IconMenuTag.java
@@ -91,6 +91,7 @@ public class IconMenuTag extends BaseBodyTagSupport implements BodyTag {
 			_cssClass = null;
 			_data = null;
 			_direction = "left";
+			_dropdownCssClass = null;
 			_endPage = null;
 			_extended = true;
 			_icon = null;
@@ -173,6 +174,10 @@ public class IconMenuTag extends BaseBodyTagSupport implements BodyTag {
 
 	public void setDisabled(boolean disabled) {
 		_disabled = disabled;
+	}
+
+	public void setDropdownCssClass(String dropdownCssClass) {
+		_dropdownCssClass = dropdownCssClass;
 	}
 
 	public void setEndPage(String endPage) {
@@ -475,6 +480,7 @@ public class IconMenuTag extends BaseBodyTagSupport implements BodyTag {
 		httpServletRequest.setAttribute("liferay-ui:icon-menu:data", _data);
 		httpServletRequest.setAttribute(
 			"liferay-ui:icon-menu:direction", _direction);
+		httpServletRequest.setAttribute("liferay-ui:icon-menu:dropdownCssClass", _dropdownCssClass);
 		httpServletRequest.setAttribute("liferay-ui:icon-menu:icon", _icon);
 		httpServletRequest.setAttribute("liferay-ui:icon-menu:id", _id);
 
@@ -508,6 +514,7 @@ public class IconMenuTag extends BaseBodyTagSupport implements BodyTag {
 	private Map<String, Object> _data;
 	private String _direction = "left";
 	private boolean _disabled;
+	private String _dropdownCssClass;
 	private String _endPage;
 	private boolean _extended = true;
 	private String _icon;

--- a/util-taglib/src/com/liferay/taglib/ui/IconMenuTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/IconMenuTag.java
@@ -480,7 +480,8 @@ public class IconMenuTag extends BaseBodyTagSupport implements BodyTag {
 		httpServletRequest.setAttribute("liferay-ui:icon-menu:data", _data);
 		httpServletRequest.setAttribute(
 			"liferay-ui:icon-menu:direction", _direction);
-		httpServletRequest.setAttribute("liferay-ui:icon-menu:dropdownCssClass", _dropdownCssClass);
+		httpServletRequest.setAttribute(
+			"liferay-ui:icon-menu:dropdownCssClass", _dropdownCssClass);
 		httpServletRequest.setAttribute("liferay-ui:icon-menu:icon", _icon);
 		httpServletRequest.setAttribute("liferay-ui:icon-menu:id", _id);
 

--- a/util-taglib/src/com/liferay/taglib/ui/packageinfo
+++ b/util-taglib/src/com/liferay/taglib/ui/packageinfo
@@ -1,1 +1,1 @@
-version 12.3.0
+version 12.4.0


### PR DESCRIPTION
Hey @adolfopa and @AliciaGarciaGarcia, 
please check the backend part before sending this over to FI, as I guess we need their approval for changing the taglib in `portal-web` ¿?. 

To test this, add `feature.flag.LPS-146954=true` to your `portal-ext.properties`. 

**Before:** 
<img width="632" alt="DM icons BEFORE" src="https://user-images.githubusercontent.com/8373764/158369860-95bf3aaa-bdb8-456e-9855-982c4d268b7d.png">

**After:** 
<img width="634" alt="DM icons AFTER" src="https://user-images.githubusercontent.com/8373764/158369906-9fc1ae78-4f60-4f01-8cdb-deb3c15bff57.png">

