### PR TITLE
LPS-152803 If we don't have order by keys then don't show the sorting icon

### DIFF
--- a/modules/apps/item-selector/item-selector-web/src/main/java/com/liferay/item/selector/web/internal/display/context/ItemSelectorViewDescriptorRendererManagementToolbarDisplayContext.java
+++ b/modules/apps/item-selector/item-selector-web/src/main/java/com/liferay/item/selector/web/internal/display/context/ItemSelectorViewDescriptorRendererManagementToolbarDisplayContext.java
@@ -21,6 +21,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
+import com.liferay.portal.kernel.util.Validator;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -72,6 +73,15 @@ public class ItemSelectorViewDescriptorRendererManagementToolbarDisplayContext
 	@Override
 	public String getSearchContainerId() {
 		return "entries";
+	}
+
+	@Override
+	public String getSortingURL() {
+		if (Validator.isNull(_itemSelectorViewDescriptor.getOrderByKeys())) {
+			return null;
+		}
+
+		return super.getSortingURL();
 	}
 
 	@Override


### PR DESCRIPTION
Motivation
----
Usually if we don't set order keys we are saying that the list of items is not sorted and we should not show the sorting icon.

<img width="1678" alt="Primary_Status_Status_-_Liferay_DXP" src="https://user-images.githubusercontent.com/922631/182193543-447d2182-19fa-4812-9ffa-f73a5711163b.png">

[Link to the issue](https://issues.liferay.com/browse/LPS-152803)

Proposed Solution
----
Implement **getSortingURL()** method on **ItemSelectorViewDescriptorRendererManagementToolbarDisplayContext** since if it is null the sorting icon is not showed, in this case if we don't have order keys we should return a null.

How to test it
---
Step-by-Step:

1. Navigate to Navigation Menus admin on the default site
2. Add a navigation menu
3. Add a Vocabulary item