### PR TITLE
LPS-179279 KB do not expire correctly when database partitioning is enabled

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-api/bnd.bnd
+++ b/modules/apps/knowledge-base/knowledge-base-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Knowledge Base API
 Bundle-SymbolicName: com.liferay.knowledge.base.api
-Bundle-Version: 19.2.1
+Bundle-Version: 20.0.0
 Export-Package:\
 	com.liferay.knowledge.base.configuration,\
 	com.liferay.knowledge.base.constants,\

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleLocalService.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleLocalService.java
@@ -130,7 +130,7 @@ public interface KBArticleLocalService
 			InputStream inputStream, String mimeType)
 		throws PortalException;
 
-	public void checkKBArticles() throws PortalException;
+	public void checkKBArticles(long companyId) throws PortalException;
 
 	/**
 	 * Creates a new kb article with the primary key. Does not add the kb article to the database.

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleLocalServiceUtil.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleLocalServiceUtil.java
@@ -133,8 +133,8 @@ public class KBArticleLocalServiceUtil {
 			groupId, userId, fileName, tempFolderName, inputStream, mimeType);
 	}
 
-	public static void checkKBArticles() throws PortalException {
-		getService().checkKBArticles();
+	public static void checkKBArticles(long companyId) throws PortalException {
+		getService().checkKBArticles(companyId);
 	}
 
 	/**

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleLocalServiceWrapper.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleLocalServiceWrapper.java
@@ -136,10 +136,10 @@ public class KBArticleLocalServiceWrapper
 	}
 
 	@Override
-	public void checkKBArticles()
+	public void checkKBArticles(long companyId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
-		_kbArticleLocalService.checkKBArticles();
+		_kbArticleLocalService.checkKBArticles(companyId);
 	}
 
 	/**

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/resources/com/liferay/knowledge/base/service/packageinfo
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/resources/com/liferay/knowledge/base/service/packageinfo
@@ -1,1 +1,1 @@
-version 8.1.0
+version 9.0.0

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/scheduler/CheckKBArticleSchedulerJobConfiguration.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/scheduler/CheckKBArticleSchedulerJobConfiguration.java
@@ -16,11 +16,13 @@ package com.liferay.knowledge.base.internal.scheduler;
 
 import com.liferay.knowledge.base.internal.configuration.KBServiceConfiguration;
 import com.liferay.knowledge.base.service.KBArticleLocalService;
+import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeRunnable;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.scheduler.SchedulerJobConfiguration;
 import com.liferay.portal.kernel.scheduler.TimeUnit;
 import com.liferay.portal.kernel.scheduler.TriggerConfiguration;
+import com.liferay.portal.kernel.service.CompanyLocalService;
 
 import java.util.Map;
 
@@ -39,8 +41,16 @@ public class CheckKBArticleSchedulerJobConfiguration
 	implements SchedulerJobConfiguration {
 
 	@Override
+	public UnsafeConsumer<Long, Exception>
+		getCompanyJobExecutorUnsafeConsumer() {
+
+		return companyId -> _kbArticleLocalService.checkKBArticles(companyId);
+	}
+
+	@Override
 	public UnsafeRunnable<Exception> getJobExecutorUnsafeRunnable() {
-		return _kbArticleLocalService::checkKBArticles;
+		return () -> _companyLocalService.forEachCompanyId(
+			companyId -> _kbArticleLocalService.checkKBArticles(companyId));
 	}
 
 	@Override
@@ -54,6 +64,9 @@ public class CheckKBArticleSchedulerJobConfiguration
 		_kbServiceConfiguration = ConfigurableUtil.createConfigurable(
 			KBServiceConfiguration.class, properties);
 	}
+
+	@Reference
+	private CompanyLocalService _companyLocalService;
 
 	@Reference
 	private KBArticleLocalService _kbArticleLocalService;

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
@@ -346,17 +346,17 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 	}
 
 	@Override
-	public void checkKBArticles() throws PortalException {
+	public void checkKBArticles(long companyId) throws PortalException {
 		Date date = new Date();
 
-		_checkKBArticlesByExpirationDate(date);
+		_checkKBArticlesByExpirationDate(companyId, date);
 
 		if (_previousCheckDate == null) {
 			_previousCheckDate = new Date(
 				date.getTime() - _getKBArticleCheckInterval());
 		}
 
-		_checkKBArticlesByReviewDate(date);
+		_checkKBArticlesByReviewDate(companyId, date);
 
 		_previousCheckDate = date;
 	}
@@ -1600,31 +1600,34 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 		return dynamicQuery.add(junction);
 	}
 
-	private void _checkKBArticlesByExpirationDate(Date expirationDate)
+	private void _checkKBArticlesByExpirationDate(
+			long companyId, Date expirationDate)
 		throws PortalException {
 
 		if (_log.isDebugEnabled()) {
 			_log.debug(
-				"Expiring file entries with expiration date previous to " +
-					expirationDate);
+				StringBundler.concat(
+					"Expiring file entries with expiration date previous to " ,
+						expirationDate,
+					" for companyId ", companyId));
 		}
 
-		_companyLocalService.forEachCompany(
-			company -> _expireKBArticlesByCompany(company, expirationDate));
+		_expireKBArticlesByCompany(_companyLocalService.getCompany(companyId), expirationDate);
 	}
 
-	private void _checkKBArticlesByReviewDate(Date reviewDate)
+	private void _checkKBArticlesByReviewDate(long companyId, Date reviewDate)
 		throws PortalException {
 
 		if (_log.isDebugEnabled()) {
 			_log.debug(
 				StringBundler.concat(
 					"Sending review notification for articles with review ",
-					"date between ", _previousCheckDate, " and ", reviewDate));
+					"date between ", _previousCheckDate, " and ", reviewDate
+					, " for companyId ", companyId));
 		}
 
-		_companyLocalService.forEachCompany(
-			company -> _notifyReviewKBArticlesByCompany(company, reviewDate));
+		_notifyReviewKBArticlesByCompany(
+			_companyLocalService.getCompany(companyId), reviewDate);
 	}
 
 	private void _deleteAssets(KBArticle kbArticle) throws PortalException {

--- a/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/web/internal/scheduler/test/CheckKBArticleSchedulerJobConfigurationTest.java
+++ b/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/web/internal/scheduler/test/CheckKBArticleSchedulerJobConfigurationTest.java
@@ -86,7 +86,7 @@ public class CheckKBArticleSchedulerJobConfigurationTest {
 
 		kbArticle = _kbArticleLocalService.updateKBArticle(kbArticle);
 
-		_kbArticleLocalService.checkKBArticles();
+		_kbArticleLocalService.checkKBArticles(_group.getCompanyId());
 
 		kbArticle = _kbArticleLocalService.getLatestKBArticle(
 			kbArticle.getResourcePrimKey(), WorkflowConstants.STATUS_ANY);


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-179279


with the same solution than for documents, change the check interval to be lauched by company and call it on the getCompanyJobExecutorUnsafeConsumer

- LPS-179279 modify method to obtain the KBArticles to check from the company received no for all the companies on the system
- LPS-179279 take into account that the previous date will change each company so change the object and update the value by company
- LPS-179279 buildService
- LPS-179279 baseline
- LPS-179279 add the call to getCompanyJobExecutorUnsafeConsumer to be called instead n times getJobExecutorUnsafeRunnable when there are more than one instances
- LPS-179279 fix test
