### PR TITLE
LPS-180298 POC: Manage multiple store areas in DLStore

### DIFF
--- a/modules/apps/change-tracking/change-tracking-store-service/src/main/java/com/liferay/change/tracking/store/internal/CTStore.java
+++ b/modules/apps/change-tracking/change-tracking-store-service/src/main/java/com/liferay/change/tracking/store/internal/CTStore.java
@@ -19,6 +19,7 @@ import com.liferay.change.tracking.model.CTEntry;
 import com.liferay.change.tracking.service.CTEntryLocalService;
 import com.liferay.change.tracking.store.model.CTSContent;
 import com.liferay.change.tracking.store.service.CTSContentLocalService;
+import com.liferay.document.library.kernel.store.AreaStore;
 import com.liferay.document.library.kernel.store.Store;
 import com.liferay.document.library.kernel.util.DLUtil;
 import com.liferay.petra.lang.SafeCloseable;
@@ -39,7 +40,7 @@ import java.util.Set;
 /**
  * @author Shuyang Zhou
  */
-public class CTStore implements Store {
+public class CTStore implements AreaStore {
 
 	public CTStore(
 		CTEntryLocalService ctEntryLocalService, long ctsContentClassNameId,
@@ -49,23 +50,24 @@ public class CTStore implements Store {
 		_ctEntryLocalService = ctEntryLocalService;
 		_ctsContentClassNameId = ctsContentClassNameId;
 		_ctsContentLocalService = ctsContentLocalService;
-		_store = store;
+		_store = (AreaStore)store;
 		_storeType = storeType;
 	}
 
 	@Override
 	public void addFile(
-			long companyId, long repositoryId, String fileName,
-			String versionLabel, InputStream inputStream)
+			AreaType areaType, long companyId, long repositoryId,
+			String fileName, String versionLabel, InputStream inputStream)
 		throws PortalException {
 
 		if (CTCollectionThreadLocal.isProductionMode()) {
 			_store.addFile(
-				companyId, repositoryId, fileName, versionLabel, inputStream);
+				areaType, companyId, repositoryId, fileName, versionLabel,
+				inputStream);
 		}
 		else {
 			_ensureCTSContentIsLoaded(
-				companyId, repositoryId, fileName, versionLabel);
+				areaType, companyId, repositoryId, fileName, versionLabel);
 
 			_ctsContentLocalService.addCTSContent(
 				companyId, repositoryId, fileName, versionLabel, _storeType,
@@ -75,24 +77,26 @@ public class CTStore implements Store {
 
 	@Override
 	public void deleteDirectory(
-		long companyId, long repositoryId, String dirName) {
+		AreaType areaType, long companyId, long repositoryId, String dirName) {
 
 		if (CTCollectionThreadLocal.isProductionMode()) {
-			_store.deleteDirectory(companyId, repositoryId, dirName);
+			_store.deleteDirectory(areaType, companyId, repositoryId, dirName);
 		}
 		else {
 			for (String fileName :
-					_store.getFileNames(companyId, repositoryId, dirName)) {
+					_store.getFileNames(
+						areaType, companyId, repositoryId, dirName)) {
 
 				for (String versionLabel :
 						_store.getFileVersions(
-							companyId, repositoryId, fileName)) {
+							areaType, companyId, repositoryId, fileName)) {
 
 					if (!_isCTSContentLoaded(
 							companyId, repositoryId, fileName, versionLabel)) {
 
 						_loadCTSContent(
-							companyId, repositoryId, fileName, versionLabel);
+							areaType, companyId, repositoryId, fileName,
+							versionLabel);
 					}
 				}
 			}
@@ -104,15 +108,16 @@ public class CTStore implements Store {
 
 	@Override
 	public void deleteFile(
-		long companyId, long repositoryId, String fileName,
+		AreaType areaType, long companyId, long repositoryId, String fileName,
 		String versionLabel) {
 
 		if (CTCollectionThreadLocal.isProductionMode()) {
-			_store.deleteFile(companyId, repositoryId, fileName, versionLabel);
+			_store.deleteFile(
+				areaType, companyId, repositoryId, fileName, versionLabel);
 		}
 		else {
 			_ensureCTSContentIsLoaded(
-				companyId, repositoryId, fileName, versionLabel);
+				areaType, companyId, repositoryId, fileName, versionLabel);
 		}
 
 		_ctsContentLocalService.deleteCTSContent(
@@ -121,8 +126,8 @@ public class CTStore implements Store {
 
 	@Override
 	public InputStream getFileAsStream(
-			long companyId, long repositoryId, String fileName,
-			String versionLabel)
+			AreaType areaType, long companyId, long repositoryId,
+			String fileName, String versionLabel)
 		throws PortalException {
 
 		if (!CTCollectionThreadLocal.isProductionMode() &&
@@ -137,15 +142,15 @@ public class CTStore implements Store {
 		}
 
 		return _store.getFileAsStream(
-			companyId, repositoryId, fileName, versionLabel);
+			areaType, companyId, repositoryId, fileName, versionLabel);
 	}
 
 	@Override
 	public String[] getFileNames(
-		long companyId, long repositoryId, String dirName) {
+		AreaType areaType, long companyId, long repositoryId, String dirName) {
 
 		String[] fileNames = _store.getFileNames(
-			companyId, repositoryId, dirName);
+			areaType, companyId, repositoryId, dirName);
 
 		if (CTCollectionThreadLocal.isProductionMode()) {
 			return fileNames;
@@ -176,7 +181,7 @@ public class CTStore implements Store {
 				new HashSet<>(
 					Arrays.asList(
 						_store.getFileVersions(
-							companyId, repositoryId, fileName))));
+							areaType, companyId, repositoryId, fileName))));
 		}
 
 		for (CTSContent ctsContent :
@@ -226,8 +231,8 @@ public class CTStore implements Store {
 
 	@Override
 	public long getFileSize(
-			long companyId, long repositoryId, String fileName,
-			String versionLabel)
+			AreaType areaType, long companyId, long repositoryId,
+			String fileName, String versionLabel)
 		throws PortalException {
 
 		if (!CTCollectionThreadLocal.isProductionMode() &&
@@ -241,15 +246,15 @@ public class CTStore implements Store {
 		}
 
 		return _store.getFileSize(
-			companyId, repositoryId, fileName, versionLabel);
+			areaType, companyId, repositoryId, fileName, versionLabel);
 	}
 
 	@Override
 	public String[] getFileVersions(
-		long companyId, long repositoryId, String fileName) {
+		AreaType areaType, long companyId, long repositoryId, String fileName) {
 
 		String[] versions = _store.getFileVersions(
-			companyId, repositoryId, fileName);
+			areaType, companyId, repositoryId, fileName);
 
 		if (CTCollectionThreadLocal.isProductionMode()) {
 			return versions;
@@ -290,7 +295,7 @@ public class CTStore implements Store {
 
 	@Override
 	public boolean hasFile(
-		long companyId, long repositoryId, String fileName,
+		AreaType areaType, long companyId, long repositoryId, String fileName,
 		String versionLabel) {
 
 		if (!CTCollectionThreadLocal.isProductionMode()) {
@@ -314,21 +319,24 @@ public class CTStore implements Store {
 			}
 		}
 
-		return _store.hasFile(companyId, repositoryId, fileName, versionLabel);
+		return _store.hasFile(
+			areaType, companyId, repositoryId, fileName, versionLabel);
 	}
 
 	private void _ensureCTSContentIsLoaded(
-		long companyId, long repositoryId, String fileName,
+		AreaType areaType, long companyId, long repositoryId, String fileName,
 		String versionLabel) {
 
 		if (_isCTSContentLoaded(
 				companyId, repositoryId, fileName, versionLabel) ||
-			!_store.hasFile(companyId, repositoryId, fileName, versionLabel)) {
+			!_store.hasFile(
+				areaType, companyId, repositoryId, fileName, versionLabel)) {
 
 			return;
 		}
 
-		_loadCTSContent(companyId, repositoryId, fileName, versionLabel);
+		_loadCTSContent(
+			areaType, companyId, repositoryId, fileName, versionLabel);
 	}
 
 	private Set<Long> _getDeletedCTSContentIds(long ctCollectionId) {
@@ -371,11 +379,11 @@ public class CTStore implements Store {
 	}
 
 	private void _loadCTSContent(
-		long companyId, long repositoryId, String fileName,
+		AreaType areaType, long companyId, long repositoryId, String fileName,
 		String versionLabel) {
 
 		try (InputStream inputStream = _store.getFileAsStream(
-				companyId, repositoryId, fileName, versionLabel);
+				areaType, companyId, repositoryId, fileName, versionLabel);
 			SafeCloseable safeCloseable =
 				CTCollectionThreadLocal.setProductionModeWithSafeCloseable()) {
 
@@ -403,7 +411,7 @@ public class CTStore implements Store {
 	private final CTEntryLocalService _ctEntryLocalService;
 	private final long _ctsContentClassNameId;
 	private final CTSContentLocalService _ctsContentLocalService;
-	private final Store _store;
+	private final AreaStore _store;
 	private final String _storeType;
 
 }

--- a/modules/apps/change-tracking/change-tracking-store-test/src/testIntegration/java/com/liferay/change/tracking/store/internal/test/CTStoreTest.java
+++ b/modules/apps/change-tracking/change-tracking-store-test/src/testIntegration/java/com/liferay/change/tracking/store/internal/test/CTStoreTest.java
@@ -22,6 +22,7 @@ import com.liferay.change.tracking.store.exception.NoSuchContentException;
 import com.liferay.change.tracking.store.model.CTSContent;
 import com.liferay.change.tracking.store.service.CTSContentLocalService;
 import com.liferay.document.library.kernel.exception.NoSuchFileException;
+import com.liferay.document.library.kernel.store.AreaStore;
 import com.liferay.document.library.kernel.store.Store;
 import com.liferay.petra.function.UnsafeRunnable;
 import com.liferay.petra.io.StreamUtil;
@@ -79,8 +80,9 @@ public class CTStoreTest {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_ctStore = _ctStoreFactory.createCTStore(
-			(Store)ProxyUtil.newProxyInstance(
-				Store.class.getClassLoader(), new Class<?>[] {Store.class},
+			(AreaStore)ProxyUtil.newProxyInstance(
+				AreaStore.class.getClassLoader(),
+				new Class<?>[] {AreaStore.class},
 				new RecorderInvocationHandler(_fileSystemStore)),
 			_STORE_TYPE);
 
@@ -1310,33 +1312,37 @@ public class CTStoreTest {
 
 	static {
 		try {
-			_ADD_FILE_METHOD = Store.class.getMethod(
-				"addFile", long.class, long.class, String.class, String.class,
-				InputStream.class);
+			_ADD_FILE_METHOD = AreaStore.class.getMethod(
+				"addFile", AreaStore.AreaType.class, long.class, long.class,
+				String.class, String.class, InputStream.class);
 
-			_DELETE_DIRECTORY_METHOD = Store.class.getMethod(
-				"deleteDirectory", long.class, long.class, String.class);
+			_DELETE_DIRECTORY_METHOD = AreaStore.class.getMethod(
+				"deleteDirectory", AreaStore.AreaType.class, long.class,
+				long.class, String.class);
 
-			_DELETE_FILE_METHOD = Store.class.getMethod(
-				"deleteFile", long.class, long.class, String.class,
-				String.class);
+			_DELETE_FILE_METHOD = AreaStore.class.getMethod(
+				"deleteFile", AreaStore.AreaType.class, long.class, long.class,
+				String.class, String.class);
 
-			_GET_FILE_AS_STREAM_METHOD = Store.class.getMethod(
-				"getFileAsStream", long.class, long.class, String.class,
-				String.class);
+			_GET_FILE_AS_STREAM_METHOD = AreaStore.class.getMethod(
+				"getFileAsStream", AreaStore.AreaType.class, long.class,
+				long.class, String.class, String.class);
 
-			_GET_FILE_NAMES = Store.class.getMethod(
-				"getFileNames", long.class, long.class, String.class);
+			_GET_FILE_NAMES = AreaStore.class.getMethod(
+				"getFileNames", AreaStore.AreaType.class, long.class,
+				long.class, String.class);
 
-			_GET_FILE_SIZE = Store.class.getMethod(
-				"getFileSize", long.class, long.class, String.class,
-				String.class);
+			_GET_FILE_SIZE = AreaStore.class.getMethod(
+				"getFileSize", AreaStore.AreaType.class, long.class, long.class,
+				String.class, String.class);
 
-			_GET_FILE_VERSIONS = Store.class.getMethod(
-				"getFileVersions", long.class, long.class, String.class);
+			_GET_FILE_VERSIONS = AreaStore.class.getMethod(
+				"getFileVersions", AreaStore.AreaType.class, long.class,
+				long.class, String.class);
 
-			_HAS_FILE_METHOD = Store.class.getMethod(
-				"hasFile", long.class, long.class, String.class, String.class);
+			_HAS_FILE_METHOD = AreaStore.class.getMethod(
+				"hasFile", AreaStore.AreaType.class, long.class, long.class,
+				String.class, String.class);
 		}
 		catch (NoSuchMethodException noSuchMethodException) {
 			throw new ExceptionInInitializerError(noSuchMethodException);

--- a/modules/apps/portal-store/portal-store-file-system/src/main/java/com/liferay/portal/store/file/system/AdvancedFileSystemStore.java
+++ b/modules/apps/portal-store/portal-store-file-system/src/main/java/com/liferay/portal/store/file/system/AdvancedFileSystemStore.java
@@ -48,10 +48,10 @@ public class AdvancedFileSystemStore extends FileSystemStore {
 
 	@Override
 	public String[] getFileVersions(
-		long companyId, long repositoryId, String fileName) {
+		AreaType areaType, long companyId, long repositoryId, String fileName) {
 
 		String[] versions = super.getFileVersions(
-			companyId, repositoryId, fileName);
+			areaType, companyId, repositoryId, fileName);
 
 		for (int i = 0; i < versions.length; i++) {
 			int x = versions[i].lastIndexOf(CharPool.UNDERLINE);
@@ -91,19 +91,20 @@ public class AdvancedFileSystemStore extends FileSystemStore {
 
 	@Override
 	protected File getDirNameDir(
-		long companyId, long repositoryId, String dirName) {
+		AreaType areaType, long companyId, long repositoryId, String dirName) {
 
-		File repositoryDir = getRepositoryDir(companyId, repositoryId);
+		File repositoryDir = getRepositoryDir(
+			areaType, companyId, repositoryId);
 
 		return new File(repositoryDir + StringPool.SLASH + dirName);
 	}
 
 	@Override
 	protected File getFileNameDir(
-		long companyId, long repositoryId, String fileName) {
+		AreaType areaType, long companyId, long repositoryId, String fileName) {
 
 		if (fileName.indexOf(CharPool.SLASH) != -1) {
-			return getDirNameDir(companyId, repositoryId, fileName);
+			return getDirNameDir(areaType, companyId, repositoryId, fileName);
 		}
 
 		String ext = StringPool.PERIOD + FileUtil.getExtension(fileName);
@@ -124,7 +125,8 @@ public class AdvancedFileSystemStore extends FileSystemStore {
 
 		buildPath(sb, fileNameFragment);
 
-		File repositoryDir = getRepositoryDir(companyId, repositoryId);
+		File repositoryDir = getRepositoryDir(
+			areaType, companyId, repositoryId);
 
 		StringBundler pathSB = new StringBundler(6);
 
@@ -162,7 +164,8 @@ public class AdvancedFileSystemStore extends FileSystemStore {
 
 	@Override
 	protected File getFileNameVersionFile(
-		long companyId, long repositoryId, String fileName, String version) {
+		AreaType areaType, long companyId, long repositoryId, String fileName,
+		String version) {
 
 		String ext = StringPool.PERIOD + FileUtil.getExtension(fileName);
 
@@ -185,7 +188,8 @@ public class AdvancedFileSystemStore extends FileSystemStore {
 
 			buildPath(sb, fileNameFragment);
 
-			File repositoryDir = getRepositoryDir(companyId, repositoryId);
+			File repositoryDir = getRepositoryDir(
+				areaType, companyId, repositoryId);
 
 			return new File(
 				StringBundler.concat(
@@ -194,7 +198,8 @@ public class AdvancedFileSystemStore extends FileSystemStore {
 					fileNameFragment, StringPool.UNDERLINE, version, ext));
 		}
 
-		File fileNameDir = getDirNameDir(companyId, repositoryId, fileName);
+		File fileNameDir = getDirNameDir(
+			areaType, companyId, repositoryId, fileName);
 
 		String fileNameFragment = FileUtil.stripExtension(
 			fileName.substring(pos + 1));
@@ -207,9 +212,10 @@ public class AdvancedFileSystemStore extends FileSystemStore {
 
 	@Override
 	protected String getHeadVersionLabel(
-		long companyId, long repositoryId, String fileName) {
+		AreaType areaType, long companyId, long repositoryId, String fileName) {
 
-		File fileNameDir = getFileNameDir(companyId, repositoryId, fileName);
+		File fileNameDir = getFileNameDir(
+			areaType, companyId, repositoryId, fileName);
 
 		if (!fileNameDir.exists()) {
 			return VERSION_DEFAULT;

--- a/modules/apps/portal-store/portal-store-file-system/src/main/java/com/liferay/portal/store/file/system/AdvancedFileSystemStoreRegister.java
+++ b/modules/apps/portal-store/portal-store-file-system/src/main/java/com/liferay/portal/store/file/system/AdvancedFileSystemStoreRegister.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.store.file.system;
 
+import com.liferay.document.library.kernel.store.AreaStore;
 import com.liferay.document.library.kernel.store.Store;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.convert.documentlibrary.FileSystemStoreRootDirException;
@@ -64,7 +65,8 @@ public class AdvancedFileSystemStoreRegister {
 		_serviceRegistration = bundleContext.registerService(
 			Store.class, _wrapStore(advancedFileSystemStore),
 			HashMapDictionaryBuilder.<String, Object>put(
-				"rootDir", advancedFileSystemStore.getRootDir()
+				"rootDir",
+				advancedFileSystemStore.getRootDir(AreaStore.AreaType.LIVE)
 			).put(
 				"store.type", AdvancedFileSystemStore.class.getName()
 			).build());

--- a/modules/apps/portal-store/portal-store-file-system/src/main/java/com/liferay/portal/store/file/system/AdvancedFileSystemStoreRegister.java
+++ b/modules/apps/portal-store/portal-store-file-system/src/main/java/com/liferay/portal/store/file/system/AdvancedFileSystemStoreRegister.java
@@ -77,7 +77,7 @@ public class AdvancedFileSystemStoreRegister {
 		_serviceRegistration.unregister();
 	}
 
-	private Store _wrapStore(Store store) {
+	private AreaStore _wrapStore(AreaStore store) {
 		if (!GetterUtil.getBoolean(
 				PropsUtil.get("dl.store.file.system.lenient"))) {
 

--- a/modules/apps/portal-store/portal-store-file-system/src/main/java/com/liferay/portal/store/file/system/FileSystemStore.java
+++ b/modules/apps/portal-store/portal-store-file-system/src/main/java/com/liferay/portal/store/file/system/FileSystemStore.java
@@ -15,9 +15,10 @@
 package com.liferay.portal.store.file.system;
 
 import com.liferay.document.library.kernel.exception.NoSuchFileException;
-import com.liferay.document.library.kernel.store.Store;
+import com.liferay.document.library.kernel.store.AreaStore;
 import com.liferay.document.library.kernel.util.DLUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
+import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.util.ArrayUtil;
@@ -37,6 +38,7 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 
 /**
@@ -46,26 +48,35 @@ import java.util.List;
  * @author Edward Han
  * @author Manuel de la Peña
  */
-public class FileSystemStore implements Store {
+public class FileSystemStore implements AreaStore {
 
 	public FileSystemStore(
 		FileSystemStoreConfiguration fileSystemStoreConfiguration) {
 
 		String path = fileSystemStoreConfiguration.rootDir();
 
-		File rootDir = new File(path);
-
-		if (!rootDir.isAbsolute()) {
-			rootDir = new File(PropsUtil.get(PropsKeys.LIFERAY_HOME), path);
+		if (StringUtil.endsWith(path, CharPool.SLASH)) {
+			path = path.substring(0, path.length() - 1);
 		}
 
-		_rootDir = rootDir;
+		for (AreaType areaType : AreaType.values()) {
+			String areaPath = path + areaType.getDirectorySuffix();
 
-		_rootDir.mkdirs();
+			File rootDir = new File(areaPath);
+
+			if (!rootDir.isAbsolute()) {
+				rootDir = new File(
+					PropsUtil.get(PropsKeys.LIFERAY_HOME), areaPath);
+			}
+
+			_rootDirs.put(areaType, rootDir);
+
+			rootDir.mkdirs();
+		}
 
 		try {
 			FileUtil.write(
-				new File(_rootDir, "README.txt"),
+				new File(_rootDirs.get(AreaType.LIVE), "README.txt"),
 				StringUtil.read(
 					FileSystemStore.class, "dependencies/README.txt"));
 		}
@@ -76,18 +87,18 @@ public class FileSystemStore implements Store {
 
 	@Override
 	public void addFile(
-		long companyId, long repositoryId, String fileName, String versionLabel,
-		InputStream inputStream) {
+		AreaType areaType, long companyId, long repositoryId, String fileName,
+		String versionLabel, InputStream inputStream) {
 
 		if (Validator.isNull(versionLabel)) {
 			versionLabel = getHeadVersionLabel(
-				companyId, repositoryId, fileName);
+				areaType, companyId, repositoryId, fileName);
 		}
 
 		try {
 			FileUtil.write(
 				getFileNameVersionFile(
-					companyId, repositoryId, fileName, versionLabel),
+					areaType, companyId, repositoryId, fileName, versionLabel),
 				inputStream);
 		}
 		catch (IOException ioException) {
@@ -97,9 +108,10 @@ public class FileSystemStore implements Store {
 
 	@Override
 	public void deleteDirectory(
-		long companyId, long repositoryId, String dirName) {
+		AreaType areaType, long companyId, long repositoryId, String dirName) {
 
-		File dirNameDir = getDirNameDir(companyId, repositoryId, dirName);
+		File dirNameDir = getDirNameDir(
+			areaType, companyId, repositoryId, dirName);
 
 		if (!dirNameDir.exists()) {
 			return;
@@ -114,16 +126,16 @@ public class FileSystemStore implements Store {
 
 	@Override
 	public void deleteFile(
-		long companyId, long repositoryId, String fileName,
+		AreaType areaType, long companyId, long repositoryId, String fileName,
 		String versionLabel) {
 
 		if (Validator.isNull(versionLabel)) {
 			versionLabel = getHeadVersionLabel(
-				companyId, repositoryId, fileName);
+				areaType, companyId, repositoryId, fileName);
 		}
 
 		File fileNameVersionFile = getFileNameVersionFile(
-			companyId, repositoryId, fileName, versionLabel);
+			areaType, companyId, repositoryId, fileName, versionLabel);
 
 		if (!fileNameVersionFile.exists()) {
 			return;
@@ -138,33 +150,34 @@ public class FileSystemStore implements Store {
 
 	@Override
 	public InputStream getFileAsStream(
-			long companyId, long repositoryId, String fileName,
-			String versionLabel)
+			AreaType areaType, long companyId, long repositoryId,
+			String fileName, String versionLabel)
 		throws NoSuchFileException {
 
 		if (Validator.isNull(versionLabel)) {
 			versionLabel = getHeadVersionLabel(
-				companyId, repositoryId, fileName);
+				areaType, companyId, repositoryId, fileName);
 		}
 
 		File fileNameVersionFile = getFileNameVersionFile(
-			companyId, repositoryId, fileName, versionLabel);
+			areaType, companyId, repositoryId, fileName, versionLabel);
 
 		try {
 			return new FileInputStream(fileNameVersionFile);
 		}
 		catch (FileNotFoundException fileNotFoundException) {
 			throw new NoSuchFileException(
-				companyId, repositoryId, fileName, versionLabel,
+				areaType, companyId, repositoryId, fileName, versionLabel,
 				fileNotFoundException);
 		}
 	}
 
 	@Override
 	public String[] getFileNames(
-		long companyId, long repositoryId, String dirName) {
+		AreaType areaType, long companyId, long repositoryId, String dirName) {
 
-		File dirNameDir = getDirNameDir(companyId, repositoryId, dirName);
+		File dirNameDir = getDirNameDir(
+			areaType, companyId, repositoryId, dirName);
 
 		if (!dirNameDir.exists()) {
 			return new String[0];
@@ -181,21 +194,21 @@ public class FileSystemStore implements Store {
 
 	@Override
 	public long getFileSize(
-			long companyId, long repositoryId, String fileName,
-			String versionLabel)
+			AreaType areaType, long companyId, long repositoryId,
+			String fileName, String versionLabel)
 		throws NoSuchFileException {
 
 		if (Validator.isNull(versionLabel)) {
 			versionLabel = getHeadVersionLabel(
-				companyId, repositoryId, fileName);
+				areaType, companyId, repositoryId, fileName);
 		}
 
 		File fileNameVersionFile = getFileNameVersionFile(
-			companyId, repositoryId, fileName, versionLabel);
+			areaType, companyId, repositoryId, fileName, versionLabel);
 
 		if (!fileNameVersionFile.exists()) {
 			throw new NoSuchFileException(
-				companyId, repositoryId, fileName, versionLabel);
+				areaType, companyId, repositoryId, fileName, versionLabel);
 		}
 
 		return fileNameVersionFile.length();
@@ -203,9 +216,10 @@ public class FileSystemStore implements Store {
 
 	@Override
 	public String[] getFileVersions(
-		long companyId, long repositoryId, String fileName) {
+		AreaType areaType, long companyId, long repositoryId, String fileName) {
 
-		File fileNameDir = getFileNameDir(companyId, repositoryId, fileName);
+		File fileNameDir = getFileNameDir(
+			areaType, companyId, repositoryId, fileName);
 
 		if (!fileNameDir.exists()) {
 			return StringPool.EMPTY_ARRAY;
@@ -218,36 +232,37 @@ public class FileSystemStore implements Store {
 		return versions;
 	}
 
-	public File getRootDir() {
-		return _rootDir;
+	public File getRootDir(AreaType areaType) {
+		return _rootDirs.get(areaType);
 	}
 
 	@Override
 	public boolean hasFile(
-		long companyId, long repositoryId, String fileName,
+		AreaType areaType, long companyId, long repositoryId, String fileName,
 		String versionLabel) {
 
 		if (Validator.isNull(versionLabel)) {
 			versionLabel = getHeadVersionLabel(
-				companyId, repositoryId, fileName);
+				areaType, companyId, repositoryId, fileName);
 		}
 
 		File fileNameVersionFile = getFileNameVersionFile(
-			companyId, repositoryId, fileName, versionLabel);
+			areaType, companyId, repositoryId, fileName, versionLabel);
 
 		return fileNameVersionFile.exists();
 	}
 
 	protected File getDirNameDir(
-		long companyId, long repositoryId, String dirName) {
+		AreaType areaType, long companyId, long repositoryId, String dirName) {
 
-		return getFileNameDir(companyId, repositoryId, dirName);
+		return getFileNameDir(areaType, companyId, repositoryId, dirName);
 	}
 
 	protected File getFileNameDir(
-		long companyId, long repositoryId, String fileName) {
+		AreaType areaType, long companyId, long repositoryId, String fileName) {
 
-		return new File(getRepositoryDir(companyId, repositoryId), fileName);
+		return new File(
+			getRepositoryDir(areaType, companyId, repositoryId), fileName);
 	}
 
 	protected void getFileNames(
@@ -281,16 +296,19 @@ public class FileSystemStore implements Store {
 	}
 
 	protected File getFileNameVersionFile(
-		long companyId, long repositoryId, String fileName, String version) {
+		AreaType areaType, long companyId, long repositoryId, String fileName,
+		String version) {
 
 		return new File(
-			getFileNameDir(companyId, repositoryId, fileName), version);
+			getFileNameDir(areaType, companyId, repositoryId, fileName),
+			version);
 	}
 
 	protected String getHeadVersionLabel(
-		long companyId, long repositoryId, String fileName) {
+		AreaType areaType, long companyId, long repositoryId, String fileName) {
 
-		File fileNameDir = getFileNameDir(companyId, repositoryId, fileName);
+		File fileNameDir = getFileNameDir(
+			areaType, companyId, repositoryId, fileName);
 
 		if (!fileNameDir.exists()) {
 			return VERSION_DEFAULT;
@@ -309,9 +327,11 @@ public class FileSystemStore implements Store {
 		return headVersionLabel;
 	}
 
-	protected File getRepositoryDir(long companyId, long repositoryId) {
+	protected File getRepositoryDir(
+		AreaType areaType, long companyId, long repositoryId) {
+
 		File repositoryDir = new File(
-			_rootDir, companyId + StringPool.SLASH + repositoryId);
+			getRootDir(areaType), companyId + StringPool.SLASH + repositoryId);
 
 		if (!repositoryDir.exists()) {
 			repositoryDir.mkdirs();
@@ -330,6 +350,7 @@ public class FileSystemStore implements Store {
 		}
 	}
 
-	private final File _rootDir;
+	private final HashMap<AreaType, File> _rootDirs = new HashMap<>(
+		ArrayUtil.getLength(AreaType.values()));
 
 }

--- a/modules/apps/portal-store/portal-store-file-system/src/main/java/com/liferay/portal/store/file/system/FileSystemStoreRegister.java
+++ b/modules/apps/portal-store/portal-store-file-system/src/main/java/com/liferay/portal/store/file/system/FileSystemStoreRegister.java
@@ -74,7 +74,7 @@ public class FileSystemStoreRegister {
 		_serviceRegistration.unregister();
 	}
 
-	private Store _wrapStore(Store store) {
+	private AreaStore _wrapStore(AreaStore store) {
 		if (!GetterUtil.getBoolean(
 				PropsUtil.get("dl.store.file.system.lenient"))) {
 

--- a/modules/apps/portal-store/portal-store-file-system/src/main/java/com/liferay/portal/store/file/system/FileSystemStoreRegister.java
+++ b/modules/apps/portal-store/portal-store-file-system/src/main/java/com/liferay/portal/store/file/system/FileSystemStoreRegister.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.store.file.system;
 
+import com.liferay.document.library.kernel.store.AreaStore;
 import com.liferay.document.library.kernel.store.Store;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.convert.documentlibrary.FileSystemStoreRootDirException;
@@ -62,7 +63,7 @@ public class FileSystemStoreRegister {
 		_serviceRegistration = bundleContext.registerService(
 			Store.class, _wrapStore(fileSystemStore),
 			HashMapDictionaryBuilder.<String, Object>put(
-				"rootDir", fileSystemStore.getRootDir()
+				"rootDir", fileSystemStore.getRootDir(AreaStore.AreaType.LIVE)
 			).put(
 				"store.type", FileSystemStore.class.getName()
 			).build());

--- a/modules/apps/portal-store/portal-store-file-system/src/main/java/com/liferay/portal/store/file/system/lenient/LenientStore.java
+++ b/modules/apps/portal-store/portal-store-file-system/src/main/java/com/liferay/portal/store/file/system/lenient/LenientStore.java
@@ -14,7 +14,7 @@
 
 package com.liferay.portal.store.file.system.lenient;
 
-import com.liferay.document.library.kernel.store.Store;
+import com.liferay.document.library.kernel.store.AreaStore;
 import com.liferay.petra.io.unsync.UnsyncByteArrayInputStream;
 import com.liferay.portal.kernel.exception.PortalException;
 
@@ -23,86 +23,93 @@ import java.io.InputStream;
 /**
  * @author Adolfo Pérez
  */
-public class LenientStore implements Store {
+public class LenientStore implements AreaStore {
 
-	public LenientStore(Store store) {
+	public LenientStore(AreaStore store) {
 		_store = store;
 	}
 
 	@Override
 	public void addFile(
-			long companyId, long repositoryId, String fileName,
-			String versionLabel, InputStream inputStream)
+			AreaType areaType, long companyId, long repositoryId,
+			String fileName, String versionLabel, InputStream inputStream)
 		throws PortalException {
 
 		_store.addFile(
-			companyId, repositoryId, fileName, versionLabel, inputStream);
+			areaType, companyId, repositoryId, fileName, versionLabel,
+			inputStream);
 	}
 
 	@Override
 	public void deleteDirectory(
-		long companyId, long repositoryId, String dirName) {
+		AreaType areaType, long companyId, long repositoryId, String dirName) {
 
-		_store.deleteDirectory(companyId, repositoryId, dirName);
+		_store.deleteDirectory(areaType, companyId, repositoryId, dirName);
 	}
 
 	@Override
 	public void deleteFile(
-		long companyId, long repositoryId, String fileName,
+		AreaType areaType, long companyId, long repositoryId, String fileName,
 		String versionLabel) {
 
-		_store.deleteFile(companyId, repositoryId, fileName, versionLabel);
+		_store.deleteFile(
+			areaType, companyId, repositoryId, fileName, versionLabel);
 	}
 
 	@Override
 	public InputStream getFileAsStream(
-			long companyId, long repositoryId, String fileName,
-			String versionLabel)
+			AreaType areaType, long companyId, long repositoryId,
+			String fileName, String versionLabel)
 		throws PortalException {
 
-		if (!_store.hasFile(companyId, repositoryId, fileName, versionLabel)) {
+		if (!_store.hasFile(
+				areaType, companyId, repositoryId, fileName, versionLabel)) {
+
 			_store.addFile(
-				companyId, repositoryId, fileName, versionLabel,
+				areaType, companyId, repositoryId, fileName, versionLabel,
 				new UnsyncByteArrayInputStream(_DUMMY_CONTENT));
 		}
 
 		return _store.getFileAsStream(
-			companyId, repositoryId, fileName, versionLabel);
+			areaType, companyId, repositoryId, fileName, versionLabel);
 	}
 
 	@Override
 	public String[] getFileNames(
-		long companyId, long repositoryId, String dirName) {
+		AreaType areaType, long companyId, long repositoryId, String dirName) {
 
-		return _store.getFileNames(companyId, repositoryId, dirName);
+		return _store.getFileNames(areaType, companyId, repositoryId, dirName);
 	}
 
 	@Override
 	public long getFileSize(
-			long companyId, long repositoryId, String fileName,
-			String versionLabel)
+			AreaType areaType, long companyId, long repositoryId,
+			String fileName, String versionLabel)
 		throws PortalException {
 
-		if (!_store.hasFile(companyId, repositoryId, fileName, versionLabel)) {
+		if (!_store.hasFile(
+				areaType, companyId, repositoryId, fileName, versionLabel)) {
+
 			_store.addFile(
-				companyId, repositoryId, fileName, versionLabel,
+				areaType, companyId, repositoryId, fileName, versionLabel,
 				new UnsyncByteArrayInputStream(_DUMMY_CONTENT));
 		}
 
 		return _store.getFileSize(
-			companyId, repositoryId, fileName, versionLabel);
+			areaType, companyId, repositoryId, fileName, versionLabel);
 	}
 
 	@Override
 	public String[] getFileVersions(
-		long companyId, long repositoryId, String fileName) {
+		AreaType areaType, long companyId, long repositoryId, String fileName) {
 
-		return _store.getFileVersions(companyId, repositoryId, fileName);
+		return _store.getFileVersions(
+			areaType, companyId, repositoryId, fileName);
 	}
 
 	@Override
 	public boolean hasFile(
-		long companyId, long repositoryId, String fileName,
+		AreaType areaType, long companyId, long repositoryId, String fileName,
 		String versionLabel) {
 
 		return true;
@@ -111,6 +118,6 @@ public class LenientStore implements Store {
 	private static final byte[] _DUMMY_CONTENT =
 		"This is a test file.".getBytes();
 
-	private final Store _store;
+	private final AreaStore _store;
 
 }

--- a/modules/apps/portal-store/portal-store-file-system/src/main/java/com/liferay/portal/store/file/system/safe/file/name/SafeFileNameStore.java
+++ b/modules/apps/portal-store/portal-store-file-system/src/main/java/com/liferay/portal/store/file/system/safe/file/name/SafeFileNameStore.java
@@ -14,7 +14,7 @@
 
 package com.liferay.portal.store.file.system.safe.file.name;
 
-import com.liferay.document.library.kernel.store.Store;
+import com.liferay.document.library.kernel.store.AreaStore;
 import com.liferay.document.library.kernel.util.DLUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.util.FileUtil;
@@ -29,92 +29,99 @@ import java.util.Set;
 /**
  * @author Roberto Díaz
  */
-public class SafeFileNameStore implements Store {
+public class SafeFileNameStore implements AreaStore {
 
-	public SafeFileNameStore(Store store) {
+	public SafeFileNameStore(AreaStore store) {
 		_store = store;
 	}
 
 	@Override
 	public void addFile(
-			long companyId, long repositoryId, String fileName,
-			String versionLabel, InputStream inputStream)
+			AreaType areaType, long companyId, long repositoryId,
+			String fileName, String versionLabel, InputStream inputStream)
 		throws PortalException {
 
 		String safeFileName = FileUtil.encodeSafeFileName(fileName);
 
 		if (!safeFileName.equals(fileName)) {
-			_store.deleteFile(companyId, repositoryId, fileName, versionLabel);
+			_store.deleteFile(
+				areaType, companyId, repositoryId, fileName, versionLabel);
 		}
 
 		_store.addFile(
-			companyId, repositoryId, safeFileName, versionLabel, inputStream);
+			areaType, companyId, repositoryId, safeFileName, versionLabel,
+			inputStream);
 	}
 
 	@Override
 	public void deleteDirectory(
-		long companyId, long repositoryId, String dirName) {
+		AreaType areaType, long companyId, long repositoryId, String dirName) {
 
 		String safeDirName = FileUtil.encodeSafeFileName(dirName);
 
 		if (!safeDirName.equals(dirName)) {
-			_store.deleteDirectory(companyId, repositoryId, dirName);
+			_store.deleteDirectory(areaType, companyId, repositoryId, dirName);
 		}
 
-		_store.deleteDirectory(companyId, repositoryId, safeDirName);
+		_store.deleteDirectory(areaType, companyId, repositoryId, safeDirName);
 	}
 
 	@Override
 	public void deleteFile(
-		long companyId, long repositoryId, String fileName,
+		AreaType areaType, long companyId, long repositoryId, String fileName,
 		String versionLabel) {
 
 		String safeFileName = FileUtil.encodeSafeFileName(fileName);
 
 		if (!safeFileName.equals(fileName)) {
-			_store.deleteFile(companyId, repositoryId, fileName, versionLabel);
+			_store.deleteFile(
+				areaType, companyId, repositoryId, fileName, versionLabel);
 		}
 
-		_store.deleteFile(companyId, repositoryId, safeFileName, versionLabel);
+		_store.deleteFile(
+			areaType, companyId, repositoryId, safeFileName, versionLabel);
 	}
 
 	@Override
 	public InputStream getFileAsStream(
-			long companyId, long repositoryId, String fileName,
-			String versionLabel)
+			AreaType areaType, long companyId, long repositoryId,
+			String fileName, String versionLabel)
 		throws PortalException {
 
 		String safeFileName = FileUtil.encodeSafeFileName(fileName);
 
 		if (safeFileName.equals(fileName) ||
 			_store.hasFile(
-				companyId, repositoryId, safeFileName, versionLabel)) {
+				areaType, companyId, repositoryId, safeFileName,
+				versionLabel)) {
 
 			return _store.getFileAsStream(
-				companyId, repositoryId, safeFileName, versionLabel);
+				areaType, companyId, repositoryId, safeFileName, versionLabel);
 		}
 
 		return _store.getFileAsStream(
-			companyId, repositoryId, fileName, versionLabel);
+			areaType, companyId, repositoryId, fileName, versionLabel);
 	}
 
 	@Override
 	public String[] getFileNames(
-		long companyId, long repositoryId, String dirName) {
+		AreaType areaType, long companyId, long repositoryId, String dirName) {
 
 		Set<String> decodedFileNameSet = new HashSet<>();
 
 		String safeDirName = FileUtil.encodeSafeFileName(dirName);
 
 		for (String fileName :
-				_store.getFileNames(companyId, repositoryId, safeDirName)) {
+				_store.getFileNames(
+					areaType, companyId, repositoryId, safeDirName)) {
 
 			decodedFileNameSet.add(FileUtil.decodeSafeFileName(fileName));
 		}
 
 		if (!safeDirName.equals(dirName)) {
 			for (String fileName :
-					_store.getFileNames(companyId, repositoryId, dirName)) {
+					_store.getFileNames(
+						areaType, companyId, repositoryId, dirName)) {
 
 				decodedFileNameSet.add(FileUtil.decodeSafeFileName(fileName));
 			}
@@ -129,27 +136,28 @@ public class SafeFileNameStore implements Store {
 
 	@Override
 	public long getFileSize(
-			long companyId, long repositoryId, String fileName,
-			String versionLabel)
+			AreaType areaType, long companyId, long repositoryId,
+			String fileName, String versionLabel)
 		throws PortalException {
 
 		String safeFileName = FileUtil.encodeSafeFileName(fileName);
 
 		if (safeFileName.equals(fileName) ||
 			_store.hasFile(
-				companyId, repositoryId, safeFileName, versionLabel)) {
+				areaType, companyId, repositoryId, safeFileName,
+				versionLabel)) {
 
 			return _store.getFileSize(
-				companyId, repositoryId, safeFileName, versionLabel);
+				areaType, companyId, repositoryId, safeFileName, versionLabel);
 		}
 
 		return _store.getFileSize(
-			companyId, repositoryId, fileName, versionLabel);
+			areaType, companyId, repositoryId, fileName, versionLabel);
 	}
 
 	@Override
 	public String[] getFileVersions(
-		long companyId, long repositoryId, String fileName) {
+		AreaType areaType, long companyId, long repositoryId, String fileName) {
 
 		Set<String> versionSet = new HashSet<>();
 
@@ -157,12 +165,14 @@ public class SafeFileNameStore implements Store {
 
 		Collections.addAll(
 			versionSet,
-			_store.getFileVersions(companyId, repositoryId, safeFileName));
+			_store.getFileVersions(
+				areaType, companyId, repositoryId, safeFileName));
 
 		if (!safeFileName.equals(fileName)) {
 			Collections.addAll(
 				versionSet,
-				_store.getFileVersions(companyId, repositoryId, fileName));
+				_store.getFileVersions(
+					areaType, companyId, repositoryId, fileName));
 		}
 
 		String[] versions = versionSet.toArray(new String[0]);
@@ -174,13 +184,14 @@ public class SafeFileNameStore implements Store {
 
 	@Override
 	public boolean hasFile(
-		long companyId, long repositoryId, String fileName,
+		AreaType areaType, long companyId, long repositoryId, String fileName,
 		String versionLabel) {
 
 		String safeFileName = FileUtil.encodeSafeFileName(fileName);
 
 		if (_store.hasFile(
-				companyId, repositoryId, safeFileName, versionLabel)) {
+				areaType, companyId, repositoryId, safeFileName,
+				versionLabel)) {
 
 			return true;
 		}
@@ -189,9 +200,10 @@ public class SafeFileNameStore implements Store {
 			return false;
 		}
 
-		return _store.hasFile(companyId, repositoryId, fileName, versionLabel);
+		return _store.hasFile(
+			areaType, companyId, repositoryId, fileName, versionLabel);
 	}
 
-	private final Store _store;
+	private final AreaStore _store;
 
 }

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/store/DLStoreImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/store/DLStoreImpl.java
@@ -17,6 +17,8 @@ package com.liferay.portlet.documentlibrary.store;
 import com.liferay.document.library.kernel.antivirus.AntivirusScannerUtil;
 import com.liferay.document.library.kernel.exception.AccessDeniedException;
 import com.liferay.document.library.kernel.exception.DirectoryNameException;
+import com.liferay.document.library.kernel.store.AreaStore;
+import com.liferay.document.library.kernel.store.AreaStoreManager;
 import com.liferay.document.library.kernel.store.DLStore;
 import com.liferay.document.library.kernel.store.DLStoreRequest;
 import com.liferay.document.library.kernel.store.Store;
@@ -187,7 +189,16 @@ public class DLStoreImpl implements DLStore {
 		for (String versionLabel :
 				_store.getFileVersions(companyId, repositoryId, fileName)) {
 
-			_store.deleteFile(companyId, repositoryId, fileName, versionLabel);
+			if (_store instanceof AreaStore) {
+				AreaStoreManager.move(
+					(AreaStore)_store, AreaStore.AreaType.LIVE,
+					AreaStore.AreaType.EVICTED, companyId, repositoryId,
+					fileName, versionLabel);
+			}
+			else {
+				_store.deleteFile(
+					companyId, repositoryId, fileName, versionLabel);
+			}
 		}
 	}
 
@@ -200,7 +211,16 @@ public class DLStoreImpl implements DLStore {
 		validate(fileName, false, versionLabel);
 
 		try {
-			_store.deleteFile(companyId, repositoryId, fileName, versionLabel);
+			if (_store instanceof AreaStore) {
+				AreaStoreManager.move(
+					(AreaStore)_store, AreaStore.AreaType.LIVE,
+					AreaStore.AreaType.EVICTED, companyId, repositoryId,
+					fileName, versionLabel);
+			}
+			else {
+				_store.deleteFile(
+					companyId, repositoryId, fileName, versionLabel);
+			}
 		}
 		catch (AccessDeniedException accessDeniedException) {
 			throw new PrincipalException(accessDeniedException);

--- a/portal-kernel/bnd.bnd
+++ b/portal-kernel/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 102.1.1
+Bundle-Version: 102.2.0
 Export-Package:\
 	!com.liferay.portal.kernel.internal.*,\
 	!com.liferay.portal.kernel.module.util,\

--- a/portal-kernel/src/com/liferay/document/library/kernel/exception/NoSuchFileException.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/exception/NoSuchFileException.java
@@ -14,6 +14,7 @@
 
 package com.liferay.document.library.kernel.exception;
 
+import com.liferay.document.library.kernel.store.AreaStore;
 import com.liferay.portal.kernel.exception.NoSuchModelException;
 
 /**
@@ -22,6 +23,30 @@ import com.liferay.portal.kernel.exception.NoSuchModelException;
 public class NoSuchFileException extends NoSuchModelException {
 
 	public NoSuchFileException() {
+	}
+
+	public NoSuchFileException(
+		AreaStore.AreaType areaType, long companyId, long repositoryId,
+		String fileName, String version) {
+
+		super(
+			String.format(
+				"{areaType=%s, companyId=%s, repositoryId=%s, fileName=%s, " +
+					"version=%s}",
+				areaType, companyId, repositoryId, fileName, version));
+	}
+
+	public NoSuchFileException(
+		AreaStore.AreaType areaType, long companyId, long repositoryId,
+		String fileName, String version, Throwable throwable) {
+
+		super(
+			String.format(
+				"{areaType=%s, companyId=%s, repositoryId=%s, fileName=%s, " +
+					"version=%s, cause=%s}",
+				areaType, companyId, repositoryId, fileName, version,
+				throwable),
+			throwable);
 	}
 
 	public NoSuchFileException(

--- a/portal-kernel/src/com/liferay/document/library/kernel/exception/packageinfo
+++ b/portal-kernel/src/com/liferay/document/library/kernel/exception/packageinfo
@@ -1,1 +1,1 @@
-version 4.1.0
+version 4.2.0

--- a/portal-kernel/src/com/liferay/document/library/kernel/store/AreaStore.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/store/AreaStore.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.document.library.kernel.store;
+
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.util.StringUtil;
+
+import java.io.InputStream;
+
+/**
+ * @author Marco Galluzzi
+ */
+public interface AreaStore extends Store {
+
+	public void addFile(
+			AreaType areaType, long companyId, long repositoryId,
+			String fileName, String versionLabel, InputStream inputStream)
+		throws PortalException;
+
+	public default void addFile(
+			long companyId, long repositoryId, String fileName,
+			String versionLabel, InputStream inputStream)
+		throws PortalException {
+
+		addFile(
+			AreaType.LIVE, companyId, repositoryId, fileName, versionLabel,
+			inputStream);
+	}
+
+	public void deleteDirectory(
+		AreaType areaType, long companyId, long repositoryId, String dirName);
+
+	public default void deleteDirectory(
+		long companyId, long repositoryId, String dirName) {
+
+		deleteDirectory(AreaType.LIVE, companyId, repositoryId, dirName);
+	}
+
+	public void deleteFile(
+		AreaType areaType, long companyId, long repositoryId, String fileName,
+		String versionLabel);
+
+	public default void deleteFile(
+		long companyId, long repositoryId, String fileName,
+		String versionLabel) {
+
+		deleteFile(
+			AreaType.LIVE, companyId, repositoryId, fileName, versionLabel);
+	}
+
+	public InputStream getFileAsStream(
+			AreaType areaType, long companyId, long repositoryId,
+			String fileName, String versionLabel)
+		throws PortalException;
+
+	public default InputStream getFileAsStream(
+			long companyId, long repositoryId, String fileName,
+			String versionLabel)
+		throws PortalException {
+
+		return getFileAsStream(
+			AreaType.LIVE, companyId, repositoryId, fileName, versionLabel);
+	}
+
+	public String[] getFileNames(
+		AreaType areaType, long companyId, long repositoryId, String dirName);
+
+	public default String[] getFileNames(
+		long companyId, long repositoryId, String dirName) {
+
+		return getFileNames(AreaType.LIVE, companyId, repositoryId, dirName);
+	}
+
+	public long getFileSize(
+			AreaType areaType, long companyId, long repositoryId,
+			String fileName, String versionLabel)
+		throws PortalException;
+
+	public default long getFileSize(
+			long companyId, long repositoryId, String fileName,
+			String versionLabel)
+		throws PortalException {
+
+		return getFileSize(
+			AreaType.LIVE, companyId, repositoryId, fileName, versionLabel);
+	}
+
+	public String[] getFileVersions(
+		AreaType areaType, long companyId, long repositoryId, String fileName);
+
+	public default String[] getFileVersions(
+		long companyId, long repositoryId, String fileName) {
+
+		return getFileVersions(
+			AreaType.LIVE, companyId, repositoryId, fileName);
+	}
+
+	public boolean hasFile(
+		AreaType areaType, long companyId, long repositoryId, String fileName,
+		String versionLabel);
+
+	public default boolean hasFile(
+		long companyId, long repositoryId, String fileName,
+		String versionLabel) {
+
+		return hasFile(
+			AreaType.LIVE, companyId, repositoryId, fileName, versionLabel);
+	}
+
+	public enum AreaType {
+
+		DELETED, EVICTED, LIVE;
+
+		public String getDirectorySuffix() {
+			if (this == LIVE) {
+				return "";
+			}
+
+			return "_" + StringUtil.lowerCase(toString());
+		}
+
+	}
+
+}

--- a/portal-kernel/src/com/liferay/document/library/kernel/store/AreaStoreManager.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/store/AreaStoreManager.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.document.library.kernel.store;
+
+import com.liferay.petra.io.unsync.UnsyncByteArrayInputStream;
+import com.liferay.portal.kernel.exception.PortalException;
+
+import java.io.InputStream;
+
+/**
+ * @author Marco Galluzzi
+ */
+public class AreaStoreManager {
+
+	public static void move(
+			AreaStore store, AreaStore.AreaType sourceAreaType,
+			AreaStore.AreaType targetAreaType, long companyId,
+			long repositoryId, String fileName, String versionLabel)
+		throws PortalException {
+
+		InputStream inputStream = store.getFileAsStream(
+			sourceAreaType, companyId, repositoryId, fileName, versionLabel);
+
+		if (inputStream == null) {
+			inputStream = new UnsyncByteArrayInputStream(new byte[0]);
+		}
+
+		store.addFile(
+			targetAreaType, companyId, repositoryId, fileName, versionLabel,
+			inputStream);
+
+		store.deleteFile(
+			sourceAreaType, companyId, repositoryId, fileName, versionLabel);
+	}
+
+}

--- a/portal-kernel/src/com/liferay/document/library/kernel/store/packageinfo
+++ b/portal-kernel/src/com/liferay/document/library/kernel/store/packageinfo
@@ -1,1 +1,1 @@
-version 4.0.0
+version 4.1.0


### PR DESCRIPTION
This is a proposal for the implementation of multiple store areas (I think the term _area_ is better than _space_). The first idea was to set thread locally the read and write areas, to avoid doing many changes. However, the concept of an _area_ should be included in every class implementing the `Store` interface, otherwise we could not change, for instance, the `rootDir` of an `FileSystemStore`. So, if we have to finally change the stores, I would add the _area_ as a parameter for all `Store` methods. In order to avoid many changes at first, I've added an intermediate interface called `AreaStore` that is only implemented by the `FileSystemStore`. All stores that want to use the _areas_ will end implementing the `AreaStore`: if all, then we could simply end changing the `Store` interface and remove the `AreaStore` interface.

Finally, in class `DLStoreImpl` I've just implemented an example of how the deletion should be done using the new `StoreArea`, there are still operations missing.

### Open questions

`FileSystemStoreRegister.acivate()` and `AdvancedFileSystemStoreRegister.activate()` register the service with parameter `rootDir`. Currently we are passing only the `AreaType.LIVE` root folder. I think this parameter is only used by the `AntivirusAsyncFileStoreMessageListener` to do the Antivirus working on the root folder. Should we pass to the Antivirus also the root folders `AreaType.EVICTED` and `AreaType.DELETED` ?

I think we should change the service `CTSContentLocalService` updated in class `CTStore` to include the `areaType` or we have to update it only when `AreaType.LIVE` is touched ?