### PR TITLE
LPS-165024 Hide card body when we don't have actions

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/servlet/taglib/clay/FileEntryVerticalCard.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/servlet/taglib/clay/FileEntryVerticalCard.java
@@ -68,7 +68,7 @@ public class FileEntryVerticalCard implements VerticalCard {
 	@Override
 	public String getCssClass() {
 		if (!_dlPortletInstanceSettingsHelper.isShowActions()) {
-			return "card-interactive card-interactive-secondary";
+			return "card-body-none card-interactive card-interactive-secondary";
 		}
 
 		return "card-interactive card-interactive-secondary";

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/servlet/taglib/clay/FileEntryVerticalCard.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/servlet/taglib/clay/FileEntryVerticalCard.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.document.library.web.internal.servlet.taglib.clay;
+
+import com.liferay.document.library.display.context.IGViewFileVersionDisplayContext;
+import com.liferay.document.library.util.DLURLHelperUtil;
+import com.liferay.document.library.web.internal.display.context.IGDisplayContextProvider;
+import com.liferay.document.library.web.internal.display.context.helper.DLPortletInstanceSettingsHelper;
+import com.liferay.frontend.taglib.clay.servlet.taglib.VerticalCard;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.repository.model.FileVersion;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.util.PropsValues;
+
+import java.util.List;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * @author Eudaldo Alonso
+ */
+public class FileEntryVerticalCard implements VerticalCard {
+
+	public FileEntryVerticalCard(
+		DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper,
+		FileEntry fileEntry, FileVersion fileVersion,
+		HttpServletRequest httpServletRequest,
+		HttpServletResponse httpServletResponse,
+		IGDisplayContextProvider igDisplayContextProvider) {
+
+		_dlPortletInstanceSettingsHelper = dlPortletInstanceSettingsHelper;
+		_fileEntry = fileEntry;
+		_fileVersion = fileVersion;
+
+		_igViewFileVersionDisplayContext =
+			igDisplayContextProvider.getIGViewFileVersionActionsDisplayContext(
+				httpServletRequest, httpServletResponse, fileVersion);
+		_themeDisplay = (ThemeDisplay)httpServletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+	}
+
+	@Override
+	public List<DropdownItem> getActionDropdownItems() {
+		if (!_dlPortletInstanceSettingsHelper.isShowActions()) {
+			return null;
+		}
+
+		return _igViewFileVersionDisplayContext.getActionDropdownItems();
+	}
+
+	@Override
+	public String getCssClass() {
+		if (!_dlPortletInstanceSettingsHelper.isShowActions()) {
+			return "card-interactive card-interactive-secondary";
+		}
+
+		return "card-interactive card-interactive-secondary";
+	}
+
+	@Override
+	public String getIcon() {
+		return "documents-and-media";
+	}
+
+	@Override
+	public String getImageSrc() {
+		if (PropsValues.DL_FILE_ENTRY_THUMBNAIL_ENABLED) {
+			try {
+				return DLURLHelperUtil.getThumbnailSrc(
+					_fileEntry, _fileVersion, _themeDisplay);
+			}
+			catch (Exception exception) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(exception);
+				}
+			}
+		}
+
+		return null;
+	}
+
+	@Override
+	public String getTitle() {
+		if (!_dlPortletInstanceSettingsHelper.isShowActions()) {
+			return null;
+		}
+
+		return _fileEntry.getTitle();
+	}
+
+	@Override
+	public Boolean isFlushHorizontal() {
+		return true;
+	}
+
+	@Override
+	public boolean isSelectable() {
+		return false;
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		FileEntryVerticalCard.class);
+
+	private final DLPortletInstanceSettingsHelper
+		_dlPortletInstanceSettingsHelper;
+	private final FileEntry _fileEntry;
+	private final FileVersion _fileVersion;
+	private final IGViewFileVersionDisplayContext
+		_igViewFileVersionDisplayContext;
+	private final ThemeDisplay _themeDisplay;
+
+}

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/image_gallery_display/css/main.scss
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/image_gallery_display/css/main.scss
@@ -15,6 +15,10 @@
 		max-width: 100%;
 	}
 
+	.card-type-asset.card-body-none .card-body {
+		display: none;
+	}
+
 	.folder-search {
 		float: right;
 		margin: 0 0 0.5em 0.5em;

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/image_gallery_display/init.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/image_gallery_display/init.jsp
@@ -16,7 +16,8 @@
 
 <%@ include file="/init.jsp" %>
 
-<%@ page import="com.liferay.document.library.web.internal.display.context.IGConfigurationDisplayContext" %>
+<%@ page import="com.liferay.document.library.web.internal.display.context.IGConfigurationDisplayContext" %><%@
+page import="com.liferay.document.library.web.internal.servlet.taglib.clay.FileEntryVerticalCard" %>
 
 <%
 if (layout.isTypeControlPanel()) {

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/image_gallery_display/view_images.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/image_gallery_display/view_images.jsp
@@ -98,30 +98,10 @@ DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper = new DLPortletI
 
 				<liferay-ui:search-container-column-text>
 					<div class="image-link preview" <%= (hasAudio || hasVideo) ? "data-options=\"height=" + playerHeight + "&thumbnailURL=" + HtmlUtil.escapeURL(DLURLHelperUtil.getPreviewURL(fileEntry, fileVersion, themeDisplay, "&videoThumbnail=1")) + "&width=640" + dataOptions + "\"" : StringPool.BLANK %> href="<%= imageURL %>" tabindex="0" thumbnailId="<%= thumbnailId %>" title="<%= title %>">
-						<c:choose>
-							<c:when test="<%= Validator.isNull(thumbnailSrc) %>">
-								<liferay-frontend:icon-vertical-card
-									actionJsp='<%= dlPortletInstanceSettingsHelper.isShowActions() ? "/image_gallery_display/image_action.jsp" : StringPool.BLANK %>'
-									actionJspServletContext="<%= application %>"
-									cardCssClass="card-interactive card-interactive-secondary"
-									cssClass="entry-display-style"
-									icon="documents-and-media"
-									resultRow="<%= row %>"
-									title="<%= dlPortletInstanceSettingsHelper.isShowActions() ? fileEntry.getTitle() : StringPool.BLANK %>"
-								/>
-							</c:when>
-							<c:otherwise>
-								<liferay-frontend:vertical-card
-									actionJsp='<%= dlPortletInstanceSettingsHelper.isShowActions() ? "/image_gallery_display/image_action.jsp" : StringPool.BLANK %>'
-									actionJspServletContext="<%= application %>"
-									cardCssClass="card-interactive card-interactive-secondary"
-									cssClass="entry-display-style"
-									imageUrl="<%= thumbnailSrc %>"
-									resultRow="<%= row %>"
-									title="<%= dlPortletInstanceSettingsHelper.isShowActions() ? fileEntry.getTitle() : StringPool.BLANK %>"
-								/>
-							</c:otherwise>
-						</c:choose>
+						<clay:vertical-card
+							propsTransformer="document_library/js/DLFileEntryDropdownPropsTransformer"
+							verticalCard="<%= new FileEntryVerticalCard(dlPortletInstanceSettingsHelper, fileEntry, fileVersion, request, response, igDisplayContextProvider) %>"
+						/>
 					</div>
 				</liferay-ui:search-container-column-text>
 			</c:when>


### PR DESCRIPTION
Motivation
=======
In order to stop using old frontend taglib replace the usages on image gallery of frontend vertical cards and replace with clay card

[LPS-165024](https://issues.liferay.com/browse/LPS-164539)

Proposed Solution
========
Creates new vertical card for file entry and replace the usages on jsps

----------

**NOTE** I added a new css class to hide the title when we don't have actions to keep the same logic that we have at this moment see: [7d87f12](https://github.com/liferay-lima/liferay-portal/pull/3566/commits/7d87f12e6eabf7450fe614dadf23c80cee55a4e3).