### PR TITLE
LPS-171026 Cannot delete blog image

### DIFF
--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/security/permission/resource/BlogsDLFileEntryModelResourcePermissionConfigurator.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/security/permission/resource/BlogsDLFileEntryModelResourcePermissionConfigurator.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.blogs.internal.security.permission.resource;
+
+import com.liferay.blogs.constants.BlogsConstants;
+import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.portal.kernel.model.Repository;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermissionFactory;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermissionLogic;
+import com.liferay.portal.kernel.security.permission.resource.PortletResourcePermission;
+import com.liferay.portal.kernel.service.RepositoryLocalService;
+import com.liferay.portal.kernel.util.SetUtil;
+
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Consumer;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Adolfo Pérez
+ */
+@Component(
+	property = "model.class.name=com.liferay.document.library.kernel.model.DLFileEntry",
+	service = ModelResourcePermissionFactory.ModelResourcePermissionConfigurator.class
+)
+public class BlogsDLFileEntryModelResourcePermissionConfigurator
+	implements ModelResourcePermissionFactory.
+				   ModelResourcePermissionConfigurator<DLFileEntry> {
+
+	@Override
+	public void configureModelResourcePermissionLogics(
+		ModelResourcePermission<DLFileEntry> modelResourcePermission,
+		Consumer<ModelResourcePermissionLogic<DLFileEntry>> consumer) {
+
+		consumer.accept(
+			(permissionChecker, name, dlFileEntry, actionId) -> {
+				if (!_delegableActionIds.contains(actionId)) {
+					return null;
+				}
+
+				Repository repository = _repositoryLocalService.fetchRepository(
+					dlFileEntry.getRepositoryId());
+
+				if ((repository == null) ||
+					!Objects.equals(
+						repository.getPortletId(),
+						BlogsConstants.RESOURCE_NAME)) {
+
+					return null;
+				}
+
+				return _portletResourcePermission.contains(
+					permissionChecker, dlFileEntry.getGroupId(),
+					ActionKeys.ADD_ENTRY);
+			});
+	}
+
+	private static final Set<String> _delegableActionIds = SetUtil.fromArray(
+		ActionKeys.DELETE, ActionKeys.UPDATE);
+
+	@Reference(target = "(resource.name=" + BlogsConstants.RESOURCE_NAME + ")")
+	private PortletResourcePermission _portletResourcePermission;
+
+	@Reference
+	private RepositoryLocalService _repositoryLocalService;
+
+}

--- a/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/display/context/BlogImagesDisplayContext.java
+++ b/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/display/context/BlogImagesDisplayContext.java
@@ -33,7 +33,6 @@ import com.liferay.portal.kernel.search.Hits;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.SearchContextFactory;
 import com.liferay.portal.kernel.search.Sort;
-import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -53,19 +52,11 @@ import javax.servlet.http.HttpServletRequest;
 public class BlogImagesDisplayContext {
 
 	public BlogImagesDisplayContext(
-		LiferayPortletRequest liferayPortletRequest,
-		ModelResourcePermission<FileEntry> modelResourcePermission) {
+		LiferayPortletRequest liferayPortletRequest) {
 
 		_liferayPortletRequest = liferayPortletRequest;
-		_modelResourcePermission = modelResourcePermission;
 
 		_httpServletRequest = _liferayPortletRequest.getHttpServletRequest();
-	}
-
-	public ModelResourcePermission<FileEntry>
-		getCustomFileEntryModelResourcePermission() {
-
-		return _modelResourcePermission;
 	}
 
 	public long getFolderId() throws PortalException {
@@ -200,7 +191,6 @@ public class BlogImagesDisplayContext {
 	private Folder _folder;
 	private final HttpServletRequest _httpServletRequest;
 	private final LiferayPortletRequest _liferayPortletRequest;
-	private final ModelResourcePermission<FileEntry> _modelResourcePermission;
 	private String _orderByCol;
 	private String _orderByType;
 

--- a/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/portlet/action/ViewMVCRenderCommand.java
+++ b/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/portlet/action/ViewMVCRenderCommand.java
@@ -14,17 +14,10 @@
 
 package com.liferay.blogs.web.internal.portlet.action;
 
-import com.liferay.blogs.constants.BlogsConstants;
 import com.liferay.blogs.constants.BlogsPortletKeys;
 import com.liferay.blogs.web.internal.display.context.BlogEntriesDisplayContext;
 import com.liferay.blogs.web.internal.display.context.BlogImagesDisplayContext;
-import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
-import com.liferay.portal.kernel.repository.model.FileEntry;
-import com.liferay.portal.kernel.security.permission.ActionKeys;
-import com.liferay.portal.kernel.security.permission.PermissionChecker;
-import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
-import com.liferay.portal.kernel.security.permission.resource.PortletResourcePermission;
 import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HtmlParser;
@@ -69,15 +62,10 @@ public class ViewMVCRenderCommand implements MVCRenderCommand {
 			new BlogEntriesDisplayContext(
 				_htmlParser, _portal, renderRequest, renderResponse,
 				_trashHelper));
-
-		ThemeDisplay themeDisplay = (ThemeDisplay)renderRequest.getAttribute(
-			WebKeys.THEME_DISPLAY);
-
 		renderRequest.setAttribute(
 			BlogImagesDisplayContext.class.getName(),
 			new BlogImagesDisplayContext(
-				_portal.getLiferayPortletRequest(renderRequest),
-				new BlogsFileEntryModelResourcePermission(themeDisplay)));
+				_portal.getLiferayPortletRequest(renderRequest)));
 
 		return "/blogs_admin/view.jsp";
 	}
@@ -94,117 +82,10 @@ public class ViewMVCRenderCommand implements MVCRenderCommand {
 	@Reference
 	private HtmlParser _htmlParser;
 
-	@Reference(
-		target = "(model.class.name=com.liferay.portal.kernel.repository.model.FileEntry)"
-	)
-	private ModelResourcePermission<FileEntry> _modelResourcePermission;
-
 	@Reference
 	private Portal _portal;
 
-	@Reference(target = "(resource.name=" + BlogsConstants.RESOURCE_NAME + ")")
-	private PortletResourcePermission _portletResourcePermission;
-
 	@Reference
 	private TrashHelper _trashHelper;
-
-	private class BlogsFileEntryModelResourcePermission
-		implements ModelResourcePermission<FileEntry> {
-
-		public BlogsFileEntryModelResourcePermission(
-			ThemeDisplay themeDisplay) {
-
-			_themeDisplay = themeDisplay;
-		}
-
-		@Override
-		public void check(
-				PermissionChecker permissionChecker, FileEntry fileEntry,
-				String actionId)
-			throws PortalException {
-
-			if (_isActionDelegable(actionId)) {
-				_portletResourcePermission.check(
-					permissionChecker, _themeDisplay.getSiteGroupId(),
-					ActionKeys.ADD_ENTRY);
-			}
-			else {
-				_modelResourcePermission.check(
-					permissionChecker, fileEntry, actionId);
-			}
-		}
-
-		@Override
-		public void check(
-				PermissionChecker permissionChecker, long primaryKey,
-				String actionId)
-			throws PortalException {
-
-			if (_isActionDelegable(actionId)) {
-				_portletResourcePermission.check(
-					permissionChecker, _themeDisplay.getSiteGroupId(),
-					ActionKeys.ADD_ENTRY);
-			}
-			else {
-				_modelResourcePermission.check(
-					permissionChecker, primaryKey, actionId);
-			}
-		}
-
-		@Override
-		public boolean contains(
-				PermissionChecker permissionChecker, FileEntry fileEntry,
-				String actionId)
-			throws PortalException {
-
-			if (_isActionDelegable(actionId)) {
-				return _portletResourcePermission.contains(
-					permissionChecker, fileEntry.getGroupId(),
-					ActionKeys.ADD_ENTRY);
-			}
-
-			return _modelResourcePermission.contains(
-				permissionChecker, fileEntry, actionId);
-		}
-
-		@Override
-		public boolean contains(
-				PermissionChecker permissionChecker, long primaryKey,
-				String actionId)
-			throws PortalException {
-
-			if (_isActionDelegable(actionId)) {
-				return _portletResourcePermission.contains(
-					permissionChecker, _themeDisplay.getSiteGroupId(),
-					ActionKeys.ADD_ENTRY);
-			}
-
-			return _modelResourcePermission.contains(
-				permissionChecker, primaryKey, actionId);
-		}
-
-		@Override
-		public String getModelName() {
-			return _modelResourcePermission.getModelName();
-		}
-
-		@Override
-		public PortletResourcePermission getPortletResourcePermission() {
-			return _modelResourcePermission.getPortletResourcePermission();
-		}
-
-		private boolean _isActionDelegable(String actionId) {
-			if (actionId.equals(ActionKeys.DELETE) ||
-				actionId.equals(ActionKeys.UPDATE)) {
-
-				return true;
-			}
-
-			return false;
-		}
-
-		private final ThemeDisplay _themeDisplay;
-
-	}
 
 }

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/view_images.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/view_images.jsp
@@ -25,7 +25,6 @@
 
 		<liferay-document-library:repository-browser
 			actions="delete"
-			customFileEntryModelResourcePermission="<%= blogImagesDisplayContext.getCustomFileEntryModelResourcePermission() %>"
 			folderId="<%= blogImagesDisplayContext.getFolderId() %>"
 			repositoryId="<%= blogImagesDisplayContext.getRepositoryId() %>"
 		/>

--- a/modules/apps/document-library/document-library-taglib/bnd.bnd
+++ b/modules/apps/document-library/document-library-taglib/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Document Library Taglib
 Bundle-SymbolicName: com.liferay.document.library.taglib
-Bundle-Version: 3.4.3
+Bundle-Version: 4.0.0
 Export-Package: com.liferay.document.library.taglib.servlet.taglib
 Provide-Capability:\
 	osgi.extender;\

--- a/modules/apps/document-library/document-library-taglib/package.json
+++ b/modules/apps/document-library/document-library-taglib/package.json
@@ -5,5 +5,5 @@
 		"checkFormat": "liferay-npm-scripts check",
 		"format": "liferay-npm-scripts fix"
 	},
-	"version": "3.4.3"
+	"version": "4.0.0"
 }

--- a/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/servlet/taglib/RepositoryBrowserTag.java
+++ b/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/servlet/taglib/RepositoryBrowserTag.java
@@ -57,12 +57,6 @@ public class RepositoryBrowserTag extends IncludeTag {
 		return _actions;
 	}
 
-	public ModelResourcePermission<FileEntry>
-		getCustomFileEntryModelResourcePermission() {
-
-		return _customFileEntryModelResourcePermission;
-	}
-
 	public long getFolderId() {
 		return _folderId;
 	}
@@ -73,14 +67,6 @@ public class RepositoryBrowserTag extends IncludeTag {
 
 	public void setActions(String actions) {
 		_actions = actions;
-	}
-
-	public void setCustomFileEntryModelResourcePermission(
-		ModelResourcePermission<FileEntry>
-			customFileEntryModelResourcePermission) {
-
-		_customFileEntryModelResourcePermission =
-			customFileEntryModelResourcePermission;
 	}
 
 	public void setFolderId(long folderId) {
@@ -103,7 +89,6 @@ public class RepositoryBrowserTag extends IncludeTag {
 		super.cleanUp();
 
 		_actions = StringPool.BLANK;
-		_customFileEntryModelResourcePermission = null;
 		_folderId = DLFolderConstants.DEFAULT_PARENT_FOLDER_ID;
 		_repositoryId = 0;
 	}
@@ -127,7 +112,7 @@ public class RepositoryBrowserTag extends IncludeTag {
 			RepositoryBrowserTagDisplayContext.class.getName(),
 			new RepositoryBrowserTagDisplayContext(
 				_getActionsSet(), DLAppServiceUtil.getService(),
-				_getFileEntryModelResourcePermission(),
+				_fileEntryModelResourcePermission,
 				_fileShortcutModelResourcePermission,
 				_folderModelResourcePermission, _getFolderId(),
 				httpServletRequest,
@@ -154,16 +139,6 @@ public class RepositoryBrowserTag extends IncludeTag {
 		}
 
 		return actionsSet;
-	}
-
-	private ModelResourcePermission<FileEntry>
-		_getFileEntryModelResourcePermission() {
-
-		if (getCustomFileEntryModelResourcePermission() == null) {
-			return _fileEntryModelResourcePermission;
-		}
-
-		return getCustomFileEntryModelResourcePermission();
 	}
 
 	private long _getFolderId() {
@@ -209,8 +184,6 @@ public class RepositoryBrowserTag extends IncludeTag {
 				"(model.class.name=" + Folder.class.getName() + ")", false);
 
 	private String _actions = StringPool.BLANK;
-	private ModelResourcePermission<FileEntry>
-		_customFileEntryModelResourcePermission;
 	private long _folderId = DLFolderConstants.DEFAULT_PARENT_FOLDER_ID;
 	private long _repositoryId;
 

--- a/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/liferay-document-library.tld
+++ b/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/liferay-document-library.tld
@@ -38,11 +38,6 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<name>customFileEntryModelResourcePermission</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
 			<name>folderId</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>

--- a/modules/apps/document-library/document-library-taglib/src/main/resources/com/liferay/document/library/taglib/servlet/taglib/packageinfo
+++ b/modules/apps/document-library/document-library-taglib/src/main/resources/com/liferay/document/library/taglib/servlet/taglib/packageinfo
@@ -1,1 +1,1 @@
-version 1.4.0
+version 2.0.0


### PR DESCRIPTION
# What is this about?

https://issues.liferay.com/browse/LPS-171026

The blogs repository has some special rule when checking deletion permissions: only users that can add blog entries, can also delete file entries.  The problem right now is that the document permissions are checked instead of the portlet ones.

Add an extension point to file entry permissions so that blogs can attach itself to it and add the custom checks when necessary.

# How do I test it?

Follow the steps described in https://issues.liferay.com/browse/LPS-171026.