### PR TITLE
LPS-129803 Keep a history of friendly URLs for documents

### DIFF
--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/service/FriendlyURLDLFileEntryLocalServiceWrapper.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/service/FriendlyURLDLFileEntryLocalServiceWrapper.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.service.ServiceWrapper;
+import com.liferay.portal.kernel.util.FriendlyURLNormalizer;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -131,7 +132,8 @@ public class FriendlyURLDLFileEntryLocalServiceWrapper
 		String uniqueUrlTitle = _friendlyURLEntryLocalService.getUniqueUrlTitle(
 			dlFileEntry.getGroupId(),
 			_classNameLocalService.getClassNameId(FileEntry.class),
-			dlFileEntry.getFileEntryId(), urlTitle,
+			dlFileEntry.getFileEntryId(),
+			_friendlyURLNormalizer.normalizeWithPeriodsAndSlashes(urlTitle),
 			LanguageUtil.getLanguageId(LocaleUtil.getSiteDefault()));
 
 		_friendlyURLEntryLocalService.addFriendlyURLEntry(
@@ -164,10 +166,14 @@ public class FriendlyURLDLFileEntryLocalServiceWrapper
 			return;
 		}
 
-		if (!Validator.isBlank(urlTitle) &&
-			!Objects.equals(friendlyURLEntry.getUrlTitle(), urlTitle)) {
+		String normalizedUrlTitle =
+			_friendlyURLNormalizer.normalizeWithPeriodsAndSlashes(urlTitle);
 
-			_addFriendlyURLEntry(dlFileEntry, urlTitle);
+		if (Validator.isNotNull(urlTitle) &&
+			!Objects.equals(
+				friendlyURLEntry.getUrlTitle(), normalizedUrlTitle)) {
+
+			_addFriendlyURLEntry(dlFileEntry, normalizedUrlTitle);
 		}
 	}
 
@@ -179,5 +185,8 @@ public class FriendlyURLDLFileEntryLocalServiceWrapper
 
 	@Reference
 	private FriendlyURLEntryLocalService _friendlyURLEntryLocalService;
+
+	@Reference
+	private FriendlyURLNormalizer _friendlyURLNormalizer;
 
 }

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/service/FriendlyURLDLFileEntryLocalServiceWrapper.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/service/FriendlyURLDLFileEntryLocalServiceWrapper.java
@@ -167,17 +167,7 @@ public class FriendlyURLDLFileEntryLocalServiceWrapper
 		if (!Validator.isBlank(urlTitle) &&
 			!Objects.equals(friendlyURLEntry.getUrlTitle(), urlTitle)) {
 
-			String uniqueUrlTitle =
-				_friendlyURLEntryLocalService.getUniqueUrlTitle(
-					dlFileEntry.getGroupId(),
-					_classNameLocalService.getClassNameId(FileEntry.class),
-					dlFileEntry.getFileEntryId(), urlTitle,
-					LanguageUtil.getLanguageId(LocaleUtil.getSiteDefault()));
-
-			_friendlyURLEntryLocalService.updateFriendlyURLEntryLocalization(
-				friendlyURLEntry,
-				LanguageUtil.getLanguageId(LocaleUtil.getSiteDefault()),
-				uniqueUrlTitle);
+			_addFriendlyURLEntry(dlFileEntry, urlTitle);
 		}
 	}
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/exportimport/data/handler/test/FileEntryStagedModelDataHandlerTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/exportimport/data/handler/test/FileEntryStagedModelDataHandlerTest.java
@@ -302,7 +302,7 @@ public class FileEntryStagedModelDataHandlerTest
 					fileEntry.getFileEntryId());
 
 			Assert.assertNotNull(friendlyURLEntry);
-			Assert.assertEquals("pdf_test.pdf", friendlyURLEntry.getUrlTitle());
+			Assert.assertEquals("pdf_test-pdf", friendlyURLEntry.getUrlTitle());
 
 			exportImportStagedModel(fileEntry);
 
@@ -316,7 +316,7 @@ public class FileEntryStagedModelDataHandlerTest
 					importedFileEntry.getFileEntryId());
 
 			Assert.assertEquals(
-				"pdf_test.pdf", importedFriendlyURLEntry.getUrlTitle());
+				"pdf_test-pdf", importedFriendlyURLEntry.getUrlTitle());
 
 			fileEntry = DLAppServiceUtil.updateFileEntry(
 				fileEntry.getFileEntryId(), StringPool.BLANK,
@@ -506,7 +506,7 @@ public class FileEntryStagedModelDataHandlerTest
 					fileEntry.getFileEntryId());
 
 			Assert.assertNotNull(friendlyURLEntry);
-			Assert.assertEquals("pdf_test.pdf", friendlyURLEntry.getUrlTitle());
+			Assert.assertEquals("pdf_test-pdf", friendlyURLEntry.getUrlTitle());
 
 			exportImportStagedModel(fileEntry);
 
@@ -520,7 +520,7 @@ public class FileEntryStagedModelDataHandlerTest
 					importedFileEntry.getFileEntryId());
 
 			Assert.assertEquals(
-				"pdf_test.pdf", importedFriendlyURLEntry.getUrlTitle());
+				"pdf_test-pdf", importedFriendlyURLEntry.getUrlTitle());
 		}
 	}
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/exportimport/data/handler/test/FileEntryStagedModelDataHandlerTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/exportimport/data/handler/test/FileEntryStagedModelDataHandlerTest.java
@@ -202,6 +202,77 @@ public class FileEntryStagedModelDataHandlerTest
 	}
 
 	@Test
+	public void testExportImportFileEntryFriendlyURLEntries() throws Exception {
+		try (ConfigurationTemporarySwapper configurationTemporarySwapper =
+				new ConfigurationTemporarySwapper(
+					_FF_FRIENDLY_URL_ENTRY_FILE_ENTRY_CONFIGURATION_PID,
+					HashMapDictionaryBuilder.<String, Object>put(
+						"enabled", true
+					).build())) {
+
+			String fileName = "PDF_Test.pdf";
+
+			ServiceContext serviceContext =
+				ServiceContextTestUtil.getServiceContext(
+					stagingGroup.getGroupId(), TestPropsValues.getUserId());
+
+			FileEntry fileEntry = _dlAppLocalService.addFileEntry(
+				null, TestPropsValues.getUserId(), stagingGroup.getGroupId(),
+				DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, fileName,
+				ContentTypes.APPLICATION_PDF,
+				FileUtil.getBytes(getClass(), "dependencies/" + fileName), null,
+				null, serviceContext);
+
+			fileEntry = DLAppServiceUtil.updateFileEntry(
+				fileEntry.getFileEntryId(), StringPool.BLANK,
+				ContentTypes.TEXT_PLAIN, fileEntry.getTitle(), "urltitle",
+				StringPool.BLANK, StringPool.BLANK,
+				DLVersionNumberIncrease.MINOR, (byte[])null, null, null,
+				serviceContext);
+
+			FriendlyURLEntry mainFriendlyURLEntry =
+				_friendlyURLEntryLocalService.getMainFriendlyURLEntry(
+					_portal.getClassNameId(FileEntry.class),
+					fileEntry.getFileEntryId());
+
+			Assert.assertEquals("urltitle", mainFriendlyURLEntry.getUrlTitle());
+
+			List<FriendlyURLEntry> friendlyURLEntries =
+				_friendlyURLEntryLocalService.getFriendlyURLEntries(
+					fileEntry.getGroupId(),
+					_portal.getClassNameId(FileEntry.class),
+					fileEntry.getFileEntryId());
+
+			Assert.assertEquals(
+				friendlyURLEntries.toString(), 2, friendlyURLEntries.size());
+
+			exportImportStagedModel(fileEntry);
+
+			FileEntry importedFileEntry =
+				DLAppLocalServiceUtil.getFileEntryByUuidAndGroupId(
+					fileEntry.getUuid(), liveGroup.getGroupId());
+
+			FriendlyURLEntry mainImportedFriendlyURLEntry =
+				_friendlyURLEntryLocalService.getMainFriendlyURLEntry(
+					_portal.getClassNameId(FileEntry.class),
+					fileEntry.getFileEntryId());
+
+			Assert.assertEquals(
+				"urltitle", mainImportedFriendlyURLEntry.getUrlTitle());
+
+			List<FriendlyURLEntry> importedFriendlyURLEntries =
+				_friendlyURLEntryLocalService.getFriendlyURLEntries(
+					importedFileEntry.getGroupId(),
+					_portal.getClassNameId(FileEntry.class),
+					importedFileEntry.getFileEntryId());
+
+			Assert.assertEquals(
+				importedFriendlyURLEntries.toString(), 2,
+				importedFriendlyURLEntries.size());
+		}
+	}
+
+	@Test
 	public void testExportImportFileEntryFriendlyURLEntriesUpdatingFileEntry()
 		throws Exception {
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/service/test/FriendlyURLDLFileEntryLocalServiceWrapperTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/service/test/FriendlyURLDLFileEntryLocalServiceWrapperTest.java
@@ -234,6 +234,43 @@ public class FriendlyURLDLFileEntryLocalServiceWrapperTest
 	}
 
 	@Test
+	public void testAddFileEntryAddsFriendlyURLEntryWithNormalizedUrlTitle()
+		throws Exception {
+
+		_testWithActiveFFFriendlyURLEntryFileEntryConfiguration(
+			() -> {
+				byte[] bytes = TestDataConstants.TEST_BYTE_ARRAY;
+
+				InputStream inputStream = new ByteArrayInputStream(bytes);
+
+				ServiceContext serviceContext =
+					ServiceContextTestUtil.getServiceContext(
+						group.getGroupId(), TestPropsValues.getUserId());
+
+				DLFileEntry dlFileEntry = _dlFileEntryLocalService.addFileEntry(
+					null, TestPropsValues.getUserId(), group.getGroupId(),
+					group.getGroupId(), parentFolder.getFolderId(),
+					RandomTestUtil.randomString(),
+					ContentTypes.APPLICATION_OCTET_STREAM,
+					RandomTestUtil.randomString(), "<script/urlTitle</script>",
+					StringPool.BLANK, StringPool.BLANK,
+					DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
+					null, null, inputStream, bytes.length, null, null,
+					serviceContext);
+
+				FriendlyURLEntry friendlyURLEntry =
+					_friendlyURLEntryLocalService.getMainFriendlyURLEntry(
+						_portal.getClassNameId(FileEntry.class),
+						dlFileEntry.getFileEntryId());
+
+				Assert.assertNotNull(friendlyURLEntry);
+				Assert.assertEquals(
+					"-script-urltitle-script-", friendlyURLEntry.getUrlTitle());
+			},
+			true);
+	}
+
+	@Test
 	public void testDeleteFileEntryDeletesFriendlyURLEntry() throws Exception {
 		_testWithActiveFFFriendlyURLEntryFileEntryConfiguration(
 			() -> {
@@ -670,6 +707,62 @@ public class FriendlyURLDLFileEntryLocalServiceWrapperTest
 						dlFileEntry.getFileEntryId());
 
 				Assert.assertEquals("urltitle", friendlyURLEntry.getUrlTitle());
+			},
+			true);
+	}
+
+	@Test
+	public void testUpdateFileEntryUpdatesFriendlyURLEntryWithNormalizedUrlTitle()
+		throws Exception {
+
+		_testWithActiveFFFriendlyURLEntryFileEntryConfiguration(
+			() -> {
+				byte[] bytes = TestDataConstants.TEST_BYTE_ARRAY;
+
+				InputStream inputStream = new ByteArrayInputStream(bytes);
+
+				ServiceContext serviceContext =
+					ServiceContextTestUtil.getServiceContext(
+						group.getGroupId(), TestPropsValues.getUserId());
+
+				DLFileEntry dlFileEntry = _dlFileEntryLocalService.addFileEntry(
+					null, TestPropsValues.getUserId(), group.getGroupId(),
+					group.getGroupId(), parentFolder.getFolderId(),
+					RandomTestUtil.randomString(),
+					ContentTypes.APPLICATION_OCTET_STREAM,
+					"<script>title</script>", StringPool.BLANK,
+					StringPool.BLANK, StringPool.BLANK,
+					DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
+					null, null, inputStream, bytes.length, null, null,
+					serviceContext);
+
+				FriendlyURLEntry mainFriendlyURLEntry =
+					_friendlyURLEntryLocalService.getMainFriendlyURLEntry(
+						_portal.getClassNameId(FileEntry.class),
+						dlFileEntry.getFileEntryId());
+
+				Assert.assertEquals(
+					"-script-title-script-",
+					mainFriendlyURLEntry.getUrlTitle());
+
+				dlFileEntry = _dlFileEntryLocalService.updateFileEntry(
+					group.getCreatorUserId(), dlFileEntry.getFileEntryId(),
+					StringUtil.randomString(),
+					ContentTypes.APPLICATION_OCTET_STREAM,
+					RandomTestUtil.randomString(), "url/title",
+					RandomTestUtil.randomString(), StringPool.BLANK,
+					DLVersionNumberIncrease.MAJOR,
+					DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
+					Collections.emptyMap(), null, inputStream, 0, null, null,
+					serviceContext);
+
+				mainFriendlyURLEntry =
+					_friendlyURLEntryLocalService.getMainFriendlyURLEntry(
+						_portal.getClassNameId(FileEntry.class),
+						dlFileEntry.getFileEntryId());
+
+				Assert.assertEquals(
+					"url-title", mainFriendlyURLEntry.getUrlTitle());
 			},
 			true);
 	}

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/service/test/FriendlyURLDLFileEntryLocalServiceWrapperTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/service/test/FriendlyURLDLFileEntryLocalServiceWrapperTest.java
@@ -136,8 +136,6 @@ public class FriendlyURLDLFileEntryLocalServiceWrapperTest
 			() -> {
 				byte[] bytes = TestDataConstants.TEST_BYTE_ARRAY;
 
-				InputStream inputStream = new ByteArrayInputStream(bytes);
-
 				ServiceContext serviceContext =
 					ServiceContextTestUtil.getServiceContext(
 						group.getGroupId(), TestPropsValues.getUserId());
@@ -149,8 +147,8 @@ public class FriendlyURLDLFileEntryLocalServiceWrapperTest
 					ContentTypes.APPLICATION_OCTET_STREAM, "title", "urltitle",
 					StringPool.BLANK, StringPool.BLANK,
 					DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
-					null, null, inputStream, bytes.length, null, null,
-					serviceContext);
+					null, null, new ByteArrayInputStream(bytes), bytes.length,
+					null, null, serviceContext);
 
 				FriendlyURLEntry friendlyURLEntry =
 					_friendlyURLEntryLocalService.getMainFriendlyURLEntry(
@@ -171,12 +169,6 @@ public class FriendlyURLDLFileEntryLocalServiceWrapperTest
 			() -> {
 				byte[] bytes = TestDataConstants.TEST_BYTE_ARRAY;
 
-				InputStream inputStream = new ByteArrayInputStream(bytes);
-
-				ServiceContext serviceContext =
-					ServiceContextTestUtil.getServiceContext(
-						group.getGroupId(), TestPropsValues.getUserId());
-
 				DLFileEntry dlFileEntry = _dlFileEntryLocalService.addFileEntry(
 					null, TestPropsValues.getUserId(), group.getGroupId(),
 					group.getGroupId(), parentFolder.getFolderId(),
@@ -184,8 +176,10 @@ public class FriendlyURLDLFileEntryLocalServiceWrapperTest
 					ContentTypes.APPLICATION_OCTET_STREAM, "title",
 					StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
 					DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
-					null, null, inputStream, bytes.length, null, null,
-					serviceContext);
+					null, null, new ByteArrayInputStream(bytes), bytes.length,
+					null, null,
+					ServiceContextTestUtil.getServiceContext(
+						group.getGroupId(), TestPropsValues.getUserId()));
 
 				FriendlyURLEntry friendlyURLEntry =
 					_friendlyURLEntryLocalService.getMainFriendlyURLEntry(
@@ -206,12 +200,6 @@ public class FriendlyURLDLFileEntryLocalServiceWrapperTest
 			() -> {
 				byte[] bytes = TestDataConstants.TEST_BYTE_ARRAY;
 
-				InputStream inputStream = new ByteArrayInputStream(bytes);
-
-				ServiceContext serviceContext =
-					ServiceContextTestUtil.getServiceContext(
-						group.getGroupId(), TestPropsValues.getUserId());
-
 				DLFileEntry dlFileEntry = _dlFileEntryLocalService.addFileEntry(
 					null, TestPropsValues.getUserId(), group.getGroupId(),
 					group.getGroupId(), parentFolder.getFolderId(),
@@ -219,8 +207,10 @@ public class FriendlyURLDLFileEntryLocalServiceWrapperTest
 					ContentTypes.APPLICATION_OCTET_STREAM, "title", null,
 					StringPool.BLANK, StringPool.BLANK,
 					DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
-					null, null, inputStream, bytes.length, null, null,
-					serviceContext);
+					null, null, new ByteArrayInputStream(bytes), bytes.length,
+					null, null,
+					ServiceContextTestUtil.getServiceContext(
+						group.getGroupId(), TestPropsValues.getUserId()));
 
 				FriendlyURLEntry friendlyURLEntry =
 					_friendlyURLEntryLocalService.getMainFriendlyURLEntry(
@@ -241,12 +231,6 @@ public class FriendlyURLDLFileEntryLocalServiceWrapperTest
 			() -> {
 				byte[] bytes = TestDataConstants.TEST_BYTE_ARRAY;
 
-				InputStream inputStream = new ByteArrayInputStream(bytes);
-
-				ServiceContext serviceContext =
-					ServiceContextTestUtil.getServiceContext(
-						group.getGroupId(), TestPropsValues.getUserId());
-
 				DLFileEntry dlFileEntry = _dlFileEntryLocalService.addFileEntry(
 					null, TestPropsValues.getUserId(), group.getGroupId(),
 					group.getGroupId(), parentFolder.getFolderId(),
@@ -255,8 +239,10 @@ public class FriendlyURLDLFileEntryLocalServiceWrapperTest
 					RandomTestUtil.randomString(), "<script/urlTitle</script>",
 					StringPool.BLANK, StringPool.BLANK,
 					DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
-					null, null, inputStream, bytes.length, null, null,
-					serviceContext);
+					null, null, new ByteArrayInputStream(bytes), bytes.length,
+					null, null,
+					ServiceContextTestUtil.getServiceContext(
+						group.getGroupId(), TestPropsValues.getUserId()));
 
 				FriendlyURLEntry friendlyURLEntry =
 					_friendlyURLEntryLocalService.getMainFriendlyURLEntry(
@@ -276,12 +262,6 @@ public class FriendlyURLDLFileEntryLocalServiceWrapperTest
 			() -> {
 				byte[] bytes = TestDataConstants.TEST_BYTE_ARRAY;
 
-				InputStream inputStream = new ByteArrayInputStream(bytes);
-
-				ServiceContext serviceContext =
-					ServiceContextTestUtil.getServiceContext(
-						group.getGroupId(), TestPropsValues.getUserId());
-
 				DLFileEntry dlFileEntry = _dlFileEntryLocalService.addFileEntry(
 					null, TestPropsValues.getUserId(), group.getGroupId(),
 					group.getGroupId(), parentFolder.getFolderId(),
@@ -291,8 +271,10 @@ public class FriendlyURLDLFileEntryLocalServiceWrapperTest
 					RandomTestUtil.randomString(), StringPool.BLANK,
 					StringPool.BLANK,
 					DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
-					null, null, inputStream, bytes.length, null, null,
-					serviceContext);
+					null, null, new ByteArrayInputStream(bytes), bytes.length,
+					null, null,
+					ServiceContextTestUtil.getServiceContext(
+						group.getGroupId(), TestPropsValues.getUserId()));
 
 				FriendlyURLEntry friendlyURLEntry =
 					_friendlyURLEntryLocalService.getMainFriendlyURLEntry(
@@ -597,8 +579,8 @@ public class FriendlyURLDLFileEntryLocalServiceWrapperTest
 					StringPool.BLANK, StringPool.BLANK,
 					DLVersionNumberIncrease.MAJOR,
 					DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
-					Collections.emptyMap(), null, inputStream, 0, null, null,
-					serviceContext);
+					Collections.emptyMap(), null, inputStream, bytes.length,
+					null, null, serviceContext);
 
 				FriendlyURLEntry friendlyURLEntry =
 					_friendlyURLEntryLocalService.getMainFriendlyURLEntry(
@@ -642,8 +624,8 @@ public class FriendlyURLDLFileEntryLocalServiceWrapperTest
 					RandomTestUtil.randomString(), "urltitle", StringPool.BLANK,
 					StringPool.BLANK, DLVersionNumberIncrease.MAJOR,
 					DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
-					Collections.emptyMap(), null, inputStream, 0, null, null,
-					serviceContext);
+					Collections.emptyMap(), null, inputStream, bytes.length,
+					null, null, serviceContext);
 
 				FriendlyURLEntry mainFriendlyURLEntry =
 					_friendlyURLEntryLocalService.getMainFriendlyURLEntry(
@@ -698,8 +680,8 @@ public class FriendlyURLDLFileEntryLocalServiceWrapperTest
 					RandomTestUtil.randomString(), null, StringPool.BLANK,
 					StringPool.BLANK, DLVersionNumberIncrease.MAJOR,
 					DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
-					Collections.emptyMap(), null, inputStream, 0, null, null,
-					serviceContext);
+					Collections.emptyMap(), null, inputStream, bytes.length,
+					null, null, serviceContext);
 
 				FriendlyURLEntry friendlyURLEntry =
 					_friendlyURLEntryLocalService.getMainFriendlyURLEntry(
@@ -753,8 +735,8 @@ public class FriendlyURLDLFileEntryLocalServiceWrapperTest
 					RandomTestUtil.randomString(), StringPool.BLANK,
 					DLVersionNumberIncrease.MAJOR,
 					DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
-					Collections.emptyMap(), null, inputStream, 0, null, null,
-					serviceContext);
+					Collections.emptyMap(), null, inputStream, bytes.length,
+					null, null, serviceContext);
 
 				mainFriendlyURLEntry =
 					_friendlyURLEntryLocalService.getMainFriendlyURLEntry(

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/info/item/provider/FileEntryInfoItemFriendlyURLProvider.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/info/item/provider/FileEntryInfoItemFriendlyURLProvider.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.document.library.web.internal.info.item.provider;
+
+import com.liferay.friendly.url.info.item.provider.InfoItemFriendlyURLProvider;
+import com.liferay.friendly.url.model.FriendlyURLEntry;
+import com.liferay.friendly.url.model.FriendlyURLEntryLocalization;
+import com.liferay.friendly.url.service.FriendlyURLEntryLocalService;
+import com.liferay.friendly.url.util.comparator.FriendlyURLEntryLocalizationComparator;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Portal;
+
+import java.util.List;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Alicia García
+ */
+@Component(
+	property = "item.class.name=com.liferay.portal.kernel.repository.model.FileEntry",
+	service = InfoItemFriendlyURLProvider.class
+)
+public class FileEntryInfoItemFriendlyURLProvider
+	implements InfoItemFriendlyURLProvider<FileEntry> {
+
+	@Override
+	public String getFriendlyURL(FileEntry fileEntry, String languageId) {
+		FriendlyURLEntry friendlyURLEntry =
+			_friendlyURLEntryLocalService.fetchMainFriendlyURLEntry(
+				_portal.getClassNameId(FileEntry.class),
+				fileEntry.getFileEntryId());
+
+		if (friendlyURLEntry != null) {
+			return friendlyURLEntry.getUrlTitle();
+		}
+
+		return null;
+	}
+
+	@Override
+	public List<FriendlyURLEntryLocalization> getFriendlyURLEntryLocalizations(
+		FileEntry fileEntry, String languageId) {
+
+		return _friendlyURLEntryLocalService.getFriendlyURLEntryLocalizations(
+			fileEntry.getGroupId(), _portal.getClassNameId(FileEntry.class),
+			fileEntry.getFileEntryId(),
+			LocaleUtil.toLanguageId(LocaleUtil.getSiteDefault()),
+			QueryUtil.ALL_POS, QueryUtil.ALL_POS,
+			_friendlyURLEntryLocalizationComparator);
+	}
+
+	private final FriendlyURLEntryLocalizationComparator
+		_friendlyURLEntryLocalizationComparator =
+			new FriendlyURLEntryLocalizationComparator();
+
+	@Reference
+	private FriendlyURLEntryLocalService _friendlyURLEntryLocalService;
+
+	@Reference
+	private Portal _portal;
+
+}

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/info/item/updater/FileEntryInfoItemFriendlyURLUpdater.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/info/item/updater/FileEntryInfoItemFriendlyURLUpdater.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.document.library.web.internal.info.item.updater;
+
+import com.liferay.friendly.url.info.item.updater.InfoItemFriendlyURLUpdater;
+import com.liferay.friendly.url.model.FriendlyURLEntry;
+import com.liferay.friendly.url.service.FriendlyURLEntryLocalService;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Alicia García
+ */
+@Component(
+	property = "item.class.name=com.liferay.portal.kernel.repository.model.FileEntry",
+	service = InfoItemFriendlyURLUpdater.class
+)
+public class FileEntryInfoItemFriendlyURLUpdater
+	implements InfoItemFriendlyURLUpdater<FileEntry> {
+
+	@Override
+	public void restoreFriendlyURL(
+			long userId, long classPK, long friendlyURLEntryId,
+			String languageId)
+		throws PortalException {
+
+		FriendlyURLEntry friendlyURLEntry =
+			_friendlyURLEntryLocalService.getFriendlyURLEntry(
+				friendlyURLEntryId);
+
+		_friendlyURLEntryLocalService.setMainFriendlyURLEntry(friendlyURLEntry);
+	}
+
+	@Reference
+	private FriendlyURLEntryLocalService _friendlyURLEntryLocalService;
+
+}

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_entry.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_entry.jsp
@@ -577,7 +577,7 @@ renderResponse.setTitle(headerTitle);
 							inputAddon="<%= dlEditFileEntryDisplayContext.getFriendlyURLBase() %>"
 							localizable="<%= false %>"
 							name="urlTitle"
-							showHistory="<%= false %>"
+							showHistory="<%= true %>"
 						/>
 
 						<p class="text-secondary"><liferay-ui:message key="the-friendly-url-may-be-modified-to-ensure-uniqueness" /></p>

--- a/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/FriendlyURLEntryLocalService.java
+++ b/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/FriendlyURLEntryLocalService.java
@@ -276,8 +276,7 @@ public interface FriendlyURLEntryLocalService
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public FriendlyURLEntry fetchMainFriendlyURLEntry(
-			long classNameId, long classPK)
-		throws PortalException;
+		long classNameId, long classPK);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public ActionableDynamicQuery getActionableDynamicQuery();

--- a/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/FriendlyURLEntryLocalServiceUtil.java
+++ b/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/FriendlyURLEntryLocalServiceUtil.java
@@ -328,8 +328,7 @@ public class FriendlyURLEntryLocalServiceUtil {
 	}
 
 	public static FriendlyURLEntry fetchMainFriendlyURLEntry(
-			long classNameId, long classPK)
-		throws PortalException {
+		long classNameId, long classPK) {
 
 		return getService().fetchMainFriendlyURLEntry(classNameId, classPK);
 	}

--- a/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/FriendlyURLEntryLocalServiceWrapper.java
+++ b/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/FriendlyURLEntryLocalServiceWrapper.java
@@ -365,8 +365,7 @@ public class FriendlyURLEntryLocalServiceWrapper
 
 	@Override
 	public FriendlyURLEntry fetchMainFriendlyURLEntry(
-			long classNameId, long classPK)
-		throws com.liferay.portal.kernel.exception.PortalException {
+		long classNameId, long classPK) {
 
 		return _friendlyURLEntryLocalService.fetchMainFriendlyURLEntry(
 			classNameId, classPK);

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
@@ -330,8 +330,7 @@ public class FriendlyURLEntryLocalServiceImpl
 
 	@Override
 	public FriendlyURLEntry fetchMainFriendlyURLEntry(
-			long classNameId, long classPK)
-		throws PortalException {
+		long classNameId, long classPK) {
 
 		FriendlyURLEntryMapping friendlyURLEntryMapping =
 			friendlyURLEntryMappingPersistence.fetchByC_C(classNameId, classPK);


### PR DESCRIPTION
- LPS-129803 no needed
- LPS-129803 buildService
- LPS-129803 when updating the friendlyURL on a file, add another to save the trace of the urlTitles to use on historic
- LPS-129803 Add history support for FileEntries
- LPS-129803 enable the show history on the input
- LPS-129803 add test to check if the updates of the file do not delete the urlTitle
- LPS-129803 we want a more normalized friendlyURL for documents
- LPS-129803 tests that the urlTitle of the friendlyURLEntries created are normalized
- LPS-129803 SF


<img width="1257" alt="image" src="https://user-images.githubusercontent.com/47524751/162209162-9051540b-e460-4223-ad6c-85439a20e79b.png">
<img width="1260" alt="Captura de pantalla 2022-04-07 a las 15 24 55" src="https://user-images.githubusercontent.com/47524751/162209291-f45eab01-72a3-47e9-a062-0858540fea09.png">

