### PR TITLE
LPS-162970 KB Edit Article updated pane

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/display/context/EditKBArticleDisplayContext.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/display/context/EditKBArticleDisplayContext.java
@@ -116,7 +116,7 @@ public class EditKBArticleDisplayContext {
 		}
 
 		return "class=\"container-fluid container-fluid-max-xl " +
-			"container-form-lg\"";
+			"container-form-lg contextual-sidebar-content\"";
 	}
 
 	public String getHeaderTitle() {

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/display/context/EditKBArticleDisplayContext.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/display/context/EditKBArticleDisplayContext.java
@@ -116,7 +116,7 @@ public class EditKBArticleDisplayContext {
 		}
 
 		return "class=\"container-fluid container-fluid-max-xl " +
-			"container-form-lg contextual-sidebar-content\"";
+			"container-form-lg\"";
 	}
 
 	public String getHeaderTitle() {

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_kb_article.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_kb_article.jsp
@@ -134,6 +134,7 @@ if (editKBArticleDisplayContext.isPortletTitleBasedNavigation()) {
 						<aui:fieldset collapsed="<%= true %>" collapsible="<%= true %>" label="permissions">
 							<liferay-ui:input-permissions
 								modelName="<%= KBArticle.class.getName() %>"
+								reverse="<%= true %>"
 							/>
 						</aui:fieldset>
 					</c:if>

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_kb_article.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_kb_article.jsp
@@ -27,22 +27,6 @@ if (editKBArticleDisplayContext.isPortletTitleBasedNavigation()) {
 }
 %>
 
-<c:if test="<%= editKBArticleDisplayContext.isNavigationBarVisible() %>">
-	<div class="management-bar management-bar-light navbar navbar-expand-md">
-		<clay:container-fluid>
-			<ul class="m-auto navbar-nav"></ul>
-
-			<ul class="middle navbar-nav">
-				<li class="nav-item">
-					<aui:workflow-status id="<%= String.valueOf(editKBArticleDisplayContext.getResourcePrimKey()) %>" showIcon="<%= false %>" showLabel="<%= false %>" status="<%= editKBArticleDisplayContext.getKBArticleStatus() %>" version="<%= editKBArticleDisplayContext.getKBArticleVersion() %>" />
-				</li>
-			</ul>
-
-			<ul class="end m-auto navbar-nav"></ul>
-		</clay:container-fluid>
-	</div>
-</c:if>
-
 <c:if test="<%= !editKBArticleDisplayContext.isHeaderVisible() %>">
 	<liferay-ui:header
 		backURL="<%= editKBArticleDisplayContext.getRedirect() %>"
@@ -117,6 +101,24 @@ if (editKBArticleDisplayContext.isPortletTitleBasedNavigation()) {
 							/>
 						</aui:fieldset>
 					</liferay-expando:custom-attributes-available>
+
+					<c:if test="<%= editKBArticleDisplayContext.isNavigationBarVisible() %>">
+						<aui:fieldset collapsed="<%= true %>" collapsible="<%= true %>" label="basic-information">
+							<p>
+								<strong><liferay-ui:message key="version" /></strong>: <%= editKBArticleDisplayContext.getKBArticleVersion() %>
+
+								<clay:label
+									cssClass="ml-2 text-uppercase"
+									displayType="<%= WorkflowConstants.getStatusStyle(editKBArticleDisplayContext.getKBArticleStatus()) %>"
+									label="<%= WorkflowConstants.getStatusLabel(editKBArticleDisplayContext.getKBArticleStatus()) %>"
+								/>
+							</p>
+
+							<p>
+								<strong><liferay-ui:message key="id" /></strong>: <%= String.valueOf(editKBArticleDisplayContext.getResourcePrimKey()) %>
+							</p>
+						</aui:fieldset>
+					</c:if>
 
 					<aui:fieldset collapsed="<%= true %>" collapsible="<%= true %>" label="categorization">
 						<liferay-asset:asset-categories-selector

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_kb_article.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_kb_article.jsp
@@ -55,6 +55,25 @@ if (editKBArticleDisplayContext.isPortletTitleBasedNavigation()) {
 	<aui:input name="redirect" type="hidden" value="<%= editKBArticleDisplayContext.getRedirect() %>" />
 	<aui:input name="workflowAction" type="hidden" value="<%= WorkflowConstants.ACTION_SAVE_DRAFT %>" />
 
+	<nav class="component-tbar subnav-tbar-light tbar tbar-knowledge-base-edit-article">
+		<clay:container-fluid>
+			<ul class="tbar-nav">
+				<li class="tbar-item tbar-item-expand">
+					<aui:input autocomplete="off" cssClass="form-control-inline" label="" name="title" placeholder='<%= LanguageUtil.get(request, "title") %>' required="<%= true %>" type="text" value="<%= HtmlUtil.escape(editKBArticleDisplayContext.getKBArticleTitle()) %>" wrapperCssClass="mb-0" />
+				</li>
+				<li class="tbar-item">
+					<div class="tbar-section text-right">
+						<aui:button disabled="<%= editKBArticleDisplayContext.isPending() %>" name="publishButton" type="submit" value="<%= editKBArticleDisplayContext.getPublishButtonLabel() %>" />
+
+						<aui:button primary="<%= false %>" type="submit" value="<%= editKBArticleDisplayContext.getSaveButtonLabel() %>" />
+
+						<aui:button href="<%= editKBArticleDisplayContext.getRedirect() %>" type="cancel" />
+					</div>
+				</li>
+			</ul>
+		</clay:container-fluid>
+	</nav>
+
 	<div class="contextual-sidebar contextual-sidebar-visible sidebar-light sidebar-sm" id="<portlet:namespace />contextualSidebarContainer">
 		<div class="sidebar-body">
 			<liferay-ui:tabs
@@ -213,10 +232,6 @@ if (editKBArticleDisplayContext.isPortletTitleBasedNavigation()) {
 
 				<aui:fieldset-group markupView="lexicon">
 					<aui:fieldset>
-						<h1 class="kb-title">
-							<aui:input autocomplete="off" label='<%= LanguageUtil.get(request, "title") %>' name="title" required="<%= true %>" type="text" value="<%= HtmlUtil.escape(editKBArticleDisplayContext.getKBArticleTitle()) %>" />
-						</h1>
-
 						<div class="kb-entity-body">
 							<liferay-editor:editor
 								contents="<%= editKBArticleDisplayContext.getContent() %>"
@@ -242,14 +257,6 @@ if (editKBArticleDisplayContext.isPortletTitleBasedNavigation()) {
 							<liferay-util:include page="/admin/common/attachments.jsp" servletContext="<%= application %>" />
 						</div>
 					</aui:fieldset>
-
-					<div class="kb-submit-buttons sheet-footer">
-						<aui:button disabled="<%= editKBArticleDisplayContext.isPending() %>" name="publishButton" type="submit" value="<%= editKBArticleDisplayContext.getPublishButtonLabel() %>" />
-
-						<aui:button primary="<%= false %>" type="submit" value="<%= editKBArticleDisplayContext.getSaveButtonLabel() %>" />
-
-						<aui:button href="<%= editKBArticleDisplayContext.getRedirect() %>" type="cancel" />
-					</div>
 				</aui:fieldset-group>
 			</div>
 		</div>

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_kb_article.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_kb_article.jsp
@@ -51,7 +51,7 @@ if (editKBArticleDisplayContext.isPortletTitleBasedNavigation()) {
 	/>
 </c:if>
 
-<aui:form action="<%= editKBArticleDisplayContext.getUpdateKBArticleURL() %>" method="post" name="fm">
+<aui:form action="<%= editKBArticleDisplayContext.getUpdateKBArticleURL() %>" cssClass="edit-knowledge-base-article-form" method="post" name="fm">
 	<aui:input name="redirect" type="hidden" value="<%= editKBArticleDisplayContext.getRedirect() %>" />
 	<aui:input name="workflowAction" type="hidden" value="<%= WorkflowConstants.ACTION_SAVE_DRAFT %>" />
 

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_kb_article.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_kb_article.jsp
@@ -51,6 +51,11 @@ if (editKBArticleDisplayContext.isPortletTitleBasedNavigation()) {
 	/>
 </c:if>
 
+<div class="contextual-sidebar contextual-sidebar-visible sidebar-light sidebar-sm" id="<portlet:namespace />contextualSidebarContainer">
+	<div class="sidebar-body">
+	</div>
+</div>
+
 <div <%= editKBArticleDisplayContext.getFormCssClass() %>>
 	<aui:form action="<%= editKBArticleDisplayContext.getUpdateKBArticleURL() %>" method="post" name="fm">
 		<aui:input name="redirect" type="hidden" value="<%= editKBArticleDisplayContext.getRedirect() %>" />

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_kb_article.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_kb_article.jsp
@@ -57,6 +57,88 @@ if (editKBArticleDisplayContext.isPortletTitleBasedNavigation()) {
 
 	<div class="contextual-sidebar contextual-sidebar-visible sidebar-light sidebar-sm" id="<portlet:namespace />contextualSidebarContainer">
 		<div class="sidebar-body">
+			<liferay-ui:tabs
+				names="properties"
+				param="tabs1"
+				refresh="<%= false %>"
+			>
+				<liferay-ui:section>
+					<liferay-expando:custom-attributes-available
+						className="<%= KBArticle.class.getName() %>"
+					>
+						<aui:fieldset collapsed="<%= true %>" collapsible="<%= true %>" label="custom-fields">
+							<liferay-expando:custom-attribute-list
+								className="<%= KBArticle.class.getName() %>"
+								classPK="<%= editKBArticleDisplayContext.getKBArticleId() %>"
+								editable="<%= true %>"
+								label="<%= true %>"
+							/>
+						</aui:fieldset>
+					</liferay-expando:custom-attributes-available>
+
+					<aui:fieldset collapsed="<%= true %>" collapsible="<%= true %>" label="categorization">
+						<liferay-asset:asset-categories-selector
+							className="<%= KBArticle.class.getName() %>"
+							classPK="<%= editKBArticleDisplayContext.getKBArticleClassPK() %>"
+							visibilityTypes="<%= AssetVocabularyConstants.VISIBILITY_TYPES %>"
+						/>
+
+						<liferay-asset:asset-tags-selector
+							className="<%= KBArticle.class.getName() %>"
+							classPK="<%= editKBArticleDisplayContext.getKBArticleClassPK() %>"
+						/>
+					</aui:fieldset>
+
+					<aui:fieldset collapsed="<%= true %>" collapsible="<%= true %>" label="related-assets">
+						<liferay-asset:input-asset-links
+							className="<%= KBArticle.class.getName() %>"
+							classPK="<%= editKBArticleDisplayContext.getKBArticleClassPK() %>"
+						/>
+					</aui:fieldset>
+
+					<aui:fieldset collapsed="<%= true %>" collapsible="<%= true %>" label="configuration">
+						<aui:input cssClass="input-medium" data-custom-url="<%= false %>" disabled="<%= editKBArticleDisplayContext.isURLTitleDisabled() %>" helpMessage='<%= LanguageUtil.format(request, "for-example-x", "<em>/introduction-to-service-builder</em>") %>' ignoreRequestValue="<%= true %>" label="friendly-url" name="urlTitle" placeholder="sample-article-url-title" prefix="<%= editKBArticleDisplayContext.getURLTitlePrefix() %>" type="text" value="<%= editKBArticleDisplayContext.getKBArticleURLTitle() %>" />
+
+						<c:if test="<%= editKBArticleDisplayContext.isKBArticleDescriptionEnabled() %>">
+							<aui:input name="description" />
+						</c:if>
+
+						<c:if test="<%= editKBArticleDisplayContext.isSourceURLEnabled() %>">
+							<aui:input label="source-url" name="sourceURL" />
+						</c:if>
+
+						<c:if test="<%= editKBArticleDisplayContext.hasKBArticleSections() %>">
+							<aui:model-context bean="<%= null %>" model="<%= KBArticle.class %>" />
+
+							<aui:select ignoreRequestValue="<%= true %>" multiple="<%= true %>" name="sections">
+
+								<%
+								Map<String, String> availableSections = editKBArticleDisplayContext.getAvailableKBArticleSections();
+
+								for (Map.Entry<String, String> entry : availableSections.entrySet()) {
+								%>
+
+									<aui:option label="<%= HtmlUtil.escape(entry.getKey()) %>" selected="<%= editKBArticleDisplayContext.isKBArticleSectionSelected(entry.getValue()) %>" value="<%= HtmlUtil.escape(entry.getValue()) %>" />
+
+								<%
+								}
+								%>
+
+							</aui:select>
+
+							<aui:model-context bean="<%= editKBArticleDisplayContext.getKBArticle() %>" model="<%= KBArticle.class %>" />
+						</c:if>
+					</aui:fieldset>
+
+					<c:if test="<%= editKBArticleDisplayContext.getKBArticle() == null %>">
+						<aui:fieldset collapsed="<%= true %>" collapsible="<%= true %>" label="permissions">
+							<liferay-ui:input-permissions
+								modelName="<%= KBArticle.class.getName() %>"
+							/>
+						</aui:fieldset>
+					</c:if>
+				</liferay-ui:section>
+			</liferay-ui:tabs>
 		</div>
 	</div>
 
@@ -155,81 +237,6 @@ if (editKBArticleDisplayContext.isPortletTitleBasedNavigation()) {
 							<liferay-util:include page="/admin/common/attachments.jsp" servletContext="<%= application %>" />
 						</div>
 					</aui:fieldset>
-
-					<liferay-expando:custom-attributes-available
-						className="<%= KBArticle.class.getName() %>"
-					>
-						<aui:fieldset collapsed="<%= true %>" collapsible="<%= true %>" label="custom-fields">
-							<liferay-expando:custom-attribute-list
-								className="<%= KBArticle.class.getName() %>"
-								classPK="<%= editKBArticleDisplayContext.getKBArticleId() %>"
-								editable="<%= true %>"
-								label="<%= true %>"
-							/>
-						</aui:fieldset>
-					</liferay-expando:custom-attributes-available>
-
-					<aui:fieldset collapsed="<%= true %>" collapsible="<%= true %>" label="categorization">
-						<liferay-asset:asset-categories-selector
-							className="<%= KBArticle.class.getName() %>"
-							classPK="<%= editKBArticleDisplayContext.getKBArticleClassPK() %>"
-							visibilityTypes="<%= AssetVocabularyConstants.VISIBILITY_TYPES %>"
-						/>
-
-						<liferay-asset:asset-tags-selector
-							className="<%= KBArticle.class.getName() %>"
-							classPK="<%= editKBArticleDisplayContext.getKBArticleClassPK() %>"
-						/>
-					</aui:fieldset>
-
-					<aui:fieldset collapsed="<%= true %>" collapsible="<%= true %>" label="related-assets">
-						<liferay-asset:input-asset-links
-							className="<%= KBArticle.class.getName() %>"
-							classPK="<%= editKBArticleDisplayContext.getKBArticleClassPK() %>"
-						/>
-					</aui:fieldset>
-
-					<aui:fieldset collapsed="<%= true %>" collapsible="<%= true %>" label="configuration">
-						<aui:input cssClass="input-medium" data-custom-url="<%= false %>" disabled="<%= editKBArticleDisplayContext.isURLTitleDisabled() %>" helpMessage='<%= LanguageUtil.format(request, "for-example-x", "<em>/introduction-to-service-builder</em>") %>' ignoreRequestValue="<%= true %>" label="friendly-url" name="urlTitle" placeholder="sample-article-url-title" prefix="<%= editKBArticleDisplayContext.getURLTitlePrefix() %>" type="text" value="<%= editKBArticleDisplayContext.getKBArticleURLTitle() %>" />
-
-						<c:if test="<%= editKBArticleDisplayContext.isKBArticleDescriptionEnabled() %>">
-							<aui:input name="description" />
-						</c:if>
-
-						<c:if test="<%= editKBArticleDisplayContext.isSourceURLEnabled() %>">
-							<aui:input label="source-url" name="sourceURL" />
-						</c:if>
-
-						<c:if test="<%= editKBArticleDisplayContext.hasKBArticleSections() %>">
-							<aui:model-context bean="<%= null %>" model="<%= KBArticle.class %>" />
-
-							<aui:select ignoreRequestValue="<%= true %>" multiple="<%= true %>" name="sections">
-
-								<%
-								Map<String, String> availableSections = editKBArticleDisplayContext.getAvailableKBArticleSections();
-
-								for (Map.Entry<String, String> entry : availableSections.entrySet()) {
-								%>
-
-									<aui:option label="<%= HtmlUtil.escape(entry.getKey()) %>" selected="<%= editKBArticleDisplayContext.isKBArticleSectionSelected(entry.getValue()) %>" value="<%= HtmlUtil.escape(entry.getValue()) %>" />
-
-								<%
-								}
-								%>
-
-							</aui:select>
-
-							<aui:model-context bean="<%= editKBArticleDisplayContext.getKBArticle() %>" model="<%= KBArticle.class %>" />
-						</c:if>
-					</aui:fieldset>
-
-					<c:if test="<%= editKBArticleDisplayContext.getKBArticle() == null %>">
-						<aui:fieldset collapsed="<%= true %>" collapsible="<%= true %>" label="permissions">
-							<liferay-ui:input-permissions
-								modelName="<%= KBArticle.class.getName() %>"
-							/>
-						</aui:fieldset>
-					</c:if>
 
 					<div class="kb-submit-buttons sheet-footer">
 						<aui:button disabled="<%= editKBArticleDisplayContext.isPending() %>" name="publishButton" type="submit" value="<%= editKBArticleDisplayContext.getPublishButtonLabel() %>" />

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_kb_article.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_kb_article.jsp
@@ -97,7 +97,11 @@ if (editKBArticleDisplayContext.isPortletTitleBasedNavigation()) {
 					</aui:fieldset>
 
 					<aui:fieldset collapsed="<%= true %>" collapsible="<%= true %>" label="configuration">
-						<aui:input cssClass="input-medium" data-custom-url="<%= false %>" disabled="<%= editKBArticleDisplayContext.isURLTitleDisabled() %>" helpMessage='<%= LanguageUtil.format(request, "for-example-x", "<em>/introduction-to-service-builder</em>") %>' ignoreRequestValue="<%= true %>" label="friendly-url" name="urlTitle" placeholder="sample-article-url-title" prefix="<%= editKBArticleDisplayContext.getURLTitlePrefix() %>" type="text" value="<%= editKBArticleDisplayContext.getKBArticleURLTitle() %>" />
+						<aui:field-wrapper cssClass="form-group" disabled="<%= editKBArticleDisplayContext.isURLTitleDisabled() %>" helpMessage='<%= LanguageUtil.format(request, "for-example-x", "<em>/introduction-to-service-builder</em>") %>' label="friendly-url" name="urlTitle">
+							<span class="form-text"><%= editKBArticleDisplayContext.getURLTitlePrefix() %></span>
+
+							<aui:input cssClass="input-medium" data-custom-url="<%= false %>" disabled="<%= editKBArticleDisplayContext.isURLTitleDisabled() %>" ignoreRequestValue="<%= true %>" label="" name="urlTitle" placeholder="sample-article-url-title" type="text" value="<%= editKBArticleDisplayContext.getKBArticleURLTitle() %>" />
+						</aui:field-wrapper>
 
 						<c:if test="<%= editKBArticleDisplayContext.isKBArticleDescriptionEnabled() %>">
 							<aui:input name="description" />

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_kb_article.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_kb_article.jsp
@@ -60,184 +60,186 @@ if (editKBArticleDisplayContext.isPortletTitleBasedNavigation()) {
 		</div>
 	</div>
 
-	<div <%= editKBArticleDisplayContext.getFormCssClass() %>>
-		<div class="lfr-form-content">
-			<c:if test="<%= editKBArticleDisplayContext.isWorkflowStatusVisible() %>">
-				<div class="text-center">
-					<aui:workflow-status id="<%= String.valueOf(editKBArticleDisplayContext.getResourcePrimKey()) %>" showIcon="<%= false %>" showLabel="<%= false %>" status="<%= editKBArticleDisplayContext.getKBArticleStatus() %>" version="<%= editKBArticleDisplayContext.getKBArticleVersion() %>" />
-				</div>
-			</c:if>
-
-			<liferay-ui:error exception="<%= FileNameException.class %>" message="please-enter-a-file-with-a-valid-file-name" />
-			<liferay-ui:error exception="<%= KBArticleStatusException.class %>" message="this-article-cannot-be-published-because-its-parent-has-not-been-published" />
-			<liferay-ui:error exception="<%= KBArticleUrlTitleException.MustNotBeDuplicate.class %>" message="please-enter-a-unique-friendly-url" />
-
-			<liferay-ui:error exception="<%= FileSizeException.class %>">
-
-				<%
-				FileSizeException fileSizeException = (FileSizeException)errorException;
-				%>
-
-				<liferay-ui:message arguments="<%= fileSizeException.getMaxSize() / 1024 %>" key="please-enter-a-file-with-a-valid-file-size-no-larger-than-x" translateArguments="<%= false %>" />
-			</liferay-ui:error>
-
-			<liferay-ui:error exception="<%= KBArticleUrlTitleException.MustNotContainInvalidCharacters.class %>" message="please-enter-a-friendly-url-that-starts-with-a-slash-and-contains-alphanumeric-characters-dashes-and-underscores" />
-
-			<liferay-ui:error exception="<%= KBArticleUrlTitleException.MustNotExceedMaximumSize.class %>">
-
-				<%
-				int friendlyURLMaxLength = ModelHintsUtil.getMaxLength(KBArticle.class.getName(), "urlTitle");
-				%>
-
-				<liferay-ui:message arguments="<%= String.valueOf(friendlyURLMaxLength) %>" key="please-enter-a-friendly-url-with-fewer-than-x-characters" />
-			</liferay-ui:error>
-
-			<liferay-ui:error exception="<%= KBArticleContentException.class %>">
-				<liferay-ui:message arguments='<%= ModelHintsUtil.getMaxLength(KBArticle.class.getName(), "urlTitle") %>' key="please-enter-valid-content" />
-			</liferay-ui:error>
-
-			<liferay-ui:error exception="<%= KBArticleSourceURLException.class %>" message="please-enter-a-valid-source-url" />
-			<liferay-ui:error exception="<%= KBArticleTitleException.class %>" message="please-enter-a-valid-title" />
-			<liferay-ui:error exception="<%= NoSuchFileException.class %>" message="the-document-could-not-be-found" />
-
-			<liferay-ui:error exception="<%= UploadRequestSizeException.class %>">
-				<liferay-ui:message arguments="<%= LanguageUtil.formatStorageSize(UploadServletRequestConfigurationHelperUtil.getMaxSize(), locale) %>" key="request-is-larger-than-x-and-could-not-be-processed" translateArguments="<%= false %>" />
-			</liferay-ui:error>
-
-			<liferay-asset:asset-categories-error />
-
-			<liferay-asset:asset-tags-error />
-
-			<c:choose>
-				<c:when test="<%= editKBArticleDisplayContext.isApproved() %>">
-					<div class="alert alert-info">
-						<liferay-ui:message key="a-new-version-is-created-automatically-if-this-content-is-modified" />
+	<div class="contextual-sidebar-content">
+		<div <%= editKBArticleDisplayContext.getFormCssClass() %>>
+			<div class="lfr-form-content">
+				<c:if test="<%= editKBArticleDisplayContext.isWorkflowStatusVisible() %>">
+					<div class="text-center">
+						<aui:workflow-status id="<%= String.valueOf(editKBArticleDisplayContext.getResourcePrimKey()) %>" showIcon="<%= false %>" showLabel="<%= false %>" status="<%= editKBArticleDisplayContext.getKBArticleStatus() %>" version="<%= editKBArticleDisplayContext.getKBArticleVersion() %>" />
 					</div>
-				</c:when>
-				<c:when test="<%= editKBArticleDisplayContext.isPending() %>">
-					<div class="alert alert-info">
-						<liferay-ui:message key="there-is-a-publication-workflow-in-process" />
-					</div>
-				</c:when>
-			</c:choose>
-
-			<aui:model-context bean="<%= editKBArticleDisplayContext.getKBArticle() %>" model="<%= KBArticle.class %>" />
-
-			<aui:fieldset-group markupView="lexicon">
-				<aui:fieldset>
-					<h1 class="kb-title">
-						<aui:input autocomplete="off" label='<%= LanguageUtil.get(request, "title") %>' name="title" required="<%= true %>" type="text" value="<%= HtmlUtil.escape(editKBArticleDisplayContext.getKBArticleTitle()) %>" />
-					</h1>
-
-					<div class="kb-entity-body">
-						<liferay-editor:editor
-							contents="<%= editKBArticleDisplayContext.getContent() %>"
-							editorName="<%= kbGroupServiceConfiguration.getEditorName() %>"
-							fileBrowserParams='<%=
-								HashMapBuilder.put(
-									"resourcePrimKey", String.valueOf(editKBArticleDisplayContext.getResourcePrimKey())
-								).build()
-							%>'
-							name="contentEditor"
-							placeholder="content"
-							required="<%= true %>"
-						>
-							<aui:validator name="required" />
-						</liferay-editor:editor>
-
-						<aui:input name="content" type="hidden" />
-					</div>
-				</aui:fieldset>
-
-				<aui:fieldset collapsed="<%= true %>" collapsible="<%= true %>" label="attachments">
-					<div id="<portlet:namespace />attachments">
-						<liferay-util:include page="/admin/common/attachments.jsp" servletContext="<%= application %>" />
-					</div>
-				</aui:fieldset>
-
-				<liferay-expando:custom-attributes-available
-					className="<%= KBArticle.class.getName() %>"
-				>
-					<aui:fieldset collapsed="<%= true %>" collapsible="<%= true %>" label="custom-fields">
-						<liferay-expando:custom-attribute-list
-							className="<%= KBArticle.class.getName() %>"
-							classPK="<%= editKBArticleDisplayContext.getKBArticleId() %>"
-							editable="<%= true %>"
-							label="<%= true %>"
-						/>
-					</aui:fieldset>
-				</liferay-expando:custom-attributes-available>
-
-				<aui:fieldset collapsed="<%= true %>" collapsible="<%= true %>" label="categorization">
-					<liferay-asset:asset-categories-selector
-						className="<%= KBArticle.class.getName() %>"
-						classPK="<%= editKBArticleDisplayContext.getKBArticleClassPK() %>"
-						visibilityTypes="<%= AssetVocabularyConstants.VISIBILITY_TYPES %>"
-					/>
-
-					<liferay-asset:asset-tags-selector
-						className="<%= KBArticle.class.getName() %>"
-						classPK="<%= editKBArticleDisplayContext.getKBArticleClassPK() %>"
-					/>
-				</aui:fieldset>
-
-				<aui:fieldset collapsed="<%= true %>" collapsible="<%= true %>" label="related-assets">
-					<liferay-asset:input-asset-links
-						className="<%= KBArticle.class.getName() %>"
-						classPK="<%= editKBArticleDisplayContext.getKBArticleClassPK() %>"
-					/>
-				</aui:fieldset>
-
-				<aui:fieldset collapsed="<%= true %>" collapsible="<%= true %>" label="configuration">
-					<aui:input cssClass="input-medium" data-custom-url="<%= false %>" disabled="<%= editKBArticleDisplayContext.isURLTitleDisabled() %>" helpMessage='<%= LanguageUtil.format(request, "for-example-x", "<em>/introduction-to-service-builder</em>") %>' ignoreRequestValue="<%= true %>" label="friendly-url" name="urlTitle" placeholder="sample-article-url-title" prefix="<%= editKBArticleDisplayContext.getURLTitlePrefix() %>" type="text" value="<%= editKBArticleDisplayContext.getKBArticleURLTitle() %>" />
-
-					<c:if test="<%= editKBArticleDisplayContext.isKBArticleDescriptionEnabled() %>">
-						<aui:input name="description" />
-					</c:if>
-
-					<c:if test="<%= editKBArticleDisplayContext.isSourceURLEnabled() %>">
-						<aui:input label="source-url" name="sourceURL" />
-					</c:if>
-
-					<c:if test="<%= editKBArticleDisplayContext.hasKBArticleSections() %>">
-						<aui:model-context bean="<%= null %>" model="<%= KBArticle.class %>" />
-
-						<aui:select ignoreRequestValue="<%= true %>" multiple="<%= true %>" name="sections">
-
-							<%
-							Map<String, String> availableSections = editKBArticleDisplayContext.getAvailableKBArticleSections();
-
-							for (Map.Entry<String, String> entry : availableSections.entrySet()) {
-							%>
-
-								<aui:option label="<%= HtmlUtil.escape(entry.getKey()) %>" selected="<%= editKBArticleDisplayContext.isKBArticleSectionSelected(entry.getValue()) %>" value="<%= HtmlUtil.escape(entry.getValue()) %>" />
-
-							<%
-							}
-							%>
-
-						</aui:select>
-
-						<aui:model-context bean="<%= editKBArticleDisplayContext.getKBArticle() %>" model="<%= KBArticle.class %>" />
-					</c:if>
-				</aui:fieldset>
-
-				<c:if test="<%= editKBArticleDisplayContext.getKBArticle() == null %>">
-					<aui:fieldset collapsed="<%= true %>" collapsible="<%= true %>" label="permissions">
-						<liferay-ui:input-permissions
-							modelName="<%= KBArticle.class.getName() %>"
-						/>
-					</aui:fieldset>
 				</c:if>
 
-				<div class="kb-submit-buttons sheet-footer">
-					<aui:button disabled="<%= editKBArticleDisplayContext.isPending() %>" name="publishButton" type="submit" value="<%= editKBArticleDisplayContext.getPublishButtonLabel() %>" />
+				<liferay-ui:error exception="<%= FileNameException.class %>" message="please-enter-a-file-with-a-valid-file-name" />
+				<liferay-ui:error exception="<%= KBArticleStatusException.class %>" message="this-article-cannot-be-published-because-its-parent-has-not-been-published" />
+				<liferay-ui:error exception="<%= KBArticleUrlTitleException.MustNotBeDuplicate.class %>" message="please-enter-a-unique-friendly-url" />
 
-					<aui:button primary="<%= false %>" type="submit" value="<%= editKBArticleDisplayContext.getSaveButtonLabel() %>" />
+				<liferay-ui:error exception="<%= FileSizeException.class %>">
 
-					<aui:button href="<%= editKBArticleDisplayContext.getRedirect() %>" type="cancel" />
-				</div>
-			</aui:fieldset-group>
+					<%
+					FileSizeException fileSizeException = (FileSizeException)errorException;
+					%>
+
+					<liferay-ui:message arguments="<%= fileSizeException.getMaxSize() / 1024 %>" key="please-enter-a-file-with-a-valid-file-size-no-larger-than-x" translateArguments="<%= false %>" />
+				</liferay-ui:error>
+
+				<liferay-ui:error exception="<%= KBArticleUrlTitleException.MustNotContainInvalidCharacters.class %>" message="please-enter-a-friendly-url-that-starts-with-a-slash-and-contains-alphanumeric-characters-dashes-and-underscores" />
+
+				<liferay-ui:error exception="<%= KBArticleUrlTitleException.MustNotExceedMaximumSize.class %>">
+
+					<%
+					int friendlyURLMaxLength = ModelHintsUtil.getMaxLength(KBArticle.class.getName(), "urlTitle");
+					%>
+
+					<liferay-ui:message arguments="<%= String.valueOf(friendlyURLMaxLength) %>" key="please-enter-a-friendly-url-with-fewer-than-x-characters" />
+				</liferay-ui:error>
+
+				<liferay-ui:error exception="<%= KBArticleContentException.class %>">
+					<liferay-ui:message arguments='<%= ModelHintsUtil.getMaxLength(KBArticle.class.getName(), "urlTitle") %>' key="please-enter-valid-content" />
+				</liferay-ui:error>
+
+				<liferay-ui:error exception="<%= KBArticleSourceURLException.class %>" message="please-enter-a-valid-source-url" />
+				<liferay-ui:error exception="<%= KBArticleTitleException.class %>" message="please-enter-a-valid-title" />
+				<liferay-ui:error exception="<%= NoSuchFileException.class %>" message="the-document-could-not-be-found" />
+
+				<liferay-ui:error exception="<%= UploadRequestSizeException.class %>">
+					<liferay-ui:message arguments="<%= LanguageUtil.formatStorageSize(UploadServletRequestConfigurationHelperUtil.getMaxSize(), locale) %>" key="request-is-larger-than-x-and-could-not-be-processed" translateArguments="<%= false %>" />
+				</liferay-ui:error>
+
+				<liferay-asset:asset-categories-error />
+
+				<liferay-asset:asset-tags-error />
+
+				<c:choose>
+					<c:when test="<%= editKBArticleDisplayContext.isApproved() %>">
+						<div class="alert alert-info">
+							<liferay-ui:message key="a-new-version-is-created-automatically-if-this-content-is-modified" />
+						</div>
+					</c:when>
+					<c:when test="<%= editKBArticleDisplayContext.isPending() %>">
+						<div class="alert alert-info">
+							<liferay-ui:message key="there-is-a-publication-workflow-in-process" />
+						</div>
+					</c:when>
+				</c:choose>
+
+				<aui:model-context bean="<%= editKBArticleDisplayContext.getKBArticle() %>" model="<%= KBArticle.class %>" />
+
+				<aui:fieldset-group markupView="lexicon">
+					<aui:fieldset>
+						<h1 class="kb-title">
+							<aui:input autocomplete="off" label='<%= LanguageUtil.get(request, "title") %>' name="title" required="<%= true %>" type="text" value="<%= HtmlUtil.escape(editKBArticleDisplayContext.getKBArticleTitle()) %>" />
+						</h1>
+
+						<div class="kb-entity-body">
+							<liferay-editor:editor
+								contents="<%= editKBArticleDisplayContext.getContent() %>"
+								editorName="<%= kbGroupServiceConfiguration.getEditorName() %>"
+								fileBrowserParams='<%=
+									HashMapBuilder.put(
+										"resourcePrimKey", String.valueOf(editKBArticleDisplayContext.getResourcePrimKey())
+									).build()
+								%>'
+								name="contentEditor"
+								placeholder="content"
+								required="<%= true %>"
+							>
+								<aui:validator name="required" />
+							</liferay-editor:editor>
+
+							<aui:input name="content" type="hidden" />
+						</div>
+					</aui:fieldset>
+
+					<aui:fieldset collapsed="<%= true %>" collapsible="<%= true %>" label="attachments">
+						<div id="<portlet:namespace />attachments">
+							<liferay-util:include page="/admin/common/attachments.jsp" servletContext="<%= application %>" />
+						</div>
+					</aui:fieldset>
+
+					<liferay-expando:custom-attributes-available
+						className="<%= KBArticle.class.getName() %>"
+					>
+						<aui:fieldset collapsed="<%= true %>" collapsible="<%= true %>" label="custom-fields">
+							<liferay-expando:custom-attribute-list
+								className="<%= KBArticle.class.getName() %>"
+								classPK="<%= editKBArticleDisplayContext.getKBArticleId() %>"
+								editable="<%= true %>"
+								label="<%= true %>"
+							/>
+						</aui:fieldset>
+					</liferay-expando:custom-attributes-available>
+
+					<aui:fieldset collapsed="<%= true %>" collapsible="<%= true %>" label="categorization">
+						<liferay-asset:asset-categories-selector
+							className="<%= KBArticle.class.getName() %>"
+							classPK="<%= editKBArticleDisplayContext.getKBArticleClassPK() %>"
+							visibilityTypes="<%= AssetVocabularyConstants.VISIBILITY_TYPES %>"
+						/>
+
+						<liferay-asset:asset-tags-selector
+							className="<%= KBArticle.class.getName() %>"
+							classPK="<%= editKBArticleDisplayContext.getKBArticleClassPK() %>"
+						/>
+					</aui:fieldset>
+
+					<aui:fieldset collapsed="<%= true %>" collapsible="<%= true %>" label="related-assets">
+						<liferay-asset:input-asset-links
+							className="<%= KBArticle.class.getName() %>"
+							classPK="<%= editKBArticleDisplayContext.getKBArticleClassPK() %>"
+						/>
+					</aui:fieldset>
+
+					<aui:fieldset collapsed="<%= true %>" collapsible="<%= true %>" label="configuration">
+						<aui:input cssClass="input-medium" data-custom-url="<%= false %>" disabled="<%= editKBArticleDisplayContext.isURLTitleDisabled() %>" helpMessage='<%= LanguageUtil.format(request, "for-example-x", "<em>/introduction-to-service-builder</em>") %>' ignoreRequestValue="<%= true %>" label="friendly-url" name="urlTitle" placeholder="sample-article-url-title" prefix="<%= editKBArticleDisplayContext.getURLTitlePrefix() %>" type="text" value="<%= editKBArticleDisplayContext.getKBArticleURLTitle() %>" />
+
+						<c:if test="<%= editKBArticleDisplayContext.isKBArticleDescriptionEnabled() %>">
+							<aui:input name="description" />
+						</c:if>
+
+						<c:if test="<%= editKBArticleDisplayContext.isSourceURLEnabled() %>">
+							<aui:input label="source-url" name="sourceURL" />
+						</c:if>
+
+						<c:if test="<%= editKBArticleDisplayContext.hasKBArticleSections() %>">
+							<aui:model-context bean="<%= null %>" model="<%= KBArticle.class %>" />
+
+							<aui:select ignoreRequestValue="<%= true %>" multiple="<%= true %>" name="sections">
+
+								<%
+								Map<String, String> availableSections = editKBArticleDisplayContext.getAvailableKBArticleSections();
+
+								for (Map.Entry<String, String> entry : availableSections.entrySet()) {
+								%>
+
+									<aui:option label="<%= HtmlUtil.escape(entry.getKey()) %>" selected="<%= editKBArticleDisplayContext.isKBArticleSectionSelected(entry.getValue()) %>" value="<%= HtmlUtil.escape(entry.getValue()) %>" />
+
+								<%
+								}
+								%>
+
+							</aui:select>
+
+							<aui:model-context bean="<%= editKBArticleDisplayContext.getKBArticle() %>" model="<%= KBArticle.class %>" />
+						</c:if>
+					</aui:fieldset>
+
+					<c:if test="<%= editKBArticleDisplayContext.getKBArticle() == null %>">
+						<aui:fieldset collapsed="<%= true %>" collapsible="<%= true %>" label="permissions">
+							<liferay-ui:input-permissions
+								modelName="<%= KBArticle.class.getName() %>"
+							/>
+						</aui:fieldset>
+					</c:if>
+
+					<div class="kb-submit-buttons sheet-footer">
+						<aui:button disabled="<%= editKBArticleDisplayContext.isPending() %>" name="publishButton" type="submit" value="<%= editKBArticleDisplayContext.getPublishButtonLabel() %>" />
+
+						<aui:button primary="<%= false %>" type="submit" value="<%= editKBArticleDisplayContext.getSaveButtonLabel() %>" />
+
+						<aui:button href="<%= editKBArticleDisplayContext.getRedirect() %>" type="cancel" />
+					</div>
+				</aui:fieldset-group>
+			</div>
 		</div>
 	</div>
 </aui:form>

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_kb_article.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_kb_article.jsp
@@ -63,11 +63,34 @@ if (editKBArticleDisplayContext.isPortletTitleBasedNavigation()) {
 				</li>
 				<li class="tbar-item">
 					<div class="tbar-section text-right">
-						<aui:button disabled="<%= editKBArticleDisplayContext.isPending() %>" name="publishButton" type="submit" value="<%= editKBArticleDisplayContext.getPublishButtonLabel() %>" />
+						<clay:link
+							borderless="<%= true %>"
+							cssClass="mr-3"
+							displayType="secondary"
+							href="<%= editKBArticleDisplayContext.getRedirect() %>"
+							label="cancel"
+							small="<%= true %>"
+							type="button"
+						/>
 
-						<aui:button primary="<%= false %>" type="submit" value="<%= editKBArticleDisplayContext.getSaveButtonLabel() %>" />
+						<clay:button
+							cssClass="mr-3"
+							displayType="secondary"
+							label="<%= editKBArticleDisplayContext.getSaveButtonLabel() %>"
+							small="<%= true %>"
+							type="submit"
+						/>
 
-						<aui:button href="<%= editKBArticleDisplayContext.getRedirect() %>" type="cancel" />
+						<clay:button
+							cssClass="mr-3"
+							disabled="<%= editKBArticleDisplayContext.isPending() %>"
+							displayType="primary"
+							id='<%= liferayPortletResponse.getNamespace() + "publishButton" %>'
+							label="<%= editKBArticleDisplayContext.getPublishButtonLabel() %>"
+							name="publishButton"
+							small="<%= true %>"
+							type="submit"
+						/>
 					</div>
 				</li>
 			</ul>

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_kb_article.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_kb_article.jsp
@@ -75,6 +75,15 @@ if (editKBArticleDisplayContext.isPortletTitleBasedNavigation()) {
 							small="<%= true %>"
 							type="submit"
 						/>
+
+						<clay:button
+							borderless="<%= true %>"
+							icon="cog"
+							id='<%= liferayPortletResponse.getNamespace() + "contextualSidebarButton" %>'
+							small="<%= true %>"
+							title='<%= LanguageUtil.get(request, "configuration") %>'
+							type="button"
+						/>
 					</div>
 				</li>
 			</ul>
@@ -287,6 +296,10 @@ if (editKBArticleDisplayContext.isPortletTitleBasedNavigation()) {
 		</div>
 	</div>
 </aui:form>
+
+<liferay-frontend:component
+	module="admin/js/EditKBArticle"
+/>
 
 <script>
 	<c:if test="<%= editKBArticleDisplayContext.getKBArticle() == null %>">

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_kb_article.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_kb_article.jsp
@@ -51,16 +51,16 @@ if (editKBArticleDisplayContext.isPortletTitleBasedNavigation()) {
 	/>
 </c:if>
 
-<div class="contextual-sidebar contextual-sidebar-visible sidebar-light sidebar-sm" id="<portlet:namespace />contextualSidebarContainer">
-	<div class="sidebar-body">
+<aui:form action="<%= editKBArticleDisplayContext.getUpdateKBArticleURL() %>" method="post" name="fm">
+	<aui:input name="redirect" type="hidden" value="<%= editKBArticleDisplayContext.getRedirect() %>" />
+	<aui:input name="workflowAction" type="hidden" value="<%= WorkflowConstants.ACTION_SAVE_DRAFT %>" />
+
+	<div class="contextual-sidebar contextual-sidebar-visible sidebar-light sidebar-sm" id="<portlet:namespace />contextualSidebarContainer">
+		<div class="sidebar-body">
+		</div>
 	</div>
-</div>
 
-<div <%= editKBArticleDisplayContext.getFormCssClass() %>>
-	<aui:form action="<%= editKBArticleDisplayContext.getUpdateKBArticleURL() %>" method="post" name="fm">
-		<aui:input name="redirect" type="hidden" value="<%= editKBArticleDisplayContext.getRedirect() %>" />
-		<aui:input name="workflowAction" type="hidden" value="<%= WorkflowConstants.ACTION_SAVE_DRAFT %>" />
-
+	<div <%= editKBArticleDisplayContext.getFormCssClass() %>>
 		<div class="lfr-form-content">
 			<c:if test="<%= editKBArticleDisplayContext.isWorkflowStatusVisible() %>">
 				<div class="text-center">
@@ -239,8 +239,8 @@ if (editKBArticleDisplayContext.isPortletTitleBasedNavigation()) {
 				</div>
 			</aui:fieldset-group>
 		</div>
-	</aui:form>
-</div>
+	</div>
+</aui:form>
 
 <script>
 	<c:if test="<%= editKBArticleDisplayContext.getKBArticle() == null %>">

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/css/_admin.scss
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/css/_admin.scss
@@ -63,4 +63,31 @@ $controlMenuHeight: 56px;
 		+ .knowledge-base-admin-content {
 		transition: none;
 	}
+
+	.edit-knowledge-base-article-form {
+		.contextual-sidebar {
+			border-left: 1px $gray-300 solid;
+			box-shadow: none;
+			overflow-y: scroll;
+		}
+
+		.sidebar-body {
+			.collapse-icon {
+				border-bottom: 1px solid $light;
+				color: $secondary;
+
+				&:hover {
+					color: $dark;
+				}
+
+				.collapse-icon-open {
+					color: $dark;
+				}
+			}
+
+			.panel {
+				margin-bottom: 0;
+			}
+		}
+	}
 }

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/css/_admin.scss
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/css/_admin.scss
@@ -1,6 +1,8 @@
 @import 'atlas-variables';
 
 $controlMenuHeight: 56px;
+$productMenuWidth: 320px;
+$productMenuTransitionDuration: 0.5s;
 $toolbarDesktopHeight: 4rem;
 $toolbarHeight: 6.875rem;
 $toolbarZIndex: 971;
@@ -73,6 +75,8 @@ $toolbarZIndex: 971;
 			box-shadow: none;
 			overflow-y: scroll;
 
+			margin-top: 2.5rem;
+
 			.sidebar-body {
 				.collapse-icon {
 					border-bottom: 1px solid $light;
@@ -95,6 +99,10 @@ $toolbarZIndex: 971;
 					}
 				}
 			}
+
+			@include media-breakpoint-up(lg) {
+				margin-top: 0;
+			}
 		}
 
 		.contextual-sidebar-content .lfr-form-content {
@@ -106,13 +114,65 @@ $toolbarZIndex: 971;
 		}
 
 		.tbar-knowledge-base-edit-article {
+			height: auto;
+			left: 0;
 			min-height: 3.5rem;
 			position: fixed;
+			transition: left ease $productMenuTransitionDuration,
+				width ease $productMenuTransitionDuration;
 			width: 100%;
 			z-index: $toolbarZIndex;
 
-			@include media-breakpoint-up(lg) {
-				min-height: $toolbarDesktopHeight;
+			body.open & {
+				left: $productMenuWidth;
+				width: calc(100% - #{$productMenuWidth});
+
+				@media (max-width: 768px) {
+					left: 0;
+					width: 100%;
+				}
+			}
+
+			> .container-fluid {
+				padding: 0;
+
+				.tbar-nav {
+					flex-wrap: wrap;
+
+					> .tbar-item {
+						padding: 0.5em;
+					}
+
+					> .tbar-item:first-child {
+						border-top: solid thin #e7e7ed;
+						order: 1;
+						width: 100%;
+					}
+
+					> .tbar-item:last-child {
+						flex-grow: 1;
+						padding-right: 1em;
+
+						> .tbar-section {
+							display: flex;
+							justify-content: flex-end;
+						}
+					}
+
+					@include media-breakpoint-up(lg) {
+						flex-wrap: nowrap;
+
+						.tbar-item:first-child {
+							border-top: none;
+							order: 0;
+							width: auto;
+						}
+
+						> .tbar-item:last-child {
+							flex-grow: 0;
+						}
+					}
+				}
 			}
 
 			@include media-breakpoint-up(lg) {

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/css/_admin.scss
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/css/_admin.scss
@@ -1,6 +1,7 @@
 @import 'atlas-variables';
 
 $controlMenuHeight: 56px;
+$toolbarDesktopHeight: 4rem;
 
 .knowledge-base-portlet-admin {
 	.knowledge-base-vertical-bar {
@@ -87,6 +88,18 @@ $controlMenuHeight: 56px;
 
 			.panel {
 				margin-bottom: 0;
+			}
+		}
+
+		.tbar-knowledge-base-edit-article {
+			min-height: 3.5rem;
+
+			@include media-breakpoint-up(lg) {
+				min-height: $toolbarDesktopHeight;
+			}
+
+			.input-text-wrapper .form-validator-stack {
+				display: none;
 			}
 		}
 	}

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/css/_admin.scss
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/css/_admin.scss
@@ -2,6 +2,8 @@
 
 $controlMenuHeight: 56px;
 $toolbarDesktopHeight: 4rem;
+$toolbarHeight: 6.875rem;
+$toolbarZIndex: 971;
 
 .knowledge-base-portlet-admin {
 	.knowledge-base-vertical-bar {
@@ -70,29 +72,48 @@ $toolbarDesktopHeight: 4rem;
 			border-left: 1px $gray-300 solid;
 			box-shadow: none;
 			overflow-y: scroll;
-		}
 
-		.sidebar-body {
-			.collapse-icon {
-				border-bottom: 1px solid $light;
-				color: $secondary;
+			.sidebar-body {
+				.collapse-icon {
+					border-bottom: 1px solid $light;
+					color: $secondary;
 
-				&:hover {
-					color: $dark;
+					&:hover {
+						color: $dark;
+					}
+
+					.collapse-icon-open {
+						color: $dark;
+					}
 				}
 
-				.collapse-icon-open {
-					color: $dark;
+				.panel {
+					margin-bottom: 0;
+
+					.panel-body {
+						padding-top: 0;
+					}
 				}
 			}
+		}
 
-			.panel {
-				margin-bottom: 0;
+		.contextual-sidebar-content .lfr-form-content {
+			margin-top: $toolbarHeight;
+
+			@include media-breakpoint-up(lg) {
+				margin-top: 2.5rem;
 			}
 		}
 
 		.tbar-knowledge-base-edit-article {
 			min-height: 3.5rem;
+			position: fixed;
+			width: 100%;
+			z-index: $toolbarZIndex;
+
+			@include media-breakpoint-up(lg) {
+				min-height: $toolbarDesktopHeight;
+			}
 
 			@include media-breakpoint-up(lg) {
 				min-height: $toolbarDesktopHeight;

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/js/EditKBArticle.js
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/js/EditKBArticle.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+export default function _EditKBArticle({namespace}) {
+	const contextualSidebarButton = document.getElementById(
+		`${namespace}contextualSidebarButton`
+	);
+
+	const contextualSidebarContainer = document.getElementById(
+		`${namespace}contextualSidebarContainer`
+	);
+
+	contextualSidebarButton.addEventListener('click', () => {
+		contextualSidebarContainer?.classList.toggle(
+			'contextual-sidebar-visible'
+		);
+	});
+}

--- a/portal-web/test/functional/com/liferay/portalweb/macros/KBArticle.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/KBArticle.macro
@@ -74,6 +74,8 @@ definition {
 				value1 = "${kbArticleTitleFormatted}");
 		}
 
+		ProductMenuHelper.closeProductMenu();
+
 		if ("${cancel}" == "true") {
 			Button.clickCancel();
 		}
@@ -81,9 +83,7 @@ definition {
 			Button.clickSaveAsDraft();
 		}
 		else {
-			AssertClick(
-				locator1 = "Button#PUBLISH",
-				value1 = "Publish");
+			Button.click(button = "Publish");
 		}
 	}
 
@@ -203,6 +203,8 @@ definition {
 		}
 
 		if ("${kbWorkflowAction}" == "Submit for Publication") {
+			ProductMenuHelper.closeProductMenu();
+
 			AssertClick(
 				locator1 = "Button#SUBMIT_FOR_PUBLICATION",
 				value1 = "Submit for Publication");
@@ -211,9 +213,9 @@ definition {
 			Button.clickSaveAsDraft();
 		}
 		else {
-			AssertClick(
-				locator1 = "Button#PUBLISH",
-				value1 = "Publish");
+			ProductMenuHelper.closeProductMenu();
+
+			Button.click(button = "Publish");
 		}
 
 		if ("${kbArticleInvalidContent}" == "true") {
@@ -273,9 +275,9 @@ definition {
 
 		CKEditor.addContent(content = "${kbArticleContent}");
 
-		AssertClick(
-			locator1 = "Button#PUBLISH",
-			value1 = "Publish");
+		ProductMenuHelper.closeProductMenu();
+
+		Button.click(button = "Publish");
 
 		Alert.viewRequiredField();
 	}
@@ -313,9 +315,7 @@ definition {
 
 		CKEditor.addContent(content = "${kbArticleContent}");
 
-		AssertClick(
-			locator1 = "Button#PUBLISH",
-			value1 = "Publish");
+		Button.click(button = "Publish");
 	}
 
 	macro cancelAddKBArticle {
@@ -716,9 +716,7 @@ definition {
 			Button.clickSaveAsDraft();
 		}
 		else {
-			AssertClick(
-				locator1 = "Button#PUBLISH",
-				value1 = "Publish");
+			Button.click(button = "Publish");
 		}
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/knowledgebase/KBArticle.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/knowledgebase/KBArticle.testcase
@@ -308,7 +308,7 @@ definition {
 	@priority = "4"
 	@refactordone
 	test CannotAddArticleWithoutContent {
-		KBArticle.viewFieldRequiredAsterisk(fieldLabel = "Title,Content");
+		KBArticle.viewFieldRequiredAsterisk(fieldLabel = "Content");
 
 		KBAdmin.openKBAdmin(siteURLKey = "guest");
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/knowledgebase/KBDisplayWidget.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/knowledgebase/KBDisplayWidget.testcase
@@ -15,7 +15,7 @@ definition {
 			layoutName = "Knowledge Base Display Page");
 
 		JSONLayout.addWidgetToPublicLayout(
-			column = "1",
+			column = "2",
 			groupName = "Guest",
 			layoutName = "Knowledge Base Display Page",
 			widgetName = "Knowledge Base Display");


### PR DESCRIPTION
Issues detected by @Jeremy-Ch in the previous pull https://github.com/liferay-lima/liferay-portal/pull/3518

1. The error message can not be displayed when publishing the article without a title => I see same behaviour in WC. Just the title input is marked in red. 
2. When I try to resize the browser, the edit page doesn't change. Some contents will go outside the browser =>  fixed in this pull
3. When I try to edit an article in the KB display widget, the side panel is pinned to the screen. It will block something => Depends on pull https://github.com/liferay-lima/liferay-portal/pull/3523
4. For the title placeholder text, maybe we can use "Untitled Basic Article" => Different subtask created https://issues.liferay.com/browse/LPS-163852


With these changes the new look and feel is:
<img width="1476" alt="Screenshot 2022-09-29 at 15 27 13" src="https://user-images.githubusercontent.com/8373764/193044884-06123cf6-d1e3-4730-bfa4-1794ecf385ab.png">

**(mobile/reduced screens)**
<img width="979" alt="Screenshot 2022-09-29 at 15 26 48" src="https://user-images.githubusercontent.com/8373764/193044905-50dfa79c-8ecb-4bbe-9af6-3175bff846a4.png">






**Note**: parent story https://issues.liferay.com/browse/LPS-154208 is not complete. If something is missing in this pull, unless it brokes or introduces errors, could be handled in a different subtask. Feel free to open it in Jira. 