### PR TITLE
[TS] LPS-159458 Restore Read more link with Liferay Learn article

### DIFF
--- a/modules/apps/document-library/document-library-web/build.gradle
+++ b/modules/apps/document-library/document-library-web/build.gradle
@@ -53,6 +53,7 @@ dependencies {
 	compileOnly project(":apps:item-selector:item-selector-criteria-api")
 	compileOnly project(":apps:layout:layout-display-page-api")
 	compileOnly project(":apps:layout:layout-page-template-api")
+	compileOnly project(":apps:learn:learn-taglib")
 	compileOnly project(":apps:petra:petra-portlet-url-builder")
 	compileOnly project(":apps:portal:portal-instance-lifecycle-api")
 	compileOnly project(":apps:portlet-display-template:portlet-display-template-api")

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/access_from_desktop.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/access_from_desktop.jsp
@@ -30,6 +30,11 @@ DLAccessFromDesktopDisplayContext dlAccessFromDesktopDisplayContext = new DLAcce
 	<div class="portlet-document-library">
 		<liferay-ui:message key="<%= dlAccessFromDesktopDisplayContext.getWebDAVHelpMessage() %>" />
 
+		<liferay-learn:message
+			key="webdav"
+			resource="document-library-web"
+		/>
+
 		<br /><br />
 
 		<aui:input cssClass="webdav-url-resource" id='<%= dlAccessFromDesktopDisplayContext.getRandomNamespace() + "webDavURL" %>' name="webDavURL" type="resource" value="<%= dlAccessFromDesktopDisplayContext.getWebDAVURL() %>" />

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/init.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/init.jsp
@@ -15,7 +15,8 @@
 --%>
 
 <%@ include file="/init.jsp" %>
-<%@ taglib uri="http://liferay.com/tld/react" prefix="react" %>
+<%@ taglib uri="http://liferay.com/tld/learn" prefix="liferay-learn" %><%@
+taglib uri="http://liferay.com/tld/react" prefix="react" %>
 
 <%@ page import="com.liferay.bulk.selection.BulkSelectionRunner" %><%@
 page import="com.liferay.digital.signature.constants.DigitalSignaturePortletKeys" %><%@


### PR DESCRIPTION
Hi Team,

Previous PRs: 
- https://github.com/liferay-lima/liferay-portal/pull/3320
- https://github.com/liferay-lima/liferay-portal/pull/3325

/cc @AliciaGarciaGarcia 

**Update**
When referencing Liferay Learn articles, we actually have a module to handle those links.

Comments from Brian on the previous PR: https://github.com/brianchandotcom/liferay-portal/pull/121239#issuecomment-1204561518

Brian helped us declare the webdav link for our Liferay Learn article under this commit:
https://github.com/brianchandotcom/liferay-portal/commit/7a5f80b41514efed36f13bed4557cfea3f19f666
- He also mentioned: Feel free to change the message, see liferay-portal/learn-resources/*.json

**Proposed Changes**
This PR utilizes the Liferay Learn link by adding it directly to the **Access from Desktop** jsp page, instead of trying to handle the addition within a language key.

From what I can tell, the 'Read more' link is only being utilized for this page. The only concern may be how translations would be affected by using this approach.
- If translations is a concern, we can use our previous approach with the language keys and just utilize the LearnMessage to inject the proper URL.

Please let me know if you have any questions or would like me to make any additional changes. 

Thanks!