### PR TITLE
LPS-149413/LPS-148961 Makeup styles in drag & drop component in D&M administration app

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/css/main.scss
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/css/main.scss
@@ -781,8 +781,13 @@ $productMenuWidth: 320px;
 			.active-area {
 				background-color: transparent !important;
 
-				.card-type-directory .card {
+				.card-type-directory .card,
+				&.list-group-item,
+				td {
 					background-color: $primary-l3 !important;
+				}
+
+				.card-type-directory .card {
 					box-shadow: 0 0 0 2px $primary-l2;
 				}
 			}

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/css/main.scss
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/css/main.scss
@@ -791,6 +791,11 @@ $productMenuWidth: 320px;
 					box-shadow: 0 0 0 2px $primary-l2;
 				}
 			}
+
+			.taglib-empty-result-message {
+				background-color: $primary-l3;
+				border-color: transparent;
+			}
 		}
 	}
 

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/css/main.scss
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/css/main.scss
@@ -808,3 +808,10 @@ $productMenuWidth: 320px;
 .autocomplete-dropdown-menu {
 	z-index: 2000;
 }
+
+.portlet-document-library-upload-mask {
+	.progress p {
+		font-weight: 600;
+		margin: auto;
+	}
+}

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/css/main.scss
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/css/main.scss
@@ -782,6 +782,7 @@ $productMenuWidth: 320px;
 				background-color: transparent !important;
 
 				.card-type-directory .card {
+					background-color: $primary-l3 !important;
 					box-shadow: 0 0 0 2px $primary-l2;
 				}
 			}

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/css/main.scss
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/css/main.scss
@@ -769,7 +769,14 @@ $productMenuWidth: 320px;
 	.upload-drop-active &,
 	.upload-drop-intent & {
 		.document-container {
-			background-color: #eef4ff;
+			background-color: $primary-l3;
+		}
+	}
+
+	.upload-drop-active & {
+		.document-container {
+			border-radius: 2px;
+			box-shadow: 0 0 0 2px $primary-l2 !important;
 		}
 	}
 

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/css/main.scss
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/css/main.scss
@@ -777,6 +777,14 @@ $productMenuWidth: 320px;
 		.document-container {
 			border-radius: 2px;
 			box-shadow: 0 0 0 2px $primary-l2 !important;
+
+			.active-area {
+				background-color: transparent !important;
+
+				.card-type-directory .card {
+					box-shadow: 0 0 0 2px $primary-l2;
+				}
+			}
 		}
 	}
 

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/css/main.scss
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/css/main.scss
@@ -776,7 +776,7 @@ $productMenuWidth: 320px;
 	.upload-drop-active & {
 		.document-container {
 			border-radius: 2px;
-			box-shadow: 0 0 0 2px $primary-l2 !important;
+			box-shadow: 0 0 0 2px $primary-l2;
 
 			.active-area {
 				background-color: transparent !important;

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/legacy/upload.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/legacy/upload.js
@@ -660,9 +660,15 @@ AUI.add(
 				},
 
 				_createOverlay(target, background) {
+					var instance = this;
+
+					var displayStyle = instance._getDisplayStyle();
 					var overlay = new A.OverlayMask({
 						background: background || null,
-						target,
+						target:
+							displayStyle !== CSS_ICON
+								? target
+								: target.one('.card'),
 					}).render();
 
 					overlay
@@ -673,12 +679,8 @@ AUI.add(
 				},
 
 				_createProgressBar(target) {
-					var height = target.height() / 5;
-
-					var width = target.width() * 0.8;
-
 					return new A.ProgressBar({
-						height,
+						height: 16,
 						on: {
 							complete() {
 								this.set(STR_LABEL, 'complete!');
@@ -687,7 +689,7 @@ AUI.add(
 								this.set(STR_LABEL, event.newVal + '%');
 							},
 						},
-						width,
+						width: target.width() * 0.8,
 					});
 				},
 

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/legacy/upload.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/legacy/upload.js
@@ -1446,12 +1446,12 @@ AUI.add(
 						var folderEntryNodeOverlay = folderEntryNode.overlay;
 
 						if (folderEntryNodeOverlay) {
-							folderEntryNodeOverlay.show();
-
 							instance._updateProgress(
 								folderEntryNode.progressBar,
 								0
 							);
+
+							folderEntryNodeOverlay.show();
 						}
 						else {
 							instance._createUploadStatus(folderEntryNode);

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/legacy/upload.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/legacy/upload.js
@@ -133,7 +133,7 @@ AUI.add(
 
 		var STR_THUMBNAIL_PATH = PATH_THEME_IMAGES + '/file_system/large/';
 
-		var TPL_ENTRIES_CONTAINER = '<ul class="{cssClass}"></ul>';
+		var TPL_ENTRIES_CONTAINER = '<dl class="{cssClass}"></dl>';
 
 		var TPL_ENTRY_ROW_TITLE =
 			'<span class="' +
@@ -152,7 +152,7 @@ AUI.add(
 			'</span>';
 
 		var TPL_ENTRY_WRAPPER =
-			'<li class="card-page-item card-page-item-asset" data-title="{title}"></li>';
+			'<dd class="card-page-item card-page-item-asset" data-title="{title}"></dd>';
 
 		var TPL_ERROR_FOLDER = new A.Template(
 			'<span class="lfr-status-success-label">{validFilesLength}</span>',
@@ -534,11 +534,11 @@ AUI.add(
 					}
 					else {
 						var entriesContainerSelector =
-							'ul.list-group:last-of-type';
+							'dl.list-group:last-of-type';
 
 						if (displayStyle === CSS_ICON) {
 							entriesContainerSelector =
-								'ul.card-page:last-of-type';
+								'dl.card-page:last-of-type';
 						}
 
 						entriesContainer =

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/legacy/upload.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/legacy/upload.js
@@ -511,7 +511,7 @@ AUI.add(
 
 					searchContainer
 						.one('.searchcontainer-content')
-						.prepend(entriesContainer);
+						.append(entriesContainer);
 
 					return entriesContainer;
 				},
@@ -539,6 +539,14 @@ AUI.add(
 						if (displayStyle === CSS_ICON) {
 							entriesContainerSelector =
 								'dl.card-page:last-of-type';
+
+							if (
+								entriesContainer
+									.one(entriesContainerSelector)
+									?.one('.card-type-directory')
+							) {
+								entriesContainerSelector = null;
+							}
 						}
 
 						entriesContainer =

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view.jsp
@@ -159,59 +159,57 @@ DLViewDisplayContext dlViewDisplayContext = new DLViewDisplayContext(dlAdminDisp
 							<liferay-ui:error exception="<%= FileEntryLockException.MustOwnLock.class %>" message="you-can-only-checkin-documents-you-have-checked-out-yourself" />
 							<liferay-ui:error key="externalServiceFailed" message="you-cannot-access-external-service-because-you-are-not-allowed-to-or-it-is-unavailable" />
 
-							<div class="document-container">
-								<c:choose>
-									<c:when test="<%= dlViewDisplayContext.isSearch() %>">
-										<liferay-util:include page="/document_library/search_resources.jsp" servletContext="<%= application %>" />
-									</c:when>
-									<c:otherwise>
-										<liferay-util:include page="/document_library/view_entries.jsp" servletContext="<%= application %>" />
-									</c:otherwise>
-								</c:choose>
+							<c:choose>
+								<c:when test="<%= dlViewDisplayContext.isSearch() %>">
+									<liferay-util:include page="/document_library/search_resources.jsp" servletContext="<%= application %>" />
+								</c:when>
+								<c:otherwise>
+									<liferay-util:include page="/document_library/view_entries.jsp" servletContext="<%= application %>" />
+								</c:otherwise>
+							</c:choose>
 
-								<div class="d-none" id="<portlet:namespace />appViewEntryTemplates">
+							<div class="d-none" id="<portlet:namespace />appViewEntryTemplates">
 
-									<%
-									String thumbnailSrc = themeDisplay.getPathThemeImages() + "/file_system/large/default.png";
-									%>
+								<%
+								String thumbnailSrc = themeDisplay.getPathThemeImages() + "/file_system/large/default.png";
+								%>
 
-									<liferay-frontend:vertical-card
-										cssClass="card-type-asset display-icon entry-display-style file-card form-check form-check-card"
-										imageUrl="<%= thumbnailSrc %>"
-										title="{title}"
-										url="<%= dlViewDisplayContext.getUploadURL() %>"
-									>
-										<liferay-frontend:vertical-card-header>
-											<liferay-ui:message arguments="<%= HtmlUtil.escape(user.getFullName()) %>" key="right-now-by-x" />
-										</liferay-frontend:vertical-card-header>
-									</liferay-frontend:vertical-card>
+								<liferay-frontend:vertical-card
+									cssClass="card-type-asset display-icon entry-display-style file-card form-check form-check-card"
+									imageUrl="<%= thumbnailSrc %>"
+									title="{title}"
+									url="<%= dlViewDisplayContext.getUploadURL() %>"
+								>
+									<liferay-frontend:vertical-card-header>
+										<liferay-ui:message arguments="<%= HtmlUtil.escape(user.getFullName()) %>" key="right-now-by-x" />
+									</liferay-frontend:vertical-card-header>
+								</liferay-frontend:vertical-card>
 
-									<dd class="display-descriptive entry-display-style list-group-item list-group-item-flex">
-										<div class="autofit-col"></div>
+								<dd class="display-descriptive entry-display-style list-group-item list-group-item-flex">
+									<div class="autofit-col"></div>
 
-										<div class="autofit-col">
-											<div class="click-selector sticker">
-												<div class="sticker-overlay">
-													<img alt="thumbnail" class="sticker-img" src="<%= thumbnailSrc %>" />
-												</div>
+									<div class="autofit-col">
+										<div class="click-selector sticker">
+											<div class="sticker-overlay">
+												<img alt="thumbnail" class="sticker-img" src="<%= thumbnailSrc %>" />
 											</div>
 										</div>
+									</div>
 
-										<div class="autofit-col autofit-col-expand">
-											<h2 class="h5">
-												<aui:a href="<%= dlViewDisplayContext.getUploadURL() %>">
-													{title}
-												</aui:a>
-											</h2>
+									<div class="autofit-col autofit-col-expand">
+										<h2 class="h5">
+											<aui:a href="<%= dlViewDisplayContext.getUploadURL() %>">
+												{title}
+											</aui:a>
+										</h2>
 
-											<span>
-												<liferay-ui:message arguments="<%= HtmlUtil.escape(user.getFullName()) %>" key="right-now-by-x" />
-											</span>
-										</div>
+										<span>
+											<liferay-ui:message arguments="<%= HtmlUtil.escape(user.getFullName()) %>" key="right-now-by-x" />
+										</span>
+									</div>
 
-										<div class="autofit-col"></div>
-									</dd>
-								</div>
+									<div class="autofit-col"></div>
+								</dd>
 							</div>
 						</aui:form>
 					</div>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view.jsp
@@ -186,7 +186,7 @@ DLViewDisplayContext dlViewDisplayContext = new DLViewDisplayContext(dlAdminDisp
 										</liferay-frontend:vertical-card-header>
 									</liferay-frontend:vertical-card>
 
-									<li class="display-descriptive entry-display-style list-group-item list-group-item-flex">
+									<dd class="display-descriptive entry-display-style list-group-item list-group-item-flex">
 										<div class="autofit-col"></div>
 
 										<div class="autofit-col">
@@ -210,7 +210,7 @@ DLViewDisplayContext dlViewDisplayContext = new DLViewDisplayContext(dlAdminDisp
 										</div>
 
 										<div class="autofit-col"></div>
-									</li>
+									</dd>
 								</div>
 							</div>
 						</aui:form>

--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/_extras.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/_extras.scss
@@ -330,10 +330,6 @@ body > .lfr-menu-list ul,
 		-webkit-animation: none;
 		animation: none;
 	}
-
-	.portlet-document-library .document-container {
-		box-shadow: inset 0 0 5px #b8c1d1;
-	}
 }
 
 .upload-drop-intent .lfr-upload-container .upload-target {


### PR DESCRIPTION
### DM upload drag and drop styles makeup
Issue: https://issues.liferay.com/browse/LPS-149413
I tried to update the styles as much as possible using old components.

#### tasks
- [x] Add drag styles general area
- [x] Apply design on cards (more or less)
- [x] Fix bug LPS-148961 DM drag and drop creates an extra container
- [x] Fix bug that mixes folders and files on the same container in cards view and breaks things
- [x] Add drag background color for list and table view
- [x] Add drag background color for empty

I found this bug [LPS-148961 ](https://issues.liferay.com/browse/LPS-148961) and fix it in this PR.

I use the `!important` key in CSS because I need to overwrite [this background](https://github.com/liferay/liferay-portal/blob/40b0e8abbae92f5ec038f629a47e888eee995fc4/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/application/_drag_drop.scss#L11). Another option is to delete these selectors of the frontend theme but I ignore the side effect.

#### Before PR
https://drive.google.com/file/d/1tzR0VcMSgUme8ApAWhkc3UugytcK1u_H/view?usp=sharing

#### After PR
https://drive.google.com/file/d/1TW8OWAZHO0XuMdycQgtm-gfgSOCjYyXK/view?usp=sharing

**Note:** I try to embed videos but are too long :( 