### PR TITLE
LPS-170143 | Fix test DepotApplication#CanNotSelectDisabledAssetsFromItemSelector

### DIFF
--- a/modules/apps/depot/depot-test/src/testFunctional/tests/DepotApplication.testcase
+++ b/modules/apps/depot/depot-test/src/testFunctional/tests/DepotApplication.testcase
@@ -123,6 +123,7 @@ definition {
 
 		WebContentDisplayPortlet.searchWebContent(
 			depotName = "Test Depot Name",
+			errorMessage = "Info:This application is not supported for Asset Libraries. Please, go back to scope selection.",
 			webContentTitleNotPresentList = "WC Depot Title");
 
 		BlogsNavigator.openToAddEntry(siteURLKey = "test-site-name");

--- a/portal-web/test/functional/com/liferay/portalweb/macros/journal/webcontentdisplay/WebContentDisplayPortlet.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/journal/webcontentdisplay/WebContentDisplayPortlet.macro
@@ -326,7 +326,7 @@ definition {
 
 				AssertTextEquals.assertPartialText(
 					locator1 = "Message#INFO",
-					value1 = "Info:Web Content is disabled for this scope.");
+					value1 = "${errorMessage}");
 			}
 			else {
 				Search.searchCP(searchTerm = "${searchTerm}");

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/journal/webcontentdisplay/WebContentDisplay.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/journal/webcontentdisplay/WebContentDisplay.testcase
@@ -826,6 +826,7 @@ Welcome to Liferay Community Edition Portal 7.4.0 CE GA1''';
 				siteName = "Test Site Name");
 
 			WebContentDisplayPortlet.searchWebContent(
+				errorMessage = "Info:Web Content is disabled for this scope.",
 				searchTerm = "Web Content Title 1",
 				webContentTitleList = "Web Content Title 1,Web Content Title 2");
 
@@ -834,6 +835,7 @@ Welcome to Liferay Community Edition Portal 7.4.0 CE GA1''';
 
 		task ("View first web content is shown when searching for specific title in Web Content Display") {
 			WebContentDisplayPortlet.searchWebContent(
+				errorMessage = "Info:Web Content is disabled for this scope.",
 				searchTerm = '''"Web Content Title 1"''',
 				webContentTitleList = "Web Content Title 1");
 
@@ -846,6 +848,7 @@ Welcome to Liferay Community Edition Portal 7.4.0 CE GA1''';
 
 		task ("View web contents are not shown when searching for invalid value in Web Content Display") {
 			WebContentDisplayPortlet.searchWebContent(
+				errorMessage = "Info:Web Content is disabled for this scope.",
 				searchTerm = '''"Web1 Content1 Title 1"''',
 				webContentTitleNotPresentList = "Web Content Title 1,Web Content Title 2");
 		}


### PR DESCRIPTION
Description: Fix test `DepotApplication#CanNotSelectDisabledAssetsFromItemSelector` to catch correct error message (`Info:This application is not supported for Asset Libraries. Please, go back to scope selection.`) instead of default one (`Info:Web Content is disabled for this scope.`).

Jira Ticket: https://issues.liferay.com/browse/LPS-170143