### PR TITLE
LPS-173780 Include only page/content available languages in sitemap

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/layout/admin/util/JournalArticleSitemapURLProvider.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/layout/admin/util/JournalArticleSitemapURLProvider.java
@@ -41,6 +41,7 @@ import com.liferay.portal.kernel.portlet.constants.FriendlyURLResolverConstants;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.LayoutSetLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
@@ -297,8 +298,9 @@ public class JournalArticleSitemapURLProvider implements SitemapURLProvider {
 			String articleURL = _portal.getCanonicalURL(
 				sb.toString(), themeDisplay, articleLayout);
 
-			Map<Locale, String> alternateURLs = _sitemap.getAlternateURLs(
-				articleURL, themeDisplay, articleLayout);
+			Map<Locale, String> alternateURLs = _portal.getAlternateURLs(
+				articleURL, themeDisplay, articleLayout,
+				_getAvailableLocales(journalArticle));
 
 			for (String alternateURL : alternateURLs.values()) {
 				_sitemap.addURLElement(
@@ -309,6 +311,19 @@ public class JournalArticleSitemapURLProvider implements SitemapURLProvider {
 
 			processedArticleIds.add(journalArticle.getArticleId());
 		}
+	}
+
+	private Set<Locale> _getAvailableLocales(JournalArticle journalArticle) {
+		Set<Locale> availableLocales = new HashSet<>();
+
+		for (String availableLanguageId :
+				journalArticle.getAvailableLanguageIds()) {
+
+			availableLocales.add(
+				LocaleUtil.fromLanguageId(availableLanguageId));
+		}
+
+		return availableLocales;
 	}
 
 	private List<JournalArticle> _getDisplayPageArticles(

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/layout/admin/util/LayoutSitemapURLProvider.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/layout/admin/util/LayoutSitemapURLProvider.java
@@ -26,14 +26,17 @@ import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.LayoutService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.xml.Element;
 import com.liferay.portal.util.LayoutTypeControllerTracker;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -128,14 +131,25 @@ public class LayoutSitemapURLProvider implements SitemapURLProvider {
 			_portal.getLayoutFullURL(layout, themeDisplay), themeDisplay,
 			layout);
 
-		Map<Locale, String> alternateURLs = _sitemap.getAlternateURLs(
-			layoutFullURL, themeDisplay, layout);
+		Map<Locale, String> alternateURLs = _portal.getAlternateURLs(
+			layoutFullURL, themeDisplay, layout, _getAvailableLocales(layout));
 
 		for (String alternateURL : alternateURLs.values()) {
 			_sitemap.addURLElement(
 				element, alternateURL, typeSettingsUnicodeProperties,
 				layout.getModifiedDate(), layoutFullURL, alternateURLs);
 		}
+	}
+
+	private Set<Locale> _getAvailableLocales(Layout layout) {
+		Set<Locale> availableLocales = new HashSet<>();
+
+		for (String availableLanguageId : layout.getAvailableLanguageIds()) {
+			availableLocales.add(
+				LocaleUtil.fromLanguageId(availableLanguageId));
+		}
+
+		return availableLocales;
 	}
 
 	@Reference

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/layout/admin/util/LayoutSitemapURLProvider.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/layout/admin/util/LayoutSitemapURLProvider.java
@@ -124,10 +124,9 @@ public class LayoutSitemapURLProvider implements SitemapURLProvider {
 			return;
 		}
 
-		String layoutFullURL = _portal.getLayoutFullURL(layout, themeDisplay);
-
-		layoutFullURL = _portal.getCanonicalURL(
-			layoutFullURL, themeDisplay, layout);
+		String layoutFullURL = _portal.getCanonicalURL(
+			_portal.getLayoutFullURL(layout, themeDisplay), themeDisplay,
+			layout);
 
 		Map<Locale, String> alternateURLs = _sitemap.getAlternateURLs(
 			layoutFullURL, themeDisplay, layout);

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -1189,7 +1189,7 @@ public class PortalImpl implements Portal {
 			Layout layout)
 		throws PortalException {
 
-		Map<Locale, String> alternateURLs = _getAlternateURLs(
+		Map<Locale, String> alternateURLs = getAlternateURLs(
 			canonicalURL, themeDisplay, layout, Collections.singleton(locale));
 
 		return alternateURLs.get(locale);
@@ -1203,7 +1203,7 @@ public class PortalImpl implements Portal {
 		Set<Locale> availableLocales = LanguageUtil.getAvailableLocales(
 			layout.getGroupId());
 
-		return _getAlternateURLs(
+		return getAlternateURLs(
 			canonicalURL, themeDisplay, layout, availableLocales);
 	}
 
@@ -8101,7 +8101,8 @@ public class PortalImpl implements Portal {
 			explicitlyAddedPortlets, staticPortlets, null);
 	}
 
-	private Map<Locale, String> _getAlternateURLs(
+	@Override
+	public Map<Locale, String> getAlternateURLs(
 			String canonicalURL, ThemeDisplay themeDisplay, Layout layout,
 			Set<Locale> availableLocales)
 		throws PortalException {

--- a/portal-kernel/src/com/liferay/portal/kernel/util/Portal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/Portal.java
@@ -308,6 +308,11 @@ public interface Portal {
 			String canonicalURL, ThemeDisplay themeDisplay, Layout layout)
 		throws PortalException;
 
+	public Map<Locale, String> getAlternateURLs(
+			String canonicalURL, ThemeDisplay themeDisplay, Layout layout,
+			Set<Locale> availableLocales)
+		throws PortalException;
+
 	public long[] getAncestorSiteGroupIds(long groupId);
 
 	/**

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PortalUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PortalUtil.java
@@ -365,6 +365,15 @@ public class PortalUtil {
 		return _portal.getAlternateURLs(canonicalURL, themeDisplay, layout);
 	}
 
+	public static Map<Locale, String> getAlternateURLs(
+			String canonicalURL, ThemeDisplay themeDisplay, Layout layout,
+			Set<Locale> availableLocales)
+		throws PortalException {
+
+		return _portal.getAlternateURLs(
+			canonicalURL, themeDisplay, layout, availableLocales);
+	}
+
 	public static long[] getAncestorSiteGroupIds(long groupId) {
 		return _portal.getAncestorSiteGroupIds(groupId);
 	}


### PR DESCRIPTION
# What is this about?

https://issues.liferay.com/browse/LPS-173780

Make sitemap include urls only for available languages (pages and web content).
# How do I test it?

1. Create a new page.
2. Translate its name to a couple of languages of your choice.
3. Request the sitemap (`/c/portal/sitemap`, then access the right one).

The returned XML should include only the languages with translations.