### PR TITLE
LPS-176280 Remove logic in DocumentRepository

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/repository/DocumentRepository.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/repository/DocumentRepository.java
@@ -25,7 +25,6 @@ import com.liferay.portal.kernel.repository.model.FileVersion;
 import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.repository.model.RepositoryEntry;
 import com.liferay.portal.kernel.service.ServiceContext;
-import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 
 import java.io.File;
@@ -101,7 +100,8 @@ public interface DocumentRepository extends CapabilityProvider {
 	public default FileEntry fetchFileEntryByExternalReferenceCode(
 		String externalReferenceCode) {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public default Folder fetchFolderByExternalReferenceCode(
@@ -156,16 +156,8 @@ public interface DocumentRepository extends CapabilityProvider {
 			String externalReferenceCode)
 		throws PortalException {
 
-		try {
-			return getFileEntry(
-				GetterUtil.getLongStrict(externalReferenceCode));
-		}
-		catch (NumberFormatException numberFormatException) {
-			throw new NoSuchFileEntryException(
-				"No file entry exists with external reference code " +
-					externalReferenceCode,
-				numberFormatException);
-		}
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public default FileEntry getFileEntryByFileName(

--- a/portal-kernel/src/com/liferay/portal/kernel/repository/DocumentRepository.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/repository/DocumentRepository.java
@@ -14,8 +14,6 @@
 
 package com.liferay.portal.kernel.repository;
 
-import com.liferay.document.library.kernel.exception.NoSuchFileEntryException;
-import com.liferay.document.library.kernel.exception.NoSuchFolderException;
 import com.liferay.document.library.kernel.model.DLVersionNumberIncrease;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.repository.capabilities.CapabilityProvider;
@@ -107,7 +105,8 @@ public interface DocumentRepository extends CapabilityProvider {
 	public default Folder fetchFolderByExternalReferenceCode(
 		String externalReferenceCode) {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public List<FileEntry> getFileEntries(
@@ -184,18 +183,8 @@ public interface DocumentRepository extends CapabilityProvider {
 			String externalReferenceCode)
 		throws PortalException {
 
-		// TODO LPS-154730 Fix bad pattern from
-		// getFileEntryByExternalReferenceCode
-
-		try {
-			return getFolder(GetterUtil.getLongStrict(externalReferenceCode));
-		}
-		catch (NumberFormatException numberFormatException) {
-			throw new NoSuchFolderException(
-				"No folder exists with external reference code " +
-					externalReferenceCode,
-				numberFormatException);
-		}
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	public List<Folder> getFolders(


### PR DESCRIPTION
Hi guys, I opened this PR because this is a Brian request to remove logic from `getFileEntryByExternalReferenCode` and `getFolderEntryByExternalReferenCode` in `DocumentRepository` interface. As the `externalReferenceCode` has changed to not being the `internalId`, we can not pass it to Long. Thanks :blush: 

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-176280