### PR TITLE
LPS-166740 Can not delete KB Display Page Template

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/action/UpdateKBArticleMVCActionCommand.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/action/UpdateKBArticleMVCActionCommand.java
@@ -161,7 +161,7 @@ public class UpdateKBArticleMVCActionCommand
 		}
 
 		_assetDisplayPageEntryFormProcessor.process(
-			KBArticle.class.getName(), kbArticle.getKbArticleId(),
+			KBArticle.class.getName(), kbArticle.getResourcePrimKey(),
 			actionRequest);
 
 		int workflowAction = ParamUtil.getInteger(

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_kb_article.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_kb_article.jsp
@@ -136,7 +136,7 @@ if (editKBArticleDisplayContext.isPortletTitleBasedNavigation()) {
 					>
 						<liferay-asset:select-asset-display-page
 							classNameId="<%= PortalUtil.getClassNameId(KBArticle.class) %>"
-							classPK="<%= editKBArticleDisplayContext.getKBArticleId() %>"
+							classPK="<%= editKBArticleDisplayContext.getResourcePrimKey() %>"
 							groupId="<%= scopeGroupId %>"
 							showViewInContextLink="<%= true %>"
 						/>


### PR DESCRIPTION
- LPS-166740 asset display page should be linked to the article not the version
- LPS-166740 obtain the asset display page by the resource prim key, that it is the id from the kbArticle not the version


If we link the asset display page to the KBArticle (resourcePrimKey) not to the version, we can delete it properly