### PR TITLE
[TS] LPS-153234 If categoryIds is empty in isMissingRequiredCategory return false

### DIFF
--- a/portal-impl/src/com/liferay/portlet/asset/model/impl/AssetVocabularyImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/model/impl/AssetVocabularyImpl.java
@@ -170,7 +170,9 @@ public class AssetVocabularyImpl extends AssetVocabularyBaseImpl {
 	public boolean isMissingRequiredCategory(
 		long classNameId, long classTypePK, long[] categoryIds) {
 
-		if (!isRequired(classNameId, classTypePK)) {
+		if (!isRequired(classNameId, classTypePK) ||
+			ArrayUtil.isEmpty(categoryIds)) {
+
 			return false;
 		}
 


### PR DESCRIPTION
Hi Team,

https://issues.liferay.com/browse/LPS-153234

**Issue**:
Draft saving fails in Blogs widget when adding a "New entry" if we have a vocabulary with associated asset type "Blogs Entry" set to "Required".
With every draft saving we run isMissingRequiredCategory() which fails, because the "categoryIds" array is empty and we try to check the contents of it.
I checked whether categoryIds should be empty or not: it comes from ServiceContext.getAssetCategoryIds() which is always empty in this scenario.

![image](https://user-images.githubusercontent.com/97447507/167630985-d0d54e6e-32c2-408c-9d34-e09fbbe24e4b.png)


**Solution**:
I added a validation in isMissingRequiredCategory to check if long[] categoryIds is empty. If it's empty we return with false. The draft saving is succeful.

![image](https://user-images.githubusercontent.com/97447507/167629183-b97f1bea-c75c-437b-9072-91210973cfe2.png)


Could you please review it?
Thank you!