### PR TITLE
LPS-173708 Assertion Error in DLAMImageCounterTest and DLAMImageOptimizerTest

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-document-library-web-test/src/testIntegration/java/com/liferay/adaptive/media/document/library/web/internal/counter/test/DLAMImageCounterTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-document-library-web-test/src/testIntegration/java/com/liferay/adaptive/media/document/library/web/internal/counter/test/DLAMImageCounterTest.java
@@ -221,7 +221,7 @@ public class DLAMImageCounterTest {
 			DLAMImageCounterTest.class, "dependencies/image.jpg");
 	}
 
-	private static final int _WELCOME_SITE_INITIALIZER_IMAGES_COUNT = 1;
+	private static final int _WELCOME_SITE_INITIALIZER_IMAGES_COUNT = 5;
 
 	@Inject(
 		filter = "adaptive.media.key=document-library",

--- a/modules/apps/adaptive-media/adaptive-media-document-library-web-test/src/testIntegration/java/com/liferay/adaptive/media/document/library/web/internal/optimizer/test/DLAMImageOptimizerTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-document-library-web-test/src/testIntegration/java/com/liferay/adaptive/media/document/library/web/internal/optimizer/test/DLAMImageOptimizerTest.java
@@ -384,7 +384,7 @@ public class DLAMImageOptimizerTest {
 			DLAMImageOptimizerTest.class, "dependencies/image.jpg");
 	}
 
-	private static final int _WELCOME_SITE_INITIALIZER_IMAGES_COUNT = 1;
+	private static final int _WELCOME_SITE_INITIALIZER_IMAGES_COUNT = 5;
 
 	@Inject
 	private AMImageConfigurationHelper _amImageConfigurationHelper;


### PR DESCRIPTION
Integrations tests were failing. The problem is that the number of default images on the Welcome site has been increased recently.

Related issue: https://issues.liferay.com/browse/LPS-173708