### PR TITLE
[TS] LPS-173703 External video cannot be added because of file ending restrictions

### DIFF
--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryLocalServiceTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryLocalServiceTest.java
@@ -126,6 +126,44 @@ public class DLFileEntryLocalServiceTest {
 		_group = GroupTestUtil.addGroup();
 	}
 
+	@Test
+	public void testAddExternalVideoWithExtensionValidation() throws Exception {
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId());
+
+		DDMStructure ddmStructure = DDMStructureTestUtil.addStructure(
+			_group.getGroupId(), DLFileEntryMetadata.class.getName());
+
+		DLFileEntryType dlFileEntryType =
+			DLFileEntryTypeLocalServiceUtil.addFileEntryType(
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				RandomTestUtil.randomString(), StringPool.BLANK,
+				new long[] {ddmStructure.getStructureId()}, serviceContext);
+
+		dlFileEntryType.setFileEntryTypeKey("DL_VIDEO_EXTERNAL_SHORTCUT");
+
+		DLFileEntryTypeLocalServiceUtil.updateDLFileEntryType(dlFileEntryType);
+
+		try (ConfigurationTemporarySwapper configurationTemporarySwapper =
+				new ConfigurationTemporarySwapper(
+					DLConfiguration.class.getName(),
+					HashMapDictionaryBuilder.<String, Object>put(
+						"fileExtensions", ".jpg"
+					).build())) {
+
+			DLFileEntryLocalServiceUtil.addFileEntry(
+				null, TestPropsValues.getUserId(), _group.getGroupId(),
+				_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+				RandomTestUtil.randomString(),
+				ContentTypes.APPLICATION_OCTET_STREAM,
+				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+				StringUtil.randomString(), RandomTestUtil.randomString(),
+				dlFileEntryType.getFileEntryTypeId(), null, null,
+				new UnsyncByteArrayInputStream(new byte[0]), 0, null, null,
+				serviceContext);
+		}
+	}
+
 	@Test(expected = FileExtensionException.class)
 	public void testAddFileEntryShouldFailIfSourceFileNameExtensionNotSupported()
 		throws Exception {

--- a/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayRepositoryDefiner.java
+++ b/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayRepositoryDefiner.java
@@ -37,6 +37,8 @@ import com.liferay.portal.kernel.repository.registry.BaseRepositoryDefiner;
 import com.liferay.portal.kernel.repository.registry.CapabilityRegistry;
 import com.liferay.portal.kernel.repository.registry.RepositoryDefiner;
 import com.liferay.portal.kernel.repository.registry.RepositoryFactoryRegistry;
+import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.util.PropsValues;
 
@@ -172,9 +174,13 @@ public class LiferayRepositoryDefiner extends BaseRepositoryDefiner {
 						fileContentReference.getSourceFileName());
 				}
 
-				if ((fileContentReference.getFileEntryId() == 0) ||
-					Validator.isNotNull(
-						fileContentReference.getSourceFileName())) {
+				if (((fileContentReference.getFileEntryId() == 0) ||
+					 Validator.isNotNull(
+						 fileContentReference.getSourceFileName())) &&
+					!StringUtil.equals(
+						fileContentReference.getMimeType(),
+						ContentTypes.
+							APPLICATION_VND_LIFERAY_VIDEO_EXTERNAL_SHORTCUT_HTML)) {
 
 					DLValidatorUtil.validateFileExtension(
 						fileContentReference.getSourceFileName());

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -245,7 +245,8 @@ public class DLFileEntryLocalServiceImpl
 			PortalUtil.getCurrentAndAncestorSiteGroupIds(groupId), folderId,
 			fileEntryTypeId);
 
-		_validateFile(groupId, folderId, 0, fileName, extension, title);
+		_validateFile(
+			groupId, folderId, 0, fileEntryTypeId, fileName, extension, title);
 
 		long fileEntryId = counterLocalService.increment();
 
@@ -3314,7 +3315,8 @@ public class DLFileEntryLocalServiceImpl
 
 			_validateFile(
 				dlFileEntry.getGroupId(), dlFileEntry.getFolderId(),
-				dlFileEntry.getFileEntryId(), fileName, extension, title);
+				dlFileEntry.getFileEntryId(), fileEntryTypeId, fileName,
+				extension, title);
 
 			// File version
 
@@ -3460,13 +3462,21 @@ public class DLFileEntryLocalServiceImpl
 	}
 
 	private void _validateFile(
-			long groupId, long folderId, long fileEntryId, String fileName,
-			String extension, String title)
+			long groupId, long folderId, long fileEntryId, long fileEntryTypeId,
+			String fileName, String extension, String title)
 		throws PortalException {
 
 		DLValidatorUtil.validateFileName(fileName);
 
-		_validateFileExtension(fileName, extension);
+		DLFileEntryType dlFileEntryType =
+			_dlFileEntryTypeLocalService.getDLFileEntryType(fileEntryTypeId);
+
+		if (!StringUtil.equals(
+				dlFileEntryType.getFileEntryTypeKey(),
+				"DL_VIDEO_EXTERNAL_SHORTCUT")) {
+
+			_validateFileExtension(fileName, extension);
+		}
 
 		validateFile(groupId, folderId, fileEntryId, fileName, title);
 	}


### PR DESCRIPTION
Dear Team,

Could you please review this pull request?

Motivation
=======
When documents of only certain extensions are allowed, the extension validation will fail on external video shortcuts because those documents do not have an extension.

Proposed Solution
========
Skipping the extension validation for documents whose type is external video shortcut.

Steps to Verify
========
Please consult the linked LPS for reproduction steps.
https://issues.liferay.com/browse/LPS-173703

Thank you and best regards,
István