### PR TITLE
LPS-164778 Use item select in Article portlet configuration

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/display/context/KBArticleConfigurationDisplayContext.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/display/context/KBArticleConfigurationDisplayContext.java
@@ -1,0 +1,266 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.knowledge.base.web.internal.display.context;
+
+import com.liferay.knowledge.base.constants.KBArticleConstants;
+import com.liferay.knowledge.base.model.KBArticle;
+import com.liferay.knowledge.base.service.KBArticleService;
+import com.liferay.knowledge.base.web.internal.configuration.KBArticlePortletInstanceConfiguration;
+import com.liferay.knowledge.base.web.internal.social.SocialBookmarksUtil;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.configuration.metatype.util.ParameterMapUtil;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.LayoutConstants;
+import com.liferay.portal.kernel.module.configuration.ConfigurationException;
+import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
+import com.liferay.portal.kernel.portlet.LiferayWindowState;
+import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
+import com.liferay.portal.kernel.theme.PortletDisplay;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.taglib.portlet.ActionURLTag;
+
+import java.util.Map;
+
+import javax.portlet.PortletRequest;
+import javax.portlet.PortletURL;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * @author Adolfo Pérez
+ */
+public class KBArticleConfigurationDisplayContext {
+
+	public KBArticleConfigurationDisplayContext(
+		HttpServletRequest httpServletRequest,
+		KBArticleService kbArticleService,
+		LiferayPortletResponse liferayPortletResponse, Portal portal) {
+
+		_httpServletRequest = httpServletRequest;
+		_kbArticleService = kbArticleService;
+		_liferayPortletResponse = liferayPortletResponse;
+		_portal = portal;
+	}
+
+	public Map<String, Object> getComponentContext()
+		throws ConfigurationException {
+
+		return HashMapBuilder.<String, Object>put(
+			"eventName",
+			_liferayPortletResponse.getNamespace() + "selectKBObject"
+		).put(
+			"namespace", _liferayPortletResponse.getNamespace()
+		).put(
+			"selectKBObjectURL",
+			PortletURLBuilder.createRenderURL(
+				_liferayPortletResponse,
+				ParamUtil.getString(_httpServletRequest, "portletResource")
+			).setMVCPath(
+				"/admin/common/select_parent.jsp"
+			).setParameter(
+				"eventName",
+				_liferayPortletResponse.getNamespace() + "selectKBObject"
+			).setParameter(
+				"originalParentResourcePrimKey", getResourcePrimKey()
+			).setParameter(
+				"parentResourceClassNameId",
+				_portal.getClassNameId(KBArticleConstants.getClassName())
+			).setParameter(
+				"parentResourcePrimKey", getResourcePrimKey()
+			).setParameter(
+				"selectableClassNameIds",
+				_portal.getClassNameId(KBArticleConstants.getClassName())
+			).setWindowState(
+				LiferayWindowState.POP_UP
+			).buildString()
+		).build();
+	}
+
+	public String getComponentId() {
+		return _liferayPortletResponse.getNamespace() +
+			"PortletConfigurationComponent";
+	}
+
+	public String getConfigurationActionURL() throws Exception {
+		PortletURL portletURL = ActionURLTag.doTag(
+			PortletRequest.ACTION_PHASE, null, null, null, null, null, null,
+			null, null, LayoutConstants.DEFAULT_PLID,
+			LayoutConstants.DEFAULT_PLID, null, null, null, 0, 0, true, null,
+			null, _httpServletRequest);
+
+		return portletURL.toString();
+	}
+
+	public String getKBArticleTitle() throws PortalException {
+		KBArticle kbArticle = _kbArticleService.fetchLatestKBArticle(
+			getResourcePrimKey(), WorkflowConstants.STATUS_APPROVED);
+
+		if (kbArticle == null) {
+			return StringPool.BLANK;
+		}
+
+		return kbArticle.getTitle();
+	}
+
+	public long getResourcePrimKey() throws ConfigurationException {
+		KBArticlePortletInstanceConfiguration
+			kbArticlePortletInstanceConfiguration =
+				_getKBArticlePortletInstanceConfiguration();
+
+		return kbArticlePortletInstanceConfiguration.resourcePrimKey();
+	}
+
+	public String getSocialBookmarksDisplayStyle()
+		throws ConfigurationException {
+
+		KBArticlePortletInstanceConfiguration
+			kbArticlePortletInstanceConfiguration =
+				_getKBArticlePortletInstanceConfiguration();
+
+		return kbArticlePortletInstanceConfiguration.
+			socialBookmarksDisplayStyle();
+	}
+
+	public String getSocialBookmarksTypes() throws ConfigurationException {
+		KBArticlePortletInstanceConfiguration
+			kbArticlePortletInstanceConfiguration =
+				_getKBArticlePortletInstanceConfiguration();
+
+		return SocialBookmarksUtil.getSocialBookmarksTypes(
+			kbArticlePortletInstanceConfiguration.socialBookmarksTypes());
+	}
+
+	public boolean isKBArticleAssetLinksEnabled()
+		throws ConfigurationException {
+
+		KBArticlePortletInstanceConfiguration
+			kbArticlePortletInstanceConfiguration =
+				_getKBArticlePortletInstanceConfiguration();
+
+		return kbArticlePortletInstanceConfiguration.
+			enableKBArticleAssetLinks();
+	}
+
+	public boolean isKBArticleDescriptionEnabled()
+		throws ConfigurationException {
+
+		KBArticlePortletInstanceConfiguration
+			kbArticlePortletInstanceConfiguration =
+				_getKBArticlePortletInstanceConfiguration();
+
+		return kbArticlePortletInstanceConfiguration.
+			enableKBArticleDescription();
+	}
+
+	public boolean isKBArticleHistoryEnabled() throws ConfigurationException {
+		KBArticlePortletInstanceConfiguration
+			kbArticlePortletInstanceConfiguration =
+				_getKBArticlePortletInstanceConfiguration();
+
+		return kbArticlePortletInstanceConfiguration.enableKBArticleHistory();
+	}
+
+	public boolean isKBArticlePrintEnabled() throws ConfigurationException {
+		KBArticlePortletInstanceConfiguration
+			kbArticlePortletInstanceConfiguration =
+				_getKBArticlePortletInstanceConfiguration();
+
+		return kbArticlePortletInstanceConfiguration.enableKBArticlePrint();
+	}
+
+	public boolean isKBArticleRatingsEnabled() throws ConfigurationException {
+		KBArticlePortletInstanceConfiguration
+			kbArticlePortletInstanceConfiguration =
+				_getKBArticlePortletInstanceConfiguration();
+
+		return kbArticlePortletInstanceConfiguration.enableKBArticleRatings();
+	}
+
+	public boolean isKBArticleSubscriptionsEnabled()
+		throws ConfigurationException {
+
+		KBArticlePortletInstanceConfiguration
+			kbArticlePortletInstanceConfiguration =
+				_getKBArticlePortletInstanceConfiguration();
+
+		return kbArticlePortletInstanceConfiguration.
+			enableKBArticleSubscriptions();
+	}
+
+	public boolean isKBArticleViewCountIncrementEnabled()
+		throws ConfigurationException {
+
+		KBArticlePortletInstanceConfiguration
+			kbArticlePortletInstanceConfiguration =
+				_getKBArticlePortletInstanceConfiguration();
+
+		return kbArticlePortletInstanceConfiguration.
+			enableKBArticleViewCountIncrement();
+	}
+
+	public boolean isShowKBArticleAssetEntries() throws ConfigurationException {
+		KBArticlePortletInstanceConfiguration
+			kbArticlePortletInstanceConfiguration =
+				_getKBArticlePortletInstanceConfiguration();
+
+		return kbArticlePortletInstanceConfiguration.
+			showKBArticleAssetEntries();
+	}
+
+	public boolean isShowKBArticleAttachments() throws ConfigurationException {
+		KBArticlePortletInstanceConfiguration
+			kbArticlePortletInstanceConfiguration =
+				_getKBArticlePortletInstanceConfiguration();
+
+		return kbArticlePortletInstanceConfiguration.showKBArticleAttachments();
+	}
+
+	private KBArticlePortletInstanceConfiguration
+			_getKBArticlePortletInstanceConfiguration()
+		throws ConfigurationException {
+
+		if (_kbArticlePortletInstanceConfiguration != null) {
+			return _kbArticlePortletInstanceConfiguration;
+		}
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)_httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		PortletDisplay portletDisplay = themeDisplay.getPortletDisplay();
+
+		_kbArticlePortletInstanceConfiguration =
+			ParameterMapUtil.setParameterMap(
+				KBArticlePortletInstanceConfiguration.class,
+				portletDisplay.getPortletInstanceConfiguration(
+					KBArticlePortletInstanceConfiguration.class),
+				_httpServletRequest.getParameterMap(), "preferences--", "--");
+
+		return _kbArticlePortletInstanceConfiguration;
+	}
+
+	private final HttpServletRequest _httpServletRequest;
+	private KBArticlePortletInstanceConfiguration
+		_kbArticlePortletInstanceConfiguration;
+	private final KBArticleService _kbArticleService;
+	private final LiferayPortletResponse _liferayPortletResponse;
+	private final Portal _portal;
+
+}

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/action/ArticleConfigurationAction.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/action/ArticleConfigurationAction.java
@@ -15,11 +15,19 @@
 package com.liferay.knowledge.base.web.internal.portlet.action;
 
 import com.liferay.knowledge.base.constants.KBPortletKeys;
+import com.liferay.knowledge.base.service.KBArticleService;
+import com.liferay.knowledge.base.web.internal.display.context.KBArticleConfigurationDisplayContext;
 import com.liferay.portal.kernel.portlet.ConfigurationAction;
 import com.liferay.portal.kernel.portlet.DefaultConfigurationAction;
+import com.liferay.portal.kernel.util.JavaConstants;
+import com.liferay.portal.kernel.util.Portal;
+
+import javax.portlet.PortletConfig;
+import javax.portlet.PortletResponse;
 
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -40,6 +48,24 @@ public class ArticleConfigurationAction extends DefaultConfigurationAction {
 	}
 
 	@Override
+	public void include(
+			PortletConfig portletConfig, HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse)
+		throws Exception {
+
+		httpServletRequest.setAttribute(
+			KBArticleConfigurationDisplayContext.class.getName(),
+			new KBArticleConfigurationDisplayContext(
+				httpServletRequest, _kbArticleService,
+				_portal.getLiferayPortletResponse(
+					(PortletResponse)httpServletRequest.getAttribute(
+						JavaConstants.JAVAX_PORTLET_RESPONSE)),
+				_portal));
+
+		super.include(portletConfig, httpServletRequest, httpServletResponse);
+	}
+
+	@Override
 	@Reference(
 		target = "(osgi.web.symbolicname=com.liferay.knowledge.base.web)",
 		unbind = "-"
@@ -47,5 +73,11 @@ public class ArticleConfigurationAction extends DefaultConfigurationAction {
 	public void setServletContext(ServletContext servletContext) {
 		super.setServletContext(servletContext);
 	}
+
+	@Reference
+	private KBArticleService _kbArticleService;
+
+	@Reference
+	private Portal _portal;
 
 }

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/action/ArticleConfigurationAction.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/action/ArticleConfigurationAction.java
@@ -14,6 +14,7 @@
 
 package com.liferay.knowledge.base.web.internal.portlet.action;
 
+import com.liferay.item.selector.ItemSelector;
 import com.liferay.knowledge.base.constants.KBPortletKeys;
 import com.liferay.knowledge.base.service.KBArticleService;
 import com.liferay.knowledge.base.web.internal.display.context.KBArticleConfigurationDisplayContext;
@@ -56,7 +57,7 @@ public class ArticleConfigurationAction extends DefaultConfigurationAction {
 		httpServletRequest.setAttribute(
 			KBArticleConfigurationDisplayContext.class.getName(),
 			new KBArticleConfigurationDisplayContext(
-				httpServletRequest, _kbArticleService,
+				httpServletRequest, _itemSelector, _kbArticleService,
 				_portal.getLiferayPortletResponse(
 					(PortletResponse)httpServletRequest.getAttribute(
 						JavaConstants.JAVAX_PORTLET_RESPONSE)),
@@ -73,6 +74,9 @@ public class ArticleConfigurationAction extends DefaultConfigurationAction {
 	public void setServletContext(ServletContext servletContext) {
 		super.setServletContext(servletContext);
 	}
+
+	@Reference
+	private ItemSelector _itemSelector;
 
 	@Reference
 	private KBArticleService _kbArticleService;

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/article/configuration.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/article/configuration.jsp
@@ -102,43 +102,34 @@ kbArticlePortletInstanceConfiguration = ParameterMapUtil.setParameterMap(KBArtic
 	</liferay-frontend:edit-form-footer>
 </liferay-frontend:edit-form>
 
-<script>
-	var <portlet:namespace />form = document.getElementById(
-		'<portlet:namespace />fm'
-	);
-
-	if (<portlet:namespace />form) {
-		document
-			.getElementById('<portlet:namespace />selectKBArticleButton')
-			.addEventListener('click', (event) => {
-				Liferay.Util.openSelectionModal({
-					onSelect: function (event) {
-						var kbArticleData = {
-							idString: 'resourcePrimKey',
-							idValue: event.resourceprimkey,
-							nameString: 'configurationKBObject',
-							nameValue: event.title,
-						};
-
-						Liferay.Util.selectFolder(
-							kbArticleData,
-							'<portlet:namespace />'
-						);
-					},
-					selectEventName: '<portlet:namespace />selectKBObject',
-					title: '<liferay-ui:message key="select-article" />',
-
-					<liferay-portlet:renderURL portletName="<%= portletResource %>" var="selectKBObjectURL" windowState="<%= LiferayWindowState.POP_UP.toString() %>">
-						<portlet:param name="mvcPath" value="/admin/common/select_parent.jsp" />
-						<portlet:param name="eventName" value='<%= liferayPortletResponse.getNamespace() + "selectKBObject" %>' />
-						<portlet:param name="parentResourceClassNameId" value="<%= String.valueOf(PortalUtil.getClassNameId(KBArticleConstants.getClassName())) %>" />
-						<portlet:param name="parentResourcePrimKey" value="<%= String.valueOf(kbArticlePortletInstanceConfiguration.resourcePrimKey()) %>" />
-						<portlet:param name="originalParentResourcePrimKey" value="<%= String.valueOf(kbArticlePortletInstanceConfiguration.resourcePrimKey()) %>" />
-						<portlet:param name="selectableClassNameIds" value="<%= String.valueOf(PortalUtil.getClassNameId(KBArticleConstants.getClassName())) %>" />
-					</liferay-portlet:renderURL>
-
-					url: '<%= HtmlUtil.escapeJS(selectKBObjectURL) %>',
-				});
-			});
-	}
-</script>
+<liferay-frontend:component
+	componentId='<%= liferayPortletResponse.getNamespace() + "PortletConfigurationComponent" %>'
+	context='<%=
+		HashMapBuilder.<String, Object>put(
+			"eventName", liferayPortletResponse.getNamespace() + "selectKBObject"
+		).put(
+			"namespace", liferayPortletResponse.getNamespace()
+		).put(
+			"selectKBObjectURL",
+			PortletURLBuilder.createRenderURL(
+				liferayPortletResponse, portletResource
+			).setMVCPath(
+				"/admin/common/select_parent.jsp"
+			).setParameter(
+				"eventName", liferayPortletResponse.getNamespace() + "selectKBObject"
+			).setParameter(
+				"originalParentResourcePrimKey", kbArticlePortletInstanceConfiguration.resourcePrimKey()
+			).setParameter(
+				"parentResourceClassNameId", PortalUtil.getClassNameId(KBArticleConstants.getClassName())
+			).setParameter(
+				"parentResourcePrimKey", kbArticlePortletInstanceConfiguration.resourcePrimKey()
+			).setParameter(
+				"selectableClassNameIds", PortalUtil.getClassNameId(KBArticleConstants.getClassName())
+			).setWindowState(
+				LiferayWindowState.POP_UP
+			).buildString()
+		).build()
+	%>'
+	module="article/js/PortletConfiguration"
+	servletContext="<%= application %>"
+/>

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/article/configuration.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/article/configuration.jsp
@@ -17,19 +17,17 @@
 <%@ include file="/article/init.jsp" %>
 
 <%
-kbArticlePortletInstanceConfiguration = ParameterMapUtil.setParameterMap(KBArticlePortletInstanceConfiguration.class, kbArticlePortletInstanceConfiguration, request.getParameterMap(), "preferences--", "--");
+KBArticleConfigurationDisplayContext kbArticleConfigurationDisplayContext = (KBArticleConfigurationDisplayContext)request.getAttribute(KBArticleConfigurationDisplayContext.class.getName());
 %>
 
-<liferay-portlet:actionURL portletConfiguration="<%= true %>" var="configurationActionURL" />
-
 <liferay-frontend:edit-form
-	action="<%= configurationActionURL %>"
+	action="<%= kbArticleConfigurationDisplayContext.getConfigurationActionURL() %>"
 	cssClass="pt-0"
 	method="post"
 	name="fm"
 >
 	<aui:input name="<%= Constants.CMD %>" type="hidden" value="<%= Constants.UPDATE %>" />
-	<aui:input name="preferences--resourcePrimKey--" type="hidden" value="<%= kbArticlePortletInstanceConfiguration.resourcePrimKey() %>" />
+	<aui:input name="preferences--resourcePrimKey--" type="hidden" value="<%= String.valueOf(kbArticleConfigurationDisplayContext.getResourcePrimKey()) %>" />
 
 	<liferay-frontend:edit-form-body>
 		<liferay-frontend:fieldset-group>
@@ -40,18 +38,7 @@ kbArticlePortletInstanceConfiguration = ParameterMapUtil.setParameterMap(KBArtic
 				label="content-selection"
 			>
 				<div class="form-group">
-
-					<%
-					String title = StringPool.BLANK;
-
-					KBArticle kbArticle = KBArticleServiceUtil.fetchLatestKBArticle(kbArticlePortletInstanceConfiguration.resourcePrimKey(), WorkflowConstants.STATUS_APPROVED);
-
-					if (kbArticle != null) {
-						title = kbArticle.getTitle();
-					}
-					%>
-
-					<aui:input label="article" name="configurationKBObject" type="resource" value="<%= title %>" />
+					<aui:input label="article" name="configurationKBObject" type="resource" value="<%= kbArticleConfigurationDisplayContext.getKBArticleTitle() %>" />
 
 					<aui:button name="selectKBArticleButton" value="select" />
 				</div>
@@ -63,23 +50,23 @@ kbArticlePortletInstanceConfiguration = ParameterMapUtil.setParameterMap(KBArtic
 				cssClass="mb-4"
 				label="set-and-enable"
 			>
-				<aui:input label="enable-description" name="preferences--enableKBArticleDescription--" type="checkbox" value="<%= kbArticlePortletInstanceConfiguration.enableKBArticleDescription() %>" />
+				<aui:input label="enable-description" name="preferences--enableKBArticleDescription--" type="checkbox" value="<%= kbArticleConfigurationDisplayContext.isKBArticleDescriptionEnabled() %>" />
 
-				<aui:input label="enable-ratings" name="preferences--enableKBArticleRatings--" type="checkbox" value="<%= kbArticlePortletInstanceConfiguration.enableKBArticleRatings() %>" />
+				<aui:input label="enable-ratings" name="preferences--enableKBArticleRatings--" type="checkbox" value="<%= kbArticleConfigurationDisplayContext.isKBArticleRatingsEnabled() %>" />
 
-				<aui:input label="show-asset-entries" name="preferences--showKBArticleAssetEntries--" type="checkbox" value="<%= kbArticlePortletInstanceConfiguration.showKBArticleAssetEntries() %>" />
+				<aui:input label="show-asset-entries" name="preferences--showKBArticleAssetEntries--" type="checkbox" value="<%= kbArticleConfigurationDisplayContext.isShowKBArticleAssetEntries() %>" />
 
-				<aui:input label="show-attachments" name="preferences--showKBArticleAttachments--" type="checkbox" value="<%= kbArticlePortletInstanceConfiguration.showKBArticleAttachments() %>" />
+				<aui:input label="show-attachments" name="preferences--showKBArticleAttachments--" type="checkbox" value="<%= kbArticleConfigurationDisplayContext.isShowKBArticleAttachments() %>" />
 
-				<aui:input label="enable-related-assets" name="preferences--enableKBArticleAssetLinks--" type="checkbox" value="<%= kbArticlePortletInstanceConfiguration.enableKBArticleAssetLinks() %>" />
+				<aui:input label="enable-related-assets" name="preferences--enableKBArticleAssetLinks--" type="checkbox" value="<%= kbArticleConfigurationDisplayContext.isKBArticleAssetLinksEnabled() %>" />
 
-				<aui:input label="enable-view-count-increment" name="preferences--enableKBArticleViewCountIncrement--" type="checkbox" value="<%= kbArticlePortletInstanceConfiguration.enableKBArticleViewCountIncrement() %>" />
+				<aui:input label="enable-view-count-increment" name="preferences--enableKBArticleViewCountIncrement--" type="checkbox" value="<%= kbArticleConfigurationDisplayContext.isKBArticleViewCountIncrementEnabled() %>" />
 
-				<aui:input label="enable-subscriptions" name="preferences--enableKBArticleSubscriptions--" type="checkbox" value="<%= kbArticlePortletInstanceConfiguration.enableKBArticleSubscriptions() %>" />
+				<aui:input label="enable-subscriptions" name="preferences--enableKBArticleSubscriptions--" type="checkbox" value="<%= kbArticleConfigurationDisplayContext.isKBArticleSubscriptionsEnabled() %>" />
 
-				<aui:input label="enable-history" name="preferences--enableKBArticleHistory--" type="checkbox" value="<%= kbArticlePortletInstanceConfiguration.enableKBArticleHistory() %>" />
+				<aui:input label="enable-history" name="preferences--enableKBArticleHistory--" type="checkbox" value="<%= kbArticleConfigurationDisplayContext.isKBArticleHistoryEnabled() %>" />
 
-				<aui:input label="enable-print" name="preferences--enableKBArticlePrint--" type="checkbox" value="<%= kbArticlePortletInstanceConfiguration.enableKBArticlePrint() %>" />
+				<aui:input label="enable-print" name="preferences--enableKBArticlePrint--" type="checkbox" value="<%= kbArticleConfigurationDisplayContext.isKBArticlePrintEnabled() %>" />
 			</liferay-frontend:fieldset>
 
 			<liferay-frontend:fieldset
@@ -88,8 +75,8 @@ kbArticlePortletInstanceConfiguration = ParameterMapUtil.setParameterMap(KBArtic
 				label="social-bookmarks"
 			>
 				<liferay-social-bookmarks:bookmarks-settings
-					displayStyle="<%= kbArticlePortletInstanceConfiguration.socialBookmarksDisplayStyle() %>"
-					types="<%= SocialBookmarksUtil.getSocialBookmarksTypes(kbArticlePortletInstanceConfiguration.socialBookmarksTypes()) %>"
+					displayStyle="<%= kbArticleConfigurationDisplayContext.getSocialBookmarksDisplayStyle() %>"
+					types="<%= kbArticleConfigurationDisplayContext.getSocialBookmarksTypes() %>"
 				/>
 			</liferay-frontend:fieldset>
 		</liferay-frontend:fieldset-group>
@@ -103,33 +90,8 @@ kbArticlePortletInstanceConfiguration = ParameterMapUtil.setParameterMap(KBArtic
 </liferay-frontend:edit-form>
 
 <liferay-frontend:component
-	componentId='<%= liferayPortletResponse.getNamespace() + "PortletConfigurationComponent" %>'
-	context='<%=
-		HashMapBuilder.<String, Object>put(
-			"eventName", liferayPortletResponse.getNamespace() + "selectKBObject"
-		).put(
-			"namespace", liferayPortletResponse.getNamespace()
-		).put(
-			"selectKBObjectURL",
-			PortletURLBuilder.createRenderURL(
-				liferayPortletResponse, portletResource
-			).setMVCPath(
-				"/admin/common/select_parent.jsp"
-			).setParameter(
-				"eventName", liferayPortletResponse.getNamespace() + "selectKBObject"
-			).setParameter(
-				"originalParentResourcePrimKey", kbArticlePortletInstanceConfiguration.resourcePrimKey()
-			).setParameter(
-				"parentResourceClassNameId", PortalUtil.getClassNameId(KBArticleConstants.getClassName())
-			).setParameter(
-				"parentResourcePrimKey", kbArticlePortletInstanceConfiguration.resourcePrimKey()
-			).setParameter(
-				"selectableClassNameIds", PortalUtil.getClassNameId(KBArticleConstants.getClassName())
-			).setWindowState(
-				LiferayWindowState.POP_UP
-			).buildString()
-		).build()
-	%>'
+	componentId="<%= kbArticleConfigurationDisplayContext.getComponentId() %>"
+	context="<%= kbArticleConfigurationDisplayContext.getComponentContext() %>"
 	module="article/js/PortletConfiguration"
 	servletContext="<%= application %>"
 />

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/article/init.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/article/init.jsp
@@ -16,10 +16,10 @@
 
 <%@ include file="/init.jsp" %>
 
+<%@ page import="com.liferay.knowledge.base.web.internal.display.context.KBArticleConfigurationDisplayContext" %>
+
 <%
 KBArticlePortletInstanceConfiguration kbArticlePortletInstanceConfiguration = portletDisplay.getPortletInstanceConfiguration(KBArticlePortletInstanceConfiguration.class);
-
-String portletResource = ParamUtil.getString(request, "portletResource");
 
 long kbFolderClassNameId = PortalUtil.getClassNameId(KBFolderConstants.getClassName());
 

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/article/js/PortletConfiguration.js
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/article/js/PortletConfiguration.js
@@ -25,15 +25,21 @@ export default function _PortletConfiguration({
 			.addEventListener('click', () => {
 				Liferay.Util.openSelectionModal({
 					onSelect: (event) => {
-						Liferay.Util.selectFolder(
-							{
-								idString: 'resourcePrimKey',
-								idValue: event.resourceprimkey,
-								nameString: 'configurationKBObject',
-								nameValue: event.title,
-							},
-							namespace
-						);
+						if (event) {
+							const item = JSON.parse(event.value);
+
+							const resourcePrimKey = document.getElementById(
+								`${namespace}resourcePrimKey`
+							);
+
+							resourcePrimKey.value = item.classPK;
+
+							const configurationKBObject = document.getElementById(
+								`${namespace}configurationKBObject`
+							);
+
+							configurationKBObject.value = item.title;
+						}
 					},
 					selectEventName: eventName,
 					title: Liferay.Language.get('select-article'),

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/article/js/PortletConfiguration.js
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/article/js/PortletConfiguration.js
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+export default function _PortletConfiguration({
+	eventName,
+	namespace,
+	selectKBObjectURL,
+}) {
+	const form = document.getElementById(`${namespace}fm`);
+
+	if (form) {
+		document
+			.getElementById(`${namespace}selectKBArticleButton`)
+			.addEventListener('click', () => {
+				Liferay.Util.openSelectionModal({
+					onSelect: (event) => {
+						Liferay.Util.selectFolder(
+							{
+								idString: 'resourcePrimKey',
+								idValue: event.resourceprimkey,
+								nameString: 'configurationKBObject',
+								nameValue: event.title,
+							},
+							namespace
+						);
+					},
+					selectEventName: eventName,
+					title: Liferay.Language.get('select-article'),
+					url: selectKBObjectURL,
+				});
+			});
+	}
+}

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/article/js/PortletConfiguration.js
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/article/js/PortletConfiguration.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-export default function _PortletConfiguration({
+export default function PortletConfiguration({
 	eventName,
 	namespace,
 	selectKBObjectURL,

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/article/js/PortletConfiguration.js
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/article/js/PortletConfiguration.js
@@ -20,31 +20,47 @@ export default function _PortletConfiguration({
 	const form = document.getElementById(`${namespace}fm`);
 
 	if (form) {
-		document
-			.getElementById(`${namespace}selectKBArticleButton`)
-			.addEventListener('click', () => {
-				Liferay.Util.openSelectionModal({
-					onSelect: (event) => {
-						if (event) {
-							const item = JSON.parse(event.value);
+		const selectKBArticleButton = document.getElementById(
+			`${namespace}selectKBArticleButton`
+		);
 
-							const resourcePrimKey = document.getElementById(
-								`${namespace}resourcePrimKey`
-							);
+		const selectKBArticleButtonClick = () => {
+			Liferay.Util.openSelectionModal({
+				onSelect: (event) => {
+					if (event) {
+						const item = JSON.parse(event.value);
 
-							resourcePrimKey.value = item.classPK;
+						const resourcePrimKey = document.getElementById(
+							`${namespace}resourcePrimKey`
+						);
 
-							const configurationKBObject = document.getElementById(
-								`${namespace}configurationKBObject`
-							);
+						resourcePrimKey.value = item.classPK;
 
-							configurationKBObject.value = item.title;
-						}
-					},
-					selectEventName: eventName,
-					title: Liferay.Language.get('select-article'),
-					url: selectKBObjectURL,
-				});
+						const configurationKBObject = document.getElementById(
+							`${namespace}configurationKBObject`
+						);
+
+						configurationKBObject.value = item.title;
+					}
+				},
+				selectEventName: eventName,
+				title: Liferay.Language.get('select-article'),
+				url: selectKBObjectURL,
 			});
+		};
+
+		selectKBArticleButton.addEventListener(
+			'click',
+			selectKBArticleButtonClick
+		);
+
+		return {
+			dispose() {
+				selectKBArticleButton.removeEventListener(
+					'click',
+					selectKBArticleButtonClick
+				);
+			},
+		};
 	}
 }


### PR DESCRIPTION
# What is this about?

This PR includes 3 changes:
1. Move all Js logic into its own file.
2. Move all Java logic into a display context.
3. Instead of a custom JSP, use the KB article item selector when configuring the portlet.

We cannot (yet) remove the custom JSP, as that is used from the Display portlet to select both folders and articles (something we don't support yet in Item Selector).

# How do I test this?

1. Create a widget page.
2. Add the "Knowledge Base Article" widget.
3. Click on the portlet title ellipsis, select "Configuration".
4. Click the "Select" button; the Item Selector should open.
5. Select an article and save the configuration.
6. Double check that the article is displayed as expected.

