### PR TITLE
LPS-155924 NullPointerException in Knowledge Base Search

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/display/context/KBSearchDisplayContext.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/display/context/KBSearchDisplayContext.java
@@ -97,6 +97,14 @@ public class KBSearchDisplayContext {
 			return _searchContainer;
 		}
 
+		_searchContainer = new SearchContainer<>(
+			_portletRequest, _iteratorURL, null,
+			LanguageUtil.format(
+				_httpServletRequest,
+				"no-articles-were-found-that-matched-the-keywords-x",
+				"<strong>" + HtmlUtil.escape(getKeywords()) + "</strong>",
+				false));
+
 		SearchContext searchContext = SearchContextFactory.getInstance(
 			_httpServletRequest);
 
@@ -132,14 +140,6 @@ public class KBSearchDisplayContext {
 						document.getDate(Field.MODIFIED_DATE)
 					}));
 		}
-
-		_searchContainer = new SearchContainer<>(
-			_portletRequest, _iteratorURL, null,
-			LanguageUtil.format(
-				_httpServletRequest,
-				"no-articles-were-found-that-matched-the-keywords-x",
-				"<strong>" + HtmlUtil.escape(getKeywords()) + "</strong>",
-				false));
 
 		_searchContainer.setResultsAndTotal(() -> tuples, hits.getLength());
 


### PR DESCRIPTION
## Motivation

https://issues.liferay.com/browse/LPS-155924

## Proposed solution

The issue is that we use the `_searchContainer` before we initialize it, due to the refactoring that moved the code from a .jsp into the DisplayContext. To resolve it, we initialize the `_searchContainer` before we use it.

## Steps to verify

Please see the linked LPS.