### PR TITLE
LPS-142112 Blogs widget card: text overflow 

### DIFF
--- a/modules/apps/blogs/blogs-web/src/main/resources/com/liferay/blogs/web/portlet/display/template/dependencies/portlet_display_template_card.ftl
+++ b/modules/apps/blogs/blogs-web/src/main/resources/com/liferay/blogs/web/portlet/display/template/dependencies/portlet_display_template_card.ftl
@@ -1,4 +1,5 @@
 <div class="row widget-mode-card">
+	<ul class="card-page">
 	<#if entries?has_content>
 		<#list entries as curBlogEntry>
 			<#if curBlogEntry.getCoverImageURL(themeDisplay)??>
@@ -7,12 +8,10 @@
 				<#assign cardImage = false />
 			</#if>
 
-			<div class="col-lg-4">
-				<div class="card">
-					<div class="card-header">
-						<div class="aspect-ratio aspect-ratio-8-to-3">
+			<li class="card-page-item card-page-item-asset">
+				<div class="card card-type-asset file-card">
+					<div class="aspect-ratio card-item-first">
 							<img alt="thumbnail" class="aspect-ratio-item-center-middle aspect-ratio-item-fluid" src="${cardImage?then(curBlogEntry.getCoverImageURL(themeDisplay), portalUtil.getPathContext(renderRequest) + "/images/cover_image_placeholder.jpg")}">
-						</div>
 					</div>
 
 					<div class="card-body widget-topbar">
@@ -161,7 +160,8 @@
 						</div>
 					</div>
 				</div>
-			</div>
+			</li>
 		</#list>
 	</#if>
+	</ul>
 </div>

--- a/modules/apps/blogs/blogs-web/src/main/resources/com/liferay/blogs/web/portlet/display/template/dependencies/portlet_display_template_card.ftl
+++ b/modules/apps/blogs/blogs-web/src/main/resources/com/liferay/blogs/web/portlet/display/template/dependencies/portlet_display_template_card.ftl
@@ -9,8 +9,8 @@
 				</#if>
 
 				<li class="card-page-item card-page-item-asset">
-					<div class="card card-type-asset file-card">
-						<div class="aspect-ratio card-item-first">
+					<div class="card">
+						<div class="aspect-ratio aspect-ratio-8-to-3 card-item-first">
 								<img alt="thumbnail" class="aspect-ratio-item-center-middle aspect-ratio-item-fluid" src="${cardImage?then(curBlogEntry.getCoverImageURL(themeDisplay), portalUtil.getPathContext(renderRequest) + "/images/cover_image_placeholder.jpg")}">
 						</div>
 

--- a/modules/apps/blogs/blogs-web/src/main/resources/com/liferay/blogs/web/portlet/display/template/dependencies/portlet_display_template_card.ftl
+++ b/modules/apps/blogs/blogs-web/src/main/resources/com/liferay/blogs/web/portlet/display/template/dependencies/portlet_display_template_card.ftl
@@ -1,167 +1,167 @@
 <div class="row widget-mode-card">
 	<ul class="card-page">
-	<#if entries?has_content>
-		<#list entries as curBlogEntry>
-			<#if curBlogEntry.getCoverImageURL(themeDisplay)??>
-				<#assign cardImage = true />
-			<#else>
-				<#assign cardImage = false />
-			</#if>
+		<#if entries?has_content>
+			<#list entries as curBlogEntry>
+				<#if curBlogEntry.getCoverImageURL(themeDisplay)??>
+					<#assign cardImage = true />
+				<#else>
+					<#assign cardImage = false />
+				</#if>
 
-			<li class="card-page-item card-page-item-asset">
-				<div class="card card-type-asset file-card">
-					<div class="aspect-ratio card-item-first">
-							<img alt="thumbnail" class="aspect-ratio-item-center-middle aspect-ratio-item-fluid" src="${cardImage?then(curBlogEntry.getCoverImageURL(themeDisplay), portalUtil.getPathContext(renderRequest) + "/images/cover_image_placeholder.jpg")}">
-					</div>
-
-					<div class="card-body widget-topbar">
-						<div class="autofit-row card-title">
-								<div class="autofit-col autofit-col-expand">
-									<#assign viewEntryPortletURL = renderResponse.createRenderURL() />
-
-									${viewEntryPortletURL.setParameter("mvcRenderCommandName", "/blogs/view_entry")}
-									${viewEntryPortletURL.setParameter("redirect", currentURL)}
-
-									<#if validator.isNotNull(curBlogEntry.getUrlTitle())>
-										${viewEntryPortletURL.setParameter("urlTitle", curBlogEntry.getUrlTitle())}
-									<#else>
-										${viewEntryPortletURL.setParameter("entryId", curBlogEntry.getEntryId()?string)}
-									</#if>
-
-									<h3 class="title">
-										<a class="title-link" href="${viewEntryPortletURL.toString()}">
-										${htmlUtil.escape(blogsEntryUtil.getDisplayTitle(resourceBundle, curBlogEntry))}</a>
-									</h3>
-								</div>
-
-								<div class="autofit-col">
-									<@clay["dropdown-actions"]
-										additionalProps=blogsEntryActionDropdownAdditionalProps
-										dropdownItems=blogsEntryActionDropdownItemsProvider.getActionDropdownItems(curBlogEntry)
-										propsTransformer="blogs_admin/js/ElementsPropsTransformer"
-										propsTransformerServletContext=blogsEntryActionDropdownPropsTransformerServletContext
-									/>
-								</div>
+				<li class="card-page-item card-page-item-asset">
+					<div class="card card-type-asset file-card">
+						<div class="aspect-ratio card-item-first">
+								<img alt="thumbnail" class="aspect-ratio-item-center-middle aspect-ratio-item-fluid" src="${cardImage?then(curBlogEntry.getCoverImageURL(themeDisplay), portalUtil.getPathContext(renderRequest) + "/images/cover_image_placeholder.jpg")}">
 						</div>
 
-						<div class="autofit-row widget-metadata">
-							<div class="autofit-col inline-item-before">
-								<@liferay_ui["user-portrait"]
-									size="lg"
-									userId=curBlogEntry.userId
-									userName=curBlogEntry.userName
-								/>
-							</div>
-
-							<div class="autofit-col autofit-col-expand">
-								<div class="autofit-row">
+						<div class="card-body widget-topbar">
+							<div class="autofit-row card-title">
 									<div class="autofit-col autofit-col-expand">
-										<#if serviceLocator??>
-											<#assign
-												userLocalService = serviceLocator.findService("com.liferay.portal.kernel.service.UserLocalService")
+										<#assign viewEntryPortletURL = renderResponse.createRenderURL() />
 
-												entryUser = userLocalService.fetchUser(curBlogEntry.getUserId())
-											/>
+										${viewEntryPortletURL.setParameter("mvcRenderCommandName", "/blogs/view_entry")}
+										${viewEntryPortletURL.setParameter("redirect", currentURL)}
 
-											<#if entryUser?? && !entryUser.isDefaultUser()>
-												<#assign entryUserURL = entryUser.getDisplayURL(themeDisplay) />
-											</#if>
+										<#if validator.isNotNull(curBlogEntry.getUrlTitle())>
+											${viewEntryPortletURL.setParameter("urlTitle", curBlogEntry.getUrlTitle())}
+										<#else>
+											${viewEntryPortletURL.setParameter("entryId", curBlogEntry.getEntryId()?string)}
 										</#if>
 
-										<div class="text-truncate-inline">
-											<a href="${(entryUserURL?? && validator.isNotNull(entryUserURL))?then(entryUserURL, "")}" class="text-truncate username">${curBlogEntry.getUserName()}</a>
-										</div>
+										<h3 class="title">
+											<a class="title-link" href="${viewEntryPortletURL.toString()}">
+											${htmlUtil.escape(blogsEntryUtil.getDisplayTitle(resourceBundle, curBlogEntry))}</a>
+										</h3>
+									</div>
 
-										<div>
-											${dateUtil.getDate(curBlogEntry.getStatusDate(), "dd MMM", locale)}
+									<div class="autofit-col">
+										<@clay["dropdown-actions"]
+											additionalProps=blogsEntryActionDropdownAdditionalProps
+											dropdownItems=blogsEntryActionDropdownItemsProvider.getActionDropdownItems(curBlogEntry)
+											propsTransformer="blogs_admin/js/ElementsPropsTransformer"
+											propsTransformerServletContext=blogsEntryActionDropdownPropsTransformerServletContext
+										/>
+									</div>
+							</div>
 
-											<#if blogsPortletInstanceConfiguration.enableReadingTime()>
-												- <@liferay_reading_time["reading-time"] displayStyle="simple" model=curBlogEntry />
+							<div class="autofit-row widget-metadata">
+								<div class="autofit-col inline-item-before">
+									<@liferay_ui["user-portrait"]
+										size="lg"
+										userId=curBlogEntry.userId
+										userName=curBlogEntry.userName
+									/>
+								</div>
+
+								<div class="autofit-col autofit-col-expand">
+									<div class="autofit-row">
+										<div class="autofit-col autofit-col-expand">
+											<#if serviceLocator??>
+												<#assign
+													userLocalService = serviceLocator.findService("com.liferay.portal.kernel.service.UserLocalService")
+
+													entryUser = userLocalService.fetchUser(curBlogEntry.getUserId())
+												/>
+
+												<#if entryUser?? && !entryUser.isDefaultUser()>
+													<#assign entryUserURL = entryUser.getDisplayURL(themeDisplay) />
+												</#if>
 											</#if>
 
-											<#assign assetEntry = blogsEntryAssetEntryUtil.getAssetEntry(request, curBlogEntry) />
+											<div class="text-truncate-inline">
+												<a href="${(entryUserURL?? && validator.isNotNull(entryUserURL))?then(entryUserURL, "")}" class="text-truncate username">${curBlogEntry.getUserName()}</a>
+											</div>
 
-											<#if blogsPortletInstanceConfiguration.enableViewCount()>
-												- <@liferay_ui["message"] arguments=assetEntry.getViewCount() key=(assetEntry.getViewCount()==0)?then("x-view", "x-views") />
-											</#if>
+											<div>
+												${dateUtil.getDate(curBlogEntry.getStatusDate(), "dd MMM", locale)}
+
+												<#if blogsPortletInstanceConfiguration.enableReadingTime()>
+													- <@liferay_reading_time["reading-time"] displayStyle="simple" model=curBlogEntry />
+												</#if>
+
+												<#assign assetEntry = blogsEntryAssetEntryUtil.getAssetEntry(request, curBlogEntry) />
+
+												<#if blogsPortletInstanceConfiguration.enableViewCount()>
+													- <@liferay_ui["message"] arguments=assetEntry.getViewCount() key=(assetEntry.getViewCount()==0)?then("x-view", "x-views") />
+												</#if>
+											</div>
 										</div>
 									</div>
 								</div>
 							</div>
+
+							<#if validator.isNotNull(curBlogEntry.getDescription())>
+								<#assign content = curBlogEntry.getDescription() />
+							<#else>
+								<#assign content = curBlogEntry.getContent() />
+							</#if>
+
+							<#if cardImage>
+								<p class="widget-resume">${stringUtil.shorten(htmlUtil.stripHtml(content), 150)}</p>
+							<#else>
+								<p class="widget-resume">${stringUtil.shorten(htmlUtil.stripHtml(content), 400)}</p>
+							</#if>
 						</div>
 
-						<#if validator.isNotNull(curBlogEntry.getDescription())>
-							<#assign content = curBlogEntry.getDescription() />
-						<#else>
-							<#assign content = curBlogEntry.getContent() />
-						</#if>
+						<div class="card-footer">
+							<div class="autofit-float autofit-row autofit-row-center widget-toolbar">
+								<#if blogsPortletInstanceConfiguration.enableComments()>
+									<div class="autofit-col">
+										<#assign viewCommentsPortletURL = renderResponse.createRenderURL() />
 
-						<#if cardImage>
-							<p class="widget-resume">${stringUtil.shorten(htmlUtil.stripHtml(content), 150)}</p>
-						<#else>
-							<p class="widget-resume">${stringUtil.shorten(htmlUtil.stripHtml(content), 400)}</p>
-						</#if>
-					</div>
+										${viewCommentsPortletURL.setParameter("mvcRenderCommandName", "/blogs/view_entry")}
+										${viewCommentsPortletURL.setParameter("scroll", renderResponse.getNamespace() + "discussionContainer")}
 
-					<div class="card-footer">
-						<div class="autofit-float autofit-row autofit-row-center widget-toolbar">
-							<#if blogsPortletInstanceConfiguration.enableComments()>
-								<div class="autofit-col">
-									<#assign viewCommentsPortletURL = renderResponse.createRenderURL() />
+										<#if validator.isNotNull(curBlogEntry.getUrlTitle())>
+											${viewCommentsPortletURL.setParameter("urlTitle", curBlogEntry.getUrlTitle())}
+										<#else>
+											${viewCommentsPortletURL.setParameter("entryId", curBlogEntry.getEntryId()?string)}
+										</#if>
 
-									${viewCommentsPortletURL.setParameter("mvcRenderCommandName", "/blogs/view_entry")}
-									${viewCommentsPortletURL.setParameter("scroll", renderResponse.getNamespace() + "discussionContainer")}
-
-									<#if validator.isNotNull(curBlogEntry.getUrlTitle())>
-										${viewCommentsPortletURL.setParameter("urlTitle", curBlogEntry.getUrlTitle())}
-									<#else>
-										${viewCommentsPortletURL.setParameter("entryId", curBlogEntry.getEntryId()?string)}
-									</#if>
-
-									<a class="btn btn-outline-borderless btn-outline-secondary btn-sm" href="${viewCommentsPortletURL.toString()}" title="${language.get(locale, "comments")}">
-										<span class="inline-item inline-item-before">
-											<@clay["icon"] symbol="comments" />
-										</span> ${commentManager.getCommentsCount("com.liferay.blogs.model.BlogsEntry", curBlogEntry.getEntryId())}
-									</a>
-								</div>
-							</#if>
-
-							<#if blogsPortletInstanceConfiguration.enableRatings()>
-								<div class="autofit-col">
-									<@liferay_ratings["ratings"]
-										className="com.liferay.blogs.model.BlogsEntry"
-										classPK=curBlogEntry.getEntryId()
-									/>
-								</div>
-							</#if>
-
-							<div class="autofit-col autofit-col-end">
-								<#assign bookmarkURL = renderResponse.createRenderURL() />
-
-								${bookmarkURL.setWindowState(windowStateFactory.getWindowState("NORMAL"))}
-								${bookmarkURL.setParameter("mvcRenderCommandName", "/blogs/view_entry")}
-
-								<#if validator.isNotNull(curBlogEntry.getUrlTitle())>
-									${bookmarkURL.setParameter("urlTitle", curBlogEntry.getUrlTitle())}
-								<#else>
-									${bookmarkURL.setParameter("entryId", curBlogEntry.getEntryId()?string)}
+										<a class="btn btn-outline-borderless btn-outline-secondary btn-sm" href="${viewCommentsPortletURL.toString()}" title="${language.get(locale, "comments")}">
+											<span class="inline-item inline-item-before">
+												<@clay["icon"] symbol="comments" />
+											</span> ${commentManager.getCommentsCount("com.liferay.blogs.model.BlogsEntry", curBlogEntry.getEntryId())}
+										</a>
+									</div>
 								</#if>
 
-								<@liferay_social_bookmarks["bookmarks"]
-									className="com.liferay.blogs.model.BlogsEntry"
-									classPK=curBlogEntry.getEntryId()
-									maxInlineItems=0
-									target="_blank"
-									title=blogsEntryUtil.getDisplayTitle(resourceBundle, curBlogEntry)
-									types=blogsPortletInstanceConfiguration.socialBookmarksTypes()
-									url=portalUtil.getCanonicalURL(bookmarkURL.toString(), themeDisplay, themeDisplay.getLayout())
-								/>
+								<#if blogsPortletInstanceConfiguration.enableRatings()>
+									<div class="autofit-col">
+										<@liferay_ratings["ratings"]
+											className="com.liferay.blogs.model.BlogsEntry"
+											classPK=curBlogEntry.getEntryId()
+										/>
+									</div>
+								</#if>
+
+								<div class="autofit-col autofit-col-end">
+									<#assign bookmarkURL = renderResponse.createRenderURL() />
+
+									${bookmarkURL.setWindowState(windowStateFactory.getWindowState("NORMAL"))}
+									${bookmarkURL.setParameter("mvcRenderCommandName", "/blogs/view_entry")}
+
+									<#if validator.isNotNull(curBlogEntry.getUrlTitle())>
+										${bookmarkURL.setParameter("urlTitle", curBlogEntry.getUrlTitle())}
+									<#else>
+										${bookmarkURL.setParameter("entryId", curBlogEntry.getEntryId()?string)}
+									</#if>
+
+									<@liferay_social_bookmarks["bookmarks"]
+										className="com.liferay.blogs.model.BlogsEntry"
+										classPK=curBlogEntry.getEntryId()
+										maxInlineItems=0
+										target="_blank"
+										title=blogsEntryUtil.getDisplayTitle(resourceBundle, curBlogEntry)
+										types=blogsPortletInstanceConfiguration.socialBookmarksTypes()
+										url=portalUtil.getCanonicalURL(bookmarkURL.toString(), themeDisplay, themeDisplay.getLayout())
+									/>
+								</div>
 							</div>
 						</div>
 					</div>
-				</div>
-			</li>
-		</#list>
-	</#if>
+				</li>
+			</#list>
+		</#if>
 	</ul>
 </div>


### PR DESCRIPTION
On a widget page with 30/70 columns: 

**BEFORE:**
30% column:
<img width="401" alt="Blogs Before 30C" src="https://user-images.githubusercontent.com/8373764/160104426-72d3b342-5c48-49ea-8019-99c9423daaf3.png">


**AFTER:** 
30% column: 
<img width="409" alt="Blogs After 30C" src="https://user-images.githubusercontent.com/8373764/160104402-76529600-6a4e-428c-8ce9-73e4f78faba6.png">

