### PR TITLE
LPS-151368 fill the languageId attribute from the default of the structure if current language is not available.

### DIFF
--- a/modules/apps/document-library/document-library-api/bnd.bnd
+++ b/modules/apps/document-library/document-library-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Document Library API
 Bundle-SymbolicName: com.liferay.document.library.api
-Bundle-Version: 13.1.1
+Bundle-Version: 14.0.0
 Export-Package:\
 	com.liferay.document.library.bulk.selection,\
 	com.liferay.document.library.configuration,\

--- a/modules/apps/document-library/document-library-api/src/main/java/com/liferay/document/library/display/context/BaseDLEditFileEntryDisplayContext.java
+++ b/modules/apps/document-library/document-library-api/src/main/java/com/liferay/document/library/display/context/BaseDLEditFileEntryDisplayContext.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 
+import java.util.Locale;
 import java.util.UUID;
 
 import javax.servlet.http.HttpServletRequest;
@@ -82,6 +83,14 @@ public class BaseDLEditFileEntryDisplayContext
 		throws PortalException {
 
 		return parentDisplayContext.getDLFilePicker(onFilePickCallback);
+	}
+
+	@Override
+	public String getDocumentTypeLanguageId(
+		DDMStructure ddmStructure, Locale locale) {
+
+		return parentDisplayContext.getDocumentTypeLanguageId(
+			ddmStructure, locale);
 	}
 
 	@Override

--- a/modules/apps/document-library/document-library-api/src/main/java/com/liferay/document/library/display/context/DLEditFileEntryDisplayContext.java
+++ b/modules/apps/document-library/document-library-api/src/main/java/com/liferay/document/library/display/context/DLEditFileEntryDisplayContext.java
@@ -18,6 +18,8 @@ import com.liferay.dynamic.data.mapping.kernel.DDMStructure;
 import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
 import com.liferay.portal.kernel.exception.PortalException;
 
+import java.util.Locale;
+
 /**
  * @author Iván Zaera
  */
@@ -27,6 +29,9 @@ public interface DLEditFileEntryDisplayContext extends DLDisplayContext {
 
 	public DLFilePicker getDLFilePicker(String onFilePickCallback)
 		throws PortalException;
+
+	public String getDocumentTypeLanguageId(
+		DDMStructure ddmStructure, Locale locale);
 
 	public default String getFriendlyURLBase() throws PortalException {
 		return null;

--- a/modules/apps/document-library/document-library-api/src/main/resources/com/liferay/document/library/display/context/packageinfo
+++ b/modules/apps/document-library/document-library-api/src/main/resources/com/liferay/document/library/display/context/packageinfo
@@ -1,1 +1,1 @@
-version 4.1.0
+version 5.0.0

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DefaultDLEditFileEntryDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DefaultDLEditFileEntryDisplayContext.java
@@ -41,11 +41,14 @@ import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.FileVersion;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.upload.UploadServletRequestConfigurationHelperUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.util.RepositoryUtil;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.UUID;
 
 import javax.servlet.http.HttpServletRequest;
@@ -88,6 +91,21 @@ public class DefaultDLEditFileEntryDisplayContext
 	@Override
 	public DLFilePicker getDLFilePicker(String onFilePickCallback) {
 		return null;
+	}
+
+	@Override
+	public String getDocumentTypeLanguageId(
+		DDMStructure ddmStructure, Locale locale) {
+
+		String languageId = LocaleUtil.toLanguageId(locale);
+
+		if (!ArrayUtil.contains(
+				ddmStructure.getAvailableLanguageIds(), languageId)) {
+
+			return ddmStructure.getDefaultLanguageId();
+		}
+
+		return languageId;
 	}
 
 	@Override

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_entry.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_entry.jsp
@@ -462,6 +462,7 @@ renderResponse.setTitle(headerTitle);
 												containerId='<%= liferayPortletResponse.getNamespace() + "dataEngineLayoutRenderer" + ddmStructure.getStructureId() %>'
 												dataDefinitionId="<%= ddmStructure.getStructureId() %>"
 												dataRecordValues="<%= ddmFormValuesToMapConverter.convert(ddmFormValues, DDMStructureLocalServiceUtil.getStructure(ddmStructure.getStructureId())) %>"
+												languageId="<%= dlEditFileEntryDisplayContext.getDocumentTypeLanguageId(ddmStructure, PortalUtil.getLocale(request)) %>"
 												namespace="<%= liferayPortletResponse.getNamespace() + ddmStructure.getStructureId() + StringPool.UNDERLINE %>"
 												persistDefaultValues="<%= true %>"
 												persisted="<%= fileEntry != null %>"


### PR DESCRIPTION
LPS-151368 if the language id is not filled, the language is taken from the httpServletRequest and the default language is not filled so the default language is not saved, only the language from the request is sent but the document is not localized so the values on DDMFieldAttribute are empty