### PR TITLE
[TS] LPS-172866 Unable to anonymize announcements flags more than once

### DIFF
--- a/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/PortalUpgradeProcessRegistryImpl.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/PortalUpgradeProcessRegistryImpl.java
@@ -256,6 +256,9 @@ public class PortalUpgradeProcessRegistryImpl
 			new Version(25, 1, 1),
 			UpgradeModulesFactory.create(
 				new String[] {"com.liferay.questions.web"}, null));
+
+		upgradeVersionTreeMap.put(
+			new Version(25, 1, 2), new DummyUpgradeProcess());
 	}
 
 }

--- a/portal-impl/src/com/liferay/portlet/announcements/service.xml
+++ b/portal-impl/src/com/liferay/portlet/announcements/service.xml
@@ -129,7 +129,7 @@
 		<finder name="EntryId" return-type="Collection">
 			<finder-column name="entryId" />
 		</finder>
-		<finder name="U_E_V" return-type="AnnouncementFlag" unique="true">
+		<finder name="U_E_V" return-type="AnnouncementFlag">
 			<finder-column name="userId" />
 			<finder-column name="entryId" />
 			<finder-column name="value" />

--- a/portal-impl/src/com/liferay/portlet/announcements/service/persistence/impl/AnnouncementsFlagPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/announcements/service/persistence/impl/AnnouncementsFlagPersistenceImpl.java
@@ -40,6 +40,7 @@ import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.ProxyUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portlet.announcements.model.impl.AnnouncementsFlagImpl;
 import com.liferay.portlet.announcements.model.impl.AnnouncementsFlagModelImpl;
 
@@ -48,6 +49,7 @@ import java.io.Serializable;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationHandler;
 
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -1221,6 +1223,23 @@ public class AnnouncementsFlagPersistenceImpl
 					}
 				}
 				else {
+					if (list.size() > 1) {
+						Collections.sort(list, Collections.reverseOrder());
+
+						if (_log.isWarnEnabled()) {
+							if (!useFinderCache) {
+								finderArgs = new Object[] {
+									userId, entryId, value
+								};
+							}
+
+							_log.warn(
+								"AnnouncementsFlagPersistenceImpl.fetchByU_E_V(long, long, int, boolean) with parameters (" +
+									StringUtil.merge(finderArgs) +
+										") yields a result set with more than 1 result. This violates the logical unique restriction. There is no order guarantee on which result is returned by this finder.");
+						}
+					}
+
 					AnnouncementsFlag announcementsFlag = list.get(0);
 
 					result = announcementsFlag;

--- a/sql/indexes.sql
+++ b/sql/indexes.sql
@@ -17,7 +17,7 @@ create index IX_F2949120 on AnnouncementsEntry (uuid_[$COLUMN_LENGTH:75$], compa
 
 create index IX_EF1F022A on AnnouncementsFlag (companyId);
 create index IX_9C7EB9F on AnnouncementsFlag (entryId);
-create unique index IX_4539A99C on AnnouncementsFlag (userId, entryId, value);
+create index IX_4539A99C on AnnouncementsFlag (userId, entryId, value);
 
 create index IX_AE8DFA7 on AssetCategory (companyId, externalReferenceCode[$COLUMN_LENGTH:75$], ctCollectionId);
 create index IX_1757FA92 on AssetCategory (ctCollectionId);


### PR DESCRIPTION
Dear Team,

Could you please review this pull request?

Motivation
=======
It is not possible to anonymize a user after the first one in sites where alerts are defined, unless the anonymous user is deleted.
The root cause is that in the AnnouncementsFlag table there is a unique index constraint, `IX_4539A99C`, which prevents duplicates of triples like _<user id, alert id, value>_. But after multiple users' anonymization, it is normal to get many _<anonymous user id, alert id, value>_ triples.

Proposed Solution
========
Removing the constraint from the index `IX_4539A99C`.

Steps to Verify
========
Please have a look at the linked LPS for the reproduction steps.
https://issues.liferay.com/browse/LPS-172866

Alternative Solutions that were discarded
========
Instead of updating the `userId` column to that of the anonymous user's ID, delete the entry.
This approach would not be feasible if the deleted user would be reinstated in the future.

Thank you and best regards,
István