### PR TITLE
LPS-155052 remove duplicate title and description fields from metadata

### DIFF
--- a/modules/apps/document-library/document-library-video/src/main/resources/com/liferay/document/library/video/internal/util/dependencies/dl-video-external-shortcut-metadata-structure.xml
+++ b/modules/apps/document-library/document-library-video/src/main/resources/com/liferay/document/library/video/internal/util/dependencies/dl-video-external-shortcut-metadata-structure.xml
@@ -13,22 +13,6 @@
 					"defaultLanguageId": "[$LOCALE_DEFAULT$]",
 					"fields": [
 						{
-							"dataType": "string",
-							"fieldNamespace": "",
-							"indexType": "keyword",
-							"label": {
-								"[$LOCALE_DEFAULT$]": "DESCRIPTION"
-							},
-							"localizable": true,
-							"multiple": false,
-							"name": "DESCRIPTION",
-							"readOnly": false,
-							"repeatable": false,
-							"required": false,
-							"showLabel": true,
-							"type": "text"
-						},
-						{
 							"dataType": "html",
 							"fieldNamespace": "",
 							"indexType": "keyword",
@@ -54,22 +38,6 @@
 							"localizable": true,
 							"multiple": false,
 							"name": "THUMBNAIL_URL",
-							"readOnly": false,
-							"repeatable": false,
-							"required": false,
-							"showLabel": true,
-							"type": "text"
-						},
-						{
-							"dataType": "string",
-							"fieldNamespace": "",
-							"indexType": "keyword",
-							"label": {
-								"[$LOCALE_DEFAULT$]": "TITLE"
-							},
-							"localizable": true,
-							"multiple": false,
-							"name": "TITLE",
 							"readOnly": false,
 							"repeatable": false,
 							"required": false,
@@ -107,16 +75,6 @@
 									"columns": [
 										{
 											"fieldNames": [
-												"DESCRIPTION"
-											],
-											"size": 12
-										}
-									]
-								},
-								{
-									"columns": [
-										{
-											"fieldNames": [
 												"HTML"
 											],
 											"size": 12
@@ -128,16 +86,6 @@
 										{
 											"fieldNames": [
 												"THUMBNAIL_URL"
-											],
-											"size": 12
-										}
-									]
-								},
-								{
-									"columns": [
-										{
-											"fieldNames": [
-												"TITLE"
 											],
 											"size": 12
 										}

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/EditFileEntryMVCActionCommand.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/EditFileEntryMVCActionCommand.java
@@ -1102,6 +1102,8 @@ public class EditFileEntryMVCActionCommand extends BaseMVCActionCommand {
 				"mvcPath", "/document_library/error.jsp");
 		}
 		else {
+			SessionErrors.add(actionRequest, exception.getClass());
+
 			if (cmd.equals(Constants.ADD_DYNAMIC)) {
 				JSONObject jsonObject;
 


### PR DESCRIPTION
- LPS-155052 remove title and description attribute that are duplicated on ddm and the fileEntry and the metadata are never used
- LPS-155052 send to session error the exception to let the user that something went wrong
