### PR TITLE
LPS-156658: Synchronize permissions of DLFileEntryType and corresponding DDMStructure

### DIFF
--- a/modules/apps/document-library/document-library-service/bnd.bnd
+++ b/modules/apps/document-library/document-library-service/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Document Library Service
 Bundle-SymbolicName: com.liferay.document.library.service
-Bundle-Version: 6.0.65
-Liferay-Require-SchemaVersion: 3.2.4
+Bundle-Version: 6.0.66
+Liferay-Require-SchemaVersion: 3.2.5
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/security/permission/DLFileEntryTypePermissionUpdateHandler.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/security/permission/DLFileEntryTypePermissionUpdateHandler.java
@@ -15,11 +15,26 @@
 package com.liferay.document.library.internal.security.permission;
 
 import com.liferay.document.library.kernel.model.DLFileEntryType;
+import com.liferay.document.library.kernel.model.DLFileEntryMetadata;
 import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalService;
+import com.liferay.dynamic.data.mapping.security.permission.DDMPermissionSupport;
+import com.liferay.petra.reflect.ReflectionUtil;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.security.permission.PermissionUpdateHandler;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
 
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -47,9 +62,74 @@ public class DLFileEntryTypePermissionUpdateHandler
 		dlFileEntryType.setModifiedDate(new Date());
 
 		_dLFileEntryTypeLocalService.updateDLFileEntryType(dlFileEntryType);
+
+                // Each DLFileEntryType is tied to a DDM structure, that holds
+                // the metadata definitions defined in the document type itself.
+                // The upload forms (and most probably other code) checks the
+                // permissions on the DDM structure to determine if the fields
+                // may be viewed/entered by a user. So the permissions on the
+                // structure need to be sychronized with the DLFilEntryType.
+                // This covers the updating case. Adding is handled in
+                // com.liferay.portlet.documentlibrary.service.impl.DLFileEntryTypeLocalServiceImpl.addFileEntryTypeResources
+
+                try {
+
+                    String metadataResourceName = _ddmPermissionSupport
+                            .getStructureModelResourceName(DLFileEntryMetadata.class.getName());
+
+                    List<ResourceAction> fileEntryTypeActions = _resourceActionLocalService
+                            .getResourceActions(DLFileEntryType.class.getName());
+
+                    Set<String> fileEntryMetadataActions = _resourceActionLocalService
+                            .getResourceActions(metadataResourceName)
+                            .stream()
+                            .map(ra -> ra.getActionId())
+                            .collect(Collectors.toSet());
+
+                    List<ResourcePermission> permissions = _resourcePermissionLocalService.getResourcePermissions(
+                            dlFileEntryType.getCompanyId(),
+                            DLFileEntryType.class.getName(),
+                            ResourceConstants.SCOPE_INDIVIDUAL,
+                            Long.toString(dlFileEntryType.getFileEntryTypeId())
+                    );
+
+                    Map<Long,String[]> roleIdsToActionIds = new HashMap<>();
+
+                    for(ResourcePermission permission: permissions) {
+                            long actionIds = permission.getActionIds();
+                            List<String> actionIdList = new ArrayList<>();
+                            for(ResourceAction ra: fileEntryTypeActions) {
+                                String actionId = ra.getActionId();
+                                if((actionIds & ra.getBitwiseValue()) == ra.getBitwiseValue()
+                                        && fileEntryMetadataActions.contains(actionId)) {
+                                    actionIdList.add(actionId);
+                                }
+                            }
+                            roleIdsToActionIds.put(permission.getRoleId(), actionIdList.toArray(new String[0]));
+                    }
+
+                    _resourcePermissionLocalService.setResourcePermissions(
+                            dlFileEntryType.getCompanyId(),
+                            metadataResourceName,
+                            ResourceConstants.SCOPE_INDIVIDUAL,
+                            Long.toString(dlFileEntryType.getDataDefinitionId()),
+                            roleIdsToActionIds
+                    );
+                }
+                catch (PortalException portalException) {
+			ReflectionUtil.throwException(portalException);
+		}
 	}
+
+        @Reference
+        private DDMPermissionSupport _ddmPermissionSupport;
 
 	@Reference
 	private DLFileEntryTypeLocalService _dLFileEntryTypeLocalService;
 
+        @Reference
+	private ResourceActionLocalService _resourceActionLocalService;
+
+        @Reference
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
 }

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/registry/DLServiceUpgradeStepRegistrator.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/registry/DLServiceUpgradeStepRegistrator.java
@@ -25,10 +25,14 @@ import com.liferay.document.library.internal.upgrade.v2_0_0.UpgradeCompanyId;
 import com.liferay.document.library.internal.upgrade.v3_2_1.DDMStructureLinkUpgradeProcess;
 import com.liferay.document.library.internal.upgrade.v3_2_2.DLFileEntryUpgradeProcess;
 import com.liferay.document.library.internal.upgrade.v3_2_4.UpgradeDLSizeLimitConfiguration;
+import com.liferay.document.library.internal.upgrade.v3_2_5.SyncDLFileEntryTypesDDMStructurePermissions;
 import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.dynamic.data.mapping.security.permission.DDMPermissionSupport;
 import com.liferay.portal.configuration.upgrade.PrefsPropsToConfigurationUpgradeHelper;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourceLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.upgrade.CTModelUpgradeProcess;
 import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
 import com.liferay.portal.kernel.upgrade.MVCCVersionUpgradeProcess;
@@ -120,6 +124,13 @@ public class DLServiceUpgradeStepRegistrator implements UpgradeStepRegistrator {
 		registry.register(
 			"3.2.3", "3.2.4",
 			new UpgradeDLSizeLimitConfiguration(_configurationAdmin));
+
+		registry.register(
+			"3.2.4", "3.2.5",
+			new SyncDLFileEntryTypesDDMStructurePermissions(
+                                _ddmPermissionSupport,
+                                _resourceActionLocalService,
+                                _resourcePermissionLocalService));
 	}
 
 	@Reference
@@ -128,12 +139,21 @@ public class DLServiceUpgradeStepRegistrator implements UpgradeStepRegistrator {
 	@Reference
 	private ConfigurationAdmin _configurationAdmin;
 
+        @Reference
+        private DDMPermissionSupport _ddmPermissionSupport;
+
 	@Reference
 	private PrefsPropsToConfigurationUpgradeHelper
 		_prefsPropsToConfigurationUpgradeHelper;
 
 	@Reference
+	private ResourceActionLocalService _resourceActionLocalService;
+
+        @Reference
 	private ResourceLocalService _resourceLocalService;
+
+        @Reference
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
 
 	@Reference(target = "(dl.store.impl.enabled=true)")
 	private StoreFactory _storeFactory;

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/v3_2_5/SyncDLFileEntryTypesDDMStructurePermissions.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/v3_2_5/SyncDLFileEntryTypesDDMStructurePermissions.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.document.library.internal.upgrade.v3_2_5;
+
+import com.liferay.petra.reflect.ReflectionUtil;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
+import com.liferay.document.library.kernel.model.DLFileEntryType;
+import com.liferay.document.library.kernel.model.DLFileEntryMetadata;
+import com.liferay.dynamic.data.mapping.security.permission.DDMPermissionSupport;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+/**
+ * @author Matthias Bläsing
+ */
+public class SyncDLFileEntryTypesDDMStructurePermissions extends UpgradeProcess {
+
+	public SyncDLFileEntryTypesDDMStructurePermissions(
+                DDMPermissionSupport ddmPermissionSupport,
+                ResourceActionLocalService resourceActionLocalService,
+		ResourcePermissionLocalService resourcePermissionLocalService) {
+
+                _ddmPermissionSupport = ddmPermissionSupport;
+                _resourceActionLocalService = resourceActionLocalService;
+		_resourcePermissionLocalService = resourcePermissionLocalService;
+	}
+
+	@Override
+	protected void doUpgrade() throws Exception {
+                String metadataResourceName = _ddmPermissionSupport
+                        .getStructureModelResourceName(DLFileEntryMetadata.class.getName());
+
+                List<ResourceAction> fileEntryTypeActions = _resourceActionLocalService
+                        .getResourceActions(DLFileEntryType.class.getName());
+
+                Set<String> fileEntryMetadataActions = _resourceActionLocalService
+                        .getResourceActions(metadataResourceName)
+                        .stream()
+                        .map(ra -> ra.getActionId())
+                        .collect(Collectors.toSet());
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				"select companyId, fileEntryTypeId, dataDefinitionId from DLFileEntryType");
+			ResultSet resultSet = preparedStatement.executeQuery()) {
+
+			while (resultSet.next()) {
+				long companyId = resultSet.getLong("companyId");
+				long fileEntryTypeId = resultSet.getLong("fileEntryTypeId");
+				long dataDefinitionId = resultSet.getLong("dataDefinitionId");
+
+                                List<ResourcePermission> permissions = _resourcePermissionLocalService.getResourcePermissions(
+                                        companyId,
+                                        DLFileEntryType.class.getName(),
+                                        ResourceConstants.SCOPE_INDIVIDUAL,
+                                        Long.toString(fileEntryTypeId)
+                                );
+
+                                Map<Long,String[]> roleIdsToActionIds = new HashMap<>();
+
+                                for(ResourcePermission permission: permissions) {
+                                        long actionIds = permission.getActionIds();
+                                        List<String> actionIdList = new ArrayList<>();
+                                        for(ResourceAction ra: fileEntryTypeActions) {
+                                            String actionId = ra.getActionId();
+                                            if((actionIds & ra.getBitwiseValue()) == ra.getBitwiseValue() && fileEntryMetadataActions.contains(actionId)) {
+                                                actionIdList.add(actionId);
+                                            }
+                                        }
+                                        roleIdsToActionIds.put(permission.getRoleId(), actionIdList.toArray(new String[0]));
+                                }
+
+                                try {
+                                    _resourcePermissionLocalService.setResourcePermissions(
+                                            companyId,
+                                            metadataResourceName,
+                                            ResourceConstants.SCOPE_INDIVIDUAL,
+                                            Long.toString(dataDefinitionId),
+                                            roleIdsToActionIds
+                                    );
+                                }
+                                catch (PortalException portalException) {
+                                        ReflectionUtil.throwException(portalException);
+                                }
+			}
+		}
+	}
+
+	private final ResourceActionLocalService _resourceActionLocalService;
+
+	private final ResourcePermissionLocalService _resourcePermissionLocalService;
+
+        private final DDMPermissionSupport _ddmPermissionSupport;
+}


### PR DESCRIPTION
Each DLFileEntryType is tied to a DDM structure, that holds the metadata definitions defined in the document type itself.

The upload forms (and most probably other code) checks the permissions on the DDM structure to determine if the fields may be viewed/entered by a user. So the permissions on the structure need to be sychronized with the DLFilEntryType.