### PR TITLE
[TS] LPS-163980 | Uppercase friendlyURL leads to layout instead of the created redirectEntry

### DIFF
--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
@@ -919,13 +919,19 @@ public class FriendlyURLServlet extends HttpServlet {
 	}
 
 	private String _normalizeFriendlyURL(String friendlyURL) {
-		if (Validator.isNotNull(friendlyURL) &&
-			friendlyURL.startsWith(StringPool.SLASH)) {
-
-			return friendlyURL.substring(1);
+		if (Validator.isNull(friendlyURL)) {
+			return friendlyURL;
 		}
 
-		return friendlyURL;
+		String normalizedFriendlyURL =
+			friendlyURLNormalizer.normalizeWithEncoding(
+				HttpComponentsUtil.decodeURL(friendlyURL));
+
+		if (normalizedFriendlyURL.startsWith(StringPool.SLASH)) {
+			return normalizedFriendlyURL.substring(1);
+		}
+
+		return normalizedFriendlyURL;
 	}
 
 	private Locale _setAlternativeLayoutFriendlyURL(


### PR DESCRIPTION
Hi Team,
Could you please review this pull request?
https://issues.liferay.com/browse/LPS-163980
Thank you!

---------

**Reproduction Steps:**

1. Add a page with firendlyURL "/testpage"
2. Add a new redirection under configuration -> redirection with a Source URL "/testpage" and a Destination URL like "https://www.google.com/"
3. Try to access /TESTPAGE

**Actual outcome:** The user is redirected to the page with the friendlyURL "/testpage".
**Expected outcome:** The user is redirected based on the redirection created in step two.

The root cause of the issue is that the friendlyURL servlet never really normalizes the URL generally. In the layout case, the getFriendlyURLLayout call normalizes the friendlyURL with the help of layoutLocalServiceHelper. When the _getRedirectProviderRedirect
called we also normalize the friendlyURL but this normalization does not convert to lowercase. My solution proposal for this issue is that we should also lowercase the friendlyURL in the _normalizeFriendlyURL.