### PR TITLE
LPS-158318 GroupThreadLocal.getGroupId() will always return as default value GroupConstants.DEFAULT_LIVE_GROUP_ID so we can cast to long and check if the value is that

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/info/item/provider/FileEntryInfoItemFriendlyURLProvider.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/info/item/provider/FileEntryInfoItemFriendlyURLProvider.java
@@ -20,6 +20,7 @@ import com.liferay.friendly.url.model.FriendlyURLEntryLocalization;
 import com.liferay.friendly.url.service.FriendlyURLEntryLocalService;
 import com.liferay.friendly.url.util.comparator.FriendlyURLEntryLocalizationComparator;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.util.GroupThreadLocal;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -51,9 +52,9 @@ public class FileEntryInfoItemFriendlyURLProvider
 			return String.valueOf(fileEntry.getFileEntryId());
 		}
 
-		Long groupId = GroupThreadLocal.getGroupId();
+		long groupId = GroupThreadLocal.getGroupId();
 
-		if ((groupId != null) &&
+		if ((groupId != GroupConstants.DEFAULT_LIVE_GROUP_ID) &&
 			(groupId != mainFriendlyURLEntry.getGroupId())) {
 
 			return String.valueOf(fileEntry.getFileEntryId());


### PR DESCRIPTION
LPS-158318 GroupThreadLocal.getGroupId() will always return as default value GroupConstants.DEFAULT_LIVE_GROUP_ID so we can cast to long and check if the value is that

https://user-images.githubusercontent.com/47524751/179209891-77325485-848c-489a-b692-422ab08d89df.mp4

