### PR TITLE
LPS-158632 add test to check that the url from a file of a depot view from a display page of a site returns the id of the file entry and not the friendlyURL

### DIFF
--- a/modules/apps/document-library/document-library-test/build.gradle
+++ b/modules/apps/document-library/document-library-test/build.gradle
@@ -10,6 +10,7 @@ dependencies {
 	testIntegrationCompile project(":apps:change-tracking:change-tracking-test-util")
 	testIntegrationCompile project(":apps:data-engine:data-engine-rest-api")
 	testIntegrationCompile project(":apps:data-engine:data-engine-rest-test-util")
+	testIntegrationCompile project(":apps:depot:depot-api")
 	testIntegrationCompile project(":apps:document-library:document-library-api")
 	testIntegrationCompile project(":apps:document-library:document-library-content-api")
 	testIntegrationCompile project(":apps:document-library:document-library-sync-api")

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/info/display/contributor/test/FileEntryInfoDisplayContributorTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/info/display/contributor/test/FileEntryInfoDisplayContributorTest.java
@@ -103,13 +103,12 @@ public class FileEntryInfoDisplayContributorTest {
 						_friendlyURLNormalizer.normalizeWithPeriodsAndSlashes(
 							fileEntry.getTitle()));
 
-					ThemeDisplay themeDisplay = _getThemeDisplay(locale);
-
 					Assert.assertEquals(
 						expectedURL,
 						_assetDisplayPageFriendlyURLProvider.getFriendlyURL(
 							FileEntry.class.getName(),
-							fileEntry.getFileEntryId(), themeDisplay));
+							fileEntry.getFileEntryId(),
+							_getThemeDisplay(locale)));
 				});
 		}
 		finally {
@@ -138,13 +137,12 @@ public class FileEntryInfoDisplayContributorTest {
 						_friendlyURLNormalizer.normalizeWithPeriodsAndSlashes(
 							fileEntry.getTitle()));
 
-					ThemeDisplay themeDisplay = _getThemeDisplay(locale);
-
 					Assert.assertEquals(
 						expectedURL,
 						_assetDisplayPageFriendlyURLProvider.getFriendlyURL(
 							FileEntry.class.getName(),
-							fileEntry.getFileEntryId(), themeDisplay));
+							fileEntry.getFileEntryId(),
+							_getThemeDisplay(locale)));
 				});
 		}
 		finally {
@@ -174,13 +172,12 @@ public class FileEntryInfoDisplayContributorTest {
 						_friendlyURLNormalizer.normalizeWithPeriodsAndSlashes(
 							fileEntry.getTitle()));
 
-					ThemeDisplay themeDisplay = _getThemeDisplay(locale);
-
 					Assert.assertEquals(
 						expectedURL,
 						_assetDisplayPageFriendlyURLProvider.getFriendlyURL(
 							FileEntry.class.getName(),
-							fileEntry.getFileEntryId(), themeDisplay));
+							fileEntry.getFileEntryId(),
+							_getThemeDisplay(locale)));
 				});
 		}
 		finally {
@@ -201,21 +198,18 @@ public class FileEntryInfoDisplayContributorTest {
 				fileEntry -> {
 					_addAssetDisplayPageEntry(fileEntry);
 
-					Locale locale = LocaleUtil.getDefault();
-
 					String expectedURL = StringBundler.concat(
 						"/web/", StringUtil.lowerCase(_group.getGroupKey()),
 						FriendlyURLResolverConstants.URL_SEPARATOR_FILE_ENTRY,
 						_friendlyURLNormalizer.normalizeWithPeriodsAndSlashes(
 							fileEntry.getTitle()));
 
-					ThemeDisplay themeDisplay = _getThemeDisplay(locale);
-
 					Assert.assertEquals(
 						expectedURL,
 						_assetDisplayPageFriendlyURLProvider.getFriendlyURL(
 							FileEntry.class.getName(),
-							fileEntry.getFileEntryId(), themeDisplay));
+							fileEntry.getFileEntryId(),
+							_getThemeDisplay(LocaleUtil.getDefault())));
 				});
 		}
 		finally {
@@ -253,15 +247,11 @@ public class FileEntryInfoDisplayContributorTest {
 				FriendlyURLResolverConstants.URL_SEPARATOR_FILE_ENTRY,
 				fileEntry.getFileEntryId());
 
-			Locale locale = LocaleUtil.getDefault();
-
-			ThemeDisplay themeDisplay = _getThemeDisplay(locale);
-
 			Assert.assertEquals(
 				expectedURL,
 				_assetDisplayPageFriendlyURLProvider.getFriendlyURL(
 					FileEntry.class.getName(), fileEntry.getFileEntryId(),
-					themeDisplay));
+					_getThemeDisplay(LocaleUtil.getDefault())));
 		}
 		finally {
 			ServiceContextThreadLocal.popServiceContext();

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/info/display/contributor/test/FileEntryInfoDisplayContributorTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/info/display/contributor/test/FileEntryInfoDisplayContributorTest.java
@@ -103,12 +103,7 @@ public class FileEntryInfoDisplayContributorTest {
 						_friendlyURLNormalizer.normalizeWithPeriodsAndSlashes(
 							fileEntry.getTitle()));
 
-					ThemeDisplay themeDisplay = new ThemeDisplay();
-
-					themeDisplay.setLocale(locale);
-					themeDisplay.setScopeGroupId(_group.getGroupId());
-					themeDisplay.setServerName("localhost");
-					themeDisplay.setSiteGroupId(_group.getGroupId());
+					ThemeDisplay themeDisplay = _getThemeDisplay(locale);
 
 					Assert.assertEquals(
 						expectedURL,
@@ -143,12 +138,7 @@ public class FileEntryInfoDisplayContributorTest {
 						_friendlyURLNormalizer.normalizeWithPeriodsAndSlashes(
 							fileEntry.getTitle()));
 
-					ThemeDisplay themeDisplay = new ThemeDisplay();
-
-					themeDisplay.setLocale(locale);
-					themeDisplay.setScopeGroupId(_group.getGroupId());
-					themeDisplay.setServerName("localhost");
-					themeDisplay.setSiteGroupId(_group.getGroupId());
+					ThemeDisplay themeDisplay = _getThemeDisplay(locale);
 
 					Assert.assertEquals(
 						expectedURL,
@@ -184,12 +174,7 @@ public class FileEntryInfoDisplayContributorTest {
 						_friendlyURLNormalizer.normalizeWithPeriodsAndSlashes(
 							fileEntry.getTitle()));
 
-					ThemeDisplay themeDisplay = new ThemeDisplay();
-
-					themeDisplay.setLocale(locale);
-					themeDisplay.setScopeGroupId(_group.getGroupId());
-					themeDisplay.setServerName("localhost");
-					themeDisplay.setSiteGroupId(_group.getGroupId());
+					ThemeDisplay themeDisplay = _getThemeDisplay(locale);
 
 					Assert.assertEquals(
 						expectedURL,
@@ -224,12 +209,7 @@ public class FileEntryInfoDisplayContributorTest {
 						_friendlyURLNormalizer.normalizeWithPeriodsAndSlashes(
 							fileEntry.getTitle()));
 
-					ThemeDisplay themeDisplay = new ThemeDisplay();
-
-					themeDisplay.setLocale(locale);
-					themeDisplay.setScopeGroupId(_group.getGroupId());
-					themeDisplay.setServerName("localhost");
-					themeDisplay.setSiteGroupId(_group.getGroupId());
+					ThemeDisplay themeDisplay = _getThemeDisplay(locale);
 
 					Assert.assertEquals(
 						expectedURL,
@@ -257,7 +237,8 @@ public class FileEntryInfoDisplayContributorTest {
 					LocaleUtil.getDefault(), RandomTestUtil.randomString()),
 				ServiceContextTestUtil.getServiceContext());
 
-			DLFolder dlFolder = DLTestUtil.addDLFolder(_depotEntry.getGroupId());
+			DLFolder dlFolder = DLTestUtil.addDLFolder(
+				_depotEntry.getGroupId());
 
 			DLFileEntry dlFileEntry = DLTestUtil.addDLFileEntry(
 				dlFolder.getFolderId());
@@ -272,14 +253,9 @@ public class FileEntryInfoDisplayContributorTest {
 				FriendlyURLResolverConstants.URL_SEPARATOR_FILE_ENTRY,
 				fileEntry.getFileEntryId());
 
-			ThemeDisplay themeDisplay = new ThemeDisplay();
-
 			Locale locale = LocaleUtil.getDefault();
 
-			themeDisplay.setLocale(locale);
-			themeDisplay.setScopeGroupId(_group.getGroupId());
-			themeDisplay.setServerName("localhost");
-			themeDisplay.setSiteGroupId(_group.getGroupId());
+			ThemeDisplay themeDisplay = _getThemeDisplay(locale);
 
 			Assert.assertEquals(
 				expectedURL,
@@ -321,6 +297,17 @@ public class FileEntryInfoDisplayContributorTest {
 			AssetDisplayPageConstants.TYPE_SPECIFIC, serviceContext);
 	}
 
+	private ThemeDisplay _getThemeDisplay(Locale locale) {
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		themeDisplay.setLocale(locale);
+		themeDisplay.setScopeGroupId(_group.getGroupId());
+		themeDisplay.setServerName("localhost");
+		themeDisplay.setSiteGroupId(_group.getGroupId());
+
+		return themeDisplay;
+	}
+
 	private void _withAndWithoutAssetEntry(
 			UnsafeConsumer<FileEntry, Exception> testFunction)
 		throws Exception {
@@ -358,6 +345,9 @@ public class FileEntryInfoDisplayContributorTest {
 	private AssetDisplayPageFriendlyURLProvider
 		_assetDisplayPageFriendlyURLProvider;
 
+	@DeleteAfterTestRun
+	private DepotEntry _depotEntry;
+
 	@Inject
 	private DepotEntryLocalService _depotEntryLocalService;
 
@@ -379,8 +369,5 @@ public class FileEntryInfoDisplayContributorTest {
 
 	@Inject
 	private Portal _portal;
-
-	@DeleteAfterTestRun
-	private DepotEntry _depotEntry;
 
 }

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/info/display/contributor/test/FileEntryInfoDisplayContributorTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/info/display/contributor/test/FileEntryInfoDisplayContributorTest.java
@@ -35,6 +35,7 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.portlet.constants.FriendlyURLResolverConstants;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
@@ -274,11 +275,10 @@ public class FileEntryInfoDisplayContributorTest {
 			UnsafeConsumer<FileEntry, Exception> testFunction)
 		throws Exception {
 
-		Long groupId = GroupThreadLocal.getGroupId();
+		ServiceContextThreadLocal.pushServiceContext(
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
 
 		try {
-			GroupThreadLocal.setGroupId(_group.getGroupId());
-
 			DLFolder dlFolder = DLTestUtil.addDLFolder(_group.getGroupId());
 
 			DLFileEntry dlFileEntry = DLTestUtil.addDLFileEntry(
@@ -296,7 +296,7 @@ public class FileEntryInfoDisplayContributorTest {
 				_dlAppLocalService.getFileEntry(dlFileEntry.getFileEntryId()));
 		}
 		finally {
-			GroupThreadLocal.setGroupId(groupId);
+			ServiceContextThreadLocal.popServiceContext();
 		}
 	}
 


### PR DESCRIPTION
- LPS-158632 fix test, now we use serviceContext instead of GroupThreadLocal
- LPS-158632 add test to check that the url from a file of a depot view from a display page of a site returns the id of the file entry and not the friendlyURL
- LPS-158632 extract common method
- LPS-158632 inline
