### PR TITLE
[TS] LPS-180462 max-age config shouldn't have space between equals and value

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/servlet/CacheControlFileEntryHttpHeaderCustomizer.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/servlet/CacheControlFileEntryHttpHeaderCustomizer.java
@@ -85,7 +85,7 @@ public class CacheControlFileEntryHttpHeaderCustomizer
 		}
 
 		return String.format(
-			"%s, max-age= %d", cacheControlConfiguration.cacheControl(),
+			"%s, max-age=%d", cacheControlConfiguration.cacheControl(),
 			cacheControlConfiguration.maxAge());
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/DMDocument.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/DMDocument.macro
@@ -2946,7 +2946,7 @@ definition {
 			}
 		}
 		else {
-			var cacheControlAttribute = "Cache-Control: ${cacheControl}, max-age= ${maxAge}";
+			var cacheControlAttribute = "Cache-Control: ${cacheControl}, max-age=${maxAge}";
 
 			if (contains(${responseHeader}, ${cacheControlAttribute})) {
 				echo("The cache control setting is correct");


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-180462

According to https://www.rfc-editor.org/rfc/rfc9111.html#name-max-age-2, max-age shouldn't have a space between the "=" and the value.  Please let me know if you have any questions, thanks!