### PR TITLE
LPS-164919 Regenerate adaptive media images if content was lost

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-document-library-thumbnails/src/main/java/com/liferay/adaptive/media/document/library/thumbnails/internal/processor/AMImageEntryProcessor.java
+++ b/modules/apps/adaptive-media/adaptive-media-document-library-thumbnails/src/main/java/com/liferay/adaptive/media/document/library/thumbnails/internal/processor/AMImageEntryProcessor.java
@@ -121,7 +121,7 @@ public class AMImageEntryProcessor implements DLProcessor, ImageProcessor {
 		Optional<AdaptiveMedia<AMImageProcessor>> adaptiveMediaOptional =
 			adaptiveMediaStream.findFirst();
 
-		if (!adaptiveMediaOptional.isPresent()) {
+		if (_isProcessingRequired(adaptiveMediaOptional, fileVersion)) {
 			_processAMImage(fileVersion);
 
 			return fileVersion.getContentStream(false);
@@ -147,7 +147,7 @@ public class AMImageEntryProcessor implements DLProcessor, ImageProcessor {
 		Optional<AdaptiveMedia<AMImageProcessor>> adaptiveMediaOptional =
 			adaptiveMediaStream.findFirst();
 
-		if (!adaptiveMediaOptional.isPresent()) {
+		if (_isProcessingRequired(adaptiveMediaOptional, fileVersion)) {
 			_processAMImage(fileVersion);
 
 			return fileVersion.getSize();
@@ -176,7 +176,7 @@ public class AMImageEntryProcessor implements DLProcessor, ImageProcessor {
 		Optional<AdaptiveMedia<AMImageProcessor>> adaptiveMediaOptional =
 			adaptiveMediaStream.findFirst();
 
-		if (!adaptiveMediaOptional.isPresent()) {
+		if (_isProcessingRequired(adaptiveMediaOptional, fileVersion)) {
 			_processAMImage(fileVersion);
 		}
 
@@ -197,7 +197,7 @@ public class AMImageEntryProcessor implements DLProcessor, ImageProcessor {
 		Optional<AdaptiveMedia<AMImageProcessor>> adaptiveMediaOptional =
 			adaptiveMediaStream.findFirst();
 
-		if (!adaptiveMediaOptional.isPresent()) {
+		if (_isProcessingRequired(adaptiveMediaOptional, fileVersion)) {
 			_processAMImage(fileVersion);
 		}
 
@@ -228,7 +228,7 @@ public class AMImageEntryProcessor implements DLProcessor, ImageProcessor {
 			Optional<AdaptiveMedia<AMImageProcessor>> adaptiveMediaOptional =
 				adaptiveMediaStream.findFirst();
 
-			if (adaptiveMediaOptional.isPresent()) {
+			if (!_isProcessingRequired(adaptiveMediaOptional, fileVersion)) {
 				return true;
 			}
 
@@ -356,6 +356,26 @@ public class AMImageEntryProcessor implements DLProcessor, ImageProcessor {
 
 	private boolean _isMimeTypeSupported(String mimeType) {
 		return _amImageMimeTypeProvider.isMimeTypeSupported(mimeType);
+	}
+
+	private boolean _isProcessingRequired(
+		Optional<AdaptiveMedia<AMImageProcessor>> adaptiveMediaOptional,
+		FileVersion fileVersion) {
+
+		if (!adaptiveMediaOptional.isPresent()) {
+			return true;
+		}
+
+		AdaptiveMedia<AMImageProcessor> adaptiveMedia =
+			adaptiveMediaOptional.get();
+
+		if (_amImageValidator.isProcessingRequired(
+				adaptiveMedia, fileVersion)) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 	private void _processAMImage(FileVersion fileVersion) {

--- a/modules/apps/adaptive-media/adaptive-media-document-library-thumbnails/src/test/java/com/liferay/adaptive/media/document/library/thumbnails/internal/processor/AMImageEntryProcessorTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-document-library-thumbnails/src/test/java/com/liferay/adaptive/media/document/library/thumbnails/internal/processor/AMImageEntryProcessorTest.java
@@ -192,6 +192,43 @@ public class AMImageEntryProcessorTest {
 	}
 
 	@Test
+	public void testGetPreviewAsStreamTriggersAMProcessorWhenNoAMImageContentExists()
+		throws Exception {
+
+		Mockito.when(
+			_amImageFinder.getAdaptiveMediaStream(Mockito.any(Function.class))
+		).thenAnswer(
+			invocation -> Stream.of(_adaptiveMedia)
+		);
+
+		Mockito.when(
+			_amImageMimeTypeProvider.isMimeTypeSupported(Mockito.anyString())
+		).thenReturn(
+			true
+		);
+
+		Mockito.when(
+			_amImageValidator.isValid(_fileVersion)
+		).thenReturn(
+			true
+		);
+
+		Mockito.when(
+			_amImageValidator.isProcessingRequired(_adaptiveMedia, _fileVersion)
+		).thenReturn(
+			true
+		);
+
+		_amImageEntryProcessor.getPreviewAsStream(_fileVersion);
+
+		Mockito.verify(
+			_amAsyncProcessor
+		).triggerProcess(
+			Mockito.any(FileVersion.class), Mockito.anyString()
+		);
+	}
+
+	@Test
 	public void testGetPreviewAsStreamTriggersAMProcessorWhenNoAMImageExists()
 		throws Exception {
 

--- a/modules/apps/adaptive-media/adaptive-media-image-api/bnd.bnd
+++ b/modules/apps/adaptive-media/adaptive-media-image-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Adaptive Media Image API
 Bundle-SymbolicName: com.liferay.adaptive.media.image.api
-Bundle-Version: 6.1.1
+Bundle-Version: 7.0.0
 Export-Package:\
 	com.liferay.adaptive.media.image.configuration,\
 	com.liferay.adaptive.media.image.constants,\

--- a/modules/apps/adaptive-media/adaptive-media-image-api/src/main/java/com/liferay/adaptive/media/image/service/AMImageEntryLocalService.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-api/src/main/java/com/liferay/adaptive/media/image/service/AMImageEntryLocalService.java
@@ -445,6 +445,10 @@ public interface AMImageEntryLocalService
 	public PersistedModel getPersistedModel(Serializable primaryKeyObj)
 		throws PortalException;
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public boolean hasAMImageEntryContent(
+		String configurationUuid, FileVersion fileVersion);
+
 	/**
 	 * Updates the am image entry in the database or adds it if it does not yet exist. Also notifies the appropriate model listeners.
 	 *

--- a/modules/apps/adaptive-media/adaptive-media-image-api/src/main/java/com/liferay/adaptive/media/image/service/AMImageEntryLocalServiceUtil.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-api/src/main/java/com/liferay/adaptive/media/image/service/AMImageEntryLocalServiceUtil.java
@@ -508,6 +508,14 @@ public class AMImageEntryLocalServiceUtil {
 		return getService().getPersistedModel(primaryKeyObj);
 	}
 
+	public static boolean hasAMImageEntryContent(
+		String configurationUuid,
+		com.liferay.portal.kernel.repository.model.FileVersion fileVersion) {
+
+		return getService().hasAMImageEntryContent(
+			configurationUuid, fileVersion);
+	}
+
 	/**
 	 * Updates the am image entry in the database or adds it if it does not yet exist. Also notifies the appropriate model listeners.
 	 *

--- a/modules/apps/adaptive-media/adaptive-media-image-api/src/main/java/com/liferay/adaptive/media/image/service/AMImageEntryLocalServiceWrapper.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-api/src/main/java/com/liferay/adaptive/media/image/service/AMImageEntryLocalServiceWrapper.java
@@ -568,6 +568,15 @@ public class AMImageEntryLocalServiceWrapper
 		return _amImageEntryLocalService.getPersistedModel(primaryKeyObj);
 	}
 
+	@Override
+	public boolean hasAMImageEntryContent(
+		String configurationUuid,
+		com.liferay.portal.kernel.repository.model.FileVersion fileVersion) {
+
+		return _amImageEntryLocalService.hasAMImageEntryContent(
+			configurationUuid, fileVersion);
+	}
+
 	/**
 	 * Updates the am image entry in the database or adds it if it does not yet exist. Also notifies the appropriate model listeners.
 	 *

--- a/modules/apps/adaptive-media/adaptive-media-image-api/src/main/java/com/liferay/adaptive/media/image/validator/AMImageValidator.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-api/src/main/java/com/liferay/adaptive/media/image/validator/AMImageValidator.java
@@ -14,6 +14,7 @@
 
 package com.liferay.adaptive.media.image.validator;
 
+import com.liferay.adaptive.media.AdaptiveMedia;
 import com.liferay.portal.kernel.repository.model.FileVersion;
 
 /**
@@ -22,6 +23,9 @@ import com.liferay.portal.kernel.repository.model.FileVersion;
  * @author Sergio González
  */
 public interface AMImageValidator {
+
+	public <T> boolean isProcessingRequired(
+		AdaptiveMedia<T> adaptiveMedia, FileVersion fileVersion);
 
 	/**
 	 * Returns <code>true</code> if the provided file version supports image

--- a/modules/apps/adaptive-media/adaptive-media-image-api/src/main/resources/com/liferay/adaptive/media/image/service/packageinfo
+++ b/modules/apps/adaptive-media/adaptive-media-image-api/src/main/resources/com/liferay/adaptive/media/image/service/packageinfo
@@ -1,1 +1,1 @@
-version 1.5.0
+version 1.6.0

--- a/modules/apps/adaptive-media/adaptive-media-image-api/src/main/resources/com/liferay/adaptive/media/image/validator/packageinfo
+++ b/modules/apps/adaptive-media/adaptive-media-image-api/src/main/resources/com/liferay/adaptive/media/image/validator/packageinfo
@@ -1,1 +1,1 @@
-version 1.2.0
+version 2.0.0

--- a/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/processor/AMImageProcessorImpl.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/processor/AMImageProcessorImpl.java
@@ -161,7 +161,10 @@ public final class AMImageProcessorImpl implements AMImageProcessor {
 			AMImageEntry amImageEntry, FileVersion fileVersion)
 		throws PortalException {
 
-		if (amImageEntry == null) {
+		if ((amImageEntry == null) ||
+			!_amImageEntryLocalService.hasAMImageEntryContent(
+				amImageEntry.getConfigurationUuid(), fileVersion)) {
+
 			return true;
 		}
 

--- a/modules/apps/adaptive-media/adaptive-media-image-impl/src/test/java/com/liferay/adaptive/media/image/internal/validator/AMImageValidatorImplTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-impl/src/test/java/com/liferay/adaptive/media/image/internal/validator/AMImageValidatorImplTest.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.adaptive.media.image.internal.validator;
+
+import com.liferay.adaptive.media.AMAttribute;
+import com.liferay.adaptive.media.AdaptiveMedia;
+import com.liferay.adaptive.media.image.service.AMImageEntryLocalService;
+import com.liferay.portal.kernel.repository.model.FileVersion;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.Optional;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Adolfo Pérez
+ */
+public class AMImageValidatorImplTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		Mockito.when(
+			_adaptiveMedia.getValueOptional(
+				AMAttribute.getConfigurationUuidAMAttribute())
+		).thenReturn(
+			Optional.of(RandomTestUtil.randomString())
+		);
+
+		_amImageValidatorImpl.setAMImageEntryLocalService(
+			_amImageEntryLocalService);
+	}
+
+	@Test
+	public void testIsProcessingRequiredWhenContentPresent() {
+		Mockito.when(
+			_amImageEntryLocalService.hasAMImageEntryContent(
+				Mockito.anyString(), Mockito.any(FileVersion.class))
+		).thenReturn(
+			true
+		);
+
+		Assert.assertFalse(
+			_amImageValidatorImpl.isProcessingRequired(
+				_adaptiveMedia, Mockito.mock(FileVersion.class)));
+
+		_verifyAMImageEntryLocalServiceMock();
+	}
+
+	@Test
+	public void testIsProcessingRequiredWhenNoContentPresent() {
+		Mockito.when(
+			_amImageEntryLocalService.hasAMImageEntryContent(
+				Mockito.anyString(), Mockito.any(FileVersion.class))
+		).thenReturn(
+			false
+		);
+
+		Assert.assertTrue(
+			_amImageValidatorImpl.isProcessingRequired(
+				_adaptiveMedia, Mockito.mock(FileVersion.class)));
+
+		_verifyAMImageEntryLocalServiceMock();
+	}
+
+	private void _verifyAMImageEntryLocalServiceMock() {
+		Mockito.verify(
+			_amImageEntryLocalService, Mockito.times(1)
+		).hasAMImageEntryContent(
+			Mockito.anyString(), Mockito.any(FileVersion.class)
+		);
+	}
+
+	private final AdaptiveMedia<Object> _adaptiveMedia = Mockito.mock(
+		AdaptiveMedia.class);
+	private final AMImageEntryLocalService _amImageEntryLocalService =
+		Mockito.mock(AMImageEntryLocalService.class);
+	private final AMImageValidatorImpl _amImageValidatorImpl =
+		new AMImageValidatorImpl();
+
+}

--- a/modules/apps/adaptive-media/adaptive-media-image-service/src/main/java/com/liferay/adaptive/media/image/internal/storage/ImageStorage.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-service/src/main/java/com/liferay/adaptive/media/image/internal/storage/ImageStorage.java
@@ -59,6 +59,22 @@ public class ImageStorage {
 		}
 	}
 
+	public boolean hasContent(
+		FileVersion fileVersion, String configurationUuid) {
+
+		try {
+			String fileVersionPath = AMStoreUtil.getFileVersionPath(
+				fileVersion, configurationUuid);
+
+			return DLStoreUtil.hasFile(
+				fileVersion.getCompanyId(), CompanyConstants.SYSTEM,
+				fileVersionPath);
+		}
+		catch (PortalException portalException) {
+			throw new AMRuntimeException.IOException(portalException);
+		}
+	}
+
 	public void save(
 		FileVersion fileVersion, String configurationUuid,
 		InputStream inputStream) {

--- a/modules/apps/adaptive-media/adaptive-media-image-service/src/main/java/com/liferay/adaptive/media/image/service/impl/AMImageEntryLocalServiceImpl.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-service/src/main/java/com/liferay/adaptive/media/image/service/impl/AMImageEntryLocalServiceImpl.java
@@ -308,6 +308,13 @@ public class AMImageEntryLocalServiceImpl
 		return Math.min(percentage, 100);
 	}
 
+	@Override
+	public boolean hasAMImageEntryContent(
+		String configurationUuid, FileVersion fileVersion) {
+
+		return _imageStorage.hasContent(fileVersion, configurationUuid);
+	}
+
 	@Activate
 	protected void activate(BundleContext bundleContext) {
 		_serviceTrackerMap = ServiceTrackerMapFactory.openSingleValueMap(

--- a/modules/apps/adaptive-media/adaptive-media-image-service/src/test/java/com/liferay/adaptive/media/image/internal/storage/ImageStorageTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-service/src/test/java/com/liferay/adaptive/media/image/internal/storage/ImageStorageTest.java
@@ -14,13 +14,19 @@
 
 package com.liferay.adaptive.media.image.internal.storage;
 
+import com.liferay.document.library.kernel.store.DLStore;
+import com.liferay.document.library.kernel.store.DLStoreUtil;
+import com.liferay.portal.kernel.repository.model.FileVersion;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+
+import org.mockito.Mockito;
 
 /**
  * @author Adolfo Pérez
@@ -31,6 +37,13 @@ public class ImageStorageTest {
 	@Rule
 	public static final LiferayUnitTestRule liferayUnitTestRule =
 		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		DLStoreUtil dlStoreUtil = new DLStoreUtil();
+
+		dlStoreUtil.setStore(_dlStore);
+	}
 
 	@Test
 	public void testGetConfigurationEntryPath() {
@@ -43,6 +56,49 @@ public class ImageStorageTest {
 			"adaptive/" + configurationUuid, configurationEntryPath);
 	}
 
+	@Test
+	public void testHasContentWithNoStoreFile() throws Exception {
+		Mockito.when(
+			_dlStore.hasFile(
+				Mockito.anyLong(), Mockito.anyLong(), Mockito.anyString())
+		).thenReturn(
+			false
+		);
+
+		Assert.assertFalse(
+			_imageStorage.hasContent(
+				Mockito.mock(FileVersion.class),
+				RandomTestUtil.randomString()));
+
+		_verifyDLStoreMock();
+	}
+
+	@Test
+	public void testHasContentWithStoreFile() throws Exception {
+		Mockito.when(
+			_dlStore.hasFile(
+				Mockito.anyLong(), Mockito.anyLong(), Mockito.anyString())
+		).thenReturn(
+			true
+		);
+
+		Assert.assertTrue(
+			_imageStorage.hasContent(
+				Mockito.mock(FileVersion.class),
+				RandomTestUtil.randomString()));
+
+		_verifyDLStoreMock();
+	}
+
+	private void _verifyDLStoreMock() throws Exception {
+		Mockito.verify(
+			_dlStore, Mockito.times(1)
+		).hasFile(
+			Mockito.anyLong(), Mockito.anyLong(), Mockito.anyString()
+		);
+	}
+
+	private final DLStore _dlStore = Mockito.mock(DLStore.class);
 	private final ImageStorage _imageStorage = new ImageStorage();
 
 }

--- a/modules/apps/adaptive-media/adaptive-media-image-test/src/testIntegration/java/com/liferay/adaptive/media/image/service/impl/test/AMImageEntryLocalServiceTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-test/src/testIntegration/java/com/liferay/adaptive/media/image/service/impl/test/AMImageEntryLocalServiceTest.java
@@ -25,10 +25,12 @@ import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalServiceUtil;
+import com.liferay.document.library.kernel.store.DLStoreUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.io.unsync.UnsyncByteArrayInputStream;
 import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.User;
@@ -590,6 +592,57 @@ public class AMImageEntryLocalServiceTest {
 		finally {
 			_companyLocalService.deleteCompany(company);
 		}
+	}
+
+	@Test
+	public void testHasAMImageEntryContentWhenContentPresent()
+		throws Exception {
+
+		AMImageConfigurationEntry amImageConfigurationEntry =
+			_addAMImageConfigurationEntry("uuid", 100, 200);
+
+		byte[] bytes = _getImageBytes();
+
+		FileEntry fileEntry = _addFileEntry(
+			bytes,
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		FileVersion fileVersion = fileEntry.getFileVersion();
+
+		AMImageEntryLocalServiceUtil.addAMImageEntry(
+			amImageConfigurationEntry, fileVersion, 100, 300,
+			new UnsyncByteArrayInputStream(bytes), 12345);
+
+		Assert.assertTrue(
+			AMImageEntryLocalServiceUtil.hasAMImageEntryContent(
+				amImageConfigurationEntry.getUUID(), fileVersion));
+	}
+
+	@Test
+	public void testHasAMImageEntryContentWhenNoContentPresent()
+		throws Exception {
+
+		AMImageConfigurationEntry amImageConfigurationEntry =
+			_addAMImageConfigurationEntry("uuid", 100, 200);
+
+		byte[] bytes = _getImageBytes();
+
+		FileEntry fileEntry = _addFileEntry(
+			bytes,
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		FileVersion fileVersion = fileEntry.getFileVersion();
+
+		AMImageEntryLocalServiceUtil.addAMImageEntry(
+			amImageConfigurationEntry, fileVersion, 100, 300,
+			new UnsyncByteArrayInputStream(bytes), 12345);
+
+		DLStoreUtil.deleteDirectory(
+			fileEntry.getCompanyId(), CompanyConstants.SYSTEM, "adaptive");
+
+		Assert.assertFalse(
+			AMImageEntryLocalServiceUtil.hasAMImageEntryContent(
+				amImageConfigurationEntry.getUUID(), fileVersion));
 	}
 
 	protected void deleteAllAMImageConfigurationEntries()


### PR DESCRIPTION
# What is this about?

A significant amount of storage is consumed by adaptive media. This is a problem in particular for backups, as they require quite  some time to finish for large installations. Adaptive media content is a huge contributor to this.

Adaptive media images can be recreated from the original content with no data loss. By making the system more robust when stored data is not present, these images can be omitted from backups or removed if rarely used.

# How do I test this?

In a fresh portal, look at the contents of `data/document_library`:
```
$ find data/document_library -type d -name 'adaptive'
```
You should see the thumbnails and previews generated by adaptive media. Now, remove them:
```
$ find data/document_library -type d -name 'adaptive' -exec rm -rf {} \+
```
If you now go to documents and media widget in DXP, you'll see that document thumbnails are not displayed (you may need to upload some images first to see this). If you refresh the page after a couple of seconds, you'll see the thumbnails again. If you now look at the `data/document_library` directory again, the files should have been restored automatically.
