### PR TITLE
LPS-170189 Add size sorting, make title sorting the default

### DIFF
--- a/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/display/context/RepositoryBrowserManagementToolbarDisplayContext.java
+++ b/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/display/context/RepositoryBrowserManagementToolbarDisplayContext.java
@@ -31,6 +31,8 @@ import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermissionUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 
 import java.util.List;
@@ -172,6 +174,12 @@ public class RepositoryBrowserManagementToolbarDisplayContext
 
 	@Override
 	protected String[] getOrderByKeys() {
+		if (Validator.isNotNull(
+				ParamUtil.getString(httpServletRequest, "keywords"))) {
+
+			return null;
+		}
+
 		return new String[] {"modified-date", "title"};
 	}
 

--- a/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/display/context/RepositoryBrowserManagementToolbarDisplayContext.java
+++ b/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/display/context/RepositoryBrowserManagementToolbarDisplayContext.java
@@ -180,7 +180,7 @@ public class RepositoryBrowserManagementToolbarDisplayContext
 			return null;
 		}
 
-		return new String[] {"modified-date", "title"};
+		return new String[] {"modified-date", "size", "title"};
 	}
 
 	private final Set<String> _actions;

--- a/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/display/context/RepositoryBrowserTagDisplayContext.java
+++ b/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/display/context/RepositoryBrowserTagDisplayContext.java
@@ -20,6 +20,7 @@ import com.liferay.document.library.kernel.service.DLAppLocalServiceUtil;
 import com.liferay.document.library.kernel.service.DLAppService;
 import com.liferay.document.library.kernel.service.DLAppServiceUtil;
 import com.liferay.document.library.kernel.util.comparator.RepositoryModelModifiedDateComparator;
+import com.liferay.document.library.kernel.util.comparator.RepositoryModelSizeComparator;
 import com.liferay.document.library.kernel.util.comparator.RepositoryModelTitleComparator;
 import com.liferay.document.library.taglib.internal.frontend.taglib.clay.servlet.FileEntryVerticalCard;
 import com.liferay.document.library.taglib.internal.frontend.taglib.clay.servlet.FileShortcutVerticalCard;
@@ -606,6 +607,10 @@ public class RepositoryBrowserTagDisplayContext {
 
 		if (Objects.equals(searchContainer.getOrderByCol(), "modified-date")) {
 			return new RepositoryModelModifiedDateComparator<>(ascending);
+		}
+
+		if (Objects.equals(searchContainer.getOrderByCol(), "size")) {
+			return new RepositoryModelSizeComparator<>(ascending);
 		}
 
 		if (Objects.equals(searchContainer.getOrderByCol(), "title")) {

--- a/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/display/context/RepositoryBrowserTagDisplayContext.java
+++ b/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/display/context/RepositoryBrowserTagDisplayContext.java
@@ -524,7 +524,8 @@ public class RepositoryBrowserTagDisplayContext {
 
 		searchContainer.setOrderByCol(
 			ParamUtil.getString(
-				_httpServletRequest, searchContainer.getOrderByColParam()));
+				_httpServletRequest, searchContainer.getOrderByColParam(),
+				"title"));
 		searchContainer.setOrderByType(
 			ParamUtil.getString(
 				_httpServletRequest, searchContainer.getOrderByTypeParam(),

--- a/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/repository_browser/js/RepositoryBrowserManagementToolbarPropsTransformer.js
+++ b/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/repository_browser/js/RepositoryBrowserManagementToolbarPropsTransformer.js
@@ -20,6 +20,32 @@ import {
 	openToast,
 } from 'frontend-js-web';
 
+function handleCreationMenuClick(
+	event,
+	item,
+	portletNamespace,
+	repositoryBrowserURL
+) {
+	if (item?.data?.action === 'addFolder') {
+		const createFolderURL = `${repositoryBrowserURL}?repositoryId=${item.data.repositoryId}&parentFolderId=${item.data.parentFolderId}`;
+
+		openSimpleInputModal({
+			dialogTitle: Liferay.Language.get('add-folder'),
+			formSubmitURL: createFolderURL,
+			mainFieldLabel: Liferay.Language.get('name'),
+			mainFieldName: 'name',
+			method: 'PUT',
+			namespace: '',
+			onFormSuccess: () => window.location.reload(),
+		});
+	}
+	else if (item?.data?.action === 'uploadFile') {
+		const fileInput = document.getElementById(`${portletNamespace}file`);
+
+		fileInput?.click();
+	}
+}
+
 export default function propsTransformer({
 	additionalProps: {repositoryBrowserURL},
 	portletNamespace,
@@ -71,27 +97,20 @@ export default function propsTransformer({
 			}
 		},
 
-		onCreationMenuItemClick: (event, {item}) => {
-			if (item?.data?.action === 'addFolder') {
-				const createFolderURL = `${repositoryBrowserURL}?repositoryId=${item.data.repositoryId}&parentFolderId=${item.data.parentFolderId}`;
+		onCreateButtonClick: (event, {item}) =>
+			handleCreationMenuClick(
+				event,
+				item,
+				portletNamespace,
+				repositoryBrowserURL
+			),
 
-				openSimpleInputModal({
-					dialogTitle: Liferay.Language.get('add-folder'),
-					formSubmitURL: createFolderURL,
-					mainFieldLabel: Liferay.Language.get('name'),
-					mainFieldName: 'name',
-					method: 'PUT',
-					namespace: '',
-					onFormSuccess: () => window.location.reload(),
-				});
-			}
-			else if (item?.data?.action === 'uploadFile') {
-				const fileInput = document.getElementById(
-					`${portletNamespace}file`
-				);
-
-				fileInput?.click();
-			}
-		},
+		onCreationMenuItemClick: (event, {item}) =>
+			handleCreationMenuClick(
+				event,
+				item,
+				portletNamespace,
+				repositoryBrowserURL
+			),
 	};
 }


### PR DESCRIPTION
# What is this about?

https://issues.liferay.com/issues/browse/LPS-170189

We were missing two details in the DM browser tag: the size sorting and making title sort the default. I've also disabled sorting when searching; we will always rely on relevance sorting.

Additionally, I've fixed a small bug when only one action in the creation menu was enabled; the management toolbar events for these two cases are handled separately. Now both cases should work in exactly the same way.

# How do I test it?

Create a bunch of blog entries with cover images. Make sure to upload those images to the blogs repository. Then:
1. Check that the "size" filter is available in the management toolbar. Create files of different sizes and verify that these are sorted correctly.
2. The "title" sorting order should be the default.
3. When searching, the sorting controls are not available.

*Note:* This is under feature flag LPS-168174.