### PR TITLE
LPS-118829 Remove AUI from DM (part 1)

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/DocumentLibrary.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/DocumentLibrary.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+export default function DocumentLibrary({namespace}) {
+	console.log('new DL created: ' + namespace);
+}

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/DocumentLibrary.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/DocumentLibrary.js
@@ -12,12 +12,7 @@
  * details.
  */
 
-const TPL_MOVE_FORM =
-	'<form action="{actionUrl}" class="hide" method="POST"><input name="{namespace}cmd" value="move"/>' +
-	'<input name="{namespace}newFolderId" value="{newFolderId}"/>' +
-	'<input name="{namespace}{parameterName}" value="{parameterValue}"/>' +
-	'<input name="{namespace}redirect" value="{redirectUrl}"/>' +
-	'</form>';
+import {buildFragment} from 'frontend-js-web';
 
 export default function DocumentLibrary({
 	editEntryUrl,
@@ -63,14 +58,15 @@ export default function DocumentLibrary({
 
 		const newForm = document.createElement('div');
 
-		newForm.innerHTML = Liferay.Util.sub(TPL_MOVE_FORM, {
-			actionUrl: editEntryUrl,
-			namespace,
-			newFolderId,
-			parameterName,
-			parameterValue,
-			redirectUrl,
-		});
+		newForm.appendChild(
+			buildFragment(
+				`<form action="${editEntryUrl}" class="hide" method="POST"><input name="${namespace}cmd" value="move"/>
+					<input name="${namespace}newFolderId" value="${newFolderId}"/>
+					<input name="${namespace}${parameterName}" value="${parameterValue}"/>
+					<input name="${namespace}redirect" value="${redirectUrl}"/>
+				</form>`
+			)
+		);
 
 		const formNode = newForm.firstElementChild;
 

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view.jsp
@@ -233,7 +233,11 @@ DLViewDisplayContext dlViewDisplayContext = new DLViewDisplayContext(dlAdminDisp
 				<liferay-frontend:component
 					context='<%=
 						HashMapBuilder.<String, Object>put(
+							"editEntryUrl", dlViewDisplayContext.getEditEntryURL()
+						).put(
 							"namespace", "<portlet:namespace />"
+						).put(
+							"searchContainerId", "entries"
 						).build()
 					%>'
 					module="document_library/js/DocumentLibrary"

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view.jsp
@@ -238,6 +238,8 @@ DLViewDisplayContext dlViewDisplayContext = new DLViewDisplayContext(dlAdminDisp
 							"namespace", "<portlet:namespace />"
 						).put(
 							"searchContainerId", "entries"
+						).put(
+							"selectFolderURL", dlViewDisplayContext.getSelectFolderURL()
 						).build()
 					%>'
 					module="document_library/js/DocumentLibrary"

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view.jsp
@@ -228,97 +228,111 @@ DLViewDisplayContext dlViewDisplayContext = new DLViewDisplayContext(dlAdminDisp
 		}
 		%>
 
-		<aui:script>
-			function <portlet:namespace />move(
-				itemsSelected,
-				parameterName,
-				parameterValue
-			) {
-				var dlComponent = Liferay.component('<portlet:namespace />DocumentLibrary');
-
-				if (dlComponent) {
-					dlComponent.showFolderDialog(
+		<c:choose>
+			<c:when test='<%= GetterUtil.getBoolean(PropsUtil.get("feature.flag.LPS-118829")) %>'>
+				<liferay-frontend:component
+					context='<%=
+						HashMapBuilder.<String, Object>put(
+							"namespace", "<portlet:namespace />"
+						).build()
+					%>'
+					module="document_library/js/DocumentLibrary"
+				/>
+			</c:when>
+			<c:otherwise>
+				<aui:script>
+					function <portlet:namespace />move(
 						itemsSelected,
 						parameterName,
 						parameterValue
+					) {
+						var dlComponent = Liferay.component('<portlet:namespace />DocumentLibrary');
+
+						if (dlComponent) {
+							dlComponent.showFolderDialog(
+								itemsSelected,
+								parameterName,
+								parameterValue
+							);
+						}
+					}
+				</aui:script>
+
+				<aui:script use="liferay-document-library">
+					Liferay.component(
+						'<portlet:namespace />DocumentLibrary',
+						new Liferay.Portlet.DocumentLibrary({
+							columnNames: ['<%= dlViewDisplayContext.getColumnNames() %>'],
+
+							<%
+							DecimalFormatSymbols decimalFormatSymbols = DecimalFormatSymbols.getInstance(locale);
+							%>
+
+							decimalSeparator: '<%= decimalFormatSymbols.getDecimalSeparator() %>',
+							displayStyle:
+								'<%= HtmlUtil.escapeJS(dlAdminDisplayContext.getDisplayStyle()) %>',
+							editEntryUrl: '<%= dlViewDisplayContext.getEditEntryURL() %>',
+							downloadEntryUrl: '<%= dlViewDisplayContext.getDownloadEntryURL() %>',
+							folders: {
+								defaultParentFolderId: '<%= dlViewDisplayContext.getFolderId() %>',
+								dimensions: {
+									height:
+										'<%= PrefsPropsUtil.getLong(PropsKeys.DL_FILE_ENTRY_THUMBNAIL_MAX_HEIGHT) %>',
+									width:
+										'<%= PrefsPropsUtil.getLong(PropsKeys.DL_FILE_ENTRY_THUMBNAIL_MAX_WIDTH) %>',
+								},
+							},
+							form: {
+								method: 'POST',
+								node: A.one(document.<portlet:namespace />fm2),
+							},
+							maxFileSize: <%= DLValidatorUtil.getMaxAllowableSize(themeDisplay.getScopeGroupId(), null) %>,
+							namespace: '<portlet:namespace />',
+							openViewMoreFileEntryTypesURL:
+								'<%= dlViewDisplayContext.getViewMoreFileEntryTypesURL() %>',
+							portletId:
+								'<%= HtmlUtil.escapeJS(dlRequestHelper.getResourcePortletId()) %>',
+							redirect: encodeURIComponent('<%= currentURL %>'),
+							selectFileEntryTypeURL:
+								'<%= dlViewDisplayContext.getSelectFileEntryTypeURL() %>',
+							selectFolderURL: '<%= dlViewDisplayContext.getSelectFolderURL() %>',
+							scopeGroupId: <%= scopeGroupId %>,
+							searchContainerId: 'entries',
+							trashEnabled: <%= dlTrashHelper.isTrashEnabled(scopeGroupId, dlViewDisplayContext.getRepositoryId()) %>,
+							uploadable: <%= dlViewDisplayContext.isUploadable() %>,
+							uploadURL: '<%= dlViewDisplayContext.getUploadURL() %>',
+							viewFileEntryTypeURL:
+								'<%= dlViewDisplayContext.getViewFileEntryTypeURL() %>',
+							viewFileEntryURL: '<%= dlViewDisplayContext.getViewFileEntryURL() %>',
+						}),
+						{
+							destroyOnNavigate: true,
+							portletId:
+								'<%= HtmlUtil.escapeJS(dlRequestHelper.getResourcePortletId()) %>',
+						}
 					);
-				}
-			}
-		</aui:script>
 
-		<aui:script use="liferay-document-library">
-			Liferay.component(
-				'<portlet:namespace />DocumentLibrary',
-				new Liferay.Portlet.DocumentLibrary({
-					columnNames: ['<%= dlViewDisplayContext.getColumnNames() %>'],
+					var changeScopeHandles = function (event) {
+						documentLibrary.destroy();
 
-					<%
-					DecimalFormatSymbols decimalFormatSymbols = DecimalFormatSymbols.getInstance(locale);
-					%>
+						Liferay.detach('changeScope', changeScopeHandles);
+					};
 
-					decimalSeparator: '<%= decimalFormatSymbols.getDecimalSeparator() %>',
-					displayStyle:
-						'<%= HtmlUtil.escapeJS(dlAdminDisplayContext.getDisplayStyle()) %>',
-					editEntryUrl: '<%= dlViewDisplayContext.getEditEntryURL() %>',
-					downloadEntryUrl: '<%= dlViewDisplayContext.getDownloadEntryURL() %>',
-					folders: {
-						defaultParentFolderId: '<%= dlViewDisplayContext.getFolderId() %>',
-						dimensions: {
-							height:
-								'<%= PrefsPropsUtil.getLong(PropsKeys.DL_FILE_ENTRY_THUMBNAIL_MAX_HEIGHT) %>',
-							width:
-								'<%= PrefsPropsUtil.getLong(PropsKeys.DL_FILE_ENTRY_THUMBNAIL_MAX_WIDTH) %>',
-						},
-					},
-					form: {
-						method: 'POST',
-						node: A.one(document.<portlet:namespace />fm2),
-					},
-					maxFileSize: <%= DLValidatorUtil.getMaxAllowableSize(themeDisplay.getScopeGroupId(), null) %>,
-					namespace: '<portlet:namespace />',
-					openViewMoreFileEntryTypesURL:
-						'<%= dlViewDisplayContext.getViewMoreFileEntryTypesURL() %>',
-					portletId:
-						'<%= HtmlUtil.escapeJS(dlRequestHelper.getResourcePortletId()) %>',
-					redirect: encodeURIComponent('<%= currentURL %>'),
-					selectFileEntryTypeURL:
-						'<%= dlViewDisplayContext.getSelectFileEntryTypeURL() %>',
-					selectFolderURL: '<%= dlViewDisplayContext.getSelectFolderURL() %>',
-					scopeGroupId: <%= scopeGroupId %>,
-					searchContainerId: 'entries',
-					trashEnabled: <%= dlTrashHelper.isTrashEnabled(scopeGroupId, dlViewDisplayContext.getRepositoryId()) %>,
-					uploadable: <%= dlViewDisplayContext.isUploadable() %>,
-					uploadURL: '<%= dlViewDisplayContext.getUploadURL() %>',
-					viewFileEntryTypeURL:
-						'<%= dlViewDisplayContext.getViewFileEntryTypeURL() %>',
-					viewFileEntryURL: '<%= dlViewDisplayContext.getViewFileEntryURL() %>',
-				}),
-				{
-					destroyOnNavigate: true,
-					portletId:
-						'<%= HtmlUtil.escapeJS(dlRequestHelper.getResourcePortletId()) %>',
-				}
-			);
+					Liferay.on('changeScope', changeScopeHandles);
 
-			var changeScopeHandles = function (event) {
-				documentLibrary.destroy();
+					var editFileEntryHandler = function (event) {
+						var uri = '<%= dlViewDisplayContext.getAddFileEntryURL() %>';
 
-				Liferay.detach('changeScope', changeScopeHandles);
-			};
+						location.href = Liferay.Util.addParams(
+							'<portlet:namespace />fileEntryTypeId' + '=' + event.fileEntryTypeId,
+							uri
+						);
+					};
 
-			Liferay.on('changeScope', changeScopeHandles);
-
-			var editFileEntryHandler = function (event) {
-				var uri = '<%= dlViewDisplayContext.getAddFileEntryURL() %>';
-
-				location.href = Liferay.Util.addParams(
-					'<portlet:namespace />fileEntryTypeId' + '=' + event.fileEntryTypeId,
-					uri
-				);
-			};
-
-			Liferay.on('<portlet:namespace />selectAddMenuItem', editFileEntryHandler);
-		</aui:script>
+					Liferay.on('<portlet:namespace />selectAddMenuItem', editFileEntryHandler);
+				</aui:script>
+			</c:otherwise>
+		</c:choose>
 
 		<%
 		long[] groupIds = PortalUtil.getCurrentAndAncestorSiteGroupIds(scopeGroupId);


### PR DESCRIPTION
I divided the main task [LPS-118829 Remove AUI from main.js in Documents&Media ](https://issues.liferay.com/browse/LPS-118829 )in two. This replaces the AUI component, and it only misses the upload related functionality. 

functions migrated from main.js: 
- [x] _moveSingleElement
- [x] _openDocument: not used 
- [x] _processAction: not used. Inline code in __moveToTrash_
- [x] _handleSearchContainerRowToggled - simplified, _selectedFileEntries_ was not used
- [x] _moveCurrentSelection
- [x] _moveToFolder
- [x] _moveToTrash
- [x] showFolderDialog

Missing functions that will be covered in subtask [LPS-155521](https://issues.liferay.com/browse/LPS-155521)
- [ ] _plugUpload 
- [ ] getFolderId
- [ ] initializations in initializer function
