### PR TITLE
LPS-181543 Add ratings for folder in its info panel

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info_panel.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info_panel.jsp
@@ -95,6 +95,22 @@ List<Folder> folders = dlInfoPanelDisplayContext.getFolders();
 							%>
 
 							<liferay-util:include page="/document_library/info_panel_location.jsp" servletContext="<%= application %>" />
+
+							<%
+							DLPortletInstanceSettings dlPortletInstanceSettings = dlRequestHelper.getDLPortletInstanceSettings();
+							%>
+
+							<c:if test="<%= dlPortletInstanceSettings.isEnableRatings() %>">
+								<dt class="sidebar-dt">
+									<liferay-ui:message key="ratings" />
+								</dt>
+								<dd class="sidebar-dd">
+									<liferay-ratings:ratings
+										className="<%= DLFolderConstants.getClassName() %>"
+										classPK="<%= folder.getFolderId() %>"
+									/>
+								</dd>
+							</c:if>
 						</c:if>
 					</dl>
 				</liferay-ui:section>


### PR DESCRIPTION
PLEASE NOTE: I don't know if the rating information of a folder should be displayed somewhere else.

### How to test

1. Go to Documents & Media
2. Checbox-select folder "Provided by Liferay"
3. Click on the info button on the toolbar
4. At the end of the information you can rate the folder

To show the folder info panel you can also enter the folder. The same info button appears in the toolbar.

You can also check that the API is effectively returning the rated folders: http://localhost:8080/o/api#operations-DocumentFolder-getSiteDocumentFoldersRatedByMePage

ADDITIONAL NOTE:
* I've based my code on file `info_panel_file_entry.jsp` line 414
* There is a main difference with file rating: a `FileEntry` has a `isSupportSocial()` method while a `Folder` don't. Should we add this support in folders?