### PR TITLE
LPS-150702 only change the folder id to default if the repository id of the folder is different from the scope group id

### DIFF
--- a/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/folder/DLFolderItemSelectorView.java
+++ b/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/folder/DLFolderItemSelectorView.java
@@ -129,7 +129,14 @@ public class DLFolderItemSelectorView
 		if (themeDisplay.getScopeGroupId() != _getRepositoryGroupId(
 				itemSelectorCriterion.getRepositoryId())) {
 
-			folderId = DLFolderConstants.DEFAULT_PARENT_FOLDER_ID;
+			Folder folder = _fetchFolder(folderId);
+
+			if ((folder == null) ||
+				(folder.getRepositoryId() != themeDisplay.getScopeGroupId())) {
+
+				folderId = DLFolderConstants.DEFAULT_PARENT_FOLDER_ID;
+			}
+
 			repositoryId = themeDisplay.getScopeGroupId();
 		}
 


### PR DESCRIPTION
Hi @adolfopa 

It's the (edited) task about the `FolderItemSelectorGroupSelector`

take a look and if you see something that can trigger some of the known issues. I tried some but maybe I'm forgetting some