### PR TITLE
[TS] LPS-157734 Remove hard coded content disposition type

### DIFF
--- a/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
+++ b/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
@@ -1198,8 +1198,7 @@ public class WebServerServlet extends HttpServlet {
 		ServletResponseUtil.sendFile(
 			null, httpServletResponse, fileEntry.getTitle(),
 			fileEntry.getContentStream(), fileEntry.getSize(),
-			fileEntry.getMimeType(),
-			HttpHeaders.CONTENT_DISPOSITION_ATTACHMENT);
+			fileEntry.getMimeType());
 	}
 
 	protected void sendGroups(


### PR DESCRIPTION
Hi Team,

[LPS: https://issues.liferay.com/browse/LPS-148758](https://issues.liferay.com/browse/LPS-157734)

**Issue:**
To be able to use friendly URL's instead of our generated ones, customers can enable directory indexing. This is important when they want to use their old directory structure and want to use the "old" file paths when referencing them. 
Example: http://testwebpage.com/documents/test-site/test-folder/test-subfolder/test-pdf-with-extension

When they enable directory indexing in Documents & media on a site, they can use the friendly URL, **but when we try to open the link** of a file, it gets downloaded. So everywhere they try to use the complete friendly URL (ex: pasted in a HTML fragment) the file gets downloaded instead of opening. But the wanted behavior would be the same as for the "not-friendly" URL, which opens the file.

**Background:**
This was implemented in https://issues.liferay.com/browse/LPS-82205 to prevent running executable files. When directory indexing is enabled, the content disposition type = attachment, which causes the file to download. 
```		
ServletResponseUtil.sendFile(
			null, httpServletResponse, fileEntry.getTitle(),
			fileEntry.getContentStream(), fileEntry.getSize(),
			fileEntry.getMimeType(),
			HttpHeaders.CONTENT_DISPOSITION_ATTACHMENT);
```

**Solution:** 
In the original implementation, there were no examination of the mimeType or the extension of the file in WebServerServlet.sendFile(), when calling ServletResponseUtil.sendFile(), so the **"content-disposition: attachment" type was hard-coded.**
Since then, an elaborated validation was implemented in ServletResponseUtil.sendHeader() to examine if the file can have a preview based on its mimeType or extension, and if it's not, then **it has to be downloaded**.
I removed the hard-coded CONTENT_DISPOSITION_ATTACHMENT from the call of sendFile(), because then we call it with 
contentDispositionType = null, then we call **setHeaders()**, in which there is our validation for contentDispositionType.
We only show preview if our file has a mimeType which can be found in mimeTypesContentDispositionInline (specifically: flv, gif, jpg, pdf, png, wmv).
In every other case the contentDispositionType is set to "attachment" and the file gets downloaded.

I tested it with several files and scenarios in my local environment and the result was consistent. The runnable test file from https://issues.liferay.com/browse/LPS-82205 was downloaded. I only got a preview from the files with extension in mimeTypesContentDispositionInline.

Could you please review it?
Thank you!