### PR TITLE
[TS] LPS-171566 An error occurs when accessing a file using a URL without a UUID if the file name contains a + or a %

### DIFF
--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/helper/DLURLHelperImpl.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/helper/DLURLHelperImpl.java
@@ -517,7 +517,7 @@ public class DLURLHelperImpl implements DLURLHelper {
 			fileName = _trashHelper.getOriginalTitle(fileEntry.getFileName());
 		}
 
-		sb.append(URLCodec.encodeURL(_html.unescape(fileName)));
+		sb.append(URLCodec.encodeURL(_html.unescape(fileName), true));
 
 		sb.append(StringPool.SLASH);
 		sb.append(URLCodec.encodeURL(fileEntry.getUuid()));

--- a/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
+++ b/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
@@ -1296,8 +1296,7 @@ public class WebServerServlet extends HttpServlet {
 			return;
 		}
 
-		String fileName = HttpComponentsUtil.decodeURL(
-			HtmlUtil.escape(pathArray[2]));
+		String fileName = HtmlUtil.escape(pathArray[2]);
 
 		if (Validator.isNull(fileName)) {
 			throw new NoSuchFileEntryException("Invalid path " + path);
@@ -1400,7 +1399,7 @@ public class WebServerServlet extends HttpServlet {
 		else if (pathArray.length == 3) {
 			long groupId = GetterUtil.getLong(pathArray[0]);
 			long folderId = GetterUtil.getLong(pathArray[1]);
-			String fileName = HttpComponentsUtil.decodeURL(pathArray[2]);
+			String fileName = pathArray[2];
 
 			try {
 				try {
@@ -1730,7 +1729,7 @@ public class WebServerServlet extends HttpServlet {
 			long groupId = GetterUtil.getLong(pathArray[0]);
 			long folderId = GetterUtil.getLong(pathArray[1]);
 
-			String fileName = HttpComponentsUtil.decodeURL(pathArray[2]);
+			String fileName = pathArray[2];
 
 			if (fileName.contains(StringPool.QUESTION)) {
 				fileName = fileName.substring(


### PR DESCRIPTION
## Motivation

https://issues.liferay.com/browse/LPS-171566
https://issues.liferay.com/browse/PTR-3533

## Problem overview

`HttpServletRequest.getPathInfo` returns the path decoded:

* https://docs.oracle.com/javaee/6/api/javax/servlet/http/HttpServletRequest.html#getPathInfo()

However, Liferay tries to decode it again after the following sequence of calls, even though doing so would be wrong:

* `VirtualHostFilter.isDocumentFriendlyURL`: https://github.com/liferay/liferay-portal/blob/7.4.3.54-ga54/portal-impl/src/com/liferay/portal/servlet/filters/virtualhost/VirtualHostFilter.java#L106-L107
* `WebServerServlet.hasFiles`: https://github.com/liferay/liferay-portal/blob/7.4.3.54-ga54/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java#L237-L242
* `WebServerServlet._checkFileEntry`: https://github.com/liferay/liferay-portal/blob/7.4.3.54-ga54/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java#L1401-L1404

As a result, any file that contains the special characters `%` or `+` winds up getting mangled by the second URL decode.

## Proposed solution

Remove the unnecessary URL decode.

## Steps to verify

You can run through the steps if you wish to check to see that it can properly fetch the file. If you just want to see if the API changes are working, we can check the `NoSuchFileException` to see if it decoded the `+` in the file entry path. To do the latter, we run the following Groovy script on a clean bundle to force it to throw an exception:

```groovy
String[] pathArray = ["20121", "0", "abc+def.png"]
try {
	com.liferay.portal.webserver.WebServerServlet._checkFileEntry(pathArray)
}
catch (Exception e) {
	e.printStackTrace(out)
}
```

An environment with the fix will show the following exception with `abc+def.png`:
```
com.liferay.document.library.kernel.exception.NoSuchFileEntryException:
No DLFileEntry exists with the key {groupId=20121, folderId=0, title=abc+def.png}
```

An environment without the fix will show the following exception with `abc def.png`:
```
com.liferay.document.library.kernel.exception.NoSuchFileEntryException:
No DLFileEntry exists with the key {groupId=20121, folderId=0, title=abc def.png}
```