### PR TITLE
LPS-166873 | LPS-166882 KB dropdown actions: move next to header and added separators

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/kb_article_tools.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/kb_article_tools.jsp
@@ -30,16 +30,4 @@ KBArticle kbArticle = (KBArticle)request.getAttribute(KBWebKeys.KNOWLEDGE_BASE_K
 			/>
 		</a>
 	</c:if>
-
-	<c:if test="<%= !rootPortletId.equals(KBPortletKeys.KNOWLEDGE_BASE_ADMIN) %>">
-
-		<%
-		KBDropdownItemsProvider kbDropdownItemsProvider = new KBDropdownItemsProvider(kbGroupServiceConfiguration, liferayPortletRequest, liferayPortletResponse);
-		%>
-
-		<clay:dropdown-actions
-			dropdownItems="<%= kbDropdownItemsProvider.getKBArticleDropdownItems(kbArticle) %>"
-			propsTransformer="admin/js/KBDropdownPropsTransformer"
-		/>
-	</c:if>
 </div>

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/view_kb_article.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/view_kb_article.jsp
@@ -95,9 +95,26 @@ if (portletTitleBasedNavigation) {
 
 	<div class="sidenav-content <%= portletTitleBasedNavigation ? "container-fluid container-fluid-max-xl container-form-lg" : StringPool.BLANK %>">
 		<c:if test="<%= !portletTitleBasedNavigation %>">
-			<liferay-ui:header
-				title="<%= kbArticle.getTitle() %>"
-			/>
+			<div class="autofit-row">
+				<div class="autofit-col autofit-col-expand">
+					<h1><%= kbArticle.getTitle() %></h1>
+				</div>
+
+				<c:if test="<%= !rootPortletId.equals(KBPortletKeys.KNOWLEDGE_BASE_ADMIN) %>">
+					<div class="autofit-col">
+
+						<%
+						KBDropdownItemsProvider kbDropdownItemsProvider = new KBDropdownItemsProvider(kbGroupServiceConfiguration, liferayPortletRequest, liferayPortletResponse);
+						%>
+
+						<clay:dropdown-actions
+							aria-label='<%= LanguageUtil.get(request, "show-actions") %>'
+							dropdownItems="<%= kbDropdownItemsProvider.getKBArticleDropdownItems(kbArticle) %>"
+							propsTransformer="admin/js/KBDropdownPropsTransformer"
+						/>
+					</div>
+				</c:if>
+			</div>
 		</c:if>
 
 		<div class="kb-tools">

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/js/utils/normalizeDropdownItems.js
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/js/utils/normalizeDropdownItems.js
@@ -14,8 +14,51 @@
 
 import KBDropdownPropsTransformer from '../KBDropdownPropsTransformer';
 
+function addSeparators(items) {
+	if (items.length < 2) {
+		return items;
+	}
+
+	const separatedItems = [items[0]];
+
+	for (let i = 1; i < items.length; i++) {
+		const item = items[i];
+
+		if (item.type === 'group' && item.separator) {
+			separatedItems.push({type: 'divider'});
+		}
+
+		separatedItems.push(item);
+	}
+
+	return separatedItems.map((item) => {
+		if (item.type === 'group') {
+			return {
+				...item,
+				items: addSeparators(item.items),
+			};
+		}
+
+		return item;
+	});
+}
+
+function filterEmptyGroups(items) {
+	return items
+		.filter(
+			(item) =>
+				item.type !== 'group' ||
+				(Array.isArray(item.items) && item.items.length)
+		)
+		.map((item) =>
+			item.type === 'group'
+				? {...item, items: filterEmptyGroups(item.items)}
+				: item
+		);
+}
+
 export default function normalizeDropdownItems(items = []) {
-	return KBDropdownPropsTransformer({
+	const transformedItems = KBDropdownPropsTransformer({
 		items: items.map((item) => {
 			return {
 				...item,
@@ -26,4 +69,8 @@ export default function normalizeDropdownItems(items = []) {
 			};
 		}),
 	}).items;
+
+	const filteredItems = filterEmptyGroups(transformedItems);
+
+	return addSeparators(filteredItems);
 }

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/knowledgebase/KnowledgeBase.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/knowledgebase/KnowledgeBase.path
@@ -140,7 +140,7 @@
 </tr>
 <tr>
 	<td>DISPLAY_TITLE</td>
-	<td>//h3[@class='header-title']//span</td>
+	<td>//div[contains(@class,'kb-article-container')]//h1</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
Built on top of https://github.com/brianchandotcom/liferay-portal/pull/126177. Only review last 2 commits.

This PR includes:

 https://issues.liferay.com/browse/LPS-166882 Dropdown group item separator not shown in Navigation tree
 https://issues.liferay.com/browse/LPS-166873 Move the dropdown menu next to the article title
 accesibility issue found in https://github.com/brianchandotcom/liferay-portal/pull/126177#discussion_r1021396460v
