### PR TITLE
LPS-165624 Merge available languages for layout default experience

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/info/item/provider/LayoutInfoItemLanguagesProvider.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/info/item/provider/LayoutInfoItemLanguagesProvider.java
@@ -22,6 +22,11 @@ import com.liferay.portal.kernel.model.Layout;
 import com.liferay.segments.service.SegmentsExperienceLocalService;
 import com.liferay.translation.info.item.provider.InfoItemLanguagesProvider;
 
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Set;
+import java.util.TreeSet;
+
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Modified;
@@ -38,12 +43,24 @@ public class LayoutInfoItemLanguagesProvider
 	public String[] getAvailableLanguageIds(Layout layout)
 		throws PortalException {
 
+		Set<String> availableLanguageIds = new TreeSet<>(
+			Comparator.naturalOrder());
+
+		if (layout.isTypeContent()) {
+			Collections.addAll(
+				availableLanguageIds, layout.getAvailableLanguageIds());
+		}
+
 		long defaultSegmentsExperienceId =
 			_segmentsExperienceLocalService.fetchDefaultSegmentsExperienceId(
 				layout.getPlid());
 
-		return _layoutInfoItemLanguagesProviderHelper.getAvailableLanguageIds(
-			layout, defaultSegmentsExperienceId);
+		Collections.addAll(
+			availableLanguageIds,
+			_layoutInfoItemLanguagesProviderHelper.getAvailableLanguageIds(
+				layout, defaultSegmentsExperienceId));
+
+		return availableLanguageIds.toArray(new String[0]);
 	}
 
 	@Override


### PR DESCRIPTION
# What is this about?

See https://issues.liferay.com/browse/LPS-165624.

Layouts have two sets of available languages: those of the layout itself (used for the title and friendly urls, among other things), and those used by its fragments.

When requesting the set of available languages for the default experience we need to include both sets of languages together so that:

1. When translating the page, we accurately display all translated languages.

2. We can display all translations of the friendly urls for that layout.

# How do I tests this?

Pleas follow the steps described in the ticket.