### PR TITLE
LPS-153629 Get all categories while automatic draft saving request

### DIFF
--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/js/blogs.js
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/js/blogs.js
@@ -272,7 +272,7 @@ export default class Blogs {
 
 	_getValuesByName(name) {
 		const nodes = document.querySelectorAll(
-			`input[name=${this._config.namespace + name}]`
+			`input[name^=${this._config.namespace}${name}]`
 		);
 
 		return [...nodes].map((node) => node.value);


### PR DESCRIPTION
Previous pull https://github.com/liferay-lima/liferay-portal/pull/3055

> Hi @ambrinchaudhary,
> I reviewed your changes and this line:
> input[name=${this._config.namespace + name}]
> must contain the *.
> like this:
> input[name*=${this._config.namespace + name}]
> 
> I understand it can seem like it is unnecessary, but the name that we search looks something like this:
> '_com_liferay_blogs_web_portlet_BlogsAdminPortlet_assetCategoryIds_40437'
> the last part (40437) being the unique id of the vocabulary.
> I used the * to search
> '_com_liferay_blogs_web_portlet_BlogsAdminPortlet_assetCategoryIds
> This returns the required nodes regardless the id.
> 
> This method returns a collection. If the user chooses multiple categories that is how it needs to be forwarded to backend.