### PR TITLE
[TECHNICAL SUPPORT] LPS-168994 Users can mention non-site members in Message Boards

### DIFF
--- a/modules/apps/mentions/mentions-service/src/main/java/com/liferay/mentions/internal/util/DefaultMentionsUserFinder.java
+++ b/modules/apps/mentions/mentions-service/src/main/java/com/liferay/mentions/internal/util/DefaultMentionsUserFinder.java
@@ -17,15 +17,20 @@ package com.liferay.mentions.internal.util;
 import com.liferay.mentions.util.MentionsUserFinder;
 import com.liferay.portal.kernel.dao.orm.WildcardMode;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.GroupThreadLocal;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.comparator.UserScreenNameComparator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.social.kernel.model.SocialRelationConstants;
+import com.liferay.social.kernel.service.SocialRelationLocalService;
 import com.liferay.social.kernel.util.SocialInteractionsConfiguration;
 
 import java.util.Collections;
@@ -68,8 +73,39 @@ public class DefaultMentionsUserFinder implements MentionsUserFinder {
 			socialInteractionsConfiguration.
 				isSocialInteractionsSitesEnabled()) {
 
-			return _userLocalService.searchBySocial(
-				groupIds, userId, _TYPES, query, 0, _MAX_USERS);
+			long currentSiteGroupId = GroupThreadLocal.getGroupId();
+
+			return ListUtil.filter(
+				_userLocalService.searchBySocial(
+					groupIds, userId, _TYPES, query, 0, _MAX_USERS),
+				mentionedUser -> {
+					try {
+						if (_socialRelationLocalService.hasRelation(
+								user.getUserId(), mentionedUser.getUserId(),
+								SocialRelationConstants.TYPE_BI_FRIEND)) {
+
+							return true;
+						}
+
+						long[] siteGroupIds = ListUtil.toLongArray(
+							_groupLocalService.getUserSitesGroups(
+								mentionedUser.getUserId()),
+							Group.GROUP_ID_ACCESSOR);
+
+						if (ArrayUtil.contains(
+								siteGroupIds, currentSiteGroupId)) {
+
+							return true;
+						}
+					}
+					catch (PortalException portalException) {
+						_log.error(portalException);
+
+						return false;
+					}
+
+					return false;
+				});
 		}
 
 		if (socialInteractionsConfiguration.
@@ -95,8 +131,14 @@ public class DefaultMentionsUserFinder implements MentionsUserFinder {
 		SocialRelationConstants.TYPE_BI_FRIEND
 	};
 
+	private static final Log _log = LogFactoryUtil.getLog(
+		DefaultMentionsUserFinder.class);
+
 	@Reference
 	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private SocialRelationLocalService _socialRelationLocalService;
 
 	@Reference
 	private UserLocalService _userLocalService;

--- a/modules/apps/mentions/mentions-web/src/main/java/com/liferay/mentions/web/internal/portlet/MentionsPortlet.java
+++ b/modules/apps/mentions/mentions-web/src/main/java/com/liferay/mentions/web/internal/portlet/MentionsPortlet.java
@@ -39,6 +39,7 @@ import com.liferay.portal.kernel.service.permission.PortletPermission;
 import com.liferay.portal.kernel.servlet.ServletResponseUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.GroupThreadLocal;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.Validator;
@@ -208,6 +209,8 @@ public class MentionsPortlet extends MVCPortlet {
 		return () -> {
 			try {
 				List<User> filteredUsers = new ArrayList<>();
+
+				GroupThreadLocal.setGroupId(themeDisplay.getSiteGroupId());
 
 				List<User> users = mentionsStrategy.getUsers(
 					themeDisplay.getCompanyId(), themeDisplay.getUserId(),


### PR DESCRIPTION
Dear Team,

Could you please review this pull request?

Motivation
=======
If an instance is configured that only site members and friends can mention each other, a user who is neither shouldn't be able to be mentioned. Currently, if _Allow Users to Mention Other Users_ is enabled on a Site level, any user can be mentioned.
https://issues.liferay.com/browse/LPS-168994

Proposed Solution
========
I added a filter in `DefaultMentionsUserFinder.getUsers()` that lets users pass only if they are friends with the mentioner OR a member of the current site.
If neither one applies, the user won't be returned by `DefaultMentionsUserFinder.getUsers()`.

Steps to Verify
========
Please see the linked LPS.

Thank you and best regards,
István