### PR TITLE
LPS-154705 Upload Fragment Image -- Cannot Edit Image and Save

### DIFF
--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/upload/FragmentCollectionResourceUploadFileEntryHandler.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/upload/FragmentCollectionResourceUploadFileEntryHandler.java
@@ -14,22 +14,16 @@
 
 package com.liferay.fragment.web.internal.upload;
 
+import com.liferay.document.library.kernel.service.DLAppService;
 import com.liferay.fragment.constants.FragmentActionKeys;
 import com.liferay.fragment.constants.FragmentConstants;
-import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.resource.PortletResourcePermission;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.upload.UploadPortletRequest;
-import com.liferay.portal.kernel.util.TempFileEntryUtil;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.upload.ImageEditorUploadHandler;
 import com.liferay.upload.UniqueFileNameProvider;
-import com.liferay.upload.UploadFileEntryHandler;
-
-import java.io.IOException;
-import java.io.InputStream;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -42,11 +36,11 @@ import org.osgi.service.component.annotations.Reference;
 	service = FragmentCollectionResourceUploadFileEntryHandler.class
 )
 public class FragmentCollectionResourceUploadFileEntryHandler
-	implements UploadFileEntryHandler {
+	extends ImageEditorUploadHandler {
 
 	@Override
-	public FileEntry upload(UploadPortletRequest uploadPortletRequest)
-		throws IOException, PortalException {
+	protected void checkPermissions(UploadPortletRequest uploadPortletRequest)
+		throws PrincipalException {
 
 		ThemeDisplay themeDisplay =
 			(ThemeDisplay)uploadPortletRequest.getAttribute(
@@ -55,51 +49,25 @@ public class FragmentCollectionResourceUploadFileEntryHandler
 		_portletResourcePermission.check(
 			themeDisplay.getPermissionChecker(), themeDisplay.getScopeGroup(),
 			FragmentActionKeys.MANAGE_FRAGMENT_ENTRIES);
-
-		String fileName = uploadPortletRequest.getFileName(_PARAMETER_NAME);
-		String contentType = uploadPortletRequest.getContentType(
-			_PARAMETER_NAME);
-
-		try (InputStream inputStream = uploadPortletRequest.getFileAsStream(
-				_PARAMETER_NAME)) {
-
-			String uniqueFileName = _uniqueFileNameProvider.provide(
-				fileName, curFileName -> _exists(themeDisplay, curFileName));
-
-			return TempFileEntryUtil.addTempFileEntry(
-				themeDisplay.getScopeGroupId(), themeDisplay.getUserId(),
-				_TEMP_FOLDER_NAME, uniqueFileName, inputStream, contentType);
-		}
 	}
 
-	private boolean _exists(ThemeDisplay themeDisplay, String curFileName) {
-		try {
-			FileEntry tempFileEntry = TempFileEntryUtil.getTempFileEntry(
-				themeDisplay.getScopeGroupId(), themeDisplay.getUserId(),
-				_TEMP_FOLDER_NAME, curFileName);
-
-			if (tempFileEntry != null) {
-				return true;
-			}
-
-			return false;
-		}
-		catch (PortalException portalException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(portalException);
-			}
-
-			return false;
-		}
+	@Override
+	protected DLAppService getDLAppService() {
+		return _dlAppService;
 	}
 
-	private static final String _PARAMETER_NAME = "imageSelectorFileName";
+	@Override
+	protected String getFolderName() {
+		return FragmentCollectionResourceUploadFileEntryHandler.class.getName();
+	}
 
-	private static final String _TEMP_FOLDER_NAME =
-		FragmentCollectionResourceUploadFileEntryHandler.class.getName();
+	@Override
+	protected UniqueFileNameProvider getUniqueFileNameProvider() {
+		return _uniqueFileNameProvider;
+	}
 
-	private static final Log _log = LogFactoryUtil.getLog(
-		FragmentCollectionResourceUploadFileEntryHandler.class);
+	@Reference
+	private DLAppService _dlAppService;
 
 	@Reference(
 		target = "(resource.name=" + FragmentConstants.RESOURCE_NAME + ")"

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/upload/FragmentCollectionResourceUploadFileEntryHandler.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/upload/FragmentCollectionResourceUploadFileEntryHandler.java
@@ -22,7 +22,7 @@ import com.liferay.portal.kernel.security.permission.resource.PortletResourcePer
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.upload.UploadPortletRequest;
 import com.liferay.portal.kernel.util.WebKeys;
-import com.liferay.upload.ImageEditorUploadHandler;
+import com.liferay.upload.BaseImageEditorUploadHandler;
 import com.liferay.upload.UniqueFileNameProvider;
 
 import org.osgi.service.component.annotations.Component;
@@ -36,7 +36,7 @@ import org.osgi.service.component.annotations.Reference;
 	service = FragmentCollectionResourceUploadFileEntryHandler.class
 )
 public class FragmentCollectionResourceUploadFileEntryHandler
-	extends ImageEditorUploadHandler {
+	extends BaseImageEditorUploadHandler {
 
 	@Override
 	protected void checkPermissions(UploadPortletRequest uploadPortletRequest)

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/upload/FragmentEntryPreviewUploadFileEntryHandler.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/upload/FragmentEntryPreviewUploadFileEntryHandler.java
@@ -14,22 +14,16 @@
 
 package com.liferay.fragment.web.internal.upload;
 
+import com.liferay.document.library.kernel.service.DLAppService;
 import com.liferay.fragment.constants.FragmentActionKeys;
 import com.liferay.fragment.constants.FragmentConstants;
-import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.resource.PortletResourcePermission;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.upload.UploadPortletRequest;
-import com.liferay.portal.kernel.util.TempFileEntryUtil;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.upload.ImageEditorUploadHandler;
 import com.liferay.upload.UniqueFileNameProvider;
-import com.liferay.upload.UploadFileEntryHandler;
-
-import java.io.IOException;
-import java.io.InputStream;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -41,11 +35,11 @@ import org.osgi.service.component.annotations.Reference;
 	immediate = true, service = FragmentEntryPreviewUploadFileEntryHandler.class
 )
 public class FragmentEntryPreviewUploadFileEntryHandler
-	implements UploadFileEntryHandler {
+	extends ImageEditorUploadHandler {
 
 	@Override
-	public FileEntry upload(UploadPortletRequest uploadPortletRequest)
-		throws IOException, PortalException {
+	protected void checkPermissions(UploadPortletRequest uploadPortletRequest)
+		throws PrincipalException {
 
 		ThemeDisplay themeDisplay =
 			(ThemeDisplay)uploadPortletRequest.getAttribute(
@@ -54,51 +48,25 @@ public class FragmentEntryPreviewUploadFileEntryHandler
 		_portletResourcePermission.check(
 			themeDisplay.getPermissionChecker(), themeDisplay.getScopeGroup(),
 			FragmentActionKeys.MANAGE_FRAGMENT_ENTRIES);
-
-		String fileName = uploadPortletRequest.getFileName(_PARAMETER_NAME);
-		String contentType = uploadPortletRequest.getContentType(
-			_PARAMETER_NAME);
-
-		try (InputStream inputStream = uploadPortletRequest.getFileAsStream(
-				_PARAMETER_NAME)) {
-
-			String uniqueFileName = _uniqueFileNameProvider.provide(
-				fileName, curFileName -> _exists(themeDisplay, curFileName));
-
-			return TempFileEntryUtil.addTempFileEntry(
-				themeDisplay.getScopeGroupId(), themeDisplay.getUserId(),
-				_TEMP_FOLDER_NAME, uniqueFileName, inputStream, contentType);
-		}
 	}
 
-	private boolean _exists(ThemeDisplay themeDisplay, String curFileName) {
-		try {
-			FileEntry tempFileEntry = TempFileEntryUtil.getTempFileEntry(
-				themeDisplay.getScopeGroupId(), themeDisplay.getUserId(),
-				_TEMP_FOLDER_NAME, curFileName);
-
-			if (tempFileEntry != null) {
-				return true;
-			}
-
-			return false;
-		}
-		catch (PortalException portalException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(portalException);
-			}
-
-			return false;
-		}
+	@Override
+	protected DLAppService getDLAppService() {
+		return _dlAppService;
 	}
 
-	private static final String _PARAMETER_NAME = "imageSelectorFileName";
+	@Override
+	protected String getFolderName() {
+		return FragmentEntryPreviewUploadFileEntryHandler.class.getName();
+	}
 
-	private static final String _TEMP_FOLDER_NAME =
-		FragmentEntryPreviewUploadFileEntryHandler.class.getName();
+	@Override
+	protected UniqueFileNameProvider getUniqueFileNameProvider() {
+		return _uniqueFileNameProvider;
+	}
 
-	private static final Log _log = LogFactoryUtil.getLog(
-		FragmentEntryPreviewUploadFileEntryHandler.class);
+	@Reference
+	private DLAppService _dlAppService;
 
 	@Reference(
 		target = "(resource.name=" + FragmentConstants.RESOURCE_NAME + ")"

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/upload/FragmentEntryPreviewUploadFileEntryHandler.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/upload/FragmentEntryPreviewUploadFileEntryHandler.java
@@ -22,7 +22,7 @@ import com.liferay.portal.kernel.security.permission.resource.PortletResourcePer
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.upload.UploadPortletRequest;
 import com.liferay.portal.kernel.util.WebKeys;
-import com.liferay.upload.ImageEditorUploadHandler;
+import com.liferay.upload.BaseImageEditorUploadHandler;
 import com.liferay.upload.UniqueFileNameProvider;
 
 import org.osgi.service.component.annotations.Component;
@@ -35,7 +35,7 @@ import org.osgi.service.component.annotations.Reference;
 	immediate = true, service = FragmentEntryPreviewUploadFileEntryHandler.class
 )
 public class FragmentEntryPreviewUploadFileEntryHandler
-	extends ImageEditorUploadHandler {
+	extends BaseImageEditorUploadHandler {
 
 	@Override
 	protected void checkPermissions(UploadPortletRequest uploadPortletRequest)

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/upload/LayoutPageTemplateEntryPreviewUploadFileEntryHandler.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/upload/LayoutPageTemplateEntryPreviewUploadFileEntryHandler.java
@@ -17,22 +17,14 @@ package com.liferay.layout.page.template.admin.web.internal.upload;
 import com.liferay.document.library.kernel.service.DLAppService;
 import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.upload.UploadPortletRequest;
 import com.liferay.portal.kernel.util.ParamUtil;
-import com.liferay.portal.kernel.util.TempFileEntryUtil;
-import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.upload.ImageEditorUploadHandler;
 import com.liferay.upload.UniqueFileNameProvider;
-import com.liferay.upload.UploadFileEntryHandler;
-
-import java.io.IOException;
-import java.io.InputStream;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -45,100 +37,39 @@ import org.osgi.service.component.annotations.Reference;
 	service = LayoutPageTemplateEntryPreviewUploadFileEntryHandler.class
 )
 public class LayoutPageTemplateEntryPreviewUploadFileEntryHandler
-	implements UploadFileEntryHandler {
+	extends ImageEditorUploadHandler {
 
 	@Override
-	public FileEntry upload(UploadPortletRequest uploadPortletRequest)
-		throws IOException, PortalException {
+	protected void checkPermissions(UploadPortletRequest uploadPortletRequest)
+		throws PortalException {
+
+		long layoutPageTemplateEntryId = ParamUtil.getLong(
+			uploadPortletRequest, "layoutPageTemplateEntryId");
 
 		ThemeDisplay themeDisplay =
 			(ThemeDisplay)uploadPortletRequest.getAttribute(
 				WebKeys.THEME_DISPLAY);
 
-		long layoutPageTemplateEntryId = ParamUtil.getLong(
-			uploadPortletRequest, "layoutPageTemplateEntryId");
-
 		_layoutPageTemplateEntryModelResourcePermission.check(
 			themeDisplay.getPermissionChecker(), layoutPageTemplateEntryId,
 			ActionKeys.UPDATE);
-
-		String fileName = uploadPortletRequest.getFileName(_PARAMETER_NAME);
-
-		if (Validator.isNotNull(fileName)) {
-			try (InputStream inputStream = uploadPortletRequest.getFileAsStream(
-					_PARAMETER_NAME)) {
-
-				return _addTempFileEntry(
-					fileName, inputStream, _PARAMETER_NAME,
-					uploadPortletRequest, themeDisplay);
-			}
-		}
-
-		return _editImageFileEntry(uploadPortletRequest, themeDisplay);
 	}
 
-	private FileEntry _addTempFileEntry(
-			String fileName, InputStream inputStream, String parameterName,
-			UploadPortletRequest uploadPortletRequest,
-			ThemeDisplay themeDisplay)
-		throws PortalException {
-
-		String uniqueFileName = _uniqueFileNameProvider.provide(
-			fileName, curFileName -> _exists(themeDisplay, curFileName));
-
-		return TempFileEntryUtil.addTempFileEntry(
-			themeDisplay.getScopeGroupId(), themeDisplay.getUserId(),
-			_TEMP_FOLDER_NAME, uniqueFileName, inputStream,
-			uploadPortletRequest.getContentType(parameterName));
+	@Override
+	protected DLAppService getDLAppService() {
+		return _dlAppService;
 	}
 
-	private FileEntry _editImageFileEntry(
-			UploadPortletRequest uploadPortletRequest,
-			ThemeDisplay themeDisplay)
-		throws IOException, PortalException {
-
-		long fileEntryId = ParamUtil.getLong(
-			uploadPortletRequest, "fileEntryId");
-
-		FileEntry fileEntry = _dlAppService.getFileEntry(fileEntryId);
-
-		try (InputStream inputStream = uploadPortletRequest.getFileAsStream(
-				"imageBlob")) {
-
-			return _addTempFileEntry(
-				fileEntry.getFileName(), inputStream, "imageBlob",
-				uploadPortletRequest, themeDisplay);
-		}
+	@Override
+	protected String getFolderName() {
+		return LayoutPageTemplateEntryPreviewUploadFileEntryHandler.class.
+			getName();
 	}
 
-	private boolean _exists(ThemeDisplay themeDisplay, String curFileName) {
-		try {
-			FileEntry tempFileEntry = TempFileEntryUtil.getTempFileEntry(
-				themeDisplay.getScopeGroupId(), themeDisplay.getUserId(),
-				_TEMP_FOLDER_NAME, curFileName);
-
-			if (tempFileEntry != null) {
-				return true;
-			}
-
-			return false;
-		}
-		catch (PortalException portalException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(portalException);
-			}
-
-			return false;
-		}
+	@Override
+	protected UniqueFileNameProvider getUniqueFileNameProvider() {
+		return _uniqueFileNameProvider;
 	}
-
-	private static final String _PARAMETER_NAME = "imageSelectorFileName";
-
-	private static final String _TEMP_FOLDER_NAME =
-		LayoutPageTemplateEntryPreviewUploadFileEntryHandler.class.getName();
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		LayoutPageTemplateEntryPreviewUploadFileEntryHandler.class);
 
 	@Reference
 	private DLAppService _dlAppService;

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/upload/LayoutPageTemplateEntryPreviewUploadFileEntryHandler.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/upload/LayoutPageTemplateEntryPreviewUploadFileEntryHandler.java
@@ -23,7 +23,7 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.upload.UploadPortletRequest;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.WebKeys;
-import com.liferay.upload.ImageEditorUploadHandler;
+import com.liferay.upload.BaseImageEditorUploadHandler;
 import com.liferay.upload.UniqueFileNameProvider;
 
 import org.osgi.service.component.annotations.Component;
@@ -37,7 +37,7 @@ import org.osgi.service.component.annotations.Reference;
 	service = LayoutPageTemplateEntryPreviewUploadFileEntryHandler.class
 )
 public class LayoutPageTemplateEntryPreviewUploadFileEntryHandler
-	extends ImageEditorUploadHandler {
+	extends BaseImageEditorUploadHandler {
 
 	@Override
 	protected void checkPermissions(UploadPortletRequest uploadPortletRequest)

--- a/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/upload/StyleBookEntryPreviewUploadFileEntryHandler.java
+++ b/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/upload/StyleBookEntryPreviewUploadFileEntryHandler.java
@@ -62,24 +62,31 @@ public class StyleBookEntryPreviewUploadFileEntryHandler
 		String fileName = uploadPortletRequest.getFileName(_PARAMETER_NAME);
 
 		if (Validator.isNotNull(fileName)) {
-			String contentType = uploadPortletRequest.getContentType(
-				_PARAMETER_NAME);
-
 			try (InputStream inputStream = uploadPortletRequest.getFileAsStream(
 					_PARAMETER_NAME)) {
 
-				String uniqueFileName = _uniqueFileNameProvider.provide(
-					fileName,
-					curFileName -> _exists(themeDisplay, curFileName));
-
-				return TempFileEntryUtil.addTempFileEntry(
-					themeDisplay.getScopeGroupId(), themeDisplay.getUserId(),
-					_TEMP_FOLDER_NAME, uniqueFileName, inputStream,
-					contentType);
+				return _addTempFileEntry(
+					fileName, inputStream, _PARAMETER_NAME,
+					uploadPortletRequest, themeDisplay);
 			}
 		}
 
 		return _editImageFileEntry(uploadPortletRequest, themeDisplay);
+	}
+
+	private FileEntry _addTempFileEntry(
+		String fileName, InputStream inputStream, String parameterName,
+		UploadPortletRequest uploadPortletRequest,
+		ThemeDisplay themeDisplay)
+		throws PortalException {
+
+		String uniqueFileName = _uniqueFileNameProvider.provide(
+			fileName, curFileName -> _exists(themeDisplay, curFileName));
+
+		return TempFileEntryUtil.addTempFileEntry(
+			themeDisplay.getScopeGroupId(), themeDisplay.getUserId(),
+			_TEMP_FOLDER_NAME, uniqueFileName, inputStream,
+			uploadPortletRequest.getContentType(parameterName));
 	}
 
 	private FileEntry _editImageFileEntry(
@@ -94,15 +101,9 @@ public class StyleBookEntryPreviewUploadFileEntryHandler
 
 		try (InputStream inputStream = uploadPortletRequest.getFileAsStream(
 				"imageBlob")) {
-
-			String uniqueFileName = _uniqueFileNameProvider.provide(
-				fileEntry.getFileName(),
-				curFileName -> _exists(themeDisplay, curFileName));
-
-			return TempFileEntryUtil.addTempFileEntry(
-				themeDisplay.getScopeGroupId(), themeDisplay.getUserId(),
-				_TEMP_FOLDER_NAME, uniqueFileName, inputStream,
-				uploadPortletRequest.getContentType("imageBlob"));
+			return _addTempFileEntry(
+				fileEntry.getFileName(), inputStream, "imageBlob",
+				uploadPortletRequest, themeDisplay);
 		}
 	}
 

--- a/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/upload/StyleBookEntryPreviewUploadFileEntryHandler.java
+++ b/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/upload/StyleBookEntryPreviewUploadFileEntryHandler.java
@@ -15,24 +15,15 @@
 package com.liferay.style.book.web.internal.upload;
 
 import com.liferay.document.library.kernel.service.DLAppService;
-import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.resource.PortletResourcePermission;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.upload.UploadPortletRequest;
-import com.liferay.portal.kernel.util.ParamUtil;
-import com.liferay.portal.kernel.util.TempFileEntryUtil;
-import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.style.book.constants.StyleBookActionKeys;
 import com.liferay.style.book.constants.StyleBookConstants;
+import com.liferay.upload.ImageEditorUploadHandler;
 import com.liferay.upload.UniqueFileNameProvider;
-import com.liferay.upload.UploadFileEntryHandler;
-
-import java.io.IOException;
-import java.io.InputStream;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -45,11 +36,11 @@ import org.osgi.service.component.annotations.Reference;
 	service = StyleBookEntryPreviewUploadFileEntryHandler.class
 )
 public class StyleBookEntryPreviewUploadFileEntryHandler
-	implements UploadFileEntryHandler {
+	extends ImageEditorUploadHandler {
 
 	@Override
-	public FileEntry upload(UploadPortletRequest uploadPortletRequest)
-		throws IOException, PortalException {
+	protected void checkPermissions(UploadPortletRequest uploadPortletRequest)
+		throws PrincipalException {
 
 		ThemeDisplay themeDisplay =
 			(ThemeDisplay)uploadPortletRequest.getAttribute(
@@ -58,83 +49,22 @@ public class StyleBookEntryPreviewUploadFileEntryHandler
 		_portletResourcePermission.check(
 			themeDisplay.getPermissionChecker(), themeDisplay.getScopeGroup(),
 			StyleBookActionKeys.MANAGE_STYLE_BOOK_ENTRIES);
-
-		String fileName = uploadPortletRequest.getFileName(_PARAMETER_NAME);
-
-		if (Validator.isNotNull(fileName)) {
-			try (InputStream inputStream = uploadPortletRequest.getFileAsStream(
-					_PARAMETER_NAME)) {
-
-				return _addTempFileEntry(
-					fileName, inputStream, _PARAMETER_NAME,
-					uploadPortletRequest, themeDisplay);
-			}
-		}
-
-		return _editImageFileEntry(uploadPortletRequest, themeDisplay);
 	}
 
-	private FileEntry _addTempFileEntry(
-		String fileName, InputStream inputStream, String parameterName,
-		UploadPortletRequest uploadPortletRequest,
-		ThemeDisplay themeDisplay)
-		throws PortalException {
-
-		String uniqueFileName = _uniqueFileNameProvider.provide(
-			fileName, curFileName -> _exists(themeDisplay, curFileName));
-
-		return TempFileEntryUtil.addTempFileEntry(
-			themeDisplay.getScopeGroupId(), themeDisplay.getUserId(),
-			_TEMP_FOLDER_NAME, uniqueFileName, inputStream,
-			uploadPortletRequest.getContentType(parameterName));
+	@Override
+	protected DLAppService getDLAppService() {
+		return _dlAppService;
 	}
 
-	private FileEntry _editImageFileEntry(
-			UploadPortletRequest uploadPortletRequest,
-			ThemeDisplay themeDisplay)
-		throws IOException, PortalException {
-
-		long fileEntryId = ParamUtil.getLong(
-			uploadPortletRequest, "fileEntryId");
-
-		FileEntry fileEntry = _dlAppService.getFileEntry(fileEntryId);
-
-		try (InputStream inputStream = uploadPortletRequest.getFileAsStream(
-				"imageBlob")) {
-			return _addTempFileEntry(
-				fileEntry.getFileName(), inputStream, "imageBlob",
-				uploadPortletRequest, themeDisplay);
-		}
+	@Override
+	protected String getFolderName() {
+		return StyleBookEntryPreviewUploadFileEntryHandler.class.getName();
 	}
 
-	private boolean _exists(ThemeDisplay themeDisplay, String curFileName) {
-		try {
-			FileEntry tempFileEntry = TempFileEntryUtil.getTempFileEntry(
-				themeDisplay.getScopeGroupId(), themeDisplay.getUserId(),
-				_TEMP_FOLDER_NAME, curFileName);
-
-			if (tempFileEntry != null) {
-				return true;
-			}
-
-			return false;
-		}
-		catch (PortalException portalException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(portalException);
-			}
-
-			return false;
-		}
+	@Override
+	protected UniqueFileNameProvider getUniqueFileNameProvider() {
+		return _uniqueFileNameProvider;
 	}
-
-	private static final String _PARAMETER_NAME = "imageSelectorFileName";
-
-	private static final String _TEMP_FOLDER_NAME =
-		StyleBookEntryPreviewUploadFileEntryHandler.class.getName();
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		StyleBookEntryPreviewUploadFileEntryHandler.class);
 
 	@Reference
 	private DLAppService _dlAppService;

--- a/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/upload/StyleBookEntryPreviewUploadFileEntryHandler.java
+++ b/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/upload/StyleBookEntryPreviewUploadFileEntryHandler.java
@@ -22,7 +22,7 @@ import com.liferay.portal.kernel.upload.UploadPortletRequest;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.style.book.constants.StyleBookActionKeys;
 import com.liferay.style.book.constants.StyleBookConstants;
-import com.liferay.upload.ImageEditorUploadHandler;
+import com.liferay.upload.BaseImageEditorUploadHandler;
 import com.liferay.upload.UniqueFileNameProvider;
 
 import org.osgi.service.component.annotations.Component;
@@ -36,7 +36,7 @@ import org.osgi.service.component.annotations.Reference;
 	service = StyleBookEntryPreviewUploadFileEntryHandler.class
 )
 public class StyleBookEntryPreviewUploadFileEntryHandler
-	extends ImageEditorUploadHandler {
+	extends BaseImageEditorUploadHandler {
 
 	@Override
 	protected void checkPermissions(UploadPortletRequest uploadPortletRequest)

--- a/modules/apps/upload/upload-api/bnd.bnd
+++ b/modules/apps/upload/upload-api/bnd.bnd
@@ -1,5 +1,5 @@
 Bundle-Name: Liferay Upload API
 Bundle-SymbolicName: com.liferay.upload.api
-Bundle-Version: 5.0.6
+Bundle-Version: 5.1.0
 Export-Package: com.liferay.upload
 -dsannotations-options: inherit

--- a/modules/apps/upload/upload-api/build.gradle
+++ b/modules/apps/upload/upload-api/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.1"
+	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	compileOnly project(":core:petra:petra-function")
 }

--- a/modules/apps/upload/upload-api/src/main/java/com/liferay/upload/BaseImageEditorUploadHandler.java
+++ b/modules/apps/upload/upload-api/src/main/java/com/liferay/upload/BaseImageEditorUploadHandler.java
@@ -32,7 +32,7 @@ import java.io.InputStream;
 /**
  * @author Alicia García
  */
-public abstract class ImageEditorUploadHandler
+public abstract class BaseImageEditorUploadHandler
 	implements UploadFileEntryHandler {
 
 	@Override
@@ -133,6 +133,6 @@ public abstract class ImageEditorUploadHandler
 	private static final String _PARAMETER_NAME = "imageSelectorFileName";
 
 	private static final Log _log = LogFactoryUtil.getLog(
-		ImageEditorUploadHandler.class);
+		BaseImageEditorUploadHandler.class);
 
 }

--- a/modules/apps/upload/upload-api/src/main/java/com/liferay/upload/ImageEditorUploadHandler.java
+++ b/modules/apps/upload/upload-api/src/main/java/com/liferay/upload/ImageEditorUploadHandler.java
@@ -1,0 +1,138 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.upload;
+
+import com.liferay.document.library.kernel.service.DLAppService;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.upload.UploadPortletRequest;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.TempFileEntryUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.util.WebKeys;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * @author Alicia García
+ */
+public abstract class ImageEditorUploadHandler
+	implements UploadFileEntryHandler {
+
+	@Override
+	public FileEntry upload(UploadPortletRequest uploadPortletRequest)
+		throws IOException, PortalException {
+
+		checkPermissions(uploadPortletRequest);
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)uploadPortletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		String fileName = uploadPortletRequest.getFileName(_PARAMETER_NAME);
+
+		if (Validator.isNotNull(fileName)) {
+			try (InputStream inputStream = uploadPortletRequest.getFileAsStream(
+					_PARAMETER_NAME)) {
+
+				return _addTempFileEntry(
+					fileName, inputStream, _PARAMETER_NAME,
+					uploadPortletRequest, themeDisplay);
+			}
+		}
+
+		return _editImageFileEntry(uploadPortletRequest, themeDisplay);
+	}
+
+	protected abstract void checkPermissions(
+			UploadPortletRequest uploadPortletRequest)
+		throws PortalException;
+
+	protected abstract DLAppService getDLAppService();
+
+	protected abstract String getFolderName();
+
+	protected abstract UniqueFileNameProvider getUniqueFileNameProvider();
+
+	private FileEntry _addTempFileEntry(
+			String fileName, InputStream inputStream, String parameterName,
+			UploadPortletRequest uploadPortletRequest,
+			ThemeDisplay themeDisplay)
+		throws PortalException {
+
+		UniqueFileNameProvider uniqueFileNameProvider =
+			getUniqueFileNameProvider();
+
+		String uniqueFileName = uniqueFileNameProvider.provide(
+			fileName, curFileName -> _exists(themeDisplay, curFileName));
+
+		return TempFileEntryUtil.addTempFileEntry(
+			themeDisplay.getScopeGroupId(), themeDisplay.getUserId(),
+			getFolderName(), uniqueFileName, inputStream,
+			uploadPortletRequest.getContentType(parameterName));
+	}
+
+	private FileEntry _editImageFileEntry(
+			UploadPortletRequest uploadPortletRequest,
+			ThemeDisplay themeDisplay)
+		throws IOException, PortalException {
+
+		long fileEntryId = ParamUtil.getLong(
+			uploadPortletRequest, "fileEntryId");
+
+		DLAppService dlAppService = getDLAppService();
+
+		FileEntry fileEntry = dlAppService.getFileEntry(fileEntryId);
+
+		try (InputStream inputStream = uploadPortletRequest.getFileAsStream(
+				"imageBlob")) {
+
+			return _addTempFileEntry(
+				fileEntry.getFileName(), inputStream, "imageBlob",
+				uploadPortletRequest, themeDisplay);
+		}
+	}
+
+	private boolean _exists(ThemeDisplay themeDisplay, String curFileName) {
+		try {
+			FileEntry tempFileEntry = TempFileEntryUtil.getTempFileEntry(
+				themeDisplay.getScopeGroupId(), themeDisplay.getUserId(),
+				getFolderName(), curFileName);
+
+			if (tempFileEntry != null) {
+				return true;
+			}
+
+			return false;
+		}
+		catch (PortalException portalException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(portalException);
+			}
+
+			return false;
+		}
+	}
+
+	private static final String _PARAMETER_NAME = "imageSelectorFileName";
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		ImageEditorUploadHandler.class);
+
+}

--- a/modules/apps/upload/upload-api/src/main/resources/com/liferay/upload/packageinfo
+++ b/modules/apps/upload/upload-api/src/main/resources/com/liferay/upload/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 1.2.0


### PR DESCRIPTION
- LPS-154705 You can upload a file or edit the image on the same modal, so you must differentiate both behaviors
- LPS-154705 extract methods and reorder
- LPS-154705 extract methods to common class to reuse on several modules
- LPS-154705 baseline
- LPS-154705 use new class on StyleBookEntryPreviewUploadFileEntryHandler
- LPS-154705 use new class on FragmentEntryPreviewUploadFileEntryHandler
- LPS-154705 use new class on FragmentCollectionResourceUploadFileEntryHandler
