### PR TITLE
LPS-166653 Allow same url title for different translations of friendly url

### DIFF
--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/upgrade/v1_1_0/BlogsEntryUpgradeProcess.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/upgrade/v1_1_0/BlogsEntryUpgradeProcess.java
@@ -63,7 +63,7 @@ public class BlogsEntryUpgradeProcess extends UpgradeProcess {
 
 				if (existingFriendlyURLEntry != null) {
 					urlTitle = _friendlyURLEntryLocalService.getUniqueUrlTitle(
-						groupId, classNameId, classPK, urlTitle);
+						groupId, classNameId, classPK, urlTitle, null);
 				}
 
 				urlTitle = _getUniqueUrlTitle(classPK, groupId, urlTitle);

--- a/modules/apps/commerce/commerce-initializer-util/src/main/java/com/liferay/commerce/initializer/util/AssetCategoriesImporter.java
+++ b/modules/apps/commerce/commerce-initializer-util/src/main/java/com/liferay/commerce/initializer/util/AssetCategoriesImporter.java
@@ -309,7 +309,7 @@ public class AssetCategoriesImporter {
 			String urlTitle = _friendlyURLEntryLocalService.getUniqueUrlTitle(
 				companyGroup.getGroupId(),
 				_portal.getClassNameId(AssetCategory.class),
-				assetCategory.getCategoryId(), titleEntry.getValue());
+				assetCategory.getCategoryId(), titleEntry.getValue(), null);
 
 			urlTitleMap.put(
 				LocaleUtil.toLanguageId(titleEntry.getKey()), urlTitle);

--- a/modules/apps/commerce/commerce-product-asset-categories-web/src/main/java/com/liferay/commerce/product/asset/categories/web/internal/portlet/action/EditAssetCategoryFriendlyURLMVCActionCommand.java
+++ b/modules/apps/commerce/commerce-product-asset-categories-web/src/main/java/com/liferay/commerce/product/asset/categories/web/internal/portlet/action/EditAssetCategoryFriendlyURLMVCActionCommand.java
@@ -118,7 +118,7 @@ public class EditAssetCategoryFriendlyURLMVCActionCommand
 
 				urlTitle = _friendlyURLEntryLocalService.getUniqueUrlTitle(
 					assetCategory.getGroupId(), classNameId,
-					assetCategory.getCategoryId(), urlTitle);
+					assetCategory.getCategoryId(), urlTitle, null);
 
 				newUrlTitleMap.put(LocaleUtil.toLanguageId(locale), urlTitle);
 			}

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/model/listener/AssetCategoryModelListener.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/model/listener/AssetCategoryModelListener.java
@@ -91,7 +91,7 @@ public class AssetCategoryModelListener
 			String urlTitle = _friendlyURLEntryLocalService.getUniqueUrlTitle(
 				assetCategory.getGroupId(),
 				_portal.getClassNameId(AssetCategory.class),
-				assetCategory.getCategoryId(), titleEntry.getValue());
+				assetCategory.getCategoryId(), titleEntry.getValue(), null);
 
 			urlTitleMap.put(
 				LocaleUtil.toLanguageId(titleEntry.getKey()), urlTitle);

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPDefinitionLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPDefinitionLocalServiceImpl.java
@@ -2960,7 +2960,7 @@ public class CPDefinitionLocalServiceImpl
 
 				urlTitle = _friendlyURLEntryLocalService.getUniqueUrlTitle(
 					companyGroup.getGroupId(), classNameId,
-					cpDefinition.getCProductId(), titleEntry.getValue());
+					cpDefinition.getCProductId(), titleEntry.getValue(), null);
 
 				newURLTitleMap.put(
 					LocaleUtil.toLanguageId(titleEntry.getKey()), urlTitle);

--- a/modules/apps/friendly-url/friendly-url-api/bnd.bnd
+++ b/modules/apps/friendly-url/friendly-url-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Friendly URL API
 Bundle-SymbolicName: com.liferay.friendly.url.api
-Bundle-Version: 5.1.2
+Bundle-Version: 6.0.0
 Export-Package:\
 	com.liferay.friendly.url.exception,\
 	com.liferay.friendly.url.info.item.provider,\

--- a/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/FriendlyURLEntryLocalService.java
+++ b/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/FriendlyURLEntryLocalService.java
@@ -272,6 +272,10 @@ public interface FriendlyURLEntryLocalService
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public FriendlyURLEntryLocalization fetchFriendlyURLEntryLocalization(
+		long groupId, long classNameId, String languageId, String urlTitle);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public FriendlyURLEntryLocalization fetchFriendlyURLEntryLocalization(
 		long friendlyURLEntryId, String languageId);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
@@ -368,6 +372,11 @@ public interface FriendlyURLEntryLocalService
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public FriendlyURLEntryLocalization getFriendlyURLEntryLocalization(
+			long groupId, long classNameId, String languageId, String urlTitle)
+		throws NoSuchFriendlyURLEntryLocalizationException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public FriendlyURLEntryLocalization getFriendlyURLEntryLocalization(
 			long friendlyURLEntryId, String languageId)
 		throws PortalException;
 
@@ -408,15 +417,6 @@ public interface FriendlyURLEntryLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public PersistedModel getPersistedModel(Serializable primaryKeyObj)
 		throws PortalException;
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 #getUniqueUrlTitle(long, long, long, String, String)}
-	 */
-	@Deprecated
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public String getUniqueUrlTitle(
-		long groupId, long classNameId, long classPK, String urlTitle);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public String getUniqueUrlTitle(
@@ -469,6 +469,11 @@ public interface FriendlyURLEntryLocalService
 
 	public void validate(
 			long groupId, long classNameId, long classPK, String urlTitle)
+		throws PortalException;
+
+	public void validate(
+			long groupId, long classNameId, long classPK, String languageId,
+			String urlTitle)
 		throws PortalException;
 
 	public void validate(long groupId, long classNameId, String urlTitle)

--- a/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/FriendlyURLEntryLocalServiceUtil.java
+++ b/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/FriendlyURLEntryLocalServiceUtil.java
@@ -321,6 +321,15 @@ public class FriendlyURLEntryLocalServiceUtil {
 
 	public static com.liferay.friendly.url.model.FriendlyURLEntryLocalization
 		fetchFriendlyURLEntryLocalization(
+			long groupId, long classNameId, String languageId,
+			String urlTitle) {
+
+		return getService().fetchFriendlyURLEntryLocalization(
+			groupId, classNameId, languageId, urlTitle);
+	}
+
+	public static com.liferay.friendly.url.model.FriendlyURLEntryLocalization
+		fetchFriendlyURLEntryLocalization(
 			long friendlyURLEntryId, String languageId) {
 
 		return getService().fetchFriendlyURLEntryLocalization(
@@ -453,6 +462,17 @@ public class FriendlyURLEntryLocalServiceUtil {
 
 	public static com.liferay.friendly.url.model.FriendlyURLEntryLocalization
 			getFriendlyURLEntryLocalization(
+				long groupId, long classNameId, String languageId,
+				String urlTitle)
+		throws com.liferay.friendly.url.exception.
+			NoSuchFriendlyURLEntryLocalizationException {
+
+		return getService().getFriendlyURLEntryLocalization(
+			groupId, classNameId, languageId, urlTitle);
+	}
+
+	public static com.liferay.friendly.url.model.FriendlyURLEntryLocalization
+			getFriendlyURLEntryLocalization(
 				long friendlyURLEntryId, String languageId)
 		throws PortalException {
 
@@ -519,18 +539,6 @@ public class FriendlyURLEntryLocalServiceUtil {
 		throws PortalException {
 
 		return getService().getPersistedModel(primaryKeyObj);
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 #getUniqueUrlTitle(long, long, long, String, String)}
-	 */
-	@Deprecated
-	public static String getUniqueUrlTitle(
-		long groupId, long classNameId, long classPK, String urlTitle) {
-
-		return getService().getUniqueUrlTitle(
-			groupId, classNameId, classPK, urlTitle);
 	}
 
 	public static String getUniqueUrlTitle(
@@ -625,6 +633,15 @@ public class FriendlyURLEntryLocalServiceUtil {
 		throws PortalException {
 
 		getService().validate(groupId, classNameId, classPK, urlTitle);
+	}
+
+	public static void validate(
+			long groupId, long classNameId, long classPK, String languageId,
+			String urlTitle)
+		throws PortalException {
+
+		getService().validate(
+			groupId, classNameId, classPK, languageId, urlTitle);
 	}
 
 	public static void validate(long groupId, long classNameId, String urlTitle)

--- a/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/FriendlyURLEntryLocalServiceWrapper.java
+++ b/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/FriendlyURLEntryLocalServiceWrapper.java
@@ -357,6 +357,16 @@ public class FriendlyURLEntryLocalServiceWrapper
 	@Override
 	public com.liferay.friendly.url.model.FriendlyURLEntryLocalization
 		fetchFriendlyURLEntryLocalization(
+			long groupId, long classNameId, String languageId,
+			String urlTitle) {
+
+		return _friendlyURLEntryLocalService.fetchFriendlyURLEntryLocalization(
+			groupId, classNameId, languageId, urlTitle);
+	}
+
+	@Override
+	public com.liferay.friendly.url.model.FriendlyURLEntryLocalization
+		fetchFriendlyURLEntryLocalization(
 			long friendlyURLEntryId, String languageId) {
 
 		return _friendlyURLEntryLocalService.fetchFriendlyURLEntryLocalization(
@@ -507,6 +517,18 @@ public class FriendlyURLEntryLocalServiceWrapper
 	@Override
 	public com.liferay.friendly.url.model.FriendlyURLEntryLocalization
 			getFriendlyURLEntryLocalization(
+				long groupId, long classNameId, String languageId,
+				String urlTitle)
+		throws com.liferay.friendly.url.exception.
+			NoSuchFriendlyURLEntryLocalizationException {
+
+		return _friendlyURLEntryLocalService.getFriendlyURLEntryLocalization(
+			groupId, classNameId, languageId, urlTitle);
+	}
+
+	@Override
+	public com.liferay.friendly.url.model.FriendlyURLEntryLocalization
+			getFriendlyURLEntryLocalization(
 				long friendlyURLEntryId, String languageId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
@@ -583,19 +605,6 @@ public class FriendlyURLEntryLocalServiceWrapper
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _friendlyURLEntryLocalService.getPersistedModel(primaryKeyObj);
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 #getUniqueUrlTitle(long, long, long, String, String)}
-	 */
-	@Deprecated
-	@Override
-	public String getUniqueUrlTitle(
-		long groupId, long classNameId, long classPK, String urlTitle) {
-
-		return _friendlyURLEntryLocalService.getUniqueUrlTitle(
-			groupId, classNameId, classPK, urlTitle);
 	}
 
 	@Override
@@ -701,6 +710,16 @@ public class FriendlyURLEntryLocalServiceWrapper
 
 		_friendlyURLEntryLocalService.validate(
 			groupId, classNameId, classPK, urlTitle);
+	}
+
+	@Override
+	public void validate(
+			long groupId, long classNameId, long classPK, String languageId,
+			String urlTitle)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		_friendlyURLEntryLocalService.validate(
+			groupId, classNameId, classPK, languageId, urlTitle);
 	}
 
 	@Override

--- a/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/persistence/FriendlyURLEntryLocalizationPersistence.java
+++ b/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/persistence/FriendlyURLEntryLocalizationPersistence.java
@@ -244,53 +244,161 @@ public interface FriendlyURLEntryLocalizationPersistence
 		long friendlyURLEntryId, String languageId);
 
 	/**
-	 * Returns the friendly url entry localization where groupId = &#63; and classNameId = &#63; and urlTitle = &#63; or throws a <code>NoSuchFriendlyURLEntryLocalizationException</code> if it could not be found.
+	 * Returns all the friendly url entry localizations where groupId = &#63; and classNameId = &#63; and urlTitle = &#63;.
 	 *
 	 * @param groupId the group ID
 	 * @param classNameId the class name ID
 	 * @param urlTitle the url title
-	 * @return the matching friendly url entry localization
-	 * @throws NoSuchFriendlyURLEntryLocalizationException if a matching friendly url entry localization could not be found
+	 * @return the matching friendly url entry localizations
 	 */
-	public FriendlyURLEntryLocalization findByG_C_U(
-			long groupId, long classNameId, String urlTitle)
-		throws NoSuchFriendlyURLEntryLocalizationException;
-
-	/**
-	 * Returns the friendly url entry localization where groupId = &#63; and classNameId = &#63; and urlTitle = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
-	 *
-	 * @param groupId the group ID
-	 * @param classNameId the class name ID
-	 * @param urlTitle the url title
-	 * @return the matching friendly url entry localization, or <code>null</code> if a matching friendly url entry localization could not be found
-	 */
-	public FriendlyURLEntryLocalization fetchByG_C_U(
+	public java.util.List<FriendlyURLEntryLocalization> findByG_C_U(
 		long groupId, long classNameId, String urlTitle);
 
 	/**
-	 * Returns the friendly url entry localization where groupId = &#63; and classNameId = &#63; and urlTitle = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns a range of all the friendly url entry localizations where groupId = &#63; and classNameId = &#63; and urlTitle = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>FriendlyURLEntryLocalizationModelImpl</code>.
+	 * </p>
 	 *
 	 * @param groupId the group ID
 	 * @param classNameId the class name ID
 	 * @param urlTitle the url title
-	 * @param useFinderCache whether to use the finder cache
-	 * @return the matching friendly url entry localization, or <code>null</code> if a matching friendly url entry localization could not be found
+	 * @param start the lower bound of the range of friendly url entry localizations
+	 * @param end the upper bound of the range of friendly url entry localizations (not inclusive)
+	 * @return the range of matching friendly url entry localizations
 	 */
-	public FriendlyURLEntryLocalization fetchByG_C_U(
-		long groupId, long classNameId, String urlTitle,
+	public java.util.List<FriendlyURLEntryLocalization> findByG_C_U(
+		long groupId, long classNameId, String urlTitle, int start, int end);
+
+	/**
+	 * Returns an ordered range of all the friendly url entry localizations where groupId = &#63; and classNameId = &#63; and urlTitle = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>FriendlyURLEntryLocalizationModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param urlTitle the url title
+	 * @param start the lower bound of the range of friendly url entry localizations
+	 * @param end the upper bound of the range of friendly url entry localizations (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching friendly url entry localizations
+	 */
+	public java.util.List<FriendlyURLEntryLocalization> findByG_C_U(
+		long groupId, long classNameId, String urlTitle, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator
+			<FriendlyURLEntryLocalization> orderByComparator);
+
+	/**
+	 * Returns an ordered range of all the friendly url entry localizations where groupId = &#63; and classNameId = &#63; and urlTitle = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>FriendlyURLEntryLocalizationModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param urlTitle the url title
+	 * @param start the lower bound of the range of friendly url entry localizations
+	 * @param end the upper bound of the range of friendly url entry localizations (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching friendly url entry localizations
+	 */
+	public java.util.List<FriendlyURLEntryLocalization> findByG_C_U(
+		long groupId, long classNameId, String urlTitle, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator
+			<FriendlyURLEntryLocalization> orderByComparator,
 		boolean useFinderCache);
 
 	/**
-	 * Removes the friendly url entry localization where groupId = &#63; and classNameId = &#63; and urlTitle = &#63; from the database.
+	 * Returns the first friendly url entry localization in the ordered set where groupId = &#63; and classNameId = &#63; and urlTitle = &#63;.
 	 *
 	 * @param groupId the group ID
 	 * @param classNameId the class name ID
 	 * @param urlTitle the url title
-	 * @return the friendly url entry localization that was removed
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching friendly url entry localization
+	 * @throws NoSuchFriendlyURLEntryLocalizationException if a matching friendly url entry localization could not be found
 	 */
-	public FriendlyURLEntryLocalization removeByG_C_U(
-			long groupId, long classNameId, String urlTitle)
+	public FriendlyURLEntryLocalization findByG_C_U_First(
+			long groupId, long classNameId, String urlTitle,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<FriendlyURLEntryLocalization> orderByComparator)
 		throws NoSuchFriendlyURLEntryLocalizationException;
+
+	/**
+	 * Returns the first friendly url entry localization in the ordered set where groupId = &#63; and classNameId = &#63; and urlTitle = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param urlTitle the url title
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching friendly url entry localization, or <code>null</code> if a matching friendly url entry localization could not be found
+	 */
+	public FriendlyURLEntryLocalization fetchByG_C_U_First(
+		long groupId, long classNameId, String urlTitle,
+		com.liferay.portal.kernel.util.OrderByComparator
+			<FriendlyURLEntryLocalization> orderByComparator);
+
+	/**
+	 * Returns the last friendly url entry localization in the ordered set where groupId = &#63; and classNameId = &#63; and urlTitle = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param urlTitle the url title
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching friendly url entry localization
+	 * @throws NoSuchFriendlyURLEntryLocalizationException if a matching friendly url entry localization could not be found
+	 */
+	public FriendlyURLEntryLocalization findByG_C_U_Last(
+			long groupId, long classNameId, String urlTitle,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<FriendlyURLEntryLocalization> orderByComparator)
+		throws NoSuchFriendlyURLEntryLocalizationException;
+
+	/**
+	 * Returns the last friendly url entry localization in the ordered set where groupId = &#63; and classNameId = &#63; and urlTitle = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param urlTitle the url title
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching friendly url entry localization, or <code>null</code> if a matching friendly url entry localization could not be found
+	 */
+	public FriendlyURLEntryLocalization fetchByG_C_U_Last(
+		long groupId, long classNameId, String urlTitle,
+		com.liferay.portal.kernel.util.OrderByComparator
+			<FriendlyURLEntryLocalization> orderByComparator);
+
+	/**
+	 * Returns the friendly url entry localizations before and after the current friendly url entry localization in the ordered set where groupId = &#63; and classNameId = &#63; and urlTitle = &#63;.
+	 *
+	 * @param friendlyURLEntryLocalizationId the primary key of the current friendly url entry localization
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param urlTitle the url title
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next friendly url entry localization
+	 * @throws NoSuchFriendlyURLEntryLocalizationException if a friendly url entry localization with the primary key could not be found
+	 */
+	public FriendlyURLEntryLocalization[] findByG_C_U_PrevAndNext(
+			long friendlyURLEntryLocalizationId, long groupId, long classNameId,
+			String urlTitle,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<FriendlyURLEntryLocalization> orderByComparator)
+		throws NoSuchFriendlyURLEntryLocalizationException;
+
+	/**
+	 * Removes all the friendly url entry localizations where groupId = &#63; and classNameId = &#63; and urlTitle = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param urlTitle the url title
+	 */
+	public void removeByG_C_U(long groupId, long classNameId, String urlTitle);
 
 	/**
 	 * Returns the number of friendly url entry localizations where groupId = &#63; and classNameId = &#63; and urlTitle = &#63;.
@@ -484,6 +592,254 @@ public interface FriendlyURLEntryLocalizationPersistence
 	 */
 	public int countByG_C_C_L(
 		long groupId, long classNameId, long classPK, String languageId);
+
+	/**
+	 * Returns the friendly url entry localization where groupId = &#63; and classNameId = &#63; and languageId = &#63; and urlTitle = &#63; or throws a <code>NoSuchFriendlyURLEntryLocalizationException</code> if it could not be found.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param languageId the language ID
+	 * @param urlTitle the url title
+	 * @return the matching friendly url entry localization
+	 * @throws NoSuchFriendlyURLEntryLocalizationException if a matching friendly url entry localization could not be found
+	 */
+	public FriendlyURLEntryLocalization findByG_C_L_U(
+			long groupId, long classNameId, String languageId, String urlTitle)
+		throws NoSuchFriendlyURLEntryLocalizationException;
+
+	/**
+	 * Returns the friendly url entry localization where groupId = &#63; and classNameId = &#63; and languageId = &#63; and urlTitle = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param languageId the language ID
+	 * @param urlTitle the url title
+	 * @return the matching friendly url entry localization, or <code>null</code> if a matching friendly url entry localization could not be found
+	 */
+	public FriendlyURLEntryLocalization fetchByG_C_L_U(
+		long groupId, long classNameId, String languageId, String urlTitle);
+
+	/**
+	 * Returns the friendly url entry localization where groupId = &#63; and classNameId = &#63; and languageId = &#63; and urlTitle = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param languageId the language ID
+	 * @param urlTitle the url title
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the matching friendly url entry localization, or <code>null</code> if a matching friendly url entry localization could not be found
+	 */
+	public FriendlyURLEntryLocalization fetchByG_C_L_U(
+		long groupId, long classNameId, String languageId, String urlTitle,
+		boolean useFinderCache);
+
+	/**
+	 * Removes the friendly url entry localization where groupId = &#63; and classNameId = &#63; and languageId = &#63; and urlTitle = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param languageId the language ID
+	 * @param urlTitle the url title
+	 * @return the friendly url entry localization that was removed
+	 */
+	public FriendlyURLEntryLocalization removeByG_C_L_U(
+			long groupId, long classNameId, String languageId, String urlTitle)
+		throws NoSuchFriendlyURLEntryLocalizationException;
+
+	/**
+	 * Returns the number of friendly url entry localizations where groupId = &#63; and classNameId = &#63; and languageId = &#63; and urlTitle = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param languageId the language ID
+	 * @param urlTitle the url title
+	 * @return the number of matching friendly url entry localizations
+	 */
+	public int countByG_C_L_U(
+		long groupId, long classNameId, String languageId, String urlTitle);
+
+	/**
+	 * Returns all the friendly url entry localizations where groupId = &#63; and classNameId = &#63; and languageId &ne; &#63; and urlTitle = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param languageId the language ID
+	 * @param urlTitle the url title
+	 * @return the matching friendly url entry localizations
+	 */
+	public java.util.List<FriendlyURLEntryLocalization> findByG_C_NotL_U(
+		long groupId, long classNameId, String languageId, String urlTitle);
+
+	/**
+	 * Returns a range of all the friendly url entry localizations where groupId = &#63; and classNameId = &#63; and languageId &ne; &#63; and urlTitle = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>FriendlyURLEntryLocalizationModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param languageId the language ID
+	 * @param urlTitle the url title
+	 * @param start the lower bound of the range of friendly url entry localizations
+	 * @param end the upper bound of the range of friendly url entry localizations (not inclusive)
+	 * @return the range of matching friendly url entry localizations
+	 */
+	public java.util.List<FriendlyURLEntryLocalization> findByG_C_NotL_U(
+		long groupId, long classNameId, String languageId, String urlTitle,
+		int start, int end);
+
+	/**
+	 * Returns an ordered range of all the friendly url entry localizations where groupId = &#63; and classNameId = &#63; and languageId &ne; &#63; and urlTitle = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>FriendlyURLEntryLocalizationModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param languageId the language ID
+	 * @param urlTitle the url title
+	 * @param start the lower bound of the range of friendly url entry localizations
+	 * @param end the upper bound of the range of friendly url entry localizations (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching friendly url entry localizations
+	 */
+	public java.util.List<FriendlyURLEntryLocalization> findByG_C_NotL_U(
+		long groupId, long classNameId, String languageId, String urlTitle,
+		int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator
+			<FriendlyURLEntryLocalization> orderByComparator);
+
+	/**
+	 * Returns an ordered range of all the friendly url entry localizations where groupId = &#63; and classNameId = &#63; and languageId &ne; &#63; and urlTitle = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>FriendlyURLEntryLocalizationModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param languageId the language ID
+	 * @param urlTitle the url title
+	 * @param start the lower bound of the range of friendly url entry localizations
+	 * @param end the upper bound of the range of friendly url entry localizations (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching friendly url entry localizations
+	 */
+	public java.util.List<FriendlyURLEntryLocalization> findByG_C_NotL_U(
+		long groupId, long classNameId, String languageId, String urlTitle,
+		int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator
+			<FriendlyURLEntryLocalization> orderByComparator,
+		boolean useFinderCache);
+
+	/**
+	 * Returns the first friendly url entry localization in the ordered set where groupId = &#63; and classNameId = &#63; and languageId &ne; &#63; and urlTitle = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param languageId the language ID
+	 * @param urlTitle the url title
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching friendly url entry localization
+	 * @throws NoSuchFriendlyURLEntryLocalizationException if a matching friendly url entry localization could not be found
+	 */
+	public FriendlyURLEntryLocalization findByG_C_NotL_U_First(
+			long groupId, long classNameId, String languageId, String urlTitle,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<FriendlyURLEntryLocalization> orderByComparator)
+		throws NoSuchFriendlyURLEntryLocalizationException;
+
+	/**
+	 * Returns the first friendly url entry localization in the ordered set where groupId = &#63; and classNameId = &#63; and languageId &ne; &#63; and urlTitle = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param languageId the language ID
+	 * @param urlTitle the url title
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching friendly url entry localization, or <code>null</code> if a matching friendly url entry localization could not be found
+	 */
+	public FriendlyURLEntryLocalization fetchByG_C_NotL_U_First(
+		long groupId, long classNameId, String languageId, String urlTitle,
+		com.liferay.portal.kernel.util.OrderByComparator
+			<FriendlyURLEntryLocalization> orderByComparator);
+
+	/**
+	 * Returns the last friendly url entry localization in the ordered set where groupId = &#63; and classNameId = &#63; and languageId &ne; &#63; and urlTitle = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param languageId the language ID
+	 * @param urlTitle the url title
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching friendly url entry localization
+	 * @throws NoSuchFriendlyURLEntryLocalizationException if a matching friendly url entry localization could not be found
+	 */
+	public FriendlyURLEntryLocalization findByG_C_NotL_U_Last(
+			long groupId, long classNameId, String languageId, String urlTitle,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<FriendlyURLEntryLocalization> orderByComparator)
+		throws NoSuchFriendlyURLEntryLocalizationException;
+
+	/**
+	 * Returns the last friendly url entry localization in the ordered set where groupId = &#63; and classNameId = &#63; and languageId &ne; &#63; and urlTitle = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param languageId the language ID
+	 * @param urlTitle the url title
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching friendly url entry localization, or <code>null</code> if a matching friendly url entry localization could not be found
+	 */
+	public FriendlyURLEntryLocalization fetchByG_C_NotL_U_Last(
+		long groupId, long classNameId, String languageId, String urlTitle,
+		com.liferay.portal.kernel.util.OrderByComparator
+			<FriendlyURLEntryLocalization> orderByComparator);
+
+	/**
+	 * Returns the friendly url entry localizations before and after the current friendly url entry localization in the ordered set where groupId = &#63; and classNameId = &#63; and languageId &ne; &#63; and urlTitle = &#63;.
+	 *
+	 * @param friendlyURLEntryLocalizationId the primary key of the current friendly url entry localization
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param languageId the language ID
+	 * @param urlTitle the url title
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next friendly url entry localization
+	 * @throws NoSuchFriendlyURLEntryLocalizationException if a friendly url entry localization with the primary key could not be found
+	 */
+	public FriendlyURLEntryLocalization[] findByG_C_NotL_U_PrevAndNext(
+			long friendlyURLEntryLocalizationId, long groupId, long classNameId,
+			String languageId, String urlTitle,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<FriendlyURLEntryLocalization> orderByComparator)
+		throws NoSuchFriendlyURLEntryLocalizationException;
+
+	/**
+	 * Removes all the friendly url entry localizations where groupId = &#63; and classNameId = &#63; and languageId &ne; &#63; and urlTitle = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param languageId the language ID
+	 * @param urlTitle the url title
+	 */
+	public void removeByG_C_NotL_U(
+		long groupId, long classNameId, String languageId, String urlTitle);
+
+	/**
+	 * Returns the number of friendly url entry localizations where groupId = &#63; and classNameId = &#63; and languageId &ne; &#63; and urlTitle = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param languageId the language ID
+	 * @param urlTitle the url title
+	 * @return the number of matching friendly url entry localizations
+	 */
+	public int countByG_C_NotL_U(
+		long groupId, long classNameId, String languageId, String urlTitle);
 
 	/**
 	 * Caches the friendly url entry localization in the entity cache if it is enabled.

--- a/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/persistence/FriendlyURLEntryLocalizationUtil.java
+++ b/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/persistence/FriendlyURLEntryLocalizationUtil.java
@@ -389,67 +389,197 @@ public class FriendlyURLEntryLocalizationUtil {
 	}
 
 	/**
-	 * Returns the friendly url entry localization where groupId = &#63; and classNameId = &#63; and urlTitle = &#63; or throws a <code>NoSuchFriendlyURLEntryLocalizationException</code> if it could not be found.
+	 * Returns all the friendly url entry localizations where groupId = &#63; and classNameId = &#63; and urlTitle = &#63;.
 	 *
 	 * @param groupId the group ID
 	 * @param classNameId the class name ID
 	 * @param urlTitle the url title
-	 * @return the matching friendly url entry localization
-	 * @throws NoSuchFriendlyURLEntryLocalizationException if a matching friendly url entry localization could not be found
+	 * @return the matching friendly url entry localizations
 	 */
-	public static FriendlyURLEntryLocalization findByG_C_U(
-			long groupId, long classNameId, String urlTitle)
-		throws com.liferay.friendly.url.exception.
-			NoSuchFriendlyURLEntryLocalizationException {
+	public static List<FriendlyURLEntryLocalization> findByG_C_U(
+		long groupId, long classNameId, String urlTitle) {
 
 		return getPersistence().findByG_C_U(groupId, classNameId, urlTitle);
 	}
 
 	/**
-	 * Returns the friendly url entry localization where groupId = &#63; and classNameId = &#63; and urlTitle = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns a range of all the friendly url entry localizations where groupId = &#63; and classNameId = &#63; and urlTitle = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>FriendlyURLEntryLocalizationModelImpl</code>.
+	 * </p>
 	 *
 	 * @param groupId the group ID
 	 * @param classNameId the class name ID
 	 * @param urlTitle the url title
-	 * @return the matching friendly url entry localization, or <code>null</code> if a matching friendly url entry localization could not be found
+	 * @param start the lower bound of the range of friendly url entry localizations
+	 * @param end the upper bound of the range of friendly url entry localizations (not inclusive)
+	 * @return the range of matching friendly url entry localizations
 	 */
-	public static FriendlyURLEntryLocalization fetchByG_C_U(
-		long groupId, long classNameId, String urlTitle) {
+	public static List<FriendlyURLEntryLocalization> findByG_C_U(
+		long groupId, long classNameId, String urlTitle, int start, int end) {
 
-		return getPersistence().fetchByG_C_U(groupId, classNameId, urlTitle);
+		return getPersistence().findByG_C_U(
+			groupId, classNameId, urlTitle, start, end);
 	}
 
 	/**
-	 * Returns the friendly url entry localization where groupId = &#63; and classNameId = &#63; and urlTitle = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns an ordered range of all the friendly url entry localizations where groupId = &#63; and classNameId = &#63; and urlTitle = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>FriendlyURLEntryLocalizationModelImpl</code>.
+	 * </p>
 	 *
 	 * @param groupId the group ID
 	 * @param classNameId the class name ID
 	 * @param urlTitle the url title
-	 * @param useFinderCache whether to use the finder cache
-	 * @return the matching friendly url entry localization, or <code>null</code> if a matching friendly url entry localization could not be found
+	 * @param start the lower bound of the range of friendly url entry localizations
+	 * @param end the upper bound of the range of friendly url entry localizations (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching friendly url entry localizations
 	 */
-	public static FriendlyURLEntryLocalization fetchByG_C_U(
-		long groupId, long classNameId, String urlTitle,
+	public static List<FriendlyURLEntryLocalization> findByG_C_U(
+		long groupId, long classNameId, String urlTitle, int start, int end,
+		OrderByComparator<FriendlyURLEntryLocalization> orderByComparator) {
+
+		return getPersistence().findByG_C_U(
+			groupId, classNameId, urlTitle, start, end, orderByComparator);
+	}
+
+	/**
+	 * Returns an ordered range of all the friendly url entry localizations where groupId = &#63; and classNameId = &#63; and urlTitle = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>FriendlyURLEntryLocalizationModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param urlTitle the url title
+	 * @param start the lower bound of the range of friendly url entry localizations
+	 * @param end the upper bound of the range of friendly url entry localizations (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching friendly url entry localizations
+	 */
+	public static List<FriendlyURLEntryLocalization> findByG_C_U(
+		long groupId, long classNameId, String urlTitle, int start, int end,
+		OrderByComparator<FriendlyURLEntryLocalization> orderByComparator,
 		boolean useFinderCache) {
 
-		return getPersistence().fetchByG_C_U(
-			groupId, classNameId, urlTitle, useFinderCache);
+		return getPersistence().findByG_C_U(
+			groupId, classNameId, urlTitle, start, end, orderByComparator,
+			useFinderCache);
 	}
 
 	/**
-	 * Removes the friendly url entry localization where groupId = &#63; and classNameId = &#63; and urlTitle = &#63; from the database.
+	 * Returns the first friendly url entry localization in the ordered set where groupId = &#63; and classNameId = &#63; and urlTitle = &#63;.
 	 *
 	 * @param groupId the group ID
 	 * @param classNameId the class name ID
 	 * @param urlTitle the url title
-	 * @return the friendly url entry localization that was removed
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching friendly url entry localization
+	 * @throws NoSuchFriendlyURLEntryLocalizationException if a matching friendly url entry localization could not be found
 	 */
-	public static FriendlyURLEntryLocalization removeByG_C_U(
-			long groupId, long classNameId, String urlTitle)
+	public static FriendlyURLEntryLocalization findByG_C_U_First(
+			long groupId, long classNameId, String urlTitle,
+			OrderByComparator<FriendlyURLEntryLocalization> orderByComparator)
 		throws com.liferay.friendly.url.exception.
 			NoSuchFriendlyURLEntryLocalizationException {
 
-		return getPersistence().removeByG_C_U(groupId, classNameId, urlTitle);
+		return getPersistence().findByG_C_U_First(
+			groupId, classNameId, urlTitle, orderByComparator);
+	}
+
+	/**
+	 * Returns the first friendly url entry localization in the ordered set where groupId = &#63; and classNameId = &#63; and urlTitle = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param urlTitle the url title
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching friendly url entry localization, or <code>null</code> if a matching friendly url entry localization could not be found
+	 */
+	public static FriendlyURLEntryLocalization fetchByG_C_U_First(
+		long groupId, long classNameId, String urlTitle,
+		OrderByComparator<FriendlyURLEntryLocalization> orderByComparator) {
+
+		return getPersistence().fetchByG_C_U_First(
+			groupId, classNameId, urlTitle, orderByComparator);
+	}
+
+	/**
+	 * Returns the last friendly url entry localization in the ordered set where groupId = &#63; and classNameId = &#63; and urlTitle = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param urlTitle the url title
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching friendly url entry localization
+	 * @throws NoSuchFriendlyURLEntryLocalizationException if a matching friendly url entry localization could not be found
+	 */
+	public static FriendlyURLEntryLocalization findByG_C_U_Last(
+			long groupId, long classNameId, String urlTitle,
+			OrderByComparator<FriendlyURLEntryLocalization> orderByComparator)
+		throws com.liferay.friendly.url.exception.
+			NoSuchFriendlyURLEntryLocalizationException {
+
+		return getPersistence().findByG_C_U_Last(
+			groupId, classNameId, urlTitle, orderByComparator);
+	}
+
+	/**
+	 * Returns the last friendly url entry localization in the ordered set where groupId = &#63; and classNameId = &#63; and urlTitle = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param urlTitle the url title
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching friendly url entry localization, or <code>null</code> if a matching friendly url entry localization could not be found
+	 */
+	public static FriendlyURLEntryLocalization fetchByG_C_U_Last(
+		long groupId, long classNameId, String urlTitle,
+		OrderByComparator<FriendlyURLEntryLocalization> orderByComparator) {
+
+		return getPersistence().fetchByG_C_U_Last(
+			groupId, classNameId, urlTitle, orderByComparator);
+	}
+
+	/**
+	 * Returns the friendly url entry localizations before and after the current friendly url entry localization in the ordered set where groupId = &#63; and classNameId = &#63; and urlTitle = &#63;.
+	 *
+	 * @param friendlyURLEntryLocalizationId the primary key of the current friendly url entry localization
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param urlTitle the url title
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next friendly url entry localization
+	 * @throws NoSuchFriendlyURLEntryLocalizationException if a friendly url entry localization with the primary key could not be found
+	 */
+	public static FriendlyURLEntryLocalization[] findByG_C_U_PrevAndNext(
+			long friendlyURLEntryLocalizationId, long groupId, long classNameId,
+			String urlTitle,
+			OrderByComparator<FriendlyURLEntryLocalization> orderByComparator)
+		throws com.liferay.friendly.url.exception.
+			NoSuchFriendlyURLEntryLocalizationException {
+
+		return getPersistence().findByG_C_U_PrevAndNext(
+			friendlyURLEntryLocalizationId, groupId, classNameId, urlTitle,
+			orderByComparator);
+	}
+
+	/**
+	 * Removes all the friendly url entry localizations where groupId = &#63; and classNameId = &#63; and urlTitle = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param urlTitle the url title
+	 */
+	public static void removeByG_C_U(
+		long groupId, long classNameId, String urlTitle) {
+
+		getPersistence().removeByG_C_U(groupId, classNameId, urlTitle);
 	}
 
 	/**
@@ -690,6 +820,319 @@ public class FriendlyURLEntryLocalizationUtil {
 
 		return getPersistence().countByG_C_C_L(
 			groupId, classNameId, classPK, languageId);
+	}
+
+	/**
+	 * Returns the friendly url entry localization where groupId = &#63; and classNameId = &#63; and languageId = &#63; and urlTitle = &#63; or throws a <code>NoSuchFriendlyURLEntryLocalizationException</code> if it could not be found.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param languageId the language ID
+	 * @param urlTitle the url title
+	 * @return the matching friendly url entry localization
+	 * @throws NoSuchFriendlyURLEntryLocalizationException if a matching friendly url entry localization could not be found
+	 */
+	public static FriendlyURLEntryLocalization findByG_C_L_U(
+			long groupId, long classNameId, String languageId, String urlTitle)
+		throws com.liferay.friendly.url.exception.
+			NoSuchFriendlyURLEntryLocalizationException {
+
+		return getPersistence().findByG_C_L_U(
+			groupId, classNameId, languageId, urlTitle);
+	}
+
+	/**
+	 * Returns the friendly url entry localization where groupId = &#63; and classNameId = &#63; and languageId = &#63; and urlTitle = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param languageId the language ID
+	 * @param urlTitle the url title
+	 * @return the matching friendly url entry localization, or <code>null</code> if a matching friendly url entry localization could not be found
+	 */
+	public static FriendlyURLEntryLocalization fetchByG_C_L_U(
+		long groupId, long classNameId, String languageId, String urlTitle) {
+
+		return getPersistence().fetchByG_C_L_U(
+			groupId, classNameId, languageId, urlTitle);
+	}
+
+	/**
+	 * Returns the friendly url entry localization where groupId = &#63; and classNameId = &#63; and languageId = &#63; and urlTitle = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param languageId the language ID
+	 * @param urlTitle the url title
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the matching friendly url entry localization, or <code>null</code> if a matching friendly url entry localization could not be found
+	 */
+	public static FriendlyURLEntryLocalization fetchByG_C_L_U(
+		long groupId, long classNameId, String languageId, String urlTitle,
+		boolean useFinderCache) {
+
+		return getPersistence().fetchByG_C_L_U(
+			groupId, classNameId, languageId, urlTitle, useFinderCache);
+	}
+
+	/**
+	 * Removes the friendly url entry localization where groupId = &#63; and classNameId = &#63; and languageId = &#63; and urlTitle = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param languageId the language ID
+	 * @param urlTitle the url title
+	 * @return the friendly url entry localization that was removed
+	 */
+	public static FriendlyURLEntryLocalization removeByG_C_L_U(
+			long groupId, long classNameId, String languageId, String urlTitle)
+		throws com.liferay.friendly.url.exception.
+			NoSuchFriendlyURLEntryLocalizationException {
+
+		return getPersistence().removeByG_C_L_U(
+			groupId, classNameId, languageId, urlTitle);
+	}
+
+	/**
+	 * Returns the number of friendly url entry localizations where groupId = &#63; and classNameId = &#63; and languageId = &#63; and urlTitle = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param languageId the language ID
+	 * @param urlTitle the url title
+	 * @return the number of matching friendly url entry localizations
+	 */
+	public static int countByG_C_L_U(
+		long groupId, long classNameId, String languageId, String urlTitle) {
+
+		return getPersistence().countByG_C_L_U(
+			groupId, classNameId, languageId, urlTitle);
+	}
+
+	/**
+	 * Returns all the friendly url entry localizations where groupId = &#63; and classNameId = &#63; and languageId &ne; &#63; and urlTitle = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param languageId the language ID
+	 * @param urlTitle the url title
+	 * @return the matching friendly url entry localizations
+	 */
+	public static List<FriendlyURLEntryLocalization> findByG_C_NotL_U(
+		long groupId, long classNameId, String languageId, String urlTitle) {
+
+		return getPersistence().findByG_C_NotL_U(
+			groupId, classNameId, languageId, urlTitle);
+	}
+
+	/**
+	 * Returns a range of all the friendly url entry localizations where groupId = &#63; and classNameId = &#63; and languageId &ne; &#63; and urlTitle = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>FriendlyURLEntryLocalizationModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param languageId the language ID
+	 * @param urlTitle the url title
+	 * @param start the lower bound of the range of friendly url entry localizations
+	 * @param end the upper bound of the range of friendly url entry localizations (not inclusive)
+	 * @return the range of matching friendly url entry localizations
+	 */
+	public static List<FriendlyURLEntryLocalization> findByG_C_NotL_U(
+		long groupId, long classNameId, String languageId, String urlTitle,
+		int start, int end) {
+
+		return getPersistence().findByG_C_NotL_U(
+			groupId, classNameId, languageId, urlTitle, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the friendly url entry localizations where groupId = &#63; and classNameId = &#63; and languageId &ne; &#63; and urlTitle = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>FriendlyURLEntryLocalizationModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param languageId the language ID
+	 * @param urlTitle the url title
+	 * @param start the lower bound of the range of friendly url entry localizations
+	 * @param end the upper bound of the range of friendly url entry localizations (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching friendly url entry localizations
+	 */
+	public static List<FriendlyURLEntryLocalization> findByG_C_NotL_U(
+		long groupId, long classNameId, String languageId, String urlTitle,
+		int start, int end,
+		OrderByComparator<FriendlyURLEntryLocalization> orderByComparator) {
+
+		return getPersistence().findByG_C_NotL_U(
+			groupId, classNameId, languageId, urlTitle, start, end,
+			orderByComparator);
+	}
+
+	/**
+	 * Returns an ordered range of all the friendly url entry localizations where groupId = &#63; and classNameId = &#63; and languageId &ne; &#63; and urlTitle = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>FriendlyURLEntryLocalizationModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param languageId the language ID
+	 * @param urlTitle the url title
+	 * @param start the lower bound of the range of friendly url entry localizations
+	 * @param end the upper bound of the range of friendly url entry localizations (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching friendly url entry localizations
+	 */
+	public static List<FriendlyURLEntryLocalization> findByG_C_NotL_U(
+		long groupId, long classNameId, String languageId, String urlTitle,
+		int start, int end,
+		OrderByComparator<FriendlyURLEntryLocalization> orderByComparator,
+		boolean useFinderCache) {
+
+		return getPersistence().findByG_C_NotL_U(
+			groupId, classNameId, languageId, urlTitle, start, end,
+			orderByComparator, useFinderCache);
+	}
+
+	/**
+	 * Returns the first friendly url entry localization in the ordered set where groupId = &#63; and classNameId = &#63; and languageId &ne; &#63; and urlTitle = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param languageId the language ID
+	 * @param urlTitle the url title
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching friendly url entry localization
+	 * @throws NoSuchFriendlyURLEntryLocalizationException if a matching friendly url entry localization could not be found
+	 */
+	public static FriendlyURLEntryLocalization findByG_C_NotL_U_First(
+			long groupId, long classNameId, String languageId, String urlTitle,
+			OrderByComparator<FriendlyURLEntryLocalization> orderByComparator)
+		throws com.liferay.friendly.url.exception.
+			NoSuchFriendlyURLEntryLocalizationException {
+
+		return getPersistence().findByG_C_NotL_U_First(
+			groupId, classNameId, languageId, urlTitle, orderByComparator);
+	}
+
+	/**
+	 * Returns the first friendly url entry localization in the ordered set where groupId = &#63; and classNameId = &#63; and languageId &ne; &#63; and urlTitle = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param languageId the language ID
+	 * @param urlTitle the url title
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching friendly url entry localization, or <code>null</code> if a matching friendly url entry localization could not be found
+	 */
+	public static FriendlyURLEntryLocalization fetchByG_C_NotL_U_First(
+		long groupId, long classNameId, String languageId, String urlTitle,
+		OrderByComparator<FriendlyURLEntryLocalization> orderByComparator) {
+
+		return getPersistence().fetchByG_C_NotL_U_First(
+			groupId, classNameId, languageId, urlTitle, orderByComparator);
+	}
+
+	/**
+	 * Returns the last friendly url entry localization in the ordered set where groupId = &#63; and classNameId = &#63; and languageId &ne; &#63; and urlTitle = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param languageId the language ID
+	 * @param urlTitle the url title
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching friendly url entry localization
+	 * @throws NoSuchFriendlyURLEntryLocalizationException if a matching friendly url entry localization could not be found
+	 */
+	public static FriendlyURLEntryLocalization findByG_C_NotL_U_Last(
+			long groupId, long classNameId, String languageId, String urlTitle,
+			OrderByComparator<FriendlyURLEntryLocalization> orderByComparator)
+		throws com.liferay.friendly.url.exception.
+			NoSuchFriendlyURLEntryLocalizationException {
+
+		return getPersistence().findByG_C_NotL_U_Last(
+			groupId, classNameId, languageId, urlTitle, orderByComparator);
+	}
+
+	/**
+	 * Returns the last friendly url entry localization in the ordered set where groupId = &#63; and classNameId = &#63; and languageId &ne; &#63; and urlTitle = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param languageId the language ID
+	 * @param urlTitle the url title
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching friendly url entry localization, or <code>null</code> if a matching friendly url entry localization could not be found
+	 */
+	public static FriendlyURLEntryLocalization fetchByG_C_NotL_U_Last(
+		long groupId, long classNameId, String languageId, String urlTitle,
+		OrderByComparator<FriendlyURLEntryLocalization> orderByComparator) {
+
+		return getPersistence().fetchByG_C_NotL_U_Last(
+			groupId, classNameId, languageId, urlTitle, orderByComparator);
+	}
+
+	/**
+	 * Returns the friendly url entry localizations before and after the current friendly url entry localization in the ordered set where groupId = &#63; and classNameId = &#63; and languageId &ne; &#63; and urlTitle = &#63;.
+	 *
+	 * @param friendlyURLEntryLocalizationId the primary key of the current friendly url entry localization
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param languageId the language ID
+	 * @param urlTitle the url title
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next friendly url entry localization
+	 * @throws NoSuchFriendlyURLEntryLocalizationException if a friendly url entry localization with the primary key could not be found
+	 */
+	public static FriendlyURLEntryLocalization[] findByG_C_NotL_U_PrevAndNext(
+			long friendlyURLEntryLocalizationId, long groupId, long classNameId,
+			String languageId, String urlTitle,
+			OrderByComparator<FriendlyURLEntryLocalization> orderByComparator)
+		throws com.liferay.friendly.url.exception.
+			NoSuchFriendlyURLEntryLocalizationException {
+
+		return getPersistence().findByG_C_NotL_U_PrevAndNext(
+			friendlyURLEntryLocalizationId, groupId, classNameId, languageId,
+			urlTitle, orderByComparator);
+	}
+
+	/**
+	 * Removes all the friendly url entry localizations where groupId = &#63; and classNameId = &#63; and languageId &ne; &#63; and urlTitle = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param languageId the language ID
+	 * @param urlTitle the url title
+	 */
+	public static void removeByG_C_NotL_U(
+		long groupId, long classNameId, String languageId, String urlTitle) {
+
+		getPersistence().removeByG_C_NotL_U(
+			groupId, classNameId, languageId, urlTitle);
+	}
+
+	/**
+	 * Returns the number of friendly url entry localizations where groupId = &#63; and classNameId = &#63; and languageId &ne; &#63; and urlTitle = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param languageId the language ID
+	 * @param urlTitle the url title
+	 * @return the number of matching friendly url entry localizations
+	 */
+	public static int countByG_C_NotL_U(
+		long groupId, long classNameId, String languageId, String urlTitle) {
+
+		return getPersistence().countByG_C_NotL_U(
+			groupId, classNameId, languageId, urlTitle);
 	}
 
 	/**

--- a/modules/apps/friendly-url/friendly-url-api/src/main/resources/com/liferay/friendly/url/service/packageinfo
+++ b/modules/apps/friendly-url/friendly-url-api/src/main/resources/com/liferay/friendly/url/service/packageinfo
@@ -1,1 +1,1 @@
-version 1.6.0
+version 2.0.0

--- a/modules/apps/friendly-url/friendly-url-api/src/main/resources/com/liferay/friendly/url/service/persistence/packageinfo
+++ b/modules/apps/friendly-url/friendly-url-api/src/main/resources/com/liferay/friendly/url/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 3.1.0
+version 4.0.0

--- a/modules/apps/friendly-url/friendly-url-service/bnd.bnd
+++ b/modules/apps/friendly-url/friendly-url-service/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Friendly URL Service
 Bundle-SymbolicName: com.liferay.friendly.url.service
 Bundle-Version: 4.0.49
-Liferay-Require-SchemaVersion: 3.1.1
+Liferay-Require-SchemaVersion: 3.2.0
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/friendly-url/friendly-url-service/service.xml
+++ b/modules/apps/friendly-url/friendly-url-service/service.xml
@@ -34,7 +34,7 @@
 
 			<!-- Finder methods -->
 
-			<finder name="G_C_U" return-type="FriendlyURLEntryLocalization" unique="true">
+			<finder name="G_C_U" return-type="Collection">
 				<finder-column name="groupId" />
 				<finder-column name="classNameId" />
 				<finder-column name="urlTitle" />
@@ -44,6 +44,12 @@
 				<finder-column name="classNameId" />
 				<finder-column name="classPK" />
 				<finder-column name="languageId" />
+			</finder>
+			<finder name="G_C_L_U" return-type="FriendlyURLEntryLocalization" unique="true">
+				<finder-column name="groupId" />
+				<finder-column name="classNameId" />
+				<finder-column name="languageId" />
+				<finder-column name="urlTitle" />
 			</finder>
 		</localized-entity>
 

--- a/modules/apps/friendly-url/friendly-url-service/service.xml
+++ b/modules/apps/friendly-url/friendly-url-service/service.xml
@@ -51,6 +51,12 @@
 				<finder-column name="languageId" />
 				<finder-column name="urlTitle" />
 			</finder>
+			<finder name="G_C_NotL_U" return-type="Collection">
+				<finder-column name="groupId" />
+				<finder-column name="classNameId" />
+				<finder-column comparator="!=" name="languageId" />
+				<finder-column name="urlTitle" />
+			</finder>
 		</localized-entity>
 
 		<!-- Finder methods -->

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/exportimport/staged/model/repository/FriendlyURLEntryStagedModelRepository.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/exportimport/staged/model/repository/FriendlyURLEntryStagedModelRepository.java
@@ -151,7 +151,7 @@ public class FriendlyURLEntryStagedModelRepository
 					friendlyURLEntry.getGroupId(),
 					friendlyURLEntry.getClassNameId(),
 					friendlyURLEntry.getClassPK(),
-					friendlyURLEntryLocalization.getUrlTitle()));
+					friendlyURLEntryLocalization.getUrlTitle(), null));
 
 			_friendlyURLEntryLocalService.updateFriendlyURLLocalization(
 				friendlyURLEntryLocalization);
@@ -201,7 +201,7 @@ public class FriendlyURLEntryStagedModelRepository
 				urlTitle = _friendlyURLEntryLocalService.getUniqueUrlTitle(
 					friendlyURLEntry.getGroupId(),
 					friendlyURLEntry.getClassNameId(),
-					friendlyURLEntry.getClassPK(), urlTitle);
+					friendlyURLEntry.getClassPK(), urlTitle, null);
 			}
 
 			languageIdLocalizationMap.put(

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/upgrade/registry/FriendlyURLServiceUpgradeStepRegistrator.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/upgrade/registry/FriendlyURLServiceUpgradeStepRegistrator.java
@@ -46,6 +46,8 @@ public class FriendlyURLServiceUpgradeStepRegistrator
 				"FriendlyURLEntryMapping"));
 
 		registry.register("3.1.0", "3.1.1", new DummyUpgradeStep());
+
+		registry.register("3.1.1", "3.2.0", new DummyUpgradeStep());
 	}
 
 }

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
@@ -33,13 +33,11 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.ModelHintsUtil;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.FriendlyURLNormalizer;
-import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
@@ -153,7 +151,7 @@ public class FriendlyURLEntryLocalServiceImpl
 		friendlyURLEntry = friendlyURLEntryPersistence.update(friendlyURLEntry);
 
 		_updateFriendlyURLEntryLocalizations(
-			friendlyURLEntry, classNameId, classPK,
+			friendlyURLEntry, classNameId,
 			_merge(urlTitleMap, existingUrlTitleMap));
 
 		return friendlyURLEntry;
@@ -515,7 +513,7 @@ public class FriendlyURLEntryLocalServiceImpl
 		friendlyURLEntry = friendlyURLEntryPersistence.update(friendlyURLEntry);
 
 		_updateFriendlyURLEntryLocalizations(
-			friendlyURLEntry, classNameId, classPK, urlTitleMap);
+			friendlyURLEntry, classNameId, urlTitleMap);
 
 		return friendlyURLEntry;
 	}
@@ -711,7 +709,7 @@ public class FriendlyURLEntryLocalServiceImpl
 	}
 
 	private void _updateFriendlyURLEntryLocalizations(
-			FriendlyURLEntry friendlyURLEntry, long classNameId, long classPK,
+			FriendlyURLEntry friendlyURLEntry, long classNameId,
 			Map<String, String> urlTitleMap)
 		throws PortalException {
 
@@ -732,27 +730,16 @@ public class FriendlyURLEntryLocalServiceImpl
 							entry.getKey(), normalizedUrlTitle);
 
 				if (existingFriendlyURLEntryLocalization != null) {
-					if (existingFriendlyURLEntryLocalization.getClassPK() ==
-							classPK) {
+					String existingUrlTitle =
+						existingFriendlyURLEntryLocalization.getUrlTitle();
 
-						String existingUrlTitle =
-							existingFriendlyURLEntryLocalization.getUrlTitle();
+					if (existingUrlTitle.equals(oldURLTitle)) {
+						existingFriendlyURLEntryLocalization.
+							setFriendlyURLEntryId(
+								friendlyURLEntry.getFriendlyURLEntryId());
 
-						if (existingUrlTitle.equals(oldURLTitle)) {
-							existingFriendlyURLEntryLocalization.
-								setFriendlyURLEntryId(
-									friendlyURLEntry.getFriendlyURLEntryId());
-
-							updateFriendlyURLLocalization(
-								existingFriendlyURLEntryLocalization);
-						}
-					}
-					else {
-						updateFriendlyURLEntryLocalization(
-							friendlyURLEntry, entry.getKey(),
-							getUniqueUrlTitle(
-								friendlyURLEntry.getGroupId(), classNameId,
-								classPK, oldURLTitle));
+						updateFriendlyURLLocalization(
+							existingFriendlyURLEntryLocalization);
 					}
 				}
 				else {

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
@@ -682,11 +682,16 @@ public class FriendlyURLEntryLocalServiceImpl
 				friendlyURLEntryLocalization.toString());
 		}
 		else if (!friendlyURLEntryLocalizationList.isEmpty()) {
-			FriendlyURLEntryLocalization friendlyURLEntryLocalization =
-				friendlyURLEntryLocalizationList.get(0);
+			for (FriendlyURLEntryLocalization friendlyURLEntryLocalization :
+					friendlyURLEntryLocalizationList) {
 
-			throw new DuplicateFriendlyURLEntryException(
-				friendlyURLEntryLocalization.toString());
+				if ((classPK <= 0) ||
+					(friendlyURLEntryLocalization.getClassPK() != classPK)) {
+
+					throw new DuplicateFriendlyURLEntryException(
+						friendlyURLEntryLocalization.toString());
+				}
+			}
 		}
 	}
 

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
@@ -328,23 +328,6 @@ public class FriendlyURLEntryLocalServiceImpl
 	}
 
 	@Override
-	public FriendlyURLEntry fetchFriendlyURLEntry(
-		long groupId, long classNameId, String languageId, String urlTitle) {
-
-		FriendlyURLEntryLocalization friendlyURLEntryLocalization =
-			friendlyURLEntryLocalizationPersistence.fetchByG_C_L_U(
-				groupId, classNameId, languageId,
-				_friendlyURLNormalizer.normalizeWithEncoding(urlTitle));
-
-		if (friendlyURLEntryLocalization != null) {
-			return friendlyURLEntryPersistence.fetchByPrimaryKey(
-				friendlyURLEntryLocalization.getFriendlyURLEntryId());
-		}
-
-		return null;
-	}
-
-	@Override
 	public FriendlyURLEntryLocalization fetchFriendlyURLEntryLocalization(
 		long groupId, long classNameId, String urlTitle) {
 

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
@@ -331,11 +331,9 @@ public class FriendlyURLEntryLocalServiceImpl
 	public FriendlyURLEntryLocalization fetchFriendlyURLEntryLocalization(
 		long groupId, long classNameId, String urlTitle) {
 
-		String defaultLanguageId = LocaleUtil.toLanguageId(
-			LocaleUtil.getSiteDefault());
-
 		return friendlyURLEntryLocalizationPersistence.fetchByG_C_L_U(
-			groupId, classNameId, defaultLanguageId,
+			groupId, classNameId,
+			LocaleUtil.toLanguageId(LocaleUtil.getSiteDefault()),
 			_friendlyURLNormalizer.normalizeWithEncoding(urlTitle));
 	}
 
@@ -377,11 +375,9 @@ public class FriendlyURLEntryLocalServiceImpl
 			long groupId, long classNameId, String urlTitle)
 		throws NoSuchFriendlyURLEntryLocalizationException {
 
-		String defaultLanguageId = LocaleUtil.toLanguageId(
-			LocaleUtil.getSiteDefault());
-
 		return friendlyURLEntryLocalizationPersistence.findByG_C_L_U(
-			groupId, classNameId, defaultLanguageId,
+			groupId, classNameId,
+			LocaleUtil.toLanguageId(LocaleUtil.getSiteDefault()),
 			_friendlyURLNormalizer.normalizeWithEncoding(urlTitle));
 	}
 
@@ -569,10 +565,9 @@ public class FriendlyURLEntryLocalServiceImpl
 			long groupId, long classNameId, long classPK, String urlTitle)
 		throws PortalException {
 
-		String defaultLanguageId = LocaleUtil.toLanguageId(
-			LocaleUtil.getSiteDefault());
-
-		validate(groupId, classNameId, classPK, defaultLanguageId, urlTitle);
+		validate(
+			groupId, classNameId, classPK,
+			LocaleUtil.toLanguageId(LocaleUtil.getSiteDefault()), urlTitle);
 	}
 
 	@Override
@@ -608,10 +603,9 @@ public class FriendlyURLEntryLocalServiceImpl
 	public void validate(long groupId, long classNameId, String urlTitle)
 		throws PortalException {
 
-		String defaultLanguageId = LocaleUtil.toLanguageId(
-			LocaleUtil.getSiteDefault());
-
-		validate(groupId, classNameId, 0, defaultLanguageId, urlTitle);
+		validate(
+			groupId, classNameId, 0,
+			LocaleUtil.toLanguageId(LocaleUtil.getSiteDefault()), urlTitle);
 	}
 
 	private boolean _containsAllURLTitles(

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
@@ -41,7 +41,7 @@ import com.liferay.portal.kernel.util.FriendlyURLNormalizer;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
-import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.util.Collections;
@@ -787,6 +787,6 @@ public class FriendlyURLEntryLocalServiceImpl
 	private Language _language;
 
 	@Reference
-	private PortalUtil _portalUtil;
+	private Portal _portal;
 
 }

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
@@ -423,13 +423,6 @@ public class FriendlyURLEntryLocalServiceImpl
 
 	@Override
 	public String getUniqueUrlTitle(
-		long groupId, long classNameId, long classPK, String urlTitle) {
-
-		return getUniqueUrlTitle(groupId, classNameId, classPK, urlTitle, null);
-	}
-
-	@Override
-	public String getUniqueUrlTitle(
 		long groupId, long classNameId, long classPK, String urlTitle,
 		String languageId) {
 

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
@@ -468,6 +468,10 @@ public class FriendlyURLEntryLocalServiceImpl
 
 		String prefix = curUrlTitle;
 
+		if (Validator.isNull(languageId)) {
+			languageId = LocaleUtil.toLanguageId(LocaleUtil.getSiteDefault());
+		}
+
 		for (int i = 1;; i++) {
 			FriendlyURLEntryLocalization friendlyURLEntryLocalization =
 				friendlyURLEntryLocalizationPersistence.fetchByG_C_L_U(
@@ -584,9 +588,10 @@ public class FriendlyURLEntryLocalServiceImpl
 			Map<String, String> urlTitleMap)
 		throws PortalException {
 
-		for (String urlKey : urlTitleMap.keySet()) {
+		for (Map.Entry<String, String> entry : urlTitleMap.entrySet()) {
 			validate(
-				groupId, classNameId, classPK, urlKey, urlTitleMap.get(urlKey));
+				groupId, classNameId, classPK, entry.getKey(),
+				entry.getValue());
 		}
 	}
 
@@ -751,12 +756,8 @@ public class FriendlyURLEntryLocalServiceImpl
 							entry.getKey(), normalizedUrlTitle);
 
 				if (existingFriendlyURLEntryLocalization != null) {
-					String existingLanguageId =
-						existingFriendlyURLEntryLocalization.getLanguageId();
-
-					if ((existingFriendlyURLEntryLocalization.getClassPK() ==
-							classPK) &&
-						existingLanguageId.equals(entry.getKey())) {
+					if (existingFriendlyURLEntryLocalization.getClassPK() ==
+							classPK) {
 
 						String existingUrlTitle =
 							existingFriendlyURLEntryLocalization.getUrlTitle();

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
@@ -38,6 +38,7 @@ import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.FriendlyURLNormalizer;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
@@ -623,19 +624,23 @@ public class FriendlyURLEntryLocalServiceImpl
 				urlTitle + " is longer than " + maxLength);
 		}
 
-		FriendlyURLEntryLocalization friendlyURLEntryLocalization =
-			friendlyURLEntryLocalizationPersistence.fetchByG_C_L_U(
-				groupId, classNameId, languageId, normalizedUrlTitle);
+		List<FriendlyURLEntryLocalization> friendlyURLEntryLocalizationList =
+			friendlyURLEntryLocalizationPersistence.findByG_C_U(
+				groupId, classNameId, normalizedUrlTitle);
 
-		if (friendlyURLEntryLocalization == null) {
+		if (ListUtil.isEmpty(friendlyURLEntryLocalizationList)) {
 			return;
 		}
 
-		if ((classPK <= 0) ||
-			(friendlyURLEntryLocalization.getClassPK() != classPK)) {
+		for (FriendlyURLEntryLocalization friendlyURLEntryLocalization :
+				friendlyURLEntryLocalizationList) {
 
-			throw new DuplicateFriendlyURLEntryException(
-				friendlyURLEntryLocalization.toString());
+			if ((classPK <= 0) ||
+				(friendlyURLEntryLocalization.getClassPK() != classPK)) {
+
+				throw new DuplicateFriendlyURLEntryException(
+					friendlyURLEntryLocalization.toString());
+			}
 		}
 	}
 

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/persistence/impl/FriendlyURLEntryLocalizationPersistenceImpl.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/persistence/impl/FriendlyURLEntryLocalizationPersistenceImpl.java
@@ -929,80 +929,93 @@ public class FriendlyURLEntryLocalizationPersistenceImpl
 		_FINDER_COLUMN_FRIENDLYURLENTRYID_LANGUAGEID_LANGUAGEID_3 =
 			"(friendlyURLEntryLocalization.languageId IS NULL OR friendlyURLEntryLocalization.languageId = '')";
 
-	private FinderPath _finderPathFetchByG_C_U;
+	private FinderPath _finderPathWithPaginationFindByG_C_U;
+	private FinderPath _finderPathWithoutPaginationFindByG_C_U;
 	private FinderPath _finderPathCountByG_C_U;
 
 	/**
-	 * Returns the friendly url entry localization where groupId = &#63; and classNameId = &#63; and urlTitle = &#63; or throws a <code>NoSuchFriendlyURLEntryLocalizationException</code> if it could not be found.
+	 * Returns all the friendly url entry localizations where groupId = &#63; and classNameId = &#63; and urlTitle = &#63;.
 	 *
 	 * @param groupId the group ID
 	 * @param classNameId the class name ID
 	 * @param urlTitle the url title
-	 * @return the matching friendly url entry localization
-	 * @throws NoSuchFriendlyURLEntryLocalizationException if a matching friendly url entry localization could not be found
+	 * @return the matching friendly url entry localizations
 	 */
 	@Override
-	public FriendlyURLEntryLocalization findByG_C_U(
-			long groupId, long classNameId, String urlTitle)
-		throws NoSuchFriendlyURLEntryLocalizationException {
-
-		FriendlyURLEntryLocalization friendlyURLEntryLocalization =
-			fetchByG_C_U(groupId, classNameId, urlTitle);
-
-		if (friendlyURLEntryLocalization == null) {
-			StringBundler sb = new StringBundler(8);
-
-			sb.append(_NO_SUCH_ENTITY_WITH_KEY);
-
-			sb.append("groupId=");
-			sb.append(groupId);
-
-			sb.append(", classNameId=");
-			sb.append(classNameId);
-
-			sb.append(", urlTitle=");
-			sb.append(urlTitle);
-
-			sb.append("}");
-
-			if (_log.isDebugEnabled()) {
-				_log.debug(sb.toString());
-			}
-
-			throw new NoSuchFriendlyURLEntryLocalizationException(
-				sb.toString());
-		}
-
-		return friendlyURLEntryLocalization;
-	}
-
-	/**
-	 * Returns the friendly url entry localization where groupId = &#63; and classNameId = &#63; and urlTitle = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
-	 *
-	 * @param groupId the group ID
-	 * @param classNameId the class name ID
-	 * @param urlTitle the url title
-	 * @return the matching friendly url entry localization, or <code>null</code> if a matching friendly url entry localization could not be found
-	 */
-	@Override
-	public FriendlyURLEntryLocalization fetchByG_C_U(
+	public List<FriendlyURLEntryLocalization> findByG_C_U(
 		long groupId, long classNameId, String urlTitle) {
 
-		return fetchByG_C_U(groupId, classNameId, urlTitle, true);
+		return findByG_C_U(
+			groupId, classNameId, urlTitle, QueryUtil.ALL_POS,
+			QueryUtil.ALL_POS, null);
 	}
 
 	/**
-	 * Returns the friendly url entry localization where groupId = &#63; and classNameId = &#63; and urlTitle = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns a range of all the friendly url entry localizations where groupId = &#63; and classNameId = &#63; and urlTitle = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>FriendlyURLEntryLocalizationModelImpl</code>.
+	 * </p>
 	 *
 	 * @param groupId the group ID
 	 * @param classNameId the class name ID
 	 * @param urlTitle the url title
-	 * @param useFinderCache whether to use the finder cache
-	 * @return the matching friendly url entry localization, or <code>null</code> if a matching friendly url entry localization could not be found
+	 * @param start the lower bound of the range of friendly url entry localizations
+	 * @param end the upper bound of the range of friendly url entry localizations (not inclusive)
+	 * @return the range of matching friendly url entry localizations
 	 */
 	@Override
-	public FriendlyURLEntryLocalization fetchByG_C_U(
-		long groupId, long classNameId, String urlTitle,
+	public List<FriendlyURLEntryLocalization> findByG_C_U(
+		long groupId, long classNameId, String urlTitle, int start, int end) {
+
+		return findByG_C_U(groupId, classNameId, urlTitle, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the friendly url entry localizations where groupId = &#63; and classNameId = &#63; and urlTitle = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>FriendlyURLEntryLocalizationModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param urlTitle the url title
+	 * @param start the lower bound of the range of friendly url entry localizations
+	 * @param end the upper bound of the range of friendly url entry localizations (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching friendly url entry localizations
+	 */
+	@Override
+	public List<FriendlyURLEntryLocalization> findByG_C_U(
+		long groupId, long classNameId, String urlTitle, int start, int end,
+		OrderByComparator<FriendlyURLEntryLocalization> orderByComparator) {
+
+		return findByG_C_U(
+			groupId, classNameId, urlTitle, start, end, orderByComparator,
+			true);
+	}
+
+	/**
+	 * Returns an ordered range of all the friendly url entry localizations where groupId = &#63; and classNameId = &#63; and urlTitle = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>FriendlyURLEntryLocalizationModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param urlTitle the url title
+	 * @param start the lower bound of the range of friendly url entry localizations
+	 * @param end the upper bound of the range of friendly url entry localizations (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching friendly url entry localizations
+	 */
+	@Override
+	public List<FriendlyURLEntryLocalization> findByG_C_U(
+		long groupId, long classNameId, String urlTitle, int start, int end,
+		OrderByComparator<FriendlyURLEntryLocalization> orderByComparator,
 		boolean useFinderCache) {
 
 		urlTitle = Objects.toString(urlTitle, "");
@@ -1010,35 +1023,59 @@ public class FriendlyURLEntryLocalizationPersistenceImpl
 		boolean productionMode = ctPersistenceHelper.isProductionMode(
 			FriendlyURLEntryLocalization.class);
 
+		FinderPath finderPath = null;
 		Object[] finderArgs = null;
 
-		if (useFinderCache && productionMode) {
-			finderArgs = new Object[] {groupId, classNameId, urlTitle};
+		if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) &&
+			(orderByComparator == null)) {
+
+			if (useFinderCache && productionMode) {
+				finderPath = _finderPathWithoutPaginationFindByG_C_U;
+				finderArgs = new Object[] {groupId, classNameId, urlTitle};
+			}
+		}
+		else if (useFinderCache && productionMode) {
+			finderPath = _finderPathWithPaginationFindByG_C_U;
+			finderArgs = new Object[] {
+				groupId, classNameId, urlTitle, start, end, orderByComparator
+			};
 		}
 
-		Object result = null;
+		List<FriendlyURLEntryLocalization> list = null;
 
 		if (useFinderCache && productionMode) {
-			result = finderCache.getResult(
-				_finderPathFetchByG_C_U, finderArgs, this);
-		}
+			list = (List<FriendlyURLEntryLocalization>)finderCache.getResult(
+				finderPath, finderArgs, this);
 
-		if (result instanceof FriendlyURLEntryLocalization) {
-			FriendlyURLEntryLocalization friendlyURLEntryLocalization =
-				(FriendlyURLEntryLocalization)result;
+			if ((list != null) && !list.isEmpty()) {
+				for (FriendlyURLEntryLocalization friendlyURLEntryLocalization :
+						list) {
 
-			if ((groupId != friendlyURLEntryLocalization.getGroupId()) ||
-				(classNameId !=
-					friendlyURLEntryLocalization.getClassNameId()) ||
-				!Objects.equals(
-					urlTitle, friendlyURLEntryLocalization.getUrlTitle())) {
+					if ((groupId !=
+							friendlyURLEntryLocalization.getGroupId()) ||
+						(classNameId !=
+							friendlyURLEntryLocalization.getClassNameId()) ||
+						!urlTitle.equals(
+							friendlyURLEntryLocalization.getUrlTitle())) {
 
-				result = null;
+						list = null;
+
+						break;
+					}
+				}
 			}
 		}
 
-		if (result == null) {
-			StringBundler sb = new StringBundler(5);
+		if (list == null) {
+			StringBundler sb = null;
+
+			if (orderByComparator != null) {
+				sb = new StringBundler(
+					5 + (orderByComparator.getOrderByFields().length * 2));
+			}
+			else {
+				sb = new StringBundler(5);
+			}
 
 			sb.append(_SQL_SELECT_FRIENDLYURLENTRYLOCALIZATION_WHERE);
 
@@ -1055,6 +1092,14 @@ public class FriendlyURLEntryLocalizationPersistenceImpl
 				bindUrlTitle = true;
 
 				sb.append(_FINDER_COLUMN_G_C_U_URLTITLE_2);
+			}
+
+			if (orderByComparator != null) {
+				appendOrderByComparator(
+					sb, _ORDER_BY_ENTITY_ALIAS, orderByComparator);
+			}
+			else {
+				sb.append(FriendlyURLEntryLocalizationModelImpl.ORDER_BY_JPQL);
 			}
 
 			String sql = sb.toString();
@@ -1076,21 +1121,13 @@ public class FriendlyURLEntryLocalizationPersistenceImpl
 					queryPos.add(urlTitle);
 				}
 
-				List<FriendlyURLEntryLocalization> list = query.list();
+				list = (List<FriendlyURLEntryLocalization>)QueryUtil.list(
+					query, getDialect(), start, end);
 
-				if (list.isEmpty()) {
-					if (useFinderCache && productionMode) {
-						finderCache.putResult(
-							_finderPathFetchByG_C_U, finderArgs, list);
-					}
-				}
-				else {
-					FriendlyURLEntryLocalization friendlyURLEntryLocalization =
-						list.get(0);
+				cacheResult(list);
 
-					result = friendlyURLEntryLocalization;
-
-					cacheResult(friendlyURLEntryLocalization);
+				if (useFinderCache && productionMode) {
+					finderCache.putResult(finderPath, finderArgs, list);
 				}
 			}
 			catch (Exception exception) {
@@ -1101,31 +1138,346 @@ public class FriendlyURLEntryLocalizationPersistenceImpl
 			}
 		}
 
-		if (result instanceof List<?>) {
-			return null;
-		}
-		else {
-			return (FriendlyURLEntryLocalization)result;
-		}
+		return list;
 	}
 
 	/**
-	 * Removes the friendly url entry localization where groupId = &#63; and classNameId = &#63; and urlTitle = &#63; from the database.
+	 * Returns the first friendly url entry localization in the ordered set where groupId = &#63; and classNameId = &#63; and urlTitle = &#63;.
 	 *
 	 * @param groupId the group ID
 	 * @param classNameId the class name ID
 	 * @param urlTitle the url title
-	 * @return the friendly url entry localization that was removed
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching friendly url entry localization
+	 * @throws NoSuchFriendlyURLEntryLocalizationException if a matching friendly url entry localization could not be found
 	 */
 	@Override
-	public FriendlyURLEntryLocalization removeByG_C_U(
-			long groupId, long classNameId, String urlTitle)
+	public FriendlyURLEntryLocalization findByG_C_U_First(
+			long groupId, long classNameId, String urlTitle,
+			OrderByComparator<FriendlyURLEntryLocalization> orderByComparator)
 		throws NoSuchFriendlyURLEntryLocalizationException {
 
-		FriendlyURLEntryLocalization friendlyURLEntryLocalization = findByG_C_U(
-			groupId, classNameId, urlTitle);
+		FriendlyURLEntryLocalization friendlyURLEntryLocalization =
+			fetchByG_C_U_First(
+				groupId, classNameId, urlTitle, orderByComparator);
 
-		return remove(friendlyURLEntryLocalization);
+		if (friendlyURLEntryLocalization != null) {
+			return friendlyURLEntryLocalization;
+		}
+
+		StringBundler sb = new StringBundler(8);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("groupId=");
+		sb.append(groupId);
+
+		sb.append(", classNameId=");
+		sb.append(classNameId);
+
+		sb.append(", urlTitle=");
+		sb.append(urlTitle);
+
+		sb.append("}");
+
+		throw new NoSuchFriendlyURLEntryLocalizationException(sb.toString());
+	}
+
+	/**
+	 * Returns the first friendly url entry localization in the ordered set where groupId = &#63; and classNameId = &#63; and urlTitle = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param urlTitle the url title
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching friendly url entry localization, or <code>null</code> if a matching friendly url entry localization could not be found
+	 */
+	@Override
+	public FriendlyURLEntryLocalization fetchByG_C_U_First(
+		long groupId, long classNameId, String urlTitle,
+		OrderByComparator<FriendlyURLEntryLocalization> orderByComparator) {
+
+		List<FriendlyURLEntryLocalization> list = findByG_C_U(
+			groupId, classNameId, urlTitle, 0, 1, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the last friendly url entry localization in the ordered set where groupId = &#63; and classNameId = &#63; and urlTitle = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param urlTitle the url title
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching friendly url entry localization
+	 * @throws NoSuchFriendlyURLEntryLocalizationException if a matching friendly url entry localization could not be found
+	 */
+	@Override
+	public FriendlyURLEntryLocalization findByG_C_U_Last(
+			long groupId, long classNameId, String urlTitle,
+			OrderByComparator<FriendlyURLEntryLocalization> orderByComparator)
+		throws NoSuchFriendlyURLEntryLocalizationException {
+
+		FriendlyURLEntryLocalization friendlyURLEntryLocalization =
+			fetchByG_C_U_Last(
+				groupId, classNameId, urlTitle, orderByComparator);
+
+		if (friendlyURLEntryLocalization != null) {
+			return friendlyURLEntryLocalization;
+		}
+
+		StringBundler sb = new StringBundler(8);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("groupId=");
+		sb.append(groupId);
+
+		sb.append(", classNameId=");
+		sb.append(classNameId);
+
+		sb.append(", urlTitle=");
+		sb.append(urlTitle);
+
+		sb.append("}");
+
+		throw new NoSuchFriendlyURLEntryLocalizationException(sb.toString());
+	}
+
+	/**
+	 * Returns the last friendly url entry localization in the ordered set where groupId = &#63; and classNameId = &#63; and urlTitle = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param urlTitle the url title
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching friendly url entry localization, or <code>null</code> if a matching friendly url entry localization could not be found
+	 */
+	@Override
+	public FriendlyURLEntryLocalization fetchByG_C_U_Last(
+		long groupId, long classNameId, String urlTitle,
+		OrderByComparator<FriendlyURLEntryLocalization> orderByComparator) {
+
+		int count = countByG_C_U(groupId, classNameId, urlTitle);
+
+		if (count == 0) {
+			return null;
+		}
+
+		List<FriendlyURLEntryLocalization> list = findByG_C_U(
+			groupId, classNameId, urlTitle, count - 1, count,
+			orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the friendly url entry localizations before and after the current friendly url entry localization in the ordered set where groupId = &#63; and classNameId = &#63; and urlTitle = &#63;.
+	 *
+	 * @param friendlyURLEntryLocalizationId the primary key of the current friendly url entry localization
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param urlTitle the url title
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next friendly url entry localization
+	 * @throws NoSuchFriendlyURLEntryLocalizationException if a friendly url entry localization with the primary key could not be found
+	 */
+	@Override
+	public FriendlyURLEntryLocalization[] findByG_C_U_PrevAndNext(
+			long friendlyURLEntryLocalizationId, long groupId, long classNameId,
+			String urlTitle,
+			OrderByComparator<FriendlyURLEntryLocalization> orderByComparator)
+		throws NoSuchFriendlyURLEntryLocalizationException {
+
+		urlTitle = Objects.toString(urlTitle, "");
+
+		FriendlyURLEntryLocalization friendlyURLEntryLocalization =
+			findByPrimaryKey(friendlyURLEntryLocalizationId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			FriendlyURLEntryLocalization[] array =
+				new FriendlyURLEntryLocalizationImpl[3];
+
+			array[0] = getByG_C_U_PrevAndNext(
+				session, friendlyURLEntryLocalization, groupId, classNameId,
+				urlTitle, orderByComparator, true);
+
+			array[1] = friendlyURLEntryLocalization;
+
+			array[2] = getByG_C_U_PrevAndNext(
+				session, friendlyURLEntryLocalization, groupId, classNameId,
+				urlTitle, orderByComparator, false);
+
+			return array;
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	protected FriendlyURLEntryLocalization getByG_C_U_PrevAndNext(
+		Session session,
+		FriendlyURLEntryLocalization friendlyURLEntryLocalization, long groupId,
+		long classNameId, String urlTitle,
+		OrderByComparator<FriendlyURLEntryLocalization> orderByComparator,
+		boolean previous) {
+
+		StringBundler sb = null;
+
+		if (orderByComparator != null) {
+			sb = new StringBundler(
+				6 + (orderByComparator.getOrderByConditionFields().length * 3) +
+					(orderByComparator.getOrderByFields().length * 3));
+		}
+		else {
+			sb = new StringBundler(5);
+		}
+
+		sb.append(_SQL_SELECT_FRIENDLYURLENTRYLOCALIZATION_WHERE);
+
+		sb.append(_FINDER_COLUMN_G_C_U_GROUPID_2);
+
+		sb.append(_FINDER_COLUMN_G_C_U_CLASSNAMEID_2);
+
+		boolean bindUrlTitle = false;
+
+		if (urlTitle.isEmpty()) {
+			sb.append(_FINDER_COLUMN_G_C_U_URLTITLE_3);
+		}
+		else {
+			bindUrlTitle = true;
+
+			sb.append(_FINDER_COLUMN_G_C_U_URLTITLE_2);
+		}
+
+		if (orderByComparator != null) {
+			String[] orderByConditionFields =
+				orderByComparator.getOrderByConditionFields();
+
+			if (orderByConditionFields.length > 0) {
+				sb.append(WHERE_AND);
+			}
+
+			for (int i = 0; i < orderByConditionFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByConditionFields[i]);
+
+				if ((i + 1) < orderByConditionFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN_HAS_NEXT);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN);
+					}
+				}
+			}
+
+			sb.append(ORDER_BY_CLAUSE);
+
+			String[] orderByFields = orderByComparator.getOrderByFields();
+
+			for (int i = 0; i < orderByFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByFields[i]);
+
+				if ((i + 1) < orderByFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC_HAS_NEXT);
+					}
+					else {
+						sb.append(ORDER_BY_DESC_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC);
+					}
+					else {
+						sb.append(ORDER_BY_DESC);
+					}
+				}
+			}
+		}
+		else {
+			sb.append(FriendlyURLEntryLocalizationModelImpl.ORDER_BY_JPQL);
+		}
+
+		String sql = sb.toString();
+
+		Query query = session.createQuery(sql);
+
+		query.setFirstResult(0);
+		query.setMaxResults(2);
+
+		QueryPos queryPos = QueryPos.getInstance(query);
+
+		queryPos.add(groupId);
+
+		queryPos.add(classNameId);
+
+		if (bindUrlTitle) {
+			queryPos.add(urlTitle);
+		}
+
+		if (orderByComparator != null) {
+			for (Object orderByConditionValue :
+					orderByComparator.getOrderByConditionValues(
+						friendlyURLEntryLocalization)) {
+
+				queryPos.add(orderByConditionValue);
+			}
+		}
+
+		List<FriendlyURLEntryLocalization> list = query.list();
+
+		if (list.size() == 2) {
+			return list.get(1);
+		}
+		else {
+			return null;
+		}
+	}
+
+	/**
+	 * Removes all the friendly url entry localizations where groupId = &#63; and classNameId = &#63; and urlTitle = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param urlTitle the url title
+	 */
+	@Override
+	public void removeByG_C_U(long groupId, long classNameId, String urlTitle) {
+		for (FriendlyURLEntryLocalization friendlyURLEntryLocalization :
+				findByG_C_U(
+					groupId, classNameId, urlTitle, QueryUtil.ALL_POS,
+					QueryUtil.ALL_POS, null)) {
+
+			remove(friendlyURLEntryLocalization);
+		}
 	}
 
 	/**
@@ -1918,6 +2270,1077 @@ public class FriendlyURLEntryLocalizationPersistenceImpl
 	private static final String _FINDER_COLUMN_G_C_C_L_LANGUAGEID_3 =
 		"(friendlyURLEntryLocalization.languageId IS NULL OR friendlyURLEntryLocalization.languageId = '')";
 
+	private FinderPath _finderPathFetchByG_C_L_U;
+	private FinderPath _finderPathCountByG_C_L_U;
+
+	/**
+	 * Returns the friendly url entry localization where groupId = &#63; and classNameId = &#63; and languageId = &#63; and urlTitle = &#63; or throws a <code>NoSuchFriendlyURLEntryLocalizationException</code> if it could not be found.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param languageId the language ID
+	 * @param urlTitle the url title
+	 * @return the matching friendly url entry localization
+	 * @throws NoSuchFriendlyURLEntryLocalizationException if a matching friendly url entry localization could not be found
+	 */
+	@Override
+	public FriendlyURLEntryLocalization findByG_C_L_U(
+			long groupId, long classNameId, String languageId, String urlTitle)
+		throws NoSuchFriendlyURLEntryLocalizationException {
+
+		FriendlyURLEntryLocalization friendlyURLEntryLocalization =
+			fetchByG_C_L_U(groupId, classNameId, languageId, urlTitle);
+
+		if (friendlyURLEntryLocalization == null) {
+			StringBundler sb = new StringBundler(10);
+
+			sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+			sb.append("groupId=");
+			sb.append(groupId);
+
+			sb.append(", classNameId=");
+			sb.append(classNameId);
+
+			sb.append(", languageId=");
+			sb.append(languageId);
+
+			sb.append(", urlTitle=");
+			sb.append(urlTitle);
+
+			sb.append("}");
+
+			if (_log.isDebugEnabled()) {
+				_log.debug(sb.toString());
+			}
+
+			throw new NoSuchFriendlyURLEntryLocalizationException(
+				sb.toString());
+		}
+
+		return friendlyURLEntryLocalization;
+	}
+
+	/**
+	 * Returns the friendly url entry localization where groupId = &#63; and classNameId = &#63; and languageId = &#63; and urlTitle = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param languageId the language ID
+	 * @param urlTitle the url title
+	 * @return the matching friendly url entry localization, or <code>null</code> if a matching friendly url entry localization could not be found
+	 */
+	@Override
+	public FriendlyURLEntryLocalization fetchByG_C_L_U(
+		long groupId, long classNameId, String languageId, String urlTitle) {
+
+		return fetchByG_C_L_U(groupId, classNameId, languageId, urlTitle, true);
+	}
+
+	/**
+	 * Returns the friendly url entry localization where groupId = &#63; and classNameId = &#63; and languageId = &#63; and urlTitle = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param languageId the language ID
+	 * @param urlTitle the url title
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the matching friendly url entry localization, or <code>null</code> if a matching friendly url entry localization could not be found
+	 */
+	@Override
+	public FriendlyURLEntryLocalization fetchByG_C_L_U(
+		long groupId, long classNameId, String languageId, String urlTitle,
+		boolean useFinderCache) {
+
+		languageId = Objects.toString(languageId, "");
+		urlTitle = Objects.toString(urlTitle, "");
+
+		boolean productionMode = ctPersistenceHelper.isProductionMode(
+			FriendlyURLEntryLocalization.class);
+
+		Object[] finderArgs = null;
+
+		if (useFinderCache && productionMode) {
+			finderArgs = new Object[] {
+				groupId, classNameId, languageId, urlTitle
+			};
+		}
+
+		Object result = null;
+
+		if (useFinderCache && productionMode) {
+			result = finderCache.getResult(
+				_finderPathFetchByG_C_L_U, finderArgs, this);
+		}
+
+		if (result instanceof FriendlyURLEntryLocalization) {
+			FriendlyURLEntryLocalization friendlyURLEntryLocalization =
+				(FriendlyURLEntryLocalization)result;
+
+			if ((groupId != friendlyURLEntryLocalization.getGroupId()) ||
+				(classNameId !=
+					friendlyURLEntryLocalization.getClassNameId()) ||
+				!Objects.equals(
+					languageId, friendlyURLEntryLocalization.getLanguageId()) ||
+				!Objects.equals(
+					urlTitle, friendlyURLEntryLocalization.getUrlTitle())) {
+
+				result = null;
+			}
+		}
+
+		if (result == null) {
+			StringBundler sb = new StringBundler(6);
+
+			sb.append(_SQL_SELECT_FRIENDLYURLENTRYLOCALIZATION_WHERE);
+
+			sb.append(_FINDER_COLUMN_G_C_L_U_GROUPID_2);
+
+			sb.append(_FINDER_COLUMN_G_C_L_U_CLASSNAMEID_2);
+
+			boolean bindLanguageId = false;
+
+			if (languageId.isEmpty()) {
+				sb.append(_FINDER_COLUMN_G_C_L_U_LANGUAGEID_3);
+			}
+			else {
+				bindLanguageId = true;
+
+				sb.append(_FINDER_COLUMN_G_C_L_U_LANGUAGEID_2);
+			}
+
+			boolean bindUrlTitle = false;
+
+			if (urlTitle.isEmpty()) {
+				sb.append(_FINDER_COLUMN_G_C_L_U_URLTITLE_3);
+			}
+			else {
+				bindUrlTitle = true;
+
+				sb.append(_FINDER_COLUMN_G_C_L_U_URLTITLE_2);
+			}
+
+			String sql = sb.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query query = session.createQuery(sql);
+
+				QueryPos queryPos = QueryPos.getInstance(query);
+
+				queryPos.add(groupId);
+
+				queryPos.add(classNameId);
+
+				if (bindLanguageId) {
+					queryPos.add(languageId);
+				}
+
+				if (bindUrlTitle) {
+					queryPos.add(urlTitle);
+				}
+
+				List<FriendlyURLEntryLocalization> list = query.list();
+
+				if (list.isEmpty()) {
+					if (useFinderCache && productionMode) {
+						finderCache.putResult(
+							_finderPathFetchByG_C_L_U, finderArgs, list);
+					}
+				}
+				else {
+					FriendlyURLEntryLocalization friendlyURLEntryLocalization =
+						list.get(0);
+
+					result = friendlyURLEntryLocalization;
+
+					cacheResult(friendlyURLEntryLocalization);
+				}
+			}
+			catch (Exception exception) {
+				throw processException(exception);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		if (result instanceof List<?>) {
+			return null;
+		}
+		else {
+			return (FriendlyURLEntryLocalization)result;
+		}
+	}
+
+	/**
+	 * Removes the friendly url entry localization where groupId = &#63; and classNameId = &#63; and languageId = &#63; and urlTitle = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param languageId the language ID
+	 * @param urlTitle the url title
+	 * @return the friendly url entry localization that was removed
+	 */
+	@Override
+	public FriendlyURLEntryLocalization removeByG_C_L_U(
+			long groupId, long classNameId, String languageId, String urlTitle)
+		throws NoSuchFriendlyURLEntryLocalizationException {
+
+		FriendlyURLEntryLocalization friendlyURLEntryLocalization =
+			findByG_C_L_U(groupId, classNameId, languageId, urlTitle);
+
+		return remove(friendlyURLEntryLocalization);
+	}
+
+	/**
+	 * Returns the number of friendly url entry localizations where groupId = &#63; and classNameId = &#63; and languageId = &#63; and urlTitle = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param languageId the language ID
+	 * @param urlTitle the url title
+	 * @return the number of matching friendly url entry localizations
+	 */
+	@Override
+	public int countByG_C_L_U(
+		long groupId, long classNameId, String languageId, String urlTitle) {
+
+		languageId = Objects.toString(languageId, "");
+		urlTitle = Objects.toString(urlTitle, "");
+
+		boolean productionMode = ctPersistenceHelper.isProductionMode(
+			FriendlyURLEntryLocalization.class);
+
+		FinderPath finderPath = null;
+		Object[] finderArgs = null;
+
+		Long count = null;
+
+		if (productionMode) {
+			finderPath = _finderPathCountByG_C_L_U;
+
+			finderArgs = new Object[] {
+				groupId, classNameId, languageId, urlTitle
+			};
+
+			count = (Long)finderCache.getResult(finderPath, finderArgs, this);
+		}
+
+		if (count == null) {
+			StringBundler sb = new StringBundler(5);
+
+			sb.append(_SQL_COUNT_FRIENDLYURLENTRYLOCALIZATION_WHERE);
+
+			sb.append(_FINDER_COLUMN_G_C_L_U_GROUPID_2);
+
+			sb.append(_FINDER_COLUMN_G_C_L_U_CLASSNAMEID_2);
+
+			boolean bindLanguageId = false;
+
+			if (languageId.isEmpty()) {
+				sb.append(_FINDER_COLUMN_G_C_L_U_LANGUAGEID_3);
+			}
+			else {
+				bindLanguageId = true;
+
+				sb.append(_FINDER_COLUMN_G_C_L_U_LANGUAGEID_2);
+			}
+
+			boolean bindUrlTitle = false;
+
+			if (urlTitle.isEmpty()) {
+				sb.append(_FINDER_COLUMN_G_C_L_U_URLTITLE_3);
+			}
+			else {
+				bindUrlTitle = true;
+
+				sb.append(_FINDER_COLUMN_G_C_L_U_URLTITLE_2);
+			}
+
+			String sql = sb.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query query = session.createQuery(sql);
+
+				QueryPos queryPos = QueryPos.getInstance(query);
+
+				queryPos.add(groupId);
+
+				queryPos.add(classNameId);
+
+				if (bindLanguageId) {
+					queryPos.add(languageId);
+				}
+
+				if (bindUrlTitle) {
+					queryPos.add(urlTitle);
+				}
+
+				count = (Long)query.uniqueResult();
+
+				if (productionMode) {
+					finderCache.putResult(finderPath, finderArgs, count);
+				}
+			}
+			catch (Exception exception) {
+				throw processException(exception);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return count.intValue();
+	}
+
+	private static final String _FINDER_COLUMN_G_C_L_U_GROUPID_2 =
+		"friendlyURLEntryLocalization.groupId = ? AND ";
+
+	private static final String _FINDER_COLUMN_G_C_L_U_CLASSNAMEID_2 =
+		"friendlyURLEntryLocalization.classNameId = ? AND ";
+
+	private static final String _FINDER_COLUMN_G_C_L_U_LANGUAGEID_2 =
+		"friendlyURLEntryLocalization.languageId = ? AND ";
+
+	private static final String _FINDER_COLUMN_G_C_L_U_LANGUAGEID_3 =
+		"(friendlyURLEntryLocalization.languageId IS NULL OR friendlyURLEntryLocalization.languageId = '') AND ";
+
+	private static final String _FINDER_COLUMN_G_C_L_U_URLTITLE_2 =
+		"friendlyURLEntryLocalization.urlTitle = ?";
+
+	private static final String _FINDER_COLUMN_G_C_L_U_URLTITLE_3 =
+		"(friendlyURLEntryLocalization.urlTitle IS NULL OR friendlyURLEntryLocalization.urlTitle = '')";
+
+	private FinderPath _finderPathWithPaginationFindByG_C_NotL_U;
+	private FinderPath _finderPathWithPaginationCountByG_C_NotL_U;
+
+	/**
+	 * Returns all the friendly url entry localizations where groupId = &#63; and classNameId = &#63; and languageId &ne; &#63; and urlTitle = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param languageId the language ID
+	 * @param urlTitle the url title
+	 * @return the matching friendly url entry localizations
+	 */
+	@Override
+	public List<FriendlyURLEntryLocalization> findByG_C_NotL_U(
+		long groupId, long classNameId, String languageId, String urlTitle) {
+
+		return findByG_C_NotL_U(
+			groupId, classNameId, languageId, urlTitle, QueryUtil.ALL_POS,
+			QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the friendly url entry localizations where groupId = &#63; and classNameId = &#63; and languageId &ne; &#63; and urlTitle = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>FriendlyURLEntryLocalizationModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param languageId the language ID
+	 * @param urlTitle the url title
+	 * @param start the lower bound of the range of friendly url entry localizations
+	 * @param end the upper bound of the range of friendly url entry localizations (not inclusive)
+	 * @return the range of matching friendly url entry localizations
+	 */
+	@Override
+	public List<FriendlyURLEntryLocalization> findByG_C_NotL_U(
+		long groupId, long classNameId, String languageId, String urlTitle,
+		int start, int end) {
+
+		return findByG_C_NotL_U(
+			groupId, classNameId, languageId, urlTitle, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the friendly url entry localizations where groupId = &#63; and classNameId = &#63; and languageId &ne; &#63; and urlTitle = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>FriendlyURLEntryLocalizationModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param languageId the language ID
+	 * @param urlTitle the url title
+	 * @param start the lower bound of the range of friendly url entry localizations
+	 * @param end the upper bound of the range of friendly url entry localizations (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching friendly url entry localizations
+	 */
+	@Override
+	public List<FriendlyURLEntryLocalization> findByG_C_NotL_U(
+		long groupId, long classNameId, String languageId, String urlTitle,
+		int start, int end,
+		OrderByComparator<FriendlyURLEntryLocalization> orderByComparator) {
+
+		return findByG_C_NotL_U(
+			groupId, classNameId, languageId, urlTitle, start, end,
+			orderByComparator, true);
+	}
+
+	/**
+	 * Returns an ordered range of all the friendly url entry localizations where groupId = &#63; and classNameId = &#63; and languageId &ne; &#63; and urlTitle = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>FriendlyURLEntryLocalizationModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param languageId the language ID
+	 * @param urlTitle the url title
+	 * @param start the lower bound of the range of friendly url entry localizations
+	 * @param end the upper bound of the range of friendly url entry localizations (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching friendly url entry localizations
+	 */
+	@Override
+	public List<FriendlyURLEntryLocalization> findByG_C_NotL_U(
+		long groupId, long classNameId, String languageId, String urlTitle,
+		int start, int end,
+		OrderByComparator<FriendlyURLEntryLocalization> orderByComparator,
+		boolean useFinderCache) {
+
+		languageId = Objects.toString(languageId, "");
+		urlTitle = Objects.toString(urlTitle, "");
+
+		boolean productionMode = ctPersistenceHelper.isProductionMode(
+			FriendlyURLEntryLocalization.class);
+
+		FinderPath finderPath = null;
+		Object[] finderArgs = null;
+
+		finderPath = _finderPathWithPaginationFindByG_C_NotL_U;
+		finderArgs = new Object[] {
+			groupId, classNameId, languageId, urlTitle, start, end,
+			orderByComparator
+		};
+
+		List<FriendlyURLEntryLocalization> list = null;
+
+		if (useFinderCache && productionMode) {
+			list = (List<FriendlyURLEntryLocalization>)finderCache.getResult(
+				finderPath, finderArgs, this);
+
+			if ((list != null) && !list.isEmpty()) {
+				for (FriendlyURLEntryLocalization friendlyURLEntryLocalization :
+						list) {
+
+					if ((groupId !=
+							friendlyURLEntryLocalization.getGroupId()) ||
+						(classNameId !=
+							friendlyURLEntryLocalization.getClassNameId()) ||
+						languageId.equals(
+							friendlyURLEntryLocalization.getLanguageId()) ||
+						!urlTitle.equals(
+							friendlyURLEntryLocalization.getUrlTitle())) {
+
+						list = null;
+
+						break;
+					}
+				}
+			}
+		}
+
+		if (list == null) {
+			StringBundler sb = null;
+
+			if (orderByComparator != null) {
+				sb = new StringBundler(
+					6 + (orderByComparator.getOrderByFields().length * 2));
+			}
+			else {
+				sb = new StringBundler(6);
+			}
+
+			sb.append(_SQL_SELECT_FRIENDLYURLENTRYLOCALIZATION_WHERE);
+
+			sb.append(_FINDER_COLUMN_G_C_NOTL_U_GROUPID_2);
+
+			sb.append(_FINDER_COLUMN_G_C_NOTL_U_CLASSNAMEID_2);
+
+			boolean bindLanguageId = false;
+
+			if (languageId.isEmpty()) {
+				sb.append(_FINDER_COLUMN_G_C_NOTL_U_LANGUAGEID_3);
+			}
+			else {
+				bindLanguageId = true;
+
+				sb.append(_FINDER_COLUMN_G_C_NOTL_U_LANGUAGEID_2);
+			}
+
+			boolean bindUrlTitle = false;
+
+			if (urlTitle.isEmpty()) {
+				sb.append(_FINDER_COLUMN_G_C_NOTL_U_URLTITLE_3);
+			}
+			else {
+				bindUrlTitle = true;
+
+				sb.append(_FINDER_COLUMN_G_C_NOTL_U_URLTITLE_2);
+			}
+
+			if (orderByComparator != null) {
+				appendOrderByComparator(
+					sb, _ORDER_BY_ENTITY_ALIAS, orderByComparator);
+			}
+			else {
+				sb.append(FriendlyURLEntryLocalizationModelImpl.ORDER_BY_JPQL);
+			}
+
+			String sql = sb.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query query = session.createQuery(sql);
+
+				QueryPos queryPos = QueryPos.getInstance(query);
+
+				queryPos.add(groupId);
+
+				queryPos.add(classNameId);
+
+				if (bindLanguageId) {
+					queryPos.add(languageId);
+				}
+
+				if (bindUrlTitle) {
+					queryPos.add(urlTitle);
+				}
+
+				list = (List<FriendlyURLEntryLocalization>)QueryUtil.list(
+					query, getDialect(), start, end);
+
+				cacheResult(list);
+
+				if (useFinderCache && productionMode) {
+					finderCache.putResult(finderPath, finderArgs, list);
+				}
+			}
+			catch (Exception exception) {
+				throw processException(exception);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return list;
+	}
+
+	/**
+	 * Returns the first friendly url entry localization in the ordered set where groupId = &#63; and classNameId = &#63; and languageId &ne; &#63; and urlTitle = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param languageId the language ID
+	 * @param urlTitle the url title
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching friendly url entry localization
+	 * @throws NoSuchFriendlyURLEntryLocalizationException if a matching friendly url entry localization could not be found
+	 */
+	@Override
+	public FriendlyURLEntryLocalization findByG_C_NotL_U_First(
+			long groupId, long classNameId, String languageId, String urlTitle,
+			OrderByComparator<FriendlyURLEntryLocalization> orderByComparator)
+		throws NoSuchFriendlyURLEntryLocalizationException {
+
+		FriendlyURLEntryLocalization friendlyURLEntryLocalization =
+			fetchByG_C_NotL_U_First(
+				groupId, classNameId, languageId, urlTitle, orderByComparator);
+
+		if (friendlyURLEntryLocalization != null) {
+			return friendlyURLEntryLocalization;
+		}
+
+		StringBundler sb = new StringBundler(10);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("groupId=");
+		sb.append(groupId);
+
+		sb.append(", classNameId=");
+		sb.append(classNameId);
+
+		sb.append(", languageId!=");
+		sb.append(languageId);
+
+		sb.append(", urlTitle=");
+		sb.append(urlTitle);
+
+		sb.append("}");
+
+		throw new NoSuchFriendlyURLEntryLocalizationException(sb.toString());
+	}
+
+	/**
+	 * Returns the first friendly url entry localization in the ordered set where groupId = &#63; and classNameId = &#63; and languageId &ne; &#63; and urlTitle = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param languageId the language ID
+	 * @param urlTitle the url title
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching friendly url entry localization, or <code>null</code> if a matching friendly url entry localization could not be found
+	 */
+	@Override
+	public FriendlyURLEntryLocalization fetchByG_C_NotL_U_First(
+		long groupId, long classNameId, String languageId, String urlTitle,
+		OrderByComparator<FriendlyURLEntryLocalization> orderByComparator) {
+
+		List<FriendlyURLEntryLocalization> list = findByG_C_NotL_U(
+			groupId, classNameId, languageId, urlTitle, 0, 1,
+			orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the last friendly url entry localization in the ordered set where groupId = &#63; and classNameId = &#63; and languageId &ne; &#63; and urlTitle = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param languageId the language ID
+	 * @param urlTitle the url title
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching friendly url entry localization
+	 * @throws NoSuchFriendlyURLEntryLocalizationException if a matching friendly url entry localization could not be found
+	 */
+	@Override
+	public FriendlyURLEntryLocalization findByG_C_NotL_U_Last(
+			long groupId, long classNameId, String languageId, String urlTitle,
+			OrderByComparator<FriendlyURLEntryLocalization> orderByComparator)
+		throws NoSuchFriendlyURLEntryLocalizationException {
+
+		FriendlyURLEntryLocalization friendlyURLEntryLocalization =
+			fetchByG_C_NotL_U_Last(
+				groupId, classNameId, languageId, urlTitle, orderByComparator);
+
+		if (friendlyURLEntryLocalization != null) {
+			return friendlyURLEntryLocalization;
+		}
+
+		StringBundler sb = new StringBundler(10);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("groupId=");
+		sb.append(groupId);
+
+		sb.append(", classNameId=");
+		sb.append(classNameId);
+
+		sb.append(", languageId!=");
+		sb.append(languageId);
+
+		sb.append(", urlTitle=");
+		sb.append(urlTitle);
+
+		sb.append("}");
+
+		throw new NoSuchFriendlyURLEntryLocalizationException(sb.toString());
+	}
+
+	/**
+	 * Returns the last friendly url entry localization in the ordered set where groupId = &#63; and classNameId = &#63; and languageId &ne; &#63; and urlTitle = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param languageId the language ID
+	 * @param urlTitle the url title
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching friendly url entry localization, or <code>null</code> if a matching friendly url entry localization could not be found
+	 */
+	@Override
+	public FriendlyURLEntryLocalization fetchByG_C_NotL_U_Last(
+		long groupId, long classNameId, String languageId, String urlTitle,
+		OrderByComparator<FriendlyURLEntryLocalization> orderByComparator) {
+
+		int count = countByG_C_NotL_U(
+			groupId, classNameId, languageId, urlTitle);
+
+		if (count == 0) {
+			return null;
+		}
+
+		List<FriendlyURLEntryLocalization> list = findByG_C_NotL_U(
+			groupId, classNameId, languageId, urlTitle, count - 1, count,
+			orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the friendly url entry localizations before and after the current friendly url entry localization in the ordered set where groupId = &#63; and classNameId = &#63; and languageId &ne; &#63; and urlTitle = &#63;.
+	 *
+	 * @param friendlyURLEntryLocalizationId the primary key of the current friendly url entry localization
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param languageId the language ID
+	 * @param urlTitle the url title
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next friendly url entry localization
+	 * @throws NoSuchFriendlyURLEntryLocalizationException if a friendly url entry localization with the primary key could not be found
+	 */
+	@Override
+	public FriendlyURLEntryLocalization[] findByG_C_NotL_U_PrevAndNext(
+			long friendlyURLEntryLocalizationId, long groupId, long classNameId,
+			String languageId, String urlTitle,
+			OrderByComparator<FriendlyURLEntryLocalization> orderByComparator)
+		throws NoSuchFriendlyURLEntryLocalizationException {
+
+		languageId = Objects.toString(languageId, "");
+		urlTitle = Objects.toString(urlTitle, "");
+
+		FriendlyURLEntryLocalization friendlyURLEntryLocalization =
+			findByPrimaryKey(friendlyURLEntryLocalizationId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			FriendlyURLEntryLocalization[] array =
+				new FriendlyURLEntryLocalizationImpl[3];
+
+			array[0] = getByG_C_NotL_U_PrevAndNext(
+				session, friendlyURLEntryLocalization, groupId, classNameId,
+				languageId, urlTitle, orderByComparator, true);
+
+			array[1] = friendlyURLEntryLocalization;
+
+			array[2] = getByG_C_NotL_U_PrevAndNext(
+				session, friendlyURLEntryLocalization, groupId, classNameId,
+				languageId, urlTitle, orderByComparator, false);
+
+			return array;
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	protected FriendlyURLEntryLocalization getByG_C_NotL_U_PrevAndNext(
+		Session session,
+		FriendlyURLEntryLocalization friendlyURLEntryLocalization, long groupId,
+		long classNameId, String languageId, String urlTitle,
+		OrderByComparator<FriendlyURLEntryLocalization> orderByComparator,
+		boolean previous) {
+
+		StringBundler sb = null;
+
+		if (orderByComparator != null) {
+			sb = new StringBundler(
+				7 + (orderByComparator.getOrderByConditionFields().length * 3) +
+					(orderByComparator.getOrderByFields().length * 3));
+		}
+		else {
+			sb = new StringBundler(6);
+		}
+
+		sb.append(_SQL_SELECT_FRIENDLYURLENTRYLOCALIZATION_WHERE);
+
+		sb.append(_FINDER_COLUMN_G_C_NOTL_U_GROUPID_2);
+
+		sb.append(_FINDER_COLUMN_G_C_NOTL_U_CLASSNAMEID_2);
+
+		boolean bindLanguageId = false;
+
+		if (languageId.isEmpty()) {
+			sb.append(_FINDER_COLUMN_G_C_NOTL_U_LANGUAGEID_3);
+		}
+		else {
+			bindLanguageId = true;
+
+			sb.append(_FINDER_COLUMN_G_C_NOTL_U_LANGUAGEID_2);
+		}
+
+		boolean bindUrlTitle = false;
+
+		if (urlTitle.isEmpty()) {
+			sb.append(_FINDER_COLUMN_G_C_NOTL_U_URLTITLE_3);
+		}
+		else {
+			bindUrlTitle = true;
+
+			sb.append(_FINDER_COLUMN_G_C_NOTL_U_URLTITLE_2);
+		}
+
+		if (orderByComparator != null) {
+			String[] orderByConditionFields =
+				orderByComparator.getOrderByConditionFields();
+
+			if (orderByConditionFields.length > 0) {
+				sb.append(WHERE_AND);
+			}
+
+			for (int i = 0; i < orderByConditionFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByConditionFields[i]);
+
+				if ((i + 1) < orderByConditionFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN_HAS_NEXT);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN);
+					}
+				}
+			}
+
+			sb.append(ORDER_BY_CLAUSE);
+
+			String[] orderByFields = orderByComparator.getOrderByFields();
+
+			for (int i = 0; i < orderByFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByFields[i]);
+
+				if ((i + 1) < orderByFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC_HAS_NEXT);
+					}
+					else {
+						sb.append(ORDER_BY_DESC_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC);
+					}
+					else {
+						sb.append(ORDER_BY_DESC);
+					}
+				}
+			}
+		}
+		else {
+			sb.append(FriendlyURLEntryLocalizationModelImpl.ORDER_BY_JPQL);
+		}
+
+		String sql = sb.toString();
+
+		Query query = session.createQuery(sql);
+
+		query.setFirstResult(0);
+		query.setMaxResults(2);
+
+		QueryPos queryPos = QueryPos.getInstance(query);
+
+		queryPos.add(groupId);
+
+		queryPos.add(classNameId);
+
+		if (bindLanguageId) {
+			queryPos.add(languageId);
+		}
+
+		if (bindUrlTitle) {
+			queryPos.add(urlTitle);
+		}
+
+		if (orderByComparator != null) {
+			for (Object orderByConditionValue :
+					orderByComparator.getOrderByConditionValues(
+						friendlyURLEntryLocalization)) {
+
+				queryPos.add(orderByConditionValue);
+			}
+		}
+
+		List<FriendlyURLEntryLocalization> list = query.list();
+
+		if (list.size() == 2) {
+			return list.get(1);
+		}
+		else {
+			return null;
+		}
+	}
+
+	/**
+	 * Removes all the friendly url entry localizations where groupId = &#63; and classNameId = &#63; and languageId &ne; &#63; and urlTitle = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param languageId the language ID
+	 * @param urlTitle the url title
+	 */
+	@Override
+	public void removeByG_C_NotL_U(
+		long groupId, long classNameId, String languageId, String urlTitle) {
+
+		for (FriendlyURLEntryLocalization friendlyURLEntryLocalization :
+				findByG_C_NotL_U(
+					groupId, classNameId, languageId, urlTitle,
+					QueryUtil.ALL_POS, QueryUtil.ALL_POS, null)) {
+
+			remove(friendlyURLEntryLocalization);
+		}
+	}
+
+	/**
+	 * Returns the number of friendly url entry localizations where groupId = &#63; and classNameId = &#63; and languageId &ne; &#63; and urlTitle = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param languageId the language ID
+	 * @param urlTitle the url title
+	 * @return the number of matching friendly url entry localizations
+	 */
+	@Override
+	public int countByG_C_NotL_U(
+		long groupId, long classNameId, String languageId, String urlTitle) {
+
+		languageId = Objects.toString(languageId, "");
+		urlTitle = Objects.toString(urlTitle, "");
+
+		boolean productionMode = ctPersistenceHelper.isProductionMode(
+			FriendlyURLEntryLocalization.class);
+
+		FinderPath finderPath = null;
+		Object[] finderArgs = null;
+
+		Long count = null;
+
+		if (productionMode) {
+			finderPath = _finderPathWithPaginationCountByG_C_NotL_U;
+
+			finderArgs = new Object[] {
+				groupId, classNameId, languageId, urlTitle
+			};
+
+			count = (Long)finderCache.getResult(finderPath, finderArgs, this);
+		}
+
+		if (count == null) {
+			StringBundler sb = new StringBundler(5);
+
+			sb.append(_SQL_COUNT_FRIENDLYURLENTRYLOCALIZATION_WHERE);
+
+			sb.append(_FINDER_COLUMN_G_C_NOTL_U_GROUPID_2);
+
+			sb.append(_FINDER_COLUMN_G_C_NOTL_U_CLASSNAMEID_2);
+
+			boolean bindLanguageId = false;
+
+			if (languageId.isEmpty()) {
+				sb.append(_FINDER_COLUMN_G_C_NOTL_U_LANGUAGEID_3);
+			}
+			else {
+				bindLanguageId = true;
+
+				sb.append(_FINDER_COLUMN_G_C_NOTL_U_LANGUAGEID_2);
+			}
+
+			boolean bindUrlTitle = false;
+
+			if (urlTitle.isEmpty()) {
+				sb.append(_FINDER_COLUMN_G_C_NOTL_U_URLTITLE_3);
+			}
+			else {
+				bindUrlTitle = true;
+
+				sb.append(_FINDER_COLUMN_G_C_NOTL_U_URLTITLE_2);
+			}
+
+			String sql = sb.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query query = session.createQuery(sql);
+
+				QueryPos queryPos = QueryPos.getInstance(query);
+
+				queryPos.add(groupId);
+
+				queryPos.add(classNameId);
+
+				if (bindLanguageId) {
+					queryPos.add(languageId);
+				}
+
+				if (bindUrlTitle) {
+					queryPos.add(urlTitle);
+				}
+
+				count = (Long)query.uniqueResult();
+
+				if (productionMode) {
+					finderCache.putResult(finderPath, finderArgs, count);
+				}
+			}
+			catch (Exception exception) {
+				throw processException(exception);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return count.intValue();
+	}
+
+	private static final String _FINDER_COLUMN_G_C_NOTL_U_GROUPID_2 =
+		"friendlyURLEntryLocalization.groupId = ? AND ";
+
+	private static final String _FINDER_COLUMN_G_C_NOTL_U_CLASSNAMEID_2 =
+		"friendlyURLEntryLocalization.classNameId = ? AND ";
+
+	private static final String _FINDER_COLUMN_G_C_NOTL_U_LANGUAGEID_2 =
+		"friendlyURLEntryLocalization.languageId != ? AND ";
+
+	private static final String _FINDER_COLUMN_G_C_NOTL_U_LANGUAGEID_3 =
+		"(friendlyURLEntryLocalization.languageId IS NULL OR friendlyURLEntryLocalization.languageId != '') AND ";
+
+	private static final String _FINDER_COLUMN_G_C_NOTL_U_URLTITLE_2 =
+		"friendlyURLEntryLocalization.urlTitle = ?";
+
+	private static final String _FINDER_COLUMN_G_C_NOTL_U_URLTITLE_3 =
+		"(friendlyURLEntryLocalization.urlTitle IS NULL OR friendlyURLEntryLocalization.urlTitle = '')";
+
 	public FriendlyURLEntryLocalizationPersistenceImpl() {
 		setModelClass(FriendlyURLEntryLocalization.class);
 
@@ -1954,10 +3377,11 @@ public class FriendlyURLEntryLocalizationPersistenceImpl
 			friendlyURLEntryLocalization);
 
 		finderCache.putResult(
-			_finderPathFetchByG_C_U,
+			_finderPathFetchByG_C_L_U,
 			new Object[] {
 				friendlyURLEntryLocalization.getGroupId(),
 				friendlyURLEntryLocalization.getClassNameId(),
+				friendlyURLEntryLocalization.getLanguageId(),
 				friendlyURLEntryLocalization.getUrlTitle()
 			},
 			friendlyURLEntryLocalization);
@@ -2070,12 +3494,13 @@ public class FriendlyURLEntryLocalizationPersistenceImpl
 		args = new Object[] {
 			friendlyURLEntryLocalizationModelImpl.getGroupId(),
 			friendlyURLEntryLocalizationModelImpl.getClassNameId(),
+			friendlyURLEntryLocalizationModelImpl.getLanguageId(),
 			friendlyURLEntryLocalizationModelImpl.getUrlTitle()
 		};
 
-		finderCache.putResult(_finderPathCountByG_C_U, args, Long.valueOf(1));
+		finderCache.putResult(_finderPathCountByG_C_L_U, args, Long.valueOf(1));
 		finderCache.putResult(
-			_finderPathFetchByG_C_U, args,
+			_finderPathFetchByG_C_L_U, args,
 			friendlyURLEntryLocalizationModelImpl);
 	}
 
@@ -2749,7 +4174,7 @@ public class FriendlyURLEntryLocalizationPersistenceImpl
 			new String[] {"friendlyURLEntryId", "languageId"});
 
 		_uniqueIndexColumnNames.add(
-			new String[] {"groupId", "classNameId", "urlTitle"});
+			new String[] {"groupId", "classNameId", "languageId", "urlTitle"});
 	}
 
 	/**
@@ -2801,8 +4226,17 @@ public class FriendlyURLEntryLocalizationPersistenceImpl
 			new String[] {Long.class.getName(), String.class.getName()},
 			new String[] {"friendlyURLEntryId", "languageId"}, false);
 
-		_finderPathFetchByG_C_U = new FinderPath(
-			FINDER_CLASS_NAME_ENTITY, "fetchByG_C_U",
+		_finderPathWithPaginationFindByG_C_U = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_C_U",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				String.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"groupId", "classNameId", "urlTitle"}, true);
+
+		_finderPathWithoutPaginationFindByG_C_U = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_C_U",
 			new String[] {
 				Long.class.getName(), Long.class.getName(),
 				String.class.getName()
@@ -2844,6 +4278,44 @@ public class FriendlyURLEntryLocalizationPersistenceImpl
 				Long.class.getName(), String.class.getName()
 			},
 			new String[] {"groupId", "classNameId", "classPK", "languageId"},
+			false);
+
+		_finderPathFetchByG_C_L_U = new FinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByG_C_L_U",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				String.class.getName(), String.class.getName()
+			},
+			new String[] {"groupId", "classNameId", "languageId", "urlTitle"},
+			true);
+
+		_finderPathCountByG_C_L_U = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_C_L_U",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				String.class.getName(), String.class.getName()
+			},
+			new String[] {"groupId", "classNameId", "languageId", "urlTitle"},
+			false);
+
+		_finderPathWithPaginationFindByG_C_NotL_U = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_C_NotL_U",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				String.class.getName(), String.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"groupId", "classNameId", "languageId", "urlTitle"},
+			true);
+
+		_finderPathWithPaginationCountByG_C_NotL_U = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByG_C_NotL_U",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				String.class.getName(), String.class.getName()
+			},
+			new String[] {"groupId", "classNameId", "languageId", "urlTitle"},
 			false);
 
 		_setFriendlyURLEntryLocalizationUtilPersistence(this);

--- a/modules/apps/friendly-url/friendly-url-service/src/main/resources/META-INF/sql/indexes.sql
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/resources/META-INF/sql/indexes.sql
@@ -6,6 +6,7 @@ create unique index IX_D51F1A48 on FriendlyURLEntry (uuid_[$COLUMN_LENGTH:75$], 
 create index IX_4F41A5C8 on FriendlyURLEntryLocalization (friendlyURLEntryId, ctCollectionId);
 create unique index IX_BBF3E90F on FriendlyURLEntryLocalization (friendlyURLEntryId, languageId[$COLUMN_LENGTH:75$], ctCollectionId);
 create index IX_40A51197 on FriendlyURLEntryLocalization (groupId, classNameId, classPK, languageId[$COLUMN_LENGTH:75$], ctCollectionId);
-create unique index IX_C753170C on FriendlyURLEntryLocalization (groupId, classNameId, urlTitle[$COLUMN_LENGTH:255$], ctCollectionId);
+create unique index IX_29720B13 on FriendlyURLEntryLocalization (groupId, classNameId, languageId[$COLUMN_LENGTH:75$], urlTitle[$COLUMN_LENGTH:255$], ctCollectionId);
+create index IX_C753170C on FriendlyURLEntryLocalization (groupId, classNameId, urlTitle[$COLUMN_LENGTH:255$], ctCollectionId);
 
 create unique index IX_5BE324B9 on FriendlyURLEntryMapping (classNameId, classPK, ctCollectionId);

--- a/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/service/persistence/test/FriendlyURLEntryLocalizationPersistenceTest.java
+++ b/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/service/persistence/test/FriendlyURLEntryLocalizationPersistenceTest.java
@@ -229,6 +229,26 @@ public class FriendlyURLEntryLocalizationPersistenceTest {
 	}
 
 	@Test
+	public void testCountByG_C_L_U() throws Exception {
+		_persistence.countByG_C_L_U(
+			RandomTestUtil.nextLong(), RandomTestUtil.nextLong(), "", "");
+
+		_persistence.countByG_C_L_U(0L, 0L, "null", "null");
+
+		_persistence.countByG_C_L_U(0L, 0L, (String)null, (String)null);
+	}
+
+	@Test
+	public void testCountByG_C_NotL_U() throws Exception {
+		_persistence.countByG_C_NotL_U(
+			RandomTestUtil.nextLong(), RandomTestUtil.nextLong(), "", "");
+
+		_persistence.countByG_C_NotL_U(0L, 0L, "null", "null");
+
+		_persistence.countByG_C_NotL_U(0L, 0L, (String)null, (String)null);
+	}
+
+	@Test
 	public void testFindByPrimaryKeyExisting() throws Exception {
 		FriendlyURLEntryLocalization newFriendlyURLEntryLocalization =
 			addFriendlyURLEntryLocalization();
@@ -564,6 +584,11 @@ public class FriendlyURLEntryLocalizationPersistenceTest {
 			ReflectionTestUtil.<Long>invoke(
 				friendlyURLEntryLocalization, "getColumnOriginalValue",
 				new Class<?>[] {String.class}, "classNameId"));
+		Assert.assertEquals(
+			friendlyURLEntryLocalization.getLanguageId(),
+			ReflectionTestUtil.invoke(
+				friendlyURLEntryLocalization, "getColumnOriginalValue",
+				new Class<?>[] {String.class}, "languageId"));
 		Assert.assertEquals(
 			friendlyURLEntryLocalization.getUrlTitle(),
 			ReflectionTestUtil.invoke(

--- a/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/service/test/FriendlyURLEntryLocalServiceTest.java
+++ b/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/service/test/FriendlyURLEntryLocalServiceTest.java
@@ -239,13 +239,71 @@ public class FriendlyURLEntryLocalServiceTest {
 		Assert.assertEquals(maxLength - 1, uniqueUrlTitle.length());
 	}
 
+	@Test
+	public void testValidateAllowsDuplicatesInDifferentLanguagesForDifferentClassPK()
+		throws Exception {
+
+		long classNameId = _classNameLocalService.getClassNameId(User.class);
+
+		String urlTitle = _getRandomURLTitle();
+
+		_friendlyURLEntryLocalService.addFriendlyURLEntry(
+			_group.getGroupId(), classNameId, TestPropsValues.getUserId(),
+			HashMapBuilder.put(
+				_language.getLanguageId(LocaleUtil.getDefault()), urlTitle
+			).build(),
+			_getServiceContext());
+
+		_friendlyURLEntryLocalService.validate(
+			_group.getGroupId(), classNameId, _user.getUserId(),
+			_language.getLanguageId(LocaleUtil.BRAZIL), urlTitle);
+	}
+
+	@Test(expected = DuplicateFriendlyURLEntryException.class)
+	public void testValidateDuplicateLocalizedUrlTitleForDifferentClassPK()
+		throws Exception {
+
+		long classNameId = _classNameLocalService.getClassNameId(User.class);
+
+		String urlTitle = _getRandomURLTitle();
+
+		_friendlyURLEntryLocalService.addFriendlyURLEntry(
+			_group.getGroupId(), classNameId, TestPropsValues.getUserId(),
+			HashMapBuilder.put(
+				_language.getLanguageId(LocaleUtil.getDefault()), urlTitle
+			).build(),
+			_getServiceContext());
+
+		_friendlyURLEntryLocalService.validate(
+			_group.getGroupId(), classNameId, _user.getUserId(),
+			_language.getLanguageId(LocaleUtil.getDefault()), urlTitle);
+	}
+
+	@Test
+	public void testValidateDuplicateLocalizedUrlTitleForSameClassPK()
+		throws Exception {
+
+		long classNameId = _classNameLocalService.getClassNameId(User.class);
+
+		String urlTitle = _getRandomURLTitle();
+
+		_friendlyURLEntryLocalService.addFriendlyURLEntry(
+			_group.getGroupId(), classNameId, TestPropsValues.getUserId(),
+			HashMapBuilder.put(
+				_language.getLanguageId(LocaleUtil.getDefault()), urlTitle
+			).build(),
+			_getServiceContext());
+
+		_friendlyURLEntryLocalService.validate(
+			_group.getGroupId(), classNameId, TestPropsValues.getUserId(),
+			_language.getLanguageId(LocaleUtil.BRAZIL), urlTitle);
+	}
+
 	@Test(expected = DuplicateFriendlyURLEntryException.class)
 	public void testValidateDuplicateUrlTitle() throws Exception {
 		long classNameId = _classNameLocalService.getClassNameId(User.class);
 
-		String urlTitle = StringUtil.randomString(
-			ModelHintsUtil.getMaxLength(
-				FriendlyURLEntryLocalization.class.getName(), "urlTitle"));
+		String urlTitle = _getRandomURLTitle();
 
 		_friendlyURLEntryLocalService.addFriendlyURLEntry(
 			_group.getGroupId(), classNameId, TestPropsValues.getUserId(),
@@ -259,9 +317,7 @@ public class FriendlyURLEntryLocalServiceTest {
 	public void testValidateUrlTitleNotOwnedByModel() throws Exception {
 		long classNameId = _classNameLocalService.getClassNameId(User.class);
 
-		String urlTitle = StringUtil.randomString(
-			ModelHintsUtil.getMaxLength(
-				FriendlyURLEntryLocalization.class.getName(), "urlTitle"));
+		String urlTitle = _getRandomURLTitle();
 
 		_friendlyURLEntryLocalService.addFriendlyURLEntry(
 			_group.getGroupId(), classNameId, TestPropsValues.getUserId(),
@@ -275,9 +331,7 @@ public class FriendlyURLEntryLocalServiceTest {
 	public void testValidateUrlTitleOwnedByModel() throws Exception {
 		long classNameId = _classNameLocalService.getClassNameId(User.class);
 
-		String urlTitle = StringUtil.randomString(
-			ModelHintsUtil.getMaxLength(
-				FriendlyURLEntryLocalization.class.getName(), "urlTitle"));
+		String urlTitle = _getRandomURLTitle();
 
 		_friendlyURLEntryLocalService.addFriendlyURLEntry(
 			_group.getGroupId(), classNameId, TestPropsValues.getUserId(),
@@ -303,14 +357,16 @@ public class FriendlyURLEntryLocalServiceTest {
 
 	@Test
 	public void testValidateUrlTitleWithMaxLength() throws Exception {
-		long classNameId = _classNameLocalService.getClassNameId(User.class);
+		_friendlyURLEntryLocalService.validate(
+			_group.getGroupId(),
+			_classNameLocalService.getClassNameId(User.class),
+			_getRandomURLTitle());
+	}
 
-		String urlTitle = StringUtil.randomString(
+	private String _getRandomURLTitle() {
+		return StringUtil.randomString(
 			ModelHintsUtil.getMaxLength(
 				FriendlyURLEntryLocalization.class.getName(), "urlTitle"));
-
-		_friendlyURLEntryLocalService.validate(
-			_group.getGroupId(), classNameId, urlTitle);
 	}
 
 	private ServiceContext _getServiceContext() throws Exception {

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/friendly/url/test/JournalArticleFriendlyURLTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/friendly/url/test/JournalArticleFriendlyURLTest.java
@@ -126,10 +126,10 @@ public class JournalArticleFriendlyURLTest {
 		Map<Locale, String> friendlyURLMap = updatedArticle.getFriendlyURLMap();
 
 		Assert.assertEquals(
-			FriendlyURLNormalizerUtil.normalizeWithEncoding(title2 + "-2"),
+			FriendlyURLNormalizerUtil.normalizeWithEncoding(title2 + "-1"),
 			friendlyURLMap.get(LocaleUtil.US));
 		Assert.assertEquals(
-			FriendlyURLNormalizerUtil.normalizeWithEncoding(title2 + "-2-1"),
+			FriendlyURLNormalizerUtil.normalizeWithEncoding(title2 + "-1"),
 			friendlyURLMap.get(LocaleUtil.FRANCE));
 	}
 
@@ -188,7 +188,7 @@ public class JournalArticleFriendlyURLTest {
 			FriendlyURLNormalizerUtil.normalizeWithEncoding(title),
 			friendlyURLMap.get(LocaleUtil.US));
 		Assert.assertEquals(
-			FriendlyURLNormalizerUtil.normalizeWithEncoding(title + "-1"),
+			FriendlyURLNormalizerUtil.normalizeWithEncoding(title),
 			friendlyURLMap.get(LocaleUtil.FRANCE));
 	}
 
@@ -208,10 +208,10 @@ public class JournalArticleFriendlyURLTest {
 		Map<Locale, String> friendlyURLMap = article.getFriendlyURLMap();
 
 		Assert.assertEquals(
-			FriendlyURLNormalizerUtil.normalizeWithEncoding(title + "-2"),
+			FriendlyURLNormalizerUtil.normalizeWithEncoding(title + "-1"),
 			friendlyURLMap.get(LocaleUtil.US));
 		Assert.assertEquals(
-			FriendlyURLNormalizerUtil.normalizeWithEncoding(title + "-2-1"),
+			FriendlyURLNormalizerUtil.normalizeWithEncoding(title + "-1"),
 			friendlyURLMap.get(LocaleUtil.FRANCE));
 	}
 

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/test/LayoutFriendlyURLTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/test/LayoutFriendlyURLTest.java
@@ -427,7 +427,7 @@ public class LayoutFriendlyURLTest {
 		}
 	}
 
-	@Test(expected = LayoutFriendlyURLsException.class)
+	@Test
 	public void testSameFriendlyURLDifferentLocalePrivateLayout()
 		throws Exception {
 
@@ -440,7 +440,7 @@ public class LayoutFriendlyURLTest {
 			).build());
 	}
 
-	@Test(expected = LayoutFriendlyURLsException.class)
+	@Test
 	public void testSameFriendlyURLDifferentLocalePublicLayout()
 		throws Exception {
 

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceHelper.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceHelper.java
@@ -66,12 +66,10 @@ import com.liferay.portal.util.LayoutTypeControllerTracker;
 import com.liferay.sites.kernel.util.SitesUtil;
 
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -401,10 +399,7 @@ public class LayoutLocalServiceHelper implements IdentifiableOSGiService {
 			Layout layout = layoutPersistence.findByPrimaryKey(
 				layoutFriendlyURL.getPlid());
 
-			if ((layout.getLayoutId() != layoutId) ||
-				(Validator.isNotNull(languageId) &&
-				 !languageId.equals(layoutFriendlyURL.getLanguageId()))) {
-
+			if (layout.getLayoutId() != layoutId) {
 				LayoutFriendlyURLException layoutFriendlyURLException =
 					new LayoutFriendlyURLException(
 						LayoutFriendlyURLException.DUPLICATE);
@@ -536,17 +531,6 @@ public class LayoutLocalServiceHelper implements IdentifiableOSGiService {
 		throws PortalException {
 
 		LayoutFriendlyURLsException layoutFriendlyURLsException = null;
-
-		Set<String> friendlyURLs = new HashSet<>(friendlyURLMap.values());
-
-		if (friendlyURLs.size() != friendlyURLMap.size()) {
-			LayoutFriendlyURLException layoutFriendlyURLException =
-				new LayoutFriendlyURLException(
-					LayoutFriendlyURLException.DUPLICATE);
-
-			layoutFriendlyURLsException = new LayoutFriendlyURLsException(
-				layoutFriendlyURLException);
-		}
 
 		for (Map.Entry<Locale, String> entry : friendlyURLMap.entrySet()) {
 			try {


### PR DESCRIPTION
# What is this about?

Allow to use the same url title for different translations for the same friendly url.

# How do I test this?

You can test it in 2 different places: journal and pages. For both, the steps a the following:
1. Create an entry with url title "abc" for the default language.
2. Edit the entry, add a url title translation for another language and put the same value ("abc").

This should *not* fail; both languages should have the same url title.

This should only work for the same entry; trying to reuse the url title for other entry should fail.
