### PR TITLE
LPS-170320 At level 0, display are articles that hang from the folder

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/display/context/KBArticleNavigationFragmentDisplayContext.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/display/context/KBArticleNavigationFragmentDisplayContext.java
@@ -74,10 +74,10 @@ public class KBArticleNavigationFragmentDisplayContext {
 		throws PortalException {
 
 		if (level == 0) {
-			return Collections.singletonList(
-				KBArticleServiceUtil.getLatestKBArticle(
-					getKBArticleRootResourcePrimKey(),
-					WorkflowConstants.STATUS_APPROVED));
+			return KBArticleServiceUtil.getKBArticles(
+				_kbArticle.getGroupId(), _kbArticle.getKbFolderId(),
+				WorkflowConstants.STATUS_APPROVED, QueryUtil.ALL_POS,
+				QueryUtil.ALL_POS, new KBArticlePriorityComparator(true));
 		}
 
 		if (_isMaxNestingLevelReached(level)) {


### PR DESCRIPTION
# What is this about?

https://issues.liferay.com/browse/LPS-170320

When the Knowledge Base Navigation fragment is not configured to use an article as a root, it should display the parent folder hierarchy. So, if you have the following hierarchy of articles hanging from a folder:

* article-1
  * article-2
* article-2
  * article-2

the whole thing should be displayed, and not only the branch from which the current article hangs.

# How do I test it?

Follow the steps described in https://issues.liferay.com/browse/LPS-170320.