### PR TITLE
LPS-179135 Do not add any mapping if the repositoryId is equals to 0

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/exportimport/portlet/preferences/processor/DLExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/exportimport/portlet/preferences/processor/DLExportImportPortletPreferencesProcessor.java
@@ -147,7 +147,9 @@ public class DLExportImportPortletPreferencesProcessor
 		if (!_exportImportHelper.isExportPortletData(portletDataContext) ||
 			(selectedRepositoryId != portletDataContext.getGroupId())) {
 
-			if (ExportImportThreadLocal.isStagingInProcess()) {
+			if (ExportImportThreadLocal.isStagingInProcess() &&
+				(selectedRepositoryId > 0)) {
+
 				_saveStagingPreferencesMapping(
 					selectedRepositoryId, null, portletDataContext);
 			}


### PR DESCRIPTION
Hi team,

This solution tries to solve the scenario reported in [LPS-179135](https://issues.liferay.com/browse/LPS-179135).

If the D&M widget has more than one portlet preferences (like some ones at User scope and some others at Layout scope), the mapping file which maps the repositories might include wrong entries pointing to repositoryId = 0, which leads to a wrong import of the portlet preferences of this widget.

Please, let me know if further indications or clarifications are needed for your review.

Best,
Daniel