### PR TITLE
LPS-168348 Allow multiple model document contributors for WikiPage and KBArticle to make Semantic Search sentence embedding working

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-service/build.gradle
+++ b/modules/apps/knowledge-base/knowledge-base-service/build.gradle
@@ -19,6 +19,7 @@ dependencies {
 	compileOnly project(":apps:export-import:export-import-api")
 	compileOnly project(":apps:knowledge-base:knowledge-base-api")
 	compileOnly project(":apps:knowledge-base:knowledge-base-markdown-converter-api")
+	compileOnly project(":apps:portal-search:portal-search-spi")
 	compileOnly project(":apps:portal:portal-aop-api")
 	compileOnly project(":apps:portal:portal-dao-orm-custom-sql-api")
 	compileOnly project(":apps:rss:rss-api")

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/search/KBArticleIndexer.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/search/KBArticleIndexer.java
@@ -15,13 +15,9 @@
 package com.liferay.knowledge.base.internal.search;
 
 import com.liferay.document.library.kernel.model.DLFileEntry;
-import com.liferay.knowledge.base.constants.KBFolderConstants;
 import com.liferay.knowledge.base.model.KBArticle;
-import com.liferay.knowledge.base.model.KBFolder;
 import com.liferay.knowledge.base.service.KBArticleLocalService;
-import com.liferay.knowledge.base.service.KBFolderLocalService;
 import com.liferay.knowledge.base.util.KnowledgeBaseUtil;
-import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.IndexableActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.Property;
@@ -47,8 +43,6 @@ import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.HtmlParser;
-import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
@@ -131,20 +125,6 @@ public class KBArticleIndexer extends BaseIndexer<KBArticle> {
 	protected Document doGetDocument(KBArticle kbArticle) throws Exception {
 		Document document = getBaseModelDocument(CLASS_NAME, kbArticle);
 
-		document.addText(
-			Field.CONTENT, _htmlParser.extractText(kbArticle.getContent()));
-		document.addText(Field.DESCRIPTION, kbArticle.getDescription());
-		document.addKeyword(Field.FOLDER_ID, kbArticle.getKbFolderId());
-		document.addText(Field.TITLE, kbArticle.getTitle());
-		document.addKeyword(
-			Field.TREE_PATH,
-			StringUtil.split(kbArticle.buildTreePath(), CharPool.SLASH));
-		document.addKeyword("folderNames", _getKBFolderNames(kbArticle));
-		document.addKeyword(
-			"parentMessageId", kbArticle.getParentResourcePrimKey());
-		document.addKeyword("titleKeyword", kbArticle.getTitle(), true);
-		document.addKeywordSortable("urlTitle", kbArticle.getUrlTitle());
-
 		return document;
 	}
 
@@ -216,25 +196,6 @@ public class KBArticleIndexer extends BaseIndexer<KBArticle> {
 	@Reference
 	protected KBArticleLocalService kbArticleLocalService;
 
-	@Reference
-	protected KBFolderLocalService kbFolderLocalService;
-
-	private String[] _getKBFolderNames(KBArticle kbArticle) throws Exception {
-		long kbFolderId = kbArticle.getKbFolderId();
-
-		Collection<String> kbFolderNames = new ArrayList<>();
-
-		while (kbFolderId != KBFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
-			KBFolder kbFolder = kbFolderLocalService.getKBFolder(kbFolderId);
-
-			kbFolderNames.add(kbFolder.getName());
-
-			kbFolderId = kbFolder.getParentKBFolderId();
-		}
-
-		return kbFolderNames.toArray(new String[0]);
-	}
-
 	private void _reindexAttachments(KBArticle kbArticle) throws Exception {
 		Indexer<DLFileEntry> indexer = IndexerRegistryUtil.nullSafeGetIndexer(
 			DLFileEntry.class);
@@ -295,9 +256,6 @@ public class KBArticleIndexer extends BaseIndexer<KBArticle> {
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		KBArticleIndexer.class);
-
-	@Reference
-	private HtmlParser _htmlParser;
 
 	@Reference(
 		target = "(model.class.name=com.liferay.knowledge.base.model.KBArticle)"

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/search/spi/model/index/contributor/KBArticleModelDocumentContributor.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/search/spi/model/index/contributor/KBArticleModelDocumentContributor.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.knowledge.base.internal.search.spi.model.index.contributor;
+
+import com.liferay.knowledge.base.model.KBArticle;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.search.spi.model.index.contributor.ModelDocumentContributor;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Tibor Lipusz
+ */
+@Component(
+	immediate = true,
+	property = "indexer.class.name=com.liferay.knowledge.base.model.KBArticle",
+	service = ModelDocumentContributor.class
+)
+public class KBArticleModelDocumentContributor
+	implements ModelDocumentContributor<KBArticle> {
+
+	@Override
+	public void contribute(Document document, KBArticle baseModel) {
+	}
+
+}

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/search/spi/model/index/contributor/KBArticleModelDocumentContributor.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/search/spi/model/index/contributor/KBArticleModelDocumentContributor.java
@@ -19,6 +19,9 @@ import com.liferay.knowledge.base.model.KBArticle;
 import com.liferay.knowledge.base.model.KBFolder;
 import com.liferay.knowledge.base.service.KBFolderLocalService;
 import com.liferay.petra.string.CharPool;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.util.HtmlParser;
@@ -49,10 +52,19 @@ public class KBArticleModelDocumentContributor
 		document.addText(Field.DESCRIPTION, kbArticle.getDescription());
 		document.addKeyword(Field.FOLDER_ID, kbArticle.getKbFolderId());
 		document.addText(Field.TITLE, kbArticle.getTitle());
-		document.addKeyword(
-			Field.TREE_PATH,
-			StringUtil.split(kbArticle.buildTreePath(), CharPool.SLASH));
-		document.addKeyword("folderNames", _getKBFolderNames(kbArticle));
+
+		try {
+			document.addKeyword(
+				Field.TREE_PATH,
+				StringUtil.split(kbArticle.buildTreePath(), CharPool.SLASH));
+			document.addKeyword("folderNames", _getKBFolderNames(kbArticle));
+		}
+		catch (PortalException portalException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(portalException);
+			}
+		}
+
 		document.addKeyword(
 			"parentMessageId", kbArticle.getParentResourcePrimKey());
 		document.addKeyword("titleKeyword", kbArticle.getTitle(), true);
@@ -62,7 +74,9 @@ public class KBArticleModelDocumentContributor
 	@Reference
 	protected KBFolderLocalService kbFolderLocalService;
 
-	private String[] _getKBFolderNames(KBArticle kbArticle) throws Exception {
+	private String[] _getKBFolderNames(KBArticle kbArticle)
+		throws PortalException {
+
 		long kbFolderId = kbArticle.getKbFolderId();
 
 		Collection<String> kbFolderNames = new ArrayList<>();
@@ -77,6 +91,9 @@ public class KBArticleModelDocumentContributor
 
 		return kbFolderNames.toArray(new String[0]);
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		KBArticleModelDocumentContributor.class);
 
 	@Reference
 	private HtmlParser _htmlParser;

--- a/modules/apps/wiki/wiki-service/build.gradle
+++ b/modules/apps/wiki/wiki-service/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	compileOnly project(":apps:export-import:export-import-api")
 	compileOnly project(":apps:item-selector:item-selector-api")
 	compileOnly project(":apps:portal-search:portal-search-api")
+	compileOnly project(":apps:portal-search:portal-search-spi")
 	compileOnly project(":apps:portal:portal-aop-api")
 	compileOnly project(":apps:portal:portal-dao-orm-custom-sql-api")
 	compileOnly project(":apps:portlet-display-template:portlet-display-template-api")

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/search/WikiPageIndexer.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/search/WikiPageIndexer.java
@@ -22,7 +22,6 @@ import com.liferay.portal.kernel.dao.orm.IndexableActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.Property;
 import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.repository.capabilities.RelatedModelCapability;
@@ -48,16 +47,12 @@ import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.HtmlParser;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Localization;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.search.model.uid.UIDFactory;
-import com.liferay.trash.TrashHelper;
-import com.liferay.wiki.engine.WikiEngineRenderer;
-import com.liferay.wiki.exception.WikiFormatException;
 import com.liferay.wiki.model.WikiNode;
 import com.liferay.wiki.model.WikiPage;
 import com.liferay.wiki.service.WikiNodeLocalService;
@@ -243,52 +238,7 @@ public class WikiPageIndexer
 
 	@Override
 	protected Document doGetDocument(WikiPage wikiPage) throws Exception {
-		Document document = getBaseModelDocument(CLASS_NAME, wikiPage);
-
-		uidFactory.setUID(wikiPage, document);
-
-		String content = null;
-
-		try {
-			content = _htmlParser.extractText(
-				_wikiEngineRenderer.convert(wikiPage, null, null, null));
-
-			document.addText(Field.CONTENT, content);
-		}
-		catch (WikiFormatException wikiFormatException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(
-					"Unable to get wiki engine for " + wikiPage.getFormat(),
-					wikiFormatException);
-			}
-		}
-
-		document.addKeyword(Field.NODE_ID, wikiPage.getNodeId());
-
-		String title = wikiPage.getTitle();
-
-		if (wikiPage.isInTrash()) {
-			title = _trashHelper.getOriginalTitle(title);
-		}
-
-		document.addText(Field.TITLE, title);
-
-		for (Locale locale :
-				_language.getAvailableLocales(wikiPage.getGroupId())) {
-
-			String languageId = LocaleUtil.toLanguageId(locale);
-
-			document.addText(
-				_localization.getLocalizedName(Field.CONTENT, languageId),
-				content);
-			document.addText(
-				_localization.getLocalizedName(Field.TITLE, languageId), title);
-		}
-
-		document.addNumber(
-			"versionCount", GetterUtil.getDouble(wikiPage.getVersion()));
-
-		return document;
+		return null;
 	}
 
 	@Override
@@ -451,25 +401,13 @@ public class WikiPageIndexer
 		WikiPageIndexer.class);
 
 	@Reference
-	private HtmlParser _htmlParser;
-
-	@Reference
 	private IndexWriterHelper _indexWriterHelper;
-
-	@Reference
-	private Language _language;
 
 	@Reference
 	private Localization _localization;
 
 	private final RelatedEntryIndexer _relatedEntryIndexer =
 		new BaseRelatedEntryIndexer();
-
-	@Reference
-	private TrashHelper _trashHelper;
-
-	@Reference
-	private WikiEngineRenderer _wikiEngineRenderer;
 
 	@Reference
 	private WikiNodeLocalService _wikiNodeLocalService;

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/search/spi/model/index/contributor/WikiPageModelDocumentContributor.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/search/spi/model/index/contributor/WikiPageModelDocumentContributor.java
@@ -14,11 +14,26 @@
 
 package com.liferay.wiki.internal.search.spi.model.index.contributor;
 
+import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HtmlParser;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Localization;
+import com.liferay.portal.search.model.uid.UIDFactory;
 import com.liferay.portal.search.spi.model.index.contributor.ModelDocumentContributor;
+import com.liferay.trash.TrashHelper;
+import com.liferay.wiki.engine.WikiEngineRenderer;
+import com.liferay.wiki.exception.WikiFormatException;
 import com.liferay.wiki.model.WikiPage;
 
+import java.util.Locale;
+
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Tibor Lipusz
@@ -32,7 +47,70 @@ public class WikiPageModelDocumentContributor
 	implements ModelDocumentContributor<WikiPage> {
 
 	@Override
-	public void contribute(Document document, WikiPage baseModel) {
+	public void contribute(Document document, WikiPage wikiPage) {
+		uidFactory.setUID(wikiPage, document);
+
+		String content = null;
+
+		try {
+			content = _htmlParser.extractText(
+				_wikiEngineRenderer.convert(wikiPage, null, null, null));
+
+			document.addText(Field.CONTENT, content);
+		}
+		catch (WikiFormatException wikiFormatException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					"Unable to get wiki engine for " + wikiPage.getFormat(),
+					wikiFormatException);
+			}
+		}
+
+		document.addKeyword(Field.NODE_ID, wikiPage.getNodeId());
+
+		String title = wikiPage.getTitle();
+
+		if (wikiPage.isInTrash()) {
+			title = _trashHelper.getOriginalTitle(title);
+		}
+
+		document.addText(Field.TITLE, title);
+
+		for (Locale locale :
+				_language.getAvailableLocales(wikiPage.getGroupId())) {
+
+			String languageId = LocaleUtil.toLanguageId(locale);
+
+			document.addText(
+				_localization.getLocalizedName(Field.CONTENT, languageId),
+				content);
+			document.addText(
+				_localization.getLocalizedName(Field.TITLE, languageId), title);
+		}
+
+		document.addNumber(
+			"versionCount", GetterUtil.getDouble(wikiPage.getVersion()));
 	}
+
+	@Reference
+	protected UIDFactory uidFactory;
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		WikiPageModelDocumentContributor.class);
+
+	@Reference
+	private HtmlParser _htmlParser;
+
+	@Reference
+	private Language _language;
+
+	@Reference
+	private Localization _localization;
+
+	@Reference
+	private TrashHelper _trashHelper;
+
+	@Reference
+	private WikiEngineRenderer _wikiEngineRenderer;
 
 }

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/search/spi/model/index/contributor/WikiPageModelDocumentContributor.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/search/spi/model/index/contributor/WikiPageModelDocumentContributor.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.wiki.internal.search.spi.model.index.contributor;
+
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.search.spi.model.index.contributor.ModelDocumentContributor;
+import com.liferay.wiki.model.WikiPage;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Tibor Lipusz
+ */
+@Component(
+	immediate = true,
+	property = "indexer.class.name=com.liferay.wiki.model.WikiPage",
+	service = ModelDocumentContributor.class
+)
+public class WikiPageModelDocumentContributor
+	implements ModelDocumentContributor<WikiPage> {
+
+	@Override
+	public void contribute(Document document, WikiPage baseModel) {
+	}
+
+}

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/search/spi/model/index/contributor/WikiPageModelDocumentContributor.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/search/spi/model/index/contributor/WikiPageModelDocumentContributor.java
@@ -27,6 +27,7 @@ import com.liferay.portal.search.model.uid.UIDFactory;
 import com.liferay.portal.search.spi.model.index.contributor.ModelDocumentContributor;
 import com.liferay.trash.TrashHelper;
 import com.liferay.wiki.engine.WikiEngineRenderer;
+import com.liferay.wiki.exception.PageContentException;
 import com.liferay.wiki.exception.WikiFormatException;
 import com.liferay.wiki.model.WikiPage;
 
@@ -58,11 +59,11 @@ public class WikiPageModelDocumentContributor
 
 			document.addText(Field.CONTENT, content);
 		}
-		catch (WikiFormatException wikiFormatException) {
+		catch (PageContentException | WikiFormatException exception) {
 			if (_log.isDebugEnabled()) {
 				_log.debug(
 					"Unable to get wiki engine for " + wikiPage.getFormat(),
-					wikiFormatException);
+					exception);
 			}
 		}
 

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/configuration/admin/display/SemanticSearchConfigurationFormRenderer.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/configuration/admin/display/SemanticSearchConfigurationFormRenderer.java
@@ -226,7 +226,7 @@ public class SemanticSearchConfigurationFormRenderer
 					httpServletRequest,
 					"model.resource.com.liferay.message.boards.model.MBMessage")
 			).put(
-				"model.resource.com.liferay.wiki.model.WikiPage",
+				"com.liferay.wiki.model.WikiPage",
 				_language.get(
 					httpServletRequest,
 					"model.resource.com.liferay.wiki.model.WikiPage")


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-168348

Hi,

We need these changes so `WikiPageSentenceEmbeddingModelDocumentContributor` and `KBArticleSentenceEmbeddingModelDocumentContributor` can start working (residing in `modules/dxp/apps/search-experiences-service`) in created part of our Semantic Search Epic ([LPS-163688](https://issues.liferay.com/browse/LPS-163688)).

We introduced similar changes for JournalArticle previously in https://github.com/liferay/liferay-portal/commit/4cabf7e23fdf15892525e48f0cff7ed97bfbb7ba

(Note: preliminary single model document contributor support was implemented for JournalArticle in [LPS-148010](https://issues.liferay.com/browse/LPS-148010), followed the pattern from there to make the necessary changes for WikiPage and KBArticle.)

Passed manual testing.

Thanks,
Tibor

/cc @peerkar
