### PR TITLE
LPS-165269 clean up the  product menu when the component is unmounted

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/js/components/VerticalBar.js
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/js/components/VerticalBar.js
@@ -51,24 +51,17 @@ const VerticalNavigationBar = ({
 
 	useEffect(() => {
 		if (productMenu && activePanel !== SUGGESTION_KEY) {
-			const productMenuOpenListener = productMenu.on(
-				'openStart.lexicon.sidenav',
-				() => {
-					setProductMenuOpen(true);
-					setVerticalBarOpen(false);
-				}
-			);
+			productMenu.on('openStart.lexicon.sidenav', () => {
+				setProductMenuOpen(true);
+				setVerticalBarOpen(false);
+			});
 
-			const productMenuCloseListener = productMenu.on(
-				'closedStart.lexicon.sidenav',
-				() => {
-					setProductMenuOpen(false);
-				}
-			);
+			productMenu.on('closedStart.lexicon.sidenav', () => {
+				setProductMenuOpen(false);
+			});
 
 			return () => {
-				productMenuOpenListener.removeListener();
-				productMenuCloseListener.removeListener();
+				productMenu.destroy();
 			};
 		}
 	}, [activePanel, productMenu]);

--- a/modules/apps/knowledge-base/knowledge-base-web/test/admin/js/components/VerticalBar.js
+++ b/modules/apps/knowledge-base/knowledge-base-web/test/admin/js/components/VerticalBar.js
@@ -80,6 +80,7 @@ describe('VerticalBar', () => {
 		};
 
 		const productMenu = {
+			destroy: jest.fn(),
 			hide: jest.fn(),
 			on: () => productMenuOn,
 		};


### PR DESCRIPTION
Hi @ambrinchaudhary, this is the fix for ticket: https://issues.liferay.com/browse/LPS-165269.

<h1>Steps to reproduce: </h1>

    1. Enable KB feature flags
    2. Go to KB to add a KB article
    3. Click the KB article title to go into this article
    4.Click the product menu icon to make the product menu collapse
    5. Go to the KB Home folder by clicking the Back icon in the control menu container or clicking the Home folder in the navigation panel
    6. Now it is on the Home page and the navigation panel is expanded
    7. Click the product menu icon again
    8. Check the product menu is expanded, but no content is displayed
    9. Repeat steps 4-7
    Check the product menu and the navigation panel is open at the same time

Expected result:
Step 8: The product menu is expanded, and the content is displayed. The navigation panel is collapsed.
Step 10: The product menu and the navigation panel can not expand at the same time.

Actual result:
Step 8: The product menu is expanded, but sometimes no content is displayed.
Step 10: The product menu and the navigation panel is open at the same time.
<br>
<h1>More details:  </h1> https://liferay.slack.com/archives/C03CAD9EF/p1665740988087679
<br>
<h1> Solution </h1>
When we use React on every time the component is unmounted, we will need to do proper clean up. In our case, the product menu and its listeners are not properly cleared so we have to get rid of the component from the top. 

Please take a look and give me your feedback!
