### PR TITLE
Tiff and Gif files do not generate previews and thumbnails with imagemagick enabled.

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/scaler/AMImageMagickImageScaler.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/scaler/AMImageMagickImageScaler.java
@@ -45,7 +45,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Eric Yan
  */
 @Component(
-	property = {"mime.type=image/heic", "mime.type=image/webp"},
+	property = {
+		"mime.type=image/gif", "mime.type=image/heic", "mime.type=image/tiff",
+		"mime.type=image/webp"
+	},
 	service = AMImageScaler.class
 )
 public class AMImageMagickImageScaler implements AMImageScaler {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-181645

When imagemagick is enabled, gif and tiff files should generate previews and thumbnails, but currently do not due to these mime types not being listed in the AMImageMagickImageScaler component property.

**Proposed solution**
Add the mime types to the AMImageMagickImageScaler component property.

This issue was discussed on [LPP-48593](https://issues.liferay.com/browse/LPP-48593?focusedCommentId=2889394&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-2889394)

During this review, please let me know if we need to add more mime.types or if these 2 are sufficient. As mentioned in [this comment](https://issues.liferay.com/browse/LPP-48593?focusedCommentId=2889613&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-2889613) .gif and .tiff are the only mime types liferay has enabled by default that currently do not work, however imagemagick supports many more image mime types.