### PR TITLE
LPS-162097 Index Expired documents.

### DIFF
--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/spi/model/index/contributor/DLFileEntryModelIndexerWriterContributor.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/spi/model/index/contributor/DLFileEntryModelIndexerWriterContributor.java
@@ -84,7 +84,9 @@ public class DLFileEntryModelIndexerWriterContributor
 			throw new SystemException(portalException);
 		}
 
-		if (!dlFileVersion.isApproved() && !dlFileEntry.isInTrash()) {
+		if (!dlFileVersion.isApproved() && !dlFileEntry.isInTrash() &&
+			!dlFileVersion.isExpired()) {
+
 			return IndexerWriterMode.SKIP;
 		}
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -1921,6 +1921,7 @@ public class DLFileEntryLocalServiceImpl
 		// Indexer
 
 		if (((status == WorkflowConstants.STATUS_APPROVED) ||
+			 (status == WorkflowConstants.STATUS_EXPIRED) ||
 			 (status == WorkflowConstants.STATUS_IN_TRASH) ||
 			 (oldStatus == WorkflowConstants.STATUS_IN_TRASH)) &&
 			((serviceContext == null) || serviceContext.isIndexingEnabled())) {


### PR DESCRIPTION
Motivation
=======
Currently expired documents are not searchable in DXP
[Link to story or ticket](https://issues.liferay.com/browse/LPS-162097)

Proposed Solution
========
I have indexed expired documents

Steps to Verify:
----------------
1. Expire a document
1. Go to the Content Dashboard
2. The document should be visible.


Screencaps:

https://user-images.githubusercontent.com/5776822/188123238-81c85277-f8ef-4042-82e4-7901ef09bbf0.mp4

Notes
========
No integration tests have been included in this PR, because I don't understand how D&M Search tests work, but if you give me some guide on it, I will try to add it