### PR TITLE
LPS-163083 Create documents and media browser tag

### DIFF
--- a/modules/apps/blogs/blogs-web/build.gradle
+++ b/modules/apps/blogs/blogs-web/build.gradle
@@ -22,6 +22,7 @@ dependencies {
 	compileOnly project(":apps:changeset:changeset-api")
 	compileOnly project(":apps:comment:comment-taglib")
 	compileOnly project(":apps:document-library:document-library-api")
+	compileOnly project(":apps:document-library:document-library-taglib")
 	compileOnly project(":apps:dynamic-data-mapping:dynamic-data-mapping-taglib")
 	compileOnly project(":apps:expando:expando-api")
 	compileOnly project(":apps:expando:expando-taglib")

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/view_images.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/view_images.jsp
@@ -16,6 +16,12 @@
 
 <%@ include file="/blogs_admin/init.jsp" %>
 
+<%@ taglib uri="http://liferay.com/tld/document-library" prefix="liferay-document-library" %>
+
+<liferay-document-library:repository-browser />
+
+<%--
+
 <%
 int delta = ParamUtil.getInteger(request, SearchContainer.DEFAULT_DELTA_PARAM);
 String orderByCol = ParamUtil.getString(request, "orderByCol", "title");
@@ -110,3 +116,4 @@ String displayStyle = blogImagesManagementToolbarDisplayContext.getDisplayStyle(
 		</liferay-ui:search-container>
 	</aui:form>
 </clay:container-fluid>
+--%>

--- a/modules/apps/document-library/document-library-taglib/build.gradle
+++ b/modules/apps/document-library/document-library-taglib/build.gradle
@@ -10,6 +10,8 @@ dependencies {
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-soy")
 	compileOnly project(":core:osgi-service-tracker-collections")
+	compileOnly project(":core:petra:petra-function")
+	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-sql-dsl-api")
 	compileOnly project(":core:petra:petra-string")
 }

--- a/modules/apps/document-library/document-library-taglib/build.gradle
+++ b/modules/apps/document-library/document-library-taglib/build.gradle
@@ -12,6 +12,7 @@ dependencies {
 	compileOnly project(":core:osgi-service-tracker-collections")
 	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-lang")
+	compileOnly project(":core:petra:petra-reflect")
 	compileOnly project(":core:petra:petra-sql-dsl-api")
 	compileOnly project(":core:petra:petra-string")
 }

--- a/modules/apps/document-library/document-library-taglib/build.gradle
+++ b/modules/apps/document-library/document-library-taglib/build.gradle
@@ -10,6 +10,7 @@ dependencies {
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-soy")
+	compileOnly project(":apps:site-navigation:site-navigation-taglib")
 	compileOnly project(":core:osgi-service-tracker-collections")
 	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-lang")

--- a/modules/apps/document-library/document-library-taglib/build.gradle
+++ b/modules/apps/document-library/document-library-taglib/build.gradle
@@ -7,6 +7,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:document-library:document-library-api")
+	compileOnly project(":apps:frontend-taglib:frontend-taglib")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-soy")
 	compileOnly project(":core:osgi-service-tracker-collections")

--- a/modules/apps/document-library/document-library-taglib/package.json
+++ b/modules/apps/document-library/document-library-taglib/package.json
@@ -1,0 +1,9 @@
+{
+	"name": "@liferay/document-library-taglib",
+	"scripts": {
+		"build": "liferay-npm-scripts build",
+		"checkFormat": "liferay-npm-scripts check",
+		"format": "liferay-npm-scripts fix"
+	},
+	"version": "3.0.9"
+}

--- a/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/display/context/RepositoryBrowserManagementToolbarDisplayContext.java
+++ b/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/display/context/RepositoryBrowserManagementToolbarDisplayContext.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.document.library.taglib.internal.display.context;
+
+import com.liferay.frontend.taglib.clay.servlet.taglib.display.context.SearchContainerManagementToolbarDisplayContext;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemListBuilder;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.dao.search.SearchContainer;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
+import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
+import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
+
+import java.util.List;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * @author Adolfo Pérez
+ */
+public class RepositoryBrowserManagementToolbarDisplayContext
+	extends SearchContainerManagementToolbarDisplayContext {
+
+	public RepositoryBrowserManagementToolbarDisplayContext(
+		HttpServletRequest httpServletRequest,
+		LiferayPortletRequest liferayPortletRequest,
+		LiferayPortletResponse liferayPortletResponse,
+		SearchContainer<Object> searchContainer) {
+
+		super(
+			httpServletRequest, liferayPortletRequest, liferayPortletResponse,
+			searchContainer);
+	}
+
+	@Override
+	public List<DropdownItem> getActionDropdownItems() {
+		return DropdownItemListBuilder.add(
+			dropdownItem -> {
+				dropdownItem.putData("action", "deleteEntries");
+				dropdownItem.setIcon("trash");
+				dropdownItem.setLabel(
+					LanguageUtil.get(httpServletRequest, "delete"));
+				dropdownItem.setQuickAction(true);
+			}
+		).build();
+	}
+
+	@Override
+	public String getClearResultsURL() {
+		return PortletURLBuilder.create(
+			getPortletURL()
+		).setKeywords(
+			StringPool.BLANK
+		).buildString();
+	}
+
+	@Override
+	public String[] getDisplayViews() {
+		return new String[] {"icon"};
+	}
+
+	@Override
+	public String getSearchActionURL() {
+		return String.valueOf(getPortletURL());
+	}
+
+	@Override
+	public String getSearchContainerId() {
+		return "repositoryEntries";
+	}
+
+	@Override
+	protected String getDefaultDisplayStyle() {
+		return "icon";
+	}
+
+}

--- a/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/display/context/RepositoryBrowserManagementToolbarDisplayContext.java
+++ b/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/display/context/RepositoryBrowserManagementToolbarDisplayContext.java
@@ -15,6 +15,8 @@
 package com.liferay.document.library.taglib.internal.display.context;
 
 import com.liferay.frontend.taglib.clay.servlet.taglib.display.context.SearchContainerManagementToolbarDisplayContext;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenuBuilder;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemListBuilder;
 import com.liferay.petra.string.StringPool;
@@ -35,14 +37,17 @@ public class RepositoryBrowserManagementToolbarDisplayContext
 	extends SearchContainerManagementToolbarDisplayContext {
 
 	public RepositoryBrowserManagementToolbarDisplayContext(
-		HttpServletRequest httpServletRequest,
+		long folderId, HttpServletRequest httpServletRequest,
 		LiferayPortletRequest liferayPortletRequest,
-		LiferayPortletResponse liferayPortletResponse,
+		LiferayPortletResponse liferayPortletResponse, long repositoryId,
 		SearchContainer<Object> searchContainer) {
 
 		super(
 			httpServletRequest, liferayPortletRequest, liferayPortletResponse,
 			searchContainer);
+
+		_folderId = folderId;
+		_repositoryId = repositoryId;
 	}
 
 	@Override
@@ -68,6 +73,21 @@ public class RepositoryBrowserManagementToolbarDisplayContext
 	}
 
 	@Override
+	public CreationMenu getCreationMenu() {
+		return CreationMenuBuilder.addPrimaryDropdownItem(
+			dropdownItem -> {
+				dropdownItem.putData("action", "addFolder");
+				dropdownItem.putData(
+					"parentFolderId", String.valueOf(_folderId));
+				dropdownItem.putData(
+					"repositoryId", String.valueOf(_repositoryId));
+				dropdownItem.setLabel(
+					LanguageUtil.get(httpServletRequest, "folder"));
+			}
+		).build();
+	}
+
+	@Override
 	public String[] getDisplayViews() {
 		return new String[] {"icon"};
 	}
@@ -86,5 +106,8 @@ public class RepositoryBrowserManagementToolbarDisplayContext
 	protected String getDefaultDisplayStyle() {
 		return "icon";
 	}
+
+	private final long _folderId;
+	private final long _repositoryId;
 
 }

--- a/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/display/context/RepositoryBrowserTagDisplayContext.java
+++ b/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/display/context/RepositoryBrowserTagDisplayContext.java
@@ -34,6 +34,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.PortletURLUtil;
+import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.FileShortcut;
 import com.liferay.portal.kernel.repository.model.Folder;
@@ -106,6 +107,15 @@ public class RepositoryBrowserTagDisplayContext {
 	public String getDeleteFolderURL(Folder folder) {
 		return HttpComponentsUtil.addParameter(
 			_getRepositoryBrowserURL(), "folderId", folder.getFolderId());
+	}
+
+	public String getFolderURL(Folder folder) {
+		return PortletURLBuilder.create(
+			PortletURLUtil.getCurrent(
+				_liferayPortletRequest, _liferayPortletResponse)
+		).setParameter(
+			"folderId", folder.getFolderId()
+		).buildString();
 	}
 
 	public HorizontalCard getHorizontalCard(RepositoryEntry repositoryEntry)

--- a/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/display/context/RepositoryBrowserTagDisplayContext.java
+++ b/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/display/context/RepositoryBrowserTagDisplayContext.java
@@ -15,8 +15,10 @@
 package com.liferay.document.library.taglib.internal.display.context;
 
 import com.liferay.document.library.kernel.service.DLAppServiceUtil;
+import com.liferay.document.library.util.DLURLHelperUtil;
 import com.liferay.frontend.taglib.clay.servlet.taglib.HorizontalCard;
 import com.liferay.frontend.taglib.clay.servlet.taglib.VerticalCard;
+import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.portal.kernel.dao.search.ResultRow;
 import com.liferay.portal.kernel.dao.search.ResultRowSplitter;
 import com.liferay.portal.kernel.dao.search.ResultRowSplitterEntry;
@@ -25,8 +27,11 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.FileShortcut;
+import com.liferay.portal.kernel.repository.model.FileVersion;
 import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.repository.model.RepositoryEntry;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
 import java.util.ArrayList;
@@ -113,17 +118,63 @@ public class RepositoryBrowserTagDisplayContext {
 		return searchContainer;
 	}
 
-	public VerticalCard getVerticalCard(RepositoryEntry repositoryEntry) {
+	public VerticalCard getVerticalCard(RepositoryEntry repositoryEntry)
+		throws PortalException {
+
 		if (repositoryEntry instanceof FileEntry) {
 			FileEntry fileEntry = (FileEntry)repositoryEntry;
 
-			return fileEntry::getTitle;
+			FileVersion fileVersion = fileEntry.getFileVersion();
+
+			return new VerticalCard() {
+
+				@Override
+				public String getImageSrc() {
+					try {
+						return DLURLHelperUtil.getThumbnailSrc(
+							fileEntry, fileVersion,
+							(ThemeDisplay)_httpServletRequest.getAttribute(
+								WebKeys.THEME_DISPLAY));
+					}
+					catch (Exception exception) {
+						return ReflectionUtil.throwException(exception);
+					}
+				}
+
+				@Override
+				public String getTitle() {
+					return fileEntry.getTitle();
+				}
+
+			};
 		}
 
 		if (repositoryEntry instanceof FileShortcut) {
 			FileShortcut fileShortcut = (FileShortcut)repositoryEntry;
 
-			return fileShortcut::getToTitle;
+			FileVersion fileVersion = fileShortcut.getFileVersion();
+
+			return new VerticalCard() {
+
+				@Override
+				public String getImageSrc() {
+					try {
+						return DLURLHelperUtil.getThumbnailSrc(
+							fileVersion.getFileEntry(), fileVersion,
+							(ThemeDisplay)_httpServletRequest.getAttribute(
+								WebKeys.THEME_DISPLAY));
+					}
+					catch (Exception exception) {
+						return ReflectionUtil.throwException(exception);
+					}
+				}
+
+				@Override
+				public String getTitle() {
+					return fileShortcut.getToTitle();
+				}
+
+			};
 		}
 
 		throw new IllegalArgumentException(

--- a/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/display/context/RepositoryBrowserTagDisplayContext.java
+++ b/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/display/context/RepositoryBrowserTagDisplayContext.java
@@ -20,21 +20,19 @@ import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLAppLocalServiceUtil;
 import com.liferay.document.library.kernel.service.DLAppServiceUtil;
 import com.liferay.document.library.taglib.internal.frontend.taglib.clay.servlet.FileEntryVerticalCard;
+import com.liferay.document.library.taglib.internal.frontend.taglib.clay.servlet.FileShortcutVerticalCard;
 import com.liferay.document.library.taglib.internal.frontend.taglib.clay.servlet.FolderHorizontalCard;
-import com.liferay.document.library.util.DLURLHelperUtil;
 import com.liferay.frontend.taglib.clay.servlet.taglib.HorizontalCard;
 import com.liferay.frontend.taglib.clay.servlet.taglib.VerticalCard;
 import com.liferay.frontend.taglib.clay.servlet.taglib.display.context.ManagementToolbarDisplayContext;
 import com.liferay.frontend.taglib.clay.servlet.taglib.display.context.SearchContainerManagementToolbarDisplayContext;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemListBuilder;
-import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.search.EmptyOnClickRowChecker;
 import com.liferay.portal.kernel.dao.search.ResultRow;
 import com.liferay.portal.kernel.dao.search.ResultRowSplitter;
 import com.liferay.portal.kernel.dao.search.ResultRowSplitterEntry;
-import com.liferay.portal.kernel.dao.search.RowChecker;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
@@ -44,7 +42,6 @@ import com.liferay.portal.kernel.portlet.PortletURLUtil;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.FileShortcut;
-import com.liferay.portal.kernel.repository.model.FileVersion;
 import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.repository.model.RepositoryEntry;
 import com.liferay.portal.kernel.search.Hits;
@@ -104,6 +101,12 @@ public class RepositoryBrowserTagDisplayContext {
 		return HttpComponentsUtil.addParameter(
 			_getRepositoryBrowserURL(), "fileEntryId",
 			fileEntry.getFileEntryId());
+	}
+
+	public String getDeleteFileShortcutURL(FileShortcut fileShortcut) {
+		return HttpComponentsUtil.addParameter(
+			_getRepositoryBrowserURL(), "fileShortcutId",
+			fileShortcut.getFileShortcutId());
 	}
 
 	public String getDeleteFolderURL(Folder folder) {
@@ -240,77 +243,13 @@ public class RepositoryBrowserTagDisplayContext {
 		throws PortalException {
 
 		if (repositoryEntry instanceof FileEntry) {
-			FileEntry fileEntry = (FileEntry)repositoryEntry;
-
 			return new FileEntryVerticalCard(
-				fileEntry, _httpServletRequest, this);
+				(FileEntry)repositoryEntry, _httpServletRequest, this);
 		}
 
 		if (repositoryEntry instanceof FileShortcut) {
-			FileShortcut fileShortcut = (FileShortcut)repositoryEntry;
-
-			FileVersion fileVersion = fileShortcut.getFileVersion();
-
-			SearchContainer<Object> searchContainer = getSearchContainer();
-
-			return new VerticalCard() {
-
-				@Override
-				public List<DropdownItem> getActionDropdownItems() {
-					return DropdownItemListBuilder.add(
-						dropdownItem -> {
-							dropdownItem.putData("action", "delete");
-							dropdownItem.putData(
-								"deleteURL",
-								_getDeleteFileShortcutURL(fileShortcut));
-							dropdownItem.setIcon("trash");
-							dropdownItem.setLabel(
-								LanguageUtil.get(
-									_httpServletRequest, "delete"));
-						}
-					).build();
-				}
-
-				@Override
-				public String getDefaultEventHandler() {
-					return "repositoryBrowserEventHandler";
-				}
-
-				@Override
-				public String getImageSrc() {
-					try {
-						return DLURLHelperUtil.getThumbnailSrc(
-							fileVersion.getFileEntry(), fileVersion,
-							(ThemeDisplay)_httpServletRequest.getAttribute(
-								WebKeys.THEME_DISPLAY));
-					}
-					catch (Exception exception) {
-						return ReflectionUtil.throwException(exception);
-					}
-				}
-
-				@Override
-				public String getInputName() {
-					RowChecker rowChecker = searchContainer.getRowChecker();
-
-					if (rowChecker == null) {
-						return null;
-					}
-
-					return rowChecker.getRowIds();
-				}
-
-				@Override
-				public String getInputValue() {
-					return String.valueOf(fileShortcut.getFileShortcutId());
-				}
-
-				@Override
-				public String getTitle() {
-					return fileShortcut.getToTitle();
-				}
-
-			};
+			return new FileShortcutVerticalCard(
+				(FileShortcut)repositoryEntry, _httpServletRequest, this);
 		}
 
 		throw new IllegalArgumentException(
@@ -323,12 +262,6 @@ public class RepositoryBrowserTagDisplayContext {
 		}
 
 		return true;
-	}
-
-	private String _getDeleteFileShortcutURL(FileShortcut fileShortcut) {
-		return HttpComponentsUtil.addParameter(
-			_getRepositoryBrowserURL(), "fileShortcutId",
-			fileShortcut.getFileShortcutId());
 	}
 
 	private SearchContainer<Object> _getDLSearchContainer()

--- a/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/display/context/RepositoryBrowserTagDisplayContext.java
+++ b/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/display/context/RepositoryBrowserTagDisplayContext.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.document.library.taglib.internal.display.context;
+
+import com.liferay.document.library.kernel.service.DLAppServiceUtil;
+import com.liferay.frontend.taglib.clay.servlet.taglib.VerticalCard;
+import com.liferay.portal.kernel.dao.search.SearchContainer;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.repository.model.FileShortcut;
+import com.liferay.portal.kernel.repository.model.Folder;
+import com.liferay.portal.kernel.repository.model.RepositoryEntry;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+
+import javax.portlet.PortletRequest;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * @author Adolfo Pérez
+ */
+public class RepositoryBrowserTagDisplayContext {
+
+	public RepositoryBrowserTagDisplayContext(
+		long folderId, HttpServletRequest httpServletRequest,
+		LiferayPortletResponse liferayPortletResponse,
+		PortletRequest portletRequest, long repositoryId) {
+
+		_folderId = folderId;
+		_httpServletRequest = httpServletRequest;
+		_liferayPortletResponse = liferayPortletResponse;
+		_portletRequest = portletRequest;
+		_repositoryId = repositoryId;
+	}
+
+	public SearchContainer<Object> getSearchContainer() throws PortalException {
+		SearchContainer<Object> searchContainer = new SearchContainer<>(
+			_portletRequest, _liferayPortletResponse.createRenderURL(), null,
+			null);
+
+		searchContainer.setResultsAndTotal(
+			() -> DLAppServiceUtil.getFoldersAndFileEntriesAndFileShortcuts(
+				_repositoryId, _folderId, WorkflowConstants.STATUS_APPROVED,
+				null, false, false, searchContainer.getStart(),
+				searchContainer.getEnd(), null),
+			DLAppServiceUtil.getFoldersAndFileEntriesAndFileShortcutsCount(
+				_repositoryId, _folderId, WorkflowConstants.STATUS_APPROVED,
+				null, false, false));
+
+		return searchContainer;
+	}
+
+	public VerticalCard getVerticalCard(RepositoryEntry repositoryEntry) {
+		if (repositoryEntry instanceof FileEntry) {
+			FileEntry fileEntry = (FileEntry)repositoryEntry;
+
+			return fileEntry::getTitle;
+		}
+		else if (repositoryEntry instanceof FileShortcut) {
+			FileShortcut fileShortcut = (FileShortcut)repositoryEntry;
+
+			return fileShortcut::getToTitle;
+		}
+		else if (repositoryEntry instanceof Folder) {
+			Folder folder = (Folder)repositoryEntry;
+
+			return folder::getName;
+		}
+
+		throw new IllegalArgumentException(
+			"Invalid repository model " + repositoryEntry);
+	}
+
+	private final long _folderId;
+	private final HttpServletRequest _httpServletRequest;
+	private final LiferayPortletResponse _liferayPortletResponse;
+	private final PortletRequest _portletRequest;
+	private final long _repositoryId;
+
+}

--- a/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/display/context/RepositoryBrowserTagDisplayContext.java
+++ b/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/display/context/RepositoryBrowserTagDisplayContext.java
@@ -25,21 +25,15 @@ import com.liferay.document.library.taglib.internal.frontend.taglib.clay.servlet
 import com.liferay.frontend.taglib.clay.servlet.taglib.HorizontalCard;
 import com.liferay.frontend.taglib.clay.servlet.taglib.VerticalCard;
 import com.liferay.frontend.taglib.clay.servlet.taglib.display.context.ManagementToolbarDisplayContext;
-import com.liferay.frontend.taglib.clay.servlet.taglib.display.context.SearchContainerManagementToolbarDisplayContext;
-import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
-import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemListBuilder;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.search.EmptyOnClickRowChecker;
 import com.liferay.portal.kernel.dao.search.ResultRow;
 import com.liferay.portal.kernel.dao.search.ResultRowSplitter;
 import com.liferay.portal.kernel.dao.search.ResultRowSplitterEntry;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.PortletURLUtil;
-import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.FileShortcut;
 import com.liferay.portal.kernel.repository.model.Folder;
@@ -129,53 +123,9 @@ public class RepositoryBrowserTagDisplayContext {
 	public ManagementToolbarDisplayContext getManagementToolbarDisplayContext()
 		throws PortalException {
 
-		return new SearchContainerManagementToolbarDisplayContext(
+		return new RepositoryBrowserManagementToolbarDisplayContext(
 			_httpServletRequest, _liferayPortletRequest,
-			_liferayPortletResponse, getSearchContainer()) {
-
-			@Override
-			public List<DropdownItem> getActionDropdownItems() {
-				return DropdownItemListBuilder.add(
-					dropdownItem -> {
-						dropdownItem.putData("action", "deleteEntries");
-						dropdownItem.setIcon("trash");
-						dropdownItem.setLabel(
-							LanguageUtil.get(_httpServletRequest, "delete"));
-						dropdownItem.setQuickAction(true);
-					}
-				).build();
-			}
-
-			@Override
-			public String getClearResultsURL() {
-				return PortletURLBuilder.create(
-					getPortletURL()
-				).setKeywords(
-					StringPool.BLANK
-				).buildString();
-			}
-
-			@Override
-			public String[] getDisplayViews() {
-				return new String[] {"icon"};
-			}
-
-			@Override
-			public String getSearchActionURL() {
-				return String.valueOf(getPortletURL());
-			}
-
-			@Override
-			public String getSearchContainerId() {
-				return "repositoryEntries";
-			}
-
-			@Override
-			protected String getDefaultDisplayStyle() {
-				return "icon";
-			}
-
-		};
+			_liferayPortletResponse, getSearchContainer());
 	}
 
 	public String getRenameFileEntryURL(FileEntry fileEntry) {

--- a/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/display/context/RepositoryBrowserTagDisplayContext.java
+++ b/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/display/context/RepositoryBrowserTagDisplayContext.java
@@ -14,34 +14,57 @@
 
 package com.liferay.document.library.taglib.internal.display.context;
 
+import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.document.library.kernel.model.DLFolder;
+import com.liferay.document.library.kernel.model.DLFolderConstants;
+import com.liferay.document.library.kernel.service.DLAppLocalServiceUtil;
 import com.liferay.document.library.kernel.service.DLAppServiceUtil;
 import com.liferay.document.library.util.DLURLHelperUtil;
 import com.liferay.frontend.taglib.clay.servlet.taglib.HorizontalCard;
 import com.liferay.frontend.taglib.clay.servlet.taglib.VerticalCard;
+import com.liferay.frontend.taglib.clay.servlet.taglib.display.context.ManagementToolbarDisplayContext;
+import com.liferay.frontend.taglib.clay.servlet.taglib.display.context.SearchContainerManagementToolbarDisplayContext;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemListBuilder;
 import com.liferay.petra.reflect.ReflectionUtil;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.dao.search.EmptyOnClickRowChecker;
 import com.liferay.portal.kernel.dao.search.ResultRow;
 import com.liferay.portal.kernel.dao.search.ResultRowSplitter;
 import com.liferay.portal.kernel.dao.search.ResultRowSplitterEntry;
+import com.liferay.portal.kernel.dao.search.RowChecker;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
+import com.liferay.portal.kernel.portlet.PortletURLUtil;
+import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.FileShortcut;
 import com.liferay.portal.kernel.repository.model.FileVersion;
 import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.repository.model.RepositoryEntry;
+import com.liferay.portal.kernel.search.Hits;
+import com.liferay.portal.kernel.search.QueryConfig;
+import com.liferay.portal.kernel.search.RelatedSearchResult;
+import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.search.SearchContextFactory;
+import com.liferay.portal.kernel.search.SearchResult;
+import com.liferay.portal.kernel.search.SearchResultUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
+import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import javax.portlet.PortletRequest;
 
@@ -54,23 +77,38 @@ public class RepositoryBrowserTagDisplayContext {
 
 	public RepositoryBrowserTagDisplayContext(
 		long folderId, HttpServletRequest httpServletRequest,
+		LiferayPortletRequest liferayPortletRequest,
 		LiferayPortletResponse liferayPortletResponse,
 		PortletRequest portletRequest, long repositoryId) {
 
 		_folderId = folderId;
 		_httpServletRequest = httpServletRequest;
+		_liferayPortletRequest = liferayPortletRequest;
 		_liferayPortletResponse = liferayPortletResponse;
 		_portletRequest = portletRequest;
 		_repositoryId = repositoryId;
+
+		_themeDisplay = (ThemeDisplay)httpServletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
 	}
 
-	public HorizontalCard getHorizontalCard(RepositoryEntry repositoryEntry) {
+	public Map<String, Object> getAdditionalProps() {
+		return HashMapBuilder.<String, Object>put(
+			"deleteURL", _getRepositoryBrowserURL()
+		).build();
+	}
+
+	public HorizontalCard getHorizontalCard(RepositoryEntry repositoryEntry)
+		throws PortalException {
+
 		if (!(repositoryEntry instanceof Folder)) {
 			throw new IllegalArgumentException(
 				"Invalid repository model " + repositoryEntry);
 		}
 
 		Folder folder = (Folder)repositoryEntry;
+
+		SearchContainer<Object> searchContainer = getSearchContainer();
 
 		return new HorizontalCard() {
 
@@ -103,8 +141,76 @@ public class RepositoryBrowserTagDisplayContext {
 			}
 
 			@Override
+			public String getInputName() {
+				RowChecker rowChecker = searchContainer.getRowChecker();
+
+				if (rowChecker == null) {
+					return null;
+				}
+
+				return rowChecker.getRowIds();
+			}
+
+			@Override
+			public String getInputValue() {
+				return String.valueOf(folder.getFolderId());
+			}
+
+			@Override
 			public String getTitle() {
 				return folder.getName();
+			}
+
+		};
+	}
+
+	public ManagementToolbarDisplayContext getManagementToolbarDisplayContext()
+		throws PortalException {
+
+		return new SearchContainerManagementToolbarDisplayContext(
+			_httpServletRequest, _liferayPortletRequest,
+			_liferayPortletResponse, getSearchContainer()) {
+
+			@Override
+			public List<DropdownItem> getActionDropdownItems() {
+				return DropdownItemListBuilder.add(
+					dropdownItem -> {
+						dropdownItem.putData("action", "deleteEntries");
+						dropdownItem.setIcon("trash");
+						dropdownItem.setLabel(
+							LanguageUtil.get(_httpServletRequest, "delete"));
+						dropdownItem.setQuickAction(true);
+					}
+				).build();
+			}
+
+			@Override
+			public String getClearResultsURL() {
+				return PortletURLBuilder.create(
+					getPortletURL()
+				).setKeywords(
+					StringPool.BLANK
+				).buildString();
+			}
+
+			@Override
+			public String[] getDisplayViews() {
+				return new String[] {"icon"};
+			}
+
+			@Override
+			public String getSearchActionURL() {
+				return String.valueOf(getPortletURL());
+			}
+
+			@Override
+			public String getSearchContainerId() {
+				return "repositoryEntries";
+			}
+
+			@Override
+			protected String getDefaultDisplayStyle() {
+				return "icon";
 			}
 
 		};
@@ -143,24 +249,27 @@ public class RepositoryBrowserTagDisplayContext {
 	}
 
 	public SearchContainer<Object> getSearchContainer() throws PortalException {
-		SearchContainer<Object> searchContainer = new SearchContainer<>(
-			_portletRequest, _liferayPortletResponse.createRenderURL(), null,
-			null);
+		if (_searchContainer != null) {
+			return _searchContainer;
+		}
 
-		searchContainer.setResultsAndTotal(
-			() -> DLAppServiceUtil.getFoldersAndFileEntriesAndFileShortcuts(
-				_repositoryId, _folderId, WorkflowConstants.STATUS_APPROVED,
-				null, false, false, searchContainer.getStart(),
-				searchContainer.getEnd(), null),
-			DLAppServiceUtil.getFoldersAndFileEntriesAndFileShortcutsCount(
-				_repositoryId, _folderId, WorkflowConstants.STATUS_APPROVED,
-				null, false, false));
+		String keywords = ParamUtil.getString(
+			_liferayPortletRequest, "keywords");
 
-		return searchContainer;
+		if (Validator.isNull(keywords)) {
+			_searchContainer = _getDLSearchContainer();
+		}
+		else {
+			_searchContainer = _getSearchSearchContainer();
+		}
+
+		return _searchContainer;
 	}
 
 	public VerticalCard getVerticalCard(RepositoryEntry repositoryEntry)
 		throws PortalException {
+
+		SearchContainer<Object> searchContainer = getSearchContainer();
 
 		if (repositoryEntry instanceof FileEntry) {
 			FileEntry fileEntry = (FileEntry)repositoryEntry;
@@ -213,6 +322,22 @@ public class RepositoryBrowserTagDisplayContext {
 				}
 
 				@Override
+				public String getInputName() {
+					RowChecker rowChecker = searchContainer.getRowChecker();
+
+					if (rowChecker == null) {
+						return null;
+					}
+
+					return rowChecker.getRowIds();
+				}
+
+				@Override
+				public String getInputValue() {
+					return String.valueOf(fileEntry.getFileEntryId());
+				}
+
+				@Override
 				public String getTitle() {
 					return fileEntry.getTitle();
 				}
@@ -262,6 +387,22 @@ public class RepositoryBrowserTagDisplayContext {
 				}
 
 				@Override
+				public String getInputName() {
+					RowChecker rowChecker = searchContainer.getRowChecker();
+
+					if (rowChecker == null) {
+						return null;
+					}
+
+					return rowChecker.getRowIds();
+				}
+
+				@Override
+				public String getInputValue() {
+					return String.valueOf(fileShortcut.getFileShortcutId());
+				}
+
+				@Override
 				public String getTitle() {
 					return fileShortcut.getToTitle();
 				}
@@ -298,6 +439,53 @@ public class RepositoryBrowserTagDisplayContext {
 			_getRepositoryBrowserURL(), "folderId", folder.getFolderId());
 	}
 
+	private SearchContainer<Object> _getDLSearchContainer()
+		throws PortalException {
+
+		SearchContainer<Object> searchContainer = new SearchContainer<>(
+			_portletRequest,
+			PortletURLUtil.getCurrent(
+				_liferayPortletRequest, _liferayPortletResponse),
+			null, null);
+
+		searchContainer.setResultsAndTotal(
+			() -> DLAppServiceUtil.getFoldersAndFileEntriesAndFileShortcuts(
+				_repositoryId, _folderId, WorkflowConstants.STATUS_APPROVED,
+				null, false, false, searchContainer.getStart(),
+				searchContainer.getEnd(), null),
+			DLAppServiceUtil.getFoldersAndFileEntriesAndFileShortcutsCount(
+				_repositoryId, _folderId, WorkflowConstants.STATUS_APPROVED,
+				null, false, false));
+		searchContainer.setRowChecker(
+			new EmptyOnClickRowChecker(_liferayPortletResponse));
+
+		return searchContainer;
+	}
+
+	private Hits _getHits(SearchContainer<Object> searchContainer)
+		throws PortalException {
+
+		SearchContext searchContext = SearchContextFactory.getInstance(
+			_httpServletRequest);
+
+		searchContext.setAttribute("paginationType", "regular");
+		searchContext.setAttribute("searchRepositoryId", _repositoryId);
+		searchContext.setEnd(searchContainer.getEnd());
+		searchContext.setFolderIds(
+			new long[] {DLFolderConstants.DEFAULT_PARENT_FOLDER_ID});
+		searchContext.setKeywords(
+			ParamUtil.getString(_httpServletRequest, "keywords"));
+		searchContext.setLocale(_themeDisplay.getSiteDefaultLocale());
+
+		QueryConfig queryConfig = searchContext.getQueryConfig();
+
+		queryConfig.setSearchSubfolders(true);
+
+		searchContext.setStart(searchContainer.getStart());
+
+		return DLAppServiceUtil.search(_repositoryId, searchContext);
+	}
+
 	private String _getRenameFileEntryURL(FileEntry fileEntry) {
 		return HttpComponentsUtil.addParameter(
 			_getRepositoryBrowserURL(), "fileEntryId",
@@ -321,11 +509,72 @@ public class RepositoryBrowserTagDisplayContext {
 		return _repositoryBrowserURL;
 	}
 
+	private List<Object> _getSearchResults(Hits hits) throws PortalException {
+		List<Object> searchResults = new ArrayList<>();
+
+		for (SearchResult searchResult :
+				SearchResultUtil.getSearchResults(
+					hits, _httpServletRequest.getLocale())) {
+
+			String className = searchResult.getClassName();
+
+			try {
+				List<RelatedSearchResult<FileEntry>>
+					fileEntryRelatedSearchResults =
+						searchResult.getFileEntryRelatedSearchResults();
+
+				if (!fileEntryRelatedSearchResults.isEmpty()) {
+					fileEntryRelatedSearchResults.forEach(
+						fileEntryRelatedSearchResult -> searchResults.add(
+							fileEntryRelatedSearchResult.getModel()));
+				}
+				else if (className.equals(DLFileEntry.class.getName()) ||
+						 FileEntry.class.isAssignableFrom(
+							 Class.forName(className))) {
+
+					searchResults.add(
+						DLAppLocalServiceUtil.getFileEntry(
+							searchResult.getClassPK()));
+				}
+				else if (className.equals(DLFolder.class.getName()) ||
+						 className.equals(Folder.class.getName())) {
+
+					searchResults.add(
+						DLAppLocalServiceUtil.getFolder(
+							searchResult.getClassPK()));
+				}
+			}
+			catch (ClassNotFoundException classNotFoundException) {
+				throw new PortalException(classNotFoundException);
+			}
+		}
+
+		return searchResults;
+	}
+
+	private SearchContainer<Object> _getSearchSearchContainer()
+		throws PortalException {
+
+		SearchContainer<Object> searchContainer = new SearchContainer<>(
+			_liferayPortletRequest, _liferayPortletResponse.createRenderURL(),
+			null, null);
+
+		Hits hits = _getHits(searchContainer);
+
+		searchContainer.setResultsAndTotal(
+			() -> _getSearchResults(hits), hits.getLength());
+
+		return searchContainer;
+	}
+
 	private final long _folderId;
 	private final HttpServletRequest _httpServletRequest;
+	private final LiferayPortletRequest _liferayPortletRequest;
 	private final LiferayPortletResponse _liferayPortletResponse;
 	private final PortletRequest _portletRequest;
 	private String _repositoryBrowserURL;
 	private final long _repositoryId;
+	private SearchContainer<Object> _searchContainer;
+	private final ThemeDisplay _themeDisplay;
 
 }

--- a/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/display/context/RepositoryBrowserTagDisplayContext.java
+++ b/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/display/context/RepositoryBrowserTagDisplayContext.java
@@ -19,6 +19,7 @@ import com.liferay.document.library.kernel.model.DLFolder;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLAppLocalServiceUtil;
 import com.liferay.document.library.kernel.service.DLAppServiceUtil;
+import com.liferay.document.library.taglib.internal.frontend.taglib.clay.servlet.FileEntryVerticalCard;
 import com.liferay.document.library.taglib.internal.frontend.taglib.clay.servlet.FolderHorizontalCard;
 import com.liferay.document.library.util.DLURLHelperUtil;
 import com.liferay.frontend.taglib.clay.servlet.taglib.HorizontalCard;
@@ -99,6 +100,12 @@ public class RepositoryBrowserTagDisplayContext {
 		).build();
 	}
 
+	public String getDeleteFileEntryURL(FileEntry fileEntry) {
+		return HttpComponentsUtil.addParameter(
+			_getRepositoryBrowserURL(), "fileEntryId",
+			fileEntry.getFileEntryId());
+	}
+
 	public String getDeleteFolderURL(Folder folder) {
 		return HttpComponentsUtil.addParameter(
 			_getRepositoryBrowserURL(), "folderId", folder.getFolderId());
@@ -168,6 +175,12 @@ public class RepositoryBrowserTagDisplayContext {
 		};
 	}
 
+	public String getRenameFileEntryURL(FileEntry fileEntry) {
+		return HttpComponentsUtil.addParameter(
+			_getRepositoryBrowserURL(), "fileEntryId",
+			fileEntry.getFileEntryId());
+	}
+
 	public String getRenameFolderURL(Folder folder) {
 		return HttpComponentsUtil.addParameter(
 			_getRepositoryBrowserURL(), "folderId", folder.getFolderId());
@@ -226,86 +239,19 @@ public class RepositoryBrowserTagDisplayContext {
 	public VerticalCard getVerticalCard(RepositoryEntry repositoryEntry)
 		throws PortalException {
 
-		SearchContainer<Object> searchContainer = getSearchContainer();
-
 		if (repositoryEntry instanceof FileEntry) {
 			FileEntry fileEntry = (FileEntry)repositoryEntry;
 
-			FileVersion fileVersion = fileEntry.getFileVersion();
-
-			return new VerticalCard() {
-
-				@Override
-				public List<DropdownItem> getActionDropdownItems() {
-					return DropdownItemListBuilder.add(
-						dropdownItem -> {
-							dropdownItem.putData("action", "rename");
-							dropdownItem.putData(
-								"renameURL", _getRenameFileEntryURL(fileEntry));
-							dropdownItem.putData("value", fileEntry.getTitle());
-							dropdownItem.setLabel(
-								LanguageUtil.get(
-									_httpServletRequest, "rename"));
-						}
-					).add(
-						dropdownItem -> {
-							dropdownItem.putData("action", "delete");
-							dropdownItem.putData(
-								"deleteURL", _getDeleteFileEntryURL(fileEntry));
-							dropdownItem.setIcon("trash");
-							dropdownItem.setLabel(
-								LanguageUtil.get(
-									_httpServletRequest, "delete"));
-						}
-					).build();
-				}
-
-				@Override
-				public String getDefaultEventHandler() {
-					return "repositoryBrowserEventHandler";
-				}
-
-				@Override
-				public String getImageSrc() {
-					try {
-						return DLURLHelperUtil.getThumbnailSrc(
-							fileEntry, fileVersion,
-							(ThemeDisplay)_httpServletRequest.getAttribute(
-								WebKeys.THEME_DISPLAY));
-					}
-					catch (Exception exception) {
-						return ReflectionUtil.throwException(exception);
-					}
-				}
-
-				@Override
-				public String getInputName() {
-					RowChecker rowChecker = searchContainer.getRowChecker();
-
-					if (rowChecker == null) {
-						return null;
-					}
-
-					return rowChecker.getRowIds();
-				}
-
-				@Override
-				public String getInputValue() {
-					return String.valueOf(fileEntry.getFileEntryId());
-				}
-
-				@Override
-				public String getTitle() {
-					return fileEntry.getTitle();
-				}
-
-			};
+			return new FileEntryVerticalCard(
+				fileEntry, _httpServletRequest, this);
 		}
 
 		if (repositoryEntry instanceof FileShortcut) {
 			FileShortcut fileShortcut = (FileShortcut)repositoryEntry;
 
 			FileVersion fileVersion = fileShortcut.getFileVersion();
+
+			SearchContainer<Object> searchContainer = getSearchContainer();
 
 			return new VerticalCard() {
 
@@ -379,12 +325,6 @@ public class RepositoryBrowserTagDisplayContext {
 		return true;
 	}
 
-	private String _getDeleteFileEntryURL(FileEntry fileEntry) {
-		return HttpComponentsUtil.addParameter(
-			_getRepositoryBrowserURL(), "fileEntryId",
-			fileEntry.getFileEntryId());
-	}
-
 	private String _getDeleteFileShortcutURL(FileShortcut fileShortcut) {
 		return HttpComponentsUtil.addParameter(
 			_getRepositoryBrowserURL(), "fileShortcutId",
@@ -436,12 +376,6 @@ public class RepositoryBrowserTagDisplayContext {
 		searchContext.setStart(searchContainer.getStart());
 
 		return DLAppServiceUtil.search(_repositoryId, searchContext);
-	}
-
-	private String _getRenameFileEntryURL(FileEntry fileEntry) {
-		return HttpComponentsUtil.addParameter(
-			_getRepositoryBrowserURL(), "fileEntryId",
-			fileEntry.getFileEntryId());
 	}
 
 	private String _getRepositoryBrowserURL() {

--- a/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/display/context/RepositoryBrowserTagDisplayContext.java
+++ b/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/display/context/RepositoryBrowserTagDisplayContext.java
@@ -78,6 +78,15 @@ public class RepositoryBrowserTagDisplayContext {
 			public List<DropdownItem> getActionDropdownItems() {
 				return DropdownItemListBuilder.add(
 					dropdownItem -> {
+						dropdownItem.putData("action", "rename");
+						dropdownItem.putData(
+							"renameURL", _getRenameFolderURL(folder));
+						dropdownItem.putData("value", folder.getName());
+						dropdownItem.setLabel(
+							LanguageUtil.get(_httpServletRequest, "rename"));
+					}
+				).add(
+					dropdownItem -> {
 						dropdownItem.putData("action", "delete");
 						dropdownItem.putData(
 							"deleteURL", _getDeleteFolderURL(folder));
@@ -163,6 +172,16 @@ public class RepositoryBrowserTagDisplayContext {
 				@Override
 				public List<DropdownItem> getActionDropdownItems() {
 					return DropdownItemListBuilder.add(
+						dropdownItem -> {
+							dropdownItem.putData("action", "rename");
+							dropdownItem.putData(
+								"renameURL", _getRenameFileEntryURL(fileEntry));
+							dropdownItem.putData("value", fileEntry.getTitle());
+							dropdownItem.setLabel(
+								LanguageUtil.get(
+									_httpServletRequest, "rename"));
+						}
+					).add(
 						dropdownItem -> {
 							dropdownItem.putData("action", "delete");
 							dropdownItem.putData(
@@ -275,6 +294,17 @@ public class RepositoryBrowserTagDisplayContext {
 	}
 
 	private String _getDeleteFolderURL(Folder folder) {
+		return HttpComponentsUtil.addParameter(
+			_getRepositoryBrowserURL(), "folderId", folder.getFolderId());
+	}
+
+	private String _getRenameFileEntryURL(FileEntry fileEntry) {
+		return HttpComponentsUtil.addParameter(
+			_getRepositoryBrowserURL(), "fileEntryId",
+			fileEntry.getFileEntryId());
+	}
+
+	private String _getRenameFolderURL(Folder folder) {
 		return HttpComponentsUtil.addParameter(
 			_getRepositoryBrowserURL(), "folderId", folder.getFolderId());
 	}

--- a/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/display/context/RepositoryBrowserTagDisplayContext.java
+++ b/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/display/context/RepositoryBrowserTagDisplayContext.java
@@ -156,8 +156,8 @@ public class RepositoryBrowserTagDisplayContext {
 		throws PortalException {
 
 		return new RepositoryBrowserManagementToolbarDisplayContext(
-			_httpServletRequest, _liferayPortletRequest,
-			_liferayPortletResponse, getSearchContainer());
+			_folderId, _httpServletRequest, _liferayPortletRequest,
+			_liferayPortletResponse, _repositoryId, getSearchContainer());
 	}
 
 	public String getRenameFileEntryURL(FileEntry fileEntry) {

--- a/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/display/context/RepositoryBrowserTagDisplayContext.java
+++ b/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/display/context/RepositoryBrowserTagDisplayContext.java
@@ -18,6 +18,7 @@ import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFolder;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLAppLocalServiceUtil;
+import com.liferay.document.library.kernel.service.DLAppService;
 import com.liferay.document.library.kernel.service.DLAppServiceUtil;
 import com.liferay.document.library.taglib.internal.frontend.taglib.clay.servlet.FileEntryVerticalCard;
 import com.liferay.document.library.taglib.internal.frontend.taglib.clay.servlet.FileShortcutVerticalCard;
@@ -31,6 +32,7 @@ import com.liferay.portal.kernel.dao.search.ResultRowSplitter;
 import com.liferay.portal.kernel.dao.search.ResultRowSplitterEntry;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.PortletURLUtil;
@@ -46,6 +48,7 @@ import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.SearchContextFactory;
 import com.liferay.portal.kernel.search.SearchResult;
 import com.liferay.portal.kernel.search.SearchResultUtil;
+import com.liferay.portal.kernel.servlet.taglib.ui.BreadcrumbEntry;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
@@ -57,6 +60,7 @@ import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -70,11 +74,13 @@ import javax.servlet.http.HttpServletRequest;
 public class RepositoryBrowserTagDisplayContext {
 
 	public RepositoryBrowserTagDisplayContext(
-		long folderId, HttpServletRequest httpServletRequest,
+		DLAppService dlAppService, long folderId,
+		HttpServletRequest httpServletRequest,
 		LiferayPortletRequest liferayPortletRequest,
 		LiferayPortletResponse liferayPortletResponse,
 		PortletRequest portletRequest, long repositoryId) {
 
+		_dlAppService = dlAppService;
 		_folderId = folderId;
 		_httpServletRequest = httpServletRequest;
 		_liferayPortletRequest = liferayPortletRequest;
@@ -90,6 +96,27 @@ public class RepositoryBrowserTagDisplayContext {
 		return HashMapBuilder.<String, Object>put(
 			"deleteURL", _getRepositoryBrowserURL()
 		).build();
+	}
+
+	public List<BreadcrumbEntry> getBreadcrumbEntries() throws PortalException {
+		LinkedList<BreadcrumbEntry> breadcrumbEntries = new LinkedList<>();
+
+		long folderId = _folderId;
+
+		while (folderId != DLFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
+			Folder folder = _dlAppService.getFolder(folderId);
+
+			breadcrumbEntries.addFirst(
+				_createBreadcrumbEntry(folderId, folder.getName()));
+
+			folderId = folder.getParentFolderId();
+		}
+
+		breadcrumbEntries.addFirst(
+			_createBreadcrumbEntry(
+				folderId, LanguageUtil.get(_httpServletRequest, "home")));
+
+		return breadcrumbEntries;
 	}
 
 	public String getDeleteFileEntryURL(FileEntry fileEntry) {
@@ -110,12 +137,7 @@ public class RepositoryBrowserTagDisplayContext {
 	}
 
 	public String getFolderURL(Folder folder) {
-		return PortletURLBuilder.create(
-			PortletURLUtil.getCurrent(
-				_liferayPortletRequest, _liferayPortletResponse)
-		).setParameter(
-			"folderId", folder.getFolderId()
-		).buildString();
+		return _getFolderURL(folder.getFolderId());
 	}
 
 	public HorizontalCard getHorizontalCard(RepositoryEntry repositoryEntry)
@@ -224,6 +246,17 @@ public class RepositoryBrowserTagDisplayContext {
 		return true;
 	}
 
+	private BreadcrumbEntry _createBreadcrumbEntry(
+		long folderId, String title) {
+
+		BreadcrumbEntry breadcrumbEntry = new BreadcrumbEntry();
+
+		breadcrumbEntry.setTitle(title);
+		breadcrumbEntry.setURL(_getFolderURL(folderId));
+
+		return breadcrumbEntry;
+	}
+
 	private SearchContainer<Object> _getDLSearchContainer()
 		throws PortalException {
 
@@ -245,6 +278,15 @@ public class RepositoryBrowserTagDisplayContext {
 			new EmptyOnClickRowChecker(_liferayPortletResponse));
 
 		return searchContainer;
+	}
+
+	private String _getFolderURL(long folderId) {
+		return PortletURLBuilder.create(
+			PortletURLUtil.getCurrent(
+				_liferayPortletRequest, _liferayPortletResponse)
+		).setParameter(
+			"folderId", folderId
+		).buildString();
 	}
 
 	private Hits _getHits(SearchContainer<Object> searchContainer)
@@ -341,6 +383,7 @@ public class RepositoryBrowserTagDisplayContext {
 		return searchContainer;
 	}
 
+	private final DLAppService _dlAppService;
 	private final long _folderId;
 	private final HttpServletRequest _httpServletRequest;
 	private final LiferayPortletRequest _liferayPortletRequest;

--- a/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/display/context/RepositoryBrowserTagDisplayContext.java
+++ b/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/display/context/RepositoryBrowserTagDisplayContext.java
@@ -19,6 +19,7 @@ import com.liferay.document.library.kernel.model.DLFolder;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLAppLocalServiceUtil;
 import com.liferay.document.library.kernel.service.DLAppServiceUtil;
+import com.liferay.document.library.taglib.internal.frontend.taglib.clay.servlet.FolderHorizontalCard;
 import com.liferay.document.library.util.DLURLHelperUtil;
 import com.liferay.frontend.taglib.clay.servlet.taglib.HorizontalCard;
 import com.liferay.frontend.taglib.clay.servlet.taglib.VerticalCard;
@@ -98,6 +99,11 @@ public class RepositoryBrowserTagDisplayContext {
 		).build();
 	}
 
+	public String getDeleteFolderURL(Folder folder) {
+		return HttpComponentsUtil.addParameter(
+			_getRepositoryBrowserURL(), "folderId", folder.getFolderId());
+	}
+
 	public HorizontalCard getHorizontalCard(RepositoryEntry repositoryEntry)
 		throws PortalException {
 
@@ -106,62 +112,8 @@ public class RepositoryBrowserTagDisplayContext {
 				"Invalid repository model " + repositoryEntry);
 		}
 
-		Folder folder = (Folder)repositoryEntry;
-
-		SearchContainer<Object> searchContainer = getSearchContainer();
-
-		return new HorizontalCard() {
-
-			@Override
-			public List<DropdownItem> getActionDropdownItems() {
-				return DropdownItemListBuilder.add(
-					dropdownItem -> {
-						dropdownItem.putData("action", "rename");
-						dropdownItem.putData(
-							"renameURL", _getRenameFolderURL(folder));
-						dropdownItem.putData("value", folder.getName());
-						dropdownItem.setLabel(
-							LanguageUtil.get(_httpServletRequest, "rename"));
-					}
-				).add(
-					dropdownItem -> {
-						dropdownItem.putData("action", "delete");
-						dropdownItem.putData(
-							"deleteURL", _getDeleteFolderURL(folder));
-						dropdownItem.setIcon("trash");
-						dropdownItem.setLabel(
-							LanguageUtil.get(_httpServletRequest, "delete"));
-					}
-				).build();
-			}
-
-			@Override
-			public String getDefaultEventHandler() {
-				return "repositoryBrowserEventHandler";
-			}
-
-			@Override
-			public String getInputName() {
-				RowChecker rowChecker = searchContainer.getRowChecker();
-
-				if (rowChecker == null) {
-					return null;
-				}
-
-				return rowChecker.getRowIds();
-			}
-
-			@Override
-			public String getInputValue() {
-				return String.valueOf(folder.getFolderId());
-			}
-
-			@Override
-			public String getTitle() {
-				return folder.getName();
-			}
-
-		};
+		return new FolderHorizontalCard(
+			(Folder)repositoryEntry, _httpServletRequest, this);
 	}
 
 	public ManagementToolbarDisplayContext getManagementToolbarDisplayContext()
@@ -214,6 +166,11 @@ public class RepositoryBrowserTagDisplayContext {
 			}
 
 		};
+	}
+
+	public String getRenameFolderURL(Folder folder) {
+		return HttpComponentsUtil.addParameter(
+			_getRepositoryBrowserURL(), "folderId", folder.getFolderId());
 	}
 
 	public ResultRowSplitter getResultRowSplitter() {
@@ -434,11 +391,6 @@ public class RepositoryBrowserTagDisplayContext {
 			fileShortcut.getFileShortcutId());
 	}
 
-	private String _getDeleteFolderURL(Folder folder) {
-		return HttpComponentsUtil.addParameter(
-			_getRepositoryBrowserURL(), "folderId", folder.getFolderId());
-	}
-
 	private SearchContainer<Object> _getDLSearchContainer()
 		throws PortalException {
 
@@ -490,11 +442,6 @@ public class RepositoryBrowserTagDisplayContext {
 		return HttpComponentsUtil.addParameter(
 			_getRepositoryBrowserURL(), "fileEntryId",
 			fileEntry.getFileEntryId());
-	}
-
-	private String _getRenameFolderURL(Folder folder) {
-		return HttpComponentsUtil.addParameter(
-			_getRepositoryBrowserURL(), "folderId", folder.getFolderId());
 	}
 
 	private String _getRepositoryBrowserURL() {

--- a/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/frontend/taglib/clay/servlet/FileEntryVerticalCard.java
+++ b/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/frontend/taglib/clay/servlet/FileEntryVerticalCard.java
@@ -1,0 +1,135 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.document.library.taglib.internal.frontend.taglib.clay.servlet;
+
+import com.liferay.document.library.taglib.internal.display.context.RepositoryBrowserTagDisplayContext;
+import com.liferay.document.library.util.DLURLHelperUtil;
+import com.liferay.frontend.taglib.clay.servlet.taglib.VerticalCard;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemListBuilder;
+import com.liferay.petra.reflect.ReflectionUtil;
+import com.liferay.portal.kernel.dao.search.RowChecker;
+import com.liferay.portal.kernel.dao.search.SearchContainer;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.repository.model.FileVersion;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.WebKeys;
+
+import java.util.List;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * @author Adolfo Pérez
+ */
+public class FileEntryVerticalCard implements VerticalCard {
+
+	public FileEntryVerticalCard(
+			FileEntry fileEntry, HttpServletRequest httpServletRequest,
+			RepositoryBrowserTagDisplayContext
+				repositoryBrowserTagDisplayContext)
+		throws PortalException {
+
+		_fileEntry = fileEntry;
+		_httpServletRequest = httpServletRequest;
+		_repositoryBrowserTagDisplayContext =
+			repositoryBrowserTagDisplayContext;
+
+		_fileVersion = fileEntry.getFileVersion();
+	}
+
+	@Override
+	public List<DropdownItem> getActionDropdownItems() {
+		return DropdownItemListBuilder.add(
+			dropdownItem -> {
+				dropdownItem.putData("action", "rename");
+				dropdownItem.putData(
+					"renameURL",
+					_repositoryBrowserTagDisplayContext.getRenameFileEntryURL(
+						_fileEntry));
+				dropdownItem.putData("value", _fileEntry.getTitle());
+				dropdownItem.setLabel(
+					LanguageUtil.get(_httpServletRequest, "rename"));
+			}
+		).add(
+			dropdownItem -> {
+				dropdownItem.putData("action", "delete");
+				dropdownItem.putData(
+					"deleteURL",
+					_repositoryBrowserTagDisplayContext.getDeleteFileEntryURL(
+						_fileEntry));
+				dropdownItem.setIcon("trash");
+				dropdownItem.setLabel(
+					LanguageUtil.get(_httpServletRequest, "delete"));
+			}
+		).build();
+	}
+
+	@Override
+	public String getDefaultEventHandler() {
+		return "repositoryBrowserEventHandler";
+	}
+
+	@Override
+	public String getImageSrc() {
+		try {
+			return DLURLHelperUtil.getThumbnailSrc(
+				_fileEntry, _fileVersion,
+				(ThemeDisplay)_httpServletRequest.getAttribute(
+					WebKeys.THEME_DISPLAY));
+		}
+		catch (Exception exception) {
+			return ReflectionUtil.throwException(exception);
+		}
+	}
+
+	@Override
+	public String getInputName() {
+		try {
+			SearchContainer<Object> searchContainer =
+				_repositoryBrowserTagDisplayContext.getSearchContainer();
+
+			RowChecker rowChecker = searchContainer.getRowChecker();
+
+			if (rowChecker == null) {
+				return null;
+			}
+
+			return rowChecker.getRowIds();
+		}
+		catch (PortalException portalException) {
+			return ReflectionUtil.throwException(portalException);
+		}
+	}
+
+	@Override
+	public String getInputValue() {
+		return String.valueOf(_fileEntry.getFileEntryId());
+	}
+
+	@Override
+	public String getTitle() {
+		return _fileEntry.getTitle();
+	}
+
+	private final FileEntry _fileEntry;
+	private final FileVersion _fileVersion;
+	private final HttpServletRequest _httpServletRequest;
+	private final RepositoryBrowserTagDisplayContext
+		_repositoryBrowserTagDisplayContext;
+
+}

--- a/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/frontend/taglib/clay/servlet/FileShortcutVerticalCard.java
+++ b/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/frontend/taglib/clay/servlet/FileShortcutVerticalCard.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.document.library.taglib.internal.frontend.taglib.clay.servlet;
+
+import com.liferay.document.library.taglib.internal.display.context.RepositoryBrowserTagDisplayContext;
+import com.liferay.document.library.util.DLURLHelperUtil;
+import com.liferay.frontend.taglib.clay.servlet.taglib.VerticalCard;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemListBuilder;
+import com.liferay.petra.reflect.ReflectionUtil;
+import com.liferay.portal.kernel.dao.search.RowChecker;
+import com.liferay.portal.kernel.dao.search.SearchContainer;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.repository.model.FileShortcut;
+import com.liferay.portal.kernel.repository.model.FileVersion;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.WebKeys;
+
+import java.util.List;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * @author Adolfo Pérez
+ */
+public class FileShortcutVerticalCard implements VerticalCard {
+
+	public FileShortcutVerticalCard(
+			FileShortcut fileShortcut, HttpServletRequest httpServletRequest,
+			RepositoryBrowserTagDisplayContext
+				repositoryBrowserTagDisplayContext)
+		throws PortalException {
+
+		_fileShortcut = fileShortcut;
+		_httpServletRequest = httpServletRequest;
+		_repositoryBrowserTagDisplayContext =
+			repositoryBrowserTagDisplayContext;
+
+		_fileVersion = fileShortcut.getFileVersion();
+	}
+
+	@Override
+	public List<DropdownItem> getActionDropdownItems() {
+		return DropdownItemListBuilder.add(
+			dropdownItem -> {
+				dropdownItem.putData("action", "delete");
+				dropdownItem.putData(
+					"deleteURL",
+					_repositoryBrowserTagDisplayContext.
+						getDeleteFileShortcutURL(_fileShortcut));
+				dropdownItem.setIcon("trash");
+				dropdownItem.setLabel(
+					LanguageUtil.get(_httpServletRequest, "delete"));
+			}
+		).build();
+	}
+
+	@Override
+	public String getDefaultEventHandler() {
+		return "repositoryBrowserEventHandler";
+	}
+
+	@Override
+	public String getImageSrc() {
+		try {
+			return DLURLHelperUtil.getThumbnailSrc(
+				_fileVersion.getFileEntry(), _fileVersion,
+				(ThemeDisplay)_httpServletRequest.getAttribute(
+					WebKeys.THEME_DISPLAY));
+		}
+		catch (Exception exception) {
+			return ReflectionUtil.throwException(exception);
+		}
+	}
+
+	@Override
+	public String getInputName() {
+		try {
+			SearchContainer<Object> searchContainer =
+				_repositoryBrowserTagDisplayContext.getSearchContainer();
+
+			RowChecker rowChecker = searchContainer.getRowChecker();
+
+			if (rowChecker == null) {
+				return null;
+			}
+
+			return rowChecker.getRowIds();
+		}
+		catch (PortalException portalException) {
+			return ReflectionUtil.throwException(portalException);
+		}
+	}
+
+	@Override
+	public String getInputValue() {
+		return String.valueOf(_fileShortcut.getFileShortcutId());
+	}
+
+	@Override
+	public String getTitle() {
+		return _fileShortcut.getToTitle();
+	}
+
+	private final FileShortcut _fileShortcut;
+	private final FileVersion _fileVersion;
+	private final HttpServletRequest _httpServletRequest;
+	private final RepositoryBrowserTagDisplayContext
+		_repositoryBrowserTagDisplayContext;
+
+}

--- a/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/frontend/taglib/clay/servlet/FolderHorizontalCard.java
+++ b/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/frontend/taglib/clay/servlet/FolderHorizontalCard.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.document.library.taglib.internal.frontend.taglib.clay.servlet;
+
+import com.liferay.document.library.taglib.internal.display.context.RepositoryBrowserTagDisplayContext;
+import com.liferay.frontend.taglib.clay.servlet.taglib.HorizontalCard;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemListBuilder;
+import com.liferay.petra.reflect.ReflectionUtil;
+import com.liferay.portal.kernel.dao.search.RowChecker;
+import com.liferay.portal.kernel.dao.search.SearchContainer;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.repository.model.Folder;
+
+import java.util.List;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * @author Adolfo Pérez
+ */
+public class FolderHorizontalCard implements HorizontalCard {
+
+	public FolderHorizontalCard(
+		Folder folder, HttpServletRequest httpServletRequest,
+		RepositoryBrowserTagDisplayContext repositoryBrowserTagDisplayContext) {
+
+		_folder = folder;
+		_httpServletRequest = httpServletRequest;
+		_repositoryBrowserTagDisplayContext =
+			repositoryBrowserTagDisplayContext;
+	}
+
+	@Override
+	public List<DropdownItem> getActionDropdownItems() {
+		return DropdownItemListBuilder.add(
+			dropdownItem -> {
+				dropdownItem.putData("action", "rename");
+				dropdownItem.putData(
+					"renameURL",
+					_repositoryBrowserTagDisplayContext.getRenameFolderURL(
+						_folder));
+				dropdownItem.putData("value", _folder.getName());
+				dropdownItem.setLabel(
+					LanguageUtil.get(_httpServletRequest, "rename"));
+			}
+		).add(
+			dropdownItem -> {
+				dropdownItem.putData("action", "delete");
+				dropdownItem.putData(
+					"deleteURL",
+					_repositoryBrowserTagDisplayContext.getDeleteFolderURL(
+						_folder));
+				dropdownItem.setIcon("trash");
+				dropdownItem.setLabel(
+					LanguageUtil.get(_httpServletRequest, "delete"));
+			}
+		).build();
+	}
+
+	@Override
+	public String getDefaultEventHandler() {
+		return "repositoryBrowserEventHandler";
+	}
+
+	@Override
+	public String getInputName() {
+		try {
+			SearchContainer<Object> searchContainer =
+				_repositoryBrowserTagDisplayContext.getSearchContainer();
+
+			RowChecker rowChecker = searchContainer.getRowChecker();
+
+			if (rowChecker == null) {
+				return null;
+			}
+
+			return rowChecker.getRowIds();
+		}
+		catch (PortalException portalException) {
+			return ReflectionUtil.throwException(portalException);
+		}
+	}
+
+	@Override
+	public String getInputValue() {
+		return String.valueOf(_folder.getFolderId());
+	}
+
+	@Override
+	public String getTitle() {
+		return _folder.getName();
+	}
+
+	private final Folder _folder;
+	private final HttpServletRequest _httpServletRequest;
+	private final RepositoryBrowserTagDisplayContext
+		_repositoryBrowserTagDisplayContext;
+
+}

--- a/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/frontend/taglib/clay/servlet/FolderHorizontalCard.java
+++ b/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/frontend/taglib/clay/servlet/FolderHorizontalCard.java
@@ -77,6 +77,11 @@ public class FolderHorizontalCard implements HorizontalCard {
 	}
 
 	@Override
+	public String getHref() {
+		return _repositoryBrowserTagDisplayContext.getFolderURL(_folder);
+	}
+
+	@Override
 	public String getInputName() {
 		try {
 			SearchContainer<Object> searchContainer =

--- a/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/servlet/RepositoryBrowserServlet.java
+++ b/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/servlet/RepositoryBrowserServlet.java
@@ -51,7 +51,7 @@ import org.osgi.service.component.annotations.Reference;
 	property = {
 		"osgi.http.whiteboard.servlet.name=com.liferay.document.library.taglib.internal.servlet.RepositoryBrowserServlet",
 		"osgi.http.whiteboard.servlet.pattern=/repository_browser",
-		"servlet.init.httpMethods=DELETE,POST"
+		"servlet.init.httpMethods=DELETE,POST,PUT"
 	},
 	service = Servlet.class
 )
@@ -139,6 +139,37 @@ public class RepositoryBrowserServlet extends HttpServlet {
 			}
 
 			SessionMessages.add(httpServletRequest, "requestProcessed");
+		}
+		catch (PortalException portalException) {
+			throw new ServletException(portalException);
+		}
+	}
+
+	@Override
+	protected void doPut(
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse)
+		throws IOException, ServletException {
+
+		try {
+			String name = ParamUtil.getString(httpServletRequest, "name");
+			long repositoryId = ParamUtil.getLong(
+				httpServletRequest, "repositoryId");
+
+			if (Validator.isNull(name) || (repositoryId <= 0)) {
+				httpServletResponse.sendError(
+					HttpServletResponse.SC_BAD_REQUEST);
+
+				return;
+			}
+
+			long parentFolderId = ParamUtil.getLong(
+				httpServletRequest, "parentFolderId");
+
+			_dlAppService.addFolder(
+				repositoryId, parentFolderId, name, StringPool.BLANK,
+				ServiceContextFactory.getInstance(
+					Folder.class.getName(), httpServletRequest));
 		}
 		catch (PortalException portalException) {
 			throw new ServletException(portalException);

--- a/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/servlet/RepositoryBrowserServlet.java
+++ b/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/servlet/RepositoryBrowserServlet.java
@@ -17,8 +17,11 @@ package com.liferay.document.library.taglib.internal.servlet;
 import com.liferay.document.library.kernel.service.DLAppService;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.repository.model.FileShortcut;
 import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
@@ -79,6 +82,17 @@ public class RepositoryBrowserServlet extends HttpServlet {
 
 			if (folderId != 0) {
 				_dlAppService.deleteFolder(folderId);
+			}
+
+			long[] repositoryEntryIds = ParamUtil.getLongValues(
+				httpServletRequest, "repositoryEntryIds");
+
+			if ((repositoryEntryIds != null) &&
+				(repositoryEntryIds.length > 0)) {
+
+				for (long repositoryEntryId : repositoryEntryIds) {
+					_deleteRepositoryEntry(repositoryEntryId);
+				}
 			}
 
 			SessionMessages.add(httpServletRequest, "requestProcessed");
@@ -156,6 +170,49 @@ public class RepositoryBrowserServlet extends HttpServlet {
 			throw new ServletException(portalException);
 		}
 	}
+
+	private void _deleteRepositoryEntry(long repositoryEntryId) {
+		try {
+			FileEntry fileEntry = _dlAppService.getFileEntry(repositoryEntryId);
+
+			_dlAppService.deleteFileEntry(fileEntry.getFileEntryId());
+
+			return;
+		}
+		catch (PortalException portalException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(portalException);
+			}
+		}
+
+		try {
+			FileShortcut fileShortcut = _dlAppService.getFileShortcut(
+				repositoryEntryId);
+
+			_dlAppService.deleteFileShortcut(fileShortcut.getFileShortcutId());
+
+			return;
+		}
+		catch (PortalException portalException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(portalException);
+			}
+		}
+
+		try {
+			Folder folder = _dlAppService.getFolder(repositoryEntryId);
+
+			_dlAppService.deleteFolder(folder.getFolderId());
+		}
+		catch (PortalException portalException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(portalException);
+			}
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		RepositoryBrowserServlet.class);
 
 	@Reference
 	private DLAppService _dlAppService;

--- a/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/servlet/RepositoryBrowserServlet.java
+++ b/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/servlet/RepositoryBrowserServlet.java
@@ -18,13 +18,17 @@ import com.liferay.document.library.kernel.service.DLAppService;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.ServiceContextFactory;
 import com.liferay.portal.kernel.servlet.SessionMessages;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.Validator;
 
 import java.io.IOException;
 
@@ -44,7 +48,7 @@ import org.osgi.service.component.annotations.Reference;
 	property = {
 		"osgi.http.whiteboard.servlet.name=com.liferay.document.library.taglib.internal.servlet.RepositoryBrowserServlet",
 		"osgi.http.whiteboard.servlet.pattern=/repository_browser",
-		"servlet.init.httpMethods=DELETE"
+		"servlet.init.httpMethods=DELETE,POST"
 	},
 	service = Servlet.class
 )
@@ -57,18 +61,6 @@ public class RepositoryBrowserServlet extends HttpServlet {
 		throws IOException, ServletException {
 
 		try {
-			User user = _portal.getUser(httpServletRequest);
-
-			if ((user == null) || user.isDefaultUser()) {
-				throw new PrincipalException.MustBeAuthenticated(
-					StringPool.BLANK);
-			}
-
-			PrincipalThreadLocal.setName(user.getUserId());
-
-			PermissionThreadLocal.setPermissionChecker(
-				_permissionCheckerFactory.create(user));
-
 			long fileEntryId = ParamUtil.getLong(
 				httpServletRequest, "fileEntryId");
 
@@ -90,6 +82,75 @@ public class RepositoryBrowserServlet extends HttpServlet {
 			}
 
 			SessionMessages.add(httpServletRequest, "requestProcessed");
+		}
+		catch (PortalException portalException) {
+			throw new ServletException(portalException);
+		}
+	}
+
+	@Override
+	protected void doPost(
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse)
+		throws IOException, ServletException {
+
+		try {
+			String name = ParamUtil.getString(httpServletRequest, "name");
+
+			if (Validator.isNull(name)) {
+				httpServletResponse.sendError(
+					HttpServletResponse.SC_BAD_REQUEST);
+
+				return;
+			}
+
+			long fileEntryId = ParamUtil.getLong(
+				httpServletRequest, "fileEntryId");
+
+			if (fileEntryId != 0) {
+				_dlAppService.updateFileEntry(
+					fileEntryId, null, null, name, null, null, null, null,
+					new byte[0], null, null,
+					ServiceContextFactory.getInstance(
+						FileEntry.class.getName(), httpServletRequest));
+			}
+
+			long folderId = ParamUtil.getLong(httpServletRequest, "folderId");
+
+			if (folderId != 0) {
+				_dlAppService.updateFolder(
+					folderId, name, null,
+					ServiceContextFactory.getInstance(
+						Folder.class.getName(), httpServletRequest));
+			}
+
+			SessionMessages.add(httpServletRequest, "requestProcessed");
+		}
+		catch (PortalException portalException) {
+			throw new ServletException(portalException);
+		}
+	}
+
+	@Override
+	protected void service(
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse)
+		throws IOException, ServletException {
+
+		try {
+			User user = _portal.getUser(httpServletRequest);
+
+			if ((user == null) || user.isDefaultUser()) {
+				throw new PrincipalException.MustBeAuthenticated(
+					StringPool.BLANK);
+			}
+
+			PrincipalThreadLocal.setName(user.getUserId());
+
+			PermissionThreadLocal.setPermissionChecker(
+				_permissionCheckerFactory.create(user));
+
+			super.service(httpServletRequest, httpServletResponse);
 		}
 		catch (PortalException portalException) {
 			throw new ServletException(portalException);

--- a/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/servlet/RepositoryBrowserServlet.java
+++ b/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/servlet/RepositoryBrowserServlet.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.document.library.taglib.internal.servlet;
+
+import com.liferay.document.library.kernel.service.DLAppService;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.servlet.SessionMessages;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.Portal;
+
+import java.io.IOException;
+
+import javax.servlet.Servlet;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Adolfo Pérez
+ */
+@Component(
+	property = {
+		"osgi.http.whiteboard.servlet.name=com.liferay.document.library.taglib.internal.servlet.RepositoryBrowserServlet",
+		"osgi.http.whiteboard.servlet.pattern=/repository_browser",
+		"servlet.init.httpMethods=DELETE"
+	},
+	service = Servlet.class
+)
+public class RepositoryBrowserServlet extends HttpServlet {
+
+	@Override
+	protected void doDelete(
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse)
+		throws IOException, ServletException {
+
+		try {
+			User user = _portal.getUser(httpServletRequest);
+
+			if ((user == null) || user.isDefaultUser()) {
+				throw new PrincipalException.MustBeAuthenticated(
+					StringPool.BLANK);
+			}
+
+			PrincipalThreadLocal.setName(user.getUserId());
+
+			PermissionThreadLocal.setPermissionChecker(
+				_permissionCheckerFactory.create(user));
+
+			long fileEntryId = ParamUtil.getLong(
+				httpServletRequest, "fileEntryId");
+
+			if (fileEntryId != 0) {
+				_dlAppService.deleteFileEntry(fileEntryId);
+			}
+
+			long fileShortcutId = ParamUtil.getLong(
+				httpServletRequest, "fileShortcutId");
+
+			if (fileShortcutId != 0) {
+				_dlAppService.deleteFileShortcut(fileShortcutId);
+			}
+
+			long folderId = ParamUtil.getLong(httpServletRequest, "folderId");
+
+			if (folderId != 0) {
+				_dlAppService.deleteFolder(folderId);
+			}
+
+			SessionMessages.add(httpServletRequest, "requestProcessed");
+		}
+		catch (PortalException portalException) {
+			throw new ServletException(portalException);
+		}
+	}
+
+	@Reference
+	private DLAppService _dlAppService;
+
+	@Reference
+	private PermissionCheckerFactory _permissionCheckerFactory;
+
+	@Reference
+	private Portal _portal;
+
+}

--- a/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/servlet/taglib/RepositoryBrowserTag.java
+++ b/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/servlet/taglib/RepositoryBrowserTag.java
@@ -14,7 +14,20 @@
 
 package com.liferay.document.library.taglib.servlet.taglib;
 
+import com.liferay.document.library.kernel.model.DLFolderConstants;
+import com.liferay.document.library.taglib.internal.display.context.RepositoryBrowserTagDisplayContext;
+import com.liferay.document.library.taglib.internal.servlet.ServletContextUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.JavaConstants;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.taglib.util.IncludeTag;
+
+import javax.portlet.PortletRequest;
+import javax.portlet.PortletResponse;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.jsp.PageContext;
 
 /**
  * @author Adolfo Pérez
@@ -26,11 +39,60 @@ public class RepositoryBrowserTag extends IncludeTag {
 		return EVAL_BODY_INCLUDE;
 	}
 
+	public long getRepositoryId() {
+		return _repositoryId;
+	}
+
+	@Override
+	public void setPageContext(PageContext pageContext) {
+		super.setPageContext(pageContext);
+
+		setServletContext(ServletContextUtil.getServletContext());
+	}
+
+	public void setRepositoryId(long repositoryId) {
+		_repositoryId = repositoryId;
+	}
+
 	@Override
 	protected String getPage() {
 		return _PAGE;
 	}
 
+	@Override
+	protected void setAttributes(HttpServletRequest httpServletRequest) {
+		PortletRequest portletRequest =
+			(PortletRequest)httpServletRequest.getAttribute(
+				JavaConstants.JAVAX_PORTLET_REQUEST);
+
+		PortletResponse portletResponse =
+			(PortletResponse)httpServletRequest.getAttribute(
+				JavaConstants.JAVAX_PORTLET_RESPONSE);
+
+		httpServletRequest.setAttribute(
+			RepositoryBrowserTagDisplayContext.class.getName(),
+			new RepositoryBrowserTagDisplayContext(
+				DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, httpServletRequest,
+				PortalUtil.getLiferayPortletResponse(portletResponse),
+				portletRequest, _getRepositoryId()));
+	}
+
+	private long _getRepositoryId() {
+		if (_repositoryId != 0) {
+			return _repositoryId;
+		}
+
+		HttpServletRequest httpServletRequest = getRequest();
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		return themeDisplay.getSiteGroupId();
+	}
+
 	private static final String _PAGE = "/repository_browser/page.jsp";
+
+	private long _repositoryId;
 
 }

--- a/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/servlet/taglib/RepositoryBrowserTag.java
+++ b/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/servlet/taglib/RepositoryBrowserTag.java
@@ -14,6 +14,7 @@
 
 package com.liferay.document.library.taglib.servlet.taglib;
 
+import com.liferay.document.library.kernel.service.DLAppServiceUtil;
 import com.liferay.document.library.taglib.internal.display.context.RepositoryBrowserTagDisplayContext;
 import com.liferay.document.library.taglib.internal.servlet.ServletContextUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -72,7 +73,8 @@ public class RepositoryBrowserTag extends IncludeTag {
 		httpServletRequest.setAttribute(
 			RepositoryBrowserTagDisplayContext.class.getName(),
 			new RepositoryBrowserTagDisplayContext(
-				_getFolderId(), httpServletRequest,
+				DLAppServiceUtil.getService(), _getFolderId(),
+				httpServletRequest,
 				PortalUtil.getLiferayPortletRequest(portletRequest),
 				PortalUtil.getLiferayPortletResponse(portletResponse),
 				portletRequest, _getRepositoryId()));

--- a/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/servlet/taglib/RepositoryBrowserTag.java
+++ b/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/servlet/taglib/RepositoryBrowserTag.java
@@ -73,6 +73,7 @@ public class RepositoryBrowserTag extends IncludeTag {
 			RepositoryBrowserTagDisplayContext.class.getName(),
 			new RepositoryBrowserTagDisplayContext(
 				DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, httpServletRequest,
+				PortalUtil.getLiferayPortletRequest(portletRequest),
 				PortalUtil.getLiferayPortletResponse(portletResponse),
 				portletRequest, _getRepositoryId()));
 	}

--- a/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/servlet/taglib/RepositoryBrowserTag.java
+++ b/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/servlet/taglib/RepositoryBrowserTag.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.document.library.taglib.servlet.taglib;
+
+import com.liferay.taglib.util.IncludeTag;
+
+/**
+ * @author Adolfo Pérez
+ */
+public class RepositoryBrowserTag extends IncludeTag {
+
+	@Override
+	public int doStartTag() {
+		return EVAL_BODY_INCLUDE;
+	}
+
+	@Override
+	protected String getPage() {
+		return _PAGE;
+	}
+
+	private static final String _PAGE = "/repository_browser/page.jsp";
+
+}

--- a/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/servlet/taglib/RepositoryBrowserTag.java
+++ b/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/servlet/taglib/RepositoryBrowserTag.java
@@ -14,11 +14,11 @@
 
 package com.liferay.document.library.taglib.servlet.taglib;
 
-import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.taglib.internal.display.context.RepositoryBrowserTagDisplayContext;
 import com.liferay.document.library.taglib.internal.servlet.ServletContextUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.JavaConstants;
+import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.taglib.util.IncludeTag;
@@ -72,10 +72,14 @@ public class RepositoryBrowserTag extends IncludeTag {
 		httpServletRequest.setAttribute(
 			RepositoryBrowserTagDisplayContext.class.getName(),
 			new RepositoryBrowserTagDisplayContext(
-				DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, httpServletRequest,
+				_getFolderId(), httpServletRequest,
 				PortalUtil.getLiferayPortletRequest(portletRequest),
 				PortalUtil.getLiferayPortletResponse(portletResponse),
 				portletRequest, _getRepositoryId()));
+	}
+
+	private long _getFolderId() {
+		return ParamUtil.getLong(getRequest(), "folderId");
 	}
 
 	private long _getRepositoryId() {

--- a/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/liferay-document-library.tld
+++ b/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/liferay-document-library.tld
@@ -28,4 +28,9 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 	</tag>
+	<tag>
+		<name>repository-browser</name>
+		<tag-class>com.liferay.document.library.taglib.servlet.taglib.RepositoryBrowserTag</tag-class>
+		<body-content>empty</body-content>
+	</tag>
 </taglib>

--- a/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/liferay-document-library.tld
+++ b/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/liferay-document-library.tld
@@ -32,5 +32,11 @@
 		<name>repository-browser</name>
 		<tag-class>com.liferay.document.library.taglib.servlet.taglib.RepositoryBrowserTag</tag-class>
 		<body-content>empty</body-content>
+		<attribute>
+			<description>The repository that will be displayed by the tag.</description>
+			<name>repositoryId</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
 	</tag>
 </taglib>

--- a/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/mime_type_sticker/init.jsp
+++ b/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/mime_type_sticker/init.jsp
@@ -14,7 +14,6 @@
  */
 --%>
 
-<%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
-taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
+<%@ include file="/init.jsp" %>
 
-<liferay-theme:defineObjects />
+<%@ page import="com.liferay.document.library.display.context.DLViewFileVersionDisplayContext" %>

--- a/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/mime_type_sticker/page.jsp
+++ b/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/mime_type_sticker/page.jsp
@@ -14,7 +14,7 @@
  */
 --%>
 
-<%@ include file="/init.jsp" %>
+<%@ include file="/mime_type_sticker/init.jsp" %>
 
 <%
 String cssClass = (String)request.getAttribute("liferay-document-library:mime-type-sticker:cssClass");

--- a/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/repository_browser/init.jsp
+++ b/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/repository_browser/init.jsp
@@ -16,6 +16,8 @@
 
 <%@ include file="/init.jsp" %>
 
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+
 <%@ taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
 <%@ page import="com.liferay.document.library.taglib.internal.display.context.RepositoryBrowserTagDisplayContext" %>

--- a/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/repository_browser/init.jsp
+++ b/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/repository_browser/init.jsp
@@ -19,6 +19,7 @@
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 
 <%@ taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
+taglib uri="http://liferay.com/tld/site-navigation" prefix="liferay-site-navigation" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
 <%@ page import="com.liferay.document.library.taglib.internal.display.context.RepositoryBrowserTagDisplayContext" %>

--- a/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/repository_browser/init.jsp
+++ b/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/repository_browser/init.jsp
@@ -18,6 +18,7 @@
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 
-<%@ taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
+<%@ taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
+taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
 <%@ page import="com.liferay.document.library.taglib.internal.display.context.RepositoryBrowserTagDisplayContext" %>

--- a/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/repository_browser/init.jsp
+++ b/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/repository_browser/init.jsp
@@ -15,3 +15,7 @@
 --%>
 
 <%@ include file="/init.jsp" %>
+
+<%@ taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
+
+<%@ page import="com.liferay.document.library.taglib.internal.display.context.RepositoryBrowserTagDisplayContext" %>

--- a/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/repository_browser/init.jsp
+++ b/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/repository_browser/init.jsp
@@ -14,7 +14,4 @@
  */
 --%>
 
-<%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
-taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
-
-<liferay-theme:defineObjects />
+<%@ include file="/init.jsp" %>

--- a/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/repository_browser/js/ElementsDefaultEventHandler.es.js
+++ b/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/repository_browser/js/ElementsDefaultEventHandler.es.js
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {
+	DefaultEventHandler,
+	fetch,
+	openConfirmModal,
+	openToast,
+} from 'frontend-js-web';
+
+class ElementsDefaultEventHandler extends DefaultEventHandler {
+	delete({deleteURL}) {
+		openConfirmModal({
+			message: Liferay.Language.get(
+				'are-you-sure-you-want-to-delete-this'
+			),
+			onConfirm: (isConfirmed) => {
+				if (isConfirmed) {
+					fetch(deleteURL, {
+						method: 'DELETE',
+					}).then((response) => {
+						if (response.ok) {
+							window.location.reload();
+						}
+						else {
+							openToast({
+								message: Liferay.Language.get(
+									'an-unexpected-error-occurred'
+								),
+								type: 'danger',
+							});
+						}
+					});
+				}
+			},
+		});
+	}
+}
+
+export default ElementsDefaultEventHandler;

--- a/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/repository_browser/js/ElementsDefaultEventHandler.es.js
+++ b/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/repository_browser/js/ElementsDefaultEventHandler.es.js
@@ -16,6 +16,7 @@ import {
 	DefaultEventHandler,
 	fetch,
 	openConfirmModal,
+	openSimpleInputModal,
 	openToast,
 } from 'frontend-js-web';
 
@@ -44,6 +45,18 @@ class ElementsDefaultEventHandler extends DefaultEventHandler {
 					});
 				}
 			},
+		});
+	}
+
+	rename({renameURL, value}) {
+		openSimpleInputModal({
+			dialogTitle: Liferay.Language.get('rename'),
+			formSubmitURL: renameURL,
+			mainFieldLabel: Liferay.Language.get('name'),
+			mainFieldName: 'name',
+			mainFieldValue: value,
+			namespace: '',
+			onFormSuccess: () => window.location.reload(),
 		});
 	}
 }

--- a/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/repository_browser/js/RepositoryBrowserManagementToolbarPropsTransformer.js
+++ b/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/repository_browser/js/RepositoryBrowserManagementToolbarPropsTransformer.js
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {fetch, getCheckedCheckboxes, openConfirmModal} from 'frontend-js-web';
+
+export default function propsTransformer({
+	additionalProps: {deleteURL},
+	portletNamespace,
+	...otherProps
+}) {
+	return {
+		...otherProps,
+		onActionButtonClick: (event, {item}) => {
+			if (item?.data?.action === 'deleteEntries') {
+				const deleteAction = () => {
+					const container = document.getElementById(
+						`${portletNamespace}repositoryEntries`
+					);
+
+					const repositoryEntryIds = getCheckedCheckboxes(
+						container,
+						`${portletNamespace}allRowIds`
+					);
+
+					fetch(
+						`${deleteURL}?repositoryEntryIds=${repositoryEntryIds}`,
+						{
+							method: 'DELETE',
+						}
+					).then(() => {
+						window.location.reload();
+					});
+				};
+
+				openConfirmModal({
+					message: Liferay.Language.get(
+						'are-you-sure-you-want-to-delete-this'
+					),
+					onConfirm: (isConfimed) => {
+						if (isConfimed) {
+							deleteAction();
+						}
+					},
+				});
+			}
+		},
+	};
+}

--- a/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/repository_browser/page.jsp
+++ b/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/repository_browser/page.jsp
@@ -1,0 +1,17 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>
+
+<%@ include file="/init.jsp" %>

--- a/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/repository_browser/page.jsp
+++ b/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/repository_browser/page.jsp
@@ -29,15 +29,25 @@ RepositoryBrowserTagDisplayContext repositoryBrowserTagDisplayContext = (Reposit
 			modelVar="repositoryEntry"
 		>
 			<liferay-ui:search-container-column-text>
-				<clay:vertical-card
-					verticalCard="<%= repositoryBrowserTagDisplayContext.getVerticalCard(repositoryEntry) %>"
-				/>
+				<c:choose>
+					<c:when test="<%= repositoryBrowserTagDisplayContext.isVerticalCard(repositoryEntry) %>">
+						<clay:vertical-card
+							verticalCard="<%= repositoryBrowserTagDisplayContext.getVerticalCard(repositoryEntry) %>"
+						/>
+					</c:when>
+					<c:otherwise>
+						<clay:horizontal-card
+							horizontalCard="<%= repositoryBrowserTagDisplayContext.getHorizontalCard(repositoryEntry) %>"
+						/>
+					</c:otherwise>
+				</c:choose>
 			</liferay-ui:search-container-column-text>
 		</liferay-ui:search-container-row>
 
 		<liferay-ui:search-iterator
 			displayStyle="icon"
 			markupView="lexicon"
+			resultRowSplitter="<%= repositoryBrowserTagDisplayContext.getResultRowSplitter() %>"
 		/>
 	</liferay-ui:search-container>
 </clay:container-fluid>

--- a/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/repository_browser/page.jsp
+++ b/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/repository_browser/page.jsp
@@ -20,12 +20,20 @@
 RepositoryBrowserTagDisplayContext repositoryBrowserTagDisplayContext = (RepositoryBrowserTagDisplayContext)request.getAttribute(RepositoryBrowserTagDisplayContext.class.getName());
 %>
 
+<clay:management-toolbar
+	additionalProps="<%= repositoryBrowserTagDisplayContext.getAdditionalProps() %>"
+	managementToolbarDisplayContext="<%= repositoryBrowserTagDisplayContext.getManagementToolbarDisplayContext() %>"
+	propsTransformer="repository_browser/js/RepositoryBrowserManagementToolbarPropsTransformer"
+/>
+
 <clay:container-fluid>
 	<liferay-ui:search-container
+		id="repositoryEntries"
 		searchContainer="<%= repositoryBrowserTagDisplayContext.getSearchContainer() %>"
 	>
 		<liferay-ui:search-container-row
 			className="com.liferay.portal.kernel.repository.model.RepositoryEntry"
+			keyProperty="primaryKey"
 			modelVar="repositoryEntry"
 		>
 			<liferay-ui:search-container-column-text>

--- a/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/repository_browser/page.jsp
+++ b/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/repository_browser/page.jsp
@@ -27,6 +27,10 @@ RepositoryBrowserTagDisplayContext repositoryBrowserTagDisplayContext = (Reposit
 />
 
 <clay:container-fluid>
+	<liferay-site-navigation:breadcrumb
+		breadcrumbEntries="<%= repositoryBrowserTagDisplayContext.getBreadcrumbEntries() %>"
+	/>
+
 	<liferay-ui:search-container
 		id="repositoryEntries"
 		searchContainer="<%= repositoryBrowserTagDisplayContext.getSearchContainer() %>"

--- a/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/repository_browser/page.jsp
+++ b/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/repository_browser/page.jsp
@@ -14,4 +14,4 @@
  */
 --%>
 
-<%@ include file="/init.jsp" %>
+<%@ include file="/repository_browser/init.jsp" %>

--- a/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/repository_browser/page.jsp
+++ b/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/repository_browser/page.jsp
@@ -15,3 +15,29 @@
 --%>
 
 <%@ include file="/repository_browser/init.jsp" %>
+
+<%
+RepositoryBrowserTagDisplayContext repositoryBrowserTagDisplayContext = (RepositoryBrowserTagDisplayContext)request.getAttribute(RepositoryBrowserTagDisplayContext.class.getName());
+%>
+
+<clay:container-fluid>
+	<liferay-ui:search-container
+		searchContainer="<%= repositoryBrowserTagDisplayContext.getSearchContainer() %>"
+	>
+		<liferay-ui:search-container-row
+			className="com.liferay.portal.kernel.repository.model.RepositoryEntry"
+			modelVar="repositoryEntry"
+		>
+			<liferay-ui:search-container-column-text>
+				<clay:vertical-card
+					verticalCard="<%= repositoryBrowserTagDisplayContext.getVerticalCard(repositoryEntry) %>"
+				/>
+			</liferay-ui:search-container-column-text>
+		</liferay-ui:search-container-row>
+
+		<liferay-ui:search-iterator
+			displayStyle="icon"
+			markupView="lexicon"
+		/>
+	</liferay-ui:search-container>
+</clay:container-fluid>

--- a/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/repository_browser/page.jsp
+++ b/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/repository_browser/page.jsp
@@ -51,3 +51,10 @@ RepositoryBrowserTagDisplayContext repositoryBrowserTagDisplayContext = (Reposit
 		/>
 	</liferay-ui:search-container>
 </clay:container-fluid>
+
+<div>
+	<liferay-frontend:component
+		componentId="repositoryBrowserEventHandler"
+		module="repository_browser/js/ElementsDefaultEventHandler.es"
+	/>
+</div>


### PR DESCRIPTION
This new tag offers a limited subset of the dm funcionality: folder navigation, create folders, rename folders/files and upload a file (via drag & drop).
To make it easier to test, I've replaced the Blogs images view with it. It should display the contents of DM:
![image](https://user-images.githubusercontent.com/729897/191737468-bd0b7189-913e-4140-be7e-02be4269251e.png)
*What is failing*:
* When trying to rename a file/folder, the page should be reloaded when saving. The name is updated correctly, but the modal seems to be ignoring the `onFormSuccess` callback I'm providing.

*What is missing*:
* Create folder. It should work roughly the same as the "rename" action: a modal that takes the folder name, make a PUT request to the servlet (I've included the impl) and then refresh so that the search container displays the updated contents.
* File upload. For the moment, it should be enough if we could integrate the single upload component in the tag.