### PR TITLE
LPS-175352 check if the widget has the show description enabled for the children articles too

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/kb_article_child.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/kb_article_child.jsp
@@ -30,6 +30,8 @@ if (portletTitleBasedNavigation) {
 List<KBArticle> childKBArticles = KBArticleServiceUtil.getKBArticles(scopeGroupId, kbArticle.getResourcePrimKey(), status, QueryUtil.ALL_POS, QueryUtil.ALL_POS, new KBArticlePriorityComparator(true));
 
 KBArticleURLHelper kbArticleURLHelper = new KBArticleURLHelper(renderRequest, renderResponse);
+
+ViewKBArticleDisplayContext viewKBArticleDisplayContext = new ViewKBArticleDisplayContext(liferayPortletRequest, liferayPortletResponse);
 %>
 
 <c:if test="<%= !portletTitleBasedNavigation %>">
@@ -66,7 +68,7 @@ KBArticleURLHelper kbArticleURLHelper = new KBArticleURLHelper(renderRequest, re
 					<span class="text-truncate-inline">
 						<span class="text-truncate">
 							<c:choose>
-								<c:when test="<%= Validator.isNotNull(childrenKBArticle.getDescription()) %>">
+								<c:when test="<%= viewKBArticleDisplayContext.isKBArticleDescriptionEnabled() && Validator.isNotNull(childrenKBArticle.getDescription()) %>">
 									<%= HtmlUtil.escape(childrenKBArticle.getDescription()) %>
 								</c:when>
 								<c:otherwise>


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-175352

**Steps to reproduce:**

1. Add a KB article with a description
2. Add a child article with a description
3. Navigate to site page
4. Add the KB display or KB article widget
5. View the child article in the child articles container under the parent article
 

**Expected result:**
Only the child article title appears because KB descriptions are disabled by default

https://user-images.githubusercontent.com/47524751/218426577-1c99b47d-c972-4888-bd74-43a66619c0c5.mp4

