### PR TITLE
LPS-178911 Filter criteria in Documents & Media is not combined

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminDisplayContext.java
@@ -644,8 +644,10 @@ public class DLAdminDisplayContext {
 			long userId = 0;
 			if (navigation.equals("mine") && _themeDisplay.isSignedIn()) {
 				userId = _themeDisplay.getUserId();
+				status = WorkflowConstants.STATUS_ANY;
 			}
 
+			searchContext.setAttribute("status", status);
 			searchContext.setBooleanClauses(
 				_getBooleanClauses(extensions, fileEntryTypeId, userId));
 
@@ -665,6 +667,8 @@ public class DLAdminDisplayContext {
 				getOrderByCol(), getOrderByType(), true);
 
 		dlSearchContainer.setOrderByComparator(orderByComparator);
+
+		long repositoryId = getRepositoryId();
 
 		long categoryId = ParamUtil.getLong(_httpServletRequest, "categoryId");
 		String tagName = ParamUtil.getString(_httpServletRequest, "tag");
@@ -701,7 +705,7 @@ public class DLAdminDisplayContext {
 									DLFolderConstants.
 										DEFAULT_PARENT_FOLDER_ID) &&
 								 (fileEntry.getRepositoryId() ==
-									 getRepositoryId()))) {
+									 repositoryId))) {
 
 								results.add(fileEntry);
 							}
@@ -718,8 +722,6 @@ public class DLAdminDisplayContext {
 						AssetEntryServiceUtil.getEntriesCount(assetEntryQuery));
 				}
 				else {
-					long repositoryId = getRepositoryId();
-
 					int dlAppStatus = status;
 
 					dlSearchContainer.setResultsAndTotal(

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminDisplayContext.java
@@ -30,7 +30,6 @@ import com.liferay.document.library.kernel.service.DLAppLocalServiceUtil;
 import com.liferay.document.library.kernel.service.DLAppServiceUtil;
 import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalServiceUtil;
 import com.liferay.document.library.kernel.util.DLUtil;
-import com.liferay.document.library.kernel.util.comparator.RepositoryModelModifiedDateComparator;
 import com.liferay.document.library.kernel.versioning.VersioningStrategy;
 import com.liferay.document.library.web.internal.display.context.helper.DLPortletInstanceSettingsHelper;
 import com.liferay.document.library.web.internal.display.context.helper.DLRequestHelper;
@@ -96,7 +95,6 @@ import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.ListUtil;
-import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PortletKeys;
@@ -555,8 +553,7 @@ public class DLAdminDisplayContext {
 
 		if (userId > 0) {
 			booleanFilter.addTerm(
-				Field.USER_ID, String.valueOf(userId),
-				BooleanClauseOccur.MUST);
+				Field.USER_ID, String.valueOf(userId), BooleanClauseOccur.MUST);
 		}
 
 		BooleanQuery booleanQuery = new BooleanQueryImpl();
@@ -629,7 +626,9 @@ public class DLAdminDisplayContext {
 		dlSearchContainer.setOrderByCol(getOrderByCol());
 		dlSearchContainer.setOrderByType(getOrderByType());
 
-		if ((fileEntryTypeId >= 0) || ArrayUtil.isNotEmpty(extensions) || navigation.equals("mine") || navigation.equals("recent")) {
+		if ((fileEntryTypeId >= 0) || ArrayUtil.isNotEmpty(extensions) ||
+			navigation.equals("mine") || navigation.equals("recent")) {
+
 			if (navigation.equals("recent")) {
 				dlSearchContainer.setOrderByCol("modifiedDate");
 				dlSearchContainer.setOrderByType("desc");
@@ -642,6 +641,7 @@ public class DLAdminDisplayContext {
 			}
 
 			long userId = 0;
+
 			if (navigation.equals("mine") && _themeDisplay.isSignedIn()) {
 				userId = _themeDisplay.getUserId();
 				status = WorkflowConstants.STATUS_ANY;
@@ -662,81 +662,73 @@ public class DLAdminDisplayContext {
 			return dlSearchContainer;
 		}
 
-		OrderByComparator<RepositoryEntry> orderByComparator =
+		dlSearchContainer.setOrderByComparator(
 			DLUtil.getRepositoryModelOrderByComparator(
-				getOrderByCol(), getOrderByType(), true);
-
-		dlSearchContainer.setOrderByComparator(orderByComparator);
+				getOrderByCol(), getOrderByType(), true));
 
 		long repositoryId = getRepositoryId();
 
 		long categoryId = ParamUtil.getLong(_httpServletRequest, "categoryId");
 		String tagName = ParamUtil.getString(_httpServletRequest, "tag");
 
-				if ((categoryId > 0) || Validator.isNotNull(tagName)) {
-					long[] classNameIds = {
-						PortalUtil.getClassNameId(
-							DLFileEntryConstants.getClassName()),
-						PortalUtil.getClassNameId(
-							DLFileShortcutConstants.getClassName())
-					};
+		if ((categoryId > 0) || Validator.isNotNull(tagName)) {
+			long[] classNameIds = {
+				PortalUtil.getClassNameId(DLFileEntryConstants.getClassName()),
+				PortalUtil.getClassNameId(
+					DLFileShortcutConstants.getClassName())
+			};
 
-					AssetEntryQuery assetEntryQuery = new AssetEntryQuery(
-						classNameIds, dlSearchContainer);
+			AssetEntryQuery assetEntryQuery = new AssetEntryQuery(
+				classNameIds, dlSearchContainer);
 
-					assetEntryQuery.setEnablePermissions(true);
-					assetEntryQuery.setExcludeZeroViewCount(false);
+			assetEntryQuery.setEnablePermissions(true);
+			assetEntryQuery.setExcludeZeroViewCount(false);
 
-					List<RepositoryEntry> results = new ArrayList<>();
+			List<RepositoryEntry> results = new ArrayList<>();
 
-					for (AssetEntry assetEntry :
-							AssetEntryServiceUtil.getEntries(assetEntryQuery)) {
+			for (AssetEntry assetEntry :
+					AssetEntryServiceUtil.getEntries(assetEntryQuery)) {
 
-						if (Objects.equals(
-								assetEntry.getClassName(),
-								DLFileEntryConstants.getClassName())) {
+				if (Objects.equals(
+						assetEntry.getClassName(),
+						DLFileEntryConstants.getClassName())) {
 
-							FileEntry fileEntry =
-								DLAppLocalServiceUtil.getFileEntry(
-									assetEntry.getClassPK());
+					FileEntry fileEntry = DLAppLocalServiceUtil.getFileEntry(
+						assetEntry.getClassPK());
 
-							if (_isAncestorFolder(folderId, fileEntry) ||
-								((folderId ==
-									DLFolderConstants.
-										DEFAULT_PARENT_FOLDER_ID) &&
-								 (fileEntry.getRepositoryId() ==
-									 repositoryId))) {
+					if (_isAncestorFolder(folderId, fileEntry) ||
+						((folderId ==
+							DLFolderConstants.DEFAULT_PARENT_FOLDER_ID) &&
+						 (fileEntry.getRepositoryId() == repositoryId))) {
 
-								results.add(fileEntry);
-							}
-						}
-						else {
-							results.add(
-								DLAppLocalServiceUtil.getFileShortcut(
-									assetEntry.getClassPK()));
-						}
+						results.add(fileEntry);
 					}
-
-					dlSearchContainer.setResultsAndTotal(
-						() -> results,
-						AssetEntryServiceUtil.getEntriesCount(assetEntryQuery));
 				}
 				else {
-					int dlAppStatus = status;
+					results.add(
+						DLAppLocalServiceUtil.getFileShortcut(
+							assetEntry.getClassPK()));
+				}
+			}
 
-					dlSearchContainer.setResultsAndTotal(
-						() ->
-							(List)
-								DLAppServiceUtil.
-									getFoldersAndFileEntriesAndFileShortcuts(
-										repositoryId, folderId, dlAppStatus,
-										true, dlSearchContainer.getStart(),
-										dlSearchContainer.getEnd(),
-										dlSearchContainer.
-											getOrderByComparator()),
+			dlSearchContainer.setResultsAndTotal(
+				() -> results,
+				AssetEntryServiceUtil.getEntriesCount(assetEntryQuery));
+		}
+		else {
+			int dlAppStatus = status;
+
+			dlSearchContainer.setResultsAndTotal(
+				() ->
+					(List)
 						DLAppServiceUtil.
-							getFoldersAndFileEntriesAndFileShortcutsCount(
-								repositoryId, folderId, dlAppStatus, true));
+							getFoldersAndFileEntriesAndFileShortcuts(
+								repositoryId, folderId, dlAppStatus, true,
+								dlSearchContainer.getStart(),
+								dlSearchContainer.getEnd(),
+								dlSearchContainer.getOrderByComparator()),
+				DLAppServiceUtil.getFoldersAndFileEntriesAndFileShortcutsCount(
+					repositoryId, folderId, dlAppStatus, true));
 		}
 
 		return dlSearchContainer;
@@ -744,6 +736,7 @@ public class DLAdminDisplayContext {
 
 	private String _getEmptyResultsMessage(long fileEntryTypeId)
 		throws PortalException {
+
 		if (fileEntryTypeId < 0) {
 			return "there-are-no-documents-or-media-files-in-this-folder";
 		}
@@ -796,8 +789,8 @@ public class DLAdminDisplayContext {
 				if (_log.isWarnEnabled()) {
 					_log.warn(
 						StringBundler.concat(
-							"Documents and Media search index is stale ",
-							"and contains file entry {", fileEntryId, "}"),
+							"Documents and Media search index is stale and ",
+							"contains file entry {", fileEntryId, "}"),
 						exception);
 				}
 
@@ -898,31 +891,13 @@ public class DLAdminDisplayContext {
 
 		searchContext.setAttribute("paginationType", "none");
 		searchContext.setEnd(searchContainer.getEnd());
+		searchContext.setSorts(
+			_getSort(
+				searchContainer.getOrderByCol(),
+				searchContainer.getOrderByType()));
 		searchContext.setStart(searchContainer.getStart());
-		searchContext.setSorts(_getSort(searchContainer.getOrderByCol(), searchContainer.getOrderByType()));
 
 		return searchContext;
-	}
-
-	private Sort _getSort(String orderByCol, String orderByType) {
-		int type = Sort.STRING_TYPE;
-		String fieldName = orderByCol;
-
-		if (Objects.equals(orderByCol, "creationDate")) {
-			fieldName = Field.CREATE_DATE;
-			type = Sort.LONG_TYPE;
-		}
-		else if (Objects.equals(orderByCol, "modifiedDate")) {
-			fieldName = Field.MODIFIED_DATE;
-			type = Sort.LONG_TYPE;
-		}
-		else if (Objects.equals(orderByCol, "size")) {
-			type = Sort.LONG_TYPE;
-		}
-
-		return SortFactoryUtil.create(
-			fieldName, type,
-			!StringUtil.equalsIgnoreCase(orderByType, "asc"));
 	}
 
 	private List<RepositoryEntry> _getSearchResults(Hits hits)
@@ -984,6 +959,26 @@ public class DLAdminDisplayContext {
 			() -> _getSearchResults(hits), hits.getLength());
 
 		return searchContainer;
+	}
+
+	private Sort _getSort(String orderByCol, String orderByType) {
+		int type = Sort.STRING_TYPE;
+		String fieldName = orderByCol;
+
+		if (Objects.equals(orderByCol, "creationDate")) {
+			fieldName = Field.CREATE_DATE;
+			type = Sort.LONG_TYPE;
+		}
+		else if (Objects.equals(orderByCol, "modifiedDate")) {
+			fieldName = Field.MODIFIED_DATE;
+			type = Sort.LONG_TYPE;
+		}
+		else if (Objects.equals(orderByCol, "size")) {
+			type = Sort.LONG_TYPE;
+		}
+
+		return SortFactoryUtil.create(
+			fieldName, type, !StringUtil.equalsIgnoreCase(orderByType, "asc"));
 	}
 
 	private boolean _isAncestorFolder(long folderId, FileEntry fileEntry) {

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminDisplayContext.java
@@ -593,15 +593,6 @@ public class DLAdminDisplayContext {
 			status = WorkflowConstants.STATUS_ANY;
 		}
 
-		long categoryId = ParamUtil.getLong(_httpServletRequest, "categoryId");
-		String tagName = ParamUtil.getString(_httpServletRequest, "tag");
-
-		boolean useAssetEntryQuery = false;
-
-		if ((categoryId > 0) || Validator.isNotNull(tagName)) {
-			useAssetEntryQuery = true;
-		}
-
 		PortletURL portletURL = _liferayPortletResponse.createRenderURL();
 
 		long folderId = getFolderId();
@@ -636,18 +627,6 @@ public class DLAdminDisplayContext {
 			ListUtil.fromArray(
 				_dlPortletInstanceSettingsHelper.getEntryColumns()));
 		dlSearchContainer.setOrderByCol(getOrderByCol());
-
-		boolean orderByModel = false;
-
-		if (navigation.equals("home")) {
-			orderByModel = true;
-		}
-
-		OrderByComparator<RepositoryEntry> orderByComparator =
-			DLUtil.getRepositoryModelOrderByComparator(
-				getOrderByCol(), getOrderByType(), orderByModel);
-
-		dlSearchContainer.setOrderByComparator(orderByComparator);
 		dlSearchContainer.setOrderByType(getOrderByType());
 
 		if ((fileEntryTypeId >= 0) || ArrayUtil.isNotEmpty(extensions) || navigation.equals("mine") || navigation.equals("recent")) {
@@ -677,10 +656,20 @@ public class DLAdminDisplayContext {
 
 			dlSearchContainer.setResultsAndTotal(
 				() -> _getFileEntries(hits), hits.getLength());
+
+			return dlSearchContainer;
 		}
-		else {
-			if (navigation.equals("home")) {
-				if (useAssetEntryQuery) {
+
+		OrderByComparator<RepositoryEntry> orderByComparator =
+			DLUtil.getRepositoryModelOrderByComparator(
+				getOrderByCol(), getOrderByType(), true);
+
+		dlSearchContainer.setOrderByComparator(orderByComparator);
+
+		long categoryId = ParamUtil.getLong(_httpServletRequest, "categoryId");
+		String tagName = ParamUtil.getString(_httpServletRequest, "tag");
+
+				if ((categoryId > 0) || Validator.isNotNull(tagName)) {
 					long[] classNameIds = {
 						PortalUtil.getClassNameId(
 							DLFileEntryConstants.getClassName()),
@@ -746,8 +735,6 @@ public class DLAdminDisplayContext {
 						DLAppServiceUtil.
 							getFoldersAndFileEntriesAndFileShortcutsCount(
 								repositoryId, folderId, dlAppStatus, true));
-				}
-			}
 		}
 
 		return dlSearchContainer;

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminDisplayContext.java
@@ -572,9 +572,6 @@ public class DLAdminDisplayContext {
 	private SearchContainer<RepositoryEntry> _getDLSearchContainer()
 		throws PortalException {
 
-		String navigation = ParamUtil.getString(
-			_httpServletRequest, "navigation", "home");
-
 		String currentFolder = ParamUtil.getString(
 			_httpServletRequest, "curFolder");
 		String deltaFolder = ParamUtil.getString(
@@ -583,9 +580,8 @@ public class DLAdminDisplayContext {
 			_httpServletRequest, "extension");
 		long fileEntryTypeId = ParamUtil.getLong(
 			_httpServletRequest, "fileEntryTypeId", -1);
-
-		String dlFileEntryTypeName = LanguageUtil.get(
-			_httpServletRequest, "basic-document");
+		String navigation = ParamUtil.getString(
+			_httpServletRequest, "navigation", "home");
 
 		int status = WorkflowConstants.STATUS_APPROVED;
 
@@ -619,44 +615,22 @@ public class DLAdminDisplayContext {
 				"mvcRenderCommandName", "/document_library/view_folder");
 		}
 
-		portletURL.setParameter("navigation", navigation);
 		portletURL.setParameter("curFolder", currentFolder);
 		portletURL.setParameter("deltaFolder", deltaFolder);
-		portletURL.setParameter("folderId", String.valueOf(folderId));
 		portletURL.setParameter("extension", extensions);
+		portletURL.setParameter("folderId", String.valueOf(folderId));
+		portletURL.setParameter("navigation", navigation);
 
 		if (fileEntryTypeId >= 0) {
 			portletURL.setParameter(
 				"fileEntryTypeId", String.valueOf(fileEntryTypeId));
-
-			if (fileEntryTypeId > 0) {
-				DLFileEntryType dlFileEntryType =
-					DLFileEntryTypeLocalServiceUtil.getFileEntryType(
-						fileEntryTypeId);
-
-				dlFileEntryTypeName = dlFileEntryType.getName(
-					_httpServletRequest.getLocale());
-			}
-		}
-
-		String emptyResultsMessage = null;
-
-		if (fileEntryTypeId >= 0) {
-			emptyResultsMessage = LanguageUtil.format(
-				_httpServletRequest,
-				"there-are-no-documents-or-media-files-of-type-x",
-				HtmlUtil.escape(dlFileEntryTypeName));
-		}
-		else {
-			emptyResultsMessage =
-				"there-are-no-documents-or-media-files-in-this-folder";
 		}
 
 		SearchContainer<RepositoryEntry> dlSearchContainer =
 			new SearchContainer<>(
 				_liferayPortletRequest, null, null, "curEntry",
 				_dlPortletInstanceSettings.getEntriesPerPage(), portletURL,
-				null, emptyResultsMessage);
+				null, _getEmptyResultsMessage(fileEntryTypeId));
 
 		dlSearchContainer.setHeaderNames(
 			ListUtil.fromArray(
@@ -777,6 +751,30 @@ public class DLAdminDisplayContext {
 		}
 
 		return dlSearchContainer;
+	}
+
+	private String _getEmptyResultsMessage(long fileEntryTypeId)
+		throws PortalException {
+		if (fileEntryTypeId < 0) {
+			return "there-are-no-documents-or-media-files-in-this-folder";
+		}
+
+		String dlFileEntryTypeName = LanguageUtil.get(
+			_httpServletRequest, "basic-document");
+
+		if (fileEntryTypeId > 0) {
+			DLFileEntryType dlFileEntryType =
+				DLFileEntryTypeLocalServiceUtil.getFileEntryType(
+					fileEntryTypeId);
+
+			dlFileEntryTypeName = dlFileEntryType.getName(
+				_httpServletRequest.getLocale());
+		}
+
+		return LanguageUtil.format(
+			_httpServletRequest,
+			"there-are-no-documents-or-media-files-of-type-x",
+			HtmlUtil.escape(dlFileEntryTypeName));
 	}
 
 	private Filter _getExtensionsFilter(String[] extensions) {

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
@@ -313,7 +313,9 @@ public class DLAdminManagementToolbarDisplayContext
 						_httpServletRequest, "filter-by-navigation"));
 			}
 		).addGroup(
-			() -> !FeatureFlagManagerUtil.isEnabled("LPS-144527") && !_dlAdminDisplayContext.isNavigationRecent(),
+			() ->
+				!FeatureFlagManagerUtil.isEnabled("LPS-144527") &&
+				!_dlAdminDisplayContext.isNavigationRecent(),
 			dropdownGroupItem -> {
 				dropdownGroupItem.setDropdownItems(_getOrderByDropdownItems());
 				dropdownGroupItem.setLabel(

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
@@ -313,7 +313,7 @@ public class DLAdminManagementToolbarDisplayContext
 						_httpServletRequest, "filter-by-navigation"));
 			}
 		).addGroup(
-			() -> !FeatureFlagManagerUtil.isEnabled("LPS-144527"),
+			() -> !FeatureFlagManagerUtil.isEnabled("LPS-144527") && !_dlAdminDisplayContext.isNavigationRecent(),
 			dropdownGroupItem -> {
 				dropdownGroupItem.setDropdownItems(_getOrderByDropdownItems());
 				dropdownGroupItem.setLabel(
@@ -388,6 +388,24 @@ public class DLAdminManagementToolbarDisplayContext
 						"%s: %s",
 						LanguageUtil.get(_httpServletRequest, "owner"),
 						HtmlUtil.escape(user.getFullName())));
+			});
+
+		labelItemListWrapper.add(
+			_dlAdminDisplayContext::isNavigationRecent,
+			labelItem -> {
+				labelItem.putData(
+					"removeLabelURL",
+					PortletURLBuilder.create(
+						PortletURLUtil.clone(
+							_currentURLObj, _liferayPortletResponse)
+					).setNavigation(
+						(String)null
+					).buildString());
+
+				labelItem.setCloseable(true);
+
+				labelItem.setLabel(
+					LanguageUtil.get(httpServletRequest, "recent"));
 			});
 
 		return labelItemListWrapper.build();


### PR DESCRIPTION
Combination of filters in Documents & Media was not working correctly. For instance, applying filter "Mine" and selecting a "Document Type" was not working. See example in https://issues.liferay.com/browse/LPS-178911

Mainly the problem was that only one filter was being applied when multiple were selected.

I've revisited all options, fixed what was not working and refactored the large and difficult to understand method `_getDLSearchContainer()`.

