### PR TITLE
[TS] LPS-168805 use fallback value in case classname is layout to mimic behavior from history feature

### DIFF
--- a/modules/apps/friendly-url/friendly-url-taglib/src/main/java/com/liferay/friendly/url/taglib/servlet/taglib/InputTag.java
+++ b/modules/apps/friendly-url/friendly-url-taglib/src/main/java/com/liferay/friendly/url/taglib/servlet/taglib/InputTag.java
@@ -246,6 +246,10 @@ public class InputTag extends IncludeTag {
 				return StringPool.BLANK;
 			}
 
+			if (Objects.equals(getClassName(), Layout.class.getName())) {
+				return _getFallbackValue();
+			}
+
 			FriendlyURLEntry mainFriendlyURLEntry =
 				FriendlyURLEntryLocalServiceUtil.getMainFriendlyURLEntry(
 					PortalUtil.getClassNameId(_getActualClassName()),


### PR DESCRIPTION
Hello Lima Team,

Steps to reproduce:

1. Create a new widget page abcd
2. Go to configure page and add a translation for the page per example for spanish
- name: "aaa"
- friendlyurl "/aaa"

3. Save the page
4. delete spanish friendlyurl
5. save the page

**Expected result:**
Friendly url input is blank and friendly url is added to the history.

**Current result:**
Friendly url input keeps the old value despite friendly url is added to history.
