### PR TITLE
LPS-174744 Item selector URL should receive the current selected item

### DIFF
--- a/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/display/context/DLItemSelectorViewDisplayContext.java
+++ b/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/display/context/DLItemSelectorViewDisplayContext.java
@@ -143,7 +143,7 @@ public class DLItemSelectorViewDisplayContext<T extends ItemSelectorCriterion> {
 
 	public long getFolderId() throws PortalException {
 		if (_folderId == null) {
-			_folderId = _getFolderIdFromRequestParameters(_httpServletRequest);
+			_folderId = _getFolderId(_httpServletRequest);
 		}
 
 		return _folderId;
@@ -377,8 +377,7 @@ public class DLItemSelectorViewDisplayContext<T extends ItemSelectorCriterion> {
 			infoItemItemSelectorCriterion.getItemSubtype());
 	}
 
-	private long _getFolderIdFromRequestParameters(
-			HttpServletRequest httpServletRequest)
+	private long _getFolderId(HttpServletRequest httpServletRequest)
 		throws PortalException {
 
 		if (httpServletRequest.getParameter("folderId") != null) {

--- a/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/display/context/DLItemSelectorViewDisplayContext.java
+++ b/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/display/context/DLItemSelectorViewDisplayContext.java
@@ -125,7 +125,8 @@ public class DLItemSelectorViewDisplayContext<T extends ItemSelectorCriterion> {
 	}
 
 	public PortletURL getEditImageURL(
-		LiferayPortletResponse liferayPortletResponse) {
+			LiferayPortletResponse liferayPortletResponse)
+		throws PortalException {
 
 		return PortletURLBuilder.createActionURL(
 			liferayPortletResponse, PortletKeys.DOCUMENT_LIBRARY
@@ -158,7 +159,7 @@ public class DLItemSelectorViewDisplayContext<T extends ItemSelectorCriterion> {
 
 	public PortletURL getPortletURL(
 			LiferayPortletResponse liferayPortletResponse)
-		throws PortletException {
+		throws PortalException, PortletException {
 
 		return PortletURLBuilder.create(
 			PortletURLUtil.clone(_portletURL, liferayPortletResponse)
@@ -368,14 +369,27 @@ public class DLItemSelectorViewDisplayContext<T extends ItemSelectorCriterion> {
 			infoItemItemSelectorCriterion.getItemSubtype());
 	}
 
-	private long _getFolderId() {
+	private long _getFolderId() throws PortalException {
 		if (_folderId != null) {
 			return _folderId;
 		}
 
+		_folderId = DLFolderConstants.DEFAULT_PARENT_FOLDER_ID;
+
+		long selectedFileEntryId = ParamUtil.getLong(
+			PortalUtil.getOriginalServletRequest(_httpServletRequest),
+			"_com_liferay_journal_web_portlet_JournalPortlet_" +
+				"selectedFileEntryId");
+
+		if (selectedFileEntryId != 0) {
+			FileEntry fileEntry = DLAppServiceUtil.getFileEntry(
+				selectedFileEntryId);
+
+			_folderId = fileEntry.getFolderId();
+		}
+
 		_folderId = ParamUtil.getLong(
-			_httpServletRequest, "folderId",
-			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID);
+			_httpServletRequest, "folderId", _folderId);
 
 		return _folderId;
 	}

--- a/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/display/context/DLItemSelectorViewDisplayContext.java
+++ b/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/display/context/DLItemSelectorViewDisplayContext.java
@@ -389,7 +389,7 @@ public class DLItemSelectorViewDisplayContext<T extends ItemSelectorCriterion> {
 
 		long selectedFileEntryId = ParamUtil.getLong(
 			PortalUtil.getOriginalServletRequest(httpServletRequest),
-			"selectedFileEntryId");
+			"selectedItemIds");
 
 		if (selectedFileEntryId != 0) {
 			FileEntry fileEntry = DLAppServiceUtil.getFileEntry(

--- a/modules/apps/document-library/document-library-item-selector-web/src/main/resources/META-INF/resources/documents.jsp
+++ b/modules/apps/document-library/document-library-item-selector-web/src/main/resources/META-INF/resources/documents.jsp
@@ -25,6 +25,7 @@ DLItemSelectorViewDisplayContext dlItemSelectorViewDisplayContext = (DLItemSelec
 	editImageURL="<%= dlItemSelectorViewDisplayContext.getEditImageURL(liferayPortletResponse) %>"
 	emptyResultsMessage='<%= LanguageUtil.get(request, "there-are-no-documents-or-media-files-in-this-folder") %>'
 	extensions="<%= ListUtil.fromArray(dlItemSelectorViewDisplayContext.getExtensions()) %>"
+	folderId="<%= dlItemSelectorViewDisplayContext.getFolderId() %>"
 	itemSelectedEventName="<%= dlItemSelectorViewDisplayContext.getItemSelectedEventName() %>"
 	itemSelectorReturnTypeResolver="<%= dlItemSelectorViewDisplayContext.getItemSelectorReturnTypeResolver() %>"
 	maxFileSize="<%= DLValidatorUtil.getMaxAllowableSize(themeDisplay.getScopeGroupId(), null) %>"

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/ImagePicker/ImagePicker.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/ImagePicker/ImagePicker.es.js
@@ -97,6 +97,15 @@ const ImagePicker = ({
 
 		onFocus(event);
 
+		let url = itemSelectorURL;
+
+		if (Liferay.FeatureFlags['LPS-153332']) {
+			url = addParams(
+				`selectedFileEntryId=${selectedImageId}`,
+				itemSelectorURL
+			);
+		}
+
 		openSelectionModal({
 			onClose: () => onBlur(event),
 			onSelect: handleFieldChanged,
@@ -105,10 +114,7 @@ const ImagePicker = ({
 				Liferay.Language.get('select-x'),
 				Liferay.Language.get('image')
 			),
-			url: addParams(
-				`selectedFileEntryId=${selectedImageId}`,
-				itemSelectorURL
-			),
+			url,
 		});
 	};
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/ImagePicker/ImagePicker.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/ImagePicker/ImagePicker.es.js
@@ -101,7 +101,7 @@ const ImagePicker = ({
 
 		if (Liferay.FeatureFlags['LPS-153332']) {
 			url = addParams(
-				`selectedFileEntryId=${selectedImageId}`,
+				`selectedItemIds=${selectedImageId}`,
 				itemSelectorURL
 			);
 		}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/ImagePicker/ImagePicker.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/ImagePicker/ImagePicker.es.js
@@ -15,7 +15,7 @@
 import ClayButton from '@clayui/button';
 import ClayForm, {ClayInput} from '@clayui/form';
 import ClayModal, {useModal} from '@clayui/modal';
-import {openSelectionModal, sub} from 'frontend-js-web';
+import {addParams, openSelectionModal, sub} from 'frontend-js-web';
 import React, {useState} from 'react';
 
 import {FieldBase} from '../FieldBase/ReactFieldBase.es';
@@ -45,6 +45,10 @@ const ImagePicker = ({
 		onClose: () => setModalVisible(false),
 	});
 
+	const [selectedImageId, setSelectedImageId] = useState(
+		inputValue?.fileEntryId
+	);
+
 	const dispatchValue = ({clear, value}, callback = () => {}) =>
 		setImageValues((oldValues) => {
 			let mergedValues = {...oldValues, ...value};
@@ -60,6 +64,8 @@ const ImagePicker = ({
 		if (selectedItem?.value) {
 			const selectedImage = new Image();
 			const selectedItemValue = JSON.parse(selectedItem.value);
+
+			setSelectedImageId(selectedItemValue.fileEntryId);
 
 			selectedImage.addEventListener('load', (event) => {
 				const {
@@ -99,7 +105,10 @@ const ImagePicker = ({
 				Liferay.Language.get('select-x'),
 				Liferay.Language.get('image')
 			),
-			url: itemSelectorURL,
+			url: addParams(
+				`selectedFileEntryId=${selectedImageId}`,
+				itemSelectorURL
+			),
 		});
 	};
 


### PR DESCRIPTION
@marcogalluzzi please let me know if this approach would work for you. 

This is working for the case described in https://issues.liferay.com/browse/LPS-153332 


This is the simplest way I have found to send to back the selected item. It does not imply to change any API (nor other teams to approve changes), but we should send this param whereever we want to open the folder where the last item was selected.