### PR TITLE
LPS-158632 Get the group  id from the theme display if GroupThreadLocal.getGroupId() returns 0

### DIFF
--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
@@ -56,6 +56,7 @@ import com.liferay.portal.kernel.servlet.SessionMessages;
 import com.liferay.portal.kernel.struts.LastPath;
 import com.liferay.portal.kernel.util.FriendlyURLNormalizer;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.GroupThreadLocal;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -171,6 +172,12 @@ public class FriendlyURLServlet extends HttpServlet {
 		Map<String, Object> requestContext = HashMapBuilder.<String, Object>put(
 			"request", httpServletRequest
 		).build();
+
+		if (GroupThreadLocal.getGroupId() ==
+				GroupConstants.DEFAULT_LIVE_GROUP_ID) {
+
+			GroupThreadLocal.setGroupId(group.getGroupId());
+		}
 
 		ServiceContext serviceContext =
 			ServiceContextThreadLocal.getServiceContext();


### PR DESCRIPTION
- LPS-158632 Get the group  id from the theme display if GroupThreadLocal.getGroupId() returns 0
- LPS-158632 In some cases the theme display is empty


Hi @adolfopa 

I found that when we come directly from the FriendlyURLServlet and try to obtain the urlTitle neither the GroupThreadLocal.getGroupId() or the theme display comes with the proper group id (the serviceContext.getScopeGroupId() returns the main group- liferay, not the actual site) 
So this is a posible solution without creating a serie of new methods `public String getFriendlyURL(long groupId, FileEntry fileEntry, String languageId) ` on InfoItemFriendlyURLProvider, up and down.


please feedback is welcome