### PR TITLE
LPS-147681 generate portlet url with the portletId when portletname and portletid are not the same

### DIFF
--- a/modules/apps/reading-time/reading-time-web/src/main/java/com/liferay/reading/time/web/internal/portlet/ReadingTimePortlet.java
+++ b/modules/apps/reading-time/reading-time-web/src/main/java/com/liferay/reading/time/web/internal/portlet/ReadingTimePortlet.java
@@ -42,7 +42,8 @@ import org.osgi.service.component.annotations.Component;
 		"javax.portlet.init-param.template-path=/META-INF/resources/",
 		"javax.portlet.name=" + ReadingTimePortletKeys.READING_TIME,
 		"javax.portlet.resource-bundle=content.Language",
-		"javax.portlet.security-role-ref=guest,power-user,user"
+		"javax.portlet.security-role-ref=guest,power-user,user",
+		"javax.portlet.version=3.0"
 	},
 	service = Portlet.class
 )

--- a/portal-impl/src/com/liferay/portlet/internal/LiferayPortletURLPrivilegedAction.java
+++ b/portal-impl/src/com/liferay/portlet/internal/LiferayPortletURLPrivilegedAction.java
@@ -139,7 +139,7 @@ public class LiferayPortletURLPrivilegedAction {
 			}
 			else {
 				portletURL = PortletURLFactoryUtil.create(
-					_portletRequest, _portletName, plid, _lifecycle, _copy);
+					_portletRequest, portletId, plid, _lifecycle, _copy);
 			}
 		}
 


### PR DESCRIPTION
- LPS-147681 pass the portletId to the creation of the portlet url instead of the portletName
- LPS-147681 Add javax.portlet.version=3.0 to ReadingTimePortlet
