### PR TITLE
LPS-174415 if the file will be downloaded add cache header to do not cache it

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-web/src/main/java/com/liferay/adaptive/media/web/internal/servlet/AMServlet.java
+++ b/modules/apps/adaptive-media/adaptive-media-web/src/main/java/com/liferay/adaptive/media/web/internal/servlet/AMServlet.java
@@ -85,16 +85,26 @@ public class AMServlet extends HttpServlet {
 				throw new AMException.AMNotFound();
 			}
 
+			boolean download = ParamUtil.getBoolean(
+				httpServletRequest, "download");
+
 			long fileEntryId = _getFileEntryId(
 				String.valueOf(adaptiveMedia.getURI()));
 
 			if (fileEntryId > 0) {
+				String cacheControlValue =
+					HttpHeaders.CACHE_CONTROL_PRIVATE_VALUE;
+
+				if (download) {
+					cacheControlValue =
+						HttpHeaders.CACHE_CONTROL_NO_CACHE_VALUE;
+				}
+
 				httpServletResponse.addHeader(
 					HttpHeaders.CACHE_CONTROL,
 					FileEntryHttpHeaderCustomizerUtil.getHttpHeaderValue(
 						_dlAppLocalService.getFileEntry(fileEntryId),
-						HttpHeaders.CACHE_CONTROL,
-						HttpHeaders.CACHE_CONTROL_PRIVATE_VALUE));
+						HttpHeaders.CACHE_CONTROL, cacheControlValue));
 			}
 
 			Optional<Long> contentLengthOptional =
@@ -114,9 +124,6 @@ public class AMServlet extends HttpServlet {
 				AMAttribute.getFileNameAMAttribute());
 
 			String fileName = fileNameOptional.orElse(null);
-
-			boolean download = ParamUtil.getBoolean(
-				httpServletRequest, "download");
 
 			if (download) {
 				ServletResponseUtil.sendFile(

--- a/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
+++ b/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
@@ -1176,11 +1176,18 @@ public class WebServerServlet extends HttpServlet {
 
 		// Send file
 
+		String cacheControlValue = HttpHeaders.CACHE_CONTROL_PRIVATE_VALUE;
+
+		boolean download = ParamUtil.getBoolean(httpServletRequest, "download");
+
+		if (download) {
+			cacheControlValue = HttpHeaders.CACHE_CONTROL_NO_CACHE_VALUE;
+		}
+
 		httpServletResponse.addHeader(
 			HttpHeaders.CACHE_CONTROL,
 			FileEntryHttpHeaderCustomizerUtil.getHttpHeaderValue(
-				fileEntry, HttpHeaders.CACHE_CONTROL,
-				HttpHeaders.CACHE_CONTROL_PRIVATE_VALUE));
+				fileEntry, HttpHeaders.CACHE_CONTROL, cacheControlValue));
 
 		if (isSupportsRangeHeader(contentType)) {
 			ServletResponseUtil.sendFileWithRangeHeader(
@@ -1188,9 +1195,6 @@ public class WebServerServlet extends HttpServlet {
 				contentLength, contentType);
 		}
 		else {
-			boolean download = ParamUtil.getBoolean(
-				httpServletRequest, "download");
-
 			if (download) {
 				ServletResponseUtil.sendFile(
 					httpServletRequest, httpServletResponse, fileName,


### PR DESCRIPTION
I added the value CACHE_CONTROL_NO_CACHE_VALUE ("private, no-cache, no-store, must-revalidate") to the downloaded file because seems reasonable

<img width="1068" alt="image" src="https://user-images.githubusercontent.com/47524751/217845510-eee9606b-c9a8-4396-a5ea-424e512893be.png">


https://issues.liferay.com/browse/LPS-174415

**Step to reproduce:**

1. Go to DM 
2. Create a document _without guest permissions_
3. View this document
4. Click the info icon to expand the info panel
5. Open the browser's developers tools and go to the Network tab
6. Click the Download button
7. Check the response headers


