### PR TITLE
LPS-173353 Configuration Listener is not updated after update the configuration

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/configuration/KBServiceConfigurationProvider.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/configuration/KBServiceConfigurationProvider.java
@@ -16,6 +16,8 @@ package com.liferay.knowledge.base.configuration;
 
 import com.liferay.portal.kernel.module.configuration.ConfigurationException;
 
+import java.io.IOException;
+
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
@@ -24,14 +26,13 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface KBServiceConfigurationProvider {
 
-	public int getCheckInterval(long companyId) throws ConfigurationException;
+	public int getCheckInterval() throws ConfigurationException;
 
-	public int getExpirationDateNotificationDateWeeks(long companyId)
+	public int getExpirationDateNotificationDateWeeks()
 		throws ConfigurationException;
 
 	public void updateExpirationDateConfiguration(
-			int checkInterval, long companyId,
-			int expirationDateNotificationDateWeeks)
-		throws Exception;
+			int checkInterval, int expirationDateNotificationDateWeeks)
+		throws IOException;
 
 }

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/configuration/KBServiceConfiguration.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/configuration/KBServiceConfiguration.java
@@ -23,7 +23,7 @@ import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClass
  */
 @ExtendedObjectClassDefinition(
 	category = "knowledge-base", generateUI = false,
-	scope = ExtendedObjectClassDefinition.Scope.COMPANY
+	scope = ExtendedObjectClassDefinition.Scope.SYSTEM
 )
 @Meta.OCD(
 	id = "com.liferay.knowledge.base.internal.configuration.KBServiceConfiguration",

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/messaging/CheckKBArticleMessageListener.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/messaging/CheckKBArticleMessageListener.java
@@ -43,7 +43,7 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	configurationPid = "com.liferay.knowledge.base.internal.configuration.KBServiceConfiguration",
-	configurationPolicy = ConfigurationPolicy.OPTIONAL, service = {}
+	configurationPolicy = ConfigurationPolicy.OPTIONAL, immediate = true, service = {}
 )
 public class CheckKBArticleMessageListener extends BaseMessageListener {
 

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/configuration/KBServiceConfigurationProviderUtil.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/configuration/KBServiceConfigurationProviderUtil.java
@@ -26,11 +26,11 @@ import org.osgi.service.component.annotations.Reference;
 @Component(service = {})
 public class KBServiceConfigurationProviderUtil {
 
-	public static int getExpirationDateNotificationDateWeeks(long companyId)
+	public static int getExpirationDateNotificationDateWeeks()
 		throws ConfigurationException {
 
 		return _kbServiceConfigurationProvider.
-			getExpirationDateNotificationDateWeeks(companyId);
+			getExpirationDateNotificationDateWeeks();
 	}
 
 	@Reference(unbind = "-")

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/display/context/KBArticleCompanyConfigurationDisplayContext.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/display/context/KBArticleCompanyConfigurationDisplayContext.java
@@ -52,7 +52,7 @@ public class KBArticleCompanyConfigurationDisplayContext {
 		return PortletURLBuilder.createActionURL(
 			_liferayPortletResponse
 		).setActionName(
-			"/instance_settings/edit_kb_article_expiration_date_configuration"
+			"/system_settings/edit_kb_article_expiration_date_configuration"
 		).setRedirect(
 			PortalUtil.getCurrentURL(_httpServletRequest)
 		).buildString();

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/display/context/KBArticleCompanyConfigurationDisplayContext.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/display/context/KBArticleCompanyConfigurationDisplayContext.java
@@ -18,9 +18,7 @@ import com.liferay.knowledge.base.configuration.KBServiceConfigurationProvider;
 import com.liferay.portal.kernel.module.configuration.ConfigurationException;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
-import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.PortalUtil;
-import com.liferay.portal.kernel.util.WebKeys;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -40,12 +38,7 @@ public class KBArticleCompanyConfigurationDisplayContext {
 	}
 
 	public int getCheckInterval() throws ConfigurationException {
-		ThemeDisplay themeDisplay =
-			(ThemeDisplay)_httpServletRequest.getAttribute(
-				WebKeys.THEME_DISPLAY);
-
-		return _kbServiceConfigurationProvider.getCheckInterval(
-			themeDisplay.getCompanyId());
+		return _kbServiceConfigurationProvider.getCheckInterval();
 	}
 
 	public String getEditKBArticleConfigurationURL() {
@@ -61,12 +54,8 @@ public class KBArticleCompanyConfigurationDisplayContext {
 	public int getExpirationDateNotificationDateWeeks()
 		throws ConfigurationException {
 
-		ThemeDisplay themeDisplay =
-			(ThemeDisplay)_httpServletRequest.getAttribute(
-				WebKeys.THEME_DISPLAY);
-
 		return _kbServiceConfigurationProvider.
-			getExpirationDateNotificationDateWeeks(themeDisplay.getCompanyId());
+			getExpirationDateNotificationDateWeeks();
 	}
 
 	private final HttpServletRequest _httpServletRequest;

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/display/context/KBArticleViewDisplayContext.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/display/context/KBArticleViewDisplayContext.java
@@ -24,10 +24,8 @@ import com.liferay.portal.kernel.module.configuration.ConfigurationException;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
-import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PropsUtil;
-import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
 import java.time.Instant;
@@ -122,15 +120,10 @@ public class KBArticleViewDisplayContext {
 
 		LocalDateTime nowLocalDateTime = LocalDateTime.now();
 
-		ThemeDisplay themeDisplay =
-			(ThemeDisplay)_httpServletRequest.getAttribute(
-				WebKeys.THEME_DISPLAY);
-
 		if (nowLocalDateTime.isAfter(
 				expirationDateLocalDateTime.minusWeeks(
 					KBServiceConfigurationProviderUtil.
-						getExpirationDateNotificationDateWeeks(
-							themeDisplay.getCompanyId())))) {
+						getExpirationDateNotificationDateWeeks()))) {
 
 			return true;
 		}

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portal/settings/configuration/admin/display/KBConfigurationScreen.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portal/settings/configuration/admin/display/KBConfigurationScreen.java
@@ -62,7 +62,7 @@ public class KBConfigurationScreen implements ConfigurationScreen {
 
 	@Override
 	public String getScope() {
-		return ExtendedObjectClassDefinition.Scope.COMPANY.getValue();
+		return ExtendedObjectClassDefinition.Scope.SYSTEM.getValue();
 	}
 
 	@Override

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/action/EditKBArticleExpirationDateConfigurationMVCActionCommand.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/action/EditKBArticleExpirationDateConfigurationMVCActionCommand.java
@@ -34,8 +34,8 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	property = {
-		"javax.portlet.name=" + ConfigurationAdminPortletKeys.INSTANCE_SETTINGS,
-		"mvc.command.name=/instance_settings/edit_kb_article_expiration_date_configuration"
+		"javax.portlet.name=" + ConfigurationAdminPortletKeys.SYSTEM_SETTINGS,
+		"mvc.command.name=/system_settings/edit_kb_article_expiration_date_configuration"
 	},
 	service = MVCActionCommand.class
 )

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/action/EditKBArticleExpirationDateConfigurationMVCActionCommand.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/action/EditKBArticleExpirationDateConfigurationMVCActionCommand.java
@@ -19,9 +19,9 @@ import com.liferay.knowledge.base.configuration.KBServiceConfigurationProvider;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCActionCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.servlet.SessionErrors;
-import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ParamUtil;
-import com.liferay.portal.kernel.util.WebKeys;
+
+import java.io.IOException;
 
 import javax.portlet.ActionRequest;
 import javax.portlet.ActionResponse;
@@ -48,17 +48,13 @@ public class EditKBArticleExpirationDateConfigurationMVCActionCommand
 		throws Exception {
 
 		try {
-			ThemeDisplay themeDisplay =
-				(ThemeDisplay)actionRequest.getAttribute(WebKeys.THEME_DISPLAY);
-
 			_kbServiceConfigurationProvider.updateExpirationDateConfiguration(
 				ParamUtil.getInteger(actionRequest, "checkInterval"),
-				themeDisplay.getCompanyId(),
 				ParamUtil.getInteger(
 					actionRequest, "expirationDateNotificationDateWeeks"));
 		}
-		catch (Exception exception) {
-			SessionErrors.add(actionRequest, exception.getClass());
+		catch (IOException ioException) {
+			SessionErrors.add(actionRequest, ioException.getClass());
 
 			actionResponse.sendRedirect(
 				ParamUtil.getString(actionRequest, "redirect"));


### PR DESCRIPTION
As the Figma says I put the configuration on the system level

if Company or group scope is needed, more work is needed too


- LPS-173353 put on system scope
- LPS-173353 id company no longer needed
- LPS-173353 It needs to be immediate for now since it is registering scheduler entries in its activate method
- LPS-173353 implements ConfigurationModelListener on the MessageListener to update the scheduler
