### PR TITLE
LPS-161585 Can't create Redirect Entries with accented characters

### DIFF
--- a/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/service/impl/RedirectEntryLocalServiceImpl.java
+++ b/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/service/impl/RedirectEntryLocalServiceImpl.java
@@ -25,6 +25,7 @@ import com.liferay.portal.kernel.service.ResourceLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.permission.ModelPermissions;
 import com.liferay.portal.kernel.util.DateUtil;
+import com.liferay.portal.kernel.util.FriendlyURLNormalizer;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -88,9 +89,14 @@ public class RedirectEntryLocalServiceImpl
 			boolean permanent, String sourceURL, ServiceContext serviceContext)
 		throws PortalException {
 
-		_validate(destinationURL, sourceURL);
+		String normalizedSourceURL =
+			_friendlyURLNormalizer.normalizeWithEncoding(sourceURL);
 
-		if (redirectEntryPersistence.fetchByG_S(groupId, sourceURL) != null) {
+		_validate(destinationURL, normalizedSourceURL);
+
+		if (redirectEntryPersistence.fetchByG_S(groupId, normalizedSourceURL) !=
+				null) {
+
 			throw new DuplicateRedirectEntrySourceURLException();
 		}
 
@@ -106,7 +112,7 @@ public class RedirectEntryLocalServiceImpl
 		redirectEntry.setDestinationURL(destinationURL);
 		redirectEntry.setExpirationDate(expirationDate);
 		redirectEntry.setPermanent(permanent);
-		redirectEntry.setSourceURL(sourceURL);
+		redirectEntry.setSourceURL(normalizedSourceURL);
 
 		redirectEntry = redirectEntryPersistence.update(redirectEntry);
 
@@ -124,7 +130,7 @@ public class RedirectEntryLocalServiceImpl
 
 		RedirectNotFoundEntry redirectNotFoundEntry =
 			_redirectNotFoundEntryLocalService.fetchRedirectNotFoundEntry(
-				groupId, sourceURL);
+				groupId, normalizedSourceURL);
 
 		if (redirectNotFoundEntry != null) {
 			_redirectNotFoundEntryLocalService.deleteRedirectNotFoundEntry(
@@ -250,13 +256,16 @@ public class RedirectEntryLocalServiceImpl
 			boolean permanent, String sourceURL)
 		throws PortalException {
 
-		_validate(destinationURL, sourceURL);
+		String normalizedSourceURL =
+			_friendlyURLNormalizer.normalizeWithEncoding(sourceURL);
+
+		_validate(destinationURL, normalizedSourceURL);
 
 		RedirectEntry redirectEntry = getRedirectEntry(redirectEntryId);
 
 		RedirectEntry existingRedirectEntry =
 			redirectEntryPersistence.fetchByG_S(
-				redirectEntry.getGroupId(), sourceURL);
+				redirectEntry.getGroupId(), normalizedSourceURL);
 
 		if ((existingRedirectEntry != null) &&
 			(existingRedirectEntry.getRedirectEntryId() != redirectEntryId)) {
@@ -267,7 +276,7 @@ public class RedirectEntryLocalServiceImpl
 		redirectEntry.setDestinationURL(destinationURL);
 		redirectEntry.setExpirationDate(expirationDate);
 		redirectEntry.setPermanent(permanent);
-		redirectEntry.setSourceURL(sourceURL);
+		redirectEntry.setSourceURL(normalizedSourceURL);
 
 		return redirectEntryPersistence.update(redirectEntry);
 	}
@@ -452,6 +461,9 @@ public class RedirectEntryLocalServiceImpl
 			throw new LayoutFriendlyURLException(exceptionType);
 		}
 	}
+
+	@Reference
+	private FriendlyURLNormalizer _friendlyURLNormalizer;
 
 	@Reference
 	private RedirectNotFoundEntryLocalService

--- a/modules/apps/redirect/redirect-test/src/testFunctional/macros/Redirect.macro
+++ b/modules/apps/redirect/redirect-test/src/testFunctional/macros/Redirect.macro
@@ -56,7 +56,7 @@ definition {
 		else if ("${sourceURLVariation}" == "Invalid") {
 			AssertTextEquals.assertPartialText(
 				locator1 = "Message#ERROR",
-				value1 = "Please enter a source URL with valid characters.");
+				value1 = "Please enter a source URL that does not begin with a slash.");
 		}
 		else if ("${sourceURLVariation}" == "LengthLimit") {
 			AssertTextEquals.assertPartialText(

--- a/modules/apps/redirect/redirect-test/src/testFunctional/tests/Redirect.testcase
+++ b/modules/apps/redirect/redirect-test/src/testFunctional/tests/Redirect.testcase
@@ -908,7 +908,7 @@ definition {
 		Redirect.addEntry(
 			destinationURL = "${portalURL}/web/test-site-name/test-destination-page",
 			siteName = "test-site-name",
-			sourceURL = "test-source-page!@#$",
+			sourceURL = "/test-source-page",
 			sourceURLVariation = "Invalid");
 
 		Redirect.openRedirectAdmin(siteURLKey = "test-site-name");

--- a/modules/apps/redirect/redirect-test/src/testIntegration/java/com/liferay/redirect/service/test/RedirectEntryLocalServiceTest.java
+++ b/modules/apps/redirect/redirect-test/src/testIntegration/java/com/liferay/redirect/service/test/RedirectEntryLocalServiceTest.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.util.DateUtil;
+import com.liferay.portal.kernel.util.FriendlyURLNormalizer;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -309,6 +310,17 @@ public class RedirectEntryLocalServiceTest {
 	}
 
 	@Test
+	public void testAddRedirectEntryNotNormalizedSourceURL() throws Exception {
+		_redirectEntry = _redirectEntryLocalService.addRedirectEntry(
+			_group.getGroupId(), "destinationURL", null, false, "attaché",
+			ServiceContextTestUtil.getServiceContext());
+
+		Assert.assertEquals(
+			_friendlyURLNormalizer.normalizeWithEncoding("attaché"),
+			_redirectEntry.getSourceURL());
+	}
+
+	@Test
 	public void testAddRedirectEntryWithTwoStepRedirectLoop() throws Exception {
 		_redirectEntry = _redirectEntryLocalService.addRedirectEntry(
 			_group.getGroupId(), "groupBaseURL/intermediateURL", null, false,
@@ -586,8 +598,26 @@ public class RedirectEntryLocalServiceTest {
 			"finalDestinationURL", _redirectEntry.getDestinationURL());
 	}
 
+	@Test
+	public void testUpdateRedirectEntryNormalizedSourceURL() throws Exception {
+		_redirectEntry = _redirectEntryLocalService.addRedirectEntry(
+			_group.getGroupId(), "destinationURL", null, false, "sourceURL",
+			ServiceContextTestUtil.getServiceContext());
+
+		_redirectEntry = _redirectEntryLocalService.updateRedirectEntry(
+			_redirectEntry.getRedirectEntryId(), "destinationURL", null,
+			false, "attaché");
+
+		Assert.assertEquals(
+			_friendlyURLNormalizer.normalizeWithEncoding("attaché"),
+			_redirectEntry.getSourceURL());
+	}
+
 	@DeleteAfterTestRun
 	private RedirectEntry _chainedRedirectEntry;
+
+	@Inject
+	private FriendlyURLNormalizer _friendlyURLNormalizer;
 
 	@DeleteAfterTestRun
 	private Group _group;

--- a/modules/apps/redirect/redirect-test/src/testIntegration/java/com/liferay/redirect/service/test/RedirectEntryLocalServiceTest.java
+++ b/modules/apps/redirect/redirect-test/src/testIntegration/java/com/liferay/redirect/service/test/RedirectEntryLocalServiceTest.java
@@ -92,7 +92,8 @@ public class RedirectEntryLocalServiceTest {
 			ServiceContextTestUtil.getServiceContext());
 
 		Assert.assertEquals(
-			"anotherSourceURL", _chainedRedirectEntry.getSourceURL());
+			_friendlyURLNormalizer.normalizeWithEncoding("anotherSourceURL"),
+			_chainedRedirectEntry.getSourceURL());
 
 		Assert.assertEquals(
 			"groupBaseURL/sourceURL",
@@ -114,7 +115,9 @@ public class RedirectEntryLocalServiceTest {
 			ServiceContextTestUtil.getServiceContext());
 
 		Assert.assertEquals(
-			"intermediateDestinationURL", _chainedRedirectEntry.getSourceURL());
+			_friendlyURLNormalizer.normalizeWithEncoding(
+				"intermediateDestinationURL"),
+			_chainedRedirectEntry.getSourceURL());
 
 		Assert.assertEquals(
 			"finalDestinationURL", _chainedRedirectEntry.getDestinationURL());
@@ -122,7 +125,9 @@ public class RedirectEntryLocalServiceTest {
 		_redirectEntry = _redirectEntryLocalService.fetchRedirectEntry(
 			_redirectEntry.getRedirectEntryId());
 
-		Assert.assertEquals("sourceURL", _redirectEntry.getSourceURL());
+		Assert.assertEquals(
+			_friendlyURLNormalizer.normalizeWithEncoding("sourceURL"),
+			_redirectEntry.getSourceURL());
 
 		Assert.assertEquals(
 			"groupBaseURL/intermediateDestinationURL",
@@ -213,15 +218,6 @@ public class RedirectEntryLocalServiceTest {
 	}
 
 	@Test(expected = LayoutFriendlyURLException.class)
-	public void testAddRedirectEntryFailsWhenSourceURLInvalidChar()
-		throws Exception {
-
-		_redirectEntry = _redirectEntryLocalService.addRedirectEntry(
-			_group.getGroupId(), "destinationURL", null, false, "~",
-			ServiceContextTestUtil.getServiceContext());
-	}
-
-	@Test(expected = LayoutFriendlyURLException.class)
 	public void testAddRedirectEntryFailsWhenSourceURLStartSlash()
 		throws Exception {
 
@@ -276,7 +272,8 @@ public class RedirectEntryLocalServiceTest {
 			ServiceContextTestUtil.getServiceContext());
 
 		Assert.assertEquals(
-			"anotherSourceURL", _chainedRedirectEntry.getSourceURL());
+			_friendlyURLNormalizer.normalizeWithEncoding("anotherSourceURL"),
+			_chainedRedirectEntry.getSourceURL());
 
 		Assert.assertEquals(
 			"destinationURL", _chainedRedirectEntry.getDestinationURL());
@@ -295,7 +292,9 @@ public class RedirectEntryLocalServiceTest {
 			ServiceContextTestUtil.getServiceContext());
 
 		Assert.assertEquals(
-			"intermediateDestinationURL", _chainedRedirectEntry.getSourceURL());
+			_friendlyURLNormalizer.normalizeWithEncoding(
+				"intermediateDestinationURL"),
+			_chainedRedirectEntry.getSourceURL());
 
 		Assert.assertEquals(
 			"finalDestinationURL", _chainedRedirectEntry.getDestinationURL());
@@ -303,7 +302,9 @@ public class RedirectEntryLocalServiceTest {
 		_redirectEntry = _redirectEntryLocalService.fetchRedirectEntry(
 			_redirectEntry.getRedirectEntryId());
 
-		Assert.assertEquals("sourceURL", _redirectEntry.getSourceURL());
+		Assert.assertEquals(
+			_friendlyURLNormalizer.normalizeWithEncoding("sourceURL"),
+			_redirectEntry.getSourceURL());
 
 		Assert.assertEquals(
 			"finalDestinationURL", _redirectEntry.getDestinationURL());
@@ -340,7 +341,9 @@ public class RedirectEntryLocalServiceTest {
 		_redirectEntry = _redirectEntryLocalService.fetchRedirectEntry(
 			_redirectEntry.getRedirectEntryId());
 
-		Assert.assertEquals("sourceURL", _redirectEntry.getSourceURL());
+		Assert.assertEquals(
+			_friendlyURLNormalizer.normalizeWithEncoding("sourceURL"),
+			_redirectEntry.getSourceURL());
 
 		Assert.assertEquals(
 			"groupBaseURL/intermediateURL", _redirectEntry.getDestinationURL());
@@ -349,14 +352,16 @@ public class RedirectEntryLocalServiceTest {
 			_chainedRedirectEntry.getRedirectEntryId());
 
 		Assert.assertEquals(
-			"destinationURL", _chainedRedirectEntry.getSourceURL());
+			_friendlyURLNormalizer.normalizeWithEncoding("destinationURL"),
+			_chainedRedirectEntry.getSourceURL());
 
 		Assert.assertEquals(
 			"groupBaseURL/sourceURL",
 			_chainedRedirectEntry.getDestinationURL());
 
 		Assert.assertEquals(
-			"intermediateURL", _intermediateRedirectEntry.getSourceURL());
+			_friendlyURLNormalizer.normalizeWithEncoding("intermediateURL"),
+			_intermediateRedirectEntry.getSourceURL());
 
 		Assert.assertEquals(
 			"groupBaseURL/destinationURL",
@@ -479,7 +484,8 @@ public class RedirectEntryLocalServiceTest {
 			"anotherSourceURL", false);
 
 		Assert.assertEquals(
-			"anotherSourceURL", _chainedRedirectEntry.getSourceURL());
+			_friendlyURLNormalizer.normalizeWithEncoding("anotherSourceURL"),
+			_chainedRedirectEntry.getSourceURL());
 
 		Assert.assertEquals(
 			"groupBaseURL/sourceURL",
@@ -505,7 +511,9 @@ public class RedirectEntryLocalServiceTest {
 			null, "groupBaseURL", false, "intermediateDestinationURL", false);
 
 		Assert.assertEquals(
-			"intermediateDestinationURL", _chainedRedirectEntry.getSourceURL());
+			_friendlyURLNormalizer.normalizeWithEncoding(
+				"intermediateDestinationURL"),
+			_chainedRedirectEntry.getSourceURL());
 
 		Assert.assertEquals(
 			"finalDestinationURL", _chainedRedirectEntry.getDestinationURL());
@@ -513,7 +521,9 @@ public class RedirectEntryLocalServiceTest {
 		_redirectEntry = _redirectEntryLocalService.fetchRedirectEntry(
 			_redirectEntry.getRedirectEntryId());
 
-		Assert.assertEquals("sourceURL", _redirectEntry.getSourceURL());
+		Assert.assertEquals(
+			_friendlyURLNormalizer.normalizeWithEncoding("sourceURL"),
+			_redirectEntry.getSourceURL());
 
 		Assert.assertEquals(
 			"groupBaseURL/intermediateDestinationURL",
@@ -531,7 +541,9 @@ public class RedirectEntryLocalServiceTest {
 			"groupBaseURL", false, "sourceURL", false,
 			ServiceContextTestUtil.getServiceContext());
 
-		Assert.assertEquals("sourceURL", _redirectEntry.getSourceURL());
+		Assert.assertEquals(
+			_friendlyURLNormalizer.normalizeWithEncoding("sourceURL"),
+			_redirectEntry.getSourceURL());
 		Assert.assertEquals(
 			"groupBaseURL/destinationURL", _redirectEntry.getDestinationURL());
 
@@ -559,7 +571,8 @@ public class RedirectEntryLocalServiceTest {
 			"anotherSourceURL", true);
 
 		Assert.assertEquals(
-			"anotherSourceURL", _chainedRedirectEntry.getSourceURL());
+			_friendlyURLNormalizer.normalizeWithEncoding("anotherSourceURL"),
+			_chainedRedirectEntry.getSourceURL());
 
 		Assert.assertEquals(
 			"destinationURL", _chainedRedirectEntry.getDestinationURL());
@@ -584,7 +597,9 @@ public class RedirectEntryLocalServiceTest {
 			null, "groupBaseURL", false, "intermediateDestinationURL", true);
 
 		Assert.assertEquals(
-			"intermediateDestinationURL", _chainedRedirectEntry.getSourceURL());
+			_friendlyURLNormalizer.normalizeWithEncoding(
+				"intermediateDestinationURL"),
+			_chainedRedirectEntry.getSourceURL());
 
 		Assert.assertEquals(
 			"finalDestinationURL", _chainedRedirectEntry.getDestinationURL());
@@ -592,7 +607,9 @@ public class RedirectEntryLocalServiceTest {
 		_redirectEntry = _redirectEntryLocalService.fetchRedirectEntry(
 			_redirectEntry.getRedirectEntryId());
 
-		Assert.assertEquals("sourceURL", _redirectEntry.getSourceURL());
+		Assert.assertEquals(
+			_friendlyURLNormalizer.normalizeWithEncoding("sourceURL"),
+			_redirectEntry.getSourceURL());
 
 		Assert.assertEquals(
 			"finalDestinationURL", _redirectEntry.getDestinationURL());
@@ -605,8 +622,8 @@ public class RedirectEntryLocalServiceTest {
 			ServiceContextTestUtil.getServiceContext());
 
 		_redirectEntry = _redirectEntryLocalService.updateRedirectEntry(
-			_redirectEntry.getRedirectEntryId(), "destinationURL", null,
-			false, "attaché");
+			_redirectEntry.getRedirectEntryId(), "destinationURL", null, false,
+			"attaché");
 
 		Assert.assertEquals(
 			_friendlyURLNormalizer.normalizeWithEncoding("attaché"),

--- a/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/edit_redirect_entry.jsp
+++ b/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/edit_redirect_entry.jsp
@@ -107,7 +107,7 @@ else {
 				</div>
 
 				<div class="input-group-item">
-					<aui:input autoFocus="<%= Validator.isNull(sourceURL) || Validator.isNotNull(destinationURL) %>" label="" name="sourceURL" required="<%= true %>" type="text" value="<%= sourceURL %>" />
+					<aui:input autoFocus="<%= Validator.isNull(sourceURL) || Validator.isNotNull(destinationURL) %>" label="" name="sourceURL" required="<%= true %>" type="text" value="<%= URLCodec.decodeURL(sourceURL) %>" />
 				</div>
 			</div>
 		</aui:field-wrapper>

--- a/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/init.jsp
@@ -44,6 +44,7 @@ page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
 page import="com.liferay.portal.kernel.util.ListUtil" %><%@
 page import="com.liferay.portal.kernel.util.ParamUtil" %><%@
 page import="com.liferay.portal.kernel.util.StringUtil" %><%@
+page import="com.liferay.portal.kernel.util.URLCodec" %><%@
 page import="com.liferay.portal.kernel.util.Validator" %><%@
 page import="com.liferay.redirect.exception.CircularRedirectEntryException" %><%@
 page import="com.liferay.redirect.exception.DuplicateRedirectEntrySourceURLException" %><%@

--- a/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/view_redirect_entries.jsp
+++ b/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/view_redirect_entries.jsp
@@ -79,7 +79,7 @@ RedirectEntriesManagementToolbarDisplayContext redirectEntriesManagementToolbarD
 					>
 
 						<%
-						String sourceURL = HtmlUtil.escape(RedirectUtil.getGroupBaseURL(themeDisplay) + StringPool.SLASH + redirectEntry.getSourceURL());
+						String sourceURL = URLCodec.decodeURL(HtmlUtil.escape(RedirectUtil.getGroupBaseURL(themeDisplay) + StringPool.SLASH + redirectEntry.getSourceURL()));
 						%>
 
 						<bdi data-title="<%= HtmlUtil.escapeAttribute(sourceURL) %>">


### PR DESCRIPTION
- LPS-161585 add test to check behavior adding or updating the redirection with accented characters
- LPS-161585 when we save the friendly URL for the page we are saving it normalized, so save the sourceURL as a normalized
- LPS-161585 show the sourceURL as decodeURL
- LPS-161585 fix tests
- LPS-161585 Update test for checking the invalid source URL
