### PR TITLE
LPS-172520 Specific DPT not working for kb articles

### DIFF
--- a/modules/apps/asset/asset-display-page-api/bnd.bnd
+++ b/modules/apps/asset/asset-display-page-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Asset Display Page API
 Bundle-SymbolicName: com.liferay.asset.display.page.api
-Bundle-Version: 11.0.4
+Bundle-Version: 11.1.0
 Export-Package:\
 	com.liferay.asset.display.page.configuration,\
 	com.liferay.asset.display.page.constants,\

--- a/modules/apps/asset/asset-display-page-api/src/main/java/com/liferay/asset/display/page/portlet/BaseAssetDisplayPageFriendlyURLResolver.java
+++ b/modules/apps/asset/asset-display-page-api/src/main/java/com/liferay/asset/display/page/portlet/BaseAssetDisplayPageFriendlyURLResolver.java
@@ -216,6 +216,15 @@ public abstract class BaseAssetDisplayPageFriendlyURLResolver
 		return new LayoutFriendlyURLComposite(layout, friendlyURL, false);
 	}
 
+	protected AssetDisplayPageEntry getAssetDisplayPageEntry(
+		long groupId,
+		LayoutDisplayPageObjectProvider<?> layoutDisplayPageObjectProvider) {
+
+		return assetDisplayPageEntryLocalService.fetchAssetDisplayPageEntry(
+			groupId, layoutDisplayPageObjectProvider.getClassNameId(),
+			layoutDisplayPageObjectProvider.getClassPK());
+	}
+
 	protected Locale getLocale(Map<String, Object> requestContext) {
 		Locale locale = (Locale)requestContext.get(WebKeys.LOCALE);
 
@@ -345,10 +354,8 @@ public abstract class BaseAssetDisplayPageFriendlyURLResolver
 		LayoutDisplayPageObjectProvider<?> layoutDisplayPageObjectProvider,
 		LayoutDisplayPageProvider<?> layoutDisplayPageProvider) {
 
-		AssetDisplayPageEntry assetDisplayPageEntry =
-			assetDisplayPageEntryLocalService.fetchAssetDisplayPageEntry(
-				groupId, layoutDisplayPageObjectProvider.getClassNameId(),
-				layoutDisplayPageObjectProvider.getClassPK());
+		AssetDisplayPageEntry assetDisplayPageEntry = getAssetDisplayPageEntry(
+			groupId, layoutDisplayPageObjectProvider);
 
 		if (assetDisplayPageEntry != null) {
 			if (assetDisplayPageEntry.getType() ==

--- a/modules/apps/asset/asset-display-page-api/src/main/resources/com/liferay/asset/display/page/portlet/packageinfo
+++ b/modules/apps/asset/asset-display-page-api/src/main/resources/com/liferay/asset/display/page/portlet/packageinfo
@@ -1,1 +1,1 @@
-version 6.0.0
+version 6.1.0

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/layout/display/page/KBArticleLayoutDisplayPageProvider.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/layout/display/page/KBArticleLayoutDisplayPageProvider.java
@@ -25,6 +25,7 @@ import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.portlet.constants.FriendlyURLResolverConstants;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
 import java.util.List;
 
@@ -51,6 +52,12 @@ public class KBArticleLayoutDisplayPageProvider
 		try {
 			KBArticle kbArticle = _kbArticleLocalService.fetchKBArticle(
 				infoItemReference.getClassPK());
+
+			if (kbArticle == null) {
+				kbArticle = _kbArticleLocalService.fetchLatestKBArticle(
+					infoItemReference.getClassPK(),
+					WorkflowConstants.STATUS_ANY);
+			}
 
 			if ((kbArticle == null) || kbArticle.isDraft()) {
 				return null;

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/info/display/contributor/portlet/KBArticleAssetDisplayPageFriendlyURLResolver.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/info/display/contributor/portlet/KBArticleAssetDisplayPageFriendlyURLResolver.java
@@ -14,7 +14,10 @@
 
 package com.liferay.knowledge.base.web.internal.portlet.info.display.contributor.portlet;
 
+import com.liferay.asset.display.page.model.AssetDisplayPageEntry;
 import com.liferay.asset.display.page.portlet.BaseAssetDisplayPageFriendlyURLResolver;
+import com.liferay.knowledge.base.model.KBArticle;
+import com.liferay.layout.display.page.LayoutDisplayPageObjectProvider;
 import com.liferay.portal.kernel.portlet.FriendlyURLResolver;
 import com.liferay.portal.kernel.portlet.constants.FriendlyURLResolverConstants;
 
@@ -31,6 +34,28 @@ public class KBArticleAssetDisplayPageFriendlyURLResolver
 	public String getURLSeparator() {
 		return FriendlyURLResolverConstants.
 			URL_SEPARATOR_KNOWLEDGE_BASE_ARTICLE;
+	}
+
+	@Override
+	protected AssetDisplayPageEntry getAssetDisplayPageEntry(
+		long groupId,
+		LayoutDisplayPageObjectProvider<?> layoutDisplayPageObjectProvider) {
+
+		KBArticle kbArticle =
+			(KBArticle)layoutDisplayPageObjectProvider.getDisplayObject();
+
+		AssetDisplayPageEntry assetDisplayPageEntry =
+			assetDisplayPageEntryLocalService.fetchAssetDisplayPageEntry(
+				groupId, layoutDisplayPageObjectProvider.getClassNameId(),
+				kbArticle.getKbArticleId());
+
+		if (assetDisplayPageEntry != null) {
+			return assetDisplayPageEntry;
+		}
+
+		return assetDisplayPageEntryLocalService.fetchAssetDisplayPageEntry(
+			groupId, layoutDisplayPageObjectProvider.getClassNameId(),
+			kbArticle.getResourcePrimKey());
 	}
 
 }


### PR DESCRIPTION
# What is this about?

https://issues.liferay.com/browse/LPS-172520

Depending on the status, KB articles use the article ID or resource prim key as class PK. This means we need to check both when looking for articles or related resources.

# How do I test it?

Follow the steps described in https://issues.liferay.com/browse/LPS-172520.