### PR TITLE
LPS-176521 asset entry is not updated when the KB expires

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
@@ -1289,6 +1289,15 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 			String[] assetTagNames, long[] assetLinkEntryIds)
 		throws PortalException {
 
+		_updateKBArticleAsset(
+			userId, kbArticle, assetCategoryIds, assetTagNames,
+			assetLinkEntryIds, WorkflowConstants.STATUS_ANY);
+	}
+
+	private void _updateKBArticleAsset(
+		long userId, KBArticle kbArticle, long[] assetCategoryIds,
+		String[] assetTagNames, long[] assetLinkEntryIds, int status)
+		throws PortalException {
 		boolean visible = false;
 
 		if (kbArticle.isApproved()) {
@@ -1298,10 +1307,16 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 		String summary = _htmlParser.extractText(
 			StringUtil.shorten(kbArticle.getContent(), 500));
 
+		long classPK = kbArticle.getClassPK();
+
+		if(status == WorkflowConstants.STATUS_EXPIRED){
+			classPK = kbArticle.getResourcePrimKey();
+		}
+
 		AssetEntry assetEntry = _assetEntryLocalService.updateEntry(
 			userId, kbArticle.getGroupId(), kbArticle.getCreateDate(),
 			kbArticle.getModifiedDate(), KBArticle.class.getName(),
-			kbArticle.getClassPK(), kbArticle.getUuid(), 0, assetCategoryIds,
+			classPK, kbArticle.getUuid(), 0, assetCategoryIds,
 			assetTagNames, true, visible, null, null, null,
 			kbArticle.getExpirationDate(), ContentTypes.TEXT_HTML,
 			kbArticle.getTitle(), kbArticle.getDescription(), summary, null,
@@ -1430,9 +1445,9 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 		long[] assetLinkEntryIds = StringUtil.split(
 			ListUtil.toString(assetLinks, AssetLink.ENTRY_ID2_ACCESSOR), 0L);
 
-		updateKBArticleAsset(
+		_updateKBArticleAsset(
 			userId, kbArticle, assetEntry.getCategoryIds(),
-			assetEntry.getTagNames(), assetLinkEntryIds);
+			assetEntry.getTagNames(), assetLinkEntryIds, status);
 
 		SystemEventHierarchyEntryThreadLocal.push(KBArticle.class);
 

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
@@ -1382,14 +1382,8 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 
 		kbArticle = kbArticlePersistence.update(kbArticle);
 
-		if (status != WorkflowConstants.STATUS_APPROVED) {
-			if (status == WorkflowConstants.STATUS_EXPIRED) {
-				_notify(
-					SetUtil.fromArray(
-						_NOTIFICATION_RECEIVER_OWNER,
-						_NOTIFICATION_RECEIVER_SUBSCRIBER),
-					userId, kbArticle, Constants.EXPIRE, serviceContext);
-			}
+		if ((status != WorkflowConstants.STATUS_APPROVED) &&
+			(status != WorkflowConstants.STATUS_EXPIRED)) {
 
 			return kbArticle;
 		}
@@ -1474,9 +1468,15 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 
 		// Subscriptions
 
-		_notify(
-			Collections.singleton(_NOTIFICATION_RECEIVER_SUBSCRIBER), userId,
-			kbArticle, action, serviceContext);
+		Set<String> receivers = SetUtil.fromArray(
+			_NOTIFICATION_RECEIVER_SUBSCRIBER);
+
+		if (status == WorkflowConstants.STATUS_EXPIRED) {
+			action = Constants.EXPIRE;
+			receivers.add(_NOTIFICATION_RECEIVER_OWNER);
+		}
+
+		_notify(receivers, userId, kbArticle, action, serviceContext);
 
 		return kbArticle;
 	}

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
@@ -1294,39 +1294,6 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 			assetLinkEntryIds, WorkflowConstants.STATUS_ANY);
 	}
 
-	private void _updateKBArticleAsset(
-		long userId, KBArticle kbArticle, long[] assetCategoryIds,
-		String[] assetTagNames, long[] assetLinkEntryIds, int status)
-		throws PortalException {
-		boolean visible = false;
-
-		if (kbArticle.isApproved()) {
-			visible = true;
-		}
-
-		String summary = _htmlParser.extractText(
-			StringUtil.shorten(kbArticle.getContent(), 500));
-
-		long classPK = kbArticle.getClassPK();
-
-		if(status == WorkflowConstants.STATUS_EXPIRED){
-			classPK = kbArticle.getResourcePrimKey();
-		}
-
-		AssetEntry assetEntry = _assetEntryLocalService.updateEntry(
-			userId, kbArticle.getGroupId(), kbArticle.getCreateDate(),
-			kbArticle.getModifiedDate(), KBArticle.class.getName(),
-			classPK, kbArticle.getUuid(), 0, assetCategoryIds,
-			assetTagNames, true, visible, null, null, null,
-			kbArticle.getExpirationDate(), ContentTypes.TEXT_HTML,
-			kbArticle.getTitle(), kbArticle.getDescription(), summary, null,
-			null, 0, 0, null);
-
-		_assetLinkLocalService.updateLinks(
-			userId, assetEntry.getEntryId(), assetLinkEntryIds,
-			AssetLinkConstants.TYPE_RELATED);
-	}
-
 	@Override
 	public void updateKBArticleResources(
 			KBArticle kbArticle, String[] groupPermissions,
@@ -2256,6 +2223,39 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 			kbArticle.getCompanyId(), kbArticle.getGroupId(), userId,
 			KBArticle.class.getName(), kbArticle.getResourcePrimKey(),
 			kbArticle, serviceContext, Collections.emptyMap());
+	}
+
+	private void _updateKBArticleAsset(
+			long userId, KBArticle kbArticle, long[] assetCategoryIds,
+			String[] assetTagNames, long[] assetLinkEntryIds, int status)
+		throws PortalException {
+
+		boolean visible = false;
+
+		if (kbArticle.isApproved()) {
+			visible = true;
+		}
+
+		String summary = _htmlParser.extractText(
+			StringUtil.shorten(kbArticle.getContent(), 500));
+
+		long classPK = kbArticle.getClassPK();
+
+		if (status == WorkflowConstants.STATUS_EXPIRED) {
+			classPK = kbArticle.getResourcePrimKey();
+		}
+
+		AssetEntry assetEntry = _assetEntryLocalService.updateEntry(
+			userId, kbArticle.getGroupId(), kbArticle.getCreateDate(),
+			kbArticle.getModifiedDate(), KBArticle.class.getName(), classPK,
+			kbArticle.getUuid(), 0, assetCategoryIds, assetTagNames, true,
+			visible, null, null, null, kbArticle.getExpirationDate(),
+			ContentTypes.TEXT_HTML, kbArticle.getTitle(),
+			kbArticle.getDescription(), summary, null, null, 0, 0, null);
+
+		_assetLinkLocalService.updateLinks(
+			userId, assetEntry.getEntryId(), assetLinkEntryIds,
+			AssetLinkConstants.TYPE_RELATED);
 	}
 
 	private void _updatePermissionFields(

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
@@ -1399,8 +1399,6 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 			return kbArticle;
 		}
 
-		String action = Constants.ADD;
-
 		if (!kbArticle.isFirstVersion()) {
 			KBArticle oldKBArticle = kbArticlePersistence.findByR_V(
 				resourcePrimKey, kbArticle.getVersion() - 1);
@@ -1416,8 +1414,6 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 				KBArticle.class);
 
 			indexer.delete(oldKBArticle);
-
-			action = Constants.UPDATE;
 		}
 
 		// Asset
@@ -1490,11 +1486,12 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 			_NOTIFICATION_RECEIVER_SUBSCRIBER);
 
 		if (status == WorkflowConstants.STATUS_EXPIRED) {
-			action = Constants.EXPIRE;
 			receivers.add(_NOTIFICATION_RECEIVER_OWNER);
 		}
 
-		_notify(receivers, userId, kbArticle, action, serviceContext);
+		_notify(
+			receivers, userId, kbArticle, _getAction(kbArticle, status),
+			serviceContext);
 
 		return kbArticle;
 	}
@@ -1704,6 +1701,18 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 				WorkflowConstants.STATUS_EXPIRED,
 				_getServiceContext(company, kbArticle));
 		}
+	}
+
+	private String _getAction(KBArticle kbArticle, int status) {
+		if (status == WorkflowConstants.STATUS_EXPIRED) {
+			return Constants.EXPIRE;
+		}
+
+		if (kbArticle.isFirstVersion()) {
+			return Constants.ADD;
+		}
+
+		return Constants.UPDATE;
 	}
 
 	private void _getAllDescendantKBArticles(

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
@@ -1272,7 +1272,7 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 
 		_removeKBArticleAttachments(removeFileEntryIds);
 
-		// indexer
+		// Indexer
 
 		_indexKBArticle(kbArticle);
 
@@ -1473,10 +1473,7 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 
 		// Indexer
 
-		Indexer<KBArticle> indexer = _indexerRegistry.getIndexer(
-			KBArticle.class);
-
-		indexer.reindex(kbArticle);
+		_indexKBArticle(kbArticle);
 
 		// Subscriptions
 

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
@@ -1221,6 +1221,13 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 				kbArticle.getCompanyId(),
 				_classNameLocalService.getClassNameId(KBArticle.class),
 				kbArticle.getPrimaryKey(), (int)oldKBArticle.getViewCount());
+
+			// Indexer
+
+			Indexer<KBArticle> indexer = _indexerRegistry.getIndexer(
+				KBArticle.class);
+
+			indexer.delete(oldKBArticle);
 		}
 		else {
 			kbArticle = oldKBArticle;
@@ -1266,6 +1273,10 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 		_addKBArticleAttachments(userId, kbArticle, selectedFileNames);
 
 		_removeKBArticleAttachments(removeFileEntryIds);
+
+		// indexer
+
+		_indexKBArticle(kbArticle);
 
 		// Workflow
 
@@ -1397,7 +1408,14 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 			oldKBArticle.setModifiedDate(oldKBArticle.getModifiedDate());
 			oldKBArticle.setMain(false);
 
-			kbArticlePersistence.update(oldKBArticle);
+			oldKBArticle = kbArticlePersistence.update(oldKBArticle);
+
+			// Indexer
+
+			Indexer<KBArticle> indexer = _indexerRegistry.getIndexer(
+				KBArticle.class);
+
+			indexer.delete(oldKBArticle);
 
 			action = Constants.UPDATE;
 		}

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
@@ -517,8 +517,6 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 
 		kbArticleLocalService.updateKBArticle(kbArticle);
 
-		serviceContext.setCommand(Constants.EXPIRE);
-
 		return updateStatus(
 			userId, resourcePrimKey, WorkflowConstants.STATUS_EXPIRED,
 			serviceContext);

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
@@ -513,6 +513,10 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 		KBArticle kbArticle = getLatestKBArticle(
 			resourcePrimKey, WorkflowConstants.STATUS_ANY);
 
+		if (kbArticle.isDraft()) {
+			return kbArticle;
+		}
+
 		kbArticle.setExpirationDate(new Date());
 
 		kbArticleLocalService.updateKBArticle(kbArticle);
@@ -1810,6 +1814,9 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 				).and(
 					KBArticleTable.INSTANCE.status.neq(
 						WorkflowConstants.STATUS_EXPIRED)
+				).and(
+					KBArticleTable.INSTANCE.status.neq(
+						WorkflowConstants.STATUS_DRAFT)
 				)
 			));
 	}

--- a/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/test/KBArticleLocalServiceTest.java
+++ b/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/test/KBArticleLocalServiceTest.java
@@ -15,6 +15,8 @@
 package com.liferay.knowledge.base.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.kernel.model.AssetEntry;
+import com.liferay.asset.kernel.service.AssetEntryLocalService;
 import com.liferay.asset.kernel.service.AssetEntryLocalServiceUtil;
 import com.liferay.knowledge.base.constants.KBArticleConstants;
 import com.liferay.knowledge.base.constants.KBFolderConstants;
@@ -221,6 +223,54 @@ public class KBArticleLocalServiceTest {
 			_serviceContext);
 	}
 
+	@Test
+	public void testAddDraftKBArticleUpdatesAssetEntry() throws Exception {
+		_serviceContext.setWorkflowAction(WorkflowConstants.ACTION_PUBLISH);
+
+		KBArticle kbArticle = _kbArticleLocalService.addKBArticle(
+			null, _user.getUserId(), _kbFolderClassNameId,
+			KBFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			StringUtil.randomString(), StringUtil.randomString(),
+			StringUtil.randomString(), StringUtil.randomString(), null, null,
+			null, null, null, _serviceContext);
+
+		Assert.assertNotNull(
+			_assetEntryLocalService.getEntry(
+				KBArticle.class.getName(), kbArticle.getResourcePrimKey()));
+
+		_serviceContext.setWorkflowAction(WorkflowConstants.ACTION_SAVE_DRAFT);
+
+		KBArticle draftKBArticle = _kbArticleLocalService.updateKBArticle(
+			_user.getUserId(), kbArticle.getResourcePrimKey(),
+			StringUtil.randomString(), StringUtil.randomString(),
+			StringUtil.randomString(), null, null, null, null, null, null,
+			_serviceContext);
+
+		Assert.assertNotNull(
+			_assetEntryLocalService.getEntry(
+				KBArticle.class.getName(), kbArticle.getResourcePrimKey()));
+
+		Assert.assertNotNull(
+			_assetEntryLocalService.getEntry(
+				KBArticle.class.getName(), draftKBArticle.getKbArticleId()));
+
+		_serviceContext.setWorkflowAction(WorkflowConstants.ACTION_PUBLISH);
+
+		kbArticle = _kbArticleLocalService.updateKBArticle(
+			_user.getUserId(), kbArticle.getResourcePrimKey(),
+			StringUtil.randomString(), StringUtil.randomString(),
+			StringUtil.randomString(), null, null, null, null, null, null,
+			_serviceContext);
+
+		Assert.assertNotNull(
+			_assetEntryLocalService.getEntry(
+				KBArticle.class.getName(), kbArticle.getResourcePrimKey()));
+
+		Assert.assertNull(
+			_assetEntryLocalService.fetchEntry(
+				KBArticle.class.getName(), draftKBArticle.getKbArticleId()));
+	}
+
 	@Test(expected = KBArticleExpirationDateException.class)
 	public void testAddKBArticleInvalidExpirationDateException()
 		throws Exception {
@@ -270,7 +320,7 @@ public class KBArticleLocalServiceTest {
 	}
 
 	@Test
-	public void testAddKBArticleUpdateExpirationReviewDate() throws Exception {
+	public void testAddKBArticleUpdatesExpirationReviewDate() throws Exception {
 		_serviceContext.setWorkflowAction(WorkflowConstants.ACTION_PUBLISH);
 
 		Date expirationDate = DateUtils.addDays(RandomTestUtil.nextDate(), 1);
@@ -1263,6 +1313,46 @@ public class KBArticleLocalServiceTest {
 			WorkflowConstants.STATUS_APPROVED, kbArticle.getStatus());
 	}
 
+	@Test
+	public void testUpdateKBArticleUpdatesAssetEntry() throws Exception {
+		_serviceContext.setWorkflowAction(WorkflowConstants.ACTION_PUBLISH);
+
+		KBArticle kbArticle = _kbArticleLocalService.addKBArticle(
+			null, _user.getUserId(), _kbFolderClassNameId,
+			KBFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			StringUtil.randomString(), StringUtil.randomString(),
+			StringUtil.randomString(), StringUtil.randomString(), null, null,
+			null, null, null, _serviceContext);
+
+		AssetEntry assetEntry = _assetEntryLocalService.getEntry(
+			KBArticle.class.getName(), kbArticle.getResourcePrimKey());
+
+		Assert.assertNull(assetEntry.getExpirationDate());
+
+		kbArticle = _kbArticleLocalService.expireKBArticle(
+			_user.getUserId(), kbArticle.getResourcePrimKey(), _serviceContext);
+
+		assetEntry = _assetEntryLocalService.getEntry(
+			KBArticle.class.getName(), kbArticle.getResourcePrimKey());
+
+		Assert.assertEquals(
+			kbArticle.getExpirationDate(), assetEntry.getExpirationDate());
+		Assert.assertFalse(assetEntry.isVisible());
+
+		kbArticle = _kbArticleLocalService.updateKBArticle(
+			_user.getUserId(), kbArticle.getResourcePrimKey(),
+			StringUtil.randomString(), StringUtil.randomString(),
+			StringUtil.randomString(), null, null, null, null, null, null,
+			_serviceContext);
+
+		assetEntry = _assetEntryLocalService.getEntry(
+			KBArticle.class.getName(), kbArticle.getResourcePrimKey());
+
+		Assert.assertNull(assetEntry.getExpirationDate());
+		Assert.assertEquals(kbArticle.getTitle(), assetEntry.getTitle());
+		Assert.assertTrue(assetEntry.isVisible());
+	}
+
 	protected void importMarkdownArticles() throws PortalException {
 		Class<?> clazz = getClass();
 
@@ -1290,6 +1380,9 @@ public class KBArticleLocalServiceTest {
 
 	private static final Pattern _targetBlankPattern = Pattern.compile(
 		".*target=\"_blank\".*");
+
+	@Inject
+	private AssetEntryLocalService _assetEntryLocalService;
 
 	@DeleteAfterTestRun
 	private Group _group;

--- a/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/test/KBArticleLocalServiceTest.java
+++ b/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/test/KBArticleLocalServiceTest.java
@@ -878,6 +878,27 @@ public class KBArticleLocalServiceTest {
 	}
 
 	@Test
+	public void testDraftKBArticleDoesNotExpire() throws Exception {
+		_serviceContext.setWorkflowAction(WorkflowConstants.ACTION_SAVE_DRAFT);
+
+		KBArticle kbArticle = _kbArticleLocalService.addKBArticle(
+			null, _user.getUserId(), _kbFolderClassNameId,
+			KBFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			StringUtil.randomString(), StringUtil.randomString(),
+			StringUtil.randomString(), StringUtil.randomString(), null, null,
+			null, null, null, _serviceContext);
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_DRAFT, kbArticle.getStatus());
+
+		kbArticle = _kbArticleLocalService.expireKBArticle(
+			_user.getUserId(), kbArticle.getResourcePrimKey(), _serviceContext);
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_DRAFT, kbArticle.getStatus());
+	}
+
+	@Test
 	public void testGetAllDescendantKBArticles() throws Exception {
 		KBArticle parentKBArticle = _kbArticleLocalService.addKBArticle(
 			null, _user.getUserId(), _kbFolderClassNameId,

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/display/context/KBArticleViewDisplayContext.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/display/context/KBArticleViewDisplayContext.java
@@ -106,7 +106,9 @@ public class KBArticleViewDisplayContext {
 
 		Date expirationDate = kbArticle.getExpirationDate();
 
-		if (kbArticle.isExpired() || (expirationDate == null)) {
+		if (kbArticle.isDraft() || kbArticle.isExpired() ||
+			(expirationDate == null)) {
+
 			return false;
 		}
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-176521


Instead of updating the kbArticle 2 times, or updating the 

The problem is the way we obtain the asset entry from the KBArticle. It depends on the approval of the previous kbArticle.
The KBArticle table stores all the versions of each article, but the asset only must point to the approved ones or the drafts. On the case when we expire the kbArticle, the status is not approved but the previous asset  still is, so we have to pickup this on to modify it.


- LPS-176521 update the asset entry and indexer if is expired too
- LPS-176521 remove old index for the old version of the KBArticle
- LPS-176521 extract the logic of the get action
- LPS-176521 not needed
- LPS-176521 use method to reindex
- LPS-176521 when we are expiring the KB Article without previous updating the asset entry, the classPK method return the not approved one, but the asset is not updated yet, so the classPK should be the one of the approved article
- LPS-176521 autoSF
- LPS-176521 add tests to check the behavior of the kb with the asset entry
