### PR TITLE
LPS-177568 add LogCapture to avoid in necessary logs on test where TikaRawMetadataProcessor is called

### DIFF
--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFileEntrySearchTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFileEntrySearchTest.java
@@ -67,6 +67,8 @@ import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.search.test.util.BaseSearchTestCase;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -230,7 +232,10 @@ public class DLFileEntrySearchTest extends BaseSearchTestCase {
 
 		File file = null;
 
-		try {
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				"org.apache.xmlbeans.impl.common.SAXHelper",
+				LoggerTestUtil.WARN)) {
+
 			String mimeType = MimeTypesUtil.getContentType(file, fileName);
 
 			file = FileUtil.createTempFile(inputStream);


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-177568

Steps to try: run
` gw tI --tests "*DLFileEntrySearch*"`
on` ./modules/apps/document-library/document-library-test`