### PR TITLE
LPS-151002 Change condition check if null and empty string

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/util/MapUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/MapUtil.java
@@ -346,11 +346,13 @@ public class MapUtil {
 
 		V value = map.get(key);
 
-		if (value != null) {
-			return value;
+		if ((value == null) ||
+			((value instanceof String) && Validator.isBlank((String)value))) {
+
+			return map.get(fallbackKey);
 		}
 
-		return map.get(fallbackKey);
+		return value;
 	}
 
 	public static boolean isEmpty(Map<?, ?> map) {


### PR DESCRIPTION
For steps please check [LPS-151002 ](https://issues.liferay.com/browse/LPS-151002)

Source format is not passing, so I had to parse the value to String:
```
Method 'Validator.isNotNull' should only be used for type 'Long', 'Serializable' or 'String': ./portal-kernel/src/com/liferay/portal/kernel/util/MapUtil.java 349 (Checkstyle:ValidatorIsNullCheck)
     [java] java.lang.Exception: Found 1 formatting issues:
     [java] 1: Method 'Validator.isNotNull' should only be used for type 'Long', 'Serializable' or 'String': ./portal-kernel/src/com/liferay/portal/kernel/util/MapUtil.java 349 (Checkstyle:ValidatorIsNullCheck)
```
