### PR TITLE
LPS-161160 Add VIEW action support to com.liferay.blogs resources

### DIFF
--- a/modules/apps/blogs/blogs-service/src/main/resources/resource-actions/default.xml
+++ b/modules/apps/blogs/blogs-service/src/main/resources/resource-actions/default.xml
@@ -15,6 +15,7 @@
 				<action-key>ADD_ENTRY</action-key>
 				<action-key>PERMISSIONS</action-key>
 				<action-key>SUBSCRIBE</action-key>
+				<action-key>VIEW</action-key>
 			</supports>
 			<site-member-defaults>
 				<action-key>SUBSCRIBE</action-key>


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-161160

Hi Team,
From Echo team, we are adding permission checks in some points of the page editor.
For example, we want that when adding a display page the user can choose only those models of which he has visibility. So, for example, a user shouldn't be able to create a Journal display page if doesn't have permission to VIEW its model resource, in this case, com.liferay.journal. This should be applied to all implementations of the info framework.
Applying this to BlogsEntry we have found that the "com.liferay.blogs" model does not support the VIEW action. In order to control these permissions also for BlogsEntry we would need to either add VIEW to the supported actions or know what the equivalent of the available permissions that we should check in this case is.
This PR adds support to the model for the action VIEW please, could you review it?
Thank you in advance! ❤️ 