### PR TITLE
Set value of Overall Maximum Upload Request Size on use.

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/feature/VulcanFeature.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/feature/VulcanFeature.java
@@ -18,9 +18,7 @@ import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
 import com.fasterxml.jackson.jaxrs.xml.JacksonXMLProvider;
 
 import com.liferay.depot.service.DepotEntryLocalService;
-import com.liferay.document.library.kernel.util.DLValidator;
 import com.liferay.portal.kernel.language.Language;
-import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
@@ -158,10 +156,7 @@ public class VulcanFeature implements Feature {
 		featureContext.register(
 			new EntityExtensionHandlerContextResolver(
 				_extensionProviderRegistry));
-		featureContext.register(
-			new MultipartBodyMessageBodyReader(
-				_dlValidator.getMaxAllowableSize(
-					GroupConstants.DEFAULT_PARENT_GROUP_ID, null)));
+		featureContext.register(new MultipartBodyMessageBodyReader());
 
 		_nestedFieldsWriterInterceptor = new NestedFieldsWriterInterceptor(
 			_bundleContext);
@@ -210,9 +205,6 @@ public class VulcanFeature implements Feature {
 
 	@Reference
 	private DepotEntryLocalService _depotEntryLocalService;
-
-	@Reference
-	private DLValidator _dlValidator;
 
 	@Reference(
 		target = "(result.class.name=com.liferay.portal.kernel.search.filter.Filter)"

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/message/body/MultipartBodyMessageBodyReader.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/message/body/MultipartBodyMessageBodyReader.java
@@ -46,7 +46,6 @@ import javax.ws.rs.ext.Provider;
 import javax.ws.rs.ext.Providers;
 
 import org.apache.commons.fileupload.FileItem;
-import org.apache.commons.fileupload.FileUploadBase;
 import org.apache.commons.fileupload.disk.DiskFileItemFactory;
 import org.apache.commons.fileupload.servlet.ServletFileUpload;
 import org.apache.commons.fileupload.util.Streams;
@@ -59,10 +58,6 @@ import org.apache.commons.fileupload.util.Streams;
 @Provider
 public class MultipartBodyMessageBodyReader
 	implements MessageBodyReader<MultipartBody> {
-
-	public MultipartBodyMessageBodyReader(long fileMaxSize) {
-		_fileMaxSize = fileMaxSize;
-	}
 
 	@Override
 	public boolean isReadable(
@@ -114,9 +109,6 @@ public class MultipartBodyMessageBodyReader
 				ServletFileUpload servletFileUpload = new ServletFileUpload(
 					new DiskFileItemFactory());
 
-				servletFileUpload.setFileSizeMax(_fileMaxSize);
-				servletFileUpload.setSizeMax(_fileMaxSize);
-
 				List<FileItem> fileItems = servletFileUpload.parseRequest(
 					_httpServletRequest);
 
@@ -136,14 +128,6 @@ public class MultipartBodyMessageBodyReader
 					}
 				}
 			}
-			catch (FileUploadBase.SizeLimitExceededException
-						sizeLimitExceededException) {
-
-				throw new BadRequestException(
-					"Please enter a file with a valid file size no larger " +
-						"than " + _fileMaxSize,
-					sizeLimitExceededException);
-			}
 			catch (Exception exception) {
 				throw new BadRequestException(
 					"Request body is not a valid multipart form", exception);
@@ -160,8 +144,6 @@ public class MultipartBodyMessageBodyReader
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		MultipartBodyMessageBodyReader.class);
-
-	private final long _fileMaxSize;
 
 	@Context
 	private HttpServletRequest _httpServletRequest;

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/message/body/MultipartBodyMessageBodyReader.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/message/body/MultipartBodyMessageBodyReader.java
@@ -16,6 +16,7 @@ package com.liferay.portal.vulcan.internal.jaxrs.message.body;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import com.liferay.document.library.kernel.util.DLValidatorUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.vulcan.internal.multipart.MultipartUtil;
@@ -46,6 +47,7 @@ import javax.ws.rs.ext.Provider;
 import javax.ws.rs.ext.Providers;
 
 import org.apache.commons.fileupload.FileItem;
+import org.apache.commons.fileupload.FileUploadBase;
 import org.apache.commons.fileupload.disk.DiskFileItemFactory;
 import org.apache.commons.fileupload.servlet.ServletFileUpload;
 import org.apache.commons.fileupload.util.Streams;
@@ -127,6 +129,14 @@ public class MultipartBodyMessageBodyReader
 								fileItem.getInputStream(), fileItem.getSize()));
 					}
 				}
+			}
+			catch (FileUploadBase.SizeLimitExceededException
+				sizeLimitExceededException) {
+
+				throw new BadRequestException(
+					"Please enter a file with a valid file size no larger than " +
+					DLValidatorUtil.getMaxAllowableSize(0, null),
+					sizeLimitExceededException);
 			}
 			catch (Exception exception) {
 				throw new BadRequestException(

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/message/body/MultipartBodyMessageBodyReader.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/message/body/MultipartBodyMessageBodyReader.java
@@ -131,11 +131,11 @@ public class MultipartBodyMessageBodyReader
 				}
 			}
 			catch (FileUploadBase.SizeLimitExceededException
-				sizeLimitExceededException) {
+						sizeLimitExceededException) {
 
 				throw new BadRequestException(
-					"Please enter a file with a valid file size no larger than " +
-					DLValidatorUtil.getMaxAllowableSize(0, null),
+					"Please enter a file with a valid file size no larger " +
+						"than " + DLValidatorUtil.getMaxAllowableSize(0, null),
 					sizeLimitExceededException);
 			}
 			catch (Exception exception) {

--- a/modules/apps/portal/portal-upload-servlet-request-filter/src/main/java/com/liferay/portal/upload/servlet/request/filter/internal/UploadServletRequestFilter.java
+++ b/modules/apps/portal/portal-upload-servlet-request-filter/src/main/java/com/liferay/portal/upload/servlet/request/filter/internal/UploadServletRequestFilter.java
@@ -76,8 +76,6 @@ public class UploadServletRequestFilter extends BasePortalFilter {
 
 		int fileSizeThreshold = 0;
 		String location = null;
-		long maxRequestSize = 0;
-		long maxFileSize = 0;
 
 		if (Validator.isNotNull(portletId)) {
 			Portlet portlet = _portletLocalService.getPortletById(
@@ -103,15 +101,12 @@ public class UploadServletRequestFilter extends BasePortalFilter {
 
 				fileSizeThreshold = portlet.getMultipartFileSizeThreshold();
 				location = portlet.getMultipartLocation();
-				maxRequestSize = portlet.getMultipartMaxRequestSize();
-				maxFileSize = portlet.getMultipartMaxFileSize();
 			}
 		}
 
 		UploadServletRequest uploadServletRequest =
 			_portal.getUploadServletRequest(
-				httpServletRequest, fileSizeThreshold, location, maxRequestSize,
-				maxFileSize);
+				httpServletRequest, fileSizeThreshold, location);
 
 		try {
 			processFilter(

--- a/modules/apps/portal/portal-upload/build.gradle
+++ b/modules/apps/portal/portal-upload/build.gradle
@@ -5,6 +5,7 @@ dependencies {
 	compileOnly group: "commons-fileupload", name: "commons-fileupload", version: "1.3.3"
 	compileOnly group: "commons-io", name: "commons-io", version: "2.11.0"
 	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.1"
+	compileOnly group: "javax.ws.rs", name: "javax.ws.rs-api", version: "2.1"
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly project(":apps:portal-configuration:portal-configuration-upgrade-api")

--- a/modules/apps/portal/portal-upload/build.gradle
+++ b/modules/apps/portal/portal-upload/build.gradle
@@ -5,7 +5,6 @@ dependencies {
 	compileOnly group: "commons-fileupload", name: "commons-fileupload", version: "1.3.3"
 	compileOnly group: "commons-io", name: "commons-io", version: "2.11.0"
 	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.1"
-	compileOnly group: "javax.ws.rs", name: "javax.ws.rs-api", version: "2.1"
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly project(":apps:portal-configuration:portal-configuration-upgrade-api")

--- a/modules/apps/portal/portal-upload/src/main/java/com/liferay/portal/upload/internal/ServletFileUploadImpl.java
+++ b/modules/apps/portal/portal-upload/src/main/java/com/liferay/portal/upload/internal/ServletFileUploadImpl.java
@@ -27,8 +27,6 @@ import java.util.List;
 
 import javax.servlet.http.HttpServletRequest;
 
-import javax.ws.rs.BadRequestException;
-
 import org.apache.commons.fileupload.FileUploadBase;
 import org.apache.commons.fileupload.FileUploadException;
 
@@ -69,14 +67,6 @@ public class ServletFileUploadImpl implements ServletFileUpload {
 			}
 
 			return fileItems;
-		}
-		catch (FileUploadBase.SizeLimitExceededException
-					sizeLimitExceededException) {
-
-			throw new BadRequestException(
-				"Please enter a file with a valid file size no larger than " +
-					fileMaxSize,
-				sizeLimitExceededException);
 		}
 		catch (FileUploadException fileUploadException) {
 			UploadException uploadException = new UploadException(

--- a/portal-impl/src/com/liferay/portal/upload/ServletFileUpload.java
+++ b/portal-impl/src/com/liferay/portal/upload/ServletFileUpload.java
@@ -27,8 +27,8 @@ import javax.servlet.http.HttpServletRequest;
 public interface ServletFileUpload {
 
 	public List<FileItem> parseRequest(
-			HttpServletRequest httpServletRequest, long sizeMax,
-			long fileSizeMax, String location, int fileSizeThreshold)
+			HttpServletRequest httpServletRequest, String location,
+			int fileSizeThreshold)
 		throws UploadException;
 
 }

--- a/portal-impl/src/com/liferay/portal/upload/UploadServletRequestImpl.java
+++ b/portal-impl/src/com/liferay/portal/upload/UploadServletRequestImpl.java
@@ -60,12 +60,12 @@ public class UploadServletRequestImpl
 	extends HttpServletRequestWrapper implements UploadServletRequest {
 
 	public UploadServletRequestImpl(HttpServletRequest httpServletRequest) {
-		this(httpServletRequest, 0, null, 0, 0);
+		this(httpServletRequest, 0, null);
 	}
 
 	public UploadServletRequestImpl(
 		HttpServletRequest httpServletRequest, int fileSizeThreshold,
-		String location, long maxRequestSize, long maxFileSize) {
+		String location) {
 
 		super(httpServletRequest);
 
@@ -85,21 +85,12 @@ public class UploadServletRequestImpl
 			long uploadServletRequestImplMaxSize =
 				UploadServletRequestConfigurationProviderUtil.getMaxSize();
 
-			if (maxRequestSize <= 0) {
-				maxRequestSize = uploadServletRequestImplMaxSize;
-			}
-
-			if (maxFileSize <= 0) {
-				maxFileSize = uploadServletRequestImplMaxSize;
-			}
-
 			location = GetterUtil.getString(
 				location,
 				UploadServletRequestConfigurationProviderUtil.getTempDir());
 
 			List<FileItem> fileItemsList = _servletFileUpload.parseRequest(
-				liferayServletRequest, maxRequestSize, maxFileSize, location,
-				fileSizeThreshold);
+				liferayServletRequest, location, fileSizeThreshold);
 
 			liferayServletRequest.setFinishedReadingOriginalStream(true);
 

--- a/portal-impl/src/com/liferay/portal/upload/packageinfo
+++ b/portal-impl/src/com/liferay/portal/upload/packageinfo
@@ -1,1 +1,1 @@
-version 4.0.0
+version 5.0.0

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -5578,13 +5578,13 @@ public class PortalImpl implements Portal {
 	public UploadServletRequest getUploadServletRequest(
 		HttpServletRequest httpServletRequest) {
 
-		return getUploadServletRequest(httpServletRequest, 0, null, 0, 0);
+		return getUploadServletRequest(httpServletRequest, 0, null);
 	}
 
 	@Override
 	public UploadServletRequest getUploadServletRequest(
 		HttpServletRequest httpServletRequest, int fileSizeThreshold,
-		String location, long maxRequestSize, long maxFileSize) {
+		String location) {
 
 		List<PersistentHttpServletRequestWrapper>
 			persistentHttpServletRequestWrappers = new ArrayList<>();
@@ -5640,8 +5640,7 @@ public class PortalImpl implements Portal {
 		}
 
 		return new UploadServletRequestImpl(
-			currentHttpServletRequest, fileSizeThreshold, location,
-			maxRequestSize, maxFileSize);
+			currentHttpServletRequest, fileSizeThreshold, location);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/util/packageinfo
+++ b/portal-impl/src/com/liferay/portal/util/packageinfo
@@ -1,1 +1,1 @@
-version 46.1.0
+version 47.0.0

--- a/portal-kernel/src/com/liferay/portal/kernel/util/Portal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/Portal.java
@@ -1060,7 +1060,7 @@ public interface Portal {
 
 	public UploadServletRequest getUploadServletRequest(
 		HttpServletRequest httpServletRequest, int fileSizeThreshold,
-		String location, long maxRequestSize, long maxFileSize);
+		String location);
 
 	public Date getUptime();
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PortalUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PortalUtil.java
@@ -1684,11 +1684,10 @@ public class PortalUtil {
 
 	public static UploadServletRequest getUploadServletRequest(
 		HttpServletRequest httpServletRequest, int fileSizeThreshold,
-		String location, long maxRequestSize, long maxFileSize) {
+		String location) {
 
 		return _portal.getUploadServletRequest(
-			httpServletRequest, fileSizeThreshold, location, maxRequestSize,
-			maxFileSize);
+			httpServletRequest, fileSizeThreshold, location);
 	}
 
 	public static Date getUptime() {

--- a/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
@@ -1,1 +1,1 @@
-version 57.2.0
+version 58.0.0


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-181612

**Issue**
When updating the Overall Maximum Upload Request Size, the value is not updated for headless calls without restarting the portal. This is due to VulcanFeature reading the value when registering the service for MultipartBodyMessageBodyReader, we read the current value from DLValidator, but the value is never updated after registering the service.

**Proposed Solution**
After speaking with @robertoDiaz regarding this issue, it was decided the best option would be to simply read the value at the time of use, rather than when registering the service.

I have removed the parameters for maxFileSize and MaxRequestSize as these values were populated from the DLValidator or UploadServletRequestConfigurationProviderImpl, both of which use the Overall Maximum Upload Request Size value.

Please let me know if there are any questions.