### PR TITLE
LPS-176524 Generate a unique identifier on each file entry update

### DIFF
--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/documentlibrary/service/persistence/test/DLFileVersionPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/documentlibrary/service/persistence/test/DLFileVersionPersistenceTest.java
@@ -165,6 +165,8 @@ public class DLFileVersionPersistenceTest {
 
 		newDLFileVersion.setFileEntryTypeId(RandomTestUtil.nextLong());
 
+		newDLFileVersion.setStoreUUID(RandomTestUtil.randomString());
+
 		newDLFileVersion.setVersion(RandomTestUtil.randomString());
 
 		newDLFileVersion.setSize(RandomTestUtil.nextLong());
@@ -252,6 +254,9 @@ public class DLFileVersionPersistenceTest {
 		Assert.assertEquals(
 			existingDLFileVersion.getFileEntryTypeId(),
 			newDLFileVersion.getFileEntryTypeId());
+		Assert.assertEquals(
+			existingDLFileVersion.getStoreUUID(),
+			newDLFileVersion.getStoreUUID());
 		Assert.assertEquals(
 			existingDLFileVersion.getVersion(), newDLFileVersion.getVersion());
 		Assert.assertEquals(
@@ -406,9 +411,9 @@ public class DLFileVersionPersistenceTest {
 			"modifiedDate", true, "repositoryId", true, "folderId", true,
 			"fileEntryId", true, "treePath", true, "fileName", true,
 			"extension", true, "mimeType", true, "title", true, "description",
-			true, "changeLog", true, "fileEntryTypeId", true, "version", true,
-			"size", true, "checksum", true, "expirationDate", true,
-			"reviewDate", true, "lastPublishDate", true, "status", true,
+			true, "changeLog", true, "fileEntryTypeId", true, "storeUUID", true,
+			"version", true, "size", true, "checksum", true, "expirationDate",
+			true, "reviewDate", true, "lastPublishDate", true, "status", true,
 			"statusByUserId", true, "statusByUserName", true, "statusDate",
 			true);
 	}
@@ -746,6 +751,8 @@ public class DLFileVersionPersistenceTest {
 		dlFileVersion.setExtraSettings(RandomTestUtil.randomString());
 
 		dlFileVersion.setFileEntryTypeId(RandomTestUtil.nextLong());
+
+		dlFileVersion.setStoreUUID(RandomTestUtil.randomString());
 
 		dlFileVersion.setVersion(RandomTestUtil.randomString());
 

--- a/portal-impl/src/META-INF/portal-hbm.xml
+++ b/portal-impl/src/META-INF/portal-hbm.xml
@@ -1446,6 +1446,7 @@
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="changeLog" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="extraSettings" type="com.liferay.portal.dao.orm.hibernate.StringClobType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="fileEntryTypeId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
+		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="storeUUID" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="version" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" column="size_" name="size" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="checksum" type="com.liferay.portal.dao.orm.hibernate.StringType" />

--- a/portal-impl/src/META-INF/portal-model-hints.xml
+++ b/portal-impl/src/META-INF/portal-model-hints.xml
@@ -351,6 +351,7 @@
 			<hint-collection name="CLOB" />
 		</field>
 		<field name="fileEntryTypeId" type="long" />
+		<field name="storeUUID" type="String" />
 		<field name="version" type="String" />
 		<field name="size" type="long" />
 		<field name="checksum" type="String" />

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/PortalUpgradeProcessRegistryImpl.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/PortalUpgradeProcessRegistryImpl.java
@@ -263,6 +263,11 @@ public class PortalUpgradeProcessRegistryImpl
 		upgradeVersionTreeMap.put(
 			new Version(25, 2, 0),
 			new CTModelUpgradeProcess("LayoutPrototype"));
+
+		upgradeVersionTreeMap.put(
+			new Version(25, 3, 0),
+			UpgradeProcessFactory.addColumns(
+				"DLFileVersion", "storeUUID VARCHAR(255) null"));
 	}
 
 }

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLFileVersionCacheModel.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLFileVersionCacheModel.java
@@ -77,7 +77,7 @@ public class DLFileVersionCacheModel
 
 	@Override
 	public String toString() {
-		StringBundler sb = new StringBundler(65);
+		StringBundler sb = new StringBundler(67);
 
 		sb.append("{mvccVersion=");
 		sb.append(mvccVersion);
@@ -123,6 +123,8 @@ public class DLFileVersionCacheModel
 		sb.append(extraSettings);
 		sb.append(", fileEntryTypeId=");
 		sb.append(fileEntryTypeId);
+		sb.append(", storeUUID=");
+		sb.append(storeUUID);
 		sb.append(", version=");
 		sb.append(version);
 		sb.append(", size=");
@@ -250,6 +252,13 @@ public class DLFileVersionCacheModel
 
 		dlFileVersionImpl.setFileEntryTypeId(fileEntryTypeId);
 
+		if (storeUUID == null) {
+			dlFileVersionImpl.setStoreUUID("");
+		}
+		else {
+			dlFileVersionImpl.setStoreUUID(storeUUID);
+		}
+
 		if (version == null) {
 			dlFileVersionImpl.setVersion("");
 		}
@@ -344,6 +353,7 @@ public class DLFileVersionCacheModel
 		extraSettings = (String)objectInput.readObject();
 
 		fileEntryTypeId = objectInput.readLong();
+		storeUUID = objectInput.readUTF();
 		version = objectInput.readUTF();
 
 		size = objectInput.readLong();
@@ -454,6 +464,13 @@ public class DLFileVersionCacheModel
 
 		objectOutput.writeLong(fileEntryTypeId);
 
+		if (storeUUID == null) {
+			objectOutput.writeUTF("");
+		}
+		else {
+			objectOutput.writeUTF(storeUUID);
+		}
+
 		if (version == null) {
 			objectOutput.writeUTF("");
 		}
@@ -510,6 +527,7 @@ public class DLFileVersionCacheModel
 	public String changeLog;
 	public String extraSettings;
 	public long fileEntryTypeId;
+	public String storeUUID;
 	public String version;
 	public long size;
 	public String checksum;

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLFileVersionModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLFileVersionModelImpl.java
@@ -86,11 +86,12 @@ public class DLFileVersionModelImpl
 		{"mimeType", Types.VARCHAR}, {"title", Types.VARCHAR},
 		{"description", Types.VARCHAR}, {"changeLog", Types.VARCHAR},
 		{"extraSettings", Types.CLOB}, {"fileEntryTypeId", Types.BIGINT},
-		{"version", Types.VARCHAR}, {"size_", Types.BIGINT},
-		{"checksum", Types.VARCHAR}, {"expirationDate", Types.TIMESTAMP},
-		{"reviewDate", Types.TIMESTAMP}, {"lastPublishDate", Types.TIMESTAMP},
-		{"status", Types.INTEGER}, {"statusByUserId", Types.BIGINT},
-		{"statusByUserName", Types.VARCHAR}, {"statusDate", Types.TIMESTAMP}
+		{"storeUUID", Types.VARCHAR}, {"version", Types.VARCHAR},
+		{"size_", Types.BIGINT}, {"checksum", Types.VARCHAR},
+		{"expirationDate", Types.TIMESTAMP}, {"reviewDate", Types.TIMESTAMP},
+		{"lastPublishDate", Types.TIMESTAMP}, {"status", Types.INTEGER},
+		{"statusByUserId", Types.BIGINT}, {"statusByUserName", Types.VARCHAR},
+		{"statusDate", Types.TIMESTAMP}
 	};
 
 	public static final Map<String, Integer> TABLE_COLUMNS_MAP =
@@ -119,6 +120,7 @@ public class DLFileVersionModelImpl
 		TABLE_COLUMNS_MAP.put("changeLog", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("extraSettings", Types.CLOB);
 		TABLE_COLUMNS_MAP.put("fileEntryTypeId", Types.BIGINT);
+		TABLE_COLUMNS_MAP.put("storeUUID", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("version", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("size_", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("checksum", Types.VARCHAR);
@@ -132,7 +134,7 @@ public class DLFileVersionModelImpl
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table DLFileVersion (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,uuid_ VARCHAR(75) null,fileVersionId LONG not null,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,repositoryId LONG,folderId LONG,fileEntryId LONG,treePath STRING null,fileName VARCHAR(255) null,extension VARCHAR(75) null,mimeType VARCHAR(75) null,title VARCHAR(255) null,description STRING null,changeLog VARCHAR(75) null,extraSettings TEXT null,fileEntryTypeId LONG,version VARCHAR(75) null,size_ LONG,checksum VARCHAR(75) null,expirationDate DATE null,reviewDate DATE null,lastPublishDate DATE null,status INTEGER,statusByUserId LONG,statusByUserName VARCHAR(75) null,statusDate DATE null,primary key (fileVersionId, ctCollectionId))";
+		"create table DLFileVersion (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,uuid_ VARCHAR(75) null,fileVersionId LONG not null,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,repositoryId LONG,folderId LONG,fileEntryId LONG,treePath STRING null,fileName VARCHAR(255) null,extension VARCHAR(75) null,mimeType VARCHAR(75) null,title VARCHAR(255) null,description STRING null,changeLog VARCHAR(75) null,extraSettings TEXT null,fileEntryTypeId LONG,storeUUID VARCHAR(75) null,version VARCHAR(75) null,size_ LONG,checksum VARCHAR(75) null,expirationDate DATE null,reviewDate DATE null,lastPublishDate DATE null,status INTEGER,statusByUserId LONG,statusByUserName VARCHAR(75) null,statusDate DATE null,primary key (fileVersionId, ctCollectionId))";
 
 	public static final String TABLE_SQL_DROP = "drop table DLFileVersion";
 
@@ -424,6 +426,10 @@ public class DLFileVersionModelImpl
 		attributeSetterBiConsumers.put(
 			"fileEntryTypeId",
 			(BiConsumer<DLFileVersion, Long>)DLFileVersion::setFileEntryTypeId);
+		attributeGetterFunctions.put("storeUUID", DLFileVersion::getStoreUUID);
+		attributeSetterBiConsumers.put(
+			"storeUUID",
+			(BiConsumer<DLFileVersion, String>)DLFileVersion::setStoreUUID);
 		attributeGetterFunctions.put("version", DLFileVersion::getVersion);
 		attributeSetterBiConsumers.put(
 			"version",
@@ -947,6 +953,26 @@ public class DLFileVersionModelImpl
 
 	@JSON
 	@Override
+	public String getStoreUUID() {
+		if (_storeUUID == null) {
+			return "";
+		}
+		else {
+			return _storeUUID;
+		}
+	}
+
+	@Override
+	public void setStoreUUID(String storeUUID) {
+		if (_columnOriginalValues == Collections.EMPTY_MAP) {
+			_setColumnOriginalValues();
+		}
+
+		_storeUUID = storeUUID;
+	}
+
+	@JSON
+	@Override
 	public String getVersion() {
 		if (_version == null) {
 			return "";
@@ -1309,6 +1335,7 @@ public class DLFileVersionModelImpl
 		dlFileVersionImpl.setChangeLog(getChangeLog());
 		dlFileVersionImpl.setExtraSettings(getExtraSettings());
 		dlFileVersionImpl.setFileEntryTypeId(getFileEntryTypeId());
+		dlFileVersionImpl.setStoreUUID(getStoreUUID());
 		dlFileVersionImpl.setVersion(getVersion());
 		dlFileVersionImpl.setSize(getSize());
 		dlFileVersionImpl.setChecksum(getChecksum());
@@ -1372,6 +1399,8 @@ public class DLFileVersionModelImpl
 			this.<String>getColumnOriginalValue("extraSettings"));
 		dlFileVersionImpl.setFileEntryTypeId(
 			this.<Long>getColumnOriginalValue("fileEntryTypeId"));
+		dlFileVersionImpl.setStoreUUID(
+			this.<String>getColumnOriginalValue("storeUUID"));
 		dlFileVersionImpl.setVersion(
 			this.<String>getColumnOriginalValue("version"));
 		dlFileVersionImpl.setSize(this.<Long>getColumnOriginalValue("size_"));
@@ -1604,6 +1633,14 @@ public class DLFileVersionModelImpl
 
 		dlFileVersionCacheModel.fileEntryTypeId = getFileEntryTypeId();
 
+		dlFileVersionCacheModel.storeUUID = getStoreUUID();
+
+		String storeUUID = dlFileVersionCacheModel.storeUUID;
+
+		if ((storeUUID != null) && (storeUUID.length() == 0)) {
+			dlFileVersionCacheModel.storeUUID = null;
+		}
+
 		dlFileVersionCacheModel.version = getVersion();
 
 		String version = dlFileVersionCacheModel.version;
@@ -1754,6 +1791,7 @@ public class DLFileVersionModelImpl
 	private String _changeLog;
 	private String _extraSettings;
 	private long _fileEntryTypeId;
+	private String _storeUUID;
 	private String _version;
 	private long _size;
 	private String _checksum;
@@ -1816,6 +1854,7 @@ public class DLFileVersionModelImpl
 		_columnOriginalValues.put("changeLog", _changeLog);
 		_columnOriginalValues.put("extraSettings", _extraSettings);
 		_columnOriginalValues.put("fileEntryTypeId", _fileEntryTypeId);
+		_columnOriginalValues.put("storeUUID", _storeUUID);
 		_columnOriginalValues.put("version", _version);
 		_columnOriginalValues.put("size_", _size);
 		_columnOriginalValues.put("checksum", _checksum);
@@ -1894,25 +1933,27 @@ public class DLFileVersionModelImpl
 
 		columnBitmasks.put("fileEntryTypeId", 2097152L);
 
-		columnBitmasks.put("version", 4194304L);
+		columnBitmasks.put("storeUUID", 4194304L);
 
-		columnBitmasks.put("size_", 8388608L);
+		columnBitmasks.put("version", 8388608L);
 
-		columnBitmasks.put("checksum", 16777216L);
+		columnBitmasks.put("size_", 16777216L);
 
-		columnBitmasks.put("expirationDate", 33554432L);
+		columnBitmasks.put("checksum", 33554432L);
 
-		columnBitmasks.put("reviewDate", 67108864L);
+		columnBitmasks.put("expirationDate", 67108864L);
 
-		columnBitmasks.put("lastPublishDate", 134217728L);
+		columnBitmasks.put("reviewDate", 134217728L);
 
-		columnBitmasks.put("status", 268435456L);
+		columnBitmasks.put("lastPublishDate", 268435456L);
 
-		columnBitmasks.put("statusByUserId", 536870912L);
+		columnBitmasks.put("status", 536870912L);
 
-		columnBitmasks.put("statusByUserName", 1073741824L);
+		columnBitmasks.put("statusByUserId", 1073741824L);
 
-		columnBitmasks.put("statusDate", 2147483648L);
+		columnBitmasks.put("statusByUserName", 2147483648L);
+
+		columnBitmasks.put("statusDate", 4294967296L);
 
 		_columnBitmasks = Collections.unmodifiableMap(columnBitmasks);
 	}

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service.xml
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service.xml
@@ -301,6 +301,7 @@
 		<column name="changeLog" type="String" />
 		<column name="extraSettings" type="String" />
 		<column name="fileEntryTypeId" type="long" />
+		<column name="storeUUID" type="String" />
 		<column name="version" type="String" />
 		<column name="size" type="long" />
 		<column name="checksum" type="String" />

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -170,6 +170,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -2084,6 +2085,7 @@ public class DLFileEntryLocalServiceImpl
 		dlFileVersion.setChangeLog(changeLog);
 		dlFileVersion.setExtraSettings(extraSettings);
 		dlFileVersion.setFileEntryTypeId(fileEntryTypeId);
+		dlFileVersion.setStoreUUID(String.valueOf(UUID.randomUUID()));
 		dlFileVersion.setVersion(version);
 		dlFileVersion.setSize(size);
 		dlFileVersion.setExpirationDate(expirationDate);
@@ -3140,6 +3142,7 @@ public class DLFileEntryLocalServiceImpl
 			latestDLFileVersion.getExtraSettings());
 		lastDLFileVersion.setFileEntryTypeId(
 			latestDLFileVersion.getFileEntryTypeId());
+		lastDLFileVersion.setStoreUUID(String.valueOf(UUID.randomUUID()));
 		lastDLFileVersion.setSize(latestDLFileVersion.getSize());
 		lastDLFileVersion.setExpirationDate(
 			latestDLFileVersion.getExpirationDate());
@@ -3425,6 +3428,7 @@ public class DLFileEntryLocalServiceImpl
 		dlFileVersion.setChangeLog(changeLog);
 		dlFileVersion.setExtraSettings(extraSettings);
 		dlFileVersion.setFileEntryTypeId(fileEntryTypeId);
+		dlFileVersion.setStoreUUID(String.valueOf(UUID.randomUUID()));
 		dlFileVersion.setVersion(version);
 		dlFileVersion.setSize(size);
 		dlFileVersion.setSize(size);

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -3431,7 +3431,6 @@ public class DLFileEntryLocalServiceImpl
 		dlFileVersion.setStoreUUID(String.valueOf(UUID.randomUUID()));
 		dlFileVersion.setVersion(version);
 		dlFileVersion.setSize(size);
-		dlFileVersion.setSize(size);
 		dlFileVersion.setExpirationDate(expirationDate);
 		dlFileVersion.setReviewDate(reviewDate);
 		dlFileVersion.setStatus(status);

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -439,6 +439,8 @@ public class DLFileEntryLocalServiceImpl
 
 		latestDLFileVersion.setChangeLog(changeLog);
 
+		latestDLFileVersion.setStoreUUID(String.valueOf(UUID.randomUUID()));
+
 		latestDLFileVersion = _dlFileVersionPersistence.update(
 			latestDLFileVersion);
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/persistence/impl/DLFileVersionPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/persistence/impl/DLFileVersionPersistenceImpl.java
@@ -6565,6 +6565,7 @@ public class DLFileVersionPersistenceImpl
 		ctStrictColumnNames.add("changeLog");
 		ctStrictColumnNames.add("extraSettings");
 		ctStrictColumnNames.add("fileEntryTypeId");
+		ctStrictColumnNames.add("storeUUID");
 		ctStrictColumnNames.add("version");
 		ctStrictColumnNames.add("size_");
 		ctStrictColumnNames.add("checksum");

--- a/portal-kernel/src/com/liferay/document/library/kernel/model/DLFileVersionModel.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/model/DLFileVersionModel.java
@@ -417,6 +417,21 @@ public interface DLFileVersionModel
 	public void setFileEntryTypeId(long fileEntryTypeId);
 
 	/**
+	 * Returns the store uuid of this document library file version.
+	 *
+	 * @return the store uuid of this document library file version
+	 */
+	@AutoEscape
+	public String getStoreUUID();
+
+	/**
+	 * Sets the store uuid of this document library file version.
+	 *
+	 * @param storeUUID the store uuid of this document library file version
+	 */
+	public void setStoreUUID(String storeUUID);
+
+	/**
 	 * Returns the version of this document library file version.
 	 *
 	 * @return the version of this document library file version

--- a/portal-kernel/src/com/liferay/document/library/kernel/model/DLFileVersionTable.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/model/DLFileVersionTable.java
@@ -78,6 +78,8 @@ public class DLFileVersionTable extends BaseTable<DLFileVersionTable> {
 	public final Column<DLFileVersionTable, Long> fileEntryTypeId =
 		createColumn(
 			"fileEntryTypeId", Long.class, Types.BIGINT, Column.FLAG_DEFAULT);
+	public final Column<DLFileVersionTable, String> storeUUID = createColumn(
+		"storeUUID", String.class, Types.VARCHAR, Column.FLAG_DEFAULT);
 	public final Column<DLFileVersionTable, String> version = createColumn(
 		"version", String.class, Types.VARCHAR, Column.FLAG_DEFAULT);
 	public final Column<DLFileVersionTable, Long> size = createColumn(

--- a/portal-kernel/src/com/liferay/document/library/kernel/model/DLFileVersionWrapper.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/model/DLFileVersionWrapper.java
@@ -68,6 +68,7 @@ public class DLFileVersionWrapper
 		attributes.put("changeLog", getChangeLog());
 		attributes.put("extraSettings", getExtraSettings());
 		attributes.put("fileEntryTypeId", getFileEntryTypeId());
+		attributes.put("storeUUID", getStoreUUID());
 		attributes.put("version", getVersion());
 		attributes.put("size", getSize());
 		attributes.put("checksum", getChecksum());
@@ -214,6 +215,12 @@ public class DLFileVersionWrapper
 
 		if (fileEntryTypeId != null) {
 			setFileEntryTypeId(fileEntryTypeId);
+		}
+
+		String storeUUID = (String)attributes.get("storeUUID");
+
+		if (storeUUID != null) {
+			setStoreUUID(storeUUID);
 		}
 
 		String version = (String)attributes.get("version");
@@ -620,6 +627,16 @@ public class DLFileVersionWrapper
 	@Override
 	public Date getStatusDate() {
 		return model.getStatusDate();
+	}
+
+	/**
+	 * Returns the store uuid of this document library file version.
+	 *
+	 * @return the store uuid of this document library file version
+	 */
+	@Override
+	public String getStoreUUID() {
+		return model.getStoreUUID();
 	}
 
 	/**
@@ -1063,6 +1080,16 @@ public class DLFileVersionWrapper
 	@Override
 	public void setStatusDate(Date statusDate) {
 		model.setStatusDate(statusDate);
+	}
+
+	/**
+	 * Sets the store uuid of this document library file version.
+	 *
+	 * @param storeUUID the store uuid of this document library file version
+	 */
+	@Override
+	public void setStoreUUID(String storeUUID) {
+		model.setStoreUUID(storeUUID);
 	}
 
 	/**

--- a/portal-kernel/src/com/liferay/document/library/kernel/model/packageinfo
+++ b/portal-kernel/src/com/liferay/document/library/kernel/model/packageinfo
@@ -1,1 +1,1 @@
-version 8.0.0
+version 8.1.0

--- a/sql/portal-tables.sql
+++ b/sql/portal-tables.sql
@@ -428,6 +428,7 @@ create table DLFileVersion (
 	changeLog VARCHAR(75) null,
 	extraSettings TEXT null,
 	fileEntryTypeId LONG,
+	storeUUID VARCHAR(75) null,
 	version VARCHAR(75) null,
 	size_ LONG,
 	checksum VARCHAR(75) null,


### PR DESCRIPTION
# What is this about?

https://issues.liferay.com/browse/LPS-176524

This is the first necessary step to implement logical deletion in Documents and Media.  On every update to a file version, we'll create a new `storeUUID`, a pseudo-random unique identifier.  In a future PR, these identifiers will be used as components of the store file name.

# How do I test it?

There are no visible changes, as file names don't use the new UUID (yet).  This PR includes integration tests to verify the basic behavior.