### PR TITLE
LPS-153705 on the update if filename is empty fix it to be aloweds by dl.char.blacklist characters

### DIFF
--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -2460,7 +2460,8 @@ public class DLFileEntryLocalServiceImpl
 				}
 			}
 
-			String fileName = DLUtil.getSanitizedFileName(title, extension);
+			String fileName = DLValidatorUtil.fixName(
+				DLUtil.getSanitizedFileName(title, extension));
 
 			if (Validator.isNotNull(sourceFileName)) {
 				fileName = DLUtil.getSanitizedFileName(


### PR DESCRIPTION

- LPS-153705 fix filename on the update if the source filename is empty, to match the dl.char.blacklist
