### PR TITLE
LPS-151510

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-image-api/bnd.bnd
+++ b/modules/apps/adaptive-media/adaptive-media-image-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Adaptive Media Image API
 Bundle-SymbolicName: com.liferay.adaptive.media.image.api
-Bundle-Version: 6.0.1
+Bundle-Version: 6.1.0
 Export-Package:\
 	com.liferay.adaptive.media.image.configuration,\
 	com.liferay.adaptive.media.image.constants,\

--- a/modules/apps/adaptive-media/adaptive-media-image-api/src/main/java/com/liferay/adaptive/media/image/scaler/AMImageScaledImage.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-api/src/main/java/com/liferay/adaptive/media/image/scaler/AMImageScaledImage.java
@@ -41,6 +41,13 @@ public interface AMImageScaledImage {
 	public InputStream getInputStream();
 
 	/**
+	 * Returns this image's mime type
+	 *
+	 * @return this image's mime type
+	 */
+	public String getMimeType();
+
+	/**
 	 * Returns this image's size in bytes.
 	 *
 	 * @return this image's size in bytes

--- a/modules/apps/adaptive-media/adaptive-media-image-api/src/main/java/com/liferay/adaptive/media/image/scaler/AMImageScaledImage.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-api/src/main/java/com/liferay/adaptive/media/image/scaler/AMImageScaledImage.java
@@ -16,11 +16,14 @@ package com.liferay.adaptive.media.image.scaler;
 
 import java.io.InputStream;
 
+import org.osgi.annotation.versioning.ProviderType;
+
 /**
  * Represents an image scaled by Adaptive Media.
  *
  * @author Sergio González
  */
+@ProviderType
 public interface AMImageScaledImage {
 
 	/**

--- a/modules/apps/adaptive-media/adaptive-media-image-api/src/main/resources/com/liferay/adaptive/media/image/scaler/packageinfo
+++ b/modules/apps/adaptive-media/adaptive-media-image-api/src/main/resources/com/liferay/adaptive/media/image/scaler/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/processor/AMImageProcessorImpl.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/processor/AMImageProcessorImpl.java
@@ -28,6 +28,8 @@ import com.liferay.adaptive.media.processor.AMProcessor;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.FileVersion;
+import com.liferay.portal.kernel.repository.model.FileVersionWrapper;
+import com.liferay.portal.kernel.util.ContentTypes;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -122,7 +124,8 @@ public final class AMImageProcessorImpl implements AMImageProcessor {
 					amImageScaledImage.getInputStream()) {
 
 				_amImageEntryLocalService.addAMImageEntry(
-					amImageConfigurationEntry, fileVersion,
+					amImageConfigurationEntry,
+					_getScaledFileVersion(fileVersion, amImageScaledImage),
 					amImageScaledImage.getHeight(),
 					amImageScaledImage.getWidth(), inputStream,
 					amImageScaledImage.getSize());
@@ -131,6 +134,29 @@ public final class AMImageProcessorImpl implements AMImageProcessor {
 		catch (IOException ioException) {
 			throw new AMRuntimeException.IOException(ioException);
 		}
+	}
+
+	private FileVersion _getScaledFileVersion(
+		FileVersion fileVersion, AMImageScaledImage amImageScaledImage) {
+
+		String amImageScaledImageMimeType = amImageScaledImage.getMimeType();
+
+		if ((amImageScaledImageMimeType == null) ||
+			!amImageScaledImageMimeType.equals(fileVersion.getMimeType()) ||
+			amImageScaledImageMimeType.equals(
+				ContentTypes.APPLICATION_OCTET_STREAM)) {
+
+			return fileVersion;
+		}
+
+		return new FileVersionWrapper(fileVersion) {
+
+			@Override
+			public String getMimeType() {
+				return amImageScaledImageMimeType;
+			}
+
+		};
 	}
 
 	private boolean _isUpdateImageEntry(

--- a/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/scaler/AMDefaultImageScaler.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/scaler/AMDefaultImageScaler.java
@@ -64,8 +64,8 @@ public class AMDefaultImageScaler implements AMImageScaler {
 			return new AMImageScaledImageImpl(
 				RenderedImageUtil.getRenderedImageContentStream(
 					scaledRenderedImage, fileVersion.getMimeType()),
-				scaledRenderedImage.getHeight(),
-				scaledRenderedImage.getWidth());
+				scaledRenderedImage.getHeight(), scaledRenderedImage.getWidth(),
+				fileVersion.getMimeType());
 		}
 		catch (AMRuntimeException.IOException | PortalException exception) {
 			throw new AMRuntimeException.IOException(

--- a/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/scaler/AMGIFImageScaler.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/scaler/AMGIFImageScaler.java
@@ -86,7 +86,8 @@ public class AMGIFImageScaler implements AMImageScaler {
 			Tuple<Integer, Integer> dimension = _getDimension(bytes);
 
 			return new AMImageScaledImageImpl(
-				bytes, dimension.second, dimension.first);
+				bytes, dimension.second, dimension.first,
+				fileVersion.getMimeType());
 		}
 		catch (ExecutionException | InterruptedException | IOException |
 			   PortalException | ProcessException exception) {

--- a/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/scaler/AMImageMagickImageScaler.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/scaler/AMImageMagickImageScaler.java
@@ -1,0 +1,161 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.adaptive.media.image.internal.scaler;
+
+import com.liferay.adaptive.media.exception.AMRuntimeException;
+import com.liferay.adaptive.media.image.configuration.AMImageConfigurationEntry;
+import com.liferay.adaptive.media.image.scaler.AMImageScaledImage;
+import com.liferay.adaptive.media.image.scaler.AMImageScaler;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.image.ImageBag;
+import com.liferay.portal.kernel.image.ImageMagick;
+import com.liferay.portal.kernel.image.ImageTool;
+import com.liferay.portal.kernel.repository.model.FileVersion;
+import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+
+import java.awt.image.RenderedImage;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Future;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Eric Yan
+ */
+@Component(
+	immediate = true, property = "mime.type=image/heic",
+	service = AMImageScaler.class
+)
+public class AMImageMagickImageScaler implements AMImageScaler {
+
+	@Override
+	public boolean isEnabled() {
+		if (_imageMagick.isEnabled()) {
+			return true;
+		}
+
+		return false;
+	}
+
+	@Override
+	public AMImageScaledImage scaleImage(
+		FileVersion fileVersion,
+		AMImageConfigurationEntry amImageConfigurationEntry) {
+
+		File imageFile = null;
+		File scaledImageFile = null;
+
+		try {
+			imageFile = _getFile(fileVersion);
+
+			scaledImageFile = _scaleAndConvertToPNG(
+				imageFile, amImageConfigurationEntry);
+
+			ImageBag imageBag = _imageTool.read(scaledImageFile);
+
+			RenderedImage renderedImage = imageBag.getRenderedImage();
+
+			return new AMImageScaledImageImpl(
+				_imageTool.getBytes(renderedImage, imageBag.getType()),
+				renderedImage.getHeight(), renderedImage.getWidth(),
+				ContentTypes.IMAGE_PNG);
+		}
+		catch (Exception exception) {
+			throw new AMRuntimeException.IOException(
+				StringBundler.concat(
+					"Unable to scale file entry ", fileVersion.getFileEntryId(),
+					" to match adaptive media configuration ",
+					amImageConfigurationEntry.getUUID()),
+				exception);
+		}
+		finally {
+			if (imageFile != null) {
+				imageFile.delete();
+			}
+
+			if (scaledImageFile != null) {
+				scaledImageFile.delete();
+			}
+		}
+	}
+
+	private File _getFile(FileVersion fileVersion)
+		throws IOException, PortalException {
+
+		try (InputStream inputStream = fileVersion.getContentStream(false)) {
+			return FileUtil.createTempFile(inputStream);
+		}
+	}
+
+	private String _getResizeArg(
+		AMImageConfigurationEntry amImageConfigurationEntry) {
+
+		Map<String, String> properties =
+			amImageConfigurationEntry.getProperties();
+
+		int maxHeight = GetterUtil.getInteger(properties.get("max-height"));
+		int maxWidth = GetterUtil.getInteger(properties.get("max-width"));
+
+		if ((maxHeight > 0) && (maxWidth > 0)) {
+			return StringBundler.concat(maxWidth, "x", maxHeight, ">");
+		}
+
+		return null;
+	}
+
+	private File _scaleAndConvertToPNG(
+			File imageFile, AMImageConfigurationEntry amImageConfigurationEntry)
+		throws Exception {
+
+		File scaledImageFile = FileUtil.createTempFile(ImageTool.TYPE_PNG);
+
+		List<String> arguments = new ArrayList<>();
+
+		arguments.add(imageFile.getAbsolutePath());
+
+		String resizeArg = _getResizeArg(amImageConfigurationEntry);
+
+		if (resizeArg != null) {
+			arguments.add("-resize");
+			arguments.add(resizeArg);
+		}
+
+		arguments.add(scaledImageFile.getAbsolutePath());
+
+		Future<?> future = _imageMagick.convert(arguments);
+
+		future.get();
+
+		return scaledImageFile;
+	}
+
+	@Reference
+	private ImageMagick _imageMagick;
+
+	@Reference
+	private ImageTool _imageTool;
+
+}

--- a/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/scaler/AMImageScaledImageImpl.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/scaler/AMImageScaledImageImpl.java
@@ -28,6 +28,17 @@ public class AMImageScaledImageImpl implements AMImageScaledImage {
 		_bytes = bytes;
 		_height = height;
 		_width = width;
+
+		_mimeType = null;
+	}
+
+	public AMImageScaledImageImpl(
+		byte[] bytes, int height, int width, String mimeType) {
+
+		_bytes = bytes;
+		_height = height;
+		_width = width;
+		_mimeType = mimeType;
 	}
 
 	@Override
@@ -38,6 +49,11 @@ public class AMImageScaledImageImpl implements AMImageScaledImage {
 	@Override
 	public InputStream getInputStream() {
 		return new UnsyncByteArrayInputStream(_bytes);
+	}
+
+	@Override
+	public String getMimeType() {
+		return _mimeType;
 	}
 
 	@Override
@@ -52,6 +68,7 @@ public class AMImageScaledImageImpl implements AMImageScaledImage {
 
 	private final byte[] _bytes;
 	private final int _height;
+	private final String _mimeType;
 	private final int _width;
 
 }

--- a/modules/apps/adaptive-media/adaptive-media-image-impl/src/test/java/com/liferay/adaptive/media/image/internal/processor/AMImageProcessorImplTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-impl/src/test/java/com/liferay/adaptive/media/image/internal/processor/AMImageProcessorImplTest.java
@@ -284,7 +284,7 @@ public class AMImageProcessorImplTest {
 				Mockito.any(FileVersion.class),
 				Mockito.any(AMImageConfigurationEntry.class))
 		).thenReturn(
-			new AMImageScaledImageImpl(new byte[100], 100, 100)
+			new AMImageScaledImageImpl(new byte[100], 100, 100, null)
 		);
 
 		_amImageProcessorImpl.process(
@@ -354,7 +354,7 @@ public class AMImageProcessorImplTest {
 				Mockito.any(FileVersion.class),
 				Mockito.any(AMImageConfigurationEntry.class))
 		).thenReturn(
-			new AMImageScaledImageImpl(new byte[100], 100, 100)
+			new AMImageScaledImageImpl(new byte[100], 100, 100, null)
 		);
 
 		_amImageProcessorImpl.process(
@@ -505,7 +505,7 @@ public class AMImageProcessorImplTest {
 		Mockito.when(
 			_amImageScaler.scaleImage(_fileVersion, amImageConfigurationEntry)
 		).thenReturn(
-			new AMImageScaledImageImpl(new byte[100], 150, 200)
+			new AMImageScaledImageImpl(new byte[100], 150, 200, null)
 		);
 
 		Mockito.doThrow(
@@ -557,7 +557,7 @@ public class AMImageProcessorImplTest {
 		Mockito.when(
 			_amImageScaler.scaleImage(_fileVersion, amImageConfigurationEntry)
 		).thenReturn(
-			new AMImageScaledImageImpl(new byte[100], 150, 200)
+			new AMImageScaledImageImpl(new byte[100], 150, 200, null)
 		);
 
 		_amImageProcessorImpl.process(_fileVersion);
@@ -676,7 +676,7 @@ public class AMImageProcessorImplTest {
 		Mockito.when(
 			_amImageScaler.scaleImage(_fileVersion, amImageConfigurationEntry)
 		).thenReturn(
-			new AMImageScaledImageImpl(new byte[100], 150, 200)
+			new AMImageScaledImageImpl(new byte[100], 150, 200, null)
 		);
 
 		Mockito.doThrow(


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-151510
https://issues.liferay.com/browse/PTR-2987

/cc @robertoDiaz 

### Related pull requests

In https://github.com/liferay-lima/liferay-portal/pull/2977, the reviewer recommended that we add getMimeType to AMImageScaledImage instead of creating a new interface for master.

I switched it to a ProviderType so that the changes could be backported without making it a unique fix, and to allow for any potential future changes to the same interface to not encounter baseline and versioning issues.

From @ericyanLr :
> As discussed, this PR adds support for HEIC images to generate previews/thumbnails for Adaptive Media when ImageMagick (with HEIC support) is setup and enabled.

https://github.com/holatuwol/liferay-portal/pull/258
https://github.com/holatuwol/liferay-portal/pull/259

### Solution notes

The solution on https://github.com/holatuwol/liferay-portal/pull/258 modified the `AMImageScaledImage` interface to add the `getMimeType` method, which (due to being a `ConsumerType` interface) resulted in a major version change when running baseline, which we would not be able to backport to earlier branches. The solution on https://github.com/holatuwol/liferay-portal/pull/259 avoids the major version change by extracting the mime type again from the InputStream.

This pull request adapts the solution in https://github.com/holatuwol/liferay-portal/pull/258 with a new interface, `AMImageConvertedImage`, as an indicator that the image might have been converted and thus can have a different mime type from the original FileVersion. The value is then read by the underlying service, and the correct mime type is persisted, without requiring a major version change.

### Other alternative solutions

Other alternatives that were explored:

* Using the solution in https://github.com/holatuwol/liferay-portal/pull/258 but updating the existing `AMImageScaledImage` to be a `ProviderType`. This resolves the issue, but switching between the two service types is risky, because it breaks the existing API contract.

* Automatically converting images so that RenderedImage is only null when a conversion is not possible. While this addresses the issue, it also changes the API contract, where the returned ImageBag may have a different content type than the file that was passed in rather than returning null.

If there is a solution you believe we should implement, please let us know.