### PR TITLE
LPS-154333 Hide wiki tree html

### DIFF
--- a/modules/apps/wiki/wiki-navigation-web/src/main/resources/META-INF/resources/tree_menu/view.jsp
+++ b/modules/apps/wiki/wiki-navigation-web/src/main/resources/META-INF/resources/tree_menu/view.jsp
@@ -35,6 +35,8 @@ List<MenuItem> menuItems = MenuItem.fromWikiNode(selNodeId, depth, viewURL);
 		<aui:script use="aui-tree-view">
 			var wikiPageList = A.one('.wiki-navigation-portlet-tree-menu .tree-menu');
 
+			wikiPageList.removeAttribute('hidden');
+
 			var treeView = new A.TreeView({
 				contentBox: wikiPageList,
 			}).render();
@@ -64,7 +66,7 @@ private String _buildTreeMenuHTML(List<MenuItem> menuItems, String curTitle, boo
 	StringBuilder sb = new StringBuilder();
 
 	if (isRoot) {
-		sb.append("<ul class=\"tree-menu\">");
+		sb.append("<ul class=\"tree-menu\" hidden>");
 	}
 
 	for (MenuItem menuItem : menuItems) {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-154333

When the wiki tree pages are being displayed, the tree is seen in html and then changes to alloy-ui elements. This can be seen when clicking on pages in the tree or refreshing the page.

https://user-images.githubusercontent.com/31672551/170383584-d28b72af-c1af-43f0-8226-4962e31193a8.mov

A solution for this is to hide the tree so this change is not seen by adding the hidden attribute to the tree. Alloy-ui will still be able to change the tree and once it is fully built, we remove the hidden attribute.

If there are any questions or comments about this please let me know.
Thank you.
