### PR TITLE
LPS-177329 Add filter by extension

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminDisplayContext.java
@@ -528,7 +528,7 @@ public class DLAdminDisplayContext {
 		long fileEntryTypeId = ParamUtil.getLong(
 			_httpServletRequest, "fileEntryTypeId", -1);
 
-		String[] fileExtensions = ParamUtil.getStringValues(
+		String[] extensions = ParamUtil.getStringValues(
 			_httpServletRequest, "extension");
 
 		String dlFileEntryTypeName = LanguageUtil.get(
@@ -570,7 +570,7 @@ public class DLAdminDisplayContext {
 		portletURL.setParameter("curFolder", currentFolder);
 		portletURL.setParameter("deltaFolder", deltaFolder);
 		portletURL.setParameter("folderId", String.valueOf(folderId));
-		portletURL.setParameter("extension", fileExtensions);
+		portletURL.setParameter("extension", extensions);
 
 		if (fileEntryTypeId >= 0) {
 			portletURL.setParameter(
@@ -629,7 +629,7 @@ public class DLAdminDisplayContext {
 
 		List<RepositoryEntry> results = new ArrayList<>();
 
-		if ((fileEntryTypeId >= 0) || ArrayUtil.isNotEmpty(fileExtensions)) {
+		if ((fileEntryTypeId >= 0) || ArrayUtil.isNotEmpty(extensions)) {
 			Indexer<?> indexer = IndexerRegistryUtil.getIndexer(
 				DLFileEntryConstants.getClassName());
 

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminDisplayContext.java
@@ -528,7 +528,8 @@ public class DLAdminDisplayContext {
 		long fileEntryTypeId = ParamUtil.getLong(
 			_httpServletRequest, "fileEntryTypeId", -1);
 
-		String[] fileExtensions = ParamUtil.getStringValues(_httpServletRequest, "extension");
+		String[] fileExtensions = ParamUtil.getStringValues(
+			_httpServletRequest, "extension");
 
 		String dlFileEntryTypeName = LanguageUtil.get(
 			_httpServletRequest, "basic-document");
@@ -628,7 +629,7 @@ public class DLAdminDisplayContext {
 
 		List<RepositoryEntry> results = new ArrayList<>();
 
-		if (fileEntryTypeId >= 0 || ArrayUtil.isNotEmpty(fileExtensions)) {
+		if ((fileEntryTypeId >= 0) || ArrayUtil.isNotEmpty(fileExtensions)) {
 			Indexer<?> indexer = IndexerRegistryUtil.getIndexer(
 				DLFileEntryConstants.getClassName());
 

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminDisplayContext.java
@@ -528,6 +528,8 @@ public class DLAdminDisplayContext {
 		long fileEntryTypeId = ParamUtil.getLong(
 			_httpServletRequest, "fileEntryTypeId", -1);
 
+		String[] fileExtensions = ParamUtil.getStringValues(_httpServletRequest, "extension");
+
 		String dlFileEntryTypeName = LanguageUtil.get(
 			_httpServletRequest, "basic-document");
 
@@ -567,6 +569,7 @@ public class DLAdminDisplayContext {
 		portletURL.setParameter("curFolder", currentFolder);
 		portletURL.setParameter("deltaFolder", deltaFolder);
 		portletURL.setParameter("folderId", String.valueOf(folderId));
+		portletURL.setParameter("extension", fileExtensions);
 
 		if (fileEntryTypeId >= 0) {
 			portletURL.setParameter(
@@ -625,7 +628,7 @@ public class DLAdminDisplayContext {
 
 		List<RepositoryEntry> results = new ArrayList<>();
 
-		if (fileEntryTypeId >= 0) {
+		if (fileEntryTypeId >= 0 || ArrayUtil.isNotEmpty(fileExtensions)) {
 			Indexer<?> indexer = IndexerRegistryUtil.getIndexer(
 				DLFileEntryConstants.getClassName());
 

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
@@ -63,6 +63,7 @@ import com.liferay.portal.kernel.servlet.taglib.ui.Menu;
 import com.liferay.portal.kernel.servlet.taglib.ui.URLMenuItem;
 import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.JavaConstants;
@@ -635,6 +636,12 @@ public class DLAdminManagementToolbarDisplayContext
 		return ParamUtil.getLong(_httpServletRequest, "fileEntryTypeId", -1);
 	}
 
+	private String[] _getFileExtensions(
+		HttpServletRequest httpServletRequest) {
+
+		return ParamUtil.getStringValues(httpServletRequest, "fileExtension");
+	}
+
 	private String _getFileExtensionsItemSelectorURL() {
 		RequestBackedPortletURLFactory requestBackedPortletURLFactory =
 			RequestBackedPortletURLFactoryUtil.create(_liferayPortletRequest);
@@ -666,13 +673,14 @@ public class DLAdminManagementToolbarDisplayContext
 
 	private List<DropdownItem> _getFilterNavigationDropdownItems() {
 		long fileEntryTypeId = _getFileEntryTypeId();
+		boolean fileExtensionsIsEmpty = ArrayUtil.isEmpty(_getFileExtensions(_httpServletRequest));
 		String navigation = ParamUtil.getString(
 			_httpServletRequest, "navigation", "home");
 
 		return DropdownItemListBuilder.add(
 			dropdownItem -> {
 				dropdownItem.setActive(
-					navigation.equals("home") && (fileEntryTypeId == -1));
+					navigation.equals("home") && (fileEntryTypeId == -1) && fileExtensionsIsEmpty);
 				dropdownItem.setHref(
 					PortletURLBuilder.create(
 						PortletURLUtil.clone(
@@ -753,6 +761,7 @@ public class DLAdminManagementToolbarDisplayContext
 		).add(
 			() -> FeatureFlagManagerUtil.isEnabled("LPS-84424"),
 			dropdownItem -> {
+				dropdownItem.setActive(!fileExtensionsIsEmpty);
 				dropdownItem.putData("action", "openExtensionSelector");
 				dropdownItem.putData(
 					"extensionsFilterURL", _getFileExtensionsItemSelectorURL());

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
@@ -331,7 +331,7 @@ public class DLAdminManagementToolbarDisplayContext
 
 		_addFileExtensionFilterLabelItems(labelItemListWrapper);
 
-		return labelItemListWrapper.add(
+		labelItemListWrapper.add(
 			() -> fileEntryTypeId != -1,
 			labelItem -> {
 				labelItem.putData(
@@ -365,8 +365,9 @@ public class DLAdminManagementToolbarDisplayContext
 						"%s: %s",
 						LanguageUtil.get(_httpServletRequest, "document-type"),
 						HtmlUtil.escape(fileEntryTypeName)));
-			}
-		).add(
+			});
+
+		labelItemListWrapper.add(
 			() -> Objects.equals(_getNavigation(), "mine"),
 			labelItem -> {
 				labelItem.putData(
@@ -387,8 +388,9 @@ public class DLAdminManagementToolbarDisplayContext
 						"%s: %s",
 						LanguageUtil.get(_httpServletRequest, "owner"),
 						HtmlUtil.escape(user.getFullName())));
-			}
-		).build();
+			});
+
+		return labelItemListWrapper.build();
 	}
 
 	private void _addFileExtensionFilterLabelItems(LabelItemListBuilder.LabelItemListWrapper labelItemListWrapper) {

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
@@ -393,39 +393,6 @@ public class DLAdminManagementToolbarDisplayContext
 		return labelItemListWrapper.build();
 	}
 
-	private void _addFileExtensionFilterLabelItems(LabelItemListBuilder.LabelItemListWrapper labelItemListWrapper) {
-		String[] fileExtensions = _getFileExtensions(_httpServletRequest);
-
-		if (ArrayUtil.isEmpty(fileExtensions)) {
-			return;
-		}
-
-		for (String fileExtension : fileExtensions) {
-			labelItemListWrapper.add(
-				labelItem -> {
-					labelItem.putData(
-						"removeLabelURL",
-						PortletURLBuilder.create(
-							PortletURLUtil.clone(
-								_currentURLObj, _liferayPortletResponse)
-						).setParameter(
-							"extension",
-							ArrayUtil.remove(fileExtensions, fileExtension)
-						).buildString());
-
-					labelItem.setCloseable(true);
-
-					labelItem.setLabel(
-						String.format(
-							"%s: %s",
-							LanguageUtil.get(
-								_httpServletRequest, "extension"),
-							HtmlUtil.escape(fileExtension)));
-				}
-			);
-		}
-	}
-
 	@Override
 	public String getInfoPanelId() {
 		return "infoPanelId";
@@ -631,6 +598,39 @@ public class DLAdminManagementToolbarDisplayContext
 		return false;
 	}
 
+	private void _addFileExtensionFilterLabelItems(
+		LabelItemListBuilder.LabelItemListWrapper labelItemListWrapper) {
+
+		String[] fileExtensions = _getFileExtensions(_httpServletRequest);
+
+		if (ArrayUtil.isEmpty(fileExtensions)) {
+			return;
+		}
+
+		for (String fileExtension : fileExtensions) {
+			labelItemListWrapper.add(
+				labelItem -> {
+					labelItem.putData(
+						"removeLabelURL",
+						PortletURLBuilder.create(
+							PortletURLUtil.clone(
+								_currentURLObj, _liferayPortletResponse)
+						).setParameter(
+							"extension",
+							ArrayUtil.remove(fileExtensions, fileExtension)
+						).buildString());
+
+					labelItem.setCloseable(true);
+
+					labelItem.setLabel(
+						String.format(
+							"%s: %s",
+							LanguageUtil.get(_httpServletRequest, "extension"),
+							HtmlUtil.escape(fileExtension)));
+				});
+		}
+	}
+
 	private PortletURL _getCurrentSortingURL() {
 		int deltaEntry = ParamUtil.getInteger(
 			_httpServletRequest, "deltaEntry");
@@ -676,9 +676,7 @@ public class DLAdminManagementToolbarDisplayContext
 		return ParamUtil.getLong(_httpServletRequest, "fileEntryTypeId", -1);
 	}
 
-	private String[] _getFileExtensions(
-		HttpServletRequest httpServletRequest) {
-
+	private String[] _getFileExtensions(HttpServletRequest httpServletRequest) {
 		return ParamUtil.getStringValues(httpServletRequest, "extension");
 	}
 
@@ -713,14 +711,16 @@ public class DLAdminManagementToolbarDisplayContext
 
 	private List<DropdownItem> _getFilterNavigationDropdownItems() {
 		long fileEntryTypeId = _getFileEntryTypeId();
-		boolean fileExtensionsIsEmpty = ArrayUtil.isEmpty(_getFileExtensions(_httpServletRequest));
+		boolean fileExtensionsIsEmpty = ArrayUtil.isEmpty(
+			_getFileExtensions(_httpServletRequest));
 		String navigation = ParamUtil.getString(
 			_httpServletRequest, "navigation", "home");
 
 		return DropdownItemListBuilder.add(
 			dropdownItem -> {
 				dropdownItem.setActive(
-					navigation.equals("home") && (fileEntryTypeId == -1) && fileExtensionsIsEmpty);
+					navigation.equals("home") && (fileEntryTypeId == -1) &&
+					fileExtensionsIsEmpty);
 				dropdownItem.setHref(
 					PortletURLBuilder.create(
 						PortletURLUtil.clone(
@@ -732,9 +732,9 @@ public class DLAdminManagementToolbarDisplayContext
 					).setParameter(
 						"browseBy", (String)null
 					).setParameter(
-						"fileEntryTypeId", (String)null
-					).setParameter(
 						"extension", (String)null
+					).setParameter(
+						"fileEntryTypeId", (String)null
 					).buildPortletURL());
 				dropdownItem.setLabel(
 					LanguageUtil.get(_httpServletRequest, "all"));
@@ -803,10 +803,10 @@ public class DLAdminManagementToolbarDisplayContext
 		).add(
 			() -> FeatureFlagManagerUtil.isEnabled("LPS-84424"),
 			dropdownItem -> {
-				dropdownItem.setActive(!fileExtensionsIsEmpty);
 				dropdownItem.putData("action", "openExtensionSelector");
 				dropdownItem.putData(
 					"extensionsFilterURL", _getFileExtensionsItemSelectorURL());
+				dropdownItem.setActive(!fileExtensionsIsEmpty);
 				dropdownItem.setLabel(
 					LanguageUtil.get(_httpServletRequest, "extension") +
 						StringPool.TRIPLE_PERIOD);

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
@@ -329,7 +329,7 @@ public class DLAdminManagementToolbarDisplayContext
 		LabelItemListBuilder.LabelItemListWrapper labelItemListWrapper =
 			new LabelItemListBuilder.LabelItemListWrapper();
 
-		_addFileExtensionFilterLabelItems(labelItemListWrapper);
+		_addExtensionFilterLabelItems(labelItemListWrapper);
 
 		labelItemListWrapper.add(
 			() -> fileEntryTypeId != -1,
@@ -598,16 +598,16 @@ public class DLAdminManagementToolbarDisplayContext
 		return false;
 	}
 
-	private void _addFileExtensionFilterLabelItems(
+	private void _addExtensionFilterLabelItems(
 		LabelItemListBuilder.LabelItemListWrapper labelItemListWrapper) {
 
-		String[] fileExtensions = _getFileExtensions(_httpServletRequest);
+		String[] extensions = _getExtensions(_httpServletRequest);
 
-		if (ArrayUtil.isEmpty(fileExtensions)) {
+		if (ArrayUtil.isEmpty(extensions)) {
 			return;
 		}
 
-		for (String fileExtension : fileExtensions) {
+		for (String extension : extensions) {
 			labelItemListWrapper.add(
 				labelItem -> {
 					labelItem.putData(
@@ -617,7 +617,7 @@ public class DLAdminManagementToolbarDisplayContext
 								_currentURLObj, _liferayPortletResponse)
 						).setParameter(
 							"extension",
-							ArrayUtil.remove(fileExtensions, fileExtension)
+							ArrayUtil.remove(extensions, extension)
 						).buildString());
 
 					labelItem.setCloseable(true);
@@ -626,7 +626,7 @@ public class DLAdminManagementToolbarDisplayContext
 						String.format(
 							"%s: %s",
 							LanguageUtil.get(_httpServletRequest, "extension"),
-							HtmlUtil.escape(fileExtension)));
+							HtmlUtil.escape(extension)));
 				});
 		}
 	}
@@ -676,11 +676,11 @@ public class DLAdminManagementToolbarDisplayContext
 		return ParamUtil.getLong(_httpServletRequest, "fileEntryTypeId", -1);
 	}
 
-	private String[] _getFileExtensions(HttpServletRequest httpServletRequest) {
+	private String[] _getExtensions(HttpServletRequest httpServletRequest) {
 		return ParamUtil.getStringValues(httpServletRequest, "extension");
 	}
 
-	private String _getFileExtensionsItemSelectorURL() {
+	private String _getExtensionsItemSelectorURL() {
 		RequestBackedPortletURLFactory requestBackedPortletURLFactory =
 			RequestBackedPortletURLFactoryUtil.create(_liferayPortletRequest);
 
@@ -705,14 +705,14 @@ public class DLAdminManagementToolbarDisplayContext
 				fileExtensionItemSelectorCriterion)
 		).setParameter(
 			"checkedFileExtensions",
-			() -> _getFileExtensions(httpServletRequest)
+			() -> _getExtensions(httpServletRequest)
 		).buildString();
 	}
 
 	private List<DropdownItem> _getFilterNavigationDropdownItems() {
 		long fileEntryTypeId = _getFileEntryTypeId();
-		boolean fileExtensionsIsEmpty = ArrayUtil.isEmpty(
-			_getFileExtensions(_httpServletRequest));
+		boolean extensionsIsEmpty = ArrayUtil.isEmpty(
+			_getExtensions(_httpServletRequest));
 		String navigation = ParamUtil.getString(
 			_httpServletRequest, "navigation", "home");
 
@@ -720,7 +720,7 @@ public class DLAdminManagementToolbarDisplayContext
 			dropdownItem -> {
 				dropdownItem.setActive(
 					navigation.equals("home") && (fileEntryTypeId == -1) &&
-					fileExtensionsIsEmpty);
+					extensionsIsEmpty);
 				dropdownItem.setHref(
 					PortletURLBuilder.create(
 						PortletURLUtil.clone(
@@ -805,8 +805,8 @@ public class DLAdminManagementToolbarDisplayContext
 			dropdownItem -> {
 				dropdownItem.putData("action", "openExtensionSelector");
 				dropdownItem.putData(
-					"extensionsFilterURL", _getFileExtensionsItemSelectorURL());
-				dropdownItem.setActive(!fileExtensionsIsEmpty);
+					"extensionsFilterURL", _getExtensionsItemSelectorURL());
+				dropdownItem.setActive(!extensionsIsEmpty);
 				dropdownItem.setLabel(
 					LanguageUtil.get(_httpServletRequest, "extension") +
 						StringPool.TRIPLE_PERIOD);

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
@@ -693,6 +693,8 @@ public class DLAdminManagementToolbarDisplayContext
 						"browseBy", (String)null
 					).setParameter(
 						"fileEntryTypeId", (String)null
+					).setParameter(
+						"fileExtension", (String)null
 					).buildPortletURL());
 				dropdownItem.setLabel(
 					LanguageUtil.get(_httpServletRequest, "all"));

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
@@ -616,8 +616,7 @@ public class DLAdminManagementToolbarDisplayContext
 							PortletURLUtil.clone(
 								_currentURLObj, _liferayPortletResponse)
 						).setParameter(
-							"extension",
-							ArrayUtil.remove(extensions, extension)
+							"extension", ArrayUtil.remove(extensions, extension)
 						).buildString());
 
 					labelItem.setCloseable(true);
@@ -672,10 +671,6 @@ public class DLAdminManagementToolbarDisplayContext
 		return dlPortletInstanceSettings.getDisplayViews();
 	}
 
-	private long _getFileEntryTypeId() {
-		return ParamUtil.getLong(_httpServletRequest, "fileEntryTypeId", -1);
-	}
-
 	private String[] _getExtensions(HttpServletRequest httpServletRequest) {
 		return ParamUtil.getStringValues(httpServletRequest, "extension");
 	}
@@ -704,9 +699,12 @@ public class DLAdminManagementToolbarDisplayContext
 				portletResponse.getNamespace() + "selectedFileExtension",
 				fileExtensionItemSelectorCriterion)
 		).setParameter(
-			"checkedFileExtensions",
-			() -> _getExtensions(httpServletRequest)
+			"checkedFileExtensions", () -> _getExtensions(httpServletRequest)
 		).buildString();
+	}
+
+	private long _getFileEntryTypeId() {
+		return ParamUtil.getLong(_httpServletRequest, "fileEntryTypeId", -1);
 	}
 
 	private List<DropdownItem> _getFilterNavigationDropdownItems() {

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
@@ -326,7 +326,12 @@ public class DLAdminManagementToolbarDisplayContext
 	public List<LabelItem> getFilterLabelItems() {
 		long fileEntryTypeId = _getFileEntryTypeId();
 
-		return LabelItemListBuilder.add(
+		LabelItemListBuilder.LabelItemListWrapper labelItemListWrapper =
+			new LabelItemListBuilder.LabelItemListWrapper();
+
+		_addFileExtensionFilterLabelItems(labelItemListWrapper);
+
+		return labelItemListWrapper.add(
 			() -> fileEntryTypeId != -1,
 			labelItem -> {
 				labelItem.putData(
@@ -384,6 +389,39 @@ public class DLAdminManagementToolbarDisplayContext
 						HtmlUtil.escape(user.getFullName())));
 			}
 		).build();
+	}
+
+	private void _addFileExtensionFilterLabelItems(LabelItemListBuilder.LabelItemListWrapper labelItemListWrapper) {
+		String[] fileExtensions = _getFileExtensions(_httpServletRequest);
+
+		if (ArrayUtil.isEmpty(fileExtensions)) {
+			return;
+		}
+
+		for (String fileExtension : fileExtensions) {
+			labelItemListWrapper.add(
+				labelItem -> {
+					labelItem.putData(
+						"removeLabelURL",
+						PortletURLBuilder.create(
+							PortletURLUtil.clone(
+								_currentURLObj, _liferayPortletResponse)
+						).setParameter(
+							"fileExtension",
+							ArrayUtil.remove(fileExtensions, fileExtension)
+						).buildString());
+
+					labelItem.setCloseable(true);
+
+					labelItem.setLabel(
+						String.format(
+							"%s: %s",
+							LanguageUtil.get(
+								_httpServletRequest, "extension"),
+							HtmlUtil.escape(fileExtension)));
+				}
+			);
+		}
 	}
 
 	@Override

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
@@ -757,7 +757,7 @@ public class DLAdminManagementToolbarDisplayContext
 				dropdownItem.putData(
 					"extensionsFilterURL", _getFileExtensionsItemSelectorURL());
 				dropdownItem.setLabel(
-					LanguageUtil.get(_httpServletRequest, "extensions") +
+					LanguageUtil.get(_httpServletRequest, "extension") +
 						StringPool.TRIPLE_PERIOD);
 			}
 		).build();

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
@@ -407,7 +407,7 @@ public class DLAdminManagementToolbarDisplayContext
 							PortletURLUtil.clone(
 								_currentURLObj, _liferayPortletResponse)
 						).setParameter(
-							"fileExtension",
+							"extension",
 							ArrayUtil.remove(fileExtensions, fileExtension)
 						).buildString());
 
@@ -677,7 +677,7 @@ public class DLAdminManagementToolbarDisplayContext
 	private String[] _getFileExtensions(
 		HttpServletRequest httpServletRequest) {
 
-		return ParamUtil.getStringValues(httpServletRequest, "fileExtension");
+		return ParamUtil.getStringValues(httpServletRequest, "extension");
 	}
 
 	private String _getFileExtensionsItemSelectorURL() {
@@ -732,7 +732,7 @@ public class DLAdminManagementToolbarDisplayContext
 					).setParameter(
 						"fileEntryTypeId", (String)null
 					).setParameter(
-						"fileExtension", (String)null
+						"extension", (String)null
 					).buildPortletURL());
 				dropdownItem.setLabel(
 					LanguageUtil.get(_httpServletRequest, "all"));

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
@@ -667,7 +667,7 @@ public class DLAdminManagementToolbarDisplayContext
 				fileExtensionItemSelectorCriterion)
 		).setParameter(
 			"checkedFileExtensions",
-			() -> ParamUtil.getStringValues(httpServletRequest, "fileExtension")
+			() -> _getFileExtensions(httpServletRequest)
 		).buildString();
 	}
 

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLViewDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLViewDisplayContext.java
@@ -200,6 +200,14 @@ public class DLViewDisplayContext {
 		).buildString();
 	}
 
+	public String getSelectExtensionURL() throws PortletException {
+		return PortletURLBuilder.create(
+			PortletURLUtil.clone(_getCurrentPortletURL(), _renderResponse)
+		).setParameter(
+			"extension", (String)null
+		).buildString();
+	}
+
 	public String getSelectFileEntryTypeURL() throws WindowStateException {
 		return PortletURLBuilder.createRenderURL(
 			_renderResponse
@@ -274,14 +282,6 @@ public class DLViewDisplayContext {
 			"browseBy", "file-entry-type"
 		).setParameter(
 			"fileEntryTypeId", (String)null
-		).buildString();
-	}
-
-	public String getSelectExtensionURL() throws PortletException {
-		return PortletURLBuilder.create(
-			PortletURLUtil.clone(_getCurrentPortletURL(), _renderResponse)
-		).setParameter(
-			"extension", (String)null
 		).buildString();
 	}
 

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLViewDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLViewDisplayContext.java
@@ -277,6 +277,14 @@ public class DLViewDisplayContext {
 		).buildString();
 	}
 
+	public String getSelectExtensionURL() throws PortletException {
+		return PortletURLBuilder.create(
+			PortletURLUtil.clone(_getCurrentPortletURL(), _renderResponse)
+		).setParameter(
+			"fileExtension", (String)null
+		).buildString();
+	}
+
 	public String getViewFileEntryURL() {
 		return PortletURLBuilder.createRenderURL(
 			_renderResponse

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLViewDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLViewDisplayContext.java
@@ -281,7 +281,7 @@ public class DLViewDisplayContext {
 		return PortletURLBuilder.create(
 			PortletURLUtil.clone(_getCurrentPortletURL(), _renderResponse)
 		).setParameter(
-			"fileExtension", (String)null
+			"extension", (String)null
 		).buildString();
 	}
 

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/DLManagementToolbarPropsTransformer.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/DLManagementToolbarPropsTransformer.js
@@ -32,11 +32,11 @@ export default function propsTransformer({
 		editEntryURL,
 		folderConfiguration,
 		openViewMoreFileEntryTypesURL,
+		selectExtensionURL,
 		selectFileEntryTypeURL,
 		selectFolderURL,
 		trashEnabled,
 		viewFileEntryTypeURL,
-		selectExtensionURL,
 	},
 	portletNamespace,
 	...otherProps

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/DLManagementToolbarPropsTransformer.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/DLManagementToolbarPropsTransformer.js
@@ -201,7 +201,7 @@ export default function propsTransformer({
 			onSelect(selectedItem) {
 				if (selectedItem) {
 					const url = addParams(
-						`${portletNamespace}fileEntryExtensions=${selectedItem.join(
+						`${portletNamespace}fileExtension=${selectedItem.join(
 							','
 						)}`,
 						viewFileEntryTypeURL

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/DLManagementToolbarPropsTransformer.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/DLManagementToolbarPropsTransformer.js
@@ -201,12 +201,15 @@ export default function propsTransformer({
 			multiple: true,
 			onSelect(selectedItem) {
 				if (selectedItem) {
-					const url = addParams(
-						`${portletNamespace}fileExtension=${selectedItem.join(
-							','
-						)}`,
-						selectExtensionURL
-					);
+					let url = selectExtensionURL;
+
+					selectedItem.forEach((item) => {
+						url = addParams(
+							`${portletNamespace}extension=${item}`,
+							url
+						);
+					});
+
 					navigate(url);
 				}
 			},

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/DLManagementToolbarPropsTransformer.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/DLManagementToolbarPropsTransformer.js
@@ -36,6 +36,7 @@ export default function propsTransformer({
 		selectFolderURL,
 		trashEnabled,
 		viewFileEntryTypeURL,
+		selectExtensionURL,
 	},
 	portletNamespace,
 	...otherProps
@@ -204,7 +205,7 @@ export default function propsTransformer({
 						`${portletNamespace}fileExtension=${selectedItem.join(
 							','
 						)}`,
-						viewFileEntryTypeURL
+						selectExtensionURL
 					);
 					navigate(url);
 				}

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/DLManagementToolbarPropsTransformer.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/DLManagementToolbarPropsTransformer.js
@@ -201,14 +201,14 @@ export default function propsTransformer({
 			multiple: true,
 			onSelect(selectedItem) {
 				if (selectedItem) {
-					let url = selectExtensionURL;
-
-					selectedItem.forEach((item) => {
-						url = addParams(
-							`${portletNamespace}extension=${item}`,
-							url
-						);
-					});
+					const url = selectedItem.reduce(
+						(acc, item) =>
+							addParams(
+								`${portletNamespace}extension=${item}`,
+								acc
+							),
+						selectExtensionURL
+					);
 
 					navigate(url);
 				}

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view.jsp
@@ -84,6 +84,8 @@ DLViewDisplayContext dlViewDisplayContext = new DLViewDisplayContext(dlAdminDisp
 				).put(
 					"openViewMoreFileEntryTypesURL", dlViewDisplayContext.getViewMoreFileEntryTypesURL()
 				).put(
+					"selectExtensionURL", dlViewDisplayContext.getSelectExtensionURL()
+				).put(
 					"selectFileEntryTypeURL", dlViewDisplayContext.getSelectFileEntryTypeURL()
 				).put(
 					"selectFolderURL", dlViewDisplayContext.getSelectFolderURL()
@@ -91,8 +93,6 @@ DLViewDisplayContext dlViewDisplayContext = new DLViewDisplayContext(dlAdminDisp
 					"trashEnabled", dlTrashHelper.isTrashEnabled(scopeGroupId, dlViewDisplayContext.getRepositoryId())
 				).put(
 					"viewFileEntryTypeURL", dlViewDisplayContext.getViewFileEntryTypeURL()
-				).put(
-					"selectExtensionURL", dlViewDisplayContext.getSelectExtensionURL()
 				).put(
 					"viewFileEntryURL", dlViewDisplayContext.getViewFileEntryURL()
 				).build()

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view.jsp
@@ -92,6 +92,8 @@ DLViewDisplayContext dlViewDisplayContext = new DLViewDisplayContext(dlAdminDisp
 				).put(
 					"viewFileEntryTypeURL", dlViewDisplayContext.getViewFileEntryTypeURL()
 				).put(
+					"selectExtensionURL", dlViewDisplayContext.getSelectExtensionURL()
+				).put(
 					"viewFileEntryURL", dlViewDisplayContext.getViewFileEntryURL()
 				).build()
 			%>'


### PR DESCRIPTION
I corrected the javascript and generation of different URLs to correctly handle the "extension" request parameter. Finally, I included this parameter for filtering the existing documents.

How to test:

1. Activate the feature flag "LPS-84424"
2. Go to Documents & Media
3. Create files with different extensions in the same folder.
4. Use the new filter "Extension..."

However, I must say the search is not working as expected:

* Before my changes I found this problem: selecting filters "Document Type" and "Mine" doesn't work, "Mine" is not applied. The problem is in method `DLAdminDisplayContext._getDLSearchContainer()` where only one filter at the time is applied.
* After my changes I also discovered that: selecting one "Extension" works good, but selecting multiple extensions doesn't. It is probably using an AND logic, while it should use an OR logic.

Since more work is needed for fixing these errors, I have created:

* Bug https://issues.liferay.com/browse/LPS-178911 Filter criteria in Documents & Media is not combined
* Impedibug https://issues.liferay.com/browse/LPS-178908 Filtering by multiple extensions doesn't work