### PR TITLE
LPS-165793 Add view action id to the power user to each fileEntryTypesIds

### DIFF
--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/instance/lifecycle/DLFileEntryTypePermissionPortalInstanceLifecycleListener.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/instance/lifecycle/DLFileEntryTypePermissionPortalInstanceLifecycleListener.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.document.library.internal.instance.lifecycle;
+
+import com.liferay.document.library.kernel.model.DLFileEntryType;
+import com.liferay.portal.instance.lifecycle.BasePortalInstanceLifecycleListener;
+import com.liferay.portal.instance.lifecycle.PortalInstanceLifecycleListener;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Alicia García
+ */
+@Component(immediate = true, service = PortalInstanceLifecycleListener.class)
+public class DLFileEntryTypePermissionPortalInstanceLifecycleListener
+	extends BasePortalInstanceLifecycleListener {
+
+	@Override
+	public void portalInstanceRegistered(Company company) throws Exception {
+		Role role = _roleLocalService.fetchRole(
+			company.getCompanyId(), RoleConstants.POWER_USER);
+
+		if (role == null) {
+			return;
+		}
+
+		ResourcePermission resourcePermission =
+			_resourcePermissionLocalService.fetchResourcePermission(
+				company.getCompanyId(), DLFileEntryType.class.getName(),
+				ResourceConstants.SCOPE_COMPANY,
+				String.valueOf(company.getCompanyId()), role.getRoleId());
+
+		if (resourcePermission != null) {
+			return;
+		}
+
+		_resourcePermissionLocalService.setResourcePermissions(
+			company.getCompanyId(), DLFileEntryType.class.getName(),
+			ResourceConstants.SCOPE_COMPANY,
+			String.valueOf(company.getCompanyId()), role.getRoleId(),
+			new String[] {ActionKeys.VIEW});
+	}
+
+	@Reference
+	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private ResourceActionLocalService _resourceActionLocalService;
+
+	@Reference
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Reference
+	private RoleLocalService _roleLocalService;
+
+}

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryTypeFinderTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryTypeFinderTest.java
@@ -134,47 +134,6 @@ public class DLFileEntryTypeFinderTest {
 	}
 
 	@Test
-	public void testFilterCountByKeywordsAsPowerUserWithoutViewPermission()
-		throws Exception {
-
-		User user = UserTestUtil.addGroupUser(_group, RoleConstants.POWER_USER);
-
-		PermissionChecker permissionChecker =
-			PermissionCheckerFactoryUtil.create(user);
-
-		PermissionChecker originalPermissionChecker =
-			PermissionThreadLocal.getPermissionChecker();
-
-		PermissionThreadLocal.setPermissionChecker(permissionChecker);
-
-		try {
-			int initialFileEntryTypesCount =
-				DLFileEntryTypeFinderUtil.filterCountByKeywords(
-					_group.getCompanyId(), new long[] {_group.getGroupId()},
-					_DL_FILE_ENTRY_TYPE_NAME, true);
-
-			ServiceContext serviceContext =
-				ServiceContextTestUtil.getServiceContext(
-					_group.getGroupId(), _user.getUserId());
-
-			serviceContext.setAddGroupPermissions(false);
-			serviceContext.setAddGuestPermissions(false);
-
-			addFileEntryType(serviceContext);
-
-			Assert.assertEquals(
-				initialFileEntryTypesCount,
-				DLFileEntryTypeFinderUtil.filterCountByKeywords(
-					_group.getCompanyId(), new long[] {_group.getGroupId()},
-					_DL_FILE_ENTRY_TYPE_NAME, true));
-		}
-		finally {
-			PermissionThreadLocal.setPermissionChecker(
-				originalPermissionChecker);
-		}
-	}
-
-	@Test
 	public void testFilterCountByKeywordsWithBlankKeywords() throws Exception {
 		int initialFileEntryTypesCount =
 			DLFileEntryTypeFinderUtil.filterCountByKeywords(
@@ -256,48 +215,6 @@ public class DLFileEntryTypeFinderTest {
 			Assert.assertEquals(
 				fileEntryTypes.toString(), 1, fileEntryTypes.size());
 			Assert.assertTrue(
-				fileEntryTypes.toString(),
-				fileEntryTypes.contains(fileEntryType));
-		}
-		finally {
-			PermissionThreadLocal.setPermissionChecker(
-				originalPermissionChecker);
-		}
-	}
-
-	@Test
-	public void testFilterFindByKeywordsAsPowerUserWithoutViewPermission()
-		throws Exception {
-
-		User user = UserTestUtil.addGroupUser(_group, RoleConstants.POWER_USER);
-
-		PermissionChecker permissionChecker =
-			PermissionCheckerFactoryUtil.create(user);
-
-		PermissionChecker originalPermissionChecker =
-			PermissionThreadLocal.getPermissionChecker();
-
-		PermissionThreadLocal.setPermissionChecker(permissionChecker);
-
-		try {
-			ServiceContext serviceContext =
-				ServiceContextTestUtil.getServiceContext(
-					_group.getGroupId(), _user.getUserId());
-
-			serviceContext.setAddGroupPermissions(false);
-			serviceContext.setAddGuestPermissions(false);
-
-			DLFileEntryType fileEntryType = addFileEntryType(serviceContext);
-
-			List<DLFileEntryType> fileEntryTypes =
-				DLFileEntryTypeFinderUtil.filterFindByKeywords(
-					_group.getCompanyId(), new long[] {_group.getGroupId()},
-					_DL_FILE_ENTRY_TYPE_NAME, true, QueryUtil.ALL_POS,
-					QueryUtil.ALL_POS, null);
-
-			Assert.assertEquals(
-				fileEntryTypes.toString(), 0, fileEntryTypes.size());
-			Assert.assertFalse(
 				fileEntryTypes.toString(),
 				fileEntryTypes.contains(fileEntryType));
 		}

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryTypeFinderTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryTypeFinderTest.java
@@ -225,6 +225,42 @@ public class DLFileEntryTypeFinderTest {
 	}
 
 	@Test
+	public void testFilterFindByKeywordsAsSiteMember() throws Exception {
+		User user = UserTestUtil.addGroupUser(
+			_group, RoleConstants.SITE_MEMBER);
+
+		PermissionChecker permissionChecker =
+			PermissionCheckerFactoryUtil.create(user);
+
+		PermissionChecker originalPermissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		PermissionThreadLocal.setPermissionChecker(permissionChecker);
+
+		try {
+			DLFileEntryType fileEntryType = addFileEntryType(
+				ServiceContextTestUtil.getServiceContext(
+					_group.getGroupId(), _user.getUserId()));
+
+			List<DLFileEntryType> fileEntryTypes =
+				DLFileEntryTypeFinderUtil.filterFindByKeywords(
+					_group.getCompanyId(), new long[] {_group.getGroupId()},
+					_DL_FILE_ENTRY_TYPE_NAME, true, QueryUtil.ALL_POS,
+					QueryUtil.ALL_POS, null);
+
+			Assert.assertEquals(
+				fileEntryTypes.toString(), 0, fileEntryTypes.size());
+			Assert.assertFalse(
+				fileEntryTypes.toString(),
+				fileEntryTypes.contains(fileEntryType));
+		}
+		finally {
+			PermissionThreadLocal.setPermissionChecker(
+				originalPermissionChecker);
+		}
+	}
+
+	@Test
 	public void testFilterFindByKeywordsWithBlankKeywords() throws Exception {
 		DLFileEntryType fileEntryType = addFileEntryType(
 			ServiceContextTestUtil.getServiceContext(


### PR DESCRIPTION
I know that after https://github.com/liferay-lima/liferay-portal/pull/3623 is merged, will be conflicts:


- LPS-165793 add the action view to the power user role on the creation of the document type
- LPS-165793 power user now has the permission by herself not by the guest role so this test is not needed
- LPS-165793 add test to check that the site members do not have now the view permissions to view the document types
- LPS-165793 upgrade the permissions for the file entries for the power user
