### PR TITLE
LPS-165649 Fix sidebar on KB template.

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/display/context/KBAdminNavigationDisplayContext.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/display/context/KBAdminNavigationDisplayContext.java
@@ -190,7 +190,8 @@ public class KBAdminNavigationDisplayContext {
 			JSONArray navigationItemsJSONArray = null;
 
 			if (!mvcPath.equals("/admin/view_kb_suggestions.jsp") &&
-				!mvcPath.equals("/admin/view_kb_templates.jsp")) {
+				!mvcPath.equals("/admin/view_kb_templates.jsp") &&
+				!mvcPath.equals("/admin/view_kb_template.jsp")) {
 
 				active = true;
 				navigationItemsJSONArray = _getChildrenJSONArray();
@@ -231,7 +232,9 @@ public class KBAdminNavigationDisplayContext {
 
 			boolean active = false;
 
-			if (mvcPath.equals("/admin/view_kb_templates.jsp")) {
+			if (mvcPath.equals("/admin/view_kb_templates.jsp") ||
+				mvcPath.equals("/admin/view_kb_template.jsp")) {
+
 				active = true;
 			}
 
@@ -251,6 +254,11 @@ public class KBAdminNavigationDisplayContext {
 					"key", "template"
 				).put(
 					"navigationItems", _getNavigationItemsJSONArray()
+				).put(
+					"selectedItemId",
+					ParamUtil.getLong(
+						_httpServletRequest, "selectedItemId",
+						KBFolderConstants.DEFAULT_PARENT_FOLDER_ID)
 				).put(
 					"title", LanguageUtil.get(_httpServletRequest, "templates")
 				));
@@ -450,12 +458,16 @@ public class KBAdminNavigationDisplayContext {
 					PortletURLBuilder.createRenderURL(
 						_liferayPortletResponse
 					).setMVCPath(
-						"/admin/common/edit_kb_template.jsp"
+						"/admin/view_kb_template.jsp"
 					).setRedirect(
 						PortalUtil.getCurrentURL(_httpServletRequest)
 					).setParameter(
 						"kbTemplateId", kbTemplate.getKbTemplateId()
+					).setParameter(
+						"selectedItemId", kbTemplate.getPrimaryKey()
 					).buildString()
+				).put(
+					"id", kbTemplate.getPrimaryKey()
 				).put(
 					"name", kbTemplate.getTitle()
 				));

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/util/KBDropdownItemsProvider.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/util/KBDropdownItemsProvider.java
@@ -452,6 +452,8 @@ public class KBDropdownItemsProvider {
 						"/admin/view_kb_template.jsp"
 					).setParameter(
 						"kbTemplateId", kbTemplate.getKbTemplateId()
+					).setParameter(
+						"selectedItemId", kbTemplate.getPrimaryKey()
 					).buildRenderURL());
 				dropdownItem.setIcon("view");
 				dropdownItem.setLabel(

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/js/components/TemplatesPanel.js
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/js/components/TemplatesPanel.js
@@ -14,24 +14,47 @@
 
 import {TreeView as ClayTreeView} from '@clayui/core';
 import ClayEmptyState from '@clayui/empty-state';
-import ClayLink from '@clayui/link';
+import classnames from 'classnames';
+import {navigate} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React from 'react';
 
 import ActionsDropdown from './ActionsDropdown';
-export default function TemplatesPanel({items}) {
+
+export default function TemplatesPanel({items, selectedItemId}) {
+	const handleClickItem = (event, item) => {
+		if (event.defaultPrevented) {
+			return;
+		}
+
+		event.stopPropagation();
+		event.preventDefault();
+
+		navigate(item.href);
+	};
+
 	return items?.length ? (
-		<ClayTreeView defaultItems={items} nestedKey="children">
+		<ClayTreeView
+			defaultItems={items}
+			defaultSelectedKeys={new Set([selectedItemId])}
+			nestedKey="children"
+			showExpanderOnHover={false}
+		>
 			{(item) => {
 				return (
 					<ClayTreeView.Item
 						actions={ActionsDropdown({actions: item.actions})}
-						className="pl-1"
+						onClick={(event) => {
+							handleClickItem(event, item);
+						}}
 					>
-						<ClayTreeView.ItemStack>
-							<ClayLink displayType="secondary" href={item.href}>
-								{item.name}
-							</ClayLink>
+						<ClayTreeView.ItemStack
+							className={classnames({
+								'knowledge-base-navigation-item-active':
+									item.id === selectedItemId,
+							})}
+						>
+							{item.name}
 						</ClayTreeView.ItemStack>
 					</ClayTreeView.Item>
 				);
@@ -52,6 +75,8 @@ TemplatesPanel.propTypes = {
 		PropTypes.shape({
 			href: PropTypes.string.isRequired,
 			name: PropTypes.string.isRequired,
+			id: PropTypes.string.isRequired,
 		})
 	),
+	selectedItemId: PropTypes.string,
 };


### PR DESCRIPTION
Hello @ambrinchaudhary 
This P/R is tended to fix the following issue: https://issues.liferay.com/browse/LPS-165649. 

The motivations for the fix are as followed:
1) When the KB templates are selected, we want to append "active" to the class so that the side bar will stay at KB templates URLs.
2) Instead of going to KB edit mode on click at the KB template's title, I want to propose the new behavior at going to KB article view mode when the KB template's title is clicked. 
3) Under development: do you think it is a good idea to at a URL at the top level in KB template's sidebar? When we click into that level it will bring the user to KB template list?

![LPS-165649](https://user-images.githubusercontent.com/73105710/196155808-f69e6d50-9249-42df-ac2d-b01807e19b49.png)
 