### PR TITLE
LPS-174625 the kbArticles are versioned, so we only want to update status/send message when the latest article is the searched

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
@@ -1789,6 +1789,8 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 				).and(
 					KBArticleTable.INSTANCE.expirationDate.lte(expirationDate)
 				).and(
+					KBArticleTable.INSTANCE.latest.eq(Boolean.TRUE)
+				).and(
 					KBArticleTable.INSTANCE.status.neq(
 						WorkflowConstants.STATUS_EXPIRED)
 				)
@@ -1806,6 +1808,8 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 			).where(
 				KBArticleTable.INSTANCE.companyId.eq(
 					companyId
+				).and(
+					KBArticleTable.INSTANCE.latest.eq(Boolean.TRUE)
 				).and(
 					KBArticleTable.INSTANCE.reviewDate.gt(reviewDateGT)
 				).and(


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-174625

**Steps to Reproduce:**

1. Enable FF
2. Add a new KB article
3. Set the expiration date in two minutes(for quick checking the test result) and publish it
4. Edit the article to set the expiration date as one week later
5. Wait 1 or 2 mins, and assert the KB article shows "Expires Soon", it is correct.
6. Wait another 1 mins


The problem was that was expiring the first version of the kbarticle