### PR TITLE
LPS-154737 Icons in drodpdowns in Media Gallery - WIP

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DefaultIGViewFileVersionDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DefaultIGViewFileVersionDisplayContext.java
@@ -20,6 +20,8 @@ import com.liferay.document.library.web.internal.display.context.helper.DLPortle
 import com.liferay.document.library.web.internal.display.context.helper.IGRequestHelper;
 import com.liferay.document.library.web.internal.display.context.logic.UIItemsBuilder;
 import com.liferay.document.library.web.internal.helper.DLTrashHelper;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemListBuilder;
 import com.liferay.image.gallery.display.kernel.display.context.IGViewFileVersionDisplayContext;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.repository.model.FileShortcut;
@@ -89,6 +91,41 @@ public class DefaultIGViewFileVersionDisplayContext
 		this(
 			httpServletRequest, httpServletResponse, fileVersion, null,
 			resourceBundle, dlTrashHelper, versioningStrategy, dlURLHelper);
+	}
+
+	public List<DropdownItem> getActionDropdownItems() {
+		if (!_dlPortletInstanceSettingsHelper.isShowActions()) {
+			return null;
+		}
+
+		return DropdownItemListBuilder.addGroup(
+			dropdownGroupItem -> {
+				dropdownGroupItem.setDropdownItems(
+					DropdownItemListBuilder.add(
+						_uiItemsBuilder::isDownloadActionAvailable,
+						_uiItemsBuilder.createDownloadDropdownItem()
+					).add(
+						_uiItemsBuilder::isViewOriginalFileActionAvailable,
+						_uiItemsBuilder.createViewOriginalFileDropdownItem()
+					).add(
+						_uiItemsBuilder::isEditActionAvailable,
+						_uiItemsBuilder.createEditDropdownItem()
+					).build());
+				dropdownGroupItem.setSeparator(true);
+			}
+		).addGroup(
+			dropdownGroupItem -> {
+				dropdownGroupItem.setDropdownItems(
+					DropdownItemListBuilder.add(
+						_uiItemsBuilder::isPermissionsActionAvailable,
+						_uiItemsBuilder.createPermissionsDropdownItem()
+					).add(
+						_uiItemsBuilder::isDeleteActionAvailable,
+						_uiItemsBuilder.createDeleteDropdownItem()
+					).build());
+				dropdownGroupItem.setSeparator(true);
+			}
+		).build();
 	}
 
 	@Override

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/image_gallery_display/image_action.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/image_gallery_display/image_action.jsp
@@ -53,6 +53,16 @@ else {
 }
 %>
 
-<liferay-ui:menu
-	menu="<%= igViewFileVersionDisplayContext.getMenu() %>"
-/>
+<c:choose>
+	<c:when test='<%= GetterUtil.getBoolean(PropsUtil.get("feature.flag.LPS-152694")) %>'>
+		<clay:dropdown-actions
+			dropdownItems="<%= igViewFileVersionDisplayContext.getActionDropdownItems() %>"
+			propsTransformer="document_library/js/DLFileEntryDropdownPropsTransformer"
+		/>
+	</c:when>
+	<c:otherwise>
+		<liferay-ui:menu
+			menu="<%= igViewFileVersionDisplayContext.getMenu() %>"
+		/>
+	</c:otherwise>
+</c:choose>


### PR DESCRIPTION
**Do not run ci test, they will fail.**

Hey @adolfopa, as we spoke yesterday, a new method `public List<DropdownItem> getActionDropdownItems()` must be added to the interface `IGViewFileVersionDisplayContext`, but this is in _portal-kernel_ and fails importing the _frontend-taglib-clay_ modules. 

I thought you may want to do the changes along with this pull, but if you prefer to do it separately, fell free. 