### PR TITLE
[TS] LPS-166867 | Cannot edit document in Office 365 when file in OneDrive has been sent to trash

### DIFF
--- a/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/src/main/java/com/liferay/document/library/opener/onedrive/web/internal/DLOpenerOneDriveManager.java
+++ b/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/src/main/java/com/liferay/document/library/opener/onedrive/web/internal/DLOpenerOneDriveManager.java
@@ -20,6 +20,7 @@ import com.liferay.document.library.opener.onedrive.web.internal.background.task
 import com.liferay.document.library.opener.onedrive.web.internal.configuration.DLOneDriveCompanyConfiguration;
 import com.liferay.document.library.opener.onedrive.web.internal.constants.DLOpenerOneDriveConstants;
 import com.liferay.document.library.opener.onedrive.web.internal.constants.OneDriveBackgroundTaskConstants;
+import com.liferay.document.library.opener.onedrive.web.internal.exception.GraphServicePortalException;
 import com.liferay.document.library.opener.onedrive.web.internal.exception.mapper.GraphServiceExceptionPortalExceptionMapper;
 import com.liferay.document.library.opener.onedrive.web.internal.graph.IAuthenticationProviderImpl;
 import com.liferay.document.library.opener.onedrive.web.internal.oauth.AccessToken;
@@ -138,8 +139,20 @@ public class DLOpenerOneDriveManager {
 					fileEntry);
 		}
 		catch (GraphServiceException graphServiceException) {
-			throw GraphServiceExceptionPortalExceptionMapper.map(
-				graphServiceException);
+			GraphServicePortalException graphServicePortalException =
+				GraphServiceExceptionPortalExceptionMapper.map(
+					graphServiceException);
+
+			if (graphServicePortalException instanceof
+					GraphServicePortalException.ItemNotFound) {
+
+				_dlOpenerFileEntryReferenceLocalService.
+					deleteDLOpenerFileEntryReference(
+						DLOpenerOneDriveConstants.ONE_DRIVE_REFERENCE_TYPE,
+						fileEntry);
+			}
+
+			throw graphServicePortalException;
 		}
 	}
 


### PR DESCRIPTION
Hi @liferay-lima!

This PR is to fix a possible inconsistency situation in the integration with Office 365, as described in [LPS-166867](https://issues.liferay.com/browse/LPS-166867).

The idea of the solution is to treat the exception `GraphServicePortalException.ItemNotFound` in a special way (as it kind of is in `DLOpenerOneDriveDLAppServiceWrapper#cancelCheckOut`) by deleting the reference in `DeleteDLOpenerFileEntryReference` so that it goes in sync with the checking out of the File Entry (that updates/removes the PWC in `DLFileVersion`).

Please let me know if you have any questions. 

Thanks!