### PR TITLE
LPS-165707 [HR_164] Giving buttons a propper aria label

### DIFF
--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/action_button_preview.jsp
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/action_button_preview.jsp
@@ -1,12 +1,20 @@
-<%-- /** * Copyright (c) 2000-present Liferay, Inc. All rights reserved. * *
-This library is free software; you can redistribute it and/or modify it under *
-the terms of the GNU Lesser General Public License as published by the Free *
-Software Foundation; either version 2.1 of the License, or (at your option) *
-any later version. * * This library is distributed in the hope that it will be
-useful, but WITHOUT * ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS * FOR A PARTICULAR PURPOSE. See the GNU Lesser
-General Public License for more * details. */ --%> <%@ include
-file="/repository_entry_browser/init.jsp" %>
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>
+
+<%@ include file="/repository_entry_browser/init.jsp" %>
 
 <clay:button
 	aria-label="preview"

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/action_button_preview.jsp
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/action_button_preview.jsp
@@ -1,22 +1,15 @@
-<%--
-/**
- * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
- *
- * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free
- * Software Foundation; either version 2.1 of the License, or (at your option)
- * any later version.
- *
- * This library is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
- * details.
- */
---%>
-
-<%@ include file="/repository_entry_browser/init.jsp" %>
+<%-- /** * Copyright (c) 2000-present Liferay, Inc. All rights reserved. * *
+This library is free software; you can redistribute it and/or modify it under *
+the terms of the GNU Lesser General Public License as published by the Free *
+Software Foundation; either version 2.1 of the License, or (at your option) *
+any later version. * * This library is distributed in the hope that it will be
+useful, but WITHOUT * ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS * FOR A PARTICULAR PURPOSE. See the GNU Lesser
+General Public License for more * details. */ --%> <%@ include
+file="/repository_entry_browser/init.jsp" %>
 
 <clay:button
+	aria-label="preview"
 	borderless="<%= true %>"
 	cssClass="component-action icon-view"
 	displayType="secondary"

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/action_button_preview.jsp
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/action_button_preview.jsp
@@ -17,7 +17,7 @@
 <%@ include file="/repository_entry_browser/init.jsp" %>
 
 <clay:button
-	aria-label="preview"
+	aria-label='<%= LanguageUtil.get(request, "preview") %>'
 	borderless="<%= true %>"
 	cssClass="component-action icon-view"
 	displayType="secondary"

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/js/ItemSelectorRepositoryEntryBrowser.es.js
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/js/ItemSelectorRepositoryEntryBrowser.es.js
@@ -38,7 +38,6 @@ const STR_DROP = 'drop';
  * @extends {PortletBase}
  */
 class ItemSelectorRepositoryEntryBrowser extends PortletBase {
-
 	/**
 	 * @inheritDoc
 	 */
@@ -87,7 +86,7 @@ class ItemSelectorRepositoryEntryBrowser extends PortletBase {
 
 		const items = itemsNodes.map((node) => node.dataset);
 
-		const clickableItems = Array.from(this.all('.icon-view'));
+		const clickableItems = Array.from(this.all('.icon'));
 
 		if (items.length === clickableItems.length) {
 			clickableItems.forEach((clickableItem, index) => {
@@ -264,8 +263,7 @@ class ItemSelectorRepositoryEntryBrowser extends PortletBase {
 
 				if (type === STR_DRAG_OVER) {
 					rootNode.classList.add('drop-active');
-				}
-				else if (type === STR_DRAG_LEAVE || eventDrop) {
+				} else if (type === STR_DRAG_LEAVE || eventDrop) {
 					rootNode.classList.remove('drop-active');
 
 					if (eventDrop) {
@@ -306,8 +304,7 @@ class ItemSelectorRepositoryEntryBrowser extends PortletBase {
 							),
 							[error.message]
 						);
-					}
-					else {
+					} else {
 						message = Liferay.Language.get(
 							'please-enter-a-file-with-a-valid-file-type'
 						);
@@ -504,8 +501,7 @@ class ItemSelectorRepositoryEntryBrowser extends PortletBase {
 
 			if (maxFileSize === 0 || file.size <= maxFileSize) {
 				this._previewFile(file);
-			}
-			else {
+			} else {
 				errorMessage = sub(
 					Liferay.Language.get(
 						'please-enter-a-file-with-a-valid-file-size-no-larger-than-x'
@@ -513,8 +509,7 @@ class ItemSelectorRepositoryEntryBrowser extends PortletBase {
 					[formatStorage(maxFileSize)]
 				);
 			}
-		}
-		else {
+		} else {
 			errorMessage = sub(
 				Liferay.Language.get(
 					'please-enter-a-file-with-a-valid-extension-x'

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/js/ItemSelectorRepositoryEntryBrowser.es.js
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/js/ItemSelectorRepositoryEntryBrowser.es.js
@@ -86,7 +86,7 @@ class ItemSelectorRepositoryEntryBrowser extends PortletBase {
 
 		const items = itemsNodes.map((node) => node.dataset);
 
-		const clickableItems = Array.from(this.all('.icon'));
+		const clickableItems = Array.from(this.all('.icon-view'));
 
 		if (items.length === clickableItems.length) {
 			clickableItems.forEach((clickableItem, index) => {

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/js/ItemSelectorRepositoryEntryBrowser.es.js
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/js/ItemSelectorRepositoryEntryBrowser.es.js
@@ -38,6 +38,7 @@ const STR_DROP = 'drop';
  * @extends {PortletBase}
  */
 class ItemSelectorRepositoryEntryBrowser extends PortletBase {
+
 	/**
 	 * @inheritDoc
 	 */
@@ -263,7 +264,8 @@ class ItemSelectorRepositoryEntryBrowser extends PortletBase {
 
 				if (type === STR_DRAG_OVER) {
 					rootNode.classList.add('drop-active');
-				} else if (type === STR_DRAG_LEAVE || eventDrop) {
+				}
+				else if (type === STR_DRAG_LEAVE || eventDrop) {
 					rootNode.classList.remove('drop-active');
 
 					if (eventDrop) {
@@ -304,7 +306,8 @@ class ItemSelectorRepositoryEntryBrowser extends PortletBase {
 							),
 							[error.message]
 						);
-					} else {
+					}
+					else {
 						message = Liferay.Language.get(
 							'please-enter-a-file-with-a-valid-file-type'
 						);
@@ -501,7 +504,8 @@ class ItemSelectorRepositoryEntryBrowser extends PortletBase {
 
 			if (maxFileSize === 0 || file.size <= maxFileSize) {
 				this._previewFile(file);
-			} else {
+			}
+			else {
 				errorMessage = sub(
 					Liferay.Language.get(
 						'please-enter-a-file-with-a-valid-file-size-no-larger-than-x'
@@ -509,7 +513,8 @@ class ItemSelectorRepositoryEntryBrowser extends PortletBase {
 					[formatStorage(maxFileSize)]
 				);
 			}
-		} else {
+		}
+		else {
 			errorMessage = sub(
 				Liferay.Language.get(
 					'please-enter-a-file-with-a-valid-extension-x'


### PR DESCRIPTION
@EugenioAntunes I rebased with master and seems that other changes were merge, so there is just one change done in this pull. 


> Motivation
> =======
> [LPS-165707](https://issues.liferay.com/browse/LPS-165707)
> 
> Proposed Solution
> ========
>  1. Search button: Was added a proper aria-label
>  2. Eye button: Was added a proper aria-label
>  3. Table icon button: Working properly
> 
> Steps to Verify
> ========
> Tools: JAWS
>  1. Open the URL:https://hrportaldev.bankofamerica.com/
>  2. HR Portal home page will be opened.
>  3. Navigate "Menu button to the top left. Click on Content and Data-> Documents & Media->Document types ->Add new Document types.
>  4. Navigate the toggle buttons beside the side navigation bar.
>  5. Click on the "Builder" button. Drag "Rich text" and drop on the text side.
>  6. Select Advanced tab.In predefined values field. Click on the image icon and a dialog box will appear. Activate JAWS and observe announcement for "search" button 
>  7. Click on "Sites and libraries" and select "sample site" and observe SR announcement for "eye" button
> 
> Issue Description Actual Result
> ========================
> The following buttons doesn't have alt text and announced as Unlabeled buttons
>  1. Search button
>  2. Eye button
>  3. Table icon button
> 
> Expected Result
> =============
> Meaningful image buttons should have appropriate alt text
>  Ex: Search button
> 

