### PR TITLE
LPS-155869 DM set icons in PortletIcons

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/configuration/icon/DeleteFolderPortletConfigurationIcon.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/configuration/icon/DeleteFolderPortletConfigurationIcon.java
@@ -56,6 +56,11 @@ public class DeleteFolderPortletConfigurationIcon
 	extends BasePortletConfigurationIcon {
 
 	@Override
+	public String getIconCssClass() {
+		return "trash";
+	}
+
+	@Override
 	public String getMessage(PortletRequest portletRequest) {
 		return LanguageUtil.get(
 			getResourceBundle(getLocale(portletRequest)), "delete");

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/configuration/icon/DownloadFolderPortletConfigurationIcon.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/configuration/icon/DownloadFolderPortletConfigurationIcon.java
@@ -52,6 +52,11 @@ public class DownloadFolderPortletConfigurationIcon
 	extends BasePortletConfigurationIcon {
 
 	@Override
+	public String getIconCssClass() {
+		return "download";
+	}
+
+	@Override
 	public String getMessage(PortletRequest portletRequest) {
 		return LanguageUtil.get(
 			getResourceBundle(getLocale(portletRequest)), "download");

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/configuration/icon/EditFolderPortletConfigurationIcon.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/configuration/icon/EditFolderPortletConfigurationIcon.java
@@ -60,6 +60,11 @@ public class EditFolderPortletConfigurationIcon
 	extends BasePortletConfigurationIcon {
 
 	@Override
+	public String getIconCssClass() {
+		return "pencil";
+	}
+
+	@Override
 	public String getMessage(PortletRequest portletRequest) {
 		return LanguageUtil.get(
 			getResourceBundle(getLocale(portletRequest)), "edit");

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/configuration/icon/FolderPermissionPortletConfigurationIcon.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/configuration/icon/FolderPermissionPortletConfigurationIcon.java
@@ -54,6 +54,11 @@ public class FolderPermissionPortletConfigurationIcon
 	extends BasePortletConfigurationIcon {
 
 	@Override
+	public String getIconCssClass() {
+		return "password-policies";
+	}
+
+	@Override
 	public String getMessage(PortletRequest portletRequest) {
 		return LanguageUtil.get(
 			getResourceBundle(getLocale(portletRequest)), "permissions");

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/configuration/icon/MoveFolderPortletConfigurationIcon.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/configuration/icon/MoveFolderPortletConfigurationIcon.java
@@ -53,6 +53,11 @@ public class MoveFolderPortletConfigurationIcon
 	extends BasePortletConfigurationIcon {
 
 	@Override
+	public String getIconCssClass() {
+		return "move-folder";
+	}
+
+	@Override
 	public String getMessage(PortletRequest portletRequest) {
 		return LanguageUtil.get(
 			getResourceBundle(getLocale(portletRequest)), "move");

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/configuration/icon/PermissionsPortletConfigurationIcon.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/configuration/icon/PermissionsPortletConfigurationIcon.java
@@ -53,6 +53,11 @@ public class PermissionsPortletConfigurationIcon
 	extends BasePortletConfigurationIcon {
 
 	@Override
+	public String getIconCssClass() {
+		return "password-policies";
+	}
+
+	@Override
 	public String getMessage(PortletRequest portletRequest) {
 		return LanguageUtil.get(
 			getResourceBundle(getLocale(portletRequest)),


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-155869

Not under a feature flag because some of this portlet icons had icons before, and in the original epic we were settings icons in the dropdowns. 

Also not that there are more icons than described in the issue (access a folder to see them). I haven't tested the sharepoint repository but I hope these actions are already covered here. 

<img width="830" alt="Screenshot 2022-06-14 at 11 59 28" src="https://user-images.githubusercontent.com/8373764/173553062-0c906c25-3ef5-4964-9c69-e85cb270f71e.png">

