### PR TITLE
LPS-175999 Adds support for DLFileEntryTypeKey as itemSubtype

### DIFF
--- a/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/BaseDLItemSelectorView.java
+++ b/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/BaseDLItemSelectorView.java
@@ -18,6 +18,7 @@ import com.liferay.asset.kernel.service.AssetVocabularyService;
 import com.liferay.document.library.constants.DLPortletKeys;
 import com.liferay.document.library.item.selector.web.internal.constants.DLItemSelectorWebKeys;
 import com.liferay.document.library.item.selector.web.internal.display.context.DLItemSelectorViewDisplayContext;
+import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalService;
 import com.liferay.item.selector.ItemSelectorCriterion;
 import com.liferay.item.selector.ItemSelectorReturnTypeResolverHandler;
 import com.liferay.portal.kernel.repository.model.Folder;
@@ -90,7 +91,8 @@ public abstract class BaseDLItemSelectorView<T extends ItemSelectorCriterion>
 
 		DLItemSelectorViewDisplayContext dlItemSelectorViewDisplayContext =
 			new DLItemSelectorViewDisplayContext<>(
-				assetVocabularyService, classNameLocalService, this,
+				assetVocabularyService, classNameLocalService,
+				dlFileEntryTypeLocalService, this,
 				folderModelResourcePermission,
 				(HttpServletRequest)servletRequest, t, itemSelectedEventName,
 				itemSelectorReturnTypeResolverHandler, portletURL, search,
@@ -115,6 +117,9 @@ public abstract class BaseDLItemSelectorView<T extends ItemSelectorCriterion>
 
 	@Reference
 	protected ClassNameLocalService classNameLocalService;
+
+	@Reference
+	protected DLFileEntryTypeLocalService dlFileEntryTypeLocalService;
 
 	@Reference(
 		target = "(model.class.name=com.liferay.portal.kernel.repository.model.Folder)"

--- a/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/display/context/DLItemSelectorViewDisplayContext.java
+++ b/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/display/context/DLItemSelectorViewDisplayContext.java
@@ -395,14 +395,14 @@ public class DLItemSelectorViewDisplayContext<T extends ItemSelectorCriterion> {
 		return fileEntryTypeId;
 	}
 
-	private long _getFileEntryTypeId(String itemSubtype) {
+	private long _getFileEntryTypeId(String fileEntryTypeKey) {
 		DLFileEntryType dlFileEntryType =
 			_dlFileEntryTypeLocalService.fetchFileEntryType(
-				_themeDisplay.getScopeGroupId(), itemSubtype);
+				_themeDisplay.getScopeGroupId(), fileEntryTypeKey);
 
 		if (dlFileEntryType == null) {
 			dlFileEntryType = _dlFileEntryTypeLocalService.fetchFileEntryType(
-				_themeDisplay.getCompanyGroupId(), itemSubtype);
+				_themeDisplay.getCompanyGroupId(), fileEntryTypeKey);
 		}
 
 		if (dlFileEntryType != null) {

--- a/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/display/context/DLItemSelectorViewDisplayContext.java
+++ b/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/display/context/DLItemSelectorViewDisplayContext.java
@@ -377,22 +377,15 @@ public class DLItemSelectorViewDisplayContext<T extends ItemSelectorCriterion> {
 		InfoItemItemSelectorCriterion infoItemItemSelectorCriterion =
 			(InfoItemItemSelectorCriterion)_itemSelectorCriterion;
 
-		Long fileEntryTypeId = GetterUtil.getLong(
-			infoItemItemSelectorCriterion.getItemSubtype(), -1);
+		Long fileEntryTypeId = _getFileEntryTypeId(
+			infoItemItemSelectorCriterion.getItemSubtype());
 
-		DLFileEntryType dlFileEntryType = null;
-
-		if (fileEntryTypeId >= 0) {
-			dlFileEntryType = _dlFileEntryTypeLocalService.fetchFileEntryType(
-				fileEntryTypeId);
+		if (fileEntryTypeId != null) {
+			return fileEntryTypeId;
 		}
 
-		if (dlFileEntryType == null) {
-			fileEntryTypeId = _getFileEntryTypeId(
-				infoItemItemSelectorCriterion.getItemSubtype());
-		}
-
-		return fileEntryTypeId;
+		return GetterUtil.getLong(
+			infoItemItemSelectorCriterion.getItemSubtype());
 	}
 
 	private Long _getFileEntryTypeId(String fileEntryTypeKey) {

--- a/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/display/context/DLItemSelectorViewDisplayContext.java
+++ b/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/display/context/DLItemSelectorViewDisplayContext.java
@@ -377,7 +377,7 @@ public class DLItemSelectorViewDisplayContext<T extends ItemSelectorCriterion> {
 		InfoItemItemSelectorCriterion infoItemItemSelectorCriterion =
 			(InfoItemItemSelectorCriterion)_itemSelectorCriterion;
 
-		long fileEntryTypeId = GetterUtil.getLong(
+		Long fileEntryTypeId = GetterUtil.getLong(
 			infoItemItemSelectorCriterion.getItemSubtype(), -1);
 
 		DLFileEntryType dlFileEntryType = null;
@@ -395,7 +395,7 @@ public class DLItemSelectorViewDisplayContext<T extends ItemSelectorCriterion> {
 		return fileEntryTypeId;
 	}
 
-	private long _getFileEntryTypeId(String fileEntryTypeKey) {
+	private Long _getFileEntryTypeId(String fileEntryTypeKey) {
 		DLFileEntryType dlFileEntryType =
 			_dlFileEntryTypeLocalService.fetchFileEntryType(
 				_themeDisplay.getScopeGroupId(), fileEntryTypeKey);
@@ -409,7 +409,7 @@ public class DLItemSelectorViewDisplayContext<T extends ItemSelectorCriterion> {
 			return dlFileEntryType.getFileEntryTypeId();
 		}
 
-		return 0;
+		return null;
 	}
 
 	private long _getFolderId(HttpServletRequest httpServletRequest)


### PR DESCRIPTION
Motivation
-----
Currently, when configuring an item selector for a fragment, we allow to specify for web contents the subtype by DDMStructure key. In the case of File Entries, the subtype is specified by fileEntryType Id.

The goal of the task is to allow also the fileEntryType key for File Entries, without removing the current behavior (so as not to break clients code).

The user will be able to specify either the fileEntryType key or the fileEntryType id in itemSubtype.

Proposed Solution
-----
Modify the logic under DLItemSelectorViewDisplayContext#_getFileEntryTypeId to take into account that the itemSubtype can be fileEntryType key or fileEntryType id.

Steps to verify
-----

1. Creates a new fragment
2. Adds something in the html like
```
<p>New Document Selector Fragment</p>
```
3. And add the following configuration
```
{
	"fieldSets": [
		{
			"fields": [
				{
		"label": "embed-asset",
		"name": "embedAsset",
		"type": "itemSelector",
		"typeOptions": {
			"itemType": "com.liferay.portal.kernel.repository.model.FileEntry",
			"itemSubtype": "DL_VIDEO_EXTERNAL_SHORTCUT"
		}		
				}
			]
		}
	]
}
```
4. Add the fragment to a content page
5. Try to configure the fragment

Expected result:
When you try to select document you should only see documents of type DL_VIDEO_EXTERNAL_SHORTCUT