### PR TITLE
LPS-150652 the input tag url is double encoded, so we need to escape the url to let the user see the xml and the proper value of the url title

### DIFF
--- a/modules/apps/friendly-url/friendly-url-taglib/src/main/java/com/liferay/friendly/url/taglib/servlet/taglib/InputTag.java
+++ b/modules/apps/friendly-url/friendly-url-taglib/src/main/java/com/liferay/friendly/url/taglib/servlet/taglib/InputTag.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.service.PersistedModelLocalService;
 import com.liferay.portal.kernel.service.PersistedModelLocalServiceRegistryUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
@@ -226,10 +227,11 @@ public class InputTag extends IncludeTag {
 					getClassPK());
 
 			if (isLocalizable()) {
-				return mainFriendlyURLEntry.getUrlTitleMapAsXML();
+				return HtmlUtil.escapeURL(
+					mainFriendlyURLEntry.getUrlTitleMapAsXML());
 			}
 
-			return mainFriendlyURLEntry.getUrlTitle();
+			return HtmlUtil.escapeURL(mainFriendlyURLEntry.getUrlTitle());
 		}
 		catch (NoSuchFriendlyURLEntryMappingException
 					noSuchFriendlyURLEntryMappingException) {

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/UpdateArticleMVCActionCommand.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/UpdateArticleMVCActionCommand.java
@@ -56,6 +56,7 @@ import com.liferay.portal.kernel.upload.LiferayFileItemException;
 import com.liferay.portal.kernel.upload.UploadException;
 import com.liferay.portal.kernel.upload.UploadPortletRequest;
 import com.liferay.portal.kernel.util.FriendlyURLNormalizer;
+import com.liferay.portal.kernel.util.Html;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.MapUtil;
@@ -472,7 +473,8 @@ public class UpdateArticleMVCActionCommand extends BaseMVCActionCommand {
 						httpServletRequest, "for-locale-x-x-was-changed-to-x",
 						new Object[] {
 							"<strong>" + locale.getLanguage() + "</strong>",
-							"<strong>" + originalFriendlyURL + "</strong>",
+							"<strong>" + _html.escapeURL(originalFriendlyURL) +
+								"</strong>",
 							"<strong>" + currentFriendlyURL + "</strong>"
 						}));
 			}
@@ -650,6 +652,9 @@ public class UpdateArticleMVCActionCommand extends BaseMVCActionCommand {
 
 	@Reference
 	private FriendlyURLNormalizer _friendlyURLNormalizer;
+
+	@Reference
+	private Html _html;
 
 	@Reference
 	private Http _http;


### PR DESCRIPTION
the input tag url is double encoded, so we need to escape the url to let the user see the xml and the proper value of the url title

The error of shown code is due to try to insert the same bad friendlyURL (<script...) several times, the system show a message of warning that if is a script breaks the portal

Whit the fix it shows as follows

<img width="550" alt="image" src="https://user-images.githubusercontent.com/47524751/161777657-3b2a7358-dc2e-4f19-9d68-a73aff9263e3.png">
