### PR TITLE
[TS] LPS-151625

### DIFF
--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/security/permission/wrapper/DepotPermissionCheckerWrapper.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/security/permission/wrapper/DepotPermissionCheckerWrapper.java
@@ -16,6 +16,7 @@ package com.liferay.depot.internal.security.permission.wrapper;
 
 import com.liferay.depot.constants.DepotRolesConstants;
 import com.liferay.depot.model.DepotEntry;
+import com.liferay.exportimport.kernel.staging.StagingUtil;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
@@ -237,8 +238,10 @@ public class DepotPermissionCheckerWrapper extends PermissionCheckerWrapper {
 			return false;
 		}
 
+		Group liveGroup = StagingUtil.getLiveGroup(group);
+
 		if (_userGroupRoleLocalService.hasUserGroupRole(
-				getUserId(), group.getGroupId(),
+				getUserId(), liveGroup.getGroupId(),
 				DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER, true)) {
 
 			return true;
@@ -262,17 +265,19 @@ public class DepotPermissionCheckerWrapper extends PermissionCheckerWrapper {
 			return false;
 		}
 
+		Group liveGroup = StagingUtil.getLiveGroup(group);
+
 		if (_userGroupRoleLocalService.hasUserGroupRole(
-				getUserId(), group.getGroupId(),
+				getUserId(), liveGroup.getGroupId(),
 				DepotRolesConstants.ASSET_LIBRARY_ADMINISTRATOR, true) ||
 			_userGroupRoleLocalService.hasUserGroupRole(
-				getUserId(), group.getGroupId(),
+				getUserId(), liveGroup.getGroupId(),
 				DepotRolesConstants.ASSET_LIBRARY_OWNER, true)) {
 
 			return true;
 		}
 
-		Group parentGroup = group;
+		Group parentGroup = liveGroup;
 
 		while (!parentGroup.isRoot()) {
 			parentGroup = parentGroup.getParentGroup();
@@ -294,10 +299,12 @@ public class DepotPermissionCheckerWrapper extends PermissionCheckerWrapper {
 			return false;
 		}
 
-		long[] roleIds = getRoleIds(getUserId(), group.getGroupId());
+		Group liveGroup = StagingUtil.getLiveGroup(group);
+
+		long[] roleIds = getRoleIds(getUserId(), liveGroup.getGroupId());
 
 		Role role = _roleLocalService.getRole(
-			group.getCompanyId(), DepotRolesConstants.ASSET_LIBRARY_MEMBER);
+			liveGroup.getCompanyId(), DepotRolesConstants.ASSET_LIBRARY_MEMBER);
 
 		if (Arrays.binarySearch(roleIds, role.getRoleId()) >= 0) {
 			return true;
@@ -311,8 +318,10 @@ public class DepotPermissionCheckerWrapper extends PermissionCheckerWrapper {
 			return false;
 		}
 
+		Group liveGroup = StagingUtil.getLiveGroup(group);
+
 		if (_userGroupRoleLocalService.hasUserGroupRole(
-				getUserId(), group.getGroupId(),
+				getUserId(), liveGroup.getGroupId(),
 				DepotRolesConstants.ASSET_LIBRARY_OWNER, true)) {
 
 			return true;

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/security/permission/wrapper/test/DepotPermissionCheckerWrapperTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/security/permission/wrapper/test/DepotPermissionCheckerWrapperTest.java
@@ -19,6 +19,7 @@ import com.liferay.depot.constants.DepotRolesConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryGroupRelLocalService;
 import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.depot.test.util.DepotStagingTestUtil;
 import com.liferay.depot.test.util.DepotTestUtil;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
@@ -46,6 +47,7 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -67,7 +69,9 @@ public class DepotPermissionCheckerWrapperTest {
 	@ClassRule
 	@Rule
 	public static final AggregateTestRule aggregateTestRule =
-		new LiferayIntegrationTestRule();
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
 
 	@Before
 	public void setUp() throws Exception {
@@ -228,6 +232,27 @@ public class DepotPermissionCheckerWrapperTest {
 	}
 
 	@Test
+	public void testHasStagingPermissionReturnsTrueForAssetLibraryOwners()
+		throws Exception {
+
+		DepotTestUtil.withRegularUser(
+			(user, role) -> {
+				DepotEntry depotEntry = _addDepotEntry(user.getUserId());
+
+				DepotEntry stagingDepotEntry =
+					DepotStagingTestUtil.enableLocalStaging(depotEntry);
+
+				PermissionChecker permissionChecker =
+					_permissionCheckerFactory.create(user);
+
+				Assert.assertTrue(
+					permissionChecker.hasPermission(
+						stagingDepotEntry.getGroup(), Group.class.getName(),
+						Group.class.getName(), ActionKeys.PUBLISH_STAGING));
+			});
+	}
+
+	@Test
 	public void testIsContentReviewerWithAssetLibraryAdministrator()
 		throws Exception {
 
@@ -260,6 +285,25 @@ public class DepotPermissionCheckerWrapperTest {
 				Assert.assertTrue(
 					permissionChecker.isContentReviewer(
 						user.getCompanyId(), depotEntry.getGroupId()));
+			});
+	}
+
+	@Test
+	public void testIsContentReviewerWithStagingEnabled() throws Exception {
+		DepotEntry depotEntry = _addDepotEntry(TestPropsValues.getUserId());
+
+		DepotEntry stagingDepotEntry = DepotStagingTestUtil.enableLocalStaging(
+			depotEntry);
+
+		DepotTestUtil.withAssetLibraryContentReviewer(
+			depotEntry,
+			user -> {
+				PermissionChecker permissionChecker =
+					_permissionCheckerFactory.create(user);
+
+				Assert.assertTrue(
+					permissionChecker.isContentReviewer(
+						user.getCompanyId(), stagingDepotEntry.getGroupId()));
 			});
 	}
 
@@ -336,6 +380,25 @@ public class DepotPermissionCheckerWrapperTest {
 
 		Assert.assertTrue(
 			permissionChecker.isGroupAdmin(TestPropsValues.getGroupId()));
+	}
+
+	@Test
+	public void testIsGroupAdminWithStagingEnabled() throws Exception {
+		DepotEntry depotEntry = _addDepotEntry(TestPropsValues.getUserId());
+
+		DepotEntry stagingDepotEntry = DepotStagingTestUtil.enableLocalStaging(
+			depotEntry);
+
+		DepotTestUtil.withAssetLibraryAdministrator(
+			depotEntry,
+			user -> {
+				PermissionChecker permissionChecker =
+					_permissionCheckerFactory.create(user);
+
+				Assert.assertTrue(
+					permissionChecker.isGroupAdmin(
+						stagingDepotEntry.getGroupId()));
+			});
 	}
 
 	@Test
@@ -431,6 +494,27 @@ public class DepotPermissionCheckerWrapperTest {
 	}
 
 	@Test
+	public void testIsGroupMemberWithStagingEnabled() throws Exception {
+		DepotEntry depotEntry = _addDepotEntry(TestPropsValues.getUserId());
+
+		DepotEntry stagingDepotEntry = DepotStagingTestUtil.enableLocalStaging(
+			depotEntry);
+
+		DepotTestUtil.withRegularUser(
+			(user, role) -> {
+				_userLocalService.addGroupUsers(
+					depotEntry.getGroupId(), new long[] {user.getUserId()});
+
+				PermissionChecker permissionChecker =
+					_permissionCheckerFactory.create(user);
+
+				Assert.assertTrue(
+					permissionChecker.isGroupMember(
+						stagingDepotEntry.getGroupId()));
+			});
+	}
+
+	@Test
 	public void testIsGroupOwnerWithDepotGroupAndAssetLibraryAdmin()
 		throws Exception {
 
@@ -520,6 +604,24 @@ public class DepotPermissionCheckerWrapperTest {
 
 		Assert.assertTrue(
 			permissionChecker.isGroupOwner(TestPropsValues.getGroupId()));
+	}
+
+	@Test
+	public void testIsGroupOwnerWithStagingEnabled() throws Exception {
+		DepotTestUtil.withRegularUser(
+			(user, role) -> {
+				DepotEntry depotEntry = _addDepotEntry(user.getUserId());
+
+				DepotEntry stagingDepotEntry =
+					DepotStagingTestUtil.enableLocalStaging(depotEntry);
+
+				PermissionChecker permissionChecker =
+					_permissionCheckerFactory.create(user);
+
+				Assert.assertTrue(
+					permissionChecker.isGroupOwner(
+						stagingDepotEntry.getGroupId()));
+			});
 	}
 
 	@Test


### PR DESCRIPTION
Hello,

I came across this issue (https://issues.liferay.com/browse/LPS-151625) while testing the behavior outlined on https://issues.liferay.com/browse/PTR-3007. In short, the permission checker was only looking at the group being passed in but sometimes this would be the staging group. Since the roles are assigned to the live group these permission checks would fail despite the user have the necessary role.

This logic is rather delicate so I tried placing the logic as close to the bottom as possible to avoid issues with with the `super` permission checks since most of those already have logic in place to handle staged groups. That being said please let me know if I'm misunderstanding the relationship between the staged group and permission checking or if you see any possible regressions with these changes.

There are five new tests. Four of them make sure that the specific roles are being checked correctly. The last one (`testHasStagingPermissionReturnsTrueForAssetLibraryOwners`) is more along the lines of PTR-3007 and can be expanded or kept the same based on the response there.

(As a note I will be off next week so if there any questions I can answer after that)

Regards.