### PR TITLE
LPS-164247 ComparisonFailure occurs on com.liferay.document.library.search.test.DLFileEntryIndexerIndexedFieldsTest

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMIndexerImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMIndexerImpl.java
@@ -138,7 +138,7 @@ public class DDMIndexerImpl implements DDMIndexer {
 							_addToDocument(
 								document, field, indexType, name, value);
 						}
-						else {
+						else if (value != null) {
 							fieldArray.addField(
 								createField(
 									ddmFormField, field, indexType, locale,
@@ -155,7 +155,7 @@ public class DDMIndexerImpl implements DDMIndexer {
 					if (legacyDDMIndexFieldsEnabled) {
 						_addToDocument(document, field, indexType, name, value);
 					}
-					else {
+					else if (value != null) {
 						fieldArray.addField(
 							createField(
 								ddmFormField, field, indexType, null, name,
@@ -370,6 +370,10 @@ public class DDMIndexerImpl implements DDMIndexer {
 				}
 
 				Serializable value = field.getValue(locale);
+
+				if (value == null) {
+					continue;
+				}
 
 				if (value instanceof Boolean || value instanceof Number) {
 					sb.append(value);


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-163433

Regression caused by this commit https://github.com/liferay-lima/liferay-portal/commit/892c42eac81ffd42cb2def90308f03a3d12c8fb5 of [LPS-163433](https://issues.liferay.com/browse/LPS-163433), that commit was necessary to avoid losing the empty DDMFormFieldValue nodes in some conversions, but it causes the side effect to index the "null" value.

I have added a check to avoid indexing the "null" value.

@AliciaGarciaGarcia 