### PR TITLE
LPS-173162 Cache extracted text when indexing

### DIFF
--- a/modules/apps/document-library/document-library-service/build.gradle
+++ b/modules/apps/document-library/document-library-service/build.gradle
@@ -49,6 +49,7 @@ dependencies {
 	compileOnly project(":apps:xstream:xstream-configurator-api")
 	compileOnly project(":core:osgi-service-tracker-collections")
 	compileOnly project(":core:petra:petra-function")
+	compileOnly project(":core:petra:petra-io")
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-reflect")
 	compileOnly project(":core:petra:petra-sql-dsl-api")
@@ -57,5 +58,4 @@ dependencies {
 
 	testCompile project(":apps:portal-search:portal-search")
 	testCompile project(":apps:portal-search:portal-search-test-util")
-	testCompile project(":core:petra:petra-io")
 }

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/spi/model/index/contributor/DLFileEntryModelDocumentContributor.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/spi/model/index/contributor/DLFileEntryModelDocumentContributor.java
@@ -35,6 +35,7 @@ import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.RelatedEntryIndexer;
 import com.liferay.portal.kernel.search.RelatedEntryIndexerRegistry;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -172,14 +173,10 @@ public class DLFileEntryModelDocumentContributor
 		}
 
 		try {
-			document.addFile(
-				fieldName, inputStream, dlFileEntry.getFileName(),
-				PropsValues.DL_FILE_INDEXING_MAX_SIZE);
-		}
-		catch (IOException ioException) {
-			if (_log.isWarnEnabled()) {
-				_log.warn("Unable to index content", ioException);
-			}
+			document.addText(
+				fieldName,
+				FileUtil.extractText(
+					inputStream, PropsValues.DL_FILE_INDEXING_MAX_SIZE));
 		}
 		finally {
 			try {

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/spi/model/index/contributor/DLFileEntryModelDocumentContributor.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/spi/model/index/contributor/DLFileEntryModelDocumentContributor.java
@@ -108,9 +108,6 @@ public class DLFileEntryModelDocumentContributor
 
 			document.addKeyword(
 				"dataRepositoryId", dlFileEntry.getDataRepositoryId());
-
-			// TODO inputStream this necessary?
-
 			document.addText(
 				"ddmContent",
 				_extractDDMContent(dlFileVersion, LocaleUtil.getSiteDefault()));

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -912,7 +912,7 @@ public class DLFileEntryLocalServiceImpl
 				}
 			}
 
-			DLStoreUtil.deleteFile(
+			_deleteFile(
 				dlFileEntry.getCompanyId(), dlFileEntry.getDataRepositoryId(),
 				dlFileEntry.getName(), version);
 		}
@@ -2488,6 +2488,15 @@ public class DLFileEntryLocalServiceImpl
 		}
 	}
 
+	private void _deleteFile(
+			long companyId, long repositoryId, String name, String versionLabel)
+		throws PortalException {
+
+		DLStoreUtil.deleteFile(companyId, repositoryId, name, versionLabel);
+		DLStoreUtil.deleteFile(
+			companyId, repositoryId, name, versionLabel + ".index");
+	}
+
 	private void _expireFileEntriesByCompanyId(
 			long companyId, Date expirationDate,
 			Map<String, Serializable> workflowContext,
@@ -3178,7 +3187,7 @@ public class DLFileEntryLocalServiceImpl
 
 		// File
 
-		DLStoreUtil.deleteFile(
+		_deleteFile(
 			user.getCompanyId(), dlFileEntry.getDataRepositoryId(),
 			dlFileEntry.getName(), lastDLFileVersion.getVersion());
 
@@ -3196,7 +3205,7 @@ public class DLFileEntryLocalServiceImpl
 	private void _registerPWCDeletionCallback(DLFileEntry dlFileEntry) {
 		TransactionCommitCallbackUtil.registerCallback(
 			() -> {
-				DLStoreUtil.deleteFile(
+				_deleteFile(
 					dlFileEntry.getCompanyId(),
 					dlFileEntry.getDataRepositoryId(), dlFileEntry.getName(),
 					DLFileEntryConstants.PRIVATE_WORKING_COPY_VERSION);
@@ -3226,7 +3235,7 @@ public class DLFileEntryLocalServiceImpl
 		_assetEntryLocalService.deleteEntry(
 			DLFileEntryConstants.getClassName(), dlFileVersion.getPrimaryKey());
 
-		DLStoreUtil.deleteFile(
+		_deleteFile(
 			dlFileEntry.getCompanyId(), dlFileEntry.getDataRepositoryId(),
 			dlFileEntry.getName(),
 			DLFileEntryConstants.PRIVATE_WORKING_COPY_VERSION);
@@ -3345,7 +3354,7 @@ public class DLFileEntryLocalServiceImpl
 			// File
 
 			if ((file != null) || (inputStream != null)) {
-				DLStoreUtil.deleteFile(
+				_deleteFile(
 					user.getCompanyId(), dlFileEntry.getDataRepositoryId(),
 					dlFileEntry.getName(), version);
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/store/DLStoreImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/store/DLStoreImpl.java
@@ -32,6 +32,7 @@ import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GroupThreadLocal;
 import com.liferay.portal.kernel.util.MimeTypesUtil;
 import com.liferay.portal.kernel.util.ServiceProxyFactory;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.util.PropsValues;
 
 import java.io.File;
@@ -405,7 +406,7 @@ public class DLStoreImpl implements DLStore {
 			dlStoreRequest.getSourceFileName(),
 			dlStoreRequest.isValidateFileExtension());
 
-		DLValidatorUtil.validateVersionLabel(dlStoreRequest.getVersionLabel());
+		_validateVersionLabel(dlStoreRequest.getVersionLabel());
 
 		if (PropsValues.DL_STORE_ANTIVIRUS_ENABLED) {
 			AntivirusScannerUtil.scan(file);
@@ -432,12 +433,11 @@ public class DLStoreImpl implements DLStore {
 			dlStoreRequest.getSourceFileName(),
 			dlStoreRequest.isValidateFileExtension());
 
+		_validateVersionLabel(dlStoreRequest.getVersionLabel());
+
 		if (inputStream1 instanceof ByteArrayFileInputStream) {
 			ByteArrayFileInputStream byteArrayFileInputStream =
 				(ByteArrayFileInputStream)inputStream1;
-
-			DLValidatorUtil.validateVersionLabel(
-				dlStoreRequest.getVersionLabel());
 
 			if (PropsValues.DL_STORE_ANTIVIRUS_ENABLED) {
 				AntivirusScannerUtil.scan(byteArrayFileInputStream.getFile());
@@ -450,8 +450,6 @@ public class DLStoreImpl implements DLStore {
 
 			return;
 		}
-
-		DLValidatorUtil.validateVersionLabel(dlStoreRequest.getVersionLabel());
 
 		if (PropsValues.DL_STORE_ANTIVIRUS_ENABLED &&
 			AntivirusScannerUtil.isActive()) {
@@ -674,7 +672,7 @@ public class DLStoreImpl implements DLStore {
 
 		validate(fileName, validateFileExtension);
 
-		DLValidatorUtil.validateVersionLabel(versionLabel);
+		_validateVersionLabel(versionLabel);
 	}
 
 	protected void validate(
@@ -686,7 +684,7 @@ public class DLStoreImpl implements DLStore {
 			fileName, fileExtension, sourceFileName, validateFileExtension,
 			file);
 
-		DLValidatorUtil.validateVersionLabel(versionLabel);
+		_validateVersionLabel(versionLabel);
 	}
 
 	protected void validate(
@@ -699,7 +697,14 @@ public class DLStoreImpl implements DLStore {
 			fileName, fileExtension, sourceFileName, validateFileExtension,
 			inputStream);
 
-		DLValidatorUtil.validateVersionLabel(versionLabel);
+		_validateVersionLabel(versionLabel);
+	}
+
+	private void _validateVersionLabel(String versionLabel)
+		throws PortalException {
+
+		DLValidatorUtil.validateVersionLabel(
+			StringUtil.removeLast(versionLabel, ".index"));
 	}
 
 	private static volatile Store _store =


### PR DESCRIPTION
# What is this about?

https://issues.liferay.com/browse/LPS-173162

Reindexing documents can be inefficient for large documents, as extracting text can be a time consuming process in some cases (e.g. large PDF files).

Cache the extracted text in the store and reuse if possible.  These cached files will be delete on update/deletion of a file version.

# How do I test it?

There should be no user visible changes, so there's really nothing to test.  If all automated tests pass this should be ready to go.