### PR TITLE
LPS-155705 Added WEBP format support to ImageMagic scaling.

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/scaler/AMImageMagickImageScaler.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/scaler/AMImageMagickImageScaler.java
@@ -46,7 +46,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Eric Yan
  */
 @Component(
-	immediate = true, property = "mime.type=image/heic",
+	immediate = true, property = {
+		"mime.type=image/heic",
+		"mime.type=image/webp"
+	},
 	service = AMImageScaler.class
 )
 public class AMImageMagickImageScaler implements AMImageScaler {


### PR DESCRIPTION
Hi @liferay-lima. This is the solution to the lack of WEBP renderer for the creation of previews that we talked about last week.

Since we have already delegated the creation of HEIC images into ImageMagic, adding this format to the list of formats that will be preconverted by ImageMagic is the best solution until we find a suitable renderer for this format.

