### PR TITLE
LPS-168177 Allow to hide actions in browser tag

### DIFF
--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/view_images.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/view_images.jsp
@@ -24,6 +24,7 @@
 		%>
 
 		<liferay-document-library:repository-browser
+			actions="delete"
 			folderId="<%= blogImagesDisplayContext.getFolderId() %>"
 			repositoryId="<%= blogImagesDisplayContext.getRepositoryId() %>"
 		/>

--- a/modules/apps/document-library/document-library-taglib/bnd.bnd
+++ b/modules/apps/document-library/document-library-taglib/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Document Library Taglib
 Bundle-SymbolicName: com.liferay.document.library.taglib
-Bundle-Version: 3.2.2
+Bundle-Version: 3.3.0
 Export-Package: com.liferay.document.library.taglib.servlet.taglib
 Provide-Capability:\
 	osgi.extender;\

--- a/modules/apps/document-library/document-library-taglib/package.json
+++ b/modules/apps/document-library/document-library-taglib/package.json
@@ -5,5 +5,5 @@
 		"checkFormat": "liferay-npm-scripts check",
 		"format": "liferay-npm-scripts fix"
 	},
-	"version": "3.2.2"
+	"version": "3.3.0"
 }

--- a/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/frontend/taglib/clay/servlet/FileEntryVerticalCard.java
+++ b/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/frontend/taglib/clay/servlet/FileEntryVerticalCard.java
@@ -35,6 +35,7 @@ import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Set;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -44,11 +45,13 @@ import javax.servlet.http.HttpServletRequest;
 public class FileEntryVerticalCard implements VerticalCard {
 
 	public FileEntryVerticalCard(
-			FileEntry fileEntry, HttpServletRequest httpServletRequest,
+			Set<String> actions, FileEntry fileEntry,
+			HttpServletRequest httpServletRequest,
 			RepositoryBrowserTagDisplayContext
 				repositoryBrowserTagDisplayContext)
 		throws PortalException {
 
+		_actions = actions;
 		_fileEntry = fileEntry;
 		_httpServletRequest = httpServletRequest;
 		_repositoryBrowserTagDisplayContext =
@@ -141,6 +144,16 @@ public class FileEntryVerticalCard implements VerticalCard {
 		return true;
 	}
 
+	@Override
+	public boolean isSelectable() {
+		if (_actions.isEmpty()) {
+			return false;
+		}
+
+		return true;
+	}
+
+	private final Set<String> _actions;
 	private final FileEntry _fileEntry;
 	private final FileVersion _fileVersion;
 	private final HttpServletRequest _httpServletRequest;

--- a/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/frontend/taglib/clay/servlet/FileShortcutVerticalCard.java
+++ b/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/frontend/taglib/clay/servlet/FileShortcutVerticalCard.java
@@ -35,6 +35,7 @@ import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Set;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -44,11 +45,13 @@ import javax.servlet.http.HttpServletRequest;
 public class FileShortcutVerticalCard implements VerticalCard {
 
 	public FileShortcutVerticalCard(
-			FileShortcut fileShortcut, HttpServletRequest httpServletRequest,
+			Set<String> actions, FileShortcut fileShortcut,
+			HttpServletRequest httpServletRequest,
 			RepositoryBrowserTagDisplayContext
 				repositoryBrowserTagDisplayContext)
 		throws PortalException {
 
+		_actions = actions;
 		_fileShortcut = fileShortcut;
 		_httpServletRequest = httpServletRequest;
 		_repositoryBrowserTagDisplayContext =
@@ -141,6 +144,16 @@ public class FileShortcutVerticalCard implements VerticalCard {
 		return true;
 	}
 
+	@Override
+	public boolean isSelectable() {
+		if (_actions.isEmpty()) {
+			return false;
+		}
+
+		return true;
+	}
+
+	private final Set<String> _actions;
 	private final FileShortcut _fileShortcut;
 	private final FileVersion _fileVersion;
 	private final HttpServletRequest _httpServletRequest;

--- a/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/frontend/taglib/clay/servlet/FolderHorizontalCard.java
+++ b/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/frontend/taglib/clay/servlet/FolderHorizontalCard.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.repository.model.Folder;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * @author Adolfo Pérez
@@ -31,9 +32,10 @@ import java.util.List;
 public class FolderHorizontalCard implements HorizontalCard {
 
 	public FolderHorizontalCard(
-		Folder folder,
+		Set<String> actions, Folder folder,
 		RepositoryBrowserTagDisplayContext repositoryBrowserTagDisplayContext) {
 
+		_actions = actions;
 		_folder = folder;
 		_repositoryBrowserTagDisplayContext =
 			repositoryBrowserTagDisplayContext;
@@ -84,6 +86,16 @@ public class FolderHorizontalCard implements HorizontalCard {
 		return _folder.getName();
 	}
 
+	@Override
+	public boolean isSelectable() {
+		if (_actions.isEmpty()) {
+			return false;
+		}
+
+		return true;
+	}
+
+	private final Set<String> _actions;
 	private final Folder _folder;
 	private final RepositoryBrowserTagDisplayContext
 		_repositoryBrowserTagDisplayContext;

--- a/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/servlet/taglib/RepositoryBrowserTag.java
+++ b/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/servlet/taglib/RepositoryBrowserTag.java
@@ -18,6 +18,7 @@ import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLAppServiceUtil;
 import com.liferay.document.library.taglib.internal.display.context.RepositoryBrowserTagDisplayContext;
 import com.liferay.document.library.taglib.internal.servlet.ServletContextUtil;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.FileShortcut;
 import com.liferay.portal.kernel.repository.model.Folder;
@@ -27,8 +28,13 @@ import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.ServiceProxyFactory;
+import com.liferay.portal.kernel.util.SetUtil;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.taglib.util.IncludeTag;
+
+import java.util.Collections;
+import java.util.Set;
 
 import javax.portlet.PortletRequest;
 import javax.portlet.PortletResponse;
@@ -46,12 +52,20 @@ public class RepositoryBrowserTag extends IncludeTag {
 		return EVAL_BODY_INCLUDE;
 	}
 
+	public String getActions() {
+		return _actions;
+	}
+
 	public long getFolderId() {
 		return _folderId;
 	}
 
 	public long getRepositoryId() {
 		return _repositoryId;
+	}
+
+	public void setActions(String actions) {
+		_actions = actions;
 	}
 
 	public void setFolderId(long folderId) {
@@ -73,6 +87,7 @@ public class RepositoryBrowserTag extends IncludeTag {
 	protected void cleanUp() {
 		super.cleanUp();
 
+		_actions = StringPool.BLANK;
 		_folderId = DLFolderConstants.DEFAULT_PARENT_FOLDER_ID;
 		_repositoryId = 0;
 	}
@@ -105,6 +120,26 @@ public class RepositoryBrowserTag extends IncludeTag {
 				portletRequest, _getRepositoryId(), getFolderId()));
 	}
 
+	private Set<String> _getActions() {
+		if (Validator.isBlank(getActions())) {
+			return _allActions;
+		}
+
+		String actions = getActions();
+
+		Set<String> set = SetUtil.fromArray(actions.split(",\\s*"));
+
+		if (actions.contains("none")) {
+			return Collections.emptySet();
+		}
+
+		if (actions.contains("all")) {
+			return _allActions;
+		}
+
+		return set;
+	}
+
 	private long _getFolderId() {
 		return ParamUtil.getLong(getRequest(), "folderId", _folderId);
 	}
@@ -125,6 +160,8 @@ public class RepositoryBrowserTag extends IncludeTag {
 
 	private static final String _PAGE = "/repository_browser/page.jsp";
 
+	private static final Set<String> _allActions = SetUtil.fromArray(
+		"add-folder", "delete", "rename", "upload");
 	private static volatile ModelResourcePermission<FileEntry>
 		_fileEntryModelResourcePermission =
 			ServiceProxyFactory.newServiceTrackedInstance(
@@ -145,6 +182,7 @@ public class RepositoryBrowserTag extends IncludeTag {
 				"_folderModelResourcePermission",
 				"(model.class.name=" + Folder.class.getName() + ")", false);
 
+	private String _actions = StringPool.BLANK;
 	private long _folderId = DLFolderConstants.DEFAULT_PARENT_FOLDER_ID;
 	private long _repositoryId;
 

--- a/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/servlet/taglib/RepositoryBrowserTag.java
+++ b/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/servlet/taglib/RepositoryBrowserTag.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.ServiceProxyFactory;
 import com.liferay.portal.kernel.util.SetUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.taglib.util.IncludeTag;
@@ -110,7 +111,7 @@ public class RepositoryBrowserTag extends IncludeTag {
 		httpServletRequest.setAttribute(
 			RepositoryBrowserTagDisplayContext.class.getName(),
 			new RepositoryBrowserTagDisplayContext(
-				DLAppServiceUtil.getService(),
+				_getActionsSet(), DLAppServiceUtil.getService(),
 				_fileEntryModelResourcePermission,
 				_fileShortcutModelResourcePermission,
 				_folderModelResourcePermission, _getFolderId(),
@@ -120,24 +121,24 @@ public class RepositoryBrowserTag extends IncludeTag {
 				portletRequest, _getRepositoryId(), getFolderId()));
 	}
 
-	private Set<String> _getActions() {
+	private Set<String> _getActionsSet() {
 		if (Validator.isBlank(getActions())) {
 			return _allActions;
 		}
 
-		String actions = getActions();
+		String actions = StringUtil.trim(getActions());
 
-		Set<String> set = SetUtil.fromArray(actions.split(",\\s*"));
+		Set<String> actionsSet = SetUtil.fromArray(actions.split("\\s*,\\s*"));
 
-		if (actions.contains("none")) {
+		if (actionsSet.contains("none")) {
 			return Collections.emptySet();
 		}
 
-		if (actions.contains("all")) {
+		if (actionsSet.contains("all")) {
 			return _allActions;
 		}
 
-		return set;
+		return actionsSet;
 	}
 
 	private long _getFolderId() {

--- a/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/liferay-document-library.tld
+++ b/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/liferay-document-library.tld
@@ -33,6 +33,11 @@
 		<tag-class>com.liferay.document.library.taglib.servlet.taglib.RepositoryBrowserTag</tag-class>
 		<body-content>empty</body-content>
 		<attribute>
+			<name>actions</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
 			<name>folderId</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>

--- a/modules/apps/document-library/document-library-taglib/src/main/resources/com/liferay/document/library/taglib/servlet/taglib/packageinfo
+++ b/modules/apps/document-library/document-library-taglib/src/main/resources/com/liferay/document/library/taglib/servlet/taglib/packageinfo
@@ -1,1 +1,1 @@
-version 1.2.0
+version 1.3.0


### PR DESCRIPTION
# What is this about?

https://issues.liferay.com/issues/browse/LPS-168177

Add an attribute to the tag that allows to hide unnecessary actions.

The new `actions` attribute accepts a comma separated string with components:

- "all"
- "add-folder"
- "delete"
- "none"
- "rename"
- "upload"

Leaving the attribute empty, or passing "all" is equivalent to passing all available options. Passing "none" will remove all actions. Individual actions can be specified separated by commas (e.g. "add-folder,delete,upload").

![image](https://user-images.githubusercontent.com/729897/202697044-e71eab85-c3d7-407e-a909-6c0f3f705a32.png)

# How do I test it?

To fully test it, you'll need to manually change the "view_images.jsp" file in blogs-web. Checking that blogs only displays the "delete" action may be enough if you're confident.