### PR TITLE
LPS-151526 make the cacheControl value be required

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/configuration/CacheControlConfiguration.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/configuration/CacheControlConfiguration.java
@@ -34,7 +34,7 @@ public interface CacheControlConfiguration {
 	@Meta.AD(
 		deflt = "private", description = "cache-control-description",
 		name = "cache-control", optionLabels = {"private", "public"},
-		optionValues = {"private", "public"}, required = false
+		optionValues = {"private", "public"}
 	)
 	public String cacheControl();
 

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/configuration/admin/service/CacheControlConfigurationManagedServiceFactory.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/configuration/admin/service/CacheControlConfigurationManagedServiceFactory.java
@@ -28,6 +28,7 @@ import org.osgi.service.cm.ConfigurationException;
 import org.osgi.service.cm.ManagedServiceFactory;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Modified;
 
 /**
@@ -35,7 +36,7 @@ import org.osgi.service.component.annotations.Modified;
  */
 @Component(
 	configurationPid = "com.liferay.document.library.web.internal.configuration.CacheControlConfiguration",
-	immediate = true,
+	configurationPolicy = ConfigurationPolicy.REQUIRE, immediate = true,
 	property = Constants.SERVICE_PID + "=com.liferay.document.library.web.internal.configuration.CacheControlConfiguration.scoped",
 	service = {
 		CacheControlConfigurationManagedServiceFactory.class,

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/servlet/CacheControlFileEntryHttpHeaderCustomizer.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/servlet/CacheControlFileEntryHttpHeaderCustomizer.java
@@ -31,6 +31,7 @@ import com.liferay.portal.kernel.servlet.HttpHeaders;
 import com.liferay.portal.kernel.util.ArrayUtil;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Reference;
 
 /**
@@ -38,6 +39,7 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	configurationPid = "com.liferay.document.library.web.internal.configuration.CacheControlConfiguration",
+	configurationPolicy = ConfigurationPolicy.REQUIRE,
 	property = "http.header.name=" + HttpHeaders.CACHE_CONTROL,
 	service = FileEntryHttpHeaderCustomizer.class
 )


### PR DESCRIPTION
There is a Bug on the configuration part

https://issues.liferay.com/browse/LPS-151870 