### PR TITLE
LPS-152536 Text is not properly rendered when generating a PDF preview

### DIFF
--- a/modules/apps/document-library/document-library-preview-pdf/src/main/java/com/liferay/document/library/preview/pdf/internal/PDFProcessorImpl.java
+++ b/modules/apps/document-library/document-library-preview-pdf/src/main/java/com/liferay/document/library/preview/pdf/internal/PDFProcessorImpl.java
@@ -544,7 +544,6 @@ public class PDFProcessorImpl
 				"-sOutputFile=" + getPreviewTempFilePath(tempFileId, -1));
 		}
 
-		arguments.add("-dPDFFitPage");
 		arguments.add("-dTextAlphaBits=4");
 		arguments.add("-dGraphicsAlphaBits=4");
 		arguments.add("-r" + PropsValues.DL_FILE_ENTRY_PREVIEW_DOCUMENT_DPI);


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-152536

### Root cause analysis

You can reproduce the issue on the first page by downloading the problematic PDF attached to internal ticket [LPP-44955](https://issues.liferay.com/browse/LPP-44955), installing ghostscript and running the ghostscript command that is run by Liferay during the preview generation process, replacing `/path/to/downloaded/file.pdf` with the path to the actual downloaded PDF file.

```bash
ghostscript -sDEVICE=png16m -dPDFFitPage \
  -dTextAlphaBits=4 -dGraphicsAlphaBits=4 -sOutputFile=test.png \
  -dFirstPage=1 -dLastPage=1 -dBATCH -dNOPAUSE -r300 -dDEVICEWIDTH=1000 \
  /path/to/downloaded/file.pdf
```

The letters are no longer hollow when you remove the `-dPDFFitPage` flag, which indicates that the re-scaling of the documents is what introduces the hollow lettering. However, there is some dithering, so you have to increase the resolution to 600 DPI for the letters to look almost as solid as they do when using PDF Box.

### Open questions

From "PDF switches" in the [How to use Ghostscript](https://www.ghostscript.com/doc/current/Use.htm#PDF_switches), the problematic `dPDFFitPage` option is used to ensure that all the pages in the preview have a uniform size that matches the device.

> `-dPDFFitPage`
> Rather than selecting a PageSize given by the PDF MediaBox, BleedBox (see -dUseBleedBox), TrimBox (see -dUseTrimBox), ArtBox (see -dUseArtBox), or CropBox (see -dUseCropBox), the PDF file will be scaled to fit the current device page size (usually the default page size).
> This is useful for creating fixed size images of PDF files that may have a variety of page sizes, for example thumbnail images.
>
> This option is also set by the `-dFitPage` option.

Is there some `ghostscript` configuration that we can set in order to preserve this kind of functionality while also avoiding the hollow lettering issue?

### Other solutions

The actual customer issue is that they are running the Liferay Docker image, which has both ghostscript and imagemagick installed, and Liferay does not provide a way to disable the faulty ghostscript PDF conversion without also disabling the functional image conversions.

Another potential solution would be to provide a different flag for disabling ghostscript, and use that functionality in order to disable ghostscript in the customer environment.