### PR TITLE
LPS 148316.2

### DIFF
--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/exportimport/data/handler/FileEntryStagedModelDataHandler.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/exportimport/data/handler/FileEntryStagedModelDataHandler.java
@@ -333,6 +333,7 @@ public class FileEntryStagedModelDataHandler
 		}
 
 		_exportMetaData(portletDataContext, fileEntryElement, fileEntry);
+
 		_exportAssetDisplayPage(portletDataContext, fileEntry);
 		_exportFriendlyURLEntries(portletDataContext, fileEntry);
 

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/exportimport/data/handler/FileEntryStagedModelDataHandler.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/exportimport/data/handler/FileEntryStagedModelDataHandler.java
@@ -674,6 +674,9 @@ public class FileEntryStagedModelDataHandler
 
 			_importAssetDisplayPage(
 				portletDataContext, fileEntry, importedFileEntry);
+			_importFriendlyURLEntries(
+				portletDataContext, fileEntry, importedFileEntry,
+				serviceContext);
 		}
 		finally {
 			serviceContext.setAttribute(
@@ -1004,6 +1007,53 @@ public class FileEntryStagedModelDataHandler
 
 				_assetDisplayPageEntryLocalService.updateAssetDisplayPageEntry(
 					existingAssetDisplayPageEntry);
+			}
+		}
+	}
+
+	private void _importFriendlyURLEntries(
+			PortletDataContext portletDataContext, FileEntry fileEntry,
+			FileEntry importedFileEntry, ServiceContext serviceContext)
+		throws PortalException {
+
+		List<Element> friendlyURLEntryElements =
+			portletDataContext.getReferenceDataElements(
+				fileEntry, FriendlyURLEntry.class);
+
+		Map<Long, Long> fileEntryNewPrimaryKeys =
+			(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
+				FileEntry.class);
+
+		fileEntryNewPrimaryKeys.put(
+			fileEntry.getFileEntryId(), importedFileEntry.getFileEntryId());
+
+		for (Element friendlyURLEntryElement : friendlyURLEntryElements) {
+			String path = friendlyURLEntryElement.attributeValue("path");
+
+			FriendlyURLEntry friendlyURLEntry =
+				(FriendlyURLEntry)portletDataContext.getZipEntryAsObject(path);
+
+			StagedModelDataHandlerUtil.importStagedModel(
+				portletDataContext, friendlyURLEntryElement);
+
+			Map<Long, Long> friendlyURLEntries =
+				(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
+					FriendlyURLEntry.class);
+
+			long friendlyURLEntryId = MapUtil.getLong(
+				friendlyURLEntries, friendlyURLEntry.getFriendlyURLEntryId(),
+				friendlyURLEntry.getFriendlyURLEntryId());
+
+			FriendlyURLEntry existingFriendlyURLEntry =
+				_friendlyURLEntryLocalService.fetchFriendlyURLEntry(
+					friendlyURLEntryId);
+
+			if (existingFriendlyURLEntry != null) {
+				existingFriendlyURLEntry.setClassPK(
+					importedFileEntry.getFileEntryId());
+
+				_friendlyURLEntryLocalService.updateFriendlyURLEntry(
+					existingFriendlyURLEntry);
 			}
 		}
 	}

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/service/FriendlyURLDLFileEntryLocalServiceWrapper.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/service/FriendlyURLDLFileEntryLocalServiceWrapper.java
@@ -79,10 +79,10 @@ public class FriendlyURLDLFileEntryLocalServiceWrapper
 	}
 
 	@Override
-	public DLFileEntry deleteFileEntry(long fileEntryId)
+	public DLFileEntry deleteFileEntry(DLFileEntry dlFileEntry)
 		throws PortalException {
 
-		DLFileEntry dlFileEntry = super.deleteFileEntry(fileEntryId);
+		dlFileEntry = super.deleteFileEntry(dlFileEntry);
 
 		if (_ffFriendlyURLEntryFileEntryConfiguration.enabled()) {
 			_friendlyURLEntryLocalService.deleteFriendlyURLEntry(

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/exportimport/data/handler/test/FileEntryStagedModelDataHandlerTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/exportimport/data/handler/test/FileEntryStagedModelDataHandlerTest.java
@@ -23,6 +23,7 @@ import com.liferay.document.library.kernel.model.DLFileEntryType;
 import com.liferay.document.library.kernel.model.DLFolder;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.model.DLVersionNumberIncrease;
+import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.kernel.service.DLAppLocalServiceUtil;
 import com.liferay.document.library.kernel.service.DLAppServiceUtil;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalServiceUtil;
@@ -38,7 +39,10 @@ import com.liferay.dynamic.data.mapping.service.DDMStructureLocalServiceUtil;
 import com.liferay.dynamic.data.mapping.test.util.DDMStructureTestUtil;
 import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.exportimport.test.util.lar.BaseStagedModelDataHandlerTestCase;
+import com.liferay.friendly.url.model.FriendlyURLEntry;
+import com.liferay.friendly.url.service.FriendlyURLEntryLocalService;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.configuration.test.util.ConfigurationTemporarySwapper;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -61,9 +65,12 @@ import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.repository.portletrepository.PortletRepository;
+import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import java.util.HashMap;
@@ -100,6 +107,61 @@ public class FileEntryStagedModelDataHandlerTest
 		exportImportStagedModel(stagedModel);
 
 		validateCompanyDependenciesImport(dependentStagedModelsMap, liveGroup);
+	}
+
+	@Test
+	public void testExportFileFriendlyURLEntries() throws Exception {
+		try (ConfigurationTemporarySwapper configurationTemporarySwapper =
+				new ConfigurationTemporarySwapper(
+					_FF_FRIENDLY_URL_ENTRY_FILE_ENTRY_CONFIGURATION_PID,
+					HashMapDictionaryBuilder.<String, Object>put(
+						"enabled", true
+					).build())) {
+
+			String fileName = "PDF_Test.pdf";
+
+			ServiceContext serviceContext =
+				ServiceContextTestUtil.getServiceContext(
+					stagingGroup.getGroupId(), TestPropsValues.getUserId());
+
+			FileEntry fileEntry = _dlAppLocalService.addFileEntry(
+				null, TestPropsValues.getUserId(), stagingGroup.getGroupId(),
+				DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, fileName,
+				ContentTypes.APPLICATION_PDF,
+				FileUtil.getBytes(getClass(), "dependencies/" + fileName), null,
+				null, serviceContext);
+
+			fileEntry = DLAppServiceUtil.updateFileEntry(
+				fileEntry.getFileEntryId(), StringPool.BLANK,
+				ContentTypes.TEXT_PLAIN, fileEntry.getTitle(), "urltitle",
+				StringPool.BLANK, StringPool.BLANK,
+				DLVersionNumberIncrease.MINOR, (byte[])null, null, null,
+				serviceContext);
+
+			FriendlyURLEntry friendlyURLEntry =
+				_friendlyURLEntryLocalService.getMainFriendlyURLEntry(
+					_portal.getClassNameId(FileEntry.class),
+					fileEntry.getFileEntryId());
+
+			Assert.assertNotNull(friendlyURLEntry);
+			Assert.assertEquals("urltitle", friendlyURLEntry.getUrlTitle());
+
+			exportImportStagedModel(fileEntry);
+
+			FileEntry importedFileEntry =
+				DLAppLocalServiceUtil.getFileEntryByUuidAndGroupId(
+					fileEntry.getUuid(), liveGroup.getGroupId());
+
+			FriendlyURLEntry importedFriendlyURLEntry =
+				_friendlyURLEntryLocalService.getMainFriendlyURLEntry(
+					_portal.getClassNameId(FileEntry.class),
+					importedFileEntry.getFileEntryId());
+
+			Assert.assertNotNull(importedFriendlyURLEntry);
+			Assert.assertEquals(
+				friendlyURLEntry.getUrlTitle(),
+				importedFriendlyURLEntry.getUrlTitle());
+		}
 	}
 
 	@Test
@@ -164,7 +226,7 @@ public class FileEntryStagedModelDataHandlerTest
 
 		String title = RandomTestUtil.randomString() + ".awesome";
 
-		DLAppServiceUtil.updateFileEntry(
+		fileEntry = DLAppServiceUtil.updateFileEntry(
 			fileEntry.getFileEntryId(), StringPool.BLANK,
 			ContentTypes.TEXT_PLAIN, title, StringPool.BLANK, StringPool.BLANK,
 			StringPool.BLANK, DLVersionNumberIncrease.MINOR, (byte[])null, null,
@@ -176,6 +238,76 @@ public class FileEntryStagedModelDataHandlerTest
 			fileEntry.getUuid(), liveGroup.getGroupId());
 
 		Assert.assertEquals("pdf", importedFileEntry.getExtension());
+		Assert.assertEquals(title, importedFileEntry.getTitle());
+	}
+
+	@Test
+	public void testExportImportFileFriendlyURLEntriesUpdatingFile()
+		throws Exception {
+
+		try (ConfigurationTemporarySwapper configurationTemporarySwapper =
+				new ConfigurationTemporarySwapper(
+					_FF_FRIENDLY_URL_ENTRY_FILE_ENTRY_CONFIGURATION_PID,
+					HashMapDictionaryBuilder.<String, Object>put(
+						"enabled", true
+					).build())) {
+
+			String fileName = "PDF_Test.pdf";
+
+			ServiceContext serviceContext =
+				ServiceContextTestUtil.getServiceContext(
+					stagingGroup.getGroupId(), TestPropsValues.getUserId());
+
+			FileEntry fileEntry = _dlAppLocalService.addFileEntry(
+				null, TestPropsValues.getUserId(), stagingGroup.getGroupId(),
+				DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, fileName,
+				ContentTypes.APPLICATION_PDF,
+				FileUtil.getBytes(getClass(), "dependencies/" + fileName), null,
+				null, serviceContext);
+
+			FriendlyURLEntry friendlyURLEntry =
+				_friendlyURLEntryLocalService.getMainFriendlyURLEntry(
+					_portal.getClassNameId(FileEntry.class),
+					fileEntry.getFileEntryId());
+
+			Assert.assertNotNull(friendlyURLEntry);
+			Assert.assertEquals("pdf_test.pdf", friendlyURLEntry.getUrlTitle());
+
+			exportImportStagedModel(fileEntry);
+
+			FileEntry importedFileEntry =
+				DLAppLocalServiceUtil.getFileEntryByUuidAndGroupId(
+					fileEntry.getUuid(), liveGroup.getGroupId());
+
+			FriendlyURLEntry importedFriendlyURLEntry =
+				_friendlyURLEntryLocalService.getMainFriendlyURLEntry(
+					_portal.getClassNameId(FileEntry.class),
+					importedFileEntry.getFileEntryId());
+
+			Assert.assertEquals(
+				"pdf_test.pdf", importedFriendlyURLEntry.getUrlTitle());
+
+			fileEntry = DLAppServiceUtil.updateFileEntry(
+				fileEntry.getFileEntryId(), StringPool.BLANK,
+				ContentTypes.TEXT_PLAIN, fileEntry.getTitle(), "urltitle",
+				StringPool.BLANK, StringPool.BLANK,
+				DLVersionNumberIncrease.MINOR, (byte[])null, null, null,
+				serviceContext);
+
+			exportImportStagedModel(fileEntry);
+
+			importedFileEntry =
+				DLAppLocalServiceUtil.getFileEntryByUuidAndGroupId(
+					fileEntry.getUuid(), liveGroup.getGroupId());
+
+			importedFriendlyURLEntry =
+				_friendlyURLEntryLocalService.getMainFriendlyURLEntry(
+					_portal.getClassNameId(FileEntry.class),
+					importedFileEntry.getFileEntryId());
+
+			Assert.assertEquals(
+				"urltitle", importedFriendlyURLEntry.getUrlTitle());
+		}
 	}
 
 	@Test
@@ -274,6 +406,50 @@ public class FileEntryStagedModelDataHandlerTest
 		}
 		finally {
 			ExportImportThreadLocal.setPortletStagingInProcess(false);
+		}
+	}
+
+	@Test
+	public void testImportFileFriendlyURLEntries() throws Exception {
+		try (ConfigurationTemporarySwapper configurationTemporarySwapper =
+				new ConfigurationTemporarySwapper(
+					_FF_FRIENDLY_URL_ENTRY_FILE_ENTRY_CONFIGURATION_PID,
+					HashMapDictionaryBuilder.<String, Object>put(
+						"enabled", true
+					).build())) {
+
+			String fileName = "PDF_Test.pdf";
+
+			FileEntry fileEntry = _dlAppLocalService.addFileEntry(
+				null, TestPropsValues.getUserId(), stagingGroup.getGroupId(),
+				DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, fileName,
+				ContentTypes.APPLICATION_PDF,
+				FileUtil.getBytes(getClass(), "dependencies/" + fileName), null,
+				null,
+				ServiceContextTestUtil.getServiceContext(
+					stagingGroup.getGroupId(), TestPropsValues.getUserId()));
+
+			FriendlyURLEntry friendlyURLEntry =
+				_friendlyURLEntryLocalService.getMainFriendlyURLEntry(
+					_portal.getClassNameId(FileEntry.class),
+					fileEntry.getFileEntryId());
+
+			Assert.assertNotNull(friendlyURLEntry);
+			Assert.assertEquals("pdf_test.pdf", friendlyURLEntry.getUrlTitle());
+
+			exportImportStagedModel(fileEntry);
+
+			FileEntry importedFileEntry =
+				DLAppLocalServiceUtil.getFileEntryByUuidAndGroupId(
+					fileEntry.getUuid(), liveGroup.getGroupId());
+
+			FriendlyURLEntry importedFriendlyURLEntry =
+				_friendlyURLEntryLocalService.getMainFriendlyURLEntry(
+					_portal.getClassNameId(FileEntry.class),
+					importedFileEntry.getFileEntryId());
+
+			Assert.assertEquals(
+				"pdf_test.pdf", importedFriendlyURLEntry.getUrlTitle());
 		}
 	}
 
@@ -642,7 +818,21 @@ public class FileEntryStagedModelDataHandlerTest
 		return DLAppLocalServiceUtil.getFileEntry(fileEntry.getFileEntryId());
 	}
 
+	private static final String
+		_FF_FRIENDLY_URL_ENTRY_FILE_ENTRY_CONFIGURATION_PID =
+			"com.liferay.document.library.configuration." +
+				"FFFriendlyURLEntryFileEntryConfiguration";
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		FileEntryStagedModelDataHandlerTest.class);
+
+	@Inject
+	private static DLAppLocalService _dlAppLocalService;
+
+	@Inject
+	private FriendlyURLEntryLocalService _friendlyURLEntryLocalService;
+
+	@Inject
+	private Portal _portal;
 
 }

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/lar/DLAdminPortletDataHandler.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/lar/DLAdminPortletDataHandler.java
@@ -39,6 +39,7 @@ import com.liferay.exportimport.kernel.lar.StagedModelType;
 import com.liferay.exportimport.kernel.staging.Staging;
 import com.liferay.exportimport.staged.model.repository.StagedModelRepository;
 import com.liferay.exportimport.staged.model.repository.StagedModelRepositoryRegistryUtil;
+import com.liferay.friendly.url.model.FriendlyURLEntry;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.ExportActionableDynamicQuery;
@@ -387,6 +388,18 @@ public class DLAdminPortletDataHandler extends BasePortletDataHandler {
 				StagedModelDataHandlerUtil.importStagedModel(
 					portletDataContext, fileShortcutElement);
 			}
+		}
+
+		Element friendlyURLEntriesElement =
+			portletDataContext.getImportDataGroupElement(
+				FriendlyURLEntry.class);
+
+		List<Element> friendlyURLEntryElements =
+			friendlyURLEntriesElement.elements();
+
+		for (Element friendlyURLEntryElement : friendlyURLEntryElements) {
+			StagedModelDataHandlerUtil.importStagedModel(
+				portletDataContext, friendlyURLEntryElement);
 		}
 
 		return portletPreferences;


### PR DESCRIPTION
- LPS-148316 when exporting a file staging export the  the URLFriendlyEntries
- LPS-148316 when importing a file on staging update the URLFriendlyEntries on the live file with the staging model has.
- LPS-148316 update the FriendlyURLEntries to match the history of imported/exported entries
- LPS-148316 override the deleteFileEntry with the lower call to let the staging model access to it
- LPS-148316 test the behavior of the staging destaging for the friendlyURLEntries
- LPS-148316 we have to export MetaData first
