### PR TITLE
[TS] LPS-152036 Set document Edit button point to DLPortletKeys.DOCUMENT_LIBRARY_ADMIN

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/logic/UIItemsBuilder.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/logic/UIItemsBuilder.java
@@ -632,7 +632,7 @@ public class UIItemsBuilder {
 			return;
 		}
 
-		PortletURL portletURL = _getRenderURL(
+		PortletURL portletURL = _getControlPanelRenderURL(
 			"/document_library/edit_file_entry");
 
 		_addURLUIItem(


### PR DESCRIPTION
Hi Team,

https://issues.liferay.com/browse/LPS-152036

Issue:
The Edit button in Documents and Media widget has different behavior from the Edit in the dropdown menu or the "add new file" button, so it is incoherent. The button opens in the view portlet, and the other two in control_panel.

Solution:
Change the portlet URL so that the button points to DLPortletKeys.DOCUMENT_LIBRARY_ADMIN, as the other menus.
As discussed in: https://issues.liferay.com/browse/PTR-2965
In the method addEditToolbarItem I changed the _getRenderURL method to the one which renders the url using DLPortletKeys.DOCUMENT_LIBRARY_ADMIN. Now the Edit button opens in control_panel.

Could you please review it?
Thank you!