### PR TITLE
LPS-181687 Ratings should be available only to supported folders

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info_panel.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info_panel.jsp
@@ -100,7 +100,7 @@ List<Folder> folders = dlInfoPanelDisplayContext.getFolders();
 							DLPortletInstanceSettings dlPortletInstanceSettings = dlRequestHelper.getDLPortletInstanceSettings();
 							%>
 
-							<c:if test="<%= dlPortletInstanceSettings.isEnableRatings() %>">
+							<c:if test="<%= dlPortletInstanceSettings.isEnableRatings() && folder.isSupportsSocial() %>">
 								<dt class="sidebar-dt">
 									<liferay-ui:message key="ratings" />
 								</dt>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info_panel.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info_panel.jsp
@@ -95,6 +95,22 @@ List<Folder> folders = dlInfoPanelDisplayContext.getFolders();
 							%>
 
 							<liferay-util:include page="/document_library/info_panel_location.jsp" servletContext="<%= application %>" />
+
+							<%
+							DLPortletInstanceSettings dlPortletInstanceSettings = dlRequestHelper.getDLPortletInstanceSettings();
+							%>
+
+							<c:if test="<%= dlPortletInstanceSettings.isEnableRatings() %>">
+								<dt class="sidebar-dt">
+									<liferay-ui:message key="ratings" />
+								</dt>
+								<dd class="sidebar-dd">
+									<liferay-ratings:ratings
+										className="<%= DLFolderConstants.getClassName() %>"
+										classPK="<%= folder.getFolderId() %>"
+									/>
+								</dd>
+							</c:if>
 						</c:if>
 					</dl>
 				</liferay-ui:section>


### PR DESCRIPTION
This PR starts from recently approved #4209 to just add a check for the Social Support of a Folder to enable the Ratings feature. I'm doing the same as in file `info_panel_file_entry.jsp` line 414. I missed it before because I thought that Folders didn't have method `isSupportsSocial()`.

### Testing

Work as in #4209. I couldn't test it for an external repository, which would return false for `isSupportsSocial()`.