### PR TITLE
[TS] LPS-164579 | master

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/messaging/TempFileEntriesMessageListener.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/messaging/TempFileEntriesMessageListener.java
@@ -50,7 +50,7 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	configurationPid = "com.liferay.document.library.configuration.DLConfiguration",
-	service = TempFileEntriesMessageListener.class
+	immediate = true, service = TempFileEntriesMessageListener.class
 )
 public class TempFileEntriesMessageListener extends BaseMessageListener {
 


### PR DESCRIPTION
**Description**:
- The component is not being scheduled becuse of it is not immediate. So, it is not activated (it remains as satisfied) and then it is not scheduled.

**Steps to reproduce:**

1. Run following groovy script to check if job is scheduled:
```
import com.liferay.portal.kernel.scheduler.*;
import com.liferay.portal.kernel.scheduler.messaging.SchedulerResponse;
import com.liferay.portal.kernel.messaging.Message;
import com.liferay.portal.kernel.util.ObjectValuePair;
import com.liferay.portal.kernel.cluster.ClusterMasterExecutorUtil;

def SCHEDULED_JOB = "com.liferay.document.library.web.internal.messaging.TempFileEntriesMessageListener";

out.println("");
out.println("** Master: "+ ClusterMasterExecutorUtil.isMaster());

boolean isJobScheduled = false;

def schedulerJobs = SchedulerEngineHelperUtil.getScheduledJobs();
for (SchedulerResponse schedulerResponse: schedulerJobs) {
    try {
        String jobName = schedulerResponse.getJobName();
        if (!jobName.equals(SCHEDULED_JOB))
            continue;

        isJobScheduled = true;

        out.println("=====");
        
        Trigger oldTrigger = schedulerResponse.getTrigger();

        String groupName = schedulerResponse.getGroupName();
        String destinationName = schedulerResponse.getDestinationName();
        String storageType = schedulerResponse.getStorageType();
        
        out.println("Job Name: " +jobName);        
        out.println("Group Name: " + groupName);
        out.println("Destination Name: " + destinationName);
        out.println("Storage Type: " + storageType);
        
        out.println ("TriggerState: " + SchedulerEngineHelperUtil.getJobState(schedulerResponse));
        
        if (oldTrigger == null) {
            out.println("Trigger is NULL");
        } else {
            out.println("TriggerStartDate: " + oldTrigger.getStartDate());
            out.println("TriggerEndDate: " + oldTrigger.getEndDate());
            out.println("PreviousFireTime: " +SchedulerEngineHelperUtil.getPreviousFireTime(schedulerResponse));
            out.println("->NextFireTime: " +SchedulerEngineHelperUtil.getNextFireTime(schedulerResponse));
            out.println("getWrappedTrigger: " + oldTrigger.getWrappedTrigger());
        }

        def jobExceptions = SchedulerEngineHelperUtil.getJobExceptions(schedulerResponse);
        if( jobExceptions != null) {
            out.println("-- exceptions:")
            out.println("");
            
            for(def je: jobExceptions){
                try {
                    out.println(je.getValue());
                    je.getKey().printStackTrace(out);
                    out.println(" ");
                } catch (Exception e1){
                    out.println ("Error processing exception");
                    e1.printStackTrace(out);
                }
            }
        }

    } catch (Exception e2) {
        out.println ("Error processing schedulerResponse");
        e2.printStackTrace(out);
    }
}

if (!isJobScheduled) {
    out.println("WARNING: " + SCHEDULED_JOB + " is not scheduled!.")
}
```



**Solution proposed:**
Reverting the component to be immediate should resolve the issue.


Best.
 Sergio.



