### PR TITLE
LPS-173256 KB Performance improvements

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/js/components/ActionsDropdown.js
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/js/components/ActionsDropdown.js
@@ -17,12 +17,10 @@ import {ClayDropDownWithItems} from '@clayui/drop-down';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import normalizeDropdownItems from '../utils/normalizeDropdownItems';
-
 export default function ActionsDropdown({actions}) {
 	return actions?.length ? (
 		<ClayDropDownWithItems
-			items={normalizeDropdownItems(actions)}
+			items={actions}
 			renderMenuOnClick
 			trigger={
 				<ClayButtonWithIcon

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/js/components/NavigationPanel.js
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/js/components/NavigationPanel.js
@@ -17,8 +17,9 @@ import ClayIcon from '@clayui/icon';
 import classnames from 'classnames';
 import {fetch, navigate, objectToFormData, openToast} from 'frontend-js-web';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, {useMemo} from 'react';
 
+import normalizeDropdownItems from '../utils/normalizeDropdownItems';
 import ActionsDropdown from './ActionsDropdown';
 
 const ITEM_TYPES_SYMBOL = {
@@ -58,12 +59,26 @@ const showSuccessMessage = (portletNamespace) => {
 	openToast(openToastSuccessProps);
 };
 
+const normalizeItems = (items) => {
+	if (items) {
+		return items.map((item) => {
+			return {
+				...item,
+				actions: normalizeDropdownItems(item.actions),
+				children: normalizeItems(item.children),
+			};
+		});
+	}
+};
+
 export default function NavigationPanel({
-	items,
+	items: initialItems,
 	moveKBObjectURL,
 	portletNamespace,
 	selectedItemId,
 }) {
+	const items = useMemo(() => normalizeItems(initialItems), [initialItems]);
+
 	const handleClickItem = (event, item) => {
 		if (event.defaultPrevented) {
 			return;

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/js/components/VerticalBar.js
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/js/components/VerticalBar.js
@@ -14,13 +14,14 @@
 
 import {ClayButtonWithIcon} from '@clayui/button';
 import {VerticalBar} from '@clayui/core';
+import ClayLoadingIndicator from '@clayui/loading-indicator';
 import {navigate} from 'frontend-js-web';
 import PropTypes from 'prop-types';
-import React, {useEffect, useState} from 'react';
+import React, {Suspense, useEffect, useState} from 'react';
 
-import NavigationPanel from './NavigationPanel';
-import SuggestionsPanel from './SuggestionsPanel';
-import TemplatesPanel from './TemplatesPanel';
+const NavigationPanel = React.lazy(() => import('./NavigationPanel'));
+const SuggestionsPanel = React.lazy(() => import('./SuggestionsPanel'));
+const TemplatesPanel = React.lazy(() => import('./TemplatesPanel'));
 
 const CSS_EXPANDED = 'expanded';
 
@@ -190,12 +191,14 @@ const VerticalNavigationBar = ({
 							</div>
 
 							<div className="sidebar-body">
-								<PanelComponent
-									items={item.navigationItems}
-									moveKBObjectURL={moveKBObjectURL}
-									portletNamespace={portletNamespace}
-									selectedItemId={item.selectedItemId}
-								/>
+								<Suspense fallback={<ClayLoadingIndicator />}>
+									<PanelComponent
+										items={item.navigationItems}
+										moveKBObjectURL={moveKBObjectURL}
+										portletNamespace={portletNamespace}
+										selectedItemId={item.selectedItemId}
+									/>
+								</Suspense>
 							</div>
 						</VerticalBar.Panel>
 					);


### PR DESCRIPTION
All actions must be normalized before the first render to properly show icons and separators in the dropdowns. The use of `useMemo()` avoid to do these actions in every render. 

Also, a lazy loading has been implemented, so while these actions are being normalized a spinner is shown. 

With this changes, and previous flag `renderMenuOnClick` that only render dropdowns when clicked, there is no significant degradation in performance 🥳 

Demo: 


https://user-images.githubusercontent.com/8373764/213688434-5fc8f05f-3ebb-437f-b698-78be35146768.mp4

