### PR TITLE
LPS-177939 Include FF on the back story and save the user agent when active

### DIFF
--- a/modules/apps/redirect/redirect-api/bnd.bnd
+++ b/modules/apps/redirect/redirect-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Redirect API
 Bundle-SymbolicName: com.liferay.redirect.api
-Bundle-Version: 9.0.1
+Bundle-Version: 10.0.0
 Export-Package:\
 	com.liferay.redirect.configuration,\
 	com.liferay.redirect.constants,\

--- a/modules/apps/redirect/redirect-api/src/main/java/com/liferay/redirect/configuration/RedirectPatternConfigurationProvider.java
+++ b/modules/apps/redirect/redirect-api/src/main/java/com/liferay/redirect/configuration/RedirectPatternConfigurationProvider.java
@@ -18,7 +18,6 @@ import com.liferay.portal.kernel.module.configuration.ConfigurationException;
 import com.liferay.redirect.model.RedirectPatternEntry;
 
 import java.util.List;
-import java.util.Map;
 
 import org.osgi.annotation.versioning.ProviderType;
 
@@ -32,7 +31,7 @@ public interface RedirectPatternConfigurationProvider {
 		throws ConfigurationException;
 
 	public void updatePatternStrings(
-			long groupId, Map<String, String> patternStrings)
+			long groupId, List<RedirectPatternEntry> redirectPatternEntries)
 		throws Exception;
 
 }

--- a/modules/apps/redirect/redirect-api/src/main/resources/com/liferay/redirect/configuration/packageinfo
+++ b/modules/apps/redirect/redirect-api/src/main/resources/com/liferay/redirect/configuration/packageinfo
@@ -1,1 +1,1 @@
-version 3.0.0
+version 4.0.0

--- a/modules/apps/redirect/redirect-service/bnd.bnd
+++ b/modules/apps/redirect/redirect-service/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Redirect Service
 Bundle-SymbolicName: com.liferay.redirect.service
 Bundle-Version: 2.0.51
-Liferay-Require-SchemaVersion: 3.0.3
+Liferay-Require-SchemaVersion: 3.0.4
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/internal/configuration/RedirectPatternConfigurationProviderImpl.java
+++ b/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/internal/configuration/RedirectPatternConfigurationProviderImpl.java
@@ -17,13 +17,14 @@ package com.liferay.redirect.internal.configuration;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.redirect.configuration.RedirectPatternConfigurationProvider;
 import com.liferay.redirect.model.RedirectPatternEntry;
 import com.liferay.redirect.provider.RedirectProvider;
 
 import java.util.Dictionary;
 import java.util.List;
-import java.util.Map;
 
 import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;
@@ -43,7 +44,7 @@ public class RedirectPatternConfigurationProviderImpl
 
 	@Override
 	public void updatePatternStrings(
-			long groupId, Map<String, String> patternStrings)
+			long groupId, List<RedirectPatternEntry> redirectPatternEntries)
 		throws Exception {
 
 		Dictionary<String, Object> properties = null;
@@ -75,17 +76,22 @@ public class RedirectPatternConfigurationProviderImpl
 			properties = configuration.getProperties();
 		}
 
-		if (patternStrings.isEmpty()) {
+		if (ListUtil.isEmpty(redirectPatternEntries)) {
 			properties.put("patternStrings", new String[0]);
 		}
 		else {
-			String[] patternStringsArray = new String[patternStrings.size()];
-
 			int i = 0;
 
-			for (Map.Entry<String, String> entry : patternStrings.entrySet()) {
-				patternStringsArray[i] =
-					entry.getKey() + StringPool.SPACE + entry.getValue();
+			String[] patternStringsArray =
+				new String[redirectPatternEntries.size()];
+
+			for (RedirectPatternEntry redirectPatternEntry :
+					redirectPatternEntries) {
+
+				patternStringsArray[i] = StringBundler.concat(
+					String.valueOf(redirectPatternEntry.getPattern()),
+					StringPool.SPACE, redirectPatternEntry.getDestinationURL(),
+					StringPool.SPACE, redirectPatternEntry.getUserAgent());
 
 				i++;
 			}

--- a/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/internal/provider/RedirectProviderImpl.java
+++ b/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/internal/provider/RedirectProviderImpl.java
@@ -15,6 +15,7 @@
 package com.liferay.redirect.internal.provider;
 
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -189,7 +190,8 @@ public class RedirectProviderImpl
 	private boolean _isUserAgentMatch(
 		RedirectPatternEntry redirectPatternEntry, String userAgent) {
 
-		if (Validator.isNull(redirectPatternEntry.getUserAgent()) ||
+		if (!FeatureFlagManagerUtil.isEnabled("LPS-175850") ||
+			Validator.isNull(redirectPatternEntry.getUserAgent()) ||
 			Validator.isNull(userAgent) ||
 			Objects.equals(
 				RedirectConstants.USER_AGENT_ALL,

--- a/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/internal/upgrade/registry/RedirectServiceUpgradeStepRegistrator.java
+++ b/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/internal/upgrade/registry/RedirectServiceUpgradeStepRegistrator.java
@@ -19,7 +19,9 @@ import com.liferay.portal.kernel.upgrade.DummyUpgradeProcess;
 import com.liferay.portal.kernel.upgrade.UpgradeProcessFactory;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 import com.liferay.redirect.internal.upgrade.v3_0_2.RedirectEntrySourceURLUpgradeProcess;
+import com.liferay.redirect.internal.upgrade.v3_0_3.RedirectPatternConfigurationUpgradeProcess;
 
+import org.osgi.service.cm.ConfigurationAdmin;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
@@ -57,7 +59,15 @@ public class RedirectServiceUpgradeStepRegistrator
 			new com.liferay.redirect.internal.upgrade.v3_0_1.
 				RedirectURLConfigurationUpgradeProcess(
 					_prefsPropsToConfigurationUpgradeHelper));
+
+		registry.register(
+			"3.0.3", "3.0.4",
+			new RedirectPatternConfigurationUpgradeProcess(
+				_configurationAdmin));
 	}
+
+	@Reference
+	private ConfigurationAdmin _configurationAdmin;
 
 	@Reference
 	private PrefsPropsToConfigurationUpgradeHelper

--- a/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/internal/upgrade/v3_0_3/RedirectPatternConfigurationUpgradeProcess.java
+++ b/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/internal/upgrade/v3_0_3/RedirectPatternConfigurationUpgradeProcess.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.redirect.internal.upgrade.v3_0_3;
+
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.redirect.constants.RedirectConstants;
+
+import java.util.Dictionary;
+
+import org.osgi.framework.Constants;
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+
+/**
+ * @author Alicia García
+ */
+public class RedirectPatternConfigurationUpgradeProcess extends UpgradeProcess {
+
+	public RedirectPatternConfigurationUpgradeProcess(
+		ConfigurationAdmin configurationAdmin) {
+
+		_configurationAdmin = configurationAdmin;
+	}
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		Configuration[] configurations = _configurationAdmin.listConfigurations(
+			String.format("(%s=%s*)", Constants.SERVICE_PID, _SERVICE_PID));
+
+		if (ArrayUtil.isEmpty(configurations)) {
+			return;
+		}
+
+		for (Configuration configuration : configurations) {
+			Dictionary<String, Object> properties =
+				configuration.getProperties();
+
+			if (properties == null) {
+				continue;
+			}
+
+			String[] patternStrings = (String[])properties.get(
+				"patternStrings");
+
+			if (ArrayUtil.isEmpty(patternStrings)) {
+				continue;
+			}
+
+			String[] patternStringsArray = new String[patternStrings.length];
+
+			int i = 0;
+
+			for (String patternString : patternStrings) {
+				String[] values = StringUtil.split(
+					patternString, StringPool.SPACE);
+
+				if (values.length > 2) {
+					patternStringsArray[i++] = patternString;
+				}
+				else {
+					patternStringsArray[i++] = StringBundler.concat(
+						values[0], StringPool.SPACE, values[1],
+						StringPool.SPACE, RedirectConstants.USER_AGENT_ALL);
+				}
+			}
+
+			properties.put("patternStrings", patternStringsArray);
+
+			configuration.update(properties);
+		}
+	}
+
+	private static final String _SERVICE_PID =
+		"com.liferay.redirect.internal.configuration." +
+			"RedirectPatternConfiguration";
+
+	private final ConfigurationAdmin _configurationAdmin;
+
+}

--- a/modules/apps/redirect/redirect-service/src/test/java/com/liferay/redirect/internal/provider/RedirectProviderImplTest.java
+++ b/modules/apps/redirect/redirect-service/src/test/java/com/liferay/redirect/internal/provider/RedirectProviderImplTest.java
@@ -17,6 +17,8 @@ package com.liferay.redirect.internal.provider;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.Props;
+import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 import com.liferay.redirect.constants.RedirectConstants;
@@ -35,7 +37,9 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
+import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
 
 /**
  * @author Adolfo Pérez
@@ -49,6 +53,8 @@ public class RedirectProviderImplTest {
 
 	@Before
 	public void setUp() {
+		MockitoAnnotations.initMocks(this);
+
 		_redirectProviderImpl.setRedirectEntryLocalService(
 			_redirectEntryLocalService);
 
@@ -58,6 +64,8 @@ public class RedirectProviderImplTest {
 		).thenReturn(
 			null
 		);
+
+		PropsUtil.setProps(_props);
 	}
 
 	@Test
@@ -206,6 +214,12 @@ public class RedirectProviderImplTest {
 	public void testSimplePatternDoesntMatchUserAgentBot() {
 		_redirectProviderImpl.setCrawlerUserAgents(_CRAWLER_USER_AGENTS);
 
+		Mockito.when(
+			_props.get("feature.flag.LPS-175850")
+		).thenReturn(
+			"true"
+		);
+
 		try {
 			_setupRedirectPatternEntries(
 				Collections.singletonList(
@@ -229,6 +243,12 @@ public class RedirectProviderImplTest {
 	public void testSimplePatternDoesntMatchUserAgentHuman() {
 		_redirectProviderImpl.setCrawlerUserAgents(_CRAWLER_USER_AGENTS);
 
+		Mockito.when(
+			_props.get("feature.flag.LPS-175850")
+		).thenReturn(
+			"true"
+		);
+
 		try {
 			_setupRedirectPatternEntries(
 				Collections.singletonList(
@@ -250,6 +270,12 @@ public class RedirectProviderImplTest {
 
 	@Test
 	public void testSimplePatternMatchesNoUserAgent() {
+		Mockito.when(
+			_props.get("feature.flag.LPS-175850")
+		).thenReturn(
+			"true"
+		);
+
 		_setupRedirectPatternEntries(
 			Collections.singletonList(
 				new RedirectPatternEntry(
@@ -265,6 +291,12 @@ public class RedirectProviderImplTest {
 
 	@Test
 	public void testSimplePatternMatchesNoUserAgentOnRedirect() {
+		Mockito.when(
+			_props.get("feature.flag.LPS-175850")
+		).thenReturn(
+			"true"
+		);
+
 		_setupRedirectPatternEntries(
 			Collections.singletonList(
 				new RedirectPatternEntry(
@@ -283,6 +315,12 @@ public class RedirectProviderImplTest {
 	public void testSimplePatternMatchesUserAgentBot() {
 		_redirectProviderImpl.setCrawlerUserAgents(_CRAWLER_USER_AGENTS);
 
+		Mockito.when(
+			_props.get("feature.flag.LPS-175850")
+		).thenReturn(
+			"true"
+		);
+
 		try {
 			_setupRedirectPatternEntries(
 				Collections.singletonList(
@@ -292,6 +330,52 @@ public class RedirectProviderImplTest {
 
 			RedirectProvider.Redirect redirect = _getRedirectProviderRedirect(
 				"abc", "CrawlerBot");
+
+			Assert.assertEquals("xyz", redirect.getDestinationURL());
+
+			_verifyMockInvocations();
+		}
+		finally {
+			_redirectProviderImpl.setCrawlerUserAgents(null);
+		}
+	}
+
+	@Test
+	public void testSimplePatternMatchUserAgentBotNoFF() {
+		_redirectProviderImpl.setCrawlerUserAgents(_CRAWLER_USER_AGENTS);
+
+		try {
+			_setupRedirectPatternEntries(
+				Collections.singletonList(
+					new RedirectPatternEntry(
+						Pattern.compile("^abc"), "xyz",
+						RedirectConstants.USER_AGENT_BOT)));
+
+			RedirectProvider.Redirect redirect = _getRedirectProviderRedirect(
+				"abc", "another");
+
+			Assert.assertEquals("xyz", redirect.getDestinationURL());
+
+			_verifyMockInvocations();
+		}
+		finally {
+			_redirectProviderImpl.setCrawlerUserAgents(null);
+		}
+	}
+
+	@Test
+	public void testSimplePatternMatchUserAgentHumanNoFF() {
+		_redirectProviderImpl.setCrawlerUserAgents(_CRAWLER_USER_AGENTS);
+
+		try {
+			_setupRedirectPatternEntries(
+				Collections.singletonList(
+					new RedirectPatternEntry(
+						Pattern.compile("^abc"), "xyz",
+						RedirectConstants.USER_AGENT_HUMAN)));
+
+			RedirectProvider.Redirect redirect = _getRedirectProviderRedirect(
+				"abc", "bot");
 
 			Assert.assertEquals("xyz", redirect.getDestinationURL());
 
@@ -319,6 +403,12 @@ public class RedirectProviderImplTest {
 
 	@Test
 	public void testSimplePatternSingleMatchesUserAgentAll() {
+		Mockito.when(
+			_props.get("feature.flag.LPS-175850")
+		).thenReturn(
+			"true"
+		);
+
 		_setupRedirectPatternEntries(
 			Collections.singletonList(
 				new RedirectPatternEntry(
@@ -335,6 +425,12 @@ public class RedirectProviderImplTest {
 
 	@Test
 	public void testSimplePatternSingleMatchesUserAgentHuman() {
+		Mockito.when(
+			_props.get("feature.flag.LPS-175850")
+		).thenReturn(
+			"true"
+		);
+
 		_setupRedirectPatternEntries(
 			Collections.singletonList(
 				new RedirectPatternEntry(
@@ -395,6 +491,9 @@ public class RedirectProviderImplTest {
 	private static final String[] _CRAWLER_USER_AGENTS = {"bot", "crawlerbot"};
 
 	private static final long _GROUP_ID = RandomTestUtil.randomLong();
+
+	@Mock
+	private Props _props;
 
 	private final RedirectEntryLocalService _redirectEntryLocalService =
 		Mockito.mock(RedirectEntryLocalService.class);

--- a/modules/apps/redirect/redirect-service/src/test/java/com/liferay/redirect/internal/util/PatternUtilTest.java
+++ b/modules/apps/redirect/redirect-service/src/test/java/com/liferay/redirect/internal/util/PatternUtilTest.java
@@ -15,6 +15,8 @@
 package com.liferay.redirect.internal.util;
 
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.Props;
+import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 import com.liferay.redirect.model.RedirectPatternEntry;
 
@@ -23,9 +25,14 @@ import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
 
 /**
  * @author Adolfo Pérez
@@ -37,10 +44,23 @@ public class PatternUtilTest {
 	public static final LiferayUnitTestRule liferayUnitTestRule =
 		LiferayUnitTestRule.INSTANCE;
 
+	@Before
+	public void setUp() {
+		MockitoAnnotations.initMocks(this);
+
+		PropsUtil.setProps(_props);
+
+		Mockito.when(
+			_props.get("feature.flag.LPS-175850")
+		).thenReturn(
+			"false"
+		);
+	}
+
 	@Test
 	public void testAnchoredPattern() {
 		List<RedirectPatternEntry> redirectPatternEntries = PatternUtil.parse(
-			new String[] {"^xyz abc"});
+			new String[] {"^xyz abc all"});
 
 		Assert.assertEquals(
 			"^xyz", _getFirstPatternString(redirectPatternEntries));
@@ -52,7 +72,7 @@ public class PatternUtilTest {
 	@Test
 	public void testCaretPattern() {
 		List<RedirectPatternEntry> redirectPatternEntries = PatternUtil.parse(
-			new String[] {"^xyz abc"});
+			new String[] {"^xyz abc all"});
 
 		Assert.assertEquals(
 			"^xyz", _getFirstPatternString(redirectPatternEntries));
@@ -64,7 +84,7 @@ public class PatternUtilTest {
 	@Test
 	public void testCaretSlashPattern() {
 		List<RedirectPatternEntry> redirectPatternEntries = PatternUtil.parse(
-			new String[] {"^/xyz abc"});
+			new String[] {"^/xyz abc all"});
 
 		Assert.assertEquals(
 			"^xyz", _getFirstPatternString(redirectPatternEntries));
@@ -74,13 +94,28 @@ public class PatternUtilTest {
 	}
 
 	@Test
-	public void testEmptyPatternOrEmptyReplacement() {
+	public void testEmptyPatternOrEmptyReplacementOrEmptyUserAgent() {
 		Assert.assertTrue(
 			ListUtil.isEmpty(PatternUtil.parse(new String[] {" xyz"})));
 		Assert.assertTrue(
 			ListUtil.isEmpty(PatternUtil.parse(new String[] {"xyz "})));
 		Assert.assertTrue(
 			ListUtil.isEmpty(PatternUtil.parse(new String[] {"xyz"})));
+
+		Mockito.when(
+			_props.get("feature.flag.LPS-175850")
+		).thenReturn(
+			"true"
+		);
+
+		Assert.assertTrue(
+			ListUtil.isEmpty(PatternUtil.parse(new String[] {" xyz abc"})));
+		Assert.assertTrue(
+			ListUtil.isEmpty(PatternUtil.parse(new String[] {"xyz abc "})));
+		Assert.assertTrue(
+			ListUtil.isEmpty(PatternUtil.parse(new String[] {"xyz abc"})));
+		Assert.assertTrue(
+			ListUtil.isEmpty(PatternUtil.parse(new String[] {" xyz  all"})));
 	}
 
 	@Test
@@ -90,13 +125,13 @@ public class PatternUtilTest {
 
 	@Test(expected = PatternSyntaxException.class)
 	public void testInvalidRegexPattern() {
-		PatternUtil.parse(new String[] {"*** a"});
+		PatternUtil.parse(new String[] {"*** a all"});
 	}
 
 	@Test
 	public void testSlashPattern() {
 		List<RedirectPatternEntry> redirectPatternEntries = PatternUtil.parse(
-			new String[] {"/xyz abc"});
+			new String[] {"/xyz abc all"});
 
 		Assert.assertEquals(
 			"^xyz", _getFirstPatternString(redirectPatternEntries));
@@ -108,7 +143,7 @@ public class PatternUtilTest {
 	@Test
 	public void testUnanchoredPattern() {
 		List<RedirectPatternEntry> redirectPatternEntries = PatternUtil.parse(
-			new String[] {"xyz abc"});
+			new String[] {"xyz abc all"});
 
 		Assert.assertEquals(
 			"^xyz", _getFirstPatternString(redirectPatternEntries));
@@ -127,5 +162,8 @@ public class PatternUtilTest {
 
 		return pattern.pattern();
 	}
+
+	@Mock
+	private Props _props;
 
 }

--- a/modules/apps/redirect/redirect-web/src/main/java/com/liferay/redirect/web/internal/display/context/RedirectPatternConfigurationDisplayContext.java
+++ b/modules/apps/redirect/redirect-web/src/main/java/com/liferay/redirect/web/internal/display/context/RedirectPatternConfigurationDisplayContext.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.util.PropsValues;
 import com.liferay.redirect.configuration.RedirectPatternConfigurationProvider;
+import com.liferay.redirect.constants.RedirectConstants;
 import com.liferay.redirect.model.RedirectPatternEntry;
 
 import java.util.ArrayList;
@@ -72,6 +73,17 @@ public class RedirectPatternConfigurationDisplayContext {
 						).put(
 							"pattern",
 							String.valueOf(redirectPatternEntry.getPattern())
+						).put(
+							"userAgent",
+							() -> {
+								if (redirectPatternEntry.getUserAgent() ==
+										null) {
+
+									return RedirectConstants.USER_AGENT_ALL;
+								}
+
+								return redirectPatternEntry.getUserAgent();
+							}
 						).build()));
 
 				return list;


### PR DESCRIPTION
This is a subsequent PR with changes on the backend to give the user the ability to save the user agent if FF is active

FF : LPS-175850


- LPS-177939 upgrade the old configurations to be for all the users
- LPS-177939 only apply the new logic if the FF is active
- LPS-177939 on the case the FF is active, the pattern string should include the user agent
- LPS-177939 update test depending the FF
- LPS-177939 modify how we update the configuration of the patterns
- LPS-177939 baseline
- LPS-177939 if the FF is enabled obtain the user agent from the page
- LPS-177939 put the user agent on the element
