### PR TITLE
LPS-178565 AddFieldInHeadlessMyUserNotification

### DIFF
--- a/modules/apps/headless/headless-user-notification/headless-user-notification-api/bnd.bnd
+++ b/modules/apps/headless/headless-user-notification/headless-user-notification-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless User Notification API
 Bundle-SymbolicName: com.liferay.headless.user.notification.api
-Bundle-Version: 1.0.2
+Bundle-Version: 1.1.0
 Export-Package:\
 	com.liferay.headless.user.notification.dto.v1_0,\
 	com.liferay.headless.user.notification.resource.v1_0

--- a/modules/apps/headless/headless-user-notification/headless-user-notification-api/src/main/java/com/liferay/headless/user/notification/dto/v1_0/UserNotification.java
+++ b/modules/apps/headless/headless-user-notification/headless-user-notification-api/src/main/java/com/liferay/headless/user/notification/dto/v1_0/UserNotification.java
@@ -99,6 +99,34 @@ public class UserNotification implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Map<String, Map<String, String>> actions;
 
+	@Schema(description = "The user notification's comment.")
+	public String getComment() {
+		return comment;
+	}
+
+	public void setComment(String comment) {
+		this.comment = comment;
+	}
+
+	@JsonIgnore
+	public void setComment(
+		UnsafeSupplier<String, Exception> commentUnsafeSupplier) {
+
+		try {
+			comment = commentUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField(description = "The user notification's comment.")
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String comment;
+
 	@Schema(description = "The user notification's creation date.")
 	public Date getDateCreated() {
 		return dateCreated;
@@ -275,6 +303,20 @@ public class UserNotification implements Serializable {
 			sb.append("\"actions\": ");
 
 			sb.append(_toJSON(actions));
+		}
+
+		if (comment != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"comment\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(comment));
+
+			sb.append("\"");
 		}
 
 		if (dateCreated != null) {

--- a/modules/apps/headless/headless-user-notification/headless-user-notification-api/src/main/resources/com/liferay/headless/user/notification/dto/v1_0/packageinfo
+++ b/modules/apps/headless/headless-user-notification/headless-user-notification-api/src/main/resources/com/liferay/headless/user/notification/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/modules/apps/headless/headless-user-notification/headless-user-notification-client/src/main/java/com/liferay/headless/user/notification/client/dto/v1_0/UserNotification.java
+++ b/modules/apps/headless/headless-user-notification/headless-user-notification-client/src/main/java/com/liferay/headless/user/notification/client/dto/v1_0/UserNotification.java
@@ -58,6 +58,27 @@ public class UserNotification implements Cloneable, Serializable {
 
 	protected Map<String, Map<String, String>> actions;
 
+	public String getComment() {
+		return comment;
+	}
+
+	public void setComment(String comment) {
+		this.comment = comment;
+	}
+
+	public void setComment(
+		UnsafeSupplier<String, Exception> commentUnsafeSupplier) {
+
+		try {
+			comment = commentUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String comment;
+
 	public Date getDateCreated() {
 		return dateCreated;
 	}

--- a/modules/apps/headless/headless-user-notification/headless-user-notification-client/src/main/java/com/liferay/headless/user/notification/client/serdes/v1_0/UserNotificationSerDes.java
+++ b/modules/apps/headless/headless-user-notification/headless-user-notification-client/src/main/java/com/liferay/headless/user/notification/client/serdes/v1_0/UserNotificationSerDes.java
@@ -71,6 +71,20 @@ public class UserNotificationSerDes {
 			sb.append(_toJSON(userNotification.getActions()));
 		}
 
+		if (userNotification.getComment() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"comment\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(userNotification.getComment()));
+
+			sb.append("\"");
+		}
+
 		if (userNotification.getDateCreated() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -160,6 +174,13 @@ public class UserNotificationSerDes {
 			map.put("actions", String.valueOf(userNotification.getActions()));
 		}
 
+		if (userNotification.getComment() == null) {
+			map.put("comment", null);
+		}
+		else {
+			map.put("comment", String.valueOf(userNotification.getComment()));
+		}
+
 		if (userNotification.getDateCreated() == null) {
 			map.put("dateCreated", null);
 		}
@@ -224,6 +245,11 @@ public class UserNotificationSerDes {
 					userNotification.setActions(
 						(Map)UserNotificationSerDes.toMap(
 							(String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "comment")) {
+				if (jsonParserFieldValue != null) {
+					userNotification.setComment((String)jsonParserFieldValue);
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "dateCreated")) {

--- a/modules/apps/headless/headless-user-notification/headless-user-notification-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-user-notification/headless-user-notification-impl/rest-openapi.yaml
@@ -14,7 +14,7 @@ components:
                         Block of actions allowed by the user making the request.
                     readOnly: true
                     type: object
-                comment:  
+                comment:
                     # @review
                     description:
                         The user notification's comment.

--- a/modules/apps/headless/headless-user-notification/headless-user-notification-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-user-notification/headless-user-notification-impl/rest-openapi.yaml
@@ -55,7 +55,7 @@ components:
 info:
     description:
         "Headless User Notification REST API. A Java client JAR is available for use with the group ID 'com.liferay',
-        artifact ID 'com.liferay.headless.user.notification.client', and version '1.0.3'."
+        artifact ID 'com.liferay.headless.user.notification.client', and version '1.0.4'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/headless/headless-user-notification/headless-user-notification-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-user-notification/headless-user-notification-impl/rest-openapi.yaml
@@ -14,6 +14,12 @@ components:
                         Block of actions allowed by the user making the request.
                     readOnly: true
                     type: object
+                comment:  
+                    # @review
+                    description:
+                        The user notification's comment.
+                    readOnly: true
+                    type: string
                 dateCreated:
                     # @review
                     description:

--- a/modules/apps/headless/headless-user-notification/headless-user-notification-impl/src/main/java/com/liferay/headless/user/notification/internal/dto/v1_0/UserNotificationDTOConverter.java
+++ b/modules/apps/headless/headless-user-notification/headless-user-notification-impl/src/main/java/com/liferay/headless/user/notification/internal/dto/v1_0/UserNotificationDTOConverter.java
@@ -72,6 +72,7 @@ public class UserNotificationDTOConverter
 
 		return new UserNotification() {
 			{
+				comment = jsonObject.getString("entryTitle", null);
 				dateCreated = new Date(userNotificationEvent.getTimestamp());
 				id = userNotificationEvent.getUserNotificationEventId();
 				message = _getNotificationMessage(

--- a/modules/apps/headless/headless-user-notification/headless-user-notification-impl/src/main/java/com/liferay/headless/user/notification/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-user-notification/headless-user-notification-impl/src/main/java/com/liferay/headless/user/notification/internal/graphql/query/v1_0/Query.java
@@ -117,7 +117,7 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {userNotification(userNotificationId: ___){actions, dateCreated, id, message, read, type}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {userNotification(userNotificationId: ___){actions, comment, dateCreated, id, message, read, type}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField(description = "Retrieves the user notification.")
 	public UserNotification userNotification(

--- a/modules/apps/headless/headless-user-notification/headless-user-notification-impl/src/main/java/com/liferay/headless/user/notification/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-user-notification/headless-user-notification-impl/src/main/java/com/liferay/headless/user/notification/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -51,7 +51,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Headless User Notification REST API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.user.notification.client', and version '1.0.3'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "HeadlessUserNotification", version = "v1.0")
+	info = @Info(description = "Headless User Notification REST API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.user.notification.client', and version '1.0.4'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "HeadlessUserNotification", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/headless/headless-user-notification/headless-user-notification-test/src/testIntegration/java/com/liferay/headless/user/notification/resource/v1_0/test/BaseUserNotificationResourceTestCase.java
+++ b/modules/apps/headless/headless-user-notification/headless-user-notification-test/src/testIntegration/java/com/liferay/headless/user/notification/resource/v1_0/test/BaseUserNotificationResourceTestCase.java
@@ -186,6 +186,7 @@ public abstract class BaseUserNotificationResourceTestCase {
 
 		UserNotification userNotification = randomUserNotification();
 
+		userNotification.setComment(regex);
 		userNotification.setMessage(regex);
 
 		String json = UserNotificationSerDes.toJSON(userNotification);
@@ -194,6 +195,7 @@ public abstract class BaseUserNotificationResourceTestCase {
 
 		userNotification = UserNotificationSerDes.toDTO(json);
 
+		Assert.assertEquals(regex, userNotification.getComment());
 		Assert.assertEquals(regex, userNotification.getMessage());
 	}
 
@@ -1155,6 +1157,14 @@ public abstract class BaseUserNotificationResourceTestCase {
 				continue;
 			}
 
+			if (Objects.equals("comment", additionalAssertFieldName)) {
+				if (userNotification.getComment() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals("message", additionalAssertFieldName)) {
 				if (userNotification.getMessage() == null) {
 					valid = false;
@@ -1299,6 +1309,17 @@ public abstract class BaseUserNotificationResourceTestCase {
 				if (!equals(
 						(Map)userNotification1.getActions(),
 						(Map)userNotification2.getActions())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("comment", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						userNotification1.getComment(),
+						userNotification2.getComment())) {
 
 					return false;
 				}
@@ -1467,6 +1488,14 @@ public abstract class BaseUserNotificationResourceTestCase {
 				"Invalid entity field " + entityFieldName);
 		}
 
+		if (entityFieldName.equals("comment")) {
+			sb.append("'");
+			sb.append(String.valueOf(userNotification.getComment()));
+			sb.append("'");
+
+			return sb.toString();
+		}
+
 		if (entityFieldName.equals("dateCreated")) {
 			if (operator.equals("between")) {
 				sb = new StringBundler();
@@ -1569,6 +1598,7 @@ public abstract class BaseUserNotificationResourceTestCase {
 	protected UserNotification randomUserNotification() throws Exception {
 		return new UserNotification() {
 			{
+				comment = StringUtil.toLowerCase(RandomTestUtil.randomString());
 				dateCreated = RandomTestUtil.nextDate();
 				id = RandomTestUtil.randomLong();
 				message = StringUtil.toLowerCase(RandomTestUtil.randomString());


### PR DESCRIPTION
## Context

Solutions -Raylife Team- We need to consume an endPoint that would return comments and mentions inside notifications:  [LPS-174067 ](https://issues.liferay.com/browse/LPS-174067 ) .

After a [Thread in DXP LIMA](https://liferay.slack.com/archives/CLD39UKM5/p1678711171719259) it was verified that the endPoint for comments and mentions did not exist.


## Purpose of PR

PR adds a new field to the `endPoint` of `my-user-notification`.
The field created was `entryTitle`, it returns comments/mentions in a notification.
The choice of name was based on the existing field of the same name in the table: `UserNotificationEvent`.

## How to test

Enable this feature flag: feature.flag.LPS-83384=true

endPoint: `o/headless-user-notification/v1.0/my-user-notifications`

You must have a comment or mention in the notification to view the new field.


## Task

[LPS-178565](https://issues.liferay.com/browse/LPS-178565)
