### PR TITLE
LPS-172863 enabling description field on KB widgets

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/display/context/EditKBArticleDisplayContext.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/display/context/EditKBArticleDisplayContext.java
@@ -360,12 +360,6 @@ public class EditKBArticleDisplayContext {
 		return false;
 	}
 
-	public boolean isKBArticleDescriptionEnabled() {
-		return GetterUtil.getBoolean(
-			_liferayPortletRequest.getAttribute(
-				"init.jsp-enableKBArticleDescription"));
-	}
-
 	public boolean isKBArticleSectionSelected(String section)
 		throws ConfigurationException {
 

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/display/context/ViewKBArticleDisplayContext.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/display/context/ViewKBArticleDisplayContext.java
@@ -93,6 +93,12 @@ public class ViewKBArticleDisplayContext {
 		).buildActionURL();
 	}
 
+	public boolean isKBArticleDescriptionEnabled() {
+		return GetterUtil.getBoolean(
+			_liferayPortletRequest.getAttribute(
+				"init.jsp-enableKBArticleDescription"));
+	}
+
 	public boolean isSubscriptionEnabled(KBArticle kbArticle) throws Exception {
 		if (_isSubscriptionEnabled() && _hasSubscriptionPermission(kbArticle)) {
 			return true;

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/action/ViewKBArticleMVCRenderCommand.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/action/ViewKBArticleMVCRenderCommand.java
@@ -15,16 +15,22 @@
 package com.liferay.knowledge.base.web.internal.portlet.action;
 
 import com.liferay.knowledge.base.constants.KBPortletKeys;
+import com.liferay.knowledge.base.web.internal.configuration.KBSearchPortletInstanceConfiguration;
+import com.liferay.portal.kernel.module.configuration.ConfigurationException;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
 import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
 
 import javax.portlet.PortletException;
 import javax.portlet.RenderRequest;
 import javax.portlet.RenderResponse;
 
+import javax.servlet.http.HttpServletRequest;
+
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Adolfo Pérez
@@ -61,6 +67,33 @@ public class ViewKBArticleMVCRenderCommand implements MVCRenderCommand {
 			return "/display/view_kb_article.jsp";
 		}
 
+		if (rootPortletId.equals(KBPortletKeys.KNOWLEDGE_BASE_SEARCH)) {
+			try {
+				ThemeDisplay themeDisplay =
+					(ThemeDisplay)renderRequest.getAttribute(
+						WebKeys.THEME_DISPLAY);
+
+				PortletDisplay portletDisplay =
+					themeDisplay.getPortletDisplay();
+
+				KBSearchPortletInstanceConfiguration
+					kbSearchPortletInstanceConfiguration =
+						portletDisplay.getPortletInstanceConfiguration(
+							KBSearchPortletInstanceConfiguration.class);
+
+				HttpServletRequest httpServletRequest =
+					_portal.getHttpServletRequest(renderRequest);
+
+				httpServletRequest.setAttribute(
+					"init.jsp-enableKBArticleDescription",
+					kbSearchPortletInstanceConfiguration.
+						enableKBArticleDescription());
+			}
+			catch (ConfigurationException configurationException) {
+				throw new RuntimeException(configurationException);
+			}
+		}
+
 		return "/admin/common/view_kb_article.jsp";
 	}
 
@@ -72,5 +105,8 @@ public class ViewKBArticleMVCRenderCommand implements MVCRenderCommand {
 
 		return portletDisplay.getRootPortletId();
 	}
+
+	@Reference
+	private Portal _portal;
 
 }

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/action/ViewKBArticleMVCRenderCommand.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/action/ViewKBArticleMVCRenderCommand.java
@@ -16,6 +16,7 @@ package com.liferay.knowledge.base.web.internal.portlet.action;
 
 import com.liferay.knowledge.base.constants.KBPortletKeys;
 import com.liferay.knowledge.base.web.internal.configuration.KBSearchPortletInstanceConfiguration;
+import com.liferay.knowledge.base.web.internal.configuration.KBSectionPortletInstanceConfiguration;
 import com.liferay.portal.kernel.module.configuration.ConfigurationException;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
 import com.liferay.portal.kernel.theme.PortletDisplay;
@@ -67,26 +68,41 @@ public class ViewKBArticleMVCRenderCommand implements MVCRenderCommand {
 			return "/display/view_kb_article.jsp";
 		}
 
+		ThemeDisplay themeDisplay = (ThemeDisplay)renderRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		PortletDisplay portletDisplay = themeDisplay.getPortletDisplay();
+
+		HttpServletRequest httpServletRequest = _portal.getHttpServletRequest(
+			renderRequest);
+
 		if (rootPortletId.equals(KBPortletKeys.KNOWLEDGE_BASE_SEARCH)) {
 			try {
-				ThemeDisplay themeDisplay =
-					(ThemeDisplay)renderRequest.getAttribute(
-						WebKeys.THEME_DISPLAY);
-
-				PortletDisplay portletDisplay =
-					themeDisplay.getPortletDisplay();
-
 				KBSearchPortletInstanceConfiguration
 					kbSearchPortletInstanceConfiguration =
 						portletDisplay.getPortletInstanceConfiguration(
 							KBSearchPortletInstanceConfiguration.class);
 
-				HttpServletRequest httpServletRequest =
-					_portal.getHttpServletRequest(renderRequest);
-
 				httpServletRequest.setAttribute(
 					"init.jsp-enableKBArticleDescription",
 					kbSearchPortletInstanceConfiguration.
+						enableKBArticleDescription());
+			}
+			catch (ConfigurationException configurationException) {
+				throw new RuntimeException(configurationException);
+			}
+		}
+
+		if (rootPortletId.equals(KBPortletKeys.KNOWLEDGE_BASE_SECTION)) {
+			try {
+				KBSectionPortletInstanceConfiguration
+					kbSectionPortletInstanceConfiguration =
+						portletDisplay.getPortletInstanceConfiguration(
+							KBSectionPortletInstanceConfiguration.class);
+
+				httpServletRequest.setAttribute(
+					"init.jsp-enableKBArticleDescription",
+					kbSectionPortletInstanceConfiguration.
 						enableKBArticleDescription());
 			}
 			catch (ConfigurationException configurationException) {

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_kb_article.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_kb_article.jsp
@@ -187,9 +187,7 @@ if (editKBArticleDisplayContext.isPortletTitleBasedNavigation()) {
 							<aui:input cssClass="input-medium" data-custom-url="<%= false %>" disabled="<%= editKBArticleDisplayContext.isURLTitleDisabled() %>" ignoreRequestValue="<%= true %>" label="" name="urlTitle" placeholder="sample-article-url-title" type="text" value="<%= editKBArticleDisplayContext.getKBArticleURLTitle() %>" />
 						</aui:field-wrapper>
 
-						<c:if test="<%= editKBArticleDisplayContext.isKBArticleDescriptionEnabled() %>">
-							<aui:input name="description" value="<%= editKBArticleDisplayContext.getKBArticleDescription() %>" />
-						</c:if>
+						<aui:input name="description" value="<%= editKBArticleDisplayContext.getKBArticleDescription() %>" />
 
 						<c:if test="<%= editKBArticleDisplayContext.isSourceURLEnabled() %>">
 							<aui:input label="source-url" name="sourceURL" value="<%= editKBArticleDisplayContext.getKBArticleSourceURL() %>" />

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/view_kb_article.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/view_kb_article.jsp
@@ -164,6 +164,23 @@ if (portletTitleBasedNavigation) {
 					<%= kbArticle.getContent() %>
 				</div>
 
+				<liferay-ui:panel-container
+					cssClass="mt-5 panel-group-flush panel-group-sm"
+					extended="<%= true %>"
+					markupView="lexicon"
+					persistState="<%= true %>"
+				>
+					<liferay-frontend:fieldset
+						collapsible="<%= false %>"
+						cssClass="panel-unstyled"
+						label="description"
+					>
+						<div class="lfr-asset-description">
+							<%= HtmlUtil.escape(kbArticle.getDescription()) %>
+						</div>
+					</liferay-frontend:fieldset>
+				</liferay-ui:panel-container>
+
 				<clay:content-row>
 					<clay:content-col>
 

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/view_kb_article.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/view_kb_article.jsp
@@ -50,14 +50,14 @@ if (portletTitleBasedNavigation) {
 	portletDisplay.setURLBack(redirect);
 	renderResponse.setTitle(kbArticle.getTitle());
 }
+
+ViewKBArticleDisplayContext viewKBArticleDisplayContext = new ViewKBArticleDisplayContext(liferayPortletRequest, liferayPortletResponse);
 %>
 
 <c:if test="<%= portletTitleBasedNavigation %>">
 
 	<%
 	KBDropdownItemsProvider kbDropdownItemsProvider = new KBDropdownItemsProvider(liferayPortletRequest, liferayPortletResponse);
-
-	ViewKBArticleDisplayContext viewKBArticleDisplayContext = new ViewKBArticleDisplayContext(liferayPortletRequest, liferayPortletResponse);
 	%>
 
 	<div class="management-bar management-bar-light navbar navbar-expand-md">
@@ -164,22 +164,24 @@ if (portletTitleBasedNavigation) {
 					<%= kbArticle.getContent() %>
 				</div>
 
-				<liferay-ui:panel-container
-					cssClass="mt-5 panel-group-flush panel-group-sm"
-					extended="<%= true %>"
-					markupView="lexicon"
-					persistState="<%= true %>"
-				>
-					<liferay-frontend:fieldset
-						collapsible="<%= false %>"
-						cssClass="panel-unstyled"
-						label="description"
+				<c:if test="<%= viewKBArticleDisplayContext.isKBArticleDescriptionEnabled() && Validator.isNotNull(kbArticle.getDescription()) %>">
+					<liferay-ui:panel-container
+						cssClass="mt-5 panel-group-flush panel-group-sm"
+						extended="<%= true %>"
+						markupView="lexicon"
+						persistState="<%= true %>"
 					>
-						<div class="lfr-asset-description">
-							<%= HtmlUtil.escape(kbArticle.getDescription()) %>
-						</div>
-					</liferay-frontend:fieldset>
-				</liferay-ui:panel-container>
+						<liferay-frontend:fieldset
+							collapsible="<%= false %>"
+							cssClass="panel-unstyled"
+							label="description"
+						>
+							<div class="lfr-asset-description">
+								<%= HtmlUtil.escape(kbArticle.getDescription()) %>
+							</div>
+						</liferay-frontend:fieldset>
+					</liferay-ui:panel-container>
+				</c:if>
 
 				<clay:content-row>
 					<clay:content-col>


### PR DESCRIPTION


- LPS-172863 on the edition show the description field
- LPS-172863 show the description panel on the view of the article
- LPS-172863 view the article description only if is enabled and is not empty
- LPS-172863 on searching the value of the attribute is lost so we must recreate it

Decisions taken here.

The editor of the file will be always be active because the change of the way we are creating the edit url (always with the admin_portlet)
On the admin portlet the description field will be always shown, the difference will be on the widgets.

use on the KB Article Wdget:
https://user-images.githubusercontent.com/47524751/213459226-65d96812-9240-4036-8d84-167cb69755b3.mp4

On the KB Display Widget
https://user-images.githubusercontent.com/47524751/213459635-6cc61f97-3869-42af-bab8-5efc35213975.mp4


On the search Widget
https://user-images.githubusercontent.com/47524751/213459988-75030fb7-6933-41bd-921a-39b321891224.mp4


