### PR TITLE
[TS] LPS-158085 | Duplicate names with URL redirects

### DIFF
--- a/modules/apps/redirect/redirect-service/bnd.bnd
+++ b/modules/apps/redirect/redirect-service/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Redirect Service
 Bundle-SymbolicName: com.liferay.redirect.service
 Bundle-Version: 2.0.34
-Liferay-Require-SchemaVersion: 3.0.1
+Liferay-Require-SchemaVersion: 3.0.2
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/internal/upgrade/registry/RedirectServiceUpgradeStepRegistrator.java
+++ b/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/internal/upgrade/registry/RedirectServiceUpgradeStepRegistrator.java
@@ -17,6 +17,7 @@ package com.liferay.redirect.internal.upgrade.registry;
 import com.liferay.portal.configuration.upgrade.PrefsPropsToConfigurationUpgradeHelper;
 import com.liferay.portal.kernel.upgrade.UpgradeProcessFactory;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.redirect.internal.upgrade.v3_0_2.RedirectEntrySourceURLUpgradeProcess;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -50,6 +51,9 @@ public class RedirectServiceUpgradeStepRegistrator
 			new com.liferay.redirect.internal.upgrade.v3_0_1.
 				RedirectURLConfigurationUpgradeProcess(
 					_prefsPropsToConfigurationUpgradeHelper));
+
+		registry.register(
+			"3.0.1", "3.0.2", new RedirectEntrySourceURLUpgradeProcess());
 	}
 
 	@Reference

--- a/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/internal/upgrade/v3_0_2/RedirectEntrySourceURLUpgradeProcess.java
+++ b/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/internal/upgrade/v3_0_2/RedirectEntrySourceURLUpgradeProcess.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.redirect.internal.upgrade.v3_0_2;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.StringUtil;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * @author Attila Bakay
+ */
+public class RedirectEntrySourceURLUpgradeProcess extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		try (PreparedStatement preparedStatement1 = connection.prepareStatement(
+				"select redirectEntryId, sourceURL from RedirectEntry");
+			PreparedStatement preparedStatement2 =
+				AutoBatchPreparedStatementUtil.concurrentAutoBatch(
+					connection,
+					"update RedirectEntry set sourceURL = ? where " +
+						"redirectEntryId = ?")) {
+
+			ResultSet resultSet = preparedStatement1.executeQuery();
+
+			while (resultSet.next()) {
+				String sourceURL = resultSet.getString(2);
+
+				String lowerCaseSourceURL = StringUtil.toLowerCase(sourceURL);
+
+				if (sourceURL.equals(lowerCaseSourceURL)) {
+					continue;
+				}
+
+				long redirectEntryId = resultSet.getLong(1);
+
+				if (!_hasRedirectEntry(redirectEntryId, lowerCaseSourceURL)) {
+					preparedStatement2.setString(1, lowerCaseSourceURL);
+					preparedStatement2.setLong(2, redirectEntryId);
+
+					preparedStatement2.addBatch();
+				}
+				else {
+					if (_log.isWarnEnabled()) {
+						_log.warn(
+							StringBundler.concat(
+								"Can not modify '", sourceURL, "' to '",
+								lowerCaseSourceURL,
+								"' because it is already in use id:  at id: ",
+								redirectEntryId));
+					}
+				}
+			}
+
+			preparedStatement2.executeBatch();
+		}
+	}
+
+	private boolean _hasRedirectEntry(long redirectEntryId, String sourceURL)
+		throws Exception {
+
+		if (_duplicateSourceURLs.contains(sourceURL)) {
+			return true;
+		}
+
+		_duplicateSourceURLs.add(sourceURL);
+
+		try (PreparedStatement preparedStatement2 = connection.prepareStatement(
+				"select count(redirectEntryId) from RedirectEntry  where " +
+					"redirectEntryId != ? and sourceURL = ?")) {
+
+			preparedStatement2.setLong(1, redirectEntryId);
+			preparedStatement2.setString(2, sourceURL);
+
+			try (ResultSet resultSet2 = preparedStatement2.executeQuery()) {
+				while (resultSet2.next()) {
+					long redirectEntryCount = resultSet2.getLong(1);
+
+					if (redirectEntryCount > 0) {
+						return true;
+					}
+				}
+			}
+		}
+
+		return false;
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		RedirectEntrySourceURLUpgradeProcess.class);
+
+	private final Set<String> _duplicateSourceURLs = new HashSet<>();
+
+}

--- a/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/service/impl/RedirectEntryLocalServiceImpl.java
+++ b/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/service/impl/RedirectEntryLocalServiceImpl.java
@@ -88,6 +88,8 @@ public class RedirectEntryLocalServiceImpl
 			boolean permanent, String sourceURL, ServiceContext serviceContext)
 		throws PortalException {
 
+		sourceURL = StringUtil.toLowerCase(sourceURL);
+
 		_validate(destinationURL, sourceURL);
 
 		if (redirectEntryPersistence.fetchByG_S(groupId, sourceURL) != null) {
@@ -141,6 +143,8 @@ public class RedirectEntryLocalServiceImpl
 			String groupBaseURL, boolean permanent, String sourceURL,
 			boolean updateChainedRedirectEntries, ServiceContext serviceContext)
 		throws PortalException {
+
+		sourceURL = StringUtil.toLowerCase(sourceURL);
 
 		_checkDestinationURLMustNotBeEqualToSourceURL(
 			destinationURL, groupBaseURL, sourceURL);
@@ -250,6 +254,8 @@ public class RedirectEntryLocalServiceImpl
 			boolean permanent, String sourceURL)
 		throws PortalException {
 
+		sourceURL = StringUtil.toLowerCase(sourceURL);
+
 		_validate(destinationURL, sourceURL);
 
 		RedirectEntry redirectEntry = getRedirectEntry(redirectEntryId);
@@ -279,6 +285,8 @@ public class RedirectEntryLocalServiceImpl
 			String groupBaseURL, boolean permanent, String sourceURL,
 			boolean updateChainedRedirectEntries)
 		throws PortalException {
+
+		sourceURL = StringUtil.toLowerCase(sourceURL);
 
 		_checkDestinationURLMustNotBeEqualToSourceURL(
 			destinationURL, groupBaseURL, sourceURL);


### PR DESCRIPTION
Hi Team,
Could you please review this pull request?
https://issues.liferay.com/browse/LPS-158085
Thank you!

----
**Reproduction Steps:**
1.  Add a new redirection under configuration -> redirection with a Source URL "/testpage" and a Destination URL like "https://www.google.com/"
2.  Try to add a new redirection with a Source URL "/TestPage" and a Destination URL like "https://www.yahoo.com/"

**Actual outcome:** user can create the second redirect with the same text but a different casing.
**Expected outcome:** The user can't create the second redirect because it is the same as the first one with a different casing.

This is an idea to fix LPS-158085. I modified the edit and update service calls for the RedirectEntrys to lowercase the source URL. I also included an upgrade step to convert the uppercase redirects to lowercase. On some DBs like PostgreSQL where the search is case sensitive, it was even possible to create multiple redirects with different formats like /tESt or /Test or /TEST in these cases only one of them is casted to lower case. For the other entries, a warning is logged and the user can later fix these entries. We could also delete these entries if required but that could lead to data loss.
