### PR TITLE
LPS-169193 Validate if the requested path could be a Folder, not a File

### DIFF
--- a/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
+++ b/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
@@ -1374,6 +1374,19 @@ public class WebServerServlet extends HttpServlet {
 
 			// Unable to check with UUID because of multiple repositories
 
+			// Check if it is a folderId and not a UUID
+
+			long groupId = GetterUtil.getLong(pathArray[0], -1L);
+			long folderId = GetterUtil.getLong(pathArray[1], -1L);
+
+			if ((groupId > -1) && (folderId > -1)) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(
+						"Trying to access a Folder, folderId=" + folderId);
+				}
+
+				throw new NoSuchFileEntryException();
+			}
 		}
 		else if (pathArray.length == 3) {
 			long groupId = GetterUtil.getLong(pathArray[0]);


### PR DESCRIPTION
Hi Team,
Can you please review?
[LPS-169193](https://issues.liferay.com/browse/LPS-169193)

Motivation
=======
Documents URLs with 3 parts, like /documents/<groupId>/<folderId>/<fileName> work with custom 404 pages, but if <fileName> is removed, Liferay returns the default 404 page

Proposed Solution
========
The 2 parts validation in WebServerServlet was left empty, its reasons only hinted by that one of the parts being a UUID. In our case, we can check if both parts are Long, and if so, conclude that this URL is not a File, but a Folder and should trigger an Exception, just like all other failing paths in this method.

Steps to Verify
========
1. Creat a 404.html file and put in {Tomcat_Home}/webapps/ROOT/html/portal folder
1. Add the following to portal-ext.properties:
layout.friendly.url.page.not.found=/html/portal/404.html
sites.friendly.url.page.not.found=/html/portal/404.html
1. Started Liferay
1. Go to Configuration > Site Settings > Site Configuration
1. Save the Site ID for later use: <groupId>
1. Go to Documents & Media
1. Create a folder named "test"
1. Open the folder
1. Check the URL for _com_liferay_document_library_web_portlet_DLAdminPortlet_folderId, save it for later use: <folderId>
1. Open a non-existent document by filling in the saved parameters: `http://localhost:8080/documents/<groupId>/<folderId>/test.jpg`
1. Assert the custom 404 page is displayed
1. Open a the same URL without the filename: `http://localhost:8080/documents/<groupId>/<folderId>`

**Expected behaviour:** The custom 404 page is displayed
**Actual behaviour:** Liferay's default error page is displayed, showing "The requested resource can not be found".