### PR TITLE
[TS] LPS-173867 - add cache control setting to headers of adaptive media files as well

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-web/src/main/java/com/liferay/adaptive/media/web/internal/servlet/AMServlet.java
+++ b/modules/apps/adaptive-media/adaptive-media-web/src/main/java/com/liferay/adaptive/media/web/internal/servlet/AMServlet.java
@@ -84,6 +84,18 @@ public class AMServlet extends HttpServlet {
 			AdaptiveMedia<?> adaptiveMedia = adaptiveMediaOptional.orElseThrow(
 				AMException.AMNotFound::new);
 
+			long fileEntryId = _getFileEntryId(
+				String.valueOf(adaptiveMedia.getURI()));
+
+			if (fileEntryId > 0) {
+				httpServletResponse.addHeader(
+					HttpHeaders.CACHE_CONTROL,
+					FileEntryHttpHeaderCustomizerUtil.getHttpHeaderValue(
+						_dlAppLocalService.getFileEntry(fileEntryId),
+						HttpHeaders.CACHE_CONTROL,
+						HttpHeaders.CACHE_CONTROL_PRIVATE_VALUE));
+			}
+
 			Optional<Long> contentLengthOptional =
 				adaptiveMedia.getValueOptional(
 					AMAttribute.getContentLengthAMAttribute());
@@ -101,19 +113,6 @@ public class AMServlet extends HttpServlet {
 				AMAttribute.getFileNameAMAttribute());
 
 			String fileName = fileNameOptional.orElse(null);
-
-			String uri = String.valueOf(adaptiveMedia.getURI());
-
-			long fileEntryId = _getFileEntryId(uri);
-
-			if (fileEntryId > -1) {
-				httpServletResponse.addHeader(
-					HttpHeaders.CACHE_CONTROL,
-					FileEntryHttpHeaderCustomizerUtil.getHttpHeaderValue(
-						_dlAppLocalService.getFileEntry(fileEntryId),
-						HttpHeaders.CACHE_CONTROL,
-						HttpHeaders.CACHE_CONTROL_PRIVATE_VALUE));
-			}
 
 			boolean download = ParamUtil.getBoolean(
 				httpServletRequest, "download");
@@ -175,7 +174,7 @@ public class AMServlet extends HttpServlet {
 			return Long.valueOf(matcher.group(2));
 		}
 
-		return -1;
+		return 0;
 	}
 
 	private String _getRequestHandlerPattern(


### PR DESCRIPTION
Hi @liferay-lima!

This is building off work done in [LPS-109977](https://issues.liferay.com/browse/LPS-109977) where configuration controls were added for cache-control. Currently this setting works properly for documents but is not applied to the adaptive media version of those documents. This fix adds this to adaptive media versions.

Please let me know if you have any questions or concerns. Thanks!