### PR TITLE
LPS-167979 Create dropdown action to expire kb articles

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-api/bnd.bnd
+++ b/modules/apps/knowledge-base/knowledge-base-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Knowledge Base API
 Bundle-SymbolicName: com.liferay.knowledge.base.api
-Bundle-Version: 15.0.1
+Bundle-Version: 15.1.0
 Export-Package:\
 	com.liferay.knowledge.base.configuration,\
 	com.liferay.knowledge.base.constants,\

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleLocalService.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleLocalService.java
@@ -266,6 +266,10 @@ public interface KBArticleLocalService
 	public long dynamicQueryCount(
 		DynamicQuery dynamicQuery, Projection projection);
 
+	public KBArticle expireKBArticle(
+			long userId, long resourcePrimKey, ServiceContext serviceContext)
+		throws PortalException;
+
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public KBArticle fetchFirstChildKBArticle(
 		long groupId, long parentResourcePrimKey);

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleLocalServiceUtil.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleLocalServiceUtil.java
@@ -313,6 +313,15 @@ public class KBArticleLocalServiceUtil {
 		return getService().dynamicQueryCount(dynamicQuery, projection);
 	}
 
+	public static KBArticle expireKBArticle(
+			long userId, long resourcePrimKey,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws PortalException {
+
+		return getService().expireKBArticle(
+			userId, resourcePrimKey, serviceContext);
+	}
+
 	public static KBArticle fetchFirstChildKBArticle(
 		long groupId, long parentResourcePrimKey) {
 

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleLocalServiceWrapper.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleLocalServiceWrapper.java
@@ -347,6 +347,16 @@ public class KBArticleLocalServiceWrapper
 	}
 
 	@Override
+	public com.liferay.knowledge.base.model.KBArticle expireKBArticle(
+			long userId, long resourcePrimKey,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _kbArticleLocalService.expireKBArticle(
+			userId, resourcePrimKey, serviceContext);
+	}
+
+	@Override
 	public com.liferay.knowledge.base.model.KBArticle fetchFirstChildKBArticle(
 		long groupId, long parentResourcePrimKey) {
 

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleService.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleService.java
@@ -90,6 +90,10 @@ public interface KBArticleService extends BaseService {
 			String tempFolderName)
 		throws PortalException;
 
+	public KBArticle expireKBArticle(
+			long resourcePrimKey, ServiceContext serviceContext)
+		throws PortalException;
+
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public KBArticle fetchFirstChildKBArticle(
 		long groupId, long parentResourcePrimKey);

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleServiceUtil.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleServiceUtil.java
@@ -100,6 +100,14 @@ public class KBArticleServiceUtil {
 			groupId, resourcePrimKey, fileName, tempFolderName);
 	}
 
+	public static KBArticle expireKBArticle(
+			long resourcePrimKey,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws PortalException {
+
+		return getService().expireKBArticle(resourcePrimKey, serviceContext);
+	}
+
 	public static KBArticle fetchFirstChildKBArticle(
 		long groupId, long parentResourcePrimKey) {
 

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleServiceWrapper.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleServiceWrapper.java
@@ -102,6 +102,16 @@ public class KBArticleServiceWrapper
 	}
 
 	@Override
+	public com.liferay.knowledge.base.model.KBArticle expireKBArticle(
+			long resourcePrimKey,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _kbArticleService.expireKBArticle(
+			resourcePrimKey, serviceContext);
+	}
+
+	@Override
 	public com.liferay.knowledge.base.model.KBArticle fetchFirstChildKBArticle(
 		long groupId, long parentResourcePrimKey) {
 

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/resources/com/liferay/knowledge/base/service/packageinfo
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/resources/com/liferay/knowledge/base/service/packageinfo
@@ -1,1 +1,1 @@
-version 7.0.0
+version 7.1.0

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/messaging/CheckKBArticleMessageListener.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/messaging/CheckKBArticleMessageListener.java
@@ -43,8 +43,7 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	configurationPid = "com.liferay.knowledge.base.internal.configuration.KBServiceConfiguration",
-	configurationPolicy = ConfigurationPolicy.OPTIONAL,
-	service = CheckKBArticleMessageListener.class
+	configurationPolicy = ConfigurationPolicy.OPTIONAL, service = {}
 )
 public class CheckKBArticleMessageListener extends BaseMessageListener {
 

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/http/KBArticleServiceHttp.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/http/KBArticleServiceHttp.java
@@ -295,6 +295,47 @@ public class KBArticleServiceHttp {
 		}
 	}
 
+	public static com.liferay.knowledge.base.model.KBArticle expireKBArticle(
+			HttpPrincipal httpPrincipal, long resourcePrimKey,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				KBArticleServiceUtil.class, "expireKBArticle",
+				_expireKBArticleParameterTypes6);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, resourcePrimKey, serviceContext);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.knowledge.base.model.KBArticle)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
 	public static com.liferay.knowledge.base.model.KBArticle
 		fetchFirstChildKBArticle(
 			HttpPrincipal httpPrincipal, long groupId,
@@ -303,7 +344,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "fetchFirstChildKBArticle",
-				_fetchFirstChildKBArticleParameterTypes6);
+				_fetchFirstChildKBArticleParameterTypes7);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, parentResourcePrimKey);
@@ -337,7 +378,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "fetchFirstChildKBArticle",
-				_fetchFirstChildKBArticleParameterTypes7);
+				_fetchFirstChildKBArticleParameterTypes8);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, parentResourcePrimKey, status);
@@ -372,7 +413,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "fetchKBArticleByUrlTitle",
-				_fetchKBArticleByUrlTitleParameterTypes8);
+				_fetchKBArticleByUrlTitleParameterTypes9);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, kbFolderId, urlTitle);
@@ -413,7 +454,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "fetchLatestKBArticle",
-				_fetchLatestKBArticleParameterTypes9);
+				_fetchLatestKBArticleParameterTypes10);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, resourcePrimKey, status);
@@ -456,7 +497,7 @@ public class KBArticleServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class,
 				"fetchLatestKBArticleByExternalReferenceCode",
-				_fetchLatestKBArticleByExternalReferenceCodeParameterTypes10);
+				_fetchLatestKBArticleByExternalReferenceCodeParameterTypes11);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, externalReferenceCode);
@@ -498,7 +539,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "fetchLatestKBArticleByUrlTitle",
-				_fetchLatestKBArticleByUrlTitleParameterTypes11);
+				_fetchLatestKBArticleByUrlTitleParameterTypes12);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, kbFolderId, urlTitle, status);
@@ -543,7 +584,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "getAllDescendantKBArticles",
-				_getAllDescendantKBArticlesParameterTypes12);
+				_getAllDescendantKBArticlesParameterTypes13);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, resourcePrimKey, status, orderByComparator);
@@ -588,7 +629,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "getGroupKBArticles",
-				_getGroupKBArticlesParameterTypes13);
+				_getGroupKBArticlesParameterTypes14);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, status, start, end, orderByComparator);
@@ -621,7 +662,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "getGroupKBArticlesCount",
-				_getGroupKBArticlesCountParameterTypes14);
+				_getGroupKBArticlesCountParameterTypes15);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, status);
@@ -656,7 +697,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "getGroupKBArticlesRSS",
-				_getGroupKBArticlesRSSParameterTypes15);
+				_getGroupKBArticlesRSSParameterTypes16);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, status, rssDelta, rssDisplayStyle, rssFormat,
@@ -697,7 +738,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "getKBArticle",
-				_getKBArticleParameterTypes16);
+				_getKBArticleParameterTypes17);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, resourcePrimKey, version);
@@ -742,7 +783,7 @@ public class KBArticleServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class,
 				"getKBArticleAndAllDescendantKBArticles",
-				_getKBArticleAndAllDescendantKBArticlesParameterTypes17);
+				_getKBArticleAndAllDescendantKBArticlesParameterTypes18);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, resourcePrimKey, status, orderByComparator);
@@ -785,7 +826,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "getKBArticleRSS",
-				_getKBArticleRSSParameterTypes18);
+				_getKBArticleRSSParameterTypes19);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, resourcePrimKey, status, rssDelta, rssDisplayStyle,
@@ -830,7 +871,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "getKBArticles",
-				_getKBArticlesParameterTypes19);
+				_getKBArticlesParameterTypes20);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, parentResourcePrimKey, status, start, end,
@@ -869,7 +910,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "getKBArticles",
-				_getKBArticlesParameterTypes20);
+				_getKBArticlesParameterTypes21);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, resourcePrimKeys, status, start, end,
@@ -908,7 +949,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "getKBArticles",
-				_getKBArticlesParameterTypes21);
+				_getKBArticlesParameterTypes22);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, resourcePrimKeys, status,
@@ -943,7 +984,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "getKBArticlesCount",
-				_getKBArticlesCountParameterTypes22);
+				_getKBArticlesCountParameterTypes23);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, parentResourcePrimKey, status);
@@ -976,7 +1017,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "getKBArticlesCount",
-				_getKBArticlesCountParameterTypes23);
+				_getKBArticlesCountParameterTypes24);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, resourcePrimKeys, status);
@@ -1016,7 +1057,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "getKBArticleSearchDisplay",
-				_getKBArticleSearchDisplayParameterTypes24);
+				_getKBArticleSearchDisplayParameterTypes25);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, title, content, status, startDate, endDate,
@@ -1062,7 +1103,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "getKBArticleVersions",
-				_getKBArticleVersionsParameterTypes25);
+				_getKBArticleVersionsParameterTypes26);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, resourcePrimKey, status, start, end,
@@ -1097,7 +1138,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "getKBArticleVersionsCount",
-				_getKBArticleVersionsCountParameterTypes26);
+				_getKBArticleVersionsCountParameterTypes27);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, resourcePrimKey, status);
@@ -1130,7 +1171,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "getLatestKBArticle",
-				_getLatestKBArticleParameterTypes27);
+				_getLatestKBArticleParameterTypes28);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, resourcePrimKey, status);
@@ -1173,7 +1214,7 @@ public class KBArticleServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class,
 				"getLatestKBArticleByExternalReferenceCode",
-				_getLatestKBArticleByExternalReferenceCodeParameterTypes28);
+				_getLatestKBArticleByExternalReferenceCodeParameterTypes29);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, externalReferenceCode);
@@ -1214,7 +1255,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "getPreviousAndNextKBArticles",
-				_getPreviousAndNextKBArticlesParameterTypes29);
+				_getPreviousAndNextKBArticlesParameterTypes30);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, kbArticleId);
@@ -1258,7 +1299,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "getSectionsKBArticles",
-				_getSectionsKBArticlesParameterTypes30);
+				_getSectionsKBArticlesParameterTypes31);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, sections, status, start, end,
@@ -1293,7 +1334,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "getSectionsKBArticlesCount",
-				_getSectionsKBArticlesCountParameterTypes31);
+				_getSectionsKBArticlesCountParameterTypes32);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, sections, status);
@@ -1326,7 +1367,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "getTempAttachmentNames",
-				_getTempAttachmentNamesParameterTypes32);
+				_getTempAttachmentNamesParameterTypes33);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, tempFolderName);
@@ -1368,7 +1409,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "moveKBArticle",
-				_moveKBArticleParameterTypes33);
+				_moveKBArticleParameterTypes34);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, resourcePrimKey, parentResourceClassNameId,
@@ -1406,7 +1447,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "revertKBArticle",
-				_revertKBArticleParameterTypes34);
+				_revertKBArticleParameterTypes35);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, resourcePrimKey, version, serviceContext);
@@ -1446,7 +1487,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "subscribeGroupKBArticles",
-				_subscribeGroupKBArticlesParameterTypes35);
+				_subscribeGroupKBArticlesParameterTypes36);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, portletId);
@@ -1482,7 +1523,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "subscribeKBArticle",
-				_subscribeKBArticleParameterTypes36);
+				_subscribeKBArticleParameterTypes37);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, resourcePrimKey);
@@ -1518,7 +1559,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "unsubscribeGroupKBArticles",
-				_unsubscribeGroupKBArticlesParameterTypes37);
+				_unsubscribeGroupKBArticlesParameterTypes38);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, portletId);
@@ -1554,7 +1595,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "unsubscribeKBArticle",
-				_unsubscribeKBArticleParameterTypes38);
+				_unsubscribeKBArticleParameterTypes39);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, resourcePrimKey);
@@ -1595,7 +1636,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "updateKBArticle",
-				_updateKBArticleParameterTypes39);
+				_updateKBArticleParameterTypes40);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, resourcePrimKey, title, content, description,
@@ -1638,7 +1679,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "updateKBArticlesPriorities",
-				_updateKBArticlesPrioritiesParameterTypes40);
+				_updateKBArticlesPrioritiesParameterTypes41);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, resourcePrimKeyToPriorityMap);
@@ -1692,121 +1733,125 @@ public class KBArticleServiceHttp {
 		new Class[] {long.class, long[].class};
 	private static final Class<?>[] _deleteTempAttachmentParameterTypes5 =
 		new Class[] {long.class, long.class, String.class, String.class};
-	private static final Class<?>[] _fetchFirstChildKBArticleParameterTypes6 =
-		new Class[] {long.class, long.class};
+	private static final Class<?>[] _expireKBArticleParameterTypes6 =
+		new Class[] {
+			long.class, com.liferay.portal.kernel.service.ServiceContext.class
+		};
 	private static final Class<?>[] _fetchFirstChildKBArticleParameterTypes7 =
+		new Class[] {long.class, long.class};
+	private static final Class<?>[] _fetchFirstChildKBArticleParameterTypes8 =
 		new Class[] {long.class, long.class, int.class};
-	private static final Class<?>[] _fetchKBArticleByUrlTitleParameterTypes8 =
+	private static final Class<?>[] _fetchKBArticleByUrlTitleParameterTypes9 =
 		new Class[] {long.class, long.class, String.class};
-	private static final Class<?>[] _fetchLatestKBArticleParameterTypes9 =
+	private static final Class<?>[] _fetchLatestKBArticleParameterTypes10 =
 		new Class[] {long.class, int.class};
 	private static final Class<?>[]
-		_fetchLatestKBArticleByExternalReferenceCodeParameterTypes10 =
+		_fetchLatestKBArticleByExternalReferenceCodeParameterTypes11 =
 			new Class[] {long.class, String.class};
 	private static final Class<?>[]
-		_fetchLatestKBArticleByUrlTitleParameterTypes11 = new Class[] {
+		_fetchLatestKBArticleByUrlTitleParameterTypes12 = new Class[] {
 			long.class, long.class, String.class, int.class
 		};
 	private static final Class<?>[]
-		_getAllDescendantKBArticlesParameterTypes12 = new Class[] {
+		_getAllDescendantKBArticlesParameterTypes13 = new Class[] {
 			long.class, long.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getGroupKBArticlesParameterTypes13 =
+	private static final Class<?>[] _getGroupKBArticlesParameterTypes14 =
 		new Class[] {
 			long.class, int.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getGroupKBArticlesCountParameterTypes14 =
+	private static final Class<?>[] _getGroupKBArticlesCountParameterTypes15 =
 		new Class[] {long.class, int.class};
-	private static final Class<?>[] _getGroupKBArticlesRSSParameterTypes15 =
+	private static final Class<?>[] _getGroupKBArticlesRSSParameterTypes16 =
 		new Class[] {
 			int.class, int.class, String.class, String.class,
 			com.liferay.portal.kernel.theme.ThemeDisplay.class
 		};
-	private static final Class<?>[] _getKBArticleParameterTypes16 =
+	private static final Class<?>[] _getKBArticleParameterTypes17 =
 		new Class[] {long.class, int.class};
 	private static final Class<?>[]
-		_getKBArticleAndAllDescendantKBArticlesParameterTypes17 = new Class[] {
+		_getKBArticleAndAllDescendantKBArticlesParameterTypes18 = new Class[] {
 			long.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getKBArticleRSSParameterTypes18 =
+	private static final Class<?>[] _getKBArticleRSSParameterTypes19 =
 		new Class[] {
 			long.class, int.class, int.class, String.class, String.class,
 			com.liferay.portal.kernel.theme.ThemeDisplay.class
 		};
-	private static final Class<?>[] _getKBArticlesParameterTypes19 =
+	private static final Class<?>[] _getKBArticlesParameterTypes20 =
 		new Class[] {
 			long.class, long.class, int.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getKBArticlesParameterTypes20 =
+	private static final Class<?>[] _getKBArticlesParameterTypes21 =
 		new Class[] {
 			long.class, long[].class, int.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getKBArticlesParameterTypes21 =
+	private static final Class<?>[] _getKBArticlesParameterTypes22 =
 		new Class[] {
 			long.class, long[].class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getKBArticlesCountParameterTypes22 =
-		new Class[] {long.class, long.class, int.class};
 	private static final Class<?>[] _getKBArticlesCountParameterTypes23 =
+		new Class[] {long.class, long.class, int.class};
+	private static final Class<?>[] _getKBArticlesCountParameterTypes24 =
 		new Class[] {long.class, long[].class, int.class};
-	private static final Class<?>[] _getKBArticleSearchDisplayParameterTypes24 =
+	private static final Class<?>[] _getKBArticleSearchDisplayParameterTypes25 =
 		new Class[] {
 			long.class, String.class, String.class, int.class,
 			java.util.Date.class, java.util.Date.class, boolean.class,
 			int[].class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getKBArticleVersionsParameterTypes25 =
+	private static final Class<?>[] _getKBArticleVersionsParameterTypes26 =
 		new Class[] {
 			long.class, long.class, int.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getKBArticleVersionsCountParameterTypes26 =
+	private static final Class<?>[] _getKBArticleVersionsCountParameterTypes27 =
 		new Class[] {long.class, long.class, int.class};
-	private static final Class<?>[] _getLatestKBArticleParameterTypes27 =
+	private static final Class<?>[] _getLatestKBArticleParameterTypes28 =
 		new Class[] {long.class, int.class};
 	private static final Class<?>[]
-		_getLatestKBArticleByExternalReferenceCodeParameterTypes28 =
+		_getLatestKBArticleByExternalReferenceCodeParameterTypes29 =
 			new Class[] {long.class, String.class};
 	private static final Class<?>[]
-		_getPreviousAndNextKBArticlesParameterTypes29 = new Class[] {
+		_getPreviousAndNextKBArticlesParameterTypes30 = new Class[] {
 			long.class
 		};
-	private static final Class<?>[] _getSectionsKBArticlesParameterTypes30 =
+	private static final Class<?>[] _getSectionsKBArticlesParameterTypes31 =
 		new Class[] {
 			long.class, String[].class, int.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
 	private static final Class<?>[]
-		_getSectionsKBArticlesCountParameterTypes31 = new Class[] {
+		_getSectionsKBArticlesCountParameterTypes32 = new Class[] {
 			long.class, String[].class, int.class
 		};
-	private static final Class<?>[] _getTempAttachmentNamesParameterTypes32 =
+	private static final Class<?>[] _getTempAttachmentNamesParameterTypes33 =
 		new Class[] {long.class, String.class};
-	private static final Class<?>[] _moveKBArticleParameterTypes33 =
+	private static final Class<?>[] _moveKBArticleParameterTypes34 =
 		new Class[] {long.class, long.class, long.class, double.class};
-	private static final Class<?>[] _revertKBArticleParameterTypes34 =
+	private static final Class<?>[] _revertKBArticleParameterTypes35 =
 		new Class[] {
 			long.class, int.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _subscribeGroupKBArticlesParameterTypes35 =
+	private static final Class<?>[] _subscribeGroupKBArticlesParameterTypes36 =
 		new Class[] {long.class, String.class};
-	private static final Class<?>[] _subscribeKBArticleParameterTypes36 =
+	private static final Class<?>[] _subscribeKBArticleParameterTypes37 =
 		new Class[] {long.class, long.class};
 	private static final Class<?>[]
-		_unsubscribeGroupKBArticlesParameterTypes37 = new Class[] {
+		_unsubscribeGroupKBArticlesParameterTypes38 = new Class[] {
 			long.class, String.class
 		};
-	private static final Class<?>[] _unsubscribeKBArticleParameterTypes38 =
+	private static final Class<?>[] _unsubscribeKBArticleParameterTypes39 =
 		new Class[] {long.class};
-	private static final Class<?>[] _updateKBArticleParameterTypes39 =
+	private static final Class<?>[] _updateKBArticleParameterTypes40 =
 		new Class[] {
 			long.class, String.class, String.class, String.class,
 			String[].class, String.class, java.util.Date.class,
@@ -1814,7 +1859,7 @@ public class KBArticleServiceHttp {
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
 	private static final Class<?>[]
-		_updateKBArticlesPrioritiesParameterTypes40 = new Class[] {
+		_updateKBArticlesPrioritiesParameterTypes41 = new Class[] {
 			long.class, java.util.Map.class
 		};
 

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
@@ -492,6 +492,23 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 	}
 
 	@Override
+	public KBArticle expireKBArticle(
+			long userId, long resourcePrimKey, ServiceContext serviceContext)
+		throws PortalException {
+
+		KBArticle kbArticle = getLatestKBArticle(
+			resourcePrimKey, WorkflowConstants.STATUS_ANY);
+
+		kbArticle.setExpirationDate(new Date());
+
+		kbArticleLocalService.updateKBArticle(kbArticle);
+
+		return kbArticleLocalService.updateStatus(
+			userId, resourcePrimKey, WorkflowConstants.STATUS_EXPIRED,
+			serviceContext);
+	}
+
+	@Override
 	public KBArticle fetchFirstChildKBArticle(
 		long groupId, long parentResourcePrimKey) {
 

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
@@ -1366,7 +1366,9 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 
 		kbArticle = kbArticlePersistence.update(kbArticle);
 
-		if (status != WorkflowConstants.STATUS_APPROVED) {
+		if ((status != WorkflowConstants.STATUS_APPROVED) &&
+			(status != WorkflowConstants.STATUS_EXPIRED)) {
+
 			return kbArticle;
 		}
 
@@ -1382,8 +1384,13 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 
 		// Asset
 
-		AssetEntry assetEntry = _assetEntryLocalService.getEntry(
-			KBArticle.class.getName(), kbArticle.getKbArticleId());
+		AssetEntry assetEntry = _assetEntryLocalService.fetchEntry(
+			KBArticle.class.getName(), kbArticle.getResourcePrimKey());
+
+		if (status == WorkflowConstants.STATUS_APPROVED) {
+			assetEntry = _assetEntryLocalService.getEntry(
+				KBArticle.class.getName(), kbArticle.getKbArticleId());
+		}
 
 		List<AssetLink> assetLinks = _assetLinkLocalService.getDirectLinks(
 			assetEntry.getEntryId(), AssetLinkConstants.TYPE_RELATED);

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
@@ -1624,7 +1624,7 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 						kbArticle.getExpirationDate()));
 			}
 
-			updateStatus(
+			kbArticleLocalService.updateStatus(
 				userId, kbArticle.getResourcePrimKey(),
 				WorkflowConstants.STATUS_EXPIRED, serviceContext);
 

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
@@ -1634,21 +1634,6 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 			kbArticleLocalService.updateStatus(
 				userId, kbArticle.getResourcePrimKey(),
 				WorkflowConstants.STATUS_EXPIRED, serviceContext);
-
-			AssetEntry assetEntry = _assetEntryLocalService.getEntry(
-				KBArticle.class.getName(), kbArticle.getResourcePrimKey());
-
-			_assetEntryLocalService.updateEntry(
-				userId, kbArticle.getGroupId(), kbArticle.getCreateDate(),
-				kbArticle.getModifiedDate(), KBArticle.class.getName(),
-				kbArticle.getResourcePrimKey(), kbArticle.getUuid(), 0,
-				assetEntry.getCategoryIds(), assetEntry.getTagNames(), true,
-				false, null, null, null, kbArticle.getExpirationDate(),
-				ContentTypes.TEXT_HTML, kbArticle.getTitle(),
-				kbArticle.getDescription(), assetEntry.getSummary(), null, null,
-				0, 0, null);
-
-			_indexKBArticle(kbArticle);
 		}
 	}
 

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleServiceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleServiceImpl.java
@@ -165,6 +165,18 @@ public class KBArticleServiceImpl extends KBArticleServiceBaseImpl {
 	}
 
 	@Override
+	public KBArticle expireKBArticle(
+			long resourcePrimKey, ServiceContext serviceContext)
+		throws PortalException {
+
+		_kbArticleModelResourcePermission.check(
+			getPermissionChecker(), resourcePrimKey, KBActionKeys.UPDATE);
+
+		return kbArticleLocalService.expireKBArticle(
+			getUserId(), resourcePrimKey, serviceContext);
+	}
+
+	@Override
 	public KBArticle fetchFirstChildKBArticle(
 		long groupId, long parentResourcePrimKey) {
 

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/action/ExpireKBArticleMVCActionCommand.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/action/ExpireKBArticleMVCActionCommand.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.knowledge.base.web.internal.portlet.action;
+
+import com.liferay.knowledge.base.constants.KBPortletKeys;
+import com.liferay.knowledge.base.model.KBArticle;
+import com.liferay.knowledge.base.service.KBArticleService;
+import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCActionCommand;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
+import com.liferay.portal.kernel.service.ServiceContextFactory;
+import com.liferay.portal.kernel.util.ParamUtil;
+
+import javax.portlet.ActionRequest;
+import javax.portlet.ActionResponse;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Alicia García
+ */
+@Component(
+	property = {
+		"javax.portlet.name=" + KBPortletKeys.KNOWLEDGE_BASE_ADMIN,
+		"mvc.command.name=/knowledge_base/expire_kb_article"
+	},
+	service = MVCActionCommand.class
+)
+public class ExpireKBArticleMVCActionCommand extends BaseMVCActionCommand {
+
+	@Override
+	protected void doProcessAction(
+			ActionRequest actionRequest, ActionResponse actionResponse)
+		throws Exception {
+
+		long resourcePrimKey = ParamUtil.getLong(
+			actionRequest, "resourcePrimKey");
+
+		_kbArticleService.expireKBArticle(
+			resourcePrimKey,
+			ServiceContextFactory.getInstance(
+				KBArticle.class.getName(), actionRequest));
+	}
+
+	@Reference
+	private KBArticleService _kbArticleService;
+
+}

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/util/KBDropdownItemsProvider.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/util/KBDropdownItemsProvider.java
@@ -112,23 +112,36 @@ public class KBDropdownItemsProvider {
 						_hasChildKBArticles(kbArticle) &&
 						_hasViewChildKBArticlesPermission(),
 					_getViewChildKBArticlesActionUnsafeConsumer(kbArticle)
-				).add(
-					() ->
-						_isSubscriptionEnabled() &&
-						_hasSubscriptionPermission(kbArticle) &&
-						_hasSubscription(kbArticle),
-					_getUnsubscribeActionUnsafeConsumer(kbArticle)
-				).add(
-					() ->
-						_isSubscriptionEnabled() &&
-						_hasSubscriptionPermission(kbArticle) &&
-						!_hasSubscription(kbArticle),
-					_getSubscribeActionUnsafeConsumer(kbArticle)
-				).add(
-					() ->
-						_isHistoryEnabled() && _hasHistoryPermission(kbArticle),
-					_getHistoryActionUnsafeConsumer(kbArticle)
 				).build())
+		).addGroup(
+			dropdownGroupItem -> {
+				dropdownGroupItem.setDropdownItems(
+					DropdownItemListBuilder.add(
+						() ->
+							_hasExpirationPermission(kbArticle) &&
+							!kbArticle.isExpired(),
+						_getExpireArticleActionConsumer(kbArticle)
+					).add(
+						() ->
+							_isSubscriptionEnabled() &&
+							_hasSubscriptionPermission(kbArticle) &&
+							_hasSubscription(kbArticle),
+						_getUnsubscribeActionUnsafeConsumer(kbArticle)
+					).add(
+						() ->
+							_isSubscriptionEnabled() &&
+							_hasSubscriptionPermission(kbArticle) &&
+							!_hasSubscription(kbArticle),
+						_getSubscribeActionUnsafeConsumer(kbArticle)
+					).add(
+						() ->
+							_isHistoryEnabled() &&
+							_hasHistoryPermission(kbArticle),
+						_getHistoryActionUnsafeConsumer(kbArticle)
+					).build());
+
+				dropdownGroupItem.setSeparator(true);
+			}
 		).addGroup(
 			dropdownGroupItem -> {
 				dropdownGroupItem.setDropdownItems(
@@ -550,6 +563,27 @@ public class KBDropdownItemsProvider {
 			dropdownItem.setLabel(
 				LanguageUtil.get(
 					_liferayPortletRequest.getHttpServletRequest(), "edit"));
+		};
+	}
+
+	private UnsafeConsumer<DropdownItem, Exception>
+		_getExpireArticleActionConsumer(KBArticle kbArticle) {
+
+		return dropdownItem -> {
+			dropdownItem.setHref(
+				PortletURLBuilder.createActionURL(
+					_liferayPortletResponse
+				).setActionName(
+					"/knowledge_base/expire_kb_article"
+				).setRedirect(
+					_currentURL
+				).setParameter(
+					"resourcePrimKey", kbArticle.getResourcePrimKey()
+				).buildActionURL());
+			dropdownItem.setIcon("time");
+			dropdownItem.setLabel(
+				LanguageUtil.get(
+					_liferayPortletRequest.getHttpServletRequest(), "expire"));
 		};
 	}
 
@@ -1030,6 +1064,20 @@ public class KBDropdownItemsProvider {
 		if (KBTemplatePermission.contains(
 				_themeDisplay.getPermissionChecker(), kbTemplate,
 				KBActionKeys.DELETE)) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	private boolean _hasExpirationPermission(KBArticle kbArticle)
+		throws Exception {
+
+		if (kbArticle.isApproved() &&
+			KBArticlePermission.contains(
+				_themeDisplay.getPermissionChecker(), kbArticle,
+				KBActionKeys.UPDATE)) {
 
 			return true;
 		}

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/util/KBDropdownItemsProvider.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/util/KBDropdownItemsProvider.java
@@ -53,6 +53,7 @@ import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.rss.util.RSSUtil;
@@ -118,6 +119,7 @@ public class KBDropdownItemsProvider {
 				dropdownGroupItem.setDropdownItems(
 					DropdownItemListBuilder.add(
 						() ->
+							_isExpirationEnabled() &&
 							_hasExpirationPermission(kbArticle) &&
 							!kbArticle.isExpired(),
 						_getExpireArticleActionConsumer(kbArticle)
@@ -1319,6 +1321,14 @@ public class KBDropdownItemsProvider {
 				_themeDisplay.getPermissionChecker(), kbTemplate,
 				KBActionKeys.VIEW)) {
 
+			return true;
+		}
+
+		return false;
+	}
+
+	private Boolean _isExpirationEnabled() {
+		if (GetterUtil.getBoolean(PropsUtil.get("feature.flag.LPS-165476"))) {
 			return true;
 		}
 


### PR DESCRIPTION
- LPS-167979 create a dropdown item to instantly expire the KB articles and add it to a group as the mockup
- LPS-167979 Add action command to expire kb Article
- LPS-167979 expire kbArticle impl methods
- LPS-167979 buildService
- LPS-167979 baseline
- LPS-167979 call the service on the class
- LPS-167979 only show dropdown if FF is enabled
- LPS-167979 update status if is expired too
- LPS-167979 Set empty value to service to make CheckKBArticleMessageListener be activated during startup since no one will reference them
- LPS-167979 no longer needed


https://issues.liferay.com/browse/LPS-167979


On this PR we are creating a new dropdown item (only visible if the FF LPS-165476 is enabled) to expire immediately the KB Article



https://user-images.githubusercontent.com/47524751/205686714-eeeb6e22-0efd-445a-ae24-55df7761a409.mp4


