### PR TITLE
LPS-169011 check if the url is on a different language to ensure uniqueness

### DIFF
--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
@@ -662,8 +662,15 @@ public class FriendlyURLEntryLocalServiceImpl
 			friendlyURLEntryLocalizationPersistence.fetchByG_C_L_U(
 				groupId, classNameId, languageId, urlTitle);
 
-		if ((friendlyURLEntryLocalization != null) &&
-			(friendlyURLEntryLocalization.getClassPK() != notClassPK)) {
+		FriendlyURLEntryLocalization friendlyURLEntryLocalizationNotLang =
+			friendlyURLEntryLocalizationPersistence.fetchByG_C_NotL_U_First(
+				groupId, classNameId, languageId, urlTitle, null);
+
+		if (((friendlyURLEntryLocalization != null) &&
+			 (friendlyURLEntryLocalization.getClassPK() != notClassPK)) ||
+			((friendlyURLEntryLocalizationNotLang != null) &&
+			 (friendlyURLEntryLocalizationNotLang.getClassPK() !=
+				 notClassPK))) {
 
 			return true;
 		}

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
@@ -662,15 +662,18 @@ public class FriendlyURLEntryLocalServiceImpl
 			friendlyURLEntryLocalizationPersistence.fetchByG_C_L_U(
 				groupId, classNameId, languageId, urlTitle);
 
+		if ((friendlyURLEntryLocalization != null) &&
+			(friendlyURLEntryLocalization.getClassPK() != notClassPK)) {
+
+			return true;
+		}
+
 		FriendlyURLEntryLocalization friendlyURLEntryLocalizationNotLang =
 			friendlyURLEntryLocalizationPersistence.fetchByG_C_NotL_U_First(
 				groupId, classNameId, languageId, urlTitle, null);
 
-		if (((friendlyURLEntryLocalization != null) &&
-			 (friendlyURLEntryLocalization.getClassPK() != notClassPK)) ||
-			((friendlyURLEntryLocalizationNotLang != null) &&
-			 (friendlyURLEntryLocalizationNotLang.getClassPK() !=
-				 notClassPK))) {
+		if ((friendlyURLEntryLocalizationNotLang != null) &&
+			(friendlyURLEntryLocalizationNotLang.getClassPK() != notClassPK)) {
 
 			return true;
 		}

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
@@ -673,7 +673,8 @@ public class FriendlyURLEntryLocalServiceImpl
 				groupId, classNameId, languageId, urlTitle, null);
 
 		if ((friendlyURLEntryLocalizationNotLanguageId != null) &&
-			(friendlyURLEntryLocalizationNotLanguageId.getClassPK() != notClassPK)) {
+			(friendlyURLEntryLocalizationNotLanguageId.getClassPK() !=
+				notClassPK)) {
 
 			return true;
 		}

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
@@ -668,12 +668,12 @@ public class FriendlyURLEntryLocalServiceImpl
 			return true;
 		}
 
-		FriendlyURLEntryLocalization friendlyURLEntryLocalizationNotLang =
+		FriendlyURLEntryLocalization friendlyURLEntryLocalizationNotLanguageId =
 			friendlyURLEntryLocalizationPersistence.fetchByG_C_NotL_U_First(
 				groupId, classNameId, languageId, urlTitle, null);
 
-		if ((friendlyURLEntryLocalizationNotLang != null) &&
-			(friendlyURLEntryLocalizationNotLang.getClassPK() != notClassPK)) {
+		if ((friendlyURLEntryLocalizationNotLanguageId != null) &&
+			(friendlyURLEntryLocalizationNotLanguageId.getClassPK() != notClassPK)) {
 
 			return true;
 		}

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/friendly/url/test/JournalArticleFriendlyURLTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/friendly/url/test/JournalArticleFriendlyURLTest.java
@@ -193,6 +193,31 @@ public class JournalArticleFriendlyURLTest {
 	}
 
 	@Test
+	public void testUniqueFriendlyURLForSameTitlesInNotDefaultLocaleWithExistingArticle()
+		throws Exception {
+
+		String frTitle = RandomTestUtil.randomString();
+
+		_addJournalArticleWithTitleMap(
+			HashMapBuilder.put(
+				LocaleUtil.FRANCE, frTitle
+			).put(
+				LocaleUtil.US, RandomTestUtil.randomString()
+			).build());
+
+		JournalArticle article = _addJournalArticleWithTitleMap(
+			HashMapBuilder.put(
+				LocaleUtil.US, frTitle
+			).build());
+
+		Map<Locale, String> friendlyURLMap = article.getFriendlyURLMap();
+
+		Assert.assertEquals(
+			FriendlyURLNormalizerUtil.normalizeWithEncoding(frTitle + "-1"),
+			friendlyURLMap.get(LocaleUtil.US));
+	}
+
+	@Test
 	public void testUniqueFriendlyURLForSameTitlesWithExistingArticle()
 		throws Exception {
 


### PR DESCRIPTION
Hi Lima Team,

I'm sending this PR to fix a little regression caused by getUniqueURL changes in friendlyURL after LPS-166653

Steps to reproduce:

1. Start master
2. Create a Journal with the default language English. Title A with A as friendlyURL.
3. Add a translation for this article in spanish. Title B with B as friendlyURL
4. Create another journal with the default language English. Title B and B as friendlyURL
5. Add a translation for this article in spanish. Title A with A as friendlyURL.

**Expected behaviour.**
Two different articles should not have the same FriendlyURL

**Current behaviour.**
This different articles have the same FriendlyURL.

