### PR TITLE
LPS-158261 Listing jpeg images as inline content

### DIFF
--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -5297,6 +5297,7 @@
         flv,\
         gif,\
         jpg,\
+        jpeg,\
         pdf,\
         png,\
         wmv


### PR DESCRIPTION
Related issue: https://issues.liferay.com/browse/LPS-158261

Hi team, this fix is allowing the portal to render the jpeg image added in the document & media. Since Jpeg and jpg are equivalent file extensions, I think that would be a good fit for our code avoid distinct results for both extensions. Let me know your thoughts about this. 

Thanks in advance,
Richard.