### PR TITLE
LPS-167676: Use unique ID for panel - there can be multiple structures per DLFileEntry

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info_panel_file_entry.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info_panel_file_entry.jsp
@@ -486,7 +486,7 @@ long assetClassPK = DLAssetHelperUtil.getAssetClassPK(fileEntry, fileVersion);
 									cssClass="metadata"
 									defaultState="closed"
 									extended="<%= true %>"
-									id='<%= "documentLibraryMetadataPanel_" + fileEntry.getFileEntryId() %>'
+									id='<%= "documentLibraryMetadataPanel_" + ddmStructure.getStructureId() %>'
 									markupView="lexicon"
 									persistState="<%= true %>"
 									title="<%= HtmlUtil.escape(ddmStructure.getName(locale)) %>"
@@ -552,7 +552,7 @@ long assetClassPK = DLAssetHelperUtil.getAssetClassPK(fileEntry, fileVersion);
 								collapsible="<%= true %>"
 								cssClass="lfr-asset-metadata panel-unstyled"
 								defaultState="closed"
-								id='<%= "documentLibraryMetadataPanel_" + fileEntry.getFileEntryId() %>'
+								id='<%= "documentLibraryMetadataPanel_" + ddmStructure.getStructureId() %>'
 								markupView="lexicon"
 								persistState="<%= true %>"
 								title='<%= "metadata." + ddmStructure.getStructureKey() %>'


### PR DESCRIPTION
Each DLFileEntry can be associated with multiple metadata entries (extracted metadata, document type, metadata fields). Each of these entries is displayed in a new panel which can be individually collapsed.

The panels were identified by an id build from a fixed prefix and the fileEntryId. So when multiple panels are present, the ids are duplicated in the page. Instead of using the fileEntryId, the id of the ddmstructures is used.