### PR TITLE
LPS-180085 Recent Bloggers portlet throws unknown column name 'blogsEntryUserId' in 'on' clause

### DIFF
--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/impl/BlogsStatsUserLocalServiceImpl.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/impl/BlogsStatsUserLocalServiceImpl.java
@@ -86,7 +86,9 @@ public class BlogsStatsUserLocalServiceImpl
 		return _getBlogsStatsUsers(
 			joinStep -> joinStep.innerJoinON(
 				Users_OrgsTable.INSTANCE,
-				Users_OrgsTable.INSTANCE.userId.eq(_userIdAlias)),
+				Users_OrgsTable.INSTANCE.userId.eq(
+					BlogsEntryTable.INSTANCE.userId
+				),
 			Users_OrgsTable.INSTANCE.organizationId.eq(organizationId),
 			_lastPostDateExpression.descending(), start, end);
 	}

--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/impl/BlogsStatsUserLocalServiceImpl.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/impl/BlogsStatsUserLocalServiceImpl.java
@@ -88,9 +88,10 @@ public class BlogsStatsUserLocalServiceImpl
 				Users_OrgsTable.INSTANCE,
 				Users_OrgsTable.INSTANCE.userId.eq(
 					BlogsEntryTable.INSTANCE.userId
-				),
-			Users_OrgsTable.INSTANCE.organizationId.eq(organizationId),
-			_lastPostDateExpression.descending(), start, end);
+				).and(
+					Users_OrgsTable.INSTANCE.organizationId.eq(organizationId)
+				)),
+			null, _lastPostDateExpression.descending(), start, end);
 	}
 
 	@Override


### PR DESCRIPTION
Dear Team,

Could you please review this pull request?

Motivation
=======
If the Recent Bloggers portlet is configured to show blog entries of users belonging to an organization, `BlogsStatsUserLocalServiceImpl` will generate a syntactically incorrect query, with these errors:

- column alias is used in the ON clause, `_userIdAlias`
- refers to a column in the WHERE clause that is neither in SELECT nor in the ON clause, `Users_OrgsTable.INSTANCE.organizationId`
 
Proposed Solution
========

- using the original name of the `userId` column
- testing for `Users_OrgsTable.INSTANCE.organizationId` in the ON clause

Steps to Verify
========
Please see the linked LPS for the reproduction steps.
https://issues.liferay.com/browse/LPS-180085

Thank you and best regards,
István