### PR TITLE
LPS-150991

### DIFF
--- a/modules/apps/commerce/commerce-frontend-js/src/main/java/com/liferay/commerce/frontend/js/internal/servlet/taglib/CommerceFrontendJsDynamicInclude.java
+++ b/modules/apps/commerce/commerce-frontend-js/src/main/java/com/liferay/commerce/frontend/js/internal/servlet/taglib/CommerceFrontendJsDynamicInclude.java
@@ -17,6 +17,7 @@ package com.liferay.commerce.frontend.js.internal.servlet.taglib;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.servlet.taglib.BaseDynamicInclude;
 import com.liferay.portal.kernel.servlet.taglib.DynamicInclude;
+import com.liferay.portal.kernel.util.Portal;
 
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -25,6 +26,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Fabio Mastrorilli
@@ -46,7 +48,8 @@ public class CommerceFrontendJsDynamicInclude extends BaseDynamicInclude {
 
 		printWriter.print(
 			StringBundler.concat(
-				"<link href=\"", httpServletRequest.getContextPath(),
+				"<link href=\"",
+				_portal.getPathProxy() + httpServletRequest.getContextPath(),
 				"/o/commerce-frontend-js/styles/main.css\" rel=\"stylesheet\"",
 				"type=\"text/css\" />"));
 	}
@@ -56,5 +59,8 @@ public class CommerceFrontendJsDynamicInclude extends BaseDynamicInclude {
 		dynamicIncludeRegistry.register(
 			"/html/common/themes/top_head.jsp#post");
 	}
+
+	@Reference
+	private Portal _portal;
 
 }

--- a/modules/apps/document-library/document-library-preview-document/src/main/resources/META-INF/resources/preview/view.jsp
+++ b/modules/apps/document-library/document-library-preview-document/src/main/resources/META-INF/resources/preview/view.jsp
@@ -41,7 +41,7 @@ String previewFileURL = previewFileURLs[0];
 <liferay-util:html-top
 	outputKey="document_library_preview_document_css"
 >
-	<link href="<%= PortalUtil.getStaticResourceURL(request, application.getContextPath() + "/preview/css/main.css") %>" rel="stylesheet" type="text/css" />
+	<link href="<%= PortalUtil.getStaticResourceURL(request, PortalUtil.getPathProxy() + application.getContextPath() + "/preview/css/main.css") %>" rel="stylesheet" type="text/css" />
 </liferay-util:html-top>
 
 <div id="<portlet:namespace /><%= randomNamespace %>previewDocument">

--- a/modules/apps/document-library/document-library-video/src/main/resources/META-INF/resources/embed/error.jsp
+++ b/modules/apps/document-library/document-library-video/src/main/resources/META-INF/resources/embed/error.jsp
@@ -19,7 +19,7 @@
 <liferay-util:html-top
 	outputKey="document_library_video_embed_css"
 >
-	<link href="<%= PortalUtil.getStaticResourceURL(request, application.getContextPath() + "/css/embed.css") %>" rel="stylesheet" type="text/css" />
+	<link href="<%= PortalUtil.getStaticResourceURL(request, PortalUtil.getPathProxy() + application.getContextPath() + "/css/embed.css") %>" rel="stylesheet" type="text/css" />
 </liferay-util:html-top>
 
 <div class="video-embed-placeholder">

--- a/modules/apps/document-library/document-library-video/src/main/resources/META-INF/resources/file_picker.jsp
+++ b/modules/apps/document-library/document-library-video/src/main/resources/META-INF/resources/file_picker.jsp
@@ -24,7 +24,7 @@ String onFilePickCallback = (String)request.getAttribute(DLVideoWebKeys.ON_FILE_
 <liferay-util:html-top
 	outputKey="document_library_video_css"
 >
-	<link href="<%= PortalUtil.getStaticResourceURL(request, application.getContextPath() + "/css/main.css") %>" rel="stylesheet" type="text/css" />
+	<link href="<%= PortalUtil.getStaticResourceURL(request, PortalUtil.getPathProxy() + application.getContextPath() + "/css/main.css") %>" rel="stylesheet" type="text/css" />
 </liferay-util:html-top>
 
 <aui:input name="contentType" type="hidden" value="<%= ContentTypes.APPLICATION_VND_LIFERAY_VIDEO_EXTERNAL_SHORTCUT_HTML %>" />

--- a/modules/apps/document-library/document-library-video/src/main/resources/META-INF/resources/preview.jsp
+++ b/modules/apps/document-library/document-library-video/src/main/resources/META-INF/resources/preview.jsp
@@ -19,7 +19,7 @@
 <liferay-util:html-top
 	outputKey="document_library_video_css"
 >
-	<link href="<%= PortalUtil.getStaticResourceURL(request, application.getContextPath() + "/css/main.css") %>" rel="stylesheet" type="text/css" />
+	<link href="<%= PortalUtil.getStaticResourceURL(request, PortalUtil.getPathProxy() + application.getContextPath() + "/css/main.css") %>" rel="stylesheet" type="text/css" />
 	<link href="<%= PortalUtil.getStaticResourceURL(request, PortalUtil.getPathModule() + "/document-library-preview-css/css/main.css") %>" rel="stylesheet" />
 </liferay-util:html-top>
 

--- a/modules/apps/friendly-url/friendly-url-taglib/src/main/resources/META-INF/resources/history/page.jsp
+++ b/modules/apps/friendly-url/friendly-url-taglib/src/main/resources/META-INF/resources/history/page.jsp
@@ -27,7 +27,7 @@ boolean localizable = (boolean)request.getAttribute("liferay-friendly-url:histor
 <liferay-util:html-top
 	outputKey="com.liferay.friendly.url.taglib.servlet.taglib.HistoryTag#/page.jsp"
 >
-	<link href="<%= PortalUtil.getStaticResourceURL(request, application.getContextPath() + "/css/main.css") %>" rel="stylesheet" type="text/css" />
+	<link href="<%= PortalUtil.getStaticResourceURL(request, PortalUtil.getPathProxy() + application.getContextPath() + "/css/main.css") %>" rel="stylesheet" type="text/css" />
 </liferay-util:html-top>
 
 <div class="btn-url-history-wrapper">

--- a/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/alloyeditor.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/alloyeditor.jsp
@@ -79,7 +79,7 @@ if (editorOptions != null) {
 </script>
 
 <liferay-util:html-top>
-	<link href="<%= PortalUtil.getStaticResourceURL(request, application.getContextPath() + "/css/main.css") %>" rel="stylesheet" type="text/css" />
+	<link href="<%= PortalUtil.getStaticResourceURL(request, PortalUtil.getPathProxy() + application.getContextPath() + "/css/main.css") %>" rel="stylesheet" type="text/css" />
 </liferay-util:html-top>
 
 <liferay-util:buffer

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/card/init.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/card/init.jsp
@@ -31,5 +31,5 @@ String url = (String)request.getAttribute("liferay-frontend:card:url");
 %>
 
 <liferay-util:html-top>
-	<link href="<%= PortalUtil.getStaticResourceURL(request, application.getContextPath() + "/css/card.css") %>" rel="stylesheet" type="text/css" />
+	<link href="<%= PortalUtil.getStaticResourceURL(request, PortalUtil.getPathProxy() + application.getContextPath() + "/css/card.css") %>" rel="stylesheet" type="text/css" />
 </liferay-util:html-top>

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/info_bar/start.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/info_bar/start.jsp
@@ -17,7 +17,7 @@
 <%@ include file="/info_bar/init.jsp" %>
 
 <liferay-util:html-top>
-	<link href="<%= PortalUtil.getStaticResourceURL(request, application.getContextPath() + "/css/info_bar.css") %>" rel="stylesheet" type="text/css" />
+	<link href="<%= PortalUtil.getStaticResourceURL(request, PortalUtil.getPathProxy() + application.getContextPath() + "/css/info_bar.css") %>" rel="stylesheet" type="text/css" />
 </liferay-util:html-top>
 
 <div class="info-bar-container">

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/image_selector/page.jsp
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/image_selector/page.jsp
@@ -41,7 +41,7 @@ if (isDraggable) {
 %>
 
 <liferay-util:html-top>
-	<link href="<%= PortalUtil.getStaticResourceURL(request, application.getContextPath() + "/css/image_selector.css") %>" rel="stylesheet" type="text/css" />
+	<link href="<%= PortalUtil.getStaticResourceURL(request, PortalUtil.getPathProxy() + application.getContextPath() + "/css/image_selector.css") %>" rel="stylesheet" type="text/css" />
 </liferay-util:html-top>
 
 <div>

--- a/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/layout/screen/navigation/entries/open_graph.jsp
+++ b/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/layout/screen/navigation/entries/open_graph.jsp
@@ -31,7 +31,7 @@ Layout selLayout = layoutsSEODisplayContext.getSelLayout();
 %>
 
 <liferay-util:html-top>
-	<link href="<%= PortalUtil.getStaticResourceURL(request, application.getContextPath() + "/css/main.css") %>" rel="stylesheet" type="text/css" />
+	<link href="<%= PortalUtil.getStaticResourceURL(request, PortalUtil.getPathProxy() + application.getContextPath() + "/css/main.css") %>" rel="stylesheet" type="text/css" />
 </liferay-util:html-top>
 
 <portlet:actionURL copyCurrentRenderParameters="<%= true %>" name="/layout/edit_open_graph" var="editOpenGraphURL" />

--- a/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/layout/screen/navigation/entries/seo.jsp
+++ b/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/layout/screen/navigation/entries/seo.jsp
@@ -33,7 +33,7 @@ UnicodeProperties layoutTypeSettings = selLayout.getTypeSettingsProperties();
 %>
 
 <liferay-util:html-top>
-	<link href="<%= PortalUtil.getStaticResourceURL(request, application.getContextPath() + "/css/main.css") %>" rel="stylesheet" type="text/css" />
+	<link href="<%= PortalUtil.getStaticResourceURL(request, PortalUtil.getPathProxy() + application.getContextPath() + "/css/main.css") %>" rel="stylesheet" type="text/css" />
 </liferay-util:html-top>
 
 <portlet:actionURL copyCurrentRenderParameters="<%= true %>" name="/layout/edit_seo" var="editSEOURL" />

--- a/modules/apps/ratings/ratings-taglib/src/main/resources/META-INF/resources/page.jsp
+++ b/modules/apps/ratings/ratings-taglib/src/main/resources/META-INF/resources/page.jsp
@@ -23,7 +23,7 @@ String type = GetterUtil.getString((String)request.getAttribute("liferay-ratings
 <liferay-util:html-top
 	outputKey="com.liferay.ratings.taglib.servlet.taglib#/page.jsp"
 >
-	<link href="<%= PortalUtil.getStaticResourceURL(request, application.getContextPath() + "/css/main.css") %>" rel="stylesheet" type="text/css" />
+	<link href="<%= PortalUtil.getStaticResourceURL(request, PortalUtil.getPathProxy() + application.getContextPath() + "/css/main.css") %>" rel="stylesheet" type="text/css" />
 </liferay-util:html-top>
 
 <div class="ratings">

--- a/modules/apps/sharing/sharing-taglib/src/main/resources/META-INF/resources/collaborators/page.jsp
+++ b/modules/apps/sharing/sharing-taglib/src/main/resources/META-INF/resources/collaborators/page.jsp
@@ -19,7 +19,7 @@
 <liferay-util:html-top
 	outputKey="collaborators_css"
 >
-	<link href="<%= PortalUtil.getStaticResourceURL(request, application.getContextPath() + "/collaborators/css/main.css") %>" rel="stylesheet" type="text/css" />
+	<link href="<%= PortalUtil.getStaticResourceURL(request, PortalUtil.getPathProxy() + application.getContextPath() + "/collaborators/css/main.css") %>" rel="stylesheet" type="text/css" />
 </liferay-util:html-top>
 
 <div class="collaborators" id="<portlet:namespace />collaborators-root">

--- a/modules/apps/social/social-activities-taglib/src/main/resources/META-INF/resources/social_activities/page.jsp
+++ b/modules/apps/social/social-activities-taglib/src/main/resources/META-INF/resources/social_activities/page.jsp
@@ -17,7 +17,7 @@
 <%@ include file="/social_activities/init.jsp" %>
 
 <liferay-util:html-top>
-	<link href="<%= PortalUtil.getStaticResourceURL(request, application.getContextPath() + "/css/main.css") %>" rel="stylesheet" type="text/css" />
+	<link href="<%= PortalUtil.getStaticResourceURL(request, PortalUtil.getPathProxy() + application.getContextPath() + "/css/main.css") %>" rel="stylesheet" type="text/css" />
 </liferay-util:html-top>
 
 <div class="taglib-social-activities">

--- a/modules/apps/social/social-bookmarks-taglib/src/main/resources/META-INF/resources/bookmarks/page.jsp
+++ b/modules/apps/social/social-bookmarks-taglib/src/main/resources/META-INF/resources/bookmarks/page.jsp
@@ -19,7 +19,7 @@
 <liferay-util:html-top
 	outputKey="social_bookmarks_css"
 >
-	<link href="<%= PortalUtil.getStaticResourceURL(request, application.getContextPath() + "/css/main.css") %>" rel="stylesheet" type="text/css" />
+	<link href="<%= PortalUtil.getStaticResourceURL(request, PortalUtil.getPathProxy() + application.getContextPath() + "/css/main.css") %>" rel="stylesheet" type="text/css" />
 </liferay-util:html-top>
 
 <div class="taglib-social-bookmarks" id="<%= PortalUtil.generateRandomKey(request, "taglib_ui_social_bookmarks_page") + StringPool.UNDERLINE %>socialBookmarks">


### PR DESCRIPTION
## Motivation

https://issues.liferay.com/browse/LPS-150991
https://issues.liferay.com/browse/PTR-3050

## Proposed solution

Searching in the source code, we found several dozen instances where something called getStaticResourceURL and getContextPath, without also calling getPathProxy.

```bash
git ls-files -- '*.java' | xargs grep -Fl 'getStaticResourceURL' | xargs grep -Fl 'getContextPath()' | xargs grep -L 'getPathProxy()'
git ls-files -- '*.jsp*' | xargs grep -Fl 'getStaticResourceURL' | xargs grep -Fl 'getContextPath()' | xargs grep -L 'getPathProxy()'
```

I asked the TSE to open [PTR-3050](https://issues.liferay.com/browse/PTR-3050) in order to get a perspective on how to best fix the issue, and the conclusion was that we should fix all instances where we see the pattern appear, rather than fix the API itself to automatically account for potentially incomplete parameter values (as is done with ComboServlet).

After preparing the pull request https://github.com/liferay-core-infra/liferay-portal/pull/964, the core infrastructure team recommended that we split up the pull request by reviewer. According to the DXP Product Teams page, Lima is responsible for Blogs, Documents and Media, and SEO Tools, and so we're sending some of the changes here.

## Steps to verify

The TSE was not able to figure out how to reproduce the issue in all the instances where the pattern appears, but they were able to identify steps to reproduce for all of the issues fixed in this pull request. They have shared a Google Drive document describing what we need to access in the portal in order to see the issue introduced by that file having an erroneous pattern.

https://docs.google.com/document/d/1dmiP23za68PAbbvxp-GrTO_EkRQ6Di0Z1-cqlDZXNts/edit