### PR TITLE
LPS-176212 Error message is not displayed when a user views an expired kb article

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/security/permission/resource/KBArticleModelResourcePermissionWrapper.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/security/permission/resource/KBArticleModelResourcePermissionWrapper.java
@@ -63,6 +63,20 @@ public class KBArticleModelResourcePermissionWrapper
 			},
 			_portletResourcePermission,
 			(modelResourcePermission, consumer) -> {
+				consumer.accept(
+					(permissionChecker, name, kbArticle, actionId) -> {
+						if (kbArticle.isExpired() &&
+							!permissionChecker.hasPermission(
+								kbArticle.getGroupId(), name,
+								kbArticle.getResourcePrimKey(),
+								ActionKeys.UPDATE)) {
+
+							return false;
+						}
+
+						return null;
+					});
+
 				if (PropsValues.PERMISSIONS_VIEW_DYNAMIC_INHERITANCE) {
 					consumer.accept(
 						new KBArticleDynamicInheritanceModelResourcePermissionLogic(


### PR DESCRIPTION
Expired KB articles should only be visible by those users with UPDATE permission.

I only have a doubt: should expired articles be listed?

# Step to reproduce:

1. Enable FF LPS-165476
2. Add two kb articles and expire one of them
3. Add a regular role with these permissions (in Knowledge Base):
   1. GENERAL PERMISSIONS: Access in Site and Asset Library Administration
   2. KNOWLEDGE BASE ARTICLE: View
4. Add a new user and give her the regular role
5. Login with the new user
6. Go to KB admin. See how both expired and non expired articles are listed <img width="918" alt="Captura de pantalla 2023-03-06 a las 11 15 07" src="https://user-images.githubusercontent.com/19521293/223101486-27388186-e858-40fb-b5e4-ee9961a6e97b.png">
8. Click the expired article title

*Expected Results:*
An error message is displayed. See: <img width="918" alt="Captura de pantalla 2023-03-06 a las 11 15 19" src="https://user-images.githubusercontent.com/19521293/223101725-8faa963c-e5b0-407f-9a21-e3d5e708feb3.png">


*Current Results:*
No error message is displayed.
