### PR TITLE
LPS-165624 Obtain the languages for the friendlyURL modal from the object not from the possible translations

### DIFF
--- a/modules/apps/friendly-url/friendly-url-web/src/main/java/com/liferay/friendly/url/web/internal/servlet/FriendlyURLServlet.java
+++ b/modules/apps/friendly-url/friendly-url-web/src/main/java/com/liferay/friendly/url/web/internal/servlet/FriendlyURLServlet.java
@@ -275,6 +275,10 @@ public class FriendlyURLServlet extends HttpServlet {
 				infoItemFriendlyURLProvider.getFriendlyURLEntryLocalizations(
 					object, languageId);
 
+			if (friendlyURLEntryLocalizations.isEmpty()) {
+				continue;
+			}
+
 			String mainUrlTitle = infoItemFriendlyURLProvider.getFriendlyURL(
 				object, languageId);
 

--- a/modules/apps/friendly-url/friendly-url-web/src/main/java/com/liferay/friendly/url/web/internal/servlet/FriendlyURLServlet.java
+++ b/modules/apps/friendly-url/friendly-url-web/src/main/java/com/liferay/friendly/url/web/internal/servlet/FriendlyURLServlet.java
@@ -383,15 +383,15 @@ public class FriendlyURLServlet extends HttpServlet {
 			new InfoItemLanguagesProvider<Object>() {
 
 				@Override
-				public String[] getContentAvailableLanguageIds(Object object)
-					throws PortalException {
+				public String[] getConfigurationAvailableLanguageIds(
+					Object object) {
 
 					return new String[] {getDefaultLanguageId(object)};
 				}
 
 				@Override
-				public String[] getConfigurationAvailableLanguageIds(
-					Object object) {
+				public String[] getContentAvailableLanguageIds(Object object)
+					throws PortalException {
 
 					return new String[] {getDefaultLanguageId(object)};
 				}

--- a/modules/apps/friendly-url/friendly-url-web/src/main/java/com/liferay/friendly/url/web/internal/servlet/FriendlyURLServlet.java
+++ b/modules/apps/friendly-url/friendly-url-web/src/main/java/com/liferay/friendly/url/web/internal/servlet/FriendlyURLServlet.java
@@ -383,7 +383,7 @@ public class FriendlyURLServlet extends HttpServlet {
 			new InfoItemLanguagesProvider<Object>() {
 
 				@Override
-				public String[] getAvailableLanguageIds(Object object)
+				public String[] getContentAvailableLanguageIds(Object object)
 					throws PortalException {
 
 					return new String[] {getDefaultLanguageId(object)};

--- a/modules/apps/friendly-url/friendly-url-web/src/main/java/com/liferay/friendly/url/web/internal/servlet/FriendlyURLServlet.java
+++ b/modules/apps/friendly-url/friendly-url-web/src/main/java/com/liferay/friendly/url/web/internal/servlet/FriendlyURLServlet.java
@@ -268,7 +268,8 @@ public class FriendlyURLServlet extends HttpServlet {
 			);
 
 		for (String languageId :
-				infoItemLanguagesProvider.getAvailableLanguageIds(object)) {
+				infoItemLanguagesProvider.getConfigurationAvailableLanguageIds(
+					object)) {
 
 			List<FriendlyURLEntryLocalization> friendlyURLEntryLocalizations =
 				infoItemFriendlyURLProvider.getFriendlyURLEntryLocalizations(

--- a/modules/apps/friendly-url/friendly-url-web/src/main/java/com/liferay/friendly/url/web/internal/servlet/FriendlyURLServlet.java
+++ b/modules/apps/friendly-url/friendly-url-web/src/main/java/com/liferay/friendly/url/web/internal/servlet/FriendlyURLServlet.java
@@ -385,6 +385,13 @@ public class FriendlyURLServlet extends HttpServlet {
 				}
 
 				@Override
+				public String[] getConfigurationAvailableLanguageIds(
+					Object object) {
+
+					return new String[] {getDefaultLanguageId(object)};
+				}
+
+				@Override
 				public String getDefaultLanguageId(Object object) {
 					return LanguageUtil.getLanguageId(
 						LocaleUtil.getSiteDefault());

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/info/item/provider/JournalArticleInfoItemLanguagesProvider.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/info/item/provider/JournalArticleInfoItemLanguagesProvider.java
@@ -32,6 +32,13 @@ public class JournalArticleInfoItemLanguagesProvider
 	}
 
 	@Override
+	public String[] getConfigurationAvailableLanguageIds(
+		JournalArticle journalArticle) {
+
+		return getAvailableLanguageIds(journalArticle);
+	}
+
+	@Override
 	public String getDefaultLanguageId(JournalArticle journalArticle) {
 		return journalArticle.getDefaultLanguageId();
 	}

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/info/item/provider/JournalArticleInfoItemLanguagesProvider.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/info/item/provider/JournalArticleInfoItemLanguagesProvider.java
@@ -27,7 +27,7 @@ public class JournalArticleInfoItemLanguagesProvider
 	implements InfoItemLanguagesProvider<JournalArticle> {
 
 	@Override
-	public String[] getAvailableLanguageIds(JournalArticle journalArticle) {
+	public String[] getContentAvailableLanguageIds(JournalArticle journalArticle) {
 		return journalArticle.getAvailableLanguageIds();
 	}
 
@@ -35,7 +35,7 @@ public class JournalArticleInfoItemLanguagesProvider
 	public String[] getConfigurationAvailableLanguageIds(
 		JournalArticle journalArticle) {
 
-		return getAvailableLanguageIds(journalArticle);
+		return getContentAvailableLanguageIds(journalArticle);
 	}
 
 	@Override

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/info/item/provider/JournalArticleInfoItemLanguagesProvider.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/info/item/provider/JournalArticleInfoItemLanguagesProvider.java
@@ -27,15 +27,17 @@ public class JournalArticleInfoItemLanguagesProvider
 	implements InfoItemLanguagesProvider<JournalArticle> {
 
 	@Override
-	public String[] getContentAvailableLanguageIds(JournalArticle journalArticle) {
-		return journalArticle.getAvailableLanguageIds();
-	}
-
-	@Override
 	public String[] getConfigurationAvailableLanguageIds(
 		JournalArticle journalArticle) {
 
 		return getContentAvailableLanguageIds(journalArticle);
+	}
+
+	@Override
+	public String[] getContentAvailableLanguageIds(
+		JournalArticle journalArticle) {
+
+		return journalArticle.getAvailableLanguageIds();
 	}
 
 	@Override

--- a/modules/apps/layout/layout-admin-web-test/src/testIntegration/java/com/liferay/layout/admin/web/internal/info/item/provider/test/LayoutInfoItemLanguagesProviderTest.java
+++ b/modules/apps/layout/layout-admin-web-test/src/testIntegration/java/com/liferay/layout/admin/web/internal/info/item/provider/test/LayoutInfoItemLanguagesProviderTest.java
@@ -20,14 +20,21 @@ import com.liferay.fragment.model.FragmentEntryLink;
 import com.liferay.fragment.service.FragmentEntryLinkLocalService;
 import com.liferay.info.item.InfoItemServiceTracker;
 import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -86,6 +93,38 @@ public class LayoutInfoItemLanguagesProviderTest {
 		Assert.assertArrayEquals(
 			_getAvailableLocalesLayoutTranslatedLanguages(layout),
 			infoItemLanguagesProvider.getAvailableLanguageIds(layout));
+	}
+
+	@Test
+	public void testGetConfigurationAvailableLanguages() throws Exception {
+		Layout layout = LayoutLocalServiceUtil.addLayout(
+			TestPropsValues.getUserId(), _group.getGroupId(), false,
+			LayoutConstants.DEFAULT_PARENT_LAYOUT_ID,
+			RandomTestUtil.randomLocaleStringMap(),
+			HashMapBuilder.put(
+				LocaleUtil.SPAIN, "casa"
+			).put(
+				LocaleUtil.US, "home"
+			).build(),
+			RandomTestUtil.randomLocaleStringMap(),
+			RandomTestUtil.randomLocaleStringMap(),
+			RandomTestUtil.randomLocaleStringMap(),
+			LayoutConstants.TYPE_PORTLET, StringPool.BLANK, false,
+			HashMapBuilder.put(
+				LocaleUtil.SPAIN, "/casa"
+			).put(
+				LocaleUtil.US, "/home"
+			).build(),
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		InfoItemLanguagesProvider<Object> infoItemLanguagesProvider =
+			_infoItemServiceTracker.getFirstInfoItemService(
+				InfoItemLanguagesProvider.class, Layout.class.getName());
+
+		Assert.assertArrayEquals(
+			infoItemLanguagesProvider.getConfigurationAvailableLanguageIds(
+				layout),
+			layout.getAvailableLanguageIds());
 	}
 
 	private String[] _getAvailableLocalesLayoutTranslatedLanguages(

--- a/modules/apps/layout/layout-admin-web-test/src/testIntegration/java/com/liferay/layout/admin/web/internal/info/item/provider/test/LayoutInfoItemLanguagesProviderTest.java
+++ b/modules/apps/layout/layout-admin-web-test/src/testIntegration/java/com/liferay/layout/admin/web/internal/info/item/provider/test/LayoutInfoItemLanguagesProviderTest.java
@@ -70,32 +70,6 @@ public class LayoutInfoItemLanguagesProviderTest {
 	}
 
 	@Test
-	public void testGetContentAvailableLanguages() throws Exception {
-		Layout layout = LayoutTestUtil.addTypePortletLayout(_group);
-
-		InfoItemLanguagesProvider<Object> infoItemLanguagesProvider =
-			_infoItemServiceTracker.getFirstInfoItemService(
-				InfoItemLanguagesProvider.class, Layout.class.getName());
-
-		Assert.assertArrayEquals(
-			infoItemLanguagesProvider.getContentAvailableLanguageIds(layout),
-			layout.getAvailableLanguageIds());
-	}
-
-	@Test
-	public void testGetContentAvailableLanguagesContentLayout() throws Exception {
-		Layout layout = LayoutTestUtil.addTypeContentLayout(_group);
-
-		InfoItemLanguagesProvider<Object> infoItemLanguagesProvider =
-			_infoItemServiceTracker.getFirstInfoItemService(
-				InfoItemLanguagesProvider.class, Layout.class.getName());
-
-		Assert.assertArrayEquals(
-			_getContentAvailableLocalesLayoutTranslatedLanguages(layout),
-			infoItemLanguagesProvider.getContentAvailableLanguageIds(layout));
-	}
-
-	@Test
 	public void testGetConfigurationAvailableLanguages() throws Exception {
 		Layout layout = LayoutLocalServiceUtil.addLayout(
 			TestPropsValues.getUserId(), _group.getGroupId(), false,
@@ -125,6 +99,34 @@ public class LayoutInfoItemLanguagesProviderTest {
 			infoItemLanguagesProvider.getConfigurationAvailableLanguageIds(
 				layout),
 			layout.getAvailableLanguageIds());
+	}
+
+	@Test
+	public void testGetContentAvailableLanguages() throws Exception {
+		Layout layout = LayoutTestUtil.addTypePortletLayout(_group);
+
+		InfoItemLanguagesProvider<Object> infoItemLanguagesProvider =
+			_infoItemServiceTracker.getFirstInfoItemService(
+				InfoItemLanguagesProvider.class, Layout.class.getName());
+
+		Assert.assertArrayEquals(
+			infoItemLanguagesProvider.getContentAvailableLanguageIds(layout),
+			layout.getAvailableLanguageIds());
+	}
+
+	@Test
+	public void testGetContentAvailableLanguagesContentLayout()
+		throws Exception {
+
+		Layout layout = LayoutTestUtil.addTypeContentLayout(_group);
+
+		InfoItemLanguagesProvider<Object> infoItemLanguagesProvider =
+			_infoItemServiceTracker.getFirstInfoItemService(
+				InfoItemLanguagesProvider.class, Layout.class.getName());
+
+		Assert.assertArrayEquals(
+			_getContentAvailableLocalesLayoutTranslatedLanguages(layout),
+			infoItemLanguagesProvider.getContentAvailableLanguageIds(layout));
 	}
 
 	private String[] _getContentAvailableLocalesLayoutTranslatedLanguages(

--- a/modules/apps/layout/layout-admin-web-test/src/testIntegration/java/com/liferay/layout/admin/web/internal/info/item/provider/test/LayoutInfoItemLanguagesProviderTest.java
+++ b/modules/apps/layout/layout-admin-web-test/src/testIntegration/java/com/liferay/layout/admin/web/internal/info/item/provider/test/LayoutInfoItemLanguagesProviderTest.java
@@ -70,7 +70,7 @@ public class LayoutInfoItemLanguagesProviderTest {
 	}
 
 	@Test
-	public void testGetAvailableLanguages() throws Exception {
+	public void testGetContentAvailableLanguages() throws Exception {
 		Layout layout = LayoutTestUtil.addTypePortletLayout(_group);
 
 		InfoItemLanguagesProvider<Object> infoItemLanguagesProvider =
@@ -78,12 +78,12 @@ public class LayoutInfoItemLanguagesProviderTest {
 				InfoItemLanguagesProvider.class, Layout.class.getName());
 
 		Assert.assertArrayEquals(
-			infoItemLanguagesProvider.getAvailableLanguageIds(layout),
+			infoItemLanguagesProvider.getContentAvailableLanguageIds(layout),
 			layout.getAvailableLanguageIds());
 	}
 
 	@Test
-	public void testGetAvailableLanguagesContentLayout() throws Exception {
+	public void testGetContentAvailableLanguagesContentLayout() throws Exception {
 		Layout layout = LayoutTestUtil.addTypeContentLayout(_group);
 
 		InfoItemLanguagesProvider<Object> infoItemLanguagesProvider =
@@ -91,8 +91,8 @@ public class LayoutInfoItemLanguagesProviderTest {
 				InfoItemLanguagesProvider.class, Layout.class.getName());
 
 		Assert.assertArrayEquals(
-			_getAvailableLocalesLayoutTranslatedLanguages(layout),
-			infoItemLanguagesProvider.getAvailableLanguageIds(layout));
+			_getContentAvailableLocalesLayoutTranslatedLanguages(layout),
+			infoItemLanguagesProvider.getContentAvailableLanguageIds(layout));
 	}
 
 	@Test
@@ -127,7 +127,7 @@ public class LayoutInfoItemLanguagesProviderTest {
 			layout.getAvailableLanguageIds());
 	}
 
-	private String[] _getAvailableLocalesLayoutTranslatedLanguages(
+	private String[] _getContentAvailableLocalesLayoutTranslatedLanguages(
 			Layout layout)
 		throws Exception {
 

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/info/item/provider/LayoutInfoItemLanguagesProvider.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/info/item/provider/LayoutInfoItemLanguagesProvider.java
@@ -35,6 +35,11 @@ public class LayoutInfoItemLanguagesProvider
 	implements InfoItemLanguagesProvider<Layout> {
 
 	@Override
+	public String[] getConfigurationAvailableLanguageIds(Layout layout) {
+		return layout.getAvailableLanguageIds();
+	}
+
+	@Override
 	public String[] getContentAvailableLanguageIds(Layout layout)
 		throws PortalException {
 
@@ -44,11 +49,6 @@ public class LayoutInfoItemLanguagesProvider
 
 		return _layoutInfoItemLanguagesProviderHelper.getAvailableLanguageIds(
 			layout, defaultSegmentsExperienceId);
-	}
-
-	@Override
-	public String[] getConfigurationAvailableLanguageIds(Layout layout) {
-		return layout.getAvailableLanguageIds();
 	}
 
 	@Override

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/info/item/provider/LayoutInfoItemLanguagesProvider.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/info/item/provider/LayoutInfoItemLanguagesProvider.java
@@ -35,7 +35,7 @@ public class LayoutInfoItemLanguagesProvider
 	implements InfoItemLanguagesProvider<Layout> {
 
 	@Override
-	public String[] getAvailableLanguageIds(Layout layout)
+	public String[] getContentAvailableLanguageIds(Layout layout)
 		throws PortalException {
 
 		long defaultSegmentsExperienceId =

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/info/item/provider/LayoutInfoItemLanguagesProvider.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/info/item/provider/LayoutInfoItemLanguagesProvider.java
@@ -47,6 +47,11 @@ public class LayoutInfoItemLanguagesProvider
 	}
 
 	@Override
+	public String[] getConfigurationAvailableLanguageIds(Layout layout) {
+		return layout.getAvailableLanguageIds();
+	}
+
+	@Override
 	public String getDefaultLanguageId(Layout layout) {
 		return _layoutInfoItemLanguagesProviderHelper.getDefaultLanguageId(
 			layout);

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/info/item/provider/LayoutSegmentsExperienceInfoItemLanguagesProvider.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/info/item/provider/LayoutSegmentsExperienceInfoItemLanguagesProvider.java
@@ -37,6 +37,14 @@ public class LayoutSegmentsExperienceInfoItemLanguagesProvider
 	implements InfoItemLanguagesProvider<SegmentsExperience> {
 
 	@Override
+	public String[] getConfigurationAvailableLanguageIds(
+			SegmentsExperience segmentsExperience)
+		throws PortalException {
+
+		return getContentAvailableLanguageIds(segmentsExperience);
+	}
+
+	@Override
 	public String[] getContentAvailableLanguageIds(
 			SegmentsExperience segmentsExperience)
 		throws PortalException {
@@ -44,14 +52,6 @@ public class LayoutSegmentsExperienceInfoItemLanguagesProvider
 		return _layoutInfoItemLanguagesProviderHelper.getAvailableLanguageIds(
 			_getLayout(segmentsExperience),
 			segmentsExperience.getSegmentsExperienceId());
-	}
-
-	@Override
-	public String[] getConfigurationAvailableLanguageIds(
-			SegmentsExperience segmentsExperience)
-		throws PortalException {
-
-		return getContentAvailableLanguageIds(segmentsExperience);
 	}
 
 	@Override

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/info/item/provider/LayoutSegmentsExperienceInfoItemLanguagesProvider.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/info/item/provider/LayoutSegmentsExperienceInfoItemLanguagesProvider.java
@@ -47,6 +47,14 @@ public class LayoutSegmentsExperienceInfoItemLanguagesProvider
 	}
 
 	@Override
+	public String[] getConfigurationAvailableLanguageIds(
+			SegmentsExperience segmentsExperience)
+		throws PortalException {
+
+		return getAvailableLanguageIds(segmentsExperience);
+	}
+
+	@Override
 	public String getDefaultLanguageId(SegmentsExperience segmentsExperience) {
 		return _layoutInfoItemLanguagesProviderHelper.getDefaultLanguageId(
 			_getLayout(segmentsExperience));

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/info/item/provider/LayoutSegmentsExperienceInfoItemLanguagesProvider.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/info/item/provider/LayoutSegmentsExperienceInfoItemLanguagesProvider.java
@@ -37,7 +37,7 @@ public class LayoutSegmentsExperienceInfoItemLanguagesProvider
 	implements InfoItemLanguagesProvider<SegmentsExperience> {
 
 	@Override
-	public String[] getAvailableLanguageIds(
+	public String[] getContentAvailableLanguageIds(
 			SegmentsExperience segmentsExperience)
 		throws PortalException {
 
@@ -51,7 +51,7 @@ public class LayoutSegmentsExperienceInfoItemLanguagesProvider
 			SegmentsExperience segmentsExperience)
 		throws PortalException {
 
-		return getAvailableLanguageIds(segmentsExperience);
+		return getContentAvailableLanguageIds(segmentsExperience);
 	}
 
 	@Override

--- a/modules/apps/layout/layout-seo-web-test/src/testIntegration/java/com/liferay/layout/seo/web/internal/servlet/taglib/test/OpenGraphTopHeadDynamicIncludeTest.java
+++ b/modules/apps/layout/layout-seo-web-test/src/testIntegration/java/com/liferay/layout/seo/web/internal/servlet/taglib/test/OpenGraphTopHeadDynamicIncludeTest.java
@@ -648,7 +648,7 @@ public class OpenGraphTopHeadDynamicIncludeTest {
 
 		_assertAlternateLinkTagAssetDisplayPage(
 			document, fileEntry,
-			_getAvailableLocalesLayoutTranslatedLanguages());
+			_getContentAvailableLocalesLayoutTranslatedLanguages());
 		_assertCanonicalLinkTag(
 			document,
 			_assetDisplayPageFriendlyURLProvider.getFriendlyURL(
@@ -680,7 +680,7 @@ public class OpenGraphTopHeadDynamicIncludeTest {
 
 		_assertAlternateLinkTagAssetDisplayPage(
 			document, fileEntry,
-			_getAvailableLocalesLayoutTranslatedLanguages());
+			_getContentAvailableLocalesLayoutTranslatedLanguages());
 		_assertCanonicalLinkTag(
 			document,
 			_assetDisplayPageFriendlyURLProvider.getFriendlyURL(
@@ -745,7 +745,7 @@ public class OpenGraphTopHeadDynamicIncludeTest {
 				_getThemeDisplay()));
 		_assertAlternateLinkTagAssetDisplayPage(
 			document, fileEntry,
-			_getAvailableLocalesLayoutTranslatedLanguages());
+			_getContentAvailableLocalesLayoutTranslatedLanguages());
 	}
 
 	@Test
@@ -765,7 +765,7 @@ public class OpenGraphTopHeadDynamicIncludeTest {
 			mockHttpServletResponse.getContentAsString());
 
 		_assertAlternateLinkTag(
-			document, _getAvailableLocalesLayoutTranslatedLanguages());
+			document, _getContentAvailableLocalesLayoutTranslatedLanguages());
 		_assertCanonicalLinkTag(
 			document,
 			PortalUtil.getCanonicalURL("", _getThemeDisplay(), _layout));
@@ -797,7 +797,7 @@ public class OpenGraphTopHeadDynamicIncludeTest {
 			document,
 			PortalUtil.getCanonicalURL("", _getThemeDisplay(), _layout));
 		_assertAlternateLinkTag(
-			document, _getAvailableLocalesLayoutTranslatedLanguages());
+			document, _getContentAvailableLocalesLayoutTranslatedLanguages());
 	}
 
 	@Test
@@ -823,7 +823,7 @@ public class OpenGraphTopHeadDynamicIncludeTest {
 			mockHttpServletResponse.getContentAsString());
 
 		_assertAlternateLinkTag(
-			document, _getAvailableLocalesLayoutTranslatedLanguages());
+			document, _getContentAvailableLocalesLayoutTranslatedLanguages());
 		_assertCanonicalLinkTag(
 			document,
 			PortalUtil.getCanonicalURL("", _getThemeDisplay(), _layout));
@@ -848,7 +848,7 @@ public class OpenGraphTopHeadDynamicIncludeTest {
 			mockHttpServletResponse.getContentAsString());
 
 		_assertAlternateLinkTag(
-			document, _getAvailableLocalesLayoutTranslatedLanguages());
+			document, _getContentAvailableLocalesLayoutTranslatedLanguages());
 		_assertCanonicalLinkTag(
 			document,
 			PortalUtil.getCanonicalURL("", _getThemeDisplay(), _layout));
@@ -890,7 +890,7 @@ public class OpenGraphTopHeadDynamicIncludeTest {
 			mockHttpServletResponse.getContentAsString());
 
 		_assertAlternateLocalesTag(
-			document, _getAvailableLocalesLayoutTranslatedLanguages());
+			document, _getContentAvailableLocalesLayoutTranslatedLanguages());
 		_assertMetaTag(document, "og:locale", _group.getDefaultLanguageId());
 	}
 
@@ -915,7 +915,7 @@ public class OpenGraphTopHeadDynamicIncludeTest {
 			mockHttpServletResponse.getContentAsString());
 
 		_assertAlternateLocalesTag(
-			document, _getAvailableLocalesLayoutTranslatedLanguages());
+			document, _getContentAvailableLocalesLayoutTranslatedLanguages());
 
 		_assertMetaTag(document, "og:locale", _group.getDefaultLanguageId());
 	}
@@ -943,7 +943,7 @@ public class OpenGraphTopHeadDynamicIncludeTest {
 			mockHttpServletResponse.getContentAsString());
 
 		_assertAlternateLocalesTag(
-			document, _getAvailableLocalesLayoutTranslatedLanguages());
+			document, _getContentAvailableLocalesLayoutTranslatedLanguages());
 		_assertMetaTag(document, "og:locale", _group.getDefaultLanguageId());
 	}
 
@@ -968,7 +968,7 @@ public class OpenGraphTopHeadDynamicIncludeTest {
 			mockHttpServletResponse.getContentAsString());
 
 		_assertAlternateLocalesTag(
-			document, _getAvailableLocalesLayoutTranslatedLanguages());
+			document, _getContentAvailableLocalesLayoutTranslatedLanguages());
 		_assertMetaTag(document, "og:locale", _group.getDefaultLanguageId());
 
 		mockHttpServletResponse.reset();
@@ -1029,7 +1029,7 @@ public class OpenGraphTopHeadDynamicIncludeTest {
 			mockHttpServletResponse.getContentAsString());
 
 		_assertAlternateLocalesTag(
-			document, _getAvailableLocalesLayoutTranslatedLanguages());
+			document, _getContentAvailableLocalesLayoutTranslatedLanguages());
 		_assertMetaTag(document, "og:locale", _group.getDefaultLanguageId());
 
 		Stream<String> stream = Arrays.stream(
@@ -1063,7 +1063,7 @@ public class OpenGraphTopHeadDynamicIncludeTest {
 			mockHttpServletResponse.getContentAsString());
 
 		_assertAlternateLocalesTag(
-			document, _getAvailableLocalesLayoutTranslatedLanguages());
+			document, _getContentAvailableLocalesLayoutTranslatedLanguages());
 		_assertMetaTag(document, "og:locale", _group.getDefaultLanguageId());
 	}
 
@@ -1577,7 +1577,7 @@ public class OpenGraphTopHeadDynamicIncludeTest {
 		return httpServletRequest;
 	}
 
-	private Set<Locale> _getAvailableLocalesLayoutTranslatedLanguages()
+	private Set<Locale> _getContentAvailableLocalesLayoutTranslatedLanguages()
 		throws Exception {
 
 		InfoItemLanguagesProvider<Object> infoItemLanguagesProvider =
@@ -1589,7 +1589,7 @@ public class OpenGraphTopHeadDynamicIncludeTest {
 		}
 
 		Stream<String> stream = Arrays.stream(
-			infoItemLanguagesProvider.getAvailableLanguageIds(_layout));
+			infoItemLanguagesProvider.getContentAvailableLanguageIds(_layout));
 
 		Stream<Locale> localesStream = stream.map(LocaleUtil::fromLanguageId);
 

--- a/modules/apps/layout/layout-seo-web/src/main/java/com/liferay/layout/seo/web/internal/servlet/taglib/OpenGraphTopHeadDynamicInclude.java
+++ b/modules/apps/layout/layout-seo-web/src/main/java/com/liferay/layout/seo/web/internal/servlet/taglib/OpenGraphTopHeadDynamicInclude.java
@@ -374,7 +374,7 @@ public class OpenGraphTopHeadDynamicInclude extends BaseDynamicInclude {
 		}
 
 		Stream<String> stream = Arrays.stream(
-			infoItemLanguagesProvider.getAvailableLanguageIds(layout));
+			infoItemLanguagesProvider.getContentAvailableLanguageIds(layout));
 
 		Stream<Locale> localesStream = stream.map(LocaleUtil::fromLanguageId);
 

--- a/modules/apps/translation/translation-api/bnd.bnd
+++ b/modules/apps/translation/translation-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Translation API
 Bundle-SymbolicName: com.liferay.translation.api
-Bundle-Version: 7.0.1
+Bundle-Version: 8.0.0
 Export-Package:\
 	com.liferay.translation.constants,\
 	com.liferay.translation.exception,\

--- a/modules/apps/translation/translation-api/src/main/java/com/liferay/translation/info/item/provider/InfoItemLanguagesProvider.java
+++ b/modules/apps/translation/translation-api/src/main/java/com/liferay/translation/info/item/provider/InfoItemLanguagesProvider.java
@@ -23,6 +23,9 @@ public interface InfoItemLanguagesProvider<T> {
 
 	public String[] getAvailableLanguageIds(T t) throws PortalException;
 
+	public String[] getConfigurationAvailableLanguageIds(T t)
+		throws PortalException;
+
 	public String getDefaultLanguageId(T t);
 
 }

--- a/modules/apps/translation/translation-api/src/main/java/com/liferay/translation/info/item/provider/InfoItemLanguagesProvider.java
+++ b/modules/apps/translation/translation-api/src/main/java/com/liferay/translation/info/item/provider/InfoItemLanguagesProvider.java
@@ -21,7 +21,7 @@ import com.liferay.portal.kernel.exception.PortalException;
  */
 public interface InfoItemLanguagesProvider<T> {
 
-	public String[] getAvailableLanguageIds(T t) throws PortalException;
+	public String[] getContentAvailableLanguageIds(T t) throws PortalException;
 
 	public String[] getConfigurationAvailableLanguageIds(T t)
 		throws PortalException;

--- a/modules/apps/translation/translation-api/src/main/java/com/liferay/translation/info/item/provider/InfoItemLanguagesProvider.java
+++ b/modules/apps/translation/translation-api/src/main/java/com/liferay/translation/info/item/provider/InfoItemLanguagesProvider.java
@@ -21,10 +21,10 @@ import com.liferay.portal.kernel.exception.PortalException;
  */
 public interface InfoItemLanguagesProvider<T> {
 
-	public String[] getContentAvailableLanguageIds(T t) throws PortalException;
-
 	public String[] getConfigurationAvailableLanguageIds(T t)
 		throws PortalException;
+
+	public String[] getContentAvailableLanguageIds(T t) throws PortalException;
 
 	public String getDefaultLanguageId(T t);
 

--- a/modules/apps/translation/translation-api/src/main/resources/com/liferay/translation/info/item/provider/packageinfo
+++ b/modules/apps/translation/translation-api/src/main/resources/com/liferay/translation/info/item/provider/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 2.0.0

--- a/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/display/context/ExportTranslationDisplayContext.java
+++ b/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/display/context/ExportTranslationDisplayContext.java
@@ -213,7 +213,8 @@ public class ExportTranslationDisplayContext {
 			_intersect(
 				languageIds,
 				Arrays.asList(
-					infoItemLanguagesProvider.getContentAvailableLanguageIds(model)));
+					infoItemLanguagesProvider.getContentAvailableLanguageIds(
+						model)));
 		}
 
 		Stream<String> stream = languageIds.stream();

--- a/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/display/context/ExportTranslationDisplayContext.java
+++ b/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/display/context/ExportTranslationDisplayContext.java
@@ -213,7 +213,7 @@ public class ExportTranslationDisplayContext {
 			_intersect(
 				languageIds,
 				Arrays.asList(
-					infoItemLanguagesProvider.getAvailableLanguageIds(model)));
+					infoItemLanguagesProvider.getContentAvailableLanguageIds(model)));
 		}
 
 		Stream<String> stream = languageIds.stream();

--- a/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/portlet/action/TranslateMVCRenderCommand.java
+++ b/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/portlet/action/TranslateMVCRenderCommand.java
@@ -125,7 +125,8 @@ public class TranslateMVCRenderCommand implements MVCRenderCommand {
 			}
 
 			List<String> availableSourceLanguageIds = Arrays.asList(
-				infoItemLanguagesProvider.getContentAvailableLanguageIds(object));
+				infoItemLanguagesProvider.getContentAvailableLanguageIds(
+					object));
 
 			String sourceLanguageId = ParamUtil.getString(
 				renderRequest, "sourceLanguageId",

--- a/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/portlet/action/TranslateMVCRenderCommand.java
+++ b/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/portlet/action/TranslateMVCRenderCommand.java
@@ -125,7 +125,7 @@ public class TranslateMVCRenderCommand implements MVCRenderCommand {
 			}
 
 			List<String> availableSourceLanguageIds = Arrays.asList(
-				infoItemLanguagesProvider.getAvailableLanguageIds(object));
+				infoItemLanguagesProvider.getContentAvailableLanguageIds(object));
 
 			String sourceLanguageId = ParamUtil.getString(
 				renderRequest, "sourceLanguageId",


### PR DESCRIPTION

- LPS-165624 the translation of the object is not affecting the translation of the friendlyURL, so we need to know another way to obtain the available languages of them. taking into account that till now the only way to translate the friendly urls is editing the object (general configuration of the object itself) we should make it getting the available languages from the info item
- LPS-165624 baseline
- LPS-165624 test new infoItem method on layouts
- LPS-165624 obtain the available languages for the friendlyURLs comes from the object no the translations
- LPS-165624 no need to show the languages without proper friendlyURL translation
