### PR TITLE
LPS-163051 Create services to retrieve paginated file versions for DL 

### DIFF
--- a/modules/apps/document-library/document-library-repository-cmis-impl/src/main/java/com/liferay/document/library/repository/cmis/internal/model/CMISFileEntry.java
+++ b/modules/apps/document-library/document-library-repository-cmis-impl/src/main/java/com/liferay/document/library/repository/cmis/internal/model/CMISFileEntry.java
@@ -273,6 +273,11 @@ public class CMISFileEntry extends BaseCMISModel implements FileEntry {
 	}
 
 	@Override
+	public List<FileVersion> getFileVersions(int status, int start, int end) {
+		return getFileVersions(status);
+	}
+
+	@Override
 	public int getFileVersionsCount(int status) {
 		try {
 			List<Document> documents = getAllVersions();

--- a/modules/apps/document-library/document-library-repository-external-api/bnd.bnd
+++ b/modules/apps/document-library/document-library-repository-external-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Document Library Repository External API
 Bundle-SymbolicName: com.liferay.document.library.repository.external.api
-Bundle-Version: 7.0.2
+Bundle-Version: 7.1.0
 Export-Package:\
 	com.liferay.document.library.repository.external,\
 	com.liferay.document.library.repository.external.cache,\

--- a/modules/apps/document-library/document-library-repository-external-api/src/main/java/com/liferay/document/library/repository/external/model/ExtRepositoryFileEntryAdapter.java
+++ b/modules/apps/document-library/document-library-repository-external-api/src/main/java/com/liferay/document/library/repository/external/model/ExtRepositoryFileEntryAdapter.java
@@ -167,6 +167,12 @@ public class ExtRepositoryFileEntryAdapter
 	}
 
 	@Override
+	@SuppressWarnings("rawtypes")
+	public List<FileVersion> getFileVersions(int status, int start, int end) {
+		return getFileVersions(status);
+	}
+
+	@Override
 	public int getFileVersionsCount(int status) {
 		List<FileVersion> fileVersions = getFileVersions(status);
 

--- a/modules/apps/document-library/document-library-repository-external-api/src/main/resources/com/liferay/document/library/repository/external/model/packageinfo
+++ b/modules/apps/document-library/document-library-repository-external-api/src/main/resources/com/liferay/document/library/repository/external/model/packageinfo
@@ -1,1 +1,1 @@
-version 2.1.0
+version 2.2.0

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/upload/test/TestFileEntry.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/upload/test/TestFileEntry.java
@@ -146,6 +146,11 @@ public class TestFileEntry implements FileEntry {
 	}
 
 	@Override
+	public List<FileVersion> getFileVersions(int status, int start, int end) {
+		return Collections.emptyList();
+	}
+
+	@Override
 	public int getFileVersionsCount(int status) {
 		return 0;
 	}

--- a/portal-impl/src/com/liferay/portal/repository/liferayrepository/model/LiferayFileEntry.java
+++ b/portal-impl/src/com/liferay/portal/repository/liferayrepository/model/LiferayFileEntry.java
@@ -226,6 +226,12 @@ public class LiferayFileEntry extends LiferayModel implements FileEntry {
 	}
 
 	@Override
+	public List<FileVersion> getFileVersions(int status, int start, int end) {
+		return RepositoryModelUtil.toFileVersions(
+			_dlFileEntry.getFileVersions(status, start, end));
+	}
+
+	@Override
 	public int getFileVersionsCount(int status) {
 		return _dlFileEntry.getFileVersionsCount(status);
 	}

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLFileEntryImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLFileEntryImpl.java
@@ -201,6 +201,12 @@ public class DLFileEntryImpl extends DLFileEntryBaseImpl {
 	}
 
 	@Override
+	public List<DLFileVersion> getFileVersions(int status, int start, int end) {
+		return DLFileVersionLocalServiceUtil.getFileVersions(
+			getFileEntryId(), status, start, end);
+	}
+
+	@Override
 	public int getFileVersionsCount(int status) {
 		return DLFileVersionLocalServiceUtil.getFileVersionsCount(
 			getFileEntryId(), status);

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileVersionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileVersionLocalServiceImpl.java
@@ -109,6 +109,20 @@ public class DLFileVersionLocalServiceImpl
 	}
 
 	@Override
+	public List<DLFileVersion> getFileVersions(
+		long fileEntryId, int status, int start, int end) {
+
+		if (status == WorkflowConstants.STATUS_ANY) {
+			return dlFileVersionPersistence.findByFileEntryId(
+				fileEntryId, start, end, new DLFileVersionVersionComparator());
+		}
+
+		return dlFileVersionPersistence.findByF_S(
+			fileEntryId, status, start, end,
+			new DLFileVersionVersionComparator());
+	}
+
+	@Override
 	public int getFileVersionsCount(long fileEntryId, int status) {
 		if (status == WorkflowConstants.STATUS_ANY) {
 			return dlFileVersionPersistence.countByFileEntryId(fileEntryId);

--- a/portal-kernel/src/com/liferay/document/library/kernel/model/DLFileEntry.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/model/DLFileEntry.java
@@ -95,6 +95,9 @@ public interface DLFileEntry
 
 	public java.util.List<DLFileVersion> getFileVersions(int status);
 
+	public java.util.List<DLFileVersion> getFileVersions(
+		int status, int start, int end);
+
 	public int getFileVersionsCount(int status);
 
 	public DLFolder getFolder()

--- a/portal-kernel/src/com/liferay/document/library/kernel/model/DLFileEntryWrapper.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/model/DLFileEntryWrapper.java
@@ -536,6 +536,13 @@ public class DLFileEntryWrapper
 	}
 
 	@Override
+	public java.util.List<DLFileVersion> getFileVersions(
+		int status, int start, int end) {
+
+		return model.getFileVersions(status, start, end);
+	}
+
+	@Override
 	public int getFileVersionsCount(int status) {
 		return model.getFileVersionsCount(status);
 	}

--- a/portal-kernel/src/com/liferay/document/library/kernel/model/packageinfo
+++ b/portal-kernel/src/com/liferay/document/library/kernel/model/packageinfo
@@ -1,1 +1,1 @@
-version 6.1.0
+version 6.2.0

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileVersionLocalService.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileVersionLocalService.java
@@ -318,6 +318,10 @@ public interface DLFileVersionLocalService
 	public List<DLFileVersion> getFileVersions(long fileEntryId, int status);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<DLFileVersion> getFileVersions(
+		long fileEntryId, int status, int start, int end);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int getFileVersionsCount(long fileEntryId, int status);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileVersionLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileVersionLocalServiceUtil.java
@@ -353,6 +353,12 @@ public class DLFileVersionLocalServiceUtil {
 		return getService().getFileVersions(fileEntryId, status);
 	}
 
+	public static List<DLFileVersion> getFileVersions(
+		long fileEntryId, int status, int start, int end) {
+
+		return getService().getFileVersions(fileEntryId, status, start, end);
+	}
+
 	public static int getFileVersionsCount(long fileEntryId, int status) {
 		return getService().getFileVersionsCount(fileEntryId, status);
 	}

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileVersionLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileVersionLocalServiceWrapper.java
@@ -391,6 +391,14 @@ public class DLFileVersionLocalServiceWrapper
 	}
 
 	@Override
+	public java.util.List<DLFileVersion> getFileVersions(
+		long fileEntryId, int status, int start, int end) {
+
+		return _dlFileVersionLocalService.getFileVersions(
+			fileEntryId, status, start, end);
+	}
+
+	@Override
 	public int getFileVersionsCount(long fileEntryId, int status) {
 		return _dlFileVersionLocalService.getFileVersionsCount(
 			fileEntryId, status);

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/packageinfo
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/packageinfo
@@ -1,1 +1,1 @@
-version 7.1.0
+version 7.2.0

--- a/portal-kernel/src/com/liferay/document/library/kernel/util/comparator/DLFileVersionVersionComparator.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/util/comparator/DLFileVersionVersionComparator.java
@@ -15,21 +15,22 @@
 package com.liferay.document.library.kernel.util.comparator;
 
 import com.liferay.document.library.kernel.model.DLFileVersion;
-
-import java.util.Comparator;
+import com.liferay.portal.kernel.util.OrderByComparator;
 
 /**
  * @author Bruno Farache
  */
 public class DLFileVersionVersionComparator
-	implements Comparator<DLFileVersion> {
+	extends OrderByComparator<DLFileVersion> {
 
 	public DLFileVersionVersionComparator() {
 		this(false);
 	}
 
 	public DLFileVersionVersionComparator(boolean ascending) {
-		_versionNumberComparator = new VersionNumberComparator(ascending);
+		_ascending = ascending;
+
+		_versionNumberComparator = new VersionNumberComparator(_ascending);
 	}
 
 	@Override
@@ -40,10 +41,31 @@ public class DLFileVersionVersionComparator
 			dlFileVersion1.getVersion(), dlFileVersion2.getVersion());
 	}
 
+	@Override
+	public String getOrderBy() {
+		if (_ascending) {
+			return _ORDER_BY_ASC;
+		}
+
+		return _ORDER_BY_DESC;
+	}
+
+	@Override
+	public String[] getOrderByFields() {
+		return _ORDER_BY_FIELDS;
+	}
+
 	public boolean isAscending() {
 		return _versionNumberComparator.isAscending();
 	}
 
+	private static final String _ORDER_BY_ASC = "DLFileVersion.version ASC";
+
+	private static final String _ORDER_BY_DESC = "DLFileVersion.version DESC";
+
+	private static final String[] _ORDER_BY_FIELDS = {"version"};
+
+	private final boolean _ascending;
 	private final VersionNumberComparator _versionNumberComparator;
 
 }

--- a/portal-kernel/src/com/liferay/document/library/kernel/util/comparator/packageinfo
+++ b/portal-kernel/src/com/liferay/document/library/kernel/util/comparator/packageinfo
@@ -1,1 +1,1 @@
-version 2.1.0
+version 3.0.0

--- a/portal-kernel/src/com/liferay/portal/kernel/repository/model/FileEntry.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/repository/model/FileEntry.java
@@ -111,6 +111,8 @@ public interface FileEntry extends RepositoryEntry, RepositoryModel<FileEntry> {
 
 	public List<FileVersion> getFileVersions(int status);
 
+	public List<FileVersion> getFileVersions(int status, int start, int end);
+
 	public int getFileVersionsCount(int status);
 
 	public Folder getFolder();

--- a/portal-kernel/src/com/liferay/portal/kernel/repository/model/FileEntryWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/repository/model/FileEntryWrapper.java
@@ -154,6 +154,11 @@ public class FileEntryWrapper implements FileEntry, ModelWrapper<FileEntry> {
 	}
 
 	@Override
+	public List<FileVersion> getFileVersions(int status, int start, int end) {
+		return _fileEntry.getFileVersions(status, start, end);
+	}
+
+	@Override
 	public int getFileVersionsCount(int status) {
 		return _fileEntry.getFileVersionsCount(status);
 	}

--- a/portal-kernel/src/com/liferay/portal/kernel/repository/model/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/repository/model/packageinfo
@@ -1,1 +1,1 @@
-version 11.0.0
+version 11.1.0

--- a/portal-kernel/src/com/liferay/portal/kernel/repository/proxy/FileEntryProxyBean.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/repository/proxy/FileEntryProxyBean.java
@@ -146,6 +146,12 @@ public class FileEntryProxyBean
 	}
 
 	@Override
+	public List<FileVersion> getFileVersions(int status, int start, int end) {
+		return toFileVersionProxyBeans(
+			_fileEntry.getFileVersions(status, start, end));
+	}
+
+	@Override
 	public int getFileVersionsCount(int status) {
 		return _fileEntry.getFileVersionsCount(status);
 	}

--- a/portal-kernel/src/com/liferay/portal/kernel/repository/proxy/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/repository/proxy/packageinfo
@@ -1,1 +1,1 @@
-version 6.1.0
+version 6.2.0


### PR DESCRIPTION
## Motivation

[Link to story](https://issues.liferay.com/browse/LPS-161544)

Tango Team is working in improving the information panel in content dashboard, and one of these improvements is adding the version history of the elements in the sidebar.  Since an element can have many versions, we would like to provide the user the ability to paginate through them.

But we have noticed that there are no services in DL that provide this feature, and we can only retrieve all versions at a time

## Proposed Solution

Since persistance layer already has a method to retrive the DLFileVersions by status, range and orderByComparator, our proposal is to implement it. In case of external repositories, the complete version list would be retrieved by calling the existing method.

## Steps to Verify:

There are no steps to verify this since it's planned for the coming weeks

## Change summary:

* Change FileVersionVersionComparator so that it can be used when calling services
* Implement the new method at local service layer
* Implement the new method in generic FileEntry class
* Integration test for retrieving versions by range
* Integration test for retrieving versions by range and status

## Notes:

* As mentioned, external repositories are not paginates
* Change in comparator requires a major bump in version 
* Versions are retrieved always in descending order, like the existing method that retrieves by status
* We didn't change existing methods, but now we could use the new comparator to order results at persistance layer instead of after retrieving them

## Acknowledments

Thanks to @robertoDiaz, @AliciaGarciaGarcia and @adolfopa  for their suggestions ❤️ 


Please let me know if I should make some changes