### PR TITLE
LPS-160436 Uses clay navigation card instead of horizontal card

### DIFF
--- a/modules/apps/item-selector/item-selector-taglib/src/main/java/com/liferay/item/selector/taglib/internal/servlet/item/selector/GroupNavigationCard.java
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/java/com/liferay/item/selector/taglib/internal/servlet/item/selector/GroupNavigationCard.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.item.selector.taglib.internal.servlet.item.selector;
+
+import com.liferay.frontend.taglib.clay.servlet.taglib.soy.NavigationCard;
+import com.liferay.item.selector.taglib.internal.display.context.GroupSelectorDisplayContext;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.WebKeys;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * @author Eudaldo Alonso
+ */
+public class GroupNavigationCard implements NavigationCard {
+
+	public GroupNavigationCard(
+		Group group, GroupSelectorDisplayContext groupSelectorDisplayContext,
+		HttpServletRequest httpServletRequest) {
+
+		_group = group;
+		_groupSelectorDisplayContext = groupSelectorDisplayContext;
+
+		_themeDisplay = (ThemeDisplay)httpServletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+	}
+
+	@Override
+	public String getHref() {
+		return _groupSelectorDisplayContext.getViewGroupURL(_group);
+	}
+
+	@Override
+	public String getIcon() {
+		return _groupSelectorDisplayContext.getGroupItemSelectorIcon();
+	}
+
+	@Override
+	public String getImageSrc() {
+		return _group.getLogoURL(_themeDisplay, false);
+	}
+
+	@Override
+	public String getTitle() {
+		try {
+			return _group.getDescriptiveName(_themeDisplay.getLocale());
+		}
+		catch (Exception exception) {
+			_log.error(exception);
+		}
+
+		return _group.getName(_themeDisplay.getLocale());
+	}
+
+	@Override
+	public boolean isSelectable() {
+		return false;
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		GroupNavigationCard.class);
+
+	private final Group _group;
+	private final GroupSelectorDisplayContext _groupSelectorDisplayContext;
+	private final ThemeDisplay _themeDisplay;
+
+}

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/group_selector/page.jsp
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/group_selector/page.jsp
@@ -55,25 +55,9 @@ Set<String> groupTypes = groupSelectorDisplayContext.getGroupTypes();
 			<liferay-ui:search-container-column-text
 				colspan="<%= 3 %>"
 			>
-				<liferay-frontend:horizontal-card
-					text="<%= curGroup.getDescriptiveName(locale) %>"
-					url="<%= groupSelectorDisplayContext.getViewGroupURL(curGroup) %>"
-				>
-					<liferay-frontend:horizontal-card-col>
-						<c:choose>
-							<c:when test="<%= Validator.isNotNull(curGroup.getLogoURL(themeDisplay, false)) %>">
-								<clay:sticker>
-									<img alt="" class="sticker-img" src="<%= curGroup.getLogoURL(themeDisplay, false) %>" />
-								</clay:sticker>
-							</c:when>
-							<c:otherwise>
-								<liferay-frontend:horizontal-card-icon
-									icon="<%= groupSelectorDisplayContext.getGroupItemSelectorIcon() %>"
-								/>
-							</c:otherwise>
-						</c:choose>
-					</liferay-frontend:horizontal-card-col>
-				</liferay-frontend:horizontal-card>
+				<clay:navigation-card
+					navigationCard="<%= new GroupNavigationCard(curGroup, groupSelectorDisplayContext, request) %>"
+				/>
 			</liferay-ui:search-container-column-text>
 		</liferay-ui:search-container-row>
 

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/init.jsp
@@ -36,6 +36,7 @@ page import="com.liferay.item.selector.taglib.internal.configuration.util.FFItem
 page import="com.liferay.item.selector.taglib.internal.dao.search.RepositoryEntryResultRowSplitter" %><%@
 page import="com.liferay.item.selector.taglib.internal.display.context.GroupSelectorDisplayContext" %><%@
 page import="com.liferay.item.selector.taglib.internal.servlet.ServletContextUtil" %><%@
+page import="com.liferay.item.selector.taglib.internal.servlet.item.selector.GroupNavigationCard" %><%@
 page import="com.liferay.item.selector.taglib.internal.util.ItemSelectorRepositoryEntryBrowserUtil" %><%@
 page import="com.liferay.petra.portlet.url.builder.PortletURLBuilder" %><%@
 page import="com.liferay.petra.string.StringPool" %><%@


### PR DESCRIPTION
Motivation
----
In order to replace all frontend:cards from portal we should update item selector taglib module to use clay:cards

[Link to the issue](https://issues.liferay.com/browse/LPS-160436)

Proposed Solution
----
Use clay navigation card instead of horizontal card, since horizontal card doesn't accept an image.

Before the changes it looks like

<img width="1695" alt="New_Web_Content_-_Liferay_DXP" src="https://user-images.githubusercontent.com/922631/184342830-bf318dbb-f88c-4651-a7f7-97fa677a194f.png">

After the changes it looks like

<img width="1685" alt="New_Web_Content_-_Liferay_DXP" src="https://user-images.githubusercontent.com/922631/184343169-e9cca02d-534d-4c67-8192-babca24b8205.png">

Please let me know if you have any question.