### PR TITLE
[TS] LPS-166188 Add addRecord method with fieldsMap input to DLL services to make it callable from JSONWS API 

### DIFF
--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-api/bnd.bnd
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Dynamic Data Lists API
 Bundle-SymbolicName: com.liferay.dynamic.data.lists.api
-Bundle-Version: 8.1.1
+Bundle-Version: 8.2.0
 Export-Package:\
 	com.liferay.dynamic.data.lists.constants,\
 	com.liferay.dynamic.data.lists.exception,\

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-api/src/main/java/com/liferay/dynamic/data/lists/service/DDLRecordLocalService.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-api/src/main/java/com/liferay/dynamic/data/lists/service/DDLRecordLocalService.java
@@ -51,6 +51,7 @@ import java.io.Serializable;
 
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 import org.osgi.annotation.versioning.ProviderType;
 
@@ -112,6 +113,31 @@ public interface DDLRecordLocalService
 	public DDLRecord addRecord(
 			long userId, long groupId, long recordSetId, int displayIndex,
 			DDMFormValues ddmFormValues, ServiceContext serviceContext)
+		throws PortalException;
+
+	/**
+	 * Adds a record that's based on the fields map and that references the
+	 * record set.
+	 *
+	 * @param userId the primary key of the record's creator/owner
+	 * @param groupId the primary key of the record's group
+	 * @param recordSetId the primary key of the record set
+	 * @param displayIndex the index position in which the record is
+	 displayed in the spreadsheet view
+	 * @param fieldsMap the record values. The fieldsMap is a map of field
+	 names and their serializable values.
+	 * @param serviceContext the service context to be applied. This can
+	 set the UUID, guest permissions, and group permissions for
+	 the record.
+	 * @return the record
+	 * @throws PortalException if a portal exception occurred
+	 * @deprecated As of Wilberforce (7.0.x), replaced by {@link
+	 #addRecord(long, long, int, DDMFormValues, ServiceContext)}
+	 */
+	@Deprecated
+	public DDLRecord addRecord(
+			long userId, long groupId, long recordSetId, int displayIndex,
+			Map<String, Serializable> fieldsMap, ServiceContext serviceContext)
 		throws PortalException;
 
 	/**

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-api/src/main/java/com/liferay/dynamic/data/lists/service/DDLRecordLocalServiceUtil.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-api/src/main/java/com/liferay/dynamic/data/lists/service/DDLRecordLocalServiceUtil.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.util.OrderByComparator;
 import java.io.Serializable;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * Provides the local service utility for DDLRecord. This utility wraps
@@ -84,6 +85,37 @@ public class DDLRecordLocalServiceUtil {
 
 		return getService().addRecord(
 			userId, groupId, recordSetId, displayIndex, ddmFormValues,
+			serviceContext);
+	}
+
+	/**
+	 * Adds a record that's based on the fields map and that references the
+	 * record set.
+	 *
+	 * @param userId the primary key of the record's creator/owner
+	 * @param groupId the primary key of the record's group
+	 * @param recordSetId the primary key of the record set
+	 * @param displayIndex the index position in which the record is
+	 displayed in the spreadsheet view
+	 * @param fieldsMap the record values. The fieldsMap is a map of field
+	 names and their serializable values.
+	 * @param serviceContext the service context to be applied. This can
+	 set the UUID, guest permissions, and group permissions for
+	 the record.
+	 * @return the record
+	 * @throws PortalException if a portal exception occurred
+	 * @deprecated As of Wilberforce (7.0.x), replaced by {@link
+	 #addRecord(long, long, int, DDMFormValues, ServiceContext)}
+	 */
+	@Deprecated
+	public static DDLRecord addRecord(
+			long userId, long groupId, long recordSetId, int displayIndex,
+			Map<String, Serializable> fieldsMap,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws PortalException {
+
+		return getService().addRecord(
+			userId, groupId, recordSetId, displayIndex, fieldsMap,
 			serviceContext);
 	}
 

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-api/src/main/java/com/liferay/dynamic/data/lists/service/DDLRecordLocalServiceWrapper.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-api/src/main/java/com/liferay/dynamic/data/lists/service/DDLRecordLocalServiceWrapper.java
@@ -84,6 +84,38 @@ public class DDLRecordLocalServiceWrapper
 	}
 
 	/**
+	 * Adds a record that's based on the fields map and that references the
+	 * record set.
+	 *
+	 * @param userId the primary key of the record's creator/owner
+	 * @param groupId the primary key of the record's group
+	 * @param recordSetId the primary key of the record set
+	 * @param displayIndex the index position in which the record is
+	 displayed in the spreadsheet view
+	 * @param fieldsMap the record values. The fieldsMap is a map of field
+	 names and their serializable values.
+	 * @param serviceContext the service context to be applied. This can
+	 set the UUID, guest permissions, and group permissions for
+	 the record.
+	 * @return the record
+	 * @throws PortalException if a portal exception occurred
+	 * @deprecated As of Wilberforce (7.0.x), replaced by {@link
+	 #addRecord(long, long, int, DDMFormValues, ServiceContext)}
+	 */
+	@Deprecated
+	@Override
+	public DDLRecord addRecord(
+			long userId, long groupId, long recordSetId, int displayIndex,
+			java.util.Map<String, java.io.Serializable> fieldsMap,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _ddlRecordLocalService.addRecord(
+			userId, groupId, recordSetId, displayIndex, fieldsMap,
+			serviceContext);
+	}
+
+	/**
 	 * @deprecated As of Athanasius (7.3.x)
 	 */
 	@Deprecated

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-api/src/main/java/com/liferay/dynamic/data/lists/service/DDLRecordService.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-api/src/main/java/com/liferay/dynamic/data/lists/service/DDLRecordService.java
@@ -27,7 +27,10 @@ import com.liferay.portal.kernel.transaction.Isolation;
 import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.Transactional;
 
+import java.io.Serializable;
+
 import java.util.List;
+import java.util.Map;
 
 import org.osgi.annotation.versioning.ProviderType;
 
@@ -74,6 +77,29 @@ public interface DDLRecordService extends BaseService {
 	public DDLRecord addRecord(
 			long groupId, long recordSetId, int displayIndex,
 			DDMFormValues ddmFormValues, ServiceContext serviceContext)
+		throws PortalException;
+
+	/**
+	 * Adds a record referencing the record set.
+	 *
+	 * @param groupId the primary key of the record's group
+	 * @param recordSetId the primary key of the record set
+	 * @param displayIndex the index position in which the record is
+	 displayed in the spreadsheet view
+	 * @param fieldsMap the record values. The fieldsMap is a map of field
+	 names and its Serializable values.
+	 * @param serviceContext the service context to be applied. This can
+	 set the UUID, guest permissions, and group permissions for
+	 the record.
+	 * @return the record
+	 * @throws PortalException if a portal exception occurred
+	 * @deprecated As of Wilberforce (7.0.x), replaced by {@link
+	 #addRecord(long, long, int, DDMFormValues, ServiceContext)}
+	 */
+	@Deprecated
+	public DDLRecord addRecord(
+			long groupId, long recordSetId, int displayIndex,
+			Map<String, Serializable> fieldsMap, ServiceContext serviceContext)
 		throws PortalException;
 
 	/**

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-api/src/main/java/com/liferay/dynamic/data/lists/service/DDLRecordServiceUtil.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-api/src/main/java/com/liferay/dynamic/data/lists/service/DDLRecordServiceUtil.java
@@ -17,7 +17,10 @@ package com.liferay.dynamic.data.lists.service;
 import com.liferay.dynamic.data.lists.model.DDLRecord;
 import com.liferay.portal.kernel.exception.PortalException;
 
+import java.io.Serializable;
+
 import java.util.List;
+import java.util.Map;
 
 /**
  * Provides the remote service utility for DDLRecord. This utility wraps
@@ -63,6 +66,34 @@ public class DDLRecordServiceUtil {
 
 		return getService().addRecord(
 			groupId, recordSetId, displayIndex, ddmFormValues, serviceContext);
+	}
+
+	/**
+	 * Adds a record referencing the record set.
+	 *
+	 * @param groupId the primary key of the record's group
+	 * @param recordSetId the primary key of the record set
+	 * @param displayIndex the index position in which the record is
+	 displayed in the spreadsheet view
+	 * @param fieldsMap the record values. The fieldsMap is a map of field
+	 names and its Serializable values.
+	 * @param serviceContext the service context to be applied. This can
+	 set the UUID, guest permissions, and group permissions for
+	 the record.
+	 * @return the record
+	 * @throws PortalException if a portal exception occurred
+	 * @deprecated As of Wilberforce (7.0.x), replaced by {@link
+	 #addRecord(long, long, int, DDMFormValues, ServiceContext)}
+	 */
+	@Deprecated
+	public static DDLRecord addRecord(
+			long groupId, long recordSetId, int displayIndex,
+			Map<String, Serializable> fieldsMap,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws PortalException {
+
+		return getService().addRecord(
+			groupId, recordSetId, displayIndex, fieldsMap, serviceContext);
 	}
 
 	/**

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-api/src/main/java/com/liferay/dynamic/data/lists/service/DDLRecordServiceWrapper.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-api/src/main/java/com/liferay/dynamic/data/lists/service/DDLRecordServiceWrapper.java
@@ -63,6 +63,35 @@ public class DDLRecordServiceWrapper
 	}
 
 	/**
+	 * Adds a record referencing the record set.
+	 *
+	 * @param groupId the primary key of the record's group
+	 * @param recordSetId the primary key of the record set
+	 * @param displayIndex the index position in which the record is
+	 displayed in the spreadsheet view
+	 * @param fieldsMap the record values. The fieldsMap is a map of field
+	 names and its Serializable values.
+	 * @param serviceContext the service context to be applied. This can
+	 set the UUID, guest permissions, and group permissions for
+	 the record.
+	 * @return the record
+	 * @throws PortalException if a portal exception occurred
+	 * @deprecated As of Wilberforce (7.0.x), replaced by {@link
+	 #addRecord(long, long, int, DDMFormValues, ServiceContext)}
+	 */
+	@Deprecated
+	@Override
+	public DDLRecord addRecord(
+			long groupId, long recordSetId, int displayIndex,
+			java.util.Map<String, java.io.Serializable> fieldsMap,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _ddlRecordService.addRecord(
+			groupId, recordSetId, displayIndex, fieldsMap, serviceContext);
+	}
+
+	/**
 	 * Deletes the record and its resources.
 	 *
 	 * @param recordId the primary key of the record to be deleted

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-api/src/main/resources/com/liferay/dynamic/data/lists/service/packageinfo
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-api/src/main/resources/com/liferay/dynamic/data/lists/service/packageinfo
@@ -1,1 +1,1 @@
-version 2.5.0
+version 2.6.0

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/service/http/DDLRecordServiceHttp.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/service/http/DDLRecordServiceHttp.java
@@ -95,13 +95,57 @@ public class DDLRecordServiceHttp {
 		}
 	}
 
+	public static com.liferay.dynamic.data.lists.model.DDLRecord addRecord(
+			HttpPrincipal httpPrincipal, long groupId, long recordSetId,
+			int displayIndex,
+			java.util.Map<String, java.io.Serializable> fieldsMap,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				DDLRecordServiceUtil.class, "addRecord",
+				_addRecordParameterTypes1);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, groupId, recordSetId, displayIndex, fieldsMap,
+				serviceContext);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.dynamic.data.lists.model.DDLRecord)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
 	public static void deleteRecord(HttpPrincipal httpPrincipal, long recordId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		try {
 			MethodKey methodKey = new MethodKey(
 				DDLRecordServiceUtil.class, "deleteRecord",
-				_deleteRecordParameterTypes1);
+				_deleteRecordParameterTypes2);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, recordId);
@@ -137,7 +181,7 @@ public class DDLRecordServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DDLRecordServiceUtil.class, "getRecord",
-				_getRecordParameterTypes2);
+				_getRecordParameterTypes3);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, recordId);
@@ -177,7 +221,7 @@ public class DDLRecordServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DDLRecordServiceUtil.class, "getRecords",
-				_getRecordsParameterTypes3);
+				_getRecordsParameterTypes4);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, recordSetId);
@@ -219,7 +263,7 @@ public class DDLRecordServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DDLRecordServiceUtil.class, "revertRecord",
-				_revertRecordParameterTypes4);
+				_revertRecordParameterTypes5);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, recordId, version, serviceContext);
@@ -259,7 +303,7 @@ public class DDLRecordServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DDLRecordServiceUtil.class, "updateRecord",
-				_updateRecordParameterTypes5);
+				_updateRecordParameterTypes6);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, recordId, majorVersion, displayIndex, ddmFormValues,
@@ -300,20 +344,24 @@ public class DDLRecordServiceHttp {
 		com.liferay.dynamic.data.mapping.storage.DDMFormValues.class,
 		com.liferay.portal.kernel.service.ServiceContext.class
 	};
-	private static final Class<?>[] _deleteRecordParameterTypes1 = new Class[] {
+	private static final Class<?>[] _addRecordParameterTypes1 = new Class[] {
+		long.class, long.class, int.class, java.util.Map.class,
+		com.liferay.portal.kernel.service.ServiceContext.class
+	};
+	private static final Class<?>[] _deleteRecordParameterTypes2 = new Class[] {
 		long.class
 	};
-	private static final Class<?>[] _getRecordParameterTypes2 = new Class[] {
+	private static final Class<?>[] _getRecordParameterTypes3 = new Class[] {
 		long.class
 	};
-	private static final Class<?>[] _getRecordsParameterTypes3 = new Class[] {
+	private static final Class<?>[] _getRecordsParameterTypes4 = new Class[] {
 		long.class
 	};
-	private static final Class<?>[] _revertRecordParameterTypes4 = new Class[] {
+	private static final Class<?>[] _revertRecordParameterTypes5 = new Class[] {
 		long.class, String.class,
 		com.liferay.portal.kernel.service.ServiceContext.class
 	};
-	private static final Class<?>[] _updateRecordParameterTypes5 = new Class[] {
+	private static final Class<?>[] _updateRecordParameterTypes6 = new Class[] {
 		long.class, boolean.class, int.class,
 		com.liferay.dynamic.data.mapping.storage.DDMFormValues.class,
 		com.liferay.portal.kernel.service.ServiceContext.class

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/service/impl/DDLRecordLocalServiceImpl.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/service/impl/DDLRecordLocalServiceImpl.java
@@ -68,6 +68,7 @@ import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
@@ -187,6 +188,49 @@ public class DDLRecordLocalServiceImpl extends DDLRecordLocalServiceBaseImpl {
 		}
 
 		return record;
+	}
+
+	/**
+	 * Adds a record that's based on the fields map and that references the
+	 * record set.
+	 *
+	 * @param      userId the primary key of the record's creator/owner
+	 * @param      groupId the primary key of the record's group
+	 * @param      recordSetId the primary key of the record set
+	 * @param      displayIndex the index position in which the record is
+	 *             displayed in the spreadsheet view
+	 * @param      fieldsMap the record values. The fieldsMap is a map of field
+	 *             names and their serializable values.
+	 * @param      serviceContext the service context to be applied. This can
+	 *             set the UUID, guest permissions, and group permissions for
+	 *             the record.
+	 * @return     the record
+	 * @throws     PortalException if a portal exception occurred
+	 * @deprecated As of Wilberforce (7.0.x), replaced by {@link
+	 *             #addRecord(long, long, int, DDMFormValues, ServiceContext)}
+	 */
+	@Deprecated
+	@Override
+	public DDLRecord addRecord(
+		long userId, long groupId, long recordSetId, int displayIndex,
+		Map<String, Serializable> fieldsMap, ServiceContext serviceContext)
+		throws PortalException {
+
+		DDLRecordSet recordSet = _ddlRecordSetPersistence.findByPrimaryKey(
+			recordSetId);
+
+		DDMStructure ddmStructure = recordSet.getDDMStructure();
+
+		Fields fields = toFields(
+			ddmStructure.getStructureId(), fieldsMap,
+			serviceContext.getLocale(), LocaleUtil.getSiteDefault());
+
+		DDMFormValues ddmFormValues = fieldsToDDMFormValuesConverter.convert(
+			ddmStructure, fields);
+
+		return ddlRecordLocalService.addRecord(
+			userId, groupId, recordSetId, displayIndex, ddmFormValues,
+			serviceContext);
 	}
 
 	/**

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/service/impl/DDLRecordServiceImpl.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/service/impl/DDLRecordServiceImpl.java
@@ -25,7 +25,9 @@ import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.ServiceContext;
 
+import java.io.Serializable;
 import java.util.List;
+import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -73,6 +75,38 @@ public class DDLRecordServiceImpl extends DDLRecordServiceBaseImpl {
 		return ddlRecordLocalService.addRecord(
 			getGuestOrUserId(), groupId, recordSetId, displayIndex,
 			ddmFormValues, serviceContext);
+	}
+
+	/**
+	 * Adds a record referencing the record set.
+	 *
+	 * @param      groupId the primary key of the record's group
+	 * @param      recordSetId the primary key of the record set
+	 * @param      displayIndex the index position in which the record is
+	 *             displayed in the spreadsheet view
+	 * @param      fieldsMap the record values. The fieldsMap is a map of field
+	 *             names and its Serializable values.
+	 * @param      serviceContext the service context to be applied. This can
+	 *             set the UUID, guest permissions, and group permissions for
+	 *             the record.
+	 * @return     the record
+	 * @throws     PortalException if a portal exception occurred
+	 * @deprecated As of Wilberforce (7.0.x), replaced by {@link
+	 *             #addRecord(long, long, int, DDMFormValues, ServiceContext)}
+	 */
+	@Deprecated
+	@Override
+	public DDLRecord addRecord(
+		long groupId, long recordSetId, int displayIndex,
+		Map<String, Serializable> fieldsMap, ServiceContext serviceContext)
+		throws PortalException {
+
+		_ddlRecordSetModelResourcePermission.check(
+			getPermissionChecker(), recordSetId, DDLActionKeys.ADD_RECORD);
+
+		return ddlRecordLocalService.addRecord(
+			getGuestOrUserId(), groupId, recordSetId, displayIndex, fieldsMap,
+			serviceContext);
 	}
 
 	/**


### PR DESCRIPTION
Hi Team,

https://issues.liferay.com/browse/LPS-166188

Issue:
It is not possible to add DDL record in JSONWS API ddl/ad-record with the ddmFormValues input. As it turned out, it was never implemented to work with this input. Multiple endpoints were implemented on 7.2.x, including this one, but never worked, and the working endpoints were deprecated.

Solution:
I implemented the solution suggested on: https://issues.liferay.com/browse/PTR-3419?focusedCommentId=2805544&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-2805544
The solution was to (re)create an endpoint with "fieldsMap" input, that is converted to 'DDMFormValues'.

I tested it on master in my local environment, and it was possible to add new records in JSONWS API add-record method.

Best regards,
Évi