### PR TITLE
item selector tabs

### DIFF
--- a/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/init.jsp
@@ -24,7 +24,8 @@ taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/item-selector" prefix="liferay-item-selector" %><%@
 taglib uri="http://liferay.com/tld/site-navigation" prefix="liferay-site-navigation" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
-taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
+taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %><%@
+taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
 
 <%@ page import="com.liferay.frontend.taglib.clay.servlet.taglib.HorizontalCard" %><%@
 page import="com.liferay.frontend.taglib.clay.servlet.taglib.VerticalCard" %><%@

--- a/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/init.jsp
@@ -46,6 +46,7 @@ page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
 page import="com.liferay.portal.kernel.log.Log" %><%@
 page import="com.liferay.portal.kernel.log.LogFactoryUtil" %><%@
 page import="com.liferay.portal.kernel.model.UserConstants" %><%@
+page import="com.liferay.portal.kernel.util.GetterUtil" %><%@
 page import="com.liferay.portal.kernel.util.HashMapBuilder" %><%@
 page import="com.liferay.portal.kernel.util.ParamUtil" %><%@
 page import="com.liferay.portal.kernel.util.StringUtil" %><%@

--- a/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/view.jsp
@@ -38,15 +38,20 @@ List<NavigationItem> navigationItems = localizedItemSelectorRendering.getNavigat
 		</div>
 	</c:when>
 	<c:otherwise>
-		<c:if test="<%= navigationItems.size() > 1 %>">
-			<clay:navigation-bar
-				cssClass="border-bottom"
-				inverted="<%= false %>"
-				navigationItems="<%= navigationItems %>"
-			/>
-		</c:if>
+		<c:choose>
+			<c:when test="<%= navigationItems.size() > 1 %>">
+				<clay:navigation-bar
+					cssClass="border-bottom"
+					inverted="<%= false %>"
+					navigationItems="<%= navigationItems %>"
+				/>
 
-		<liferay-util:include page="/view_entries.jsp" servletContext="<%= application %>" />
+				<liferay-util:include page="/view_entries.jsp" servletContext="<%= application %>" />
+			</c:when>
+			<c:otherwise>
+				<liferay-util:include page="/view_entries.jsp" servletContext="<%= application %>" />
+			</c:otherwise>
+		</c:choose>
 	</c:otherwise>
 </c:choose>
 

--- a/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/view.jsp
@@ -46,20 +46,7 @@ List<NavigationItem> navigationItems = localizedItemSelectorRendering.getNavigat
 			/>
 		</c:if>
 
-		<c:choose>
-			<c:when test='<%= ParamUtil.getBoolean(request, "showGroupSelector") %>'>
-				<liferay-item-selector:group-selector />
-			</c:when>
-			<c:otherwise>
-
-				<%
-				ItemSelectorViewRenderer itemSelectorViewRenderer = localizedItemSelectorRendering.getSelectedItemSelectorViewRenderer();
-
-				itemSelectorViewRenderer.renderHTML(pageContext);
-				%>
-
-			</c:otherwise>
-		</c:choose>
+		<liferay-util:include page="/view_entries.jsp" servletContext="<%= application %>" />
 	</c:otherwise>
 </c:choose>
 

--- a/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/view.jsp
@@ -40,13 +40,80 @@ List<NavigationItem> navigationItems = localizedItemSelectorRendering.getNavigat
 	<c:otherwise>
 		<c:choose>
 			<c:when test="<%= navigationItems.size() > 1 %>">
-				<clay:navigation-bar
-					cssClass="border-bottom"
-					inverted="<%= false %>"
-					navigationItems="<%= navigationItems %>"
-				/>
+				<c:choose>
+					<c:when test="<%= navigationItems.size() <= 5 %>">
+						<clay:navigation-bar
+							cssClass="border-bottom"
+							inverted="<%= false %>"
+							navigationItems="<%= navigationItems %>"
+						/>
 
-				<liferay-util:include page="/view_entries.jsp" servletContext="<%= application %>" />
+						<liferay-util:include page="/view_entries.jsp" servletContext="<%= application %>" />
+					</c:when>
+					<c:otherwise>
+
+						<%
+						NavigationItem activeNavigationItem = null;
+						%>
+
+						<clay:container-fluid
+							cssClass="container-view"
+						>
+							<clay:row>
+								<clay:col
+									lg="3"
+								>
+									<nav class="menubar menubar-transparent menubar-vertical-expand-lg">
+										<ul class="mb-2 nav nav-stacked">
+
+											<%
+											for (NavigationItem navigationItem : navigationItems) {
+												if (GetterUtil.getBoolean(navigationItem.get("active"))) {
+													activeNavigationItem = navigationItem;
+												}
+											%>
+
+												<li class="nav-item">
+													<a class="d-flex nav-link <%= GetterUtil.getBoolean(navigationItem.get("active")) ? "active" : StringPool.BLANK %>" href="<%= GetterUtil.getString(navigationItem.get("href")) %>">
+														<span class="text-truncate"><%= GetterUtil.getString(navigationItem.get("label")) %></span>
+													</a>
+												</li>
+
+											<%
+											}
+											%>
+
+										</ul>
+									</nav>
+								</clay:col>
+
+								<clay:col
+									lg="9"
+								>
+									<clay:sheet
+										size="full"
+									>
+										<c:if test="<%= activeNavigationItem != null %>">
+											<h2 class="sheet-title">
+												<clay:content-row
+													verticalAlign="center"
+												>
+													<clay:content-col>
+														<%= GetterUtil.getString(activeNavigationItem.get("label")) %>
+													</clay:content-col>
+												</clay:content-row>
+											</h2>
+										</c:if>
+
+										<clay:sheet-section>
+											<liferay-util:include page="/view_entries.jsp" servletContext="<%= application %>" />
+										</clay:sheet-section>
+									</clay:sheet>
+								</clay:col>
+							</clay:row>
+						</clay:container-fluid>
+					</c:otherwise>
+				</c:choose>
 			</c:when>
 			<c:otherwise>
 				<liferay-util:include page="/view_entries.jsp" servletContext="<%= application %>" />

--- a/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/view_entries.jsp
+++ b/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/view_entries.jsp
@@ -1,0 +1,36 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>
+
+<%@ include file="/init.jsp" %>
+
+<%
+LocalizedItemSelectorRendering localizedItemSelectorRendering = LocalizedItemSelectorRendering.get(liferayPortletRequest);
+%>
+
+<c:choose>
+	<c:when test='<%= ParamUtil.getBoolean(request, "showGroupSelector") %>'>
+		<liferay-item-selector:group-selector />
+	</c:when>
+	<c:otherwise>
+
+		<%
+		ItemSelectorViewRenderer itemSelectorViewRenderer = localizedItemSelectorRendering.getSelectedItemSelectorViewRenderer();
+
+		itemSelectorViewRenderer.renderHTML(pageContext);
+		%>
+
+	</c:otherwise>
+</c:choose>


### PR DESCRIPTION
Motivation
-----
Tab component is not scaling well when dealing with many types of elements inside item selector. As you can see:

<img width="1725" alt="Home_-_Liferay__Editing_" src="https://user-images.githubusercontent.com/922631/220312883-94fb4275-4d50-405c-bfee-631e41c38a15.png">

Proposed Solution
-----
Adapt the markup to change from tabs to vertical navigation when we have more than 5 navigation items. So, after the changes we are moving from this:

<img width="1725" alt="Home_-_Liferay__Editing_" src="https://user-images.githubusercontent.com/922631/220312883-94fb4275-4d50-405c-bfee-631e41c38a15.png">

To this:

<img width="1667" alt="Home_-_Liferay__Editing_" src="https://user-images.githubusercontent.com/922631/220313481-53fa0414-60d5-447c-8936-d8ba182476cd.png">


Steps to verify
-----
1. Go to a content page
2. Try to map an item

Please let me know what do you think.