### PR TITLE
LPS-165775 Redirection error when saving page SEO settings

### DIFF
--- a/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/layout/screen/navigation/entries/seo.jsp
+++ b/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/layout/screen/navigation/entries/seo.jsp
@@ -36,7 +36,7 @@ UnicodeProperties layoutTypeSettings = selLayout.getTypeSettingsProperties();
 	<link href="<%= PortalUtil.getStaticResourceURL(request, PortalUtil.getPathProxy() + application.getContextPath() + "/css/main.css") %>" rel="stylesheet" type="text/css" />
 </liferay-util:html-top>
 
-<portlet:actionURL copyCurrentRenderParameters="<%= true %>" name="/layout/edit_seo" var="editSEOURL">
+<portlet:actionURL name="/layout/edit_seo" var="editSEOURL">
 	<portlet:param name="mvcRenderCommandName" value="/layout/edit_seo" />
 	<portlet:param name="redirect" value="<%= currentURL %>" />
 	<portlet:param name="portletResource" value='<%= ParamUtil.getString(request, "portletResource") %>' />


### PR DESCRIPTION
Forwarded from sontruongces#50

Motivation
=======

This work solves the problem reported in the [LPS-165775](https://issues.liferay.com/browse/LPS-165775) ticket.

Proposed Solution
========

Cause:
- Regression-bug after [commit](https://github.com/brianchandotcom/liferay-portal/compare/57434f4e59...2ea93d113d). 
If we use `portlet:actionURL` and `portlet:param`, `HttpComponentsUtil#shortenURL` will remove `redirect` param because the URL is too long.

What I/we did to solve this problem:
- I use `aui:input` instead of `portlet:param` for `redirect` param.


Steps to Verify
========
1.Go to Site Builder and add a new widget page to the site.
2.Navigate to the configuration page of the site.
3.Click the SEO panel and save.

Actual result:
-Redirection to the page.
Expected Result:
-Stay in the SEO setting panel.