### PR TITLE
[TS] [Urgent] LPS-179366 Make sure we do not append the doAsUserId param twice when redirecting the user from a Link to URL page

### DIFF
--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
@@ -78,6 +78,7 @@ import com.liferay.site.service.SiteFriendlyURLLocalService;
 
 import java.io.IOException;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -427,6 +428,10 @@ public class FriendlyURLServlet extends HttpServlet {
 
 				actualURL = HttpComponentsUtil.setParameter(
 					actualURL, "doAsUserId", encDoAsUserId);
+
+				params = new HashMap<>(params);
+
+				params.remove("doAsUserId");
 			}
 			catch (EncryptorException encryptorException) {
 				if (_log.isDebugEnabled()) {


### PR DESCRIPTION
See detailed explanation on [LPS-179366](https://issues.liferay.com/browse/LPS-179366)

Marked urgent because this was marked as a Risk ticket for the customer who is facing this issue.