### PR TITLE
[TS] LPS-158085 | Duplicate names with URL redirects

### DIFF
--- a/modules/apps/redirect/redirect-service/bnd.bnd
+++ b/modules/apps/redirect/redirect-service/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Redirect Service
 Bundle-SymbolicName: com.liferay.redirect.service
 Bundle-Version: 2.0.34
-Liferay-Require-SchemaVersion: 3.0.1
+Liferay-Require-SchemaVersion: 3.0.2
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/internal/upgrade/registry/RedirectServiceUpgradeStepRegistrator.java
+++ b/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/internal/upgrade/registry/RedirectServiceUpgradeStepRegistrator.java
@@ -17,6 +17,7 @@ package com.liferay.redirect.internal.upgrade.registry;
 import com.liferay.portal.configuration.upgrade.PrefsPropsToConfigurationUpgradeHelper;
 import com.liferay.portal.kernel.upgrade.UpgradeProcessFactory;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.redirect.internal.upgrade.v3_0_2.RedirectEntrySourceURLUpgradeProcess;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -50,6 +51,9 @@ public class RedirectServiceUpgradeStepRegistrator
 			new com.liferay.redirect.internal.upgrade.v3_0_1.
 				RedirectURLConfigurationUpgradeProcess(
 					_prefsPropsToConfigurationUpgradeHelper));
+
+		registry.register(
+			"3.0.1", "3.0.2", new RedirectEntrySourceURLUpgradeProcess());
 	}
 
 	@Reference

--- a/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/internal/upgrade/v3_0_2/RedirectEntrySourceURLUpgradeProcess.java
+++ b/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/internal/upgrade/v3_0_2/RedirectEntrySourceURLUpgradeProcess.java
@@ -52,53 +52,52 @@ public class RedirectEntrySourceURLUpgradeProcess extends UpgradeProcess {
 				long groupId = resultSet.getLong(2);
 				String sourceURL = resultSet.getString(3);
 
-				Set<String> groupSpecificSourceURLs;
-				Map<String, Long> groupSpecificUpgrades;
+				Set<String> groupSourceURLs;
+				Map<String, Long> groupSourceURLEntryIdMap;
 
-				if (!_redirectEntries.containsKey(groupId)) {
-					groupSpecificSourceURLs = new HashSet<>();
-					groupSpecificUpgrades = new LinkedHashMap<>();
+				if (!_sourceURLs.containsKey(groupId)) {
+					groupSourceURLs = new HashSet<>();
+					groupSourceURLEntryIdMap = new LinkedHashMap<>();
 				}
 				else {
-					groupSpecificSourceURLs = _redirectEntries.get(groupId);
-					groupSpecificUpgrades = _upgradeEntries.get(groupId);
+					groupSourceURLs = _sourceURLs.get(groupId);
+					groupSourceURLEntryIdMap = _sourceURLEntryIdMap.get(
+						groupId);
 				}
 
 				String lowerCaseSourceURL = StringUtil.toLowerCase(sourceURL);
 
-				if (!groupSpecificSourceURLs.contains(lowerCaseSourceURL)) {
-					groupSpecificSourceURLs.add(lowerCaseSourceURL);
+				if (!groupSourceURLs.contains(lowerCaseSourceURL)) {
+					groupSourceURLs.add(lowerCaseSourceURL);
 
 					if (!sourceURL.equals(lowerCaseSourceURL)) {
-						groupSpecificUpgrades.put(
+						groupSourceURLEntryIdMap.put(
 							lowerCaseSourceURL, redirectEntryId);
 					}
 
-					_upgradeEntries.put(groupId, groupSpecificUpgrades);
-					_redirectEntries.put(groupId, groupSpecificSourceURLs);
+					_sourceURLEntryIdMap.put(groupId, groupSourceURLEntryIdMap);
+					_sourceURLs.put(groupId, groupSourceURLs);
 				}
 				else {
 					if (sourceURL.equals(lowerCaseSourceURL)) {
-						groupSpecificUpgrades.remove(lowerCaseSourceURL);
+						groupSourceURLEntryIdMap.remove(lowerCaseSourceURL);
 					}
-					else {
-						if (_log.isWarnEnabled()) {
-							_log.warn(
-								StringBundler.concat(
-									"Can not modify '", sourceURL, "' to '",
-									lowerCaseSourceURL,
-									"' because it is already in use in group: ",
-									groupId, " at id: ", redirectEntryId));
-						}
+					else if (_log.isWarnEnabled()) {
+						_log.warn(
+							StringBundler.concat(
+								"Can not modify '", sourceURL, "' to '",
+								lowerCaseSourceURL,
+								"' because it is already in use in group: ",
+								groupId, " at id: ", redirectEntryId));
 					}
 				}
 			}
 
-			for (Map<String, Long> groupSpecificUpgrades :
-					_upgradeEntries.values()) {
+			for (Map<String, Long> groupSourceURLEntryIdMap :
+					_sourceURLEntryIdMap.values()) {
 
 				for (Map.Entry<String, Long> upgradeRedirectEntry :
-						groupSpecificUpgrades.entrySet()) {
+						groupSourceURLEntryIdMap.entrySet()) {
 
 					String lowerCaseSourceURL = upgradeRedirectEntry.getKey();
 					long redirectEntryId = upgradeRedirectEntry.getValue();
@@ -117,9 +116,8 @@ public class RedirectEntrySourceURLUpgradeProcess extends UpgradeProcess {
 	private static final Log _log = LogFactoryUtil.getLog(
 		RedirectEntrySourceURLUpgradeProcess.class);
 
-	private final Map<Long, Set<String>> _redirectEntries =
+	private final Map<Long, Map<String, Long>> _sourceURLEntryIdMap =
 		new LinkedHashMap<>();
-	private final Map<Long, Map<String, Long>> _upgradeEntries =
-		new LinkedHashMap<>();
+	private final Map<Long, Set<String>> _sourceURLs = new LinkedHashMap<>();
 
 }

--- a/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/internal/upgrade/v3_0_2/RedirectEntrySourceURLUpgradeProcess.java
+++ b/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/internal/upgrade/v3_0_2/RedirectEntrySourceURLUpgradeProcess.java
@@ -1,0 +1,125 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.redirect.internal.upgrade.v3_0_2;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.StringUtil;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @author Attila Bakay
+ */
+public class RedirectEntrySourceURLUpgradeProcess extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		try (PreparedStatement preparedStatement1 = connection.prepareStatement(
+				"select redirectEntryId, groupId, sourceURL from " +
+					"RedirectEntry ORDER BY redirectentryid ASC");
+			PreparedStatement preparedStatement2 =
+				AutoBatchPreparedStatementUtil.concurrentAutoBatch(
+					connection,
+					"update RedirectEntry set sourceURL = ? where " +
+						"redirectEntryId = ?")) {
+
+			ResultSet resultSet = preparedStatement1.executeQuery();
+
+			while (resultSet.next()) {
+				long redirectEntryId = resultSet.getLong(1);
+				long groupId = resultSet.getLong(2);
+				String sourceURL = resultSet.getString(3);
+
+				Set<String> groupSpecificSourceURLs;
+				Map<String, Long> groupSpecificUpgrades;
+
+				if (!_redirectEntries.containsKey(groupId)) {
+					groupSpecificSourceURLs = new HashSet<>();
+					groupSpecificUpgrades = new LinkedHashMap<>();
+				}
+				else {
+					groupSpecificSourceURLs = _redirectEntries.get(groupId);
+					groupSpecificUpgrades = _upgradeEntries.get(groupId);
+				}
+
+				String lowerCaseSourceURL = StringUtil.toLowerCase(sourceURL);
+
+				if (!groupSpecificSourceURLs.contains(lowerCaseSourceURL)) {
+					groupSpecificSourceURLs.add(lowerCaseSourceURL);
+
+					if (!sourceURL.equals(lowerCaseSourceURL)) {
+						groupSpecificUpgrades.put(
+							lowerCaseSourceURL, redirectEntryId);
+					}
+
+					_upgradeEntries.put(groupId, groupSpecificUpgrades);
+					_redirectEntries.put(groupId, groupSpecificSourceURLs);
+				}
+				else {
+					if (sourceURL.equals(lowerCaseSourceURL)) {
+						groupSpecificUpgrades.remove(lowerCaseSourceURL);
+					}
+					else {
+						if (_log.isWarnEnabled()) {
+							_log.warn(
+								StringBundler.concat(
+									"Can not modify '", sourceURL, "' to '",
+									lowerCaseSourceURL,
+									"' because it is already in use in group: ",
+									groupId, " at id: ", redirectEntryId));
+						}
+					}
+				}
+			}
+
+			for (Map<String, Long> groupSpecificUpgrades :
+					_upgradeEntries.values()) {
+
+				for (Map.Entry<String, Long> upgradeRedirectEntry :
+						groupSpecificUpgrades.entrySet()) {
+
+					String lowerCaseSourceURL = upgradeRedirectEntry.getKey();
+					long redirectEntryId = upgradeRedirectEntry.getValue();
+
+					preparedStatement2.setString(1, lowerCaseSourceURL);
+					preparedStatement2.setLong(2, redirectEntryId);
+
+					preparedStatement2.addBatch();
+				}
+			}
+
+			preparedStatement2.executeBatch();
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		RedirectEntrySourceURLUpgradeProcess.class);
+
+	private final Map<Long, Set<String>> _redirectEntries =
+		new LinkedHashMap<>();
+	private final Map<Long, Map<String, Long>> _upgradeEntries =
+		new LinkedHashMap<>();
+
+}

--- a/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/service/impl/RedirectEntryLocalServiceImpl.java
+++ b/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/service/impl/RedirectEntryLocalServiceImpl.java
@@ -88,6 +88,8 @@ public class RedirectEntryLocalServiceImpl
 			boolean permanent, String sourceURL, ServiceContext serviceContext)
 		throws PortalException {
 
+		sourceURL = StringUtil.toLowerCase(sourceURL);
+
 		_validate(destinationURL, sourceURL);
 
 		if (redirectEntryPersistence.fetchByG_S(groupId, sourceURL) != null) {
@@ -141,6 +143,8 @@ public class RedirectEntryLocalServiceImpl
 			String groupBaseURL, boolean permanent, String sourceURL,
 			boolean updateChainedRedirectEntries, ServiceContext serviceContext)
 		throws PortalException {
+
+		sourceURL = StringUtil.toLowerCase(sourceURL);
 
 		_checkDestinationURLMustNotBeEqualToSourceURL(
 			destinationURL, groupBaseURL, sourceURL);
@@ -250,6 +254,8 @@ public class RedirectEntryLocalServiceImpl
 			boolean permanent, String sourceURL)
 		throws PortalException {
 
+		sourceURL = StringUtil.toLowerCase(sourceURL);
+
 		_validate(destinationURL, sourceURL);
 
 		RedirectEntry redirectEntry = getRedirectEntry(redirectEntryId);
@@ -279,6 +285,8 @@ public class RedirectEntryLocalServiceImpl
 			String groupBaseURL, boolean permanent, String sourceURL,
 			boolean updateChainedRedirectEntries)
 		throws PortalException {
+
+		sourceURL = StringUtil.toLowerCase(sourceURL);
 
 		_checkDestinationURLMustNotBeEqualToSourceURL(
 			destinationURL, groupBaseURL, sourceURL);


### PR DESCRIPTION
Hi Team,
Could you please review this pull request?
https://issues.liferay.com/browse/LPS-158085
Thank you!

----
**Reproduction Steps:**
1.  Add a new redirection under configuration -> redirection with a Source URL "/testpage" and a Destination URL like "https://www.google.com/"
2.  Try to add a new redirection with a Source URL "/TestPage" and a Destination URL like "https://www.yahoo.com/"

**Actual outcome:** user can create the second redirect with the same text but a different casing.
**Expected outcome:** The user can't create the second redirect because it is the same as the first one with a different casing.

This is an idea to fix LPS-158085. I modified the edit and update service calls for the RedirectEntrys to lowercase the source URL. I also included an upgrade step to convert the uppercase redirects to lowercase. On some DBs like PostgreSQL where the search is case sensitive, it was even possible to create multiple redirects with different formats like /tESt or /Test or /TEST in these cases only one of them is casted to lower case. For the other entries, a warning is logged and the user can later fix these entries. We could also delete these entries if required but that could lead to data loss.

previous pulls: #3424 https://github.com/brianchandotcom/liferay-portal/pull/122516