### PR TITLE
[TS] LPS-153629 Add assetCategoryIds to automatic draft saving request

### DIFF
--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/js/blogs.js
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/js/blogs.js
@@ -270,6 +270,22 @@ export default class Blogs {
 		return document.getElementById(`${this._config.namespace}${id}`);
 	}
 
+	_getValuesByName(name) {
+		const nodes = document.querySelectorAll(
+			`input[name*=${this._config.namespace + name}]`
+		);
+
+		const values = [];
+
+		for (let i = 0; i < nodes.length; i++) {
+			const input = nodes[i].value;
+
+			values.push(input);
+		}
+
+		return values;
+	}
+
 	_getTempImages() {
 		return this._rootNode.querySelectorAll('img[data-random-id]');
 	}
@@ -359,13 +375,14 @@ export default class Blogs {
 				const allowPingbacks = this._getElementById('allowPingbacks');
 				const allowTrackbacks = this._getElementById('allowTrackbacks');
 
-				const assetTagNames = this._getElementById('assetTagNames');
-
 				const bodyData = addNamespace(
 					{
 						allowPingbacks: allowPingbacks?.value,
 						allowTrackbacks: allowTrackbacks?.value,
-						assetTagNames: assetTagNames?.value || '',
+						assetCategoryIds: this._getValuesByName(
+							'assetCategoryIds'
+						),
+						assetTagNames: this._getValuesByName('assetTagNames'),
 						cmd: constants.ADD,
 						content,
 						coverImageCaption,


### PR DESCRIPTION
Hi Team,

https://issues.liferay.com/browse/LPS-153629

Issue:
The frontend request does not send the selected categories ("assetCategoryIds") during automatic draft saving. Upon debugging I found the same case for "assetTagnames". That means that these values are not saved during automatic draft saving.

Solution:

I added the missing parameters to the frontend request, so now the values are saved after automatic draft saving.

Please review my PR!

Best regards,
Évi