### PR TITLE
LPS-169522 Fix sorting controls and add permission customization

### DIFF
--- a/modules/apps/blogs/blogs-web-test/src/testIntegration/java/com/liferay/blogs/web/test/BlogEntriesDisplayContextTest.java
+++ b/modules/apps/blogs/blogs-web-test/src/testIntegration/java/com/liferay/blogs/web/test/BlogEntriesDisplayContextTest.java
@@ -275,7 +275,8 @@ public class BlogEntriesDisplayContextTest {
 
 		Object blogEntriesDisplayContext =
 			mockLiferayPortletRenderRequest.getAttribute(
-				"BLOG_ENTRIES_DISPLAY_CONTEXT");
+				"com.liferay.blogs.web.internal.display.context." +
+					"BlogEntriesDisplayContext");
 
 		return ReflectionTestUtil.invoke(
 			blogEntriesDisplayContext, "getSearchContainer", new Class<?>[0],

--- a/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/constants/BlogsWebKeys.java
+++ b/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/constants/BlogsWebKeys.java
@@ -19,9 +19,6 @@ package com.liferay.blogs.web.internal.constants;
  */
 public class BlogsWebKeys {
 
-	public static final String BLOG_ENTRIES_DISPLAY_CONTEXT =
-		"BLOG_ENTRIES_DISPLAY_CONTEXT";
-
 	public static final String BLOGS_ITEM_SELECTOR_DISPLAY_CONTEXT =
 		"BLOGS_ITEM_SELECTOR_DISPLAY_CONTEXT";
 

--- a/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/display/context/BlogImagesDisplayContext.java
+++ b/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/display/context/BlogImagesDisplayContext.java
@@ -33,6 +33,7 @@ import com.liferay.portal.kernel.search.Hits;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.SearchContextFactory;
 import com.liferay.portal.kernel.search.Sort;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -52,11 +53,19 @@ import javax.servlet.http.HttpServletRequest;
 public class BlogImagesDisplayContext {
 
 	public BlogImagesDisplayContext(
-		LiferayPortletRequest liferayPortletRequest) {
+		LiferayPortletRequest liferayPortletRequest,
+		ModelResourcePermission<FileEntry> modelResourcePermission) {
 
 		_liferayPortletRequest = liferayPortletRequest;
+		_modelResourcePermission = modelResourcePermission;
 
 		_httpServletRequest = _liferayPortletRequest.getHttpServletRequest();
+	}
+
+	public ModelResourcePermission<FileEntry>
+		getCustomFileEntryModelResourcePermission() {
+
+		return _modelResourcePermission;
 	}
 
 	public long getFolderId() throws PortalException {
@@ -191,6 +200,7 @@ public class BlogImagesDisplayContext {
 	private Folder _folder;
 	private final HttpServletRequest _httpServletRequest;
 	private final LiferayPortletRequest _liferayPortletRequest;
+	private final ModelResourcePermission<FileEntry> _modelResourcePermission;
 	private String _orderByCol;
 	private String _orderByType;
 

--- a/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/portlet/action/ViewMVCRenderCommand.java
+++ b/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/portlet/action/ViewMVCRenderCommand.java
@@ -15,7 +15,6 @@
 package com.liferay.blogs.web.internal.portlet.action;
 
 import com.liferay.blogs.constants.BlogsPortletKeys;
-import com.liferay.blogs.web.internal.constants.BlogsWebKeys;
 import com.liferay.blogs.web.internal.display.context.BlogEntriesDisplayContext;
 import com.liferay.blogs.web.internal.display.context.BlogImagesDisplayContext;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
@@ -59,7 +58,7 @@ public class ViewMVCRenderCommand implements MVCRenderCommand {
 		}
 
 		renderRequest.setAttribute(
-			BlogsWebKeys.BLOG_ENTRIES_DISPLAY_CONTEXT,
+			BlogEntriesDisplayContext.class.getName(),
 			new BlogEntriesDisplayContext(
 				_htmlParser, _portal, renderRequest, renderResponse,
 				_trashHelper));

--- a/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/portlet/action/ViewMVCRenderCommand.java
+++ b/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/portlet/action/ViewMVCRenderCommand.java
@@ -17,6 +17,7 @@ package com.liferay.blogs.web.internal.portlet.action;
 import com.liferay.blogs.constants.BlogsPortletKeys;
 import com.liferay.blogs.web.internal.constants.BlogsWebKeys;
 import com.liferay.blogs.web.internal.display.context.BlogEntriesDisplayContext;
+import com.liferay.blogs.web.internal.display.context.BlogImagesDisplayContext;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
 import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -62,6 +63,10 @@ public class ViewMVCRenderCommand implements MVCRenderCommand {
 			new BlogEntriesDisplayContext(
 				_htmlParser, _portal, renderRequest, renderResponse,
 				_trashHelper));
+		renderRequest.setAttribute(
+			BlogImagesDisplayContext.class.getName(),
+			new BlogImagesDisplayContext(
+				_portal.getLiferayPortletRequest(renderRequest)));
 
 		return "/blogs_admin/view.jsp";
 	}

--- a/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/portlet/action/ViewMVCRenderCommand.java
+++ b/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/portlet/action/ViewMVCRenderCommand.java
@@ -14,10 +14,17 @@
 
 package com.liferay.blogs.web.internal.portlet.action;
 
+import com.liferay.blogs.constants.BlogsConstants;
 import com.liferay.blogs.constants.BlogsPortletKeys;
 import com.liferay.blogs.web.internal.display.context.BlogEntriesDisplayContext;
 import com.liferay.blogs.web.internal.display.context.BlogImagesDisplayContext;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.security.permission.resource.PortletResourcePermission;
 import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HtmlParser;
@@ -62,10 +69,15 @@ public class ViewMVCRenderCommand implements MVCRenderCommand {
 			new BlogEntriesDisplayContext(
 				_htmlParser, _portal, renderRequest, renderResponse,
 				_trashHelper));
+
+		ThemeDisplay themeDisplay = (ThemeDisplay)renderRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
 		renderRequest.setAttribute(
 			BlogImagesDisplayContext.class.getName(),
 			new BlogImagesDisplayContext(
-				_portal.getLiferayPortletRequest(renderRequest)));
+				_portal.getLiferayPortletRequest(renderRequest),
+				new BlogsFileEntryModelResourcePermission(themeDisplay)));
 
 		return "/blogs_admin/view.jsp";
 	}
@@ -82,10 +94,117 @@ public class ViewMVCRenderCommand implements MVCRenderCommand {
 	@Reference
 	private HtmlParser _htmlParser;
 
+	@Reference(
+		target = "(model.class.name=com.liferay.portal.kernel.repository.model.FileEntry)"
+	)
+	private ModelResourcePermission<FileEntry> _modelResourcePermission;
+
 	@Reference
 	private Portal _portal;
 
+	@Reference(target = "(resource.name=" + BlogsConstants.RESOURCE_NAME + ")")
+	private PortletResourcePermission _portletResourcePermission;
+
 	@Reference
 	private TrashHelper _trashHelper;
+
+	private class BlogsFileEntryModelResourcePermission
+		implements ModelResourcePermission<FileEntry> {
+
+		public BlogsFileEntryModelResourcePermission(
+			ThemeDisplay themeDisplay) {
+
+			_themeDisplay = themeDisplay;
+		}
+
+		@Override
+		public void check(
+				PermissionChecker permissionChecker, FileEntry fileEntry,
+				String actionId)
+			throws PortalException {
+
+			if (_isActionDelegable(actionId)) {
+				_portletResourcePermission.check(
+					permissionChecker, _themeDisplay.getSiteGroupId(),
+					ActionKeys.ADD_ENTRY);
+			}
+			else {
+				_modelResourcePermission.check(
+					permissionChecker, fileEntry, actionId);
+			}
+		}
+
+		@Override
+		public void check(
+				PermissionChecker permissionChecker, long primaryKey,
+				String actionId)
+			throws PortalException {
+
+			if (_isActionDelegable(actionId)) {
+				_portletResourcePermission.check(
+					permissionChecker, _themeDisplay.getSiteGroupId(),
+					ActionKeys.ADD_ENTRY);
+			}
+			else {
+				_modelResourcePermission.check(
+					permissionChecker, primaryKey, actionId);
+			}
+		}
+
+		@Override
+		public boolean contains(
+				PermissionChecker permissionChecker, FileEntry fileEntry,
+				String actionId)
+			throws PortalException {
+
+			if (_isActionDelegable(actionId)) {
+				return _portletResourcePermission.contains(
+					permissionChecker, fileEntry.getGroupId(),
+					ActionKeys.ADD_ENTRY);
+			}
+
+			return _modelResourcePermission.contains(
+				permissionChecker, fileEntry, actionId);
+		}
+
+		@Override
+		public boolean contains(
+				PermissionChecker permissionChecker, long primaryKey,
+				String actionId)
+			throws PortalException {
+
+			if (_isActionDelegable(actionId)) {
+				return _portletResourcePermission.contains(
+					permissionChecker, _themeDisplay.getSiteGroupId(),
+					ActionKeys.ADD_ENTRY);
+			}
+
+			return _modelResourcePermission.contains(
+				permissionChecker, primaryKey, actionId);
+		}
+
+		@Override
+		public String getModelName() {
+			return _modelResourcePermission.getModelName();
+		}
+
+		@Override
+		public PortletResourcePermission getPortletResourcePermission() {
+			return _modelResourcePermission.getPortletResourcePermission();
+		}
+
+		private boolean _isActionDelegable(String actionId) {
+			if (actionId.equals(ActionKeys.DELETE) ||
+				actionId.equals(ActionKeys.UPDATE)) {
+
+				return true;
+			}
+
+			return false;
+		}
+
+		private final ThemeDisplay _themeDisplay;
+
+	}
 
 }

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/view_entries.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/view_entries.jsp
@@ -20,7 +20,7 @@
 long assetCategoryId = ParamUtil.getLong(request, "categoryId");
 String assetTagName = ParamUtil.getString(request, "tag");
 
-BlogEntriesDisplayContext blogEntriesDisplayContext = (BlogEntriesDisplayContext)request.getAttribute(BlogsWebKeys.BLOG_ENTRIES_DISPLAY_CONTEXT);
+BlogEntriesDisplayContext blogEntriesDisplayContext = (BlogEntriesDisplayContext)request.getAttribute(BlogEntriesDisplayContext.class.getName());
 
 String displayStyle = blogEntriesDisplayContext.getDisplayStyle();
 

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/view_images.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/view_images.jsp
@@ -20,7 +20,7 @@
 	<c:when test='<%= GetterUtil.getBoolean(PropsUtil.get("feature.flag.LPS-168174")) %>'>
 
 		<%
-		BlogImagesDisplayContext blogImagesDisplayContext = new BlogImagesDisplayContext(liferayPortletRequest);
+		BlogImagesDisplayContext blogImagesDisplayContext = (BlogImagesDisplayContext)request.getAttribute(BlogImagesDisplayContext.class.getName());
 		%>
 
 		<liferay-document-library:repository-browser
@@ -59,7 +59,7 @@
 
 		blogImagesSearchContainer.setRowChecker(new EmptyOnClickRowChecker(renderResponse));
 
-		BlogImagesDisplayContext blogImagesDisplayContext = new BlogImagesDisplayContext(liferayPortletRequest);
+		BlogImagesDisplayContext blogImagesDisplayContext = (BlogImagesDisplayContext)request.getAttribute(BlogImagesDisplayContext.class.getName());
 
 		blogImagesDisplayContext.populateResults(blogImagesSearchContainer);
 

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/view_images.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/view_images.jsp
@@ -25,6 +25,7 @@
 
 		<liferay-document-library:repository-browser
 			actions="delete"
+			customFileEntryModelResourcePermission="<%= blogImagesDisplayContext.getCustomFileEntryModelResourcePermission() %>"
 			folderId="<%= blogImagesDisplayContext.getFolderId() %>"
 			repositoryId="<%= blogImagesDisplayContext.getRepositoryId() %>"
 		/>

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/init.jsp
@@ -67,7 +67,6 @@ page import="com.liferay.blogs.service.BlogsEntryServiceUtil" %><%@
 page import="com.liferay.blogs.settings.BlogsGroupServiceSettings" %><%@
 page import="com.liferay.blogs.web.internal.configuration.BlogsPortletInstanceConfiguration" %><%@
 page import="com.liferay.blogs.web.internal.constants.BlogsWebConstants" %><%@
-page import="com.liferay.blogs.web.internal.constants.BlogsWebKeys" %><%@
 page import="com.liferay.blogs.web.internal.display.context.BlogEntriesDisplayContext" %><%@
 page import="com.liferay.blogs.web.internal.display.context.BlogEntriesManagementToolbarDisplayContext" %><%@
 page import="com.liferay.blogs.web.internal.display.context.BlogImagesDisplayContext" %><%@

--- a/modules/apps/document-library/document-library-taglib/bnd.bnd
+++ b/modules/apps/document-library/document-library-taglib/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Document Library Taglib
 Bundle-SymbolicName: com.liferay.document.library.taglib
-Bundle-Version: 3.3.1
+Bundle-Version: 3.4.0
 Export-Package: com.liferay.document.library.taglib.servlet.taglib
 Provide-Capability:\
 	osgi.extender;\

--- a/modules/apps/document-library/document-library-taglib/package.json
+++ b/modules/apps/document-library/document-library-taglib/package.json
@@ -5,5 +5,5 @@
 		"checkFormat": "liferay-npm-scripts check",
 		"format": "liferay-npm-scripts fix"
 	},
-	"version": "3.3.1"
+	"version": "3.4.0"
 }

--- a/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/display/context/RepositoryBrowserTagDisplayContext.java
+++ b/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/display/context/RepositoryBrowserTagDisplayContext.java
@@ -527,7 +527,8 @@ public class RepositoryBrowserTagDisplayContext {
 				_httpServletRequest, searchContainer.getOrderByColParam()));
 		searchContainer.setOrderByType(
 			ParamUtil.getString(
-				_httpServletRequest, searchContainer.getOrderByTypeParam()));
+				_httpServletRequest, searchContainer.getOrderByTypeParam(),
+				"asc"));
 
 		searchContainer.setResultsAndTotal(
 			() -> DLAppServiceUtil.getFoldersAndFileEntriesAndFileShortcuts(

--- a/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/servlet/taglib/RepositoryBrowserTag.java
+++ b/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/servlet/taglib/RepositoryBrowserTag.java
@@ -57,6 +57,12 @@ public class RepositoryBrowserTag extends IncludeTag {
 		return _actions;
 	}
 
+	public ModelResourcePermission<FileEntry>
+		getCustomFileEntryModelResourcePermission() {
+
+		return _customFileEntryModelResourcePermission;
+	}
+
 	public long getFolderId() {
 		return _folderId;
 	}
@@ -67,6 +73,14 @@ public class RepositoryBrowserTag extends IncludeTag {
 
 	public void setActions(String actions) {
 		_actions = actions;
+	}
+
+	public void setCustomFileEntryModelResourcePermission(
+		ModelResourcePermission<FileEntry>
+			customFileEntryModelResourcePermission) {
+
+		_customFileEntryModelResourcePermission =
+			customFileEntryModelResourcePermission;
 	}
 
 	public void setFolderId(long folderId) {
@@ -89,6 +103,7 @@ public class RepositoryBrowserTag extends IncludeTag {
 		super.cleanUp();
 
 		_actions = StringPool.BLANK;
+		_customFileEntryModelResourcePermission = null;
 		_folderId = DLFolderConstants.DEFAULT_PARENT_FOLDER_ID;
 		_repositoryId = 0;
 	}
@@ -112,7 +127,7 @@ public class RepositoryBrowserTag extends IncludeTag {
 			RepositoryBrowserTagDisplayContext.class.getName(),
 			new RepositoryBrowserTagDisplayContext(
 				_getActionsSet(), DLAppServiceUtil.getService(),
-				_fileEntryModelResourcePermission,
+				_getFileEntryModelResourcePermission(),
 				_fileShortcutModelResourcePermission,
 				_folderModelResourcePermission, _getFolderId(),
 				httpServletRequest,
@@ -139,6 +154,16 @@ public class RepositoryBrowserTag extends IncludeTag {
 		}
 
 		return actionsSet;
+	}
+
+	private ModelResourcePermission<FileEntry>
+		_getFileEntryModelResourcePermission() {
+
+		if (getCustomFileEntryModelResourcePermission() == null) {
+			return _fileEntryModelResourcePermission;
+		}
+
+		return getCustomFileEntryModelResourcePermission();
 	}
 
 	private long _getFolderId() {
@@ -184,6 +209,8 @@ public class RepositoryBrowserTag extends IncludeTag {
 				"(model.class.name=" + Folder.class.getName() + ")", false);
 
 	private String _actions = StringPool.BLANK;
+	private ModelResourcePermission<FileEntry>
+		_customFileEntryModelResourcePermission;
 	private long _folderId = DLFolderConstants.DEFAULT_PARENT_FOLDER_ID;
 	private long _repositoryId;
 

--- a/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/liferay-document-library.tld
+++ b/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/liferay-document-library.tld
@@ -38,6 +38,11 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
+			<name>customFileEntryModelResourcePermission</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
 			<name>folderId</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>

--- a/modules/apps/document-library/document-library-taglib/src/main/resources/com/liferay/document/library/taglib/servlet/taglib/packageinfo
+++ b/modules/apps/document-library/document-library-taglib/src/main/resources/com/liferay/document/library/taglib/servlet/taglib/packageinfo
@@ -1,1 +1,1 @@
-version 1.3.0
+version 1.4.0


### PR DESCRIPTION
# What is this about?

https://issues.liferay.com/issues/browse/LPS-169522

The sorting selector in the management toolbar was not correctly initialized, so it magically disappeared when entering the images tab.

Also, the blogs images tab had some custom permission checking: if a user had permissions to add blog entries, then deletion was allowed independently of the file entry permissions. To allow for this, I've added a new attribute that receives an (optional) model resource permission to use for file entries.

# How do I test it?

This issues were discovered while testing, so follow the steps described in https://issues.liferay.com/browse/LPS-169384.