### PR TITLE
LPS-167443 KB CKEditor custom required message

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_kb_article.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_kb_article.jsp
@@ -294,7 +294,7 @@ if (editKBArticleDisplayContext.isPortletTitleBasedNavigation()) {
 								placeholder="content"
 								required="<%= true %>"
 							>
-								<aui:validator name="required" />
+								<aui:validator errorMessage='<%= LanguageUtil.format(resourceBundle, "the-x-field-is-required", "content", true) %>' name="required" />
 							</liferay-editor:editor>
 
 							<aui:input name="content" type="hidden" />

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_kb_template.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_kb_template.jsp
@@ -57,7 +57,7 @@ renderResponse.setTitle((kbTemplate == null) ? LanguageUtil.get(request, "new-te
 					placeholder="content"
 					required="<%= true %>"
 				>
-					<aui:validator name="required" />
+					<aui:validator errorMessage='<%= LanguageUtil.format(resourceBundle, "the-x-field-is-required", "content", true) %>' name="required" />
 				</liferay-editor:editor>
 
 				<aui:input name="content" type="hidden" />


### PR DESCRIPTION
By default, editors take its name to render a validation message, and in this case was content-editor. Fortunately this can be manually defined. 

**Before:** 

<img width="1639" alt="Screenshot 2022-11-03 at 14 24 36" src="https://user-images.githubusercontent.com/8373764/199954938-ec683cdd-7aa7-4174-8bc6-1a0ad9907ae7.png">

**After:** 

<img width="1629" alt="Screenshot 2022-11-04 at 11 40 52" src="https://user-images.githubusercontent.com/8373764/199954966-773d1b58-2903-4209-a896-477b48ce4f20.png">
