### PR TITLE
LPS-155973 Add loading to render the correct wiki tree

### DIFF
--- a/modules/apps/wiki/wiki-navigation-web/src/main/resources/META-INF/resources/tree_menu/view.jsp
+++ b/modules/apps/wiki/wiki-navigation-web/src/main/resources/META-INF/resources/tree_menu/view.jsp
@@ -35,7 +35,9 @@ List<MenuItem> menuItems = MenuItem.fromWikiNode(selNodeId, depth, viewURL);
 			<%= _buildTreeMenuHTML(menuItems, title, true) %>
 
 			<aui:script use="aui-tree-view">
-				var wikiPageList = A.one('.wiki-navigation-portlet-tree-menu .tree-menu');
+				var wikiPageList = A.one(
+					'.wiki-navigation-portlet-tree-menu .loading .tree-menu'
+				);
 				var wikiPageListContainer = wikiPageList.ancestor('.tree-view-container');
 
 				var treeView = new A.TreeView({


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-155973

When adding a second wiki tree to the page, the portlet will be stuck with an animation. This was due to getting the first wiki tree and ignoring all the other trees. By adding `.loading`, we are able to grab the first tree and then continue with the next tree when the script runs again.
Let me know if there are any questions or comments about this.

Thank you.