### PR TITLE
[TECHNICAL SUPPORT] LPS-168994 Users can mention non-site members in Message Boards

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/mentions/strategy/PageEditorCommentMentionsStrategy.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/mentions/strategy/PageEditorCommentMentionsStrategy.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
@@ -46,7 +47,8 @@ public class PageEditorCommentMentionsStrategy implements MentionsStrategy {
 
 	@Override
 	public List<User> getUsers(
-			long companyId, long userId, String query, JSONObject jsonObject)
+			long companyId, long groupId, long userId, String query,
+			JSONObject jsonObject)
 		throws PortalException {
 
 		SocialInteractionsConfiguration socialInteractionsConfiguration =
@@ -55,7 +57,7 @@ public class PageEditorCommentMentionsStrategy implements MentionsStrategy {
 					companyId, MentionsPortletKeys.MENTIONS);
 
 		List<User> users = _mentionsUserFinder.getUsers(
-			companyId, userId, query, socialInteractionsConfiguration);
+			companyId, groupId, userId, query, socialInteractionsConfiguration);
 
 		long plid = jsonObject.getLong("plid");
 
@@ -79,6 +81,16 @@ public class PageEditorCommentMentionsStrategy implements MentionsStrategy {
 		).collect(
 			Collectors.toList()
 		);
+	}
+
+	@Override
+	public List<User> getUsers(
+			long companyId, long userId, String query, JSONObject jsonObject)
+		throws PortalException {
+
+		return getUsers(
+			companyId, GroupConstants.DEFAULT_PARENT_GROUP_ID, userId, query,
+			jsonObject);
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/mentions/mentions-api/bnd.bnd
+++ b/modules/apps/mentions/mentions-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Mentions API
 Bundle-SymbolicName: com.liferay.mentions.api
-Bundle-Version: 6.0.10
+Bundle-Version: 7.0.0
 Export-Package:\
 	com.liferay.mentions.configuration,\
 	com.liferay.mentions.constants,\

--- a/modules/apps/mentions/mentions-api/src/main/java/com/liferay/mentions/strategy/MentionsStrategy.java
+++ b/modules/apps/mentions/mentions-api/src/main/java/com/liferay/mentions/strategy/MentionsStrategy.java
@@ -26,6 +26,11 @@ import java.util.List;
 public interface MentionsStrategy {
 
 	public List<User> getUsers(
+			long companyId, long groupId, long user, String query,
+			JSONObject jsonObject)
+		throws PortalException;
+
+	public List<User> getUsers(
 			long companyId, long user, String query, JSONObject jsonObject)
 		throws PortalException;
 

--- a/modules/apps/mentions/mentions-api/src/main/java/com/liferay/mentions/util/MentionsUserFinder.java
+++ b/modules/apps/mentions/mentions-api/src/main/java/com/liferay/mentions/util/MentionsUserFinder.java
@@ -26,6 +26,11 @@ import java.util.List;
 public interface MentionsUserFinder {
 
 	public List<User> getUsers(
+			long companyId, long groupId, long userId, String query,
+			SocialInteractionsConfiguration socialInteractionsConfiguration)
+		throws PortalException;
+
+	public List<User> getUsers(
 			long companyId, long userId, String query,
 			SocialInteractionsConfiguration socialInteractionsConfiguration)
 		throws PortalException;

--- a/modules/apps/mentions/mentions-api/src/main/resources/com/liferay/mentions/strategy/packageinfo
+++ b/modules/apps/mentions/mentions-api/src/main/resources/com/liferay/mentions/strategy/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 2.0.0

--- a/modules/apps/mentions/mentions-api/src/main/resources/com/liferay/mentions/util/packageinfo
+++ b/modules/apps/mentions/mentions-api/src/main/resources/com/liferay/mentions/util/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.1
+version 2.0.0

--- a/modules/apps/mentions/mentions-service/src/main/java/com/liferay/mentions/internal/strategy/DefaultMentionsStrategy.java
+++ b/modules/apps/mentions/mentions-service/src/main/java/com/liferay/mentions/internal/strategy/DefaultMentionsStrategy.java
@@ -19,6 +19,7 @@ import com.liferay.mentions.strategy.MentionsStrategy;
 import com.liferay.mentions.util.MentionsUserFinder;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.social.kernel.util.SocialInteractionsConfiguration;
 import com.liferay.social.kernel.util.SocialInteractionsConfigurationUtil;
@@ -38,7 +39,8 @@ public class DefaultMentionsStrategy implements MentionsStrategy {
 
 	@Override
 	public List<User> getUsers(
-			long companyId, long userId, String query, JSONObject jsonObject)
+			long companyId, long groupId, long userId, String query,
+			JSONObject jsonObject)
 		throws PortalException {
 
 		SocialInteractionsConfiguration socialInteractionsConfiguration =
@@ -47,7 +49,17 @@ public class DefaultMentionsStrategy implements MentionsStrategy {
 					companyId, MentionsPortletKeys.MENTIONS);
 
 		return _mentionsUserFinder.getUsers(
-			companyId, userId, query, socialInteractionsConfiguration);
+			companyId, groupId, userId, query, socialInteractionsConfiguration);
+	}
+
+	@Override
+	public List<User> getUsers(
+			long companyId, long userId, String query, JSONObject jsonObject)
+		throws PortalException {
+
+		return getUsers(
+			companyId, GroupConstants.DEFAULT_PARENT_GROUP_ID, userId, query,
+			jsonObject);
 	}
 
 	@Reference

--- a/modules/apps/mentions/mentions-service/src/main/java/com/liferay/mentions/internal/util/DefaultMentionsUserFinder.java
+++ b/modules/apps/mentions/mentions-service/src/main/java/com/liferay/mentions/internal/util/DefaultMentionsUserFinder.java
@@ -18,6 +18,7 @@ import com.liferay.mentions.util.MentionsUserFinder;
 import com.liferay.portal.kernel.dao.orm.WildcardMode;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
@@ -42,7 +43,7 @@ public class DefaultMentionsUserFinder implements MentionsUserFinder {
 
 	@Override
 	public List<User> getUsers(
-			long companyId, long userId, String query,
+			long companyId, long groupId, long userId, String query,
 			SocialInteractionsConfiguration socialInteractionsConfiguration)
 		throws PortalException {
 
@@ -87,6 +88,17 @@ public class DefaultMentionsUserFinder implements MentionsUserFinder {
 		}
 
 		return Collections.emptyList();
+	}
+
+	@Override
+	public List<User> getUsers(
+			long companyId, long userId, String query,
+			SocialInteractionsConfiguration socialInteractionsConfiguration)
+		throws PortalException {
+
+		return getUsers(
+			companyId, GroupConstants.DEFAULT_PARENT_GROUP_ID, userId, query,
+			socialInteractionsConfiguration);
 	}
 
 	private static final int _MAX_USERS = 20;

--- a/modules/apps/mentions/mentions-web/src/main/java/com/liferay/mentions/web/internal/portlet/MentionsPortlet.java
+++ b/modules/apps/mentions/mentions-web/src/main/java/com/liferay/mentions/web/internal/portlet/MentionsPortlet.java
@@ -210,8 +210,8 @@ public class MentionsPortlet extends MVCPortlet {
 				List<User> filteredUsers = new ArrayList<>();
 
 				List<User> users = mentionsStrategy.getUsers(
-					themeDisplay.getCompanyId(), themeDisplay.getUserId(),
-					query, jsonObject);
+					themeDisplay.getCompanyId(), themeDisplay.getSiteGroupId(),
+					themeDisplay.getUserId(), query, jsonObject);
 
 				for (User user : users) {
 					PermissionChecker permissionChecker =


### PR DESCRIPTION
Dear Team,

Could you please review this pull request?

Motivation
=======
If an instance is configured that only site members and friends can mention each other, a user who is neither shouldn't be able to be mentioned. Currently, if _Allow Users to Mention Other Users_ is enabled on a Site level, any user can be mentioned.
https://issues.liferay.com/browse/LPS-168994

Proposed Solution
========
I added a filter in `DefaultMentionsUserFinder.getUsers()` that lets users pass only if they are friends with the mentioner OR a member of the current site.
If neither one applies, the user won't be returned by `DefaultMentionsUserFinder.getUsers()`.

**In order to be able to pass groupId, I extended the strategy/finder API.**

Steps to Verify
========
Please see the linked LPS.

Thank you and best regards,
István