### PR TITLE
LPS 158632.2

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/info/item/provider/FileEntryInfoItemFriendlyURLProvider.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/info/item/provider/FileEntryInfoItemFriendlyURLProvider.java
@@ -22,7 +22,8 @@ import com.liferay.friendly.url.util.comparator.FriendlyURLEntryLocalizationComp
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.repository.model.FileEntry;
-import com.liferay.portal.kernel.util.GroupThreadLocal;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 
@@ -52,7 +53,10 @@ public class FileEntryInfoItemFriendlyURLProvider
 			return String.valueOf(fileEntry.getFileEntryId());
 		}
 
-		long groupId = GroupThreadLocal.getGroupId();
+		ServiceContext serviceContext =
+			ServiceContextThreadLocal.getServiceContext();
+
+		long groupId = serviceContext.getScopeGroupId();
 
 		if ((groupId != GroupConstants.DEFAULT_LIVE_GROUP_ID) &&
 			(groupId != mainFriendlyURLEntry.getGroupId())) {

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
@@ -172,15 +172,10 @@ public class FriendlyURLServlet extends HttpServlet {
 			"request", httpServletRequest
 		).build();
 
-		ServiceContext serviceContext =
-			ServiceContextThreadLocal.getServiceContext();
+		ServiceContext serviceContext = _getServiceContext(httpServletRequest);
 
-		if (serviceContext == null) {
-			serviceContext = ServiceContextFactory.getInstance(
-				httpServletRequest);
-
-			ServiceContextThreadLocal.pushServiceContext(serviceContext);
-		}
+		serviceContext.setCompanyId(group.getCompanyId());
+		serviceContext.setScopeGroupId(group.getGroupId());
 
 		Layout defaultLayout = null;
 
@@ -799,6 +794,23 @@ public class FriendlyURLServlet extends HttpServlet {
 		}
 
 		return requestURI.substring(_pathInfoOffset, pos);
+	}
+
+	private ServiceContext _getServiceContext(
+			HttpServletRequest httpServletRequest)
+		throws PortalException {
+
+		ServiceContext serviceContext =
+			ServiceContextThreadLocal.getServiceContext();
+
+		if (serviceContext == null) {
+			serviceContext = ServiceContextFactory.getInstance(
+				httpServletRequest);
+
+			ServiceContextThreadLocal.pushServiceContext(serviceContext);
+		}
+
+		return serviceContext;
 	}
 
 	private User _getUser(HttpServletRequest httpServletRequest)

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
@@ -172,10 +172,10 @@ public class FriendlyURLServlet extends HttpServlet {
 			"request", httpServletRequest
 		).build();
 
-		ServiceContext serviceContext = _getServiceContext(httpServletRequest);
+		ServiceContext serviceContext = _getServiceContext(
+			group, httpServletRequest);
 
-		serviceContext.setCompanyId(group.getCompanyId());
-		serviceContext.setScopeGroupId(group.getGroupId());
+		ServiceContextThreadLocal.pushServiceContext(serviceContext);
 
 		Layout defaultLayout = null;
 
@@ -373,6 +373,9 @@ public class FriendlyURLServlet extends HttpServlet {
 			}
 
 			layoutFriendlyURL = null;
+		}
+		finally {
+			ServiceContextThreadLocal.popServiceContext();
 		}
 
 		String actualURL = portal.getActualURL(
@@ -797,7 +800,7 @@ public class FriendlyURLServlet extends HttpServlet {
 	}
 
 	private ServiceContext _getServiceContext(
-			HttpServletRequest httpServletRequest)
+			Group group, HttpServletRequest httpServletRequest)
 		throws PortalException {
 
 		ServiceContext serviceContext =
@@ -809,6 +812,11 @@ public class FriendlyURLServlet extends HttpServlet {
 
 			ServiceContextThreadLocal.pushServiceContext(serviceContext);
 		}
+
+		serviceContext = (ServiceContext)serviceContext.clone();
+
+		serviceContext.setCompanyId(group.getCompanyId());
+		serviceContext.setScopeGroupId(group.getGroupId());
 
 		return serviceContext;
 	}


### PR DESCRIPTION
- LPS-158632 GroupThreadLocal does not is always initiated so use the service context instead
- LPS-158632 in some cases, the group initialised on the service context is not properly with the group of the friendlyGroupURL
- LPS-158632 restore the initial service context after we use it for obtaining the urlTitle
