### PR TITLE
LPS-154859 dm dnd notifications buttons timming

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/legacy/upload.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/legacy/upload.js
@@ -1100,6 +1100,8 @@ AUI.add(
 						if (!currentUploadData.folder && !invalidFilesLength) {
 							var reloadButtonClassName = 'dl-reload-button';
 
+							openToastProps.autoClose = 10000;
+
 							openToastProps.message =
 								openToastProps.message +
 								`<div class="alert-footer">
@@ -1164,6 +1166,8 @@ AUI.add(
 						});
 
 						Liferay.Util.openToast({
+							autoClose:
+								invalidFilesLength > 3 ? undefined : false,
 							message,
 							toastProps: {
 								className: 'alert-full',

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/legacy/upload.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/legacy/upload.js
@@ -1102,7 +1102,11 @@ AUI.add(
 
 							openToastProps.message =
 								openToastProps.message +
-								` <button class="btn btn-sm btn-link alert-link ${reloadButtonClassName}">${instance._strings.reloadButton}</button>`;
+								`<div class="alert-footer">
+										<div class="btn-group" role="group">
+											<button class="btn btn-sm btn-primary alert-btn ${reloadButtonClassName}">${instance._strings.reloadButton}</button>
+										</div>
+								</div>`;
 
 							openToastProps.onClick = ({event}) => {
 								if (

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/legacy/upload.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/legacy/upload.js
@@ -1110,7 +1110,10 @@ AUI.add(
 										</div>
 								</div>`;
 
-							openToastSuccessProps.onClick = ({event}) => {
+							openToastSuccessProps.onClick = ({
+								event,
+								onClose: closeToast,
+							}) => {
 								if (
 									event.target.classList.contains(
 										reloadButtonClassName
@@ -1119,6 +1122,7 @@ AUI.add(
 									Liferay.Portlet.refresh(
 										`#p_p_id${instance._documentLibraryNamespace}`
 									);
+									closeToast();
 								}
 							};
 						}

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/legacy/upload.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/legacy/upload.js
@@ -1086,7 +1086,7 @@ AUI.add(
 					}
 
 					if (validFilesLength) {
-						var openToastProps = {
+						var openToastSuccessProps = {
 							message: Liferay.Util.sub(
 								instance._strings.xValidFilesUploaded,
 								validFilesLength
@@ -1100,17 +1100,17 @@ AUI.add(
 						if (!currentUploadData.folder && !invalidFilesLength) {
 							var reloadButtonClassName = 'dl-reload-button';
 
-							openToastProps.autoClose = 10000;
+							openToastSuccessProps.autoClose = 10000;
 
-							openToastProps.message =
-								openToastProps.message +
+							openToastSuccessProps.message =
+								openToastSuccessProps.message +
 								`<div class="alert-footer">
 										<div class="btn-group" role="group">
 											<button class="btn btn-sm btn-primary alert-btn ${reloadButtonClassName}">${instance._strings.reloadButton}</button>
 										</div>
 								</div>`;
 
-							openToastProps.onClick = ({event}) => {
+							openToastSuccessProps.onClick = ({event}) => {
 								if (
 									event.target.classList.contains(
 										reloadButtonClassName
@@ -1123,7 +1123,7 @@ AUI.add(
 							};
 						}
 
-						Liferay.Util.openToast(openToastProps);
+						Liferay.Util.openToast(openToastSuccessProps);
 					}
 
 					if (invalidFilesLength) {
@@ -1157,23 +1157,25 @@ AUI.add(
 							}
 						}
 
-						var message = TPL_ERROR_NOTIFICATION.parse({
-							invalidFiles: currentUploadData.invalidFiles,
-							title: Liferay.Util.sub(
-								instance._strings.xInvalidFilesUploaded,
-								invalidFilesLength
-							),
-						});
-
-						Liferay.Util.openToast({
-							autoClose:
-								invalidFilesLength > 3 ? undefined : false,
-							message,
+						var openToastErrorProps = {
+							message: TPL_ERROR_NOTIFICATION.parse({
+								invalidFiles: currentUploadData.invalidFiles,
+								title: Liferay.Util.sub(
+									instance._strings.xInvalidFilesUploaded,
+									invalidFilesLength
+								),
+							}),
 							toastProps: {
 								className: 'alert-full',
 							},
 							type: 'danger',
-						});
+						};
+
+						if (invalidFilesLength < 3) {
+							openToastErrorProps.autoClose = false;
+						}
+
+						Liferay.Util.openToast(openToastErrorProps);
 					}
 				},
 


### PR DESCRIPTION
Issue: https://issues.liferay.com/browse/LPS-154859

Updated the markup to show a real button on notifications

### Before
![image](https://user-images.githubusercontent.com/67901/170705083-7e2c69fc-800c-44ae-acee-2bd99b25f93d.png)

### After
![image](https://user-images.githubusercontent.com/67901/170705357-df22c573-c844-4a07-8416-1c9bcbccf33c.png)


---

Issue: https://issues.liferay.com/browse/LPS-154856

Apply different `autoClose` to notification depending on the context.

**all files success:** we add a refresh action on this case, up to 10000ms
**less than 3 files fail:** we add some details attached to the names of the files, cancel autoClose
**3 or more files fail**: we don't render the error details, leave as default 5000ms
**mixed result (success and failures)**: we don't add the refresh action on success, leave as default 5000ms