### PR TITLE
LPS-162866 If virus detected, message is skipped on the create/edit page on DM

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_entry.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_entry.jsp
@@ -211,6 +211,15 @@ renderResponse.setTitle(headerTitle);
 				<liferay-ui:message key="<%= ase.getMessageKey() %>" />
 			</liferay-ui:error>
 
+			<liferay-ui:error exception="<%= AntivirusVirusFoundException.class %>">
+
+				<%
+				AntivirusVirusFoundException antivirusVirusFoundException = (AntivirusVirusFoundException)errorException;
+				%>
+
+				<liferay-ui:message key="<%= antivirusVirusFoundException.getMessageKey() %>" />
+			</liferay-ui:error>
+
 			<liferay-ui:error exception="<%= DLStorageQuotaExceededException.class %>">
 				<liferay-ui:message arguments="<%= LanguageUtil.formatStorageSize(PropsValues.DATA_LIMIT_DL_STORAGE_MAX_SIZE, locale) %>" key="you-have-exceeded-the-x-storage-quota-for-this-instance" />
 			</liferay-ui:error>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_entry.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_entry.jsp
@@ -205,10 +205,10 @@ renderResponse.setTitle(headerTitle);
 			<liferay-ui:error exception="<%= AntivirusScannerException.class %>">
 
 				<%
-				AntivirusScannerException ase = (AntivirusScannerException)errorException;
+				AntivirusScannerException antivirusScannerException = (AntivirusScannerException)errorException;
 				%>
 
-				<liferay-ui:message key="<%= ase.getMessageKey() %>" />
+				<liferay-ui:message key="<%= antivirusScannerException.getMessageKey() %>" />
 			</liferay-ui:error>
 
 			<liferay-ui:error exception="<%= AntivirusVirusFoundException.class %>">

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/init.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/init.jsp
@@ -22,6 +22,7 @@ taglib uri="http://liferay.com/tld/react" prefix="react" %>
 page import="com.liferay.digital.signature.constants.DigitalSignaturePortletKeys" %><%@
 page import="com.liferay.document.library.configuration.DLConfiguration" %><%@
 page import="com.liferay.document.library.exception.DLStorageQuotaExceededException" %><%@
+page import="com.liferay.document.library.kernel.antivirus.AntivirusVirusFoundException" %><%@
 page import="com.liferay.document.library.kernel.model.DLVersionNumberIncrease" %><%@
 page import="com.liferay.document.library.kernel.util.DLValidatorUtil" %><%@
 page import="com.liferay.document.library.web.internal.bulk.selection.BulkSelectionRunnerUtil" %><%@


### PR DESCRIPTION
- LPS-162866 Error Tag compares by name not by instanceOf, and we are getting an AntivirusVirusFoundException so no message is found
- LPS-162866 rename exception
