### PR TITLE
[TS] LPS-153234 Move publishButton disabling at draft saving

### DIFF
--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/js/blogs.js
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/js/blogs.js
@@ -471,12 +471,13 @@ export default class Blogs {
 					})
 					.catch(() => {
 						this._updateStatus(strings.saveDraftError);
+					})
+					.finally(() => {
+						Liferay.Util.toggleDisabled(
+							this._getElementById('publishButton'),
+							false
+						);
 					});
-
-				Liferay.Util.toggleDisabled(
-					this._getElementById('publishButton'),
-					false
-				);
 			}
 		}
 		else {

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/js/blogs.js
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/js/blogs.js
@@ -468,15 +468,15 @@ export default class Blogs {
 							saveStatus.classList.add('hide');
 							saveStatus.hidden = true;
 						}
-
-						Liferay.Util.toggleDisabled(
-							this._getElementById('publishButton'),
-							false
-						);
 					})
 					.catch(() => {
 						this._updateStatus(strings.saveDraftError);
 					});
+
+				Liferay.Util.toggleDisabled(
+					this._getElementById('publishButton'),
+					false
+				);
 			}
 		}
 		else {


### PR DESCRIPTION
Hi Team,

https://issues.liferay.com/browse/LPS-153234

Previous discarded PR: https://github.com/liferay-lima/liferay-portal/pull/3030

Issue:
 "Publish Button" becomes disabled in Blogs widget when adding a "New entry" if we have a vocabulary with associated asset type "Blogs Entry" set to "Required" whether we choose a required category or not.
 
 
![image](https://user-images.githubusercontent.com/97447507/168229720-af5c060c-f8da-4241-89c2-529b285a2d4e.png)
---------------
![image](https://user-images.githubusercontent.com/97447507/168229793-95d72e49-968c-494e-a077-fe154eb7d366.png)


Solution:
I discussed this issue and the previous PR, and upon debugging the code, we discovered that the frontend request does not actually send the filled "categoryIds" value during **automatic** draft saving. So after draft saving the required category stays empty (we concluded that this is another issue and needs an LPS ticket [LPS-153629](https://issues.liferay.com/browse/LPS-153629)). That is why "categoryIds" is always empty in isMissingRequiredCategory() when saving draft, so the validation will always fail (and the Publish button won't turn enabled even after selecting category).
The solution for this issue now is to move the "publishButton" disabling after the validations/draft saving process to prevent unnecessary disabling, because the publish process (and the "Save as draft" process) will check the required categories, but unlike the automatic draft saving, publish (and "Save as draft") will save the required category too. (and with the other LPS, the root cause will be solved)

Please review my PR!

Best regards,
Évi  

