### PR TITLE
LPS-169658 some errors with tests checking the Existing External Reference Code

### DIFF
--- a/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/service/test/BlogsEntryLocalServiceTest.java
+++ b/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/service/test/BlogsEntryLocalServiceTest.java
@@ -156,7 +156,7 @@ public class BlogsEntryLocalServiceTest {
 		BlogsEntryLocalServiceUtil.addEntry(
 			blogsEntry.getExternalReferenceCode(), blogsEntry.getUserId(),
 			blogsEntry.getTitle(), blogsEntry.getSubtitle(),
-			blogsEntry.getUrlTitle(), blogsEntry.getDescription(),
+			StringUtil.randomString(), blogsEntry.getDescription(),
 			blogsEntry.getContent(), blogsEntry.getDisplayDate(),
 			blogsEntry.isAllowPingbacks(), blogsEntry.isAllowTrackbacks(),
 			new String[] {blogsEntry.getTrackbacks()},

--- a/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/service/test/BlogsEntryLocalServiceTest.java
+++ b/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/service/test/BlogsEntryLocalServiceTest.java
@@ -17,7 +17,7 @@ package com.liferay.blogs.service.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.blogs.attachments.test.BlogsEntryAttachmentFileEntryHelperTest;
 import com.liferay.blogs.constants.BlogsConstants;
-import com.liferay.blogs.exception.DuplicateEntryExternalReferenceCodeException;
+import com.liferay.blogs.exception.DuplicateBlogsEntryExternalReferenceCodeException;
 import com.liferay.blogs.exception.EntryContentException;
 import com.liferay.blogs.exception.EntrySmallImageNameException;
 import com.liferay.blogs.exception.EntryTitleException;
@@ -144,7 +144,7 @@ public class BlogsEntryLocalServiceTest {
 		UserTestUtil.setUser(TestPropsValues.getUser());
 	}
 
-	@Test(expected = DuplicateEntryExternalReferenceCodeException.class)
+	@Test(expected = DuplicateBlogsEntryExternalReferenceCodeException.class)
 	public void testAddBlogsEntryWithExistingExternalReferenceCode()
 		throws Exception {
 

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.knowledge.base.constants.KBArticleConstants;
 import com.liferay.knowledge.base.constants.KBConstants;
 import com.liferay.knowledge.base.constants.KBFolderConstants;
 import com.liferay.knowledge.base.constants.KBPortletKeys;
+import com.liferay.knowledge.base.exception.DuplicateKBArticleExternalReferenceCodeException;
 import com.liferay.knowledge.base.exception.KBArticleContentException;
 import com.liferay.knowledge.base.exception.KBArticleExpirationDateException;
 import com.liferay.knowledge.base.exception.KBArticleParentException;
@@ -187,6 +188,8 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 		double priority = _getPriority(groupId, parentResourcePrimKey);
 
 		long kbArticleId = counterLocalService.increment();
+
+		_validateExternalReferenceCode(externalReferenceCode, groupId);
 
 		_validate(expirationDate, content, reviewDate, sourceURL, title);
 		_validateParent(parentResourceClassNameId, parentResourcePrimKey);
@@ -2107,6 +2110,25 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 		if ((reviewDate != null) && reviewDate.before(now)) {
 			throw new KBArticleReviewDateException(
 				"Review date is " + reviewDate + " in the past");
+		}
+	}
+
+	private void _validateExternalReferenceCode(
+			String externalReferenceCode, long groupId)
+		throws PortalException {
+
+		if (Validator.isNull(externalReferenceCode)) {
+			return;
+		}
+
+		KBArticle kbArticle = fetchLatestKBArticleByExternalReferenceCode(
+			groupId, externalReferenceCode);
+
+		if (kbArticle != null) {
+			throw new DuplicateKBArticleExternalReferenceCodeException(
+				StringBundler.concat(
+					"Duplicate knowledge base article external reference code ",
+					externalReferenceCode, " in group ", groupId));
 		}
 	}
 

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/test/MBMessageLocalServiceTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/test/MBMessageLocalServiceTest.java
@@ -17,7 +17,7 @@ package com.liferay.message.boards.service.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.message.boards.constants.MBCategoryConstants;
 import com.liferay.message.boards.constants.MBMessageConstants;
-import com.liferay.message.boards.exception.DuplicateMessageExternalReferenceCodeException;
+import com.liferay.message.boards.exception.DuplicateMBMessageExternalReferenceCodeException;
 import com.liferay.message.boards.model.MBMessage;
 import com.liferay.message.boards.model.MBThread;
 import com.liferay.message.boards.service.MBMessageLocalServiceUtil;
@@ -163,7 +163,7 @@ public class MBMessageLocalServiceTest {
 		Assert.assertEquals(subject, mbMessage.getBody());
 	}
 
-	@Test(expected = DuplicateMessageExternalReferenceCodeException.class)
+	@Test(expected = DuplicateMBMessageExternalReferenceCodeException.class)
 	public void testAddMessageWithExistingExternalReferenceCode()
 		throws Exception {
 

--- a/modules/apps/wiki/wiki-api/bnd.bnd
+++ b/modules/apps/wiki/wiki-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Wiki API
 Bundle-SymbolicName: com.liferay.wiki.api
-Bundle-Version: 12.0.1
+Bundle-Version: 13.0.0
 Export-Package:\
 	com.liferay.wiki.configuration,\
 	com.liferay.wiki.configuration.definition,\

--- a/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/exception/DuplicateWikiPageExternalReferenceCodeException.java
+++ b/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/exception/DuplicateWikiPageExternalReferenceCodeException.java
@@ -19,23 +19,23 @@ import com.liferay.portal.kernel.exception.SystemException;
 /**
  * @author Brian Wing Shun Chan
  */
-public class DuplicatePageExternalReferenceCodeException
+public class DuplicateWikiPageExternalReferenceCodeException
 	extends SystemException {
 
-	public DuplicatePageExternalReferenceCodeException() {
+	public DuplicateWikiPageExternalReferenceCodeException() {
 	}
 
-	public DuplicatePageExternalReferenceCodeException(String msg) {
+	public DuplicateWikiPageExternalReferenceCodeException(String msg) {
 		super(msg);
 	}
 
-	public DuplicatePageExternalReferenceCodeException(
+	public DuplicateWikiPageExternalReferenceCodeException(
 		String msg, Throwable throwable) {
 
 		super(msg, throwable);
 	}
 
-	public DuplicatePageExternalReferenceCodeException(Throwable throwable) {
+	public DuplicateWikiPageExternalReferenceCodeException(Throwable throwable) {
 		super(throwable);
 	}
 

--- a/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/exception/DuplicateWikiPageExternalReferenceCodeException.java
+++ b/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/exception/DuplicateWikiPageExternalReferenceCodeException.java
@@ -35,7 +35,9 @@ public class DuplicateWikiPageExternalReferenceCodeException
 		super(msg, throwable);
 	}
 
-	public DuplicateWikiPageExternalReferenceCodeException(Throwable throwable) {
+	public DuplicateWikiPageExternalReferenceCodeException(
+		Throwable throwable) {
+
 		super(throwable);
 	}
 

--- a/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiNodeLocalService.java
+++ b/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiNodeLocalService.java
@@ -73,8 +73,8 @@ public interface WikiNodeLocalService
 		throws PortalException;
 
 	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
-	 #addNode(String, long, String, String, ServiceContext)}
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #addNode(String,
+	 long, String, String, ServiceContext)}
 	 */
 	@Deprecated
 	@Indexable(type = IndexableType.REINDEX)

--- a/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiNodeLocalServiceUtil.java
+++ b/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiNodeLocalServiceUtil.java
@@ -55,8 +55,8 @@ public class WikiNodeLocalServiceUtil {
 	}
 
 	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
-	 #addNode(String, long, String, String, ServiceContext)}
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #addNode(String,
+	 long, String, String, ServiceContext)}
 	 */
 	@Deprecated
 	public static WikiNode addNode(

--- a/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiNodeLocalServiceWrapper.java
+++ b/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiNodeLocalServiceWrapper.java
@@ -46,8 +46,8 @@ public class WikiNodeLocalServiceWrapper
 	}
 
 	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
-	 #addNode(String, long, String, String, ServiceContext)}
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #addNode(String,
+	 long, String, String, ServiceContext)}
 	 */
 	@Deprecated
 	@Override

--- a/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiNodeService.java
+++ b/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiNodeService.java
@@ -58,8 +58,8 @@ public interface WikiNodeService extends BaseService {
 	 */
 
 	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
-	 #addNode(String, String, String, ServiceContext)}
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #addNode(String,
+	 String, String, ServiceContext)}
 	 */
 	@Deprecated
 	public WikiNode addNode(

--- a/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiNodeServiceUtil.java
+++ b/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiNodeServiceUtil.java
@@ -44,8 +44,8 @@ public class WikiNodeServiceUtil {
 	 */
 
 	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
-	 #addNode(String, String, String, ServiceContext)}
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #addNode(String,
+	 String, String, ServiceContext)}
 	 */
 	@Deprecated
 	public static WikiNode addNode(

--- a/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiNodeServiceWrapper.java
+++ b/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiNodeServiceWrapper.java
@@ -35,8 +35,8 @@ public class WikiNodeServiceWrapper
 	}
 
 	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
-	 #addNode(String, String, String, ServiceContext)}
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #addNode(String,
+	 String, String, ServiceContext)}
 	 */
 	@Deprecated
 	@Override

--- a/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiPageLocalService.java
+++ b/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiPageLocalService.java
@@ -83,9 +83,9 @@ public interface WikiPageLocalService
 	 */
 
 	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
-	 #addPage(String, long, long, String, double, String, String, boolean,
-	 String, boolean, String, String, ServiceContext)}
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #addPage(String,
+	 long, long, String, double, String, String, boolean, String,
+	 boolean, String, String, ServiceContext)}
 	 */
 	@Deprecated
 	public WikiPage addPage(

--- a/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiPageLocalServiceUtil.java
+++ b/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiPageLocalServiceUtil.java
@@ -48,9 +48,9 @@ public class WikiPageLocalServiceUtil {
 	 */
 
 	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
-	 #addPage(String, long, long, String, double, String, String, boolean,
-	 String, boolean, String, String, ServiceContext)}
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #addPage(String,
+	 long, long, String, double, String, String, boolean, String,
+	 boolean, String, String, ServiceContext)}
 	 */
 	@Deprecated
 	public static WikiPage addPage(

--- a/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiPageLocalServiceWrapper.java
+++ b/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiPageLocalServiceWrapper.java
@@ -37,9 +37,9 @@ public class WikiPageLocalServiceWrapper
 	}
 
 	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
-	 #addPage(String, long, long, String, double, String, String, boolean,
-	 String, boolean, String, String, ServiceContext)}
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #addPage(String,
+	 long, long, String, double, String, String, boolean, String,
+	 boolean, String, String, ServiceContext)}
 	 */
 	@Deprecated
 	@Override

--- a/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiPageService.java
+++ b/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiPageService.java
@@ -66,8 +66,8 @@ public interface WikiPageService extends BaseService {
 		throws PortalException;
 
 	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
-	 #addPage(String, long, String, String, String, boolean, String, String,
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #addPage(String,
+	 long, String, String, String, boolean, String, String,
 	 String, ServiceContext)}
 	 */
 	@Deprecated

--- a/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiPageServiceUtil.java
+++ b/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiPageServiceUtil.java
@@ -52,8 +52,8 @@ public class WikiPageServiceUtil {
 	}
 
 	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
-	 #addPage(String, long, String, String, String, boolean, String, String,
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #addPage(String,
+	 long, String, String, String, boolean, String, String,
 	 String, ServiceContext)}
 	 */
 	@Deprecated

--- a/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiPageServiceWrapper.java
+++ b/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiPageServiceWrapper.java
@@ -46,8 +46,8 @@ public class WikiPageServiceWrapper
 	}
 
 	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
-	 #addPage(String, long, String, String, String, boolean, String, String,
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #addPage(String,
+	 long, String, String, String, boolean, String, String,
 	 String, ServiceContext)}
 	 */
 	@Deprecated

--- a/modules/apps/wiki/wiki-api/src/main/resources/com/liferay/wiki/exception/packageinfo
+++ b/modules/apps/wiki/wiki-api/src/main/resources/com/liferay/wiki/exception/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 3.0.0

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiNodeLocalServiceImpl.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiNodeLocalServiceImpl.java
@@ -101,8 +101,8 @@ public class WikiNodeLocalServiceImpl extends WikiNodeLocalServiceBaseImpl {
 	}
 
 	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
-	 * #addNode(String, long, String, String, ServiceContext)}
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #addNode(String,
+	 *             long, String, String, ServiceContext)}
 	 */
 	@Deprecated
 	@Indexable(type = IndexableType.REINDEX)

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiNodeServiceImpl.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiNodeServiceImpl.java
@@ -53,8 +53,8 @@ import org.osgi.service.component.annotations.Reference;
 public class WikiNodeServiceImpl extends WikiNodeServiceBaseImpl {
 
 	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
-	 * #addNode(String, String, String, ServiceContext)}
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #addNode(String,
+	 *             String, String, ServiceContext)}
 	 */
 	@Deprecated
 	@Override

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiPageLocalServiceImpl.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiPageLocalServiceImpl.java
@@ -114,7 +114,7 @@ import com.liferay.wiki.engine.WikiEngine;
 import com.liferay.wiki.engine.WikiEngineRenderer;
 import com.liferay.wiki.escape.WikiEscapeUtil;
 import com.liferay.wiki.exception.DuplicatePageException;
-import com.liferay.wiki.exception.DuplicatePageExternalReferenceCodeException;
+import com.liferay.wiki.exception.DuplicateWikiPageExternalReferenceCodeException;
 import com.liferay.wiki.exception.NoSuchPageException;
 import com.liferay.wiki.exception.PageContentException;
 import com.liferay.wiki.exception.PageTitleException;
@@ -3444,9 +3444,9 @@ public class WikiPageLocalServiceImpl extends WikiPageLocalServiceBaseImpl {
 			groupId, externalReferenceCode);
 
 		if (wikiPage != null) {
-			throw new DuplicatePageExternalReferenceCodeException(
+			throw new DuplicateWikiPageExternalReferenceCodeException(
 				StringBundler.concat(
-					"Duplicate page external reference code ",
+					"Duplicate wiki page external reference code ",
 					externalReferenceCode, " in group ", groupId));
 		}
 	}

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiPageLocalServiceImpl.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiPageLocalServiceImpl.java
@@ -194,9 +194,9 @@ import org.osgi.service.component.annotations.Reference;
 public class WikiPageLocalServiceImpl extends WikiPageLocalServiceBaseImpl {
 
 	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
-	 * #addPage(String, long, long, String, double, String, String, boolean,
-	 * String, boolean, String, String, ServiceContext)}
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #addPage(String,
+	 *             long, long, String, double, String, String, boolean, String,
+	 *             boolean, String, String, ServiceContext)}
 	 */
 	@Deprecated
 	@Override
@@ -896,8 +896,8 @@ public class WikiPageLocalServiceImpl extends WikiPageLocalServiceBaseImpl {
 	 * Returns the latest wiki page matching the group and the external
 	 * reference code
 	 *
-	 * @param groupId the primary key of the group
-	 * @param externalReferenceCode the wiki page external reference code
+	 * @param  groupId the primary key of the group
+	 * @param  externalReferenceCode the wiki page external reference code
 	 * @return the latest matching wiki page, or <code>null</code> if no
 	 *         matching wiki page could be found
 	 */
@@ -1130,8 +1130,8 @@ public class WikiPageLocalServiceImpl extends WikiPageLocalServiceBaseImpl {
 	 * Returns the latest wiki page matching the group and the external
 	 * reference code
 	 *
-	 * @param groupId the primary key of the group
-	 * @param externalReferenceCode the wiki page external reference code
+	 * @param  groupId the primary key of the group
+	 * @param  externalReferenceCode the wiki page external reference code
 	 * @return the latest matching wiki page
 	 * @throws PortalException if a portal exception occurred
 	 */

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiPageLocalServiceImpl.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiPageLocalServiceImpl.java
@@ -114,6 +114,7 @@ import com.liferay.wiki.engine.WikiEngine;
 import com.liferay.wiki.engine.WikiEngineRenderer;
 import com.liferay.wiki.escape.WikiEscapeUtil;
 import com.liferay.wiki.exception.DuplicatePageException;
+import com.liferay.wiki.exception.DuplicatePageExternalReferenceCodeException;
 import com.liferay.wiki.exception.NoSuchPageException;
 import com.liferay.wiki.exception.PageContentException;
 import com.liferay.wiki.exception.PageTitleException;
@@ -254,6 +255,9 @@ public class WikiPageLocalServiceImpl extends WikiPageLocalServiceBaseImpl {
 		Date date = new Date();
 
 		long pageId = counterLocalService.increment();
+
+		_validateExternalReferenceCode(
+			externalReferenceCode, node.getGroupId());
 
 		content = SanitizerUtil.sanitize(
 			user.getCompanyId(), node.getGroupId(), userId,
@@ -3426,6 +3430,25 @@ public class WikiPageLocalServiceImpl extends WikiPageLocalServiceBaseImpl {
 		_wikiPageTitleValidator.validate(title);
 
 		_validate(nodeId, content, format);
+	}
+
+	private void _validateExternalReferenceCode(
+			String externalReferenceCode, long groupId)
+		throws PortalException {
+
+		if (Validator.isNull(externalReferenceCode)) {
+			return;
+		}
+
+		WikiPage wikiPage = fetchLatestPageByExternalReferenceCode(
+			groupId, externalReferenceCode);
+
+		if (wikiPage != null) {
+			throw new DuplicatePageExternalReferenceCodeException(
+				StringBundler.concat(
+					"Duplicate page external reference code ",
+					externalReferenceCode, " in group ", groupId));
+		}
 	}
 
 	private static final String _OUTGOING_LINKS = "OUTGOING_LINKS";

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiPageServiceImpl.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiPageServiceImpl.java
@@ -102,9 +102,9 @@ public class WikiPageServiceImpl extends WikiPageServiceBaseImpl {
 	}
 
 	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
-	 * #addPage(String, long, String, String, String, boolean, String, String,
-	 * String, ServiceContext)}
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #addPage(String,
+	 *             long, String, String, String, boolean, String, String,
+	 *             String, ServiceContext)}
 	 */
 	@Deprecated
 	@Override
@@ -332,8 +332,8 @@ public class WikiPageServiceImpl extends WikiPageServiceBaseImpl {
 	 * Returns the latest wiki page matching the group and the external
 	 * reference code
 	 *
-	 * @param groupId the primary key of the group
-	 * @param externalReferenceCode the wiki page external reference code
+	 * @param  groupId the primary key of the group
+	 * @param  externalReferenceCode the wiki page external reference code
 	 * @return the latest matching wiki page, or <code>null</code> if no
 	 *         matching wiki page could be found
 	 */
@@ -397,8 +397,8 @@ public class WikiPageServiceImpl extends WikiPageServiceBaseImpl {
 	 * Returns the latest wiki page matching the group and the external
 	 * reference code
 	 *
-	 * @param groupId the primary key of the group
-	 * @param externalReferenceCode the wiki page external reference code
+	 * @param  groupId the primary key of the group
+	 * @param  externalReferenceCode the wiki page external reference code
 	 * @return the latest matching wiki page
 	 * @throws PortalException if a portal exception occurred
 	 */

--- a/modules/apps/wiki/wiki-test/src/testIntegration/java/com/liferay/wiki/service/test/WikiNodeLocalServiceTest.java
+++ b/modules/apps/wiki/wiki-test/src/testIntegration/java/com/liferay/wiki/service/test/WikiNodeLocalServiceTest.java
@@ -34,7 +34,7 @@ import com.liferay.portal.kernel.util.ProgressTracker;
 import com.liferay.portal.kernel.util.ProgressTrackerThreadLocal;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
-import com.liferay.wiki.exception.DuplicateNodeExternalReferenceCodeException;
+import com.liferay.wiki.exception.DuplicateWikiNodeExternalReferenceCodeException;
 import com.liferay.wiki.model.WikiNode;
 import com.liferay.wiki.model.WikiPage;
 import com.liferay.wiki.service.WikiNodeLocalServiceUtil;
@@ -63,7 +63,7 @@ public class WikiNodeLocalServiceTest {
 	public static final AggregateTestRule aggregateTestRule =
 		new LiferayIntegrationTestRule();
 
-	@Test(expected = DuplicateNodeExternalReferenceCodeException.class)
+	@Test(expected = DuplicateWikiNodeExternalReferenceCodeException.class)
 	public void testAddNodeWithExistingExternalReferenceCode()
 		throws Exception {
 

--- a/modules/apps/wiki/wiki-test/src/testIntegration/java/com/liferay/wiki/service/test/WikiPageLocalServiceTest.java
+++ b/modules/apps/wiki/wiki-test/src/testIntegration/java/com/liferay/wiki/service/test/WikiPageLocalServiceTest.java
@@ -66,7 +66,7 @@ import com.liferay.portal.kernel.workflow.WorkflowThreadLocal;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portlet.expando.util.test.ExpandoTestUtil;
 import com.liferay.wiki.exception.DuplicatePageException;
-import com.liferay.wiki.exception.DuplicatePageExternalReferenceCodeException;
+import com.liferay.wiki.exception.DuplicateWikiPageExternalReferenceCodeException;
 import com.liferay.wiki.exception.NoSuchPageResourceException;
 import com.liferay.wiki.exception.PageTitleException;
 import com.liferay.wiki.model.WikiNode;
@@ -132,7 +132,7 @@ public class WikiPageLocalServiceTest {
 					WikiPage.class.getName(), frontPage.getResourcePrimKey())));
 	}
 
-	@Test(expected = DuplicatePageExternalReferenceCodeException.class)
+	@Test(expected = DuplicateWikiPageExternalReferenceCodeException.class)
 	public void testAddPageWithExistingExternalReferenceCode()
 		throws Exception {
 


### PR DESCRIPTION
- LPS-169658 fix test, blog entry can not have same urlTitle
- LPS-169658 throw proper exception
- LPS-169658 rename exception to match others
- LPS-169658 baseline
- LPS-169658 partial revert of LPS-163008 Remove_validateExternalReference method in LocalServices
- LPS-169658 rename exception
- LPS-169658 autoSF


@sergiojimcos @LuismiBarcos As we talked (thanks for the HELP) i will sent this PR with changes on the services to check the existence on KBArticle and WikiPage of the ERC and the group WITH the version

the revert is partial to this commit 02bcc1ecfcb5fdc37d0e7c691268c6ca7c7b4065 