### PR TITLE
LPS-151172 Make basic document type company scoped

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-image-test/src/testIntegration/java/com/liferay/adaptive/media/image/service/impl/test/AMImageEntryLocalServiceTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-test/src/testIntegration/java/com/liferay/adaptive/media/image/service/impl/test/AMImageEntryLocalServiceTest.java
@@ -22,9 +22,10 @@ import com.liferay.adaptive.media.image.model.AMImageEntry;
 import com.liferay.adaptive.media.image.service.AMImageEntryLocalServiceUtil;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.document.library.kernel.model.DLFileEntry;
-import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
+import com.liferay.document.library.kernel.model.DLFileEntryType;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalServiceUtil;
+import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalServiceUtil;
 import com.liferay.document.library.kernel.store.DLStoreUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -699,13 +700,17 @@ public class AMImageEntryLocalServiceTest {
 			ServiceContext serviceContext)
 		throws PortalException {
 
+		DLFileEntryType basicDocumentDLFileEntryType =
+			DLFileEntryTypeLocalServiceUtil.getBasicDocumentDLFileEntryType(
+				serviceContext.getCompanyId());
+
 		DLFileEntry dlFileEntry = DLFileEntryLocalServiceUtil.addFileEntry(
 			null, userId, groupId, groupId,
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), ContentTypes.IMAGE_JPEG,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			StringPool.BLANK, StringPool.BLANK,
-			DLFileEntryTypeConstants.COMPANY_ID_BASIC_DOCUMENT,
+			basicDocumentDLFileEntryType.getFileEntryTypeId(),
 			Collections.emptyMap(), null, new UnsyncByteArrayInputStream(bytes),
 			bytes.length, null, null, serviceContext);
 

--- a/modules/apps/analytics/analytics-layout-page-template-test/src/testIntegration/java/com/liferay/analytics/layout/page/template/web/internal/servlet/taglib/test/AnalyticsRenderFragmentLayoutPostDynamicIncludeTest.java
+++ b/modules/apps/analytics/analytics-layout-page-template-test/src/testIntegration/java/com/liferay/analytics/layout/page/template/web/internal/servlet/taglib/test/AnalyticsRenderFragmentLayoutPostDynamicIncludeTest.java
@@ -32,7 +32,6 @@ import com.liferay.portal.kernel.model.ClassName;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
-import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.servlet.taglib.DynamicInclude;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
@@ -114,7 +113,8 @@ public class AnalyticsRenderFragmentLayoutPostDynamicIncludeTest {
 			FileUtil.getBytes(
 				AnalyticsRenderFragmentLayoutPreDynamicIncludeTest.class,
 				"dependencies/image.jpg"),
-			null, null, new ServiceContext());
+			null, null,
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
 
 		mockHttpServletRequest.setAttribute(
 			LayoutDisplayPageWebKeys.LAYOUT_DISPLAY_PAGE_OBJECT_PROVIDER,

--- a/modules/apps/asset/asset-list-service/bnd.bnd
+++ b/modules/apps/asset/asset-list-service/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Asset List Service
 Bundle-SymbolicName: com.liferay.asset.list.service
 Bundle-Version: 3.0.52
-Liferay-Require-SchemaVersion: 2.0.0
+Liferay-Require-SchemaVersion: 2.0.1
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/upgrade/registry/AssetListServiceUpgradeStepRegistrator.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/upgrade/registry/AssetListServiceUpgradeStepRegistrator.java
@@ -94,6 +94,11 @@ public class AssetListServiceUpgradeStepRegistrator
 			UpgradeProcessFactory.dropColumns(
 				"AssetListEntryUsage", "assetListEntryId", "classPK",
 				"portletId"));
+
+		registry.register(
+			"2.0.0", "2.0.1",
+			new com.liferay.asset.list.internal.upgrade.v2_0_1.
+				AssetListEntryUpgradeProcess());
 	}
 
 	@Reference

--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/upgrade/v2_0_1/AssetListEntryUpgradeProcess.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/upgrade/v2_0_1/AssetListEntryUpgradeProcess.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.asset.list.internal.upgrade.v2_0_1;
+
+import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
+import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
+import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+/**
+ * @author Adolfo Pérez
+ */
+public class AssetListEntryUpgradeProcess extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		try (PreparedStatement preparedStatement1 = connection.prepareStatement(
+				"select companyId, fileEntryTypeId from DLFileEntryType " +
+					"where groupId = ? and fileEntryTypeKey = ?");
+			PreparedStatement preparedStatement2 =
+				AutoBatchPreparedStatementUtil.autoBatch(
+					connection,
+					"update AssetListEntry set assetEntrySubType = ? where " +
+						"companyId = ? and assetEntryType = ?")) {
+
+			preparedStatement1.setLong(1, GroupConstants.DEFAULT_LIVE_GROUP_ID);
+			preparedStatement1.setString(
+				2, DLFileEntryTypeConstants.FILE_ENTRY_TYPE_KEY_BASIC_DOCUMENT);
+
+			try (ResultSet resultSet = preparedStatement1.executeQuery()) {
+				while (resultSet.next()) {
+					preparedStatement2.setLong(
+						1, resultSet.getLong("fileEntryTypeId"));
+					preparedStatement2.setLong(
+						2, resultSet.getLong("companyId"));
+					preparedStatement2.setString(
+						3, DLFileEntry.class.getName());
+
+					preparedStatement2.addBatch();
+				}
+
+				preparedStatement2.executeBatch();
+			}
+		}
+	}
+
+}

--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/exportimport/portlet/preferences/processor/AssetPublisherExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/exportimport/portlet/preferences/processor/AssetPublisherExportImportPortletPreferencesProcessor.java
@@ -394,7 +394,9 @@ public class AssetPublisherExportImportPortletPreferencesProcessor
 					if (preloaded) {
 						dlFileEntryType =
 							dlFileEntryTypeLocalService.fetchFileEntryType(
-								companyGroupId, fileEntryTypeKey);
+								companyGroupId,
+								portletDataContext.getCompanyId(),
+								fileEntryTypeKey);
 					}
 				}
 			}

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/change/tracking/test/CPAttachmentFileEntryTableReferenceDefinitionTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/change/tracking/test/CPAttachmentFileEntryTableReferenceDefinitionTest.java
@@ -83,7 +83,8 @@ public class CPAttachmentFileEntryTableReferenceDefinitionTest
 			_serviceContext);
 
 		DLFileEntryType basicDocumentDLFileEntryType =
-			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType();
+			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType(
+				group.getCompanyId());
 
 		byte[] bytes = TestDataConstants.TEST_BYTE_ARRAY;
 

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/change/tracking/test/CPAttachmentFileEntryTableReferenceDefinitionTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/change/tracking/test/CPAttachmentFileEntryTableReferenceDefinitionTest.java
@@ -24,10 +24,11 @@ import com.liferay.commerce.product.service.CommerceCatalogLocalService;
 import com.liferay.commerce.product.test.util.CPTestUtil;
 import com.liferay.commerce.product.type.simple.constants.SimpleCPTypeConstants;
 import com.liferay.document.library.kernel.model.DLFileEntry;
-import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
+import com.liferay.document.library.kernel.model.DLFileEntryType;
 import com.liferay.document.library.kernel.model.DLFolder;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
+import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalService;
 import com.liferay.document.library.kernel.service.DLFolderLocalService;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.change.tracking.CTModel;
@@ -81,6 +82,9 @@ public class CPAttachmentFileEntryTableReferenceDefinitionTest
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(), false,
 			_serviceContext);
 
+		DLFileEntryType basicDocumentDLFileEntryType =
+			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType();
+
 		byte[] bytes = TestDataConstants.TEST_BYTE_ARRAY;
 
 		InputStream inputStream = new ByteArrayInputStream(bytes);
@@ -91,8 +95,8 @@ public class CPAttachmentFileEntryTableReferenceDefinitionTest
 			RandomTestUtil.randomString(), ContentTypes.TEXT_PLAIN,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			StringPool.BLANK, StringPool.BLANK,
-			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT, null,
-			null, inputStream, bytes.length, null, null, _serviceContext);
+			basicDocumentDLFileEntryType.getFileEntryTypeId(), null, null,
+			inputStream, bytes.length, null, null, _serviceContext);
 
 		CommerceCatalog commerceCatalog =
 			_commerceCatalogLocalService.addCommerceCatalog(
@@ -132,6 +136,10 @@ public class CPAttachmentFileEntryTableReferenceDefinitionTest
 
 	private CPDefinition _cpDefinition;
 	private DLFileEntry _dlFileEntry;
+
+	@Inject
+	private DLFileEntryTypeLocalService _dlFileEntryTypeLocalService;
+
 	private ServiceContext _serviceContext;
 
 }

--- a/modules/apps/commerce/commerce-shop-by-diagram-test/src/testIntegration/java/com/liferay/commerce/shop/by/diagram/change/tracking/test/CSDiagramSettingTableReferenceDefinitionTest.java
+++ b/modules/apps/commerce/commerce-shop-by-diagram-test/src/testIntegration/java/com/liferay/commerce/shop/by/diagram/change/tracking/test/CSDiagramSettingTableReferenceDefinitionTest.java
@@ -25,10 +25,11 @@ import com.liferay.commerce.product.service.CommerceCatalogLocalService;
 import com.liferay.commerce.product.test.util.CPTestUtil;
 import com.liferay.commerce.shop.by.diagram.service.CSDiagramSettingLocalService;
 import com.liferay.document.library.kernel.model.DLFileEntry;
-import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
+import com.liferay.document.library.kernel.model.DLFileEntryType;
 import com.liferay.document.library.kernel.model.DLFolder;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
+import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalService;
 import com.liferay.document.library.kernel.service.DLFolderLocalService;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.change.tracking.CTModel;
@@ -82,6 +83,9 @@ public class CSDiagramSettingTableReferenceDefinitionTest
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(), false,
 			_serviceContext);
 
+		DLFileEntryType basicDocumentDLFileEntryType =
+			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType();
+
 		byte[] bytes = TestDataConstants.TEST_BYTE_ARRAY;
 
 		InputStream inputStream = new ByteArrayInputStream(bytes);
@@ -91,9 +95,8 @@ public class CSDiagramSettingTableReferenceDefinitionTest
 			dlFolder.getRepositoryId(), dlFolder.getFolderId(),
 			RandomTestUtil.randomString(), ContentTypes.TEXT_PLAIN,
 			RandomTestUtil.randomString(), StringPool.BLANK, StringPool.BLANK,
-			StringPool.BLANK,
-			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT, null,
-			null, inputStream, bytes.length, null, null, _serviceContext);
+			StringPool.BLANK, basicDocumentDLFileEntryType.getFileEntryTypeId(),
+			null, null, inputStream, bytes.length, null, null, _serviceContext);
 
 		CommerceCatalog commerceCatalog =
 			_commerceCatalogLocalService.addCommerceCatalog(
@@ -145,6 +148,10 @@ public class CSDiagramSettingTableReferenceDefinitionTest
 
 	private CPDefinition _cpDefinition;
 	private DLFileEntry _dlFileEntry;
+
+	@Inject
+	private DLFileEntryTypeLocalService _dlFileEntryTypeLocalService;
+
 	private ServiceContext _serviceContext;
 
 }

--- a/modules/apps/commerce/commerce-shop-by-diagram-test/src/testIntegration/java/com/liferay/commerce/shop/by/diagram/change/tracking/test/CSDiagramSettingTableReferenceDefinitionTest.java
+++ b/modules/apps/commerce/commerce-shop-by-diagram-test/src/testIntegration/java/com/liferay/commerce/shop/by/diagram/change/tracking/test/CSDiagramSettingTableReferenceDefinitionTest.java
@@ -84,7 +84,8 @@ public class CSDiagramSettingTableReferenceDefinitionTest
 			_serviceContext);
 
 		DLFileEntryType basicDocumentDLFileEntryType =
-			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType();
+			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType(
+				group.getCompanyId());
 
 		byte[] bytes = TestDataConstants.TEST_BYTE_ARRAY;
 

--- a/modules/apps/content-dashboard/content-dashboard-document-library-impl/src/main/java/com/liferay/content/dashboard/document/library/internal/item/type/DLFileEntryTypeContentDashboardItemSubtypeFactory.java
+++ b/modules/apps/content-dashboard/content-dashboard-document-library-impl/src/main/java/com/liferay/content/dashboard/document/library/internal/item/type/DLFileEntryTypeContentDashboardItemSubtypeFactory.java
@@ -39,10 +39,12 @@ public class DLFileEntryTypeContentDashboardItemSubtypeFactory
 			long classPK, long entryClassPK)
 		throws PortalException {
 
-		DLFileEntryType basicDocumentDLFileEntryType =
-			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType();
 		DLFileEntryType dlFileEntryType =
 			_dlFileEntryTypeLocalService.getFileEntryType(classPK);
+
+		DLFileEntryType basicDocumentDLFileEntryType =
+			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType(
+				dlFileEntryType.getCompanyId());
 
 		return new DLFileEntryTypeContentDashboardItemSubtype(
 			basicDocumentDLFileEntryType,

--- a/modules/apps/content-dashboard/content-dashboard-document-library-impl/src/main/java/com/liferay/content/dashboard/document/library/internal/item/type/DLFileEntryTypeContentDashboardItemSubtypeFactory.java
+++ b/modules/apps/content-dashboard/content-dashboard-document-library-impl/src/main/java/com/liferay/content/dashboard/document/library/internal/item/type/DLFileEntryTypeContentDashboardItemSubtypeFactory.java
@@ -18,7 +18,6 @@ import com.liferay.content.dashboard.document.library.internal.item.provider.Fil
 import com.liferay.content.dashboard.item.type.ContentDashboardItemSubtype;
 import com.liferay.content.dashboard.item.type.ContentDashboardItemSubtypeFactory;
 import com.liferay.document.library.kernel.model.DLFileEntryType;
-import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
 import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalService;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -41,8 +40,7 @@ public class DLFileEntryTypeContentDashboardItemSubtypeFactory
 		throws PortalException {
 
 		DLFileEntryType basicDocumentDLFileEntryType =
-			_dlFileEntryTypeLocalService.fetchDLFileEntryType(
-				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT);
+			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType();
 		DLFileEntryType dlFileEntryType =
 			_dlFileEntryTypeLocalService.getFileEntryType(classPK);
 

--- a/modules/apps/content-dashboard/content-dashboard-document-library-test/src/testIntegration/java/com/liferay/content/dashboard/document/library/internal/item/item/test/FileEntryContentDashboardItemTest.java
+++ b/modules/apps/content-dashboard/content-dashboard-document-library-test/src/testIntegration/java/com/liferay/content/dashboard/document/library/internal/item/item/test/FileEntryContentDashboardItemTest.java
@@ -28,10 +28,12 @@ import com.liferay.content.dashboard.item.ContentDashboardItemVersion;
 import com.liferay.content.dashboard.item.VersionableContentDashboardItem;
 import com.liferay.content.dashboard.item.action.ContentDashboardItemAction;
 import com.liferay.content.dashboard.item.type.ContentDashboardItemSubtype;
+import com.liferay.document.library.kernel.model.DLFileEntryType;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.model.DLVersionNumberIncrease;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
+import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalService;
 import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeConstants;
 import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalService;
@@ -713,10 +715,15 @@ public class FileEntryContentDashboardItemTest {
 			fileEntry.getExpirationDate(), fileEntry.getReviewDate(),
 			serviceContext);
 
+		DLFileEntryType basicDocumentDLFileEntryType =
+			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType(
+				_group.getCompanyId());
+
 		LayoutPageTemplateEntry layoutPageTemplateEntry =
 			_layoutPageTemplateEntryLocalService.addLayoutPageTemplateEntry(
 				_group.getCreatorUserId(), _group.getGroupId(), 0,
-				_portal.getClassNameId(FileEntry.class.getName()), 0,
+				_portal.getClassNameId(FileEntry.class.getName()),
+				basicDocumentDLFileEntryType.getFileEntryTypeId(),
 				RandomTestUtil.randomString(),
 				LayoutPageTemplateEntryTypeConstants.TYPE_DISPLAY_PAGE, 0, true,
 				0, 0, 0, 0, serviceContext);
@@ -765,6 +772,9 @@ public class FileEntryContentDashboardItemTest {
 
 	@Inject
 	private DLFileEntryLocalService _dlFileEntryLocalService;
+
+	@Inject
+	private DLFileEntryTypeLocalService _dlFileEntryTypeLocalService;
 
 	@DeleteAfterTestRun
 	private Group _group;

--- a/modules/apps/content-dashboard/content-dashboard-test/src/testIntegration/java/com/liferay/content/dashboard/web/internal/portlet/test/ContentDashboardAdminPortletTest.java
+++ b/modules/apps/content-dashboard/content-dashboard-test/src/testIntegration/java/com/liferay/content/dashboard/web/internal/portlet/test/ContentDashboardAdminPortletTest.java
@@ -1045,7 +1045,8 @@ public class ContentDashboardAdminPortletTest {
 
 			DLFileEntryType googleDocsDLFileEntryType =
 				DLFileEntryTypeLocalServiceUtil.getFileEntryType(
-					_company.getGroupId(), "GOOGLE_DOCS");
+					_company.getGroupId(), _company.getCompanyId(),
+					"GOOGLE_DOCS");
 
 			googleDriveShortcutFileEntry.setFileEntryTypeId(
 				googleDocsDLFileEntryType.getFileEntryTypeId());

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/item/selector/ContentDashboardItemSubtypeItemSelectorView.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/item/selector/ContentDashboardItemSubtypeItemSelectorView.java
@@ -330,7 +330,8 @@ public class ContentDashboardItemSubtypeItemSelectorView
 
 				DLFileEntryType googleDocsDLFileEntryType =
 					_dlFileEntryTypeLocalService.fetchFileEntryType(
-						company.getGroupId(), "GOOGLE_DOCS");
+						company.getGroupId(), company.getCompanyId(),
+						"GOOGLE_DOCS");
 
 				if (googleDocsDLFileEntryType != null) {
 					String fileEntryTypeIdString = String.valueOf(

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/search/request/ContentDashboardSearchContextBuilder.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/search/request/ContentDashboardSearchContextBuilder.java
@@ -325,7 +325,8 @@ public class ContentDashboardSearchContextBuilder {
 
 			DLFileEntryType googleDocsDLFileEntryType =
 				DLFileEntryTypeLocalServiceUtil.fetchFileEntryType(
-					company.getGroupId(), "GOOGLE_DOCS");
+					company.getGroupId(), company.getCompanyId(),
+					"GOOGLE_DOCS");
 
 			if (googleDocsDLFileEntryType == null) {
 				return Optional.empty();

--- a/modules/apps/depot/depot-test/src/testFunctional/macros/DepotNavigator.macro
+++ b/modules/apps/depot/depot-test/src/testFunctional/macros/DepotNavigator.macro
@@ -412,7 +412,7 @@ definition {
 			}
 		}
 		else {
-			var typeId = 0;
+			var typeId = JSONDLfileentrytype._getBasicFileEntryTypeIdWithCurrentCompany();
 		}
 
 		if (isSet(folderName)) {

--- a/modules/apps/document-library-google-docs/document-library-google-docs/src/main/java/com/liferay/document/library/google/docs/internal/helper/GoogleDocsDLFileEntryTypeHelper.java
+++ b/modules/apps/document-library-google-docs/document-library-google-docs/src/main/java/com/liferay/document/library/google/docs/internal/helper/GoogleDocsDLFileEntryTypeHelper.java
@@ -73,7 +73,8 @@ public class GoogleDocsDLFileEntryTypeHelper {
 
 		DLFileEntryType dlFileEntryType =
 			_dlFileEntryTypeLocalService.fetchDataDefinitionFileEntryType(
-				_company.getGroupId(), ddmStructure.getStructureId());
+				_company.getGroupId(), _company.getCompanyId(),
+				ddmStructure.getStructureId());
 
 		if (dlFileEntryType == null) {
 			_addGoogleDocsDLFileEntryType(ddmStructure.getStructureId());

--- a/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/display/context/DLItemSelectorViewDisplayContext.java
+++ b/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/display/context/DLItemSelectorViewDisplayContext.java
@@ -313,7 +313,7 @@ public class DLItemSelectorViewDisplayContext<T extends ItemSelectorCriterion> {
 				DLFileEntryConstants.getClassName());
 			long defaultFileEntryTypeId =
 				DLFileEntryTypeLocalServiceUtil.getDefaultFileEntryTypeId(
-					getFolderId());
+					_themeDisplay.getCompanyId(), getFolderId());
 
 			for (AssetVocabulary assetVocabulary : assetVocabularies) {
 				if (assetVocabulary.isRequired(
@@ -351,7 +351,7 @@ public class DLItemSelectorViewDisplayContext<T extends ItemSelectorCriterion> {
 					_themeDisplay.getCompanyId(),
 					_themeDisplay.getScopeGroupId(), getFolderId(),
 					DLFileEntryTypeLocalServiceUtil.getDefaultFileEntryTypeId(
-						getFolderId()))) {
+						_themeDisplay.getCompanyId(), getFolderId()))) {
 
 				_showDragAndDropZone = false;
 			}

--- a/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/display/context/DLItemSelectorViewDisplayContext.java
+++ b/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/display/context/DLItemSelectorViewDisplayContext.java
@@ -391,11 +391,13 @@ public class DLItemSelectorViewDisplayContext<T extends ItemSelectorCriterion> {
 	private Long _getFileEntryTypeId(String fileEntryTypeKey) {
 		DLFileEntryType dlFileEntryType =
 			_dlFileEntryTypeLocalService.fetchFileEntryType(
-				_themeDisplay.getScopeGroupId(), fileEntryTypeKey);
+				_themeDisplay.getScopeGroupId(), _themeDisplay.getCompanyId(),
+				fileEntryTypeKey);
 
 		if (dlFileEntryType == null) {
 			dlFileEntryType = _dlFileEntryTypeLocalService.fetchFileEntryType(
-				_themeDisplay.getCompanyGroupId(), fileEntryTypeKey);
+				_themeDisplay.getCompanyGroupId(), _themeDisplay.getCompanyId(),
+				fileEntryTypeKey);
 		}
 
 		if (dlFileEntryType != null) {

--- a/modules/apps/document-library/document-library-repository-external-api/src/main/java/com/liferay/document/library/repository/external/ExtRepositoryAdapter.java
+++ b/modules/apps/document-library/document-library-repository-external-api/src/main/java/com/liferay/document/library/repository/external/ExtRepositoryAdapter.java
@@ -17,10 +17,11 @@ package com.liferay.document.library.repository.external;
 import com.liferay.document.library.kernel.exception.NoSuchFileEntryException;
 import com.liferay.document.library.kernel.exception.NoSuchFileVersionException;
 import com.liferay.document.library.kernel.exception.NoSuchFolderException;
-import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
+import com.liferay.document.library.kernel.model.DLFileEntryType;
 import com.liferay.document.library.kernel.model.DLFolder;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.model.DLVersionNumberIncrease;
+import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalServiceUtil;
 import com.liferay.document.library.kernel.service.DLFolderLocalServiceUtil;
 import com.liferay.document.library.repository.external.model.ExtRepositoryFileEntryAdapter;
 import com.liferay.document.library.repository.external.model.ExtRepositoryFileVersionAdapter;
@@ -345,8 +346,11 @@ public class ExtRepositoryAdapter extends BaseRepositoryImpl {
 			OrderByComparator<FileEntry> orderByComparator)
 		throws PortalException {
 
+		DLFileEntryType basicDocumentDLFileEntryType =
+			DLFileEntryTypeLocalServiceUtil.getBasicDocumentDLFileEntryType();
+
 		if (fileEntryTypeId ==
-				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT) {
+				basicDocumentDLFileEntryType.getFileEntryTypeId()) {
 
 			return getFileEntries(folderId, start, end, orderByComparator);
 		}
@@ -396,8 +400,11 @@ public class ExtRepositoryAdapter extends BaseRepositoryImpl {
 	public int getFileEntriesCount(long folderId, long fileEntryTypeId)
 		throws PortalException {
 
+		DLFileEntryType basicDocumentDLFileEntryType =
+			DLFileEntryTypeLocalServiceUtil.getBasicDocumentDLFileEntryType();
+
 		if (fileEntryTypeId ==
-				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT) {
+				basicDocumentDLFileEntryType.getFileEntryTypeId()) {
 
 			String extRepositoryFolderKey = getExtRepositoryObjectKey(folderId);
 

--- a/modules/apps/document-library/document-library-repository-external-api/src/main/java/com/liferay/document/library/repository/external/ExtRepositoryAdapter.java
+++ b/modules/apps/document-library/document-library-repository-external-api/src/main/java/com/liferay/document/library/repository/external/ExtRepositoryAdapter.java
@@ -346,8 +346,11 @@ public class ExtRepositoryAdapter extends BaseRepositoryImpl {
 			OrderByComparator<FileEntry> orderByComparator)
 		throws PortalException {
 
+		Folder folder = getFolder(folderId);
+
 		DLFileEntryType basicDocumentDLFileEntryType =
-			DLFileEntryTypeLocalServiceUtil.getBasicDocumentDLFileEntryType();
+			DLFileEntryTypeLocalServiceUtil.getBasicDocumentDLFileEntryType(
+				folder.getCompanyId());
 
 		if (fileEntryTypeId ==
 				basicDocumentDLFileEntryType.getFileEntryTypeId()) {
@@ -400,8 +403,11 @@ public class ExtRepositoryAdapter extends BaseRepositoryImpl {
 	public int getFileEntriesCount(long folderId, long fileEntryTypeId)
 		throws PortalException {
 
+		Folder folder = getFolder(folderId);
+
 		DLFileEntryType basicDocumentDLFileEntryType =
-			DLFileEntryTypeLocalServiceUtil.getBasicDocumentDLFileEntryType();
+			DLFileEntryTypeLocalServiceUtil.getBasicDocumentDLFileEntryType(
+				folder.getCompanyId());
 
 		if (fileEntryTypeId ==
 				basicDocumentDLFileEntryType.getFileEntryTypeId()) {

--- a/modules/apps/document-library/document-library-repository-portlet-file-repository-impl/src/main/java/com/liferay/document/library/repository/portlet/file/repository/internal/PortletFileRepositoryImpl.java
+++ b/modules/apps/document-library/document-library-repository-portlet-file-repository-impl/src/main/java/com/liferay/document/library/repository/portlet/file/repository/internal/PortletFileRepositoryImpl.java
@@ -138,6 +138,10 @@ public class PortletFileRepositoryImpl implements PortletFileRepository {
 
 		ServiceContext serviceContext = new ServiceContext();
 
+		Group group = _groupLocalService.getGroup(groupId);
+
+		serviceContext.setCompanyId(group.getCompanyId());
+
 		serviceContext.setAddGroupPermissions(true);
 		serviceContext.setAddGuestPermissions(true);
 

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/exportimport/data/handler/DLFileEntryTypeStagedModelDataHandler.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/exportimport/data/handler/DLFileEntryTypeStagedModelDataHandler.java
@@ -15,7 +15,6 @@
 package com.liferay.document.library.internal.exportimport.data.handler;
 
 import com.liferay.document.library.kernel.model.DLFileEntryType;
-import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
 import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalService;
 import com.liferay.document.library.kernel.util.DLUtil;
 import com.liferay.dynamic.data.mapping.kernel.DDMStructure;
@@ -122,11 +121,14 @@ public class DLFileEntryTypeStagedModelDataHandler
 					}
 				}
 
+				DLFileEntryType basicDocumentDLFileEntryType =
+					_dlFileEntryTypeLocalService.
+						getBasicDocumentDLFileEntryType();
+
 				boolean preloaded = false;
 
 				if ((fileEntryType.getFileEntryTypeId() ==
-						DLFileEntryTypeConstants.
-							FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT) ||
+						basicDocumentDLFileEntryType.getFileEntryTypeId()) ||
 					(defaultUserId == fileEntryType.getUserId())) {
 
 					preloaded = true;

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/exportimport/data/handler/DLFileEntryTypeStagedModelDataHandler.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/exportimport/data/handler/DLFileEntryTypeStagedModelDataHandler.java
@@ -168,7 +168,8 @@ public class DLFileEntryTypeStagedModelDataHandler
 
 		DLFileEntryType existingFileEntryType =
 			_fetchExistingFileEntryTypeWithParentGroups(
-				uuid, groupId, fileEntryTypeKey, preloaded);
+				uuid, groupId, portletDataContext.getCompanyId(),
+				fileEntryTypeKey, preloaded);
 
 		if (existingFileEntryType == null) {
 			return false;
@@ -242,7 +243,8 @@ public class DLFileEntryTypeStagedModelDataHandler
 		}
 		else {
 			existingFileEntryType = _fetchExistingFileEntryTypeWithParentGroups(
-				uuid, groupId, fileEntryTypeKey, preloaded);
+				uuid, groupId, portletDataContext.getCompanyId(),
+				fileEntryTypeKey, preloaded);
 		}
 
 		if (existingFileEntryType == null) {
@@ -307,6 +309,7 @@ public class DLFileEntryTypeStagedModelDataHandler
 				_fetchExistingFileEntryType(
 					fileEntryType.getUuid(),
 					portletDataContext.getScopeGroupId(),
+					portletDataContext.getCompanyId(),
 					fileEntryType.getFileEntryTypeKey(), preloaded);
 
 			if (existingDLFileEntryType == null) {
@@ -376,7 +379,8 @@ public class DLFileEntryTypeStagedModelDataHandler
 	}
 
 	private DLFileEntryType _fetchExistingFileEntryType(
-		String uuid, long groupId, String fileEntryTypeKey, boolean preloaded) {
+		String uuid, long groupId, long companyId, String fileEntryTypeKey,
+		boolean preloaded) {
 
 		DLFileEntryType existingDLFileEntryType = null;
 
@@ -387,28 +391,28 @@ public class DLFileEntryTypeStagedModelDataHandler
 		else {
 			existingDLFileEntryType =
 				_dlFileEntryTypeLocalService.fetchFileEntryType(
-					groupId, fileEntryTypeKey);
+					groupId, companyId, fileEntryTypeKey);
 		}
 
 		return existingDLFileEntryType;
 	}
 
 	private DLFileEntryType _fetchExistingFileEntryTypeWithParentGroups(
-		String uuid, long groupId, String fileEntryTypeKey, boolean preloaded) {
+		String uuid, long groupId, long companyId, String fileEntryTypeKey,
+		boolean preloaded) {
 
 		Group group = _groupLocalService.fetchGroup(groupId);
 
 		if (group == null) {
 			return _fetchExistingFileEntryType(
-				uuid, groupId, fileEntryTypeKey, preloaded);
+				uuid, groupId, companyId, fileEntryTypeKey, preloaded);
 		}
-
-		long companyId = group.getCompanyId();
 
 		while (group != null) {
 			DLFileEntryType existingDLFileEntryType =
 				_fetchExistingFileEntryType(
-					uuid, group.getGroupId(), fileEntryTypeKey, preloaded);
+					uuid, group.getGroupId(), group.getCompanyId(),
+					fileEntryTypeKey, preloaded);
 
 			if (existingDLFileEntryType != null) {
 				return existingDLFileEntryType;
@@ -424,7 +428,8 @@ public class DLFileEntryTypeStagedModelDataHandler
 		}
 
 		return _fetchExistingFileEntryType(
-			uuid, companyGroup.getGroupId(), fileEntryTypeKey, preloaded);
+			uuid, companyGroup.getGroupId(), companyGroup.getCompanyId(),
+			fileEntryTypeKey, preloaded);
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/exportimport/data/handler/DLFileEntryTypeStagedModelDataHandler.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/exportimport/data/handler/DLFileEntryTypeStagedModelDataHandler.java
@@ -123,7 +123,8 @@ public class DLFileEntryTypeStagedModelDataHandler
 
 				DLFileEntryType basicDocumentDLFileEntryType =
 					_dlFileEntryTypeLocalService.
-						getBasicDocumentDLFileEntryType();
+						getBasicDocumentDLFileEntryType(
+							fileEntryType.getCompanyId());
 
 				boolean preloaded = false;
 

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/exportimport/data/handler/FolderStagedModelDataHandler.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/exportimport/data/handler/FolderStagedModelDataHandler.java
@@ -407,10 +407,11 @@ public class FolderStagedModelDataHandler
 
 		long defaultFileEntryTypeId =
 			_dlFileEntryTypeLocalService.getDefaultFileEntryTypeId(
-				folder.getFolderId());
+				folder.getCompanyId(), folder.getFolderId());
 
 		DLFileEntryType basicDocumentDLFileEntryType =
-			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType();
+			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType(
+				folder.getCompanyId());
 
 		String defaultFileEntryTypeUuid = StringPool.BLANK;
 
@@ -495,7 +496,8 @@ public class FolderStagedModelDataHandler
 				folderElement.attributeValue("basic-document"))) {
 
 			DLFileEntryType basicDocumentDLFileEntryType =
-				_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType();
+				_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType(
+					portletDataContext.getCompanyId());
 
 			currentFolderFileEntryTypeIds.add(
 				basicDocumentDLFileEntryType.getFileEntryTypeId());

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/exportimport/data/handler/FolderStagedModelDataHandler.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/exportimport/data/handler/FolderStagedModelDataHandler.java
@@ -15,7 +15,6 @@
 package com.liferay.document.library.internal.exportimport.data.handler;
 
 import com.liferay.document.library.kernel.model.DLFileEntryType;
-import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
 import com.liferay.document.library.kernel.model.DLFolder;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
@@ -410,12 +409,14 @@ public class FolderStagedModelDataHandler
 			_dlFileEntryTypeLocalService.getDefaultFileEntryTypeId(
 				folder.getFolderId());
 
+		DLFileEntryType basicDocumentDLFileEntryType =
+			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType();
+
 		String defaultFileEntryTypeUuid = StringPool.BLANK;
 
 		for (DLFileEntryType dlFileEntryType : dlFileEntryTypes) {
 			if (dlFileEntryType.getFileEntryTypeId() ==
-					DLFileEntryTypeConstants.
-						FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT) {
+					basicDocumentDLFileEntryType.getFileEntryTypeId()) {
 
 				folderElement.addAttribute("basic-document", "true");
 
@@ -493,8 +494,11 @@ public class FolderStagedModelDataHandler
 		if (GetterUtil.getBoolean(
 				folderElement.attributeValue("basic-document"))) {
 
+			DLFileEntryType basicDocumentDLFileEntryType =
+				_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType();
+
 			currentFolderFileEntryTypeIds.add(
-				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT);
+				basicDocumentDLFileEntryType.getFileEntryTypeId());
 		}
 
 		if (!currentFolderFileEntryTypeIds.isEmpty()) {

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/repository/capabilities/TemporaryFileEntriesCapabilityImpl.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/repository/capabilities/TemporaryFileEntriesCapabilityImpl.java
@@ -85,6 +85,8 @@ public class TemporaryFileEntriesCapabilityImpl
 			serviceContext.setAddGroupPermissions(true);
 			serviceContext.setAddGuestPermissions(true);
 
+			serviceContext.setCompanyId(folder.getCompanyId());
+
 			return _documentRepository.addFileEntry(
 				null, temporaryFileEntriesScope.getUserId(),
 				folder.getFolderId(), fileName, mimeType, fileName, fileName,

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/service/SubscriptionDLAppHelperLocalServiceWrapper.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/service/SubscriptionDLAppHelperLocalServiceWrapper.java
@@ -295,7 +295,8 @@ public class SubscriptionDLAppHelperLocalServiceWrapper
 		}
 
 		DLFileEntryType basicDocumentDLFileEntryType =
-			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType();
+			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType(
+				dlFileEntryType.getCompanyId());
 
 		if (dlFileEntryType.getFileEntryTypeId() ==
 				basicDocumentDLFileEntryType.getFileEntryTypeId()) {

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/service/SubscriptionDLAppHelperLocalServiceWrapper.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/service/SubscriptionDLAppHelperLocalServiceWrapper.java
@@ -18,7 +18,6 @@ import com.liferay.document.library.internal.util.DLSubscriptionSender;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFileEntryConstants;
 import com.liferay.document.library.kernel.model.DLFileEntryType;
-import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
 import com.liferay.document.library.kernel.model.DLFolder;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLAppHelperLocalServiceWrapper;
@@ -295,8 +294,11 @@ public class SubscriptionDLAppHelperLocalServiceWrapper
 			}
 		}
 
+		DLFileEntryType basicDocumentDLFileEntryType =
+			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType();
+
 		if (dlFileEntryType.getFileEntryTypeId() ==
-				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT) {
+				basicDocumentDLFileEntryType.getFileEntryTypeId()) {
 
 			subscriptionSender.addPersistedSubscribers(
 				DLFileEntryType.class.getName(), fileVersion.getGroupId());

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/service/SubscriptionDLAppLocalServiceWrapper.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/service/SubscriptionDLAppLocalServiceWrapper.java
@@ -15,10 +15,10 @@
 package com.liferay.document.library.internal.service;
 
 import com.liferay.document.library.kernel.model.DLFileEntryType;
-import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
 import com.liferay.document.library.kernel.model.DLFolder;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLAppLocalServiceWrapper;
+import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.service.ServiceWrapper;
 import com.liferay.subscription.service.SubscriptionLocalService;
@@ -40,8 +40,11 @@ public class SubscriptionDLAppLocalServiceWrapper
 
 		super.subscribeFileEntryType(userId, groupId, fileEntryTypeId);
 
+		DLFileEntryType basicDocumentDLFileEntryType =
+			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType();
+
 		if (fileEntryTypeId ==
-				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT) {
+				basicDocumentDLFileEntryType.getFileEntryTypeId()) {
 
 			fileEntryTypeId = groupId;
 		}
@@ -71,8 +74,11 @@ public class SubscriptionDLAppLocalServiceWrapper
 
 		super.unsubscribeFileEntryType(userId, groupId, fileEntryTypeId);
 
+		DLFileEntryType basicDocumentDLFileEntryType =
+			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType();
+
 		if (fileEntryTypeId ==
-				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT) {
+				basicDocumentDLFileEntryType.getFileEntryTypeId()) {
 
 			fileEntryTypeId = groupId;
 		}
@@ -94,6 +100,9 @@ public class SubscriptionDLAppLocalServiceWrapper
 		_subscriptionLocalService.deleteSubscription(
 			userId, DLFolder.class.getName(), folderId);
 	}
+
+	@Reference
+	private DLFileEntryTypeLocalService _dlFileEntryTypeLocalService;
 
 	@Reference
 	private SubscriptionLocalService _subscriptionLocalService;

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/service/SubscriptionDLAppLocalServiceWrapper.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/service/SubscriptionDLAppLocalServiceWrapper.java
@@ -40,8 +40,12 @@ public class SubscriptionDLAppLocalServiceWrapper
 
 		super.subscribeFileEntryType(userId, groupId, fileEntryTypeId);
 
+		DLFileEntryType dlFileEntryType =
+			_dlFileEntryTypeLocalService.getDLFileEntryType(fileEntryTypeId);
+
 		DLFileEntryType basicDocumentDLFileEntryType =
-			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType();
+			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType(
+				dlFileEntryType.getCompanyId());
 
 		if (fileEntryTypeId ==
 				basicDocumentDLFileEntryType.getFileEntryTypeId()) {
@@ -74,8 +78,12 @@ public class SubscriptionDLAppLocalServiceWrapper
 
 		super.unsubscribeFileEntryType(userId, groupId, fileEntryTypeId);
 
+		DLFileEntryType dlFileEntryType =
+			_dlFileEntryTypeLocalService.getDLFileEntryType(fileEntryTypeId);
+
 		DLFileEntryType basicDocumentDLFileEntryType =
-			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType();
+			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType(
+				dlFileEntryType.getCompanyId());
 
 		if (fileEntryTypeId ==
 				basicDocumentDLFileEntryType.getFileEntryTypeId()) {

--- a/modules/apps/document-library/document-library-test-util/bnd.bnd
+++ b/modules/apps/document-library/document-library-test-util/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Document Library Test Utilities
 Bundle-SymbolicName: com.liferay.document.library.test.util
-Bundle-Version: 4.0.13
+Bundle-Version: 5.0.0
 Export-Package:\
 	com.liferay.document.library.test.util,\
 	com.liferay.document.library.test.util.search

--- a/modules/apps/document-library/document-library-test-util/src/main/java/com/liferay/document/library/test/util/BaseDLAppTestCase.java
+++ b/modules/apps/document-library/document-library-test-util/src/main/java/com/liferay/document/library/test/util/BaseDLAppTestCase.java
@@ -87,7 +87,8 @@ public abstract class BaseDLAppTestCase {
 			ActionKeys.VIEW);
 
 		basicDocumentDLFileEntryType =
-			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType();
+			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType(
+				group.getCompanyId());
 	}
 
 	@After

--- a/modules/apps/document-library/document-library-test-util/src/main/java/com/liferay/document/library/test/util/BaseDLAppTestCase.java
+++ b/modules/apps/document-library/document-library-test-util/src/main/java/com/liferay/document/library/test/util/BaseDLAppTestCase.java
@@ -15,8 +15,10 @@
 package com.liferay.document.library.test.util;
 
 import com.liferay.document.library.kernel.exception.NoSuchFolderException;
+import com.liferay.document.library.kernel.model.DLFileEntryType;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLAppService;
+import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalService;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
@@ -83,12 +85,17 @@ public abstract class BaseDLAppTestCase {
 			RoleConstants.GUEST, DLConstants.RESOURCE_NAME,
 			ResourceConstants.SCOPE_GROUP, String.valueOf(group.getGroupId()),
 			ActionKeys.VIEW);
+
+		basicDocumentDLFileEntryType =
+			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType();
 	}
 
 	@After
 	public void tearDown() throws Exception {
 		PrincipalThreadLocal.setName(_name);
 	}
+
+	protected DLFileEntryType basicDocumentDLFileEntryType;
 
 	@DeleteAfterTestRun
 	protected Group group;
@@ -103,6 +110,9 @@ public abstract class BaseDLAppTestCase {
 
 	@Inject
 	private DLAppService _dlAppService;
+
+	@Inject
+	private DLFileEntryTypeLocalService _dlFileEntryTypeLocalService;
 
 	private String _name;
 

--- a/modules/apps/document-library/document-library-test-util/src/main/java/com/liferay/document/library/test/util/DLTestUtil.java
+++ b/modules/apps/document-library/document-library-test-util/src/main/java/com/liferay/document/library/test/util/DLTestUtil.java
@@ -16,10 +16,11 @@ package com.liferay.document.library.test.util;
 
 import com.liferay.document.library.kernel.exception.NoSuchFolderException;
 import com.liferay.document.library.kernel.model.DLFileEntry;
-import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
+import com.liferay.document.library.kernel.model.DLFileEntryType;
 import com.liferay.document.library.kernel.model.DLFolder;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalServiceUtil;
+import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalServiceUtil;
 import com.liferay.document.library.kernel.service.DLFolderLocalServiceUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.log.Log;
@@ -39,6 +40,9 @@ import java.io.ByteArrayInputStream;
 public class DLTestUtil {
 
 	public static DLFileEntry addDLFileEntry(long dlFolderId) throws Exception {
+		DLFileEntryType basicDocumentDLFileEntryType =
+			DLFileEntryTypeLocalServiceUtil.getBasicDocumentDLFileEntryType();
+
 		DLFolder dlFolder = DLFolderLocalServiceUtil.fetchDLFolder(dlFolderId);
 
 		byte[] bytes = TestDataConstants.TEST_BYTE_ARRAY;
@@ -48,9 +52,9 @@ public class DLTestUtil {
 			dlFolder.getRepositoryId(), dlFolder.getFolderId(),
 			RandomTestUtil.randomString(), ContentTypes.TEXT_PLAIN,
 			RandomTestUtil.randomString(), StringPool.BLANK, StringPool.BLANK,
-			StringPool.BLANK,
-			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT, null,
-			null, new ByteArrayInputStream(bytes), bytes.length, null, null,
+			StringPool.BLANK, basicDocumentDLFileEntryType.getFileEntryTypeId(),
+			null, null, new ByteArrayInputStream(bytes), bytes.length, null,
+			null,
 			ServiceContextTestUtil.getServiceContext(dlFolder.getGroupId()));
 	}
 

--- a/modules/apps/document-library/document-library-test-util/src/main/java/com/liferay/document/library/test/util/DLTestUtil.java
+++ b/modules/apps/document-library/document-library-test-util/src/main/java/com/liferay/document/library/test/util/DLTestUtil.java
@@ -41,7 +41,8 @@ public class DLTestUtil {
 
 	public static DLFileEntry addDLFileEntry(long dlFolderId) throws Exception {
 		DLFileEntryType basicDocumentDLFileEntryType =
-			DLFileEntryTypeLocalServiceUtil.getBasicDocumentDLFileEntryType();
+			DLFileEntryTypeLocalServiceUtil.getBasicDocumentDLFileEntryType(
+				TestPropsValues.getCompanyId());
 
 		DLFolder dlFolder = DLFolderLocalServiceUtil.fetchDLFolder(dlFolderId);
 

--- a/modules/apps/document-library/document-library-test-util/src/main/java/com/liferay/document/library/test/util/search/DLFolderSearchFixture.java
+++ b/modules/apps/document-library/document-library-test-util/src/main/java/com/liferay/document/library/test/util/search/DLFolderSearchFixture.java
@@ -60,7 +60,8 @@ public class DLFolderSearchFixture {
 			keywords, false, serviceContext);
 
 		DLFileEntryType basicDocumentDLFileEntryType =
-			dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType();
+			dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType(
+				user.getCompanyId());
 
 		dlFileEntryLocalService.addFileEntry(
 			null, user.getUserId(), group.getGroupId(), group.getGroupId(),

--- a/modules/apps/document-library/document-library-test-util/src/main/java/com/liferay/document/library/test/util/search/DLFolderSearchFixture.java
+++ b/modules/apps/document-library/document-library-test-util/src/main/java/com/liferay/document/library/test/util/search/DLFolderSearchFixture.java
@@ -14,11 +14,12 @@
 
 package com.liferay.document.library.test.util.search;
 
-import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
+import com.liferay.document.library.kernel.model.DLFileEntryType;
 import com.liferay.document.library.kernel.model.DLFolder;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
+import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalService;
 import com.liferay.document.library.kernel.service.DLFolderLocalService;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Group;
@@ -40,6 +41,7 @@ public class DLFolderSearchFixture {
 	public DLFolderSearchFixture(
 		DLAppLocalService dlAppLocalService,
 		DLFileEntryLocalService dlFileEntryLocalService,
+		DLFileEntryTypeLocalService dlFileEntryTypeLocalService,
 		DLFolderLocalService dlFolderLocalService) {
 
 		this.dlAppLocalService = dlAppLocalService;
@@ -57,13 +59,16 @@ public class DLFolderSearchFixture {
 			false, DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, keywords,
 			keywords, false, serviceContext);
 
+		DLFileEntryType basicDocumentDLFileEntryType =
+			dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType();
+
 		dlFileEntryLocalService.addFileEntry(
 			null, user.getUserId(), group.getGroupId(), group.getGroupId(),
 			dlFolder.getFolderId(), RandomTestUtil.randomString(), null,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			keywords, StringPool.BLANK,
-			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT, null,
-			null, new ByteArrayInputStream(content.getBytes()), 0, null, null,
+			basicDocumentDLFileEntryType.getFileEntryTypeId(), null, null,
+			new ByteArrayInputStream(content.getBytes()), 0, null, null,
 			serviceContext);
 
 		_dlFolders.add(dlFolder);
@@ -103,6 +108,7 @@ public class DLFolderSearchFixture {
 
 	protected DLAppLocalService dlAppLocalService;
 	protected DLFileEntryLocalService dlFileEntryLocalService;
+	protected DLFileEntryTypeLocalService dlFileEntryTypeLocalService;
 	protected DLFolderLocalService dlFolderLocalService;
 
 	private final List<DLFolder> _dlFolders = new ArrayList<>();

--- a/modules/apps/document-library/document-library-test-util/src/main/resources/com/liferay/document/library/test/util/packageinfo
+++ b/modules/apps/document-library/document-library-test-util/src/main/resources/com/liferay/document/library/test/util/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 1.2.0

--- a/modules/apps/document-library/document-library-test-util/src/main/resources/com/liferay/document/library/test/util/search/packageinfo
+++ b/modules/apps/document-library/document-library-test-util/src/main/resources/com/liferay/document/library/test/util/search/packageinfo
@@ -1,1 +1,1 @@
-version 3.0.0
+version 4.0.0

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenCheckingInAFileEntryTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenCheckingInAFileEntryTest.java
@@ -159,7 +159,8 @@ public class DLAppServiceWhenCheckingInAFileEntryTest
 			"ddmFormValues", _SERIALIZED_DDM_FORM_VALUES);
 
 		DLFileEntryType basicDocumentDLFileEntryType =
-			DLFileEntryTypeLocalServiceUtil.getBasicDocumentDLFileEntryType();
+			DLFileEntryTypeLocalServiceUtil.getBasicDocumentDLFileEntryType(
+				group.getCompanyId());
 
 		serviceContext.setAttribute(
 			"fileEntryTypeId",

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/change/tracking/test/DLFileEntryMetadataTableReferenceDefinitionTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/change/tracking/test/DLFileEntryMetadataTableReferenceDefinitionTest.java
@@ -81,6 +81,9 @@ public class DLFileEntryMetadataTableReferenceDefinitionTest
 	public void setUp() throws Exception {
 		super.setUp();
 
+		DLFileEntryType basicDocumentDLFileEntryType =
+			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType();
+
 		byte[] bytes = TestDataConstants.TEST_BYTE_ARRAY;
 
 		InputStream inputStream = new ByteArrayInputStream(bytes);
@@ -91,8 +94,8 @@ public class DLFileEntryMetadataTableReferenceDefinitionTest
 			RandomTestUtil.randomString(), ContentTypes.TEXT_PLAIN,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			StringPool.BLANK, StringPool.BLANK,
-			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT, null,
-			null, inputStream, bytes.length, null, null,
+			basicDocumentDLFileEntryType.getFileEntryTypeId(), null, null,
+			inputStream, bytes.length, null, null,
 			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
 
 		_ddmStructure = _ddmStructureLocalService.addStructure(

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/change/tracking/test/DLFileEntryMetadataTableReferenceDefinitionTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/change/tracking/test/DLFileEntryMetadataTableReferenceDefinitionTest.java
@@ -82,7 +82,8 @@ public class DLFileEntryMetadataTableReferenceDefinitionTest
 		super.setUp();
 
 		DLFileEntryType basicDocumentDLFileEntryType =
-			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType();
+			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType(
+				group.getCompanyId());
 
 		byte[] bytes = TestDataConstants.TEST_BYTE_ARRAY;
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/change/tracking/test/DLFileEntryTableReferenceDefinitionTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/change/tracking/test/DLFileEntryTableReferenceDefinitionTest.java
@@ -55,7 +55,8 @@ public class DLFileEntryTableReferenceDefinitionTest
 	@Override
 	protected CTModel<?> addCTModel() throws Exception {
 		DLFileEntryType basicDocumentDLFileEntryType =
-			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType();
+			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType(
+				group.getCompanyId());
 
 		byte[] bytes = TestDataConstants.TEST_BYTE_ARRAY;
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/change/tracking/test/DLFileEntryTableReferenceDefinitionTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/change/tracking/test/DLFileEntryTableReferenceDefinitionTest.java
@@ -16,9 +16,10 @@ package com.liferay.document.library.change.tracking.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.change.tracking.test.util.BaseTableReferenceDefinitionTestCase;
-import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
+import com.liferay.document.library.kernel.model.DLFileEntryType;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
+import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalService;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.change.tracking.CTModel;
 import com.liferay.portal.kernel.test.constants.TestDataConstants;
@@ -53,6 +54,9 @@ public class DLFileEntryTableReferenceDefinitionTest
 
 	@Override
 	protected CTModel<?> addCTModel() throws Exception {
+		DLFileEntryType basicDocumentDLFileEntryType =
+			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType();
+
 		byte[] bytes = TestDataConstants.TEST_BYTE_ARRAY;
 
 		InputStream inputStream = new ByteArrayInputStream(bytes);
@@ -63,12 +67,15 @@ public class DLFileEntryTableReferenceDefinitionTest
 			RandomTestUtil.randomString(), ContentTypes.TEXT_PLAIN,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			StringPool.BLANK, StringPool.BLANK,
-			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT, null,
-			null, inputStream, bytes.length, null, null,
+			basicDocumentDLFileEntryType.getFileEntryTypeId(), null, null,
+			inputStream, bytes.length, null, null,
 			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
 	}
 
 	@Inject
 	private static DLFileEntryLocalService _dlFileEntryLocalService;
+
+	@Inject
+	private DLFileEntryTypeLocalService _dlFileEntryTypeLocalService;
 
 }

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/change/tracking/test/DLFileShortcutTableReferenceDefinitionTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/change/tracking/test/DLFileShortcutTableReferenceDefinitionTest.java
@@ -61,7 +61,8 @@ public class DLFileShortcutTableReferenceDefinitionTest
 		super.setUp();
 
 		DLFileEntryType basicDocumentDLFileEntryType =
-			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType();
+			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType(
+				group.getCompanyId());
 
 		byte[] bytes = TestDataConstants.TEST_BYTE_ARRAY;
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/change/tracking/test/DLFileShortcutTableReferenceDefinitionTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/change/tracking/test/DLFileShortcutTableReferenceDefinitionTest.java
@@ -17,9 +17,10 @@ package com.liferay.document.library.change.tracking.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.change.tracking.test.util.BaseTableReferenceDefinitionTestCase;
 import com.liferay.document.library.kernel.model.DLFileEntry;
-import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
+import com.liferay.document.library.kernel.model.DLFileEntryType;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
+import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalService;
 import com.liferay.document.library.kernel.service.DLFileShortcutLocalService;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.change.tracking.CTModel;
@@ -59,6 +60,9 @@ public class DLFileShortcutTableReferenceDefinitionTest
 	public void setUp() throws Exception {
 		super.setUp();
 
+		DLFileEntryType basicDocumentDLFileEntryType =
+			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType();
+
 		byte[] bytes = TestDataConstants.TEST_BYTE_ARRAY;
 
 		InputStream inputStream = new ByteArrayInputStream(bytes);
@@ -69,8 +73,8 @@ public class DLFileShortcutTableReferenceDefinitionTest
 			RandomTestUtil.randomString(), ContentTypes.TEXT_PLAIN,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			StringPool.BLANK, StringPool.BLANK,
-			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT, null,
-			null, inputStream, bytes.length, null, null,
+			basicDocumentDLFileEntryType.getFileEntryTypeId(), null, null,
+			inputStream, bytes.length, null, null,
 			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
 	}
 
@@ -91,5 +95,8 @@ public class DLFileShortcutTableReferenceDefinitionTest
 	private static DLFileShortcutLocalService _dlFileShortcutLocalService;
 
 	private DLFileEntry _dlFileEntry;
+
+	@Inject
+	private DLFileEntryTypeLocalService _dlFileEntryTypeLocalService;
 
 }

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/change/tracking/test/DLFileVersionPreviewTableReferenceDefinitionTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/change/tracking/test/DLFileVersionPreviewTableReferenceDefinitionTest.java
@@ -63,7 +63,8 @@ public class DLFileVersionPreviewTableReferenceDefinitionTest
 		super.setUp();
 
 		DLFileEntryType basicDocumentDLFileEntryType =
-			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType();
+			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType(
+				group.getCompanyId());
 
 		byte[] bytes = TestDataConstants.TEST_BYTE_ARRAY;
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/change/tracking/test/DLFileVersionPreviewTableReferenceDefinitionTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/change/tracking/test/DLFileVersionPreviewTableReferenceDefinitionTest.java
@@ -18,10 +18,11 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.change.tracking.test.util.BaseTableReferenceDefinitionTestCase;
 import com.liferay.document.library.constants.DLFileVersionPreviewConstants;
 import com.liferay.document.library.kernel.model.DLFileEntry;
-import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
+import com.liferay.document.library.kernel.model.DLFileEntryType;
 import com.liferay.document.library.kernel.model.DLFileVersion;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
+import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalService;
 import com.liferay.document.library.service.DLFileVersionPreviewLocalService;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.change.tracking.CTModel;
@@ -61,6 +62,9 @@ public class DLFileVersionPreviewTableReferenceDefinitionTest
 	public void setUp() throws Exception {
 		super.setUp();
 
+		DLFileEntryType basicDocumentDLFileEntryType =
+			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType();
+
 		byte[] bytes = TestDataConstants.TEST_BYTE_ARRAY;
 
 		InputStream inputStream = new ByteArrayInputStream(bytes);
@@ -71,8 +75,8 @@ public class DLFileVersionPreviewTableReferenceDefinitionTest
 			RandomTestUtil.randomString(), ContentTypes.TEXT_PLAIN,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			StringPool.BLANK, StringPool.BLANK,
-			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT, null,
-			null, inputStream, bytes.length, null, null,
+			basicDocumentDLFileEntryType.getFileEntryTypeId(), null, null,
+			inputStream, bytes.length, null, null,
 			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
 
 		_dlFileVersion = dlFileEntry.getFileVersion();
@@ -94,6 +98,9 @@ public class DLFileVersionPreviewTableReferenceDefinitionTest
 	@Inject
 	private static DLFileVersionPreviewLocalService
 		_dlFileVersionPreviewLocalService;
+
+	@Inject
+	private DLFileEntryTypeLocalService _dlFileEntryTypeLocalService;
 
 	private DLFileVersion _dlFileVersion;
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/change/tracking/test/DLFileVersionTableReferenceDefinitionTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/change/tracking/test/DLFileVersionTableReferenceDefinitionTest.java
@@ -17,10 +17,11 @@ package com.liferay.document.library.change.tracking.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.change.tracking.test.util.BaseTableReferenceDefinitionTestCase;
 import com.liferay.document.library.kernel.model.DLFileEntry;
-import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
+import com.liferay.document.library.kernel.model.DLFileEntryType;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.model.DLVersionNumberIncrease;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
+import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalService;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.change.tracking.CTModel;
 import com.liferay.portal.kernel.test.constants.TestDataConstants;
@@ -64,6 +65,9 @@ public class DLFileVersionTableReferenceDefinitionTest
 	public void setUp() throws Exception {
 		super.setUp();
 
+		DLFileEntryType basicDocumentDLFileEntryType =
+			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType();
+
 		byte[] bytes = TestDataConstants.TEST_BYTE_ARRAY;
 
 		InputStream inputStream = new ByteArrayInputStream(bytes);
@@ -74,13 +78,16 @@ public class DLFileVersionTableReferenceDefinitionTest
 			RandomTestUtil.randomString(), ContentTypes.TEXT_PLAIN,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			StringPool.BLANK, StringPool.BLANK,
-			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT, null,
-			null, inputStream, bytes.length, null, null,
+			basicDocumentDLFileEntryType.getFileEntryTypeId(), null, null,
+			inputStream, bytes.length, null, null,
 			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
 	}
 
 	@Override
 	protected CTModel<?> addCTModel() throws Exception {
+		DLFileEntryType basicDocumentDLFileEntryType =
+			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType();
+
 		byte[] bytes = TestDataConstants.TEST_BYTE_ARRAY;
 
 		InputStream inputStream = new ByteArrayInputStream(bytes);
@@ -90,7 +97,7 @@ public class DLFileVersionTableReferenceDefinitionTest
 			StringUtil.randomString(), ContentTypes.TEXT_PLAIN,
 			StringUtil.randomString(), RandomTestUtil.randomString(),
 			StringPool.BLANK, StringPool.BLANK, DLVersionNumberIncrease.MAJOR,
-			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
+			basicDocumentDLFileEntryType.getFileEntryTypeId(),
 			Collections.emptyMap(), null, inputStream, 0, null, null,
 			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
 
@@ -101,5 +108,8 @@ public class DLFileVersionTableReferenceDefinitionTest
 	private static DLFileEntryLocalService _dlFileEntryLocalService;
 
 	private DLFileEntry _dlFileEntry;
+
+	@Inject
+	private DLFileEntryTypeLocalService _dlFileEntryTypeLocalService;
 
 }

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/change/tracking/test/DLFileVersionTableReferenceDefinitionTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/change/tracking/test/DLFileVersionTableReferenceDefinitionTest.java
@@ -66,7 +66,8 @@ public class DLFileVersionTableReferenceDefinitionTest
 		super.setUp();
 
 		DLFileEntryType basicDocumentDLFileEntryType =
-			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType();
+			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType(
+				group.getCompanyId());
 
 		byte[] bytes = TestDataConstants.TEST_BYTE_ARRAY;
 
@@ -86,7 +87,8 @@ public class DLFileVersionTableReferenceDefinitionTest
 	@Override
 	protected CTModel<?> addCTModel() throws Exception {
 		DLFileEntryType basicDocumentDLFileEntryType =
-			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType();
+			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType(
+				group.getCompanyId());
 
 		byte[] bytes = TestDataConstants.TEST_BYTE_ARRAY;
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/change/tracking/test/DLFolderTableReferenceDefinitionTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/change/tracking/test/DLFolderTableReferenceDefinitionTest.java
@@ -16,10 +16,11 @@ package com.liferay.document.library.change.tracking.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.change.tracking.test.util.BaseTableReferenceDefinitionTestCase;
-import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
+import com.liferay.document.library.kernel.model.DLFileEntryType;
 import com.liferay.document.library.kernel.model.DLFolder;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
+import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalService;
 import com.liferay.document.library.kernel.service.DLFolderLocalService;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.change.tracking.CTModel;
@@ -72,6 +73,9 @@ public class DLFolderTableReferenceDefinitionTest
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(), false,
 			serviceContext);
 
+		DLFileEntryType basicDocumentDLFileEntryType =
+			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType();
+
 		byte[] bytes = TestDataConstants.TEST_BYTE_ARRAY;
 
 		InputStream inputStream = new ByteArrayInputStream(bytes);
@@ -82,14 +86,17 @@ public class DLFolderTableReferenceDefinitionTest
 			RandomTestUtil.randomString(), ContentTypes.TEXT_PLAIN,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			StringPool.BLANK, StringPool.BLANK,
-			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT, null,
-			null, inputStream, bytes.length, null, null, serviceContext);
+			basicDocumentDLFileEntryType.getFileEntryTypeId(), null, null,
+			inputStream, bytes.length, null, null, serviceContext);
 
 		return parentFolder;
 	}
 
 	@Inject
 	private static DLFileEntryLocalService _dlFileEntryLocalService;
+
+	@Inject
+	private static DLFileEntryTypeLocalService _dlFileEntryTypeLocalService;
 
 	@Inject
 	private static DLFolderLocalService _dlFolderLocalService;

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/change/tracking/test/DLFolderTableReferenceDefinitionTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/change/tracking/test/DLFolderTableReferenceDefinitionTest.java
@@ -74,7 +74,8 @@ public class DLFolderTableReferenceDefinitionTest
 			serviceContext);
 
 		DLFileEntryType basicDocumentDLFileEntryType =
-			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType();
+			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType(
+				group.getCompanyId());
 
 		byte[] bytes = TestDataConstants.TEST_BYTE_ARRAY;
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/service/test/FriendlyURLDLFileEntryLocalServiceWrapperTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/service/test/FriendlyURLDLFileEntryLocalServiceWrapperTest.java
@@ -16,7 +16,6 @@ package com.liferay.document.library.internal.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.document.library.kernel.model.DLFileEntry;
-import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
 import com.liferay.document.library.kernel.model.DLVersionNumberIncrease;
 import com.liferay.document.library.kernel.service.DLAppService;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
@@ -80,9 +79,8 @@ public class FriendlyURLDLFileEntryLocalServiceWrapperTest
 			RandomTestUtil.randomString(),
 			ContentTypes.APPLICATION_OCTET_STREAM,
 			RandomTestUtil.randomString(), "urltitle", StringPool.BLANK,
-			StringPool.BLANK,
-			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT, null,
-			null, inputStream, bytes.length, null, null, serviceContext);
+			StringPool.BLANK, basicDocumentDLFileEntryType.getFileEntryTypeId(),
+			null, null, inputStream, bytes.length, null, null, serviceContext);
 
 		FriendlyURLEntry friendlyURLEntry1 =
 			_friendlyURLEntryLocalService.getMainFriendlyURLEntry(
@@ -99,9 +97,8 @@ public class FriendlyURLDLFileEntryLocalServiceWrapperTest
 			RandomTestUtil.randomString(),
 			ContentTypes.APPLICATION_OCTET_STREAM,
 			RandomTestUtil.randomString(), "urltitle", StringPool.BLANK,
-			StringPool.BLANK,
-			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT, null,
-			null, inputStream, bytes.length, null, null, serviceContext);
+			StringPool.BLANK, basicDocumentDLFileEntryType.getFileEntryTypeId(),
+			null, null, inputStream, bytes.length, null, null, serviceContext);
 
 		FriendlyURLEntry friendlyURLEntry2 =
 			_friendlyURLEntryLocalService.getMainFriendlyURLEntry(
@@ -129,8 +126,8 @@ public class FriendlyURLDLFileEntryLocalServiceWrapperTest
 			RandomTestUtil.randomString(),
 			ContentTypes.APPLICATION_OCTET_STREAM, "title", "urltitle",
 			StringPool.BLANK, StringPool.BLANK,
-			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT, null,
-			null, inputStream, bytes.length, null, null, serviceContext);
+			basicDocumentDLFileEntryType.getFileEntryTypeId(), null, null,
+			inputStream, bytes.length, null, null, serviceContext);
 
 		FriendlyURLEntry friendlyURLEntry1 =
 			_friendlyURLEntryLocalService.getMainFriendlyURLEntry(
@@ -151,8 +148,8 @@ public class FriendlyURLDLFileEntryLocalServiceWrapperTest
 			RandomTestUtil.randomString(),
 			ContentTypes.APPLICATION_OCTET_STREAM, "title", "urltitle",
 			StringPool.BLANK, StringPool.BLANK,
-			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT, null,
-			null, inputStream, bytes.length, null, null, serviceContext);
+			basicDocumentDLFileEntryType.getFileEntryTypeId(), null, null,
+			inputStream, bytes.length, null, null, serviceContext);
 
 		FriendlyURLEntry friendlyURLEntry2 =
 			_friendlyURLEntryLocalService.getMainFriendlyURLEntry(
@@ -173,8 +170,8 @@ public class FriendlyURLDLFileEntryLocalServiceWrapperTest
 			RandomTestUtil.randomString(),
 			ContentTypes.APPLICATION_OCTET_STREAM, "title", "urltitle",
 			StringPool.BLANK, StringPool.BLANK,
-			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT, null,
-			null, new ByteArrayInputStream(bytes), bytes.length, null, null,
+			basicDocumentDLFileEntryType.getFileEntryTypeId(), null, null,
+			new ByteArrayInputStream(bytes), bytes.length, null, null,
 			ServiceContextTestUtil.getServiceContext(
 				group.getGroupId(), TestPropsValues.getUserId()));
 
@@ -199,8 +196,8 @@ public class FriendlyURLDLFileEntryLocalServiceWrapperTest
 			RandomTestUtil.randomString(),
 			ContentTypes.APPLICATION_OCTET_STREAM, "title", StringPool.BLANK,
 			StringPool.BLANK, StringPool.BLANK,
-			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT, null,
-			null, new ByteArrayInputStream(bytes), bytes.length, null, null,
+			basicDocumentDLFileEntryType.getFileEntryTypeId(), null, null,
+			new ByteArrayInputStream(bytes), bytes.length, null, null,
 			ServiceContextTestUtil.getServiceContext(
 				group.getGroupId(), TestPropsValues.getUserId()));
 
@@ -225,8 +222,8 @@ public class FriendlyURLDLFileEntryLocalServiceWrapperTest
 			RandomTestUtil.randomString(),
 			ContentTypes.APPLICATION_OCTET_STREAM, "title", null,
 			StringPool.BLANK, StringPool.BLANK,
-			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT, null,
-			null, new ByteArrayInputStream(bytes), bytes.length, null, null,
+			basicDocumentDLFileEntryType.getFileEntryTypeId(), null, null,
+			new ByteArrayInputStream(bytes), bytes.length, null, null,
 			ServiceContextTestUtil.getServiceContext(
 				group.getGroupId(), TestPropsValues.getUserId()));
 
@@ -252,8 +249,8 @@ public class FriendlyURLDLFileEntryLocalServiceWrapperTest
 			ContentTypes.APPLICATION_OCTET_STREAM,
 			RandomTestUtil.randomString(), "<script/urlTitle</script>",
 			StringPool.BLANK, StringPool.BLANK,
-			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT, null,
-			null, new ByteArrayInputStream(bytes), bytes.length, null, null,
+			basicDocumentDLFileEntryType.getFileEntryTypeId(), null, null,
+			new ByteArrayInputStream(bytes), bytes.length, null, null,
 			ServiceContextTestUtil.getServiceContext(
 				group.getGroupId(), TestPropsValues.getUserId()));
 
@@ -278,8 +275,8 @@ public class FriendlyURLDLFileEntryLocalServiceWrapperTest
 			ContentTypes.APPLICATION_OCTET_STREAM,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			StringPool.BLANK, StringPool.BLANK,
-			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT, null,
-			null, new ByteArrayInputStream(bytes), bytes.length, null, null,
+			basicDocumentDLFileEntryType.getFileEntryTypeId(), null, null,
+			new ByteArrayInputStream(bytes), bytes.length, null, null,
 			ServiceContextTestUtil.getServiceContext(
 				group.getGroupId(), TestPropsValues.getUserId()));
 
@@ -313,16 +310,15 @@ public class FriendlyURLDLFileEntryLocalServiceWrapperTest
 			RandomTestUtil.randomString(),
 			ContentTypes.APPLICATION_OCTET_STREAM,
 			RandomTestUtil.randomString(), "oldurltitle", StringPool.BLANK,
-			StringPool.BLANK,
-			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT, null,
-			null, inputStream, bytes.length, null, null, serviceContext);
+			StringPool.BLANK, basicDocumentDLFileEntryType.getFileEntryTypeId(),
+			null, null, inputStream, bytes.length, null, null, serviceContext);
 
 		dlFileEntry = _dlFileEntryLocalService.updateFileEntry(
 			group.getCreatorUserId(), dlFileEntry.getFileEntryId(),
 			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
 			RandomTestUtil.randomString(), "urltitle", StringPool.BLANK,
 			StringPool.BLANK, DLVersionNumberIncrease.MAJOR,
-			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
+			basicDocumentDLFileEntryType.getFileEntryTypeId(),
 			Collections.emptyMap(), null, inputStream, 0, null, null,
 			serviceContext);
 
@@ -387,16 +383,15 @@ public class FriendlyURLDLFileEntryLocalServiceWrapperTest
 			RandomTestUtil.randomString(),
 			ContentTypes.APPLICATION_OCTET_STREAM,
 			RandomTestUtil.randomString(), "urltitle", StringPool.BLANK,
-			StringPool.BLANK,
-			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT, null,
-			null, inputStream, bytes.length, null, null, serviceContext);
+			StringPool.BLANK, basicDocumentDLFileEntryType.getFileEntryTypeId(),
+			null, null, inputStream, bytes.length, null, null, serviceContext);
 
 		dlFileEntry = _dlFileEntryLocalService.updateFileEntry(
 			group.getCreatorUserId(), dlFileEntry.getFileEntryId(),
 			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			StringPool.BLANK, StringPool.BLANK, DLVersionNumberIncrease.MAJOR,
-			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
+			basicDocumentDLFileEntryType.getFileEntryTypeId(),
 			Collections.emptyMap(), null, inputStream, 0, null, null,
 			serviceContext);
 
@@ -460,15 +455,15 @@ public class FriendlyURLDLFileEntryLocalServiceWrapperTest
 			ContentTypes.APPLICATION_OCTET_STREAM,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			StringPool.BLANK, StringPool.BLANK,
-			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT, null,
-			null, inputStream, bytes.length, null, null, serviceContext);
+			basicDocumentDLFileEntryType.getFileEntryTypeId(), null, null,
+			inputStream, bytes.length, null, null, serviceContext);
 
 		dlFileEntry = _dlFileEntryLocalService.updateFileEntry(
 			group.getCreatorUserId(), dlFileEntry.getFileEntryId(),
 			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
 			RandomTestUtil.randomString(), "urltitle", StringPool.BLANK,
 			StringPool.BLANK, DLVersionNumberIncrease.MAJOR,
-			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
+			basicDocumentDLFileEntryType.getFileEntryTypeId(),
 			Collections.emptyMap(), null, inputStream, 0, null, null,
 			serviceContext);
 
@@ -498,16 +493,15 @@ public class FriendlyURLDLFileEntryLocalServiceWrapperTest
 			RandomTestUtil.randomString(),
 			ContentTypes.APPLICATION_OCTET_STREAM,
 			RandomTestUtil.randomString(), "urltitle", StringPool.BLANK,
-			StringPool.BLANK,
-			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT, null,
-			null, inputStream, bytes.length, null, null, serviceContext);
+			StringPool.BLANK, basicDocumentDLFileEntryType.getFileEntryTypeId(),
+			null, null, inputStream, bytes.length, null, null, serviceContext);
 
 		dlFileEntry = _dlFileEntryLocalService.updateFileEntry(
 			group.getCreatorUserId(), dlFileEntry.getFileEntryId(),
 			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
 			RandomTestUtil.randomString(), StringPool.BLANK, StringPool.BLANK,
 			StringPool.BLANK, DLVersionNumberIncrease.MAJOR,
-			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
+			basicDocumentDLFileEntryType.getFileEntryTypeId(),
 			Collections.emptyMap(), null, inputStream, bytes.length, null, null,
 			serviceContext);
 
@@ -537,16 +531,15 @@ public class FriendlyURLDLFileEntryLocalServiceWrapperTest
 			RandomTestUtil.randomString(),
 			ContentTypes.APPLICATION_OCTET_STREAM,
 			RandomTestUtil.randomString(), "originalURLTitle", StringPool.BLANK,
-			StringPool.BLANK,
-			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT, null,
-			null, inputStream, bytes.length, null, null, serviceContext);
+			StringPool.BLANK, basicDocumentDLFileEntryType.getFileEntryTypeId(),
+			null, null, inputStream, bytes.length, null, null, serviceContext);
 
 		dlFileEntry = _dlFileEntryLocalService.updateFileEntry(
 			group.getCreatorUserId(), dlFileEntry.getFileEntryId(),
 			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
 			RandomTestUtil.randomString(), "urltitle", StringPool.BLANK,
 			StringPool.BLANK, DLVersionNumberIncrease.MAJOR,
-			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
+			basicDocumentDLFileEntryType.getFileEntryTypeId(),
 			Collections.emptyMap(), null, inputStream, bytes.length, null, null,
 			serviceContext);
 
@@ -585,16 +578,15 @@ public class FriendlyURLDLFileEntryLocalServiceWrapperTest
 			RandomTestUtil.randomString(),
 			ContentTypes.APPLICATION_OCTET_STREAM,
 			RandomTestUtil.randomString(), "urltitle", StringPool.BLANK,
-			StringPool.BLANK,
-			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT, null,
-			null, inputStream, bytes.length, null, null, serviceContext);
+			StringPool.BLANK, basicDocumentDLFileEntryType.getFileEntryTypeId(),
+			null, null, inputStream, bytes.length, null, null, serviceContext);
 
 		dlFileEntry = _dlFileEntryLocalService.updateFileEntry(
 			group.getCreatorUserId(), dlFileEntry.getFileEntryId(),
 			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
 			RandomTestUtil.randomString(), null, StringPool.BLANK,
 			StringPool.BLANK, DLVersionNumberIncrease.MAJOR,
-			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
+			basicDocumentDLFileEntryType.getFileEntryTypeId(),
 			Collections.emptyMap(), null, inputStream, bytes.length, null, null,
 			serviceContext);
 
@@ -624,8 +616,8 @@ public class FriendlyURLDLFileEntryLocalServiceWrapperTest
 			RandomTestUtil.randomString(),
 			ContentTypes.APPLICATION_OCTET_STREAM, "<script>title</script>",
 			StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
-			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT, null,
-			null, inputStream, bytes.length, null, null, serviceContext);
+			basicDocumentDLFileEntryType.getFileEntryTypeId(), null, null,
+			inputStream, bytes.length, null, null, serviceContext);
 
 		FriendlyURLEntry mainFriendlyURLEntry =
 			_friendlyURLEntryLocalService.getMainFriendlyURLEntry(
@@ -641,7 +633,7 @@ public class FriendlyURLDLFileEntryLocalServiceWrapperTest
 			RandomTestUtil.randomString(), "url/title",
 			RandomTestUtil.randomString(), StringPool.BLANK,
 			DLVersionNumberIncrease.MAJOR,
-			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
+			basicDocumentDLFileEntryType.getFileEntryTypeId(),
 			Collections.emptyMap(), null, inputStream, bytes.length, null, null,
 			serviceContext);
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/service/test/FriendlyURLDLFileEntryServiceWrapperTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/service/test/FriendlyURLDLFileEntryServiceWrapperTest.java
@@ -16,7 +16,6 @@ package com.liferay.document.library.internal.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.document.library.kernel.model.DLFileEntry;
-import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
 import com.liferay.document.library.kernel.model.DLVersionNumberIncrease;
 import com.liferay.document.library.kernel.service.DLAppService;
 import com.liferay.document.library.kernel.service.DLFileEntryService;
@@ -71,8 +70,8 @@ public class FriendlyURLDLFileEntryServiceWrapperTest
 			parentFolder.getFolderId(), RandomTestUtil.randomString(),
 			ContentTypes.APPLICATION_OCTET_STREAM, "title", "urltitle",
 			StringPool.BLANK, StringPool.BLANK,
-			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT, null,
-			null, inputStream, bytes.length, null, null,
+			basicDocumentDLFileEntryType.getFileEntryTypeId(), null, null,
+			inputStream, bytes.length, null, null,
 			ServiceContextTestUtil.getServiceContext(
 				group.getGroupId(), TestPropsValues.getUserId()));
 
@@ -101,15 +100,15 @@ public class FriendlyURLDLFileEntryServiceWrapperTest
 			ContentTypes.APPLICATION_OCTET_STREAM,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			StringPool.BLANK, StringPool.BLANK,
-			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT, null,
-			null, inputStream, bytes.length, null, null, serviceContext);
+			basicDocumentDLFileEntryType.getFileEntryTypeId(), null, null,
+			inputStream, bytes.length, null, null, serviceContext);
 
 		dlFileEntry = _dlFileEntryService.updateFileEntry(
 			dlFileEntry.getFileEntryId(), StringUtil.randomString(),
 			ContentTypes.APPLICATION_OCTET_STREAM,
 			RandomTestUtil.randomString(), "urltitle", StringPool.BLANK,
 			StringPool.BLANK, DLVersionNumberIncrease.MAJOR,
-			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
+			basicDocumentDLFileEntryType.getFileEntryTypeId(),
 			Collections.emptyMap(), null, inputStream, 0, null, null,
 			serviceContext);
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/BaseDLIndexerTestCase.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/BaseDLIndexerTestCase.java
@@ -17,6 +17,7 @@ package com.liferay.document.library.search.test;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
 import com.liferay.document.library.kernel.service.DLFileEntryMetadataLocalService;
+import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalService;
 import com.liferay.document.library.kernel.service.DLFolderLocalService;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
@@ -88,6 +89,9 @@ public abstract class BaseDLIndexerTestCase {
 
 	@Inject
 	protected DLFileEntryMetadataLocalService dlFileEntryMetadataLocalService;
+
+	@Inject
+	protected DLFileEntryTypeLocalService dlFileEntryTypeLocalService;
 
 	protected DLFixture dlFixture;
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFileEntryMetadataDDMStructureIndexerTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFileEntryMetadataDDMStructureIndexerTest.java
@@ -16,7 +16,6 @@ package com.liferay.document.library.search.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.document.library.kernel.model.DLFileEntry;
-import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalService;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -124,9 +123,6 @@ public class DLFileEntryMetadataDDMStructureIndexerTest
 
 	@Inject
 	protected DDMStructureLocalService ddmStructureLocalService;
-
-	@Inject
-	protected DLFileEntryTypeLocalService dlFileEntryTypeLocalService;
 
 	protected DLFileEntryMetadataDDMStructureFixture fileEntryMetadataFixture;
 	protected IndexerFixture<DLFileEntry> indexerFixture;

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFolderIndexerIndexedFieldsTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFolderIndexerIndexedFieldsTest.java
@@ -74,7 +74,8 @@ public class DLFolderIndexerIndexedFieldsTest extends BaseDLIndexerTestCase {
 		super.setUp();
 
 		dlFolderSearchFixture = new DLFolderSearchFixture(
-			dlAppLocalService, dlFileEntryLocalService, dlFolderLocalService);
+			dlAppLocalService, dlFileEntryLocalService,
+			dlFileEntryTypeLocalService, dlFolderLocalService);
 
 		setGroup(dlFixture.addGroup());
 		setIndexerClass(DLFolder.class);

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryFinderTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryFinderTest.java
@@ -17,6 +17,7 @@ package com.liferay.document.library.service.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.asset.kernel.service.AssetEntryLocalServiceUtil;
 import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.document.library.kernel.model.DLFileEntryType;
 import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
 import com.liferay.document.library.kernel.model.DLFileVersion;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
@@ -24,6 +25,7 @@ import com.liferay.document.library.kernel.model.DLVersionNumberIncrease;
 import com.liferay.document.library.kernel.service.DLAppLocalServiceUtil;
 import com.liferay.document.library.kernel.service.DLAppServiceUtil;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalServiceUtil;
+import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalServiceUtil;
 import com.liferay.document.library.kernel.service.DLFileVersionLocalServiceUtil;
 import com.liferay.document.library.kernel.service.DLTrashServiceUtil;
 import com.liferay.document.library.test.util.DLAppTestUtil;
@@ -1486,10 +1488,13 @@ public class DLFileEntryFinderTest {
 
 		DLTrashServiceUtil.moveFolderToTrash(folderC.getFolderId());
 
+		DLFileEntryType basicDocumentDLFileEntryType =
+			DLFileEntryTypeLocalServiceUtil.getBasicDocumentDLFileEntryType();
+
 		FileEntry fileEntry = addFileEntry(
 			_user.getUserId(), repositoryId, folder.getFolderId(), "FE1.txt",
 			titleSuffix, ContentTypes.TEXT_PLAIN,
-			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT);
+			basicDocumentDLFileEntryType.getFileEntryTypeId());
 
 		LiferayFileEntry liferayFileEntry = (LiferayFileEntry)fileEntry;
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryFinderTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryFinderTest.java
@@ -1489,7 +1489,8 @@ public class DLFileEntryFinderTest {
 		DLTrashServiceUtil.moveFolderToTrash(folderC.getFolderId());
 
 		DLFileEntryType basicDocumentDLFileEntryType =
-			DLFileEntryTypeLocalServiceUtil.getBasicDocumentDLFileEntryType();
+			DLFileEntryTypeLocalServiceUtil.getBasicDocumentDLFileEntryType(
+				_user.getCompanyId());
 
 		FileEntry fileEntry = addFileEntry(
 			_user.getUserId(), repositoryId, folder.getFolderId(), "FE1.txt",

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryLocalServiceTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryLocalServiceTest.java
@@ -28,7 +28,6 @@ import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFileEntryConstants;
 import com.liferay.document.library.kernel.model.DLFileEntryMetadata;
 import com.liferay.document.library.kernel.model.DLFileEntryType;
-import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
 import com.liferay.document.library.kernel.model.DLFileVersion;
 import com.liferay.document.library.kernel.model.DLFolder;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
@@ -123,6 +122,9 @@ public class DLFileEntryLocalServiceTest {
 
 	@Before
 	public void setUp() throws Exception {
+		_basicDocumentDLFileEntryType =
+			DLFileEntryTypeLocalServiceUtil.getBasicDocumentDLFileEntryType();
+
 		_group = GroupTestUtil.addGroup();
 	}
 
@@ -168,9 +170,8 @@ public class DLFileEntryLocalServiceTest {
 				ContentTypes.APPLICATION_OCTET_STREAM,
 				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 				RandomTestUtil.randomString(), StringUtil.randomString(),
-				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
-				null, null, new UnsyncByteArrayInputStream(new byte[0]), 0,
-				null, null,
+				_basicDocumentDLFileEntryType.getFileEntryTypeId(), null, null,
+				new UnsyncByteArrayInputStream(new byte[0]), 0, null, null,
 				ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
 		}
 		finally {
@@ -200,9 +201,8 @@ public class DLFileEntryLocalServiceTest {
 				ContentTypes.APPLICATION_OCTET_STREAM,
 				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 				StringUtil.randomString(), RandomTestUtil.randomString(),
-				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
-				null, null, new UnsyncByteArrayInputStream(new byte[0]), 0,
-				null, null,
+				_basicDocumentDLFileEntryType.getFileEntryTypeId(), null, null,
+				new UnsyncByteArrayInputStream(new byte[0]), 0, null, null,
 				ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
 		}
 		finally {
@@ -635,9 +635,8 @@ public class DLFileEntryLocalServiceTest {
 			StringUtil.randomString(), ContentTypes.TEXT_PLAIN,
 			StringUtil.randomString(), StringUtil.randomString(),
 			StringPool.BLANK, StringPool.BLANK,
-			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
-			new HashMap<>(), null, new ByteArrayInputStream(new byte[0]), 0,
-			null, null,
+			_basicDocumentDLFileEntryType.getFileEntryTypeId(), new HashMap<>(),
+			null, new ByteArrayInputStream(new byte[0]), 0, null, null,
 			ServiceContextTestUtil.getServiceContext(
 				_group.getGroupId(), TestPropsValues.getUserId()));
 
@@ -664,7 +663,7 @@ public class DLFileEntryLocalServiceTest {
 			dlFolder.getFolderId(), StringUtil.randomString(),
 			ContentTypes.TEXT_PLAIN, StringUtil.randomString(),
 			StringUtil.randomString(), StringPool.BLANK, StringPool.BLANK,
-			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
+			_basicDocumentDLFileEntryType.getFileEntryTypeId(),
 			ddmFormValuesMap, null, inputStream, 0, null, null, serviceContext);
 
 		DLFileEntryLocalServiceUtil.addFileEntry(
@@ -673,7 +672,7 @@ public class DLFileEntryLocalServiceTest {
 			dlFolder.getFolderId(), StringUtil.randomString(),
 			ContentTypes.TEXT_PLAIN, StringUtil.randomString(),
 			StringUtil.randomString(), StringPool.BLANK, StringPool.BLANK,
-			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
+			_basicDocumentDLFileEntryType.getFileEntryTypeId(),
 			ddmFormValuesMap, null, inputStream, 0, null, null, serviceContext);
 	}
 
@@ -718,7 +717,7 @@ public class DLFileEntryLocalServiceTest {
 			dlFolder.getRepositoryId(), dlFolder.getFolderId(),
 			StringUtil.randomString(), ContentTypes.TEXT_PLAIN, title,
 			StringUtil.randomString(), StringPool.BLANK, StringPool.BLANK,
-			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
+			_basicDocumentDLFileEntryType.getFileEntryTypeId(),
 			ddmFormValuesMap, null, inputStream, 0, null, null, serviceContext);
 
 		DLFileEntryLocalServiceUtil.addFileEntry(
@@ -726,7 +725,7 @@ public class DLFileEntryLocalServiceTest {
 			dlFolder.getRepositoryId(), dlFolder.getFolderId(),
 			StringUtil.randomString(), ContentTypes.TEXT_PLAIN, title,
 			StringUtil.randomString(), StringPool.BLANK, StringPool.BLANK,
-			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
+			_basicDocumentDLFileEntryType.getFileEntryTypeId(),
 			ddmFormValuesMap, null, inputStream, 0, null, null, serviceContext);
 	}
 
@@ -892,9 +891,9 @@ public class DLFileEntryLocalServiceTest {
 			StringUtil.randomString(), ContentTypes.TEXT_PLAIN,
 			StringUtil.randomString(), StringUtil.randomString(),
 			StringPool.BLANK, StringPool.BLANK,
-			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
-			new HashMap<>(), null, new ByteArrayInputStream(new byte[0]), 0,
-			null, null, serviceContext);
+			_basicDocumentDLFileEntryType.getFileEntryTypeId(), new HashMap<>(),
+			null, new ByteArrayInputStream(new byte[0]), 0, null, null,
+			serviceContext);
 
 		DLFolder destinationDLFolder = DLTestUtil.addDLFolder(
 			_group.getGroupId());
@@ -905,9 +904,9 @@ public class DLFileEntryLocalServiceTest {
 			destinationDLFolder.getFolderId(), StringUtil.randomString(),
 			ContentTypes.TEXT_PLAIN, StringUtil.randomString(),
 			StringUtil.randomString(), StringPool.BLANK, StringPool.BLANK,
-			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
-			new HashMap<>(), null, new ByteArrayInputStream(new byte[0]), 0,
-			null, null, serviceContext);
+			_basicDocumentDLFileEntryType.getFileEntryTypeId(), new HashMap<>(),
+			null, new ByteArrayInputStream(new byte[0]), 0, null, null,
+			serviceContext);
 
 		DLFileEntryLocalServiceUtil.moveFileEntry(
 			TestPropsValues.getUserId(), dlFileEntry.getFileEntryId(),
@@ -936,9 +935,9 @@ public class DLFileEntryLocalServiceTest {
 			originDLFolder.getRepositoryId(), originDLFolder.getFolderId(),
 			StringUtil.randomString(), ContentTypes.TEXT_PLAIN, title,
 			StringUtil.randomString(), StringPool.BLANK, StringPool.BLANK,
-			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
-			new HashMap<>(), null, new ByteArrayInputStream(new byte[0]), 0,
-			null, null, serviceContext);
+			_basicDocumentDLFileEntryType.getFileEntryTypeId(), new HashMap<>(),
+			null, new ByteArrayInputStream(new byte[0]), 0, null, null,
+			serviceContext);
 
 		DLFolder destinationDLFolder = DLTestUtil.addDLFolder(
 			_group.getGroupId());
@@ -949,9 +948,9 @@ public class DLFileEntryLocalServiceTest {
 			destinationDLFolder.getFolderId(), StringUtil.randomString(),
 			ContentTypes.TEXT_PLAIN, title, StringUtil.randomString(),
 			StringPool.BLANK, StringPool.BLANK,
-			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
-			new HashMap<>(), null, new ByteArrayInputStream(new byte[0]), 0,
-			null, null, serviceContext);
+			_basicDocumentDLFileEntryType.getFileEntryTypeId(), new HashMap<>(),
+			null, new ByteArrayInputStream(new byte[0]), 0, null, null,
+			serviceContext);
 
 		DLFileEntryLocalServiceUtil.moveFileEntry(
 			TestPropsValues.getUserId(), dlFileEntry.getFileEntryId(),
@@ -971,9 +970,9 @@ public class DLFileEntryLocalServiceTest {
 			StringUtil.randomString(), ContentTypes.TEXT_PLAIN,
 			StringUtil.randomString(), StringUtil.randomString(),
 			StringPool.BLANK, StringPool.BLANK,
-			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
-			new HashMap<>(), null, new ByteArrayInputStream(new byte[0]), 0,
-			null, null, serviceContext);
+			_basicDocumentDLFileEntryType.getFileEntryTypeId(), new HashMap<>(),
+			null, new ByteArrayInputStream(new byte[0]), 0, null, null,
+			serviceContext);
 
 		Group destinationGroup = GroupTestUtil.addGroup();
 
@@ -1183,7 +1182,7 @@ public class DLFileEntryLocalServiceTest {
 			StringUtil.randomString(), ContentTypes.TEXT_PLAIN,
 			StringUtil.randomString(), StringUtil.randomString(),
 			StringPool.BLANK, StringPool.BLANK,
-			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
+			_basicDocumentDLFileEntryType.getFileEntryTypeId(),
 			ddmFormValuesMap, null, inputStream, 0, null, null, serviceContext);
 
 		DLFileVersion dlFileVersion = dlFileEntry.getLatestFileVersion(true);
@@ -1275,7 +1274,7 @@ public class DLFileEntryLocalServiceTest {
 			StringUtil.randomString(), ContentTypes.TEXT_PLAIN,
 			StringUtil.randomString(), StringUtil.randomString(),
 			StringPool.BLANK, StringPool.BLANK, DLVersionNumberIncrease.MAJOR,
-			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
+			_basicDocumentDLFileEntryType.getFileEntryTypeId(),
 			ddmFormValuesMap, null, inputStream, 0,
 			dlFileEntry.getExpirationDate(), dlFileEntry.getReviewDate(),
 			serviceContext);
@@ -1286,6 +1285,8 @@ public class DLFileEntryLocalServiceTest {
 			TestPropsValues.getUserId(), dlFileVersion.getFileVersionId(),
 			WorkflowConstants.STATUS_APPROVED, serviceContext, new HashMap<>());
 	}
+
+	private DLFileEntryType _basicDocumentDLFileEntryType;
 
 	@DeleteAfterTestRun
 	private Group _group;

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryLocalServiceTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryLocalServiceTest.java
@@ -123,7 +123,8 @@ public class DLFileEntryLocalServiceTest {
 	@Before
 	public void setUp() throws Exception {
 		_basicDocumentDLFileEntryType =
-			DLFileEntryTypeLocalServiceUtil.getBasicDocumentDLFileEntryType();
+			DLFileEntryTypeLocalServiceUtil.getBasicDocumentDLFileEntryType(
+				TestPropsValues.getCompanyId());
 
 		_group = GroupTestUtil.addGroup();
 	}
@@ -351,6 +352,7 @@ public class DLFileEntryLocalServiceTest {
 
 		Assert.assertEquals(
 			DLFileEntryTypeLocalServiceUtil.getDefaultFileEntryTypeId(
+				_group.getCompanyId(),
 				DLFolderConstants.DEFAULT_PARENT_FOLDER_ID),
 			dlFileEntry.getFileEntryTypeId());
 	}

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryServiceTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryServiceTest.java
@@ -16,13 +16,14 @@ package com.liferay.document.library.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.document.library.kernel.model.DLFileEntry;
-import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
+import com.liferay.document.library.kernel.model.DLFileEntryType;
 import com.liferay.document.library.kernel.model.DLFileVersion;
 import com.liferay.document.library.kernel.model.DLFolder;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.model.DLVersionNumberIncrease;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalServiceUtil;
 import com.liferay.document.library.kernel.service.DLFileEntryServiceUtil;
+import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalServiceUtil;
 import com.liferay.document.library.kernel.service.DLFileVersionLocalServiceUtil;
 import com.liferay.document.library.kernel.service.DLFolderLocalServiceUtil;
 import com.liferay.document.library.kernel.util.DLUtil;
@@ -315,14 +316,16 @@ public class DLFileEntryServiceTest {
 
 		String fileEntryTitle = RandomTestUtil.randomString();
 
+		DLFileEntryType basicDocumentDLFileEntryType =
+			DLFileEntryTypeLocalServiceUtil.getBasicDocumentDLFileEntryType();
+
 		return DLFileEntryLocalServiceUtil.addFileEntry(
 			null, TestPropsValues.getUserId(), _group.getGroupId(),
 			_group.getGroupId(), folderId, sourceFileName, null, fileEntryTitle,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-			StringPool.BLANK,
-			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT, null,
-			null, new ByteArrayInputStream(_CONTENT.getBytes()), 0, null, null,
-			serviceContext);
+			StringPool.BLANK, basicDocumentDLFileEntryType.getFileEntryTypeId(),
+			null, null, new ByteArrayInputStream(_CONTENT.getBytes()), 0, null,
+			null, serviceContext);
 	}
 
 	protected DLFileEntry updateDLFileEntry(

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryServiceTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryServiceTest.java
@@ -317,7 +317,8 @@ public class DLFileEntryServiceTest {
 		String fileEntryTitle = RandomTestUtil.randomString();
 
 		DLFileEntryType basicDocumentDLFileEntryType =
-			DLFileEntryTypeLocalServiceUtil.getBasicDocumentDLFileEntryType();
+			DLFileEntryTypeLocalServiceUtil.getBasicDocumentDLFileEntryType(
+				_group.getCompanyId());
 
 		return DLFileEntryLocalServiceUtil.addFileEntry(
 			null, TestPropsValues.getUserId(), _group.getGroupId(),

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryTypeFinderTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryTypeFinderTest.java
@@ -276,14 +276,11 @@ public class DLFileEntryTypeFinderTest {
 			fileEntryTypes.toString(), 2, fileEntryTypes.size());
 		Assert.assertTrue(
 			fileEntryTypes.toString(), fileEntryTypes.contains(fileEntryType));
-
-		DLFileEntryType basicFileEntryType =
-			DLFileEntryTypeLocalServiceUtil.getFileEntryType(
-				0, "BASIC-DOCUMENT");
-
 		Assert.assertTrue(
 			fileEntryTypes.toString(),
-			fileEntryTypes.contains(basicFileEntryType));
+			fileEntryTypes.contains(
+				DLFileEntryTypeLocalServiceUtil.
+					getBasicDocumentDLFileEntryType()));
 	}
 
 	@Test
@@ -298,14 +295,11 @@ public class DLFileEntryTypeFinderTest {
 
 		Assert.assertEquals(
 			fileEntryTypes.toString(), 1, fileEntryTypes.size());
-
-		DLFileEntryType basicFileEntryType =
-			DLFileEntryTypeLocalServiceUtil.getFileEntryType(
-				0, "BASIC-DOCUMENT");
-
 		Assert.assertTrue(
 			fileEntryTypes.toString(),
-			fileEntryTypes.contains(basicFileEntryType));
+			fileEntryTypes.contains(
+				DLFileEntryTypeLocalServiceUtil.
+					getBasicDocumentDLFileEntryType()));
 	}
 
 	@Test

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryTypeFinderTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryTypeFinderTest.java
@@ -279,8 +279,8 @@ public class DLFileEntryTypeFinderTest {
 		Assert.assertTrue(
 			fileEntryTypes.toString(),
 			fileEntryTypes.contains(
-				DLFileEntryTypeLocalServiceUtil.
-					getBasicDocumentDLFileEntryType()));
+				DLFileEntryTypeLocalServiceUtil.getBasicDocumentDLFileEntryType(
+					_group.getCompanyId())));
 	}
 
 	@Test
@@ -298,8 +298,8 @@ public class DLFileEntryTypeFinderTest {
 		Assert.assertTrue(
 			fileEntryTypes.toString(),
 			fileEntryTypes.contains(
-				DLFileEntryTypeLocalServiceUtil.
-					getBasicDocumentDLFileEntryType()));
+				DLFileEntryTypeLocalServiceUtil.getBasicDocumentDLFileEntryType(
+					_group.getCompanyId())));
 	}
 
 	@Test

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryTypeServiceTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryTypeServiceTest.java
@@ -18,7 +18,6 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFileEntryMetadata;
 import com.liferay.document.library.kernel.model.DLFileEntryType;
-import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLAppLocalServiceUtil;
 import com.liferay.document.library.kernel.service.DLAppServiceUtil;
@@ -96,8 +95,7 @@ public class DLFileEntryTypeServiceTest {
 			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
 
 		_basicDocumentDLFileEntryType =
-			DLFileEntryTypeLocalServiceUtil.getFileEntryType(
-				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT);
+			DLFileEntryTypeLocalServiceUtil.getBasicDocumentDLFileEntryType();
 
 		DDMStructure ddmStructure1 = DDMStructureTestUtil.addStructure(
 			_group.getGroupId(), DLFileEntryMetadata.class.getName());

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryTypeServiceTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryTypeServiceTest.java
@@ -95,7 +95,8 @@ public class DLFileEntryTypeServiceTest {
 			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
 
 		_basicDocumentDLFileEntryType =
-			DLFileEntryTypeLocalServiceUtil.getBasicDocumentDLFileEntryType();
+			DLFileEntryTypeLocalServiceUtil.getBasicDocumentDLFileEntryType(
+				_group.getCompanyId());
 
 		DDMStructure ddmStructure1 = DDMStructureTestUtil.addStructure(
 			_group.getGroupId(), DLFileEntryMetadata.class.getName());

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileVersionTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileVersionTest.java
@@ -20,7 +20,6 @@ import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFileEntryConstants;
 import com.liferay.document.library.kernel.model.DLFileEntryMetadata;
 import com.liferay.document.library.kernel.model.DLFileEntryType;
-import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
 import com.liferay.document.library.kernel.model.DLFileVersion;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.model.DLVersionNumberIncrease;
@@ -239,9 +238,11 @@ public class DLFileVersionTest {
 
 	@Test
 	public void testUpdateFileEntryType() throws Exception {
+		DLFileEntryType basicDocumentDLFileEntryType =
+			DLFileEntryTypeLocalServiceUtil.getBasicDocumentDLFileEntryType();
+
 		updateServiceContext(
-			StringPool.BLANK,
-			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
+			StringPool.BLANK, basicDocumentDLFileEntryType.getFileEntryTypeId(),
 			StringPool.BLANK);
 
 		FileEntry fileEntry = DLAppServiceUtil.updateFileEntry(

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileVersionTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileVersionTest.java
@@ -239,7 +239,8 @@ public class DLFileVersionTest {
 	@Test
 	public void testUpdateFileEntryType() throws Exception {
 		DLFileEntryType basicDocumentDLFileEntryType =
-			DLFileEntryTypeLocalServiceUtil.getBasicDocumentDLFileEntryType();
+			DLFileEntryTypeLocalServiceUtil.getBasicDocumentDLFileEntryType(
+				_fileVersion.getCompanyId());
 
 		updateServiceContext(
 			StringPool.BLANK, basicDocumentDLFileEntryType.getFileEntryTypeId(),

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/subscription/test/DLSubscriptionClassTypeTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/subscription/test/DLSubscriptionClassTypeTest.java
@@ -17,7 +17,6 @@ package com.liferay.document.library.subscription.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.document.library.kernel.model.DLFileEntryMetadata;
 import com.liferay.document.library.kernel.model.DLFileEntryType;
-import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
 import com.liferay.document.library.kernel.model.DLVersionNumberIncrease;
 import com.liferay.document.library.kernel.service.DLAppLocalServiceUtil;
 import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalServiceUtil;
@@ -112,8 +111,7 @@ public class DLSubscriptionClassTypeTest
 	@Override
 	protected Long getDefaultClassTypeId() throws Exception {
 		DLFileEntryType basicEntryType =
-			DLFileEntryTypeLocalServiceUtil.getDLFileEntryType(
-				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT);
+			DLFileEntryTypeLocalServiceUtil.getBasicDocumentDLFileEntryType();
 
 		Assert.assertNotNull(basicEntryType);
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/subscription/test/DLSubscriptionClassTypeTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/subscription/test/DLSubscriptionClassTypeTest.java
@@ -111,7 +111,8 @@ public class DLSubscriptionClassTypeTest
 	@Override
 	protected Long getDefaultClassTypeId() throws Exception {
 		DLFileEntryType basicEntryType =
-			DLFileEntryTypeLocalServiceUtil.getBasicDocumentDLFileEntryType();
+			DLFileEntryTypeLocalServiceUtil.getBasicDocumentDLFileEntryType(
+				user.getCompanyId());
 
 		Assert.assertNotNull(basicEntryType);
 

--- a/modules/apps/document-library/document-library-uad-test/src/testIntegration/java/com/liferay/document/library/uad/anonymizer/test/DLFileShortcutUADAnonymizerTest.java
+++ b/modules/apps/document-library/document-library-uad-test/src/testIntegration/java/com/liferay/document/library/uad/anonymizer/test/DLFileShortcutUADAnonymizerTest.java
@@ -17,6 +17,7 @@ package com.liferay.document.library.uad.anonymizer.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.document.library.kernel.model.DLFileShortcut;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
+import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalService;
 import com.liferay.document.library.kernel.service.DLFileShortcutLocalService;
 import com.liferay.document.library.kernel.service.DLFolderLocalService;
 import com.liferay.document.library.uad.test.DLFileShortcutUADTestUtil;
@@ -57,8 +58,9 @@ public class DLFileShortcutUADAnonymizerTest
 		throws Exception {
 
 		return DLFileShortcutUADTestUtil.addDLFileShortcutWithStatusByUserId(
-			_dlFileEntryLocalService, _dlFileShortcutLocalService,
-			_dlFolderLocalService, userId, _group.getGroupId(), statusByUserId);
+			_dlFileEntryLocalService, _dlFileEntryTypeLocalService,
+			_dlFileShortcutLocalService, _dlFolderLocalService, userId,
+			_group.getGroupId(), statusByUserId);
 	}
 
 	@Before
@@ -80,8 +82,9 @@ public class DLFileShortcutUADAnonymizerTest
 		throws Exception {
 
 		return DLFileShortcutUADTestUtil.addDLFileShortcut(
-			_dlFileEntryLocalService, _dlFileShortcutLocalService,
-			_dlFolderLocalService, userId, _group.getGroupId());
+			_dlFileEntryLocalService, _dlFileEntryTypeLocalService,
+			_dlFileShortcutLocalService, _dlFolderLocalService, userId,
+			_group.getGroupId());
 	}
 
 	@Override
@@ -134,6 +137,9 @@ public class DLFileShortcutUADAnonymizerTest
 
 	@Inject
 	private DLFileEntryLocalService _dlFileEntryLocalService;
+
+	@Inject
+	private DLFileEntryTypeLocalService _dlFileEntryTypeLocalService;
 
 	@Inject
 	private DLFileShortcutLocalService _dlFileShortcutLocalService;

--- a/modules/apps/document-library/document-library-uad-test/src/testIntegration/java/com/liferay/document/library/uad/exporter/test/DLFileShortcutUADExporterTest.java
+++ b/modules/apps/document-library/document-library-uad-test/src/testIntegration/java/com/liferay/document/library/uad/exporter/test/DLFileShortcutUADExporterTest.java
@@ -17,6 +17,7 @@ package com.liferay.document.library.uad.exporter.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.document.library.kernel.model.DLFileShortcut;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
+import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalService;
 import com.liferay.document.library.kernel.service.DLFileShortcutLocalService;
 import com.liferay.document.library.kernel.service.DLFolderLocalService;
 import com.liferay.document.library.uad.test.DLFileShortcutUADTestUtil;
@@ -54,8 +55,9 @@ public class DLFileShortcutUADExporterTest
 		throws Exception {
 
 		return DLFileShortcutUADTestUtil.addDLFileShortcutWithStatusByUserId(
-			_dlFileEntryLocalService, _dlFileShortcutLocalService,
-			_dlFolderLocalService, userId, _group.getGroupId(), statusByUserId);
+			_dlFileEntryLocalService, _dlFileEntryTypeLocalService,
+			_dlFileShortcutLocalService, _dlFolderLocalService, userId,
+			_group.getGroupId(), statusByUserId);
 	}
 
 	@Before
@@ -69,8 +71,9 @@ public class DLFileShortcutUADExporterTest
 	@Override
 	protected DLFileShortcut addBaseModel(long userId) throws Exception {
 		return DLFileShortcutUADTestUtil.addDLFileShortcut(
-			_dlFileEntryLocalService, _dlFileShortcutLocalService,
-			_dlFolderLocalService, userId, _group.getGroupId());
+			_dlFileEntryLocalService, _dlFileEntryTypeLocalService,
+			_dlFileShortcutLocalService, _dlFolderLocalService, userId,
+			_group.getGroupId());
 	}
 
 	@Override
@@ -85,6 +88,9 @@ public class DLFileShortcutUADExporterTest
 
 	@Inject
 	private DLFileEntryLocalService _dlFileEntryLocalService;
+
+	@Inject
+	private DLFileEntryTypeLocalService _dlFileEntryTypeLocalService;
 
 	@Inject
 	private DLFileShortcutLocalService _dlFileShortcutLocalService;

--- a/modules/apps/document-library/document-library-uad-test/src/testIntegration/java/com/liferay/document/library/uad/test/DLFileShortcutUADTestUtil.java
+++ b/modules/apps/document-library/document-library-uad-test/src/testIntegration/java/com/liferay/document/library/uad/test/DLFileShortcutUADTestUtil.java
@@ -15,10 +15,11 @@
 package com.liferay.document.library.uad.test;
 
 import com.liferay.document.library.kernel.model.DLFileEntry;
-import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
+import com.liferay.document.library.kernel.model.DLFileEntryType;
 import com.liferay.document.library.kernel.model.DLFileShortcut;
 import com.liferay.document.library.kernel.model.DLFolder;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
+import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalService;
 import com.liferay.document.library.kernel.service.DLFileShortcutLocalService;
 import com.liferay.document.library.kernel.service.DLFolderLocalService;
 import com.liferay.petra.string.StringPool;
@@ -41,6 +42,7 @@ public class DLFileShortcutUADTestUtil {
 
 	public static DLFileShortcut addDLFileShortcut(
 			DLFileEntryLocalService dlFileEntryLocalService,
+			DLFileEntryTypeLocalService dlFileEntryTypeLocalService,
 			DLFileShortcutLocalService dlFileShortcutLocalService,
 			DLFolderLocalService dlFolderLocalService, long userId,
 			long groupId)
@@ -54,6 +56,9 @@ public class DLFileShortcutUADTestUtil {
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(), false,
 			serviceContext);
 
+		DLFileEntryType basicDocumentDLFileEntryType =
+			dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType();
+
 		byte[] bytes = TestDataConstants.TEST_BYTE_ARRAY;
 
 		InputStream inputStream = new ByteArrayInputStream(bytes);
@@ -63,8 +68,8 @@ public class DLFileShortcutUADTestUtil {
 			dlFolder.getFolderId(), RandomTestUtil.randomString(),
 			ContentTypes.TEXT_PLAIN, RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(), StringPool.BLANK, StringPool.BLANK,
-			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT, null,
-			null, inputStream, bytes.length, null, null, serviceContext);
+			basicDocumentDLFileEntryType.getFileEntryTypeId(), null, null,
+			inputStream, bytes.length, null, null, serviceContext);
 
 		return dlFileShortcutLocalService.addFileShortcut(
 			userId, groupId, groupId, dlFolder.getFolderId(),
@@ -73,14 +78,15 @@ public class DLFileShortcutUADTestUtil {
 
 	public static DLFileShortcut addDLFileShortcutWithStatusByUserId(
 			DLFileEntryLocalService dlFileEntryLocalService,
+			DLFileEntryTypeLocalService dlFileEntryTypeLocalService,
 			DLFileShortcutLocalService dlFileShortcutLocalService,
 			DLFolderLocalService dlFolderLocalService, long userId,
 			long groupId, long statusByUserId)
 		throws Exception {
 
 		DLFileShortcut dlFileShortcut = addDLFileShortcut(
-			dlFileEntryLocalService, dlFileShortcutLocalService,
-			dlFolderLocalService, userId, groupId);
+			dlFileEntryLocalService, dlFileEntryTypeLocalService,
+			dlFileShortcutLocalService, dlFolderLocalService, userId, groupId);
 
 		return dlFileShortcutLocalService.updateStatus(
 			statusByUserId, dlFileShortcut.getFileShortcutId(),

--- a/modules/apps/document-library/document-library-uad-test/src/testIntegration/java/com/liferay/document/library/uad/test/DLFileShortcutUADTestUtil.java
+++ b/modules/apps/document-library/document-library-uad-test/src/testIntegration/java/com/liferay/document/library/uad/test/DLFileShortcutUADTestUtil.java
@@ -57,7 +57,8 @@ public class DLFileShortcutUADTestUtil {
 			serviceContext);
 
 		DLFileEntryType basicDocumentDLFileEntryType =
-			dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType();
+			dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType(
+				serviceContext.getCompanyId());
 
 		byte[] bytes = TestDataConstants.TEST_BYTE_ARRAY;
 

--- a/modules/apps/document-library/document-library-video/src/main/java/com/liferay/document/library/video/internal/helper/DLVideoExternalShortcutDLFileEntryTypeHelper.java
+++ b/modules/apps/document-library/document-library-video/src/main/java/com/liferay/document/library/video/internal/helper/DLVideoExternalShortcutDLFileEntryTypeHelper.java
@@ -80,7 +80,8 @@ public class DLVideoExternalShortcutDLFileEntryTypeHelper {
 		else {
 			DLFileEntryType dlFileEntryType =
 				_dlFileEntryTypeLocalService.fetchDataDefinitionFileEntryType(
-					_company.getGroupId(), ddmStructure.getStructureId());
+					_company.getGroupId(), _company.getCompanyId(),
+					ddmStructure.getStructureId());
 
 			if (dlFileEntryType == null) {
 				_addDLVideoExternalShortcutDLFileEntryType(

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/asset/model/DLFileEntryAssetRendererFactory.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/asset/model/DLFileEntryAssetRendererFactory.java
@@ -189,7 +189,7 @@ public class DLFileEntryAssetRendererFactory
 			() -> {
 				DLFileEntryType basicDocumentDLFileEntryType =
 					_dlFileEntryTypeLocalService.
-						getBasicDocumentDLFileEntryType();
+						getBasicDocumentDLFileEntryType(group.getCompanyId());
 
 				long fileEntryTypeId =
 					basicDocumentDLFileEntryType.getFileEntryTypeId();

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/asset/model/DLFileEntryAssetRendererFactory.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/asset/model/DLFileEntryAssetRendererFactory.java
@@ -23,7 +23,6 @@ import com.liferay.document.library.constants.DLPortletKeys;
 import com.liferay.document.library.kernel.exception.NoSuchFileEntryException;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFileEntryType;
-import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
@@ -188,8 +187,12 @@ public class DLFileEntryAssetRendererFactory
 		).setParameter(
 			"fileEntryTypeId",
 			() -> {
+				DLFileEntryType basicDocumentDLFileEntryType =
+					_dlFileEntryTypeLocalService.
+						getBasicDocumentDLFileEntryType();
+
 				long fileEntryTypeId =
-					DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT;
+					basicDocumentDLFileEntryType.getFileEntryTypeId();
 
 				if (classTypeId >= 0) {
 					fileEntryTypeId = classTypeId;

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/asset/model/DLFileEntryAssetRendererFactory.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/asset/model/DLFileEntryAssetRendererFactory.java
@@ -23,6 +23,7 @@ import com.liferay.document.library.constants.DLPortletKeys;
 import com.liferay.document.library.kernel.exception.NoSuchFileEntryException;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFileEntryType;
+import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
@@ -237,7 +238,13 @@ public class DLFileEntryAssetRendererFactory
 			PermissionChecker permissionChecker, long groupId, long classTypeId)
 		throws Exception {
 
-		if ((classTypeId > 0) &&
+		DLFileEntryType basicDocumentDLFileEntryType =
+			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType(
+				permissionChecker.getCompanyId());
+
+		if ((classTypeId != DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_ALL) &&
+			(classTypeId !=
+				basicDocumentDLFileEntryType.getFileEntryTypeId()) &&
 			!_dlFileEntryTypeModelResourcePermission.contains(
 				permissionChecker, classTypeId, ActionKeys.VIEW)) {
 

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/data/engine/content/type/DLDataDefinitionContentType.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/data/engine/content/type/DLDataDefinitionContentType.java
@@ -89,7 +89,7 @@ public class DLDataDefinitionContentType implements DataDefinitionContentType {
 
 			DLFileEntryType dlFileEntryType =
 				_dlFileEntryTypeLocalService.fetchDataDefinitionFileEntryType(
-					groupId, primKey);
+					groupId, companyId, primKey);
 
 			if (dlFileEntryType != null) {
 				resourceName = DLFileEntryType.class.getName();

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminDisplayContext.java
@@ -23,6 +23,7 @@ import com.liferay.document.library.kernel.exception.NoSuchFolderException;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFileEntryConstants;
 import com.liferay.document.library.kernel.model.DLFileEntryType;
+import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
 import com.liferay.document.library.kernel.model.DLFileShortcutConstants;
 import com.liferay.document.library.kernel.model.DLFolder;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
@@ -206,9 +207,13 @@ public class DLAdminDisplayContext {
 			_httpServletRequest, "orderByCol");
 
 		long fileEntryTypeId = ParamUtil.getLong(
-			_httpServletRequest, "fileEntryTypeId", -1);
+			_httpServletRequest, "fileEntryTypeId",
+			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_ALL);
 
-		if (orderByCol.equals("downloads") && (fileEntryTypeId >= 0)) {
+		if (orderByCol.equals("downloads") &&
+			(fileEntryTypeId !=
+				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_ALL)) {
+
 			orderByCol = "modifiedDate";
 		}
 
@@ -525,7 +530,8 @@ public class DLAdminDisplayContext {
 			_httpServletRequest, "deltaFolder");
 
 		long fileEntryTypeId = ParamUtil.getLong(
-			_httpServletRequest, "fileEntryTypeId", -1);
+			_httpServletRequest, "fileEntryTypeId",
+			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_ALL);
 
 		String dlFileEntryTypeName = LanguageUtil.get(
 			_httpServletRequest, "basic-document");
@@ -567,23 +573,25 @@ public class DLAdminDisplayContext {
 		portletURL.setParameter("deltaFolder", deltaFolder);
 		portletURL.setParameter("folderId", String.valueOf(folderId));
 
-		if (fileEntryTypeId >= 0) {
+		if (fileEntryTypeId !=
+				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_ALL) {
+
 			portletURL.setParameter(
 				"fileEntryTypeId", String.valueOf(fileEntryTypeId));
 
-			if (fileEntryTypeId > 0) {
-				DLFileEntryType dlFileEntryType =
-					DLFileEntryTypeLocalServiceUtil.getFileEntryType(
-						fileEntryTypeId);
+			DLFileEntryType dlFileEntryType =
+				DLFileEntryTypeLocalServiceUtil.getFileEntryType(
+					fileEntryTypeId);
 
-				dlFileEntryTypeName = dlFileEntryType.getName(
-					_httpServletRequest.getLocale());
-			}
+			dlFileEntryTypeName = dlFileEntryType.getName(
+				_httpServletRequest.getLocale());
 		}
 
 		String emptyResultsMessage = null;
 
-		if (fileEntryTypeId >= 0) {
+		if (fileEntryTypeId !=
+				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_ALL) {
+
 			emptyResultsMessage = LanguageUtil.format(
 				_httpServletRequest,
 				"there-are-no-documents-or-media-files-of-type-x",
@@ -624,7 +632,9 @@ public class DLAdminDisplayContext {
 
 		List<RepositoryEntry> results = new ArrayList<>();
 
-		if (fileEntryTypeId >= 0) {
+		if (fileEntryTypeId !=
+				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_ALL) {
+
 			Indexer<?> indexer = IndexerRegistryUtil.getIndexer(
 				DLFileEntryConstants.getClassName());
 

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
@@ -320,7 +320,9 @@ public class DLAdminManagementToolbarDisplayContext
 		long fileEntryTypeId = _getFileEntryTypeId();
 
 		return LabelItemListBuilder.add(
-			() -> fileEntryTypeId != -1,
+			() ->
+				fileEntryTypeId !=
+					DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_ALL,
 			labelItem -> {
 				labelItem.putData(
 					"removeLabelURL",
@@ -513,7 +515,9 @@ public class DLAdminManagementToolbarDisplayContext
 			() -> {
 				long fileEntryTypeId = _getFileEntryTypeId();
 
-				if (fileEntryTypeId != -1) {
+				if (fileEntryTypeId !=
+						DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_ALL) {
+
 					return fileEntryTypeId;
 				}
 
@@ -619,7 +623,9 @@ public class DLAdminManagementToolbarDisplayContext
 	}
 
 	private long _getFileEntryTypeId() {
-		return ParamUtil.getLong(_httpServletRequest, "fileEntryTypeId", -1);
+		return ParamUtil.getLong(
+			_httpServletRequest, "fileEntryTypeId",
+			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_ALL);
 	}
 
 	private List<DropdownItem> _getFilterNavigationDropdownItems() {
@@ -630,7 +636,9 @@ public class DLAdminManagementToolbarDisplayContext
 		return DropdownItemListBuilder.add(
 			dropdownItem -> {
 				dropdownItem.setActive(
-					navigation.equals("home") && (fileEntryTypeId == -1));
+					navigation.equals("home") &&
+					(fileEntryTypeId ==
+						DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_ALL));
 				dropdownItem.setHref(
 					PortletURLBuilder.create(
 						PortletURLUtil.clone(
@@ -680,14 +688,18 @@ public class DLAdminManagementToolbarDisplayContext
 			}
 		).add(
 			dropdownItem -> {
-				dropdownItem.setActive(fileEntryTypeId != -1);
+				dropdownItem.setActive(
+					fileEntryTypeId !=
+						DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_ALL);
 
 				dropdownItem.putData("action", "openDocumentTypesSelector");
 
 				String label = LanguageUtil.get(
 					_httpServletRequest, "document-type");
 
-				if (fileEntryTypeId != -1) {
+				if (fileEntryTypeId !=
+						DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_ALL) {
+
 					DLFileEntryType fileEntryType =
 						DLFileEntryTypeLocalServiceUtil.getFileEntryType(
 							fileEntryTypeId);

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
@@ -333,26 +333,17 @@ public class DLAdminManagementToolbarDisplayContext
 
 				labelItem.setCloseable(true);
 
-				String fileEntryTypeName = LanguageUtil.get(
-					_httpServletRequest, "basic-document");
-
-				if (fileEntryTypeId !=
-						DLFileEntryTypeConstants.
-							FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT) {
-
-					DLFileEntryType fileEntryType =
-						DLFileEntryTypeLocalServiceUtil.getFileEntryType(
-							fileEntryTypeId);
-
-					fileEntryTypeName = fileEntryType.getName(
-						_httpServletRequest.getLocale());
-				}
+				DLFileEntryType fileEntryType =
+					DLFileEntryTypeLocalServiceUtil.getFileEntryType(
+						fileEntryTypeId);
 
 				labelItem.setLabel(
 					String.format(
 						"%s: %s",
 						LanguageUtil.get(_httpServletRequest, "document-type"),
-						HtmlUtil.escape(fileEntryTypeName)));
+						HtmlUtil.escape(
+							fileEntryType.getName(
+								_httpServletRequest.getLocale()))));
 			}
 		).add(
 			() -> Objects.equals(_getNavigation(), "mine"),
@@ -697,22 +688,13 @@ public class DLAdminManagementToolbarDisplayContext
 					_httpServletRequest, "document-type");
 
 				if (fileEntryTypeId != -1) {
-					String fileEntryTypeName = LanguageUtil.get(
-						_httpServletRequest, "basic-document");
+					DLFileEntryType fileEntryType =
+						DLFileEntryTypeLocalServiceUtil.getFileEntryType(
+							fileEntryTypeId);
 
-					if (fileEntryTypeId !=
-							DLFileEntryTypeConstants.
-								FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT) {
-
-						DLFileEntryType fileEntryType =
-							DLFileEntryTypeLocalServiceUtil.getFileEntryType(
-								fileEntryTypeId);
-
-						fileEntryTypeName = fileEntryType.getName(
-							_httpServletRequest.getLocale());
-					}
-
-					label = String.format("%s: %s", label, fileEntryTypeName);
+					label = String.format(
+						"%s: %s", label,
+						fileEntryType.getName(_httpServletRequest.getLocale()));
 				}
 
 				dropdownItem.setLabel(label);

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLViewDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLViewDisplayContext.java
@@ -405,7 +405,8 @@ public class DLViewDisplayContext {
 			DLFileEntryConstants.getClassName());
 
 		DLFileEntryType basicDocumentDLFileEntryType =
-			DLFileEntryTypeLocalServiceUtil.getBasicDocumentDLFileEntryType();
+			DLFileEntryTypeLocalServiceUtil.getBasicDocumentDLFileEntryType(
+				themeDisplay.getCompanyId());
 
 		for (AssetVocabulary assetVocabulary : assetVocabularies) {
 			if (assetVocabulary.isRequired(

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLViewDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLViewDisplayContext.java
@@ -19,7 +19,8 @@ import com.liferay.asset.kernel.model.AssetVocabulary;
 import com.liferay.asset.kernel.service.AssetVocabularyServiceUtil;
 import com.liferay.document.library.constants.DLPortletKeys;
 import com.liferay.document.library.kernel.model.DLFileEntryConstants;
-import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
+import com.liferay.document.library.kernel.model.DLFileEntryType;
+import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalServiceUtil;
 import com.liferay.document.library.web.internal.display.context.helper.DLPortletInstanceSettingsHelper;
 import com.liferay.document.library.web.internal.display.context.helper.DLRequestHelper;
 import com.liferay.document.library.web.internal.security.permission.resource.DLFolderPermission;
@@ -403,11 +404,13 @@ public class DLViewDisplayContext {
 		long classNameId = ClassNameLocalServiceUtil.getClassNameId(
 			DLFileEntryConstants.getClassName());
 
+		DLFileEntryType basicDocumentDLFileEntryType =
+			DLFileEntryTypeLocalServiceUtil.getBasicDocumentDLFileEntryType();
+
 		for (AssetVocabulary assetVocabulary : assetVocabularies) {
 			if (assetVocabulary.isRequired(
 					classNameId,
-					DLFileEntryTypeConstants.
-						FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT)) {
+					basicDocumentDLFileEntryType.getFileEntryTypeId())) {
 
 				return false;
 			}

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DefaultDLEditFileEntryDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DefaultDLEditFileEntryDisplayContext.java
@@ -454,8 +454,8 @@ public class DefaultDLEditFileEntryDisplayContext
 				_fileEntry, _dlRequestHelper.getRequest(), "folderId");
 
 			DLFileEntryType basicDocumentDLFileEntryType =
-				DLFileEntryTypeLocalServiceUtil.
-					getBasicDocumentDLFileEntryType();
+				DLFileEntryTypeLocalServiceUtil.getBasicDocumentDLFileEntryType(
+					_dlRequestHelper.getCompanyId());
 
 			long fileEntryTypeId =
 				basicDocumentDLFileEntryType.getFileEntryTypeId();

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DefaultDLEditFileEntryDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DefaultDLEditFileEntryDisplayContext.java
@@ -18,8 +18,8 @@ import com.liferay.document.library.display.context.DLEditFileEntryDisplayContex
 import com.liferay.document.library.display.context.DLFilePicker;
 import com.liferay.document.library.kernel.model.DLFileEntryMetadata;
 import com.liferay.document.library.kernel.model.DLFileEntryType;
-import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
 import com.liferay.document.library.kernel.service.DLFileEntryMetadataLocalServiceUtil;
+import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalServiceUtil;
 import com.liferay.document.library.kernel.util.DLUtil;
 import com.liferay.document.library.kernel.util.DLValidator;
 import com.liferay.document.library.web.internal.display.context.helper.DLRequestHelper;
@@ -453,8 +453,12 @@ public class DefaultDLEditFileEntryDisplayContext
 			long folderId = BeanParamUtil.getLong(
 				_fileEntry, _dlRequestHelper.getRequest(), "folderId");
 
+			DLFileEntryType basicDocumentDLFileEntryType =
+				DLFileEntryTypeLocalServiceUtil.
+					getBasicDocumentDLFileEntryType();
+
 			long fileEntryTypeId =
-				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT;
+				basicDocumentDLFileEntryType.getFileEntryTypeId();
 
 			if (_dlFileEntryType != null) {
 				fileEntryTypeId = _dlFileEntryType.getFileEntryTypeId();

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/info/item/provider/FileEntryInfoItemFormVariationsProvider.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/info/item/provider/FileEntryInfoItemFormVariationsProvider.java
@@ -26,7 +26,9 @@ import com.liferay.info.localized.InfoLocalizedValue;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
@@ -78,8 +80,10 @@ public class FileEntryInfoItemFormVariationsProvider
 			List<InfoItemFormVariation> infoItemFormVariations =
 				new ArrayList<>();
 
+			Group group = _groupLocalService.fetchGroup(groupId);
+
 			infoItemFormVariations.add(
-				_getBasicDocumentInfoItemFormVariation());
+				_getBasicDocumentInfoItemFormVariation(group.getCompanyId()));
 
 			return getInfoItemFormVariations(
 				_getCurrentAndAncestorSiteGroupIds(groupId));
@@ -98,8 +102,10 @@ public class FileEntryInfoItemFormVariationsProvider
 			List<InfoItemFormVariation> infoItemFormVariations =
 				new ArrayList<>();
 
+			Group group = _groupLocalService.fetchGroup(groupIds[0]);
+
 			infoItemFormVariations.add(
-				_getBasicDocumentInfoItemFormVariation());
+				_getBasicDocumentInfoItemFormVariation(group.getCompanyId()));
 
 			List<DLFileEntryType> dlFileEntryTypes =
 				_dlFileEntryTypeLocalService.getFileEntryTypes(groupIds);
@@ -122,11 +128,13 @@ public class FileEntryInfoItemFormVariationsProvider
 		}
 	}
 
-	private InfoItemFormVariation _getBasicDocumentInfoItemFormVariation()
+	private InfoItemFormVariation _getBasicDocumentInfoItemFormVariation(
+			long companyId)
 		throws NoSuchFileEntryTypeException {
 
 		DLFileEntryType basicDocumentDLFileEntryType =
-			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType();
+			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType(
+				companyId);
 
 		return new InfoItemFormVariation(
 			basicDocumentDLFileEntryType.getGroupId(),
@@ -162,6 +170,9 @@ public class FileEntryInfoItemFormVariationsProvider
 
 	@Reference
 	private DLFileEntryTypeLocalService _dlFileEntryTypeLocalService;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/info/item/provider/FileEntryInfoItemFormVariationsProvider.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/info/item/provider/FileEntryInfoItemFormVariationsProvider.java
@@ -16,12 +16,14 @@ package com.liferay.document.library.web.internal.info.item.provider;
 
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.document.library.kernel.exception.NoSuchFileEntryTypeException;
 import com.liferay.document.library.kernel.model.DLFileEntryType;
 import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
 import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalService;
 import com.liferay.info.item.InfoItemFormVariation;
 import com.liferay.info.item.provider.InfoItemFormVariationsProvider;
 import com.liferay.info.localized.InfoLocalizedValue;
+import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.repository.model.FileEntry;
@@ -72,11 +74,13 @@ public class FileEntryInfoItemFormVariationsProvider
 	public Collection<InfoItemFormVariation> getInfoItemFormVariations(
 		long groupId) {
 
-		List<InfoItemFormVariation> infoItemFormVariations = new ArrayList<>();
-
-		infoItemFormVariations.add(_getBasicDocumentInfoItemFormVariation());
-
 		try {
+			List<InfoItemFormVariation> infoItemFormVariations =
+				new ArrayList<>();
+
+			infoItemFormVariations.add(
+				_getBasicDocumentInfoItemFormVariation());
+
 			return getInfoItemFormVariations(
 				_getCurrentAndAncestorSiteGroupIds(groupId));
 		}
@@ -90,31 +94,39 @@ public class FileEntryInfoItemFormVariationsProvider
 	public Collection<InfoItemFormVariation> getInfoItemFormVariations(
 		long[] groupIds) {
 
-		List<InfoItemFormVariation> infoItemFormVariations = new ArrayList<>();
+		try {
+			List<InfoItemFormVariation> infoItemFormVariations =
+				new ArrayList<>();
 
-		infoItemFormVariations.add(_getBasicDocumentInfoItemFormVariation());
-
-		List<DLFileEntryType> dlFileEntryTypes =
-			_dlFileEntryTypeLocalService.getFileEntryTypes(groupIds);
-
-		for (DLFileEntryType dlFileEntryType : dlFileEntryTypes) {
 			infoItemFormVariations.add(
-				new InfoItemFormVariation(
-					dlFileEntryType.getGroupId(),
-					String.valueOf(dlFileEntryType.getFileEntryTypeId()),
-					InfoLocalizedValue.<String>builder(
-					).values(
-						dlFileEntryType.getNameMap()
-					).build()));
-		}
+				_getBasicDocumentInfoItemFormVariation());
 
-		return infoItemFormVariations;
+			List<DLFileEntryType> dlFileEntryTypes =
+				_dlFileEntryTypeLocalService.getFileEntryTypes(groupIds);
+
+			for (DLFileEntryType dlFileEntryType : dlFileEntryTypes) {
+				infoItemFormVariations.add(
+					new InfoItemFormVariation(
+						dlFileEntryType.getGroupId(),
+						String.valueOf(dlFileEntryType.getFileEntryTypeId()),
+						InfoLocalizedValue.<String>builder(
+						).values(
+							dlFileEntryType.getNameMap()
+						).build()));
+			}
+
+			return infoItemFormVariations;
+		}
+		catch (NoSuchFileEntryTypeException noSuchFileEntryTypeException) {
+			return ReflectionUtil.throwException(noSuchFileEntryTypeException);
+		}
 	}
 
-	private InfoItemFormVariation _getBasicDocumentInfoItemFormVariation() {
+	private InfoItemFormVariation _getBasicDocumentInfoItemFormVariation()
+		throws NoSuchFileEntryTypeException {
+
 		DLFileEntryType basicDocumentDLFileEntryType =
-			_dlFileEntryTypeLocalService.fetchDLFileEntryType(
-				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT);
+			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType();
 
 		return new InfoItemFormVariation(
 			basicDocumentDLFileEntryType.getGroupId(),

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/info/item/provider/FileEntryInfoItemFormVariationsProvider.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/info/item/provider/FileEntryInfoItemFormVariationsProvider.java
@@ -56,9 +56,8 @@ public class FileEntryInfoItemFormVariationsProvider
 	public InfoItemFormVariation getInfoItemFormVariation(
 		long groupId, String formVariationKey) {
 
-		DLFileEntryType dlFileEntryType =
-			_dlFileEntryTypeLocalService.fetchDLFileEntryType(
-				GetterUtil.getLong(formVariationKey));
+		DLFileEntryType dlFileEntryType = _getDLFileEntryType(
+			groupId, formVariationKey);
 
 		if (dlFileEntryType == null) {
 			return null;
@@ -159,6 +158,24 @@ public class FileEntryInfoItemFormVariationsProvider
 				depotEntryLocalService.getGroupConnectedDepotEntries(
 					groupId, true, QueryUtil.ALL_POS, QueryUtil.ALL_POS),
 				DepotEntry::getGroupId));
+	}
+
+	private DLFileEntryType _getDLFileEntryType(
+		long groupId, String formVariationKey) {
+
+		long fileEntryTypeId = GetterUtil.getLong(formVariationKey);
+
+		if (fileEntryTypeId !=
+				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT) {
+
+			return _dlFileEntryTypeLocalService.fetchDLFileEntryType(
+				fileEntryTypeId);
+		}
+
+		Group group = _groupLocalService.fetchGroup(groupId);
+
+		return _dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType(
+			group.getCompanyId());
 	}
 
 	@Reference(

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/model/listener/DLFileEntryTypeModelListener.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/model/listener/DLFileEntryTypeModelListener.java
@@ -15,7 +15,6 @@
 package com.liferay.document.library.web.internal.model.listener;
 
 import com.liferay.document.library.kernel.model.DLFileEntryType;
-import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalService;
 import com.liferay.document.library.web.internal.info.collection.provider.DLFileEntryTypeRelatedInfoCollectionProvider;
@@ -23,8 +22,10 @@ import com.liferay.info.collection.provider.RelatedInfoItemCollectionProvider;
 import com.liferay.portal.instance.lifecycle.PortalInstanceLifecycleListener;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.ModelListenerException;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.ModelListener;
 import com.liferay.portal.kernel.service.CompanyLocalService;
@@ -93,7 +94,9 @@ public class DLFileEntryTypeModelListener
 	}
 
 	@Override
-	public void portalInstanceRegistered(Company company) {
+	public void portalInstanceRegistered(Company company)
+		throws PortalException {
+
 		_registerCompanyDLFileEntryTypes(company);
 		_registerDefaultDLFileEntryType();
 	}
@@ -144,17 +147,16 @@ public class DLFileEntryTypeModelListener
 		}
 	}
 
-	private void _registerDefaultDLFileEntryType() {
-		if (_serviceRegistrations.containsKey(0L)) {
+	private void _registerDefaultDLFileEntryType() throws PortalException {
+		if (_serviceRegistrations.containsKey(CompanyConstants.SYSTEM)) {
 			return;
 		}
 
 		DLFileEntryType basicDocumentDLFileEntryType =
-			_dlFileEntryTypeLocalService.fetchDLFileEntryType(
-				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT);
+			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType();
 
 		_serviceRegistrations.put(
-			0L,
+			CompanyConstants.SYSTEM,
 			HashMapBuilder.<Long, ServiceRegistration<?>>put(
 				basicDocumentDLFileEntryType.getFileEntryTypeId(),
 				_bundleContext.registerService(

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/model/listener/DLFileEntryTypeModelListener.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/model/listener/DLFileEntryTypeModelListener.java
@@ -25,12 +25,10 @@ import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.Company;
-import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.ModelListener;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
-import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 
@@ -98,7 +96,6 @@ public class DLFileEntryTypeModelListener
 		throws PortalException {
 
 		_registerCompanyDLFileEntryTypes(company);
-		_registerDefaultDLFileEntryType();
 	}
 
 	@Override
@@ -141,30 +138,22 @@ public class DLFileEntryTypeModelListener
 					null));
 		}
 
+		DLFileEntryType basicDocumentDLFileEntryType =
+			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType(
+				company.getCompanyId());
+
+		serviceRegistrations.put(
+			basicDocumentDLFileEntryType.getFileEntryTypeId(),
+			_bundleContext.registerService(
+				RelatedInfoItemCollectionProvider.class,
+				new DLFileEntryTypeRelatedInfoCollectionProvider(
+					_dlAppLocalService, basicDocumentDLFileEntryType),
+				null));
+
 		if (MapUtil.isNotEmpty(serviceRegistrations)) {
 			_serviceRegistrations.put(
 				company.getCompanyId(), serviceRegistrations);
 		}
-	}
-
-	private void _registerDefaultDLFileEntryType() throws PortalException {
-		if (_serviceRegistrations.containsKey(CompanyConstants.SYSTEM)) {
-			return;
-		}
-
-		DLFileEntryType basicDocumentDLFileEntryType =
-			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType();
-
-		_serviceRegistrations.put(
-			CompanyConstants.SYSTEM,
-			HashMapBuilder.<Long, ServiceRegistration<?>>put(
-				basicDocumentDLFileEntryType.getFileEntryTypeId(),
-				_bundleContext.registerService(
-					RelatedInfoItemCollectionProvider.class,
-					new DLFileEntryTypeRelatedInfoCollectionProvider(
-						_dlAppLocalService, basicDocumentDLFileEntryType),
-					null)
-			).build());
 	}
 
 	private void _unregisterCompanyDLFileEntryTypes(long companyId) {

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/toolbar/contributor/DefaultDLPortletToolbarContributor.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/toolbar/contributor/DefaultDLPortletToolbarContributor.java
@@ -21,6 +21,10 @@ import com.liferay.document.library.web.internal.portlet.toolbar.contributor.hel
 import com.liferay.document.library.web.internal.portlet.toolbar.contributor.helper.MenuItemProvider;
 import com.liferay.osgi.service.tracker.collections.list.ServiceTrackerList;
 import com.liferay.osgi.service.tracker.collections.list.ServiceTrackerListFactory;
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.portlet.toolbar.contributor.BasePortletToolbarContributor;
 import com.liferay.portal.kernel.portlet.toolbar.contributor.PortletToolbarContributor;
 import com.liferay.portal.kernel.repository.model.Folder;
@@ -94,7 +98,7 @@ public class DefaultDLPortletToolbarContributor
 
 		_add(
 			menuItems,
-			_menuItemProvider.getAddFileMenuItem(
+			() -> _menuItemProvider.getAddFileMenuItem(
 				folder, themeDisplay, portletRequest));
 
 		_add(
@@ -138,8 +142,9 @@ public class DefaultDLPortletToolbarContributor
 			lastExtensionMenuItem = menuItems.get(menuItems.size() - 1);
 		}
 
-		menuItems.addAll(
-			_menuItemProvider.getAddDocumentTypesMenuItems(
+		_addAll(
+			menuItems,
+			() -> _menuItemProvider.getAddDocumentTypesMenuItems(
 				folder, themeDisplay, portletRequest));
 
 		if ((lastStaticMenuItem != null) &&
@@ -163,6 +168,30 @@ public class DefaultDLPortletToolbarContributor
 		}
 	}
 
+	private void _add(
+		List<MenuItem> menuItems,
+		UnsafeSupplier<MenuItem, PortalException> unsafeSupplier) {
+
+		try {
+			_add(menuItems, unsafeSupplier.get());
+		}
+		catch (PortalException portalException) {
+			_log.error(portalException);
+		}
+	}
+
+	private void _addAll(
+		List<MenuItem> menuItems,
+		UnsafeSupplier<List<MenuItem>, PortalException> unsafeSupplier) {
+
+		try {
+			menuItems.addAll(unsafeSupplier.get());
+		}
+		catch (PortalException portalException) {
+			_log.error(portalException);
+		}
+	}
+
 	private boolean _isDLPortlet(ThemeDisplay themeDisplay) {
 		PortletDisplay portletDisplay = themeDisplay.getPortletDisplay();
 
@@ -178,6 +207,9 @@ public class DefaultDLPortletToolbarContributor
 
 		return false;
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		DefaultDLPortletToolbarContributor.class);
 
 	private ServiceTrackerList<DLPortletToolbarContributorContext>
 		_dlPortletToolbarContributorContexts;

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/toolbar/contributor/IGPortletToolbarContributor.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/toolbar/contributor/IGPortletToolbarContributor.java
@@ -17,6 +17,10 @@ package com.liferay.document.library.web.internal.portlet.toolbar.contributor;
 import com.liferay.document.library.constants.DLPortletKeys;
 import com.liferay.document.library.web.internal.portlet.toolbar.contributor.helper.DLPortletToolbarContributorHelper;
 import com.liferay.document.library.web.internal.portlet.toolbar.contributor.helper.MenuItemProvider;
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.portlet.toolbar.contributor.BasePortletToolbarContributor;
 import com.liferay.portal.kernel.portlet.toolbar.contributor.PortletToolbarContributor;
 import com.liferay.portal.kernel.repository.model.Folder;
@@ -66,7 +70,7 @@ public class IGPortletToolbarContributor extends BasePortletToolbarContributor {
 
 		_add(
 			menuItems,
-			_menuItemProvider.getAddFileMenuItem(
+			() -> _menuItemProvider.getAddFileMenuItem(
 				folder, themeDisplay, portletRequest));
 
 		_add(
@@ -92,6 +96,21 @@ public class IGPortletToolbarContributor extends BasePortletToolbarContributor {
 			menuItems.add(menuItem);
 		}
 	}
+
+	private void _add(
+		List<MenuItem> menuItems,
+		UnsafeSupplier<MenuItem, PortalException> unsafeSupplier) {
+
+		try {
+			_add(menuItems, unsafeSupplier.get());
+		}
+		catch (PortalException portalException) {
+			_log.error(portalException);
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		IGPortletToolbarContributor.class);
 
 	@Reference
 	private DLPortletToolbarContributorHelper

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/toolbar/contributor/helper/MenuItemProvider.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/toolbar/contributor/helper/MenuItemProvider.java
@@ -130,7 +130,9 @@ public class MenuItemProvider {
 					return portletDisplay.getId();
 				}
 			).setParameter(
-				"fileEntryTypeId", _getDefaultFileEntryTypeId(folderId)
+				"fileEntryTypeId",
+				_getDefaultFileEntryTypeId(
+					themeDisplay.getCompanyId(), folderId)
 			).setParameter(
 				"folderId", folderId
 			).setParameter(
@@ -330,12 +332,12 @@ public class MenuItemProvider {
 		_serviceTrackerMap = null;
 	}
 
-	private long _getDefaultFileEntryTypeId(long folderId)
+	private long _getDefaultFileEntryTypeId(long companyId, long folderId)
 		throws PortalException {
 
 		try {
 			return _dlFileEntryTypeLocalService.getDefaultFileEntryTypeId(
-				folderId);
+				companyId, folderId);
 		}
 		catch (PortalException portalException) {
 			if (_log.isWarnEnabled()) {
@@ -346,7 +348,8 @@ public class MenuItemProvider {
 			}
 
 			DLFileEntryType basicDocumentDLFileEntryType =
-				_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType();
+				_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType(
+					companyId);
 
 			return basicDocumentDLFileEntryType.getFileEntryTypeId();
 		}
@@ -453,7 +456,8 @@ public class MenuItemProvider {
 		List<MenuItem> menuItems = new ArrayList<>();
 
 		DLFileEntryType basicDocumentDLFileEntryType =
-			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType();
+			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType(
+				themeDisplay.getCompanyId());
 
 		List<DLFileEntryType> fileEntryTypes = _getFileEntryTypes(
 			themeDisplay.getScopeGroupId(), folder);

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/toolbar/contributor/helper/MenuItemProvider.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/toolbar/contributor/helper/MenuItemProvider.java
@@ -18,7 +18,6 @@ import com.liferay.depot.group.provider.SiteConnectedGroupGroupProvider;
 import com.liferay.document.library.constants.DLPortletKeys;
 import com.liferay.document.library.display.context.DLUIItemKeys;
 import com.liferay.document.library.kernel.model.DLFileEntryType;
-import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
 import com.liferay.document.library.kernel.model.DLFolder;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalService;
@@ -67,8 +66,9 @@ import org.osgi.service.component.annotations.Reference;
 public class MenuItemProvider {
 
 	public List<MenuItem> getAddDocumentTypesMenuItems(
-		Folder folder, ThemeDisplay themeDisplay,
-		PortletRequest portletRequest) {
+			Folder folder, ThemeDisplay themeDisplay,
+			PortletRequest portletRequest)
+		throws PortalException {
 
 		if (!_hasPermission(
 				themeDisplay.getPermissionChecker(),
@@ -92,8 +92,9 @@ public class MenuItemProvider {
 	}
 
 	public MenuItem getAddFileMenuItem(
-		Folder folder, ThemeDisplay themeDisplay,
-		PortletRequest portletRequest) {
+			Folder folder, ThemeDisplay themeDisplay,
+			PortletRequest portletRequest)
+		throws PortalException {
 
 		long folderId = _getFolderId(folder);
 
@@ -329,7 +330,9 @@ public class MenuItemProvider {
 		_serviceTrackerMap = null;
 	}
 
-	private long _getDefaultFileEntryTypeId(long folderId) {
+	private long _getDefaultFileEntryTypeId(long folderId)
+		throws PortalException {
+
 		try {
 			return _dlFileEntryTypeLocalService.getDefaultFileEntryTypeId(
 				folderId);
@@ -342,7 +345,10 @@ public class MenuItemProvider {
 					portalException);
 			}
 
-			return DLFileEntryTypeConstants.COMPANY_ID_BASIC_DOCUMENT;
+			DLFileEntryType basicDocumentDLFileEntryType =
+				_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType();
+
+			return basicDocumentDLFileEntryType.getFileEntryTypeId();
 		}
 	}
 
@@ -440,10 +446,14 @@ public class MenuItemProvider {
 	}
 
 	private List<MenuItem> _getPortletTitleAddDocumentTypeMenuItems(
-		Folder folder, ThemeDisplay themeDisplay,
-		PortletRequest portletRequest) {
+			Folder folder, ThemeDisplay themeDisplay,
+			PortletRequest portletRequest)
+		throws PortalException {
 
 		List<MenuItem> menuItems = new ArrayList<>();
+
+		DLFileEntryType basicDocumentDLFileEntryType =
+			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType();
 
 		List<DLFileEntryType> fileEntryTypes = _getFileEntryTypes(
 			themeDisplay.getScopeGroupId(), folder);
@@ -451,7 +461,7 @@ public class MenuItemProvider {
 		for (DLFileEntryType fileEntryType : fileEntryTypes) {
 			try {
 				if ((fileEntryType.getFileEntryTypeId() !=
-						DLFileEntryTypeConstants.COMPANY_ID_BASIC_DOCUMENT) &&
+						basicDocumentDLFileEntryType.getFileEntryTypeId()) &&
 					_isFileEntryTypeVisible(
 						themeDisplay.getUserId(), fileEntryType)) {
 

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/util/DLSubscriptionUtil.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/util/DLSubscriptionUtil.java
@@ -15,10 +15,10 @@
 package com.liferay.document.library.web.internal.util;
 
 import com.liferay.document.library.kernel.model.DLFileEntryType;
-import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
 import com.liferay.document.library.kernel.model.DLFolder;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLAppLocalServiceUtil;
+import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalServiceUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.util.ArrayUtil;
@@ -33,10 +33,14 @@ import java.util.List;
 public class DLSubscriptionUtil {
 
 	public static boolean isSubscribedToFileEntryType(
-		long companyId, long groupId, long userId, long fileEntryTypeId) {
+			long companyId, long groupId, long userId, long fileEntryTypeId)
+		throws PortalException {
+
+		DLFileEntryType basicDocumentDLFileEntryType =
+			DLFileEntryTypeLocalServiceUtil.getBasicDocumentDLFileEntryType();
 
 		if (fileEntryTypeId ==
-				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT) {
+				basicDocumentDLFileEntryType.getFileEntryTypeId()) {
 
 			fileEntryTypeId = groupId;
 		}

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/util/DLSubscriptionUtil.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/util/DLSubscriptionUtil.java
@@ -37,7 +37,8 @@ public class DLSubscriptionUtil {
 		throws PortalException {
 
 		DLFileEntryType basicDocumentDLFileEntryType =
-			DLFileEntryTypeLocalServiceUtil.getBasicDocumentDLFileEntryType();
+			DLFileEntryTypeLocalServiceUtil.getBasicDocumentDLFileEntryType(
+				companyId);
 
 		if (fileEntryTypeId ==
 				basicDocumentDLFileEntryType.getFileEntryTypeId()) {

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_entry.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_entry.jsp
@@ -73,7 +73,7 @@ DLFileEntryType basicDocumentDLFileEntryType = DLFileEntryTypeLocalServiceUtil.g
 
 DLFileEntryType dlFileEntryType = null;
 
-if (fileEntryTypeId != -1) {
+if (fileEntryTypeId != DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_ALL) {
 	dlFileEntryType = DLFileEntryTypeLocalServiceUtil.getFileEntryType(fileEntryTypeId);
 }
 

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_entry.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_entry.jsp
@@ -69,9 +69,11 @@ if (fileEntry != null) {
 	}
 }
 
+DLFileEntryType basicDocumentDLFileEntryType = DLFileEntryTypeLocalServiceUtil.getBasicDocumentDLFileEntryType();
+
 DLFileEntryType dlFileEntryType = null;
 
-if (fileEntryTypeId >= 0) {
+if (fileEntryTypeId != -1) {
 	dlFileEntryType = DLFileEntryTypeLocalServiceUtil.getFileEntryType(fileEntryTypeId);
 }
 
@@ -404,7 +406,7 @@ renderResponse.setTitle(headerTitle);
 										for (DLFileEntryType curDLFileEntryType : dlFileEntryTypes) {
 										%>
 
-											<c:if test="<%= (curDLFileEntryType.getFileEntryTypeId() == DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT) || (fileEntryTypeId == curDLFileEntryType.getFileEntryTypeId()) || DLFileEntryTypePermission.contains(permissionChecker, curDLFileEntryType, ActionKeys.VIEW) %>">
+											<c:if test="<%= (curDLFileEntryType.getFileEntryTypeId() == basicDocumentDLFileEntryType.getFileEntryTypeId()) || (fileEntryTypeId == curDLFileEntryType.getFileEntryTypeId()) || DLFileEntryTypePermission.contains(permissionChecker, curDLFileEntryType, ActionKeys.VIEW) %>">
 												<aui:option label="<%= HtmlUtil.escape(curDLFileEntryType.getName(locale)) %>" selected="<%= fileEntryTypeId == curDLFileEntryType.getPrimaryKey() %>" value="<%= curDLFileEntryType.getPrimaryKey() %>" />
 											</c:if>
 
@@ -528,7 +530,7 @@ renderResponse.setTitle(headerTitle);
 							<liferay-asset:select-asset-display-page
 								classNameId="<%= PortalUtil.getClassNameId(FileEntry.class) %>"
 								classPK="<%= (fileEntry != null) ? fileEntry.getFileEntryId() : 0 %>"
-								classTypeId="<%= (fileEntryTypeId < 0) ? DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT : fileEntryTypeId %>"
+								classTypeId="<%= (fileEntryTypeId == -1) ? basicDocumentDLFileEntryType.getFileEntryTypeId() : fileEntryTypeId %>"
 								groupId="<%= scopeGroupId %>"
 								showViewInContextLink="<%= true %>"
 							/>
@@ -555,7 +557,7 @@ renderResponse.setTitle(headerTitle);
 							<liferay-asset:asset-categories-selector
 								className="<%= DLFileEntry.class.getName() %>"
 								classPK="<%= assetClassPK %>"
-								classTypePK="<%= (fileEntryTypeId < 0) ? DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT : fileEntryTypeId %>"
+								classTypePK="<%= (fileEntryTypeId == -1) ? basicDocumentDLFileEntryType.getFileEntryTypeId() : fileEntryTypeId %>"
 								visibilityTypes="<%= AssetVocabularyConstants.VISIBILITY_TYPES %>"
 							/>
 

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_entry.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_entry.jsp
@@ -69,7 +69,7 @@ if (fileEntry != null) {
 	}
 }
 
-DLFileEntryType basicDocumentDLFileEntryType = DLFileEntryTypeLocalServiceUtil.getBasicDocumentDLFileEntryType();
+DLFileEntryType basicDocumentDLFileEntryType = DLFileEntryTypeLocalServiceUtil.getBasicDocumentDLFileEntryType(themeDisplay.getCompanyId());
 
 DLFileEntryType dlFileEntryType = null;
 

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/upload_multiple_file_entries_resources.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/upload_multiple_file_entries_resources.jsp
@@ -138,7 +138,7 @@ else {
 						<liferay-ui:icon-menu
 							direction="down"
 							id="groupSelector"
-							message='<%= (fileEntryTypeId > 0) ? HtmlUtil.escape(fileEntryType.getName(locale)) : "basic-document" %>'
+							message="<%= HtmlUtil.escape(fileEntryType.getName(locale)) %>"
 							showWhenSingleIcon="<%= true %>"
 						>
 

--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-freemarker-test/src/testIntegration/java/com/liferay/fragment/entry/processor/freemarker/test/FragmentEntryProcessorFreemarkerTest.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-freemarker-test/src/testIntegration/java/com/liferay/fragment/entry/processor/freemarker/test/FragmentEntryProcessorFreemarkerTest.java
@@ -313,7 +313,7 @@ public class FragmentEntryProcessorFreemarkerTest {
 			FileUtil.getBytes(
 				FragmentEntryProcessorFreemarkerTest.class,
 				"dependencies/image.jpg"),
-			null, null, new ServiceContext());
+			null, null, ServiceContextTestUtil.getServiceContext());
 
 		FragmentEntry fragmentEntry = _addFragmentEntry(
 			"fragment_entry_with_configuration_itemselector_file_entry.html",

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/LayoutsImporterImpl.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/LayoutsImporterImpl.java
@@ -1946,21 +1946,29 @@ public class LayoutsImporterImpl implements LayoutsImporter {
 				displayPageTemplate.getContentSubtype();
 
 			if (contentSubtype == null) {
-				return 0;
+				return _resolveSubtypeKey(classNameId, null);
 			}
 
 			Long subtypeId = contentSubtype.getSubtypeId();
 
 			if (subtypeId != null) {
+				if (subtypeId == 0) {
+					return _resolveSubtypeKey(classNameId, null);
+				}
+
 				return subtypeId;
 			}
 
 			String subtypeKey = contentSubtype.getSubtypeKey();
 
 			if (Validator.isNull(subtypeKey)) {
-				return 0;
+				return _resolveSubtypeKey(classNameId, null);
 			}
 
+			return _resolveSubtypeKey(classNameId, subtypeKey);
+		}
+
+		private long _resolveSubtypeKey(long classNameId, String subtypeKey) {
 			InfoItemFormVariationsProvider<?> infoItemFormVariationsProvider =
 				_infoItemServiceRegistry.getFirstInfoItemService(
 					InfoItemFormVariationsProvider.class,

--- a/modules/apps/layout/layout-page-template-service/bnd.bnd
+++ b/modules/apps/layout/layout-page-template-service/bnd.bnd
@@ -5,6 +5,6 @@ Import-Package:\
 	com.liferay.layout.page.template.util.comparator,\
 	\
 	*
-Liferay-Require-SchemaVersion: 5.1.1
+Liferay-Require-SchemaVersion: 5.1.2
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/registry/LayoutPageTemplateServiceUpgradeStepRegistrator.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/registry/LayoutPageTemplateServiceUpgradeStepRegistrator.java
@@ -14,6 +14,7 @@
 
 package com.liferay.layout.page.template.internal.upgrade.registry;
 
+import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalService;
 import com.liferay.fragment.service.FragmentEntryLinkLocalService;
 import com.liferay.fragment.util.configuration.FragmentEntryConfigurationParser;
 import com.liferay.layout.helper.CollectionPaginationHelper;
@@ -26,6 +27,8 @@ import com.liferay.layout.page.template.internal.upgrade.v2_1_0.LayoutUpgradePro
 import com.liferay.layout.page.template.internal.upgrade.v3_1_4.ResourcePermissionUpgradeProcess;
 import com.liferay.layout.page.template.internal.upgrade.v3_3_0.LayoutPageTemplateStructureRelUpgradeProcess;
 import com.liferay.layout.page.template.internal.upgrade.v3_4_1.FragmentEntryLinkEditableValuesUpgradeProcess;
+import com.liferay.layout.page.template.internal.upgrade.v5_1_2.FileEntryLayoutPageTemplateEntryUpgradeProcess;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.LayoutPrototypeLocalService;
@@ -193,13 +196,25 @@ public class LayoutPageTemplateServiceUpgradeStepRegistrator
 			"5.1.0", "5.1.1",
 			new com.liferay.layout.page.template.internal.upgrade.v5_1_1.
 				LayoutPageTemplateStructureUpgradeProcess(_layoutLocalService));
+
+		registry.register(
+			"5.1.1", "5.1.2",
+			new FileEntryLayoutPageTemplateEntryUpgradeProcess(
+				_classNameLocalService, _companyLocalService,
+				_dlFileEntryTypeLocalService));
 	}
+
+	@Reference
+	private ClassNameLocalService _classNameLocalService;
 
 	@Reference
 	private CollectionPaginationHelper _collectionPaginationHelper;
 
 	@Reference
 	private CompanyLocalService _companyLocalService;
+
+	@Reference
+	private DLFileEntryTypeLocalService _dlFileEntryTypeLocalService;
 
 	@Reference
 	private FragmentEntryConfigurationParser _fragmentEntryConfigurationParser;

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v5_1_2/FileEntryLayoutPageTemplateEntryUpgradeProcess.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v5_1_2/FileEntryLayoutPageTemplateEntryUpgradeProcess.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.layout.page.template.internal.upgrade.v5_1_2;
+
+import com.liferay.document.library.kernel.model.DLFileEntryType;
+import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalService;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+
+import java.sql.PreparedStatement;
+
+/**
+ * @author Adolfo Pérez
+ */
+public class FileEntryLayoutPageTemplateEntryUpgradeProcess
+	extends UpgradeProcess {
+
+	public FileEntryLayoutPageTemplateEntryUpgradeProcess(
+		ClassNameLocalService classNameLocalService,
+		CompanyLocalService companyLocalService,
+		DLFileEntryTypeLocalService dlFileEntryTypeLocalService) {
+
+		_classNameLocalService = classNameLocalService;
+		_companyLocalService = companyLocalService;
+		_dlFileEntryTypeLocalService = dlFileEntryTypeLocalService;
+	}
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		long classNameId = _classNameLocalService.getClassNameId(
+			FileEntry.class);
+
+		_companyLocalService.forEachCompanyId(
+			companyId -> {
+				try (PreparedStatement preparedStatement =
+						connection.prepareStatement(
+							"update LayoutPageTemplateEntry set classTypeId " +
+								"= ? where companyId = ? and classNameId = ? " +
+									"and classTypeId = 0")) {
+
+					DLFileEntryType basicDocumentDLFileEntryType =
+						_dlFileEntryTypeLocalService.
+							getBasicDocumentDLFileEntryType(companyId);
+
+					preparedStatement.setLong(
+						1, basicDocumentDLFileEntryType.getFileEntryTypeId());
+
+					preparedStatement.setLong(2, companyId);
+					preparedStatement.setLong(3, classNameId);
+
+					preparedStatement.execute();
+				}
+			});
+	}
+
+	private final ClassNameLocalService _classNameLocalService;
+	private final CompanyLocalService _companyLocalService;
+	private final DLFileEntryTypeLocalService _dlFileEntryTypeLocalService;
+
+}

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/internal/exportimport/test/LayoutPageTemplateStructureRelExportImportTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/internal/exportimport/test/LayoutPageTemplateStructureRelExportImportTest.java
@@ -15,10 +15,12 @@
 package com.liferay.layout.page.template.internal.exportimport.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.document.library.kernel.model.DLFileEntryType;
 import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.kernel.service.DLAppLocalServiceUtil;
+import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalService;
 import com.liferay.exportimport.test.util.lar.BaseExportImportTestCase;
 import com.liferay.layout.page.template.model.LayoutPageTemplateStructure;
 import com.liferay.layout.page.template.model.LayoutPageTemplateStructureRel;
@@ -135,9 +137,14 @@ public class LayoutPageTemplateStructureRelExportImportTest
 					"classPK", exportedFileEntry.getFileEntryId()
 				).put(
 					"classTypeId",
-					String.valueOf(
-						DLFileEntryTypeConstants.
-							FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT)
+					() -> {
+						DLFileEntryType basicDocumentDLFileEntryType =
+							_dlFileEntryTypeLocalService.
+								getBasicDocumentDLFileEntryType();
+
+						return String.valueOf(
+							basicDocumentDLFileEntryType.getFileEntryTypeId());
+					}
 				).put(
 					"itemSubtype",
 					_language.get(
@@ -216,6 +223,9 @@ public class LayoutPageTemplateStructureRelExportImportTest
 
 	@Inject
 	private DLAppLocalService _dlAppLocalService;
+
+	@Inject
+	private DLFileEntryTypeLocalService _dlFileEntryTypeLocalService;
 
 	@Inject
 	private Language _language;

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/internal/exportimport/test/LayoutPageTemplateStructureRelExportImportTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/internal/exportimport/test/LayoutPageTemplateStructureRelExportImportTest.java
@@ -140,7 +140,8 @@ public class LayoutPageTemplateStructureRelExportImportTest
 					() -> {
 						DLFileEntryType basicDocumentDLFileEntryType =
 							_dlFileEntryTypeLocalService.
-								getBasicDocumentDLFileEntryType();
+								getBasicDocumentDLFileEntryType(
+									exportedFileEntry.getCompanyId());
 
 						return String.valueOf(
 							basicDocumentDLFileEntryType.getFileEntryTypeId());

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
@@ -1993,7 +1993,8 @@ public class DefaultObjectEntryManagerImplTest {
 
 	private Long _getAttachmentObjectFieldValue() throws Exception {
 		DLFileEntryType basicDocumentDLFileEntryType =
-			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType();
+			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType(
+				_group.getCompanyId());
 
 		byte[] bytes = TestDataConstants.TEST_BYTE_ARRAY;
 

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
@@ -24,10 +24,11 @@ import com.liferay.account.service.AccountEntryUserRelLocalService;
 import com.liferay.account.service.AccountRoleLocalService;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.document.library.kernel.model.DLFileEntry;
-import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
+import com.liferay.document.library.kernel.model.DLFileEntryType;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLAppService;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
+import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalService;
 import com.liferay.document.library.util.DLURLHelper;
 import com.liferay.list.type.model.ListTypeDefinition;
 import com.liferay.list.type.model.ListTypeEntry;
@@ -1991,6 +1992,9 @@ public class DefaultObjectEntryManagerImplTest {
 	}
 
 	private Long _getAttachmentObjectFieldValue() throws Exception {
+		DLFileEntryType basicDocumentDLFileEntryType =
+			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType();
+
 		byte[] bytes = TestDataConstants.TEST_BYTE_ARRAY;
 
 		InputStream inputStream = new ByteArrayInputStream(bytes);
@@ -2002,8 +2006,8 @@ public class DefaultObjectEntryManagerImplTest {
 			MimeTypesUtil.getExtensionContentType("txt"),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			StringPool.BLANK, StringPool.BLANK,
-			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT, null,
-			null, inputStream, bytes.length, null, null,
+			basicDocumentDLFileEntryType.getFileEntryTypeId(), null, null,
+			inputStream, bytes.length, null, null,
 			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
 
 		return dlFileEntry.getFileEntryId();
@@ -2127,6 +2131,9 @@ public class DefaultObjectEntryManagerImplTest {
 
 	@Inject
 	private DLFileEntryLocalService _dlFileEntryLocalService;
+
+	@Inject
+	private DLFileEntryTypeLocalService _dlFileEntryTypeLocalService;
 
 	@Inject
 	private DLURLHelper _dlURLHelper;

--- a/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/FolderFacetTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/FolderFacetTest.java
@@ -19,6 +19,7 @@ import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFolder;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
+import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalService;
 import com.liferay.document.library.kernel.service.DLFolderLocalService;
 import com.liferay.document.library.test.util.DLAppTestUtil;
 import com.liferay.document.library.test.util.search.DLFolderSearchFixture;
@@ -253,7 +254,8 @@ public class FolderFacetTest extends BaseFacetedSearcherTestCase {
 
 	protected void setUpDLFolderSearchFixture() {
 		dlFolderSearchFixture = new DLFolderSearchFixture(
-			dlAppLocalService, dlFileEntryLocalService, dlFolderLocalService);
+			dlAppLocalService, dlFileEntryLocalService,
+			dlFileEntryTypeLocalService, dlFolderLocalService);
 
 		dlFolderSearchFixture.setUp();
 
@@ -280,6 +282,9 @@ public class FolderFacetTest extends BaseFacetedSearcherTestCase {
 
 	@Inject
 	protected DLFileEntryLocalService dlFileEntryLocalService;
+
+	@Inject
+	protected DLFileEntryTypeLocalService dlFileEntryTypeLocalService;
 
 	@Inject
 	protected DLFolderLocalService dlFolderLocalService;

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/internal/runtime/integration/test/WorkflowTaskManagerImplTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/internal/runtime/integration/test/WorkflowTaskManagerImplTest.java
@@ -295,7 +295,7 @@ public class WorkflowTaskManagerImplTest extends BaseWorkflowManagerTestCase {
 			() -> {
 				DLFileEntryType basicFileEntryType =
 					_dlFileEntryTypeLocalService.
-						getBasicDocumentDLFileEntryType();
+						getBasicDocumentDLFileEntryType(_group.getCompanyId());
 
 				return String.valueOf(basicFileEntryType.getFileEntryTypeId());
 			},

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/internal/runtime/integration/test/WorkflowTaskManagerImplTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/internal/runtime/integration/test/WorkflowTaskManagerImplTest.java
@@ -293,7 +293,9 @@ public class WorkflowTaskManagerImplTest extends BaseWorkflowManagerTestCase {
 			"Single Approver@1"
 		).put(
 			() -> {
-				DLFileEntryType basicFileEntryType = _getBasicFileEntryType();
+				DLFileEntryType basicFileEntryType =
+					_dlFileEntryTypeLocalService.
+						getBasicDocumentDLFileEntryType();
 
 				return String.valueOf(basicFileEntryType.getFileEntryTypeId());
 			},
@@ -1649,11 +1651,6 @@ public class WorkflowTaskManagerImplTest extends BaseWorkflowManagerTestCase {
 
 	private String _getBasePath() {
 		return "com/liferay/portal/workflow/kaleo/dependencies/";
-	}
-
-	private DLFileEntryType _getBasicFileEntryType() throws Exception {
-		return _dlFileEntryTypeLocalService.getFileEntryType(
-			0, "BASIC-DOCUMENT");
 	}
 
 	private WorkflowInstance _getWorkflowInstance(

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/documentlibrary/service/persistence/test/DLFileEntryTypePersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/documentlibrary/service/persistence/test/DLFileEntryTypePersistenceTest.java
@@ -246,20 +246,22 @@ public class DLFileEntryTypePersistenceTest {
 	}
 
 	@Test
-	public void testCountByG_DDI() throws Exception {
-		_persistence.countByG_DDI(
-			RandomTestUtil.nextLong(), RandomTestUtil.nextLong());
+	public void testCountByG_C_DDI() throws Exception {
+		_persistence.countByG_C_DDI(
+			RandomTestUtil.nextLong(), RandomTestUtil.nextLong(),
+			RandomTestUtil.nextLong());
 
-		_persistence.countByG_DDI(0L, 0L);
+		_persistence.countByG_C_DDI(0L, 0L, 0L);
 	}
 
 	@Test
-	public void testCountByG_F() throws Exception {
-		_persistence.countByG_F(RandomTestUtil.nextLong(), "");
+	public void testCountByG_C_F() throws Exception {
+		_persistence.countByG_C_F(
+			RandomTestUtil.nextLong(), RandomTestUtil.nextLong(), "");
 
-		_persistence.countByG_F(0L, "null");
+		_persistence.countByG_C_F(0L, 0L, "null");
 
-		_persistence.countByG_F(0L, (String)null);
+		_persistence.countByG_C_F(0L, 0L, (String)null);
 	}
 
 	@Test
@@ -583,6 +585,11 @@ public class DLFileEntryTypePersistenceTest {
 				dlFileEntryType, "getColumnOriginalValue",
 				new Class<?>[] {String.class}, "groupId"));
 		Assert.assertEquals(
+			Long.valueOf(dlFileEntryType.getCompanyId()),
+			ReflectionTestUtil.<Long>invoke(
+				dlFileEntryType, "getColumnOriginalValue",
+				new Class<?>[] {String.class}, "companyId"));
+		Assert.assertEquals(
 			Long.valueOf(dlFileEntryType.getDataDefinitionId()),
 			ReflectionTestUtil.<Long>invoke(
 				dlFileEntryType, "getColumnOriginalValue",
@@ -593,6 +600,11 @@ public class DLFileEntryTypePersistenceTest {
 			ReflectionTestUtil.<Long>invoke(
 				dlFileEntryType, "getColumnOriginalValue",
 				new Class<?>[] {String.class}, "groupId"));
+		Assert.assertEquals(
+			Long.valueOf(dlFileEntryType.getCompanyId()),
+			ReflectionTestUtil.<Long>invoke(
+				dlFileEntryType, "getColumnOriginalValue",
+				new Class<?>[] {String.class}, "companyId"));
 		Assert.assertEquals(
 			dlFileEntryType.getFileEntryTypeKey(),
 			ReflectionTestUtil.invoke(

--- a/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
@@ -216,7 +216,6 @@ import com.liferay.portal.kernel.model.AddressModel;
 import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.model.ClassNameModel;
 import com.liferay.portal.kernel.model.Company;
-import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.model.CompanyModel;
 import com.liferay.portal.kernel.model.ContactConstants;
 import com.liferay.portal.kernel.model.ContactModel;
@@ -3736,7 +3735,7 @@ public class DataFactory {
 
 		// Audit fields
 
-		defaultDLFileEntryTypeModel.setCompanyId(CompanyConstants.SYSTEM);
+		defaultDLFileEntryTypeModel.setCompanyId(_companyId);
 		defaultDLFileEntryTypeModel.setCreateDate(nextFutureDate());
 		defaultDLFileEntryTypeModel.setModifiedDate(nextFutureDate());
 

--- a/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
@@ -3734,8 +3734,7 @@ public class DataFactory {
 		// Other fields
 
 		defaultDLFileEntryTypeModel.setFileEntryTypeKey(
-			StringUtil.toUpperCase(
-				DLFileEntryTypeConstants.NAME_BASIC_DOCUMENT));
+			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_KEY_BASIC_DOCUMENT);
 
 		defaultDLFileEntryTypeModel.setName(
 			StringBundler.concat(

--- a/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
@@ -216,6 +216,7 @@ import com.liferay.portal.kernel.model.AddressModel;
 import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.model.ClassNameModel;
 import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.model.CompanyModel;
 import com.liferay.portal.kernel.model.ContactConstants;
 import com.liferay.portal.kernel.model.ContactModel;
@@ -3718,16 +3719,24 @@ public class DataFactory {
 	}
 
 	public DLFileEntryTypeModel newDLFileEntryTypeModel() {
+		_defaultDLFileEntryTypeId = _counter.get();
+
 		DLFileEntryTypeModel defaultDLFileEntryTypeModel =
 			new DLFileEntryTypeModelImpl();
 
 		// PK fields
 
 		defaultDLFileEntryTypeModel.setFileEntryTypeId(
-			_DEFAULT_DL_FILE_ENTRY_TYPE_ID);
+			_defaultDLFileEntryTypeId);
+
+		// Group instance
+
+		defaultDLFileEntryTypeModel.setGroupId(
+			GroupConstants.DEFAULT_LIVE_GROUP_ID);
 
 		// Audit fields
 
+		defaultDLFileEntryTypeModel.setCompanyId(CompanyConstants.SYSTEM);
 		defaultDLFileEntryTypeModel.setCreateDate(nextFutureDate());
 		defaultDLFileEntryTypeModel.setModifiedDate(nextFutureDate());
 
@@ -6345,7 +6354,7 @@ public class DataFactory {
 		dlFolderModel.setTreePath(treePath);
 		dlFolderModel.setName(name);
 		dlFolderModel.setLastPostDate(nextFutureDate());
-		dlFolderModel.setDefaultFileEntryTypeId(_DEFAULT_DL_FILE_ENTRY_TYPE_ID);
+		dlFolderModel.setDefaultFileEntryTypeId(_defaultDLFileEntryTypeId);
 		dlFolderModel.setLastPublishDate(nextFutureDate());
 		dlFolderModel.setStatusDate(nextFutureDate());
 
@@ -7393,9 +7402,6 @@ public class DataFactory {
 
 	private static final long _CURRENT_TIME = System.currentTimeMillis();
 
-	private static final long _DEFAULT_DL_FILE_ENTRY_TYPE_ID =
-		DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT;
-
 	private static final String _DEPENDENCIES_DIR =
 		"/com/liferay/portal/tools/sample/sql/builder/dependencies/data/";
 
@@ -7447,6 +7453,7 @@ public class DataFactory {
 		_defaultAssetPublisherPortletPreferencesImpl;
 	private long _defaultDLDDMStructureId;
 	private long _defaultDLDDMStructureVersionId;
+	private long _defaultDLFileEntryTypeId;
 	private long _defaultJournalDDMStructureId;
 	private long _defaultJournalDDMStructureVersionId;
 	private long _defaultJournalDDMTemplateId;

--- a/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/company.ftl
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/company.ftl
@@ -17,5 +17,7 @@
 
 	<#include "roles.ftl">
 
+	<#include "default_dl_file_type.ftl">
+
 	<#include "groups.ftl">
 </#list>

--- a/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/sample.ftl
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/sample.ftl
@@ -4,8 +4,6 @@
 
 <#include "class_names.ftl">
 
-<#include "default_dl_file_type.ftl">
-
 <#include "release.ftl">
 
 <#include "counters.ftl">

--- a/portal-impl/src/com/liferay/portal/events/StartupAction.java
+++ b/portal-impl/src/com/liferay/portal/events/StartupAction.java
@@ -14,7 +14,6 @@
 
 package com.liferay.portal.events;
 
-import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalServiceUtil;
 import com.liferay.petra.io.StreamUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.db.index.IndexUpdaterUtil;
@@ -171,10 +170,9 @@ public class StartupAction extends SimpleAction {
 
 		StartupHelperUtil.initResourceActions();
 
-		if (StartupHelperUtil.isDBNew()) {
-			DLFileEntryTypeLocalServiceUtil.getBasicDocumentDLFileEntryType();
-		}
-		else if (PropsValues.DATABASE_INDEXES_UPDATE_ON_STARTUP) {
+		if (!StartupHelperUtil.isDBNew() &&
+			PropsValues.DATABASE_INDEXES_UPDATE_ON_STARTUP) {
+
 			IndexUpdaterUtil.updateAllIndexes();
 		}
 	}

--- a/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayRepositoryBase.java
+++ b/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayRepositoryBase.java
@@ -33,8 +33,10 @@ import com.liferay.dynamic.data.mapping.kernel.DDMStructure;
 import com.liferay.dynamic.data.mapping.kernel.StorageEngineManagerUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.repository.capabilities.Capability;
 import com.liferay.portal.kernel.repository.capabilities.CapabilityProvider;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.RepositoryLocalService;
 import com.liferay.portal.kernel.service.RepositoryService;
 import com.liferay.portal.kernel.service.ResourceLocalService;
@@ -113,7 +115,7 @@ public abstract class LiferayRepositoryBase implements CapabilityProvider {
 
 		DLFileEntryType basicDocumentDLFileEntryType =
 			DLFileEntryTypeLocalServiceUtil.getBasicDocumentDLFileEntryType(
-				serviceContext.getCompanyId());
+				_getCompanyId(serviceContext));
 
 		if ((fileEntryTypeId ==
 				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_ALL) ||
@@ -152,10 +154,10 @@ public abstract class LiferayRepositoryBase implements CapabilityProvider {
 		throws PortalException {
 
 		folderId = dlFolderLocalService.getFolderId(
-			serviceContext.getCompanyId(), folderId);
+			_getCompanyId(serviceContext), folderId);
 
 		return dlFileEntryTypeLocalService.getDefaultFileEntryTypeId(
-			serviceContext.getCompanyId(), folderId);
+			_getCompanyId(serviceContext), folderId);
 	}
 
 	protected long getGroupId() {
@@ -221,6 +223,14 @@ public abstract class LiferayRepositoryBase implements CapabilityProvider {
 	protected RepositoryLocalService repositoryLocalService;
 	protected RepositoryService repositoryService;
 	protected ResourceLocalService resourceLocalService;
+
+	private long _getCompanyId(ServiceContext serviceContext) {
+		if (serviceContext.getCompanyId() != CompanyConstants.SYSTEM) {
+			return serviceContext.getCompanyId();
+		}
+
+		return CompanyThreadLocal.getCompanyId();
+	}
 
 	private final long _dlFolderId;
 	private final long _groupId;

--- a/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayRepositoryBase.java
+++ b/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayRepositoryBase.java
@@ -112,7 +112,8 @@ public abstract class LiferayRepositoryBase implements CapabilityProvider {
 		HashMap<String, DDMFormValues> ddmFormValuesMap = new HashMap<>();
 
 		DLFileEntryType basicDocumentDLFileEntryType =
-			DLFileEntryTypeLocalServiceUtil.getBasicDocumentDLFileEntryType();
+			DLFileEntryTypeLocalServiceUtil.getBasicDocumentDLFileEntryType(
+				serviceContext.getCompanyId());
 
 		if ((fileEntryTypeId ==
 				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_ALL) ||
@@ -153,7 +154,8 @@ public abstract class LiferayRepositoryBase implements CapabilityProvider {
 		folderId = dlFolderLocalService.getFolderId(
 			serviceContext.getCompanyId(), folderId);
 
-		return dlFileEntryTypeLocalService.getDefaultFileEntryTypeId(folderId);
+		return dlFileEntryTypeLocalService.getDefaultFileEntryTypeId(
+			serviceContext.getCompanyId(), folderId);
 	}
 
 	protected long getGroupId() {

--- a/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayRepositoryBase.java
+++ b/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayRepositoryBase.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.repository.liferayrepository;
 
 import com.liferay.document.library.kernel.model.DLFileEntryType;
+import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLAppHelperLocalService;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
@@ -110,7 +111,14 @@ public abstract class LiferayRepositoryBase implements CapabilityProvider {
 
 		HashMap<String, DDMFormValues> ddmFormValuesMap = new HashMap<>();
 
-		if (fileEntryTypeId <= 0) {
+		DLFileEntryType basicDocumentDLFileEntryType =
+			DLFileEntryTypeLocalServiceUtil.getBasicDocumentDLFileEntryType();
+
+		if ((fileEntryTypeId ==
+				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_ALL) ||
+			(fileEntryTypeId ==
+				basicDocumentDLFileEntryType.getFileEntryTypeId())) {
+
 			return ddmFormValuesMap;
 		}
 

--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -220,9 +220,6 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 			DBPartitionUtil.setDefaultCompanyId(company.getCompanyId());
 		}
 
-		boolean newDBPartitionAdded = DBPartitionUtil.addDBPartition(
-			company.getCompanyId());
-
 		SafeCloseable safeCloseable =
 			CompanyThreadLocal.setInitializingCompanyIdWithSafeCloseable(
 				company.getCompanyId());
@@ -239,10 +236,8 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 
 			updateVirtualHostname(company.getCompanyId(), virtualHostname);
 
-			if (newDBPartitionAdded) {
-				_dlFileEntryTypeLocalService.
-					createBasicDocumentDLFileEntryType();
-			}
+			_dlFileEntryTypeLocalService.createBasicDocumentDLFileEntryType(
+				companyId);
 
 			String name = webId;
 

--- a/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
+++ b/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
@@ -14,7 +14,6 @@
 
 package com.liferay.portal.tools;
 
-import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalServiceUtil;
 import com.liferay.document.library.kernel.store.Store;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.dao.orm.common.SQLTransformer;
@@ -312,8 +311,6 @@ public class DBUpgrader {
 			_checkClassNamesAndResourceActions();
 
 			verify();
-
-			DLFileEntryTypeLocalServiceUtil.getBasicDocumentDLFileEntryType();
 		}
 		finally {
 			UpgradeLogContext.clearContext();

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/PortalUpgradeProcessRegistryImpl.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/PortalUpgradeProcessRegistryImpl.java
@@ -259,6 +259,10 @@ public class PortalUpgradeProcessRegistryImpl
 
 		upgradeVersionTreeMap.put(
 			new Version(25, 1, 2), new DummyUpgradeProcess());
+
+		upgradeVersionTreeMap.put(
+			new Version(25, 1, 3), new UpgradeBasicDocumentDLFileEntryType(),
+			new UpgradeDLFolder());
 	}
 
 }

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/UpgradeBasicDocumentDLFileEntryType.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/UpgradeBasicDocumentDLFileEntryType.java
@@ -1,0 +1,188 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.upgrade.v7_4_x;
+
+import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
+import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.upgrade.UpgradeException;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+
+import java.sql.Date;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * @author Adolfo Pérez
+ */
+public class UpgradeBasicDocumentDLFileEntryType extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		DLFileEntryTypeData dlFileEntryTypeData = _getDLFileEntryTypeData();
+
+		if (dlFileEntryTypeData == null) {
+			throw new UpgradeException(
+				"Could not find basic document dl file entry type");
+		}
+
+		runSQL(
+			"delete from DLFileEntryType where fileEntryTypeId = '" +
+				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT +
+					"'");
+
+		try (PreparedStatement preparedStatement1 = connection.prepareStatement(
+				"select companyId from Company");
+			PreparedStatement preparedStatement2 =
+				AutoBatchPreparedStatementUtil.autoBatch(
+					connection,
+					StringBundler.concat(
+						"insert into DLFileEntryType (uuid_, fileEntryTypeId, ",
+						"groupId, companyId, createDate, modifiedDate, ",
+						"dataDefinitionId, fileEntryTypeKey, name, ",
+						"lastPublishDate) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ",
+						"?)"));
+			PreparedStatement preparedStatement3 =
+				AutoBatchPreparedStatementUtil.autoBatch(
+					connection,
+					"update DLFileEntry set fileEntryTypeId = ? where " +
+						"companyId = ? and fileEntryTypeId = ?");
+			PreparedStatement preparedStatement4 =
+				AutoBatchPreparedStatementUtil.autoBatch(
+					connection,
+					"update DLFileVersion set fileEntryTypeId = ? where " +
+						"companyId = ? and fileEntryTypeId = ?");
+			ResultSet resultSet = preparedStatement1.executeQuery()) {
+
+			Map<Long, Long> fileEntryTypeIds = new HashMap<>();
+
+			while (resultSet.next()) {
+				long companyId = resultSet.getLong("companyId");
+
+				long fileEntryTypeId = increment();
+
+				fileEntryTypeIds.put(companyId, fileEntryTypeId);
+
+				preparedStatement2.setString(
+					1, String.valueOf(UUID.randomUUID()));
+				preparedStatement2.setLong(2, fileEntryTypeId);
+				preparedStatement2.setLong(
+					3, GroupConstants.DEFAULT_LIVE_GROUP_ID);
+				preparedStatement2.setLong(4, companyId);
+				preparedStatement2.setDate(
+					5, dlFileEntryTypeData.getCreateDate());
+				preparedStatement2.setDate(
+					6, dlFileEntryTypeData.getModifiedDate());
+				preparedStatement2.setLong(7, _DEFAULT_DDM_STRUCTURE_ID);
+				preparedStatement2.setString(
+					8,
+					DLFileEntryTypeConstants.
+						FILE_ENTRY_TYPE_KEY_BASIC_DOCUMENT);
+				preparedStatement2.setString(9, dlFileEntryTypeData.getName());
+				preparedStatement2.setDate(
+					10, dlFileEntryTypeData.getLastPublishedDate());
+
+				preparedStatement2.addBatch();
+			}
+
+			preparedStatement2.executeBatch();
+
+			for (Map.Entry<Long, Long> entry : fileEntryTypeIds.entrySet()) {
+				preparedStatement3.setLong(1, entry.getValue());
+				preparedStatement3.setLong(2, entry.getKey());
+				preparedStatement3.setLong(
+					3,
+					DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT);
+
+				preparedStatement3.addBatch();
+
+				preparedStatement4.setLong(1, entry.getValue());
+				preparedStatement4.setLong(2, entry.getKey());
+				preparedStatement4.setLong(
+					3,
+					DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT);
+
+				preparedStatement4.addBatch();
+			}
+
+			preparedStatement3.executeBatch();
+			preparedStatement4.executeBatch();
+		}
+	}
+
+	private DLFileEntryTypeData _getDLFileEntryTypeData() throws Exception {
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				"select createDate, lastPublishDate, modifiedDate, name from " +
+					"DLFileEntryType where fileEntryTypeId = ?")) {
+
+			preparedStatement.setLong(
+				1, DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT);
+
+			ResultSet resultSet = preparedStatement.executeQuery();
+
+			if (!resultSet.next()) {
+				return null;
+			}
+
+			return new DLFileEntryTypeData(
+				resultSet.getDate("createDate"),
+				resultSet.getDate("lastPublishDate"),
+				resultSet.getDate("modifiedDate"), resultSet.getString("name"));
+		}
+	}
+
+	private static final long _DEFAULT_DDM_STRUCTURE_ID = 0;
+
+	private static final class DLFileEntryTypeData {
+
+		public Date getCreateDate() {
+			return _createDate;
+		}
+
+		public Date getLastPublishedDate() {
+			return _lastPublishedDate;
+		}
+
+		public Date getModifiedDate() {
+			return _modifiedDate;
+		}
+
+		public String getName() {
+			return _name;
+		}
+
+		private DLFileEntryTypeData(
+			Date createDate, Date lastPublishedDate, Date modifiedDate,
+			String name) {
+
+			_createDate = createDate;
+			_lastPublishedDate = lastPublishedDate;
+			_modifiedDate = modifiedDate;
+			_name = name;
+		}
+
+		private final Date _createDate;
+		private final Date _lastPublishedDate;
+		private final Date _modifiedDate;
+		private final String _name;
+
+	}
+
+}

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/UpgradeDLFolder.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/UpgradeDLFolder.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.upgrade.v7_4_x;
+
+import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
+import com.liferay.document.library.kernel.model.DLFolderConstants;
+import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
+import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+/**
+ * @author Adolfo Pérez
+ */
+public class UpgradeDLFolder extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		try (PreparedStatement preparedStatement1 = connection.prepareStatement(
+				"select companyId, fileEntryTypeId from DLFileEntryType " +
+					"where groupId = ? and fileEntryTypeKey = ?");
+			PreparedStatement preparedStatement2 =
+				AutoBatchPreparedStatementUtil.autoBatch(
+					connection,
+					"update DLFolder set defaultFileEntryTypeId = ? where " +
+						"companyId = ? and restrictionType = ?")) {
+
+			preparedStatement1.setLong(1, GroupConstants.DEFAULT_LIVE_GROUP_ID);
+			preparedStatement1.setString(
+				2, DLFileEntryTypeConstants.FILE_ENTRY_TYPE_KEY_BASIC_DOCUMENT);
+
+			try (ResultSet resultSet = preparedStatement1.executeQuery()) {
+				while (resultSet.next()) {
+					preparedStatement2.setLong(
+						1, resultSet.getLong("fileEntryTypeId"));
+					preparedStatement2.setLong(
+						2, resultSet.getLong("companyId"));
+					preparedStatement2.setInt(
+						3,
+						DLFolderConstants.
+							RESTRICTION_TYPE_FILE_ENTRY_TYPES_AND_WORKFLOW);
+
+					preparedStatement2.addBatch();
+				}
+
+				preparedStatement2.executeBatch();
+			}
+		}
+	}
+
+}

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/asset/model/DLFileEntryClassTypeReader.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/asset/model/DLFileEntryClassTypeReader.java
@@ -20,6 +20,8 @@ import com.liferay.document.library.kernel.model.DLFileEntryType;
 import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalServiceUtil;
 import com.liferay.document.library.kernel.service.DLFileEntryTypeServiceUtil;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portlet.documentlibrary.asset.DLFileEntryClassType;
 
@@ -38,7 +40,10 @@ public class DLFileEntryClassTypeReader implements ClassTypeReader {
 
 		List<ClassType> classTypes = new ArrayList<>();
 
-		classTypes.add(_getBasicDocumentClassType(locale));
+		Group group = GroupLocalServiceUtil.fetchGroup(groupIds[0]);
+
+		classTypes.add(
+			_getBasicDocumentClassType(group.getCompanyId(), locale));
 
 		String languageId = LocaleUtil.toLanguageId(locale);
 
@@ -67,9 +72,12 @@ public class DLFileEntryClassTypeReader implements ClassTypeReader {
 			dlFileEntryType.getName(locale), LocaleUtil.toLanguageId(locale));
 	}
 
-	private ClassType _getBasicDocumentClassType(Locale locale) {
+	private ClassType _getBasicDocumentClassType(
+		long companyId, Locale locale) {
+
 		DLFileEntryType dlFileEntryType =
-			DLFileEntryTypeLocalServiceUtil.getBasicDocumentDLFileEntryType();
+			DLFileEntryTypeLocalServiceUtil.getBasicDocumentDLFileEntryType(
+				companyId);
 
 		return new DLFileEntryClassType(
 			dlFileEntryType.getFileEntryTypeId(),

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/asset/model/DLFileEntryClassTypeReader.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/asset/model/DLFileEntryClassTypeReader.java
@@ -17,11 +17,10 @@ package com.liferay.portlet.documentlibrary.asset.model;
 import com.liferay.asset.kernel.model.ClassType;
 import com.liferay.asset.kernel.model.ClassTypeReader;
 import com.liferay.document.library.kernel.model.DLFileEntryType;
-import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
 import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalServiceUtil;
 import com.liferay.document.library.kernel.service.DLFileEntryTypeServiceUtil;
+import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portlet.documentlibrary.asset.DLFileEntryClassType;
 
@@ -40,7 +39,7 @@ public class DLFileEntryClassTypeReader implements ClassTypeReader {
 
 		List<ClassType> classTypes = new ArrayList<>();
 
-		classTypes.add(getBasicDocumentClassType(locale));
+		classTypes.add(_getBasicDocumentClassType(locale));
 
 		String languageId = LocaleUtil.toLanguageId(locale);
 
@@ -61,12 +60,6 @@ public class DLFileEntryClassTypeReader implements ClassTypeReader {
 	public ClassType getClassType(long classTypeId, Locale locale)
 		throws PortalException {
 
-		if (classTypeId ==
-				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT) {
-
-			return getBasicDocumentClassType(locale);
-		}
-
 		DLFileEntryType dlFileEntryType =
 			DLFileEntryTypeServiceUtil.getFileEntryType(classTypeId);
 
@@ -75,16 +68,20 @@ public class DLFileEntryClassTypeReader implements ClassTypeReader {
 			dlFileEntryType.getName(locale), LocaleUtil.toLanguageId(locale));
 	}
 
-	protected ClassType getBasicDocumentClassType(Locale locale) {
-		DLFileEntryType basicDocumentDLFileEntryType =
-			DLFileEntryTypeLocalServiceUtil.fetchDLFileEntryType(
-				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT);
+	private ClassType _getBasicDocumentClassType(Locale locale) {
+		try {
+			DLFileEntryType dlFileEntryType =
+				DLFileEntryTypeLocalServiceUtil.
+					getBasicDocumentDLFileEntryType();
 
-		return new DLFileEntryClassType(
-			basicDocumentDLFileEntryType.getFileEntryTypeId(),
-			LanguageUtil.get(
-				locale, DLFileEntryTypeConstants.NAME_BASIC_DOCUMENT),
-			LocaleUtil.toLanguageId(locale));
+			return new DLFileEntryClassType(
+				dlFileEntryType.getFileEntryTypeId(),
+				dlFileEntryType.getName(locale),
+				LocaleUtil.toLanguageId(locale));
+		}
+		catch (PortalException portalException) {
+			return ReflectionUtil.throwException(portalException);
+		}
 	}
 
 }

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/asset/model/DLFileEntryClassTypeReader.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/asset/model/DLFileEntryClassTypeReader.java
@@ -19,7 +19,6 @@ import com.liferay.asset.kernel.model.ClassTypeReader;
 import com.liferay.document.library.kernel.model.DLFileEntryType;
 import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalServiceUtil;
 import com.liferay.document.library.kernel.service.DLFileEntryTypeServiceUtil;
-import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portlet.documentlibrary.asset.DLFileEntryClassType;
@@ -69,19 +68,12 @@ public class DLFileEntryClassTypeReader implements ClassTypeReader {
 	}
 
 	private ClassType _getBasicDocumentClassType(Locale locale) {
-		try {
-			DLFileEntryType dlFileEntryType =
-				DLFileEntryTypeLocalServiceUtil.
-					getBasicDocumentDLFileEntryType();
+		DLFileEntryType dlFileEntryType =
+			DLFileEntryTypeLocalServiceUtil.getBasicDocumentDLFileEntryType();
 
-			return new DLFileEntryClassType(
-				dlFileEntryType.getFileEntryTypeId(),
-				dlFileEntryType.getName(locale),
-				LocaleUtil.toLanguageId(locale));
-		}
-		catch (PortalException portalException) {
-			return ReflectionUtil.throwException(portalException);
-		}
+		return new DLFileEntryClassType(
+			dlFileEntryType.getFileEntryTypeId(),
+			dlFileEntryType.getName(locale), LocaleUtil.toLanguageId(locale));
 	}
 
 }

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLFileEntryTypeImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLFileEntryTypeImpl.java
@@ -15,6 +15,7 @@
 package com.liferay.portlet.documentlibrary.model.impl;
 
 import com.liferay.document.library.kernel.model.DLFileEntryType;
+import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
 import com.liferay.dynamic.data.mapping.kernel.DDMStructure;
 import com.liferay.dynamic.data.mapping.kernel.DDMStructureLink;
 import com.liferay.dynamic.data.mapping.kernel.DDMStructureLinkManagerUtil;
@@ -68,7 +69,10 @@ public class DLFileEntryTypeImpl extends DLFileEntryTypeBaseImpl {
 
 	@Override
 	public String getName(Locale locale) {
-		if (Objects.equals(getFileEntryTypeKey(), "BASIC-DOCUMENT")) {
+		if (Objects.equals(
+				getFileEntryTypeKey(),
+				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_KEY_BASIC_DOCUMENT)) {
+
 			return LanguageUtil.get(locale, super.getName(locale));
 		}
 
@@ -77,7 +81,10 @@ public class DLFileEntryTypeImpl extends DLFileEntryTypeBaseImpl {
 
 	@Override
 	public String getName(String languageId) {
-		if (Objects.equals(getFileEntryTypeKey(), "BASIC-DOCUMENT")) {
+		if (Objects.equals(
+				getFileEntryTypeKey(),
+				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_KEY_BASIC_DOCUMENT)) {
+
 			return LanguageUtil.get(
 				LanguageUtil.getLocale(languageId), super.getName(languageId));
 		}
@@ -115,7 +122,10 @@ public class DLFileEntryTypeImpl extends DLFileEntryTypeBaseImpl {
 
 	@Override
 	public boolean isExportable() {
-		if (Objects.equals(getFileEntryTypeKey(), "BASIC-DOCUMENT")) {
+		if (Objects.equals(
+				getFileEntryTypeKey(),
+				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_KEY_BASIC_DOCUMENT)) {
+
 			return false;
 		}
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLFileEntryTypeImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLFileEntryTypeImpl.java
@@ -41,6 +41,13 @@ public class DLFileEntryTypeImpl extends DLFileEntryTypeBaseImpl {
 
 	@Override
 	public List<DDMStructure> getDDMStructures() {
+		if (Objects.equals(
+				getFileEntryTypeKey(),
+				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_KEY_BASIC_DOCUMENT)) {
+
+			return new ArrayList<>();
+		}
+
 		List<DDMStructureLink> ddmStructureLinks =
 			DDMStructureLinkManagerUtil.getStructureLinks(
 				PortalUtil.getClassNameId(DLFileEntryType.class),

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLFileEntryTypeImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLFileEntryTypeImpl.java
@@ -15,7 +15,6 @@
 package com.liferay.portlet.documentlibrary.model.impl;
 
 import com.liferay.document.library.kernel.model.DLFileEntryType;
-import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
 import com.liferay.dynamic.data.mapping.kernel.DDMStructure;
 import com.liferay.dynamic.data.mapping.kernel.DDMStructureLink;
 import com.liferay.dynamic.data.mapping.kernel.DDMStructureLinkManagerUtil;
@@ -31,6 +30,7 @@ import com.liferay.portal.kernel.util.PortalUtil;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 
 /**
  * @author Alexander Chow
@@ -68,28 +68,21 @@ public class DLFileEntryTypeImpl extends DLFileEntryTypeBaseImpl {
 
 	@Override
 	public String getName(Locale locale) {
-		String name = super.getName(locale);
-
-		if (getFileEntryTypeId() ==
-				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT) {
-
-			name = LanguageUtil.get(locale, name);
+		if (Objects.equals(getFileEntryTypeKey(), "BASIC-DOCUMENT")) {
+			return LanguageUtil.get(locale, super.getName(locale));
 		}
 
-		return name;
+		return super.getName(locale);
 	}
 
 	@Override
 	public String getName(String languageId) {
-		String name = super.getName(languageId);
-
-		if (getFileEntryTypeId() ==
-				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT) {
-
-			name = LanguageUtil.get(LanguageUtil.getLocale(languageId), name);
+		if (Objects.equals(getFileEntryTypeKey(), "BASIC-DOCUMENT")) {
+			return LanguageUtil.get(
+				LanguageUtil.getLocale(languageId), super.getName(languageId));
 		}
 
-		return name;
+		return super.getName(languageId);
 	}
 
 	@Override
@@ -122,9 +115,7 @@ public class DLFileEntryTypeImpl extends DLFileEntryTypeBaseImpl {
 
 	@Override
 	public boolean isExportable() {
-		if (getFileEntryTypeId() ==
-				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT) {
-
+		if (Objects.equals(getFileEntryTypeKey(), "BASIC-DOCUMENT")) {
 			return false;
 		}
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service.xml
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service.xml
@@ -201,12 +201,14 @@
 		<finder name="GroupId" return-type="Collection">
 			<finder-column arrayable-operator="OR" name="groupId" />
 		</finder>
-		<finder name="G_DDI" return-type="DLFileEntryType" unique="true">
+		<finder name="G_C_DDI" return-type="DLFileEntryType" unique="true">
 			<finder-column name="groupId" />
+			<finder-column name="companyId" />
 			<finder-column name="dataDefinitionId" />
 		</finder>
-		<finder name="G_F" return-type="DLFileEntryType" unique="true">
+		<finder name="G_C_F" return-type="DLFileEntryType" unique="true">
 			<finder-column name="groupId" />
+			<finder-column name="companyId" />
 			<finder-column name="fileEntryTypeKey" />
 		</finder>
 	</entity>

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/http/DLFileEntryTypeServiceHttp.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/http/DLFileEntryTypeServiceHttp.java
@@ -227,13 +227,47 @@ public class DLFileEntryTypeServiceHttp {
 	}
 
 	public static com.liferay.document.library.kernel.model.DLFileEntryType
+		getBasicDocumentDLFileEntryType(
+			HttpPrincipal httpPrincipal, long company) {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				DLFileEntryTypeServiceUtil.class,
+				"getBasicDocumentDLFileEntryType",
+				_getBasicDocumentDLFileEntryTypeParameterTypes4);
+
+			MethodHandler methodHandler = new MethodHandler(methodKey, company);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.document.library.kernel.model.DLFileEntryType)
+				returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
+	public static com.liferay.document.library.kernel.model.DLFileEntryType
 			getFileEntryType(HttpPrincipal httpPrincipal, long fileEntryTypeId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryTypeServiceUtil.class, "getFileEntryType",
-				_getFileEntryTypeParameterTypes4);
+				_getFileEntryTypeParameterTypes5);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, fileEntryTypeId);
@@ -274,7 +308,7 @@ public class DLFileEntryTypeServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryTypeServiceUtil.class, "getFileEntryTypes",
-				_getFileEntryTypesParameterTypes5);
+				_getFileEntryTypesParameterTypes6);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupIds);
@@ -311,7 +345,7 @@ public class DLFileEntryTypeServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryTypeServiceUtil.class, "getFileEntryTypes",
-				_getFileEntryTypesParameterTypes6);
+				_getFileEntryTypesParameterTypes7);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupIds, start, end);
@@ -345,7 +379,7 @@ public class DLFileEntryTypeServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryTypeServiceUtil.class, "getFileEntryTypesCount",
-				_getFileEntryTypesCountParameterTypes7);
+				_getFileEntryTypesCountParameterTypes8);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupIds);
@@ -381,7 +415,7 @@ public class DLFileEntryTypeServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryTypeServiceUtil.class, "getFolderFileEntryTypes",
-				_getFolderFileEntryTypesParameterTypes8);
+				_getFolderFileEntryTypesParameterTypes9);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupIds, folderId, inherited);
@@ -427,7 +461,7 @@ public class DLFileEntryTypeServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryTypeServiceUtil.class, "search",
-				_searchParameterTypes9);
+				_searchParameterTypes10);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, folderId, groupIds, keywords,
@@ -475,7 +509,7 @@ public class DLFileEntryTypeServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryTypeServiceUtil.class, "search",
-				_searchParameterTypes10);
+				_searchParameterTypes11);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, groupIds, keywords,
@@ -517,7 +551,7 @@ public class DLFileEntryTypeServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryTypeServiceUtil.class, "search",
-				_searchParameterTypes11);
+				_searchParameterTypes12);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, groupIds, keywords,
@@ -554,7 +588,7 @@ public class DLFileEntryTypeServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryTypeServiceUtil.class, "searchCount",
-				_searchCountParameterTypes12);
+				_searchCountParameterTypes13);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, folderId, groupIds, keywords,
@@ -588,7 +622,7 @@ public class DLFileEntryTypeServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryTypeServiceUtil.class, "searchCount",
-				_searchCountParameterTypes13);
+				_searchCountParameterTypes14);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, groupIds, keywords,
@@ -622,7 +656,7 @@ public class DLFileEntryTypeServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryTypeServiceUtil.class, "searchCount",
-				_searchCountParameterTypes14);
+				_searchCountParameterTypes15);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, groupIds, keywords,
@@ -659,7 +693,7 @@ public class DLFileEntryTypeServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryTypeServiceUtil.class, "updateFileEntryType",
-				_updateFileEntryTypeParameterTypes15);
+				_updateFileEntryTypeParameterTypes16);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, fileEntryTypeId, nameMap, descriptionMap);
@@ -704,7 +738,7 @@ public class DLFileEntryTypeServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryTypeServiceUtil.class, "updateFileEntryType",
-				_updateFileEntryTypeParameterTypes16);
+				_updateFileEntryTypeParameterTypes17);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, fileEntryTypeId, nameMap, descriptionMap,
@@ -743,7 +777,7 @@ public class DLFileEntryTypeServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryTypeServiceUtil.class, "updateFileEntryType",
-				_updateFileEntryTypeParameterTypes17);
+				_updateFileEntryTypeParameterTypes18);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, fileEntryTypeId, name, description, ddmStructureIds,
@@ -794,47 +828,51 @@ public class DLFileEntryTypeServiceHttp {
 		};
 	private static final Class<?>[] _deleteFileEntryTypeParameterTypes3 =
 		new Class[] {long.class};
-	private static final Class<?>[] _getFileEntryTypeParameterTypes4 =
+	private static final Class<?>[]
+		_getBasicDocumentDLFileEntryTypeParameterTypes4 = new Class[] {
+			long.class
+		};
+	private static final Class<?>[] _getFileEntryTypeParameterTypes5 =
 		new Class[] {long.class};
-	private static final Class<?>[] _getFileEntryTypesParameterTypes5 =
-		new Class[] {long[].class};
 	private static final Class<?>[] _getFileEntryTypesParameterTypes6 =
-		new Class[] {long[].class, int.class, int.class};
-	private static final Class<?>[] _getFileEntryTypesCountParameterTypes7 =
 		new Class[] {long[].class};
-	private static final Class<?>[] _getFolderFileEntryTypesParameterTypes8 =
+	private static final Class<?>[] _getFileEntryTypesParameterTypes7 =
+		new Class[] {long[].class, int.class, int.class};
+	private static final Class<?>[] _getFileEntryTypesCountParameterTypes8 =
+		new Class[] {long[].class};
+	private static final Class<?>[] _getFolderFileEntryTypesParameterTypes9 =
 		new Class[] {long[].class, long.class, boolean.class};
-	private static final Class<?>[] _searchParameterTypes9 = new Class[] {
+	private static final Class<?>[] _searchParameterTypes10 = new Class[] {
 		long.class, long.class, long[].class, String.class, boolean.class,
 		boolean.class, int.class, int.class
 	};
-	private static final Class<?>[] _searchParameterTypes10 = new Class[] {
+	private static final Class<?>[] _searchParameterTypes11 = new Class[] {
 		long.class, long[].class, String.class, boolean.class, int.class,
 		int.class, int.class,
 		com.liferay.portal.kernel.util.OrderByComparator.class
 	};
-	private static final Class<?>[] _searchParameterTypes11 = new Class[] {
+	private static final Class<?>[] _searchParameterTypes12 = new Class[] {
 		long.class, long[].class, String.class, boolean.class, int.class,
 		int.class, com.liferay.portal.kernel.util.OrderByComparator.class
 	};
-	private static final Class<?>[] _searchCountParameterTypes12 = new Class[] {
+	private static final Class<?>[] _searchCountParameterTypes13 = new Class[] {
 		long.class, long.class, long[].class, String.class, boolean.class,
 		boolean.class
 	};
-	private static final Class<?>[] _searchCountParameterTypes13 = new Class[] {
+	private static final Class<?>[] _searchCountParameterTypes14 = new Class[] {
 		long.class, long[].class, String.class, boolean.class
 	};
-	private static final Class<?>[] _searchCountParameterTypes14 = new Class[] {
+	private static final Class<?>[] _searchCountParameterTypes15 = new Class[] {
 		long.class, long[].class, String.class, boolean.class, int.class
 	};
-	private static final Class<?>[] _updateFileEntryTypeParameterTypes15 =
-		new Class[] {long.class, java.util.Map.class, java.util.Map.class};
 	private static final Class<?>[] _updateFileEntryTypeParameterTypes16 =
+		new Class[] {long.class, java.util.Map.class, java.util.Map.class};
+	private static final Class<?>[] _updateFileEntryTypeParameterTypes17 =
 		new Class[] {
 			long.class, java.util.Map.class, java.util.Map.class, long[].class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _updateFileEntryTypeParameterTypes17 =
+	private static final Class<?>[] _updateFileEntryTypeParameterTypes18 =
 		new Class[] {
 			long.class, String.class, String.class, long[].class,
 			com.liferay.portal.kernel.service.ServiceContext.class

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -30,6 +30,7 @@ import com.liferay.document.library.kernel.model.DLFileEntryConstants;
 import com.liferay.document.library.kernel.model.DLFileEntryMetadata;
 import com.liferay.document.library.kernel.model.DLFileEntryTable;
 import com.liferay.document.library.kernel.model.DLFileEntryType;
+import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
 import com.liferay.document.library.kernel.model.DLFileVersion;
 import com.liferay.document.library.kernel.model.DLFolder;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
@@ -1773,7 +1774,8 @@ public class DLFileEntryLocalServiceImpl
 
 		if ((fileEntryTypeId != dlFileEntryType.getFileEntryTypeId()) &&
 			!Objects.equals(
-				dlFileEntryType.getFileEntryTypeKey(), "BASIC-DOCUMENT")) {
+				dlFileEntryType.getFileEntryTypeKey(),
+				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_KEY_BASIC_DOCUMENT)) {
 
 			DLFileEntryMetadata dlFileEntryMetadata =
 				_dlFileEntryMetadataPersistence.fetchByFileEntryId_Last(
@@ -3082,7 +3084,8 @@ public class DLFileEntryLocalServiceImpl
 		}
 
 		if (Objects.equals(
-				dlFileEntryType.getFileEntryTypeKey(), "BASIC-DOCUMENT")) {
+				dlFileEntryType.getFileEntryTypeKey(),
+				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_KEY_BASIC_DOCUMENT)) {
 
 			subscriptionSender.addPersistedSubscribers(
 				DLFileEntryType.class.getName(), fileVersion.getGroupId());

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -30,7 +30,6 @@ import com.liferay.document.library.kernel.model.DLFileEntryConstants;
 import com.liferay.document.library.kernel.model.DLFileEntryMetadata;
 import com.liferay.document.library.kernel.model.DLFileEntryTable;
 import com.liferay.document.library.kernel.model.DLFileEntryType;
-import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
 import com.liferay.document.library.kernel.model.DLFileVersion;
 import com.liferay.document.library.kernel.model.DLFolder;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
@@ -1770,9 +1769,11 @@ public class DLFileEntryLocalServiceImpl
 				dlFileEntry.getGroupId()),
 			dlFileEntry.getFolderId(), fileEntryTypeId);
 
-		if ((fileEntryTypeId != dlFileEntry.getFileEntryTypeId()) &&
-			(dlFileEntry.getFileEntryTypeId() !=
-				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT)) {
+		DLFileEntryType dlFileEntryType = dlFileEntry.getDLFileEntryType();
+
+		if ((fileEntryTypeId != dlFileEntryType.getFileEntryTypeId()) &&
+			!Objects.equals(
+				dlFileEntryType.getFileEntryTypeKey(), "BASIC-DOCUMENT")) {
 
 			DLFileEntryMetadata dlFileEntryMetadata =
 				_dlFileEntryMetadataPersistence.fetchByFileEntryId_Last(
@@ -3080,8 +3081,8 @@ public class DLFileEntryLocalServiceImpl
 			}
 		}
 
-		if (dlFileEntryType.getFileEntryTypeId() ==
-				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT) {
+		if (Objects.equals(
+				dlFileEntryType.getFileEntryTypeKey(), "BASIC-DOCUMENT")) {
 
 			subscriptionSender.addPersistedSubscribers(
 				DLFileEntryType.class.getName(), fileVersion.getGroupId());

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -635,7 +635,14 @@ public class DLFileEntryLocalServiceImpl
 
 		List<DDMStructure> ddmStructures;
 
-		if (fileEntryTypeId > 0) {
+		DLFileEntryType basicDocumentDLFileEntryType =
+			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType();
+
+		if ((fileEntryTypeId !=
+				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_ALL) &&
+			(fileEntryTypeId !=
+				basicDocumentDLFileEntryType.getFileEntryTypeId())) {
+
 			DLFileEntryType dlFileEntryType =
 				_dlFileEntryTypeLocalService.getFileEntryType(fileEntryTypeId);
 
@@ -2111,7 +2118,15 @@ public class DLFileEntryLocalServiceImpl
 
 		dlFileVersion = _dlFileVersionPersistence.update(dlFileVersion);
 
-		if ((fileEntryTypeId > 0) && (ddmFormValuesMap != null)) {
+		DLFileEntryType basicDocumentDLFileEntryType =
+			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType();
+
+		if ((fileEntryTypeId !=
+				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_ALL) &&
+			(fileEntryTypeId !=
+				basicDocumentDLFileEntryType.getFileEntryTypeId()) &&
+			(ddmFormValuesMap != null)) {
+
 			_dlFileEntryMetadataLocalService.updateFileEntryMetadata(
 				fileEntryTypeId, dlFileEntry.getFileEntryId(), fileVersionId,
 				ddmFormValuesMap, serviceContext);
@@ -3445,7 +3460,15 @@ public class DLFileEntryLocalServiceImpl
 
 		dlFileVersion = _dlFileVersionPersistence.update(dlFileVersion);
 
-		if ((fileEntryTypeId > 0) && (ddmFormValuesMap != null)) {
+		DLFileEntryType basicDocumentDLFileEntryType =
+			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType();
+
+		if ((fileEntryTypeId !=
+				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_ALL) &&
+			(fileEntryTypeId !=
+				basicDocumentDLFileEntryType.getFileEntryTypeId()) &&
+			(ddmFormValuesMap != null)) {
+
 			_dlFileEntryMetadataLocalService.updateFileEntryMetadata(
 				fileEntryTypeId, dlFileVersion.getFileEntryId(),
 				dlFileVersion.getFileVersionId(), ddmFormValuesMap,

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -238,7 +238,7 @@ public class DLFileEntryLocalServiceImpl
 		if (fileEntryTypeId == -1) {
 			fileEntryTypeId =
 				_dlFileEntryTypeLocalService.getDefaultFileEntryTypeId(
-					folderId);
+					user.getCompanyId(), folderId);
 		}
 
 		_validateFileEntryTypeId(
@@ -636,7 +636,8 @@ public class DLFileEntryLocalServiceImpl
 		List<DDMStructure> ddmStructures;
 
 		DLFileEntryType basicDocumentDLFileEntryType =
-			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType();
+			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType(
+				companyId);
 
 		if ((fileEntryTypeId !=
 				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_ALL) &&
@@ -2119,7 +2120,8 @@ public class DLFileEntryLocalServiceImpl
 		dlFileVersion = _dlFileVersionPersistence.update(dlFileVersion);
 
 		DLFileEntryType basicDocumentDLFileEntryType =
-			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType();
+			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType(
+				dlFileEntry.getCompanyId());
 
 		if ((fileEntryTypeId !=
 				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_ALL) &&
@@ -2725,7 +2727,7 @@ public class DLFileEntryLocalServiceImpl
 			}
 
 			return _dlFileEntryTypeLocalService.getDefaultFileEntryTypeId(
-				dlFileEntry.getFolderId());
+				dlFileEntry.getCompanyId(), dlFileEntry.getFolderId());
 		}
 	}
 
@@ -3461,7 +3463,8 @@ public class DLFileEntryLocalServiceImpl
 		dlFileVersion = _dlFileVersionPersistence.update(dlFileVersion);
 
 		DLFileEntryType basicDocumentDLFileEntryType =
-			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType();
+			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType(
+				dlFileVersion.getCompanyId());
 
 		if ((fileEntryTypeId !=
 				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_ALL) &&

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -3524,12 +3524,22 @@ public class DLFileEntryLocalServiceImpl
 			long[] groupIds, long folderId, long fileEntryTypeId)
 		throws PortalException {
 
-		List<DLFileEntryType> dlFileEntryTypes =
+		DLFileEntryType dlFileEntryType =
+			_dlFileEntryTypeLocalService.getDLFileEntryType(fileEntryTypeId);
+
+		if (Objects.equals(
+				dlFileEntryType.getFileEntryTypeKey(),
+				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_KEY_BASIC_DOCUMENT)) {
+
+			return;
+		}
+
+		List<DLFileEntryType> folderDLFileEntryTypes =
 			_dlFileEntryTypeLocalService.getFolderFileEntryTypes(
 				groupIds, folderId, true);
 
-		for (DLFileEntryType dlFileEntryType : dlFileEntryTypes) {
-			if (dlFileEntryType.getFileEntryTypeId() == fileEntryTypeId) {
+		for (DLFileEntryType folderDLFileEntryType : folderDLFileEntryTypes) {
+			if (folderDLFileEntryType.getFileEntryTypeId() == fileEntryTypeId) {
 				return;
 			}
 		}

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryTypeLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryTypeLocalServiceImpl.java
@@ -319,11 +319,14 @@ public class DLFileEntryTypeLocalServiceImpl
 	}
 
 	@Override
-	public DLFileEntryType createBasicDocumentDLFileEntryType() {
+	public DLFileEntryType createBasicDocumentDLFileEntryType(
+		long companyId) {
+
 		DLFileEntryType dlFileEntryType = dlFileEntryTypePersistence.create(
 			counterLocalService.increment());
 
-		dlFileEntryType.setCompanyId(CompanyConstants.SYSTEM);
+		dlFileEntryType.setCompanyId(companyId);
+		dlFileEntryType.setGroupId(GroupConstants.DEFAULT_LIVE_GROUP_ID);
 		dlFileEntryType.setFileEntryTypeKey(
 			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_KEY_BASIC_DOCUMENT);
 		dlFileEntryType.setName(
@@ -439,21 +442,22 @@ public class DLFileEntryTypeLocalServiceImpl
 	}
 
 	@Override
-	public DLFileEntryType getBasicDocumentDLFileEntryType() {
+	public DLFileEntryType getBasicDocumentDLFileEntryType(long companyId) {
 		DLFileEntryType dlFileEntryType =
 			dlFileEntryTypePersistence.fetchByG_C_F(
-				GroupConstants.DEFAULT_LIVE_GROUP_ID, CompanyConstants.SYSTEM,
+				GroupConstants.DEFAULT_LIVE_GROUP_ID, companyId,
 				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_KEY_BASIC_DOCUMENT);
 
 		if (dlFileEntryType != null) {
 			return dlFileEntryType;
 		}
 
-		return dlFileEntryTypeLocalService.createBasicDocumentDLFileEntryType();
+		return dlFileEntryTypeLocalService.createBasicDocumentDLFileEntryType(
+			companyId);
 	}
 
 	@Override
-	public long getDefaultFileEntryTypeId(long folderId)
+	public long getDefaultFileEntryTypeId(long companyId, long folderId)
 		throws PortalException {
 
 		folderId = _getFileEntryTypesPrimaryFolderId(folderId);

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryTypeLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryTypeLocalServiceImpl.java
@@ -48,6 +48,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.CompanyConstants;
+import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.ResourceAction;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.SystemEventConstants;
@@ -318,7 +319,7 @@ public class DLFileEntryTypeLocalServiceImpl
 	@Override
 	public DLFileEntryType createBasicDocumentDLFileEntryType() {
 		DLFileEntryType dlFileEntryType = dlFileEntryTypePersistence.create(
-			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT);
+			counterLocalService.increment());
 
 		dlFileEntryType.setCompanyId(CompanyConstants.SYSTEM);
 		dlFileEntryType.setFileEntryTypeKey(
@@ -430,9 +431,9 @@ public class DLFileEntryTypeLocalServiceImpl
 	public DLFileEntryType getBasicDocumentDLFileEntryType()
 		throws NoSuchFileEntryTypeException {
 
-		DLFileEntryType dlFileEntryType =
-			dlFileEntryTypePersistence.fetchByPrimaryKey(
-				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT);
+		DLFileEntryType dlFileEntryType = dlFileEntryTypePersistence.fetchByG_F(
+			GroupConstants.DEFAULT_LIVE_GROUP_ID,
+			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_KEY_BASIC_DOCUMENT);
 
 		if (dlFileEntryType != null) {
 			return dlFileEntryType;

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryTypeLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryTypeLocalServiceImpl.java
@@ -46,13 +46,14 @@ import com.liferay.portal.kernel.bean.BeanReference;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.model.CompanyConstants;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.ResourceAction;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourceLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -304,7 +305,7 @@ public class DLFileEntryTypeLocalServiceImpl
 			groupIds, dlFolder.getFolderId(), true);
 
 		long defaultFileEntryTypeId = getDefaultFileEntryTypeId(
-			dlFolder.getFolderId());
+			dlFolder.getCompanyId(), dlFolder.getFolderId());
 
 		ServiceContext serviceContext = new ServiceContext();
 
@@ -319,14 +320,12 @@ public class DLFileEntryTypeLocalServiceImpl
 	}
 
 	@Override
-	public DLFileEntryType createBasicDocumentDLFileEntryType(
-		long companyId) {
-
+	public DLFileEntryType createBasicDocumentDLFileEntryType(long companyId) {
 		DLFileEntryType dlFileEntryType = dlFileEntryTypePersistence.create(
 			counterLocalService.increment());
 
-		dlFileEntryType.setCompanyId(companyId);
 		dlFileEntryType.setGroupId(GroupConstants.DEFAULT_LIVE_GROUP_ID);
+		dlFileEntryType.setCompanyId(companyId);
 		dlFileEntryType.setFileEntryTypeKey(
 			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_KEY_BASIC_DOCUMENT);
 		dlFileEntryType.setName(
@@ -430,8 +429,8 @@ public class DLFileEntryTypeLocalServiceImpl
 				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_KEY_BASIC_DOCUMENT,
 				fileEntryTypeKey)) {
 
-			return dlFileEntryTypeLocalService.
-				getBasicDocumentDLFileEntryType();
+			return dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType(
+				companyId);
 		}
 
 		fileEntryTypeKey = StringUtil.toUpperCase(
@@ -469,7 +468,8 @@ public class DLFileEntryTypeLocalServiceImpl
 		}
 
 		DLFileEntryType basicDocumentDLFileEntryType =
-			dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType();
+			dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType(
+				companyId);
 
 		return basicDocumentDLFileEntryType.getFileEntryTypeId();
 	}
@@ -518,8 +518,11 @@ public class DLFileEntryTypeLocalServiceImpl
 		List<DLFileEntryType> dlFileEntryTypes = new ArrayList<>(
 			getFileEntryTypes(groupIds));
 
+		Group group = _groupLocalService.getGroup(groupIds[0]);
+
 		DLFileEntryType dlFileEntryType =
-			dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType();
+			dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType(
+				group.getCompanyId());
 
 		dlFileEntryTypes.add(0, dlFileEntryType);
 
@@ -616,8 +619,8 @@ public class DLFileEntryTypeLocalServiceImpl
 			serviceContext.getUserId(), dlFileEntry.getFileEntryId(), null,
 			null, null, null, null, null,
 			DLVersionNumberIncrease.fromMajorVersion(false),
-			getDefaultFileEntryTypeId(folderId), null, null, null, 0, null,
-			null, serviceContext);
+			getDefaultFileEntryTypeId(serviceContext.getCompanyId(), folderId),
+			null, null, null, 0, null, null, serviceContext);
 	}
 
 	/**
@@ -1139,6 +1142,9 @@ public class DLFileEntryTypeLocalServiceImpl
 
 	@BeanReference(type = DLFolderPersistence.class)
 	private DLFolderPersistence _dlFolderPersistence;
+
+	@BeanReference(type = GroupLocalService.class)
+	private GroupLocalService _groupLocalService;
 
 	@BeanReference(type = ResourceActionLocalService.class)
 	private ResourceActionLocalService _resourceActionLocalService;

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryTypeLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryTypeLocalServiceImpl.java
@@ -15,7 +15,6 @@
 package com.liferay.portlet.documentlibrary.service.impl;
 
 import com.liferay.document.library.kernel.exception.DuplicateFileEntryTypeException;
-import com.liferay.document.library.kernel.exception.NoSuchFileEntryTypeException;
 import com.liferay.document.library.kernel.exception.NoSuchFolderException;
 import com.liferay.document.library.kernel.exception.NoSuchMetadataSetException;
 import com.liferay.document.library.kernel.exception.RequiredFileEntryTypeException;
@@ -84,6 +83,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -137,7 +137,8 @@ public class DLFileEntryTypeLocalServiceImpl
 			}
 		}
 
-		_validateFileEntryTypeKey(groupId, fileEntryTypeKey);
+		_validateFileEntryTypeKey(
+			groupId, user.getCompanyId(), fileEntryTypeKey);
 
 		_validateDDMStructures(fileEntryTypeKey, new long[] {dataDefinitionId});
 
@@ -231,7 +232,8 @@ public class DLFileEntryTypeLocalServiceImpl
 			userId, fileEntryTypeUuid, fileEntryTypeId, groupId, nameMap,
 			descriptionMap, ddmStructureIds, serviceContext);
 
-		_validateFileEntryTypeKey(groupId, fileEntryTypeKey);
+		_validateFileEntryTypeKey(
+			groupId, user.getCompanyId(), fileEntryTypeKey);
 
 		_validateDDMStructures(fileEntryTypeKey, ddmStructureIds);
 
@@ -406,10 +408,10 @@ public class DLFileEntryTypeLocalServiceImpl
 
 	@Override
 	public DLFileEntryType fetchDataDefinitionFileEntryType(
-		long groupId, long dataDefinitionId) {
+		long groupId, long companyId, long dataDefinitionId) {
 
-		return dlFileEntryTypePersistence.fetchByG_DDI(
-			groupId, dataDefinitionId);
+		return dlFileEntryTypePersistence.fetchByG_C_DDI(
+			groupId, companyId, dataDefinitionId);
 	}
 
 	@Override
@@ -419,21 +421,29 @@ public class DLFileEntryTypeLocalServiceImpl
 
 	@Override
 	public DLFileEntryType fetchFileEntryType(
-		long groupId, String fileEntryTypeKey) {
+		long groupId, long companyId, String fileEntryTypeKey) {
+
+		if (Objects.equals(
+				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_KEY_BASIC_DOCUMENT,
+				fileEntryTypeKey)) {
+
+			return dlFileEntryTypeLocalService.
+				getBasicDocumentDLFileEntryType();
+		}
 
 		fileEntryTypeKey = StringUtil.toUpperCase(
 			StringUtil.trim(fileEntryTypeKey));
 
-		return dlFileEntryTypePersistence.fetchByG_F(groupId, fileEntryTypeKey);
+		return dlFileEntryTypePersistence.fetchByG_C_F(
+			groupId, companyId, fileEntryTypeKey);
 	}
 
 	@Override
-	public DLFileEntryType getBasicDocumentDLFileEntryType()
-		throws NoSuchFileEntryTypeException {
-
-		DLFileEntryType dlFileEntryType = dlFileEntryTypePersistence.fetchByG_F(
-			GroupConstants.DEFAULT_LIVE_GROUP_ID,
-			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_KEY_BASIC_DOCUMENT);
+	public DLFileEntryType getBasicDocumentDLFileEntryType() {
+		DLFileEntryType dlFileEntryType =
+			dlFileEntryTypePersistence.fetchByG_C_F(
+				GroupConstants.DEFAULT_LIVE_GROUP_ID, CompanyConstants.SYSTEM,
+				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_KEY_BASIC_DOCUMENT);
 
 		if (dlFileEntryType != null) {
 			return dlFileEntryType;
@@ -469,13 +479,14 @@ public class DLFileEntryTypeLocalServiceImpl
 
 	@Override
 	public DLFileEntryType getFileEntryType(
-			long groupId, String fileEntryTypeKey)
+			long groupId, long companyId, String fileEntryTypeKey)
 		throws PortalException {
 
 		fileEntryTypeKey = StringUtil.toUpperCase(
 			StringUtil.trim(fileEntryTypeKey));
 
-		return dlFileEntryTypePersistence.findByG_F(groupId, fileEntryTypeKey);
+		return dlFileEntryTypePersistence.findByG_C_F(
+			groupId, companyId, fileEntryTypeKey);
 	}
 
 	@Override
@@ -1086,11 +1097,12 @@ public class DLFileEntryTypeLocalServiceImpl
 	}
 
 	private void _validateFileEntryTypeKey(
-			long groupId, String fileEntryTypeKey)
+			long groupId, long companyId, String fileEntryTypeKey)
 		throws DuplicateFileEntryTypeException {
 
-		DLFileEntryType dlFileEntryType = dlFileEntryTypePersistence.fetchByG_F(
-			groupId, fileEntryTypeKey);
+		DLFileEntryType dlFileEntryType =
+			dlFileEntryTypePersistence.fetchByG_C_F(
+				groupId, companyId, fileEntryTypeKey);
 
 		if (dlFileEntryType != null) {
 			throw new DuplicateFileEntryTypeException(

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryTypeLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryTypeLocalServiceImpl.java
@@ -15,6 +15,7 @@
 package com.liferay.portlet.documentlibrary.service.impl;
 
 import com.liferay.document.library.kernel.exception.DuplicateFileEntryTypeException;
+import com.liferay.document.library.kernel.exception.NoSuchFileEntryTypeException;
 import com.liferay.document.library.kernel.exception.NoSuchFolderException;
 import com.liferay.document.library.kernel.exception.NoSuchMetadataSetException;
 import com.liferay.document.library.kernel.exception.RequiredFileEntryTypeException;
@@ -42,6 +43,7 @@ import com.liferay.dynamic.data.mapping.kernel.DDMStructureManager;
 import com.liferay.dynamic.data.mapping.kernel.DDMStructureManagerUtil;
 import com.liferay.dynamic.data.mapping.kernel.StorageEngineManager;
 import com.liferay.dynamic.data.mapping.kernel.StructureDefinitionException;
+import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.portal.kernel.bean.BeanReference;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
@@ -442,17 +444,17 @@ public class DLFileEntryTypeLocalServiceImpl
 
 	@Override
 	public DLFileEntryType getBasicDocumentDLFileEntryType(long companyId) {
-		DLFileEntryType dlFileEntryType =
-			dlFileEntryTypePersistence.fetchByG_C_F(
+		try {
+			return dlFileEntryTypePersistence.findByG_C_F(
 				GroupConstants.DEFAULT_LIVE_GROUP_ID, companyId,
 				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_KEY_BASIC_DOCUMENT);
-
-		if (dlFileEntryType != null) {
-			return dlFileEntryType;
 		}
+		catch (NoSuchFileEntryTypeException noSuchFileEntryTypeException) {
+			_log.error(
+				"Could not find basic document type for company " + companyId);
 
-		return dlFileEntryTypeLocalService.createBasicDocumentDLFileEntryType(
-			companyId);
+			return ReflectionUtil.throwException(noSuchFileEntryTypeException);
+		}
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryTypeLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryTypeLocalServiceImpl.java
@@ -454,7 +454,10 @@ public class DLFileEntryTypeLocalServiceImpl
 			return dlFolder.getDefaultFileEntryTypeId();
 		}
 
-		return DLFileEntryTypeConstants.COMPANY_ID_BASIC_DOCUMENT;
+		DLFileEntryType basicDocumentDLFileEntryType =
+			dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType();
+
+		return basicDocumentDLFileEntryType.getFileEntryTypeId();
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryTypeLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryTypeLocalServiceImpl.java
@@ -322,8 +322,7 @@ public class DLFileEntryTypeLocalServiceImpl
 
 		dlFileEntryType.setCompanyId(CompanyConstants.SYSTEM);
 		dlFileEntryType.setFileEntryTypeKey(
-			StringUtil.toUpperCase(
-				DLFileEntryTypeConstants.NAME_BASIC_DOCUMENT));
+			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_KEY_BASIC_DOCUMENT);
 		dlFileEntryType.setName(
 			DLFileEntryTypeConstants.NAME_BASIC_DOCUMENT,
 			LocaleUtil.getDefault());

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryTypeServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryTypeServiceImpl.java
@@ -122,6 +122,12 @@ public class DLFileEntryTypeServiceImpl extends DLFileEntryTypeServiceBaseImpl {
 	}
 
 	@Override
+	public DLFileEntryType getBasicDocumentDLFileEntryType(long company) {
+		return dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType(
+			company);
+	}
+
+	@Override
 	public DLFileEntryType getFileEntryType(long fileEntryTypeId)
 		throws PortalException {
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryTypeServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryTypeServiceImpl.java
@@ -15,6 +15,7 @@
 package com.liferay.portlet.documentlibrary.service.impl;
 
 import com.liferay.document.library.kernel.model.DLFileEntryType;
+import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
 import com.liferay.document.library.kernel.model.DLFileEntryTypeTable;
 import com.liferay.petra.sql.dsl.DSLFunctionFactoryUtil;
 import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
@@ -41,6 +42,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Provides the remote service for accessing, adding, deleting, and updating
@@ -298,7 +300,12 @@ public class DLFileEntryTypeServiceImpl extends DLFileEntryTypeServiceBaseImpl {
 		while (iterator.hasNext()) {
 			DLFileEntryType fileEntryType = iterator.next();
 
-			if ((fileEntryType.getFileEntryTypeId() > 0) &&
+			if ((fileEntryType.getFileEntryTypeId() !=
+					DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_ALL) &&
+				!Objects.equals(
+					fileEntryType.getFileEntryTypeKey(),
+					DLFileEntryTypeConstants.
+						FILE_ENTRY_TYPE_KEY_BASIC_DOCUMENT) &&
 				!_dlFileEntryTypeModelResourcePermission.contains(
 					permissionChecker, fileEntryType, ActionKeys.VIEW)) {
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryTypeServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryTypeServiceImpl.java
@@ -125,10 +125,20 @@ public class DLFileEntryTypeServiceImpl extends DLFileEntryTypeServiceBaseImpl {
 	public DLFileEntryType getFileEntryType(long fileEntryTypeId)
 		throws PortalException {
 
+		DLFileEntryType fileEntryType =
+			dlFileEntryTypeLocalService.getFileEntryType(fileEntryTypeId);
+
+		if (Objects.equals(
+				fileEntryType.getFileEntryTypeKey(),
+				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_KEY_BASIC_DOCUMENT)) {
+
+			return fileEntryType;
+		}
+
 		_dlFileEntryTypeModelResourcePermission.check(
 			getPermissionChecker(), fileEntryTypeId, ActionKeys.VIEW);
 
-		return dlFileEntryTypeLocalService.getFileEntryType(fileEntryTypeId);
+		return fileEntryType;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/persistence/impl/DLFileEntryTypePersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/persistence/impl/DLFileEntryTypePersistenceImpl.java
@@ -2876,31 +2876,36 @@ public class DLFileEntryTypePersistenceImpl
 	private static final String _FINDER_COLUMN_GROUPID_GROUPID_7 =
 		"dlFileEntryType.groupId IN (";
 
-	private FinderPath _finderPathFetchByG_DDI;
-	private FinderPath _finderPathCountByG_DDI;
+	private FinderPath _finderPathFetchByG_C_DDI;
+	private FinderPath _finderPathCountByG_C_DDI;
 
 	/**
-	 * Returns the document library file entry type where groupId = &#63; and dataDefinitionId = &#63; or throws a <code>NoSuchFileEntryTypeException</code> if it could not be found.
+	 * Returns the document library file entry type where groupId = &#63; and companyId = &#63; and dataDefinitionId = &#63; or throws a <code>NoSuchFileEntryTypeException</code> if it could not be found.
 	 *
 	 * @param groupId the group ID
+	 * @param companyId the company ID
 	 * @param dataDefinitionId the data definition ID
 	 * @return the matching document library file entry type
 	 * @throws NoSuchFileEntryTypeException if a matching document library file entry type could not be found
 	 */
 	@Override
-	public DLFileEntryType findByG_DDI(long groupId, long dataDefinitionId)
+	public DLFileEntryType findByG_C_DDI(
+			long groupId, long companyId, long dataDefinitionId)
 		throws NoSuchFileEntryTypeException {
 
-		DLFileEntryType dlFileEntryType = fetchByG_DDI(
-			groupId, dataDefinitionId);
+		DLFileEntryType dlFileEntryType = fetchByG_C_DDI(
+			groupId, companyId, dataDefinitionId);
 
 		if (dlFileEntryType == null) {
-			StringBundler sb = new StringBundler(6);
+			StringBundler sb = new StringBundler(8);
 
 			sb.append(_NO_SUCH_ENTITY_WITH_KEY);
 
 			sb.append("groupId=");
 			sb.append(groupId);
+
+			sb.append(", companyId=");
+			sb.append(companyId);
 
 			sb.append(", dataDefinitionId=");
 			sb.append(dataDefinitionId);
@@ -2918,28 +2923,33 @@ public class DLFileEntryTypePersistenceImpl
 	}
 
 	/**
-	 * Returns the document library file entry type where groupId = &#63; and dataDefinitionId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the document library file entry type where groupId = &#63; and companyId = &#63; and dataDefinitionId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
 	 * @param groupId the group ID
+	 * @param companyId the company ID
 	 * @param dataDefinitionId the data definition ID
 	 * @return the matching document library file entry type, or <code>null</code> if a matching document library file entry type could not be found
 	 */
 	@Override
-	public DLFileEntryType fetchByG_DDI(long groupId, long dataDefinitionId) {
-		return fetchByG_DDI(groupId, dataDefinitionId, true);
+	public DLFileEntryType fetchByG_C_DDI(
+		long groupId, long companyId, long dataDefinitionId) {
+
+		return fetchByG_C_DDI(groupId, companyId, dataDefinitionId, true);
 	}
 
 	/**
-	 * Returns the document library file entry type where groupId = &#63; and dataDefinitionId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the document library file entry type where groupId = &#63; and companyId = &#63; and dataDefinitionId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
 	 * @param groupId the group ID
+	 * @param companyId the company ID
 	 * @param dataDefinitionId the data definition ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching document library file entry type, or <code>null</code> if a matching document library file entry type could not be found
 	 */
 	@Override
-	public DLFileEntryType fetchByG_DDI(
-		long groupId, long dataDefinitionId, boolean useFinderCache) {
+	public DLFileEntryType fetchByG_C_DDI(
+		long groupId, long companyId, long dataDefinitionId,
+		boolean useFinderCache) {
 
 		boolean productionMode = CTPersistenceHelperUtil.isProductionMode(
 			DLFileEntryType.class);
@@ -2947,20 +2957,21 @@ public class DLFileEntryTypePersistenceImpl
 		Object[] finderArgs = null;
 
 		if (useFinderCache && productionMode) {
-			finderArgs = new Object[] {groupId, dataDefinitionId};
+			finderArgs = new Object[] {groupId, companyId, dataDefinitionId};
 		}
 
 		Object result = null;
 
 		if (useFinderCache && productionMode) {
 			result = FinderCacheUtil.getResult(
-				_finderPathFetchByG_DDI, finderArgs, this);
+				_finderPathFetchByG_C_DDI, finderArgs, this);
 		}
 
 		if (result instanceof DLFileEntryType) {
 			DLFileEntryType dlFileEntryType = (DLFileEntryType)result;
 
 			if ((groupId != dlFileEntryType.getGroupId()) ||
+				(companyId != dlFileEntryType.getCompanyId()) ||
 				(dataDefinitionId != dlFileEntryType.getDataDefinitionId())) {
 
 				result = null;
@@ -2968,13 +2979,15 @@ public class DLFileEntryTypePersistenceImpl
 		}
 
 		if (result == null) {
-			StringBundler sb = new StringBundler(4);
+			StringBundler sb = new StringBundler(5);
 
 			sb.append(_SQL_SELECT_DLFILEENTRYTYPE_WHERE);
 
-			sb.append(_FINDER_COLUMN_G_DDI_GROUPID_2);
+			sb.append(_FINDER_COLUMN_G_C_DDI_GROUPID_2);
 
-			sb.append(_FINDER_COLUMN_G_DDI_DATADEFINITIONID_2);
+			sb.append(_FINDER_COLUMN_G_C_DDI_COMPANYID_2);
+
+			sb.append(_FINDER_COLUMN_G_C_DDI_DATADEFINITIONID_2);
 
 			String sql = sb.toString();
 
@@ -2989,6 +3002,8 @@ public class DLFileEntryTypePersistenceImpl
 
 				queryPos.add(groupId);
 
+				queryPos.add(companyId);
+
 				queryPos.add(dataDefinitionId);
 
 				List<DLFileEntryType> list = query.list();
@@ -2996,7 +3011,7 @@ public class DLFileEntryTypePersistenceImpl
 				if (list.isEmpty()) {
 					if (useFinderCache && productionMode) {
 						FinderCacheUtil.putResult(
-							_finderPathFetchByG_DDI, finderArgs, list);
+							_finderPathFetchByG_C_DDI, finderArgs, list);
 					}
 				}
 				else {
@@ -3024,31 +3039,36 @@ public class DLFileEntryTypePersistenceImpl
 	}
 
 	/**
-	 * Removes the document library file entry type where groupId = &#63; and dataDefinitionId = &#63; from the database.
+	 * Removes the document library file entry type where groupId = &#63; and companyId = &#63; and dataDefinitionId = &#63; from the database.
 	 *
 	 * @param groupId the group ID
+	 * @param companyId the company ID
 	 * @param dataDefinitionId the data definition ID
 	 * @return the document library file entry type that was removed
 	 */
 	@Override
-	public DLFileEntryType removeByG_DDI(long groupId, long dataDefinitionId)
+	public DLFileEntryType removeByG_C_DDI(
+			long groupId, long companyId, long dataDefinitionId)
 		throws NoSuchFileEntryTypeException {
 
-		DLFileEntryType dlFileEntryType = findByG_DDI(
-			groupId, dataDefinitionId);
+		DLFileEntryType dlFileEntryType = findByG_C_DDI(
+			groupId, companyId, dataDefinitionId);
 
 		return remove(dlFileEntryType);
 	}
 
 	/**
-	 * Returns the number of document library file entry types where groupId = &#63; and dataDefinitionId = &#63;.
+	 * Returns the number of document library file entry types where groupId = &#63; and companyId = &#63; and dataDefinitionId = &#63;.
 	 *
 	 * @param groupId the group ID
+	 * @param companyId the company ID
 	 * @param dataDefinitionId the data definition ID
 	 * @return the number of matching document library file entry types
 	 */
 	@Override
-	public int countByG_DDI(long groupId, long dataDefinitionId) {
+	public int countByG_C_DDI(
+		long groupId, long companyId, long dataDefinitionId) {
+
 		boolean productionMode = CTPersistenceHelperUtil.isProductionMode(
 			DLFileEntryType.class);
 
@@ -3058,22 +3078,24 @@ public class DLFileEntryTypePersistenceImpl
 		Long count = null;
 
 		if (productionMode) {
-			finderPath = _finderPathCountByG_DDI;
+			finderPath = _finderPathCountByG_C_DDI;
 
-			finderArgs = new Object[] {groupId, dataDefinitionId};
+			finderArgs = new Object[] {groupId, companyId, dataDefinitionId};
 
 			count = (Long)FinderCacheUtil.getResult(
 				finderPath, finderArgs, this);
 		}
 
 		if (count == null) {
-			StringBundler sb = new StringBundler(3);
+			StringBundler sb = new StringBundler(4);
 
 			sb.append(_SQL_COUNT_DLFILEENTRYTYPE_WHERE);
 
-			sb.append(_FINDER_COLUMN_G_DDI_GROUPID_2);
+			sb.append(_FINDER_COLUMN_G_C_DDI_GROUPID_2);
 
-			sb.append(_FINDER_COLUMN_G_DDI_DATADEFINITIONID_2);
+			sb.append(_FINDER_COLUMN_G_C_DDI_COMPANYID_2);
+
+			sb.append(_FINDER_COLUMN_G_C_DDI_DATADEFINITIONID_2);
 
 			String sql = sb.toString();
 
@@ -3087,6 +3109,8 @@ public class DLFileEntryTypePersistenceImpl
 				QueryPos queryPos = QueryPos.getInstance(query);
 
 				queryPos.add(groupId);
+
+				queryPos.add(companyId);
 
 				queryPos.add(dataDefinitionId);
 
@@ -3107,36 +3131,45 @@ public class DLFileEntryTypePersistenceImpl
 		return count.intValue();
 	}
 
-	private static final String _FINDER_COLUMN_G_DDI_GROUPID_2 =
+	private static final String _FINDER_COLUMN_G_C_DDI_GROUPID_2 =
 		"dlFileEntryType.groupId = ? AND ";
 
-	private static final String _FINDER_COLUMN_G_DDI_DATADEFINITIONID_2 =
+	private static final String _FINDER_COLUMN_G_C_DDI_COMPANYID_2 =
+		"dlFileEntryType.companyId = ? AND ";
+
+	private static final String _FINDER_COLUMN_G_C_DDI_DATADEFINITIONID_2 =
 		"dlFileEntryType.dataDefinitionId = ?";
 
-	private FinderPath _finderPathFetchByG_F;
-	private FinderPath _finderPathCountByG_F;
+	private FinderPath _finderPathFetchByG_C_F;
+	private FinderPath _finderPathCountByG_C_F;
 
 	/**
-	 * Returns the document library file entry type where groupId = &#63; and fileEntryTypeKey = &#63; or throws a <code>NoSuchFileEntryTypeException</code> if it could not be found.
+	 * Returns the document library file entry type where groupId = &#63; and companyId = &#63; and fileEntryTypeKey = &#63; or throws a <code>NoSuchFileEntryTypeException</code> if it could not be found.
 	 *
 	 * @param groupId the group ID
+	 * @param companyId the company ID
 	 * @param fileEntryTypeKey the file entry type key
 	 * @return the matching document library file entry type
 	 * @throws NoSuchFileEntryTypeException if a matching document library file entry type could not be found
 	 */
 	@Override
-	public DLFileEntryType findByG_F(long groupId, String fileEntryTypeKey)
+	public DLFileEntryType findByG_C_F(
+			long groupId, long companyId, String fileEntryTypeKey)
 		throws NoSuchFileEntryTypeException {
 
-		DLFileEntryType dlFileEntryType = fetchByG_F(groupId, fileEntryTypeKey);
+		DLFileEntryType dlFileEntryType = fetchByG_C_F(
+			groupId, companyId, fileEntryTypeKey);
 
 		if (dlFileEntryType == null) {
-			StringBundler sb = new StringBundler(6);
+			StringBundler sb = new StringBundler(8);
 
 			sb.append(_NO_SUCH_ENTITY_WITH_KEY);
 
 			sb.append("groupId=");
 			sb.append(groupId);
+
+			sb.append(", companyId=");
+			sb.append(companyId);
 
 			sb.append(", fileEntryTypeKey=");
 			sb.append(fileEntryTypeKey);
@@ -3154,28 +3187,33 @@ public class DLFileEntryTypePersistenceImpl
 	}
 
 	/**
-	 * Returns the document library file entry type where groupId = &#63; and fileEntryTypeKey = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the document library file entry type where groupId = &#63; and companyId = &#63; and fileEntryTypeKey = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
 	 * @param groupId the group ID
+	 * @param companyId the company ID
 	 * @param fileEntryTypeKey the file entry type key
 	 * @return the matching document library file entry type, or <code>null</code> if a matching document library file entry type could not be found
 	 */
 	@Override
-	public DLFileEntryType fetchByG_F(long groupId, String fileEntryTypeKey) {
-		return fetchByG_F(groupId, fileEntryTypeKey, true);
+	public DLFileEntryType fetchByG_C_F(
+		long groupId, long companyId, String fileEntryTypeKey) {
+
+		return fetchByG_C_F(groupId, companyId, fileEntryTypeKey, true);
 	}
 
 	/**
-	 * Returns the document library file entry type where groupId = &#63; and fileEntryTypeKey = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the document library file entry type where groupId = &#63; and companyId = &#63; and fileEntryTypeKey = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
 	 * @param groupId the group ID
+	 * @param companyId the company ID
 	 * @param fileEntryTypeKey the file entry type key
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching document library file entry type, or <code>null</code> if a matching document library file entry type could not be found
 	 */
 	@Override
-	public DLFileEntryType fetchByG_F(
-		long groupId, String fileEntryTypeKey, boolean useFinderCache) {
+	public DLFileEntryType fetchByG_C_F(
+		long groupId, long companyId, String fileEntryTypeKey,
+		boolean useFinderCache) {
 
 		fileEntryTypeKey = Objects.toString(fileEntryTypeKey, "");
 
@@ -3185,20 +3223,21 @@ public class DLFileEntryTypePersistenceImpl
 		Object[] finderArgs = null;
 
 		if (useFinderCache && productionMode) {
-			finderArgs = new Object[] {groupId, fileEntryTypeKey};
+			finderArgs = new Object[] {groupId, companyId, fileEntryTypeKey};
 		}
 
 		Object result = null;
 
 		if (useFinderCache && productionMode) {
 			result = FinderCacheUtil.getResult(
-				_finderPathFetchByG_F, finderArgs, this);
+				_finderPathFetchByG_C_F, finderArgs, this);
 		}
 
 		if (result instanceof DLFileEntryType) {
 			DLFileEntryType dlFileEntryType = (DLFileEntryType)result;
 
 			if ((groupId != dlFileEntryType.getGroupId()) ||
+				(companyId != dlFileEntryType.getCompanyId()) ||
 				!Objects.equals(
 					fileEntryTypeKey, dlFileEntryType.getFileEntryTypeKey())) {
 
@@ -3207,21 +3246,23 @@ public class DLFileEntryTypePersistenceImpl
 		}
 
 		if (result == null) {
-			StringBundler sb = new StringBundler(4);
+			StringBundler sb = new StringBundler(5);
 
 			sb.append(_SQL_SELECT_DLFILEENTRYTYPE_WHERE);
 
-			sb.append(_FINDER_COLUMN_G_F_GROUPID_2);
+			sb.append(_FINDER_COLUMN_G_C_F_GROUPID_2);
+
+			sb.append(_FINDER_COLUMN_G_C_F_COMPANYID_2);
 
 			boolean bindFileEntryTypeKey = false;
 
 			if (fileEntryTypeKey.isEmpty()) {
-				sb.append(_FINDER_COLUMN_G_F_FILEENTRYTYPEKEY_3);
+				sb.append(_FINDER_COLUMN_G_C_F_FILEENTRYTYPEKEY_3);
 			}
 			else {
 				bindFileEntryTypeKey = true;
 
-				sb.append(_FINDER_COLUMN_G_F_FILEENTRYTYPEKEY_2);
+				sb.append(_FINDER_COLUMN_G_C_F_FILEENTRYTYPEKEY_2);
 			}
 
 			String sql = sb.toString();
@@ -3237,6 +3278,8 @@ public class DLFileEntryTypePersistenceImpl
 
 				queryPos.add(groupId);
 
+				queryPos.add(companyId);
+
 				if (bindFileEntryTypeKey) {
 					queryPos.add(fileEntryTypeKey);
 				}
@@ -3246,7 +3289,7 @@ public class DLFileEntryTypePersistenceImpl
 				if (list.isEmpty()) {
 					if (useFinderCache && productionMode) {
 						FinderCacheUtil.putResult(
-							_finderPathFetchByG_F, finderArgs, list);
+							_finderPathFetchByG_C_F, finderArgs, list);
 					}
 				}
 				else {
@@ -3274,30 +3317,36 @@ public class DLFileEntryTypePersistenceImpl
 	}
 
 	/**
-	 * Removes the document library file entry type where groupId = &#63; and fileEntryTypeKey = &#63; from the database.
+	 * Removes the document library file entry type where groupId = &#63; and companyId = &#63; and fileEntryTypeKey = &#63; from the database.
 	 *
 	 * @param groupId the group ID
+	 * @param companyId the company ID
 	 * @param fileEntryTypeKey the file entry type key
 	 * @return the document library file entry type that was removed
 	 */
 	@Override
-	public DLFileEntryType removeByG_F(long groupId, String fileEntryTypeKey)
+	public DLFileEntryType removeByG_C_F(
+			long groupId, long companyId, String fileEntryTypeKey)
 		throws NoSuchFileEntryTypeException {
 
-		DLFileEntryType dlFileEntryType = findByG_F(groupId, fileEntryTypeKey);
+		DLFileEntryType dlFileEntryType = findByG_C_F(
+			groupId, companyId, fileEntryTypeKey);
 
 		return remove(dlFileEntryType);
 	}
 
 	/**
-	 * Returns the number of document library file entry types where groupId = &#63; and fileEntryTypeKey = &#63;.
+	 * Returns the number of document library file entry types where groupId = &#63; and companyId = &#63; and fileEntryTypeKey = &#63;.
 	 *
 	 * @param groupId the group ID
+	 * @param companyId the company ID
 	 * @param fileEntryTypeKey the file entry type key
 	 * @return the number of matching document library file entry types
 	 */
 	@Override
-	public int countByG_F(long groupId, String fileEntryTypeKey) {
+	public int countByG_C_F(
+		long groupId, long companyId, String fileEntryTypeKey) {
+
 		fileEntryTypeKey = Objects.toString(fileEntryTypeKey, "");
 
 		boolean productionMode = CTPersistenceHelperUtil.isProductionMode(
@@ -3309,30 +3358,32 @@ public class DLFileEntryTypePersistenceImpl
 		Long count = null;
 
 		if (productionMode) {
-			finderPath = _finderPathCountByG_F;
+			finderPath = _finderPathCountByG_C_F;
 
-			finderArgs = new Object[] {groupId, fileEntryTypeKey};
+			finderArgs = new Object[] {groupId, companyId, fileEntryTypeKey};
 
 			count = (Long)FinderCacheUtil.getResult(
 				finderPath, finderArgs, this);
 		}
 
 		if (count == null) {
-			StringBundler sb = new StringBundler(3);
+			StringBundler sb = new StringBundler(4);
 
 			sb.append(_SQL_COUNT_DLFILEENTRYTYPE_WHERE);
 
-			sb.append(_FINDER_COLUMN_G_F_GROUPID_2);
+			sb.append(_FINDER_COLUMN_G_C_F_GROUPID_2);
+
+			sb.append(_FINDER_COLUMN_G_C_F_COMPANYID_2);
 
 			boolean bindFileEntryTypeKey = false;
 
 			if (fileEntryTypeKey.isEmpty()) {
-				sb.append(_FINDER_COLUMN_G_F_FILEENTRYTYPEKEY_3);
+				sb.append(_FINDER_COLUMN_G_C_F_FILEENTRYTYPEKEY_3);
 			}
 			else {
 				bindFileEntryTypeKey = true;
 
-				sb.append(_FINDER_COLUMN_G_F_FILEENTRYTYPEKEY_2);
+				sb.append(_FINDER_COLUMN_G_C_F_FILEENTRYTYPEKEY_2);
 			}
 
 			String sql = sb.toString();
@@ -3347,6 +3398,8 @@ public class DLFileEntryTypePersistenceImpl
 				QueryPos queryPos = QueryPos.getInstance(query);
 
 				queryPos.add(groupId);
+
+				queryPos.add(companyId);
 
 				if (bindFileEntryTypeKey) {
 					queryPos.add(fileEntryTypeKey);
@@ -3369,13 +3422,16 @@ public class DLFileEntryTypePersistenceImpl
 		return count.intValue();
 	}
 
-	private static final String _FINDER_COLUMN_G_F_GROUPID_2 =
+	private static final String _FINDER_COLUMN_G_C_F_GROUPID_2 =
 		"dlFileEntryType.groupId = ? AND ";
 
-	private static final String _FINDER_COLUMN_G_F_FILEENTRYTYPEKEY_2 =
+	private static final String _FINDER_COLUMN_G_C_F_COMPANYID_2 =
+		"dlFileEntryType.companyId = ? AND ";
+
+	private static final String _FINDER_COLUMN_G_C_F_FILEENTRYTYPEKEY_2 =
 		"dlFileEntryType.fileEntryTypeKey = ?";
 
-	private static final String _FINDER_COLUMN_G_F_FILEENTRYTYPEKEY_3 =
+	private static final String _FINDER_COLUMN_G_C_F_FILEENTRYTYPEKEY_3 =
 		"(dlFileEntryType.fileEntryTypeKey IS NULL OR dlFileEntryType.fileEntryTypeKey = '')";
 
 	public DLFileEntryTypePersistenceImpl() {
@@ -3416,17 +3472,17 @@ public class DLFileEntryTypePersistenceImpl
 			dlFileEntryType);
 
 		FinderCacheUtil.putResult(
-			_finderPathFetchByG_DDI,
+			_finderPathFetchByG_C_DDI,
 			new Object[] {
-				dlFileEntryType.getGroupId(),
+				dlFileEntryType.getGroupId(), dlFileEntryType.getCompanyId(),
 				dlFileEntryType.getDataDefinitionId()
 			},
 			dlFileEntryType);
 
 		FinderCacheUtil.putResult(
-			_finderPathFetchByG_F,
+			_finderPathFetchByG_C_F,
 			new Object[] {
-				dlFileEntryType.getGroupId(),
+				dlFileEntryType.getGroupId(), dlFileEntryType.getCompanyId(),
 				dlFileEntryType.getFileEntryTypeKey()
 			},
 			dlFileEntryType);
@@ -3522,22 +3578,25 @@ public class DLFileEntryTypePersistenceImpl
 
 		args = new Object[] {
 			dlFileEntryTypeModelImpl.getGroupId(),
+			dlFileEntryTypeModelImpl.getCompanyId(),
 			dlFileEntryTypeModelImpl.getDataDefinitionId()
 		};
 
 		FinderCacheUtil.putResult(
-			_finderPathCountByG_DDI, args, Long.valueOf(1));
+			_finderPathCountByG_C_DDI, args, Long.valueOf(1));
 		FinderCacheUtil.putResult(
-			_finderPathFetchByG_DDI, args, dlFileEntryTypeModelImpl);
+			_finderPathFetchByG_C_DDI, args, dlFileEntryTypeModelImpl);
 
 		args = new Object[] {
 			dlFileEntryTypeModelImpl.getGroupId(),
+			dlFileEntryTypeModelImpl.getCompanyId(),
 			dlFileEntryTypeModelImpl.getFileEntryTypeKey()
 		};
 
-		FinderCacheUtil.putResult(_finderPathCountByG_F, args, Long.valueOf(1));
 		FinderCacheUtil.putResult(
-			_finderPathFetchByG_F, args, dlFileEntryTypeModelImpl);
+			_finderPathCountByG_C_F, args, Long.valueOf(1));
+		FinderCacheUtil.putResult(
+			_finderPathFetchByG_C_F, args, dlFileEntryTypeModelImpl);
 	}
 
 	/**
@@ -4555,10 +4614,10 @@ public class DLFileEntryTypePersistenceImpl
 		_uniqueIndexColumnNames.add(new String[] {"uuid_", "groupId"});
 
 		_uniqueIndexColumnNames.add(
-			new String[] {"groupId", "dataDefinitionId"});
+			new String[] {"groupId", "companyId", "dataDefinitionId"});
 
 		_uniqueIndexColumnNames.add(
-			new String[] {"groupId", "fileEntryTypeKey"});
+			new String[] {"groupId", "companyId", "fileEntryTypeKey"});
 	}
 
 	/**
@@ -4655,25 +4714,35 @@ public class DLFileEntryTypePersistenceImpl
 			new String[] {Long.class.getName()}, new String[] {"groupId"},
 			false);
 
-		_finderPathFetchByG_DDI = new FinderPath(
-			FINDER_CLASS_NAME_ENTITY, "fetchByG_DDI",
-			new String[] {Long.class.getName(), Long.class.getName()},
-			new String[] {"groupId", "dataDefinitionId"}, true);
+		_finderPathFetchByG_C_DDI = new FinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByG_C_DDI",
+			new String[] {
+				Long.class.getName(), Long.class.getName(), Long.class.getName()
+			},
+			new String[] {"groupId", "companyId", "dataDefinitionId"}, true);
 
-		_finderPathCountByG_DDI = new FinderPath(
-			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_DDI",
-			new String[] {Long.class.getName(), Long.class.getName()},
-			new String[] {"groupId", "dataDefinitionId"}, false);
+		_finderPathCountByG_C_DDI = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_C_DDI",
+			new String[] {
+				Long.class.getName(), Long.class.getName(), Long.class.getName()
+			},
+			new String[] {"groupId", "companyId", "dataDefinitionId"}, false);
 
-		_finderPathFetchByG_F = new FinderPath(
-			FINDER_CLASS_NAME_ENTITY, "fetchByG_F",
-			new String[] {Long.class.getName(), String.class.getName()},
-			new String[] {"groupId", "fileEntryTypeKey"}, true);
+		_finderPathFetchByG_C_F = new FinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByG_C_F",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				String.class.getName()
+			},
+			new String[] {"groupId", "companyId", "fileEntryTypeKey"}, true);
 
-		_finderPathCountByG_F = new FinderPath(
-			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_F",
-			new String[] {Long.class.getName(), String.class.getName()},
-			new String[] {"groupId", "fileEntryTypeKey"}, false);
+		_finderPathCountByG_C_F = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_C_F",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				String.class.getName()
+			},
+			new String[] {"groupId", "companyId", "fileEntryTypeKey"}, false);
 
 		_setDLFileEntryTypeUtilPersistence(this);
 	}

--- a/portal-kernel/src/com/liferay/document/library/kernel/model/DLFileEntryTypeConstants.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/model/DLFileEntryTypeConstants.java
@@ -21,8 +21,6 @@ package com.liferay.document.library.kernel.model;
  */
 public class DLFileEntryTypeConstants {
 
-	public static final long COMPANY_ID_BASIC_DOCUMENT = 0;
-
 	public static final long FILE_ENTRY_TYPE_ID_ALL = -1;
 
 	public static final long FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT = 0;

--- a/portal-kernel/src/com/liferay/document/library/kernel/model/DLFileEntryTypeConstants.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/model/DLFileEntryTypeConstants.java
@@ -25,6 +25,9 @@ public class DLFileEntryTypeConstants {
 
 	public static final long FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT = 0;
 
+	public static final String FILE_ENTRY_TYPE_KEY_BASIC_DOCUMENT =
+		"BASIC-DOCUMENT";
+
 	public static final String FILE_ENTRY_TYPE_KEY_CONTRACT = "CONTRACT";
 
 	public static final String FILE_ENTRY_TYPE_KEY_IG_IMAGE =

--- a/portal-kernel/src/com/liferay/document/library/kernel/model/packageinfo
+++ b/portal-kernel/src/com/liferay/document/library/kernel/model/packageinfo
@@ -1,1 +1,1 @@
-version 8.0.0
+version 9.0.0

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryTypeLocalService.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryTypeLocalService.java
@@ -14,7 +14,6 @@
 
 package com.liferay.document.library.kernel.service;
 
-import com.liferay.document.library.kernel.exception.NoSuchFileEntryTypeException;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFileEntryType;
 import com.liferay.document.library.kernel.model.DLFolder;
@@ -152,7 +151,7 @@ public interface DLFileEntryTypeLocalService
 
 	public void clearDLFolderDLFileEntryTypes(long folderId);
 
-	public DLFileEntryType createBasicDocumentDLFileEntryType();
+	public DLFileEntryType createBasicDocumentDLFileEntryType(long companyId);
 
 	/**
 	 * Creates a new document library file entry type with the primary key. Does not add the document library file entry type to the database.
@@ -303,7 +302,7 @@ public interface DLFileEntryTypeLocalService
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public DLFileEntryType fetchDataDefinitionFileEntryType(
-		long groupId, long dataDefinitionId);
+		long groupId, long companyId, long dataDefinitionId);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public DLFileEntryType fetchDLFileEntryType(long fileEntryTypeId);
@@ -324,17 +323,17 @@ public interface DLFileEntryTypeLocalService
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public DLFileEntryType fetchFileEntryType(
-		long groupId, String fileEntryTypeKey);
+		long groupId, long companyId, String fileEntryTypeKey);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public ActionableDynamicQuery getActionableDynamicQuery();
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public DLFileEntryType getBasicDocumentDLFileEntryType()
-		throws NoSuchFileEntryTypeException;
+	public DLFileEntryType getBasicDocumentDLFileEntryType(long companyId);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public long getDefaultFileEntryTypeId(long folderId) throws PortalException;
+	public long getDefaultFileEntryTypeId(long companyId, long folderId)
+		throws PortalException;
 
 	/**
 	 * Returns the document library file entry type with the primary key.
@@ -442,7 +441,7 @@ public interface DLFileEntryTypeLocalService
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public DLFileEntryType getFileEntryType(
-			long groupId, String fileEntryTypeKey)
+			long groupId, long companyId, String fileEntryTypeKey)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryTypeLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryTypeLocalServiceUtil.java
@@ -170,8 +170,10 @@ public class DLFileEntryTypeLocalServiceUtil {
 		getService().clearDLFolderDLFileEntryTypes(folderId);
 	}
 
-	public static DLFileEntryType createBasicDocumentDLFileEntryType() {
-		return getService().createBasicDocumentDLFileEntryType();
+	public static DLFileEntryType createBasicDocumentDLFileEntryType(
+		long companyId) {
+
+		return getService().createBasicDocumentDLFileEntryType(companyId);
 	}
 
 	/**
@@ -365,10 +367,10 @@ public class DLFileEntryTypeLocalServiceUtil {
 	}
 
 	public static DLFileEntryType fetchDataDefinitionFileEntryType(
-		long groupId, long dataDefinitionId) {
+		long groupId, long companyId, long dataDefinitionId) {
 
 		return getService().fetchDataDefinitionFileEntryType(
-			groupId, dataDefinitionId);
+			groupId, companyId, dataDefinitionId);
 	}
 
 	public static DLFileEntryType fetchDLFileEntryType(long fileEntryTypeId) {
@@ -393,9 +395,10 @@ public class DLFileEntryTypeLocalServiceUtil {
 	}
 
 	public static DLFileEntryType fetchFileEntryType(
-		long groupId, String fileEntryTypeKey) {
+		long groupId, long companyId, String fileEntryTypeKey) {
 
-		return getService().fetchFileEntryType(groupId, fileEntryTypeKey);
+		return getService().fetchFileEntryType(
+			groupId, companyId, fileEntryTypeKey);
 	}
 
 	public static com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery
@@ -404,17 +407,16 @@ public class DLFileEntryTypeLocalServiceUtil {
 		return getService().getActionableDynamicQuery();
 	}
 
-	public static DLFileEntryType getBasicDocumentDLFileEntryType()
-		throws com.liferay.document.library.kernel.exception.
-			NoSuchFileEntryTypeException {
+	public static DLFileEntryType getBasicDocumentDLFileEntryType(
+		long companyId) {
 
-		return getService().getBasicDocumentDLFileEntryType();
+		return getService().getBasicDocumentDLFileEntryType(companyId);
 	}
 
-	public static long getDefaultFileEntryTypeId(long folderId)
+	public static long getDefaultFileEntryTypeId(long companyId, long folderId)
 		throws PortalException {
 
-		return getService().getDefaultFileEntryTypeId(folderId);
+		return getService().getDefaultFileEntryTypeId(companyId, folderId);
 	}
 
 	/**
@@ -552,10 +554,11 @@ public class DLFileEntryTypeLocalServiceUtil {
 	}
 
 	public static DLFileEntryType getFileEntryType(
-			long groupId, String fileEntryTypeKey)
+			long groupId, long companyId, String fileEntryTypeKey)
 		throws PortalException {
 
-		return getService().getFileEntryType(groupId, fileEntryTypeKey);
+		return getService().getFileEntryType(
+			groupId, companyId, fileEntryTypeKey);
 	}
 
 	public static List<DLFileEntryType> getFileEntryTypes(long[] groupIds) {

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryTypeLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryTypeLocalServiceWrapper.java
@@ -182,9 +182,9 @@ public class DLFileEntryTypeLocalServiceWrapper
 	}
 
 	@Override
-	public DLFileEntryType createBasicDocumentDLFileEntryType() {
-		return _dlFileEntryTypeLocalService.
-			createBasicDocumentDLFileEntryType();
+	public DLFileEntryType createBasicDocumentDLFileEntryType(long companyId) {
+		return _dlFileEntryTypeLocalService.createBasicDocumentDLFileEntryType(
+			companyId);
 	}
 
 	/**
@@ -417,10 +417,10 @@ public class DLFileEntryTypeLocalServiceWrapper
 
 	@Override
 	public DLFileEntryType fetchDataDefinitionFileEntryType(
-		long groupId, long dataDefinitionId) {
+		long groupId, long companyId, long dataDefinitionId) {
 
 		return _dlFileEntryTypeLocalService.fetchDataDefinitionFileEntryType(
-			groupId, dataDefinitionId);
+			groupId, companyId, dataDefinitionId);
 	}
 
 	@Override
@@ -451,10 +451,10 @@ public class DLFileEntryTypeLocalServiceWrapper
 
 	@Override
 	public DLFileEntryType fetchFileEntryType(
-		long groupId, String fileEntryTypeKey) {
+		long groupId, long companyId, String fileEntryTypeKey) {
 
 		return _dlFileEntryTypeLocalService.fetchFileEntryType(
-			groupId, fileEntryTypeKey);
+			groupId, companyId, fileEntryTypeKey);
 	}
 
 	@Override
@@ -465,18 +465,17 @@ public class DLFileEntryTypeLocalServiceWrapper
 	}
 
 	@Override
-	public DLFileEntryType getBasicDocumentDLFileEntryType()
-		throws com.liferay.document.library.kernel.exception.
-			NoSuchFileEntryTypeException {
-
-		return _dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType();
+	public DLFileEntryType getBasicDocumentDLFileEntryType(long companyId) {
+		return _dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType(
+			companyId);
 	}
 
 	@Override
-	public long getDefaultFileEntryTypeId(long folderId)
+	public long getDefaultFileEntryTypeId(long companyId, long folderId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
-		return _dlFileEntryTypeLocalService.getDefaultFileEntryTypeId(folderId);
+		return _dlFileEntryTypeLocalService.getDefaultFileEntryTypeId(
+			companyId, folderId);
 	}
 
 	/**
@@ -638,11 +637,11 @@ public class DLFileEntryTypeLocalServiceWrapper
 
 	@Override
 	public DLFileEntryType getFileEntryType(
-			long groupId, String fileEntryTypeKey)
+			long groupId, long companyId, String fileEntryTypeKey)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _dlFileEntryTypeLocalService.getFileEntryType(
-			groupId, fileEntryTypeKey);
+			groupId, companyId, fileEntryTypeKey);
 	}
 
 	@Override

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryTypeService.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryTypeService.java
@@ -90,6 +90,9 @@ public interface DLFileEntryTypeService extends BaseService {
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public DLFileEntryType getBasicDocumentDLFileEntryType(long company);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public DLFileEntryType getFileEntryType(long fileEntryTypeId)
 		throws PortalException;
 

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryTypeServiceUtil.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryTypeServiceUtil.java
@@ -93,6 +93,12 @@ public class DLFileEntryTypeServiceUtil {
 		getService().deleteFileEntryType(fileEntryTypeId);
 	}
 
+	public static DLFileEntryType getBasicDocumentDLFileEntryType(
+		long company) {
+
+		return getService().getBasicDocumentDLFileEntryType(company);
+	}
+
 	public static DLFileEntryType getFileEntryType(long fileEntryTypeId)
 		throws PortalException {
 

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryTypeServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryTypeServiceWrapper.java
@@ -95,6 +95,11 @@ public class DLFileEntryTypeServiceWrapper
 	}
 
 	@Override
+	public DLFileEntryType getBasicDocumentDLFileEntryType(long company) {
+		return _dlFileEntryTypeService.getBasicDocumentDLFileEntryType(company);
+	}
+
+	@Override
 	public DLFileEntryType getFileEntryType(long fileEntryTypeId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/persistence/DLFileEntryTypePersistence.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/persistence/DLFileEntryTypePersistence.java
@@ -720,104 +720,124 @@ public interface DLFileEntryTypePersistence
 	public int filterCountByGroupId(long[] groupIds);
 
 	/**
-	 * Returns the document library file entry type where groupId = &#63; and dataDefinitionId = &#63; or throws a <code>NoSuchFileEntryTypeException</code> if it could not be found.
+	 * Returns the document library file entry type where groupId = &#63; and companyId = &#63; and dataDefinitionId = &#63; or throws a <code>NoSuchFileEntryTypeException</code> if it could not be found.
 	 *
 	 * @param groupId the group ID
+	 * @param companyId the company ID
 	 * @param dataDefinitionId the data definition ID
 	 * @return the matching document library file entry type
 	 * @throws NoSuchFileEntryTypeException if a matching document library file entry type could not be found
 	 */
-	public DLFileEntryType findByG_DDI(long groupId, long dataDefinitionId)
+	public DLFileEntryType findByG_C_DDI(
+			long groupId, long companyId, long dataDefinitionId)
 		throws NoSuchFileEntryTypeException;
 
 	/**
-	 * Returns the document library file entry type where groupId = &#63; and dataDefinitionId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the document library file entry type where groupId = &#63; and companyId = &#63; and dataDefinitionId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
 	 * @param groupId the group ID
+	 * @param companyId the company ID
 	 * @param dataDefinitionId the data definition ID
 	 * @return the matching document library file entry type, or <code>null</code> if a matching document library file entry type could not be found
 	 */
-	public DLFileEntryType fetchByG_DDI(long groupId, long dataDefinitionId);
+	public DLFileEntryType fetchByG_C_DDI(
+		long groupId, long companyId, long dataDefinitionId);
 
 	/**
-	 * Returns the document library file entry type where groupId = &#63; and dataDefinitionId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the document library file entry type where groupId = &#63; and companyId = &#63; and dataDefinitionId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
 	 * @param groupId the group ID
+	 * @param companyId the company ID
 	 * @param dataDefinitionId the data definition ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching document library file entry type, or <code>null</code> if a matching document library file entry type could not be found
 	 */
-	public DLFileEntryType fetchByG_DDI(
-		long groupId, long dataDefinitionId, boolean useFinderCache);
+	public DLFileEntryType fetchByG_C_DDI(
+		long groupId, long companyId, long dataDefinitionId,
+		boolean useFinderCache);
 
 	/**
-	 * Removes the document library file entry type where groupId = &#63; and dataDefinitionId = &#63; from the database.
+	 * Removes the document library file entry type where groupId = &#63; and companyId = &#63; and dataDefinitionId = &#63; from the database.
 	 *
 	 * @param groupId the group ID
+	 * @param companyId the company ID
 	 * @param dataDefinitionId the data definition ID
 	 * @return the document library file entry type that was removed
 	 */
-	public DLFileEntryType removeByG_DDI(long groupId, long dataDefinitionId)
+	public DLFileEntryType removeByG_C_DDI(
+			long groupId, long companyId, long dataDefinitionId)
 		throws NoSuchFileEntryTypeException;
 
 	/**
-	 * Returns the number of document library file entry types where groupId = &#63; and dataDefinitionId = &#63;.
+	 * Returns the number of document library file entry types where groupId = &#63; and companyId = &#63; and dataDefinitionId = &#63;.
 	 *
 	 * @param groupId the group ID
+	 * @param companyId the company ID
 	 * @param dataDefinitionId the data definition ID
 	 * @return the number of matching document library file entry types
 	 */
-	public int countByG_DDI(long groupId, long dataDefinitionId);
+	public int countByG_C_DDI(
+		long groupId, long companyId, long dataDefinitionId);
 
 	/**
-	 * Returns the document library file entry type where groupId = &#63; and fileEntryTypeKey = &#63; or throws a <code>NoSuchFileEntryTypeException</code> if it could not be found.
+	 * Returns the document library file entry type where groupId = &#63; and companyId = &#63; and fileEntryTypeKey = &#63; or throws a <code>NoSuchFileEntryTypeException</code> if it could not be found.
 	 *
 	 * @param groupId the group ID
+	 * @param companyId the company ID
 	 * @param fileEntryTypeKey the file entry type key
 	 * @return the matching document library file entry type
 	 * @throws NoSuchFileEntryTypeException if a matching document library file entry type could not be found
 	 */
-	public DLFileEntryType findByG_F(long groupId, String fileEntryTypeKey)
+	public DLFileEntryType findByG_C_F(
+			long groupId, long companyId, String fileEntryTypeKey)
 		throws NoSuchFileEntryTypeException;
 
 	/**
-	 * Returns the document library file entry type where groupId = &#63; and fileEntryTypeKey = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the document library file entry type where groupId = &#63; and companyId = &#63; and fileEntryTypeKey = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
 	 * @param groupId the group ID
+	 * @param companyId the company ID
 	 * @param fileEntryTypeKey the file entry type key
 	 * @return the matching document library file entry type, or <code>null</code> if a matching document library file entry type could not be found
 	 */
-	public DLFileEntryType fetchByG_F(long groupId, String fileEntryTypeKey);
+	public DLFileEntryType fetchByG_C_F(
+		long groupId, long companyId, String fileEntryTypeKey);
 
 	/**
-	 * Returns the document library file entry type where groupId = &#63; and fileEntryTypeKey = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the document library file entry type where groupId = &#63; and companyId = &#63; and fileEntryTypeKey = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
 	 * @param groupId the group ID
+	 * @param companyId the company ID
 	 * @param fileEntryTypeKey the file entry type key
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching document library file entry type, or <code>null</code> if a matching document library file entry type could not be found
 	 */
-	public DLFileEntryType fetchByG_F(
-		long groupId, String fileEntryTypeKey, boolean useFinderCache);
+	public DLFileEntryType fetchByG_C_F(
+		long groupId, long companyId, String fileEntryTypeKey,
+		boolean useFinderCache);
 
 	/**
-	 * Removes the document library file entry type where groupId = &#63; and fileEntryTypeKey = &#63; from the database.
+	 * Removes the document library file entry type where groupId = &#63; and companyId = &#63; and fileEntryTypeKey = &#63; from the database.
 	 *
 	 * @param groupId the group ID
+	 * @param companyId the company ID
 	 * @param fileEntryTypeKey the file entry type key
 	 * @return the document library file entry type that was removed
 	 */
-	public DLFileEntryType removeByG_F(long groupId, String fileEntryTypeKey)
+	public DLFileEntryType removeByG_C_F(
+			long groupId, long companyId, String fileEntryTypeKey)
 		throws NoSuchFileEntryTypeException;
 
 	/**
-	 * Returns the number of document library file entry types where groupId = &#63; and fileEntryTypeKey = &#63;.
+	 * Returns the number of document library file entry types where groupId = &#63; and companyId = &#63; and fileEntryTypeKey = &#63;.
 	 *
 	 * @param groupId the group ID
+	 * @param companyId the company ID
 	 * @param fileEntryTypeKey the file entry type key
 	 * @return the number of matching document library file entry types
 	 */
-	public int countByG_F(long groupId, String fileEntryTypeKey);
+	public int countByG_C_F(
+		long groupId, long companyId, String fileEntryTypeKey);
 
 	/**
 	 * Caches the document library file entry type in the entity cache if it is enabled.

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/persistence/DLFileEntryTypeUtil.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/persistence/DLFileEntryTypeUtil.java
@@ -933,143 +933,167 @@ public class DLFileEntryTypeUtil {
 	}
 
 	/**
-	 * Returns the document library file entry type where groupId = &#63; and dataDefinitionId = &#63; or throws a <code>NoSuchFileEntryTypeException</code> if it could not be found.
+	 * Returns the document library file entry type where groupId = &#63; and companyId = &#63; and dataDefinitionId = &#63; or throws a <code>NoSuchFileEntryTypeException</code> if it could not be found.
 	 *
 	 * @param groupId the group ID
+	 * @param companyId the company ID
 	 * @param dataDefinitionId the data definition ID
 	 * @return the matching document library file entry type
 	 * @throws NoSuchFileEntryTypeException if a matching document library file entry type could not be found
 	 */
-	public static DLFileEntryType findByG_DDI(
-			long groupId, long dataDefinitionId)
+	public static DLFileEntryType findByG_C_DDI(
+			long groupId, long companyId, long dataDefinitionId)
 		throws com.liferay.document.library.kernel.exception.
 			NoSuchFileEntryTypeException {
 
-		return getPersistence().findByG_DDI(groupId, dataDefinitionId);
+		return getPersistence().findByG_C_DDI(
+			groupId, companyId, dataDefinitionId);
 	}
 
 	/**
-	 * Returns the document library file entry type where groupId = &#63; and dataDefinitionId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the document library file entry type where groupId = &#63; and companyId = &#63; and dataDefinitionId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
 	 * @param groupId the group ID
+	 * @param companyId the company ID
 	 * @param dataDefinitionId the data definition ID
 	 * @return the matching document library file entry type, or <code>null</code> if a matching document library file entry type could not be found
 	 */
-	public static DLFileEntryType fetchByG_DDI(
-		long groupId, long dataDefinitionId) {
+	public static DLFileEntryType fetchByG_C_DDI(
+		long groupId, long companyId, long dataDefinitionId) {
 
-		return getPersistence().fetchByG_DDI(groupId, dataDefinitionId);
+		return getPersistence().fetchByG_C_DDI(
+			groupId, companyId, dataDefinitionId);
 	}
 
 	/**
-	 * Returns the document library file entry type where groupId = &#63; and dataDefinitionId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the document library file entry type where groupId = &#63; and companyId = &#63; and dataDefinitionId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
 	 * @param groupId the group ID
+	 * @param companyId the company ID
 	 * @param dataDefinitionId the data definition ID
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching document library file entry type, or <code>null</code> if a matching document library file entry type could not be found
 	 */
-	public static DLFileEntryType fetchByG_DDI(
-		long groupId, long dataDefinitionId, boolean useFinderCache) {
+	public static DLFileEntryType fetchByG_C_DDI(
+		long groupId, long companyId, long dataDefinitionId,
+		boolean useFinderCache) {
 
-		return getPersistence().fetchByG_DDI(
-			groupId, dataDefinitionId, useFinderCache);
+		return getPersistence().fetchByG_C_DDI(
+			groupId, companyId, dataDefinitionId, useFinderCache);
 	}
 
 	/**
-	 * Removes the document library file entry type where groupId = &#63; and dataDefinitionId = &#63; from the database.
+	 * Removes the document library file entry type where groupId = &#63; and companyId = &#63; and dataDefinitionId = &#63; from the database.
 	 *
 	 * @param groupId the group ID
+	 * @param companyId the company ID
 	 * @param dataDefinitionId the data definition ID
 	 * @return the document library file entry type that was removed
 	 */
-	public static DLFileEntryType removeByG_DDI(
-			long groupId, long dataDefinitionId)
+	public static DLFileEntryType removeByG_C_DDI(
+			long groupId, long companyId, long dataDefinitionId)
 		throws com.liferay.document.library.kernel.exception.
 			NoSuchFileEntryTypeException {
 
-		return getPersistence().removeByG_DDI(groupId, dataDefinitionId);
+		return getPersistence().removeByG_C_DDI(
+			groupId, companyId, dataDefinitionId);
 	}
 
 	/**
-	 * Returns the number of document library file entry types where groupId = &#63; and dataDefinitionId = &#63;.
+	 * Returns the number of document library file entry types where groupId = &#63; and companyId = &#63; and dataDefinitionId = &#63;.
 	 *
 	 * @param groupId the group ID
+	 * @param companyId the company ID
 	 * @param dataDefinitionId the data definition ID
 	 * @return the number of matching document library file entry types
 	 */
-	public static int countByG_DDI(long groupId, long dataDefinitionId) {
-		return getPersistence().countByG_DDI(groupId, dataDefinitionId);
+	public static int countByG_C_DDI(
+		long groupId, long companyId, long dataDefinitionId) {
+
+		return getPersistence().countByG_C_DDI(
+			groupId, companyId, dataDefinitionId);
 	}
 
 	/**
-	 * Returns the document library file entry type where groupId = &#63; and fileEntryTypeKey = &#63; or throws a <code>NoSuchFileEntryTypeException</code> if it could not be found.
+	 * Returns the document library file entry type where groupId = &#63; and companyId = &#63; and fileEntryTypeKey = &#63; or throws a <code>NoSuchFileEntryTypeException</code> if it could not be found.
 	 *
 	 * @param groupId the group ID
+	 * @param companyId the company ID
 	 * @param fileEntryTypeKey the file entry type key
 	 * @return the matching document library file entry type
 	 * @throws NoSuchFileEntryTypeException if a matching document library file entry type could not be found
 	 */
-	public static DLFileEntryType findByG_F(
-			long groupId, String fileEntryTypeKey)
+	public static DLFileEntryType findByG_C_F(
+			long groupId, long companyId, String fileEntryTypeKey)
 		throws com.liferay.document.library.kernel.exception.
 			NoSuchFileEntryTypeException {
 
-		return getPersistence().findByG_F(groupId, fileEntryTypeKey);
+		return getPersistence().findByG_C_F(
+			groupId, companyId, fileEntryTypeKey);
 	}
 
 	/**
-	 * Returns the document library file entry type where groupId = &#63; and fileEntryTypeKey = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the document library file entry type where groupId = &#63; and companyId = &#63; and fileEntryTypeKey = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
 	 * @param groupId the group ID
+	 * @param companyId the company ID
 	 * @param fileEntryTypeKey the file entry type key
 	 * @return the matching document library file entry type, or <code>null</code> if a matching document library file entry type could not be found
 	 */
-	public static DLFileEntryType fetchByG_F(
-		long groupId, String fileEntryTypeKey) {
+	public static DLFileEntryType fetchByG_C_F(
+		long groupId, long companyId, String fileEntryTypeKey) {
 
-		return getPersistence().fetchByG_F(groupId, fileEntryTypeKey);
+		return getPersistence().fetchByG_C_F(
+			groupId, companyId, fileEntryTypeKey);
 	}
 
 	/**
-	 * Returns the document library file entry type where groupId = &#63; and fileEntryTypeKey = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the document library file entry type where groupId = &#63; and companyId = &#63; and fileEntryTypeKey = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
 	 * @param groupId the group ID
+	 * @param companyId the company ID
 	 * @param fileEntryTypeKey the file entry type key
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching document library file entry type, or <code>null</code> if a matching document library file entry type could not be found
 	 */
-	public static DLFileEntryType fetchByG_F(
-		long groupId, String fileEntryTypeKey, boolean useFinderCache) {
+	public static DLFileEntryType fetchByG_C_F(
+		long groupId, long companyId, String fileEntryTypeKey,
+		boolean useFinderCache) {
 
-		return getPersistence().fetchByG_F(
-			groupId, fileEntryTypeKey, useFinderCache);
+		return getPersistence().fetchByG_C_F(
+			groupId, companyId, fileEntryTypeKey, useFinderCache);
 	}
 
 	/**
-	 * Removes the document library file entry type where groupId = &#63; and fileEntryTypeKey = &#63; from the database.
+	 * Removes the document library file entry type where groupId = &#63; and companyId = &#63; and fileEntryTypeKey = &#63; from the database.
 	 *
 	 * @param groupId the group ID
+	 * @param companyId the company ID
 	 * @param fileEntryTypeKey the file entry type key
 	 * @return the document library file entry type that was removed
 	 */
-	public static DLFileEntryType removeByG_F(
-			long groupId, String fileEntryTypeKey)
+	public static DLFileEntryType removeByG_C_F(
+			long groupId, long companyId, String fileEntryTypeKey)
 		throws com.liferay.document.library.kernel.exception.
 			NoSuchFileEntryTypeException {
 
-		return getPersistence().removeByG_F(groupId, fileEntryTypeKey);
+		return getPersistence().removeByG_C_F(
+			groupId, companyId, fileEntryTypeKey);
 	}
 
 	/**
-	 * Returns the number of document library file entry types where groupId = &#63; and fileEntryTypeKey = &#63;.
+	 * Returns the number of document library file entry types where groupId = &#63; and companyId = &#63; and fileEntryTypeKey = &#63;.
 	 *
 	 * @param groupId the group ID
+	 * @param companyId the company ID
 	 * @param fileEntryTypeKey the file entry type key
 	 * @return the number of matching document library file entry types
 	 */
-	public static int countByG_F(long groupId, String fileEntryTypeKey) {
-		return getPersistence().countByG_F(groupId, fileEntryTypeKey);
+	public static int countByG_C_F(
+		long groupId, long companyId, String fileEntryTypeKey) {
+
+		return getPersistence().countByG_C_F(
+			groupId, companyId, fileEntryTypeKey);
 	}
 
 	/**

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/persistence/packageinfo
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 6.0.0
+version 7.0.0

--- a/portal-web/test/functional/com/liferay/portalweb/macros/DMNavigator.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/DMNavigator.macro
@@ -360,7 +360,7 @@ definition {
 			}
 		}
 		else {
-			var typeId = 0;
+			var typeId = JSONDLfileentrytype._getBasicFileEntryTypeIdWithCurrentCompany();
 		}
 
 		if (isSet(folderName)) {

--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/asset-list/JSONAssetlistSetter.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/asset-list/JSONAssetlistSetter.macro
@@ -78,7 +78,7 @@ definition {
 		var externalVideoShortcutClassTypeId = JSONDLfileentrytype._getFileEntryTypeId(
 			fileEntryTypeName = "External Video Shortcut",
 			groupId = ${globalGroupId});
-		var basicDocumentClassTypeId = 0;
+		var basicDocumentClassTypeId = JSONDLfileentrytype._getBasicFileEntryTypeIdWithCurrentCompany();
 		var classTypeIdsDLFileEntry = JSONDLfileentrytype._getFileEntryTypeIds(groupId = ${groupId});
 
 		if (${classTypeIdsDLFileEntry} == "") {

--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/dlfileentry/JSONDLfileentrytype.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/dlfileentry/JSONDLfileentrytype.macro
@@ -1,5 +1,21 @@
 definition {
 
+	@summary = "Get the basic fileEntryTypeId in the current company."
+	macro _getBasicFileEntryTypeIdWithCurrentCompany {
+		var portalURL = JSONCompany.getPortalURL();
+		var companyId = JSONCompany.getCompanyId();
+
+		var curl = '''
+			${portalURL}/api/jsonws/dlfileentrytype/get-basic-document-dl-file-entry-type \
+				-u test@liferay.com:test \
+				-d company=${companyId}
+		''';
+
+		var fileEntryTypeId = JSONCurlUtil.post(${curl}, "$..fileEntryTypeId");
+
+		return ${fileEntryTypeId};
+	}
+
 	@summary = "Get a fileEntryTypeId from dlFileEntryType"
 	macro _getFileEntryTypeId {
 		Variables.assertDefined(parameterList = "${fileEntryTypeName},${groupId}");

--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/layoutpagetemplate/JSONLayoutpagetemplate.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/layoutpagetemplate/JSONLayoutpagetemplate.macro
@@ -11,7 +11,7 @@ definition {
 			site = ${site});
 		var classNameId = JSONLayoutpagetemplateSetter.setClassNameId(contentType = ${contentType});
 
-		if ((${subType} == "Basic Document") || (${contentType} == "Blogs Entry") || (${contentType} == "Category") || (${contentType} == "Commerce Order") || (${contentType} == "Commerce Product") || (${contentType} == "Knowledge Base Article")) {
+		if ((${contentType} == "Blogs Entry") || (${contentType} == "Category") || (${contentType} == "Commerce Order") || (${contentType} == "Commerce Product") || (${contentType} == "Knowledge Base Article")) {
 			var classTypeId = 0;
 		}
 		else {

--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/layoutpagetemplate/JSONLayoutpagetemplate.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/layoutpagetemplate/JSONLayoutpagetemplate.macro
@@ -34,6 +34,9 @@ definition {
 					fileEntryTypeName = ${subType},
 					groupId = ${globalGroupId});
 			}
+			else if (${subType} == "Basic Document") {
+				var classTypeId = JSONDLfileentrytype._getBasicFileEntryTypeIdWithCurrentCompany();
+			}
 			else {
 				if (isSet(depotName)) {
 					var depotId = JSONLayoutpagetemplateSetter.setGroupId(

--- a/sql/indexes.sql
+++ b/sql/indexes.sql
@@ -137,9 +137,9 @@ create index IX_A158EA62 on DLFileEntryMetadata (fileVersionId, ctCollectionId);
 create index IX_EABA15 on DLFileEntryMetadata (uuid_[$COLUMN_LENGTH:75$], companyId, ctCollectionId);
 create index IX_EAA9CA2F on DLFileEntryMetadata (uuid_[$COLUMN_LENGTH:75$], ctCollectionId);
 
+create unique index IX_18E0E5F6 on DLFileEntryType (groupId, companyId, dataDefinitionId, ctCollectionId);
+create unique index IX_A210FB2D on DLFileEntryType (groupId, companyId, fileEntryTypeKey[$COLUMN_LENGTH:75$], ctCollectionId);
 create index IX_C0561BFA on DLFileEntryType (groupId, ctCollectionId);
-create unique index IX_B6F21286 on DLFileEntryType (groupId, dataDefinitionId, ctCollectionId);
-create unique index IX_402227BD on DLFileEntryType (groupId, fileEntryTypeKey[$COLUMN_LENGTH:75$], ctCollectionId);
 create index IX_F147FBA0 on DLFileEntryType (uuid_[$COLUMN_LENGTH:75$], companyId, ctCollectionId);
 create index IX_17A61184 on DLFileEntryType (uuid_[$COLUMN_LENGTH:75$], ctCollectionId);
 create unique index IX_1773A6A2 on DLFileEntryType (uuid_[$COLUMN_LENGTH:75$], groupId, ctCollectionId);


### PR DESCRIPTION
# What is this about?

https://issues.liferay.com/browse/LPS-151172

The Basic Document Type was global to all companies (i.e. it wasstored under the SYSTEM company).  This goes against true multitenancyin the product.

This PR changes things so that there's one basic document type per company, and removes most usages of magic identifiers.

# How do I test it?

Follow the steps described in https://issues.liferay.com/browse/LPS-151172.

Additional tests will require running the upgrade process.  One possible scenario is the following:

1. Create a Collection to display basic document types.
2. Create two pages, each one with its own Asset Publisher portlet.
3. Configure one Asset Publisher to display the contents of the collection.
4. Configure the other Asset Publisher to display basic documents (legacy configuration).
5. Add a fragment to a page, and map the title of a basic document to it.

After running the upgrade, everything should be displayed correctly.