### PR TITLE
LPS-158064 KB Folder Navigation interaction with the Product Menu

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/display/context/KBAdminNavigationDisplayContext.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/display/context/KBAdminNavigationDisplayContext.java
@@ -40,12 +40,14 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.SessionClicks;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portlet.LiferayPortletUtil;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import javax.portlet.RenderRequest;
 import javax.portlet.RenderResponse;
@@ -351,6 +353,15 @@ public class KBAdminNavigationDisplayContext {
 		}
 
 		return articleNavigationJSONArray;
+	}
+
+	public boolean isProductMenuOpen() {
+		String productMenuState = SessionClicks.get(
+			_httpServletRequest,
+			"com.liferay.product.navigation.product.menu.web_productMenuState",
+			"closed");
+
+		return Objects.equals(productMenuState, "open");
 	}
 
 	private final HttpServletRequest _httpServletRequest;

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/display/context/KBAdminNavigationDisplayContext.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/display/context/KBAdminNavigationDisplayContext.java
@@ -268,6 +268,15 @@ public class KBAdminNavigationDisplayContext {
 		return verticalNavigationItems;
 	}
 
+	public boolean isProductMenuOpen() {
+		String productMenuState = SessionClicks.get(
+			_httpServletRequest,
+			"com.liferay.product.navigation.product.menu.web_productMenuState",
+			"closed");
+
+		return Objects.equals(productMenuState, "open");
+	}
+
 	private JSONArray _getKBArticleNavigationJSONArray()
 		throws PortalException {
 
@@ -353,15 +362,6 @@ public class KBAdminNavigationDisplayContext {
 		}
 
 		return articleNavigationJSONArray;
-	}
-
-	public boolean isProductMenuOpen() {
-		String productMenuState = SessionClicks.get(
-			_httpServletRequest,
-			"com.liferay.product.navigation.product.menu.web_productMenuState",
-			"closed");
-
-		return Objects.equals(productMenuState, "open");
 	}
 
 	private final HttpServletRequest _httpServletRequest;

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/vertical_menu.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/vertical_menu.jsp
@@ -21,7 +21,7 @@ KBAdminNavigationDisplayContext kbAdminNavigationDisplayContext = new KBAdminNav
 %>
 
 <c:if test='<%= GetterUtil.getBoolean(PropsUtil.get("feature.flag.LPS-156421")) %>'>
-	<div class="expanded knowledge-base-vertical-bar" id="<portlet:namespace />verticalBarId">
+	<div class="knowledge-base-vertical-bar" id="<portlet:namespace />verticalBarId">
 		<react:component
 			componentId="verticalBarId"
 			module="admin/js/components/VerticalBar"

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/vertical_menu.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/vertical_menu.jsp
@@ -18,10 +18,12 @@
 
 <%
 KBAdminNavigationDisplayContext kbAdminNavigationDisplayContext = new KBAdminNavigationDisplayContext(request, renderRequest, renderResponse);
+
+boolean isProductMenuOpen = kbAdminNavigationDisplayContext.isProductMenuOpen();
 %>
 
 <c:if test='<%= GetterUtil.getBoolean(PropsUtil.get("feature.flag.LPS-156421")) %>'>
-	<div class="knowledge-base-vertical-bar" id="<portlet:namespace />verticalBarId">
+	<div class="knowledge-base-vertical-bar <%= isProductMenuOpen ? StringPool.BLANK : "expanded" %>" id="<portlet:namespace />verticalBarId">
 		<react:component
 			componentId="verticalBarId"
 			module="admin/js/components/VerticalBar"

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/vertical_menu.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/vertical_menu.jsp
@@ -32,6 +32,8 @@ boolean isProductMenuOpen = kbAdminNavigationDisplayContext.isProductMenuOpen();
 					"items", kbAdminNavigationDisplayContext.getVerticalNavigationJSONObjects()
 				).put(
 					"parentContainerId", liferayPortletResponse.getNamespace() + "verticalBarId"
+				).put(
+					"productMenuOpen", isProductMenuOpen
 				).build()
 			%>'
 		/>

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/css/_admin.scss
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/css/_admin.scss
@@ -4,6 +4,9 @@ $controlMenuHeight: 56px;
 
 .knowledge-base-portlet-admin {
 	.knowledge-base-vertical-bar {
+		position: relative;
+		z-index: 1;
+
 		> div {
 			height: 100%;
 			min-height: calc(100vh - #{$controlMenuHeight});

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/js/components/VerticalBar.js
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/js/components/VerticalBar.js
@@ -24,10 +24,10 @@ const CSS_EXPANDED = 'expanded';
 const VerticalNavigationBar = ({items, parentContainerId}) => {
 	const parentContainer = document.getElementById(parentContainerId);
 
-	const activeItem = items.find((item) => item.active);
+	const currentItem = items.find((item) => item.active);
 
 	const onIconClick = (item) => {
-		if (item.key !== activeItem.key) {
+		if (item.key !== currentItem.key) {
 			parentContainer.classList.add(CSS_EXPANDED);
 
 			navigate(item.href);
@@ -44,7 +44,7 @@ const VerticalNavigationBar = ({items, parentContainerId}) => {
 	};
 
 	return (
-		<VerticalBar absolute defaultActive={activeItem?.key} position="left">
+		<VerticalBar absolute position="left">
 			<VerticalBar.Bar displayType="light" items={items}>
 				{(item) => (
 					<VerticalBar.Item key={item.key}>

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/js/components/VerticalBar.js
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/js/components/VerticalBar.js
@@ -20,6 +20,7 @@ import React, {useEffect, useState} from 'react';
 import NavigationPanel from './NavigationPanel';
 
 const CSS_EXPANDED = 'expanded';
+const BLANK = '';
 
 const VerticalNavigationBar = ({items, parentContainerId}) => {
 	const parentContainer = document.getElementById(parentContainerId);
@@ -27,6 +28,7 @@ const VerticalNavigationBar = ({items, parentContainerId}) => {
 	const currentItem = items.find((item) => item.active);
 
 	const [productMenuOpen, setProductMenuOpen] = useState(false);
+	const [activePanel, setActivePanel] = useState();
 
 	useEffect(() => {
 		const productMenu = Liferay.SideNavigation.instance(
@@ -58,13 +60,8 @@ const VerticalNavigationBar = ({items, parentContainerId}) => {
 	}, []);
 
 	useEffect(() => {
-		if (productMenuOpen) {
-			parentContainer.classList.remove(CSS_EXPANDED);
-		}
-		else {
-			parentContainer.classList.add(CSS_EXPANDED);
-		}
-	}, [productMenuOpen, parentContainer]);
+		setActivePanel(productMenuOpen ? BLANK : currentItem.key);
+	}, [productMenuOpen, parentContainer, currentItem]);
 
 	const onIconClick = (event, item) => {
 		if (item.key !== currentItem.key) {
@@ -72,10 +69,23 @@ const VerticalNavigationBar = ({items, parentContainerId}) => {
 
 			navigate(item.href);
 		}
-		else {
-			parentContainer.classList.toggle(CSS_EXPANDED);
-		}
 	};
+
+	const onActiveChange = () => {
+		setActivePanel(activePanel ? BLANK : currentItem.key);
+
+		// TODO hide product menu
+
+	};
+
+	useEffect(() => {
+		if (activePanel) {
+			parentContainer.classList.add(CSS_EXPANDED);
+		}
+		else {
+			parentContainer.classList.remove(CSS_EXPANDED);
+		}
+	}, [activePanel, parentContainer]);
 
 	const VerticalBarPanels = {
 		article: NavigationPanel,
@@ -86,7 +96,8 @@ const VerticalNavigationBar = ({items, parentContainerId}) => {
 	return (
 		<VerticalBar
 			absolute
-			active={productMenuOpen ? undefined : currentItem.key}
+			active={activePanel}
+			onActiveChange={onActiveChange}
 			position="left"
 		>
 			<VerticalBar.Bar displayType="light" items={items}>

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/js/components/VerticalBar.js
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/js/components/VerticalBar.js
@@ -63,22 +63,6 @@ const VerticalNavigationBar = ({items, parentContainerId}) => {
 		setActivePanel(productMenuOpen ? BLANK : currentItem.key);
 	}, [productMenuOpen, parentContainer, currentItem]);
 
-	const onIconClick = (event, item) => {
-		if (item.key !== currentItem.key) {
-			event.preventDefault();
-
-			navigate(item.href);
-		}
-	};
-
-	const onActiveChange = () => {
-		setActivePanel(activePanel ? BLANK : currentItem.key);
-
-		if (productMenuOpen) {
-			productMenu.hide();
-		}
-	};
-
 	useEffect(() => {
 		if (activePanel) {
 			parentContainer.classList.add(CSS_EXPANDED);
@@ -87,6 +71,14 @@ const VerticalNavigationBar = ({items, parentContainerId}) => {
 			parentContainer.classList.remove(CSS_EXPANDED);
 		}
 	}, [activePanel, parentContainer]);
+
+	const onActiveChange = () => {
+		setActivePanel(activePanel ? BLANK : currentItem.key);
+
+		if (productMenuOpen) {
+			productMenu.hide();
+		}
+	};
 
 	const VerticalBarPanels = {
 		article: NavigationPanel,
@@ -108,7 +100,11 @@ const VerticalNavigationBar = ({items, parentContainerId}) => {
 							data-tooltip-align="right"
 							displayType="unstyled"
 							onClick={(event) => {
-								onIconClick(event, item);
+								if (item.key !== currentItem.key) {
+									event.preventDefault();
+
+									navigate(item.href);
+								}
 							}}
 							symbol={item.icon}
 							title={Liferay.Language.get(item.title)}

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/js/components/VerticalBar.js
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/js/components/VerticalBar.js
@@ -15,6 +15,7 @@
 import {ClayButtonWithIcon} from '@clayui/button';
 import {VerticalBar} from '@clayui/core';
 import {navigate} from 'frontend-js-web';
+import PropTypes from 'prop-types';
 import React, {useEffect, useState} from 'react';
 
 import NavigationPanel from './NavigationPanel';
@@ -137,6 +138,19 @@ const VerticalNavigationBar = ({items, parentContainerId}) => {
 			</VerticalBar.Content>
 		</VerticalBar>
 	);
+};
+
+const itemShape = {
+	active: PropTypes.bool,
+	href: PropTypes.string.isRequired,
+	icon: PropTypes.string.isRequired,
+	key: PropTypes.string.isRequired,
+	title: PropTypes.string.isRequired,
+};
+
+VerticalNavigationBar.propTypes = {
+	items: PropTypes.arrayOf(PropTypes.shape(itemShape)),
+	parentContainerId: PropTypes.string.isRequired,
 };
 
 export default VerticalNavigationBar;

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/js/components/VerticalBar.js
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/js/components/VerticalBar.js
@@ -94,9 +94,13 @@ const VerticalNavigationBar = ({
 			if (productMenuOpen) {
 				productMenu.hide();
 
-				setTimeout(() => {
-					navigate(href);
-				}, 500);
+				const productMenuOpenListener = productMenu.on(
+					'closed.lexicon.sidenav',
+					() => {
+						productMenuOpenListener.removeListener();
+						navigate(href);
+					}
+				);
 			}
 			else {
 				navigate(href);

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/js/components/VerticalBar.js
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/js/components/VerticalBar.js
@@ -30,11 +30,11 @@ const VerticalNavigationBar = ({items, parentContainerId}) => {
 	const [productMenuOpen, setProductMenuOpen] = useState(false);
 	const [activePanel, setActivePanel] = useState();
 
-	useEffect(() => {
-		const productMenu = Liferay.SideNavigation.instance(
-			document.querySelector('.product-menu-toggle')
-		);
+	const productMenu = Liferay.SideNavigation.instance(
+		document.querySelector('.product-menu-toggle')
+	);
 
+	useEffect(() => {
 		if (productMenu) {
 			setProductMenuOpen(productMenu.visible());
 
@@ -57,7 +57,7 @@ const VerticalNavigationBar = ({items, parentContainerId}) => {
 				productMenuCloseListener.removeListener();
 			};
 		}
-	}, []);
+	}, [productMenu]);
 
 	useEffect(() => {
 		setActivePanel(productMenuOpen ? BLANK : currentItem.key);
@@ -74,8 +74,9 @@ const VerticalNavigationBar = ({items, parentContainerId}) => {
 	const onActiveChange = () => {
 		setActivePanel(activePanel ? BLANK : currentItem.key);
 
-		// TODO hide product menu
-
+		if (productMenuOpen) {
+			productMenu.hide();
+		}
 	};
 
 	useEffect(() => {


### PR DESCRIPTION
There is one think I don't know how to fix: on reload when the product menu is closed, there is a css transition because the Vertical Bar should be open. I have no way to add the "expanded" class before the rendering (there is no way in backend to know if PM is open or closed), so I'm checking this in js and that is why the transition is triggered.  -> SOLVED.