### PR TITLE
LPS-168781 Do not show expired articles on asset publisher

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
@@ -1546,9 +1546,7 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 		return dynamicQuery.add(junction);
 	}
 
-	private void _checkKBArticles(Date expirationDate)
-		throws PortalException {
-
+	private void _checkKBArticles(Date expirationDate) throws PortalException {
 		if (_log.isDebugEnabled()) {
 			_log.debug(
 				"Expiring file entries with expiration date previous to " +
@@ -1605,6 +1603,25 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 			updateStatus(
 				userId, kbArticle.getResourcePrimKey(),
 				WorkflowConstants.STATUS_EXPIRED, serviceContext);
+
+			// Asset
+
+			AssetEntry assetEntry = _assetEntryLocalService.getEntry(
+				KBArticle.class.getName(), kbArticle.getResourcePrimKey());
+
+			_assetEntryLocalService.updateEntry(
+				userId, kbArticle.getGroupId(), kbArticle.getCreateDate(),
+				kbArticle.getModifiedDate(), KBArticle.class.getName(),
+				kbArticle.getResourcePrimKey(), kbArticle.getUuid(), 0,
+				assetEntry.getCategoryIds(), assetEntry.getTagNames(), true,
+				false, null, null, null, kbArticle.getExpirationDate(),
+				ContentTypes.TEXT_HTML, kbArticle.getTitle(),
+				kbArticle.getDescription(), assetEntry.getSummary(), null, null,
+				0, 0, null);
+
+			// Index
+
+			_indexKBArticle(kbArticle);
 		}
 	}
 

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
@@ -1562,9 +1562,16 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 		_assetEntryLocalService.deleteEntry(
 			KBArticle.class.getName(), kbArticle.getClassPK());
 
-		if (!kbArticle.isApproved() && !kbArticle.isFirstVersion()) {
-			_assetEntryLocalService.deleteEntry(
-				KBArticle.class.getName(), kbArticle.getResourcePrimKey());
+		if (!kbArticle.isApproved()) {
+			int kbArticleVersionsCount =
+				kbArticleLocalService.getKBArticleVersionsCount(
+					kbArticle.getResourcePrimKey(),
+					WorkflowConstants.STATUS_ANY);
+
+			if ((kbArticleVersionsCount == 0) || !kbArticle.isFirstVersion()) {
+				_assetEntryLocalService.deleteEntry(
+					KBArticle.class.getName(), kbArticle.getResourcePrimKey());
+			}
 		}
 	}
 

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
@@ -1159,7 +1159,7 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 
 		KBArticle kbArticle = null;
 
-		if (oldKBArticle.isApproved()) {
+		if (oldKBArticle.isApproved() || oldKBArticle.isExpired()) {
 			long kbArticleId = counterLocalService.increment();
 
 			kbArticle = kbArticlePersistence.create(kbArticleId);
@@ -1214,7 +1214,7 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 
 		kbArticle = kbArticlePersistence.update(kbArticle);
 
-		if (oldKBArticle.isApproved()) {
+		if (oldKBArticle.isApproved() || oldKBArticle.isExpired()) {
 			oldKBArticle.setModifiedDate(oldKBArticle.getModifiedDate());
 			oldKBArticle.setLatest(false);
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-168781


- LPS-168781 update the asset entry with the expiration date and no visible
- LPS-168781 create a version for the expired one, not overwrite it
- LPS-168781 when deleting a kbarticle, make sure we delete the asset entry if the article was not approved but was the last one



If you add and asset publisher and select the KB articles, we are still showing the expired KB articles

another issues is that we do not delete the asset if it's not approved
and we do not save the expired version.l
