### PR TITLE
LPS-169426 Disambiguate blogs friendly urls

### DIFF
--- a/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/info/item/provider/BlogsEntryInfoItemFriendlyURLProvider.java
+++ b/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/info/item/provider/BlogsEntryInfoItemFriendlyURLProvider.java
@@ -16,10 +16,19 @@ package com.liferay.blogs.web.internal.info.item.provider;
 
 import com.liferay.blogs.model.BlogsEntry;
 import com.liferay.friendly.url.info.item.provider.InfoItemFriendlyURLProvider;
+import com.liferay.friendly.url.model.FriendlyURLEntry;
 import com.liferay.friendly.url.model.FriendlyURLEntryLocalization;
 import com.liferay.friendly.url.service.FriendlyURLEntryLocalService;
 import com.liferay.friendly.url.util.comparator.FriendlyURLEntryLocalizationComparator;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.GroupThreadLocal;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 
@@ -40,7 +49,25 @@ public class BlogsEntryInfoItemFriendlyURLProvider
 
 	@Override
 	public String getFriendlyURL(BlogsEntry blogsEntry, String languageId) {
-		return blogsEntry.getUrlTitle();
+		FriendlyURLEntry mainFriendlyURLEntry =
+			_friendlyURLEntryLocalService.fetchMainFriendlyURLEntry(
+				_portal.getClassNameId(BlogsEntry.class),
+				blogsEntry.getEntryId());
+
+		if (mainFriendlyURLEntry == null) {
+			return blogsEntry.getUrlTitle();
+		}
+
+		long groupId = _getGroupId();
+
+		if ((groupId != GroupConstants.DEFAULT_LIVE_GROUP_ID) &&
+			(groupId != mainFriendlyURLEntry.getGroupId())) {
+
+			return _getGroupFriendlyURL(
+				blogsEntry.getEntryId(), mainFriendlyURLEntry);
+		}
+
+		return mainFriendlyURLEntry.getUrlTitle();
 	}
 
 	@Override
@@ -55,12 +82,54 @@ public class BlogsEntryInfoItemFriendlyURLProvider
 			_friendlyURLEntryLocalizationComparator);
 	}
 
+	private String _getGroupFriendlyURL(
+		long entryId, FriendlyURLEntry friendlyURLEntry) {
+
+		Group group = _groupLocalService.fetchGroup(
+			friendlyURLEntry.getGroupId());
+
+		if (group == null) {
+			return String.valueOf(entryId);
+		}
+
+		String groupFriendlyURL = group.getFriendlyURL();
+
+		return groupFriendlyURL.replaceFirst(StringPool.SLASH, "") +
+			StringPool.SLASH + friendlyURLEntry.getUrlTitle();
+	}
+
+	private long _getGroupId() {
+		ServiceContext serviceContext =
+			ServiceContextThreadLocal.getServiceContext();
+
+		if (serviceContext == null) {
+			return GroupThreadLocal.getGroupId();
+		}
+
+		if (serviceContext.getThemeDisplay() == null) {
+			return serviceContext.getScopeGroupId();
+		}
+
+		ThemeDisplay themeDisplay = serviceContext.getThemeDisplay();
+
+		if (themeDisplay.getSiteGroupId() !=
+				GroupConstants.DEFAULT_LIVE_GROUP_ID) {
+
+			return themeDisplay.getSiteGroupId();
+		}
+
+		return themeDisplay.getScopeGroupId();
+	}
+
 	private final FriendlyURLEntryLocalizationComparator
 		_friendlyURLEntryLocalizationComparator =
 			new FriendlyURLEntryLocalizationComparator();
 
 	@Reference
 	private FriendlyURLEntryLocalService _friendlyURLEntryLocalService;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/layout/display/page/BlogsLayoutDisplayPageObjectProvider.java
+++ b/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/layout/display/page/BlogsLayoutDisplayPageObjectProvider.java
@@ -16,8 +16,10 @@ package com.liferay.blogs.web.internal.layout.display.page;
 
 import com.liferay.asset.util.AssetHelper;
 import com.liferay.blogs.model.BlogsEntry;
+import com.liferay.friendly.url.info.item.provider.InfoItemFriendlyURLProvider;
 import com.liferay.layout.display.page.LayoutDisplayPageObjectProvider;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.util.PortalUtil;
 
 import java.util.Locale;
@@ -29,11 +31,15 @@ public class BlogsLayoutDisplayPageObjectProvider
 	implements LayoutDisplayPageObjectProvider<BlogsEntry> {
 
 	public BlogsLayoutDisplayPageObjectProvider(
-			BlogsEntry blogsEntry, AssetHelper assetHelper)
+			AssetHelper assetHelper, BlogsEntry blogsEntry,
+			InfoItemFriendlyURLProvider<BlogsEntry> infoItemFriendlyURLProvider,
+			Language language)
 		throws PortalException {
 
-		_blogsEntry = blogsEntry;
 		_assetHelper = assetHelper;
+		_blogsEntry = blogsEntry;
+		_infoItemFriendlyURLProvider = infoItemFriendlyURLProvider;
+		_language = language;
 	}
 
 	@Override
@@ -84,10 +90,14 @@ public class BlogsLayoutDisplayPageObjectProvider
 
 	@Override
 	public String getURLTitle(Locale locale) {
-		return _blogsEntry.getUrlTitle();
+		return _infoItemFriendlyURLProvider.getFriendlyURL(
+			_blogsEntry, _language.getLanguageId(locale));
 	}
 
 	private final AssetHelper _assetHelper;
 	private final BlogsEntry _blogsEntry;
+	private final InfoItemFriendlyURLProvider<BlogsEntry>
+		_infoItemFriendlyURLProvider;
+	private final Language _language;
 
 }


### PR DESCRIPTION
# What is this about?

https://issues.liferay.com/browse/LPS-169426

It is possible for blog entries of different groups to have the same friendly URLs (relative to that site).  When referencing global or depot content from a site, it is necessary to disambiguate these friendly urls so that global/depot content can be resolved.

As is already done for Documents, prepend the group name to the url title when a conflict arises.

# How do I test it?

Follow the steps described in https://issues.liferay.com/browse/LPS-169426.