### PR TITLE
LPS-176119

### DIFF
--- a/modules/apps/asset/asset-browser-web/src/main/java/com/liferay/asset/browser/web/internal/item/selector/AssetEntryItemSelectorView.java
+++ b/modules/apps/asset/asset-browser-web/src/main/java/com/liferay/asset/browser/web/internal/item/selector/AssetEntryItemSelectorView.java
@@ -24,6 +24,8 @@ import com.liferay.item.selector.ItemSelectorViewDescriptorRenderer;
 import com.liferay.item.selector.criteria.AssetEntryItemSelectorReturnType;
 import com.liferay.item.selector.criteria.asset.criterion.AssetEntryItemSelectorCriterion;
 import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.servlet.DynamicServletRequest;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.Portal;
 
@@ -77,8 +79,8 @@ public class AssetEntryItemSelectorView
 			PortletURL portletURL, String itemSelectedEventName, boolean search)
 		throws IOException, ServletException {
 
-		HttpServletRequest httpServletRequest =
-			(HttpServletRequest)servletRequest;
+		HttpServletRequest httpServletRequest = _getDynamicServletRequest(
+			assetEntryItemSelectorCriterion, servletRequest);
 
 		RenderRequest renderRequest =
 			(RenderRequest)httpServletRequest.getAttribute(
@@ -100,6 +102,26 @@ public class AssetEntryItemSelectorView
 			search,
 			new AssetEntryItemSelectorViewDescriptor(
 				httpServletRequest, assetBrowserDisplayContext, portletURL));
+	}
+
+	private DynamicServletRequest _getDynamicServletRequest(
+		AssetEntryItemSelectorCriterion assetEntryItemSelectorCriterion,
+		ServletRequest servletRequest) {
+
+		HttpServletRequest httpServletRequest =
+			(HttpServletRequest)servletRequest;
+
+		return new DynamicServletRequest(
+			httpServletRequest,
+			HashMapBuilder.put(
+				"multipleSelection",
+				_toStringArray(
+					!assetEntryItemSelectorCriterion.isSingleSelect())
+			).build());
+	}
+
+	private <T> String[] _toStringArray(T value) {
+		return new String[] {String.valueOf(value)};
 	}
 
 	private static final List<ItemSelectorReturnType>

--- a/modules/apps/asset/asset-browser-web/src/main/java/com/liferay/asset/browser/web/internal/item/selector/AssetEntryItemSelectorView.java
+++ b/modules/apps/asset/asset-browser-web/src/main/java/com/liferay/asset/browser/web/internal/item/selector/AssetEntryItemSelectorView.java
@@ -24,8 +24,6 @@ import com.liferay.item.selector.ItemSelectorViewDescriptorRenderer;
 import com.liferay.item.selector.criteria.AssetEntryItemSelectorReturnType;
 import com.liferay.item.selector.criteria.asset.criterion.AssetEntryItemSelectorCriterion;
 import com.liferay.portal.kernel.language.Language;
-import com.liferay.portal.kernel.servlet.DynamicServletRequest;
-import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.Portal;
 
@@ -79,8 +77,8 @@ public class AssetEntryItemSelectorView
 			PortletURL portletURL, String itemSelectedEventName, boolean search)
 		throws IOException, ServletException {
 
-		HttpServletRequest httpServletRequest = _getDynamicServletRequest(
-			assetEntryItemSelectorCriterion, servletRequest);
+		HttpServletRequest httpServletRequest =
+			(HttpServletRequest)servletRequest;
 
 		RenderRequest renderRequest =
 			(RenderRequest)httpServletRequest.getAttribute(
@@ -101,27 +99,8 @@ public class AssetEntryItemSelectorView
 			assetEntryItemSelectorCriterion, portletURL, itemSelectedEventName,
 			search,
 			new AssetEntryItemSelectorViewDescriptor(
-				httpServletRequest, assetBrowserDisplayContext, portletURL));
-	}
-
-	private DynamicServletRequest _getDynamicServletRequest(
-		AssetEntryItemSelectorCriterion assetEntryItemSelectorCriterion,
-		ServletRequest servletRequest) {
-
-		HttpServletRequest httpServletRequest =
-			(HttpServletRequest)servletRequest;
-
-		return new DynamicServletRequest(
-			httpServletRequest,
-			HashMapBuilder.put(
-				"multipleSelection",
-				_toStringArray(
-					!assetEntryItemSelectorCriterion.isSingleSelect())
-			).build());
-	}
-
-	private <T> String[] _toStringArray(T value) {
-		return new String[] {String.valueOf(value)};
+				httpServletRequest, assetBrowserDisplayContext,
+				assetEntryItemSelectorCriterion, portletURL));
 	}
 
 	private static final List<ItemSelectorReturnType>

--- a/modules/apps/asset/asset-browser-web/src/main/java/com/liferay/asset/browser/web/internal/item/selector/AssetEntryItemSelectorViewDescriptor.java
+++ b/modules/apps/asset/asset-browser-web/src/main/java/com/liferay/asset/browser/web/internal/item/selector/AssetEntryItemSelectorViewDescriptor.java
@@ -22,6 +22,7 @@ import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemListBuil
 import com.liferay.item.selector.ItemSelectorReturnType;
 import com.liferay.item.selector.ItemSelectorViewDescriptor;
 import com.liferay.item.selector.criteria.AssetEntryItemSelectorReturnType;
+import com.liferay.item.selector.criteria.asset.criterion.AssetEntryItemSelectorCriterion;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
@@ -46,10 +47,12 @@ public class AssetEntryItemSelectorViewDescriptor
 	public AssetEntryItemSelectorViewDescriptor(
 		HttpServletRequest httpServletRequest,
 		AssetBrowserDisplayContext assetBrowserDisplayContext,
+		AssetEntryItemSelectorCriterion assetEntryItemSelectorCriterion,
 		PortletURL portletURL) {
 
 		_httpServletRequest = httpServletRequest;
 		_assetBrowserDisplayContext = assetBrowserDisplayContext;
+		_assetEntryItemSelectorCriterion = assetEntryItemSelectorCriterion;
 		_portletURL = portletURL;
 
 		_themeDisplay = (ThemeDisplay)httpServletRequest.getAttribute(
@@ -147,6 +150,11 @@ public class AssetEntryItemSelectorViewDescriptor
 	}
 
 	@Override
+	public boolean isMultipleSelection() {
+		return !_assetEntryItemSelectorCriterion.isSingleSelect();
+	}
+
+	@Override
 	public boolean isShowSearch() {
 		return true;
 	}
@@ -172,6 +180,8 @@ public class AssetEntryItemSelectorViewDescriptor
 	}
 
 	private final AssetBrowserDisplayContext _assetBrowserDisplayContext;
+	private final AssetEntryItemSelectorCriterion
+		_assetEntryItemSelectorCriterion;
 	private final HttpServletRequest _httpServletRequest;
 	private final PortletURL _portletURL;
 	private final ThemeDisplay _themeDisplay;

--- a/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/display/context/EditAssetListDisplayContext.java
+++ b/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/display/context/EditAssetListDisplayContext.java
@@ -1184,8 +1184,6 @@ public class EditAssetListDisplayContext {
 				RequestBackedPortletURLFactoryUtil.create(_portletRequest),
 				_portletResponse.getNamespace() + "selectAsset",
 				assetEntryItemSelectorCriterion)
-		).setParameter(
-			"multipleSelection", true
 		).buildPortletURL();
 	}
 

--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/display/context/AssetPublisherDisplayContext.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/display/context/AssetPublisherDisplayContext.java
@@ -2288,8 +2288,6 @@ public class AssetPublisherDisplayContext {
 				scopeGroup, _themeDisplay.getScopeGroupId(),
 				_portletResponse.getNamespace() + "selectAsset",
 				assetEntryItemSelectorCriterion)
-		).setParameter(
-			"multipleSelection", true
 		).buildString();
 	}
 

--- a/modules/apps/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/internal/display/context/InputAssetLinksDisplayContext.java
+++ b/modules/apps/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/internal/display/context/InputAssetLinksDisplayContext.java
@@ -389,8 +389,6 @@ public class InputAssetLinksDisplayContext {
 				RequestBackedPortletURLFactoryUtil.create(_portletRequest),
 				getEventName(), assetEntryItemSelectorCriterion)
 		).setParameter(
-			"multipleSelection", true
-		).setParameter(
 			"refererAssetEntryId", _assetEntryId
 		).buildPortletURL();
 	}

--- a/modules/apps/asset/asset-vocabulary-item-selector-web/src/main/java/com/liferay/asset/vocabulary/item/selector/web/internal/AssetVocabularyItemSelectorViewDescriptor.java
+++ b/modules/apps/asset/asset-vocabulary-item-selector-web/src/main/java/com/liferay/asset/vocabulary/item/selector/web/internal/AssetVocabularyItemSelectorViewDescriptor.java
@@ -110,6 +110,11 @@ public class AssetVocabularyItemSelectorViewDescriptor
 	}
 
 	@Override
+	public boolean isMultipleSelection() {
+		return _assetVocabularyItemSelectorCriterion.isMultiSelection();
+	}
+
+	@Override
 	public boolean isShowBreadcrumb() {
 		return false;
 	}

--- a/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/item/selector/BlogsEntryItemSelectorView.java
+++ b/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/item/selector/BlogsEntryItemSelectorView.java
@@ -105,7 +105,8 @@ public class BlogsEntryItemSelectorView
 			servletRequest, servletResponse, infoItemItemSelectorCriterion,
 			portletURL, itemSelectedEventName, search,
 			new BlogsItemSelectorViewDescriptor(
-				(HttpServletRequest)servletRequest, portletURL));
+				(HttpServletRequest)servletRequest,
+				infoItemItemSelectorCriterion, portletURL));
 	}
 
 	private static final List<ItemSelectorReturnType>
@@ -233,9 +234,12 @@ public class BlogsEntryItemSelectorView
 		implements ItemSelectorViewDescriptor<BlogsEntry> {
 
 		public BlogsItemSelectorViewDescriptor(
-			HttpServletRequest httpServletRequest, PortletURL portletURL) {
+			HttpServletRequest httpServletRequest,
+			InfoItemItemSelectorCriterion infoItemItemSelectorCriterion,
+			PortletURL portletURL) {
 
 			_httpServletRequest = httpServletRequest;
+			_infoItemItemSelectorCriterion = infoItemItemSelectorCriterion;
 			_portletURL = portletURL;
 		}
 
@@ -312,7 +316,14 @@ public class BlogsEntryItemSelectorView
 			return entriesSearchContainer;
 		}
 
+		@Override
+		public boolean isMultipleSelection() {
+			return _infoItemItemSelectorCriterion.isMultiSelection();
+		}
+
 		private HttpServletRequest _httpServletRequest;
+		private final InfoItemItemSelectorCriterion
+			_infoItemItemSelectorCriterion;
 		private String _orderByCol;
 		private String _orderByType;
 		private final PortletURL _portletURL;

--- a/modules/apps/client-extension/client-extension-type-api/bnd.bnd
+++ b/modules/apps/client-extension/client-extension-type-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Client Extension Type API
 Bundle-SymbolicName: com.liferay.client.extension.type.api
-Bundle-Version: 6.2.2
+Bundle-Version: 6.3.0
 Export-Package:\
 	com.liferay.client.extension.type,\
 	com.liferay.client.extension.type.annotation,\

--- a/modules/apps/client-extension/client-extension-type-api/src/main/resources/com/liferay/client/extension/type/packageinfo
+++ b/modules/apps/client-extension/client-extension-type-api/src/main/resources/com/liferay/client/extension/type/packageinfo
@@ -1,1 +1,1 @@
-version 3.3.0
+version 3.4.0

--- a/modules/apps/client-extension/client-extension-type-item-selector-api/bnd.bnd
+++ b/modules/apps/client-extension/client-extension-type-item-selector-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Client Extension Type Item Selector API
 Bundle-SymbolicName: com.liferay.client.extension.type.item.selector.api
-Bundle-Version: 1.0.3
+Bundle-Version: 1.1.0
 Export-Package:\
 	com.liferay.client.extension.type.item.selector,\
 	com.liferay.client.extension.type.item.selector.criterion

--- a/modules/apps/client-extension/client-extension-type-item-selector-api/src/main/java/com/liferay/client/extension/type/item/selector/criterion/CETItemSelectorCriterion.java
+++ b/modules/apps/client-extension/client-extension-type-item-selector-api/src/main/java/com/liferay/client/extension/type/item/selector/criterion/CETItemSelectorCriterion.java
@@ -25,10 +25,19 @@ public class CETItemSelectorCriterion extends BaseItemSelectorCriterion {
 		return _type;
 	}
 
+	public boolean isMultipleSelection() {
+		return _multipleSelection;
+	}
+
+	public void setMultipleSelection(boolean multipleSelection) {
+		_multipleSelection = multipleSelection;
+	}
+
 	public void setType(String type) {
 		_type = type;
 	}
 
+	private boolean _multipleSelection;
 	private String _type;
 
 }

--- a/modules/apps/client-extension/client-extension-type-item-selector-api/src/main/resources/com/liferay/client/extension/type/item/selector/criterion/packageinfo
+++ b/modules/apps/client-extension/client-extension-type-item-selector-api/src/main/resources/com/liferay/client/extension/type/item/selector/criterion/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/modules/apps/client-extension/client-extension-type-item-selector-web/src/main/java/com/liferay/client/extension/type/item/selector/web/internal/item/selector/CETItemSelectorViewDescriptor.java
+++ b/modules/apps/client-extension/client-extension-type-item-selector-web/src/main/java/com/liferay/client/extension/type/item/selector/web/internal/item/selector/CETItemSelectorViewDescriptor.java
@@ -87,7 +87,7 @@ public class CETItemSelectorViewDescriptor
 
 	@Override
 	public boolean isMultipleSelection() {
-		return true;
+		return _cetItemSelectorCriterion.isMultipleSelection();
 	}
 
 	@Override

--- a/modules/apps/client-extension/client-extension-type-item-selector-web/src/main/java/com/liferay/client/extension/type/item/selector/web/internal/item/selector/CETItemSelectorViewDescriptor.java
+++ b/modules/apps/client-extension/client-extension-type-item-selector-web/src/main/java/com/liferay/client/extension/type/item/selector/web/internal/item/selector/CETItemSelectorViewDescriptor.java
@@ -86,6 +86,11 @@ public class CETItemSelectorViewDescriptor
 	}
 
 	@Override
+	public boolean isMultipleSelection() {
+		return true;
+	}
+
+	@Override
 	public boolean isShowBreadcrumb() {
 		return false;
 	}

--- a/modules/apps/commerce/commerce-order-content-web/src/main/java/com/liferay/commerce/order/content/web/internal/item/selector/CommerceOrderItemSelectorView.java
+++ b/modules/apps/commerce/commerce-order-content-web/src/main/java/com/liferay/commerce/order/content/web/internal/item/selector/CommerceOrderItemSelectorView.java
@@ -111,7 +111,8 @@ public class CommerceOrderItemSelectorView
 			servletRequest, servletResponse, infoItemItemSelectorCriterion,
 			portletURL, itemSelectedEventName, search,
 			new CommerceOrderItemSelectorViewDescriptor(
-				(HttpServletRequest)servletRequest, portletURL));
+				(HttpServletRequest)servletRequest,
+				infoItemItemSelectorCriterion, portletURL));
 	}
 
 	private static final List<ItemSelectorReturnType>
@@ -218,9 +219,12 @@ public class CommerceOrderItemSelectorView
 		implements ItemSelectorViewDescriptor<CommerceOrder> {
 
 		public CommerceOrderItemSelectorViewDescriptor(
-			HttpServletRequest httpServletRequest, PortletURL portletURL) {
+			HttpServletRequest httpServletRequest,
+			InfoItemItemSelectorCriterion infoItemItemSelectorCriterion,
+			PortletURL portletURL) {
 
 			_httpServletRequest = httpServletRequest;
+			_infoItemItemSelectorCriterion = infoItemItemSelectorCriterion;
 			_portletURL = portletURL;
 		}
 
@@ -252,7 +256,14 @@ public class CommerceOrderItemSelectorView
 			return entriesSearchContainer;
 		}
 
+		@Override
+		public boolean isMultipleSelection() {
+			return _infoItemItemSelectorCriterion.isMultiSelection();
+		}
+
 		private HttpServletRequest _httpServletRequest;
+		private final InfoItemItemSelectorCriterion
+			_infoItemItemSelectorCriterion;
 		private final PortletURL _portletURL;
 
 	}

--- a/modules/apps/commerce/commerce-product-content-web/src/main/java/com/liferay/commerce/product/content/web/internal/item/selector/CPDefinitionItemSelectorView.java
+++ b/modules/apps/commerce/commerce-product-content-web/src/main/java/com/liferay/commerce/product/content/web/internal/item/selector/CPDefinitionItemSelectorView.java
@@ -112,7 +112,8 @@ public class CPDefinitionItemSelectorView
 			servletRequest, servletResponse, infoItemItemSelectorCriterion,
 			portletURL, itemSelectedEventName, search,
 			new CPDefinitionItemSelectorViewDescriptor(
-				(HttpServletRequest)servletRequest, portletURL));
+				(HttpServletRequest)servletRequest,
+				infoItemItemSelectorCriterion, portletURL));
 	}
 
 	private static final List<ItemSelectorReturnType>
@@ -226,9 +227,12 @@ public class CPDefinitionItemSelectorView
 		implements ItemSelectorViewDescriptor<CPDefinition> {
 
 		public CPDefinitionItemSelectorViewDescriptor(
-			HttpServletRequest httpServletRequest, PortletURL portletURL) {
+			HttpServletRequest httpServletRequest,
+			InfoItemItemSelectorCriterion infoItemItemSelectorCriterion,
+			PortletURL portletURL) {
 
 			_httpServletRequest = httpServletRequest;
+			_infoItemItemSelectorCriterion = infoItemItemSelectorCriterion;
 			_portletURL = portletURL;
 		}
 
@@ -260,7 +264,14 @@ public class CPDefinitionItemSelectorView
 			return entriesSearchContainer;
 		}
 
+		@Override
+		public boolean isMultipleSelection() {
+			return _infoItemItemSelectorCriterion.isMultiSelection();
+		}
+
 		private HttpServletRequest _httpServletRequest;
+		private final InfoItemItemSelectorCriterion
+			_infoItemItemSelectorCriterion;
 		private final PortletURL _portletURL;
 
 	}

--- a/modules/apps/item-selector/item-selector-api/bnd.bnd
+++ b/modules/apps/item-selector/item-selector-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Item Selector API
 Bundle-SymbolicName: com.liferay.item.selector.api
-Bundle-Version: 6.6.1
+Bundle-Version: 6.7.0
 Export-Package:\
 	com.liferay.item.selector,\
 	com.liferay.item.selector.constants,\

--- a/modules/apps/item-selector/item-selector-api/src/main/java/com/liferay/item/selector/ItemSelectorViewDescriptor.java
+++ b/modules/apps/item-selector/item-selector-api/src/main/java/com/liferay/item/selector/ItemSelectorViewDescriptor.java
@@ -70,6 +70,10 @@ public interface ItemSelectorViewDescriptor<T> {
 		return null;
 	}
 
+	public default boolean isMultipleSelection() {
+		return false;
+	}
+
 	public default boolean isShowBreadcrumb() {
 		return true;
 	}

--- a/modules/apps/item-selector/item-selector-api/src/main/resources/com/liferay/item/selector/packageinfo
+++ b/modules/apps/item-selector/item-selector-api/src/main/resources/com/liferay/item/selector/packageinfo
@@ -1,1 +1,1 @@
-version 4.9.0
+version 4.10.0

--- a/modules/apps/item-selector/item-selector-web/src/main/java/com/liferay/item/selector/web/internal/display/context/ItemSelectorViewDescriptorRendererDisplayContext.java
+++ b/modules/apps/item-selector/item-selector-web/src/main/java/com/liferay/item/selector/web/internal/display/context/ItemSelectorViewDescriptorRendererDisplayContext.java
@@ -134,7 +134,7 @@ public class ItemSelectorViewDescriptorRendererDisplayContext {
 	}
 
 	public boolean isMultipleSelection() {
-		return ParamUtil.getBoolean(_httpServletRequest, "multipleSelection");
+		return _itemSelectorViewDescriptor.isMultipleSelection();
 	}
 
 	private BreadcrumbEntry _getCurrentGroupBreadcrumbEntry(

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutLookAndFeelDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutLookAndFeelDisplayContext.java
@@ -131,8 +131,6 @@ public class LayoutLookAndFeelDisplayContext {
 				_layoutsAdminDisplayContext.getCETItemSelectorURL(
 					"selectGlobalCSSCETs",
 					ClientExtensionEntryConstants.TYPE_GLOBAL_CSS)
-			).setParameter(
-				"multipleSelection", true
 			).buildString()
 		).put(
 			"selectGlobalCSSCETsEventName", "selectGlobalCSSCETs"
@@ -153,8 +151,6 @@ public class LayoutLookAndFeelDisplayContext {
 				_layoutsAdminDisplayContext.getCETItemSelectorURL(
 					"selectGlobalJSCETs",
 					ClientExtensionEntryConstants.TYPE_GLOBAL_JS)
-			).setParameter(
-				"multipleSelection", true
 			).buildString()
 		).put(
 			"selectGlobalJSCETsEventName", "selectGlobalJSCETs"

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutLookAndFeelDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutLookAndFeelDisplayContext.java
@@ -129,7 +129,7 @@ public class LayoutLookAndFeelDisplayContext {
 			"globalCSSCETSelectorURL",
 			() -> PortletURLBuilder.create(
 				_layoutsAdminDisplayContext.getCETItemSelectorURL(
-					"selectGlobalCSSCETs",
+					true, "selectGlobalCSSCETs",
 					ClientExtensionEntryConstants.TYPE_GLOBAL_CSS)
 			).buildString()
 		).put(
@@ -149,7 +149,7 @@ public class LayoutLookAndFeelDisplayContext {
 			"globalJSCETSelectorURL",
 			() -> PortletURLBuilder.create(
 				_layoutsAdminDisplayContext.getCETItemSelectorURL(
-					"selectGlobalJSCETs",
+					true, "selectGlobalJSCETs",
 					ClientExtensionEntryConstants.TYPE_GLOBAL_JS)
 			).buildString()
 		).put(
@@ -354,7 +354,7 @@ public class LayoutLookAndFeelDisplayContext {
 			"themeSpritemapCETSelectorURL",
 			() -> PortletURLBuilder.create(
 				_layoutsAdminDisplayContext.getCETItemSelectorURL(
-					"selectThemeSpritemapCET",
+					false, "selectThemeSpritemapCET",
 					ClientExtensionEntryConstants.TYPE_THEME_SPRITEMAP)
 			).buildString()
 		).build();

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminDisplayContext.java
@@ -311,13 +311,14 @@ public class LayoutsAdminDisplayContext {
 	}
 
 	public PortletURL getCETItemSelectorURL(
-		String selectEventName, String type) {
+		boolean multipleSelection, String selectEventName, String type) {
 
 		CETItemSelectorCriterion cetItemSelectorCriterion =
 			new CETItemSelectorCriterion();
 
 		cetItemSelectorCriterion.setDesiredItemSelectorReturnTypes(
 			new CETItemSelectorReturnType());
+		cetItemSelectorCriterion.setMultipleSelection(multipleSelection);
 		cetItemSelectorCriterion.setType(type);
 
 		return _itemSelector.getItemSelectorURL(
@@ -1272,7 +1273,7 @@ public class LayoutsAdminDisplayContext {
 			"selectThemeCSSClientExtensionURL",
 			() -> String.valueOf(
 				getCETItemSelectorURL(
-					selectThemeCSSClientExtensionEventName,
+					false, selectThemeCSSClientExtensionEventName,
 					ClientExtensionEntryConstants.TYPE_THEME_CSS))
 		).put(
 			"themeCSSCETExternalReferenceCode",

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/item/selector/SystemObjectEntryItemSelectorView.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/item/selector/SystemObjectEntryItemSelectorView.java
@@ -122,7 +122,8 @@ public class SystemObjectEntryItemSelectorView
 			servletRequest, servletResponse, infoItemItemSelectorCriterion,
 			portletURL, itemSelectedEventName, search,
 			new SystemObjectItemSelectorViewDescriptor(
-				(HttpServletRequest)servletRequest, _objectDefinition,
+				(HttpServletRequest)servletRequest,
+				infoItemItemSelectorCriterion, _objectDefinition,
 				_objectEntryLocalService, _objectRelatedModelsProviderRegistry,
 				portletURL));
 	}
@@ -241,6 +242,7 @@ public class SystemObjectEntryItemSelectorView
 
 		public SystemObjectItemSelectorViewDescriptor(
 			HttpServletRequest httpServletRequest,
+			InfoItemItemSelectorCriterion infoItemItemSelectorCriterion,
 			ObjectDefinition objectDefinition,
 			ObjectEntryLocalService objectEntryLocalService,
 			ObjectRelatedModelsProviderRegistry
@@ -248,6 +250,7 @@ public class SystemObjectEntryItemSelectorView
 			PortletURL portletURL) {
 
 			_httpServletRequest = httpServletRequest;
+			_infoItemItemSelectorCriterion = infoItemItemSelectorCriterion;
 			_objectDefinition = objectDefinition;
 			_objectEntryLocalService = objectEntryLocalService;
 			_objectRelatedModelsProviderRegistry =
@@ -319,7 +322,14 @@ public class SystemObjectEntryItemSelectorView
 			return searchContainer;
 		}
 
+		@Override
+		public boolean isMultipleSelection() {
+			return _infoItemItemSelectorCriterion.isMultiSelection();
+		}
+
 		private final HttpServletRequest _httpServletRequest;
+		private final InfoItemItemSelectorCriterion
+			_infoItemItemSelectorCriterion;
 		private final ObjectDefinition _objectDefinition;
 		private final ObjectEntryLocalService _objectEntryLocalService;
 		private final ObjectRelatedModelsProviderRegistry

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/item/selector/ObjectEntryItemSelectorView.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/item/selector/ObjectEntryItemSelectorView.java
@@ -149,7 +149,8 @@ public class ObjectEntryItemSelectorView
 			servletRequest, servletResponse, infoItemItemSelectorCriterion,
 			portletURL, itemSelectedEventName, search,
 			new ObjectItemSelectorViewDescriptor(
-				(HttpServletRequest)servletRequest, _objectDefinition,
+				(HttpServletRequest)servletRequest,
+				infoItemItemSelectorCriterion, _objectDefinition,
 				_objectEntryManager, _objectRelatedModelsProviderRegistry,
 				portletURL));
 	}
@@ -265,6 +266,7 @@ public class ObjectEntryItemSelectorView
 
 		public ObjectItemSelectorViewDescriptor(
 			HttpServletRequest httpServletRequest,
+			InfoItemItemSelectorCriterion infoItemItemSelectorCriterion,
 			ObjectDefinition objectDefinition,
 			ObjectEntryManager objectEntryManager,
 			ObjectRelatedModelsProviderRegistry
@@ -272,6 +274,7 @@ public class ObjectEntryItemSelectorView
 			PortletURL portletURL) {
 
 			_httpServletRequest = httpServletRequest;
+			_infoItemItemSelectorCriterion = infoItemItemSelectorCriterion;
 			_objectDefinition = objectDefinition;
 			_objectEntryManager = objectEntryManager;
 			_objectRelatedModelsProviderRegistry =
@@ -322,6 +325,11 @@ public class ObjectEntryItemSelectorView
 			}
 
 			return searchContainer;
+		}
+
+		@Override
+		public boolean isMultipleSelection() {
+			return _infoItemItemSelectorCriterion.isMultiSelection();
 		}
 
 		private DTOConverterContext _getDTOConverterContext() {
@@ -378,6 +386,8 @@ public class ObjectEntryItemSelectorView
 		}
 
 		private final HttpServletRequest _httpServletRequest;
+		private final InfoItemItemSelectorCriterion
+			_infoItemItemSelectorCriterion;
 		private final ObjectDefinition _objectDefinition;
 		private final ObjectEntryManager _objectEntryManager;
 		private final ObjectRelatedModelsProviderRegistry

--- a/modules/apps/site-navigation/site-navigation-menu-item-asset-vocabulary/src/main/java/com/liferay/site/navigation/menu/item/asset/vocabulary/internal/type/AssetVocabularySiteNavigationMenuItemType.java
+++ b/modules/apps/site-navigation/site-navigation-menu-item-asset-vocabulary/src/main/java/com/liferay/site/navigation/menu/item/asset/vocabulary/internal/type/AssetVocabularySiteNavigationMenuItemType.java
@@ -198,8 +198,6 @@ public class AssetVocabularySiteNavigationMenuItemType
 				RequestBackedPortletURLFactoryUtil.create(httpServletRequest),
 				renderResponse.getNamespace() + "selectItem",
 				assetVocabularyItemSelectorCriterion)
-		).setParameter(
-			"multipleSelection", isMultiSelection()
 		).buildString();
 	}
 

--- a/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/java/com/liferay/site/navigation/menu/item/display/page/internal/type/DisplayPageTypeSiteNavigationMenuItemType.java
+++ b/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/java/com/liferay/site/navigation/menu/item/display/page/internal/type/DisplayPageTypeSiteNavigationMenuItemType.java
@@ -192,8 +192,6 @@ public class DisplayPageTypeSiteNavigationMenuItemType
 				RequestBackedPortletURLFactoryUtil.create(httpServletRequest),
 				renderResponse.getNamespace() + "selectItem",
 				itemSelectorCriterion)
-		).setParameter(
-			"multipleSelection", isMultiSelection()
 		).buildString();
 	}
 

--- a/modules/apps/site-navigation/site-navigation-menu-item-layout/src/main/java/com/liferay/site/navigation/menu/item/layout/internal/type/LayoutSiteNavigationMenuItemType.java
+++ b/modules/apps/site-navigation/site-navigation-menu-item-layout/src/main/java/com/liferay/site/navigation/menu/item/layout/internal/type/LayoutSiteNavigationMenuItemType.java
@@ -192,8 +192,6 @@ public class LayoutSiteNavigationMenuItemType
 				RequestBackedPortletURLFactoryUtil.create(httpServletRequest),
 				renderResponse.getNamespace() + "selectItem",
 				layoutItemSelectorCriterion)
-		).setParameter(
-			"multipleSelection", isMultiSelection()
 		).buildString();
 	}
 


### PR DESCRIPTION
Motivation
----
In order to fix [LPS-176119](https://issues.liferay.com/browse/LPS-176119), I revert some changes done in LPS-175547 since we need to set multiple selection parameter through the request.

As I could see, we are adding this logic only for assets:

```
new DynamicServletRequest(
	httpServletRequest,
	HashMapBuilder.put(
		"multipleSelection",
		_toStringArray(
			!assetEntryItemSelectorCriterion.isSingleSelect())
	).build());
```
so, in other places we are going to have the same problem if we follow the LPS steps.

Proposed Solution
----
Adds a new method on [ItemSelectorViewDescriptor.java](https://github.com/liferay-lima/liferay-portal/pull/4016/files#diff-0b7a1d83a7872f0a5186997e1eb1a0f754ee2f2b26bf30cbd3ed37bd5acb12ac) to specify if we allow multiple selection or not. This method is implemented as default returning false.

In that way we are not going to loose the multiple selection when we navigate through site or asset library selector. Also, we are avoiding to use the request to share this kind of information.

Steps to verify
----
1. Add a shortcut video to document&media
2. Add a web content
3. Open the Related Assets panel to select the External Video Shortcut
4. You can see the checkbox and shortcut video title on the default page
5. Try to click the Sites and Libraries button and re-navigate to the Liferay DXP page

I send the first commit to fix the problem that we have for assets to echo use (https://github.com/liferay-echo/liferay-portal/pull/11194), but I would like to fix it for all cases, please let me know what do you think, maybe it is not the correct solution.