### PR TITLE
LPS-169410 | master

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeBatchActionForHeadlessDeliveryAPI.testcase
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeBatchActionForHeadlessDeliveryAPI.testcase
@@ -3,7 +3,7 @@ definition {
 
 	property portal.release = "true";
 	property portal.upstream = "true";
-	property testray.main.component.name = "Headless";
+	property testray.main.component.name = "Lima Headless";
 
 	setUp {
 		TestCase.setUpPortalInstanceNoSelenium();

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeErcFromAssetLibraryForComments.testcase
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeErcFromAssetLibraryForComments.testcase
@@ -3,7 +3,7 @@ definition {
 
 	property portal.release = "true";
 	property portal.upstream = "true";
-	property testray.main.component.name = "Headless";
+	property testray.main.component.name = "Lima Headless";
 
 	setUp {
 		TestCase.setUpPortalInstanceNoSelenium();

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeErcFromAssetLibraryForDocument.testcase
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeErcFromAssetLibraryForDocument.testcase
@@ -3,7 +3,7 @@ definition {
 
 	property portal.release = "true";
 	property portal.upstream = "true";
-	property testray.main.component.name = "Headless";
+	property testray.main.component.name = "Lima Headless";
 
 	setUp {
 		TestCase.setUpPortalInstance();

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeErcInWikiPageAttachment.testcase
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeErcInWikiPageAttachment.testcase
@@ -3,7 +3,7 @@ definition {
 
 	property portal.release = "true";
 	property portal.upstream = "true";
-	property testray.main.component.name = "Headless";
+	property testray.main.component.name = "Lima Headless";
 
 	setUp {
 		TestCase.setUpPortalInstanceNoSelenium();

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/HeadlessDeliverySupportDifferentParameters.testcase
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/HeadlessDeliverySupportDifferentParameters.testcase
@@ -3,7 +3,7 @@ definition {
 
 	property portal.release = "true";
 	property portal.upstream = "true";
-	property testray.main.component.name = "Headless";
+	property testray.main.component.name = "Lima Headless";
 
 	setUp {
 		TestCase.setUpPortalInstance();

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/HeadlessDeliverySupportDifferentParameters.testcase
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/HeadlessDeliverySupportDifferentParameters.testcase
@@ -3,7 +3,7 @@ definition {
 
 	property portal.release = "true";
 	property portal.upstream = "true";
-	property testray.main.component.name = "Lima Headless";
+	property testray.main.component.name = "Headless";
 
 	setUp {
 		TestCase.setUpPortalInstance();
@@ -17,8 +17,6 @@ definition {
 		if ("${testPortalInstance}" == "true") {
 			PortalInstances.tearDownCP();
 		}
-
-		BlogPostingAPI.deleteAllBlogPostings();
 
 		JSONDepot.deleteDepot(depotName = "Test Depot Name");
 	}
@@ -102,93 +100,6 @@ definition {
 			TestUtils.assertEquals(
 				actual = "${actualValue}",
 				expected = "/web/test");
-		}
-	}
-
-	@priority = "4"
-	test CanReceiveIdFieldValuesOnlyInResponse {
-		property portal.acceptance = "true";
-
-		task ("Given a blog-posting created") {
-			var blogPostingId = BlogPostingAPI.getIdOfCreatedBlogPosting(
-				articleBody = "ArticleBody",
-				headline = "Headline");
-		}
-
-		task ("When with curl I request GET getSiteBlogPostingsPage with siteId and restrictFields equal all fields except id field") {
-			var response = BlogPostingAPI.getBlogPostingsbyDifferentParameters(
-				parameter = "restrictFields",
-				restrictFieldsValue = "aggregateRating,alternativeHeadline,articleBody,creator,customFields,dateCreated,dateModified,datePublished,description,encodingFormat,externalReferenceCode,friendlyUrlPath,headline,image,keywords,numberOfComments,relatedContents,renderedContents,siteId,taxonomyCategoryBriefs,x-class-name,facets,actions");
-		}
-
-		task ("Then in a response I receive a with id field values only") {
-			BlogPostingAPI.assertResponseHasIdFieldValueOnly(
-				expectedValue = "{id=${blogPostingId}}",
-				responseToParse = "${response}");
-		}
-	}
-
-	@priority = "4"
-	test CanReceiveIdFieldValuesOnlyInResponseForIndividualElement {
-		property portal.acceptance = "true";
-
-		task ("Given a document of a site") {
-			JSONDepot.addDepot(depotName = "Test Depot Name");
-
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
-			var filePath = TestCase.getDependenciesDirPath(fileName = "Document_1.txt");
-
-			var documentId = DocumentAPI.getIdOfCreatedDocument(
-				assetLibraryId = "${assetLibraryId}",
-				externalReferenceCode = "erc",
-				filePath = "${filePath}");
-		}
-
-		task ("When with curl I request getDocument with fields=id") {
-			var response = DocumentAPI.getDocumentsByDifferentParameters(
-				documentId = "${documentId}",
-				parameter = "fields",
-				parameterValue = "id");
-		}
-
-		task ("Then in a response I received an id value only") {
-			var actualValue = JSONUtil.getWithJSONPath("${response}", "$");
-
-			TestUtils.assertEquals(
-				actual = "${actualValue}",
-				expected = "{id=${documentId}}");
-		}
-	}
-
-	@priority = "4"
-	test CanReceiveTitleFieldValuesOnlyInResponseForIndividualElement {
-		property portal.acceptance = "true";
-
-		task ("Given a document of a site") {
-			JSONDepot.addDepot(depotName = "Test Depot Name");
-
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
-			var filePath = TestCase.getDependenciesDirPath(fileName = "Document_1.txt");
-
-			var documentId = DocumentAPI.getIdOfCreatedDocument(
-				assetLibraryId = "${assetLibraryId}",
-				externalReferenceCode = "erc",
-				filePath = "${filePath}");
-		}
-
-		task ("When with curl I request getDocument with restrictFields equal all fields except title field") {
-			var response = DocumentAPI.getDocumentsByDifferentParameters(
-				documentId = "${documentId}",
-				parameter = "restrictFields",
-				parameterValue = "actions,adaptedImages,assetLibraryKey,contentUrl,creator,customFields,dateCreated,dateModified,description,documentFolderId,documentType,encodingFormat,externalReferenceCode,fileExtension,id,keywords,numberOfComments,relatedContents,renderedContents,siteId,sizeInBytes,taxonomyCategoryBriefs");
-		}
-
-		task ("Then in a response I receive a body with title field values only") {
-			var actualValue = JSONUtil.getWithJSONPath("${response}", "$");
-
-			TestUtils.assertEquals(
-				actual = "${actualValue}",
-				expected = "{title=Document_1.txt}");
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/HeadlessDeliverySupportDifferentParametersBlogs.testcase
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/HeadlessDeliverySupportDifferentParametersBlogs.testcase
@@ -1,0 +1,47 @@
+@component-name = "portal-headless"
+definition {
+
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.main.component.name = "Lima Headless";
+
+	setUp {
+		TestCase.setUpPortalInstance();
+
+		User.firstLoginPG();
+	}
+
+	tearDown {
+		var testPortalInstance = PropsUtil.get("test.portal.instance");
+
+		if ("${testPortalInstance}" == "true") {
+			PortalInstances.tearDownCP();
+		}
+
+		BlogPostingAPI.deleteAllBlogPostings();
+	}
+
+	@priority = "4"
+	test CanReceiveIdFieldValuesOnlyInResponse {
+		property portal.acceptance = "true";
+
+		task ("Given a blog-posting created") {
+			var blogPostingId = BlogPostingAPI.getIdOfCreatedBlogPosting(
+				articleBody = "ArticleBody",
+				headline = "Headline");
+		}
+
+		task ("When with curl I request GET getSiteBlogPostingsPage with siteId and restrictFields equal all fields except id field") {
+			var response = BlogPostingAPI.getBlogPostingsbyDifferentParameters(
+				parameter = "restrictFields",
+				restrictFieldsValue = "aggregateRating,alternativeHeadline,articleBody,creator,customFields,dateCreated,dateModified,datePublished,description,encodingFormat,externalReferenceCode,friendlyUrlPath,headline,image,keywords,numberOfComments,relatedContents,renderedContents,siteId,taxonomyCategoryBriefs,x-class-name,facets,actions");
+		}
+
+		task ("Then in a response I receive a with id field values only") {
+			BlogPostingAPI.assertResponseHasIdFieldValueOnly(
+				expectedValue = "{id=${blogPostingId}}",
+				responseToParse = "${response}");
+		}
+	}
+
+}

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/HeadlessDeliverySupportDifferentParametersDM.testcase
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/HeadlessDeliverySupportDifferentParametersDM.testcase
@@ -1,0 +1,88 @@
+@component-name = "portal-headless"
+definition {
+
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.main.component.name = "Headless";
+
+	setUp {
+		TestCase.setUpPortalInstance();
+
+		User.firstLoginPG();
+	}
+
+	tearDown {
+		var testPortalInstance = PropsUtil.get("test.portal.instance");
+
+		if ("${testPortalInstance}" == "true") {
+			PortalInstances.tearDownCP();
+		}
+
+		JSONDepot.deleteDepot(depotName = "Test Depot Name");
+	}
+
+	@priority = "4"
+	test CanReceiveIdFieldValuesOnlyInResponseForIndividualElement {
+		property portal.acceptance = "true";
+
+		task ("Given a document of a site") {
+			JSONDepot.addDepot(depotName = "Test Depot Name");
+
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+			var filePath = TestCase.getDependenciesDirPath(fileName = "Document_1.txt");
+
+			var documentId = DocumentAPI.getIdOfCreatedDocument(
+				assetLibraryId = "${assetLibraryId}",
+				externalReferenceCode = "erc",
+				filePath = "${filePath}");
+		}
+
+		task ("When with curl I request getDocument with fields=id") {
+			var response = DocumentAPI.getDocumentsByDifferentParameters(
+				documentId = "${documentId}",
+				parameter = "fields",
+				parameterValue = "id");
+		}
+
+		task ("Then in a response I received an id value only") {
+			var actualValue = JSONUtil.getWithJSONPath("${response}", "$");
+
+			TestUtils.assertEquals(
+				actual = "${actualValue}",
+				expected = "{id=${documentId}}");
+		}
+	}
+
+	@priority = "4"
+	test CanReceiveTitleFieldValuesOnlyInResponseForIndividualElement {
+		property portal.acceptance = "true";
+
+		task ("Given a document of a site") {
+			JSONDepot.addDepot(depotName = "Test Depot Name");
+
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+			var filePath = TestCase.getDependenciesDirPath(fileName = "Document_1.txt");
+
+			var documentId = DocumentAPI.getIdOfCreatedDocument(
+				assetLibraryId = "${assetLibraryId}",
+				externalReferenceCode = "erc",
+				filePath = "${filePath}");
+		}
+
+		task ("When with curl I request getDocument with restrictFields equal all fields except title field") {
+			var response = DocumentAPI.getDocumentsByDifferentParameters(
+				documentId = "${documentId}",
+				parameter = "restrictFields",
+				parameterValue = "actions,adaptedImages,assetLibraryKey,contentUrl,creator,customFields,dateCreated,dateModified,description,documentFolderId,documentType,encodingFormat,externalReferenceCode,fileExtension,id,keywords,numberOfComments,relatedContents,renderedContents,siteId,sizeInBytes,taxonomyCategoryBriefs");
+		}
+
+		task ("Then in a response I receive a body with title field values only") {
+			var actualValue = JSONUtil.getWithJSONPath("${response}", "$");
+
+			TestUtils.assertEquals(
+				actual = "${actualValue}",
+				expected = "{title=Document_1.txt}");
+		}
+	}
+
+}

--- a/modules/apps/headless/headless-delivery/test.properties
+++ b/modules/apps/headless/headless-delivery/test.properties
@@ -8,7 +8,8 @@
 
     test.batch.run.property.query[functional-tomcat*-mysql*-jdk8][relevant]=\
         (portal.acceptance == true) AND \
-        (testray.main.component.name ~ "Headless")
+        (testray.main.component.name ~ "Headless") OR \
+        (testray.main.component.name ~ "Lima Headless")
 
 ##
 ## Testray

--- a/test.properties
+++ b/test.properties
@@ -4983,6 +4983,12 @@
         **/document-library-web-test/**/*Test.java,\
         **/friendly-url-service/**/*Test.java,\
         **/friendly-url-test/**/*Test.java,\
+        **/headless/headless-delivery/**/*BlogPosting*Test.java,\
+        **/headless/headless-delivery/**/*CommentResource*Test.java,\
+        **/headless/headless-delivery/**/*Document*Test.java,\
+        **/headless/headless-delivery/**/*KnowledgeBase*Test.java,\
+        **/headless/headless-delivery/**/*MessageBoard*Test.java,\
+        **/headless/headless-delivery/**/*Wiki*Test.java,\
         **/item-selector-taglib/**/*Test.java,\
         **/item-selector-test/**/*Test.java,\
         **/item-selector-web/**/*Test.java,\
@@ -5053,6 +5059,7 @@
             (testray.main.component.name ~ "Friendly URL Service") OR \
             (testray.main.component.name ~ "Item Selector") OR \
             (testray.main.component.name ~ "Knowledge Base") OR \
+            (testray.main.component.name ~ "Lima Headless") OR \
             (testray.main.component.name ~ "Mentions") OR \
             (testray.main.component.name ~ "Message Boards") OR \
             (testray.main.component.name ~ "Notifications") OR \
@@ -5117,6 +5124,12 @@
         **/document-library-uad-test/**/*Test.java,\
         **/document-library-video-test/**/*Test.java,\
         **/document-library-web-test/**/*Test.java,\
+        **/headless/headless-delivery/**/*BlogPosting*Test.java,\
+        **/headless/headless-delivery/**/*CommentResource*Test.java,\
+        **/headless/headless-delivery/**/*Document*Test.java,\
+        **/headless/headless-delivery/**/*KnowledgeBase*Test.java,\
+        **/headless/headless-delivery/**/*MessageBoard*Test.java,\
+        **/headless/headless-delivery/**/*Wiki*Test.java,\
         **/item-selector-taglib/**/*Test.java,\
         **/item-selector-test/**/*Test.java,\
         **/item-selector-web/**/*Test.java,\
@@ -5188,6 +5201,7 @@
             (testray.main.component.name ~ "Friendly URL Service") OR \
             (testray.main.component.name ~ "Item Selector") OR \
             (testray.main.component.name ~ "Knowledge Base") OR \
+            (testray.main.component.name ~ "Lima Headless") OR \
             (testray.main.component.name ~ "Mentions") OR \
             (testray.main.component.name ~ "Message Boards") OR \
             (testray.main.component.name ~ "Notifications") OR \


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-169410

@austinchiang and @david-gutierrez-mesa 
There are some modules involving the **asset library** and **site**, such as StructuredContent and Language.
I divided the headless tests according to whether the API is **assetLibraries** related: 
For example, `getAssetLibraryStructuredContentsPage` is under the StructuredContent module, but it is assetLibraries related, then I moved the test to Lima.
Another example, `getAssetLibraryLanguagesPage` is under the Language module, it is related to assetLibraries, I moved it to Lima as well.
Please let me know what you think, thanks