### PR TITLE
LPS-163961 Adapt logic to take into account actions in vertical card, Copy logic from DDMStructrureElementsDefaultPropsTransformer.js

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/servlet/taglib/clay/FileEntryTemplateVerticalCard.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/servlet/taglib/clay/FileEntryTemplateVerticalCard.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.document.library.web.internal.servlet.taglib.clay;
+
+import com.liferay.document.library.web.internal.display.context.DLViewDisplayContext;
+import com.liferay.frontend.taglib.clay.servlet.taglib.VerticalCard;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.HtmlUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * @author Eudaldo Alonso
+ */
+public class FileEntryTemplateVerticalCard implements VerticalCard {
+
+	public FileEntryTemplateVerticalCard(
+		DLViewDisplayContext dlViewDisplayContext,
+		HttpServletRequest httpServletRequest) {
+
+		_dlViewDisplayContext = dlViewDisplayContext;
+
+		_themeDisplay = (ThemeDisplay)httpServletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+	}
+
+	@Override
+	public String getCssClass() {
+		return "card-type-asset display-icon entry-display-style file-card " +
+			"form-check form-check-card";
+	}
+
+	@Override
+	public String getHref() {
+		try {
+			return _dlViewDisplayContext.getUploadURL();
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
+		}
+
+		return StringPool.BLANK;
+	}
+
+	@Override
+	public String getIcon() {
+		return "documents-and-media";
+	}
+
+	@Override
+	public String getStickerCssClass() {
+		return "file-icon-color-0 sticker-bottom-left sticker-document";
+	}
+
+	@Override
+	public String getStickerIcon() {
+		return "document-default";
+	}
+
+	@Override
+	public String getSubtitle() {
+		User user = _themeDisplay.getUser();
+
+		return LanguageUtil.format(
+			_themeDisplay.getLocale(), "right-now-by-x",
+			HtmlUtil.escape(user.getFullName()));
+	}
+
+	@Override
+	public String getTitle() {
+		return "{title}";
+	}
+
+	@Override
+	public boolean isSelectable() {
+		return false;
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		FileEntryTemplateVerticalCard.class);
+
+	private final DLViewDisplayContext _dlViewDisplayContext;
+	private final ThemeDisplay _themeDisplay;
+
+}

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/servlet/taglib/clay/FolderHorizontalCard.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/servlet/taglib/clay/FolderHorizontalCard.java
@@ -1,0 +1,131 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.document.library.web.internal.servlet.taglib.clay;
+
+import com.liferay.document.library.web.internal.display.context.FolderActionDisplayContext;
+import com.liferay.document.library.web.internal.display.context.helper.DLPortletInstanceSettingsHelper;
+import com.liferay.document.library.web.internal.helper.DLTrashHelper;
+import com.liferay.frontend.taglib.clay.servlet.taglib.HorizontalCard;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
+import com.liferay.portal.kernel.dao.search.RowChecker;
+import com.liferay.portal.kernel.repository.model.Folder;
+
+import java.util.List;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * @author Eudaldo Alonso
+ */
+public class FolderHorizontalCard implements HorizontalCard {
+
+	public FolderHorizontalCard(
+		DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper,
+		DLTrashHelper dlTrashHelper, Folder folder,
+		HttpServletRequest httpServletRequest, RowChecker rowChecker,
+		String viewFolderURL) {
+
+		_dlPortletInstanceSettingsHelper = dlPortletInstanceSettingsHelper;
+		_folder = folder;
+		_rowChecker = rowChecker;
+		_viewFolderURL = viewFolderURL;
+
+		_folderActionDisplayContext = new FolderActionDisplayContext(
+			dlTrashHelper, httpServletRequest);
+	}
+
+	@Override
+	public List<DropdownItem> getActionDropdownItems() {
+		if (!_dlPortletInstanceSettingsHelper.isShowActions() ||
+			!_folderActionDisplayContext.isShowActions()) {
+
+			return null;
+		}
+
+		return _folderActionDisplayContext.getActionDropdownItems();
+	}
+
+	@Override
+	public String getHref() {
+		return _viewFolderURL;
+	}
+
+	@Override
+	public String getIcon() {
+		if (_folder.isMountPoint()) {
+			return "repository";
+		}
+
+		return "folder";
+	}
+
+	@Override
+	public String getInputName() {
+		if (_rowChecker == null) {
+			return null;
+		}
+
+		return _rowChecker.getRowIds();
+	}
+
+	@Override
+	public String getInputValue() {
+		if (_rowChecker == null) {
+			return null;
+		}
+
+		return String.valueOf(_folder.getFolderId());
+	}
+
+	@Override
+	public String getTitle() {
+		return _folder.getName();
+	}
+
+	@Override
+	public boolean isDisabled() {
+		if (_rowChecker == null) {
+			return false;
+		}
+
+		return _rowChecker.isDisabled(_folder);
+	}
+
+	@Override
+	public boolean isSelectable() {
+		if (_rowChecker == null) {
+			return false;
+		}
+
+		return true;
+	}
+
+	@Override
+	public boolean isSelected() {
+		if (_rowChecker == null) {
+			return false;
+		}
+
+		return _rowChecker.isChecked(_folder);
+	}
+
+	private final DLPortletInstanceSettingsHelper
+		_dlPortletInstanceSettingsHelper;
+	private final Folder _folder;
+	private final FolderActionDisplayContext _folderActionDisplayContext;
+	private final RowChecker _rowChecker;
+	private final String _viewFolderURL;
+
+}

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/DLFolderDropdownPropsTransformer.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/DLFolderDropdownPropsTransformer.js
@@ -98,41 +98,36 @@ const ACTIONS = {
 	},
 };
 
-export default function propsTransformer({items, portletNamespace, ...props}) {
+export default function propsTransformer({
+	actions,
+	items,
+	portletNamespace,
+	...props
+}) {
+	const updateItem = (item) => {
+		const newItem = {
+			...item,
+			onClick(event) {
+				const action = item.data?.action;
+
+				if (action) {
+					event.preventDefault();
+
+					ACTIONS[action]?.(item.data, portletNamespace);
+				}
+			},
+		};
+
+		if (Array.isArray(item.items)) {
+			newItem.items = item.items.map(updateItem);
+		}
+
+		return newItem;
+	};
+
 	return {
 		...props,
-		items: items.map((item) =>
-			item?.type === 'group'
-				? {
-						...item,
-						items: item.items?.map((child) => ({
-							...child,
-							onClick(event) {
-								const action = child.data?.action;
-
-								if (action) {
-									event.preventDefault();
-
-									ACTIONS[action](
-										child.data,
-										portletNamespace
-									);
-								}
-							},
-						})),
-				  }
-				: {
-						...item,
-						onClick(event) {
-							const action = item.data?.action;
-
-							if (action) {
-								event.preventDefault();
-
-								ACTIONS[action](item.data, portletNamespace);
-							}
-						},
-				  }
-		),
+		actions: actions?.map(updateItem),
+		items: items?.map(updateItem),
 	};
 }

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view.jsp
@@ -167,23 +167,9 @@ DLViewDisplayContext dlViewDisplayContext = new DLViewDisplayContext(dlAdminDisp
 						</c:choose>
 
 						<div class="d-none" id="<portlet:namespace />appViewEntryTemplates">
-							<liferay-frontend:icon-vertical-card
-								cssClass="card-type-asset display-icon entry-display-style file-card form-check form-check-card"
-								icon="documents-and-media"
-								title="{title}"
-								url="<%= dlViewDisplayContext.getUploadURL() %>"
-							>
-								<liferay-frontend:vertical-card-sticker-bottom>
-									<clay:sticker
-										cssClass="file-icon-color-0 sticker-bottom-left sticker-document"
-										icon="document-default"
-									/>
-								</liferay-frontend:vertical-card-sticker-bottom>
-
-								<liferay-frontend:vertical-card-header>
-									<liferay-ui:message arguments="<%= HtmlUtil.escape(user.getFullName()) %>" key="right-now-by-x" />
-								</liferay-frontend:vertical-card-header>
-							</liferay-frontend:icon-vertical-card>
+							<clay:vertical-card
+								verticalCard="<%= new FileEntryTemplateVerticalCard(dlViewDisplayContext, request) %>"
+							/>
 
 							<dd class="display-descriptive entry-display-style list-group-item list-group-item-flex">
 								<div class="autofit-col"></div>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp
@@ -330,35 +330,27 @@ DLViewEntriesDisplayContext dlViewEntriesDisplayContext = new DLViewEntriesDispl
 
 							<%
 							row.setCssClass("card-page-item card-page-item-directory");
+
+							String viewFolderURL = PortletURLBuilder.createRenderURL(
+								liferayPortletResponse
+							).setMVCRenderCommandName(
+								"/document_library/view_folder"
+							).setRedirect(
+								currentURL
+							).setParameter(
+								"folderId", curFolder.getFolderId()
+							).buildString();
+
+							request.setAttribute(WebKeys.SEARCH_CONTAINER_RESULT_ROW, row);
 							%>
 
 							<liferay-ui:search-container-column-text
 								colspan="<%= 2 %>"
 							>
-								<liferay-frontend:horizontal-card
-									actionJsp='<%= dlPortletInstanceSettingsHelper.isShowActions() ? "/document_library/folder_action.jsp" : null %>'
-									actionJspServletContext="<%= application %>"
-									resultRow="<%= row %>"
-									rowChecker="<%= searchContainer.getRowChecker() %>"
-									text="<%= curFolder.getName() %>"
-									url='<%=
-										PortletURLBuilder.createRenderURL(
-											liferayPortletResponse
-										).setMVCRenderCommandName(
-											"/document_library/view_folder"
-										).setRedirect(
-											currentURL
-										).setParameter(
-											"folderId", curFolder.getFolderId()
-										).buildString()
-									%>'
-								>
-									<liferay-frontend:horizontal-card-col>
-										<liferay-frontend:horizontal-card-icon
-											icon='<%= curFolder.isMountPoint() ? "repository" : "folder" %>'
-										/>
-									</liferay-frontend:horizontal-card-col>
-								</liferay-frontend:horizontal-card>
+								<clay:horizontal-card
+									horizontalCard="<%= new FolderHorizontalCard(dlPortletInstanceSettingsHelper, dlTrashHelper, curFolder, request, searchContainer.getRowChecker(), viewFolderURL) %>"
+									propsTransformer="document_library/js/DLFolderDropdownPropsTransformer"
+								/>
 							</liferay-ui:search-container-column-text>
 						</c:when>
 						<c:otherwise>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/image_gallery_display/view_images.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/image_gallery_display/view_images.jsp
@@ -126,30 +126,24 @@ DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper = new DLPortletI
 				</liferay-ui:search-container-column-text>
 			</c:when>
 			<c:otherwise>
+
+				<%
+				row.setCssClass("card-page-item card-page-item-directory");
+
+				request.setAttribute(WebKeys.SEARCH_CONTAINER_RESULT_ROW, row);
+				%>
+
 				<portlet:renderURL var="viewFolderURL">
 					<portlet:param name="mvcRenderCommandName" value="/image_gallery_display/view" />
 					<portlet:param name="redirect" value="<%= currentURL %>" />
 					<portlet:param name="folderId" value="<%= String.valueOf(curFolder.getFolderId()) %>" />
 				</portlet:renderURL>
 
-				<%
-				row.setCssClass("card-page-item card-page-item-directory");
-				%>
-
 				<liferay-ui:search-container-column-text>
-					<liferay-frontend:horizontal-card
-						actionJsp='<%= dlPortletInstanceSettingsHelper.isShowActions() ? "/document_library/folder_action.jsp" : StringPool.BLANK %>'
-						actionJspServletContext="<%= application %>"
-						resultRow="<%= row %>"
-						text="<%= curFolder.getName() %>"
-						url="<%= viewFolderURL %>"
-					>
-						<liferay-frontend:horizontal-card-col>
-							<liferay-frontend:horizontal-card-icon
-								icon='<%= curFolder.isMountPoint() ? "repository" : "folder" %>'
-							/>
-						</liferay-frontend:horizontal-card-col>
-					</liferay-frontend:horizontal-card>
+					<clay:horizontal-card
+						horizontalCard="<%= new FolderHorizontalCard(dlPortletInstanceSettingsHelper, dlTrashHelper, curFolder, request, null, viewFolderURL) %>"
+						propsTransformer="document_library/js/DLFolderDropdownPropsTransformer"
+					/>
 				</liferay-ui:search-container-column-text>
 			</c:otherwise>
 		</c:choose>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/init.jsp
@@ -125,6 +125,7 @@ page import="com.liferay.document.library.web.internal.security.permission.resou
 page import="com.liferay.document.library.web.internal.security.permission.resource.DLFileEntryPermission" %><%@
 page import="com.liferay.document.library.web.internal.security.permission.resource.DLFileEntryTypePermission" %><%@
 page import="com.liferay.document.library.web.internal.security.permission.resource.DLFolderPermission" %><%@
+page import="com.liferay.document.library.web.internal.servlet.taglib.clay.FileEntryTemplateVerticalCard" %><%@
 page import="com.liferay.document.library.web.internal.settings.DLPortletInstanceSettings" %><%@
 page import="com.liferay.document.library.web.internal.util.DLBreadcrumbUtil" %><%@
 page import="com.liferay.document.library.web.internal.util.DLSubscriptionUtil" %><%@

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/init.jsp
@@ -126,6 +126,7 @@ page import="com.liferay.document.library.web.internal.security.permission.resou
 page import="com.liferay.document.library.web.internal.security.permission.resource.DLFileEntryTypePermission" %><%@
 page import="com.liferay.document.library.web.internal.security.permission.resource.DLFolderPermission" %><%@
 page import="com.liferay.document.library.web.internal.servlet.taglib.clay.FileEntryTemplateVerticalCard" %><%@
+page import="com.liferay.document.library.web.internal.servlet.taglib.clay.FolderHorizontalCard" %><%@
 page import="com.liferay.document.library.web.internal.settings.DLPortletInstanceSettings" %><%@
 page import="com.liferay.document.library.web.internal.util.DLBreadcrumbUtil" %><%@
 page import="com.liferay.document.library.web.internal.util.DLSubscriptionUtil" %><%@

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/documentsandmedia/DocumentsAndMedia.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/documentsandmedia/DocumentsAndMedia.path
@@ -212,7 +212,7 @@
 
 <tr>
 	<td>DESCRIPTIVE_LIST_VERTICAL_ELLIPSIS</td>
-	<td>//dd[contains(.,'${key_dmFolderName}')]//*[span/*[name()='svg'][contains(@class,'icon-ellipsis')]]</td>
+	<td>//dd[contains(.,'${key_dmFolderName}')]//*[*[name()='svg'][contains(@class,'icon-ellipsis')]]</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
Original pull request comment:

> **Motivation**
> In order to not use deprecated or old frontend cards, use the new clay card for horizontal cards in DL portlet
> 
> [LPS-163961](https://issues.liferay.com/browse/LPS-163961)
> 
> **Proposed Solution**
> Replace usages of frontend:horizontal-card with clay:horizontal-card