### PR TITLE
LPS-165394 | [HR_105] Removing unnecessary heading

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/upload.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/upload.js
@@ -134,7 +134,7 @@ AUI.add(
 			'<div class="upload-target" id="{$ns}uploader">',
 			'<div class="drag-drop-area" id="{$ns}uploaderContent">',
 			'<tpl if="this.uploaderType == \'html5\'">',
-			'<h4 class="drop-file-text">{[ this.dropFileText ]}<span class="small">{[ this.strings.orText ]}</span></h4>',
+			'<span class="drop-file-text">{[ this.dropFileText ]}<span class="small">{[ this.strings.orText ]}</span></span>',
 			'</tpl>',
 
 			'<span class="select-files-container" id="{$ns}selectFilesButton">',


### PR DESCRIPTION
Related Issue: https://issues.liferay.com/browse/LPS-165394

Related HR:

HR_105 (partially fixes, the additional fix has https://github.com/ethib137/liferay-portal/pull/67 )

The solution: Replaces the h4 tag to keep the page organized hierarchically i.e. h1, h2, h3 etc. To not modify the content of the `<h4>` tag to an `<h2>`. Since the title label must be meaningful and convey meaning of relevant content, I modified the `<h4>` tag to a tag.

Reproduction Steps:

Turn on JAWS and navigate to Documents & Media.
Click on the + button to add a Multiple Files Upload.
Press H using JAWS to navigate between the headings.

Actual Results
Screen reader announce two `<h1>` sr-only tags "admin-header" and "navigation", and one `<h4>` "Drop Files Here to Upload".

Warning: Since we are changing tags that are reflected in the whole portal, this is potentially a breaking change.

[Slack question associate](https://liferay.slack.com/archives/C0457LJPCPN/p1665501824832779)