### PR TITLE
LPS-164071 Update empty state title for folder (not Home)

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/view.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/view.jsp
@@ -326,7 +326,7 @@ KBArticleURLHelper kbArticleURLHelper = new KBArticleURLHelper(renderRequest, re
 						actionDropdownItems="<%= kbAdminManagementToolbarDisplayContext.getEmptyStateActionDropdownItems() %>"
 						animationType="<%= EmptyResultMessageKeys.AnimationType.EMPTY %>"
 						buttonCssClass="secondary"
-						title='<%= (parentResourcePrimKey == 0) ? LanguageUtil.get(request, "knowledge-base-is-empty") : LanguageUtil.get(request, "this-folder-is-empty") %>'
+						title='<%= (parentResourcePrimKey == KBFolderConstants.DEFAULT_PARENT_FOLDER_ID) ? LanguageUtil.get(request, "knowledge-base-is-empty") : LanguageUtil.get(request, "this-folder-is-empty") %>'
 					/>
 				</c:otherwise>
 			</c:choose>

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/view.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/view.jsp
@@ -326,7 +326,7 @@ KBArticleURLHelper kbArticleURLHelper = new KBArticleURLHelper(renderRequest, re
 						actionDropdownItems="<%= kbAdminManagementToolbarDisplayContext.getEmptyStateActionDropdownItems() %>"
 						animationType="<%= EmptyResultMessageKeys.AnimationType.EMPTY %>"
 						buttonCssClass="secondary"
-						title='<%= LanguageUtil.get(request, "knowledge-base-is-empty") %>'
+						title='<%= (parentResourcePrimKey == 0) ? LanguageUtil.get(request, "knowledge-base-is-empty") : LanguageUtil.get(request, "this-folder-is-empty") %>'
 					/>
 				</c:otherwise>
 			</c:choose>


### PR DESCRIPTION
Added the conditional operator to check for the parent resource primary key. If nothing exists the message is 'knowledge-base-is-empty', if we are inside an empty folder the already existing message 'this-folder-is-empty' is used.