### PR TITLE
[TS] LPS-179148 MS SQL cannot handle aliases in GROUP BY clause

### DIFF
--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/impl/BlogsStatsUserLocalServiceImpl.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/impl/BlogsStatsUserLocalServiceImpl.java
@@ -146,7 +146,8 @@ public class BlogsStatsUserLocalServiceImpl
 					BlogsEntryTable.INSTANCE.entryId)
 			)
 		).groupBy(
-			_groupIdAlias, _userIdAlias, _companyIdAlias
+			BlogsEntryTable.INSTANCE.groupId, BlogsEntryTable.INSTANCE.userId,
+			BlogsEntryTable.INSTANCE.companyId
 		).as(
 			"innerTable"
 		);


### PR DESCRIPTION
Dear Team,

Could you please review this pull request?

Motivation
=======
Recent Bloggers portlet throws Invalid column name 'blogsEntryGroupId' with MS SQL server.
This is because MS SQL cannot handle aliases in the GROUP BY clause.
https://stackoverflow.com/questions/497241/how-do-i-perform-a-group-by-on-an-aliased-column-in-sql-server

Proposed Solution
========
Instead of the aliases, use the column names directly in the GROUP BY clause.

Steps to Verify
========
Please see the linked LPS for the reproduction steps.
https://issues.liferay.com/browse/LPP-48372

Thank you and best regards,
István