### PR TITLE
LPS-149694 Create placeholder view for DM size limit settings

### DIFF
--- a/modules/apps/document-library/document-library-web/build.gradle
+++ b/modules/apps/document-library/document-library-web/build.gradle
@@ -21,6 +21,7 @@ dependencies {
 	compileOnly project(":apps:bulk:bulk-selection-api")
 	compileOnly project(":apps:change-tracking:change-tracking-spi")
 	compileOnly project(":apps:comment:comment-taglib")
+	compileOnly project(":apps:configuration-admin:configuration-admin-api")
 	compileOnly project(":apps:data-engine:data-engine-api")
 	compileOnly project(":apps:data-engine:data-engine-rest-api")
 	compileOnly project(":apps:data-engine:data-engine-taglib")

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portal/settings/configuration/admin/display/DLSizeLimitConfigurationScreen.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portal/settings/configuration/admin/display/DLSizeLimitConfigurationScreen.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.document.library.web.internal.portal.settings.configuration.admin.display;
+
+import com.liferay.configuration.admin.display.ConfigurationScreen;
+import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
+import com.liferay.portal.kernel.language.LanguageUtil;
+
+import java.io.IOException;
+
+import java.util.Locale;
+
+import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Adolfo Pérez
+ */
+@Component(service = ConfigurationScreen.class)
+public class DLSizeLimitConfigurationScreen implements ConfigurationScreen {
+
+	@Override
+	public String getCategoryKey() {
+		return "documents-and-media";
+	}
+
+	@Override
+	public String getKey() {
+		return "dl-size-limit-configuration";
+	}
+
+	@Override
+	public String getName(Locale locale) {
+		return LanguageUtil.get(locale, "dl-size-limit-configuration-name");
+	}
+
+	@Override
+	public String getScope() {
+		return ExtendedObjectClassDefinition.Scope.GROUP.getValue();
+	}
+
+	@Override
+	public void render(
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse)
+		throws IOException {
+
+		try {
+			RequestDispatcher requestDispatcher =
+				_servletContext.getRequestDispatcher(
+					"/document_library_settings/size_limit.jsp");
+
+			requestDispatcher.include(httpServletRequest, httpServletResponse);
+		}
+		catch (Exception exception) {
+			throw new IOException("Unable to render size_limit.jsp", exception);
+		}
+	}
+
+	@Reference(
+		target = "(osgi.web.symbolicname=com.liferay.document.library.web)"
+	)
+	private ServletContext _servletContext;
+
+}

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library_settings/size_limit.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library_settings/size_limit.jsp
@@ -1,0 +1,15 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library_settings/size_limit.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library_settings/size_limit.jsp
@@ -13,3 +13,26 @@
  * details.
  */
 --%>
+
+<%@ include file="/document_library/init.jsp" %>
+
+<clay:sheet>
+	<clay:sheet-header>
+		<h2>
+			<liferay-ui:message key="dl-size-limit-configuration-name" />
+		</h2>
+	</clay:sheet-header>
+
+	<clay:sheet-section>
+		<span aria-hidden="true" class="loading-animation"></span>
+
+		<react:component
+			module="document_library/js/file-size-limit/FileSizeMimetypes"
+			props='<%=
+				HashMapBuilder.<String, Object>put(
+					"portletNamespace", liferayPortletResponse.getNamespace()
+				).build()
+			%>'
+		/>
+	</clay:sheet-section>
+</clay:sheet>


### PR DESCRIPTION
@ambrinchaudhary @boton Here I've created an empty JSP and wired it so that is shows up in site settings. Note that there will be 2 "Size Limit Configurations" available: the autogenerated one and the placeholder. This is intentional, to make it easier to compare both views. I'll remove the default one later.