### PR TITLE
LPS-163136 Upgrade Tika to 1.28.2

### DIFF
--- a/lib/versions-complete.xml
+++ b/lib/versions-complete.xml
@@ -5938,7 +5938,7 @@
 			</library>
 			<library>
 				<file-name>com.liferay.portal.tika.jar!tika-core.jar</file-name>
-				<version>1.26</version>
+				<version>1.28.2</version>
 				<project-name>Apache Tika core</project-name>
 				<project-url>http://tika.apache.org/</project-url>
 				<licenses>

--- a/lib/versions.html
+++ b/lib/versions.html
@@ -2152,7 +2152,7 @@
 </td><td></td>
 </tr>
 <tr>
-<td nowrap="nowrap">com.liferay.portal.tika.jar!tika-core.jar</td><td nowrap="nowrap">1.26</td><td nowrap="nowrap"><a href="http://tika.apache.org/">Apache Tika core</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.txt">Apache License, Version 2.0</a>
+<td nowrap="nowrap">com.liferay.portal.tika.jar!tika-core.jar</td><td nowrap="nowrap">1.28.2</td><td nowrap="nowrap"><a href="http://tika.apache.org/">Apache Tika core</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.txt">Apache License, Version 2.0</a>
 <br>
 </td><td></td>
 </tr>

--- a/modules/apps/portal/portal-tika/build.gradle
+++ b/modules/apps/portal/portal-tika/build.gradle
@@ -19,7 +19,7 @@ dependencies {
 	compileInclude group: "org.apache.poi", name: "poi-ooxml", version: "4.1.2"
 	compileInclude group: "org.apache.poi", name: "poi-ooxml-schemas", version: "4.1.2"
 	compileInclude group: "org.apache.poi", name: "poi-scratchpad", version: "4.1.2"
-	compileInclude group: "org.apache.tika", name: "tika-core", version: "1.26"
+	compileInclude group: "org.apache.tika", name: "tika-core", version: "1.28.2"
 	compileInclude group: "org.apache.tika", name: "tika-parsers", version: "1.26"
 	compileInclude group: "org.apache.xmlbeans", name: "xmlbeans", version: "3.0.2"
 	compileInclude group: "org.ccil.cowan.tagsoup", name: "tagsoup", version: "1.2.1"

--- a/modules/sdk/gradle-plugins-alloy-taglib/src/gradleTest/smoke/build.gradle
+++ b/modules/sdk/gradle-plugins-alloy-taglib/src/gradleTest/smoke/build.gradle
@@ -26,7 +26,7 @@ dependencies {
 	alloyTaglib group: "commons-logging", name: "commons-logging", version: "1.2"
 	alloyTaglib group: "easyconf", name: "easyconf", transitive: false, version: "0.9.5"
 	alloyTaglib group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
-	alloyTaglib group: "org.apache.tika", name: "tika-core", version: "1.26"
+	alloyTaglib group: "org.apache.tika", name: "tika-core", version: "1.28.2"
 	alloyTaglib group: "org.dom4j", name: "dom4j", version: "2.1.3"
 	alloyTaglib group: "org.freemarker", name: "freemarker", version: "2.3.23"
 	alloyTaglib group: "xerces", name: "xercesImpl", version: "2.12.2"

--- a/modules/source-formatter.properties
+++ b/modules/source-formatter.properties
@@ -88,7 +88,7 @@
         org.apache.poi:poi-ooxml-schemas:4.1.2,\
         org.apache.poi:poi-ooxml:4.1.2,\
         org.apache.poi:poi:4.1.2,\
-        org.apache.tika:tika-core:1.26,\
+        org.apache.tika:tika-core:1.28.2,\
         org.apache.tika:tika-parsers:1.26,\
         org.bouncycastle:bcmail-jdk15on:1.69,\
         org.bouncycastle:bcpkix-jdk15on:1.69,\


### PR DESCRIPTION
Notes from @javalosjr96:

> Ticket:
> https://issues.liferay.com/browse/LPS-163136
> 
> Issue:
> A customer has recently flagged tika-core and tika-parser with CVE-2022-30126.
> 
> Solution:
> Bump Tika to 1.28.2

Note: SF is currently broken. I sent pull requests to fix the unrelated SF errors:
* https://github.com/brianchandotcom/liferay-portal/pull/124898
* https://github.com/brianchandotcom/liferay-portal/pull/124897