### PR TITLE
LPS-170626 Remove menu-item usages in wiki

### DIFF
--- a/modules/apps/wiki/wiki-web/src/main/java/com/liferay/wiki/web/internal/display/context/WikiListPagesDisplayContext.java
+++ b/modules/apps/wiki/wiki-web/src/main/java/com/liferay/wiki/web/internal/display/context/WikiListPagesDisplayContext.java
@@ -104,6 +104,7 @@ public class WikiListPagesDisplayContext {
 					).setParameter(
 						"title", HtmlUtil.unescape(wikiPage.getTitle())
 					).buildString());
+				dropdownItem.setIcon("pencil");
 				dropdownItem.setKey(WikiUIItemKeys.EDIT);
 				dropdownItem.setLabel(
 					LanguageUtil.get(_httpServletRequest, "edit"));
@@ -121,6 +122,7 @@ public class WikiListPagesDisplayContext {
 						null, String.valueOf(wikiPage.getResourcePrimKey()),
 						LiferayWindowState.POP_UP.toString(), null,
 						_httpServletRequest));
+				dropdownItem.setIcon("password-policies");
 				dropdownItem.setKey(WikiUIItemKeys.PERMISSIONS);
 				dropdownItem.setLabel(
 					LanguageUtil.get(_httpServletRequest, "permissions"));
@@ -146,6 +148,7 @@ public class WikiListPagesDisplayContext {
 					).setParameter(
 						"title", StringPool.BLANK
 					).buildString());
+				dropdownItem.setIcon("copy");
 				dropdownItem.setKey(WikiUIItemKeys.COPY);
 				dropdownItem.setLabel(
 					LanguageUtil.get(_httpServletRequest, "copy"));
@@ -165,6 +168,7 @@ public class WikiListPagesDisplayContext {
 					).setParameter(
 						"title", HtmlUtil.unescape(wikiPage.getTitle())
 					).buildString());
+				dropdownItem.setIcon("move-folder");
 				dropdownItem.setKey(WikiUIItemKeys.MOVE);
 				dropdownItem.setLabel(
 					LanguageUtil.get(_httpServletRequest, "move"));
@@ -192,6 +196,7 @@ public class WikiListPagesDisplayContext {
 					).setParameter(
 						"title", StringPool.BLANK
 					).buildString());
+				dropdownItem.setIcon("wiki-page");
 				dropdownItem.setKey(WikiUIItemKeys.ADD_CHILD_PAGE);
 				dropdownItem.setLabel(
 					LanguageUtil.get(_httpServletRequest, "add-child-page"));
@@ -213,6 +218,7 @@ public class WikiListPagesDisplayContext {
 					).setParameter(
 						"title", HtmlUtil.unescape(wikiPage.getTitle())
 					).buildString());
+				dropdownItem.setIcon("bell-off");
 				dropdownItem.setKey(WikiUIItemKeys.UNSUBSCRIBE);
 				dropdownItem.setLabel(
 					LanguageUtil.get(_httpServletRequest, "unsubscribe"));
@@ -234,6 +240,7 @@ public class WikiListPagesDisplayContext {
 					).setParameter(
 						"title", HtmlUtil.unescape(wikiPage.getTitle())
 					).buildString());
+				dropdownItem.setIcon("bell-on");
 				dropdownItem.setKey(WikiUIItemKeys.SUBSCRIBE);
 				dropdownItem.setLabel(
 					LanguageUtil.get(_httpServletRequest, "subscribe"));
@@ -261,6 +268,7 @@ public class WikiListPagesDisplayContext {
 					).setWindowState(
 						LiferayWindowState.POP_UP
 					).buildString());
+				dropdownItem.setIcon("print");
 				dropdownItem.setKey(WikiUIItemKeys.PRINT);
 				dropdownItem.setLabel(
 					LanguageUtil.get(_httpServletRequest, "print"));
@@ -301,6 +309,7 @@ public class WikiListPagesDisplayContext {
 						!wikiPage.isDraft() &&
 						_trashHelper.isTrashEnabled(
 							_wikiRequestHelper.getScopeGroupId())));
+				dropdownItem.setIcon("trash");
 				dropdownItem.setKey(WikiUIItemKeys.DELETE);
 
 				String label = "delete";

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/js/WikiPageDropdownPropsTransformer.js
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/js/WikiPageDropdownPropsTransformer.js
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {openConfirmModal, openModal} from 'frontend-js-web';
+
+const ACTIONS = {
+	delete({deleteURL, trashEnabled}) {
+		if (!trashEnabled) {
+			openConfirmModal({
+				message: Liferay.Language.get(
+					'are-you-sure-you-want-to-delete-this'
+				),
+				onConfirm: (isConfirmed) => {
+					if (isConfirmed) {
+						submitForm(document.hrefFm, deleteURL);
+					}
+				},
+			});
+		}
+		else {
+			submitForm(document.hrefFm, deleteURL);
+		}
+	},
+
+	permissions({permissionsURL}) {
+		openModal({
+			title: Liferay.Language.get('permissions'),
+			url: permissionsURL,
+		});
+	},
+
+	print({printURL}) {
+		openModal({
+			title: Liferay.Language.get('print'),
+			url: printURL,
+		});
+	},
+};
+
+export default function propsTransformer({items, ...props}) {
+	return {
+		...props,
+		items: items.map((item) => {
+			return {
+				...item,
+				items: item.items?.map((child) => ({
+					...child,
+					onClick(event) {
+						const action = child.data?.action;
+
+						if (action) {
+							event.preventDefault();
+
+							ACTIONS[action](child.data);
+						}
+					},
+				})),
+			};
+		}),
+	};
+}

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/js/WikiPageDropdownPropsTransformer.js
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/js/WikiPageDropdownPropsTransformer.js
@@ -54,18 +54,15 @@ export default function propsTransformer({items, ...props}) {
 		items: items.map((item) => {
 			return {
 				...item,
-				items: item.items?.map((child) => ({
-					...child,
-					onClick(event) {
-						const action = child.data?.action;
+				onClick(event) {
+					const action = item.data?.action;
 
-						if (action) {
-							event.preventDefault();
+					if (action) {
+						event.preventDefault();
 
-							ACTIONS[action](child.data);
-						}
-					},
-				})),
+						ACTIONS[action](item.data);
+					}
+				},
 			};
 		}),
 	};

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/page_action.jsp
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/page_action.jsp
@@ -31,6 +31,8 @@ else {
 WikiListPagesDisplayContext wikiListPagesDisplayContext = new WikiListPagesDisplayContext(request, (TrashHelper)request.getAttribute(TrashWebKeys.TRASH_HELPER), wikiPage.getNode());
 %>
 
-<liferay-ui:menu
-	menu="<%= wikiListPagesDisplayContext.getMenu(wikiPage) %>"
+<clay:dropdown-actions
+	aria-label='<%= LanguageUtil.get(request, "show-actions") %>'
+	dropdownItems="<%= wikiListPagesDisplayContext.getActionDropdownItems(wikiPage) %>"
+	propsTransformer="wiki/js/WikiPageDropdownPropsTransformer"
 />

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/wiki/WikiTable.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/wiki/WikiTable.path
@@ -45,7 +45,7 @@
 </tr>
 <tr>
 	<td>ALL_PAGES_VERTICAL_ELLIPSIS</td>
-	<td>//tr[contains(.,'${key_wikiPageTitle}')]/.//td//div/a[contains(@class,'dropdown-toggle')]</td>
+	<td>//tr[contains(.,'${key_wikiPageTitle}')]/.//td//div[contains(@class,'dropdown-action')]</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
# What is this about?

https://issues.liferay.com/browse/LPS-170626

Remove all usages of the `menu-item` taglib in wiki, replacing it with `dropdown-actions`.

# Do I need to do something with this?

@ambrinchaudhary I need help with the Js logic. I've created the props transformer, but it is not being invoked.  I'm sure I'm missing some important step, but I have no idea which one.

# How do I test it?

These are internal changes; the app should behave the same way as before.