### PR TITLE
LPS-154730: Expose ERC in DocumentsFolder

### DIFF
--- a/modules/apps/archived/document-library-file-rank-test/src/testIntegration/java/com/liferay/document/library/file/rank/trash/test/DLFileRankTrashHandlerTest.java
+++ b/modules/apps/archived/document-library-file-rank-test/src/testIntegration/java/com/liferay/document/library/file/rank/trash/test/DLFileRankTrashHandlerTest.java
@@ -81,7 +81,7 @@ public class DLFileRankTrashHandlerTest {
 		throws Exception {
 
 		return DLAppServiceUtil.addFolder(
-			group.getGroupId(), parentBaseModelId,
+			null, group.getGroupId(), parentBaseModelId,
 			RandomTestUtil.randomString(_FOLDER_NAME_MAX_LENGTH),
 			RandomTestUtil.randomString(), serviceContext);
 	}

--- a/modules/apps/archived/sync-service/src/main/java/com/liferay/sync/service/impl/SyncDLObjectServiceImpl.java
+++ b/modules/apps/archived/sync-service/src/main/java/com/liferay/sync/service/impl/SyncDLObjectServiceImpl.java
@@ -223,7 +223,7 @@ public class SyncDLObjectServiceImpl extends SyncDLObjectServiceBaseImpl {
 			}
 
 			Folder folder = _dlAppService.addFolder(
-				repositoryId, parentFolderId, name, description,
+				null, repositoryId, parentFolderId, name, description,
 				serviceContext);
 
 			return toSyncDLObject(folder, SyncDLObjectConstants.EVENT_ADD);

--- a/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/internal/conflict/test/CTColumnResolutionMaxTest.java
+++ b/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/internal/conflict/test/CTColumnResolutionMaxTest.java
@@ -74,8 +74,9 @@ public class CTColumnResolutionMaxTest {
 			ServiceContextTestUtil.getServiceContext(_group.getGroupId());
 
 		DLFolder parentDLFolder = _dlFolderLocalService.addFolder(
-			_group.getCreatorUserId(), _group.getGroupId(), _group.getGroupId(),
-			false, DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			null, _group.getCreatorUserId(), _group.getGroupId(),
+			_group.getGroupId(), false,
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(), false,
 			serviceContext);
 
@@ -84,7 +85,7 @@ public class CTColumnResolutionMaxTest {
 					_ctCollection.getCtCollectionId())) {
 
 			_dlFolderLocalService.addFolder(
-				_group.getCreatorUserId(), _group.getGroupId(),
+				null, _group.getCreatorUserId(), _group.getGroupId(),
 				_group.getGroupId(), false, parentDLFolder.getFolderId(),
 				_ctCollection.getName(), null, false, serviceContext);
 		}
@@ -123,8 +124,9 @@ public class CTColumnResolutionMaxTest {
 		String originalName = "original_name";
 
 		DLFolder parentDLFolder = _dlFolderLocalService.addFolder(
-			_group.getCreatorUserId(), _group.getGroupId(), _group.getGroupId(),
-			false, DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, originalName,
+			null, _group.getCreatorUserId(), _group.getGroupId(),
+			_group.getGroupId(), false,
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, originalName,
 			RandomTestUtil.randomString(), false, serviceContext);
 
 		try (SafeCloseable safeCloseable =
@@ -132,7 +134,7 @@ public class CTColumnResolutionMaxTest {
 					_ctCollection.getCtCollectionId())) {
 
 			_dlFolderLocalService.addFolder(
-				_group.getCreatorUserId(), _group.getGroupId(),
+				null, _group.getCreatorUserId(), _group.getGroupId(),
 				_group.getGroupId(), false, parentDLFolder.getFolderId(),
 				_ctCollection.getName(), null, false, serviceContext);
 		}

--- a/modules/apps/commerce/commerce-initializer-util/src/main/java/com/liferay/commerce/initializer/util/DLImporter.java
+++ b/modules/apps/commerce/commerce-initializer-util/src/main/java/com/liferay/commerce/initializer/util/DLImporter.java
@@ -203,7 +203,7 @@ public class DLImporter {
 		Repository repository = repositories.get(0);
 
 		DLFolder dlFolder = _dlFolderLocalService.addFolder(
-			userId, scopeGroupId, repository.getRepositoryId(), false,
+			null, userId, scopeGroupId, repository.getRepositoryId(), false,
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, name, description,
 			false, serviceContext);
 

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/change/tracking/test/CPAttachmentFileEntryTableReferenceDefinitionTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/change/tracking/test/CPAttachmentFileEntryTableReferenceDefinitionTest.java
@@ -75,8 +75,9 @@ public class CPAttachmentFileEntryTableReferenceDefinitionTest
 			group.getGroupId());
 
 		DLFolder dlFolder = _dlFolderLocalService.addFolder(
-			TestPropsValues.getUserId(), group.getGroupId(), group.getGroupId(),
-			false, DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			null, TestPropsValues.getUserId(), group.getGroupId(),
+			group.getGroupId(), false,
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(), false,
 			_serviceContext);
 

--- a/modules/apps/commerce/commerce-shop-by-diagram-test/src/testIntegration/java/com/liferay/commerce/shop/by/diagram/change/tracking/test/CSDiagramSettingTableReferenceDefinitionTest.java
+++ b/modules/apps/commerce/commerce-shop-by-diagram-test/src/testIntegration/java/com/liferay/commerce/shop/by/diagram/change/tracking/test/CSDiagramSettingTableReferenceDefinitionTest.java
@@ -76,8 +76,9 @@ public class CSDiagramSettingTableReferenceDefinitionTest
 			group.getGroupId());
 
 		DLFolder dlFolder = _dlFolderLocalService.addFolder(
-			TestPropsValues.getUserId(), group.getGroupId(), group.getGroupId(),
-			false, DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			null, TestPropsValues.getUserId(), group.getGroupId(),
+			group.getGroupId(), false,
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(), false,
 			_serviceContext);
 

--- a/modules/apps/document-library-opener/document-library-opener-google-drive-test/src/testIntegration/java/com/liferay/document/library/opener/google/drive/test/DLOpenerGoogleDriveManagerTest.java
+++ b/modules/apps/document-library-opener/document-library-opener-google-drive-test/src/testIntegration/java/com/liferay/document/library/opener/google/drive/test/DLOpenerGoogleDriveManagerTest.java
@@ -244,7 +244,7 @@ public class DLOpenerGoogleDriveManagerTest {
 			ServiceContextTestUtil.getServiceContext(_company.getGroupId());
 
 		Folder folder = _dlAppLocalService.addFolder(
-			TestPropsValues.getUserId(), _company.getGroupId(),
+			null, TestPropsValues.getUserId(), _company.getGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			serviceContext);

--- a/modules/apps/document-library-opener/document-library-opener-test/src/testIntegration/java/com/liferay/document/library/opener/upload/test/UniqueFileEntryTitleProviderTest.java
+++ b/modules/apps/document-library-opener/document-library-opener-test/src/testIntegration/java/com/liferay/document/library/opener/upload/test/UniqueFileEntryTitleProviderTest.java
@@ -58,7 +58,7 @@ public class UniqueFileEntryTitleProviderTest {
 		_group = GroupTestUtil.addGroup();
 
 		_folder = _dlAppLocalService.addFolder(
-			TestPropsValues.getUserId(), _group.getGroupId(),
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));

--- a/modules/apps/document-library/document-library-demo-data-creator-impl/src/main/java/com/liferay/document/library/demo/data/creator/internal/BaseFolderDemoDataCreatorImpl.java
+++ b/modules/apps/document-library/document-library-demo-data-creator-impl/src/main/java/com/liferay/document/library/demo/data/creator/internal/BaseFolderDemoDataCreatorImpl.java
@@ -66,7 +66,7 @@ public abstract class BaseFolderDemoDataCreatorImpl
 			}
 
 			folder = dlAppLocalService.addFolder(
-				userId, groupId, folderId, name, StringPool.BLANK,
+				null, userId, groupId, folderId, name, StringPool.BLANK,
 				new ServiceContext());
 		}
 

--- a/modules/apps/document-library/document-library-repository-cmis-impl/src/main/java/com/liferay/document/library/repository/cmis/internal/RepositoryProxyBean.java
+++ b/modules/apps/document-library/document-library-repository-cmis-impl/src/main/java/com/liferay/document/library/repository/cmis/internal/RepositoryProxyBean.java
@@ -108,6 +108,19 @@ public class RepositoryProxyBean
 	}
 
 	@Override
+	public Folder addFolder(
+			String externalReferenceCode, long userId, long parentFolderId,
+			String name, String description, ServiceContext serviceContext)
+		throws PortalException {
+
+		Folder folder = _repository.addFolder(
+			externalReferenceCode, userId, parentFolderId, name, description,
+			serviceContext);
+
+		return newFolderProxyBean(folder);
+	}
+
+	@Override
 	public FileVersion cancelCheckOut(long fileEntryId) throws PortalException {
 		FileVersion fileVersion = _repository.cancelCheckOut(fileEntryId);
 

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/exportimport/data/handler/FolderStagedModelDataHandler.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/exportimport/data/handler/FolderStagedModelDataHandler.java
@@ -285,8 +285,9 @@ public class FolderStagedModelDataHandler
 					folder.getName(), 2);
 
 				importedFolder = _dlAppLocalService.addFolder(
-					userId, repositoryId, parentFolderId, name,
-					folder.getDescription(), serviceContext);
+					folder.getExternalReferenceCode(), userId, repositoryId,
+					parentFolderId, name, folder.getDescription(),
+					serviceContext);
 			}
 			else {
 				String name = _dlFolderLocalService.getUniqueFolderName(

--- a/modules/apps/document-library/document-library-test-util/src/main/java/com/liferay/document/library/test/util/BaseDLAppTestCase.java
+++ b/modules/apps/document-library/document-library-test-util/src/main/java/com/liferay/document/library/test/util/BaseDLAppTestCase.java
@@ -73,8 +73,9 @@ public abstract class BaseDLAppTestCase {
 		}
 
 		parentFolder = _dlAppService.addFolder(
-			group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-			"Test Folder", RandomTestUtil.randomString(),
+			null, group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, "Test Folder",
+			RandomTestUtil.randomString(),
 			ServiceContextTestUtil.getServiceContext(
 				group.getGroupId(), TestPropsValues.getUserId()));
 

--- a/modules/apps/document-library/document-library-test-util/src/main/java/com/liferay/document/library/test/util/DLTestUtil.java
+++ b/modules/apps/document-library/document-library-test-util/src/main/java/com/liferay/document/library/test/util/DLTestUtil.java
@@ -90,7 +90,7 @@ public class DLTestUtil {
 		}
 
 		return DLFolderLocalServiceUtil.addFolder(
-			TestPropsValues.getUserId(), groupId, groupId, false,
+			null, TestPropsValues.getUserId(), groupId, groupId, false,
 			parentFolderId, name, StringPool.BLANK, false, serviceContext);
 	}
 

--- a/modules/apps/document-library/document-library-test-util/src/main/java/com/liferay/document/library/test/util/search/DLFolderSearchFixture.java
+++ b/modules/apps/document-library/document-library-test-util/src/main/java/com/liferay/document/library/test/util/search/DLFolderSearchFixture.java
@@ -53,9 +53,9 @@ public class DLFolderSearchFixture {
 		throws Exception {
 
 		DLFolder dlFolder = dlFolderLocalService.addFolder(
-			user.getUserId(), group.getGroupId(), group.getGroupId(), false,
-			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, keywords, keywords,
-			false, serviceContext);
+			null, user.getUserId(), group.getGroupId(), group.getGroupId(),
+			false, DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, keywords,
+			keywords, false, serviceContext);
 
 		dlFileEntryLocalService.addFileEntry(
 			null, user.getUserId(), group.getGroupId(), group.getGroupId(),
@@ -77,7 +77,7 @@ public class DLFolderSearchFixture {
 		throws Exception {
 
 		Folder folder = dlAppLocalService.addFolder(
-			serviceContext.getUserId(), serviceContext.getScopeGroupId(),
+			null, serviceContext.getUserId(), serviceContext.getScopeGroupId(),
 			parentFolderId, name, description, serviceContext);
 
 		DLFolder dlFolder = (DLFolder)folder.getModel();

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/local/service/test/DLAppLocalServiceWhenDeletingAFolderTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/local/service/test/DLAppLocalServiceWhenDeletingAFolderTest.java
@@ -52,7 +52,7 @@ public class DLAppLocalServiceWhenDeletingAFolderTest {
 		_group = GroupTestUtil.addGroup();
 
 		_folder = DLAppLocalServiceUtil.addFolder(
-			TestPropsValues.getUserId(), _group.getGroupId(),
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), StringPool.BLANK,
 			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenAddingAFolderTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenAddingAFolderTest.java
@@ -51,7 +51,7 @@ public class DLAppServiceWhenAddingAFolderTest extends BaseDLAppTestCase {
 	@Test
 	public void testShouldAddAssetEntry() throws PortalException {
 		Folder folder = DLAppServiceUtil.addFolder(
-			group.getGroupId(), parentFolder.getFolderId(),
+			null, group.getGroupId(), parentFolder.getFolderId(),
 			RandomTestUtil.randomString(), StringPool.BLANK,
 			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
 
@@ -68,7 +68,7 @@ public class DLAppServiceWhenAddingAFolderTest extends BaseDLAppTestCase {
 				DLSyncConstants.EVENT_ADD);
 
 		DLAppServiceUtil.addFolder(
-			group.getGroupId(), parentFolder.getFolderId(),
+			null, group.getGroupId(), parentFolder.getFolderId(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenCopyingAFolderTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenCopyingAFolderTest.java
@@ -60,7 +60,7 @@ public class DLAppServiceWhenCopyingAFolderTest extends BaseDLAppTestCase {
 				ServiceContextTestUtil.getServiceContext(group.getGroupId());
 
 			Folder folder = DLAppServiceUtil.addFolder(
-				group.getGroupId(), parentFolder.getFolderId(),
+				null, group.getGroupId(), parentFolder.getFolderId(),
 				RandomTestUtil.randomString(), StringPool.BLANK,
 				serviceContext);
 
@@ -94,11 +94,11 @@ public class DLAppServiceWhenCopyingAFolderTest extends BaseDLAppTestCase {
 			ServiceContextTestUtil.getServiceContext(group.getGroupId());
 
 		Folder folder = DLAppServiceUtil.addFolder(
-			group.getGroupId(), parentFolder.getFolderId(),
+			null, group.getGroupId(), parentFolder.getFolderId(),
 			RandomTestUtil.randomString(), StringPool.BLANK, serviceContext);
 
 		DLAppServiceUtil.addFolder(
-			group.getGroupId(), folder.getFolderId(),
+			null, group.getGroupId(), folder.getFolderId(),
 			RandomTestUtil.randomString(), StringPool.BLANK, serviceContext);
 
 		DLAppServiceUtil.copyFolder(

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenDeletingAFolderByNameTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenDeletingAFolderByNameTest.java
@@ -54,12 +54,12 @@ public class DLAppServiceWhenDeletingAFolderByNameTest
 			ServiceContextTestUtil.getServiceContext(group.getGroupId());
 
 		Folder folder = DLAppServiceUtil.addFolder(
-			group.getGroupId(), parentFolder.getFolderId(),
+			null, group.getGroupId(), parentFolder.getFolderId(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			serviceContext);
 
 		DLAppServiceUtil.addFolder(
-			group.getGroupId(), folder.getFolderId(),
+			null, group.getGroupId(), folder.getFolderId(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			serviceContext);
 
@@ -83,12 +83,12 @@ public class DLAppServiceWhenDeletingAFolderByNameTest
 			ServiceContextTestUtil.getServiceContext(group.getGroupId());
 
 		Folder folder = DLAppServiceUtil.addFolder(
-			group.getGroupId(), parentFolder.getFolderId(),
+			null, group.getGroupId(), parentFolder.getFolderId(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			serviceContext);
 
 		Folder subfolder = DLAppServiceUtil.addFolder(
-			group.getGroupId(), folder.getFolderId(),
+			null, group.getGroupId(), folder.getFolderId(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			serviceContext);
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenDeletingAFolderTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenDeletingAFolderTest.java
@@ -56,12 +56,12 @@ public class DLAppServiceWhenDeletingAFolderTest extends BaseDLAppTestCase {
 			ServiceContextTestUtil.getServiceContext(group.getGroupId());
 
 		Folder folder = DLAppServiceUtil.addFolder(
-			group.getGroupId(), parentFolder.getFolderId(),
+			null, group.getGroupId(), parentFolder.getFolderId(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			serviceContext);
 
 		DLAppServiceUtil.addFolder(
-			group.getGroupId(), folder.getFolderId(),
+			null, group.getGroupId(), folder.getFolderId(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			serviceContext);
 
@@ -82,7 +82,7 @@ public class DLAppServiceWhenDeletingAFolderTest extends BaseDLAppTestCase {
 				DLSyncConstants.EVENT_DELETE);
 
 		Folder folder = DLAppServiceUtil.addFolder(
-			group.getGroupId(), parentFolder.getFolderId(),
+			null, group.getGroupId(), parentFolder.getFolderId(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
 
@@ -97,12 +97,12 @@ public class DLAppServiceWhenDeletingAFolderTest extends BaseDLAppTestCase {
 			ServiceContextTestUtil.getServiceContext(group.getGroupId());
 
 		Folder folder = DLAppServiceUtil.addFolder(
-			group.getGroupId(), parentFolder.getFolderId(),
+			null, group.getGroupId(), parentFolder.getFolderId(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			serviceContext);
 
 		Folder subfolder = DLAppServiceUtil.addFolder(
-			group.getGroupId(), folder.getFolderId(),
+			null, group.getGroupId(), folder.getFolderId(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			serviceContext);
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenMovingAFolderTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenMovingAFolderTest.java
@@ -55,7 +55,7 @@ public class DLAppServiceWhenMovingAFolderTest extends BaseDLAppTestCase {
 			ServiceContextTestUtil.getServiceContext(group.getGroupId());
 
 		Folder folder = DLAppServiceUtil.addFolder(
-			group.getGroupId(), parentFolder.getFolderId(),
+			null, group.getGroupId(), parentFolder.getFolderId(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			serviceContext);
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenUpdatingAFolderTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenUpdatingAFolderTest.java
@@ -56,7 +56,7 @@ public class DLAppServiceWhenUpdatingAFolderTest extends BaseDLAppTestCase {
 			ServiceContextTestUtil.getServiceContext(group.getGroupId());
 
 		Folder folder = DLAppServiceUtil.addFolder(
-			group.getGroupId(), parentFolder.getFolderId(),
+			null, group.getGroupId(), parentFolder.getFolderId(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			serviceContext);
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenViewingFolderContentsTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenViewingFolderContentsTest.java
@@ -133,7 +133,7 @@ public class DLAppServiceWhenViewingFolderContentsTest
 			ServiceContextTestUtil.getServiceContext(group.getGroupId());
 
 		Folder targetGroupFolder = _dlAppService.addFolder(
-			targetGroup.getGroupId(),
+			null, targetGroup.getGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			ServiceContextTestUtil.getServiceContext(targetGroup.getGroupId()));
@@ -214,7 +214,7 @@ public class DLAppServiceWhenViewingFolderContentsTest
 			(byte[])null, null, null, serviceContext);
 
 		_dlAppService.addFolder(
-			group.getGroupId(), parentFolder.getFolderId(),
+			null, group.getGroupId(), parentFolder.getFolderId(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/change/tracking/test/DLFolderTableReferenceDefinitionTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/change/tracking/test/DLFolderTableReferenceDefinitionTest.java
@@ -60,15 +60,17 @@ public class DLFolderTableReferenceDefinitionTest
 			ServiceContextTestUtil.getServiceContext(group.getGroupId());
 
 		DLFolder parentFolder = _dlFolderLocalService.addFolder(
-			group.getCreatorUserId(), group.getGroupId(), group.getGroupId(),
-			false, DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			null, group.getCreatorUserId(), group.getGroupId(),
+			group.getGroupId(), false,
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(), false,
 			serviceContext);
 
 		DLFolder childFolder = _dlFolderLocalService.addFolder(
-			group.getCreatorUserId(), group.getGroupId(), group.getGroupId(),
-			false, parentFolder.getFolderId(), RandomTestUtil.randomString(),
-			RandomTestUtil.randomString(), false, serviceContext);
+			null, group.getCreatorUserId(), group.getGroupId(),
+			group.getGroupId(), false, parentFolder.getFolderId(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(), false,
+			serviceContext);
 
 		byte[] bytes = TestDataConstants.TEST_BYTE_ARRAY;
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/convert/test/DocumentLibraryConvertProcessTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/convert/test/DocumentLibraryConvertProcessTest.java
@@ -163,7 +163,8 @@ public class DocumentLibraryConvertProcessTest {
 	@Test
 	public void testMigrateDLWhenFileEntryInFolder() throws Exception {
 		Folder folder = _dlAppService.addFolder(
-			_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			null, _group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			ServiceContextTestUtil.getServiceContext(
 				_group.getGroupId(), TestPropsValues.getUserId()));
@@ -297,7 +298,8 @@ public class DocumentLibraryConvertProcessTest {
 			TestDataConstants.TEST_BYTE_ARRAY);
 
 		Folder folder = _dlAppService.addFolder(
-			_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			null, _group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			ServiceContextTestUtil.getServiceContext(
 				_group.getGroupId(), TestPropsValues.getUserId()));

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/exportimport/data/handler/test/FileEntryStagedModelDataHandlerTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/exportimport/data/handler/test/FileEntryStagedModelDataHandlerTest.java
@@ -540,7 +540,7 @@ public class FileEntryStagedModelDataHandlerTest
 			new UnicodeProperties(), true, serviceContext);
 
 		Folder folder = _dlAppLocalService.addFolder(
-			TestPropsValues.getUserId(), repository.getRepositoryId(),
+			null, TestPropsValues.getUserId(), repository.getRepositoryId(),
 			repository.getDlFolderId(), "testFolder", "test folder",
 			serviceContext);
 
@@ -598,7 +598,7 @@ public class FileEntryStagedModelDataHandlerTest
 			dependentStagedModelsMap, DLFileEntryType.class, dlFileEntryType);
 
 		Folder folder = _dlAppService.addFolder(
-			stagingGroup.getGroupId(),
+			null, stagingGroup.getGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			ServiceContextTestUtil.getServiceContext(
@@ -631,7 +631,8 @@ public class FileEntryStagedModelDataHandlerTest
 			dependentStagedModelsMap, DDMStructure.class, ddmStructure);
 
 		Folder folder = _dlAppService.addFolder(
-			group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			null, group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			ServiceContextTestUtil.getServiceContext(
 				group.getGroupId(), TestPropsValues.getUserId()));

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/exportimport/data/handler/test/FileShortcutStagedModelDataHandlerTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/exportimport/data/handler/test/FileShortcutStagedModelDataHandlerTest.java
@@ -107,7 +107,8 @@ public class FileShortcutStagedModelDataHandlerTest
 				group.getGroupId(), TestPropsValues.getUserId());
 
 		Folder folder = DLAppServiceUtil.addFolder(
-			group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			null, group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			serviceContext);
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/exportimport/data/handler/test/FolderStagedModelDataHandlerTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/exportimport/data/handler/test/FolderStagedModelDataHandlerTest.java
@@ -118,7 +118,7 @@ public class FolderStagedModelDataHandlerTest
 			dependentStagedModelsMap, DLFileEntryType.class, dlFileEntryType);
 
 		Folder folder = DLAppServiceUtil.addFolder(
-			stagingGroup.getGroupId(),
+			null, stagingGroup.getGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			ServiceContextTestUtil.getServiceContext(
@@ -152,7 +152,8 @@ public class FolderStagedModelDataHandlerTest
 			dependentStagedModelsMap, DLFileEntryType.class, dlFileEntryType);
 
 		Folder folder = DLAppServiceUtil.addFolder(
-			group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			null, group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			ServiceContextTestUtil.getServiceContext(
 				group.getGroupId(), TestPropsValues.getUserId()));
@@ -205,7 +206,7 @@ public class FolderStagedModelDataHandlerTest
 				group.getGroupId(), TestPropsValues.getUserId());
 
 		folder = DLAppServiceUtil.addFolder(
-			group.getGroupId(), folder.getFolderId(),
+			null, group.getGroupId(), folder.getFolderId(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			serviceContext);
 
@@ -367,6 +368,10 @@ public class FolderStagedModelDataHandlerTest
 
 		Folder folder = (Folder)stagedModel;
 		Folder importedFolder = (Folder)importedStagedModel;
+
+		Assert.assertEquals(
+			folder.getExternalReferenceCode(),
+			importedFolder.getExternalReferenceCode());
 
 		Assert.assertEquals(folder.getName(), importedFolder.getName());
 		Assert.assertEquals(

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/exportimport/data/handler/test/RepositoryStagedModelDataHandlerTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/exportimport/data/handler/test/RepositoryStagedModelDataHandlerTest.java
@@ -73,7 +73,8 @@ public class RepositoryStagedModelDataHandlerTest
 				group.getGroupId(), TestPropsValues.getUserId());
 
 		Folder mountFolder = DLAppServiceUtil.addFolder(
-			group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			null, group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			serviceContext);
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/service/test/FriendlyURLDLFileEntryLocalServiceWrapperTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/service/test/FriendlyURLDLFileEntryLocalServiceWrapperTest.java
@@ -141,7 +141,7 @@ public class FriendlyURLDLFileEntryLocalServiceWrapperTest
 		Assert.assertEquals("urltitle", friendlyURLEntry1.getUrlTitle());
 
 		Folder folder = _dlAppService.addFolder(
-			group.getGroupId(), parentFolder.getFolderId(),
+			null, group.getGroupId(), parentFolder.getFolderId(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			serviceContext);
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/notifications/test/DocumentLibraryUserNotificationTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/notifications/test/DocumentLibraryUserNotificationTest.java
@@ -86,7 +86,8 @@ public class DocumentLibraryUserNotificationTest
 	@Override
 	protected void addContainerModel() throws Exception {
 		_folder = DLAppServiceUtil.addFolder(
-			group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			null, group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			ServiceContextTestUtil.getServiceContext(
 				group.getGroupId(), TestPropsValues.getUserId()));

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/permission/test/DLFileEntryPermissionCheckerTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/permission/test/DLFileEntryPermissionCheckerTest.java
@@ -106,8 +106,9 @@ public class DLFileEntryPermissionCheckerTest extends BasePermissionTestCase {
 		}
 
 		Folder folder = DLAppServiceUtil.addFolder(
-			group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-			name, RandomTestUtil.randomString(),
+			null, group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, name,
+			RandomTestUtil.randomString(),
 			ServiceContextTestUtil.getServiceContext(
 				group.getGroupId(), TestPropsValues.getUserId()));
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/permission/test/DLFolderPermissionCheckerTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/permission/test/DLFolderPermissionCheckerTest.java
@@ -96,8 +96,9 @@ public class DLFolderPermissionCheckerTest extends BasePermissionTestCase {
 				group.getGroupId(), TestPropsValues.getUserId());
 
 		_folder = DLAppServiceUtil.addFolder(
-			group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-			name, RandomTestUtil.randomString(), serviceContext);
+			null, group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, name,
+			RandomTestUtil.randomString(), serviceContext);
 
 		name = RandomTestUtil.randomString();
 
@@ -112,7 +113,7 @@ public class DLFolderPermissionCheckerTest extends BasePermissionTestCase {
 		}
 
 		_subfolder = DLAppServiceUtil.addFolder(
-			group.getGroupId(), _folder.getFolderId(), name,
+			null, group.getGroupId(), _folder.getFolderId(), name,
 			RandomTestUtil.randomString(), serviceContext);
 	}
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFileEntrySearchTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFileEntrySearchTest.java
@@ -261,7 +261,7 @@ public class DLFileEntrySearchTest extends BaseSearchTestCase {
 			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
 
 		Folder folder = DLAppLocalServiceUtil.addFolder(
-			TestPropsValues.getUserId(), group.getGroupId(),
+			null, TestPropsValues.getUserId(), group.getGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			StringUtil.randomString(), StringUtil.randomString(),
 			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
@@ -447,7 +447,7 @@ public class DLFileEntrySearchTest extends BaseSearchTestCase {
 		throws Exception {
 
 		Folder folder = DLAppServiceUtil.addFolder(
-			serviceContext.getScopeGroupId(),
+			null, serviceContext.getScopeGroupId(),
 			(Long)parentBaseModel.getPrimaryKeyObj(),
 			RandomTestUtil.randomString(_FOLDER_NAME_MAX_LENGTH),
 			RandomTestUtil.randomString(), serviceContext);
@@ -461,7 +461,7 @@ public class DLFileEntrySearchTest extends BaseSearchTestCase {
 		throws Exception {
 
 		Folder folder = DLAppServiceUtil.addFolder(
-			serviceContext.getScopeGroupId(),
+			null, serviceContext.getScopeGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(_FOLDER_NAME_MAX_LENGTH),
 			RandomTestUtil.randomString(), serviceContext);

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFolderSearchTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFolderSearchTest.java
@@ -145,7 +145,7 @@ public class DLFolderSearchTest extends BaseSearchTestCase {
 		}
 
 		Folder folder = DLAppServiceUtil.addFolder(
-			serviceContext.getScopeGroupId(), folderId, keywords,
+			null, serviceContext.getScopeGroupId(), folderId, keywords,
 			RandomTestUtil.randomString(), serviceContext);
 
 		return (DLFolder)folder.getModel();
@@ -167,7 +167,7 @@ public class DLFolderSearchTest extends BaseSearchTestCase {
 		throws Exception {
 
 		Folder folder = DLAppServiceUtil.addFolder(
-			serviceContext.getScopeGroupId(),
+			null, serviceContext.getScopeGroupId(),
 			(Long)parentBaseModel.getPrimaryKeyObj(),
 			RandomTestUtil.randomString(_FOLDER_NAME_MAX_LENGTH),
 			RandomTestUtil.randomString(), serviceContext);
@@ -181,7 +181,7 @@ public class DLFolderSearchTest extends BaseSearchTestCase {
 		throws Exception {
 
 		Folder folder = DLAppServiceUtil.addFolder(
-			serviceContext.getScopeGroupId(),
+			null, serviceContext.getScopeGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(_FOLDER_NAME_MAX_LENGTH),
 			RandomTestUtil.randomString(), serviceContext);

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLCheckInCheckOutTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLCheckInCheckOutTest.java
@@ -535,7 +535,7 @@ public class DLCheckInCheckOutTest {
 		long repositoryId = _group.getGroupId();
 
 		Folder folder = DLAppServiceUtil.addFolder(
-			repositoryId, DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			null, repositoryId, DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			folderName, StringPool.BLANK, _serviceContext);
 
 		Assert.assertNotNull(folder);

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryFinderTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryFinderTest.java
@@ -1472,17 +1472,17 @@ public class DLFileEntryFinderTest {
 		throws Exception {
 
 		Folder folder = DLAppLocalServiceUtil.addFolder(
-			TestPropsValues.getUserId(), repositoryId,
+			null, TestPropsValues.getUserId(), repositoryId,
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, "Folder A",
 			StringPool.BLANK, serviceContext);
 
 		DLAppLocalServiceUtil.addFolder(
-			TestPropsValues.getUserId(), repositoryId, folder.getFolderId(),
-			"Folder B", StringPool.BLANK, serviceContext);
+			null, TestPropsValues.getUserId(), repositoryId,
+			folder.getFolderId(), "Folder B", StringPool.BLANK, serviceContext);
 
 		Folder folderC = DLAppLocalServiceUtil.addFolder(
-			TestPropsValues.getUserId(), repositoryId, folder.getFolderId(),
-			"Folder C", StringPool.BLANK, serviceContext);
+			null, TestPropsValues.getUserId(), repositoryId,
+			folder.getFolderId(), "Folder C", StringPool.BLANK, serviceContext);
 
 		DLTrashServiceUtil.moveFolderToTrash(folderC.getFolderId());
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryLocalServiceTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryLocalServiceTest.java
@@ -449,7 +449,8 @@ public class DLFileEntryLocalServiceTest {
 					_group.getGroupId(), TestPropsValues.getUserId());
 
 			Folder folder = DLAppServiceUtil.addFolder(
-				_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+				null, _group.getGroupId(),
+				DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 				serviceContext);
 
@@ -471,7 +472,8 @@ public class DLFileEntryLocalServiceTest {
 				_group.getGroupId(), TestPropsValues.getUserId());
 
 			Folder destinationFolder = DLAppServiceUtil.addFolder(
-				_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+				null, _group.getGroupId(),
+				DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 				serviceContext);
 
@@ -530,7 +532,8 @@ public class DLFileEntryLocalServiceTest {
 				_group.getGroupId(), TestPropsValues.getUserId());
 
 		Folder folder = DLAppServiceUtil.addFolder(
-			_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			null, _group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			serviceContext);
 
@@ -975,7 +978,8 @@ public class DLFileEntryLocalServiceTest {
 	@Test(expected = DuplicateFolderNameException.class)
 	public void testValidateFileFailsWithAnExistingFolder() throws Exception {
 		Folder folder = DLAppServiceUtil.addFolder(
-			_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			null, _group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			ServiceContextTestUtil.getServiceContext(
 				_group.getGroupId(), TestPropsValues.getUserId()));

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryLocalServiceTreeTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryLocalServiceTreeTest.java
@@ -73,11 +73,12 @@ public class DLFileEntryLocalServiceTreeTest {
 				_group.getGroupId(), TestPropsValues.getUserId());
 
 		Folder folderA = DLAppServiceUtil.addFolder(
-			_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-			"Folder A", RandomTestUtil.randomString(), serviceContext);
+			null, _group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, "Folder A",
+			RandomTestUtil.randomString(), serviceContext);
 
 		Folder folderAA = DLAppServiceUtil.addFolder(
-			_group.getGroupId(), folderA.getFolderId(), "Folder AA",
+			null, _group.getGroupId(), folderA.getFolderId(), "Folder AA",
 			RandomTestUtil.randomString(), serviceContext);
 
 		FileEntry fileEntry = addFileEntry(folderAA.getFolderId(), "Entry.txt");
@@ -137,8 +138,9 @@ public class DLFileEntryLocalServiceTreeTest {
 		fileEntries.add(fileEntryA);
 
 		Folder folder = DLAppServiceUtil.addFolder(
-			_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-			"Folder A", RandomTestUtil.randomString(),
+			null, _group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, "Folder A",
+			RandomTestUtil.randomString(),
 			ServiceContextTestUtil.getServiceContext(
 				_group.getGroupId(), TestPropsValues.getUserId()));
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryServiceTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryServiceTest.java
@@ -77,7 +77,7 @@ public class DLFileEntryServiceTest {
 			ServiceContextTestUtil.getServiceContext(_group.getGroupId());
 
 		DLFolder folder = DLFolderLocalServiceUtil.addFolder(
-			TestPropsValues.getUserId(), _group.getGroupId(),
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
 			_group.getGroupId(), false,
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(), false,
@@ -86,7 +86,7 @@ public class DLFileEntryServiceTest {
 		DLFileEntry dlFileEntry = addDLFileEntry(folder.getFolderId(), true);
 
 		DLFolder destFolder = DLFolderLocalServiceUtil.addFolder(
-			TestPropsValues.getUserId(), _group.getGroupId(),
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
 			_group.getGroupId(), false,
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(), false,
@@ -106,7 +106,7 @@ public class DLFileEntryServiceTest {
 			ServiceContextTestUtil.getServiceContext(_group.getGroupId());
 
 		DLFolder folder = DLFolderLocalServiceUtil.addFolder(
-			TestPropsValues.getUserId(), _group.getGroupId(),
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
 			_group.getGroupId(), false,
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(), false,
@@ -131,7 +131,7 @@ public class DLFileEntryServiceTest {
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, true);
 
 		DLFolder destFolder = DLFolderLocalServiceUtil.addFolder(
-			TestPropsValues.getUserId(), _group.getGroupId(),
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
 			_group.getGroupId(), false,
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(), false,
@@ -151,7 +151,7 @@ public class DLFileEntryServiceTest {
 			ServiceContextTestUtil.getServiceContext(_group.getGroupId());
 
 		DLFolder folder = DLFolderLocalServiceUtil.addFolder(
-			TestPropsValues.getUserId(), _group.getGroupId(),
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
 			_group.getGroupId(), false,
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(), false,
@@ -160,7 +160,7 @@ public class DLFileEntryServiceTest {
 		DLFileEntry dlFileEntry = addDLFileEntry(folder.getFolderId(), false);
 
 		DLFolder destFolder = DLFolderLocalServiceUtil.addFolder(
-			TestPropsValues.getUserId(), _group.getGroupId(),
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
 			_group.getGroupId(), false,
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(), false,
@@ -180,7 +180,7 @@ public class DLFileEntryServiceTest {
 			ServiceContextTestUtil.getServiceContext(_group.getGroupId());
 
 		DLFolder folder = DLFolderLocalServiceUtil.addFolder(
-			TestPropsValues.getUserId(), _group.getGroupId(),
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
 			_group.getGroupId(), false,
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(), false,
@@ -205,7 +205,7 @@ public class DLFileEntryServiceTest {
 			ServiceContextTestUtil.getServiceContext(_group.getGroupId());
 
 		DLFolder destFolder = DLFolderLocalServiceUtil.addFolder(
-			TestPropsValues.getUserId(), _group.getGroupId(),
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
 			_group.getGroupId(), false,
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(), false,

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryTypeServiceTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryTypeServiceTest.java
@@ -85,13 +85,13 @@ public class DLFileEntryTypeServiceTest {
 		_group = GroupTestUtil.addGroup();
 
 		_folder = DLAppLocalServiceUtil.addFolder(
-			TestPropsValues.getUserId(), _group.getGroupId(),
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, "Folder A",
 			StringPool.BLANK,
 			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
 
 		_subfolder = DLAppLocalServiceUtil.addFolder(
-			TestPropsValues.getUserId(), _group.getGroupId(),
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
 			_folder.getFolderId(), "SubFolder AA", StringPool.BLANK,
 			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileShortcutLocalServiceTreeTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileShortcutLocalServiceTreeTest.java
@@ -73,11 +73,12 @@ public class DLFileShortcutLocalServiceTreeTest {
 				_group.getGroupId(), TestPropsValues.getUserId());
 
 		Folder folderA = DLAppServiceUtil.addFolder(
-			_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-			"Folder A", RandomTestUtil.randomString(), serviceContext);
+			null, _group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, "Folder A",
+			RandomTestUtil.randomString(), serviceContext);
 
 		Folder folderAA = DLAppServiceUtil.addFolder(
-			_group.getGroupId(), folderA.getFolderId(), "Folder AA",
+			null, _group.getGroupId(), folderA.getFolderId(), "Folder AA",
 			RandomTestUtil.randomString(), serviceContext);
 
 		FileEntry fileEntry = addFileEntry(folderA.getFolderId(), "Entry.txt");
@@ -159,8 +160,9 @@ public class DLFileShortcutLocalServiceTreeTest {
 		_fileShortcuts.add(fileShortcutA);
 
 		_folder = DLAppServiceUtil.addFolder(
-			_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-			"Folder A", RandomTestUtil.randomString(),
+			null, _group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, "Folder A",
+			RandomTestUtil.randomString(),
 			ServiceContextTestUtil.getServiceContext(
 				_group.getGroupId(), TestPropsValues.getUserId()));
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileVersionLocalServiceTreeTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileVersionLocalServiceTreeTest.java
@@ -73,11 +73,12 @@ public class DLFileVersionLocalServiceTreeTest {
 				_group.getGroupId(), TestPropsValues.getUserId());
 
 		Folder folderA = DLAppServiceUtil.addFolder(
-			_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-			"Folder A", RandomTestUtil.randomString(), serviceContext);
+			null, _group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, "Folder A",
+			RandomTestUtil.randomString(), serviceContext);
 
 		Folder folderAA = DLAppServiceUtil.addFolder(
-			_group.getGroupId(), folderA.getFolderId(), "Folder AA",
+			null, _group.getGroupId(), folderA.getFolderId(), "Folder AA",
 			RandomTestUtil.randomString(), serviceContext);
 
 		FileEntry fileEntry = addFileEntry(folderAA.getFolderId(), "Entry.txt");
@@ -142,8 +143,9 @@ public class DLFileVersionLocalServiceTreeTest {
 		_fileEntries.add(fileEntryA);
 
 		_folder = DLAppServiceUtil.addFolder(
-			_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-			"Folder A", RandomTestUtil.randomString(),
+			null, _group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, "Folder A",
+			RandomTestUtil.randomString(),
 			ServiceContextTestUtil.getServiceContext(
 				_group.getGroupId(), TestPropsValues.getUserId()));
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileVersionTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileVersionTest.java
@@ -409,8 +409,9 @@ public class DLFileVersionTest {
 		}
 
 		_parentFolder = DLAppServiceUtil.addFolder(
-			_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-			"Test Folder", RandomTestUtil.randomString(),
+			null, _group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, "Test Folder",
+			RandomTestUtil.randomString(),
 			ServiceContextTestUtil.getServiceContext(
 				_group.getGroupId(), TestPropsValues.getUserId()));
 	}

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFolderFinderTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFolderFinderTest.java
@@ -85,17 +85,17 @@ public class DLFolderFinderTest {
 			new UnicodeProperties(), false, serviceContext);
 
 		_folder = DLAppLocalServiceUtil.addFolder(
-			TestPropsValues.getUserId(), _group.getGroupId(),
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, "Folder A",
 			StringPool.BLANK, serviceContext);
 
 		DLAppLocalServiceUtil.addFolder(
-			TestPropsValues.getUserId(), _group.getGroupId(),
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
 			_folder.getFolderId(), "Folder B", StringPool.BLANK,
 			serviceContext);
 
 		Folder folder = DLAppLocalServiceUtil.addFolder(
-			TestPropsValues.getUserId(), _group.getGroupId(),
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
 			_folder.getFolderId(), "Folder C", StringPool.BLANK,
 			serviceContext);
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFolderLocalServiceTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFolderLocalServiceTest.java
@@ -69,12 +69,13 @@ public class DLFolderLocalServiceTest {
 				_group.getGroupId(), TestPropsValues.getUserId());
 
 		Folder parentFolder = _dlAppService.addFolder(
-			_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			null, _group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			serviceContext);
 
 		_dlAppService.addFolder(
-			_group.getGroupId(), parentFolder.getFolderId(),
+			null, _group.getGroupId(), parentFolder.getFolderId(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			serviceContext);
 
@@ -94,7 +95,8 @@ public class DLFolderLocalServiceTest {
 	@Test
 	public void testGetNoAssetEntries() throws Exception {
 		Folder folder = _dlAppService.addFolder(
-			_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			null, _group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			ServiceContextTestUtil.getServiceContext(
 				_group.getGroupId(), TestPropsValues.getUserId()));

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFolderLocalServiceTreeTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFolderLocalServiceTreeTest.java
@@ -64,19 +64,20 @@ public class DLFolderLocalServiceTreeTest extends BaseLocalServiceTreeTestCase {
 				group.getGroupId(), TestPropsValues.getUserId());
 
 		Folder folderA = DLAppServiceUtil.addFolder(
-			group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-			"Folder A", RandomTestUtil.randomString(), serviceContext);
+			null, group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, "Folder A",
+			RandomTestUtil.randomString(), serviceContext);
 
 		folders.add(folderA);
 
 		Folder folderAA = DLAppServiceUtil.addFolder(
-			group.getGroupId(), folderA.getFolderId(), "Folder AA",
+			null, group.getGroupId(), folderA.getFolderId(), "Folder AA",
 			RandomTestUtil.randomString(), serviceContext);
 
 		folders.add(folderAA);
 
 		Folder folderAAA = DLAppServiceUtil.addFolder(
-			group.getGroupId(), folderAA.getFolderId(), "Folder AAA",
+			null, group.getGroupId(), folderAA.getFolderId(), "Folder AAA",
 			RandomTestUtil.randomString(), serviceContext);
 
 		folders.add(folderAAA);
@@ -107,8 +108,8 @@ public class DLFolderLocalServiceTreeTest extends BaseLocalServiceTreeTestCase {
 		}
 
 		Folder folder = DLAppServiceUtil.addFolder(
-			group.getGroupId(), parentFolderId, RandomTestUtil.randomString(),
-			RandomTestUtil.randomString(),
+			null, group.getGroupId(), parentFolderId,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			ServiceContextTestUtil.getServiceContext(
 				group.getGroupId(), TestPropsValues.getUserId()));
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFolderServiceTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFolderServiceTest.java
@@ -80,8 +80,9 @@ public class DLFolderServiceTest {
 		_group = GroupTestUtil.addGroup();
 
 		_parentFolder = _dlAppService.addFolder(
-			_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-			"Test Folder", RandomTestUtil.randomString(),
+			null, _group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, "Test Folder",
+			RandomTestUtil.randomString(),
 			ServiceContextTestUtil.getServiceContext(
 				_group.getGroupId(), TestPropsValues.getUserId()));
 
@@ -201,7 +202,7 @@ public class DLFolderServiceTest {
 		expectedFileEntries.add(fileEntry);
 
 		Folder folder = _dlAppService.addFolder(
-			_group.getGroupId(), _parentFolder.getFolderId(),
+			null, _group.getGroupId(), _parentFolder.getFolderId(),
 			StringUtil.randomString(), RandomTestUtil.randomString(),
 			ServiceContextTestUtil.getServiceContext(
 				_group.getGroupId(), TestPropsValues.getUserId()));
@@ -315,8 +316,9 @@ public class DLFolderServiceTest {
 			fileEntry3.getFileEntryId(), 4);
 
 		Folder hiddenFolder = _dlAppService.addFolder(
-			_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-			"Hidden Folder", RandomTestUtil.randomString(),
+			null, _group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, "Hidden Folder",
+			RandomTestUtil.randomString(),
 			ServiceContextTestUtil.getServiceContext(
 				_group.getGroupId(), TestPropsValues.getUserId()));
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFolderServiceTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFolderServiceTest.java
@@ -15,6 +15,7 @@
 package com.liferay.document.library.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.document.library.kernel.exception.DuplicateFolderNameException;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFileEntryMetadata;
 import com.liferay.document.library.kernel.model.DLFileEntryType;
@@ -96,6 +97,35 @@ public class DLFolderServiceTest {
 			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
 
 		_alternativeGroup = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	public void testAddDLFolderWithExternalReferenceCode() throws Exception {
+		String externalReferenceCode = RandomTestUtil.randomString();
+
+		Folder folder = addFolder(externalReferenceCode);
+
+		Assert.assertEquals(
+			externalReferenceCode, folder.getExternalReferenceCode());
+	}
+
+	@Test
+	public void testAddDLFolderWithoutExternalReferenceCode() throws Exception {
+		Folder folder = addFolder(null);
+
+		Assert.assertEquals(
+			folder.getExternalReferenceCode(), folder.getUuid());
+	}
+
+	@Test(expected = DuplicateFolderNameException.class)
+	public void testDLFolderWithExistingExternalReferenceCode()
+		throws Exception {
+
+		String externalReferenceCode = RandomTestUtil.randomString();
+
+		addFolder(externalReferenceCode);
+
+		addFolder(externalReferenceCode);
 	}
 
 	@Test
@@ -455,6 +485,15 @@ public class DLFolderServiceTest {
 				expectedFileEntry.getFileEntryId(),
 				actualDLFileEntry.getFileEntryId());
 		}
+	}
+
+	protected Folder addFolder(String externalReferenceCode) throws Exception {
+		return _dlAppService.addFolder(
+			externalReferenceCode, _group.getGroupId(),
+			_parentFolder.getFolderId(), "Test Folder",
+			RandomTestUtil.randomString(),
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId()));
 	}
 
 	@Inject

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/social/test/DLFolderActivityInterpreterTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/social/test/DLFolderActivityInterpreterTest.java
@@ -58,7 +58,8 @@ public class DLFolderActivityInterpreterTest
 	@Override
 	protected void addActivities() throws Exception {
 		_folder = DLAppServiceUtil.addFolder(
-			group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			null, group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			ServiceContextTestUtil.getServiceContext(
 				group.getGroupId(), TestPropsValues.getUserId()));

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/subscription/test/DLSubscriptionAuthorTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/subscription/test/DLSubscriptionAuthorTest.java
@@ -76,7 +76,7 @@ public class DLSubscriptionAuthorTest extends BaseSubscriptionAuthorTestCase {
 				group.getGroupId(), userId);
 
 		Folder folder = DLAppLocalServiceUtil.addFolder(
-			userId, group.getGroupId(), containerModelId,
+			null, userId, group.getGroupId(), containerModelId,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			serviceContext);
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/subscription/test/DLSubscriptionContainerModelTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/subscription/test/DLSubscriptionContainerModelTest.java
@@ -78,7 +78,7 @@ public class DLSubscriptionContainerModelTest
 				group.getGroupId(), userId);
 
 		Folder folder = DLAppLocalServiceUtil.addFolder(
-			userId, group.getGroupId(), containerModelId,
+			null, userId, group.getGroupId(), containerModelId,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			serviceContext);
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/subscription/test/DLSubscriptionRootContainerModelTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/subscription/test/DLSubscriptionRootContainerModelTest.java
@@ -78,7 +78,7 @@ public class DLSubscriptionRootContainerModelTest
 				group.getGroupId(), userId);
 
 		Folder folder = DLAppLocalServiceUtil.addFolder(
-			userId, group.getGroupId(), containerModelId,
+			null, userId, group.getGroupId(), containerModelId,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			serviceContext);
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/trash/test/DLFileEntryTrashHandlerTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/trash/test/DLFileEntryTrashHandlerTest.java
@@ -350,7 +350,7 @@ public class DLFileEntryTrashHandlerTest
 		throws Exception {
 
 		Folder folder = DLAppServiceUtil.addFolder(
-			group.getGroupId(), parentBaseModelId,
+			null, group.getGroupId(), parentBaseModelId,
 			RandomTestUtil.randomString(_FOLDER_NAME_MAX_LENGTH),
 			RandomTestUtil.randomString(), serviceContext);
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/trash/test/DLFileShortcutTrashHandlerTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/trash/test/DLFileShortcutTrashHandlerTest.java
@@ -255,8 +255,9 @@ public class DLFileShortcutTrashHandlerTest
 		throws Exception {
 
 		Folder folder = DLAppLocalServiceUtil.addFolder(
-			TestPropsValues.getUserId(), group.getGroupId(), parentBaseModelId,
-			RandomTestUtil.randomString(), StringPool.BLANK, serviceContext);
+			null, TestPropsValues.getUserId(), group.getGroupId(),
+			parentBaseModelId, RandomTestUtil.randomString(), StringPool.BLANK,
+			serviceContext);
 
 		return (BaseModel<?>)folder.getModel();
 	}

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/trash/test/DLFolderTrashHandlerTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/trash/test/DLFolderTrashHandlerTest.java
@@ -219,7 +219,7 @@ public class DLFolderTrashHandlerTest
 				groupId, TestPropsValues.getUserId());
 
 		Folder folder = DLAppServiceUtil.addFolder(
-			groupId, folderId, getSearchKeywords(),
+			null, groupId, folderId, getSearchKeywords(),
 			RandomTestUtil.randomString(), serviceContext);
 
 		return (DLFolder)folder.getModel();
@@ -272,7 +272,7 @@ public class DLFolderTrashHandlerTest
 		throws Exception {
 
 		Folder folder = DLAppServiceUtil.addFolder(
-			group.getGroupId(), parentBaseModelId,
+			null, group.getGroupId(), parentBaseModelId,
 			RandomTestUtil.randomString(_FOLDER_NAME_MAX_LENGTH),
 			RandomTestUtil.randomString(), serviceContext);
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/util/test/DLDirectoryNameAndFileNameTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/util/test/DLDirectoryNameAndFileNameTest.java
@@ -79,8 +79,9 @@ public class DLDirectoryNameAndFileNameTest {
 			StringUtil.randomString(20) + PropsValues.DL_CHAR_BLACKLIST[0];
 
 		DLAppServiceUtil.addFolder(
-			_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-			name, RandomTestUtil.randomString(),
+			null, _group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, name,
+			RandomTestUtil.randomString(),
 			ServiceContextTestUtil.getServiceContext(
 				_group.getGroupId(), TestPropsValues.getUserId()));
 	}
@@ -275,7 +276,8 @@ public class DLDirectoryNameAndFileNameTest {
 	@Test(expected = FolderNameException.class)
 	public void testUpdateFolder() throws Exception {
 		Folder folder = DLAppServiceUtil.addFolder(
-			_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			null, _group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			ServiceContextTestUtil.getServiceContext(
 				_group.getGroupId(), TestPropsValues.getUserId()));

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/util/test/RepositoryModelUtilTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/util/test/RepositoryModelUtilTest.java
@@ -75,7 +75,8 @@ public class RepositoryModelUtilTest {
 			_group.getGroupId(), TestPropsValues.getUserId());
 
 		_folder = DLAppServiceUtil.addFolder(
-			_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			null, _group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			_serviceContext);
 	}

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/verify/test/DLServiceVerifyProcessTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/verify/test/DLServiceVerifyProcessTest.java
@@ -196,7 +196,8 @@ public class DLServiceVerifyProcessTest extends BaseVerifyProcessTestCase {
 		throws Exception {
 
 		Folder parentFolder = DLAppServiceUtil.addFolder(
-			_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			null, _group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			ServiceContextTestUtil.getServiceContext(
 				_group.getGroupId(), TestPropsValues.getUserId()));
@@ -220,12 +221,13 @@ public class DLServiceVerifyProcessTest extends BaseVerifyProcessTestCase {
 				_group.getGroupId(), TestPropsValues.getUserId());
 
 		Folder grandparentFolder = DLAppServiceUtil.addFolder(
-			_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			null, _group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			serviceContext);
 
 		Folder parentFolder = DLAppServiceUtil.addFolder(
-			_group.getGroupId(), grandparentFolder.getFolderId(),
+			null, _group.getGroupId(), grandparentFolder.getFolderId(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			serviceContext);
 
@@ -274,7 +276,8 @@ public class DLServiceVerifyProcessTest extends BaseVerifyProcessTestCase {
 				_group.getGroupId(), TestPropsValues.getUserId());
 
 		Folder parentFolder = DLAppServiceUtil.addFolder(
-			_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			null, _group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			serviceContext);
 
@@ -303,12 +306,13 @@ public class DLServiceVerifyProcessTest extends BaseVerifyProcessTestCase {
 				_group.getGroupId(), TestPropsValues.getUserId());
 
 		Folder grandparentFolder = DLAppServiceUtil.addFolder(
-			_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			null, _group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			serviceContext);
 
 		Folder parentFolder = DLAppServiceUtil.addFolder(
-			_group.getGroupId(), grandparentFolder.getFolderId(),
+			null, _group.getGroupId(), grandparentFolder.getFolderId(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			serviceContext);
 
@@ -329,12 +333,13 @@ public class DLServiceVerifyProcessTest extends BaseVerifyProcessTestCase {
 				_group.getGroupId(), TestPropsValues.getUserId());
 
 		Folder parentFolder = DLAppServiceUtil.addFolder(
-			_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			null, _group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			serviceContext);
 
 		Folder folder = DLAppServiceUtil.addFolder(
-			_group.getGroupId(), parentFolder.getFolderId(),
+			null, _group.getGroupId(), parentFolder.getFolderId(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			serviceContext);
 
@@ -355,17 +360,18 @@ public class DLServiceVerifyProcessTest extends BaseVerifyProcessTestCase {
 				_group.getGroupId(), TestPropsValues.getUserId());
 
 		Folder grandparentFolder = DLAppServiceUtil.addFolder(
-			_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			null, _group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			serviceContext);
 
 		Folder parentFolder = DLAppServiceUtil.addFolder(
-			_group.getGroupId(), grandparentFolder.getFolderId(),
+			null, _group.getGroupId(), grandparentFolder.getFolderId(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			serviceContext);
 
 		DLAppServiceUtil.addFolder(
-			_group.getGroupId(), parentFolder.getFolderId(),
+			null, _group.getGroupId(), parentFolder.getFolderId(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			serviceContext);
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/web/exportimport/data/handler/test/DLPortletDataHandlerTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/web/exportimport/data/handler/test/DLPortletDataHandlerTest.java
@@ -197,11 +197,12 @@ public class DLPortletDataHandlerTest extends BasePortletDataHandlerTestCase {
 				group.getGroupId(), TestPropsValues.getUserId());
 
 		Folder parentFolder = DLAppServiceUtil.addFolder(
-			group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-			"parent", RandomTestUtil.randomString(), serviceContext);
+			null, group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, "parent",
+			RandomTestUtil.randomString(), serviceContext);
 
 		Folder childFolder = DLAppServiceUtil.addFolder(
-			group.getGroupId(), parentFolder.getFolderId(), "child",
+			null, group.getGroupId(), parentFolder.getFolderId(), "child",
 			RandomTestUtil.randomString(), serviceContext);
 
 		DLTrashServiceUtil.moveFolderToTrash(childFolder.getFolderId());
@@ -293,7 +294,7 @@ public class DLPortletDataHandlerTest extends BasePortletDataHandlerTestCase {
 		Group stagingGroup = this.stagingGroup.getStagingGroup();
 
 		Folder folder = DLAppServiceUtil.addFolder(
-			stagingGroup.getGroupId(),
+			null, stagingGroup.getGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			new ServiceContext());
@@ -349,7 +350,7 @@ public class DLPortletDataHandlerTest extends BasePortletDataHandlerTestCase {
 		Group stagingGroup = this.stagingGroup.getStagingGroup();
 
 		Folder folder = DLAppServiceUtil.addFolder(
-			stagingGroup.getGroupId(),
+			null, stagingGroup.getGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			new ServiceContext());
@@ -480,7 +481,7 @@ public class DLPortletDataHandlerTest extends BasePortletDataHandlerTestCase {
 				stagingGroup.getGroupId(), TestPropsValues.getUserId());
 
 		Folder folder = DLAppServiceUtil.addFolder(
-			repository.getRepositoryId(),
+			null, repository.getRepositoryId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			serviceContext);
@@ -501,7 +502,7 @@ public class DLPortletDataHandlerTest extends BasePortletDataHandlerTestCase {
 				stagingGroup.getGroupId(), TestPropsValues.getUserId());
 
 		Folder folder = DLAppServiceUtil.addFolder(
-			stagingGroup.getGroupId(),
+			null, stagingGroup.getGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			serviceContext);

--- a/modules/apps/document-library/document-library-uad-test/src/testIntegration/java/com/liferay/document/library/uad/test/DLFileEntryUADTestUtil.java
+++ b/modules/apps/document-library/document-library-uad-test/src/testIntegration/java/com/liferay/document/library/uad/test/DLFileEntryUADTestUtil.java
@@ -46,8 +46,8 @@ public class DLFileEntryUADTestUtil {
 		throws Exception {
 
 		DLFolder dlFolder = dlFolderLocalService.addFolder(
-			userId, groupId, groupId, false, 0L, RandomTestUtil.randomString(),
-			RandomTestUtil.randomString(), false,
+			null, userId, groupId, groupId, false, 0L,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(), false,
 			ServiceContextTestUtil.getServiceContext());
 
 		return addDLFileEntry(

--- a/modules/apps/document-library/document-library-uad-test/src/testIntegration/java/com/liferay/document/library/uad/test/DLFileShortcutUADTestUtil.java
+++ b/modules/apps/document-library/document-library-uad-test/src/testIntegration/java/com/liferay/document/library/uad/test/DLFileShortcutUADTestUtil.java
@@ -50,8 +50,9 @@ public class DLFileShortcutUADTestUtil {
 			ServiceContextTestUtil.getServiceContext();
 
 		DLFolder dlFolder = dlFolderLocalService.addFolder(
-			userId, groupId, groupId, false, 0L, RandomTestUtil.randomString(),
-			RandomTestUtil.randomString(), false, serviceContext);
+			null, userId, groupId, groupId, false, 0L,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(), false,
+			serviceContext);
 
 		byte[] bytes = TestDataConstants.TEST_BYTE_ARRAY;
 

--- a/modules/apps/document-library/document-library-uad-test/src/testIntegration/java/com/liferay/document/library/uad/test/DLFolderUADTestUtil.java
+++ b/modules/apps/document-library/document-library-uad-test/src/testIntegration/java/com/liferay/document/library/uad/test/DLFolderUADTestUtil.java
@@ -46,8 +46,8 @@ public class DLFolderUADTestUtil {
 		throws Exception {
 
 		Folder folder = dlAppLocalService.addFolder(
-			userId, groupId, parentFolderId, RandomTestUtil.randomString(),
-			RandomTestUtil.randomString(),
+			null, userId, groupId, parentFolderId,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			ServiceContextTestUtil.getServiceContext());
 
 		return (DLFolder)folder.getModel();

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/EditFolderMVCActionCommand.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/EditFolderMVCActionCommand.java
@@ -233,7 +233,7 @@ public class EditFolderMVCActionCommand extends BaseMVCActionCommand {
 				actionRequest, "parentFolderId");
 
 			_dlAppService.addFolder(
-				repositoryId, parentFolderId, name, description,
+				null, repositoryId, parentFolderId, name, description,
 				serviceContext);
 		}
 		else {

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/webdav/DLWebDAVStorageImpl.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/webdav/DLWebDAVStorageImpl.java
@@ -146,7 +146,8 @@ public class DLWebDAVStorageImpl extends BaseWebDAVStorageImpl {
 
 			if (depth == 0) {
 				_dlAppService.addFolder(
-					groupId, parentFolderId, name, description, serviceContext);
+					null, groupId, parentFolderId, name, description,
+					serviceContext);
 			}
 			else {
 				_dlAppService.copyFolder(
@@ -537,7 +538,7 @@ public class DLWebDAVStorageImpl extends BaseWebDAVStorageImpl {
 				DLFolder.class.getName(), webDAVRequest);
 
 			_dlAppService.addFolder(
-				webDAVRequest.getGroupId(), parentFolderId, name,
+				null, webDAVRequest.getGroupId(), parentFolderId, name,
 				StringPool.BLANK, serviceContext);
 
 			String location = StringUtil.merge(pathArray, StringPool.SLASH);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/document/library/DocumentLibraryDDMFormFieldTemplateContextContributor.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/document/library/DocumentLibraryDDMFormFieldTemplateContextContributor.java
@@ -248,7 +248,7 @@ public class DocumentLibraryDDMFormFieldTemplateContextContributor
 
 		try {
 			return _dlAppService.addFolder(
-				repositoryId, parentFolderId, user.getScreenName(),
+				null, repositoryId, parentFolderId, user.getScreenName(),
 				_language.get(
 					getResourceBundle(user.getLocale()),
 					"this-folder-was-automatically-created-by-forms-to-store-" +

--- a/modules/apps/export-import/export-import-resources-importer/src/main/java/com/liferay/exportimport/resources/importer/internal/util/FileSystemImporter.java
+++ b/modules/apps/export-import/export-import-resources-importer/src/main/java/com/liferay/exportimport/resources/importer/internal/util/FileSystemImporter.java
@@ -835,8 +835,8 @@ public class FileSystemImporter extends BaseImporter {
 
 		if (dlFolder == null) {
 			dlFolder = dlFolderLocalService.addFolder(
-				userId, groupId, groupId, false, parentFolderId, folderName,
-				null, false, serviceContext);
+				null, userId, groupId, groupId, false, parentFolderId,
+				folderName, null, false, serviceContext);
 		}
 
 		_addPrimaryKey(DLFolder.class.getName(), dlFolder.getPrimaryKey());

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/DocumentFolder.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/DocumentFolder.java
@@ -284,6 +284,36 @@ public class DocumentFolder implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String description;
 
+	@Schema(description = "The document folder's external reference code.")
+	public String getExternalReferenceCode() {
+		return externalReferenceCode;
+	}
+
+	public void setExternalReferenceCode(String externalReferenceCode) {
+		this.externalReferenceCode = externalReferenceCode;
+	}
+
+	@JsonIgnore
+	public void setExternalReferenceCode(
+		UnsafeSupplier<String, Exception> externalReferenceCodeUnsafeSupplier) {
+
+		try {
+			externalReferenceCode = externalReferenceCodeUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField(
+		description = "The document folder's external reference code."
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String externalReferenceCode;
+
 	@Schema(description = "The folder's ID.")
 	public Long getId() {
 		return id;
@@ -649,6 +679,20 @@ public class DocumentFolder implements Serializable {
 			sb.append("\"");
 
 			sb.append(_escape(description));
+
+			sb.append("\"");
+		}
+
+		if (externalReferenceCode != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"externalReferenceCode\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(externalReferenceCode));
 
 			sb.append("\"");
 		}

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/DocumentFolderResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/DocumentFolderResource.java
@@ -154,6 +154,19 @@ public interface DocumentFolderResource {
 				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
 
+	public void deleteSiteDocumentsFolderByExternalReferenceCode(
+			Long siteId, String externalReferenceCode)
+		throws Exception;
+
+	public DocumentFolder getSiteDocumentsFolderByExternalReferenceCode(
+			Long siteId, String externalReferenceCode)
+		throws Exception;
+
+	public DocumentFolder putSiteDocumentsFolderByExternalReferenceCode(
+			Long siteId, String externalReferenceCode,
+			DocumentFolder documentFolder)
+		throws Exception;
+
 	public default void setContextAcceptLanguage(
 		AcceptLanguage contextAcceptLanguage) {
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/resources/com/liferay/headless/delivery/resource/v1_0/packageinfo
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/resources/com/liferay/headless/delivery/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 15.6.0
+version 15.7.0

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/DocumentFolder.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/DocumentFolder.java
@@ -184,6 +184,27 @@ public class DocumentFolder implements Cloneable, Serializable {
 
 	protected String description;
 
+	public String getExternalReferenceCode() {
+		return externalReferenceCode;
+	}
+
+	public void setExternalReferenceCode(String externalReferenceCode) {
+		this.externalReferenceCode = externalReferenceCode;
+	}
+
+	public void setExternalReferenceCode(
+		UnsafeSupplier<String, Exception> externalReferenceCodeUnsafeSupplier) {
+
+		try {
+			externalReferenceCode = externalReferenceCodeUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String externalReferenceCode;
+
 	public Long getId() {
 		return id;
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/DocumentFolderResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/DocumentFolderResource.java
@@ -235,6 +235,35 @@ public interface DocumentFolderResource {
 				Long siteId, Permission[] permissions)
 		throws Exception;
 
+	public void deleteSiteDocumentsFolderByExternalReferenceCode(
+			Long siteId, String externalReferenceCode)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse
+			deleteSiteDocumentsFolderByExternalReferenceCodeHttpResponse(
+				Long siteId, String externalReferenceCode)
+		throws Exception;
+
+	public DocumentFolder getSiteDocumentsFolderByExternalReferenceCode(
+			Long siteId, String externalReferenceCode)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse
+			getSiteDocumentsFolderByExternalReferenceCodeHttpResponse(
+				Long siteId, String externalReferenceCode)
+		throws Exception;
+
+	public DocumentFolder putSiteDocumentsFolderByExternalReferenceCode(
+			Long siteId, String externalReferenceCode,
+			DocumentFolder documentFolder)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse
+			putSiteDocumentsFolderByExternalReferenceCodeHttpResponse(
+				Long siteId, String externalReferenceCode,
+				DocumentFolder documentFolder)
+		throws Exception;
+
 	public static class Builder {
 
 		public Builder authentication(String login, String password) {
@@ -2246,6 +2275,265 @@ public interface DocumentFolderResource {
 						"/o/headless-delivery/v1.0/sites/{siteId}/document-folders/permissions");
 
 			httpInvoker.path("siteId", siteId);
+
+			httpInvoker.userNameAndPassword(
+				_builder._login + ":" + _builder._password);
+
+			return httpInvoker.invoke();
+		}
+
+		public void deleteSiteDocumentsFolderByExternalReferenceCode(
+				Long siteId, String externalReferenceCode)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				deleteSiteDocumentsFolderByExternalReferenceCodeHttpResponse(
+					siteId, externalReferenceCode);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return;
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				deleteSiteDocumentsFolderByExternalReferenceCodeHttpResponse(
+					Long siteId, String externalReferenceCode)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.DELETE);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-delivery/v1.0/sites/{siteId}/documents-folder/by-external-reference-code/{externalReferenceCode}");
+
+			httpInvoker.path("siteId", siteId);
+			httpInvoker.path("externalReferenceCode", externalReferenceCode);
+
+			httpInvoker.userNameAndPassword(
+				_builder._login + ":" + _builder._password);
+
+			return httpInvoker.invoke();
+		}
+
+		public DocumentFolder getSiteDocumentsFolderByExternalReferenceCode(
+				Long siteId, String externalReferenceCode)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				getSiteDocumentsFolderByExternalReferenceCodeHttpResponse(
+					siteId, externalReferenceCode);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return DocumentFolderSerDes.toDTO(content);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				getSiteDocumentsFolderByExternalReferenceCodeHttpResponse(
+					Long siteId, String externalReferenceCode)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-delivery/v1.0/sites/{siteId}/documents-folder/by-external-reference-code/{externalReferenceCode}");
+
+			httpInvoker.path("siteId", siteId);
+			httpInvoker.path("externalReferenceCode", externalReferenceCode);
+
+			httpInvoker.userNameAndPassword(
+				_builder._login + ":" + _builder._password);
+
+			return httpInvoker.invoke();
+		}
+
+		public DocumentFolder putSiteDocumentsFolderByExternalReferenceCode(
+				Long siteId, String externalReferenceCode,
+				DocumentFolder documentFolder)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				putSiteDocumentsFolderByExternalReferenceCodeHttpResponse(
+					siteId, externalReferenceCode, documentFolder);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return DocumentFolderSerDes.toDTO(content);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				putSiteDocumentsFolderByExternalReferenceCodeHttpResponse(
+					Long siteId, String externalReferenceCode,
+					DocumentFolder documentFolder)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body(documentFolder.toString(), "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.PUT);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-delivery/v1.0/sites/{siteId}/documents-folder/by-external-reference-code/{externalReferenceCode}");
+
+			httpInvoker.path("siteId", siteId);
+			httpInvoker.path("externalReferenceCode", externalReferenceCode);
 
 			httpInvoker.userNameAndPassword(
 				_builder._login + ":" + _builder._password);

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/DocumentFolderSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/DocumentFolderSerDes.java
@@ -163,6 +163,20 @@ public class DocumentFolderSerDes {
 			sb.append("\"");
 		}
 
+		if (documentFolder.getExternalReferenceCode() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"externalReferenceCode\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(documentFolder.getExternalReferenceCode()));
+
+			sb.append("\"");
+		}
+
 		if (documentFolder.getId() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -333,6 +347,15 @@ public class DocumentFolderSerDes {
 				"description", String.valueOf(documentFolder.getDescription()));
 		}
 
+		if (documentFolder.getExternalReferenceCode() == null) {
+			map.put("externalReferenceCode", null);
+		}
+		else {
+			map.put(
+				"externalReferenceCode",
+				String.valueOf(documentFolder.getExternalReferenceCode()));
+		}
+
 		if (documentFolder.getId() == null) {
 			map.put("id", null);
 		}
@@ -464,6 +487,14 @@ public class DocumentFolderSerDes {
 			else if (Objects.equals(jsonParserFieldName, "description")) {
 				if (jsonParserFieldValue != null) {
 					documentFolder.setDescription((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(
+						jsonParserFieldName, "externalReferenceCode")) {
+
+				if (jsonParserFieldValue != null) {
+					documentFolder.setExternalReferenceCode(
+						(String)jsonParserFieldValue);
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "id")) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
@@ -1464,6 +1464,7 @@ components:
                         The folder's description.
                     type: string
                 externalReferenceCode:
+                    # @review
                     description:
                         The document folder's external reference code.
                     type: string
@@ -11747,6 +11748,7 @@ paths:
             # @review
             description:
                 Deletes the site's document folder by external reference code returns a 204 if the operation succeeds.
+            operationId: deleteSiteDocumentsFolderByExternalReferenceCode
             parameters:
                 - in: path
                   name: siteId
@@ -11769,6 +11771,7 @@ paths:
             # @review
             description:
                 Retrieves the site's document folder by external reference code.
+            operationId: getSiteDocumentsFolderByExternalReferenceCode
             parameters:
                 - in: path
                   name: siteId
@@ -11792,6 +11795,11 @@ paths:
                                 $ref: "#/components/schemas/DocumentFolder"
             tags: ["DocumentFolder"]
         put:
+            # @review
+            description:
+                Replaces the document folder by external reference code with the information sent in the request body,
+                or replaces it if it not exists.
+            operationId: putSiteDocumentsFolderByExternalReferenceCode
             parameters:
                 - in: path
                   name: siteId

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
@@ -1463,6 +1463,10 @@ components:
                     description:
                         The folder's description.
                     type: string
+                externalReferenceCode:
+                    description:
+                        The document folder's external reference code.
+                    type: string
                 id:
                     description:
                         The folder's ID.
@@ -11738,6 +11742,86 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Document"
             tags: ["Document"]
+    "/sites/{siteId}/documents-folder/by-external-reference-code/{externalReferenceCode}":
+        delete:
+            # @review
+            description:
+                Deletes the site's document folder by external reference code returns a 204 if the operation succeeds.
+            parameters:
+                - in: path
+                  name: siteId
+                  required: true
+                  schema:
+                      format: int64
+                      type: integer
+                - in: path
+                  name: externalReferenceCode
+                  required: true
+                  schema:
+                      type: string
+            responses:
+                204:
+                    content:
+                        application/json: {}
+                        application/xml: {}
+            tags: ["DocumentFolder"]
+        get:
+            # @review
+            description:
+                Retrieves the site's document folder by external reference code.
+            parameters:
+                - in: path
+                  name: siteId
+                  required: true
+                  schema:
+                      format: int64
+                      type: integer
+                - in: path
+                  name: externalReferenceCode
+                  required: true
+                  schema:
+                      type: string
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/DocumentFolder"
+                        application/xml:
+                            schema:
+                                $ref: "#/components/schemas/DocumentFolder"
+            tags: ["DocumentFolder"]
+        put:
+            parameters:
+                - in: path
+                  name: siteId
+                  required: true
+                  schema:
+                      format: int64
+                      type: integer
+                - in: path
+                  name: externalReferenceCode
+                  required: true
+                  schema:
+                      type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/DocumentFolder"
+                    application/xml:
+                        schema:
+                            $ref: "#/components/schemas/DocumentFolder"
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/DocumentFolder"
+                        application/xml:
+                            schema:
+                                $ref: "#/components/schemas/DocumentFolder"
+            tags: ["DocumentFolder"]
     "/sites/{siteId}/documents/by-external-reference-code/{documentExternalReferenceCode}/comments/by-external-reference-code/{externalReferenceCode}":
         delete:
             # @review

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/DocumentFolderDTOConverter.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/DocumentFolderDTOConverter.java
@@ -70,6 +70,7 @@ public class DocumentFolderDTOConverter
 				dateCreated = folder.getCreateDate();
 				dateModified = folder.getModifiedDate();
 				description = folder.getDescription();
+				externalReferenceCode = folder.getExternalReferenceCode();
 				id = folder.getFolderId();
 				name = folder.getName();
 				numberOfDocumentFolders = _dlAppService.getFoldersCount(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/mutation/v1_0/Mutation.java
@@ -1582,6 +1582,44 @@ public class Mutation {
 	}
 
 	@GraphQLField(
+		description = "Deletes the site's document folder by external reference code returns a 204 if the operation succeeds."
+	)
+	public boolean deleteSiteDocumentsFolderByExternalReferenceCode(
+			@GraphQLName("siteKey") @NotEmpty String siteKey,
+			@GraphQLName("externalReferenceCode") String externalReferenceCode)
+		throws Exception {
+
+		_applyVoidComponentServiceObjects(
+			_documentFolderResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			documentFolderResource ->
+				documentFolderResource.
+					deleteSiteDocumentsFolderByExternalReferenceCode(
+						Long.valueOf(siteKey), externalReferenceCode));
+
+		return true;
+	}
+
+	@GraphQLField(
+		description = "Replaces the document folder by external reference code with the information sent in the request body, or replaces it if it not exists."
+	)
+	public DocumentFolder updateSiteDocumentsFolderByExternalReferenceCode(
+			@GraphQLName("siteKey") @NotEmpty String siteKey,
+			@GraphQLName("externalReferenceCode") String externalReferenceCode,
+			@GraphQLName("documentFolder") DocumentFolder documentFolder)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_documentFolderResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			documentFolderResource ->
+				documentFolderResource.
+					putSiteDocumentsFolderByExternalReferenceCode(
+						Long.valueOf(siteKey), externalReferenceCode,
+						documentFolder));
+	}
+
+	@GraphQLField(
 		description = "Deletes the knowledge base article and returns a 204 if the operation succeeds."
 	)
 	public boolean deleteKnowledgeBaseArticle(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/query/v1_0/Query.java
@@ -1444,7 +1444,7 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {documentFolder(documentFolderId: ___){actions, assetLibraryKey, creator, customFields, dateCreated, dateModified, description, id, name, numberOfDocumentFolders, numberOfDocuments, parentDocumentFolderId, siteId, subscribed, viewableBy}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {documentFolder(documentFolderId: ___){actions, assetLibraryKey, creator, customFields, dateCreated, dateModified, description, externalReferenceCode, id, name, numberOfDocumentFolders, numberOfDocuments, parentDocumentFolderId, siteId, subscribed, viewableBy}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField(description = "Retrieves the document folder.")
 	public DocumentFolder documentFolder(
@@ -1562,6 +1562,28 @@ public class Query {
 			documentFolderResource -> new DocumentFolderPage(
 				documentFolderResource.getSiteDocumentFolderPermissionsPage(
 					Long.valueOf(siteKey), roleNames)));
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {documentsFolderByExternalReferenceCode(externalReferenceCode: ___, siteKey: ___){actions, assetLibraryKey, creator, customFields, dateCreated, dateModified, description, externalReferenceCode, id, name, numberOfDocumentFolders, numberOfDocuments, parentDocumentFolderId, siteId, subscribed, viewableBy}}"}' -u 'test@liferay.com:test'
+	 */
+	@GraphQLField(
+		description = "Retrieves the site's document folder by external reference code."
+	)
+	public DocumentFolder documentsFolderByExternalReferenceCode(
+			@GraphQLName("siteKey") @NotEmpty String siteKey,
+			@GraphQLName("externalReferenceCode") String externalReferenceCode)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_documentFolderResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			documentFolderResource ->
+				documentFolderResource.
+					getSiteDocumentsFolderByExternalReferenceCode(
+						Long.valueOf(siteKey), externalReferenceCode));
 	}
 
 	/**

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentFolderResourceImpl.java
@@ -166,7 +166,7 @@ public abstract class BaseDocumentFolderResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/document-folders' -d $'{"customFields": ___, "description": ___, "name": ___, "parentDocumentFolderId": ___, "viewableBy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/document-folders' -d $'{"customFields": ___, "description": ___, "externalReferenceCode": ___, "name": ___, "parentDocumentFolderId": ___, "viewableBy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -520,7 +520,7 @@ public abstract class BaseDocumentFolderResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PATCH' 'http://localhost:8080/o/headless-delivery/v1.0/document-folders/{documentFolderId}' -d $'{"customFields": ___, "description": ___, "name": ___, "parentDocumentFolderId": ___, "viewableBy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PATCH' 'http://localhost:8080/o/headless-delivery/v1.0/document-folders/{documentFolderId}' -d $'{"customFields": ___, "description": ___, "externalReferenceCode": ___, "name": ___, "parentDocumentFolderId": ___, "viewableBy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Updates only the fields received in the request body. Any other fields are left untouched."
@@ -578,6 +578,11 @@ public abstract class BaseDocumentFolderResourceImpl
 				documentFolder.getDescription());
 		}
 
+		if (documentFolder.getExternalReferenceCode() != null) {
+			existingDocumentFolder.setExternalReferenceCode(
+				documentFolder.getExternalReferenceCode());
+		}
+
 		if (documentFolder.getName() != null) {
 			existingDocumentFolder.setName(documentFolder.getName());
 		}
@@ -619,7 +624,7 @@ public abstract class BaseDocumentFolderResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/headless-delivery/v1.0/document-folders/{documentFolderId}' -d $'{"customFields": ___, "description": ___, "name": ___, "parentDocumentFolderId": ___, "viewableBy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/headless-delivery/v1.0/document-folders/{documentFolderId}' -d $'{"customFields": ___, "description": ___, "externalReferenceCode": ___, "name": ___, "parentDocumentFolderId": ___, "viewableBy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Replaces the document folder with the information sent in the request body. Any missing fields are deleted, unless they are required."
@@ -985,7 +990,7 @@ public abstract class BaseDocumentFolderResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/headless-delivery/v1.0/document-folders/{parentDocumentFolderId}/document-folders' -d $'{"customFields": ___, "description": ___, "name": ___, "parentDocumentFolderId": ___, "viewableBy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-delivery/v1.0/document-folders/{parentDocumentFolderId}/document-folders' -d $'{"customFields": ___, "description": ___, "externalReferenceCode": ___, "name": ___, "parentDocumentFolderId": ___, "viewableBy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Creates a new folder in a folder identified by `parentDocumentFolderId`."
@@ -1110,7 +1115,7 @@ public abstract class BaseDocumentFolderResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/headless-delivery/v1.0/sites/{siteId}/document-folders' -d $'{"customFields": ___, "description": ___, "name": ___, "parentDocumentFolderId": ___, "viewableBy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-delivery/v1.0/sites/{siteId}/document-folders' -d $'{"customFields": ___, "description": ___, "externalReferenceCode": ___, "name": ___, "parentDocumentFolderId": ___, "viewableBy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Creates a new document folder."
@@ -1326,6 +1331,141 @@ public abstract class BaseDocumentFolderResourceImpl
 					"putSiteDocumentFolderPermissionsPage", portletName, siteId)
 			).build(),
 			siteId, portletName, null);
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'DELETE' 'http://localhost:8080/o/headless-delivery/v1.0/sites/{siteId}/documents-folder/by-external-reference-code/{externalReferenceCode}'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Deletes the site's document folder by external reference code returns a 204 if the operation succeeds."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "siteId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "externalReferenceCode"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(name = "DocumentFolder")
+		}
+	)
+	@javax.ws.rs.DELETE
+	@javax.ws.rs.Path(
+		"/sites/{siteId}/documents-folder/by-external-reference-code/{externalReferenceCode}"
+	)
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public void deleteSiteDocumentsFolderByExternalReferenceCode(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("siteId")
+			Long siteId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("externalReferenceCode")
+			String externalReferenceCode)
+		throws Exception {
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'GET' 'http://localhost:8080/o/headless-delivery/v1.0/sites/{siteId}/documents-folder/by-external-reference-code/{externalReferenceCode}'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Retrieves the site's document folder by external reference code."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "siteId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "externalReferenceCode"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(name = "DocumentFolder")
+		}
+	)
+	@javax.ws.rs.GET
+	@javax.ws.rs.Path(
+		"/sites/{siteId}/documents-folder/by-external-reference-code/{externalReferenceCode}"
+	)
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public DocumentFolder getSiteDocumentsFolderByExternalReferenceCode(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("siteId")
+			Long siteId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("externalReferenceCode")
+			String externalReferenceCode)
+		throws Exception {
+
+		return new DocumentFolder();
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'PUT' 'http://localhost:8080/o/headless-delivery/v1.0/sites/{siteId}/documents-folder/by-external-reference-code/{externalReferenceCode}' -d $'{"customFields": ___, "description": ___, "externalReferenceCode": ___, "name": ___, "parentDocumentFolderId": ___, "viewableBy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Replaces the document folder by external reference code with the information sent in the request body, or replaces it if it not exists."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "siteId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "externalReferenceCode"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(name = "DocumentFolder")
+		}
+	)
+	@javax.ws.rs.Consumes({"application/json", "application/xml"})
+	@javax.ws.rs.Path(
+		"/sites/{siteId}/documents-folder/by-external-reference-code/{externalReferenceCode}"
+	)
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@javax.ws.rs.PUT
+	@Override
+	public DocumentFolder putSiteDocumentsFolderByExternalReferenceCode(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("siteId")
+			Long siteId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("externalReferenceCode")
+			String externalReferenceCode,
+			DocumentFolder documentFolder)
+		throws Exception {
+
+		return new DocumentFolder();
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentFolderResourceImpl.java
@@ -16,13 +16,13 @@ package com.liferay.headless.delivery.internal.resource.v1_0;
 
 import com.liferay.document.library.kernel.model.DLFolder;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
+import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.kernel.service.DLAppService;
 import com.liferay.dynamic.data.mapping.util.DDMIndexer;
 import com.liferay.expando.kernel.service.ExpandoColumnLocalService;
 import com.liferay.expando.kernel.service.ExpandoTableLocalService;
 import com.liferay.headless.common.spi.odata.entity.EntityFieldsUtil;
 import com.liferay.headless.common.spi.service.context.ServiceContextRequestUtil;
-import com.liferay.headless.delivery.dto.v1_0.CustomField;
 import com.liferay.headless.delivery.dto.v1_0.DocumentFolder;
 import com.liferay.headless.delivery.dto.v1_0.util.CustomFieldsUtil;
 import com.liferay.headless.delivery.internal.dto.v1_0.converter.DocumentFolderDTOConverter;
@@ -58,7 +58,6 @@ import com.liferay.portal.vulcan.util.SearchUtil;
 import com.liferay.portlet.documentlibrary.constants.DLConstants;
 
 import java.util.Map;
-import java.util.Optional;
 
 import javax.ws.rs.core.MultivaluedMap;
 
@@ -78,6 +77,17 @@ public class DocumentFolderResourceImpl extends BaseDocumentFolderResourceImpl {
 	@Override
 	public void deleteDocumentFolder(Long documentFolderId) throws Exception {
 		_dlAppService.deleteFolder(documentFolderId);
+	}
+
+	@Override
+	public void deleteSiteDocumentsFolderByExternalReferenceCode(
+			Long siteId, String externalReferenceCode)
+		throws Exception {
+
+		Folder folder = _dlAppService.getFolderByExternalReferenceCode(
+			siteId, externalReferenceCode);
+
+		_dlAppService.deleteFolder(folder.getFolderId());
 	}
 
 	@Override
@@ -165,24 +175,14 @@ public class DocumentFolderResourceImpl extends BaseDocumentFolderResourceImpl {
 	}
 
 	@Override
-	public DocumentFolder patchDocumentFolder(
-			Long documentFolderId, DocumentFolder documentFolder)
+	public DocumentFolder getSiteDocumentsFolderByExternalReferenceCode(
+			Long siteId, String externalReferenceCode)
 		throws Exception {
 
-		Folder existingFolder = _dlAppService.getFolder(documentFolderId);
+		Folder folder = _dlAppService.getFolderByExternalReferenceCode(
+			siteId, externalReferenceCode);
 
-		return _updateDocumentFolder(
-			documentFolderId, documentFolder.getCustomFields(),
-			Optional.ofNullable(
-				documentFolder.getDescription()
-			).orElse(
-				existingFolder.getDescription()
-			),
-			Optional.ofNullable(
-				documentFolder.getName()
-			).orElse(
-				existingFolder.getName()
-			));
+		return _toDocumentFolder(folder);
 	}
 
 	@Override
@@ -201,7 +201,8 @@ public class DocumentFolderResourceImpl extends BaseDocumentFolderResourceImpl {
 		Folder folder = _dlAppService.getFolder(parentDocumentFolderId);
 
 		return _addFolder(
-			folder.getGroupId(), folder.getFolderId(), documentFolder);
+			documentFolder.getExternalReferenceCode(), folder.getGroupId(),
+			folder.getFolderId(), documentFolder);
 	}
 
 	@Override
@@ -209,7 +210,9 @@ public class DocumentFolderResourceImpl extends BaseDocumentFolderResourceImpl {
 			Long siteId, DocumentFolder documentFolder)
 		throws Exception {
 
-		return _addFolder(siteId, 0L, documentFolder);
+		return _addFolder(
+			documentFolder.getExternalReferenceCode(), siteId, 0L,
+			documentFolder);
 	}
 
 	@Override
@@ -218,8 +221,7 @@ public class DocumentFolderResourceImpl extends BaseDocumentFolderResourceImpl {
 		throws Exception {
 
 		return _updateDocumentFolder(
-			documentFolderId, documentFolder.getCustomFields(),
-			documentFolder.getDescription(), documentFolder.getName());
+			_dlAppService.getFolder(documentFolderId), documentFolder);
 	}
 
 	@Override
@@ -243,6 +245,22 @@ public class DocumentFolderResourceImpl extends BaseDocumentFolderResourceImpl {
 	}
 
 	@Override
+	public DocumentFolder putSiteDocumentsFolderByExternalReferenceCode(
+			Long siteId, String externalReferenceCode,
+			DocumentFolder documentFolder)
+		throws Exception {
+
+		Folder folder = _dlAppLocalService.fetchFolderByExternalReferenceCode(
+			siteId, externalReferenceCode);
+
+		if (folder != null) {
+			return _updateDocumentFolder(folder, documentFolder);
+		}
+
+		return _addFolder(externalReferenceCode, siteId, 0L, documentFolder);
+	}
+
+	@Override
 	protected Long getPermissionCheckerGroupId(Object id) throws Exception {
 		Folder folder = _dlAppService.getFolder((Long)id);
 
@@ -260,20 +278,20 @@ public class DocumentFolderResourceImpl extends BaseDocumentFolderResourceImpl {
 	}
 
 	private DocumentFolder _addFolder(
-			Long siteId, Long parentDocumentFolderId,
+			String externalReferenceCode, Long groupId, Long parentFolderId,
 			DocumentFolder documentFolder)
 		throws Exception {
 
 		return _toDocumentFolder(
 			_dlAppService.addFolder(
-				siteId, parentDocumentFolderId, documentFolder.getName(),
-				documentFolder.getDescription(),
+				externalReferenceCode, groupId, parentFolderId,
+				documentFolder.getName(), documentFolder.getDescription(),
 				ServiceContextRequestUtil.createServiceContext(
 					CustomFieldsUtil.toMap(
 						DLFolder.class.getName(), contextCompany.getCompanyId(),
 						documentFolder.getCustomFields(),
 						contextAcceptLanguage.getPreferredLocale()),
-					siteId, contextHttpServletRequest,
+					groupId, contextHttpServletRequest,
 					documentFolder.getViewableByAsString())));
 	}
 
@@ -380,17 +398,17 @@ public class DocumentFolderResourceImpl extends BaseDocumentFolderResourceImpl {
 	}
 
 	private DocumentFolder _updateDocumentFolder(
-			Long documentFolderId, CustomField[] customFields,
-			String description, String name)
+			Folder folder, DocumentFolder documentFolder)
 		throws Exception {
 
 		return _toDocumentFolder(
 			_dlAppService.updateFolder(
-				documentFolderId, name, description,
+				folder.getFolderId(), documentFolder.getName(),
+				documentFolder.getDescription(),
 				ServiceContextRequestUtil.createServiceContext(
 					CustomFieldsUtil.toMap(
 						DLFolder.class.getName(), contextCompany.getCompanyId(),
-						customFields,
+						documentFolder.getCustomFields(),
 						contextAcceptLanguage.getPreferredLocale()),
 					0, contextHttpServletRequest, null)));
 	}
@@ -400,6 +418,9 @@ public class DocumentFolderResourceImpl extends BaseDocumentFolderResourceImpl {
 
 	@Reference
 	private DDMIndexer _ddmIndexer;
+
+	@Reference
+	private DLAppLocalService _dlAppLocalService;
 
 	@Reference
 	private DLAppService _dlAppService;

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentFolderResourceTestCase.java
@@ -208,6 +208,7 @@ public abstract class BaseDocumentFolderResourceTestCase {
 
 		documentFolder.setAssetLibraryKey(regex);
 		documentFolder.setDescription(regex);
+		documentFolder.setExternalReferenceCode(regex);
 		documentFolder.setName(regex);
 
 		String json = DocumentFolderSerDes.toJSON(documentFolder);
@@ -218,6 +219,7 @@ public abstract class BaseDocumentFolderResourceTestCase {
 
 		Assert.assertEquals(regex, documentFolder.getAssetLibraryKey());
 		Assert.assertEquals(regex, documentFolder.getDescription());
+		Assert.assertEquals(regex, documentFolder.getExternalReferenceCode());
 		Assert.assertEquals(regex, documentFolder.getName());
 	}
 
@@ -1913,6 +1915,207 @@ public abstract class BaseDocumentFolderResourceTestCase {
 			testGroup.getGroupId(), randomDocumentFolder());
 	}
 
+	@Test
+	public void testDeleteSiteDocumentsFolderByExternalReferenceCode()
+		throws Exception {
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		DocumentFolder documentFolder =
+			testDeleteSiteDocumentsFolderByExternalReferenceCode_addDocumentFolder();
+
+		assertHttpResponseStatusCode(
+			204,
+			documentFolderResource.
+				deleteSiteDocumentsFolderByExternalReferenceCodeHttpResponse(
+					documentFolder.getSiteId(),
+					documentFolder.getExternalReferenceCode()));
+
+		assertHttpResponseStatusCode(
+			404,
+			documentFolderResource.
+				getSiteDocumentsFolderByExternalReferenceCodeHttpResponse(
+					documentFolder.getSiteId(),
+					documentFolder.getExternalReferenceCode()));
+
+		assertHttpResponseStatusCode(
+			404,
+			documentFolderResource.
+				getSiteDocumentsFolderByExternalReferenceCodeHttpResponse(
+					documentFolder.getSiteId(),
+					documentFolder.getExternalReferenceCode()));
+	}
+
+	protected DocumentFolder
+			testDeleteSiteDocumentsFolderByExternalReferenceCode_addDocumentFolder()
+		throws Exception {
+
+		return documentFolderResource.postSiteDocumentFolder(
+			testGroup.getGroupId(), randomDocumentFolder());
+	}
+
+	@Test
+	public void testGetSiteDocumentsFolderByExternalReferenceCode()
+		throws Exception {
+
+		DocumentFolder postDocumentFolder =
+			testGetSiteDocumentsFolderByExternalReferenceCode_addDocumentFolder();
+
+		DocumentFolder getDocumentFolder =
+			documentFolderResource.
+				getSiteDocumentsFolderByExternalReferenceCode(
+					postDocumentFolder.getSiteId(),
+					postDocumentFolder.getExternalReferenceCode());
+
+		assertEquals(postDocumentFolder, getDocumentFolder);
+		assertValid(getDocumentFolder);
+	}
+
+	protected DocumentFolder
+			testGetSiteDocumentsFolderByExternalReferenceCode_addDocumentFolder()
+		throws Exception {
+
+		return documentFolderResource.postSiteDocumentFolder(
+			testGroup.getGroupId(), randomDocumentFolder());
+	}
+
+	@Test
+	public void testGraphQLGetSiteDocumentsFolderByExternalReferenceCode()
+		throws Exception {
+
+		DocumentFolder documentFolder =
+			testGraphQLGetSiteDocumentsFolderByExternalReferenceCode_addDocumentFolder();
+
+		Assert.assertTrue(
+			equals(
+				documentFolder,
+				DocumentFolderSerDes.toDTO(
+					JSONUtil.getValueAsString(
+						invokeGraphQLQuery(
+							new GraphQLField(
+								"documentsFolderByExternalReferenceCode",
+								new HashMap<String, Object>() {
+									{
+										put(
+											"siteKey",
+											"\"" + documentFolder.getSiteId() +
+												"\"");
+										put(
+											"externalReferenceCode",
+											"\"" +
+												documentFolder.
+													getExternalReferenceCode() +
+														"\"");
+									}
+								},
+								getGraphQLFields())),
+						"JSONObject/data",
+						"Object/documentsFolderByExternalReferenceCode"))));
+	}
+
+	@Test
+	public void testGraphQLGetSiteDocumentsFolderByExternalReferenceCodeNotFound()
+		throws Exception {
+
+		String irrelevantExternalReferenceCode =
+			"\"" + RandomTestUtil.randomString() + "\"";
+
+		Assert.assertEquals(
+			"Not Found",
+			JSONUtil.getValueAsString(
+				invokeGraphQLQuery(
+					new GraphQLField(
+						"documentsFolderByExternalReferenceCode",
+						new HashMap<String, Object>() {
+							{
+								put(
+									"siteKey",
+									"\"" + irrelevantGroup.getGroupId() + "\"");
+								put(
+									"externalReferenceCode",
+									irrelevantExternalReferenceCode);
+							}
+						},
+						getGraphQLFields())),
+				"JSONArray/errors", "Object/0", "JSONObject/extensions",
+				"Object/code"));
+	}
+
+	protected DocumentFolder
+			testGraphQLGetSiteDocumentsFolderByExternalReferenceCode_addDocumentFolder()
+		throws Exception {
+
+		return testGraphQLDocumentFolder_addDocumentFolder();
+	}
+
+	@Test
+	public void testPutSiteDocumentsFolderByExternalReferenceCode()
+		throws Exception {
+
+		DocumentFolder postDocumentFolder =
+			testPutSiteDocumentsFolderByExternalReferenceCode_addDocumentFolder();
+
+		DocumentFolder randomDocumentFolder = randomDocumentFolder();
+
+		DocumentFolder putDocumentFolder =
+			documentFolderResource.
+				putSiteDocumentsFolderByExternalReferenceCode(
+					postDocumentFolder.getSiteId(),
+					postDocumentFolder.getExternalReferenceCode(),
+					randomDocumentFolder);
+
+		assertEquals(randomDocumentFolder, putDocumentFolder);
+		assertValid(putDocumentFolder);
+
+		DocumentFolder getDocumentFolder =
+			documentFolderResource.
+				getSiteDocumentsFolderByExternalReferenceCode(
+					putDocumentFolder.getSiteId(),
+					putDocumentFolder.getExternalReferenceCode());
+
+		assertEquals(randomDocumentFolder, getDocumentFolder);
+		assertValid(getDocumentFolder);
+
+		DocumentFolder newDocumentFolder =
+			testPutSiteDocumentsFolderByExternalReferenceCode_createDocumentFolder();
+
+		putDocumentFolder =
+			documentFolderResource.
+				putSiteDocumentsFolderByExternalReferenceCode(
+					newDocumentFolder.getSiteId(),
+					newDocumentFolder.getExternalReferenceCode(),
+					newDocumentFolder);
+
+		assertEquals(newDocumentFolder, putDocumentFolder);
+		assertValid(putDocumentFolder);
+
+		getDocumentFolder =
+			documentFolderResource.
+				getSiteDocumentsFolderByExternalReferenceCode(
+					putDocumentFolder.getSiteId(),
+					putDocumentFolder.getExternalReferenceCode());
+
+		assertEquals(newDocumentFolder, getDocumentFolder);
+
+		Assert.assertEquals(
+			newDocumentFolder.getExternalReferenceCode(),
+			putDocumentFolder.getExternalReferenceCode());
+	}
+
+	protected DocumentFolder
+			testPutSiteDocumentsFolderByExternalReferenceCode_createDocumentFolder()
+		throws Exception {
+
+		return randomDocumentFolder();
+	}
+
+	protected DocumentFolder
+			testPutSiteDocumentsFolderByExternalReferenceCode_addDocumentFolder()
+		throws Exception {
+
+		return documentFolderResource.postSiteDocumentFolder(
+			testGroup.getGroupId(), randomDocumentFolder());
+	}
+
 	@Rule
 	public SearchTestRule searchTestRule = new SearchTestRule();
 
@@ -1999,6 +2202,8 @@ public abstract class BaseDocumentFolderResourceTestCase {
 		sb.append("}");
 
 		List<GraphQLField> graphQLFields = getGraphQLFields();
+
+		graphQLFields.add(new GraphQLField("externalReferenceCode"));
 
 		graphQLFields.add(new GraphQLField("id"));
 
@@ -2152,6 +2357,16 @@ public abstract class BaseDocumentFolderResourceTestCase {
 
 			if (Objects.equals("description", additionalAssertFieldName)) {
 				if (documentFolder.getDescription() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(
+					"externalReferenceCode", additionalAssertFieldName)) {
+
+				if (documentFolder.getExternalReferenceCode() == null) {
 					valid = false;
 				}
 
@@ -2366,6 +2581,19 @@ public abstract class BaseDocumentFolderResourceTestCase {
 				if (!Objects.deepEquals(
 						documentFolder1.getDescription(),
 						documentFolder2.getDescription())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(
+					"externalReferenceCode", additionalAssertFieldName)) {
+
+				if (!Objects.deepEquals(
+						documentFolder1.getExternalReferenceCode(),
+						documentFolder2.getExternalReferenceCode())) {
 
 					return false;
 				}
@@ -2649,6 +2877,15 @@ public abstract class BaseDocumentFolderResourceTestCase {
 			return sb.toString();
 		}
 
+		if (entityFieldName.equals("externalReferenceCode")) {
+			sb.append("'");
+			sb.append(
+				String.valueOf(documentFolder.getExternalReferenceCode()));
+			sb.append("'");
+
+			return sb.toString();
+		}
+
 		if (entityFieldName.equals("id")) {
 			throw new IllegalArgumentException(
 				"Invalid entity field " + entityFieldName);
@@ -2744,6 +2981,8 @@ public abstract class BaseDocumentFolderResourceTestCase {
 				dateCreated = RandomTestUtil.nextDate();
 				dateModified = RandomTestUtil.nextDate();
 				description = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+				externalReferenceCode = StringUtil.toLowerCase(
 					RandomTestUtil.randomString());
 				id = RandomTestUtil.randomLong();
 				name = StringUtil.toLowerCase(RandomTestUtil.randomString());

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/DocumentResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/DocumentResourceTest.java
@@ -179,6 +179,7 @@ public class DocumentResourceTest extends BaseDocumentResourceTestCase {
 		serviceContext.setAddGuestPermissions(true);
 
 		Folder folder = DLAppLocalServiceUtil.addFolder(
+			null,
 			UserLocalServiceUtil.getDefaultUserId(testGroup.getCompanyId()),
 			testGroup.getGroupId(), 0, RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(), serviceContext);

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -1550,7 +1550,7 @@ public class ObjectEntryLocalServiceImpl
 
 		try {
 			dlFolder = _dlFolderLocalService.addFolder(
-				_userLocalService.getDefaultUserId(companyId),
+				null, _userLocalService.getDefaultUserId(companyId),
 				repository.getGroupId(), repository.getRepositoryId(), false,
 				repository.getDlFolderId(), String.valueOf(userId), null, false,
 				serviceContext);
@@ -1907,8 +1907,8 @@ public class ObjectEntryLocalServiceImpl
 
 			try {
 				Folder folder = _dlAppLocalService.addFolder(
-					_userLocalService.getDefaultUserId(companyId), groupId,
-					storageDLFolderId, name, null, serviceContext);
+					null, _userLocalService.getDefaultUserId(companyId),
+					groupId, storageDLFolderId, name, null, serviceContext);
 
 				storageDLFolderId = folder.getFolderId();
 			}

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/internal/runtime/integration/test/WorkflowTaskManagerImplTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/internal/runtime/integration/test/WorkflowTaskManagerImplTest.java
@@ -1342,7 +1342,7 @@ public class WorkflowTaskManagerImplTest extends BaseWorkflowManagerTestCase {
 
 	private Folder _addFolder() throws Exception {
 		return _dlAppService.addFolder(
-			_group.getGroupId(), 0, RandomTestUtil.randomString(),
+			null, _group.getGroupId(), 0, RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(), _serviceContext);
 	}
 

--- a/modules/apps/repository/repository-test/src/testIntegration/java/com/liferay/repository/test/RepositoryTest.java
+++ b/modules/apps/repository/repository-test/src/testIntegration/java/com/liferay/repository/test/RepositoryTest.java
@@ -120,7 +120,7 @@ public class RepositoryTest {
 		repositoryIds[0] = repository.getRepositoryId();
 
 		DLFolder dlFolder = DLFolderServiceUtil.addFolder(
-			_group.getGroupId(), _group.getGroupId(), false,
+			null, _group.getGroupId(), _group.getGroupId(), false,
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			new ServiceContext());

--- a/modules/apps/sharing/sharing-document-library-test/src/testIntegration/java/com/liferay/sharing/document/library/internal/test/DLFileEntrySharingTest.java
+++ b/modules/apps/sharing/sharing-document-library-test/src/testIntegration/java/com/liferay/sharing/document/library/internal/test/DLFileEntrySharingTest.java
@@ -106,7 +106,7 @@ public class DLFileEntrySharingTest extends BaseSharingTestCase<DLFileEntry> {
 		serviceContext.setAddGuestPermissions(false);
 
 		Folder folder = _dlAppLocalService.addFolder(
-			user.getUserId(), group.getGroupId(),
+			null, user.getUserId(), group.getGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			serviceContext);

--- a/modules/dxp/apps/analytics/analytics-reports-document-library-test/src/testIntegration/java/com/liferay/analytics/reports/document/library/internal/info/item/test/FileEntryAnalyticsReportsInfoItemTest.java
+++ b/modules/dxp/apps/analytics/analytics-reports-document-library-test/src/testIntegration/java/com/liferay/analytics/reports/document/library/internal/info/item/test/FileEntryAnalyticsReportsInfoItemTest.java
@@ -231,7 +231,7 @@ public class FileEntryAnalyticsReportsInfoItemTest {
 				TestPropsValues.getGroupId());
 
 		Folder folder = _dlAppLocalService.addFolder(
-			TestPropsValues.getUserId(), group.getGroupId(),
+			null, TestPropsValues.getUserId(), group.getGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			serviceContext);

--- a/portal-impl/src/com/liferay/portal/repository/InitializedDocumentRepository.java
+++ b/portal-impl/src/com/liferay/portal/repository/InitializedDocumentRepository.java
@@ -97,6 +97,19 @@ public abstract class InitializedDocumentRepository
 	}
 
 	@Override
+	public Folder addFolder(
+			String externalReferenceCode, long userId, long parentFolderId,
+			String name, String description, ServiceContext serviceContext)
+		throws PortalException {
+
+		checkDocumentRepository();
+
+		return documentRepository.addFolder(
+			externalReferenceCode, userId, parentFolderId, name, description,
+			serviceContext);
+	}
+
+	@Override
 	public void checkInFileEntry(
 			long userId, long fileEntryId,
 			DLVersionNumberIncrease dlVersionNumberIncrease, String changeLog,

--- a/portal-impl/src/com/liferay/portal/repository/capabilities/CapabilityLocalRepository.java
+++ b/portal-impl/src/com/liferay/portal/repository/capabilities/CapabilityLocalRepository.java
@@ -128,6 +128,24 @@ public class CapabilityLocalRepository
 	}
 
 	@Override
+	public Folder addFolder(
+			String externalReferenCode, long userId, long parentFolderId,
+			String name, String description, ServiceContext serviceContext)
+		throws PortalException {
+
+		LocalRepository localRepository = getRepository();
+
+		Folder folder = localRepository.addFolder(
+			externalReferenCode, userId, parentFolderId, name, description,
+			serviceContext);
+
+		_repositoryEventTrigger.trigger(
+			RepositoryEventType.Add.class, Folder.class, folder);
+
+		return folder;
+	}
+
+	@Override
 	public void checkInFileEntry(
 			long userId, long fileEntryId,
 			DLVersionNumberIncrease dlVersionNumberIncrease, String changeLog,
@@ -266,6 +284,14 @@ public class CapabilityLocalRepository
 	}
 
 	@Override
+	public Folder fetchFolderByExternalReferenceCode(
+		String externalReferenceCode) {
+
+		return getRepository().fetchFolderByExternalReferenceCode(
+			externalReferenceCode);
+	}
+
+	@Override
 	public List<FileEntry> getFileEntries(
 			long folderId, int status, int start, int end,
 			OrderByComparator<FileEntry> orderByComparator)
@@ -389,6 +415,14 @@ public class CapabilityLocalRepository
 		throws PortalException {
 
 		return getRepository().getFolder(parentFolderId, name);
+	}
+
+	@Override
+	public Folder getFolderByExternalReferenceCode(String externalReferenceCode)
+		throws PortalException {
+
+		return getRepository().getFolderByExternalReferenceCode(
+			externalReferenceCode);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/repository/capabilities/CapabilityRepository.java
+++ b/portal-impl/src/com/liferay/portal/repository/capabilities/CapabilityRepository.java
@@ -133,6 +133,24 @@ public class CapabilityRepository
 	}
 
 	@Override
+	public Folder addFolder(
+			String externalReferenceCode, long userId, long parentFolderId,
+			String name, String description, ServiceContext serviceContext)
+		throws PortalException {
+
+		Repository repository = getRepository();
+
+		Folder folder = repository.addFolder(
+			externalReferenceCode, userId, parentFolderId, name, description,
+			serviceContext);
+
+		_repositoryEventTrigger.trigger(
+			RepositoryEventType.Add.class, Folder.class, folder);
+
+		return folder;
+	}
+
+	@Override
 	public FileVersion cancelCheckOut(long fileEntryId) throws PortalException {
 		Repository repository = getRepository();
 
@@ -520,6 +538,14 @@ public class CapabilityRepository
 		throws PortalException {
 
 		return getRepository().getFolder(parentFolderId, name);
+	}
+
+	@Override
+	public Folder getFolderByExternalReferenceCode(String externalReferenceCode)
+		throws PortalException {
+
+		return getRepository().getFolderByExternalReferenceCode(
+			externalReferenceCode);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayLocalRepository.java
+++ b/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayLocalRepository.java
@@ -169,11 +169,21 @@ public class LiferayLocalRepository
 			ServiceContext serviceContext)
 		throws PortalException {
 
+		return addFolder(
+			null, userId, parentFolderId, name, description, serviceContext);
+	}
+
+	@Override
+	public Folder addFolder(
+			String externalReferenceCode, long userId, long parentFolderId,
+			String name, String description, ServiceContext serviceContext)
+		throws PortalException {
+
 		boolean mountPoint = ParamUtil.getBoolean(serviceContext, "mountPoint");
 
 		DLFolder dlFolder = dlFolderLocalService.addFolder(
-			userId, getGroupId(), getRepositoryId(), mountPoint,
-			toFolderId(parentFolderId), name, description, false,
+			externalReferenceCode, userId, getGroupId(), getRepositoryId(),
+			mountPoint, toFolderId(parentFolderId), name, description, false,
 			serviceContext);
 
 		return new LiferayFolder(dlFolder);
@@ -270,6 +280,21 @@ public class LiferayLocalRepository
 
 		if (dlFileEntry != null) {
 			return new LiferayFileEntry(dlFileEntry);
+		}
+
+		return null;
+	}
+
+	@Override
+	public Folder fetchFolderByExternalReferenceCode(
+		String externalReferenceCode) {
+
+		DLFolder dlFolder =
+			dlFolderLocalService.fetchDLFolderByExternalReferenceCode(
+				getGroupId(), externalReferenceCode);
+
+		if (dlFolder != null) {
+			return new LiferayFolder(dlFolder);
 		}
 
 		return null;

--- a/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayRepository.java
+++ b/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayRepository.java
@@ -176,10 +176,20 @@ public class LiferayRepository
 			ServiceContext serviceContext)
 		throws PortalException {
 
+		return addFolder(
+			null, userId, parentFolderId, name, description, serviceContext);
+	}
+
+	@Override
+	public Folder addFolder(
+			String externalReferenceCode, long userId, long parentFolderId,
+			String name, String description, ServiceContext serviceContext)
+		throws PortalException {
+
 		boolean mountPoint = ParamUtil.getBoolean(serviceContext, "mountPoint");
 
 		DLFolder dlFolder = dlFolderService.addFolder(
-			getGroupId(), getRepositoryId(), mountPoint,
+			externalReferenceCode, getGroupId(), getRepositoryId(), mountPoint,
 			toFolderId(parentFolderId), name, description, serviceContext);
 
 		return new LiferayFolder(dlFolder);
@@ -538,6 +548,16 @@ public class LiferayRepository
 
 		DLFolder dlFolder = dlFolderService.getFolder(
 			getGroupId(), toFolderId(parentFolderId), name);
+
+		return new LiferayFolder(dlFolder);
+	}
+
+	@Override
+	public Folder getFolderByExternalReferenceCode(String externalReferenceCode)
+		throws PortalException {
+
+		DLFolder dlFolder = dlFolderService.getDLFolderByExternalReferenceCode(
+			getGroupId(), externalReferenceCode);
 
 		return new LiferayFolder(dlFolder);
 	}

--- a/portal-impl/src/com/liferay/portal/repository/liferayrepository/model/LiferayFolder.java
+++ b/portal-impl/src/com/liferay/portal/repository/liferayrepository/model/LiferayFolder.java
@@ -136,6 +136,11 @@ public class LiferayFolder extends LiferayModel implements Folder {
 	}
 
 	@Override
+	public String getExternalReferenceCode() {
+		return _dlFolder.getExternalReferenceCode();
+	}
+
+	@Override
 	public long getFolderId() {
 		return _dlFolder.getFolderId();
 	}

--- a/portal-impl/src/com/liferay/portal/repository/util/LocalRepositoryWrapper.java
+++ b/portal-impl/src/com/liferay/portal/repository/util/LocalRepositoryWrapper.java
@@ -91,6 +91,17 @@ public class LocalRepositoryWrapper implements LocalRepository {
 	}
 
 	@Override
+	public Folder addFolder(
+			String externalReferenceCode, long userId, long parentFolderId,
+			String name, String description, ServiceContext serviceContext)
+		throws PortalException {
+
+		return _localRepository.addFolder(
+			externalReferenceCode, userId, parentFolderId, name, description,
+			serviceContext);
+	}
+
+	@Override
 	public void checkInFileEntry(
 			long userId, long fileEntryId,
 			DLVersionNumberIncrease dlVersionNumberIncrease, String changeLog,
@@ -164,6 +175,14 @@ public class LocalRepositoryWrapper implements LocalRepository {
 		String externalReferenceCode) {
 
 		return _localRepository.fetchFileEntryByExternalReferenceCode(
+			externalReferenceCode);
+	}
+
+	@Override
+	public Folder fetchFolderByExternalReferenceCode(
+		String externalReferenceCode) {
+
+		return _localRepository.fetchFolderByExternalReferenceCode(
 			externalReferenceCode);
 	}
 
@@ -297,6 +316,14 @@ public class LocalRepositoryWrapper implements LocalRepository {
 		throws PortalException {
 
 		return _localRepository.getFolder(parentFolderId, name);
+	}
+
+	@Override
+	public Folder getFolderByExternalReferenceCode(String externalReferenceCode)
+		throws PortalException {
+
+		return _localRepository.getFolderByExternalReferenceCode(
+			externalReferenceCode);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/repository/util/RepositoryWrapper.java
+++ b/portal-impl/src/com/liferay/portal/repository/util/RepositoryWrapper.java
@@ -96,6 +96,17 @@ public class RepositoryWrapper implements Repository {
 	}
 
 	@Override
+	public Folder addFolder(
+			String externalReferenceCode, long userId, long parentFolderId,
+			String name, String description, ServiceContext serviceContext)
+		throws PortalException {
+
+		return _repository.addFolder(
+			externalReferenceCode, userId, parentFolderId, name, description,
+			serviceContext);
+	}
+
+	@Override
 	public FileVersion cancelCheckOut(long fileEntryId) throws PortalException {
 		return _repository.cancelCheckOut(fileEntryId);
 	}
@@ -380,6 +391,14 @@ public class RepositoryWrapper implements Repository {
 		throws PortalException {
 
 		return _repository.getFolder(parentFolderId, name);
+	}
+
+	@Override
+	public Folder getFolderByExternalReferenceCode(String externalReferenceCode)
+		throws PortalException {
+
+		return _repository.getFolderByExternalReferenceCode(
+			externalReferenceCode);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/service/impl/RepositoryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/RepositoryLocalServiceImpl.java
@@ -277,8 +277,8 @@ public class RepositoryLocalServiceImpl extends RepositoryLocalServiceBaseImpl {
 		}
 
 		DLFolder dlFolder = _dlFolderLocalService.addFolder(
-			user.getUserId(), groupId, repositoryId, true, parentFolderId, name,
-			description, hidden, serviceContext);
+			null, user.getUserId(), groupId, repositoryId, true, parentFolderId,
+			name, description, hidden, serviceContext);
 
 		return dlFolder.getFolderId();
 	}

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/http/DLAppServiceHttp.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/http/DLAppServiceHttp.java
@@ -291,8 +291,9 @@ public class DLAppServiceHttp {
 	}
 
 	public static com.liferay.portal.kernel.repository.model.Folder addFolder(
-			HttpPrincipal httpPrincipal, long repositoryId, long parentFolderId,
-			String name, String description,
+			HttpPrincipal httpPrincipal, String externalReferenceCode,
+			long repositoryId, long parentFolderId, String name,
+			String description,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
@@ -301,8 +302,8 @@ public class DLAppServiceHttp {
 				DLAppServiceUtil.class, "addFolder", _addFolderParameterTypes5);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, repositoryId, parentFolderId, name, description,
-				serviceContext);
+				methodKey, externalReferenceCode, repositoryId, parentFolderId,
+				name, description, serviceContext);
 
 			Object returnObj = null;
 
@@ -1933,6 +1934,48 @@ public class DLAppServiceHttp {
 		}
 	}
 
+	public static com.liferay.portal.kernel.repository.model.Folder
+			getFolderByExternalReferenceCode(
+				HttpPrincipal httpPrincipal, long groupId,
+				String externalReferenceCode)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				DLAppServiceUtil.class, "getFolderByExternalReferenceCode",
+				_getFolderByExternalReferenceCodeParameterTypes45);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, groupId, externalReferenceCode);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.portal.kernel.repository.model.Folder)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
 	public static java.util.List
 		<com.liferay.portal.kernel.repository.model.Folder> getFolders(
 				HttpPrincipal httpPrincipal, long repositoryId,
@@ -1942,7 +1985,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getFolders",
-				_getFoldersParameterTypes45);
+				_getFoldersParameterTypes46);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, parentFolderId);
@@ -1985,7 +2028,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getFolders",
-				_getFoldersParameterTypes46);
+				_getFoldersParameterTypes47);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, parentFolderId, includeMountFolders);
@@ -2029,7 +2072,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getFolders",
-				_getFoldersParameterTypes47);
+				_getFoldersParameterTypes48);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, parentFolderId, includeMountFolders,
@@ -2077,7 +2120,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getFolders",
-				_getFoldersParameterTypes48);
+				_getFoldersParameterTypes49);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, parentFolderId, includeMountFolders,
@@ -2125,7 +2168,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getFolders",
-				_getFoldersParameterTypes49);
+				_getFoldersParameterTypes50);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, parentFolderId, status,
@@ -2169,7 +2212,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getFolders",
-				_getFoldersParameterTypes50);
+				_getFoldersParameterTypes51);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, parentFolderId, start, end);
@@ -2215,7 +2258,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getFolders",
-				_getFoldersParameterTypes51);
+				_getFoldersParameterTypes52);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, parentFolderId, start, end,
@@ -2260,7 +2303,7 @@ public class DLAppServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class,
 				"getFoldersAndFileEntriesAndFileShortcuts",
-				_getFoldersAndFileEntriesAndFileShortcutsParameterTypes52);
+				_getFoldersAndFileEntriesAndFileShortcutsParameterTypes53);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, folderId, status, includeMountFolders,
@@ -2306,7 +2349,7 @@ public class DLAppServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class,
 				"getFoldersAndFileEntriesAndFileShortcuts",
-				_getFoldersAndFileEntriesAndFileShortcutsParameterTypes53);
+				_getFoldersAndFileEntriesAndFileShortcutsParameterTypes54);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, folderId, status, includeMountFolders,
@@ -2353,7 +2396,7 @@ public class DLAppServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class,
 				"getFoldersAndFileEntriesAndFileShortcuts",
-				_getFoldersAndFileEntriesAndFileShortcutsParameterTypes54);
+				_getFoldersAndFileEntriesAndFileShortcutsParameterTypes55);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, folderId, status, mimeTypes,
@@ -2401,7 +2444,7 @@ public class DLAppServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class,
 				"getFoldersAndFileEntriesAndFileShortcuts",
-				_getFoldersAndFileEntriesAndFileShortcutsParameterTypes55);
+				_getFoldersAndFileEntriesAndFileShortcutsParameterTypes56);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, folderId, status, mimeTypes,
@@ -2444,7 +2487,7 @@ public class DLAppServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class,
 				"getFoldersAndFileEntriesAndFileShortcutsCount",
-				_getFoldersAndFileEntriesAndFileShortcutsCountParameterTypes56);
+				_getFoldersAndFileEntriesAndFileShortcutsCountParameterTypes57);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, folderId, status, includeMountFolders);
@@ -2486,7 +2529,7 @@ public class DLAppServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class,
 				"getFoldersAndFileEntriesAndFileShortcutsCount",
-				_getFoldersAndFileEntriesAndFileShortcutsCountParameterTypes57);
+				_getFoldersAndFileEntriesAndFileShortcutsCountParameterTypes58);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, folderId, status, mimeTypes,
@@ -2530,7 +2573,7 @@ public class DLAppServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class,
 				"getFoldersAndFileEntriesAndFileShortcutsCount",
-				_getFoldersAndFileEntriesAndFileShortcutsCountParameterTypes58);
+				_getFoldersAndFileEntriesAndFileShortcutsCountParameterTypes59);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, folderId, status, mimeTypes,
@@ -2571,7 +2614,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getFoldersCount",
-				_getFoldersCountParameterTypes59);
+				_getFoldersCountParameterTypes60);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, parentFolderId);
@@ -2612,7 +2655,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getFoldersCount",
-				_getFoldersCountParameterTypes60);
+				_getFoldersCountParameterTypes61);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, parentFolderId, includeMountFolders);
@@ -2653,7 +2696,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getFoldersCount",
-				_getFoldersCountParameterTypes61);
+				_getFoldersCountParameterTypes62);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, parentFolderId, status,
@@ -2695,7 +2738,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getFoldersFileEntriesCount",
-				_getFoldersFileEntriesCountParameterTypes62);
+				_getFoldersFileEntriesCountParameterTypes63);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, folderIds, status);
@@ -2738,7 +2781,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getGroupFileEntries",
-				_getGroupFileEntriesParameterTypes63);
+				_getGroupFileEntriesParameterTypes64);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, userId, start, end);
@@ -2786,7 +2829,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getGroupFileEntries",
-				_getGroupFileEntriesParameterTypes64);
+				_getGroupFileEntriesParameterTypes65);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, userId, start, end, orderByComparator);
@@ -2831,7 +2874,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getGroupFileEntries",
-				_getGroupFileEntriesParameterTypes65);
+				_getGroupFileEntriesParameterTypes66);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, userId, rootFolderId, start, end);
@@ -2879,7 +2922,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getGroupFileEntries",
-				_getGroupFileEntriesParameterTypes66);
+				_getGroupFileEntriesParameterTypes67);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, userId, rootFolderId, start, end,
@@ -2929,7 +2972,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getGroupFileEntries",
-				_getGroupFileEntriesParameterTypes67);
+				_getGroupFileEntriesParameterTypes68);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, userId, rootFolderId, mimeTypes, status,
@@ -2972,7 +3015,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getGroupFileEntriesCount",
-				_getGroupFileEntriesCountParameterTypes68);
+				_getGroupFileEntriesCountParameterTypes69);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, userId);
@@ -3013,7 +3056,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getGroupFileEntriesCount",
-				_getGroupFileEntriesCountParameterTypes69);
+				_getGroupFileEntriesCountParameterTypes70);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, userId, rootFolderId);
@@ -3054,7 +3097,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getGroupFileEntriesCount",
-				_getGroupFileEntriesCountParameterTypes70);
+				_getGroupFileEntriesCountParameterTypes71);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, userId, rootFolderId, mimeTypes, status);
@@ -3096,7 +3139,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getMountFolders",
-				_getMountFoldersParameterTypes71);
+				_getMountFoldersParameterTypes72);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, parentFolderId);
@@ -3139,7 +3182,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getMountFolders",
-				_getMountFoldersParameterTypes72);
+				_getMountFoldersParameterTypes73);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, parentFolderId, start, end);
@@ -3185,7 +3228,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getMountFolders",
-				_getMountFoldersParameterTypes73);
+				_getMountFoldersParameterTypes74);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, parentFolderId, start, end,
@@ -3227,7 +3270,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getMountFoldersCount",
-				_getMountFoldersCountParameterTypes74);
+				_getMountFoldersCountParameterTypes75);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, parentFolderId);
@@ -3268,7 +3311,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getSubfolderIds",
-				_getSubfolderIdsParameterTypes75);
+				_getSubfolderIdsParameterTypes76);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, folderIds, folderId);
@@ -3304,7 +3347,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getSubfolderIds",
-				_getSubfolderIdsParameterTypes76);
+				_getSubfolderIdsParameterTypes77);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, folderId);
@@ -3345,7 +3388,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getSubfolderIds",
-				_getSubfolderIdsParameterTypes77);
+				_getSubfolderIdsParameterTypes78);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, folderId, recurse);
@@ -3386,7 +3429,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "getTempFileNames",
-				_getTempFileNamesParameterTypes78);
+				_getTempFileNamesParameterTypes79);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId, folderName);
@@ -3426,7 +3469,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "lockFolder",
-				_lockFolderParameterTypes79);
+				_lockFolderParameterTypes80);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, folderId);
@@ -3467,7 +3510,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "lockFolder",
-				_lockFolderParameterTypes80);
+				_lockFolderParameterTypes81);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, folderId, owner, inheritable,
@@ -3510,7 +3553,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "moveFileEntry",
-				_moveFileEntryParameterTypes81);
+				_moveFileEntryParameterTypes82);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, fileEntryId, newFolderId, serviceContext);
@@ -3552,7 +3595,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "moveFolder",
-				_moveFolderParameterTypes82);
+				_moveFolderParameterTypes83);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, folderId, parentFolderId, serviceContext);
@@ -3593,7 +3636,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "refreshFileEntryLock",
-				_refreshFileEntryLockParameterTypes83);
+				_refreshFileEntryLockParameterTypes84);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, lockUuid, companyId, expirationTime);
@@ -3634,7 +3677,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "refreshFolderLock",
-				_refreshFolderLockParameterTypes84);
+				_refreshFolderLockParameterTypes85);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, lockUuid, companyId, expirationTime);
@@ -3675,7 +3718,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "revertFileEntry",
-				_revertFileEntryParameterTypes85);
+				_revertFileEntryParameterTypes86);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, fileEntryId, version, serviceContext);
@@ -3711,7 +3754,7 @@ public class DLAppServiceHttp {
 
 		try {
 			MethodKey methodKey = new MethodKey(
-				DLAppServiceUtil.class, "search", _searchParameterTypes86);
+				DLAppServiceUtil.class, "search", _searchParameterTypes87);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, creatorUserId, status, start, end);
@@ -3751,7 +3794,7 @@ public class DLAppServiceHttp {
 
 		try {
 			MethodKey methodKey = new MethodKey(
-				DLAppServiceUtil.class, "search", _searchParameterTypes87);
+				DLAppServiceUtil.class, "search", _searchParameterTypes88);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, creatorUserId, folderId, mimeTypes,
@@ -3792,7 +3835,7 @@ public class DLAppServiceHttp {
 
 		try {
 			MethodKey methodKey = new MethodKey(
-				DLAppServiceUtil.class, "search", _searchParameterTypes88);
+				DLAppServiceUtil.class, "search", _searchParameterTypes89);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, searchContext);
@@ -3833,7 +3876,7 @@ public class DLAppServiceHttp {
 
 		try {
 			MethodKey methodKey = new MethodKey(
-				DLAppServiceUtil.class, "search", _searchParameterTypes89);
+				DLAppServiceUtil.class, "search", _searchParameterTypes90);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, searchContext, query);
@@ -3873,7 +3916,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "subscribeFileEntryType",
-				_subscribeFileEntryTypeParameterTypes90);
+				_subscribeFileEntryTypeParameterTypes91);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, fileEntryTypeId);
@@ -3909,7 +3952,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "subscribeFolder",
-				_subscribeFolderParameterTypes91);
+				_subscribeFolderParameterTypes92);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId);
@@ -3946,7 +3989,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "unlockFolder",
-				_unlockFolderParameterTypes92);
+				_unlockFolderParameterTypes93);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, folderId, lockUuid);
@@ -3983,7 +4026,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "unlockFolder",
-				_unlockFolderParameterTypes93);
+				_unlockFolderParameterTypes94);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, parentFolderId, name, lockUuid);
@@ -4019,7 +4062,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "unsubscribeFileEntryType",
-				_unsubscribeFileEntryTypeParameterTypes94);
+				_unsubscribeFileEntryTypeParameterTypes95);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, fileEntryTypeId);
@@ -4055,7 +4098,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "unsubscribeFolder",
-				_unsubscribeFolderParameterTypes95);
+				_unsubscribeFolderParameterTypes96);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId);
@@ -4099,7 +4142,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "updateFileEntry",
-				_updateFileEntryParameterTypes96);
+				_updateFileEntryParameterTypes97);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, fileEntryId, sourceFileName, mimeType, title,
@@ -4150,7 +4193,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "updateFileEntry",
-				_updateFileEntryParameterTypes97);
+				_updateFileEntryParameterTypes98);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, fileEntryId, sourceFileName, mimeType, title,
@@ -4201,7 +4244,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "updateFileEntry",
-				_updateFileEntryParameterTypes98);
+				_updateFileEntryParameterTypes99);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, fileEntryId, sourceFileName, mimeType, title,
@@ -4252,7 +4295,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "updateFileEntryAndCheckIn",
-				_updateFileEntryAndCheckInParameterTypes99);
+				_updateFileEntryAndCheckInParameterTypes100);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, fileEntryId, sourceFileName, mimeType, title,
@@ -4303,7 +4346,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "updateFileEntryAndCheckIn",
-				_updateFileEntryAndCheckInParameterTypes100);
+				_updateFileEntryAndCheckInParameterTypes101);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, fileEntryId, sourceFileName, mimeType, title,
@@ -4349,7 +4392,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "updateFileShortcut",
-				_updateFileShortcutParameterTypes101);
+				_updateFileShortcutParameterTypes102);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, fileShortcutId, folderId, toFileEntryId,
@@ -4394,7 +4437,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "updateFolder",
-				_updateFolderParameterTypes102);
+				_updateFolderParameterTypes103);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, folderId, name, description, serviceContext);
@@ -4435,7 +4478,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "verifyFileEntryCheckOut",
-				_verifyFileEntryCheckOutParameterTypes103);
+				_verifyFileEntryCheckOutParameterTypes104);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, fileEntryId, lockUuid);
@@ -4476,7 +4519,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "verifyFileEntryLock",
-				_verifyFileEntryLockParameterTypes104);
+				_verifyFileEntryLockParameterTypes105);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, fileEntryId, lockUuid);
@@ -4517,7 +4560,7 @@ public class DLAppServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLAppServiceUtil.class, "verifyInheritableLock",
-				_verifyInheritableLockParameterTypes105);
+				_verifyInheritableLockParameterTypes106);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, repositoryId, folderId, lockUuid);
@@ -4582,7 +4625,7 @@ public class DLAppServiceHttp {
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
 	private static final Class<?>[] _addFolderParameterTypes5 = new Class[] {
-		long.class, long.class, String.class, String.class,
+		String.class, long.class, long.class, String.class, String.class,
 		com.liferay.portal.kernel.service.ServiceContext.class
 	};
 	private static final Class<?>[] _addTempFileEntryParameterTypes6 =
@@ -4705,179 +4748,183 @@ public class DLAppServiceHttp {
 	private static final Class<?>[] _getFolderParameterTypes44 = new Class[] {
 		long.class, long.class, String.class
 	};
-	private static final Class<?>[] _getFoldersParameterTypes45 = new Class[] {
+	private static final Class<?>[]
+		_getFolderByExternalReferenceCodeParameterTypes45 = new Class[] {
+			long.class, String.class
+		};
+	private static final Class<?>[] _getFoldersParameterTypes46 = new Class[] {
 		long.class, long.class
 	};
-	private static final Class<?>[] _getFoldersParameterTypes46 = new Class[] {
+	private static final Class<?>[] _getFoldersParameterTypes47 = new Class[] {
 		long.class, long.class, boolean.class
 	};
-	private static final Class<?>[] _getFoldersParameterTypes47 = new Class[] {
+	private static final Class<?>[] _getFoldersParameterTypes48 = new Class[] {
 		long.class, long.class, boolean.class, int.class, int.class
 	};
-	private static final Class<?>[] _getFoldersParameterTypes48 = new Class[] {
+	private static final Class<?>[] _getFoldersParameterTypes49 = new Class[] {
 		long.class, long.class, boolean.class, int.class, int.class,
 		com.liferay.portal.kernel.util.OrderByComparator.class
 	};
-	private static final Class<?>[] _getFoldersParameterTypes49 = new Class[] {
+	private static final Class<?>[] _getFoldersParameterTypes50 = new Class[] {
 		long.class, long.class, int.class, boolean.class, int.class, int.class,
 		com.liferay.portal.kernel.util.OrderByComparator.class
 	};
-	private static final Class<?>[] _getFoldersParameterTypes50 = new Class[] {
+	private static final Class<?>[] _getFoldersParameterTypes51 = new Class[] {
 		long.class, long.class, int.class, int.class
 	};
-	private static final Class<?>[] _getFoldersParameterTypes51 = new Class[] {
+	private static final Class<?>[] _getFoldersParameterTypes52 = new Class[] {
 		long.class, long.class, int.class, int.class,
 		com.liferay.portal.kernel.util.OrderByComparator.class
 	};
 	private static final Class<?>[]
-		_getFoldersAndFileEntriesAndFileShortcutsParameterTypes52 =
+		_getFoldersAndFileEntriesAndFileShortcutsParameterTypes53 =
 			new Class[] {
 				long.class, long.class, int.class, boolean.class, int.class,
 				int.class
 			};
 	private static final Class<?>[]
-		_getFoldersAndFileEntriesAndFileShortcutsParameterTypes53 =
+		_getFoldersAndFileEntriesAndFileShortcutsParameterTypes54 =
 			new Class[] {
 				long.class, long.class, int.class, boolean.class, int.class,
 				int.class,
 				com.liferay.portal.kernel.util.OrderByComparator.class
 			};
 	private static final Class<?>[]
-		_getFoldersAndFileEntriesAndFileShortcutsParameterTypes54 =
+		_getFoldersAndFileEntriesAndFileShortcutsParameterTypes55 =
 			new Class[] {
 				long.class, long.class, int.class, String[].class,
 				boolean.class, boolean.class, int.class, int.class,
 				com.liferay.portal.kernel.util.OrderByComparator.class
 			};
 	private static final Class<?>[]
-		_getFoldersAndFileEntriesAndFileShortcutsParameterTypes55 =
+		_getFoldersAndFileEntriesAndFileShortcutsParameterTypes56 =
 			new Class[] {
 				long.class, long.class, int.class, String[].class,
 				boolean.class, int.class, int.class,
 				com.liferay.portal.kernel.util.OrderByComparator.class
 			};
 	private static final Class<?>[]
-		_getFoldersAndFileEntriesAndFileShortcutsCountParameterTypes56 =
+		_getFoldersAndFileEntriesAndFileShortcutsCountParameterTypes57 =
 			new Class[] {long.class, long.class, int.class, boolean.class};
 	private static final Class<?>[]
-		_getFoldersAndFileEntriesAndFileShortcutsCountParameterTypes57 =
+		_getFoldersAndFileEntriesAndFileShortcutsCountParameterTypes58 =
 			new Class[] {
 				long.class, long.class, int.class, String[].class, boolean.class
 			};
 	private static final Class<?>[]
-		_getFoldersAndFileEntriesAndFileShortcutsCountParameterTypes58 =
+		_getFoldersAndFileEntriesAndFileShortcutsCountParameterTypes59 =
 			new Class[] {
 				long.class, long.class, int.class, String[].class,
 				boolean.class, boolean.class
 			};
-	private static final Class<?>[] _getFoldersCountParameterTypes59 =
-		new Class[] {long.class, long.class};
 	private static final Class<?>[] _getFoldersCountParameterTypes60 =
-		new Class[] {long.class, long.class, boolean.class};
+		new Class[] {long.class, long.class};
 	private static final Class<?>[] _getFoldersCountParameterTypes61 =
+		new Class[] {long.class, long.class, boolean.class};
+	private static final Class<?>[] _getFoldersCountParameterTypes62 =
 		new Class[] {long.class, long.class, int.class, boolean.class};
 	private static final Class<?>[]
-		_getFoldersFileEntriesCountParameterTypes62 = new Class[] {
+		_getFoldersFileEntriesCountParameterTypes63 = new Class[] {
 			long.class, java.util.List.class, int.class
 		};
-	private static final Class<?>[] _getGroupFileEntriesParameterTypes63 =
-		new Class[] {long.class, long.class, int.class, int.class};
 	private static final Class<?>[] _getGroupFileEntriesParameterTypes64 =
+		new Class[] {long.class, long.class, int.class, int.class};
+	private static final Class<?>[] _getGroupFileEntriesParameterTypes65 =
 		new Class[] {
 			long.class, long.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getGroupFileEntriesParameterTypes65 =
-		new Class[] {long.class, long.class, long.class, int.class, int.class};
 	private static final Class<?>[] _getGroupFileEntriesParameterTypes66 =
+		new Class[] {long.class, long.class, long.class, int.class, int.class};
+	private static final Class<?>[] _getGroupFileEntriesParameterTypes67 =
 		new Class[] {
 			long.class, long.class, long.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getGroupFileEntriesParameterTypes67 =
+	private static final Class<?>[] _getGroupFileEntriesParameterTypes68 =
 		new Class[] {
 			long.class, long.class, long.class, String[].class, int.class,
 			int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getGroupFileEntriesCountParameterTypes68 =
-		new Class[] {long.class, long.class};
 	private static final Class<?>[] _getGroupFileEntriesCountParameterTypes69 =
-		new Class[] {long.class, long.class, long.class};
+		new Class[] {long.class, long.class};
 	private static final Class<?>[] _getGroupFileEntriesCountParameterTypes70 =
+		new Class[] {long.class, long.class, long.class};
+	private static final Class<?>[] _getGroupFileEntriesCountParameterTypes71 =
 		new Class[] {
 			long.class, long.class, long.class, String[].class, int.class
 		};
-	private static final Class<?>[] _getMountFoldersParameterTypes71 =
-		new Class[] {long.class, long.class};
 	private static final Class<?>[] _getMountFoldersParameterTypes72 =
-		new Class[] {long.class, long.class, int.class, int.class};
+		new Class[] {long.class, long.class};
 	private static final Class<?>[] _getMountFoldersParameterTypes73 =
+		new Class[] {long.class, long.class, int.class, int.class};
+	private static final Class<?>[] _getMountFoldersParameterTypes74 =
 		new Class[] {
 			long.class, long.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getMountFoldersCountParameterTypes74 =
+	private static final Class<?>[] _getMountFoldersCountParameterTypes75 =
 		new Class[] {long.class, long.class};
-	private static final Class<?>[] _getSubfolderIdsParameterTypes75 =
-		new Class[] {long.class, java.util.List.class, long.class};
 	private static final Class<?>[] _getSubfolderIdsParameterTypes76 =
-		new Class[] {long.class, long.class};
+		new Class[] {long.class, java.util.List.class, long.class};
 	private static final Class<?>[] _getSubfolderIdsParameterTypes77 =
+		new Class[] {long.class, long.class};
+	private static final Class<?>[] _getSubfolderIdsParameterTypes78 =
 		new Class[] {long.class, long.class, boolean.class};
-	private static final Class<?>[] _getTempFileNamesParameterTypes78 =
+	private static final Class<?>[] _getTempFileNamesParameterTypes79 =
 		new Class[] {long.class, long.class, String.class};
-	private static final Class<?>[] _lockFolderParameterTypes79 = new Class[] {
+	private static final Class<?>[] _lockFolderParameterTypes80 = new Class[] {
 		long.class, long.class
 	};
-	private static final Class<?>[] _lockFolderParameterTypes80 = new Class[] {
+	private static final Class<?>[] _lockFolderParameterTypes81 = new Class[] {
 		long.class, long.class, String.class, boolean.class, long.class
 	};
-	private static final Class<?>[] _moveFileEntryParameterTypes81 =
+	private static final Class<?>[] _moveFileEntryParameterTypes82 =
 		new Class[] {
 			long.class, long.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _moveFolderParameterTypes82 = new Class[] {
+	private static final Class<?>[] _moveFolderParameterTypes83 = new Class[] {
 		long.class, long.class,
 		com.liferay.portal.kernel.service.ServiceContext.class
 	};
-	private static final Class<?>[] _refreshFileEntryLockParameterTypes83 =
+	private static final Class<?>[] _refreshFileEntryLockParameterTypes84 =
 		new Class[] {String.class, long.class, long.class};
-	private static final Class<?>[] _refreshFolderLockParameterTypes84 =
+	private static final Class<?>[] _refreshFolderLockParameterTypes85 =
 		new Class[] {String.class, long.class, long.class};
-	private static final Class<?>[] _revertFileEntryParameterTypes85 =
+	private static final Class<?>[] _revertFileEntryParameterTypes86 =
 		new Class[] {
 			long.class, String.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _searchParameterTypes86 = new Class[] {
+	private static final Class<?>[] _searchParameterTypes87 = new Class[] {
 		long.class, long.class, int.class, int.class, int.class
 	};
-	private static final Class<?>[] _searchParameterTypes87 = new Class[] {
+	private static final Class<?>[] _searchParameterTypes88 = new Class[] {
 		long.class, long.class, long.class, String[].class, int.class,
 		int.class, int.class
 	};
-	private static final Class<?>[] _searchParameterTypes88 = new Class[] {
+	private static final Class<?>[] _searchParameterTypes89 = new Class[] {
 		long.class, com.liferay.portal.kernel.search.SearchContext.class
 	};
-	private static final Class<?>[] _searchParameterTypes89 = new Class[] {
+	private static final Class<?>[] _searchParameterTypes90 = new Class[] {
 		long.class, com.liferay.portal.kernel.search.SearchContext.class,
 		com.liferay.portal.kernel.search.Query.class
 	};
-	private static final Class<?>[] _subscribeFileEntryTypeParameterTypes90 =
+	private static final Class<?>[] _subscribeFileEntryTypeParameterTypes91 =
 		new Class[] {long.class, long.class};
-	private static final Class<?>[] _subscribeFolderParameterTypes91 =
+	private static final Class<?>[] _subscribeFolderParameterTypes92 =
 		new Class[] {long.class, long.class};
-	private static final Class<?>[] _unlockFolderParameterTypes92 =
-		new Class[] {long.class, long.class, String.class};
 	private static final Class<?>[] _unlockFolderParameterTypes93 =
+		new Class[] {long.class, long.class, String.class};
+	private static final Class<?>[] _unlockFolderParameterTypes94 =
 		new Class[] {long.class, long.class, String.class, String.class};
-	private static final Class<?>[] _unsubscribeFileEntryTypeParameterTypes94 =
+	private static final Class<?>[] _unsubscribeFileEntryTypeParameterTypes95 =
 		new Class[] {long.class, long.class};
-	private static final Class<?>[] _unsubscribeFolderParameterTypes95 =
+	private static final Class<?>[] _unsubscribeFolderParameterTypes96 =
 		new Class[] {long.class, long.class};
-	private static final Class<?>[] _updateFileEntryParameterTypes96 =
+	private static final Class<?>[] _updateFileEntryParameterTypes97 =
 		new Class[] {
 			long.class, String.class, String.class, String.class, String.class,
 			String.class, String.class,
@@ -4886,7 +4933,7 @@ public class DLAppServiceHttp {
 			byte[].class, java.util.Date.class, java.util.Date.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _updateFileEntryParameterTypes97 =
+	private static final Class<?>[] _updateFileEntryParameterTypes98 =
 		new Class[] {
 			long.class, String.class, String.class, String.class, String.class,
 			String.class, String.class,
@@ -4895,7 +4942,7 @@ public class DLAppServiceHttp {
 			java.io.File.class, java.util.Date.class, java.util.Date.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _updateFileEntryParameterTypes98 =
+	private static final Class<?>[] _updateFileEntryParameterTypes99 =
 		new Class[] {
 			long.class, String.class, String.class, String.class, String.class,
 			String.class, String.class,
@@ -4903,15 +4950,6 @@ public class DLAppServiceHttp {
 				class,
 			java.io.InputStream.class, long.class, java.util.Date.class,
 			java.util.Date.class,
-			com.liferay.portal.kernel.service.ServiceContext.class
-		};
-	private static final Class<?>[] _updateFileEntryAndCheckInParameterTypes99 =
-		new Class[] {
-			long.class, String.class, String.class, String.class, String.class,
-			String.class, String.class,
-			com.liferay.document.library.kernel.model.DLVersionNumberIncrease.
-				class,
-			java.io.File.class, java.util.Date.class, java.util.Date.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
 	private static final Class<?>[]
@@ -4920,25 +4958,34 @@ public class DLAppServiceHttp {
 			String.class, String.class,
 			com.liferay.document.library.kernel.model.DLVersionNumberIncrease.
 				class,
+			java.io.File.class, java.util.Date.class, java.util.Date.class,
+			com.liferay.portal.kernel.service.ServiceContext.class
+		};
+	private static final Class<?>[]
+		_updateFileEntryAndCheckInParameterTypes101 = new Class[] {
+			long.class, String.class, String.class, String.class, String.class,
+			String.class, String.class,
+			com.liferay.document.library.kernel.model.DLVersionNumberIncrease.
+				class,
 			java.io.InputStream.class, long.class, java.util.Date.class,
 			java.util.Date.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _updateFileShortcutParameterTypes101 =
+	private static final Class<?>[] _updateFileShortcutParameterTypes102 =
 		new Class[] {
 			long.class, long.class, long.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _updateFolderParameterTypes102 =
+	private static final Class<?>[] _updateFolderParameterTypes103 =
 		new Class[] {
 			long.class, String.class, String.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _verifyFileEntryCheckOutParameterTypes103 =
+	private static final Class<?>[] _verifyFileEntryCheckOutParameterTypes104 =
 		new Class[] {long.class, long.class, String.class};
-	private static final Class<?>[] _verifyFileEntryLockParameterTypes104 =
+	private static final Class<?>[] _verifyFileEntryLockParameterTypes105 =
 		new Class[] {long.class, long.class, String.class};
-	private static final Class<?>[] _verifyInheritableLockParameterTypes105 =
+	private static final Class<?>[] _verifyInheritableLockParameterTypes106 =
 		new Class[] {long.class, long.class, String.class};
 
 }

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/http/DLFolderServiceHttp.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/http/DLFolderServiceHttp.java
@@ -51,9 +51,9 @@ import com.liferay.portal.kernel.util.MethodKey;
 public class DLFolderServiceHttp {
 
 	public static com.liferay.document.library.kernel.model.DLFolder addFolder(
-			HttpPrincipal httpPrincipal, long groupId, long repositoryId,
-			boolean mountPoint, long parentFolderId, String name,
-			String description,
+			HttpPrincipal httpPrincipal, String externalReferenceCode,
+			long groupId, long repositoryId, boolean mountPoint,
+			long parentFolderId, String name, String description,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
@@ -63,8 +63,8 @@ public class DLFolderServiceHttp {
 				_addFolderParameterTypes0);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, groupId, repositoryId, mountPoint, parentFolderId,
-				name, description, serviceContext);
+				methodKey, externalReferenceCode, groupId, repositoryId,
+				mountPoint, parentFolderId, name, description, serviceContext);
 
 			Object returnObj = null;
 
@@ -204,6 +204,49 @@ public class DLFolderServiceHttp {
 		}
 	}
 
+	public static com.liferay.document.library.kernel.model.DLFolder
+			getDLFolderByExternalReferenceCode(
+				HttpPrincipal httpPrincipal, long groupId,
+				String externalReferenceCode)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				DLFolderServiceUtil.class, "getDLFolderByExternalReferenceCode",
+				_getDLFolderByExternalReferenceCodeParameterTypes4);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, groupId, externalReferenceCode);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.document.library.kernel.model.DLFolder)
+				returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
 	public static java.util.List<Object> getFileEntriesAndFileShortcuts(
 			HttpPrincipal httpPrincipal, long groupId, long folderId,
 			int status, int start, int end)
@@ -212,7 +255,7 @@ public class DLFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFolderServiceUtil.class, "getFileEntriesAndFileShortcuts",
-				_getFileEntriesAndFileShortcutsParameterTypes4);
+				_getFileEntriesAndFileShortcutsParameterTypes5);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId, status, start, end);
@@ -254,7 +297,7 @@ public class DLFolderServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				DLFolderServiceUtil.class,
 				"getFileEntriesAndFileShortcutsCount",
-				_getFileEntriesAndFileShortcutsCountParameterTypes5);
+				_getFileEntriesAndFileShortcutsCountParameterTypes6);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId, status);
@@ -296,7 +339,7 @@ public class DLFolderServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				DLFolderServiceUtil.class,
 				"getFileEntriesAndFileShortcutsCount",
-				_getFileEntriesAndFileShortcutsCountParameterTypes6);
+				_getFileEntriesAndFileShortcutsCountParameterTypes7);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId, mimeTypes, status);
@@ -336,7 +379,7 @@ public class DLFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFolderServiceUtil.class, "getFolder",
-				_getFolderParameterTypes7);
+				_getFolderParameterTypes8);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, folderId);
@@ -378,7 +421,7 @@ public class DLFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFolderServiceUtil.class, "getFolder",
-				_getFolderParameterTypes8);
+				_getFolderParameterTypes9);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, parentFolderId, name);
@@ -419,7 +462,7 @@ public class DLFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFolderServiceUtil.class, "getFolderIds",
-				_getFolderIdsParameterTypes9);
+				_getFolderIdsParameterTypes10);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId);
@@ -464,7 +507,7 @@ public class DLFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFolderServiceUtil.class, "getFolders",
-				_getFoldersParameterTypes10);
+				_getFoldersParameterTypes11);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, parentFolderId, includeMountfolders, status,
@@ -511,7 +554,7 @@ public class DLFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFolderServiceUtil.class, "getFolders",
-				_getFoldersParameterTypes11);
+				_getFoldersParameterTypes12);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, parentFolderId, start, end,
@@ -558,7 +601,7 @@ public class DLFolderServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				DLFolderServiceUtil.class,
 				"getFoldersAndFileEntriesAndFileShortcuts",
-				_getFoldersAndFileEntriesAndFileShortcutsParameterTypes12);
+				_getFoldersAndFileEntriesAndFileShortcutsParameterTypes13);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId, includeMountFolders, status,
@@ -605,7 +648,7 @@ public class DLFolderServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				DLFolderServiceUtil.class,
 				"getFoldersAndFileEntriesAndFileShortcuts",
-				_getFoldersAndFileEntriesAndFileShortcutsParameterTypes13);
+				_getFoldersAndFileEntriesAndFileShortcutsParameterTypes14);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId, mimeTypes, includeMountFolders,
@@ -651,7 +694,7 @@ public class DLFolderServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				DLFolderServiceUtil.class,
 				"getFoldersAndFileEntriesAndFileShortcuts",
-				_getFoldersAndFileEntriesAndFileShortcutsParameterTypes14);
+				_getFoldersAndFileEntriesAndFileShortcutsParameterTypes15);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId, mimeTypes, includeMountFolders,
@@ -698,7 +741,7 @@ public class DLFolderServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				DLFolderServiceUtil.class,
 				"getFoldersAndFileEntriesAndFileShortcuts",
-				_getFoldersAndFileEntriesAndFileShortcutsParameterTypes15);
+				_getFoldersAndFileEntriesAndFileShortcutsParameterTypes16);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId, mimeTypes, fileEntryTypeId,
@@ -741,7 +784,7 @@ public class DLFolderServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				DLFolderServiceUtil.class,
 				"getFoldersAndFileEntriesAndFileShortcutsCount",
-				_getFoldersAndFileEntriesAndFileShortcutsCountParameterTypes16);
+				_getFoldersAndFileEntriesAndFileShortcutsCountParameterTypes17);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId, status, includeMountFolders);
@@ -783,7 +826,7 @@ public class DLFolderServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				DLFolderServiceUtil.class,
 				"getFoldersAndFileEntriesAndFileShortcutsCount",
-				_getFoldersAndFileEntriesAndFileShortcutsCountParameterTypes17);
+				_getFoldersAndFileEntriesAndFileShortcutsCountParameterTypes18);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId, status, mimeTypes,
@@ -826,7 +869,7 @@ public class DLFolderServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				DLFolderServiceUtil.class,
 				"getFoldersAndFileEntriesAndFileShortcutsCount",
-				_getFoldersAndFileEntriesAndFileShortcutsCountParameterTypes18);
+				_getFoldersAndFileEntriesAndFileShortcutsCountParameterTypes19);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId, mimeTypes, includeMountFolders,
@@ -871,7 +914,7 @@ public class DLFolderServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				DLFolderServiceUtil.class,
 				"getFoldersAndFileEntriesAndFileShortcutsCount",
-				_getFoldersAndFileEntriesAndFileShortcutsCountParameterTypes19);
+				_getFoldersAndFileEntriesAndFileShortcutsCountParameterTypes20);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId, mimeTypes, includeMountFolders,
@@ -915,7 +958,7 @@ public class DLFolderServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				DLFolderServiceUtil.class,
 				"getFoldersAndFileEntriesAndFileShortcutsCount",
-				_getFoldersAndFileEntriesAndFileShortcutsCountParameterTypes20);
+				_getFoldersAndFileEntriesAndFileShortcutsCountParameterTypes21);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId, mimeTypes, fileEntryTypeId,
@@ -956,7 +999,7 @@ public class DLFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFolderServiceUtil.class, "getFoldersCount",
-				_getFoldersCountParameterTypes21);
+				_getFoldersCountParameterTypes22);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, parentFolderId);
@@ -997,7 +1040,7 @@ public class DLFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFolderServiceUtil.class, "getFoldersCount",
-				_getFoldersCountParameterTypes22);
+				_getFoldersCountParameterTypes23);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, parentFolderId, includeMountfolders,
@@ -1039,7 +1082,7 @@ public class DLFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFolderServiceUtil.class, "getFoldersCount",
-				_getFoldersCountParameterTypes23);
+				_getFoldersCountParameterTypes24);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, parentFolderId, status,
@@ -1085,7 +1128,7 @@ public class DLFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFolderServiceUtil.class, "getMountFolders",
-				_getMountFoldersParameterTypes24);
+				_getMountFoldersParameterTypes25);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, parentFolderId, start, end,
@@ -1127,7 +1170,7 @@ public class DLFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFolderServiceUtil.class, "getMountFoldersCount",
-				_getMountFoldersCountParameterTypes25);
+				_getMountFoldersCountParameterTypes26);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, parentFolderId);
@@ -1168,7 +1211,7 @@ public class DLFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFolderServiceUtil.class, "getSubfolderIds",
-				_getSubfolderIdsParameterTypes26);
+				_getSubfolderIdsParameterTypes27);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, folderIds, groupId, folderId, recurse);
@@ -1205,7 +1248,7 @@ public class DLFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFolderServiceUtil.class, "getSubfolderIds",
-				_getSubfolderIdsParameterTypes27);
+				_getSubfolderIdsParameterTypes28);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId, recurse);
@@ -1245,7 +1288,7 @@ public class DLFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFolderServiceUtil.class, "hasFolderLock",
-				_hasFolderLockParameterTypes28);
+				_hasFolderLockParameterTypes29);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, folderId);
@@ -1285,7 +1328,7 @@ public class DLFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFolderServiceUtil.class, "hasInheritableLock",
-				_hasInheritableLockParameterTypes29);
+				_hasInheritableLockParameterTypes30);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, folderId);
@@ -1324,7 +1367,7 @@ public class DLFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFolderServiceUtil.class, "isFolderLocked",
-				_isFolderLockedParameterTypes30);
+				_isFolderLockedParameterTypes31);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, folderId);
@@ -1357,7 +1400,7 @@ public class DLFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFolderServiceUtil.class, "lockFolder",
-				_lockFolderParameterTypes31);
+				_lockFolderParameterTypes32);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, folderId);
@@ -1398,7 +1441,7 @@ public class DLFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFolderServiceUtil.class, "lockFolder",
-				_lockFolderParameterTypes32);
+				_lockFolderParameterTypes33);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, folderId, owner, inheritable, expirationTime);
@@ -1439,7 +1482,7 @@ public class DLFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFolderServiceUtil.class, "moveFolder",
-				_moveFolderParameterTypes33);
+				_moveFolderParameterTypes34);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, folderId, parentFolderId, serviceContext);
@@ -1481,7 +1524,7 @@ public class DLFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFolderServiceUtil.class, "refreshFolderLock",
-				_refreshFolderLockParameterTypes34);
+				_refreshFolderLockParameterTypes35);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, lockUuid, companyId, expirationTime);
@@ -1522,7 +1565,7 @@ public class DLFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFolderServiceUtil.class, "unlockFolder",
-				_unlockFolderParameterTypes35);
+				_unlockFolderParameterTypes36);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, parentFolderId, name, lockUuid);
@@ -1558,7 +1601,7 @@ public class DLFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFolderServiceUtil.class, "unlockFolder",
-				_unlockFolderParameterTypes36);
+				_unlockFolderParameterTypes37);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, folderId, lockUuid);
@@ -1598,7 +1641,7 @@ public class DLFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFolderServiceUtil.class, "updateFolder",
-				_updateFolderParameterTypes37);
+				_updateFolderParameterTypes38);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, folderId, parentFolderId, name, description,
@@ -1645,7 +1688,7 @@ public class DLFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFolderServiceUtil.class, "updateFolder",
-				_updateFolderParameterTypes38);
+				_updateFolderParameterTypes39);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, folderId, name, description, defaultFileEntryTypeId,
@@ -1687,7 +1730,7 @@ public class DLFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFolderServiceUtil.class, "verifyInheritableLock",
-				_verifyInheritableLockParameterTypes39);
+				_verifyInheritableLockParameterTypes40);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, folderId, lockUuid);
@@ -1723,8 +1766,9 @@ public class DLFolderServiceHttp {
 	private static Log _log = LogFactoryUtil.getLog(DLFolderServiceHttp.class);
 
 	private static final Class<?>[] _addFolderParameterTypes0 = new Class[] {
-		long.class, long.class, boolean.class, long.class, String.class,
-		String.class, com.liferay.portal.kernel.service.ServiceContext.class
+		String.class, long.class, long.class, boolean.class, long.class,
+		String.class, String.class,
+		com.liferay.portal.kernel.service.ServiceContext.class
 	};
 	private static final Class<?>[] _deleteFolderParameterTypes1 = new Class[] {
 		long.class
@@ -1736,140 +1780,143 @@ public class DLFolderServiceHttp {
 		long.class, long.class, String.class
 	};
 	private static final Class<?>[]
-		_getFileEntriesAndFileShortcutsParameterTypes4 = new Class[] {
+		_getDLFolderByExternalReferenceCodeParameterTypes4 = new Class[] {
+			long.class, String.class
+		};
+	private static final Class<?>[]
+		_getFileEntriesAndFileShortcutsParameterTypes5 = new Class[] {
 			long.class, long.class, int.class, int.class, int.class
 		};
 	private static final Class<?>[]
-		_getFileEntriesAndFileShortcutsCountParameterTypes5 = new Class[] {
+		_getFileEntriesAndFileShortcutsCountParameterTypes6 = new Class[] {
 			long.class, long.class, int.class
 		};
 	private static final Class<?>[]
-		_getFileEntriesAndFileShortcutsCountParameterTypes6 = new Class[] {
+		_getFileEntriesAndFileShortcutsCountParameterTypes7 = new Class[] {
 			long.class, long.class, String[].class, int.class
 		};
-	private static final Class<?>[] _getFolderParameterTypes7 = new Class[] {
+	private static final Class<?>[] _getFolderParameterTypes8 = new Class[] {
 		long.class
 	};
-	private static final Class<?>[] _getFolderParameterTypes8 = new Class[] {
+	private static final Class<?>[] _getFolderParameterTypes9 = new Class[] {
 		long.class, long.class, String.class
 	};
-	private static final Class<?>[] _getFolderIdsParameterTypes9 = new Class[] {
-		long.class, long.class
-	};
-	private static final Class<?>[] _getFoldersParameterTypes10 = new Class[] {
+	private static final Class<?>[] _getFolderIdsParameterTypes10 =
+		new Class[] {long.class, long.class};
+	private static final Class<?>[] _getFoldersParameterTypes11 = new Class[] {
 		long.class, long.class, boolean.class, int.class, int.class, int.class,
 		com.liferay.portal.kernel.util.OrderByComparator.class
 	};
-	private static final Class<?>[] _getFoldersParameterTypes11 = new Class[] {
+	private static final Class<?>[] _getFoldersParameterTypes12 = new Class[] {
 		long.class, long.class, int.class, int.class,
 		com.liferay.portal.kernel.util.OrderByComparator.class
 	};
 	private static final Class<?>[]
-		_getFoldersAndFileEntriesAndFileShortcutsParameterTypes12 =
+		_getFoldersAndFileEntriesAndFileShortcutsParameterTypes13 =
 			new Class[] {
 				long.class, long.class, boolean.class, int.class, int.class,
 				int.class,
 				com.liferay.portal.kernel.util.OrderByComparator.class
 			};
 	private static final Class<?>[]
-		_getFoldersAndFileEntriesAndFileShortcutsParameterTypes13 =
+		_getFoldersAndFileEntriesAndFileShortcutsParameterTypes14 =
 			new Class[] {
 				long.class, long.class, String[].class, boolean.class,
 				int.class, int.class, int.class,
 				com.liferay.portal.kernel.util.OrderByComparator.class
 			};
 	private static final Class<?>[]
-		_getFoldersAndFileEntriesAndFileShortcutsParameterTypes14 =
+		_getFoldersAndFileEntriesAndFileShortcutsParameterTypes15 =
 			new Class[] {
 				long.class, long.class, String[].class, boolean.class,
 				com.liferay.portal.kernel.dao.orm.QueryDefinition.class
 			};
 	private static final Class<?>[]
-		_getFoldersAndFileEntriesAndFileShortcutsParameterTypes15 =
+		_getFoldersAndFileEntriesAndFileShortcutsParameterTypes16 =
 			new Class[] {
 				long.class, long.class, String[].class, long.class,
 				boolean.class, int.class, int.class, int.class,
 				com.liferay.portal.kernel.util.OrderByComparator.class
 			};
 	private static final Class<?>[]
-		_getFoldersAndFileEntriesAndFileShortcutsCountParameterTypes16 =
+		_getFoldersAndFileEntriesAndFileShortcutsCountParameterTypes17 =
 			new Class[] {long.class, long.class, int.class, boolean.class};
 	private static final Class<?>[]
-		_getFoldersAndFileEntriesAndFileShortcutsCountParameterTypes17 =
+		_getFoldersAndFileEntriesAndFileShortcutsCountParameterTypes18 =
 			new Class[] {
 				long.class, long.class, int.class, String[].class, boolean.class
 			};
 	private static final Class<?>[]
-		_getFoldersAndFileEntriesAndFileShortcutsCountParameterTypes18 =
+		_getFoldersAndFileEntriesAndFileShortcutsCountParameterTypes19 =
 			new Class[] {
 				long.class, long.class, String[].class, boolean.class, int.class
 			};
 	private static final Class<?>[]
-		_getFoldersAndFileEntriesAndFileShortcutsCountParameterTypes19 =
+		_getFoldersAndFileEntriesAndFileShortcutsCountParameterTypes20 =
 			new Class[] {
 				long.class, long.class, String[].class, boolean.class,
 				com.liferay.portal.kernel.dao.orm.QueryDefinition.class
 			};
 	private static final Class<?>[]
-		_getFoldersAndFileEntriesAndFileShortcutsCountParameterTypes20 =
+		_getFoldersAndFileEntriesAndFileShortcutsCountParameterTypes21 =
 			new Class[] {
 				long.class, long.class, String[].class, long.class,
 				boolean.class, int.class
 			};
-	private static final Class<?>[] _getFoldersCountParameterTypes21 =
-		new Class[] {long.class, long.class};
 	private static final Class<?>[] _getFoldersCountParameterTypes22 =
-		new Class[] {long.class, long.class, boolean.class, int.class};
+		new Class[] {long.class, long.class};
 	private static final Class<?>[] _getFoldersCountParameterTypes23 =
+		new Class[] {long.class, long.class, boolean.class, int.class};
+	private static final Class<?>[] _getFoldersCountParameterTypes24 =
 		new Class[] {long.class, long.class, int.class, boolean.class};
-	private static final Class<?>[] _getMountFoldersParameterTypes24 =
+	private static final Class<?>[] _getMountFoldersParameterTypes25 =
 		new Class[] {
 			long.class, long.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getMountFoldersCountParameterTypes25 =
+	private static final Class<?>[] _getMountFoldersCountParameterTypes26 =
 		new Class[] {long.class, long.class};
-	private static final Class<?>[] _getSubfolderIdsParameterTypes26 =
+	private static final Class<?>[] _getSubfolderIdsParameterTypes27 =
 		new Class[] {
 			java.util.List.class, long.class, long.class, boolean.class
 		};
-	private static final Class<?>[] _getSubfolderIdsParameterTypes27 =
+	private static final Class<?>[] _getSubfolderIdsParameterTypes28 =
 		new Class[] {long.class, long.class, boolean.class};
-	private static final Class<?>[] _hasFolderLockParameterTypes28 =
+	private static final Class<?>[] _hasFolderLockParameterTypes29 =
 		new Class[] {long.class};
-	private static final Class<?>[] _hasInheritableLockParameterTypes29 =
+	private static final Class<?>[] _hasInheritableLockParameterTypes30 =
 		new Class[] {long.class};
-	private static final Class<?>[] _isFolderLockedParameterTypes30 =
+	private static final Class<?>[] _isFolderLockedParameterTypes31 =
 		new Class[] {long.class};
-	private static final Class<?>[] _lockFolderParameterTypes31 = new Class[] {
+	private static final Class<?>[] _lockFolderParameterTypes32 = new Class[] {
 		long.class
 	};
-	private static final Class<?>[] _lockFolderParameterTypes32 = new Class[] {
+	private static final Class<?>[] _lockFolderParameterTypes33 = new Class[] {
 		long.class, String.class, boolean.class, long.class
 	};
-	private static final Class<?>[] _moveFolderParameterTypes33 = new Class[] {
+	private static final Class<?>[] _moveFolderParameterTypes34 = new Class[] {
 		long.class, long.class,
 		com.liferay.portal.kernel.service.ServiceContext.class
 	};
-	private static final Class<?>[] _refreshFolderLockParameterTypes34 =
+	private static final Class<?>[] _refreshFolderLockParameterTypes35 =
 		new Class[] {String.class, long.class, long.class};
-	private static final Class<?>[] _unlockFolderParameterTypes35 =
-		new Class[] {long.class, long.class, String.class, String.class};
 	private static final Class<?>[] _unlockFolderParameterTypes36 =
+		new Class[] {long.class, long.class, String.class, String.class};
+	private static final Class<?>[] _unlockFolderParameterTypes37 =
 		new Class[] {long.class, String.class};
-	private static final Class<?>[] _updateFolderParameterTypes37 =
+	private static final Class<?>[] _updateFolderParameterTypes38 =
 		new Class[] {
 			long.class, long.class, String.class, String.class, long.class,
 			java.util.List.class, int.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _updateFolderParameterTypes38 =
+	private static final Class<?>[] _updateFolderParameterTypes39 =
 		new Class[] {
 			long.class, String.class, String.class, long.class,
 			java.util.List.class, int.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _verifyInheritableLockParameterTypes39 =
+	private static final Class<?>[] _verifyInheritableLockParameterTypes40 =
 		new Class[] {long.class, String.class};
 
 }

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppLocalServiceImpl.java
@@ -408,14 +408,16 @@ public class DLAppLocalServiceImpl extends DLAppLocalServiceBaseImpl {
 	 */
 	@Override
 	public Folder addFolder(
-			long userId, long repositoryId, long parentFolderId, String name,
-			String description, ServiceContext serviceContext)
+			String externalReferenceCode, long userId, long repositoryId,
+			long parentFolderId, String name, String description,
+			ServiceContext serviceContext)
 		throws PortalException {
 
 		LocalRepository localRepository = getLocalRepository(repositoryId);
 
 		Folder folder = localRepository.addFolder(
-			userId, parentFolderId, name, description, serviceContext);
+			externalReferenceCode, userId, parentFolderId, name, description,
+			serviceContext);
 
 		_dlAppHelperLocalService.addFolder(userId, folder, serviceContext);
 
@@ -572,6 +574,17 @@ public class DLAppLocalServiceImpl extends DLAppLocalServiceBaseImpl {
 		LocalRepository localRepository = getLocalRepository(groupId);
 
 		return localRepository.fetchFileEntryByExternalReferenceCode(
+			externalReferenceCode);
+	}
+
+	@Override
+	public Folder fetchFolderByExternalReferenceCode(
+			long groupId, String externalReferenceCode)
+		throws PortalException {
+
+		LocalRepository localRepository = getLocalRepository(groupId);
+
+		return localRepository.fetchFolderByExternalReferenceCode(
 			externalReferenceCode);
 	}
 
@@ -782,6 +795,17 @@ public class DLAppLocalServiceImpl extends DLAppLocalServiceBaseImpl {
 		LocalRepository localRepository = getLocalRepository(repositoryId);
 
 		return localRepository.getFolder(parentFolderId, name);
+	}
+
+	@Override
+	public Folder getFolderByExternalReferenceCode(
+			long groupId, String externalReferenceCode)
+		throws PortalException {
+
+		LocalRepository localRepository = getLocalRepository(groupId);
+
+		return localRepository.getFolderByExternalReferenceCode(
+			externalReferenceCode);
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppServiceImpl.java
@@ -418,14 +418,16 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 	 */
 	@Override
 	public Folder addFolder(
-			long repositoryId, long parentFolderId, String name,
-			String description, ServiceContext serviceContext)
+			String externalReferenceCode, long repositoryId,
+			long parentFolderId, String name, String description,
+			ServiceContext serviceContext)
 		throws PortalException {
 
 		Repository repository = getRepository(repositoryId);
 
 		Folder folder = repository.addFolder(
-			getUserId(), parentFolderId, name, description, serviceContext);
+			externalReferenceCode, getUserId(), parentFolderId, name,
+			description, serviceContext);
 
 		_dlAppHelperLocalService.addFolder(getUserId(), folder, serviceContext);
 
@@ -1429,6 +1431,17 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 		Repository repository = getRepository(repositoryId);
 
 		return repository.getFolder(parentFolderId, name);
+	}
+
+	@Override
+	public Folder getFolderByExternalReferenceCode(
+			long groupId, String externalReferenceCode)
+		throws PortalException {
+
+		Repository repository = getRepository(groupId);
+
+		return repository.getFolderByExternalReferenceCode(
+			externalReferenceCode);
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFolderLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFolderLocalServiceImpl.java
@@ -16,6 +16,7 @@ package com.liferay.portlet.documentlibrary.service.impl;
 
 import com.liferay.asset.kernel.service.AssetEntryLocalService;
 import com.liferay.document.library.kernel.exception.DuplicateFileEntryException;
+import com.liferay.document.library.kernel.exception.DuplicateFolderExternalReferenceCodeException;
 import com.liferay.document.library.kernel.exception.DuplicateFolderNameException;
 import com.liferay.document.library.kernel.exception.FolderNameException;
 import com.liferay.document.library.kernel.exception.InvalidFolderException;
@@ -108,9 +109,10 @@ public class DLFolderLocalServiceImpl extends DLFolderLocalServiceBaseImpl {
 
 	@Override
 	public DLFolder addFolder(
-			long userId, long groupId, long repositoryId, boolean mountPoint,
-			long parentFolderId, String name, String description,
-			boolean hidden, ServiceContext serviceContext)
+			String externalReferenceCode, long userId, long groupId,
+			long repositoryId, boolean mountPoint, long parentFolderId,
+			String name, String description, boolean hidden,
+			ServiceContext serviceContext)
 		throws PortalException {
 
 		// Folder
@@ -124,11 +126,14 @@ public class DLFolderLocalServiceImpl extends DLFolderLocalServiceBaseImpl {
 
 		long folderId = counterLocalService.increment();
 
+		_validateExternalReferenceCode(externalReferenceCode, groupId);
+
 		DLFolder dlFolder = dlFolderPersistence.create(folderId);
 
 		dlFolder.setUuid(serviceContext.getUuid());
 		dlFolder.setGroupId(groupId);
 		dlFolder.setCompanyId(user.getCompanyId());
+		dlFolder.setExternalReferenceCode(externalReferenceCode);
 		dlFolder.setUserId(user.getUserId());
 		dlFolder.setUserName(user.getFullName());
 		dlFolder.setRepositoryId(repositoryId);
@@ -1394,6 +1399,25 @@ public class DLFolderLocalServiceImpl extends DLFolderLocalServiceBaseImpl {
 				StringBundler.concat(
 					"Folder name ", folderName,
 					" is invalid because it contains a /"));
+		}
+	}
+
+	private void _validateExternalReferenceCode(
+			String externalReferenceCode, long groupId)
+		throws PortalException {
+
+		if (Validator.isNull(externalReferenceCode)) {
+			return;
+		}
+
+		DLFolder dlFolder = dlFolderPersistence.fetchByG_ERC(
+			groupId, externalReferenceCode);
+
+		if (dlFolder != null) {
+			throw new DuplicateFolderExternalReferenceCodeException(
+				StringBundler.concat(
+					"Duplicate folder external reference code ",
+					externalReferenceCode, " in group ", groupId));
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFolderServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFolderServiceImpl.java
@@ -43,9 +43,9 @@ public class DLFolderServiceImpl extends DLFolderServiceBaseImpl {
 
 	@Override
 	public DLFolder addFolder(
-			long groupId, long repositoryId, boolean mountPoint,
-			long parentFolderId, String name, String description,
-			ServiceContext serviceContext)
+			String externalReferenceCode, long groupId, long repositoryId,
+			boolean mountPoint, long parentFolderId, String name,
+			String description, ServiceContext serviceContext)
 		throws PortalException {
 
 		ModelResourcePermissionUtil.check(
@@ -53,8 +53,9 @@ public class DLFolderServiceImpl extends DLFolderServiceBaseImpl {
 			parentFolderId, ActionKeys.ADD_FOLDER);
 
 		return dlFolderLocalService.addFolder(
-			getUserId(), groupId, repositoryId, mountPoint, parentFolderId,
-			name, description, false, serviceContext);
+			externalReferenceCode, getUserId(), groupId, repositoryId,
+			mountPoint, parentFolderId, name, description, false,
+			serviceContext);
 	}
 
 	@Override
@@ -82,6 +83,21 @@ public class DLFolderServiceImpl extends DLFolderServiceBaseImpl {
 		DLFolder dlFolder = getFolder(groupId, parentFolderId, name);
 
 		deleteFolder(dlFolder.getFolderId());
+	}
+
+	@Override
+	public DLFolder getDLFolderByExternalReferenceCode(
+			long groupId, String externalReferenceCode)
+		throws PortalException {
+
+		DLFolder dlFolder =
+			dlFolderLocalService.getDLFolderByExternalReferenceCode(
+				groupId, externalReferenceCode);
+
+		_dlFolderModelResourcePermission.check(
+			getPermissionChecker(), dlFolder, ActionKeys.VIEW);
+
+		return dlFolder;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/sharepoint/DLSharepointStorageImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/sharepoint/DLSharepointStorageImpl.java
@@ -105,7 +105,8 @@ public class DLSharepointStorageImpl extends BaseSharepointStorageImpl {
 		serviceContext.setAddGuestPermissions(true);
 
 		DLAppServiceUtil.addFolder(
-			groupId, parentFolderId, folderName, description, serviceContext);
+			null, groupId, parentFolderId, folderName, description,
+			serviceContext);
 	}
 
 	@Override

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppLocalService.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppLocalService.java
@@ -270,8 +270,9 @@ public interface DLAppLocalService extends BaseLocalService {
 	 * @throws PortalException if a portal exception occurred
 	 */
 	public Folder addFolder(
-			long userId, long repositoryId, long parentFolderId, String name,
-			String description, ServiceContext serviceContext)
+			String externalReferenceCode, long userId, long repositoryId,
+			long parentFolderId, String name, String description,
+			ServiceContext serviceContext)
 		throws PortalException;
 
 	/**
@@ -349,6 +350,11 @@ public interface DLAppLocalService extends BaseLocalService {
 	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public FileEntry fetchFileEntryByExternalReferenceCode(
+			long groupId, String externalReferenceCode)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public Folder fetchFolderByExternalReferenceCode(
 			long groupId, String externalReferenceCode)
 		throws PortalException;
 
@@ -458,6 +464,11 @@ public interface DLAppLocalService extends BaseLocalService {
 	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public Folder getFolder(long repositoryId, long parentFolderId, String name)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public Folder getFolderByExternalReferenceCode(
+			long groupId, String externalReferenceCode)
 		throws PortalException;
 
 	/**

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppLocalServiceUtil.java
@@ -296,14 +296,14 @@ public class DLAppLocalServiceUtil {
 	 * @throws PortalException if a portal exception occurred
 	 */
 	public static com.liferay.portal.kernel.repository.model.Folder addFolder(
-			long userId, long repositoryId, long parentFolderId, String name,
-			String description,
+			String externalReferenceCode, long userId, long repositoryId,
+			long parentFolderId, String name, String description,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {
 
 		return getService().addFolder(
-			userId, repositoryId, parentFolderId, name, description,
-			serviceContext);
+			externalReferenceCode, userId, repositoryId, parentFolderId, name,
+			description, serviceContext);
 	}
 
 	/**
@@ -414,6 +414,15 @@ public class DLAppLocalServiceUtil {
 		throws PortalException {
 
 		return getService().fetchFileEntryByExternalReferenceCode(
+			groupId, externalReferenceCode);
+	}
+
+	public static com.liferay.portal.kernel.repository.model.Folder
+			fetchFolderByExternalReferenceCode(
+				long groupId, String externalReferenceCode)
+		throws PortalException {
+
+		return getService().fetchFolderByExternalReferenceCode(
 			groupId, externalReferenceCode);
 	}
 
@@ -552,6 +561,15 @@ public class DLAppLocalServiceUtil {
 		throws PortalException {
 
 		return getService().getFolder(repositoryId, parentFolderId, name);
+	}
+
+	public static com.liferay.portal.kernel.repository.model.Folder
+			getFolderByExternalReferenceCode(
+				long groupId, String externalReferenceCode)
+		throws PortalException {
+
+		return getService().getFolderByExternalReferenceCode(
+			groupId, externalReferenceCode);
 	}
 
 	/**

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppLocalServiceWrapper.java
@@ -292,14 +292,14 @@ public class DLAppLocalServiceWrapper
 	 */
 	@Override
 	public com.liferay.portal.kernel.repository.model.Folder addFolder(
-			long userId, long repositoryId, long parentFolderId, String name,
-			String description,
+			String externalReferenceCode, long userId, long repositoryId,
+			long parentFolderId, String name, String description,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _dlAppLocalService.addFolder(
-			userId, repositoryId, parentFolderId, name, description,
-			serviceContext);
+			externalReferenceCode, userId, repositoryId, parentFolderId, name,
+			description, serviceContext);
 	}
 
 	/**
@@ -423,6 +423,16 @@ public class DLAppLocalServiceWrapper
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _dlAppLocalService.fetchFileEntryByExternalReferenceCode(
+			groupId, externalReferenceCode);
+	}
+
+	@Override
+	public com.liferay.portal.kernel.repository.model.Folder
+			fetchFolderByExternalReferenceCode(
+				long groupId, String externalReferenceCode)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _dlAppLocalService.fetchFolderByExternalReferenceCode(
 			groupId, externalReferenceCode);
 	}
 
@@ -571,6 +581,16 @@ public class DLAppLocalServiceWrapper
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _dlAppLocalService.getFolder(repositoryId, parentFolderId, name);
+	}
+
+	@Override
+	public com.liferay.portal.kernel.repository.model.Folder
+			getFolderByExternalReferenceCode(
+				long groupId, String externalReferenceCode)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _dlAppLocalService.getFolderByExternalReferenceCode(
+			groupId, externalReferenceCode);
 	}
 
 	/**

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppService.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppService.java
@@ -271,8 +271,9 @@ public interface DLAppService extends BaseService {
 	 * @throws PortalException if a portal exception occurred
 	 */
 	public Folder addFolder(
-			long repositoryId, long parentFolderId, String name,
-			String description, ServiceContext serviceContext)
+			String externalReferenceCode, long repositoryId,
+			long parentFolderId, String name, String description,
+			ServiceContext serviceContext)
 		throws PortalException;
 
 	/**
@@ -884,6 +885,11 @@ public interface DLAppService extends BaseService {
 	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public Folder getFolder(long repositoryId, long parentFolderId, String name)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public Folder getFolderByExternalReferenceCode(
+			long groupId, String externalReferenceCode)
 		throws PortalException;
 
 	/**

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppServiceUtil.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppServiceUtil.java
@@ -280,13 +280,14 @@ public class DLAppServiceUtil {
 	 * @throws PortalException if a portal exception occurred
 	 */
 	public static com.liferay.portal.kernel.repository.model.Folder addFolder(
-			long repositoryId, long parentFolderId, String name,
-			String description,
+			String externalReferenceCode, long repositoryId,
+			long parentFolderId, String name, String description,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {
 
 		return getService().addFolder(
-			repositoryId, parentFolderId, name, description, serviceContext);
+			externalReferenceCode, repositoryId, parentFolderId, name,
+			description, serviceContext);
 	}
 
 	/**
@@ -1045,6 +1046,15 @@ public class DLAppServiceUtil {
 		throws PortalException {
 
 		return getService().getFolder(repositoryId, parentFolderId, name);
+	}
+
+	public static com.liferay.portal.kernel.repository.model.Folder
+			getFolderByExternalReferenceCode(
+				long groupId, String externalReferenceCode)
+		throws PortalException {
+
+		return getService().getFolderByExternalReferenceCode(
+			groupId, externalReferenceCode);
 	}
 
 	/**

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppServiceWrapper.java
@@ -274,13 +274,14 @@ public class DLAppServiceWrapper
 	 */
 	@Override
 	public com.liferay.portal.kernel.repository.model.Folder addFolder(
-			long repositoryId, long parentFolderId, String name,
-			String description,
+			String externalReferenceCode, long repositoryId,
+			long parentFolderId, String name, String description,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _dlAppService.addFolder(
-			repositoryId, parentFolderId, name, description, serviceContext);
+			externalReferenceCode, repositoryId, parentFolderId, name,
+			description, serviceContext);
 	}
 
 	/**
@@ -1083,6 +1084,16 @@ public class DLAppServiceWrapper
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _dlAppService.getFolder(repositoryId, parentFolderId, name);
+	}
+
+	@Override
+	public com.liferay.portal.kernel.repository.model.Folder
+			getFolderByExternalReferenceCode(
+				long groupId, String externalReferenceCode)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _dlAppService.getFolderByExternalReferenceCode(
+			groupId, externalReferenceCode);
 	}
 
 	/**

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFolderLocalService.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFolderLocalService.java
@@ -102,9 +102,10 @@ public interface DLFolderLocalService
 	public DLFolder addDLFolder(DLFolder dlFolder);
 
 	public DLFolder addFolder(
-			long userId, long groupId, long repositoryId, boolean mountPoint,
-			long parentFolderId, String name, String description,
-			boolean hidden, ServiceContext serviceContext)
+			String externalReferenceCode, long userId, long groupId,
+			long repositoryId, boolean mountPoint, long parentFolderId,
+			String name, String description, boolean hidden,
+			ServiceContext serviceContext)
 		throws PortalException;
 
 	public void clearDLFileEntryTypeDLFolders(long fileEntryTypeId);

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFolderLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFolderLocalServiceUtil.java
@@ -84,15 +84,15 @@ public class DLFolderLocalServiceUtil {
 	}
 
 	public static DLFolder addFolder(
-			long userId, long groupId, long repositoryId, boolean mountPoint,
-			long parentFolderId, String name, String description,
-			boolean hidden,
+			String externalReferenceCode, long userId, long groupId,
+			long repositoryId, boolean mountPoint, long parentFolderId,
+			String name, String description, boolean hidden,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {
 
 		return getService().addFolder(
-			userId, groupId, repositoryId, mountPoint, parentFolderId, name,
-			description, hidden, serviceContext);
+			externalReferenceCode, userId, groupId, repositoryId, mountPoint,
+			parentFolderId, name, description, hidden, serviceContext);
 	}
 
 	public static void clearDLFileEntryTypeDLFolders(long fileEntryTypeId) {

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFolderLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFolderLocalServiceWrapper.java
@@ -88,15 +88,15 @@ public class DLFolderLocalServiceWrapper
 
 	@Override
 	public DLFolder addFolder(
-			long userId, long groupId, long repositoryId, boolean mountPoint,
-			long parentFolderId, String name, String description,
-			boolean hidden,
+			String externalReferenceCode, long userId, long groupId,
+			long repositoryId, boolean mountPoint, long parentFolderId,
+			String name, String description, boolean hidden,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _dlFolderLocalService.addFolder(
-			userId, groupId, repositoryId, mountPoint, parentFolderId, name,
-			description, hidden, serviceContext);
+			externalReferenceCode, userId, groupId, repositoryId, mountPoint,
+			parentFolderId, name, description, hidden, serviceContext);
 	}
 
 	@Override

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFolderService.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFolderService.java
@@ -58,9 +58,9 @@ public interface DLFolderService extends BaseService {
 	 * Never modify this interface directly. Add custom service methods to <code>com.liferay.portlet.documentlibrary.service.impl.DLFolderServiceImpl</code> and rerun ServiceBuilder to automatically copy the method declarations to this interface. Consume the document library folder remote service via injection or a <code>org.osgi.util.tracker.ServiceTracker</code>. Use {@link DLFolderServiceUtil} if injection and service tracking are not available.
 	 */
 	public DLFolder addFolder(
-			long groupId, long repositoryId, boolean mountPoint,
-			long parentFolderId, String name, String description,
-			ServiceContext serviceContext)
+			String externalReferenceCode, long groupId, long repositoryId,
+			boolean mountPoint, long parentFolderId, String name,
+			String description, ServiceContext serviceContext)
 		throws PortalException;
 
 	public void deleteFolder(long folderId) throws PortalException;
@@ -69,6 +69,11 @@ public interface DLFolderService extends BaseService {
 		throws PortalException;
 
 	public void deleteFolder(long groupId, long parentFolderId, String name)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public DLFolder getDLFolderByExternalReferenceCode(
+			long groupId, String externalReferenceCode)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFolderServiceUtil.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFolderServiceUtil.java
@@ -40,14 +40,15 @@ public class DLFolderServiceUtil {
 	 * Never modify this class directly. Add custom service methods to <code>com.liferay.portlet.documentlibrary.service.impl.DLFolderServiceImpl</code> and rerun ServiceBuilder to regenerate this class.
 	 */
 	public static DLFolder addFolder(
-			long groupId, long repositoryId, boolean mountPoint,
-			long parentFolderId, String name, String description,
+			String externalReferenceCode, long groupId, long repositoryId,
+			boolean mountPoint, long parentFolderId, String name,
+			String description,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {
 
 		return getService().addFolder(
-			groupId, repositoryId, mountPoint, parentFolderId, name,
-			description, serviceContext);
+			externalReferenceCode, groupId, repositoryId, mountPoint,
+			parentFolderId, name, description, serviceContext);
 	}
 
 	public static void deleteFolder(long folderId) throws PortalException {
@@ -66,6 +67,14 @@ public class DLFolderServiceUtil {
 		throws PortalException {
 
 		getService().deleteFolder(groupId, parentFolderId, name);
+	}
+
+	public static DLFolder getDLFolderByExternalReferenceCode(
+			long groupId, String externalReferenceCode)
+		throws PortalException {
+
+		return getService().getDLFolderByExternalReferenceCode(
+			groupId, externalReferenceCode);
 	}
 
 	public static List<Object> getFileEntriesAndFileShortcuts(

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFolderServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFolderServiceWrapper.java
@@ -37,14 +37,15 @@ public class DLFolderServiceWrapper
 
 	@Override
 	public DLFolder addFolder(
-			long groupId, long repositoryId, boolean mountPoint,
-			long parentFolderId, String name, String description,
+			String externalReferenceCode, long groupId, long repositoryId,
+			boolean mountPoint, long parentFolderId, String name,
+			String description,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _dlFolderService.addFolder(
-			groupId, repositoryId, mountPoint, parentFolderId, name,
-			description, serviceContext);
+			externalReferenceCode, groupId, repositoryId, mountPoint,
+			parentFolderId, name, description, serviceContext);
 	}
 
 	@Override
@@ -66,6 +67,15 @@ public class DLFolderServiceWrapper
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		_dlFolderService.deleteFolder(groupId, parentFolderId, name);
+	}
+
+	@Override
+	public DLFolder getDLFolderByExternalReferenceCode(
+			long groupId, String externalReferenceCode)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _dlFolderService.getDLFolderByExternalReferenceCode(
+			groupId, externalReferenceCode);
 	}
 
 	@Override

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/packageinfo
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/packageinfo
@@ -1,1 +1,1 @@
-version 7.1.0
+version 8.0.0

--- a/portal-kernel/src/com/liferay/portal/kernel/repository/BaseRepositoryImpl.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/repository/BaseRepositoryImpl.java
@@ -84,6 +84,17 @@ public abstract class BaseRepositoryImpl
 		throws PortalException;
 
 	@Override
+	public Folder addFolder(
+			String externalReferenceCode, long userId, long parentFolderId,
+			String name, String description, ServiceContext serviceContext)
+		throws PortalException {
+
+		return addFolder(
+			externalReferenceCode, userId, parentFolderId, name, description,
+			serviceContext);
+	}
+
+	@Override
 	public abstract void checkInFileEntry(
 			long userId, long fileEntryId,
 			DLVersionNumberIncrease dlVersionNumberIncrease, String changeLog,

--- a/portal-kernel/src/com/liferay/portal/kernel/repository/DefaultLocalRepositoryImpl.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/repository/DefaultLocalRepositoryImpl.java
@@ -90,6 +90,14 @@ public class DefaultLocalRepositoryImpl implements LocalRepository {
 	}
 
 	@Override
+	public Folder addFolder(
+		String externalReferenceCode, long userId, long parentFolderId,
+		String name, String description, ServiceContext serviceContext) {
+
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
 	public void checkInFileEntry(
 			long userId, long fileEntryId,
 			DLVersionNumberIncrease dlVersionNumberIncrease, String changeLog,

--- a/portal-kernel/src/com/liferay/portal/kernel/repository/DocumentRepository.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/repository/DocumentRepository.java
@@ -63,6 +63,11 @@ public interface DocumentRepository extends CapabilityProvider {
 			ServiceContext serviceContext)
 		throws PortalException;
 
+	public Folder addFolder(
+			String externalReferenceCode, long userId, long parentFolderId,
+			String name, String description, ServiceContext serviceContext)
+		throws PortalException;
+
 	public void checkInFileEntry(
 			long userId, long fileEntryId,
 			DLVersionNumberIncrease dlVersionNumberIncrease, String changeLog,
@@ -98,6 +103,12 @@ public interface DocumentRepository extends CapabilityProvider {
 	}
 
 	public default FileEntry fetchFileEntryByExternalReferenceCode(
+		String externalReferenceCode) {
+
+		return null;
+	}
+
+	public default Folder fetchFolderByExternalReferenceCode(
 		String externalReferenceCode) {
 
 		return null;
@@ -180,6 +191,13 @@ public interface DocumentRepository extends CapabilityProvider {
 
 	public Folder getFolder(long parentFolderId, String name)
 		throws PortalException;
+
+	public default Folder getFolderByExternalReferenceCode(
+			String externalReferenceCode)
+		throws PortalException {
+
+		return null;
+	}
 
 	public List<Folder> getFolders(
 			long parentFolderId, boolean includeMountFolders, int start,

--- a/portal-kernel/src/com/liferay/portal/kernel/repository/model/Folder.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/repository/model/Folder.java
@@ -63,6 +63,10 @@ public interface Folder extends RepositoryEntry, RepositoryModel<Folder> {
 
 	public String getDescription();
 
+	public default String getExternalReferenceCode() {
+		return getUuid();
+	}
+
 	public long getFolderId();
 
 	@Override

--- a/portal-kernel/src/com/liferay/portal/kernel/repository/model/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/repository/model/packageinfo
@@ -1,1 +1,1 @@
-version 11.0.0
+version 11.1.0

--- a/portal-kernel/src/com/liferay/portal/kernel/repository/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/repository/packageinfo
@@ -1,1 +1,1 @@
-version 12.1.0
+version 13.0.0

--- a/portal-kernel/src/com/liferay/portal/kernel/repository/proxy/BaseRepositoryProxyBean.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/repository/proxy/BaseRepositoryProxyBean.java
@@ -121,6 +121,19 @@ public class BaseRepositoryProxyBean
 	}
 
 	@Override
+	public Folder addFolder(
+			String externalReferenceCode, long userId, long parentFolderId,
+			String name, String description, ServiceContext serviceContext)
+		throws PortalException {
+
+		Folder folder = _baseRepository.addFolder(
+			externalReferenceCode, userId, parentFolderId, name, description,
+			serviceContext);
+
+		return newFolderProxyBean(folder);
+	}
+
+	@Override
 	public FileVersion cancelCheckOut(long fileEntryId) throws PortalException {
 		return _baseRepository.cancelCheckOut(fileEntryId);
 	}

--- a/portal-kernel/src/com/liferay/portal/kernel/repository/proxy/LocalRepositoryProxyBean.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/repository/proxy/LocalRepositoryProxyBean.java
@@ -104,6 +104,19 @@ public class LocalRepositoryProxyBean
 	}
 
 	@Override
+	public Folder addFolder(
+			String externalReferenceCode, long userId, long parentFolderId,
+			String name, String description, ServiceContext serviceContext)
+		throws PortalException {
+
+		Folder folder = _localRepository.addFolder(
+			externalReferenceCode, userId, parentFolderId, name, description,
+			serviceContext);
+
+		return newFolderProxyBean(folder);
+	}
+
+	@Override
 	public void checkInFileEntry(
 			long userId, long fileEntryId,
 			DLVersionNumberIncrease dlVersionNumberIncrease, String changeLog,

--- a/portal-kernel/src/com/liferay/portal/kernel/repository/proxy/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/repository/proxy/packageinfo
@@ -1,1 +1,1 @@
-version 6.1.0
+version 6.2.0


### PR DESCRIPTION
Hi guys, I've opened this PR because most of the service changes I've made are related to your components. I'm going to introduced what are the changes that you should reviewed. Our team has verified that the errors appearing in the CI are not related, but we still want your approval, you can see [here](https://github.com/liferay-frontend/liferay-portal/pull/2548). You can check the desciption in the link of the PR from frontend-infra. Let's give you a little context.

## Main Objective
The main of this PR is to expose `externalReferenceCode` in DocumentsFolder. For that reason I have made some changes in the service part and in the API part.

## Service part
The main changes that you should review, are the following:

- Those changes related to `documentlibrary` in portal-impl. These changes are related because we add the new argument using `externalReferenceCode`.
- In the same way, in those modules I have implemented two new methods to obtain a DLFolder usign the `externalReferenceCode`, which are `fetchFolderByExteranlReferenceCode` and `getFolderByExteranlReferenceCode`.
- As there are some changes that affect the service part of DLFolder, I want to be sure that the Staging mode works correctly, some changes are added.
- New Upgrade process, if the `externalReferenceCode` is `null` or "", the data base will save the `externalReferenceCode` using the `UUID`.
- Requested changes in https://github.com/brianchandotcom/liferay-portal/pull/121934#issuecomment-1221215791

## API part
However, this part can be ignored, beause it is reviewed by our members of the team.

If you have any problem, or any doubt, please contact me :smiley: 

**JIRA TICKET**
https://issues.liferay.com/browse/LPS-154730