### PR TITLE
LPS-180912 because we save all the versions of the articles, we have to check if the latest version is expired or not to let it show on the display page

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/layout/display/page/KBArticleLayoutDisplayPageProvider.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/layout/display/page/KBArticleLayoutDisplayPageProvider.java
@@ -87,6 +87,14 @@ public class KBArticleLayoutDisplayPageProvider
 				return null;
 			}
 
+			KBArticle latestKBArticle =
+				_kbArticleLocalService.fetchLatestKBArticle(
+					kbArticle.getResourcePrimKey(), kbArticle.getGroupId());
+
+			if ((latestKBArticle == null) || latestKBArticle.isExpired()) {
+				return null;
+			}
+
 			return new KBArticleLayoutDisplayPageObjectProvider(
 				kbArticle, _assetHelper);
 		}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-180912

- Steps to reproduce

1. Add an Display page template for KB articles and mark as default
2. Add a KB article (expireme)
3. Add to home page Asset publisher widget
4. select on manual, the KB article previously created
5. publish and copy link to article ( _http://localhost:8080/k/expireme_ )
6. Expire the KB article
7. access to link to kb article http://localhost:8080/k/expireme

-  Expected Result:

Not found but no error on console