### PR TITLE
LPS-168175 Add descriptive/list view to dm browser; use it in blogs

### DIFF
--- a/modules/apps/blogs/blogs-web/build.gradle
+++ b/modules/apps/blogs/blogs-web/build.gradle
@@ -23,6 +23,7 @@ dependencies {
 	compileOnly project(":apps:changeset:changeset-api")
 	compileOnly project(":apps:comment:comment-taglib")
 	compileOnly project(":apps:document-library:document-library-api")
+	compileOnly project(":apps:document-library:document-library-taglib")
 	compileOnly project(":apps:dynamic-data-mapping:dynamic-data-mapping-taglib")
 	compileOnly project(":apps:expando:expando-api")
 	compileOnly project(":apps:expando:expando-taglib")

--- a/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/display/context/BlogImagesDisplayContext.java
+++ b/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/display/context/BlogImagesDisplayContext.java
@@ -59,6 +59,16 @@ public class BlogImagesDisplayContext {
 		_httpServletRequest = _liferayPortletRequest.getHttpServletRequest();
 	}
 
+	public long getFolderId() throws PortalException {
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)_httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		Folder folder = _getAttachmentsFolder(themeDisplay);
+
+		return folder.getFolderId();
+	}
+
 	public String getOrderByCol() {
 		if (Validator.isNotNull(_orderByCol)) {
 			return _orderByCol;
@@ -83,6 +93,16 @@ public class BlogImagesDisplayContext {
 		return _orderByType;
 	}
 
+	public long getRepositoryId() throws PortalException {
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)_httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		Folder folder = _getAttachmentsFolder(themeDisplay);
+
+		return folder.getRepositoryId();
+	}
+
 	public void populateResults(SearchContainer<FileEntry> searchContainer)
 		throws PortalException {
 
@@ -90,9 +110,7 @@ public class BlogImagesDisplayContext {
 			(ThemeDisplay)_httpServletRequest.getAttribute(
 				WebKeys.THEME_DISPLAY);
 
-		Folder attachmentsFolder =
-			BlogsEntryLocalServiceUtil.addAttachmentsFolder(
-				themeDisplay.getUserId(), themeDisplay.getScopeGroupId());
+		Folder attachmentsFolder = _getAttachmentsFolder(themeDisplay);
 
 		String keywords = ParamUtil.getString(_httpServletRequest, "keywords");
 
@@ -154,9 +172,23 @@ public class BlogImagesDisplayContext {
 		}
 	}
 
+	private Folder _getAttachmentsFolder(ThemeDisplay themeDisplay)
+		throws PortalException {
+
+		if (_folder != null) {
+			return _folder;
+		}
+
+		_folder = BlogsEntryLocalServiceUtil.addAttachmentsFolder(
+			themeDisplay.getUserId(), themeDisplay.getScopeGroupId());
+
+		return _folder;
+	}
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		BlogImagesDisplayContext.class);
 
+	private Folder _folder;
 	private final HttpServletRequest _httpServletRequest;
 	private final LiferayPortletRequest _liferayPortletRequest;
 	private String _orderByCol;

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/init.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/init.jsp
@@ -16,6 +16,8 @@
 
 <%@ include file="/init.jsp" %>
 
+<%@ taglib uri="http://liferay.com/tld/document-library" prefix="liferay-document-library" %>
+
 <%
 BlogsGroupServiceSettings blogsGroupServiceSettings = BlogsGroupServiceSettings.getInstance(scopeGroupId);
 %>

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/view_images.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/view_images.jsp
@@ -16,97 +16,113 @@
 
 <%@ include file="/blogs_admin/init.jsp" %>
 
-<%
-int delta = ParamUtil.getInteger(request, SearchContainer.DEFAULT_DELTA_PARAM);
-String orderByCol = ParamUtil.getString(request, "orderByCol", "title");
-String orderByType = ParamUtil.getString(request, "orderByType", "asc");
+<c:choose>
+	<c:when test='<%= GetterUtil.getBoolean(PropsUtil.get("feature.flag.LPS-168174")) %>'>
 
-PortletURL portletURL = PortletURLBuilder.createRenderURL(
-	renderResponse
-).setMVCRenderCommandName(
-	"/blogs/view"
-).setNavigation(
-	"images"
-).buildPortletURL();
+		<%
+		BlogImagesDisplayContext blogImagesDisplayContext = new BlogImagesDisplayContext(liferayPortletRequest);
+		%>
 
-if (delta > 0) {
-	portletURL.setParameter("delta", String.valueOf(delta));
-}
+		<liferay-document-library:repository-browser
+			folderId="<%= blogImagesDisplayContext.getFolderId() %>"
+			repositoryId="<%= blogImagesDisplayContext.getRepositoryId() %>"
+		/>
+	</c:when>
+	<c:otherwise>
 
-portletURL.setParameter("orderBycol", orderByCol);
-portletURL.setParameter("orderByType", orderByType);
+		<%
+		int delta = ParamUtil.getInteger(request, SearchContainer.DEFAULT_DELTA_PARAM);
+		String orderByCol = ParamUtil.getString(request, "orderByCol", "title");
+		String orderByType = ParamUtil.getString(request, "orderByType", "asc");
 
-request.setAttribute("view_images.jsp-portletURL", portletURL);
+		PortletURL portletURL = PortletURLBuilder.createRenderURL(
+			renderResponse
+		).setMVCRenderCommandName(
+			"/blogs/view"
+		).setNavigation(
+			"images"
+		).buildPortletURL();
 
-SearchContainer<FileEntry> blogImagesSearchContainer = new SearchContainer(renderRequest, PortletURLUtil.clone(portletURL, liferayPortletResponse), null, "no-images-were-found");
+		if (delta > 0) {
+			portletURL.setParameter("delta", String.valueOf(delta));
+		}
 
-blogImagesSearchContainer.setOrderByComparator(DLUtil.getRepositoryModelOrderByComparator(orderByCol, orderByType));
+		portletURL.setParameter("orderBycol", orderByCol);
+		portletURL.setParameter("orderByType", orderByType);
 
-blogImagesSearchContainer.setRowChecker(new EmptyOnClickRowChecker(renderResponse));
+		request.setAttribute("view_images.jsp-portletURL", portletURL);
 
-BlogImagesDisplayContext blogImagesDisplayContext = new BlogImagesDisplayContext(liferayPortletRequest);
+		SearchContainer<FileEntry> blogImagesSearchContainer = new SearchContainer(renderRequest, PortletURLUtil.clone(portletURL, liferayPortletResponse), null, "no-images-were-found");
 
-blogImagesDisplayContext.populateResults(blogImagesSearchContainer);
+		blogImagesSearchContainer.setOrderByComparator(DLUtil.getRepositoryModelOrderByComparator(orderByCol, orderByType));
 
-BlogImagesManagementToolbarDisplayContext blogImagesManagementToolbarDisplayContext = new BlogImagesManagementToolbarDisplayContext(request, liferayPortletRequest, liferayPortletResponse, blogImagesSearchContainer);
+		blogImagesSearchContainer.setRowChecker(new EmptyOnClickRowChecker(renderResponse));
 
-String displayStyle = blogImagesManagementToolbarDisplayContext.getDisplayStyle();
-%>
+		BlogImagesDisplayContext blogImagesDisplayContext = new BlogImagesDisplayContext(liferayPortletRequest);
 
-<clay:management-toolbar
-	actionDropdownItems="<%= blogImagesManagementToolbarDisplayContext.getActionDropdownItems() %>"
-	clearResultsURL="<%= blogImagesManagementToolbarDisplayContext.getSearchActionURL() %>"
-	disabled="<%= blogImagesSearchContainer.getTotal() <= 0 %>"
-	filterDropdownItems="<%= blogImagesManagementToolbarDisplayContext.getFilterDropdownItems() %>"
-	itemsTotal="<%= blogImagesSearchContainer.getTotal() %>"
-	managementToolbarDisplayContext="<%= blogImagesManagementToolbarDisplayContext %>"
-	propsTransformer="blogs_admin/js/BlogImagesManagementToolbarPropsTransformer"
-	searchActionURL="<%= blogImagesManagementToolbarDisplayContext.getSearchActionURL() %>"
-	searchContainerId="images"
-	searchFormName="searchFm"
-	showCreationMenu="<%= false %>"
-	showInfoButton="<%= false %>"
-	sortingOrder="<%= blogImagesManagementToolbarDisplayContext.getOrderByType() %>"
-	sortingURL="<%= blogImagesManagementToolbarDisplayContext.getSortingURL() %>"
-	viewTypeItems="<%= blogImagesManagementToolbarDisplayContext.getViewTypes() %>"
-/>
+		blogImagesDisplayContext.populateResults(blogImagesSearchContainer);
 
-<clay:container-fluid>
-	<portlet:actionURL name="/blogs/edit_image" var="editImageURL" />
+		BlogImagesManagementToolbarDisplayContext blogImagesManagementToolbarDisplayContext = new BlogImagesManagementToolbarDisplayContext(request, liferayPortletRequest, liferayPortletResponse, blogImagesSearchContainer);
 
-	<aui:form action="<%= editImageURL %>" name="fm">
-		<aui:input name="<%= Constants.CMD %>" type="hidden" />
-		<aui:input name="redirect" type="hidden" value="<%= portletURL.toString() %>" />
-		<aui:input name="deleteFileEntryIds" type="hidden" />
+		String displayStyle = blogImagesManagementToolbarDisplayContext.getDisplayStyle();
+		%>
 
-		<liferay-ui:search-container
-			id="images"
-			searchContainer="<%= blogImagesSearchContainer %>"
-		>
-			<liferay-ui:search-container-row
-				className="com.liferay.portal.kernel.repository.model.FileEntry"
-				keyProperty="fileEntryId"
-				modelVar="fileEntry"
-			>
-				<liferay-portlet:renderURL varImpl="rowURL">
-					<portlet:param name="mvcRenderCommandName" value="/blogs/edit_image" />
-					<portlet:param name="fileEntryId" value="<%= String.valueOf(fileEntry.getFileEntryId()) %>" />
-				</liferay-portlet:renderURL>
+		<clay:management-toolbar
+			actionDropdownItems="<%= blogImagesManagementToolbarDisplayContext.getActionDropdownItems() %>"
+			clearResultsURL="<%= blogImagesManagementToolbarDisplayContext.getSearchActionURL() %>"
+			disabled="<%= blogImagesSearchContainer.getTotal() <= 0 %>"
+			filterDropdownItems="<%= blogImagesManagementToolbarDisplayContext.getFilterDropdownItems() %>"
+			itemsTotal="<%= blogImagesSearchContainer.getTotal() %>"
+			managementToolbarDisplayContext="<%= blogImagesManagementToolbarDisplayContext %>"
+			propsTransformer="blogs_admin/js/BlogImagesManagementToolbarPropsTransformer"
+			searchActionURL="<%= blogImagesManagementToolbarDisplayContext.getSearchActionURL() %>"
+			searchContainerId="images"
+			searchFormName="searchFm"
+			showCreationMenu="<%= false %>"
+			showInfoButton="<%= false %>"
+			sortingOrder="<%= blogImagesManagementToolbarDisplayContext.getOrderByType() %>"
+			sortingURL="<%= blogImagesManagementToolbarDisplayContext.getSortingURL() %>"
+			viewTypeItems="<%= blogImagesManagementToolbarDisplayContext.getViewTypes() %>"
+		/>
 
-				<%
-				row.setData(
-					HashMapBuilder.<String, Object>put(
-						"actions", StringUtil.merge(blogImagesManagementToolbarDisplayContext.getAvailableActions(fileEntry))
-					).build());
-				%>
+		<clay:container-fluid>
+			<portlet:actionURL name="/blogs/edit_image" var="editImageURL" />
 
-				<%@ include file="/blogs_admin/image_search_columns.jspf" %>
-			</liferay-ui:search-container-row>
+			<aui:form action="<%= editImageURL %>" name="fm">
+				<aui:input name="<%= Constants.CMD %>" type="hidden" />
+				<aui:input name="redirect" type="hidden" value="<%= portletURL.toString() %>" />
+				<aui:input name="deleteFileEntryIds" type="hidden" />
 
-			<liferay-ui:search-iterator
-				displayStyle="<%= displayStyle %>"
-				markupView="lexicon"
-			/>
-		</liferay-ui:search-container>
-	</aui:form>
-</clay:container-fluid>
+				<liferay-ui:search-container
+					id="images"
+					searchContainer="<%= blogImagesSearchContainer %>"
+				>
+					<liferay-ui:search-container-row
+						className="com.liferay.portal.kernel.repository.model.FileEntry"
+						keyProperty="fileEntryId"
+						modelVar="fileEntry"
+					>
+						<liferay-portlet:renderURL varImpl="rowURL">
+							<portlet:param name="mvcRenderCommandName" value="/blogs/edit_image" />
+							<portlet:param name="fileEntryId" value="<%= String.valueOf(fileEntry.getFileEntryId()) %>" />
+						</liferay-portlet:renderURL>
+
+						<%
+						row.setData(
+							HashMapBuilder.<String, Object>put(
+								"actions", StringUtil.merge(blogImagesManagementToolbarDisplayContext.getAvailableActions(fileEntry))
+							).build());
+						%>
+
+						<%@ include file="/blogs_admin/image_search_columns.jspf" %>
+					</liferay-ui:search-container-row>
+
+					<liferay-ui:search-iterator
+						displayStyle="<%= displayStyle %>"
+						markupView="lexicon"
+					/>
+				</liferay-ui:search-container>
+			</aui:form>
+		</clay:container-fluid>
+	</c:otherwise>
+</c:choose>

--- a/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/display/context/RepositoryBrowserManagementToolbarDisplayContext.java
+++ b/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/display/context/RepositoryBrowserManagementToolbarDisplayContext.java
@@ -129,7 +129,7 @@ public class RepositoryBrowserManagementToolbarDisplayContext
 
 	@Override
 	public String[] getDisplayViews() {
-		return new String[] {"icon"};
+		return new String[] {"icon", "descriptive", "list"};
 	}
 
 	@Override

--- a/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/display/context/RepositoryBrowserTagDisplayContext.java
+++ b/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/display/context/RepositoryBrowserTagDisplayContext.java
@@ -109,7 +109,7 @@ public class RepositoryBrowserTagDisplayContext {
 			WebKeys.THEME_DISPLAY);
 	}
 
-	public List<DropdownItem> getActionDropdownItems(FileEntry fileEntry) {
+	private List<DropdownItem> _getActionDropdownItems(FileEntry fileEntry) {
 		return DropdownItemListBuilder.add(
 			() -> _fileEntryModelResourcePermission.contains(
 				_themeDisplay.getPermissionChecker(), fileEntry,
@@ -117,7 +117,7 @@ public class RepositoryBrowserTagDisplayContext {
 			dropdownItem -> {
 				dropdownItem.putData("action", "rename");
 				dropdownItem.putData(
-					"renameURL", getRenameFileEntryURL(fileEntry));
+					"renameURL", _getRenameFileEntryURL(fileEntry));
 				dropdownItem.putData("value", fileEntry.getTitle());
 				dropdownItem.setIcon("pencil");
 				dropdownItem.setLabel(
@@ -130,7 +130,7 @@ public class RepositoryBrowserTagDisplayContext {
 			dropdownItem -> {
 				dropdownItem.putData("action", "delete");
 				dropdownItem.putData(
-					"deleteURL", getDeleteFileEntryURL(fileEntry));
+					"deleteURL", _getDeleteFileEntryURL(fileEntry));
 				dropdownItem.setIcon("trash");
 				dropdownItem.setLabel(
 					LanguageUtil.get(_httpServletRequest, "delete"));
@@ -138,7 +138,7 @@ public class RepositoryBrowserTagDisplayContext {
 		).build();
 	}
 
-	public List<DropdownItem> getActionDropdownItems(
+	private List<DropdownItem> _getActionDropdownItems(
 		FileShortcut fileShortcut) {
 
 		return DropdownItemListBuilder.add(
@@ -148,7 +148,7 @@ public class RepositoryBrowserTagDisplayContext {
 			dropdownItem -> {
 				dropdownItem.putData("action", "delete");
 				dropdownItem.putData(
-					"deleteURL", getDeleteFileShortcutURL(fileShortcut));
+					"deleteURL", _getDeleteFileShortcutURL(fileShortcut));
 				dropdownItem.setIcon("trash");
 				dropdownItem.setLabel(
 					LanguageUtil.get(_httpServletRequest, "delete"));
@@ -156,14 +156,14 @@ public class RepositoryBrowserTagDisplayContext {
 		).build();
 	}
 
-	public List<DropdownItem> getActionDropdownItems(Folder folder) {
+	private List<DropdownItem> _getActionDropdownItems(Folder folder) {
 		return DropdownItemListBuilder.add(
 			() -> _folderModelResourcePermission.contains(
 				_themeDisplay.getPermissionChecker(), folder,
 				ActionKeys.UPDATE),
 			dropdownItem -> {
 				dropdownItem.putData("action", "rename");
-				dropdownItem.putData("renameURL", getRenameFolderURL(folder));
+				dropdownItem.putData("renameURL", _getRenameFolderURL(folder));
 				dropdownItem.putData("value", folder.getName());
 				dropdownItem.setIcon("pencil");
 				dropdownItem.setLabel(
@@ -175,7 +175,7 @@ public class RepositoryBrowserTagDisplayContext {
 				ActionKeys.DELETE),
 			dropdownItem -> {
 				dropdownItem.putData("action", "delete");
-				dropdownItem.putData("deleteURL", getDeleteFolderURL(folder));
+				dropdownItem.putData("deleteURL", _getDeleteFolderURL(folder));
 				dropdownItem.setIcon("trash");
 				dropdownItem.setLabel(
 					LanguageUtil.get(_httpServletRequest, "delete"));
@@ -184,19 +184,18 @@ public class RepositoryBrowserTagDisplayContext {
 	}
 
 	public List<DropdownItem> getActionDropdownItems(
-			RepositoryEntry repositoryEntry)
-		throws PortalException {
+		RepositoryEntry repositoryEntry) {
 
 		if (repositoryEntry instanceof FileEntry) {
-			return getActionDropdownItems((FileEntry)repositoryEntry);
+			return _getActionDropdownItems((FileEntry)repositoryEntry);
 		}
 
 		if (repositoryEntry instanceof FileShortcut) {
-			return getActionDropdownItems((FileShortcut)repositoryEntry);
+			return _getActionDropdownItems((FileShortcut)repositoryEntry);
 		}
 
 		if (repositoryEntry instanceof Folder) {
-			return getActionDropdownItems((Folder)repositoryEntry);
+			return _getActionDropdownItems((Folder)repositoryEntry);
 		}
 
 		throw new IllegalArgumentException(
@@ -234,19 +233,19 @@ public class RepositoryBrowserTagDisplayContext {
 		return breadcrumbEntries;
 	}
 
-	public String getDeleteFileEntryURL(FileEntry fileEntry) {
+	private String _getDeleteFileEntryURL(FileEntry fileEntry) {
 		return HttpComponentsUtil.addParameter(
 			_getRepositoryBrowserURL(), "fileEntryId",
 			fileEntry.getFileEntryId());
 	}
 
-	public String getDeleteFileShortcutURL(FileShortcut fileShortcut) {
+	private String _getDeleteFileShortcutURL(FileShortcut fileShortcut) {
 		return HttpComponentsUtil.addParameter(
 			_getRepositoryBrowserURL(), "fileShortcutId",
 			fileShortcut.getFileShortcutId());
 	}
 
-	public String getDeleteFolderURL(Folder folder) {
+	private String _getDeleteFolderURL(Folder folder) {
 		return HttpComponentsUtil.addParameter(
 			_getRepositoryBrowserURL(), "folderId", folder.getFolderId());
 	}
@@ -286,13 +285,13 @@ public class RepositoryBrowserTagDisplayContext {
 			getSearchContainer());
 	}
 
-	public String getRenameFileEntryURL(FileEntry fileEntry) {
+	private String _getRenameFileEntryURL(FileEntry fileEntry) {
 		return HttpComponentsUtil.addParameter(
 			_getRepositoryBrowserURL(), "fileEntryId",
 			fileEntry.getFileEntryId());
 	}
 
-	public String getRenameFolderURL(Folder folder) {
+	private String _getRenameFolderURL(Folder folder) {
 		return HttpComponentsUtil.addParameter(
 			_getRepositoryBrowserURL(), "folderId", folder.getFolderId());
 	}

--- a/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/display/context/RepositoryBrowserTagDisplayContext.java
+++ b/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/display/context/RepositoryBrowserTagDisplayContext.java
@@ -109,80 +109,6 @@ public class RepositoryBrowserTagDisplayContext {
 			WebKeys.THEME_DISPLAY);
 	}
 
-	private List<DropdownItem> _getActionDropdownItems(FileEntry fileEntry) {
-		return DropdownItemListBuilder.add(
-			() -> _fileEntryModelResourcePermission.contains(
-				_themeDisplay.getPermissionChecker(), fileEntry,
-				ActionKeys.UPDATE),
-			dropdownItem -> {
-				dropdownItem.putData("action", "rename");
-				dropdownItem.putData(
-					"renameURL", _getRenameFileEntryURL(fileEntry));
-				dropdownItem.putData("value", fileEntry.getTitle());
-				dropdownItem.setIcon("pencil");
-				dropdownItem.setLabel(
-					LanguageUtil.get(_httpServletRequest, "rename"));
-			}
-		).add(
-			() -> _fileEntryModelResourcePermission.contains(
-				_themeDisplay.getPermissionChecker(), fileEntry,
-				ActionKeys.DELETE),
-			dropdownItem -> {
-				dropdownItem.putData("action", "delete");
-				dropdownItem.putData(
-					"deleteURL", _getDeleteFileEntryURL(fileEntry));
-				dropdownItem.setIcon("trash");
-				dropdownItem.setLabel(
-					LanguageUtil.get(_httpServletRequest, "delete"));
-			}
-		).build();
-	}
-
-	private List<DropdownItem> _getActionDropdownItems(
-		FileShortcut fileShortcut) {
-
-		return DropdownItemListBuilder.add(
-			() -> _fileShortcutModelResourcePermission.contains(
-				_themeDisplay.getPermissionChecker(), fileShortcut,
-				ActionKeys.DELETE),
-			dropdownItem -> {
-				dropdownItem.putData("action", "delete");
-				dropdownItem.putData(
-					"deleteURL", _getDeleteFileShortcutURL(fileShortcut));
-				dropdownItem.setIcon("trash");
-				dropdownItem.setLabel(
-					LanguageUtil.get(_httpServletRequest, "delete"));
-			}
-		).build();
-	}
-
-	private List<DropdownItem> _getActionDropdownItems(Folder folder) {
-		return DropdownItemListBuilder.add(
-			() -> _folderModelResourcePermission.contains(
-				_themeDisplay.getPermissionChecker(), folder,
-				ActionKeys.UPDATE),
-			dropdownItem -> {
-				dropdownItem.putData("action", "rename");
-				dropdownItem.putData("renameURL", _getRenameFolderURL(folder));
-				dropdownItem.putData("value", folder.getName());
-				dropdownItem.setIcon("pencil");
-				dropdownItem.setLabel(
-					LanguageUtil.get(_httpServletRequest, "rename"));
-			}
-		).add(
-			() -> _folderModelResourcePermission.contains(
-				_themeDisplay.getPermissionChecker(), folder,
-				ActionKeys.DELETE),
-			dropdownItem -> {
-				dropdownItem.putData("action", "delete");
-				dropdownItem.putData("deleteURL", _getDeleteFolderURL(folder));
-				dropdownItem.setIcon("trash");
-				dropdownItem.setLabel(
-					LanguageUtil.get(_httpServletRequest, "delete"));
-			}
-		).build();
-	}
-
 	public List<DropdownItem> getActionDropdownItems(
 		RepositoryEntry repositoryEntry) {
 
@@ -233,23 +159,6 @@ public class RepositoryBrowserTagDisplayContext {
 		return breadcrumbEntries;
 	}
 
-	private String _getDeleteFileEntryURL(FileEntry fileEntry) {
-		return HttpComponentsUtil.addParameter(
-			_getRepositoryBrowserURL(), "fileEntryId",
-			fileEntry.getFileEntryId());
-	}
-
-	private String _getDeleteFileShortcutURL(FileShortcut fileShortcut) {
-		return HttpComponentsUtil.addParameter(
-			_getRepositoryBrowserURL(), "fileShortcutId",
-			fileShortcut.getFileShortcutId());
-	}
-
-	private String _getDeleteFolderURL(Folder folder) {
-		return HttpComponentsUtil.addParameter(
-			_getRepositoryBrowserURL(), "folderId", folder.getFolderId());
-	}
-
 	public String getDisplayStyle() {
 		if (_displayStyle != null) {
 			return _displayStyle;
@@ -283,17 +192,6 @@ public class RepositoryBrowserTagDisplayContext {
 			_folderId, _folderModelResourcePermission, _httpServletRequest,
 			_liferayPortletRequest, _liferayPortletResponse, _repositoryId,
 			getSearchContainer());
-	}
-
-	private String _getRenameFileEntryURL(FileEntry fileEntry) {
-		return HttpComponentsUtil.addParameter(
-			_getRepositoryBrowserURL(), "fileEntryId",
-			fileEntry.getFileEntryId());
-	}
-
-	private String _getRenameFolderURL(Folder folder) {
-		return HttpComponentsUtil.addParameter(
-			_getRepositoryBrowserURL(), "folderId", folder.getFolderId());
 	}
 
 	public Map<String, Object> getRepositoryBrowserComponentContext() {
@@ -506,6 +404,97 @@ public class RepositoryBrowserTagDisplayContext {
 		return breadcrumbEntry;
 	}
 
+	private List<DropdownItem> _getActionDropdownItems(FileEntry fileEntry) {
+		return DropdownItemListBuilder.add(
+			() -> _fileEntryModelResourcePermission.contains(
+				_themeDisplay.getPermissionChecker(), fileEntry,
+				ActionKeys.UPDATE),
+			dropdownItem -> {
+				dropdownItem.putData("action", "rename");
+				dropdownItem.putData(
+					"renameURL", _getRenameFileEntryURL(fileEntry));
+				dropdownItem.putData("value", fileEntry.getTitle());
+				dropdownItem.setIcon("pencil");
+				dropdownItem.setLabel(
+					LanguageUtil.get(_httpServletRequest, "rename"));
+			}
+		).add(
+			() -> _fileEntryModelResourcePermission.contains(
+				_themeDisplay.getPermissionChecker(), fileEntry,
+				ActionKeys.DELETE),
+			dropdownItem -> {
+				dropdownItem.putData("action", "delete");
+				dropdownItem.putData(
+					"deleteURL", _getDeleteFileEntryURL(fileEntry));
+				dropdownItem.setIcon("trash");
+				dropdownItem.setLabel(
+					LanguageUtil.get(_httpServletRequest, "delete"));
+			}
+		).build();
+	}
+
+	private List<DropdownItem> _getActionDropdownItems(
+		FileShortcut fileShortcut) {
+
+		return DropdownItemListBuilder.add(
+			() -> _fileShortcutModelResourcePermission.contains(
+				_themeDisplay.getPermissionChecker(), fileShortcut,
+				ActionKeys.DELETE),
+			dropdownItem -> {
+				dropdownItem.putData("action", "delete");
+				dropdownItem.putData(
+					"deleteURL", _getDeleteFileShortcutURL(fileShortcut));
+				dropdownItem.setIcon("trash");
+				dropdownItem.setLabel(
+					LanguageUtil.get(_httpServletRequest, "delete"));
+			}
+		).build();
+	}
+
+	private List<DropdownItem> _getActionDropdownItems(Folder folder) {
+		return DropdownItemListBuilder.add(
+			() -> _folderModelResourcePermission.contains(
+				_themeDisplay.getPermissionChecker(), folder,
+				ActionKeys.UPDATE),
+			dropdownItem -> {
+				dropdownItem.putData("action", "rename");
+				dropdownItem.putData("renameURL", _getRenameFolderURL(folder));
+				dropdownItem.putData("value", folder.getName());
+				dropdownItem.setIcon("pencil");
+				dropdownItem.setLabel(
+					LanguageUtil.get(_httpServletRequest, "rename"));
+			}
+		).add(
+			() -> _folderModelResourcePermission.contains(
+				_themeDisplay.getPermissionChecker(), folder,
+				ActionKeys.DELETE),
+			dropdownItem -> {
+				dropdownItem.putData("action", "delete");
+				dropdownItem.putData("deleteURL", _getDeleteFolderURL(folder));
+				dropdownItem.setIcon("trash");
+				dropdownItem.setLabel(
+					LanguageUtil.get(_httpServletRequest, "delete"));
+			}
+		).build();
+	}
+
+	private String _getDeleteFileEntryURL(FileEntry fileEntry) {
+		return HttpComponentsUtil.addParameter(
+			_getRepositoryBrowserURL(), "fileEntryId",
+			fileEntry.getFileEntryId());
+	}
+
+	private String _getDeleteFileShortcutURL(FileShortcut fileShortcut) {
+		return HttpComponentsUtil.addParameter(
+			_getRepositoryBrowserURL(), "fileShortcutId",
+			fileShortcut.getFileShortcutId());
+	}
+
+	private String _getDeleteFolderURL(Folder folder) {
+		return HttpComponentsUtil.addParameter(
+			_getRepositoryBrowserURL(), "folderId", folder.getFolderId());
+	}
+
 	private SearchContainer<Object> _getDLSearchContainer()
 		throws PortalException {
 
@@ -573,6 +562,17 @@ public class RepositoryBrowserTagDisplayContext {
 		searchContext.setStart(searchContainer.getStart());
 
 		return DLAppServiceUtil.search(_repositoryId, searchContext);
+	}
+
+	private String _getRenameFileEntryURL(FileEntry fileEntry) {
+		return HttpComponentsUtil.addParameter(
+			_getRepositoryBrowserURL(), "fileEntryId",
+			fileEntry.getFileEntryId());
+	}
+
+	private String _getRenameFolderURL(Folder folder) {
+		return HttpComponentsUtil.addParameter(
+			_getRepositoryBrowserURL(), "folderId", folder.getFolderId());
 	}
 
 	private String _getRepositoryBrowserURL() {

--- a/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/frontend/taglib/clay/servlet/FileEntryVerticalCard.java
+++ b/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/frontend/taglib/clay/servlet/FileEntryVerticalCard.java
@@ -18,16 +18,12 @@ import com.liferay.document.library.taglib.internal.display.context.RepositoryBr
 import com.liferay.document.library.util.DLURLHelperUtil;
 import com.liferay.frontend.taglib.clay.servlet.taglib.VerticalCard;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
-import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemListBuilder;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.portal.kernel.dao.search.RowChecker;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.FileVersion;
-import com.liferay.portal.kernel.security.permission.ActionKeys;
-import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.WebKeys;
 
@@ -41,56 +37,23 @@ import javax.servlet.http.HttpServletRequest;
 public class FileEntryVerticalCard implements VerticalCard {
 
 	public FileEntryVerticalCard(
-			FileEntry fileEntry,
-			ModelResourcePermission<FileEntry> fileEntryModelResourcePermission,
-			HttpServletRequest httpServletRequest,
+			FileEntry fileEntry, HttpServletRequest httpServletRequest,
 			RepositoryBrowserTagDisplayContext
 				repositoryBrowserTagDisplayContext)
 		throws PortalException {
 
 		_fileEntry = fileEntry;
-		_fileEntryModelResourcePermission = fileEntryModelResourcePermission;
 		_httpServletRequest = httpServletRequest;
 		_repositoryBrowserTagDisplayContext =
 			repositoryBrowserTagDisplayContext;
 
 		_fileVersion = fileEntry.getFileVersion();
-		_themeDisplay = (ThemeDisplay)httpServletRequest.getAttribute(
-			WebKeys.THEME_DISPLAY);
 	}
 
 	@Override
 	public List<DropdownItem> getActionDropdownItems() {
-		return DropdownItemListBuilder.add(
-			() -> _fileEntryModelResourcePermission.contains(
-				_themeDisplay.getPermissionChecker(), _fileEntry,
-				ActionKeys.UPDATE),
-			dropdownItem -> {
-				dropdownItem.putData("action", "rename");
-				dropdownItem.putData(
-					"renameURL",
-					_repositoryBrowserTagDisplayContext.getRenameFileEntryURL(
-						_fileEntry));
-				dropdownItem.putData("value", _fileEntry.getTitle());
-				dropdownItem.setIcon("pencil");
-				dropdownItem.setLabel(
-					LanguageUtil.get(_httpServletRequest, "rename"));
-			}
-		).add(
-			() -> _fileEntryModelResourcePermission.contains(
-				_themeDisplay.getPermissionChecker(), _fileEntry,
-				ActionKeys.DELETE),
-			dropdownItem -> {
-				dropdownItem.putData("action", "delete");
-				dropdownItem.putData(
-					"deleteURL",
-					_repositoryBrowserTagDisplayContext.getDeleteFileEntryURL(
-						_fileEntry));
-				dropdownItem.setIcon("trash");
-				dropdownItem.setLabel(
-					LanguageUtil.get(_httpServletRequest, "delete"));
-			}
-		).build();
+		return _repositoryBrowserTagDisplayContext.getActionDropdownItems(
+			_fileEntry);
 	}
 
 	@Override
@@ -141,12 +104,9 @@ public class FileEntryVerticalCard implements VerticalCard {
 	}
 
 	private final FileEntry _fileEntry;
-	private final ModelResourcePermission<FileEntry>
-		_fileEntryModelResourcePermission;
 	private final FileVersion _fileVersion;
 	private final HttpServletRequest _httpServletRequest;
 	private final RepositoryBrowserTagDisplayContext
 		_repositoryBrowserTagDisplayContext;
-	private final ThemeDisplay _themeDisplay;
 
 }

--- a/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/frontend/taglib/clay/servlet/FileShortcutVerticalCard.java
+++ b/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/frontend/taglib/clay/servlet/FileShortcutVerticalCard.java
@@ -18,16 +18,12 @@ import com.liferay.document.library.taglib.internal.display.context.RepositoryBr
 import com.liferay.document.library.util.DLURLHelperUtil;
 import com.liferay.frontend.taglib.clay.servlet.taglib.VerticalCard;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
-import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemListBuilder;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.portal.kernel.dao.search.RowChecker;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.repository.model.FileShortcut;
 import com.liferay.portal.kernel.repository.model.FileVersion;
-import com.liferay.portal.kernel.security.permission.ActionKeys;
-import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.WebKeys;
 
@@ -41,43 +37,23 @@ import javax.servlet.http.HttpServletRequest;
 public class FileShortcutVerticalCard implements VerticalCard {
 
 	public FileShortcutVerticalCard(
-			FileShortcut fileShortcut,
-			ModelResourcePermission<FileShortcut>
-				fileShortcutModelResourcePermission,
-			HttpServletRequest httpServletRequest,
+			FileShortcut fileShortcut, HttpServletRequest httpServletRequest,
 			RepositoryBrowserTagDisplayContext
 				repositoryBrowserTagDisplayContext)
 		throws PortalException {
 
 		_fileShortcut = fileShortcut;
-		_fileShortcutModelResourcePermission =
-			fileShortcutModelResourcePermission;
 		_httpServletRequest = httpServletRequest;
 		_repositoryBrowserTagDisplayContext =
 			repositoryBrowserTagDisplayContext;
 
 		_fileVersion = fileShortcut.getFileVersion();
-		_themeDisplay = (ThemeDisplay)httpServletRequest.getAttribute(
-			WebKeys.THEME_DISPLAY);
 	}
 
 	@Override
 	public List<DropdownItem> getActionDropdownItems() {
-		return DropdownItemListBuilder.add(
-			() -> _fileShortcutModelResourcePermission.contains(
-				_themeDisplay.getPermissionChecker(), _fileShortcut,
-				ActionKeys.DELETE),
-			dropdownItem -> {
-				dropdownItem.putData("action", "delete");
-				dropdownItem.putData(
-					"deleteURL",
-					_repositoryBrowserTagDisplayContext.
-						getDeleteFileShortcutURL(_fileShortcut));
-				dropdownItem.setIcon("trash");
-				dropdownItem.setLabel(
-					LanguageUtil.get(_httpServletRequest, "delete"));
-			}
-		).build();
+		return _repositoryBrowserTagDisplayContext.getActionDropdownItems(
+			_fileShortcut);
 	}
 
 	@Override
@@ -128,12 +104,9 @@ public class FileShortcutVerticalCard implements VerticalCard {
 	}
 
 	private final FileShortcut _fileShortcut;
-	private final ModelResourcePermission<FileShortcut>
-		_fileShortcutModelResourcePermission;
 	private final FileVersion _fileVersion;
 	private final HttpServletRequest _httpServletRequest;
 	private final RepositoryBrowserTagDisplayContext
 		_repositoryBrowserTagDisplayContext;
-	private final ThemeDisplay _themeDisplay;
 
 }

--- a/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/frontend/taglib/clay/servlet/FolderHorizontalCard.java
+++ b/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/frontend/taglib/clay/servlet/FolderHorizontalCard.java
@@ -17,21 +17,13 @@ package com.liferay.document.library.taglib.internal.frontend.taglib.clay.servle
 import com.liferay.document.library.taglib.internal.display.context.RepositoryBrowserTagDisplayContext;
 import com.liferay.frontend.taglib.clay.servlet.taglib.HorizontalCard;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
-import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemListBuilder;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.portal.kernel.dao.search.RowChecker;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.repository.model.Folder;
-import com.liferay.portal.kernel.security.permission.ActionKeys;
-import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
-import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.WebKeys;
 
 import java.util.List;
-
-import javax.servlet.http.HttpServletRequest;
 
 /**
  * @author Adolfo Pérez
@@ -40,52 +32,17 @@ public class FolderHorizontalCard implements HorizontalCard {
 
 	public FolderHorizontalCard(
 		Folder folder,
-		ModelResourcePermission<Folder> folderModelResourcePermission,
-		HttpServletRequest httpServletRequest,
 		RepositoryBrowserTagDisplayContext repositoryBrowserTagDisplayContext) {
 
 		_folder = folder;
-		_folderModelResourcePermission = folderModelResourcePermission;
-		_httpServletRequest = httpServletRequest;
 		_repositoryBrowserTagDisplayContext =
 			repositoryBrowserTagDisplayContext;
-
-		_themeDisplay = (ThemeDisplay)httpServletRequest.getAttribute(
-			WebKeys.THEME_DISPLAY);
 	}
 
 	@Override
 	public List<DropdownItem> getActionDropdownItems() {
-		return DropdownItemListBuilder.add(
-			() -> _folderModelResourcePermission.contains(
-				_themeDisplay.getPermissionChecker(), _folder,
-				ActionKeys.UPDATE),
-			dropdownItem -> {
-				dropdownItem.putData("action", "rename");
-				dropdownItem.putData(
-					"renameURL",
-					_repositoryBrowserTagDisplayContext.getRenameFolderURL(
-						_folder));
-				dropdownItem.putData("value", _folder.getName());
-				dropdownItem.setIcon("pencil");
-				dropdownItem.setLabel(
-					LanguageUtil.get(_httpServletRequest, "rename"));
-			}
-		).add(
-			() -> _folderModelResourcePermission.contains(
-				_themeDisplay.getPermissionChecker(), _folder,
-				ActionKeys.DELETE),
-			dropdownItem -> {
-				dropdownItem.putData("action", "delete");
-				dropdownItem.putData(
-					"deleteURL",
-					_repositoryBrowserTagDisplayContext.getDeleteFolderURL(
-						_folder));
-				dropdownItem.setIcon("trash");
-				dropdownItem.setLabel(
-					LanguageUtil.get(_httpServletRequest, "delete"));
-			}
-		).build();
+		return _repositoryBrowserTagDisplayContext.getActionDropdownItems(
+			_folder);
 	}
 
 	@Override
@@ -128,11 +85,7 @@ public class FolderHorizontalCard implements HorizontalCard {
 	}
 
 	private final Folder _folder;
-	private final ModelResourcePermission<Folder>
-		_folderModelResourcePermission;
-	private final HttpServletRequest _httpServletRequest;
 	private final RepositoryBrowserTagDisplayContext
 		_repositoryBrowserTagDisplayContext;
-	private final ThemeDisplay _themeDisplay;
 
 }

--- a/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/servlet/RepositoryBrowserServlet.java
+++ b/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/servlet/RepositoryBrowserServlet.java
@@ -14,6 +14,7 @@
 
 package com.liferay.document.library.taglib.internal.servlet;
 
+import com.liferay.document.library.kernel.model.DLVersionNumberIncrease;
 import com.liferay.document.library.kernel.service.DLAppService;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -132,8 +133,8 @@ public class RepositoryBrowserServlet extends HttpServlet {
 
 			if (fileEntryId != 0) {
 				_dlAppService.updateFileEntry(
-					fileEntryId, null, null, name, null, null, null, null,
-					new byte[0], null, null,
+					fileEntryId, null, null, name, null, null, null,
+					DLVersionNumberIncrease.NONE, (byte[])null, null, null,
 					ServiceContextFactory.getInstance(
 						FileEntry.class.getName(), httpServletRequest));
 			}

--- a/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/repository_browser/init.jsp
+++ b/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/repository_browser/init.jsp
@@ -20,8 +20,10 @@
 
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
-<%@ taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
+<%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/site-navigation" prefix="liferay-site-navigation" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
-<%@ page import="com.liferay.document.library.taglib.internal.display.context.RepositoryBrowserTagDisplayContext" %>
+<%@ page import="com.liferay.document.library.taglib.internal.display.context.RepositoryBrowserTagDisplayContext" %><%@
+page import="com.liferay.portal.kernel.util.HtmlUtil" %>

--- a/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/repository_browser/js/RepositoryBrowserDropdownActions.js
+++ b/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/repository_browser/js/RepositoryBrowserDropdownActions.js
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {
+	fetch,
+	openConfirmModal,
+	openSimpleInputModal,
+	openToast,
+} from 'frontend-js-web';
+
+function deleteEntry(deleteURL) {
+	openConfirmModal({
+		message: Liferay.Language.get('are-you-sure-you-want-to-delete-this'),
+		onConfirm: (isConfirmed) => {
+			if (isConfirmed) {
+				fetch(deleteURL, {
+					method: 'DELETE',
+				}).then((response) => {
+					if (response.ok) {
+						window.location.reload();
+					}
+					else {
+						openToast({
+							message: Liferay.Language.get(
+								'an-unexpected-error-occurred'
+							),
+							type: 'danger',
+						});
+					}
+				});
+			}
+		},
+	});
+}
+
+function renameEntry(renameURL, value) {
+	openSimpleInputModal({
+		dialogTitle: Liferay.Language.get('rename'),
+		formSubmitURL: renameURL,
+		mainFieldLabel: Liferay.Language.get('name'),
+		mainFieldName: 'name',
+		mainFieldValue: value,
+		namespace: '',
+		onFormSuccess: (response) => {
+			if (response.success) {
+				window.location.reload();
+			}
+			else {
+				openToast({
+					message: Liferay.Language.get(
+						'an-unexpected-error-occurred'
+					),
+					type: 'danger',
+				});
+			}
+		},
+	});
+}
+
+export {deleteEntry, renameEntry};

--- a/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/repository_browser/js/RepositoryBrowserDropdownPropsTransformer.js
+++ b/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/repository_browser/js/RepositoryBrowserDropdownPropsTransformer.js
@@ -12,18 +12,32 @@
  * details.
  */
 
-import {DefaultEventHandler} from 'frontend-js-web';
-
 import {deleteEntry, renameEntry} from './RepositoryBrowserDropdownActions';
 
-class ElementsDefaultEventHandler extends DefaultEventHandler {
+const ACTIONS = {
 	delete({deleteURL}) {
 		deleteEntry(deleteURL);
-	}
+	},
 
 	rename({renameURL, value}) {
 		renameEntry(renameURL, value);
-	}
-}
+	},
+};
 
-export default ElementsDefaultEventHandler;
+export default function propsTransformer({items, portletNamespace, ...props}) {
+	return {
+		...props,
+		items: items.map((item) => ({
+			...item,
+			onClick(event) {
+				const action = item.data?.action;
+
+				if (action) {
+					event.preventDefault();
+
+					ACTIONS[action](item.data, portletNamespace);
+				}
+			},
+		})),
+	};
+}

--- a/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/repository_browser/page.jsp
+++ b/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/repository_browser/page.jsp
@@ -83,6 +83,7 @@ RepositoryBrowserTagDisplayContext repositoryBrowserTagDisplayContext = (Reposit
 					<liferay-ui:search-container-column-text>
 						<clay:dropdown-actions
 							dropdownItems="<%= repositoryBrowserTagDisplayContext.getActionDropdownItems(repositoryEntry) %>"
+							propsTransformer="repository_browser/js/RepositoryBrowserDropdownPropsTransformer"
 						/>
 					</liferay-ui:search-container-column-text>
 				</c:when>
@@ -126,6 +127,7 @@ RepositoryBrowserTagDisplayContext repositoryBrowserTagDisplayContext = (Reposit
 					<liferay-ui:search-container-column-text>
 						<clay:dropdown-actions
 							dropdownItems="<%= repositoryBrowserTagDisplayContext.getActionDropdownItems(repositoryEntry) %>"
+							propsTransformer="repository_browser/js/RepositoryBrowserDropdownPropsTransformer"
 						/>
 					</liferay-ui:search-container-column-text>
 				</c:otherwise>

--- a/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/repository_browser/page.jsp
+++ b/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/repository_browser/page.jsp
@@ -79,6 +79,12 @@ RepositoryBrowserTagDisplayContext repositoryBrowserTagDisplayContext = (Reposit
 							<liferay-ui:message arguments="<%= new String[] {repositoryEntry.getUserName(), repositoryBrowserTagDisplayContext.getRepositoryEntryModifiedDateDescription(repositoryEntry)} %>" key="x-modified-x-ago" />
 						</span>
 					</liferay-ui:search-container-column-text>
+
+					<liferay-ui:search-container-column-text>
+						<clay:dropdown-actions
+							dropdownItems="<%= repositoryBrowserTagDisplayContext.getActionDropdownItems(repositoryEntry) %>"
+						/>
+					</liferay-ui:search-container-column-text>
 				</c:when>
 				<c:when test="<%= repositoryBrowserTagDisplayContext.isIconDisplayStyle() %>">
 					<liferay-ui:search-container-column-text>
@@ -115,6 +121,12 @@ RepositoryBrowserTagDisplayContext repositoryBrowserTagDisplayContext = (Reposit
 						name="modified-date"
 					>
 						<liferay-ui:message arguments="<%= new String[] {repositoryEntry.getUserName(), repositoryBrowserTagDisplayContext.getRepositoryEntryModifiedDateDescription(repositoryEntry)} %>" key="x-modified-x-ago" />
+					</liferay-ui:search-container-column-text>
+
+					<liferay-ui:search-container-column-text>
+						<clay:dropdown-actions
+							dropdownItems="<%= repositoryBrowserTagDisplayContext.getActionDropdownItems(repositoryEntry) %>"
+						/>
 					</liferay-ui:search-container-column-text>
 				</c:otherwise>
 			</c:choose>

--- a/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/repository_browser/page.jsp
+++ b/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/repository_browser/page.jsp
@@ -42,24 +42,86 @@ RepositoryBrowserTagDisplayContext repositoryBrowserTagDisplayContext = (Reposit
 			keyProperty="primaryKey"
 			modelVar="repositoryEntry"
 		>
-			<liferay-ui:search-container-column-text>
-				<c:choose>
-					<c:when test="<%= repositoryBrowserTagDisplayContext.isVerticalCard(repositoryEntry) %>">
-						<clay:vertical-card
-							verticalCard="<%= repositoryBrowserTagDisplayContext.getVerticalCard(repositoryEntry) %>"
-						/>
-					</c:when>
-					<c:otherwise>
-						<clay:horizontal-card
-							horizontalCard="<%= repositoryBrowserTagDisplayContext.getHorizontalCard(repositoryEntry) %>"
-						/>
-					</c:otherwise>
-				</c:choose>
-			</liferay-ui:search-container-column-text>
+			<c:choose>
+				<c:when test="<%= repositoryBrowserTagDisplayContext.isDescriptiveDisplayStyle() %>">
+					<c:choose>
+						<c:when test="<%= !repositoryBrowserTagDisplayContext.isRepositoryEntryThumbnailAvailable(repositoryEntry) %>">
+							<liferay-ui:search-container-column-icon
+								icon="<%= repositoryBrowserTagDisplayContext.getRepositoryEntryIcon(repositoryEntry) %>"
+							/>
+						</c:when>
+						<c:otherwise>
+							<liferay-ui:search-container-column-image
+								src="<%= repositoryBrowserTagDisplayContext.getRepositoryEntryThumbnailSrc(repositoryEntry) %>"
+							/>
+						</c:otherwise>
+					</c:choose>
+
+					<liferay-ui:search-container-column-text
+						colspan="<%= 2 %>"
+					>
+						<c:choose>
+							<c:when test="<%= repositoryBrowserTagDisplayContext.isRepositoryEntryNavigable(repositoryEntry) %>">
+								<p class="font-weight-bold h5">
+									<aui:a href="<%= repositoryBrowserTagDisplayContext.getRepositoryEntryURL(repositoryEntry) %>">
+										<%= HtmlUtil.escape(repositoryBrowserTagDisplayContext.getRepositoryEntryTitle(repositoryEntry)) %>
+									</aui:a>
+								</p>
+							</c:when>
+							<c:otherwise>
+								<p class="font-weight-bold h5">
+									<%= HtmlUtil.escape(repositoryBrowserTagDisplayContext.getRepositoryEntryTitle(repositoryEntry)) %>
+								</p>
+							</c:otherwise>
+						</c:choose>
+
+						<span class="text-default">
+							<liferay-ui:message arguments="<%= new String[] {repositoryEntry.getUserName(), repositoryBrowserTagDisplayContext.getRepositoryEntryModifiedDateDescription(repositoryEntry)} %>" key="x-modified-x-ago" />
+						</span>
+					</liferay-ui:search-container-column-text>
+				</c:when>
+				<c:when test="<%= repositoryBrowserTagDisplayContext.isIconDisplayStyle() %>">
+					<liferay-ui:search-container-column-text>
+						<c:choose>
+							<c:when test="<%= repositoryBrowserTagDisplayContext.isVerticalCard(repositoryEntry) %>">
+								<clay:vertical-card
+									verticalCard="<%= repositoryBrowserTagDisplayContext.getVerticalCard(repositoryEntry) %>"
+								/>
+							</c:when>
+							<c:otherwise>
+								<clay:horizontal-card
+									horizontalCard="<%= repositoryBrowserTagDisplayContext.getHorizontalCard(repositoryEntry) %>"
+								/>
+							</c:otherwise>
+						</c:choose>
+					</liferay-ui:search-container-column-text>
+				</c:when>
+				<c:otherwise>
+					<liferay-ui:search-container-column-text
+						cssClass="table-cell-expand table-cell-minw-200 table-title"
+						name="title"
+					>
+						<%= HtmlUtil.escape(repositoryBrowserTagDisplayContext.getRepositoryEntryTitle(repositoryEntry)) %>
+					</liferay-ui:search-container-column-text>
+
+					<liferay-ui:search-container-column-text
+						cssClass="table-cell-expand-smaller"
+						name="size"
+						value="<%= repositoryBrowserTagDisplayContext.getRepositoryEntrySizeValue(repositoryEntry) %>"
+					/>
+
+					<liferay-ui:search-container-column-text
+						cssClass="table-cell-expand-smaller table-cell-minw-150"
+						name="modified-date"
+					>
+						<liferay-ui:message arguments="<%= new String[] {repositoryEntry.getUserName(), repositoryBrowserTagDisplayContext.getRepositoryEntryModifiedDateDescription(repositoryEntry)} %>" key="x-modified-x-ago" />
+					</liferay-ui:search-container-column-text>
+				</c:otherwise>
+			</c:choose>
 		</liferay-ui:search-container-row>
 
 		<liferay-ui:search-iterator
-			displayStyle="icon"
+			displayStyle="<%= repositoryBrowserTagDisplayContext.getDisplayStyle() %>"
 			markupView="lexicon"
 			resultRowSplitter="<%= repositoryBrowserTagDisplayContext.getResultRowSplitter() %>"
 		/>


### PR DESCRIPTION
# What is this about?

https://issues.liferay.com/browse/LPS-168175

Up until now, the DM browser tag only supported the icon (card) view. Add descriptive and list views for completeness.

Also, this view uses this tag in the Blogs Images section. This change is under feature flag `feature.flag.LPS-168174'.

![image](https://user-images.githubusercontent.com/729897/201142054-4dff156c-f968-45dd-b04b-fad3da832ec7.png)

# How do I test this?

Enable the feature flag and go to Blogs > Images. You should see the new UI.

# Things to take into account

The DM tag is still a WIP. There will be some behavior differences between the old Blogs Images interface and the new one (e.g. now it is possible to create folders, which doesn't make much sense in Blogs). These things will be fixed in future PRs.