### PR TITLE
LPS-177496 capture warn messages when we disable default image scaler on test

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-image-impl-test/src/testIntegration/java/com/liferay/adaptive/media/image/internal/scaler/test/AMImageScalerRegistryImplTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-impl-test/src/testIntegration/java/com/liferay/adaptive/media/image/internal/scaler/test/AMImageScalerRegistryImplTest.java
@@ -241,7 +241,10 @@ public class AMImageScalerRegistryImplTest {
 	public void testAMImageScalerRegistryReturnsNullWhenNoThereIsNoDefaultImageScaler()
 		throws Exception {
 
-		try {
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				_CLASS_NAME_ADAPTIVE_MEDIA_IMAGE_SCALER_TRACKER_IMPL,
+				LoggerTestUtil.WARN)) {
+
 			_disableAMDefaultImageScaler();
 
 			Assert.assertNull(
@@ -260,7 +263,10 @@ public class AMImageScalerRegistryImplTest {
 		ServiceRegistration<AMImageScaler> amImageScalerServiceRegistration =
 			null;
 
-		try {
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				_CLASS_NAME_ADAPTIVE_MEDIA_IMAGE_SCALER_TRACKER_IMPL,
+				LoggerTestUtil.WARN)) {
+
 			_disableAMDefaultImageScaler();
 
 			AMImageScaler disabledAMImageScaler = new TestAMImageScaler(false);


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-177496

