### PR TITLE
[TS] Adding Friendly URL redirect configuration for locale.prepend.friendly.url.style=2

### DIFF
--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/configuration/helper/FriendlyURLRedirectionConfigurationHelperImpl.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/configuration/helper/FriendlyURLRedirectionConfigurationHelperImpl.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.friendly.url.internal.configuration.helper;
+
+import com.liferay.friendly.url.internal.configuration.FriendlyURLRedirectionConfiguration;
+import com.liferay.friendly.url.internal.configuration.admin.service.FriendlyURLRedirectionManagedServiceFactory;
+import com.liferay.portal.kernel.friendly.url.FriendlyURLRedirectionConfigurationHelper;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Daniel Mijarra
+ */
+@Component(
+	configurationPid = "com.liferay.friendly.url.internal.configuration.FriendlyURLRedirectionConfiguration",
+	service = FriendlyURLRedirectionConfigurationHelper.class
+)
+public class FriendlyURLRedirectionConfigurationHelperImpl
+	implements FriendlyURLRedirectionConfigurationHelper {
+
+	@Override
+	public String redirectionType(long companyId) {
+		FriendlyURLRedirectionConfiguration
+			friendlyURLRedirectionConfiguration =
+				friendlyURLRedirectionManagedServiceFactory.
+					getCompanyFriendlyURLConfiguration(companyId);
+
+		return friendlyURLRedirectionConfiguration.redirectionType();
+	}
+
+	@Reference
+	protected FriendlyURLRedirectionManagedServiceFactory
+		friendlyURLRedirectionManagedServiceFactory;
+
+}

--- a/portal-impl/src/com/liferay/portal/servlet/filters/i18n/I18nFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/i18n/I18nFilter.java
@@ -18,12 +18,14 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.cookies.CookiesManagerUtil;
 import com.liferay.portal.kernel.cookies.constants.CookiesConstants;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.friendly.url.FriendlyURLRedirectionConfigurationHelperUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.servlet.HttpMethods;
 import com.liferay.portal.kernel.util.JavaConstants;
@@ -40,6 +42,7 @@ import com.liferay.portal.util.PropsValues;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.Set;
 
 import javax.servlet.FilterChain;
@@ -381,11 +384,36 @@ public class I18nFilter extends BasePortalFilter {
 			return;
 		}
 
-		if (_log.isDebugEnabled()) {
-			_log.debug("Redirect " + redirect);
+		if (_isPermanentRedirect(CompanyThreadLocal.getCompanyId())) {
+			httpServletResponse.setHeader("Location", redirect);
+			httpServletResponse.setStatus(
+				HttpServletResponse.SC_MOVED_PERMANENTLY);
+
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					HttpServletResponse.SC_MOVED_PERMANENTLY +
+						" Moved Permanently to Location " + redirect);
+			}
+		}
+		else {
+			if (_log.isDebugEnabled()) {
+				_log.debug("Redirect " + redirect);
+			}
+
+			httpServletResponse.sendRedirect(redirect);
+		}
+	}
+
+	private boolean _isPermanentRedirect(long companyId) {
+		if (Objects.equals(
+				FriendlyURLRedirectionConfigurationHelperUtil.redirectionType(
+					companyId),
+				"permanent")) {
+
+			return true;
 		}
 
-		httpServletResponse.sendRedirect(redirect);
+		return false;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(I18nFilter.class);

--- a/portal-kernel/src/com/liferay/portal/kernel/friendly/url/FriendlyURLRedirectionConfigurationHelper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/friendly/url/FriendlyURLRedirectionConfigurationHelper.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.friendly.url;
+
+import org.osgi.annotation.versioning.ProviderType;
+
+/**
+ * @author Daniel Mijarra
+ */
+@ProviderType
+public interface FriendlyURLRedirectionConfigurationHelper {
+
+	public String redirectionType(long companyId);
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/friendly/url/FriendlyURLRedirectionConfigurationHelperUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/friendly/url/FriendlyURLRedirectionConfigurationHelperUtil.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.friendly.url;
+
+import com.liferay.portal.kernel.util.ServiceProxyFactory;
+
+/**
+ * @author Daniel Mijarra
+ */
+public class FriendlyURLRedirectionConfigurationHelperUtil {
+
+	public static String redirectionType(long companyId) {
+		return _friendlyURLRedirectionConfigurationHelper.redirectionType(
+			companyId);
+	}
+
+	private static volatile FriendlyURLRedirectionConfigurationHelper
+		_friendlyURLRedirectionConfigurationHelper =
+			ServiceProxyFactory.newServiceTrackedInstance(
+				FriendlyURLRedirectionConfigurationHelper.class,
+				FriendlyURLRedirectionConfigurationHelperUtil.class,
+				"_friendlyURLRedirectionConfigurationHelper", false);
+
+}


### PR DESCRIPTION
Hello @liferay-lima,
this pull fixes [LPS-173562](https://issues.liferay.com/browse/LPS-173562).

The _Friendly URL Redirection configuration_ functionality now also applies to `locale.prepend.friendly.url.style=2`.
We add a "Helper" in `portal-kernel` to allow `I18nFilter` to read this configuration. 
We use _UploadServletRequestConfigurationHelper_ as an example to do the _FriendlyURLRedirectionConfigurationHelper_.

I agreed with @robertoDiaz that he would do a pre-review.
Could you please assign him this pull then?

