### PR TITLE
LPS-165650 Restrict navigation to specific folder in repository browser tag

### DIFF
--- a/modules/apps/document-library/document-library-taglib/bnd.bnd
+++ b/modules/apps/document-library/document-library-taglib/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Document Library Taglib
 Bundle-SymbolicName: com.liferay.document.library.taglib
-Bundle-Version: 3.1.1
+Bundle-Version: 3.2.0
 Export-Package: com.liferay.document.library.taglib.servlet.taglib
 Provide-Capability:\
 	osgi.extender;\

--- a/modules/apps/document-library/document-library-taglib/package.json
+++ b/modules/apps/document-library/document-library-taglib/package.json
@@ -5,5 +5,5 @@
 		"checkFormat": "liferay-npm-scripts check",
 		"format": "liferay-npm-scripts fix"
 	},
-	"version": "3.1.1"
+	"version": "3.2.0"
 }

--- a/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/display/context/RepositoryBrowserTagDisplayContext.java
+++ b/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/display/context/RepositoryBrowserTagDisplayContext.java
@@ -16,7 +16,6 @@ package com.liferay.document.library.taglib.internal.display.context;
 
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFolder;
-import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLAppLocalServiceUtil;
 import com.liferay.document.library.kernel.service.DLAppService;
 import com.liferay.document.library.kernel.service.DLAppServiceUtil;
@@ -83,7 +82,7 @@ public class RepositoryBrowserTagDisplayContext {
 		long folderId, HttpServletRequest httpServletRequest,
 		LiferayPortletRequest liferayPortletRequest,
 		LiferayPortletResponse liferayPortletResponse,
-		PortletRequest portletRequest, long repositoryId) {
+		PortletRequest portletRequest, long repositoryId, long rootFolderId) {
 
 		_dlAppService = dlAppService;
 		_fileEntryModelResourcePermission = fileEntryModelResourcePermission;
@@ -96,6 +95,7 @@ public class RepositoryBrowserTagDisplayContext {
 		_liferayPortletResponse = liferayPortletResponse;
 		_portletRequest = portletRequest;
 		_repositoryId = repositoryId;
+		_rootFolderId = rootFolderId;
 
 		_themeDisplay = (ThemeDisplay)httpServletRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
@@ -112,7 +112,7 @@ public class RepositoryBrowserTagDisplayContext {
 
 		long folderId = _folderId;
 
-		while (folderId != DLFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
+		while (folderId != _rootFolderId) {
 			Folder folder = _dlAppService.getFolder(folderId);
 
 			if (folder.isMountPoint()) {
@@ -326,8 +326,7 @@ public class RepositoryBrowserTagDisplayContext {
 		searchContext.setAttribute("paginationType", "regular");
 		searchContext.setAttribute("searchRepositoryId", _repositoryId);
 		searchContext.setEnd(searchContainer.getEnd());
-		searchContext.setFolderIds(
-			new long[] {DLFolderConstants.DEFAULT_PARENT_FOLDER_ID});
+		searchContext.setFolderIds(new long[] {_rootFolderId});
 		searchContext.setKeywords(
 			ParamUtil.getString(_httpServletRequest, "keywords"));
 		searchContext.setLocale(_themeDisplay.getSiteDefaultLocale());
@@ -425,6 +424,7 @@ public class RepositoryBrowserTagDisplayContext {
 	private final PortletRequest _portletRequest;
 	private String _repositoryBrowserURL;
 	private final long _repositoryId;
+	private final long _rootFolderId;
 	private SearchContainer<Object> _searchContainer;
 	private final ThemeDisplay _themeDisplay;
 

--- a/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/servlet/taglib/RepositoryBrowserTag.java
+++ b/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/servlet/taglib/RepositoryBrowserTag.java
@@ -102,7 +102,7 @@ public class RepositoryBrowserTag extends IncludeTag {
 				httpServletRequest,
 				PortalUtil.getLiferayPortletRequest(portletRequest),
 				PortalUtil.getLiferayPortletResponse(portletResponse),
-				portletRequest, _getRepositoryId()));
+				portletRequest, _getRepositoryId(), getFolderId()));
 	}
 
 	private long _getFolderId() {

--- a/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/servlet/taglib/RepositoryBrowserTag.java
+++ b/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/servlet/taglib/RepositoryBrowserTag.java
@@ -14,6 +14,7 @@
 
 package com.liferay.document.library.taglib.servlet.taglib;
 
+import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLAppServiceUtil;
 import com.liferay.document.library.taglib.internal.display.context.RepositoryBrowserTagDisplayContext;
 import com.liferay.document.library.taglib.internal.servlet.ServletContextUtil;
@@ -45,8 +46,16 @@ public class RepositoryBrowserTag extends IncludeTag {
 		return EVAL_BODY_INCLUDE;
 	}
 
+	public long getFolderId() {
+		return _folderId;
+	}
+
 	public long getRepositoryId() {
 		return _repositoryId;
+	}
+
+	public void setFolderId(long folderId) {
+		_folderId = folderId;
 	}
 
 	@Override
@@ -58,6 +67,14 @@ public class RepositoryBrowserTag extends IncludeTag {
 
 	public void setRepositoryId(long repositoryId) {
 		_repositoryId = repositoryId;
+	}
+
+	@Override
+	protected void cleanUp() {
+		super.cleanUp();
+
+		_folderId = DLFolderConstants.DEFAULT_PARENT_FOLDER_ID;
+		_repositoryId = 0;
 	}
 
 	@Override
@@ -89,7 +106,7 @@ public class RepositoryBrowserTag extends IncludeTag {
 	}
 
 	private long _getFolderId() {
-		return ParamUtil.getLong(getRequest(), "folderId");
+		return ParamUtil.getLong(getRequest(), "folderId", _folderId);
 	}
 
 	private long _getRepositoryId() {
@@ -128,6 +145,7 @@ public class RepositoryBrowserTag extends IncludeTag {
 				"_folderModelResourcePermission",
 				"(model.class.name=" + Folder.class.getName() + ")", false);
 
+	private long _folderId = DLFolderConstants.DEFAULT_PARENT_FOLDER_ID;
 	private long _repositoryId;
 
 }

--- a/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/liferay-document-library.tld
+++ b/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/liferay-document-library.tld
@@ -33,6 +33,11 @@
 		<tag-class>com.liferay.document.library.taglib.servlet.taglib.RepositoryBrowserTag</tag-class>
 		<body-content>empty</body-content>
 		<attribute>
+			<name>folderId</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
 			<name>repositoryId</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>

--- a/modules/apps/document-library/document-library-taglib/src/main/resources/com/liferay/document/library/taglib/servlet/taglib/packageinfo
+++ b/modules/apps/document-library/document-library-taglib/src/main/resources/com/liferay/document/library/taglib/servlet/taglib/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 1.2.0


### PR DESCRIPTION
# What is this about?

In some cases, it is necessary to use a specific folder in a repository as the root folder. This PR adds a new `folderId` attribute for that purpose. If a value is provided, that folder will be used as root folder, and anything above it will not be visible.

# How to test this?

First, you need to add the tag to a page. For example replace the contents `blogs-web/*/view_images.jsp` with this:
```
<liferay-document-library:repository-browser folderId="<%= folderId %>" />
```
where `folderId` is an existing folder in Documents & Media (you may need to create sample folders and documents).

After doing that, go to Blogs > Images and verify that you can only navigate inside the folder you specified.
