### PR TITLE
LPS-164704 Add max nesting level property to fragment

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/display/context/KBArticleNavigationFragmentDisplayContext.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/display/context/KBArticleNavigationFragmentDisplayContext.java
@@ -36,9 +36,11 @@ import java.util.List;
 public class KBArticleNavigationFragmentDisplayContext {
 
 	public KBArticleNavigationFragmentDisplayContext(
+		int maxNestingLevel,
 		InfoItemFriendlyURLProvider<KBArticle> infoItemFriendlyURLProvider,
 		KBArticle kbArticle) {
 
+		_maxNestingLevel = maxNestingLevel;
 		_infoItemFriendlyURLProvider = infoItemFriendlyURLProvider;
 		_kbArticle = kbArticle;
 	}
@@ -152,18 +154,17 @@ public class KBArticleNavigationFragmentDisplayContext {
 	}
 
 	private boolean _isMaxNestingLevelReached(int level) {
-		if ((_MAX_NESTING_LEVEL - level) <= 1) {
+		if ((_maxNestingLevel - level) <= 1) {
 			return true;
 		}
 
 		return false;
 	}
 
-	private static final int _MAX_NESTING_LEVEL = 3;
-
 	private final InfoItemFriendlyURLProvider<KBArticle>
 		_infoItemFriendlyURLProvider;
 	private final KBArticle _kbArticle;
 	private List<Long> _kbArticleAncestorResourcePrimKeys;
+	private final int _maxNestingLevel;
 
 }

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/fragment/renderer/KBArticleNavigationFragmentRenderer.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/fragment/renderer/KBArticleNavigationFragmentRenderer.java
@@ -32,6 +32,7 @@ import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -80,6 +81,25 @@ public class KBArticleNavigationFragmentRenderer implements FragmentRenderer {
 							"name", "itemSelector"
 						).put(
 							"type", "itemSelector"
+						),
+						JSONUtil.put(
+							"defaultValue",
+							String.valueOf(_DEFAULT_MAX_NESTING_LEVEL)
+						).put(
+							"label", "maximum-nesting-level"
+						).put(
+							"name", "maxNestingLevel"
+						).put(
+							"type", "text"
+						).put(
+							"typeOptions",
+							JSONUtil.put(
+								"validation",
+								JSONUtil.put(
+									"min", 1
+								).put(
+									"type", "number"
+								))
 						))))
 		).toString();
 	}
@@ -132,6 +152,7 @@ public class KBArticleNavigationFragmentRenderer implements FragmentRenderer {
 			httpServletRequest.setAttribute(
 				KBArticleNavigationFragmentDisplayContext.class.getName(),
 				new KBArticleNavigationFragmentDisplayContext(
+					_getMaxNestingLevel(fragmentRendererContext),
 					_infoItemFriendlyURLProvider, kbArticle));
 
 			RequestDispatcher requestDispatcher =
@@ -204,6 +225,20 @@ public class KBArticleNavigationFragmentRenderer implements FragmentRenderer {
 		}
 	}
 
+	private int _getMaxNestingLevel(
+		FragmentRendererContext fragmentRendererContext) {
+
+		FragmentEntryLink fragmentEntryLink =
+			fragmentRendererContext.getFragmentEntryLink();
+
+		return GetterUtil.getInteger(
+			_fragmentEntryConfigurationParser.getFieldValue(
+				getConfiguration(fragmentRendererContext),
+				fragmentEntryLink.getEditableValues(),
+				fragmentRendererContext.getLocale(), "maxNestingLevel"),
+			_DEFAULT_MAX_NESTING_LEVEL);
+	}
+
 	private void _printPortletMessageInfo(
 		HttpServletRequest httpServletRequest,
 		HttpServletResponse httpServletResponse, String message) {
@@ -235,6 +270,8 @@ public class KBArticleNavigationFragmentRenderer implements FragmentRenderer {
 					"fragmentElementId", fragmentElementId
 				).build()));
 	}
+
+	private static final int _DEFAULT_MAX_NESTING_LEVEL = 3;
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		KBArticleNavigationFragmentRenderer.class);


### PR DESCRIPTION
Let admins configure the maximum nesting level in the kb navigation fragment. The navigation tree will collapse, flattening all descendants below the max nesting level, so that the navigation tree doesn't expand to the right when displaying deep hierarchies.
To see the configuration in action, create a display page template, drop the kb navigation fragment on it, and go to the "general" tab after selecting the fragment.