### PR TITLE
LPS-175163 item selector other cases

### DIFF
--- a/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/display/context/DLItemSelectorViewDisplayContext.java
+++ b/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/display/context/DLItemSelectorViewDisplayContext.java
@@ -143,7 +143,7 @@ public class DLItemSelectorViewDisplayContext<T extends ItemSelectorCriterion> {
 
 	public long getFolderId() throws PortalException {
 		if (_folderId == null) {
-			_folderId = _getFolderIdFromRequestParameters(_httpServletRequest);
+			_folderId = _getFolderId(_httpServletRequest);
 		}
 
 		return _folderId;
@@ -377,8 +377,7 @@ public class DLItemSelectorViewDisplayContext<T extends ItemSelectorCriterion> {
 			infoItemItemSelectorCriterion.getItemSubtype());
 	}
 
-	private long _getFolderIdFromRequestParameters(
-			HttpServletRequest httpServletRequest)
+	private long _getFolderId(HttpServletRequest httpServletRequest)
 		throws PortalException {
 
 		if (httpServletRequest.getParameter("folderId") != null) {

--- a/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/display/context/DLItemSelectorViewDisplayContext.java
+++ b/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/display/context/DLItemSelectorViewDisplayContext.java
@@ -125,7 +125,8 @@ public class DLItemSelectorViewDisplayContext<T extends ItemSelectorCriterion> {
 	}
 
 	public PortletURL getEditImageURL(
-		LiferayPortletResponse liferayPortletResponse) {
+			LiferayPortletResponse liferayPortletResponse)
+		throws PortalException {
 
 		return PortletURLBuilder.createActionURL(
 			liferayPortletResponse, PortletKeys.DOCUMENT_LIBRARY
@@ -158,7 +159,7 @@ public class DLItemSelectorViewDisplayContext<T extends ItemSelectorCriterion> {
 
 	public PortletURL getPortletURL(
 			LiferayPortletResponse liferayPortletResponse)
-		throws PortletException {
+		throws PortalException, PortletException {
 
 		return PortletURLBuilder.create(
 			PortletURLUtil.clone(_portletURL, liferayPortletResponse)
@@ -368,14 +369,27 @@ public class DLItemSelectorViewDisplayContext<T extends ItemSelectorCriterion> {
 			infoItemItemSelectorCriterion.getItemSubtype());
 	}
 
-	private long _getFolderId() {
+	private long _getFolderId() throws PortalException {
 		if (_folderId != null) {
 			return _folderId;
 		}
 
+		_folderId = DLFolderConstants.DEFAULT_PARENT_FOLDER_ID;
+
+		long selectedFileEntryId = ParamUtil.getLong(
+			PortalUtil.getOriginalServletRequest(_httpServletRequest),
+			"_com_liferay_journal_web_portlet_JournalPortlet_" +
+				"selectedFileEntryId");
+
+		if (selectedFileEntryId != 0) {
+			FileEntry fileEntry = DLAppServiceUtil.getFileEntry(
+				selectedFileEntryId);
+
+			_folderId = fileEntry.getFolderId();
+		}
+
 		_folderId = ParamUtil.getLong(
-			_httpServletRequest, "folderId",
-			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID);
+			_httpServletRequest, "folderId", _folderId);
 
 		return _folderId;
 	}

--- a/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/display/context/DLItemSelectorViewDisplayContext.java
+++ b/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/display/context/DLItemSelectorViewDisplayContext.java
@@ -389,7 +389,7 @@ public class DLItemSelectorViewDisplayContext<T extends ItemSelectorCriterion> {
 
 		long selectedFileEntryId = ParamUtil.getLong(
 			PortalUtil.getOriginalServletRequest(httpServletRequest),
-			"selectedFileEntryId");
+			"selectedItemIds");
 
 		if (selectedFileEntryId != 0) {
 			FileEntry fileEntry = DLAppServiceUtil.getFileEntry(

--- a/modules/apps/document-library/document-library-item-selector-web/src/main/resources/META-INF/resources/documents.jsp
+++ b/modules/apps/document-library/document-library-item-selector-web/src/main/resources/META-INF/resources/documents.jsp
@@ -25,6 +25,7 @@ DLItemSelectorViewDisplayContext dlItemSelectorViewDisplayContext = (DLItemSelec
 	editImageURL="<%= dlItemSelectorViewDisplayContext.getEditImageURL(liferayPortletResponse) %>"
 	emptyResultsMessage='<%= LanguageUtil.get(request, "there-are-no-documents-or-media-files-in-this-folder") %>'
 	extensions="<%= ListUtil.fromArray(dlItemSelectorViewDisplayContext.getExtensions()) %>"
+	folderId="<%= dlItemSelectorViewDisplayContext.getFolderId() %>"
 	itemSelectedEventName="<%= dlItemSelectorViewDisplayContext.getItemSelectedEventName() %>"
 	itemSelectorReturnTypeResolver="<%= dlItemSelectorViewDisplayContext.getItemSelectorReturnTypeResolver() %>"
 	maxFileSize="<%= DLValidatorUtil.getMaxAllowableSize(themeDisplay.getScopeGroupId(), null) %>"

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/ImagePicker/ImagePicker.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/ImagePicker/ImagePicker.es.js
@@ -97,6 +97,15 @@ const ImagePicker = ({
 
 		onFocus(event);
 
+		let url = itemSelectorURL;
+
+		if (Liferay.FeatureFlags['LPS-153332']) {
+			url = addParams(
+				`selectedFileEntryId=${selectedImageId}`,
+				itemSelectorURL
+			);
+		}
+
 		openSelectionModal({
 			onClose: () => onBlur(event),
 			onSelect: handleFieldChanged,
@@ -105,10 +114,7 @@ const ImagePicker = ({
 				Liferay.Language.get('select-x'),
 				Liferay.Language.get('image')
 			),
-			url: addParams(
-				`selectedFileEntryId=${selectedImageId}`,
-				itemSelectorURL
-			),
+			url,
 		});
 	};
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/ImagePicker/ImagePicker.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/ImagePicker/ImagePicker.es.js
@@ -101,7 +101,7 @@ const ImagePicker = ({
 
 		if (Liferay.FeatureFlags['LPS-153332']) {
 			url = addParams(
-				`selectedFileEntryId=${selectedImageId}`,
+				`selectedItemIds=${selectedImageId}`,
 				itemSelectorURL
 			);
 		}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/ImagePicker/ImagePicker.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/ImagePicker/ImagePicker.es.js
@@ -15,7 +15,7 @@
 import ClayButton from '@clayui/button';
 import ClayForm, {ClayInput} from '@clayui/form';
 import ClayModal, {useModal} from '@clayui/modal';
-import {openSelectionModal, sub} from 'frontend-js-web';
+import {addParams, openSelectionModal, sub} from 'frontend-js-web';
 import React, {useState} from 'react';
 
 import {FieldBase} from '../FieldBase/ReactFieldBase.es';
@@ -45,6 +45,10 @@ const ImagePicker = ({
 		onClose: () => setModalVisible(false),
 	});
 
+	const [selectedImageId, setSelectedImageId] = useState(
+		inputValue?.fileEntryId
+	);
+
 	const dispatchValue = ({clear, value}, callback = () => {}) =>
 		setImageValues((oldValues) => {
 			let mergedValues = {...oldValues, ...value};
@@ -60,6 +64,8 @@ const ImagePicker = ({
 		if (selectedItem?.value) {
 			const selectedImage = new Image();
 			const selectedItemValue = JSON.parse(selectedItem.value);
+
+			setSelectedImageId(selectedItemValue.fileEntryId);
 
 			selectedImage.addEventListener('load', (event) => {
 				const {
@@ -99,7 +105,10 @@ const ImagePicker = ({
 				Liferay.Language.get('select-x'),
 				Liferay.Language.get('image')
 			),
-			url: itemSelectorURL,
+			url: addParams(
+				`selectedFileEntryId=${selectedImageId}`,
+				itemSelectorURL
+			),
 		});
 	};
 

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/itemselector/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/itemselector/plugin.js
@@ -191,6 +191,21 @@
 			return commitValueFn;
 		},
 
+		_getItemId(selectedItem) {
+			let itemId;
+
+			try {
+				itemId = JSON.parse(selectedItem.value);
+			}
+			catch (error) {
+				itemId = selectedItem;
+			}
+
+			itemId = itemId?.fileEntryId || itemId?.value?.fileEntryId;
+
+			return itemId;
+		},
+
 		_getItemSrc(editor, selectedItem) {
 			let itemSrc;
 
@@ -258,6 +273,7 @@
 			const instance = this;
 
 			if (selectedItem) {
+				instance._selectedImageId = instance._getItemId(selectedItem);
 				const imageSrc = instance._getItemSrc(editor, selectedItem);
 
 				if (imageSrc) {
@@ -333,6 +349,8 @@
 			instance._audioTPL = new CKEDITOR.template(TPL_AUDIO_SCRIPT);
 			instance._videoTPL = new CKEDITOR.template(TPL_VIDEO_SCRIPT);
 
+			instance._selectedImageId = 0;
+
 			editor.addCommand('audioselector', {
 				canUndo: false,
 				exec(editor, callback) {
@@ -361,9 +379,20 @@
 						callback
 					);
 
+					let url = editor.config.filebrowserImageBrowseUrl;
+
+					if (Liferay.FeatureFlags['LPS-153332']) {
+						const itemSelectorURL = new URL(url);
+						itemSelectorURL.searchParams.append(
+							'selectedItemIds',
+							instance._selectedImageId
+						);
+						url = itemSelectorURL.toString();
+					}
+
 					instance._openSelectionModal(
 						editor,
-						editor.config.filebrowserImageBrowseUrl,
+						url,
 						onSelectedImageChangeFn
 					);
 				},

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/image_selector/js/ImageSelector.js
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/image_selector/js/ImageSelector.js
@@ -17,6 +17,7 @@ import {State} from '@liferay/frontend-js-state-web';
 import classNames from 'classnames';
 import {
 	STATUS_CODE,
+	addParams,
 	formatStorage,
 	openSelectionModal,
 	sub,
@@ -161,6 +162,15 @@ const ImageSelector = ({
 	};
 
 	const handleSelectFileClick = () => {
+		let url = itemSelectorURL;
+
+		if (Liferay.FeatureFlags['LPS-153332']) {
+			url = addParams(
+				`selectedItemIds=${image.fileEntryId}`,
+				itemSelectorURL
+			);
+		}
+
 		openSelectionModal({
 			onSelect: (selectedItem) => {
 				if (selectedItem) {
@@ -176,7 +186,7 @@ const ImageSelector = ({
 			},
 			selectEventName: itemSelectorEventName,
 			title: Liferay.Language.get('select-file'),
-			url: itemSelectorURL,
+			url,
 		});
 	};
 


### PR DESCRIPTION
 ---- **Only review the two last commits** ----

Hey @marcogalluzzi, I've tried to make it work in Blogs and CKEditor but it isn't. The URL is correct and sends the selected item as param, but maybe it does not pass through `DLItemSelectorViewDisplayContext.java `and is not getting the value, could you please check what is missing in back? 

1) Blogs - cover image. Go to Blogs, create/edit an entry and select a cover image (in the section above the Blog title)

2) CKEditor. You can test it for example in KB, while creating/editing an article and selecting an image. 

![Screenshot 2023-02-16 at 21 53 44](https://user-images.githubusercontent.com/8373764/219484632-49815272-381b-4ea1-93db-7327037b64fe.png)

**Note**: This does not work in all cases. In the CKEditor of Web Content the **returnType** is `URLReturnType`, so when you select an item, it only returns the url/src of the item (not the fileEntryId). I guess that any Item Selector that includes the URL tab will not be able to return the fileEntryId, thus we won't be able to open it in the folder where the last item was selected. 

At this point it makes me doubt if we are taking the correct approach for this story. Thinking from the user point of view, it doesn't makes sense to work only depending on the returnType, if it returns the item Id or not. Maybe we should save in session the tab and the selected item once it is selected, and avoid all this? 

cc/ @adolfopa @AliciaGarciaGarcia thoughts? 🤔 