### PR TITLE
LPS-177939 Add the user agent variable to the method to obtain the redirections

### DIFF
--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
@@ -847,7 +847,8 @@ public class FriendlyURLServlet extends HttpServlet {
 
 		RedirectProvider.Redirect redirect = redirectProvider.getRedirect(
 			groupId, _normalizeFriendlyURL(layoutFriendlyURL),
-			_normalizeFriendlyURL(originalHttpServletRequest.getRequestURI()));
+			_normalizeFriendlyURL(originalHttpServletRequest.getRequestURI()),
+			httpServletRequest.getHeader(HttpHeaders.USER_AGENT));
 
 		if (redirect == null) {
 			return null;

--- a/modules/apps/redirect/redirect-api/bnd.bnd
+++ b/modules/apps/redirect/redirect-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Redirect API
 Bundle-SymbolicName: com.liferay.redirect.api
-Bundle-Version: 8.0.1
+Bundle-Version: 9.0.0
 Export-Package:\
 	com.liferay.redirect.configuration,\
 	com.liferay.redirect.constants,\

--- a/modules/apps/redirect/redirect-api/src/main/java/com/liferay/redirect/constants/RedirectConstants.java
+++ b/modules/apps/redirect/redirect-api/src/main/java/com/liferay/redirect/constants/RedirectConstants.java
@@ -21,4 +21,10 @@ public class RedirectConstants {
 
 	public static final String RESOURCE_NAME = "com.liferay.redirect";
 
+	public static final String USER_AGENT_ALL = "all";
+
+	public static final String USER_AGENT_BOT = "bot";
+
+	public static final String USER_AGENT_HUMAN = "human";
+
 }

--- a/modules/apps/redirect/redirect-api/src/main/java/com/liferay/redirect/provider/RedirectProvider.java
+++ b/modules/apps/redirect/redirect-api/src/main/java/com/liferay/redirect/provider/RedirectProvider.java
@@ -24,7 +24,7 @@ import java.util.List;
 public interface RedirectProvider {
 
 	public Redirect getRedirect(
-		long groupId, String friendlyURL, String fullURL);
+		long groupId, String friendlyURL, String fullURL, String userAgent);
 
 	public List<RedirectPatternEntry> getRedirectPatternEntries(long groupId);
 

--- a/modules/apps/redirect/redirect-api/src/main/resources/com/liferay/redirect/constants/packageinfo
+++ b/modules/apps/redirect/redirect-api/src/main/resources/com/liferay/redirect/constants/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/modules/apps/redirect/redirect-api/src/main/resources/com/liferay/redirect/provider/packageinfo
+++ b/modules/apps/redirect/redirect-api/src/main/resources/com/liferay/redirect/provider/packageinfo
@@ -1,1 +1,1 @@
-version 3.0.0
+version 4.0.0

--- a/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/internal/provider/RedirectProviderImpl.java
+++ b/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/internal/provider/RedirectProviderImpl.java
@@ -160,7 +160,21 @@ public class RedirectProviderImpl
 		_redirectPatternEntries = redirectPatternEntries;
 	}
 
+	private String[] _getCrawlerUserAgents() {
+		return new String[0];
+	}
+
 	private boolean _isCrawlerUserAgent(String userAgent) {
+		if (Validator.isNull(userAgent)) {
+			return false;
+		}
+
+		for (String crawlerUserAgent : _getCrawlerUserAgents()) {
+			if (userAgent.contains(StringUtil.toLowerCase(crawlerUserAgent))) {
+				return true;
+			}
+		}
+
 		return false;
 	}
 

--- a/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/internal/provider/RedirectProviderImpl.java
+++ b/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/internal/provider/RedirectProviderImpl.java
@@ -17,6 +17,9 @@ package com.liferay.redirect.internal.provider;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.redirect.constants.RedirectConstants;
 import com.liferay.redirect.internal.configuration.RedirectPatternConfiguration;
 import com.liferay.redirect.internal.util.PatternUtil;
 import com.liferay.redirect.model.RedirectEntry;
@@ -29,6 +32,7 @@ import java.util.Collections;
 import java.util.Dictionary;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -62,7 +66,7 @@ public class RedirectProviderImpl
 
 	@Override
 	public Redirect getRedirect(
-		long groupId, String friendlyURL, String fullURL) {
+		long groupId, String friendlyURL, String fullURL, String userAgent) {
 
 		if (friendlyURL.contains("/control_panel/manage")) {
 			return null;

--- a/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/internal/provider/RedirectProviderImpl.java
+++ b/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/internal/provider/RedirectProviderImpl.java
@@ -148,6 +148,10 @@ public class RedirectProviderImpl
 			PatternUtil.parse(redirectPatternConfiguration.patternStrings()));
 	}
 
+	protected void setCrawlerUserAgents(String[] crawlerUserAgents) {
+		_crawlerUserAgents = crawlerUserAgents;
+	}
+
 	protected void setRedirectEntryLocalService(
 		RedirectEntryLocalService redirectEntryLocalService) {
 
@@ -161,7 +165,11 @@ public class RedirectProviderImpl
 	}
 
 	private String[] _getCrawlerUserAgents() {
-		return new String[0];
+		if (_crawlerUserAgents == null) {
+			return new String[0];
+		}
+
+		return _crawlerUserAgents;
 	}
 
 	private boolean _isCrawlerUserAgent(String userAgent) {
@@ -219,6 +227,7 @@ public class RedirectProviderImpl
 		}
 	}
 
+	private String[] _crawlerUserAgents;
 	private final Map<String, Long> _groupIds = new ConcurrentHashMap<>();
 
 	@Reference

--- a/modules/apps/redirect/redirect-service/src/test/java/com/liferay/redirect/internal/provider/RedirectProviderImplTest.java
+++ b/modules/apps/redirect/redirect-service/src/test/java/com/liferay/redirect/internal/provider/RedirectProviderImplTest.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.redirect.constants.RedirectConstants;
 import com.liferay.redirect.model.RedirectPatternEntry;
 import com.liferay.redirect.provider.RedirectProvider;
 import com.liferay.redirect.service.RedirectEntryLocalService;
@@ -202,6 +203,106 @@ public class RedirectProviderImplTest {
 	}
 
 	@Test
+	public void testSimplePatternDoesntMatchUserAgentBot() {
+		_redirectProviderImpl.setCrawlerUserAgents(_CRAWLER_USER_AGENTS);
+
+		try {
+			_setupRedirectPatternEntries(
+				Collections.singletonList(
+					new RedirectPatternEntry(
+						Pattern.compile("^abc"), "xyz",
+						RedirectConstants.USER_AGENT_BOT)));
+
+			RedirectProvider.Redirect redirect = _getRedirectProviderRedirect(
+				"abc", "another");
+
+			Assert.assertNull(redirect);
+
+			_verifyMockInvocations();
+		}
+		finally {
+			_redirectProviderImpl.setCrawlerUserAgents(null);
+		}
+	}
+
+	@Test
+	public void testSimplePatternDoesntMatchUserAgentHuman() {
+		_redirectProviderImpl.setCrawlerUserAgents(_CRAWLER_USER_AGENTS);
+
+		try {
+			_setupRedirectPatternEntries(
+				Collections.singletonList(
+					new RedirectPatternEntry(
+						Pattern.compile("^abc"), "xyz",
+						RedirectConstants.USER_AGENT_HUMAN)));
+
+			RedirectProvider.Redirect redirect = _getRedirectProviderRedirect(
+				"abc", "bot");
+
+			Assert.assertNull(redirect);
+
+			_verifyMockInvocations();
+		}
+		finally {
+			_redirectProviderImpl.setCrawlerUserAgents(null);
+		}
+	}
+
+	@Test
+	public void testSimplePatternMatchesNoUserAgent() {
+		_setupRedirectPatternEntries(
+			Collections.singletonList(
+				new RedirectPatternEntry(
+					Pattern.compile("^abc"), "xyz", StringPool.BLANK)));
+
+		RedirectProvider.Redirect redirect = _getRedirectProviderRedirect(
+			"abc", "CrawlerBot");
+
+		Assert.assertEquals("xyz", redirect.getDestinationURL());
+
+		_verifyMockInvocations();
+	}
+
+	@Test
+	public void testSimplePatternMatchesNoUserAgentOnRedirect() {
+		_setupRedirectPatternEntries(
+			Collections.singletonList(
+				new RedirectPatternEntry(
+					Pattern.compile("^abc"), "xyz",
+					RedirectConstants.USER_AGENT_BOT)));
+
+		RedirectProvider.Redirect redirect = _getRedirectProviderRedirect(
+			"abc", StringPool.BLANK);
+
+		Assert.assertEquals("xyz", redirect.getDestinationURL());
+
+		_verifyMockInvocations();
+	}
+
+	@Test
+	public void testSimplePatternMatchesUserAgentBot() {
+		_redirectProviderImpl.setCrawlerUserAgents(_CRAWLER_USER_AGENTS);
+
+		try {
+			_setupRedirectPatternEntries(
+				Collections.singletonList(
+					new RedirectPatternEntry(
+						Pattern.compile("^abc"), "xyz",
+						RedirectConstants.USER_AGENT_BOT)));
+
+			RedirectProvider.Redirect redirect = _getRedirectProviderRedirect(
+				"abc", "CrawlerBot");
+
+			Assert.assertEquals("xyz", redirect.getDestinationURL());
+
+			_verifyMockInvocations();
+		}
+		finally {
+			_redirectProviderImpl.setCrawlerUserAgents(null);
+		}
+	}
+
+	@Test
 	public void testSimplePatternSingleMatch() {
 		_setupRedirectPatternEntries(
 			Collections.singletonList(
@@ -210,6 +311,38 @@ public class RedirectProviderImplTest {
 
 		RedirectProvider.Redirect redirect = _getRedirectProviderRedirect(
 			"abc", StringPool.BLANK);
+
+		Assert.assertEquals("xyz", redirect.getDestinationURL());
+
+		_verifyMockInvocations();
+	}
+
+	@Test
+	public void testSimplePatternSingleMatchesUserAgentAll() {
+		_setupRedirectPatternEntries(
+			Collections.singletonList(
+				new RedirectPatternEntry(
+					Pattern.compile("^abc"), "xyz",
+					RedirectConstants.USER_AGENT_ALL)));
+
+		RedirectProvider.Redirect redirect = _getRedirectProviderRedirect(
+			"abc", "CrawlerBot");
+
+		Assert.assertEquals("xyz", redirect.getDestinationURL());
+
+		_verifyMockInvocations();
+	}
+
+	@Test
+	public void testSimplePatternSingleMatchesUserAgentHuman() {
+		_setupRedirectPatternEntries(
+			Collections.singletonList(
+				new RedirectPatternEntry(
+					Pattern.compile("^abc"), "xyz",
+					RedirectConstants.USER_AGENT_HUMAN)));
+
+		RedirectProvider.Redirect redirect = _getRedirectProviderRedirect(
+			"abc", "human");
 
 		Assert.assertEquals("xyz", redirect.getDestinationURL());
 
@@ -258,6 +391,8 @@ public class RedirectProviderImplTest {
 			Mockito.eq(_GROUP_ID), Mockito.anyString(), Mockito.eq(true)
 		);
 	}
+
+	private static final String[] _CRAWLER_USER_AGENTS = {"bot", "crawlerbot"};
 
 	private static final long _GROUP_ID = RandomTestUtil.randomLong();
 

--- a/modules/apps/redirect/redirect-service/src/test/java/com/liferay/redirect/internal/provider/RedirectProviderImplTest.java
+++ b/modules/apps/redirect/redirect-service/src/test/java/com/liferay/redirect/internal/provider/RedirectProviderImplTest.java
@@ -68,7 +68,8 @@ public class RedirectProviderImplTest {
 					StringPool.BLANK)));
 
 		Assert.assertNull(
-			_getRedirectProviderRedirect("/control_panel/manage"));
+			_getRedirectProviderRedirect(
+				"/control_panel/manage", StringPool.BLANK));
 
 		Mockito.verify(
 			_redirectEntryLocalService, Mockito.never()
@@ -82,7 +83,8 @@ public class RedirectProviderImplTest {
 		_setupRedirectPatternEntries(Collections.emptyList());
 
 		Assert.assertNull(
-			_getRedirectProviderRedirect(StringUtil.randomString()));
+			_getRedirectProviderRedirect(
+				StringUtil.randomString(), StringPool.BLANK));
 
 		_verifyMockInvocations();
 	}
@@ -101,7 +103,7 @@ public class RedirectProviderImplTest {
 		_setupRedirectPatternEntries(redirectPatternEntries);
 
 		RedirectProvider.Redirect redirect = _getRedirectProviderRedirect(
-			"abc");
+			"abc", StringPool.BLANK);
 
 		Assert.assertEquals("ubw", redirect.getDestinationURL());
 
@@ -122,7 +124,7 @@ public class RedirectProviderImplTest {
 		_setupRedirectPatternEntries(redirectPatternEntries);
 
 		RedirectProvider.Redirect redirect = _getRedirectProviderRedirect(
-			"abc");
+			"abc", StringPool.BLANK);
 
 		Assert.assertEquals("xyz", redirect.getDestinationURL());
 
@@ -143,7 +145,7 @@ public class RedirectProviderImplTest {
 		_setupRedirectPatternEntries(redirectPatternEntries);
 
 		RedirectProvider.Redirect redirect = _getRedirectProviderRedirect(
-			"abc");
+			"abc", StringPool.BLANK);
 
 		Assert.assertEquals("ubw", redirect.getDestinationURL());
 
@@ -164,7 +166,7 @@ public class RedirectProviderImplTest {
 		_setupRedirectPatternEntries(redirectPatternEntries);
 
 		RedirectProvider.Redirect redirect = _getRedirectProviderRedirect(
-			"abc");
+			"abc", StringPool.BLANK);
 
 		Assert.assertEquals("123", redirect.getDestinationURL());
 
@@ -179,7 +181,7 @@ public class RedirectProviderImplTest {
 					Pattern.compile("^a(b)c"), "x$1z", StringPool.BLANK)));
 
 		RedirectProvider.Redirect redirect = _getRedirectProviderRedirect(
-			"abc");
+			"abc", StringPool.BLANK);
 
 		Assert.assertEquals("xbz", redirect.getDestinationURL());
 
@@ -193,7 +195,8 @@ public class RedirectProviderImplTest {
 				new RedirectPatternEntry(
 					Pattern.compile("^a(b)c"), "x$1z", StringPool.BLANK)));
 
-		Assert.assertNull(_getRedirectProviderRedirect("123"));
+		Assert.assertNull(
+			_getRedirectProviderRedirect("123", StringPool.BLANK));
 
 		_verifyMockInvocations();
 	}
@@ -206,7 +209,7 @@ public class RedirectProviderImplTest {
 					Pattern.compile("^abc"), "xyz", StringPool.BLANK)));
 
 		RedirectProvider.Redirect redirect = _getRedirectProviderRedirect(
-			"abc");
+			"abc", StringPool.BLANK);
 
 		Assert.assertEquals("xyz", redirect.getDestinationURL());
 
@@ -220,16 +223,17 @@ public class RedirectProviderImplTest {
 				new RedirectPatternEntry(
 					Pattern.compile("^abc"), "xyz", StringPool.BLANK)));
 
-		Assert.assertNull(_getRedirectProviderRedirect("123"));
+		Assert.assertNull(
+			_getRedirectProviderRedirect("123", StringPool.BLANK));
 
 		_verifyMockInvocations();
 	}
 
 	private RedirectProvider.Redirect _getRedirectProviderRedirect(
-		String friendlyURL) {
+		String friendlyURL, String userAgent) {
 
 		return _redirectProviderImpl.getRedirect(
-			_GROUP_ID, friendlyURL, StringUtil.randomString());
+			_GROUP_ID, friendlyURL, StringUtil.randomString(), userAgent);
 	}
 
 	private void _setupRedirectPatternEntries(


### PR DESCRIPTION
This is the second backend part for the task about adding the user agent to the redirection patterns

Some thing to take into account:
- `crawlerUserAgents` is the name of the configuration that now has the LayoutSEODynamicRenderingConfiguration and will be merged with the new configuration that we will create. 
- the method `_getCrawlerUserAgents`() returns a `new String[0];` This is temporary till the configuration is done so this be changed. And the method maybe removed.

When the PR of the frontend part will be merged, more changes will come but I prefer to send smaller PRs

Thanks!
