### PR TITLE
LPS-160247 KB info panel - visual adjustments

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/kb_article_history.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/kb_article_history.jsp
@@ -37,12 +37,12 @@ List<KBArticle> kbArticles = KBArticleServiceUtil.getKBArticleVersions(scopeGrou
 
 		<li class="list-group-item list-group-item-flex">
 			<div class="autofit-col autofit-col-expand">
-				<div class="h5">
+				<div class="list-group-title">
 					<liferay-ui:message arguments="<%= curKBArticle.getVersion() %>" key="version-x" />
 				</div>
 
-				<div class="h6 sidebar-caption">
-					<liferay-ui:message arguments="<%= new Object[] {HtmlUtil.escape(curKBArticle.getUserName()), dateFormatDateTime.format(curKBArticle.getModifiedDate())} %>" key="by-x-on-x" />
+				<div class="list-group-subtitle">
+					<liferay-ui:message arguments="<%= new Object[] {HtmlUtil.escape(curKBArticle.getUserName()), dateFormatDateTime.format(curKBArticle.getCreateDate())} %>" key="by-x-on-x" translateArguments="<%= false %>" />
 				</div>
 			</div>
 

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/view_kb_article.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/view_kb_article.jsp
@@ -55,18 +55,13 @@ if (portletTitleBasedNavigation) {
 <c:if test="<%= portletTitleBasedNavigation %>">
 	<div class="management-bar management-bar-light navbar navbar-expand-md">
 		<clay:container-fluid>
-			<ul class="m-auto navbar-nav"></ul>
-
-			<ul class="m-auto middle navbar-nav">
-				<li class="nav-item">
+			<ul class="navbar-nav navbar-nav-expand">
+				<li class="m-auto nav-item">
 					<aui:workflow-status markupView="lexicon" showHelpMessage="<%= false %>" showIcon="<%= false %>" showLabel="<%= false %>" status="<%= kbArticle.getStatus() %>" version="<%= String.valueOf(kbArticle.getVersion()) %>" />
 				</li>
-			</ul>
-
-			<ul class="end m-auto navbar-nav">
 				<li class="nav-item">
 					<liferay-frontend:management-bar-sidenav-toggler-button
-						cssClass="btn-secondary"
+						cssClass="btn-unstyled"
 						icon="info-circle-open"
 						label="info"
 					/>

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/info_panel.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/info_panel.jsp
@@ -120,19 +120,25 @@ if (ListUtil.isEmpty(kbFolders) && ListUtil.isEmpty(kbArticles)) {
 		%>
 
 		<div class="sidebar-header">
-			<div class="autofit-row sidebar-section">
-				<div class="autofit-col autofit-col-expand">
-					<h4 class="component-title"><%= HtmlUtil.escape(kbArticle.getTitle()) %></h4>
+			<clay:content-row
+				cssClass="sidebar-section"
+			>
+				<clay:content-col
+					expand="<%= true %>"
+				>
+					<clay:content-section>
+						<h4 class="component-title"><%= HtmlUtil.escape(kbArticle.getTitle()) %></h4>
 
-					<clay:label
-						displayType="info"
-						label='<%= LanguageUtil.get(request, "version") + StringPool.SPACE + kbArticle.getPriority() %>'
-					/>
+						<clay:label
+							displayType="info"
+							label='<%= LanguageUtil.get(request, "version") + StringPool.SPACE + kbArticle.getPriority() %>'
+						/>
 
-					<aui:workflow-status markupView="lexicon" showIcon="<%= false %>" showLabel="<%= false %>" status="<%= kbArticle.getStatus() %>" />
-				</div>
+						<aui:workflow-status markupView="lexicon" showIcon="<%= false %>" showLabel="<%= false %>" status="<%= kbArticle.getStatus() %>" />
+					</clay:content-section>
+				</clay:content-col>
 
-				<div class="autofit-col">
+				<clay:content-col>
 					<c:if test='<%= ParamUtil.getBoolean(request, "showSidebarHeader", GetterUtil.getBoolean(request.getAttribute(KBWebKeys.SHOW_SIDEBAR_HEADER))) %>'>
 						<ul class="autofit-padded-no-gutters autofit-row">
 							<li class="autofit-col">
@@ -143,8 +149,8 @@ if (ListUtil.isEmpty(kbFolders) && ListUtil.isEmpty(kbArticles)) {
 							</li>
 						</ul>
 					</c:if>
-				</div>
-			</div>
+				</clay:content-col>
+			</clay:content-row>
 		</div>
 
 		<div class="sidebar-body">

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/info_panel.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/info_panel.jsp
@@ -124,9 +124,12 @@ if (ListUtil.isEmpty(kbFolders) && ListUtil.isEmpty(kbArticles)) {
 				<div class="autofit-col autofit-col-expand">
 					<h4 class="component-title"><%= HtmlUtil.escape(kbArticle.getTitle()) %></h4>
 
-					<h5>
-						<liferay-ui:message key="entry" />
-					</h5>
+					<clay:label
+						displayType="info"
+						label='<%= LanguageUtil.get(request, "version") + StringPool.SPACE + kbArticle.getPriority() %>'
+					/>
+
+					<aui:workflow-status markupView="lexicon" showIcon="<%= false %>" showLabel="<%= false %>" status="<%= kbArticle.getStatus() %>" />
 				</div>
 
 				<div class="autofit-col">


### PR DESCRIPTION
After the fixes (described in https://issues.liferay.com/browse/LPS-160247): 
**Info icon aligment:** 
<img width="1318" alt="Screenshot 2022-08-10 at 16 51 16" src="https://user-images.githubusercontent.com/8373764/183938678-6fe23d45-d24e-402a-a4ef-b3655b40c4cf.png">

**Version's info and article status** 

<img width="1673" alt="Screenshot 2022-08-10 at 17 06 02" src="https://user-images.githubusercontent.com/8373764/183939338-fd61c20d-a44d-4d77-a8ad-399250d1f5fd.png">


Not behind a FF because these issues are like bugs in master and does not depend on the improvements we are doing in the revamp. 

