### PR TITLE
LPS-174156 Test AMImageEntryLocalServiceTest.testGetPercentageMax100 is failing

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-image-test/src/testIntegration/java/com/liferay/adaptive/media/image/service/impl/test/AMImageEntryLocalServiceTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-test/src/testIntegration/java/com/liferay/adaptive/media/image/service/impl/test/AMImageEntryLocalServiceTest.java
@@ -539,8 +539,12 @@ public class AMImageEntryLocalServiceTest {
 			null;
 
 		try {
+			int initialSiteAMImageEntriesCount =
+				AMImageEntryLocalServiceUtil.getExpectedAMImageEntriesCount(
+					company.getCompanyId());
+
 			amImageCounterServiceRegistration = _registerAMImageCounter(
-				"test", -1);
+				"test", -initialSiteAMImageEntriesCount);
 
 			ServiceContext serviceContext =
 				ServiceContextTestUtil.getServiceContext(group.getGroupId());


### PR DESCRIPTION
Changed a constant value to take into account that there are 5 images in default Liferay site instead of 1.