### PR TITLE
LPS-166850 Permission error when trying to edit web content in an asset library

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalEditArticleDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalEditArticleDisplayContext.java
@@ -313,7 +313,7 @@ public class JournalEditArticleDisplayContext {
 			() -> {
 				List<Map<String, Object>> languages = new ArrayList<>();
 
-				LinkedHashSet<String> uniqueLanguageIds = new LinkedHashSet<>();
+				Set<String> uniqueLanguageIds = new LinkedHashSet<>();
 
 				uniqueLanguageIds.add(getSelectedLanguageId());
 

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalEditArticleDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalEditArticleDisplayContext.java
@@ -595,22 +595,6 @@ public class JournalEditArticleDisplayContext {
 		return _defaultArticleLanguageId;
 	}
 
-	public String getEditArticleURL() {
-		return PortletURLBuilder.createRenderURL(
-			_liferayPortletResponse
-		).setMVCPath(
-			"/edit_article.jsp"
-		).setRedirect(
-			getRedirect()
-		).setParameter(
-			"articleId", getArticleId()
-		).setParameter(
-			"groupId", getGroupId()
-		).setParameter(
-			"version", getVersion()
-		).buildString();
-	}
-
 	public long getFolderId() {
 		if (_folderId != null) {
 			return _folderId;
@@ -911,14 +895,6 @@ public class JournalEditArticleDisplayContext {
 		return JournalFolderPermission.contains(
 			_themeDisplay.getPermissionChecker(), getGroupId(), getFolderId(),
 			ActionKeys.ADD_ARTICLE);
-	}
-
-	public boolean isApproved() {
-		if ((_article != null) && (getVersion() > 0)) {
-			return _article.isApproved();
-		}
-
-		return false;
 	}
 
 	public boolean isChangeStructure() {

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalEditArticleDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalEditArticleDisplayContext.java
@@ -63,6 +63,7 @@ import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.GroupServiceUtil;
 import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalServiceUtil;
+import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
 import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Constants;
@@ -279,6 +280,13 @@ public class JournalEditArticleDisplayContext {
 		).put(
 			"sitesCount",
 			() -> {
+				if (!GroupPermissionUtil.contains(
+						_themeDisplay.getPermissionChecker(),
+						ActionKeys.VIEW)) {
+
+					return 0;
+				}
+
 				int groupsCount = GroupServiceUtil.getGroupsCount(
 					_themeDisplay.getCompanyId(), 0, Boolean.TRUE);
 

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalEditArticleDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalEditArticleDisplayContext.java
@@ -290,7 +290,7 @@ public class JournalEditArticleDisplayContext {
 				int groupsCount = GroupServiceUtil.getGroupsCount(
 					_themeDisplay.getCompanyId(), 0, Boolean.TRUE);
 
-				return groupsCount - 1;
+				return Math.max(groupsCount - 1, 0);
 			}
 		).build();
 	}


### PR DESCRIPTION
# Motivation

https://issues.liferay.com/browse/LPS-166850

Users with roles that don't have the global group VIEW permission explicitly assigned won't be able to edit web content in an asset library (this may happen too in sites, but we haven't checked it).

The fix is to explicitly check for that permission before invoking the services.

# Change summary

- Make explicit permission check.
- Make sure the display context doesn't return a negative value.
- Minor SF changes.

# How to test the changes


1. Add a new asset library.
2. Add a new regular role and define the permissions below:
  * Asset Libraries: Access in Control Panel
    - Asset Libraries: View
    - Asset Library Settings > Asset Library Entry: View Site and Asset Library Administration Menu
4. Create a new user
5. Edit the new user > Memberships to select the added asset library and save it
6. Edit the new user > Roles to select the regular role(under REGULAR ROLES) and Asset Library Owner(under ASSET LIBRARY ROLES)
7. Login in with the new user
8. Go to the added asset library > Web Content
9. Try to add a new web content
