### PR TITLE
LPS-166432 Show article in display page if available

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/asset/model/KBArticleAssetRenderer.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/asset/model/KBArticleAssetRenderer.java
@@ -14,6 +14,7 @@
 
 package com.liferay.knowledge.base.web.internal.asset.model;
 
+import com.liferay.asset.display.page.portlet.AssetDisplayPageFriendlyURLProvider;
 import com.liferay.asset.kernel.model.BaseJSPAssetRenderer;
 import com.liferay.knowledge.base.constants.KBActionKeys;
 import com.liferay.knowledge.base.constants.KBArticleConstants;
@@ -50,7 +51,12 @@ import javax.servlet.http.HttpServletResponse;
  */
 public class KBArticleAssetRenderer extends BaseJSPAssetRenderer<KBArticle> {
 
-	public KBArticleAssetRenderer(HtmlParser htmlParser, KBArticle kbArticle) {
+	public KBArticleAssetRenderer(
+		AssetDisplayPageFriendlyURLProvider assetDisplayPageFriendlyURLProvider,
+		HtmlParser htmlParser, KBArticle kbArticle) {
+
+		_assetDisplayPageFriendlyURLProvider =
+			assetDisplayPageFriendlyURLProvider;
 		_htmlParser = htmlParser;
 		_kbArticle = kbArticle;
 	}
@@ -130,22 +136,30 @@ public class KBArticleAssetRenderer extends BaseJSPAssetRenderer<KBArticle> {
 
 	@Override
 	public String getURLViewInContext(
-		LiferayPortletRequest liferayPortletRequest,
-		LiferayPortletResponse liferayPortletResponse,
-		String noSuchEntryRedirect) {
+			LiferayPortletRequest liferayPortletRequest,
+			LiferayPortletResponse liferayPortletResponse,
+			String noSuchEntryRedirect)
+		throws PortalException {
 
 		ThemeDisplay themeDisplay =
 			(ThemeDisplay)liferayPortletRequest.getAttribute(
 				KBWebKeys.THEME_DISPLAY);
 
-		return KnowledgeBaseUtil.getKBArticleURL(
-			themeDisplay.getPlid(), _kbArticle.getResourcePrimKey(),
-			_kbArticle.getStatus(), themeDisplay.getPortalURL(), false);
+		return getURLViewInContext(themeDisplay, noSuchEntryRedirect);
 	}
 
 	@Override
 	public String getURLViewInContext(
-		ThemeDisplay themeDisplay, String noSuchEntryRedirect) {
+			ThemeDisplay themeDisplay, String noSuchEntryRedirect)
+		throws PortalException {
+
+		String friendlyURL =
+			_assetDisplayPageFriendlyURLProvider.getFriendlyURL(
+				getClassName(), _kbArticle.getKbArticleId(), themeDisplay);
+
+		if (Validator.isNotNull(friendlyURL)) {
+			return friendlyURL;
+		}
 
 		return KnowledgeBaseUtil.getKBArticleURL(
 			themeDisplay.getPlid(), _kbArticle.getResourcePrimKey(),
@@ -224,6 +238,8 @@ public class KBArticleAssetRenderer extends BaseJSPAssetRenderer<KBArticle> {
 		return themeDisplay.getScopeGroup();
 	}
 
+	private final AssetDisplayPageFriendlyURLProvider
+		_assetDisplayPageFriendlyURLProvider;
 	private final HtmlParser _htmlParser;
 	private final KBArticle _kbArticle;
 

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/asset/model/KBArticleAssetRendererFactory.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/asset/model/KBArticleAssetRendererFactory.java
@@ -14,6 +14,7 @@
 
 package com.liferay.knowledge.base.web.internal.asset.model;
 
+import com.liferay.asset.display.page.portlet.AssetDisplayPageFriendlyURLProvider;
 import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.asset.kernel.model.AssetRenderer;
 import com.liferay.asset.kernel.model.AssetRendererFactory;
@@ -76,7 +77,8 @@ public class KBArticleAssetRendererFactory
 
 		KBArticleAssetRenderer kbArticleAssetRenderer =
 			new KBArticleAssetRenderer(
-				_htmlParser, _getKBArticle(classPK, _getTypeStatus(type)));
+				_assetDisplayPageFriendlyURLProvider, _htmlParser,
+				_getKBArticle(classPK, _getTypeStatus(type)));
 
 		kbArticleAssetRenderer.setAssetRendererType(type);
 		kbArticleAssetRenderer.setServletContext(_servletContext);
@@ -156,6 +158,10 @@ public class KBArticleAssetRendererFactory
 
 		return WorkflowConstants.STATUS_ANY;
 	}
+
+	@Reference
+	private AssetDisplayPageFriendlyURLProvider
+		_assetDisplayPageFriendlyURLProvider;
 
 	@Reference
 	private HtmlParser _htmlParser;


### PR DESCRIPTION
# What is this about?

When there is a display page for kb articles, use that page to display elements if possible.

# How do I test this?

- Create a display page template for kb articles. Mark it as default.
- Create a knowledge base article.
- Drop an Asset Publisher portlet in a page, configure it to display kb articles.
- Assert that the asset publisher portlet redirects the user to the display page when trying to view the kb article.

The old behavior will be kept as a fallback. See FindKBArticleStrutsAction.
