### PR TITLE
LPS-158752 Add the toolbar "select all" checkbox when the item selector is multi-selection

### DIFF
--- a/modules/apps/item-selector/item-selector-web/src/main/java/com/liferay/item/selector/web/internal/display/context/ItemSelectorViewDescriptorRendererManagementToolbarDisplayContext.java
+++ b/modules/apps/item-selector/item-selector-web/src/main/java/com/liferay/item/selector/web/internal/display/context/ItemSelectorViewDescriptorRendererManagementToolbarDisplayContext.java
@@ -71,7 +71,8 @@ public class ItemSelectorViewDescriptorRendererManagementToolbarDisplayContext
 
 	@Override
 	public Boolean isSelectable() {
-		return false;
+		return _itemSelectorViewDescriptorRendererDisplayContext.
+			isMultipleSelection();
 	}
 
 	@Override

--- a/modules/apps/item-selector/item-selector-web/src/main/java/com/liferay/item/selector/web/internal/display/context/ItemSelectorViewDescriptorRendererManagementToolbarDisplayContext.java
+++ b/modules/apps/item-selector/item-selector-web/src/main/java/com/liferay/item/selector/web/internal/display/context/ItemSelectorViewDescriptorRendererManagementToolbarDisplayContext.java
@@ -70,6 +70,11 @@ public class ItemSelectorViewDescriptorRendererManagementToolbarDisplayContext
 	}
 
 	@Override
+	public String getSearchContainerId() {
+		return "entries";
+	}
+
+	@Override
 	public Boolean isSelectable() {
 		return _itemSelectorViewDescriptorRendererDisplayContext.
 			isMultipleSelection();


### PR DESCRIPTION
**Motivation**
In order to migrate some custom implementations of item selectors, it would be really nice if we have the ability to select all the records when there is multi-selection using the toolbar selectable checkbox.

[Link to the issue](https://issues.liferay.com/browse/LPS-158752)

**Proposed Solution**

Sets as selectable the toolbar when multi-selection is enabled and overrides the method getSearchContainerId to return the proper id.

**How to test it**

1. Go to Builder -> Site Navigation Menus
2. Create a new Menu
3. Click on the plus icon and select "Vocabulary"

It will open a popup with a standard view of Item Selector with multiselection. You can check that the "select all" check is present in the toolbar and that it is working properly.