### PR TITLE
LPS-163072 KB add navigation article preview

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/display/context/KBAdminNavigationDisplayContext.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/display/context/KBAdminNavigationDisplayContext.java
@@ -213,10 +213,7 @@ public class KBAdminNavigationDisplayContext {
 				).put(
 					"navigationItems", navigationItemsJSONArray
 				).put(
-					"selectedItemId",
-					ParamUtil.getLong(
-						_httpServletRequest, "parentResourcePrimKey",
-						KBFolderConstants.DEFAULT_PARENT_FOLDER_ID)
+					"selectedItemId", _getSelectedItemId()
 				).put(
 					"title",
 					LanguageUtil.get(
@@ -460,6 +457,14 @@ public class KBAdminNavigationDisplayContext {
 		}
 
 		return navigationItemsJSONArray;
+	}
+
+	private long _getSelectedItemId() {
+		return ParamUtil.getLong(
+			_httpServletRequest, "parentResourcePrimKey",
+			ParamUtil.getLong(
+				_httpServletRequest, "selectedItemId",
+				KBFolderConstants.DEFAULT_PARENT_FOLDER_ID));
 	}
 
 	private final HttpServletRequest _httpServletRequest;

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/display/context/KBAdminNavigationDisplayContext.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/display/context/KBAdminNavigationDisplayContext.java
@@ -213,7 +213,10 @@ public class KBAdminNavigationDisplayContext {
 				).put(
 					"navigationItems", navigationItemsJSONArray
 				).put(
-					"selectedItemId", _getSelectedItemId()
+					"selectedItemId",
+					ParamUtil.getLong(
+						_httpServletRequest, "selectedItemId",
+						KBFolderConstants.DEFAULT_PARENT_FOLDER_ID)
 				).put(
 					"title",
 					LanguageUtil.get(
@@ -387,6 +390,8 @@ public class KBAdminNavigationDisplayContext {
 						"parentResourceClassNameId", kbFolder.getClassNameId()
 					).setParameter(
 						"parentResourcePrimKey", kbFolder.getKbFolderId()
+					).setParameter(
+						"selectedItemId", kbFolder.getKbFolderId()
 					).buildString()
 				).put(
 					"id", kbFolder.getKbFolderId()
@@ -457,14 +462,6 @@ public class KBAdminNavigationDisplayContext {
 		}
 
 		return navigationItemsJSONArray;
-	}
-
-	private long _getSelectedItemId() {
-		return ParamUtil.getLong(
-			_httpServletRequest, "parentResourcePrimKey",
-			ParamUtil.getLong(
-				_httpServletRequest, "selectedItemId",
-				KBFolderConstants.DEFAULT_PARENT_FOLDER_ID));
 	}
 
 	private final HttpServletRequest _httpServletRequest;

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/display/context/helper/KBArticleURLHelper.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/display/context/helper/KBArticleURLHelper.java
@@ -92,6 +92,8 @@ public class KBArticleURLHelper {
 			"resourceClassNameId", kbArticle.getClassNameId()
 		).setParameter(
 			"resourcePrimKey", kbArticle.getResourcePrimKey()
+		).setParameter(
+			"selectedItemId", kbArticle.getKbArticleId()
 		).buildPortletURL();
 	}
 

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/view_kb_article.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/view_kb_article.jsp
@@ -18,17 +18,11 @@
 
 <c:choose>
 	<c:when test='<%= GetterUtil.getBoolean(PropsUtil.get("feature.flag.LPS-156421")) %>'>
-		<c:if test="<%= redirect.equals(currentURL) %>">
-			<liferay-util:include page="/admin/common/vertical_menu.jsp" servletContext="<%= application %>" />
+		<liferay-util:include page="/admin/common/vertical_menu.jsp" servletContext="<%= application %>" />
 
-			<div class="knowledge-base-admin-content">
-		</c:if>
-
-		<liferay-util:include page="/admin/common/view_kb_article.jsp" servletContext="<%= application %>" />
-
-		<c:if test="<%= redirect.equals(currentURL) %>">
-			</div>
-		</c:if>
+		<div class="knowledge-base-admin-content">
+			<liferay-util:include page="/admin/common/view_kb_article.jsp" servletContext="<%= application %>" />
+		</div>
 	</c:when>
 	<c:otherwise>
 		<c:if test="<%= redirect.equals(currentURL) %>">


### PR DESCRIPTION
## Issue: https://issues.liferay.com/browse/LPS-163072

We need to show the side navigation always for the article preview.

@AliciaGarciaGarcia and I are not sure what it's the best idea when getting the `selectedItemId`:

- e597c44f7fefa8e16bca33e8140a9b78330b4ff3 getetting two params and only go for `selectedItemId` when `parentResourcePrimKey` is empty
- ea18132b2ed2b50429e9b1e33774471afbe6719f or duplicate params for folders and always get from `selectedItemId`

Feel free to drop the last commit if the first option is better.

### After PR
<img width="1280" alt="image" src="https://user-images.githubusercontent.com/67901/190644831-8bf8b9d7-b73c-44e2-9580-177ec08f0440.png">


