### PR TITLE
LPS-175896 KB child article permissions are not properly processed in KB widgets

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-service/service.xml
+++ b/modules/apps/knowledge-base/knowledge-base-service/service.xml
@@ -11,7 +11,7 @@
 
 		<!-- Resource -->
 
-		<column name="resourcePrimKey" type="long" />
+		<column filter-primary="true" name="resourcePrimKey" type="long" />
 
 		<!-- Group instance -->
 
@@ -28,7 +28,7 @@
 		<!-- Other fields -->
 
 		<column name="externalReferenceCode" type="String" />
-		<column filter-primary="true" name="rootResourcePrimKey" type="long" />
+		<column name="rootResourcePrimKey" type="long" />
 		<column name="parentResourceClassNameId" type="long" />
 		<column name="parentResourcePrimKey" type="long" />
 		<column name="kbFolderId" type="long" />

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/security/permission/resource/KBArticleModelResourcePermissionWrapper.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/security/permission/resource/KBArticleModelResourcePermissionWrapper.java
@@ -49,7 +49,7 @@ public class KBArticleModelResourcePermissionWrapper
 		doGetModelResourcePermission() {
 
 		return ModelResourcePermissionFactory.create(
-			KBArticle.class, KBArticle::getRootResourcePrimKey,
+			KBArticle.class, KBArticle::getResourcePrimKey,
 			classPK -> {
 				KBArticle kbArticle =
 					_kbArticleLocalService.fetchLatestKBArticle(

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/persistence/impl/KBArticlePersistenceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/persistence/impl/KBArticlePersistenceImpl.java
@@ -36258,7 +36258,7 @@ public class KBArticlePersistenceImpl
 		"SELECT COUNT(kbArticle) FROM KBArticle kbArticle WHERE ";
 
 	private static final String _FILTER_ENTITY_TABLE_FILTER_PK_COLUMN =
-		"kbArticle.rootResourcePrimKey";
+		"kbArticle.resourcePrimKey";
 
 	private static final String _FILTER_SQL_SELECT_KBARTICLE_WHERE =
 		"SELECT DISTINCT {kbArticle.*} FROM KBArticle kbArticle WHERE ";


### PR DESCRIPTION
This PR solves the problem described in issue https://issues.liferay.com/browse/LPS-175896

It also solves this problem. 

Steps to reproduce:
* Create a KB Article with two child articles
* Remove view permissions for guest from one child article
* Add a site page
* Add a KB display/article widget to display the parent KB article
* Assert that the parent with the two child articles is shown (this is expected because the user is still an admin)
* Log out
* As guest, navigate to the site page and view the parent article

Expected result: the parent with one child page is shown

Actual result: the parent with the two child pages is shown