### PR TITLE
[TS]LPP-48211 -> LPS-178147

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminDisplayContext.java
@@ -690,7 +690,10 @@ public class DLAdminDisplayContext {
 			AssetEntryQuery assetEntryQuery = new AssetEntryQuery(
 				classNameIds, dlSearchContainer);
 
-			assetEntryQuery.setAllCategoryIds(new long[] {categoryId});
+			if (categoryId > 0) {
+				assetEntryQuery.setAllCategoryIds(new long[] {categoryId});
+			}
+
 			assetEntryQuery.setEnablePermissions(true);
 			assetEntryQuery.setExcludeZeroViewCount(false);
 

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminDisplayContext.java
@@ -94,6 +94,7 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HtmlUtil;
+import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
@@ -668,7 +669,15 @@ public class DLAdminDisplayContext {
 
 		long repositoryId = getRepositoryId();
 
-		long categoryId = ParamUtil.getLong(_httpServletRequest, "categoryId");
+		long categoryId = GetterUtil.getLong(
+			HttpComponentsUtil.getParameter(
+				PortalUtil.getCurrentURL(_httpServletRequest),
+				"p_r_p_categoryId", true));
+
+		if (categoryId == 0) {
+			categoryId = ParamUtil.getLong(_httpServletRequest, "categoryId");
+		}
+
 		String tagName = ParamUtil.getString(_httpServletRequest, "tag");
 
 		if ((categoryId > 0) || Validator.isNotNull(tagName)) {
@@ -681,6 +690,7 @@ public class DLAdminDisplayContext {
 			AssetEntryQuery assetEntryQuery = new AssetEntryQuery(
 				classNameIds, dlSearchContainer);
 
+			assetEntryQuery.setAllCategoryIds(new long[] {categoryId});
 			assetEntryQuery.setEnablePermissions(true);
 			assetEntryQuery.setExcludeZeroViewCount(false);
 

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminDisplayContext.java
@@ -783,36 +783,6 @@ public class DLAdminDisplayContext {
 		return termsFilter;
 	}
 
-	private List<RepositoryEntry> _getRepositoryEntries(Hits hits) {
-		List<RepositoryEntry> results = new ArrayList<>();
-
-		for (Document doc : hits.getDocs()) {
-			long fileEntryId = GetterUtil.getLong(
-				doc.get(Field.ENTRY_CLASS_PK));
-
-			FileEntry fileEntry = null;
-
-			try {
-				fileEntry = DLAppLocalServiceUtil.getFileEntry(fileEntryId);
-			}
-			catch (Exception exception) {
-				if (_log.isWarnEnabled()) {
-					_log.warn(
-						StringBundler.concat(
-							"Documents and Media search index is stale and ",
-							"contains file entry ", fileEntryId),
-						exception);
-				}
-
-				continue;
-			}
-
-			results.add(fileEntry);
-		}
-
-		return results;
-	}
-
 	private Hits _getHits(SearchContainer<RepositoryEntry> searchContainer)
 		throws PortalException {
 
@@ -888,6 +858,36 @@ public class DLAdminDisplayContext {
 				_dlRequestHelper.getPortletId(), StringPool.BLANK);
 
 		return _portletPreferences;
+	}
+
+	private List<RepositoryEntry> _getRepositoryEntries(Hits hits) {
+		List<RepositoryEntry> results = new ArrayList<>();
+
+		for (Document doc : hits.getDocs()) {
+			long fileEntryId = GetterUtil.getLong(
+				doc.get(Field.ENTRY_CLASS_PK));
+
+			FileEntry fileEntry = null;
+
+			try {
+				fileEntry = DLAppLocalServiceUtil.getFileEntry(fileEntryId);
+			}
+			catch (Exception exception) {
+				if (_log.isWarnEnabled()) {
+					_log.warn(
+						StringBundler.concat(
+							"Documents and Media search index is stale and ",
+							"contains file entry ", fileEntryId),
+						exception);
+				}
+
+				continue;
+			}
+
+			results.add(fileEntry);
+		}
+
+		return results;
 	}
 
 	private SearchContext _getSearchContext(

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetEntryServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetEntryServiceImpl.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.cache.thread.local.Lifecycle;
 import com.liferay.portal.kernel.cache.thread.local.ThreadLocalCache;
 import com.liferay.portal.kernel.cache.thread.local.ThreadLocalCacheManager;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.dao.search.SearchPaginationUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -288,13 +289,11 @@ public class AssetEntryServiceImpl extends AssetEntryServiceBaseImpl {
 			count = filteredEntries.size();
 
 			if ((end != QueryUtil.ALL_POS) && (start != QueryUtil.ALL_POS)) {
-				if (end > count) {
-					end = count;
-				}
+				int[] startAndEnd = SearchPaginationUtil.calculateStartAndEnd(
+					start, end, count);
 
-				if (start > count) {
-					start = count;
-				}
+				start = startAndEnd[0];
+				end = startAndEnd[1];
 
 				filteredEntries = filteredEntries.subList(start, end);
 			}


### PR DESCRIPTION
Hi team,

Motivation
This PR is for ticket: https://issues.liferay.com/browse/LPS-178147 (resolve issue [LPP-48211](https://issues.liferay.com/browse/LPP-48211))
This is reviewed in https://github.com/liferay-echo/liferay-portal/pull/11410 and https://github.com/liferay-lima/liferay-portal/pull/4096

Proposed Solution
There are 2 causes that make the document library not working with the category filter: AssetEntryServiceImpl not working with pagination and the category URL is escaped which make the DocumentLibrary portlet does not get the categoryId.
In this PR, I fixed the start which is auto reset to the total (searched entries). Moreover, because the categoryId is escaped in the URL, the document library can not get the categoryId, in the second commit , I change the way to get the categoryId for the DocumentLibrary portlet.

Steps to Verify
Create new site
Added new vocabulary (named "DXP") and new category (named "test")
Go to Content & Data > Documents and Media
Add 20 new documents with the category (test) added in step 2
Add one document without category
Add a new page with a category filter widget and a documents and media widget
In the category filter, select "test"
Confirm that 20 documents are displayed (expected behavior)
Remove filtering and go to second page of documents and media widget
Select "test" in the category filter
Actual result
Categories do not filter content.
(please refer attached "steps to reproduce.mov")

Expected result
Filtering by category works correctly.

Alternative Solutions that were discarded
Other solution, I tried to prevent escaped in the category URL, this effect to a lot of portlets which use the categoryId. It is rejected by liferay-echo team in https://github.com/liferay-echo/liferay-portal/pull/11410
Please help me review this request.