### PR TITLE
LPS-175152 Accept a leading slash in redirection patterns

### DIFF
--- a/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/internal/util/PatternUtil.java
+++ b/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/internal/util/PatternUtil.java
@@ -45,7 +45,11 @@ public class PatternUtil {
 
 	private static String _normalize(String patternString) {
 		if (patternString.startsWith(StringPool.CARET)) {
-			return patternString;
+			patternString = patternString.substring(1);
+		}
+
+		if (patternString.startsWith(StringPool.SLASH)) {
+			patternString = patternString.substring(1);
 		}
 
 		return StringPool.CARET + patternString;

--- a/modules/apps/redirect/redirect-service/src/test/java/com/liferay/redirect/internal/util/PatternUtilTest.java
+++ b/modules/apps/redirect/redirect-service/src/test/java/com/liferay/redirect/internal/util/PatternUtilTest.java
@@ -43,7 +43,7 @@ public class PatternUtilTest {
 		Map<Pattern, String> patternStrings = PatternUtil.parse(
 			new String[] {"^xyz abc"});
 
-		Assert.assertEquals("^xyz", _getFistPatternString(patternStrings));
+		Assert.assertEquals("^xyz", _getFirstPatternString(patternStrings));
 		Assert.assertEquals(
 			patternStrings.toString(), 1, patternStrings.size());
 	}
@@ -63,7 +63,7 @@ public class PatternUtilTest {
 		Map<Pattern, String> patternStrings = PatternUtil.parse(
 			new String[] {"^/xyz abc"});
 
-		Assert.assertEquals("^xyz", _getFistPatternString(patternStrings));
+		Assert.assertEquals("^xyz", _getFirstPatternString(patternStrings));
 		Assert.assertEquals(
 			patternStrings.toString(), 1, patternStrings.size());
 	}
@@ -93,7 +93,7 @@ public class PatternUtilTest {
 		Map<Pattern, String> patternStrings = PatternUtil.parse(
 			new String[] {"/xyz abc"});
 
-		Assert.assertEquals("^xyz", _getFistPatternString(patternStrings));
+		Assert.assertEquals("^xyz", _getFirstPatternString(patternStrings));
 		Assert.assertEquals(
 			patternStrings.toString(), 1, patternStrings.size());
 	}
@@ -103,12 +103,12 @@ public class PatternUtilTest {
 		Map<Pattern, String> patternStrings = PatternUtil.parse(
 			new String[] {"xyz abc"});
 
-		Assert.assertEquals("^xyz", _getFistPatternString(patternStrings));
+		Assert.assertEquals("^xyz", _getFirstPatternString(patternStrings));
 		Assert.assertEquals(
 			patternStrings.toString(), 1, patternStrings.size());
 	}
 
-	private String _getFistPatternString(Map<Pattern, String> patternStrings) {
+	private String _getFirstPatternString(Map<Pattern, String> patternStrings) {
 		Set<Map.Entry<Pattern, String>> entries = patternStrings.entrySet();
 
 		Iterator<Map.Entry<Pattern, String>> iterator = entries.iterator();

--- a/modules/apps/redirect/redirect-service/src/test/java/com/liferay/redirect/internal/util/PatternUtilTest.java
+++ b/modules/apps/redirect/redirect-service/src/test/java/com/liferay/redirect/internal/util/PatternUtilTest.java
@@ -49,6 +49,26 @@ public class PatternUtilTest {
 	}
 
 	@Test
+	public void testCaretPattern() {
+		Map<Pattern, String> patternStrings = PatternUtil.parse(
+			new String[] {"^xyz abc"});
+
+		Assert.assertEquals("^xyz", _getFirstPatternString(patternStrings));
+		Assert.assertEquals(
+			patternStrings.toString(), 1, patternStrings.size());
+	}
+
+	@Test
+	public void testCaretSlashPattern() {
+		Map<Pattern, String> patternStrings = PatternUtil.parse(
+			new String[] {"^/xyz abc"});
+
+		Assert.assertEquals("^xyz", _getFistPatternString(patternStrings));
+		Assert.assertEquals(
+			patternStrings.toString(), 1, patternStrings.size());
+	}
+
+	@Test
 	public void testEmptyPatternOrEmptyReplacement() {
 		Assert.assertTrue(
 			MapUtil.isEmpty(PatternUtil.parse(new String[] {" xyz"})));
@@ -66,6 +86,16 @@ public class PatternUtilTest {
 	@Test(expected = PatternSyntaxException.class)
 	public void testInvalidRegexPattern() {
 		PatternUtil.parse(new String[] {"*** a"});
+	}
+
+	@Test
+	public void testSlashPattern() {
+		Map<Pattern, String> patternStrings = PatternUtil.parse(
+			new String[] {"/xyz abc"});
+
+		Assert.assertEquals("^xyz", _getFistPatternString(patternStrings));
+		Assert.assertEquals(
+			patternStrings.toString(), 1, patternStrings.size());
 	}
 
 	@Test


### PR DESCRIPTION
# What is this about?

https://issues.liferay.com/browse/LPS-175152

Redirection patterns will not match with a leading slash, but replacement patterns must begin with one.  Ignore the first leading slash in the pattern to make matching a bit less confusing.