### PR TITLE
LPS-169909 Handle duplicate name exceptions in repository tag

### DIFF
--- a/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/servlet/RepositoryBrowserServlet.java
+++ b/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/servlet/RepositoryBrowserServlet.java
@@ -14,6 +14,8 @@
 
 package com.liferay.document.library.taglib.internal.servlet;
 
+import com.liferay.document.library.kernel.exception.DuplicateFileEntryException;
+import com.liferay.document.library.kernel.exception.DuplicateFolderNameException;
 import com.liferay.document.library.kernel.model.DLVersionNumberIncrease;
 import com.liferay.document.library.kernel.service.DLAppService;
 import com.liferay.petra.string.StringPool;
@@ -31,6 +33,7 @@ import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.ServiceContextFactory;
 import com.liferay.portal.kernel.servlet.ServletResponseUtil;
+import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.servlet.SessionMessages;
 import com.liferay.portal.kernel.upload.UploadServletRequest;
 import com.liferay.portal.kernel.util.ContentTypes;
@@ -155,6 +158,13 @@ public class RepositoryBrowserServlet extends HttpServlet {
 
 			_sendResponse(httpServletResponse, HttpServletResponse.SC_OK);
 		}
+		catch (DuplicateFileEntryException | DuplicateFolderNameException
+					exception) {
+
+			SessionErrors.add(httpServletRequest, exception.getClass());
+
+			_sendResponse(httpServletResponse, HttpServletResponse.SC_CONFLICT);
+		}
 		catch (PortalException portalException) {
 			throw new ServletException(portalException);
 		}
@@ -227,6 +237,13 @@ public class RepositoryBrowserServlet extends HttpServlet {
 				"your-request-completed-successfully");
 
 			_sendResponse(httpServletResponse, HttpServletResponse.SC_OK);
+		}
+		catch (DuplicateFileEntryException | DuplicateFolderNameException
+					exception) {
+
+			SessionErrors.add(httpServletRequest, exception.getClass());
+
+			_sendResponse(httpServletResponse, HttpServletResponse.SC_CONFLICT);
 		}
 		catch (PortalException portalException) {
 			throw new ServletException(portalException);

--- a/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/repository_browser/init.jsp
+++ b/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/repository_browser/init.jsp
@@ -25,6 +25,8 @@ taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/site-navigation" prefix="liferay-site-navigation" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
-<%@ page import="com.liferay.document.library.taglib.internal.display.context.RepositoryBrowserTagDisplayContext" %><%@
+<%@ page import="com.liferay.document.library.kernel.exception.DuplicateFileEntryException" %><%@
+page import="com.liferay.document.library.kernel.exception.DuplicateFolderNameException" %><%@
+page import="com.liferay.document.library.taglib.internal.display.context.RepositoryBrowserTagDisplayContext" %><%@
 page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
 page import="com.liferay.portal.kernel.util.HtmlUtil" %>

--- a/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/repository_browser/page.jsp
+++ b/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/repository_browser/page.jsp
@@ -27,6 +27,9 @@ RepositoryBrowserTagDisplayContext repositoryBrowserTagDisplayContext = (Reposit
 />
 
 <clay:container-fluid>
+	<liferay-ui:error exception="<%= DuplicateFileEntryException.class %>" message="please-enter-a-unique-name" />
+	<liferay-ui:error exception="<%= DuplicateFolderNameException.class %>" message="please-enter-a-unique-name" />
+
 	<liferay-site-navigation:breadcrumb
 		breadcrumbEntries="<%= repositoryBrowserTagDisplayContext.getBreadcrumbEntries() %>"
 	/>


### PR DESCRIPTION
# What is this about?

https://issues.liferay.com/browse/LPS-169909

When trying to create a duplicate entry (document or folder) no error is displayed in the UI, and an exception is logged.

Handle the error in the backend and display an error message to the user.

# How do I test it?

Follow the steps described in https://issues.liferay.com/browse/LPS-169909.