### PR TITLE
LPS-166740 asset entry is linked to the classPK that changes if the kbArticle is approved or not

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/action/UpdateKBArticleMVCActionCommand.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/action/UpdateKBArticleMVCActionCommand.java
@@ -138,8 +138,7 @@ public class UpdateKBArticleMVCActionCommand
 		}
 
 		_assetDisplayPageEntryFormProcessor.process(
-			KBArticle.class.getName(), kbArticle.getKbArticleId(),
-			actionRequest);
+			KBArticle.class.getName(), kbArticle.getClassPK(), actionRequest);
 
 		int workflowAction = ParamUtil.getInteger(
 			actionRequest, "workflowAction");


### PR DESCRIPTION
 *Step to reproduce:*

1. Enable KB FF
2. Create a display page template for knowledge base articles
3. Add a KB article 
4. Select this added Display page template for this KB article and publish it
5. Delete this KB article
6. Go to Page Templates > Display Page Templates to delete the KB display page template

*Expected Results:*
Able to delete it.
