### PR TITLE
LPS-166740 Create a model listener to delete the assetDisplayPageEntry each time an kbArticle is deleted 

### DIFF
--- a/modules/apps/asset/asset-display-page-service/build.gradle
+++ b/modules/apps/asset/asset-display-page-service/build.gradle
@@ -14,6 +14,7 @@ dependencies {
 	compileOnly project(":apps:change-tracking:change-tracking-spi")
 	compileOnly project(":apps:export-import:export-import-api")
 	compileOnly project(":apps:info:info-api")
+	compileOnly project(":apps:knowledge-base:knowledge-base-api")
 	compileOnly project(":apps:layout:layout-api")
 	compileOnly project(":apps:layout:layout-display-page-api")
 	compileOnly project(":apps:layout:layout-page-template-api")

--- a/modules/apps/asset/asset-display-page-service/src/main/java/com/liferay/asset/display/page/internal/model/listener/KBArticleModelListener.java
+++ b/modules/apps/asset/asset-display-page-service/src/main/java/com/liferay/asset/display/page/internal/model/listener/KBArticleModelListener.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.asset.display.page.internal.model.listener;
+
+import com.liferay.asset.display.page.model.AssetDisplayPageEntry;
+import com.liferay.asset.display.page.service.AssetDisplayPageEntryLocalService;
+import com.liferay.knowledge.base.model.KBArticle;
+import com.liferay.portal.kernel.model.BaseModelListener;
+import com.liferay.portal.kernel.model.ModelListener;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Alicia García
+ */
+@Component(immediate = true, service = ModelListener.class)
+public class KBArticleModelListener extends BaseModelListener<KBArticle> {
+
+	@Override
+	public void onBeforeRemove(KBArticle kbArticle) {
+		AssetDisplayPageEntry assetDisplayPageEntry =
+			_assetDisplayPageEntryLocalService.fetchAssetDisplayPageEntry(
+				kbArticle.getGroupId(),
+				_classNameLocalService.getClassNameId(KBArticle.class),
+				kbArticle.getKbArticleId());
+
+		if (assetDisplayPageEntry != null) {
+			_assetDisplayPageEntryLocalService.deleteAssetDisplayPageEntry(
+				assetDisplayPageEntry);
+		}
+	}
+
+	@Reference
+	private AssetDisplayPageEntryLocalService
+		_assetDisplayPageEntryLocalService;
+
+	@Reference
+	private ClassNameLocalService _classNameLocalService;
+
+}


### PR DESCRIPTION
 ***Step to reproduce:***

1. Enable KB FF
2. Create a display page template for knowledge base articles
3. Add a KB article 
4. Select this added Display page template for this KB article and publish it
5. Delete this KB article
6. Go to Page Templates > Display Page Templates to delete the KB display page template

***Expected Results:***
Able to delete it.

@adolfopa it's another approach from https://github.com/liferay-lima/liferay-portal/pull/3652


- LPS-166740 Delete assetDisplayPageEntry by kbArticleId.
 The asset entry is modified to work with the classPk of the article, but the assetDisplayPageEntry is linked to the articleId (the versioned article) so we need to delete it each time we delete the article.
