### PR TITLE
LPS-171232 The description field can not be displayed after enabling it on the widget

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/init.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/init.jsp
@@ -31,6 +31,7 @@ if (resourceClassNameId == 0) {
 
 long resourcePrimKey = GetterUtil.getLong(request.getAttribute("init.jsp-resourcePrimKey"));
 
+boolean enableKBArticleDescription = GetterUtil.getBoolean(request.getAttribute("init.jsp-enableKBArticleDescription"));
 boolean enableKBArticleRatings = GetterUtil.getBoolean(request.getAttribute("init.jsp-enableKBArticleRatings"));
 boolean showKBArticleAssetEntries = GetterUtil.getBoolean(request.getAttribute("init.jsp-showKBArticleAssetEntries"));
 boolean showKBArticleAttachments = GetterUtil.getBoolean(request.getAttribute("init.jsp-showKBArticleAttachments"));

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/view_kb_article.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/view_kb_article.jsp
@@ -176,6 +176,16 @@ if (portletTitleBasedNavigation) {
 					/>
 				</liferay-expando:custom-attributes-available>
 
+				<c:if test="<%= enableKBArticleDescription && Validator.isNotNull(kbArticle.getDescription()) %>">
+					<div class="kb-attachments">
+						<h5 class="text-default"><liferay-ui:message key="description" /></h5>
+
+						<p class="text-default">
+							<%= HtmlUtil.escape(kbArticle.getDescription()) %>
+						</p>
+					</div>
+				</c:if>
+
 				<liferay-util:include page="/admin/common/kb_article_assets.jsp" servletContext="<%= application %>" />
 
 				<c:if test="<%= showKBArticleAttachments %>">


### PR DESCRIPTION
Hi, 
This is the PR for the ticket https://issues.liferay.com/browse/LPS-171232.
Please review this and leave your comments.
Thank you.

**Summary:**
There is no implementation for displaying descriptions on KB widget
**Reproduce Step:**
Please see the ticket https://issues.liferay.com/browse/LPS-171232
**Solution:**
Add new implementation for description displaying

CC: @ces-huynguyen