### PR TITLE
LPS-162585: Incorrect Subscribe icon in the Info Panel

### DIFF
--- a/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks/subscribe.jsp
+++ b/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks/subscribe.jsp
@@ -41,7 +41,7 @@ BookmarksEntry entry = (BookmarksEntry)request.getAttribute("info_panel.jsp-entr
 						</portlet:actionURL>
 
 						<liferay-ui:icon
-							icon="star"
+							icon="bell-off"
 							linkCssClass="icon-monospaced"
 							markupView="lexicon"
 							message="unsubscribe"
@@ -56,7 +56,7 @@ BookmarksEntry entry = (BookmarksEntry)request.getAttribute("info_panel.jsp-entr
 						</portlet:actionURL>
 
 						<liferay-ui:icon
-							icon="star-o"
+							icon="bell-on"
 							linkCssClass="icon-monospaced"
 							markupView="lexicon"
 							message="subscribe"
@@ -77,7 +77,7 @@ BookmarksEntry entry = (BookmarksEntry)request.getAttribute("info_panel.jsp-entr
 						</portlet:actionURL>
 
 						<liferay-ui:icon
-							icon="star"
+							icon="bell-off"
 							linkCssClass="icon-monospaced"
 							markupView="lexicon"
 							message="unsubscribe"
@@ -92,7 +92,7 @@ BookmarksEntry entry = (BookmarksEntry)request.getAttribute("info_panel.jsp-entr
 						</portlet:actionURL>
 
 						<liferay-ui:icon
-							icon="star-o"
+							icon="bell-on"
 							linkCssClass="icon-monospaced"
 							markupView="lexicon"
 							message="subscribe"

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/subscribe.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/subscribe.jsp
@@ -69,7 +69,7 @@ boolean emailFileEntryAnyEventEnabled = dlGroupServiceSettings.isEmailFileEntryA
 					</portlet:actionURL>
 
 					<liferay-ui:icon
-						icon="star"
+						icon="bell-off"
 						linkCssClass="icon-monospaced"
 						markupView="lexicon"
 						message="unsubscribe"
@@ -78,7 +78,7 @@ boolean emailFileEntryAnyEventEnabled = dlGroupServiceSettings.isEmailFileEntryA
 				</c:when>
 				<c:otherwise>
 					<liferay-ui:icon
-						icon="star"
+						icon="bell-off"
 						linkCssClass="icon-monospaced"
 						markupView="lexicon"
 						message="subscribed-to-a-parent-folder"
@@ -102,7 +102,7 @@ boolean emailFileEntryAnyEventEnabled = dlGroupServiceSettings.isEmailFileEntryA
 			</portlet:actionURL>
 
 			<liferay-ui:icon
-				icon="star-o"
+				icon="bell-on"
 				linkCssClass="icon-monospaced"
 				markupView="lexicon"
 				message="subscribe"

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/subscribe.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/subscribe.jsp
@@ -94,7 +94,7 @@ String unsubscribeActionName = StringPool.BLANK;
 						</portlet:actionURL>
 
 						<liferay-ui:icon
-							icon="star"
+							icon="bell-off"
 							linkCssClass="icon-monospaced"
 							markupView="lexicon"
 							message="unsubscribe"
@@ -103,7 +103,7 @@ String unsubscribeActionName = StringPool.BLANK;
 					</c:when>
 					<c:otherwise>
 						<liferay-ui:icon
-							icon="star"
+							icon="bell-off"
 							linkCssClass="icon-monospaced"
 							markupView="lexicon"
 							message="subscribed-to-a-parent-folder"
@@ -129,7 +129,7 @@ String unsubscribeActionName = StringPool.BLANK;
 				</portlet:actionURL>
 
 				<liferay-ui:icon
-					icon="star-o"
+					icon="bell-on"
 					linkCssClass="icon-monospaced"
 					markupView="lexicon"
 					message="subscribe"


### PR DESCRIPTION
Hi @adolfopa
I have some updates on three modules to change the Subscribe's icon from star to bell icon based on the requirement on [LPS-162585](https://issues.liferay.com/browse/LPS-162585). They are as below:
1.   bookmarks-web
2.   document-library-web
3.   journal-web

I know your team is the owner of both bookmarks-web and document-library-web modules, so please help me to review my PR and leave your comments.
In case you want me to separate the change on the journal-web module to a separate commit for sending to another team, please let me know. 

Previous PR: https://github.com/liferay-frontend/liferay-portal/pull/2723

Thank you!
Thien.Quach