### PR TITLE
LPS-154652 Convert .heic to .jpg for profile image

### DIFF
--- a/modules/apps/image-uploader/image-uploader-web/src/main/java/com/liferay/image/uploader/web/internal/portlet/action/UploadImageMVCActionCommand.java
+++ b/modules/apps/image-uploader/image-uploader-web/src/main/java/com/liferay/image/uploader/web/internal/portlet/action/UploadImageMVCActionCommand.java
@@ -28,6 +28,7 @@ import com.liferay.portal.kernel.exception.ImageTypeException;
 import com.liferay.portal.kernel.exception.NoSuchRepositoryException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.image.ImageBag;
+import com.liferay.portal.kernel.image.ImageMagick;
 import com.liferay.portal.kernel.image.ImageTool;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
@@ -54,6 +55,7 @@ import com.liferay.portal.kernel.util.MimeTypesUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.SetUtil;
+import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.TempFileEntryUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -66,8 +68,11 @@ import java.awt.image.RenderedImage;
 import java.io.File;
 import java.io.InputStream;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.Future;
 
 import javax.portlet.ActionRequest;
 import javax.portlet.ActionResponse;
@@ -201,6 +206,26 @@ public class UploadImageMVCActionCommand extends BaseMVCActionCommand {
 			throw new ImageTypeException();
 		}
 
+		if (StringUtil.equalsIgnoreCase(mimeType, ContentTypes.IMAGE_HEIC)) {
+			try {
+				file = _convertToJPEG(
+					file, UploadImageUtil.getMaxFileSize(portletRequest));
+			}
+			catch (Exception exception) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(exception);
+				}
+
+				throw new UploadException(exception);
+			}
+
+			contentType = ContentTypes.IMAGE_JPEG;
+
+			fileName = StringBundler.concat(
+				FileUtil.stripExtension(fileName), StringPool.PERIOD,
+				ImageTool.TYPE_JPEG);
+		}
+
 		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
@@ -219,6 +244,36 @@ public class UploadImageMVCActionCommand extends BaseMVCActionCommand {
 			themeDisplay.getScopeGroupId(), themeDisplay.getUserId(),
 			UploadImageUtil.getTempImageFolderName(), fileName, file,
 			contentType);
+	}
+
+	private File _convertToJPEG(File imageFile, long maxFileSize)
+		throws Exception {
+
+		File scaledImageFile = FileUtil.createTempFile(ImageTool.TYPE_JPEG);
+
+		List<String> arguments = new ArrayList<>();
+
+		if (maxFileSize > 0) {
+
+			// Convert bytes to kb
+
+			long maxFileSizeInKB = maxFileSize / 1024L;
+
+			// Arguments for keeping the image size valid
+
+			arguments.add("-define");
+			arguments.add(String.format("jpeg:extent=%dkb", maxFileSizeInKB));
+		}
+
+		arguments.add(imageFile.getAbsolutePath());
+
+		arguments.add(scaledImageFile.getAbsolutePath());
+
+		Future<?> future = _imageMagick.convert(arguments);
+
+		future.get();
+
+		return scaledImageFile;
 	}
 
 	private String _getTempImageFileName(PortletRequest portletRequest) {
@@ -409,6 +464,9 @@ public class UploadImageMVCActionCommand extends BaseMVCActionCommand {
 		PropsValues.MIME_TYPES_WEB_IMAGES);
 
 	private volatile DLConfiguration _dlConfiguration;
+
+	@Reference
+	private ImageMagick _imageMagick;
 
 	@Reference
 	private ImageTool _imageTool;

--- a/portal-kernel/src/com/liferay/portal/kernel/util/ContentTypes.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/ContentTypes.java
@@ -72,6 +72,8 @@ public interface ContentTypes {
 
 	public static final String IMAGE_GIF = "image/gif";
 
+	public static final String IMAGE_HEIC = "image/heic";
+
 	public static final String IMAGE_JPEG = "image/jpeg";
 
 	public static final String IMAGE_PNG = "image/png";


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-154652

/cc @hongvo2308

### Solution notes

The solution models [LPS-151510](https://issues.liferay.com/browse/LPS-151510), which has adaptive media invoke imagemagick in order to perform the conversion. In this case, the solution is localized to image-uploader-web.

The original solution from the TSE created a new ImageMagickException with a more detailed error message telling a user to reach out to their portal administrator to install ImageMagick with HEIC support.

I didn't think that was necessary (the default Unexpected Error message seemed okay to me) and so I removed the extra complexity to avoid the kernel exception package version update. Let me know if you disagree, and I can instead move it to an internal package in image-uploader-web as an alternate way to avoid the kernel exception package version update.

### Testing steps

Note from the TSE, applicable to developers running Linux:

> PS: You will need to install the ImageMagick based on these instructions https://gist.github.com/hurricup/e14ae5bc47705fca6b1680e7a1fb6580 and [LPS-151510](https://issues.liferay.com/browse/LPS-151510) to test.
Update the portal-ext.properties with this value
`mime.types.web.images=image/gif,image/jpeg,image/pjpeg,image/png,image/x-png,image/heic`

If your local system is not Linux, you can also install a minimal ImageMagick with HEIC support to a Liferay Docker container (the default ImageMagick installed to the Docker container does not have HEIC support) using the instructions mentioned in the comment on [LPS-154652](https://issues.liferay.com/browse/LPS-154652)