### PR TITLE
LPS-117012 Don't assume task submitter has owner view permissions

### DIFF
--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/security/permission/resource/DLFileEntryModelResourcePermissionWrapper.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/security/permission/resource/DLFileEntryModelResourcePermissionWrapper.java
@@ -218,18 +218,10 @@ public class DLFileEntryModelResourcePermissionWrapper
 					fileVersion.getFileVersionId(), actionId);
 
 				if (hasPermission != null) {
-					return hasPermission.booleanValue();
+					return hasPermission;
 				}
 
-				boolean hasOwnerPermission =
-					permissionChecker.hasOwnerPermission(
-						dlFileEntry.getCompanyId(), name,
-						dlFileEntry.getFileEntryId(), dlFileEntry.getUserId(),
-						actionId);
-
-				if (!hasOwnerPermission) {
-					return false;
-				}
+				return false;
 			}
 
 			return null;

--- a/portal-impl/src/com/liferay/portal/workflow/permission/WorkflowPermissionImpl.java
+++ b/portal-impl/src/com/liferay/portal/workflow/permission/WorkflowPermissionImpl.java
@@ -26,6 +26,8 @@ import com.liferay.portal.kernel.workflow.WorkflowInstanceManagerUtil;
 import com.liferay.portal.kernel.workflow.WorkflowTaskManagerUtil;
 import com.liferay.portal.kernel.workflow.permission.WorkflowPermission;
 
+import java.util.Objects;
+
 /**
  * @author Jorge Ferrer
  */
@@ -64,6 +66,13 @@ public class WorkflowPermissionImpl implements WorkflowPermission {
 			WorkflowInstanceLink workflowInstanceLink =
 				WorkflowInstanceLinkLocalServiceUtil.getWorkflowInstanceLink(
 					companyId, groupId, className, classPK);
+
+			if (Objects.equals(actionId, ActionKeys.VIEW) &&
+				(workflowInstanceLink.getUserId() ==
+					permissionChecker.getUserId())) {
+
+				return Boolean.TRUE;
+			}
 
 			WorkflowInstance workflowInstance =
 				WorkflowInstanceManagerUtil.getWorkflowInstance(


### PR DESCRIPTION
# What is this about?

https://issues.liferay.com/browse/LPS-117012

When in workflow, implicitly grant VIEW permissions to the task submitter instead of assuming it will have owner VIEW permissions. Both DM and workflow rely on this assumption.

# How do I test it?

Follow the steps described in https://issues.liferay.com/browse/LPS-117012.