### PR TITLE
LPS-166518 Add empty state message

### DIFF
--- a/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/display/context/RepositoryBrowserTagDisplayContext.java
+++ b/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/display/context/RepositoryBrowserTagDisplayContext.java
@@ -292,7 +292,7 @@ public class RepositoryBrowserTagDisplayContext {
 			_portletRequest,
 			PortletURLUtil.getCurrent(
 				_liferayPortletRequest, _liferayPortletResponse),
-			null, null);
+			null, "there-are-no-documents-in-this-folder");
 
 		searchContainer.setResultsAndTotal(
 			() -> DLAppServiceUtil.getFoldersAndFileEntriesAndFileShortcuts(


### PR DESCRIPTION
# What is this about?

This simply adds a generic empty state message to the browser tag.

![image](https://user-images.githubusercontent.com/729897/197567597-35ce59db-9347-4e6a-8f42-aa85afb22779.png)

# How can I test this

First, you need to make use of the tag in one jsp (e.g. `blogs-web/*/view_images.jsp`).
```
<liferay-document-library:repository-browser />
```

Next, go to that JSP, create a folder, get into it and see what is displayed (see the screenshot in this pr for the expected outcome). You should see a generic message telling you that there are no documents.
