### PR TITLE
LPS-154907 Added staging label

### DIFF
--- a/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/display/context/DepotAdminSitesDisplayContext.java
+++ b/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/display/context/DepotAdminSitesDisplayContext.java
@@ -24,6 +24,7 @@ import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemListBuil
 import com.liferay.item.selector.ItemSelector;
 import com.liferay.item.selector.ItemSelectorCriterion;
 import com.liferay.item.selector.criteria.URLItemSelectorReturnType;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Group;
@@ -165,7 +166,23 @@ public class DepotAdminSitesDisplayContext {
 		Group group = GroupServiceUtil.getGroup(
 			depotEntryGroupRel.getToGroupId());
 
-		return group.getDescriptiveName(locale);
+		StringBuilder sb = new StringBuilder();
+
+		sb.append(group.getDescriptiveName(locale));
+
+		if (group.isStaged() && !group.isStagedRemotely() &&
+			group.isStagingGroup()) {
+
+			sb.append(StringPool.SPACE);
+			sb.append(StringPool.OPEN_PARENTHESIS);
+			sb.append(
+				LanguageUtil.get(
+					PortalUtil.getHttpServletRequest(_liferayPortletRequest),
+					"staging"));
+			sb.append(StringPool.CLOSE_PARENTHESIS);
+		}
+
+		return sb.toString();
 	}
 
 	public boolean isLiveDepotEntry() throws PortalException {


### PR DESCRIPTION
Fwd: https://github.com/fortunatomaldonado/liferay-portal/pull/20

https://issues.liferay.com/browse/LPS-154907

The solution was approved here: https://issues.liferay.com/browse/PTR-3099?focusedCommentId=2690422&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-2690422

Let me know if this should be sent elsewhere.

> LPS-154907 Added staging label to staging version of sites in Asset Libraries connected sites list. This allows for both the staging and live versions of the site to show up as connected sites while being able to tell the versions apart visually.