### PR TITLE
LPS-181099 catch Pattern Exception and show the error toast to the user

### DIFF
--- a/modules/apps/redirect/redirect-web/src/main/java/com/liferay/redirect/web/internal/portlet/action/EditRedirectPatternsMVCActionCommand.java
+++ b/modules/apps/redirect/redirect-web/src/main/java/com/liferay/redirect/web/internal/portlet/action/EditRedirectPatternsMVCActionCommand.java
@@ -16,6 +16,8 @@ package com.liferay.redirect.web.internal.portlet.action;
 
 import com.liferay.portal.configuration.persistence.listener.ConfigurationModelListenerException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCActionCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.servlet.SessionErrors;
@@ -32,6 +34,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 import javax.portlet.ActionRequest;
 import javax.portlet.ActionResponse;
@@ -64,11 +67,12 @@ public class EditRedirectPatternsMVCActionCommand extends BaseMVCActionCommand {
 				themeDisplay.getScopeGroupId(),
 				_getRedirectPatternEntries(actionRequest));
 		}
-		catch (ConfigurationModelListenerException
-					configurationModelListenerException) {
+		catch (ConfigurationModelListenerException | PatternSyntaxException
+					exception) {
 
-			SessionErrors.add(
-				actionRequest, configurationModelListenerException.getClass());
+			_log.error(exception);
+
+			SessionErrors.add(actionRequest, "redirectPatternInvalid");
 
 			hideDefaultErrorMessage(actionRequest);
 
@@ -133,6 +137,9 @@ public class EditRedirectPatternsMVCActionCommand extends BaseMVCActionCommand {
 
 		return null;
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		EditRedirectPatternsMVCActionCommand.class);
 
 	@Reference
 	private RedirectPatternConfigurationProvider

--- a/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/init.jsp
@@ -28,7 +28,6 @@ taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
 
 <%@ page import="com.liferay.frontend.taglib.servlet.taglib.util.EmptyResultMessageKeys" %><%@
 page import="com.liferay.petra.string.StringPool" %><%@
-page import="com.liferay.portal.configuration.persistence.listener.ConfigurationModelListenerException" %><%@
 page import="com.liferay.portal.kernel.exception.LayoutFriendlyURLException" %><%@
 page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
 page import="com.liferay.portal.kernel.servlet.SessionErrors" %><%@

--- a/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/view.jsp
@@ -45,7 +45,7 @@ RedirectDisplayContext redirectDisplayContext = (RedirectDisplayContext)request.
 			/>
 		</div>
 
-		<c:if test="<%= SessionErrors.contains(renderRequest, ConfigurationModelListenerException.class) %>">
+		<c:if test='<%= SessionErrors.contains(renderRequest, "redirectPatternInvalid") %>'>
 			<aui:script>
 				Liferay.Util.openToast({
 					message:


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-181099

Before the transformation from string to pattern was be doing on the listener, but now it's the command who take this responsability so we will check it on the command creating a new exception because there is no reason to throw a ConfigurationModelListenerException on the action command (but without deleting it from the listener)