### PR TITLE
[TS] LPS-173031 | Inconsistency in the FriendlyURLNormalization with accented characters

### DIFF
--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/util/FriendlyURLNormalizerImpl.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/util/FriendlyURLNormalizerImpl.java
@@ -99,6 +99,8 @@ public class FriendlyURLNormalizerImpl implements FriendlyURLNormalizer {
 				}
 			}
 			else {
+				c = Character.toLowerCase(c);
+
 				if (charsetEncoder == null) {
 					charsetEncoder = CharsetEncoderUtil.getCharsetEncoder(
 						StringPool.UTF8);


### PR DESCRIPTION
Hi Team,
Could you please review this pull request?
https://issues.liferay.com/browse/LPS-173031
Thank you!

---------

I found a conflicting use case with the friendlyURLNormalizer. The friendlyURLNormalizer converts the uppercase letters to lowercase letters so the friendlyURL "/TEST" will become "/test" when we save a layout with the upper case URL or a redirect. But if the original URL contains an uppercase accented letter like "/FÖOLDAL" the normalizer will lowercase the traditional letters and encode the accented letter for the DB. In this fix changed it by trying to lowercase the accented letter first before encoding it.

**Reproduction Steps:**
1. Create a new page called "FŐOLDAL"
2. Check the friendlyURL generated for the new page

**Expected outcome:** The friendlyURL is normalized in lowercase, after that the accented character is encoded "/főoldal".
**Actual outcome:** The friendlyURL accented character is encoded and the rest is normalized to lowercase "/fŐoldal".