### PR TITLE
LPS-177633 add validation for negative values

### DIFF
--- a/modules/apps/document-library/document-library-preview-pdf/src/main/java/com/liferay/document/library/preview/pdf/internal/portlet/action/EditPDFPreviewMVCActionCommand.java
+++ b/modules/apps/document-library/document-library-preview-pdf/src/main/java/com/liferay/document/library/preview/pdf/internal/portlet/action/EditPDFPreviewMVCActionCommand.java
@@ -68,9 +68,17 @@ public class EditPDFPreviewMVCActionCommand extends BaseMVCActionCommand {
 		}
 
 		try {
+			int maxNumberOfPages = ParamUtil.getInteger(
+				actionRequest, "maxNumberOfPages");
+
+			if (maxNumberOfPages < 0) {
+				throw new PDFPreviewException(
+					"Maximum number of pages limit must be a non-negative " +
+						"integer");
+			}
+
 			_pdfPreviewManagedServiceFactory.updatePDFPreview(
-				ParamUtil.getInteger(actionRequest, "maxNumberOfPages"), scope,
-				scopePK);
+				maxNumberOfPages, scope, scopePK);
 		}
 		catch (ConfigurationModelListenerException | PDFPreviewException
 					exception) {

--- a/modules/apps/document-library/document-library-preview-pdf/src/main/resources/META-INF/resources/document_library_preview_pdf_settings/js/PDFPreviewLimit.js
+++ b/modules/apps/document-library/document-library-preview-pdf/src/main/resources/META-INF/resources/document_library_preview_pdf_settings/js/PDFPreviewLimit.js
@@ -38,6 +38,7 @@ const PDFPreviewLimit = ({maxLimitSize, namespace, scopeLabel, value}) => {
 			<ClayInput
 				autoFocus
 				className="form-control"
+				min={0}
 				name={`${namespace}maxNumberOfPages`}
 				onChange={onChange}
 				type="number"

--- a/modules/apps/document-library/document-library-preview-pdf/src/main/resources/META-INF/resources/document_library_preview_pdf_settings/js/PDFPreviewLimit.js
+++ b/modules/apps/document-library/document-library-preview-pdf/src/main/resources/META-INF/resources/document_library_preview_pdf_settings/js/PDFPreviewLimit.js
@@ -36,6 +36,7 @@ const PDFPreviewLimit = ({maxLimitSize, namespace, scopeLabel, value}) => {
 			</label>
 
 			<ClayInput
+				aria-label={Liferay.Language.get('maximum-number-of-pages')}
 				autoFocus
 				className="form-control"
 				min={0}


### PR DESCRIPTION
[LPS-177633](https://issues.liferay.com/browse/LPS-177633)

Steps to reproduce:

1. Set the Maximum Number of Pages in the system setting (e.g. set 200 as the maximum number)
2. Navigate to the site setting
3. Choose the PDF Preview site scope
4. Configure the number of pages as -1

- LPS-177633 add validation for negative numbers on command
- LPS-177633 add min value to the input
- LPS-177633 add aria-label to input


asked to resend rebased due rebase [errors](https://github.com/brianchandotcom/liferay-portal/pull/131331#issuecomment-1460167248)