### PR TITLE
LPS-172117 Default canonical URLs are html escaped

### DIFF
--- a/modules/apps/layout/layout-seo-web/src/main/java/com/liferay/layout/seo/web/internal/display/context/LayoutsSEODisplayContext.java
+++ b/modules/apps/layout/layout-seo-web/src/main/java/com/liferay/layout/seo/web/internal/display/context/LayoutsSEODisplayContext.java
@@ -65,6 +65,7 @@ import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.URLCodec;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portlet.display.template.PortletDisplayTemplate;
@@ -156,8 +157,9 @@ public class LayoutsSEODisplayContext {
 	}
 
 	public String getDefaultCanonicalURL() throws PortalException {
-		return _layoutSEOCanonicalURLProvider.getDefaultCanonicalURL(
-			_selLayout, _themeDisplay);
+		return URLCodec.decodeURL(
+			_layoutSEOCanonicalURLProvider.getDefaultCanonicalURL(
+				_selLayout, _themeDisplay));
 	}
 
 	public Map<Locale, String> getDefaultCanonicalURLMap()

--- a/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/js/seo/PreviewSeo.es.js
+++ b/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/js/seo/PreviewSeo.es.js
@@ -37,7 +37,7 @@ const PreviewSeo = ({
 			{titleSuffix && ` - ${titleSuffix}`}
 		</div>,
 		<div className="preview-seo-url text-truncate" key="url">
-			{url}
+			{decodeURIComponent(url)}
 		</div>,
 	];
 


### PR DESCRIPTION
- LPS-172117 decode the default canonical url
- LPS-172117 decode uri from the url from the map of the canonical urls


![image](https://user-images.githubusercontent.com/47524751/211582524-9e5bc257-8fc0-48d2-ac60-019892dfa81f.png)
