### PR TITLE
LPS-153891 partial revert from LPS-147681 Add javax.portlet.version=3.0

### DIFF
--- a/modules/apps/reading-time/reading-time-web/src/main/java/com/liferay/reading/time/web/internal/portlet/ReadingTimePortlet.java
+++ b/modules/apps/reading-time/reading-time-web/src/main/java/com/liferay/reading/time/web/internal/portlet/ReadingTimePortlet.java
@@ -42,8 +42,7 @@ import org.osgi.service.component.annotations.Component;
 		"javax.portlet.init-param.template-path=/META-INF/resources/",
 		"javax.portlet.name=" + ReadingTimePortletKeys.READING_TIME,
 		"javax.portlet.resource-bundle=content.Language",
-		"javax.portlet.security-role-ref=guest,power-user,user",
-		"javax.portlet.version=3.0"
+		"javax.portlet.security-role-ref=guest,power-user,user"
 	},
 	service = Portlet.class
 )


### PR DESCRIPTION
The changes on the reading time is making to fail the Blogs Entry portlet.
