### PR TITLE
LPS-181146 add LogCaptures to avoid unnecessary warning logs on WEBDav tests

### DIFF
--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/webdav/test/BaseWebDAVTestCase.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/webdav/test/BaseWebDAVTestCase.java
@@ -27,6 +27,8 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.webdav.WebDAVStorage;
 import com.liferay.portal.kernel.webdav.WebDAVUtil;
 import com.liferay.portal.kernel.webdav.methods.Method;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.webdav.WebDAVServlet;
 
@@ -131,7 +133,12 @@ public class BaseWebDAVTestCase {
 			mockHttpServletRequest.addHeader(entry.getKey(), entry.getValue());
 		}
 
-		try {
+		try (LogCapture logCapture1 = LoggerTestUtil.configureLog4JLogger(
+				"org.apache.poi.util.XMLHelper", LoggerTestUtil.WARN);
+			LogCapture logCapture2 = LoggerTestUtil.configureLog4JLogger(
+				"org.apache.xmlbeans.impl.common.SAXHelper",
+				LoggerTestUtil.WARN)) {
+
 			WebDAVServlet webDAVServlet = new WebDAVServlet();
 
 			MockHttpServletResponse mockHttpServletResponse =


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-181146


The `beforeClass`from `WebDAVEnvironmentConfigClassTestRule`  the message that was thrown was by `org.apache.poi.util.XMLHelper` and on `setUp` of `WebDAVOSXTest` the message origin is `org.apache.xmlbeans.impl.common.SAXHelper`


to test : 
```
❯ gw tI --tests "*WebDAV*"
```

From `portal/modules/apps/document-library/document-library-test`