### PR TITLE
LPS-154971 Show the permission option on the toolbar

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
@@ -121,6 +121,7 @@ public class DLAdminManagementToolbarDisplayContext
 		DigitalSignatureConfiguration digitalSignatureConfiguration =
 			DigitalSignatureConfigurationUtil.getDigitalSignatureConfiguration(
 				_themeDisplay.getCompanyId(), _themeDisplay.getSiteGroupId());
+		boolean enableBulkPermissions = _isEnableBulkPermissions();
 		boolean enableOnBulk = _isEnableOnBulk();
 		boolean stagedActions = _isStagedActions();
 		User user = _themeDisplay.getUser();
@@ -211,6 +212,16 @@ public class DLAdminManagementToolbarDisplayContext
 				dropdownItem.setLabel(
 					LanguageUtil.get(
 						_httpServletRequest, "checkout[document]"));
+				dropdownItem.setQuickAction(false);
+			}
+		).add(
+			() ->
+				stagedActions && !user.isDefaultUser() && enableBulkPermissions,
+			dropdownItem -> {
+				dropdownItem.putData("action", "permissions");
+				dropdownItem.setIcon("password-policies");
+				dropdownItem.setLabel(
+					LanguageUtil.get(_httpServletRequest, "permissions"));
 				dropdownItem.setQuickAction(false);
 			}
 		).build();
@@ -829,6 +840,14 @@ public class DLAdminManagementToolbarDisplayContext
 		return DLUtil.hasWorkflowDefinitionLink(
 			_themeDisplay.getCompanyId(), _themeDisplay.getScopeGroupId(),
 			folderId, fileEntryTypeId);
+	}
+
+	private boolean _isEnableBulkPermissions() {
+		if (GetterUtil.getBoolean(PropsUtil.get("feature.flag.LPS-87806"))) {
+			return true;
+		}
+
+		return false;
 	}
 
 	private boolean _isEnableOnBulk() {

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLViewDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLViewDisplayContext.java
@@ -48,7 +48,7 @@ import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portlet.asset.util.comparator.AssetVocabularyGroupLocalizedTitleComparator;
-import com.liferay.portlet.configuration.kernel.util.PortletConfigurationApplicationType;
+import com.liferay.taglib.security.PermissionsURLTag;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -174,30 +174,10 @@ public class DLViewDisplayContext {
 			return StringPool.BLANK;
 		}
 
-		return PortletURLBuilder.create(
-			PortletProviderUtil.getPortletURL(
-				_httpServletRequest,
-				PortletConfigurationApplicationType.PortletConfiguration.
-					CLASS_NAME,
-				PortletProvider.Action.VIEW)
-		).setMVCPath(
-			"/edit_permissions.jsp"
-		).setPortletResource(
-			() -> {
-				PortletDisplay portletDisplay =
-					themeDisplay.getPortletDisplay();
-
-				return portletDisplay.getId();
-			}
-		).setParameter(
-			"modelResource", DLFileEntryConstants.getClassName()
-		).setParameter(
-			"portletConfiguration", true
-		).setParameter(
-			"resourceGroupId", themeDisplay.getScopeGroupId()
-		).setWindowState(
-			LiferayWindowState.POP_UP
-		).buildString();
+		return PermissionsURLTag.doTag(
+			null, DLFileEntryConstants.getClassName(),
+			themeDisplay.getScopeGroupId(),
+			LiferayWindowState.POP_UP.toString(), _httpServletRequest);
 	}
 
 	public long getRepositoryId() {

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLViewDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLViewDisplayContext.java
@@ -41,11 +41,14 @@ import com.liferay.portal.kernel.servlet.BrowserSnifferUtil;
 import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Constants;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portlet.asset.util.comparator.AssetVocabularyGroupLocalizedTitleComparator;
+import com.liferay.portlet.configuration.kernel.util.PortletConfigurationApplicationType;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -156,6 +159,45 @@ public class DLViewDisplayContext {
 
 	public long getFolderId() {
 		return _dlAdminDisplayContext.getFolderId();
+	}
+
+	public String getPermissionURL() throws Exception {
+		if (!GetterUtil.getBoolean(PropsUtil.get("feature.flag.LPS-87806"))) {
+			return StringPool.BLANK;
+		}
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)_httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		if (!themeDisplay.isSignedIn()) {
+			return StringPool.BLANK;
+		}
+
+		return PortletURLBuilder.create(
+			PortletProviderUtil.getPortletURL(
+				_httpServletRequest,
+				PortletConfigurationApplicationType.PortletConfiguration.
+					CLASS_NAME,
+				PortletProvider.Action.VIEW)
+		).setMVCPath(
+			"/edit_permissions.jsp"
+		).setPortletResource(
+			() -> {
+				PortletDisplay portletDisplay =
+					themeDisplay.getPortletDisplay();
+
+				return portletDisplay.getId();
+			}
+		).setParameter(
+			"modelResource", DLFileEntryConstants.getClassName()
+		).setParameter(
+			"portletConfiguration", true
+		).setParameter(
+			"resourceGroupId", themeDisplay.getScopeGroupId()
+		).setWindowState(
+			LiferayWindowState.POP_UP
+		).buildString();
 	}
 
 	public long getRepositoryId() {

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLViewEntriesDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLViewEntriesDisplayContext.java
@@ -48,6 +48,7 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.util.RepositoryUtil;
 
@@ -138,6 +139,13 @@ public class DLViewEntriesDisplayContext {
 				permissionChecker, fileEntry, ActionKeys.VIEW)) {
 
 			availableActions.add("download");
+		}
+
+		if (GetterUtil.getBoolean(PropsUtil.get("feature.flag.LPS-87806")) &&
+			DLFileEntryPermission.contains(
+				permissionChecker, fileEntry, ActionKeys.PERMISSIONS)) {
+
+			availableActions.add("permissions");
 		}
 
 		return availableActions;

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/DLManagementToolbarPropsTransformer.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/DLManagementToolbarPropsTransformer.js
@@ -28,6 +28,7 @@ export default function propsTransformer({
 		editEntryURL,
 		folderConfiguration,
 		openViewMoreFileEntryTypesURL,
+		permissionsURL,
 		selectFileEntryTypeURL,
 		selectFolderURL,
 		trashEnabled,
@@ -231,6 +232,37 @@ export default function propsTransformer({
 		});
 	};
 
+	const permissions = () => {
+		const searchContainer = Liferay.SearchContainer.get(
+			otherProps.searchContainerId
+		);
+
+		if (searchContainer.select) {
+			const keys = searchContainer.select
+				.getAllSelectedElements()
+				.get('value');
+
+			if (keys) {
+				const url = new URL(permissionsURL);
+
+				const urlSearchParams = new URLSearchParams(url.search);
+
+				const paramName = `_${urlSearchParams.get(
+					'p_p_id'
+				)}_resourcePrimKey`;
+
+				for (const key of keys) {
+					url.searchParams.append(paramName, key);
+				}
+
+				openSelectionModal({
+					title: Liferay.Language.get('permissions'),
+					url: url.toString(),
+				});
+			}
+		}
+	};
+
 	return {
 		...otherProps,
 		onActionButtonClick(event, {item}) {
@@ -262,6 +294,9 @@ export default function propsTransformer({
 			}
 			else if (action === 'move') {
 				move();
+			}
+			else if (action === 'permissions') {
+				permissions();
 			}
 		},
 		onFilterDropdownItemClick(event, {item}) {

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/DLManagementToolbarPropsTransformer.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/DLManagementToolbarPropsTransformer.js
@@ -233,34 +233,22 @@ export default function propsTransformer({
 	};
 
 	const permissions = () => {
-		const searchContainer = Liferay.SearchContainer.get(
-			otherProps.searchContainerId
-		);
+		const keys = getAllSelectedElements().get('value');
 
-		if (searchContainer.select) {
-			const keys = searchContainer.select
-				.getAllSelectedElements()
-				.get('value');
+		const url = new URL(permissionsURL);
 
-			if (keys) {
-				const url = new URL(permissionsURL);
+		const urlSearchParams = new URLSearchParams(url.search);
 
-				const urlSearchParams = new URLSearchParams(url.search);
+		const paramName = `_${urlSearchParams.get('p_p_id')}_resourcePrimKey`;
 
-				const paramName = `_${urlSearchParams.get(
-					'p_p_id'
-				)}_resourcePrimKey`;
-
-				for (const key of keys) {
-					url.searchParams.append(paramName, key);
-				}
-
-				openSelectionModal({
-					title: Liferay.Language.get('permissions'),
-					url: url.toString(),
-				});
-			}
+		for (const key of keys) {
+			url.searchParams.append(paramName, key);
 		}
+
+		openSelectionModal({
+			title: Liferay.Language.get('permissions'),
+			url: url.toString(),
+		});
 	};
 
 	return {

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view.jsp
@@ -70,6 +70,8 @@ DLViewDisplayContext dlViewDisplayContext = new DLViewDisplayContext(dlAdminDisp
 				).put(
 					"openViewMoreFileEntryTypesURL", dlViewDisplayContext.getViewMoreFileEntryTypesURL()
 				).put(
+					"permissionsURL", dlViewDisplayContext.getPermissionURL()
+				).put(
 					"selectFileEntryTypeURL", dlViewDisplayContext.getSelectFileEntryTypeURL()
 				).put(
 					"selectFolderURL", dlViewDisplayContext.getSelectFolderURL()

--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/java/com/liferay/portlet/configuration/web/internal/portlet/PortletConfigurationPortlet.java
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/java/com/liferay/portlet/configuration/web/internal/portlet/PortletConfigurationPortlet.java
@@ -710,11 +710,13 @@ public class PortletConfigurationPortlet extends MVCPortlet {
 			request, "resourceGroupId", themeDisplay.getScopeGroupId());
 
 		if (Validator.isNotNull(modelResource)) {
-			String resourcePrimKey = ParamUtil.getString(
+			String[] resourcePrimKeys = ParamUtil.getStringValues(
 				request, "resourcePrimKey");
 
-			_permissionService.checkPermission(
-				resourceGroupId, modelResource, resourcePrimKey);
+			for (String resourcePrimKey : resourcePrimKeys) {
+				_permissionService.checkPermission(
+					resourceGroupId, modelResource, resourcePrimKey);
+			}
 
 			return;
 		}

--- a/util-taglib/bnd.bnd
+++ b/util-taglib/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 9.1.5
+Bundle-Version: 9.2.0
 Export-Package:\
 	com.liferay.alloy.taglib.*;version="3.0.0",\
 	com.liferay.taglib.*

--- a/util-taglib/src/com/liferay/taglib/security/PermissionsURLTag.java
+++ b/util-taglib/src/com/liferay/taglib/security/PermissionsURLTag.java
@@ -84,9 +84,9 @@ public class PermissionsURLTag extends TagSupport {
 			}
 		}
 		else if (resourceGroupId instanceof String) {
-			String esourceGroupIdString = (String)resourceGroupId;
+			String resourceGroupIdString = (String)resourceGroupId;
 
-			if (esourceGroupIdString.length() == 0) {
+			if (resourceGroupIdString.length() == 0) {
 				resourceGroupId = null;
 			}
 		}

--- a/util-taglib/src/com/liferay/taglib/security/PermissionsURLTag.java
+++ b/util-taglib/src/com/liferay/taglib/security/PermissionsURLTag.java
@@ -49,24 +49,7 @@ public class PermissionsURLTag extends TagSupport {
 			(ThemeDisplay)httpServletRequest.getAttribute(
 				WebKeys.THEME_DISPLAY);
 
-		if (resourceGroupId instanceof Number) {
-			Number resourceGroupIdNumber = (Number)resourceGroupId;
-
-			if (resourceGroupIdNumber.longValue() < 0) {
-				resourceGroupId = null;
-			}
-		}
-		else if (resourceGroupId instanceof String) {
-			String resourceGroupIdString = (String)resourceGroupId;
-
-			if (resourceGroupIdString.length() == 0) {
-				resourceGroupId = null;
-			}
-		}
-
-		if (resourceGroupId == null) {
-			resourceGroupId = String.valueOf(themeDisplay.getScopeGroupId());
-		}
+		resourceGroupId = _getResourceGroupId(resourceGroupId, themeDisplay);
 
 		if (Validator.isNull(redirect) &&
 			(Validator.isNull(windowState) ||
@@ -154,24 +137,7 @@ public class PermissionsURLTag extends TagSupport {
 			(ThemeDisplay)httpServletRequest.getAttribute(
 				WebKeys.THEME_DISPLAY);
 
-		if (resourceGroupId instanceof Number) {
-			Number resourceGroupIdNumber = (Number)resourceGroupId;
-
-			if (resourceGroupIdNumber.longValue() < 0) {
-				resourceGroupId = null;
-			}
-		}
-		else if (resourceGroupId instanceof String) {
-			String resourceGroupIdString = (String)resourceGroupId;
-
-			if (resourceGroupIdString.length() == 0) {
-				resourceGroupId = null;
-			}
-		}
-
-		if (resourceGroupId == null) {
-			resourceGroupId = String.valueOf(themeDisplay.getScopeGroupId());
-		}
+		resourceGroupId = _getResourceGroupId(resourceGroupId, themeDisplay);
 
 		if (Validator.isNull(redirect) &&
 			(Validator.isNull(windowState) ||
@@ -281,6 +247,31 @@ public class PermissionsURLTag extends TagSupport {
 
 	public void setWindowState(String windowState) {
 		_windowState = windowState;
+	}
+
+	private static Object _getResourceGroupId(
+		Object resourceGroupId, ThemeDisplay themeDisplay) {
+
+		if (resourceGroupId instanceof Number) {
+			Number resourceGroupIdNumber = (Number)resourceGroupId;
+
+			if (resourceGroupIdNumber.longValue() < 0) {
+				resourceGroupId = null;
+			}
+		}
+		else if (resourceGroupId instanceof String) {
+			String resourceGroupIdString = (String)resourceGroupId;
+
+			if (resourceGroupIdString.length() == 0) {
+				resourceGroupId = null;
+			}
+		}
+
+		if (resourceGroupId == null) {
+			resourceGroupId = String.valueOf(themeDisplay.getScopeGroupId());
+		}
+
+		return resourceGroupId;
 	}
 
 	private String _modelResource;

--- a/util-taglib/src/com/liferay/taglib/security/packageinfo
+++ b/util-taglib/src/com/liferay/taglib/security/packageinfo
@@ -1,1 +1,1 @@
-version 8.0.0
+version 8.1.0


### PR DESCRIPTION
- LPS-154971 add action of permissions on bulk if FF is enabled and only if documents are selected
- LPS-154971 generate the permissionsURL to use it from the management toolbar of the document view
- LPS-154971 rename
- LPS-154971 now the resourcePrimKey param can be an array so check the permissions for each of them
- LPS-154971 create a new method doTag without the not needed parameters to add several files
- LPS-154971 extract method
- LPS-154971 baseline
- LPS-154971 use new method to obtain the permission url
- LPS-154971 no need checking select on search container and add fallback value on keys to avoid indentation
