### PR TITLE
LPS-181099 restore the error message on invalid pattern

### DIFF
--- a/modules/apps/redirect/redirect-api/bnd.bnd
+++ b/modules/apps/redirect/redirect-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Redirect API
 Bundle-SymbolicName: com.liferay.redirect.api
-Bundle-Version: 10.0.1
+Bundle-Version: 10.1.0
 Export-Package:\
 	com.liferay.redirect.configuration,\
 	com.liferay.redirect.constants,\

--- a/modules/apps/redirect/redirect-api/src/main/java/com/liferay/redirect/exception/InvalidRedirectionPatternException.java
+++ b/modules/apps/redirect/redirect-api/src/main/java/com/liferay/redirect/exception/InvalidRedirectionPatternException.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.redirect.exception;
+
+import com.liferay.portal.kernel.exception.PortalException;
+
+/**
+ * @author Alicia García
+ */
+public class InvalidRedirectionPatternException extends PortalException {
+
+	public InvalidRedirectionPatternException() {
+	}
+
+	public InvalidRedirectionPatternException(String msg) {
+		super(msg);
+	}
+
+	public InvalidRedirectionPatternException(String msg, Throwable throwable) {
+		super(msg, throwable);
+	}
+
+	public InvalidRedirectionPatternException(Throwable throwable) {
+		super(throwable);
+	}
+
+}

--- a/modules/apps/redirect/redirect-api/src/main/resources/com/liferay/redirect/exception/packageinfo
+++ b/modules/apps/redirect/redirect-api/src/main/resources/com/liferay/redirect/exception/packageinfo
@@ -1,1 +1,1 @@
-version 1.2.0
+version 1.3.0

--- a/modules/apps/redirect/redirect-web/src/main/java/com/liferay/redirect/web/internal/portlet/action/EditRedirectPatternsMVCActionCommand.java
+++ b/modules/apps/redirect/redirect-web/src/main/java/com/liferay/redirect/web/internal/portlet/action/EditRedirectPatternsMVCActionCommand.java
@@ -16,6 +16,8 @@ package com.liferay.redirect.web.internal.portlet.action;
 
 import com.liferay.portal.configuration.persistence.listener.ConfigurationModelListenerException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCActionCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.servlet.SessionErrors;
@@ -25,6 +27,7 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.redirect.configuration.RedirectPatternConfigurationProvider;
 import com.liferay.redirect.constants.RedirectConstants;
+import com.liferay.redirect.exception.InvalidRedirectionPatternException;
 import com.liferay.redirect.model.RedirectPatternEntry;
 import com.liferay.redirect.web.internal.constants.RedirectPortletKeys;
 
@@ -32,6 +35,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 import javax.portlet.ActionRequest;
 import javax.portlet.ActionResponse;
@@ -64,11 +68,10 @@ public class EditRedirectPatternsMVCActionCommand extends BaseMVCActionCommand {
 				themeDisplay.getScopeGroupId(),
 				_getRedirectPatternEntries(actionRequest));
 		}
-		catch (ConfigurationModelListenerException
-					configurationModelListenerException) {
+		catch (ConfigurationModelListenerException |
+			   InvalidRedirectionPatternException exception) {
 
-			SessionErrors.add(
-				actionRequest, configurationModelListenerException.getClass());
+			SessionErrors.add(actionRequest, exception.getClass());
 
 			hideDefaultErrorMessage(actionRequest);
 
@@ -78,7 +81,8 @@ public class EditRedirectPatternsMVCActionCommand extends BaseMVCActionCommand {
 	}
 
 	private List<RedirectPatternEntry> _getRedirectPatternEntries(
-		ActionRequest actionRequest) {
+			ActionRequest actionRequest)
+		throws InvalidRedirectionPatternException {
 
 		List<RedirectPatternEntry> redirectPatternEntries = new ArrayList<>();
 
@@ -110,10 +114,19 @@ public class EditRedirectPatternsMVCActionCommand extends BaseMVCActionCommand {
 			if ((patternString != null) && (destinationURL != null) &&
 				(userAgent != null)) {
 
-				redirectPatternEntries.add(
-					new RedirectPatternEntry(
-						Pattern.compile(patternString), destinationURL,
-						userAgent));
+				try {
+					redirectPatternEntries.add(
+						new RedirectPatternEntry(
+							Pattern.compile(patternString), destinationURL,
+							userAgent));
+				}
+				catch (PatternSyntaxException patternSyntaxException) {
+					_log.error(patternSyntaxException);
+
+					throw new InvalidRedirectionPatternException(
+						patternString + " must contain regular expression",
+						patternSyntaxException);
+				}
 			}
 		}
 
@@ -133,6 +146,9 @@ public class EditRedirectPatternsMVCActionCommand extends BaseMVCActionCommand {
 
 		return null;
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		EditRedirectPatternsMVCActionCommand.class);
 
 	@Reference
 	private RedirectPatternConfigurationProvider

--- a/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/init.jsp
@@ -42,6 +42,7 @@ page import="com.liferay.portal.kernel.util.URLCodec" %><%@
 page import="com.liferay.portal.kernel.util.Validator" %><%@
 page import="com.liferay.redirect.exception.CircularRedirectEntryException" %><%@
 page import="com.liferay.redirect.exception.DuplicateRedirectEntrySourceURLException" %><%@
+page import="com.liferay.redirect.exception.InvalidRedirectionPatternException" %><%@
 page import="com.liferay.redirect.exception.RequiredRedirectEntryDestinationURLException" %><%@
 page import="com.liferay.redirect.exception.RequiredRedirectEntrySourceURLException" %><%@
 page import="com.liferay.redirect.web.internal.display.context.EditRedirectEntryDisplayContext" %><%@

--- a/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/view.jsp
@@ -45,7 +45,7 @@ RedirectDisplayContext redirectDisplayContext = (RedirectDisplayContext)request.
 			/>
 		</div>
 
-		<c:if test="<%= SessionErrors.contains(renderRequest, ConfigurationModelListenerException.class) %>">
+		<c:if test="<%= SessionErrors.contains(renderRequest, ConfigurationModelListenerException.class) || SessionErrors.contains(renderRequest, InvalidRedirectionPatternException.class) %>">
 			<aui:script>
 				Liferay.Util.openToast({
 					message:


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-181099


Before the transformation from string to pattern was be doing on the listener, but now it's the command who take this responsability so we will check it on the command creating a new exception because there is no reason to throw a ConfigurationModelListenerException on the action command (but without deleting it from the listener)

- LPS-181099 create new exception for the invalid redirection pattens
- LPS-181099 baseline
- LPS-181099 catch Pattern Exception and show the error toast to the user
