### PR TITLE
LPS-167717 Manually triggering scheduled jobs invokes all jobs

### DIFF
--- a/modules/apps/portal-scheduler/portal-scheduler-quartz/src/main/java/com/liferay/portal/scheduler/quartz/internal/QuartzSchedulerEngine.java
+++ b/modules/apps/portal-scheduler/portal-scheduler-quartz/src/main/java/com/liferay/portal/scheduler/quartz/internal/QuartzSchedulerEngine.java
@@ -636,6 +636,12 @@ public class QuartzSchedulerEngine implements SchedulerEngine {
 		String jobName = jobKey.getName();
 		String groupName = jobKey.getGroup();
 
+		message.put(
+			SchedulerEngine.DESTINATION_NAME,
+			jobDataMap.getString(SchedulerEngine.DESTINATION_NAME));
+		message.put(SchedulerEngine.JOB_NAME, jobName);
+		message.put(SchedulerEngine.GROUP_NAME, groupName);
+
 		TriggerKey triggerKey = new TriggerKey(jobName, groupName);
 
 		Trigger trigger = scheduler.getTrigger(triggerKey);


### PR DESCRIPTION
The web interface triggers the job invocation through SchedulerResponseManagerImpl#run. The method uses a call to SchedulerEngineHelper#getScheduledJob to fetch the SchedulerResponse, which is used to access the message, that is then send over the liferay MessageBus.

The message is received by SchedulerEventMessageListenerWrapper, which uses the message parts DESTINATION_NAME, JOB_NAME and GROUP_NAME to find the right scheduled job to invoke.

If DESTINATION_NAME is missing, the complete check will be skipped and all jobs will be triggered by this message. If JOB_NAME or GROUP_NAME are missing a NullPointerException could be raised.

To fix this described parts need to be added to the message in QuartzSchedulerEngine#getScheduledJob.