### PR TITLE
LPS-167658 The "everywhere" filter is not display in depots

### DIFF
--- a/modules/apps/asset/asset-browser-web/src/main/java/com/liferay/asset/browser/web/internal/item/selector/AssetEntryItemSelectorView.java
+++ b/modules/apps/asset/asset-browser-web/src/main/java/com/liferay/asset/browser/web/internal/item/selector/AssetEntryItemSelectorView.java
@@ -15,6 +15,7 @@
 package com.liferay.asset.browser.web.internal.item.selector;
 
 import com.liferay.asset.browser.web.internal.display.context.AssetBrowserDisplayContext;
+import com.liferay.asset.browser.web.internal.display.context.AssetBrowserManagementToolbarDisplayContext;
 import com.liferay.asset.kernel.service.AssetEntryLocalService;
 import com.liferay.asset.util.AssetHelper;
 import com.liferay.depot.service.DepotEntryService;
@@ -25,6 +26,7 @@ import com.liferay.item.selector.criteria.AssetEntryItemSelectorReturnType;
 import com.liferay.item.selector.criteria.asset.criterion.AssetEntryItemSelectorCriterion;
 import com.liferay.petra.string.StringPool;
 import com.liferay.petra.string.StringUtil;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.service.GroupService;
 import com.liferay.portal.kernel.servlet.DynamicServletRequest;
@@ -40,6 +42,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 
+import javax.portlet.PortletException;
 import javax.portlet.PortletURL;
 import javax.portlet.RenderRequest;
 import javax.portlet.RenderResponse;
@@ -84,25 +87,37 @@ public class AssetEntryItemSelectorView
 			PortletURL portletURL, String itemSelectedEventName, boolean search)
 		throws IOException, ServletException {
 
-		HttpServletRequest httpServletRequest = _getDynamicServletRequest(
-			itemSelectorCriterion, servletRequest);
+		try {
+			HttpServletRequest httpServletRequest = _getDynamicServletRequest(
+				itemSelectorCriterion, servletRequest);
 
-		RenderRequest renderRequest =
-			(RenderRequest)httpServletRequest.getAttribute(
-				JavaConstants.JAVAX_PORTLET_REQUEST);
-		RenderResponse renderResponse =
-			(RenderResponse)httpServletRequest.getAttribute(
-				JavaConstants.JAVAX_PORTLET_RESPONSE);
+			RenderRequest renderRequest =
+				(RenderRequest)httpServletRequest.getAttribute(
+					JavaConstants.JAVAX_PORTLET_REQUEST);
+			RenderResponse renderResponse =
+				(RenderResponse)httpServletRequest.getAttribute(
+					JavaConstants.JAVAX_PORTLET_RESPONSE);
 
-		_itemSelectorViewDescriptorRenderer.renderHTML(
-			httpServletRequest, servletResponse, itemSelectorCriterion,
-			portletURL, itemSelectedEventName, search,
-			new AssetEntryItemSelectorViewDescriptor(
-				httpServletRequest,
+			AssetBrowserDisplayContext assetBrowserDisplayContext =
 				new AssetBrowserDisplayContext(
 					_assetEntryLocalService, _assetHelper, _depotEntryService,
 					_groupService, httpServletRequest, _language, _portal,
-					portletURL, renderRequest, renderResponse)));
+					portletURL, renderRequest, renderResponse);
+
+			_itemSelectorViewDescriptorRenderer.renderHTML(
+				httpServletRequest, servletResponse, itemSelectorCriterion,
+				portletURL, itemSelectedEventName, search,
+				new AssetEntryItemSelectorViewDescriptor(
+					httpServletRequest, assetBrowserDisplayContext,
+					new AssetBrowserManagementToolbarDisplayContext(
+						httpServletRequest,
+						_portal.getLiferayPortletRequest(renderRequest),
+						_portal.getLiferayPortletResponse(renderResponse),
+						assetBrowserDisplayContext)));
+		}
+		catch (PortalException | PortletException exception) {
+			throw new ServletException(exception);
+		}
 	}
 
 	private DynamicServletRequest _getDynamicServletRequest(

--- a/modules/apps/asset/asset-browser-web/src/main/java/com/liferay/asset/browser/web/internal/item/selector/AssetEntryItemSelectorViewDescriptor.java
+++ b/modules/apps/asset/asset-browser-web/src/main/java/com/liferay/asset/browser/web/internal/item/selector/AssetEntryItemSelectorViewDescriptor.java
@@ -15,12 +15,16 @@
 package com.liferay.asset.browser.web.internal.item.selector;
 
 import com.liferay.asset.browser.web.internal.display.context.AssetBrowserDisplayContext;
+import com.liferay.asset.browser.web.internal.display.context.AssetBrowserManagementToolbarDisplayContext;
 import com.liferay.asset.kernel.model.AssetEntry;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
 import com.liferay.item.selector.ItemSelectorReturnType;
 import com.liferay.item.selector.ItemSelectorViewDescriptor;
 import com.liferay.item.selector.criteria.AssetEntryItemSelectorReturnType;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.exception.PortalException;
+
+import java.util.List;
 
 import javax.portlet.PortletException;
 
@@ -34,15 +38,25 @@ public class AssetEntryItemSelectorViewDescriptor
 
 	public AssetEntryItemSelectorViewDescriptor(
 		HttpServletRequest httpServletRequest,
-		AssetBrowserDisplayContext assetBrowserDisplayContext) {
+		AssetBrowserDisplayContext assetBrowserDisplayContext,
+		AssetBrowserManagementToolbarDisplayContext
+			assetBrowserManagementToolbarDisplayContext) {
 
 		_httpServletRequest = httpServletRequest;
 		_assetBrowserDisplayContext = assetBrowserDisplayContext;
+		_assetBrowserManagementToolbarDisplayContext =
+			assetBrowserManagementToolbarDisplayContext;
 	}
 
 	@Override
 	public String getDefaultDisplayStyle() {
 		return "list";
+	}
+
+	@Override
+	public List<DropdownItem> getFilterNavigationDropdownItems() {
+		return _assetBrowserManagementToolbarDisplayContext.
+			getFilterNavigationDropdownItems();
 	}
 
 	@Override
@@ -79,6 +93,8 @@ public class AssetEntryItemSelectorViewDescriptor
 	}
 
 	private final AssetBrowserDisplayContext _assetBrowserDisplayContext;
+	private final AssetBrowserManagementToolbarDisplayContext
+		_assetBrowserManagementToolbarDisplayContext;
 	private final HttpServletRequest _httpServletRequest;
 
 }


### PR DESCRIPTION
# What is this about?

https://issues.liferay.com/browse/LPS-167658

The "everywhere" and "current site"/"current asset library" filters where omitted by mistake during a refactor. Add them back by reusing the display context from the asset browser.

![image](https://user-images.githubusercontent.com/729897/201957874-583c7b01-91e4-403a-aff5-fb035b5f99cd.png)

# How do I test this

Follow the steps described in the linked ticket.