### PR TITLE
LPS-175313 No folder shown in folder facet for documents and media

### DIFF
--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/spi/model/index/contributor/DLFolderModelDocumentContributor.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/spi/model/index/contributor/DLFolderModelDocumentContributor.java
@@ -20,7 +20,6 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
-import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.search.spi.model.index.contributor.ModelDocumentContributor;
 import com.liferay.trash.TrashHelper;
@@ -60,9 +59,7 @@ public class DLFolderModelDocumentContributor
 		document.addKeyword(Field.TREE_PATH, dlFolder.getTreePath());
 		document.addKeyword(
 			Field.TREE_PATH,
-			ArrayUtil.remove(
-				StringUtil.split(dlFolder.getTreePath(), CharPool.SLASH),
-				String.valueOf(dlFolder.getFolderId())));
+			StringUtil.split(dlFolder.getTreePath(), CharPool.SLASH));
 
 		if (_log.isDebugEnabled()) {
 			_log.debug("Document " + dlFolder + " indexed successfully");

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFolderIndexerIndexedFieldsTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFolderIndexerIndexedFieldsTest.java
@@ -30,7 +30,6 @@ import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
-import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.search.searcher.SearchResponse;
@@ -204,9 +203,7 @@ public class DLFolderIndexerIndexedFieldsTest extends BaseDLIndexerTestCase {
 
 		List<String> treePathValues = new ArrayList<>(
 			Arrays.asList(
-				ArrayUtil.remove(
-					StringUtil.split(dlFolder.getTreePath(), CharPool.SLASH),
-					String.valueOf(dlFolder.getFolderId()))));
+				StringUtil.split(dlFolder.getTreePath(), CharPool.SLASH)));
 
 		if (treePathValues.size() == 1) {
 			map.put(Field.TREE_PATH, treePathValues.get(0));

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFolderIndexerIndexedFieldsTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFolderIndexerIndexedFieldsTest.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.search.searcher.SearchResponse;
@@ -203,9 +204,9 @@ public class DLFolderIndexerIndexedFieldsTest extends BaseDLIndexerTestCase {
 
 		List<String> treePathValues = new ArrayList<>(
 			Arrays.asList(
-				StringUtil.split(dlFolder.getTreePath(), CharPool.SLASH)));
-
-		treePathValues.remove(String.valueOf(dlFolder.getFolderId()));
+				ArrayUtil.remove(
+					StringUtil.split(dlFolder.getTreePath(), CharPool.SLASH),
+					String.valueOf(dlFolder.getFolderId()))));
 
 		if (treePathValues.size() == 1) {
 			map.put(Field.TREE_PATH, treePathValues.get(0));

--- a/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/FolderFacetTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/FolderFacetTest.java
@@ -199,21 +199,18 @@ public class FolderFacetTest extends BaseFacetedSearcherTestCase {
 
 		Hits hits = search(searchContext);
 
-		Assert.assertEquals(hits.toString(), 1, hits.getLength());
+		Assert.assertEquals(hits.toString(), 2, hits.getLength());
 
 		assertEntryClassNames(
-			Arrays.asList(DLFileEntry.class.getName()), hits, facet,
-			searchContext);
+			Arrays.asList(
+				DLFolder.class.getName(), DLFileEntry.class.getName()),
+			hits, facet, searchContext);
 
 		List<String> dlFolderIds = Arrays.asList(
 			ArrayUtil.append(getFolderIds(_dlFolders), StringPool.BLANK));
 
-		Map<String, Integer> expected = toMap(dlFolderIds, 1);
-
-		expected.put(StringPool.BLANK, 2);
-
 		FacetsAssert.assertFrequencies(
-			facet.getFieldName(), searchContext, hits, expected);
+			facet.getFieldName(), searchContext, hits, toMap(dlFolderIds, 2));
 	}
 
 	protected void assertEntryClassNames(

--- a/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/FolderFacetTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/FolderFacetTest.java
@@ -208,12 +208,12 @@ public class FolderFacetTest extends BaseFacetedSearcherTestCase {
 		List<String> dlFolderIds = Arrays.asList(
 			ArrayUtil.append(getFolderIds(_dlFolders), StringPool.BLANK));
 
-		Map<String, Integer> map = toMap(dlFolderIds, 1);
+		Map<String, Integer> expected = toMap(dlFolderIds, 1);
 
-		map.put(StringPool.BLANK, 2);
+		expected.put(StringPool.BLANK, 2);
 
 		FacetsAssert.assertFrequencies(
-			facet.getFieldName(), searchContext, hits, map);
+			facet.getFieldName(), searchContext, hits, expected);
 	}
 
 	protected void assertEntryClassNames(


### PR DESCRIPTION
As said on [LPS-175313](https://issues.liferay.com/browse/LPS-175313?focusedCommentId=2854751&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-2854751)  This PR restore the behavior of the model contributos
 

- LPS-175313 Revert "LPS-172530 Rename"
- LPS-175313 Revert "LPS-172530 SF"
- LPS-175313 Revert "LPS-172530 Add test integration"
- LPS-175313 Revert "LPS-172530 Update test"
- LPS-175313 Revert "LPS-172530 Don't show the searchFolder in the result."
