### PR TITLE
[TS] LPS-173703 External video cannot be added because of file ending restrictions

### DIFF
--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryLocalServiceTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryLocalServiceTest.java
@@ -728,6 +728,47 @@ public class DLFileEntryLocalServiceTest {
 	}
 
 	@Test
+	public void testExtensionValidationWithSystemScopedFileEntryType()
+		throws Exception {
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId());
+
+		DDMStructure ddmStructure = DDMStructureTestUtil.addStructure(
+			_group.getGroupId(), DLFileEntryMetadata.class.getName());
+
+		DLFileEntryType dlFileEntryType =
+			DLFileEntryTypeLocalServiceUtil.addFileEntryType(
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				RandomTestUtil.randomString(), StringPool.BLANK,
+				new long[] {ddmStructure.getStructureId()}, serviceContext);
+
+		dlFileEntryType.setScope(
+			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_SCOPE_SYSTEM);
+
+		DLFileEntryTypeLocalServiceUtil.updateDLFileEntryType(dlFileEntryType);
+
+		try (ConfigurationTemporarySwapper configurationTemporarySwapper =
+				new ConfigurationTemporarySwapper(
+					DLConfiguration.class.getName(),
+					HashMapDictionaryBuilder.<String, Object>put(
+						"fileExtensions", ".jpg"
+					).build())) {
+
+			DLFileEntryLocalServiceUtil.addFileEntry(
+				null, TestPropsValues.getUserId(), _group.getGroupId(),
+				_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+				RandomTestUtil.randomString(),
+				ContentTypes.APPLICATION_OCTET_STREAM,
+				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+				StringUtil.randomString(), RandomTestUtil.randomString(),
+				dlFileEntryType.getFileEntryTypeId(), null, null,
+				new UnsyncByteArrayInputStream(new byte[0]), 0, null, null,
+				serviceContext);
+		}
+	}
+
+	@Test
 	public void testFileNameUpdatedWhenUpdatingAFileEntryKeepingFileVersionLabel()
 		throws Exception {
 

--- a/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayRepositoryDefiner.java
+++ b/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayRepositoryDefiner.java
@@ -170,18 +170,15 @@ public class LiferayRepositoryDefiner extends BaseRepositoryDefiner {
 
 					DLValidatorUtil.validateFileName(
 						fileContentReference.getSourceFileName());
-				}
 
-				if ((fileContentReference.getFileEntryId() == 0) ||
-					Validator.isNotNull(
-						fileContentReference.getSourceFileName())) {
+					if (fileContentReference.getFileEntryId() == 0) {
+						DLValidatorUtil.validateFileExtension(
+							fileContentReference.getSourceFileName());
 
-					DLValidatorUtil.validateFileExtension(
-						fileContentReference.getSourceFileName());
-
-					DLValidatorUtil.validateSourceFileExtension(
-						fileContentReference.getExtension(),
-						fileContentReference.getSourceFileName());
+						DLValidatorUtil.validateSourceFileExtension(
+							fileContentReference.getExtension(),
+							fileContentReference.getSourceFileName());
+					}
 				}
 
 				DLValidatorUtil.validateFileSize(


### PR DESCRIPTION
Dear Team,

Could you please review this pull request?

Motivation
=======
When documents of only certain extensions are allowed, the extension validation will fail on external video shortcuts because those documents do not have an extension.

Proposed Solution
========
Skipping the extension validation for documents where an extension is not present in the name, no file is being uploaded, and the document type scope is system.

Steps to Verify
========
Please consult the linked LPS for reproduction steps.
https://issues.liferay.com/browse/LPS-173703

Thank you and best regards,
István