### PR TITLE
LPS-176519 Assets Libraries Settings page doesn't work if you access from the Assets Library Settings button

### DIFF
--- a/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/portlet/DepotSettingsPortlet.java
+++ b/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/portlet/DepotSettingsPortlet.java
@@ -48,6 +48,7 @@ import org.osgi.service.component.annotations.Reference;
 	property = {
 		"com.liferay.portlet.css-class-wrapper=portlet-depot-admin",
 		"com.liferay.portlet.display-category=category.hidden",
+		"com.liferay.portlet.header-portlet-css=/css/main.css",
 		"com.liferay.portlet.instanceable=false",
 		"com.liferay.portlet.use-default-template=true",
 		"javax.portlet.display-name=Depot",


### PR DESCRIPTION
There was a missing CSS reference from one the two portlets rendering the same settings page.

For more info see: https://issues.liferay.com/browse/LPS-176519