### PR TITLE
LPS-156273 Add dropdown support for DM extensions

### DIFF
--- a/modules/apps/document-library-google-docs/document-library-google-docs/build.gradle
+++ b/modules/apps/document-library-google-docs/document-library-google-docs/build.gradle
@@ -10,6 +10,7 @@ dependencies {
 	compileOnly project(":apps:document-library:document-library-api")
 	compileOnly project(":apps:document-library:document-library-google-drive-api")
 	compileOnly project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")
+	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
 	compileOnly project(":apps:item-selector:item-selector-api")
 	compileOnly project(":apps:item-selector:item-selector-criteria-api")
 	compileOnly project(":apps:portal:portal-instance-lifecycle-api")

--- a/modules/apps/document-library-google-docs/document-library-google-docs/src/main/java/com/liferay/document/library/google/docs/internal/display/context/GoogleDocsDLViewFileVersionDisplayContext.java
+++ b/modules/apps/document-library-google-docs/document-library-google-docs/src/main/java/com/liferay/document/library/google/docs/internal/display/context/GoogleDocsDLViewFileVersionDisplayContext.java
@@ -19,6 +19,7 @@ import com.liferay.document.library.display.context.DLViewFileVersionDisplayCont
 import com.liferay.document.library.google.docs.internal.helper.GoogleDocsMetadataHelper;
 import com.liferay.document.library.google.docs.internal.util.constants.GoogleDocsConstants;
 import com.liferay.dynamic.data.mapping.kernel.DDMStructure;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.repository.model.FileVersion;
@@ -60,6 +61,32 @@ public class GoogleDocsDLViewFileVersionDisplayContext
 
 		_googleDocsUIItemsProcessor = new GoogleDocsUIItemsProcessor(
 			httpServletRequest, googleDocsMetadataHelper);
+	}
+
+	@Override
+	public List<DropdownItem> getActionDropdownItems() throws PortalException {
+		List<DropdownItem> actionDropdownItems = super.getActionDropdownItems();
+
+		if (!isActionsVisible()) {
+			return actionDropdownItems;
+		}
+
+		// See LPS-79987
+
+		if (Validator.isNull(
+				_googleDocsMetadataHelper.getFieldValue(
+					GoogleDocsConstants.DDM_FIELD_NAME_URL))) {
+
+			return actionDropdownItems;
+		}
+
+		actionDropdownItems.removeIf(
+			dropdownItem -> Objects.equals(
+				dropdownItem.get("key"), "#edit-with-image-editor"));
+
+		_googleDocsUIItemsProcessor.processDropdownItems(actionDropdownItems);
+
+		return actionDropdownItems;
 	}
 
 	@Override

--- a/modules/apps/document-library-google-docs/document-library-google-docs/src/main/java/com/liferay/document/library/google/docs/internal/display/context/GoogleDocsUIItemsProcessor.java
+++ b/modules/apps/document-library-google-docs/document-library-google-docs/src/main/java/com/liferay/document/library/google/docs/internal/display/context/GoogleDocsUIItemsProcessor.java
@@ -17,6 +17,8 @@ package com.liferay.document.library.google.docs.internal.display.context;
 import com.liferay.document.library.display.context.DLUIItemKeys;
 import com.liferay.document.library.google.docs.internal.helper.GoogleDocsMetadataHelper;
 import com.liferay.document.library.google.docs.internal.util.constants.GoogleDocsConstants;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemBuilder;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.servlet.taglib.ui.MenuItem;
 import com.liferay.portal.kernel.servlet.taglib.ui.ToolbarItem;
@@ -26,10 +28,16 @@ import com.liferay.portal.kernel.servlet.taglib.ui.URLToolbarItem;
 import com.liferay.portal.kernel.servlet.taglib.ui.URLUIItem;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 
+import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import java.util.ResourceBundle;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Predicate;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -44,6 +52,12 @@ public class GoogleDocsUIItemsProcessor {
 
 		_httpServletRequest = httpServletRequest;
 		_googleDocsMetadataHelper = googleDocsMetadataHelper;
+	}
+
+	public void processDropdownItems(List<DropdownItem> dropdownItems) {
+		_removeUnsupportedDropdownItems(dropdownItems);
+
+		_insertEditInGoogleDropdownItem(dropdownItems);
 	}
 
 	public void processMenuItems(List<MenuItem> menuItems) {
@@ -61,16 +75,53 @@ public class GoogleDocsUIItemsProcessor {
 		_insertEditInGoogleURLUIItem(new URLToolbarItem(), toolbarItems);
 	}
 
-	private int _getIndex(List<? extends UIItem> uiItems, String key) {
-		for (int i = 0; i < uiItems.size(); i++) {
-			UIItem uiItem = uiItems.get(i);
-
-			if (key.equals(uiItem.getKey())) {
+	private <T> int _getIndex(List<T> items, Predicate<T> predicate) {
+		for (int i = 0; i < items.size(); i++) {
+			if (predicate.test(items.get(i))) {
 				return i;
 			}
 		}
 
 		return -1;
+	}
+
+	private void _insertEditInGoogleDropdownItem(
+		List<DropdownItem> dropdownItems) {
+
+		if (!_googleDocsMetadataHelper.containsField(
+				GoogleDocsConstants.DDM_FIELD_NAME_URL)) {
+
+			return;
+		}
+
+		int index = _getIndex(
+			dropdownItems,
+			dropdownItem -> Objects.equals(
+				dropdownItem.get("key"), DLUIItemKeys.EDIT));
+
+		if (index == -1) {
+			index = 0;
+		}
+
+		dropdownItems.add(
+			index,
+			DropdownItemBuilder.setHref(
+				_googleDocsMetadataHelper.getFieldValue(
+					GoogleDocsConstants.DDM_FIELD_NAME_URL)
+			).setKey(
+				GoogleDocsUIItemKeys.EDIT_IN_GOOGLE
+			).setLabel(
+				() -> {
+					ThemeDisplay themeDisplay =
+						(ThemeDisplay)_httpServletRequest.getAttribute(
+							WebKeys.THEME_DISPLAY);
+
+					return LanguageUtil.get(
+						themeDisplay.getLocale(), "edit-in-google-drive");
+				}
+			).setTarget(
+				"_blank"
+			).build());
 	}
 
 	private <T extends URLUIItem> T _insertEditInGoogleURLUIItem(
@@ -83,7 +134,8 @@ public class GoogleDocsUIItemsProcessor {
 		}
 
 		int index = _getIndex(
-			(List<? extends UIItem>)urlUIItems, DLUIItemKeys.EDIT);
+			(List<? extends UIItem>)urlUIItems,
+			uiItem -> Objects.equals(uiItem.getKey(), DLUIItemKeys.EDIT));
 
 		if (index == -1) {
 			index = 0;
@@ -115,21 +167,38 @@ public class GoogleDocsUIItemsProcessor {
 		return urlUIItem;
 	}
 
-	private void _removeUIItem(List<? extends UIItem> uiItems, String key) {
-		int index = _getIndex(uiItems, key);
+	private <T> void _removeItems(
+		List<T> items, Function<T, String> function, Set<String> keys) {
 
-		if (index != -1) {
-			uiItems.remove(index);
+		Iterator<T> iterator = items.iterator();
+
+		while (iterator.hasNext()) {
+			T item = iterator.next();
+
+			if (keys.contains(function.apply(item))) {
+				iterator.remove();
+			}
 		}
 	}
 
+	private void _removeUnsupportedDropdownItems(
+		List<DropdownItem> dropdownItems) {
+
+		_removeItems(
+			dropdownItems, dropdownItem -> (String)dropdownItem.get("key"),
+			SetUtil.fromArray(
+				DLUIItemKeys.CANCEL_CHECKOUT, DLUIItemKeys.CHECKIN,
+				DLUIItemKeys.CHECKOUT, DLUIItemKeys.DOWNLOAD,
+				DLUIItemKeys.OPEN_IN_MS_OFFICE, "#edit-in-google-drive"));
+	}
+
 	private void _removeUnsupportedUIItems(List<? extends UIItem> uiItems) {
-		_removeUIItem(uiItems, DLUIItemKeys.CANCEL_CHECKOUT);
-		_removeUIItem(uiItems, DLUIItemKeys.CHECKIN);
-		_removeUIItem(uiItems, DLUIItemKeys.CHECKOUT);
-		_removeUIItem(uiItems, DLUIItemKeys.DOWNLOAD);
-		_removeUIItem(uiItems, DLUIItemKeys.OPEN_IN_MS_OFFICE);
-		_removeUIItem(uiItems, "#edit-in-google-drive");
+		_removeItems(
+			uiItems, UIItem::getKey,
+			SetUtil.fromArray(
+				DLUIItemKeys.CANCEL_CHECKOUT, DLUIItemKeys.CHECKIN,
+				DLUIItemKeys.CHECKOUT, DLUIItemKeys.DOWNLOAD,
+				DLUIItemKeys.OPEN_IN_MS_OFFICE, "#edit-in-google-drive"));
 	}
 
 	private final GoogleDocsMetadataHelper _googleDocsMetadataHelper;

--- a/modules/apps/document-library/document-library-video/src/main/java/com/liferay/document/library/video/internal/display/context/DLVideoExternalShortcutDLViewFileVersionDisplayContext.java
+++ b/modules/apps/document-library/document-library-video/src/main/java/com/liferay/document/library/video/internal/display/context/DLVideoExternalShortcutDLViewFileVersionDisplayContext.java
@@ -19,6 +19,7 @@ import com.liferay.document.library.display.context.DLViewFileVersionDisplayCont
 import com.liferay.document.library.video.internal.constants.DLVideoConstants;
 import com.liferay.document.library.video.internal.util.DLVideoExternalShortcutUIItemsUtil;
 import com.liferay.dynamic.data.mapping.kernel.DDMStructure;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.repository.model.FileVersion;
 import com.liferay.portal.kernel.servlet.taglib.ui.Menu;
@@ -46,6 +47,16 @@ public class DLVideoExternalShortcutDLViewFileVersionDisplayContext
 		super(
 			_UUID, parentDLDisplayContext, httpServletRequest,
 			httpServletResponse, fileVersion);
+	}
+
+	@Override
+	public List<DropdownItem> getActionDropdownItems() throws PortalException {
+		List<DropdownItem> actionDropdownItems = super.getActionDropdownItems();
+
+		DLVideoExternalShortcutUIItemsUtil.processDropdownItems(
+			actionDropdownItems);
+
+		return actionDropdownItems;
 	}
 
 	@Override

--- a/modules/apps/document-library/document-library-video/src/main/java/com/liferay/document/library/video/internal/util/DLVideoExternalShortcutUIItemsUtil.java
+++ b/modules/apps/document-library/document-library-video/src/main/java/com/liferay/document/library/video/internal/util/DLVideoExternalShortcutUIItemsUtil.java
@@ -15,9 +15,14 @@
 package com.liferay.document.library.video.internal.util;
 
 import com.liferay.document.library.display.context.DLUIItemKeys;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
 import com.liferay.portal.kernel.servlet.taglib.ui.UIItem;
+import com.liferay.portal.kernel.util.SetUtil;
 
+import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
 
 /**
  * @author Iván Zaera
@@ -25,33 +30,35 @@ import java.util.List;
  */
 public class DLVideoExternalShortcutUIItemsUtil {
 
+	public static void processDropdownItems(List<DropdownItem> dropdownItems) {
+		_removeItems(
+			dropdownItems, dropdownItem -> (String)dropdownItem.get("key"),
+			SetUtil.fromArray(
+				DLUIItemKeys.CANCEL_CHECKOUT, DLUIItemKeys.CHECKIN,
+				DLUIItemKeys.CHECKOUT, DLUIItemKeys.DOWNLOAD,
+				DLUIItemKeys.OPEN_IN_MS_OFFICE));
+	}
+
 	public static void processUIItems(List<? extends UIItem> uiItems) {
-		_removeUIItem(uiItems, DLUIItemKeys.CANCEL_CHECKOUT);
-		_removeUIItem(uiItems, DLUIItemKeys.CHECKIN);
-		_removeUIItem(uiItems, DLUIItemKeys.CHECKOUT);
-		_removeUIItem(uiItems, DLUIItemKeys.DOWNLOAD);
-		_removeUIItem(uiItems, DLUIItemKeys.OPEN_IN_MS_OFFICE);
+		_removeItems(
+			uiItems, UIItem::getKey,
+			SetUtil.fromArray(
+				DLUIItemKeys.CANCEL_CHECKOUT, DLUIItemKeys.CHECKIN,
+				DLUIItemKeys.CHECKOUT, DLUIItemKeys.DOWNLOAD,
+				DLUIItemKeys.OPEN_IN_MS_OFFICE));
 	}
 
-	private static int _getIndex(List<? extends UIItem> uiItems, String key) {
-		for (int i = 0; i < uiItems.size(); i++) {
-			UIItem uiItem = uiItems.get(i);
+	private static <T> void _removeItems(
+		List<T> items, Function<T, String> function, Set<String> keys) {
 
-			if (key.equals(uiItem.getKey())) {
-				return i;
+		Iterator<T> iterator = items.iterator();
+
+		while (iterator.hasNext()) {
+			T item = iterator.next();
+
+			if (keys.contains(function.apply(item))) {
+				iterator.remove();
 			}
-		}
-
-		return -1;
-	}
-
-	private static void _removeUIItem(
-		List<? extends UIItem> uiItems, String key) {
-
-		int index = _getIndex(uiItems, key);
-
-		if (index != -1) {
-			uiItems.remove(index);
 		}
 	}
 

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/logic/UIItemsBuilder.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/logic/UIItemsBuilder.java
@@ -930,6 +930,8 @@ public class UIItemsBuilder {
 			).setParameter(
 				"fileEntryId", _fileEntry.getFileEntryId()
 			).buildString()
+		).setKey(
+			DLUIItemKeys.CANCEL_CHECKOUT
 		).setLabel(
 			LanguageUtil.get(_httpServletRequest, "cancel-checkout[document]")
 		).build();
@@ -948,6 +950,8 @@ public class UIItemsBuilder {
 				portletURL.toString()
 			).setIcon(
 				"unlock"
+			).setKey(
+				DLUIItemKeys.CHECKIN
 			).setLabel(
 				LanguageUtil.get(_httpServletRequest, "checkin")
 			).build();
@@ -964,6 +968,8 @@ public class UIItemsBuilder {
 				HtmlUtil.escapeJS(portletURL.toString()), "');")
 		).setIcon(
 			"unlock"
+		).setKey(
+			DLUIItemKeys.CHECKIN
 		).setLabel(
 			LanguageUtil.get(_httpServletRequest, "checkin")
 		).build();
@@ -979,6 +985,8 @@ public class UIItemsBuilder {
 			).buildString()
 		).setIcon(
 			"lock"
+		).setKey(
+			DLUIItemKeys.CHECKOUT
 		).setLabel(
 			LanguageUtil.get(_httpServletRequest, "checkout[document]")
 		).build();
@@ -1000,6 +1008,8 @@ public class UIItemsBuilder {
 					"fileEntryId", _fileEntry.getFileEntryId()
 				).buildString();
 			}
+		).setKey(
+			DLUIItemKeys.COLLECT_DIGITAL_SIGNATURE
 		).setLabel(
 			LanguageUtil.get(_httpServletRequest, "collect-digital-signature")
 		).build();
@@ -1080,6 +1090,8 @@ public class UIItemsBuilder {
 			"deleteURL", portletURL.toString()
 		).setIcon(
 			"trash"
+		).setKey(
+			DLUIItemKeys.DELETE
 		).setLabel(
 			LanguageUtil.get(_httpServletRequest, "delete")
 		).build();
@@ -1131,6 +1143,8 @@ public class UIItemsBuilder {
 				appendVersion, true)
 		).setIcon(
 			"download"
+		).setKey(
+			DLUIItemKeys.DOWNLOAD
 		).setLabel(
 			StringBundler.concat(
 				_themeDisplay.translate("download"), " (",
@@ -1158,6 +1172,8 @@ public class UIItemsBuilder {
 			portletURL.toString()
 		).setIcon(
 			"pencil"
+		).setKey(
+			DLUIItemKeys.EDIT
 		).setLabel(
 			LanguageUtil.get(_httpServletRequest, "edit")
 		).build();
@@ -1172,6 +1188,8 @@ public class UIItemsBuilder {
 			"imageURL",
 			_dlURLHelper.getPreviewURL(
 				_fileEntry, _fileVersion, _themeDisplay, StringPool.BLANK)
+		).setKey(
+			DLUIItemKeys.EDIT_IMAGE
 		).setLabel(
 			LanguageUtil.get(_httpServletRequest, "edit-image")
 		).build();
@@ -1190,6 +1208,8 @@ public class UIItemsBuilder {
 					String.valueOf(_fileEntry.getFileEntryId())
 		).setIcon(
 			"move-folder"
+		).setKey(
+			DLUIItemKeys.MOVE
 		).setLabel(
 			LanguageUtil.get(_httpServletRequest, "move")
 		).build();
@@ -1227,6 +1247,8 @@ public class UIItemsBuilder {
 			"permissionsURL", url
 		).setIcon(
 			"password-policies"
+		).setKey(
+			DLUIItemKeys.PERMISSIONS
 		).setLabel(
 			LanguageUtil.get(_httpServletRequest, "permissions")
 		).build();
@@ -1257,6 +1279,8 @@ public class UIItemsBuilder {
 			"action", "publish"
 		).putData(
 			"publishURL", portletURL.toString()
+		).setKey(
+			DLUIItemKeys.PUBLISH
 		).setLabel(
 			LanguageUtil.get(_httpServletRequest, "publish-to-live")
 		).build();
@@ -1291,6 +1315,8 @@ public class UIItemsBuilder {
 			).setParameter(
 				"fileEntryId", _fileShortcut.getToFileEntryId()
 			).buildString()
+		).setKey(
+			DLUIItemKeys.VIEW_ORIGINAL_FILE
 		).setLabel(
 			LanguageUtil.get(_httpServletRequest, "view-original-file")
 		).build();

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/util/DropdownItem.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/util/DropdownItem.java
@@ -27,6 +27,10 @@ public class DropdownItem extends NavigationItem {
 		put("icon", icon);
 	}
 
+	public void setKey(String key) {
+		put("key", key);
+	}
+
 	public void setQuickAction(boolean quickAction) {
 		put("quickAction", quickAction);
 	}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/util/DropdownItemBuilder.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/util/DropdownItemBuilder.java
@@ -181,7 +181,7 @@ public class DropdownItemBuilder {
 
 	public static class DropdownItemStep
 		implements ActiveStep, AfterActiveStep, AfterDisabledStep,
-				   AfterHrefStep, AfterIconStep, AfterLabelStep,
+				   AfterHrefStep, AfterIconStep, AfterKeyStep, AfterLabelStep,
 				   AfterPutDataStep, AfterQuickActionStep, AfterSeparatorStep,
 				   AfterSetDataStep, AfterTargetStep, AfterTypeStep, BuildStep,
 				   DisabledStep, HrefStep, IconStep, LabelStep, PutDataStep,
@@ -325,6 +325,31 @@ public class DropdownItemBuilder {
 
 				if (icon != null) {
 					_dropdownItem.setIcon(icon);
+				}
+
+				return this;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		}
+
+		@Override
+		public AfterKeyStep setKey(String key) {
+			_dropdownItem.setKey(key);
+
+			return this;
+		}
+
+		@Override
+		public AfterKeyStep setKey(
+			UnsafeSupplier<String, Exception> keyUnsafeSupplier) {
+
+			try {
+				String key = keyUnsafeSupplier.get();
+
+				if (key != null) {
+					_dropdownItem.setKey(key);
 				}
 
 				return this;
@@ -484,11 +509,16 @@ public class DropdownItemBuilder {
 	}
 
 	public interface AfterHrefStep
-		extends BuildStep, IconStep, LabelStep, QuickActionStep, SeparatorStep,
-				TargetStep, TypeStep {
+		extends BuildStep, IconStep, KeyStep, LabelStep, QuickActionStep,
+				SeparatorStep, TargetStep, TypeStep {
 	}
 
 	public interface AfterIconStep
+		extends BuildStep, KeyStep, LabelStep, QuickActionStep, SeparatorStep,
+				TargetStep, TypeStep {
+	}
+
+	public interface AfterKeyStep
 		extends BuildStep, LabelStep, QuickActionStep, SeparatorStep,
 				TargetStep, TypeStep {
 	}
@@ -500,7 +530,7 @@ public class DropdownItemBuilder {
 
 	public interface AfterPutDataStep
 		extends ActiveStep, BuildStep, DisabledStep, HrefStep, IconStep,
-				LabelStep, PutDataStep, QuickActionStep, SeparatorStep,
+				KeyStep, LabelStep, PutDataStep, QuickActionStep, SeparatorStep,
 				SetDataStep, TargetStep, TypeStep {
 	}
 
@@ -556,6 +586,15 @@ public class DropdownItemBuilder {
 
 		public AfterIconStep setIcon(
 			UnsafeSupplier<String, Exception> iconUnsafeSupplier);
+
+	}
+
+	public interface KeyStep {
+
+		public AfterKeyStep setKey(String key);
+
+		public AfterKeyStep setKey(
+			UnsafeSupplier<String, Exception> keyUnsafeSupplier);
 
 	}
 

--- a/modules/apps/sharing/sharing-document-library/src/main/java/com/liferay/sharing/document/library/internal/display/context/SharingDLViewFileVersionDisplayContext.java
+++ b/modules/apps/sharing/sharing-document-library/src/main/java/com/liferay/sharing/document/library/internal/display/context/SharingDLViewFileVersionDisplayContext.java
@@ -181,7 +181,9 @@ public class SharingDLViewFileVersionDisplayContext
 					return dropdownItems;
 				}
 			}
-			else if (Objects.equals("download", dropdownItem.get("icon"))) {
+			else if (Objects.equals(
+						DLUIItemKeys.DOWNLOAD, dropdownItem.get("key"))) {
+
 				break;
 			}
 
@@ -215,7 +217,9 @@ public class SharingDLViewFileVersionDisplayContext
 					return true;
 				}
 			}
-			else if (Objects.equals("download", dropdownItem.get("icon"))) {
+			else if (Objects.equals(
+						DLUIItemKeys.DOWNLOAD, dropdownItem.get("key"))) {
+
 				break;
 			}
 


### PR DESCRIPTION
@ambrinchaudhary This is a prerrequisite for https://github.com/liferay-lima/liferay-portal/pull/3061, but it isn't complete yet.

Two of the display contexts that remain unchanged, `DLOpenerOneDriveDLViewFileVersionDisplayContext` and `DLOpenerGoogleDriveDLViewFileVersionDisplayContext`, rely on the menu item ability to embed javascript and/or trigger URLs with POST. To continue working on this, the frontend logic needs to be changed so that the views use regular events. These classes (and the views) are located in the `document-library-opener-google-drive` and `document-library-opener-one-drive` (this one is DXP only).

We can talk about this on monday if you need more context.

Thanks!