### PR TITLE
LPS-174913 Invalid company, group or organization IDs should fail

### DIFF
--- a/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/struts/RSSStrutsAction.java
+++ b/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/struts/RSSStrutsAction.java
@@ -20,6 +20,9 @@ import com.liferay.blogs.service.BlogsEntryService;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
+import com.liferay.portal.kernel.model.CompanyConstants;
+import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.model.OrganizationConstants;
 import com.liferay.portal.kernel.module.configuration.ConfigurationProvider;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.permission.GroupPermission;
@@ -118,14 +121,14 @@ public class RSSStrutsAction implements StrutsAction {
 
 		String rss = StringPool.BLANK;
 
-		if (companyId > 0) {
+		if (companyId != CompanyConstants.SYSTEM) {
 			String entryURL = _getFindEntryURL(themeDisplay);
 
 			rss = _blogsEntryService.getCompanyEntriesRSS(
 				companyId, new Date(), status, max, type, version, displayStyle,
 				StringPool.BLANK, entryURL, themeDisplay);
 		}
-		else if (groupId > 0) {
+		else if (groupId != GroupConstants.DEFAULT_LIVE_GROUP_ID) {
 			long plid = ParamUtil.getLong(
 				httpServletRequest, "plid", themeDisplay.getPlid());
 
@@ -135,7 +138,9 @@ public class RSSStrutsAction implements StrutsAction {
 				groupId, new Date(), status, max, type, version, displayStyle,
 				feedURL, feedURL, themeDisplay);
 		}
-		else if (organizationId > 0) {
+		else if (organizationId !=
+					OrganizationConstants.DEFAULT_PARENT_ORGANIZATION_ID) {
+
 			String entryURL = _getFindEntryURL(themeDisplay);
 
 			rss = _blogsEntryService.getOrganizationEntriesRSS(


### PR DESCRIPTION
# What is this about?

https://issues.liferay.com/browse/LPS-174913

The current implementation of RSS feeds will return an empty feed when invoked with negative IDs. It should fail with a NoSuch*Exception instead for consistency.

# How do I test it?

Follow the steps described in https://issues.liferay.com/browse/LPS-174913.