### PR TITLE
LPS-169428 MediaGallery input security bug

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/image_gallery_display/view_images.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/image_gallery_display/view_images.jsp
@@ -36,6 +36,8 @@ DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper = new DLPortletI
 			<c:when test="<%= fileEntry != null %>">
 
 				<%
+				row.setPrimaryKey(String.valueOf(fileEntry.getFileEntryId()));
+
 				String dataOptions = StringPool.BLANK;
 
 				FileVersion fileVersion = fileEntry.getFileVersion();
@@ -151,6 +153,8 @@ DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper = new DLPortletI
 
 				<%
 				row.setCssClass("card-page-item card-page-item-directory");
+
+				row.setPrimaryKey(String.valueOf(curFolder.getPrimaryKey()));
 
 				request.setAttribute(WebKeys.SEARCH_CONTAINER_RESULT_ROW, row);
 				%>


### PR DESCRIPTION
Issue https://issues.liferay.com/browse/LPS-169428

Apparently search container sets an [input with all the primary keys](https://github.com/ambrinchaudhary/liferay-portal/blame/LPS-169428_MediaGallery_input_security/portal-web/docroot/html/taglib/ui/search_iterator/deprecated/list.jsp#L384-L384). By default, these are the [model](https://github.com/ambrinchaudhary/liferay-portal/blame/LPS-169428_MediaGallery_input_security/util-taglib/src/com/liferay/taglib/ui/SearchContainerRowTag.java#L310-L310) in json format. 

I changed it to set only the id's of the entries shown in the media gallery, so it does not contain any internal info

<img width="1077" alt="Screenshot 2023-01-05 at 11 59 55" src="https://user-images.githubusercontent.com/8373764/210765773-d10e8e36-f355-4f53-afec-c101c83f2777.png">
