### PR TITLE
[TS] LPP-47606 > LPS-172261 | Modified Date is displayed incorrectly

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp
@@ -145,7 +145,7 @@ DLViewEntriesDisplayContext dlViewEntriesDisplayContext = new DLViewEntriesDispl
 													</aui:a>
 
 													<div class="card-subtitle text-truncate">
-														<%= LanguageUtil.format(request, "x-ago-by-x", new String[] {LanguageUtil.getTimeDescription(locale, System.currentTimeMillis() - latestFileVersion.getCreateDate().getTime(), true), HtmlUtil.escape(latestFileVersion.getUserName())}, false) %>
+														<%= LanguageUtil.format(request, "modified-x-ago-by-x", new String[] {LanguageUtil.getTimeDescription(locale, System.currentTimeMillis() - fileEntry.getModifiedDate().getTime(), true), HtmlUtil.escape(latestFileVersion.getUserName())}, false) %>
 													</div>
 
 													<div class="card-detail">
@@ -299,7 +299,7 @@ DLViewEntriesDisplayContext dlViewEntriesDisplayContext = new DLViewEntriesDispl
 										<liferay-ui:search-container-column-date
 											cssClass="table-cell-expand-smallest table-cell-ws-nowrap"
 											name="modified-date"
-											value="<%= latestFileVersion.getModifiedDate() %>"
+											value="<%= fileEntry.getModifiedDate() %>"
 										/>
 									</c:when>
 									<c:when test='<%= curEntryColumn.equals("action") %>'>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry_descriptive.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry_descriptive.jsp
@@ -57,7 +57,7 @@ if ((user.getUserId() == fileEntry.getUserId()) || permissionChecker.isContentRe
 
 latestFileVersion = latestFileVersion.toEscapedModel();
 
-Date modifiedDate = latestFileVersion.getModifiedDate();
+Date modifiedDate = fileEntry.getModifiedDate();
 
 String modifiedDateDescription = LanguageUtil.getTimeDescription(request, System.currentTimeMillis() - modifiedDate.getTime(), true);
 
@@ -90,7 +90,7 @@ else {
 </h2>
 
 <span>
-	<liferay-ui:message arguments="<%= new String[] {HtmlUtil.escape(latestFileVersion.getUserName()), modifiedDateDescription} %>" key="x-modified-x-ago" />
+	<liferay-ui:message arguments="<%= new String[] {modifiedDateDescription, HtmlUtil.escape(latestFileVersion.getUserName())} %>" key="modified-x-ago-by-x" />
 </span>
 <span>
 	<%= DLUtil.getAbsolutePath(liferayPortletRequest, fileEntry.getFolderId()).replace(StringPool.RAQUO_CHAR, StringPool.GREATER_THAN) %>


### PR DESCRIPTION
Motivation
=======
This work solves the problem reported in the [LPS-172261](https://issues.liferay.com/browse/LPS-172261) ticket.
cc: @TaiPhamLR @tototrinh 

Proposed Solution
========
Cause:
   - The modified date that displays on the "Documents and Media" UI is fetched from `DLFileVersion`.
   After updating the Permissions of a document, no records will be added to `DLFileVersion`. A new `DLFileVersion` record will be added when the user edits the document (use the 'Edit' action).
   Both actions can make updating the modified date of the document in table `DLFileEntry`.

What we did to solve this problem:
   - Using modified date from `DLFileEntry` for displaying.

Steps to Verify
========
1. Go to Default site > Content & Data > Documents and Media
2. Upload several documents (wait a few minutes between each upload)
3. Update a document permission settings
4. Sort Modified Date + descending-order

- Actual result: The document appears at the top of the list even though the Modified Date has not been updated.
- Expected result: The Modified Date is shown correctly.