### PR TITLE
LPS-167112 KBArticle RSS url does not change with parameters

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-api/bnd.bnd
+++ b/modules/apps/knowledge-base/knowledge-base-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Knowledge Base API
 Bundle-SymbolicName: com.liferay.knowledge.base.api
-Bundle-Version: 14.0.1
+Bundle-Version: 15.0.0
 Export-Package:\
 	com.liferay.knowledge.base.configuration,\
 	com.liferay.knowledge.base.constants,\

--- a/modules/apps/knowledge-base/knowledge-base-api/build.gradle
+++ b/modules/apps/knowledge-base/knowledge-base-api/build.gradle
@@ -7,6 +7,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.annotation.versioning", version: "1.1.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:diff:diff-api")
+	compileOnly project(":apps:rss:rss-api")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-sql-dsl-api")

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/configuration/KBGroupServiceConfiguration.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/configuration/KBGroupServiceConfiguration.java
@@ -181,16 +181,17 @@ public interface KBGroupServiceConfiguration {
 	@Meta.AD(deflt = "true", name = "enable-rss", required = false)
 	public boolean enableRSS();
 
-	@Meta.AD(deflt = "20", name = "rss-delta", required = false)
-	public int rssDelta();
+	@Meta.AD(
+		deflt = "${server-property://com.liferay.portal/search.container.page.default.delta}",
+		name = "rss-delta", required = false
+	)
+	public String rssDelta();
 
 	@Meta.AD(
-		deflt = "full-content", name = "rss-display-style", required = false
+		deflt = "${server-property://com.liferay.portal/rss.feed.display.style.default}",
+		name = "rss-display-style", required = false
 	)
 	public String rssDisplayStyle();
-
-	@Meta.AD(deflt = "atom10", name = "rss-format", required = false)
-	public String rssFormat();
 
 	@Meta.AD(
 		deflt = "${server-property://com.liferay.portal/rss.feed.type.default}",

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleService.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleService.java
@@ -133,8 +133,8 @@ public interface KBArticleService extends BaseService {
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public String getGroupKBArticlesRSS(
-			int status, int rssDelta, String rssDisplayStyle, String rssFormat,
-			ThemeDisplay themeDisplay)
+		int status, int max, String type, double version, String displayStyle,
+		ThemeDisplay themeDisplay)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
@@ -149,8 +149,8 @@ public interface KBArticleService extends BaseService {
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public String getKBArticleRSS(
-			long resourcePrimKey, int status, int rssDelta,
-			String rssDisplayStyle, String rssFormat, ThemeDisplay themeDisplay)
+		long resourcePrimKey, int status, int max,
+		String type, double version, String displayStyle, ThemeDisplay themeDisplay)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleService.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleService.java
@@ -133,8 +133,8 @@ public interface KBArticleService extends BaseService {
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public String getGroupKBArticlesRSS(
-		int status, int max, String type, double version, String displayStyle,
-		ThemeDisplay themeDisplay)
+			int status, int max, String type, double version,
+			String displayStyle, ThemeDisplay themeDisplay)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
@@ -149,8 +149,8 @@ public interface KBArticleService extends BaseService {
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public String getKBArticleRSS(
-		long resourcePrimKey, int status, int max,
-		String type, double version, String displayStyle, ThemeDisplay themeDisplay)
+			long resourcePrimKey, int status, int max, String type,
+			double version, String displayStyle, ThemeDisplay themeDisplay)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleServiceUtil.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleServiceUtil.java
@@ -17,6 +17,7 @@ package com.liferay.knowledge.base.service;
 import com.liferay.knowledge.base.model.KBArticle;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.util.OrderByComparator;
+import com.liferay.rss.util.RSSUtil;
 
 import java.io.InputStream;
 
@@ -172,7 +173,7 @@ public class KBArticleServiceUtil {
 		throws PortalException {
 
 		return getService().getGroupKBArticlesRSS(
-			status, rssDelta, rssDisplayStyle, rssFormat, themeDisplay);
+			status, rssDelta, RSSUtil.getFormatType(rssFormat), RSSUtil.getFormatVersion(rssFormat), rssDisplayStyle, themeDisplay);
 	}
 
 	public static KBArticle getKBArticle(long resourcePrimKey, int version)
@@ -197,8 +198,8 @@ public class KBArticleServiceUtil {
 		throws PortalException {
 
 		return getService().getKBArticleRSS(
-			resourcePrimKey, status, rssDelta, rssDisplayStyle, rssFormat,
-			themeDisplay);
+			resourcePrimKey, status, rssDelta, RSSUtil.getFormatType(rssFormat), RSSUtil.getFormatVersion(rssFormat),
+			rssDisplayStyle, themeDisplay);
 	}
 
 	public static List<KBArticle> getKBArticles(

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleServiceUtil.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleServiceUtil.java
@@ -17,7 +17,6 @@ package com.liferay.knowledge.base.service;
 import com.liferay.knowledge.base.model.KBArticle;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.util.OrderByComparator;
-import com.liferay.rss.util.RSSUtil;
 
 import java.io.InputStream;
 
@@ -168,12 +167,13 @@ public class KBArticleServiceUtil {
 	}
 
 	public static String getGroupKBArticlesRSS(
-			int status, int rssDelta, String rssDisplayStyle, String rssFormat,
+			int status, int max, String type, double version,
+			String displayStyle,
 			com.liferay.portal.kernel.theme.ThemeDisplay themeDisplay)
 		throws PortalException {
 
 		return getService().getGroupKBArticlesRSS(
-			status, rssDelta, RSSUtil.getFormatType(rssFormat), RSSUtil.getFormatVersion(rssFormat), rssDisplayStyle, themeDisplay);
+			status, max, type, version, displayStyle, themeDisplay);
 	}
 
 	public static KBArticle getKBArticle(long resourcePrimKey, int version)
@@ -192,14 +192,14 @@ public class KBArticleServiceUtil {
 	}
 
 	public static String getKBArticleRSS(
-			long resourcePrimKey, int status, int rssDelta,
-			String rssDisplayStyle, String rssFormat,
+			long resourcePrimKey, int status, int max, String type,
+			double version, String displayStyle,
 			com.liferay.portal.kernel.theme.ThemeDisplay themeDisplay)
 		throws PortalException {
 
 		return getService().getKBArticleRSS(
-			resourcePrimKey, status, rssDelta, RSSUtil.getFormatType(rssFormat), RSSUtil.getFormatVersion(rssFormat),
-			rssDisplayStyle, themeDisplay);
+			resourcePrimKey, status, max, type, version, displayStyle,
+			themeDisplay);
 	}
 
 	public static List<KBArticle> getKBArticles(

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleServiceWrapper.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleServiceWrapper.java
@@ -15,6 +15,7 @@
 package com.liferay.knowledge.base.service;
 
 import com.liferay.portal.kernel.service.ServiceWrapper;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
 
 /**
  * Provides a wrapper for {@link KBArticleService}.
@@ -186,12 +187,12 @@ public class KBArticleServiceWrapper
 
 	@Override
 	public String getGroupKBArticlesRSS(
-			int status, int rssDelta, String rssDisplayStyle, String rssFormat,
-			com.liferay.portal.kernel.theme.ThemeDisplay themeDisplay)
+		int status, int max, String type, double version, String displayStyle,
+		ThemeDisplay themeDisplay)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _kbArticleService.getGroupKBArticlesRSS(
-			status, rssDelta, rssDisplayStyle, rssFormat, themeDisplay);
+			status, max, type, version, displayStyle, themeDisplay);
 	}
 
 	@Override
@@ -217,14 +218,14 @@ public class KBArticleServiceWrapper
 
 	@Override
 	public String getKBArticleRSS(
-			long resourcePrimKey, int status, int rssDelta,
-			String rssDisplayStyle, String rssFormat,
-			com.liferay.portal.kernel.theme.ThemeDisplay themeDisplay)
+		long resourcePrimKey, int status, int max,
+		String type, double version, String displayStyle,
+		ThemeDisplay themeDisplay)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _kbArticleService.getKBArticleRSS(
-			resourcePrimKey, status, rssDelta, rssDisplayStyle, rssFormat,
-			themeDisplay);
+			resourcePrimKey, status, max, type, version,
+			displayStyle, themeDisplay);
 	}
 
 	@Override

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleServiceWrapper.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleServiceWrapper.java
@@ -15,7 +15,6 @@
 package com.liferay.knowledge.base.service;
 
 import com.liferay.portal.kernel.service.ServiceWrapper;
-import com.liferay.portal.kernel.theme.ThemeDisplay;
 
 /**
  * Provides a wrapper for {@link KBArticleService}.
@@ -187,8 +186,9 @@ public class KBArticleServiceWrapper
 
 	@Override
 	public String getGroupKBArticlesRSS(
-		int status, int max, String type, double version, String displayStyle,
-		ThemeDisplay themeDisplay)
+			int status, int max, String type, double version,
+			String displayStyle,
+			com.liferay.portal.kernel.theme.ThemeDisplay themeDisplay)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _kbArticleService.getGroupKBArticlesRSS(
@@ -218,14 +218,14 @@ public class KBArticleServiceWrapper
 
 	@Override
 	public String getKBArticleRSS(
-		long resourcePrimKey, int status, int max,
-		String type, double version, String displayStyle,
-		ThemeDisplay themeDisplay)
+			long resourcePrimKey, int status, int max, String type,
+			double version, String displayStyle,
+			com.liferay.portal.kernel.theme.ThemeDisplay themeDisplay)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _kbArticleService.getKBArticleRSS(
-			resourcePrimKey, status, max, type, version,
-			displayStyle, themeDisplay);
+			resourcePrimKey, status, max, type, version, displayStyle,
+			themeDisplay);
 	}
 
 	@Override

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/resources/com/liferay/knowledge/base/configuration/packageinfo
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/resources/com/liferay/knowledge/base/configuration/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.1
+version 2.0.0

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/resources/com/liferay/knowledge/base/service/packageinfo
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/resources/com/liferay/knowledge/base/service/packageinfo
@@ -1,1 +1,1 @@
-version 6.0.0
+version 7.0.0

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/http/KBArticleServiceHttp.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/http/KBArticleServiceHttp.java
@@ -648,8 +648,8 @@ public class KBArticleServiceHttp {
 	}
 
 	public static String getGroupKBArticlesRSS(
-			HttpPrincipal httpPrincipal, int status, int rssDelta,
-			String rssDisplayStyle, String rssFormat,
+			HttpPrincipal httpPrincipal, int status, int max, String type,
+			double version, String displayStyle,
 			com.liferay.portal.kernel.theme.ThemeDisplay themeDisplay)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
@@ -659,7 +659,7 @@ public class KBArticleServiceHttp {
 				_getGroupKBArticlesRSSParameterTypes15);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, status, rssDelta, rssDisplayStyle, rssFormat,
+				methodKey, status, max, type, version, displayStyle,
 				themeDisplay);
 
 			Object returnObj = null;
@@ -778,7 +778,7 @@ public class KBArticleServiceHttp {
 
 	public static String getKBArticleRSS(
 			HttpPrincipal httpPrincipal, long resourcePrimKey, int status,
-			int rssDelta, String rssDisplayStyle, String rssFormat,
+			int max, String type, double version, String displayStyle,
 			com.liferay.portal.kernel.theme.ThemeDisplay themeDisplay)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
@@ -788,8 +788,8 @@ public class KBArticleServiceHttp {
 				_getKBArticleRSSParameterTypes18);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, resourcePrimKey, status, rssDelta, rssDisplayStyle,
-				rssFormat, themeDisplay);
+				methodKey, resourcePrimKey, status, max, type, version,
+				displayStyle, themeDisplay);
 
 			Object returnObj = null;
 
@@ -1721,7 +1721,7 @@ public class KBArticleServiceHttp {
 		new Class[] {long.class, int.class};
 	private static final Class<?>[] _getGroupKBArticlesRSSParameterTypes15 =
 		new Class[] {
-			int.class, int.class, String.class, String.class,
+			int.class, int.class, String.class, double.class, String.class,
 			com.liferay.portal.kernel.theme.ThemeDisplay.class
 		};
 	private static final Class<?>[] _getKBArticleParameterTypes16 =
@@ -1733,8 +1733,8 @@ public class KBArticleServiceHttp {
 		};
 	private static final Class<?>[] _getKBArticleRSSParameterTypes18 =
 		new Class[] {
-			long.class, int.class, int.class, String.class, String.class,
-			com.liferay.portal.kernel.theme.ThemeDisplay.class
+			long.class, int.class, int.class, String.class, double.class,
+			String.class, com.liferay.portal.kernel.theme.ThemeDisplay.class
 		};
 	private static final Class<?>[] _getKBArticlesParameterTypes19 =
 		new Class[] {

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleServiceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleServiceImpl.java
@@ -312,8 +312,8 @@ public class KBArticleServiceImpl extends KBArticleServiceBaseImpl {
 
 	@Override
 	public String getGroupKBArticlesRSS(
-			int status, int rssDelta, String rssDisplayStyle, String rssFormat,
-			ThemeDisplay themeDisplay)
+			int status, int max, String type, double version,
+			String displayStyle, ThemeDisplay themeDisplay)
 		throws PortalException {
 
 		Group group = themeDisplay.getScopeGroup();
@@ -327,12 +327,12 @@ public class KBArticleServiceImpl extends KBArticleServiceBaseImpl {
 		String feedURL = _portal.getLayoutFullURL(themeDisplay);
 
 		List<KBArticle> kbArticles = getGroupKBArticles(
-			group.getGroupId(), status, 0, rssDelta,
+			group.getGroupId(), status, 0, max,
 			new KBArticleModifiedDateComparator());
 
 		return _exportToRSS(
-			rssDisplayStyle, rssFormat, name, description, feedURL, kbArticles,
-			themeDisplay);
+			feedURL, description, displayStyle, kbArticles, name, themeDisplay,
+			type, version);
 	}
 
 	@Override
@@ -358,8 +358,8 @@ public class KBArticleServiceImpl extends KBArticleServiceBaseImpl {
 
 	@Override
 	public String getKBArticleRSS(
-			long resourcePrimKey, int status, int rssDelta,
-			String rssDisplayStyle, String rssFormat, ThemeDisplay themeDisplay)
+			long resourcePrimKey, int status, int max, String type,
+			double version, String displayStyle, ThemeDisplay themeDisplay)
 		throws PortalException {
 
 		KBArticle kbArticle = kbArticleLocalService.getLatestKBArticle(
@@ -377,8 +377,9 @@ public class KBArticleServiceImpl extends KBArticleServiceBaseImpl {
 			new KBArticleModifiedDateComparator());
 
 		return _exportToRSS(
-			rssDisplayStyle, rssFormat, name, description, feedURL,
-			ListUtil.subList(kbArticles, 0, rssDelta), themeDisplay);
+			feedURL, description, displayStyle,
+			ListUtil.subList(kbArticles, 0, max), name, themeDisplay, type,
+			version);
 	}
 
 	@Override
@@ -891,9 +892,9 @@ public class KBArticleServiceImpl extends KBArticleServiceBaseImpl {
 	}
 
 	private String _exportToRSS(
-		String rssDisplayStyle, String rssFormat, String name,
-		String description, String feedURL, List<KBArticle> kbArticles,
-		ThemeDisplay themeDisplay) {
+		String feedURL, String description, String displayStyle,
+		List<KBArticle> kbArticles, String name, ThemeDisplay themeDisplay,
+		String type, double version) {
 
 		SyndFeed syndFeed = _syndModelFactory.createSyndFeed();
 
@@ -914,7 +915,7 @@ public class KBArticleServiceImpl extends KBArticleServiceBaseImpl {
 
 			String value = null;
 
-			if (rssDisplayStyle.equals(RSSUtil.DISPLAY_STYLE_ABSTRACT)) {
+			if (displayStyle.equals(RSSUtil.DISPLAY_STYLE_ABSTRACT)) {
 				value = _htmlParser.extractText(kbArticle.getDescription());
 
 				if (Validator.isNull(value)) {
@@ -922,7 +923,7 @@ public class KBArticleServiceImpl extends KBArticleServiceBaseImpl {
 						_htmlParser.extractText(kbArticle.getContent()), 200);
 				}
 			}
-			else if (rssDisplayStyle.equals(RSSUtil.DISPLAY_STYLE_TITLE)) {
+			else if (displayStyle.equals(RSSUtil.DISPLAY_STYLE_TITLE)) {
 				value = StringPool.BLANK;
 			}
 			else {
@@ -953,10 +954,7 @@ public class KBArticleServiceImpl extends KBArticleServiceBaseImpl {
 			syndEntries.add(syndEntry);
 		}
 
-		syndFeed.setFeedType(
-			RSSUtil.getFeedType(
-				RSSUtil.getFormatType(rssFormat),
-				RSSUtil.getFormatVersion(rssFormat)));
+		syndFeed.setFeedType(RSSUtil.getFeedType(type, version));
 
 		List<SyndLink> syndLinks = new ArrayList<>();
 

--- a/modules/apps/knowledge-base/knowledge-base-web/build.gradle
+++ b/modules/apps/knowledge-base/knowledge-base-web/build.gradle
@@ -45,6 +45,7 @@ dependencies {
 	compileOnly project(":apps:message-boards:message-boards-api")
 	compileOnly project(":apps:portal:portal-aop-api")
 	compileOnly project(":apps:ratings:ratings-taglib")
+	compileOnly project(":apps:rss:rss-api")
 	compileOnly project(":apps:rss:rss-taglib")
 	compileOnly project(":apps:site-navigation:site-navigation-taglib")
 	compileOnly project(":apps:social:social-bookmarks-taglib")

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/BaseKBPortlet.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/BaseKBPortlet.java
@@ -32,6 +32,7 @@ import com.liferay.knowledge.base.service.KBFolderService;
 import com.liferay.knowledge.base.service.KBTemplateService;
 import com.liferay.knowledge.base.util.AdminHelper;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.portlet.PortletResponseUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
@@ -45,6 +46,7 @@ import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.rss.util.RSSUtil;
 
 import java.io.IOException;
 
@@ -102,14 +104,18 @@ public abstract class BaseKBPortlet extends MVCPortlet {
 		long resourcePrimKey = ParamUtil.getLong(
 			resourceRequest, "resourcePrimKey");
 
-		int rssDelta = ParamUtil.getInteger(resourceRequest, "rssDelta");
-		String rssDisplayStyle = ParamUtil.getString(
-			resourceRequest, "rssDisplayStyle");
-		String rssFormat = ParamUtil.getString(resourceRequest, "rssFormat");
+		String displayStyle = ParamUtil.getString(
+			resourceRequest, "displayStyle", RSSUtil.DISPLAY_STYLE_DEFAULT);
+		int max = ParamUtil.getInteger(
+			resourceRequest, "max", SearchContainer.DEFAULT_DELTA);
+		String type = ParamUtil.getString(
+			resourceRequest, "type", RSSUtil.FORMAT_DEFAULT);
+		double version = ParamUtil.getDouble(
+			resourceRequest, "version", RSSUtil.VERSION_DEFAULT);
 
 		String rss = kbArticleService.getKBArticleRSS(
-			resourcePrimKey, WorkflowConstants.STATUS_APPROVED, rssDelta,
-			rssDisplayStyle, rssFormat, themeDisplay);
+			resourcePrimKey, WorkflowConstants.STATUS_APPROVED, max, type,
+			version, displayStyle, themeDisplay);
 
 		PortletResponseUtil.sendFile(
 			resourceRequest, resourceResponse, null,

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/init.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/init.jsp
@@ -41,9 +41,4 @@ boolean enableKBArticleHistory = GetterUtil.getBoolean(request.getAttribute("ini
 boolean enableKBArticlePrint = GetterUtil.getBoolean(request.getAttribute("init.jsp-enableKBArticlePrint"));
 String socialBookmarksDisplayStyle = GetterUtil.getString(request.getAttribute("init.jsp-socialBookmarksDisplayStyle"));
 String socialBookmarksTypes = GetterUtil.getString(request.getAttribute("init.jsp-socialBookmarksTypes"), null);
-
-boolean enableRSS = kbGroupServiceConfiguration.enableRSS();
-int rssDelta = kbGroupServiceConfiguration.rssDelta();
-String rssDisplayStyle = kbGroupServiceConfiguration.rssDisplayStyle();
-String rssFeedType = kbGroupServiceConfiguration.rssFeedType();
 %>

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/kb_article_tools.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/kb_article_tools.jsp
@@ -33,16 +33,16 @@ int status = (Integer)request.getAttribute(KBWebKeys.KNOWLEDGE_BASE_STATUS);
 		</a>
 	</c:if>
 
-	<c:if test="<%= enableRSS && (kbArticle.isApproved() || !kbArticle.isFirstVersion()) && !Objects.equals(portletDisplay.getRootPortletId(), KBPortletKeys.KNOWLEDGE_BASE_ADMIN) %>">
+	<c:if test="<%= kbGroupServiceConfiguration.enableRSS() && (kbArticle.isApproved() || !kbArticle.isFirstVersion()) && !Objects.equals(portletDisplay.getRootPortletId(), KBPortletKeys.KNOWLEDGE_BASE_ADMIN) %>">
 		<liferay-portlet:resourceURL id="kbArticleRSS" varImpl="kbArticleRSSURL">
 			<portlet:param name="resourceClassNameId" value="<%= String.valueOf(kbArticle.getClassNameId()) %>" />
 			<portlet:param name="resourcePrimKey" value="<%= String.valueOf(kbArticle.getResourcePrimKey()) %>" />
 		</liferay-portlet:resourceURL>
 
 		<liferay-rss:rss
-			delta="<%= rssDelta %>"
-			displayStyle="<%= rssDisplayStyle %>"
-			feedType="<%= rssFeedType %>"
+			delta="<%= GetterUtil.getInteger(kbGroupServiceConfiguration.rssDelta()) %>"
+			displayStyle="<%= kbGroupServiceConfiguration.rssDisplayStyle() %>"
+			feedType="<%= kbGroupServiceConfiguration.rssFeedType() %>"
 			resourceURL="<%= kbArticleRSSURL %>"
 		/>
 	</c:if>

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/configuration.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/configuration.jsp
@@ -236,7 +236,7 @@ kbGroupServiceConfiguration = ParameterMapUtil.setParameterMap(KBGroupServiceCon
 					<liferay-frontend:fieldset-group>
 						<liferay-frontend:fieldset>
 							<liferay-rss:rss-settings
-								delta="<%= kbGroupServiceConfiguration.rssDelta() %>"
+								delta="<%= GetterUtil.getInteger(kbGroupServiceConfiguration.rssDelta()) %>"
 								displayStyle="<%= kbGroupServiceConfiguration.rssDisplayStyle() %>"
 								enabled="<%= kbGroupServiceConfiguration.enableRSS() %>"
 								feedType="<%= kbGroupServiceConfiguration.rssFeedType() %>"

--- a/modules/apps/rss/rss-api/src/main/java/com/liferay/rss/util/RSSUtil.java
+++ b/modules/apps/rss/rss-api/src/main/java/com/liferay/rss/util/RSSUtil.java
@@ -128,15 +128,11 @@ public class RSSUtil {
 			return VERSION_DEFAULT;
 		}
 
-		int x = format.indexOf("10");
-
-		if (x >= 0) {
+		if (format.contains("10") || format.contains("1.0")) {
 			return 1.0;
 		}
 
-		int y = format.indexOf("20");
-
-		if (y >= 0) {
+		if (format.contains("20") || format.contains("2.0")) {
 			return 2.0;
 		}
 


### PR DESCRIPTION
Hi, this PR solves the problem described in issue. I've found two problems and I've made some refactorization based on similar classes: _WikiGroupServiceConfiguration_, _WikiPageService_ and _RSSStrutsAction_

- LPS-167112 FIX add support for "atom_1.0", "rss_1.0" or "rss_2.0" formats
- LPS-167112 Removed duplicated attribute "rssFormat", using server properties instead of hardcoded default values
- LPS-167112 Changed method signature in KBArticleService to separate rss format in type+version
- LPS-167112 auto baseline for module knowledge-base-api
- LPS-167112 Using type+version instead of single rss format string
- LPS-167112 Removed unnecessary variables and casting String to Integer
- LPS-167112 FIX using correct request parameters
