### PR TITLE
LPS-149526 Reflect the changes of the creation/edition of the file when filling the urlTitle

### DIFF
--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/service/test/FriendlyURLDLFileEntryLocalServiceWrapperTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/service/test/FriendlyURLDLFileEntryLocalServiceWrapperTest.java
@@ -279,6 +279,69 @@ public class FriendlyURLDLFileEntryLocalServiceWrapperTest
 	}
 
 	@Test
+	public void testUpdateFileEntryUpdatesBlankCreateFriendlyURLEntryWithTitle()
+		throws Exception {
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				group.getGroupId(), TestPropsValues.getUserId());
+
+		byte[] bytes = TestDataConstants.TEST_BYTE_ARRAY;
+
+		InputStream inputStream = new ByteArrayInputStream(bytes);
+
+		AtomicLong fileEntryId = new AtomicLong();
+
+		_testWithActiveFFFriendlyURLEntryFileEntryConfiguration(
+			() -> {
+				DLFileEntry dlFileEntry = _dlFileEntryLocalService.addFileEntry(
+					null, TestPropsValues.getUserId(), group.getGroupId(),
+					group.getGroupId(), parentFolder.getFolderId(),
+					RandomTestUtil.randomString(),
+					ContentTypes.APPLICATION_OCTET_STREAM,
+					RandomTestUtil.randomString(),
+					RandomTestUtil.randomString(), StringPool.BLANK,
+					StringPool.BLANK,
+					DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
+					null, null, inputStream, bytes.length, null, null,
+					serviceContext);
+
+				fileEntryId.set(dlFileEntry.getFileEntryId());
+
+				FriendlyURLEntry friendlyURLEntry =
+					_friendlyURLEntryLocalService.fetchMainFriendlyURLEntry(
+						_portal.getClassNameId(FileEntry.class),
+						fileEntryId.get());
+
+				Assert.assertNull(friendlyURLEntry);
+			},
+			false);
+
+		_testWithActiveFFFriendlyURLEntryFileEntryConfiguration(
+			() -> {
+				_dlFileEntryLocalService.updateFileEntry(
+					group.getCreatorUserId(), fileEntryId.get(),
+					StringUtil.randomString(),
+					ContentTypes.APPLICATION_OCTET_STREAM, "title",
+					StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
+					DLVersionNumberIncrease.MAJOR,
+					DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
+					Collections.emptyMap(), null, inputStream, 0, null, null,
+					serviceContext);
+
+				FriendlyURLEntry friendlyURLEntry =
+					_friendlyURLEntryLocalService.getMainFriendlyURLEntry(
+						_portal.getClassNameId(FileEntry.class),
+						fileEntryId.get());
+
+				Assert.assertNotNull(friendlyURLEntry);
+
+				Assert.assertEquals("title", friendlyURLEntry.getUrlTitle());
+			},
+			true);
+	}
+
+	@Test
 	public void testUpdateFileEntryUpdatesCreateFriendlyURLEntryIfPreviousExisted()
 		throws Exception {
 

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/EditFileEntryMVCActionCommand.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/EditFileEntryMVCActionCommand.java
@@ -1147,6 +1147,7 @@ public class EditFileEntryMVCActionCommand extends BaseMVCActionCommand {
 			uploadPortletRequest, "fileName",
 			uploadPortletRequest.getFileName("file"));
 		String title = ParamUtil.getString(uploadPortletRequest, "title");
+		String urlTitle = StringPool.BLANK;
 		String description = ParamUtil.getString(
 			uploadPortletRequest, "description");
 		String changeLog = ParamUtil.getString(
@@ -1243,7 +1244,7 @@ public class EditFileEntryMVCActionCommand extends BaseMVCActionCommand {
 
 				fileEntry = _dlAppService.addFileEntry(
 					null, repositoryId, folderId, sourceFileName, contentType,
-					title, title, description, changeLog, inputStream, size,
+					title, urlTitle, description, changeLog, inputStream, size,
 					expirationDate, reviewDate, serviceContext);
 			}
 			else if (cmd.equals(Constants.ADD_DYNAMIC)) {
@@ -1280,20 +1281,20 @@ public class EditFileEntryMVCActionCommand extends BaseMVCActionCommand {
 					// Update file entry and checkin
 
 					fileEntry = _dlAppService.updateFileEntryAndCheckIn(
-						fileEntryId, sourceFileName, contentType, title, title,
-						description, changeLog, dlVersionNumberIncrease,
-						inputStream, size, expirationDate, reviewDate,
-						serviceContext);
+						fileEntryId, sourceFileName, contentType, title,
+						urlTitle, description, changeLog,
+						dlVersionNumberIncrease, inputStream, size,
+						expirationDate, reviewDate, serviceContext);
 				}
 				else {
 
 					// Update file entry
 
 					fileEntry = _dlAppService.updateFileEntry(
-						fileEntryId, sourceFileName, contentType, title, title,
-						description, changeLog, dlVersionNumberIncrease,
-						inputStream, size, expirationDate, reviewDate,
-						serviceContext);
+						fileEntryId, sourceFileName, contentType, title,
+						urlTitle, description, changeLog,
+						dlVersionNumberIncrease, inputStream, size,
+						expirationDate, reviewDate, serviceContext);
 				}
 			}
 

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/EditFileEntryMVCActionCommand.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/EditFileEntryMVCActionCommand.java
@@ -19,6 +19,7 @@ import com.liferay.asset.kernel.exception.AssetCategoryException;
 import com.liferay.asset.kernel.exception.AssetTagException;
 import com.liferay.asset.kernel.model.AssetVocabulary;
 import com.liferay.document.library.configuration.DLConfiguration;
+import com.liferay.document.library.configuration.FFFriendlyURLEntryFileEntryConfiguration;
 import com.liferay.document.library.constants.DLPortletKeys;
 import com.liferay.document.library.exception.DLStorageQuotaExceededException;
 import com.liferay.document.library.kernel.antivirus.AntivirusScannerException;
@@ -151,7 +152,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Kenneth Chang
  */
 @Component(
-	configurationPid = "com.liferay.document.library.configuration.DLConfiguration",
+	configurationPid = {
+		"com.liferay.document.library.configuration.DLConfiguration",
+		"com.liferay.document.library.configuration.FFFriendlyURLEntryFileEntryConfiguration"
+	},
 	property = {
 		"javax.portlet.name=" + DLPortletKeys.DOCUMENT_LIBRARY,
 		"javax.portlet.name=" + DLPortletKeys.DOCUMENT_LIBRARY_ADMIN,
@@ -171,6 +175,9 @@ public class EditFileEntryMVCActionCommand extends BaseMVCActionCommand {
 	protected void activate(Map<String, Object> properties) {
 		_dlConfiguration = ConfigurableUtil.createConfigurable(
 			DLConfiguration.class, properties);
+		_ffFriendlyURLEntryFileEntryConfiguration =
+			ConfigurableUtil.createConfigurable(
+				FFFriendlyURLEntryFileEntryConfiguration.class, properties);
 	}
 
 	@Override
@@ -1147,7 +1154,13 @@ public class EditFileEntryMVCActionCommand extends BaseMVCActionCommand {
 			uploadPortletRequest, "fileName",
 			uploadPortletRequest.getFileName("file"));
 		String title = ParamUtil.getString(uploadPortletRequest, "title");
+
 		String urlTitle = StringPool.BLANK;
+
+		if (_ffFriendlyURLEntryFileEntryConfiguration.enabled()) {
+			urlTitle = ParamUtil.getString(uploadPortletRequest, "urlTitle");
+		}
+
 		String description = ParamUtil.getString(
 			uploadPortletRequest, "description");
 		String changeLog = ParamUtil.getString(
@@ -1360,6 +1373,9 @@ public class EditFileEntryMVCActionCommand extends BaseMVCActionCommand {
 
 	@Reference
 	private DLValidator _dlValidator;
+
+	private volatile FFFriendlyURLEntryFileEntryConfiguration
+		_ffFriendlyURLEntryFileEntryConfiguration;
 
 	@Reference
 	private Http _http;

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/EditFileEntryMVCActionCommand.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/EditFileEntryMVCActionCommand.java
@@ -467,7 +467,7 @@ public class EditFileEntryMVCActionCommand extends BaseMVCActionCommand {
 
 			FileEntry fileEntry = _dlAppService.addFileEntry(
 				null, repositoryId, folderId, uniqueFileName,
-				tempFileEntry.getMimeType(), uniqueFileTitle, uniqueFileTitle,
+				tempFileEntry.getMimeType(), uniqueFileTitle, StringPool.BLANK,
 				description, changeLog, tempFileEntry.getContentStream(),
 				tempFileEntry.getSize(), expirationDate, reviewDate,
 				serviceContext);
@@ -1260,7 +1260,7 @@ public class EditFileEntryMVCActionCommand extends BaseMVCActionCommand {
 
 				fileEntry = _dlAppService.addFileEntry(
 					null, repositoryId, folderId, uniqueFileName, contentType,
-					uniqueFileTitle, uniqueFileTitle, description, changeLog,
+					uniqueFileTitle, StringPool.BLANK, description, changeLog,
 					inputStream, size, expirationDate, reviewDate,
 					serviceContext);
 

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_entry.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_entry.jsp
@@ -574,7 +574,6 @@ renderResponse.setTitle(headerTitle);
 						<liferay-friendly-url:input
 							className="<%= FileEntry.class.getName() %>"
 							classPK="<%= fileEntryId %>"
-							disabled="<%= true %>"
 							inputAddon="<%= dlEditFileEntryDisplayContext.getFriendlyURLBase() %>"
 							localizable="<%= false %>"
 							name="urlTitle"

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_entry.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_entry.jsp
@@ -727,6 +727,11 @@ renderResponse.setTitle(headerTitle);
 
 	function <portlet:namespace />updateFileNameAndTitle() {
 		var titleElement = document.getElementById('<portlet:namespace />title');
+
+		var urlTitleElement = document.getElementById(
+			'<portlet:namespace />urlTitle'
+		);
+
 		var fileNameElement = document.getElementById(
 			'<portlet:namespace />fileName'
 		);
@@ -741,6 +746,10 @@ renderResponse.setTitle(headerTitle);
 
 			if (fileNameElement && !fileNameElement.value) {
 				fileNameElement.value = fileFileName;
+			}
+
+			if (urlTitleElement && !urlTitleElement.value) {
+				urlTitleElement.value = fileFileName.replace(/\.[^.]*$/, '');
 			}
 		}
 


### PR DESCRIPTION
When the FF is enabled : 

`echo enabled=B\"true\" > ../bundles/osgi/configs/com.liferay.document.library.configuration.FFFriendlyURLEntryFileEntryConfiguration.config`

When you create a File, a friendlyURL is generated:

https://user-images.githubusercontent.com/47524751/159013757-15dbb445-e378-4c29-a2fa-4b0107a98d30.mp4

On this PR we let the value of the field be reflected on the creation of the friendlyURL for the document


https://user-images.githubusercontent.com/47524751/159014068-094a18c5-14e2-45ba-a9a1-3c92da2d6d04.mp4


