### PR TITLE
LPS-151368 Video URL is not saved when adding external video shortcut in non-default language

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/EditFileEntryMVCActionCommand.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/EditFileEntryMVCActionCommand.java
@@ -96,6 +96,7 @@ import com.liferay.portal.kernel.upload.LiferayFileItemException;
 import com.liferay.portal.kernel.upload.UploadException;
 import com.liferay.portal.kernel.upload.UploadPortletRequest;
 import com.liferay.portal.kernel.upload.UploadRequestSizeException;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -103,6 +104,7 @@ import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.KeyValuePair;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MimeTypesUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -880,6 +882,10 @@ public class EditFileEntryMVCActionCommand extends BaseMVCActionCommand {
 		DynamicServletRequest dynamicServletRequest = new DynamicServletRequest(
 			httpServletRequest, new HashMap<>());
 
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
 		String namespace = String.valueOf(structureId) + StringPool.UNDERLINE;
 
 		Map<String, String[]> parameterMap =
@@ -889,6 +895,11 @@ public class EditFileEntryMVCActionCommand extends BaseMVCActionCommand {
 			String parameterName = entry.getKey();
 
 			if (StringUtil.startsWith(parameterName, namespace)) {
+				_setDefaultLanguageParameterNames(
+					dynamicServletRequest,
+					parameterName.substring(namespace.length()),
+					entry.getValue(), themeDisplay);
+
 				dynamicServletRequest.setParameterValues(
 					parameterName.substring(namespace.length()),
 					entry.getValue());
@@ -1123,6 +1134,26 @@ public class EditFileEntryMVCActionCommand extends BaseMVCActionCommand {
 			DLFileEntry.class.getName(), actionRequest);
 
 		_dlAppService.revertFileEntry(fileEntryId, version, serviceContext);
+	}
+
+	private void _setDefaultLanguageParameterNames(
+		DynamicServletRequest dynamicServletRequest, String parameterName,
+		String[] value, ThemeDisplay themeDisplay) {
+
+		if (!LocaleUtil.equals(
+				themeDisplay.getLocale(),
+				themeDisplay.getSiteDefaultLocale()) &&
+			parameterName.contains(
+				_language.getLanguageId(themeDisplay.getLocale()))) {
+
+			dynamicServletRequest.setParameterValues(
+				StringUtil.replace(
+					parameterName,
+					_language.getLanguageId(themeDisplay.getLocale()),
+					_language.getLanguageId(
+						themeDisplay.getSiteDefaultLocale())),
+				value);
+		}
 	}
 
 	private void _setUpDDMFormValues(ServiceContext serviceContext)

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/EditFileEntryMVCActionCommand.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/EditFileEntryMVCActionCommand.java
@@ -895,14 +895,19 @@ public class EditFileEntryMVCActionCommand extends BaseMVCActionCommand {
 			String parameterName = entry.getKey();
 
 			if (StringUtil.startsWith(parameterName, namespace)) {
-				_setDefaultLanguageParameterNames(
-					dynamicServletRequest,
-					parameterName.substring(namespace.length()),
-					entry.getValue(), themeDisplay);
+				parameterName = parameterName.substring(namespace.length());
 
-				dynamicServletRequest.setParameterValues(
-					parameterName.substring(namespace.length()),
-					entry.getValue());
+				_setDefaultLanguageParameterNames(
+					dynamicServletRequest, parameterName, entry.getValue(),
+					themeDisplay);
+
+				if (ArrayUtil.isEmpty(
+						dynamicServletRequest.getParameterValues(
+							parameterName))) {
+
+					dynamicServletRequest.setParameterValues(
+						parameterName, entry.getValue());
+				}
 			}
 		}
 

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/EditFileEntryMVCActionCommand.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/EditFileEntryMVCActionCommand.java
@@ -130,6 +130,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TimeZone;
 
@@ -877,7 +878,7 @@ public class EditFileEntryMVCActionCommand extends BaseMVCActionCommand {
 	}
 
 	private HttpServletRequest _getDDMStructureHttpServletRequest(
-		HttpServletRequest httpServletRequest, long structureId) {
+		HttpServletRequest httpServletRequest, DDMStructure ddmStructure) {
 
 		DynamicServletRequest dynamicServletRequest = new DynamicServletRequest(
 			httpServletRequest, new HashMap<>());
@@ -886,7 +887,9 @@ public class EditFileEntryMVCActionCommand extends BaseMVCActionCommand {
 			(ThemeDisplay)httpServletRequest.getAttribute(
 				WebKeys.THEME_DISPLAY);
 
-		String namespace = String.valueOf(structureId) + StringPool.UNDERLINE;
+		String namespace =
+			String.valueOf(ddmStructure.getStructureId()) +
+				StringPool.UNDERLINE;
 
 		Map<String, String[]> parameterMap =
 			httpServletRequest.getParameterMap();
@@ -898,8 +901,8 @@ public class EditFileEntryMVCActionCommand extends BaseMVCActionCommand {
 				parameterName = parameterName.substring(namespace.length());
 
 				_setDefaultLanguageParameterNames(
-					dynamicServletRequest, parameterName, entry.getValue(),
-					themeDisplay);
+					dynamicServletRequest, ddmStructure, parameterName,
+					entry.getValue(), themeDisplay);
 
 				if (ArrayUtil.isEmpty(
 						dynamicServletRequest.getParameterValues(
@@ -1142,14 +1145,15 @@ public class EditFileEntryMVCActionCommand extends BaseMVCActionCommand {
 	}
 
 	private void _setDefaultLanguageParameterNames(
-		DynamicServletRequest dynamicServletRequest, String parameterName,
-		String[] value, ThemeDisplay themeDisplay) {
+		DynamicServletRequest dynamicServletRequest, DDMStructure ddmStructure,
+		String parameterName, String[] value, ThemeDisplay themeDisplay) {
 
 		if (!LocaleUtil.equals(
 				themeDisplay.getLocale(),
 				themeDisplay.getSiteDefaultLocale()) &&
-			parameterName.contains(
-				_language.getLanguageId(themeDisplay.getLocale()))) {
+			parameterName.contains(themeDisplay.getLanguageId()) &&
+			Objects.equals(
+				ddmStructure.getStructureKey(), "DL_VIDEO_EXTERNAL_SHORTCUT")) {
 
 			dynamicServletRequest.setParameterValues(
 				StringUtil.replace(
@@ -1181,7 +1185,7 @@ public class EditFileEntryMVCActionCommand extends BaseMVCActionCommand {
 
 			DDMFormValues ddmFormValues = _ddmFormValuesFactory.create(
 				_getDDMStructureHttpServletRequest(
-					serviceContext.getRequest(), ddmStructure.getStructureId()),
+					serviceContext.getRequest(), ddmStructure),
 				_ddmBeanTranslator.translate(ddmStructure.getDDMForm()));
 
 			serviceContext.setAttribute(


### PR DESCRIPTION
- LPS-151368 in some cases the default language is not filled, so we must fill it with the value of the current language
- LPS-151368 we do not want to override the already filled parameter values

https://issues.liferay.com/browse/LPS-151368

I'm not happy with this solution.
I need @adolfopa to take a look on the LPS and review it because this solution ... I do not like it.

