### PR TITLE
LPS-157175 | Automate LPS-148397

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/DMFolder.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/DMFolder.macro
@@ -146,6 +146,34 @@ definition {
 		DMFolder.viewEntryPresent(dmFolderName = "${mgFolderName}");
 	}
 
+	macro assertExpectedFileNames {
+		var tempDir = PropsUtil.get("output.dir.name");
+
+		var fileName = FileUtil.exists("${tempDir}/${key_fileName}");
+
+		if ("${fileName}" == "false") {
+			fail("Filename "${fileName}" was not expected.");
+		}
+	}
+
+	macro assertExpectedFileNumber {
+		var tempDir = PropsUtil.get("output.dir.name");
+
+		var folderPath = "${tempDir}";
+
+		if (isSet(key_folder)) {
+			var folderPath = "${folderPath}${key_folder}";
+		}
+
+		var fileList = FileUtil.listFiles("${folderPath}");
+
+		var listSize = ListUtil.size("${fileList}");
+
+		if ("${listSize}" != "${expectedFileNumber}") {
+			fail("Number of files on "${key_folder}" differ from expected.");
+		}
+	}
+
 	macro cannotViewCP {
 		var key_dmFolderName = "${dmFolderName}";
 
@@ -249,6 +277,14 @@ definition {
 		VerifyElementPresent(locator1 = "Message#SUCCESS");
 
 		AssertElementNotPresent(locator1 = "DocumentsAndMedia#DESCRIPTIVE_LIST_FOLDER_ICON");
+	}
+
+	macro downloadViaEllipsisMenu {
+		Click(
+			key_rowEntry = "${dmFolderName}",
+			locator1 = "Icon#ROW_VERTICAL_ELLIPSIS");
+
+		MenuItem.click(menuItem = "Download");
 	}
 
 	macro editCP {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMFileEntry.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMFileEntry.testcase
@@ -2893,6 +2893,58 @@ definition {
 		BlogsEntry.viewInlineImage(uploadFileName = "static-gif");
 	}
 
+	@description = "This test covers LPS-157175. Check that there is no corrupted filename on downloaded folder."
+	@priority = "3"
+	test NoCorruptedNameInDownloadedZip {
+		JSONFolder.addFolder(
+			dmFolderName = "日本語フォルダ1",
+			groupName = "Guest");
+
+		JSONDocument.addFileWithUploadedFile(
+			dmDocumentTitle = "Document_1.doc",
+			folderName = "日本語フォルダ1",
+			groupName = "Guest",
+			mimeType = "application/msword",
+			sourceFileName = "Document_1.doc");
+
+		JSONFolder.addFolder(
+			dmFolderName = "日本語フォルダ2",
+			groupName = "Guest",
+			parentFolderName = "日本語フォルダ1");
+
+		JSONDocument.addFileWithUploadedFile(
+			dmDocumentTitle = "Document_2.doc",
+			folderName = "日本語フォルダ2",
+			groupName = "Guest",
+			mimeType = "application/msword",
+			parentFolderName = "日本語フォルダ1",
+			sourceFileName = "Document_2.doc");
+
+		DMNavigator.openDocumentsAndMediaAdmin(siteURLKey = "Guest");
+
+		DMFolder.downloadViaEllipsisMenu(dmFolderName = "日本語フォルダ1");
+
+		AntCommand(
+			locator1 = "build-test.xml",
+			value1 = "unzip-temp-file -DfileName=日本語フォルダ1.zip");
+
+		DMFolder.assertExpectedFileNames(key_fileName = "日本語フォルダ1.zip");
+
+		DMFolder.assertExpectedFileNames(key_fileName = "Document_1.doc");
+
+		DMFolder.assertExpectedFileNames(key_fileName = "日本語フォルダ2");
+
+		DMFolder.assertExpectedFileNames(key_fileName = "日本語フォルダ2/Document_2.doc");
+
+		DMFolder.assertExpectedFileNumber(
+			expectedFileNumber = "3",
+			key_folder = "");
+
+		DMFolder.assertExpectedFileNumber(
+			expectedFileNumber = "1",
+			key_folder = "/日本語フォルダ2");
+	}
+
 	@description = "This test covers LPS-144687. It validates that a temp zip is not created if NoSuchFileException occurs during a download."
 	@priority = "4"
 	test NoZipFileIsCreatedIfDownloadResultsInError {


### PR DESCRIPTION
Description: Creation of Priority 3 test to verify that when we download a zip file with a given structure, and we unzip it, there are no corrupted filenames as described in [LPS-148397](https://issues.liferay.com/browse/LPS-148397)

Jira Ticket: https://issues.liferay.com/browse/LPS-157175