### PR TITLE
LPS-152920 in some cases propsvalues were not been unsetted and this could interfere with another test and props of the portal

### DIFF
--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/exportimport/data/handler/test/JournalExportImportTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/exportimport/data/handler/test/JournalExportImportTest.java
@@ -46,7 +46,6 @@ import com.liferay.journal.model.JournalArticleResource;
 import com.liferay.journal.service.JournalArticleLocalServiceUtil;
 import com.liferay.journal.test.util.JournalTestUtil;
 import com.liferay.journal.util.JournalContent;
-import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -76,12 +75,8 @@ import com.liferay.portal.kernel.zip.ZipReaderFactoryUtil;
 import com.liferay.portal.kernel.zip.ZipWriter;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
-import com.liferay.portal.util.PropsValues;
 
 import java.io.Serializable;
-
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 
 import java.util.Date;
 import java.util.HashMap;
@@ -119,22 +114,6 @@ public class JournalExportImportTest extends BasePortletExportImportTestCase {
 	@Override
 	public String getPortletId() {
 		return JournalPortletKeys.JOURNAL;
-	}
-
-	public void setPortalProperty(String propertyName, Object value)
-		throws Exception {
-
-		Field field = ReflectionUtil.getDeclaredField(
-			PropsValues.class, propertyName);
-
-		field.setAccessible(true);
-
-		Field modifiersField = Field.class.getDeclaredField("modifiers");
-
-		modifiersField.setAccessible(true);
-		modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
-
-		field.set(null, value);
 	}
 
 	@Before

--- a/modules/apps/staging/staging-test/src/testIntegration/java/com/liferay/staging/test/StagingGroupHelperTest.java
+++ b/modules/apps/staging/staging-test/src/testIntegration/java/com/liferay/staging/test/StagingGroupHelperTest.java
@@ -17,6 +17,7 @@ package com.liferay.staging.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.exportimport.kernel.service.StagingLocalServiceUtil;
 import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.kernel.exception.NoSuchGroupException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -900,38 +901,42 @@ public class StagingGroupHelperTest {
 		_remoteLiveGroup = GroupTestUtil.addGroup();
 		_remoteStagingGroup = GroupTestUtil.addGroup();
 
-		PropsValuesTestUtil.setPortalProperty(
-			"TUNNELING_SERVLET_SHARED_SECRET",
-			"F0E1D2C3B4A5968778695A4B3C2D1E0F");
-		PropsValuesTestUtil.setPortalProperty(
-			"TUNNELING_SERVLET_SHARED_SECRET_HEX", true);
+		try (SafeCloseable safeCloseable1 =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"TUNNELING_SERVLET_SHARED_SECRET",
+					"F0E1D2C3B4A5968778695A4B3C2D1E0F");
+			SafeCloseable safeCloseable2 =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"TUNNELING_SERVLET_SHARED_SECRET_HEX", true)) {
 
-		int serverPort = PortalUtil.getPortalServerPort(false);
+			int serverPort = PortalUtil.getPortalServerPort(false);
 
-		Assert.assertFalse(
-			"Invalid server port: " + serverPort,
-			(serverPort < 1) || (serverPort > 65535));
+			Assert.assertFalse(
+				"Invalid server port: " + serverPort,
+				(serverPort < 1) || (serverPort > 65535));
 
-		String pathContext = PortalUtil.getPathContext();
+			String pathContext = PortalUtil.getPathContext();
 
-		UserTestUtil.setUser(TestPropsValues.getUser());
+			UserTestUtil.setUser(TestPropsValues.getUser());
 
-		ServiceContext serviceContext = new ServiceContext();
+			ServiceContext serviceContext = new ServiceContext();
 
-		serviceContext.setAttribute(
-			"staged--staged-portlet_" + _PORTLET_ID_BLOGS + "--", "false");
-		serviceContext.setAttribute(
-			"staged--staged-portlet_" + _PORTLET_ID_BOOKMARKS + "--", "true");
+			serviceContext.setAttribute(
+				"staged--staged-portlet_" + _PORTLET_ID_BLOGS + "--", "false");
+			serviceContext.setAttribute(
+				"staged--staged-portlet_" + _PORTLET_ID_BOOKMARKS + "--",
+				"true");
 
-		StagingLocalServiceUtil.enableRemoteStaging(
-			TestPropsValues.getUserId(), _remoteStagingGroup, false, false,
-			"localhost", serverPort, pathContext, false,
-			_remoteLiveGroup.getGroupId(), serviceContext);
+			StagingLocalServiceUtil.enableRemoteStaging(
+				TestPropsValues.getUserId(), _remoteStagingGroup, false, false,
+				"localhost", serverPort, pathContext, false,
+				_remoteLiveGroup.getGroupId(), serviceContext);
 
-		GroupUtil.clearCache();
+			GroupUtil.clearCache();
 
-		_remoteLiveGroup = GroupLocalServiceUtil.getGroup(
-			_remoteLiveGroup.getGroupId());
+			_remoteLiveGroup = GroupLocalServiceUtil.getGroup(
+				_remoteLiveGroup.getGroupId());
+		}
 	}
 
 	private Group _addScopeGroup(Group group) throws Exception {

--- a/modules/apps/staging/staging-test/src/testIntegration/java/com/liferay/staging/test/StagingGroupHelperTest.java
+++ b/modules/apps/staging/staging-test/src/testIntegration/java/com/liferay/staging/test/StagingGroupHelperTest.java
@@ -42,6 +42,8 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.staging.StagingGroupHelper;
 
+import java.util.function.Supplier;
+
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -144,14 +146,21 @@ public class StagingGroupHelperTest {
 
 		Assert.assertEquals(
 			_remoteLiveGroup,
-			_stagingGroupHelper.fetchLiveGroup(_remoteStagingGroup));
+			_executeWithRemoteCredentials(
+				() -> _stagingGroupHelper.fetchLiveGroup(_remoteStagingGroup)));
 		Assert.assertEquals(
 			_remoteLiveGroup,
-			_stagingGroupHelper.fetchLiveGroup(_remoteStagingScopeGroup));
+			_executeWithRemoteCredentials(
+				() -> _stagingGroupHelper.fetchLiveGroup(
+					_remoteStagingScopeGroup)));
 
-		Assert.assertNull(_stagingGroupHelper.fetchLiveGroup(_remoteLiveGroup));
 		Assert.assertNull(
-			_stagingGroupHelper.fetchLiveGroup(_remoteLiveScopeGroup));
+			_executeWithRemoteCredentials(
+				() -> _stagingGroupHelper.fetchLiveGroup(_remoteLiveGroup)));
+		Assert.assertNull(
+			_executeWithRemoteCredentials(
+				() -> _stagingGroupHelper.fetchLiveGroup(
+					_remoteLiveScopeGroup)));
 
 		Assert.assertNull(_stagingGroupHelper.fetchLiveGroup(_regularGroup));
 	}
@@ -228,15 +237,23 @@ public class StagingGroupHelperTest {
 
 		Assert.assertEquals(
 			_remoteLiveGroup,
-			_stagingGroupHelper.fetchRemoteLiveGroup(_remoteStagingGroup));
+			_executeWithRemoteCredentials(
+				() -> _stagingGroupHelper.fetchRemoteLiveGroup(
+					_remoteStagingGroup)));
 		Assert.assertEquals(
 			_remoteLiveGroup,
-			_stagingGroupHelper.fetchRemoteLiveGroup(_remoteStagingScopeGroup));
+			_executeWithRemoteCredentials(
+				() -> _stagingGroupHelper.fetchRemoteLiveGroup(
+					_remoteStagingScopeGroup)));
 
 		Assert.assertNull(
-			_stagingGroupHelper.fetchRemoteLiveGroup(_remoteLiveGroup));
+			_executeWithRemoteCredentials(
+				() -> _stagingGroupHelper.fetchRemoteLiveGroup(
+					_remoteLiveGroup)));
 		Assert.assertNull(
-			_stagingGroupHelper.fetchRemoteLiveGroup(_remoteLiveScopeGroup));
+			_executeWithRemoteCredentials(
+				() -> _stagingGroupHelper.fetchRemoteLiveGroup(
+					_remoteLiveScopeGroup)));
 
 		Assert.assertNull(
 			_stagingGroupHelper.fetchRemoteLiveGroup(_regularGroup));
@@ -951,6 +968,19 @@ public class StagingGroupHelperTest {
 			).build(),
 			null, 0, true, GroupConstants.DEFAULT_MEMBERSHIP_RESTRICTION, null,
 			false, true, null);
+	}
+
+	private Group _executeWithRemoteCredentials(Supplier<Group> groupSupplier) {
+		try (SafeCloseable safeCloseable1 =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"TUNNELING_SERVLET_SHARED_SECRET",
+					"F0E1D2C3B4A5968778695A4B3C2D1E0F");
+			SafeCloseable safeCloseable2 =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"TUNNELING_SERVLET_SHARED_SECRET_HEX", true)) {
+
+			return groupSupplier.get();
+		}
 	}
 
 	private static final String _PORTLET_ID_BLOGS =

--- a/portal-test/bnd.bnd
+++ b/portal-test/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 12.0.2
+Bundle-Version: 13.0.0
 Export-Package:\
 	com.liferay.portal.kernel.dao.db.test,\
 	com.liferay.portal.kernel.test,\

--- a/portal-test/src/com/liferay/portal/kernel/test/util/PropsValuesTestUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/util/PropsValuesTestUtil.java
@@ -15,35 +15,15 @@
 package com.liferay.portal.kernel.test.util;
 
 import com.liferay.petra.lang.SafeCloseable;
-import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.util.PropsUtil;
 import com.liferay.portal.util.PropsValues;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
-
 /**
  * @author Shuyang Zhou
  */
 public class PropsValuesTestUtil {
-
-	public static void setPortalProperty(String propertyName, Object value)
-		throws Exception {
-
-		Field field = ReflectionUtil.getDeclaredField(
-			PropsValues.class, propertyName);
-
-		field.setAccessible(true);
-
-		Field modifiersField = Field.class.getDeclaredField("modifiers");
-
-		modifiersField.setAccessible(true);
-		modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
-
-		field.set(null, value);
-	}
 
 	public static SafeCloseable swapWithSafeCloseable(
 		String propsKeysFieldName, Object value) {

--- a/portal-test/src/com/liferay/portal/kernel/test/util/packageinfo
+++ b/portal-test/src/com/liferay/portal/kernel/test/util/packageinfo
@@ -1,1 +1,1 @@
-version 4.0.0
+version 5.0.0


### PR DESCRIPTION
- LPS-152920 propsvalues were not been unsetted and this could interfere with another test and props of the portal
- LPS-152920 some methods need the credentials for remote when checking remote groups or layouts
- LPS-152920 no longer needed
- LPS-152920 baseline
- LPS-152920 not needed
