### PR TITLE
LPS-155227

### DIFF
--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/service/SubscriptionDLAppHelperLocalServiceWrapper.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/service/SubscriptionDLAppHelperLocalServiceWrapper.java
@@ -14,6 +14,7 @@
 
 package com.liferay.document.library.internal.service;
 
+import com.liferay.document.library.internal.util.DLSubscriptionSender;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFileEntryConstants;
 import com.liferay.document.library.kernel.model.DLFileEntryType;
@@ -37,7 +38,6 @@ import com.liferay.portal.kernel.service.ServiceWrapper;
 import com.liferay.portal.kernel.settings.LocalizedValuesMap;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.EscapableLocalizableFunction;
-import com.liferay.portal.kernel.util.GroupSubscriptionCheckSubscriptionSender;
 import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.SubscriptionSender;
 import com.liferay.portal.kernel.util.Validator;
@@ -197,9 +197,8 @@ public class SubscriptionDLAppHelperLocalServiceWrapper
 			folder = _dlAppLocalService.getFolder(folderId);
 		}
 
-		SubscriptionSender subscriptionSender =
-			new GroupSubscriptionCheckSubscriptionSender(
-				DLConstants.RESOURCE_NAME);
+		SubscriptionSender subscriptionSender = new DLSubscriptionSender(
+			DLConstants.RESOURCE_NAME, folderId);
 
 		DLFileEntry dlFileEntry = (DLFileEntry)fileEntry.getModel();
 

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/util/DLSubscriptionSender.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/util/DLSubscriptionSender.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.document.library.internal.util;
+
+import com.liferay.document.library.kernel.model.DLFolder;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Subscription;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermissionUtil;
+import com.liferay.portal.kernel.util.GroupSubscriptionCheckSubscriptionSender;
+import com.liferay.portal.kernel.util.ServiceProxyFactory;
+
+/**
+ * @author tototrinh
+ */
+public class DLSubscriptionSender
+	extends GroupSubscriptionCheckSubscriptionSender {
+
+	public DLSubscriptionSender() {
+	}
+
+	public DLSubscriptionSender(String resourceName, long targetFolderId) {
+		super(resourceName);
+
+		_targetFolderId = targetFolderId;
+	}
+
+	@Override
+	protected Boolean hasSubscribePermission(
+			PermissionChecker permissionChecker, Subscription subscription)
+		throws PortalException {
+
+		if (!ModelResourcePermissionUtil.contains(
+				_dlFolderModelResourcePermission, permissionChecker,
+				subscription.getGroupId(), _targetFolderId,
+				ActionKeys.SUBSCRIBE)) {
+
+			return false;
+		}
+
+		return super.hasSubscribePermission(permissionChecker, subscription);
+	}
+
+	private static volatile ModelResourcePermission<DLFolder>
+		_dlFolderModelResourcePermission =
+			ServiceProxyFactory.newServiceTrackedInstance(
+				ModelResourcePermission.class, DLSubscriptionSender.class,
+				"_dlFolderModelResourcePermission",
+				"(model.class.name=" + DLFolder.class.getName() + ")", true);
+
+	private long _targetFolderId;
+
+}


### PR DESCRIPTION
## Motivation

https://issues.liferay.com/browse/LPS-155227
https://issues.liferay.com/browse/PTR-3104

## Proposed solution

The issue arises because a user subscribes to a parent folder, and then Liferay checks to see if they should receive notifications for a child folder. However, the permission check only checks whether they have still subscribe permissions on the parent folder they'd subscribed to, not whether they have permissions on the child folder.

This solution introduces a new `DLSubscriptionSender` which has a reference to the original folder that we are sending notifications on, which we can then use for permission checks.

In theory, this pattern may be needed on other assets where you can subscribe to a parent asset (message boards being one example), but we are focusing on document library for this one, as we've established that it's not desirable behavior there and we do not know whether it's desirable on other assets.

## Steps to verify

Please see linked LPS.