### PR TITLE
LPS-156905 It should work for lower branches as well

### DIFF
--- a/modules/apps/image/image-impl/src/main/java/com/liferay/image/internal/ImageMagickImpl.java
+++ b/modules/apps/image/image-impl/src/main/java/com/liferay/image/internal/ImageMagickImpl.java
@@ -48,15 +48,15 @@ import org.osgi.service.component.annotations.Component;
 @Component(immediate = true, service = ImageMagick.class)
 public class ImageMagickImpl implements ImageMagick {
 
-	public ImageMagickImpl() {
-		reset();
-	}
-
 	@Override
 	public Future<?> convert(List<String> arguments) throws Exception {
 		if (!isEnabled()) {
 			throw new IllegalStateException(
 				"Cannot call \"convert\" when ImageMagick is disabled");
+		}
+
+		if (_globalSearchPath == null) {
+			reset();
 		}
 
 		ProcessExecutor processExecutor = _getProcessExecutor();


### PR DESCRIPTION
Dear Team,

Could you please review this pull request?

During backporting to 7.3.x I discovered that during the instantiation of `ImageMagickImpl`, the system isn't initialized to the point where the properties can be read.
Therefore, I moved the reset() call inside a null check for the `_globalSearchPath` property.

Thank you and best regards,
István