### PR TITLE
LPS-142110 Add margin to card's widget

### DIFF
--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/css/main.scss
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/css/main.scss
@@ -387,6 +387,7 @@ html#{$cadmin-selector} {
 		padding-top: 0.5rem;
 	}
 
+	.widget-mode-card,
 	.widget-mode-simple {
 		margin-top: 24px;
 	}


### PR DESCRIPTION
Added space between buttons and card's header, same than with other templates. 
<img width="821" alt="Screenshot 2022-03-25 at 11 42 40" src="https://user-images.githubusercontent.com/8373764/160106148-2d836a8f-acc5-4903-a1dc-5644bae81157.png">

