### PR TITLE
LPS-181899 Item Selector won't show all Sites grouped to the paginated page

### DIFF
--- a/modules/apps/item-selector/item-selector-impl/src/main/java/com/liferay/item/selector/internal/provider/GroupItemSelectorProviderImpl.java
+++ b/modules/apps/item-selector/item-selector-impl/src/main/java/com/liferay/item/selector/internal/provider/GroupItemSelectorProviderImpl.java
@@ -15,6 +15,7 @@
 package com.liferay.item.selector.internal.provider;
 
 import com.liferay.item.selector.provider.GroupItemSelectorProvider;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
@@ -30,6 +31,7 @@ import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.GroupService;
 import com.liferay.portal.kernel.service.permission.GroupPermission;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portlet.usersadmin.search.GroupSearch;
 
 import java.util.ArrayList;
@@ -73,10 +75,22 @@ public class GroupItemSelectorProviderImpl
 			).build();
 
 		try {
-			return _filterGroups(
-				_groupLocalService.search(
-					companyId, _classNameIds, keywords, groupParams, start, end,
-					null));
+			List<Group> groups = _groupLocalService.search(
+				companyId, _classNameIds, keywords, groupParams, start, end,
+				null);
+
+			List<Group> filteredGroups = _filterGroups(groups);
+
+			if (filteredGroups.size() < groups.size()) {
+				filteredGroups = ListUtil.subList(
+					_filterGroups(
+						_groupLocalService.search(
+							companyId, _classNameIds, keywords, groupParams,
+							QueryUtil.ALL_POS, QueryUtil.ALL_POS, null)),
+					start, end);
+			}
+
+			return filteredGroups;
 		}
 		catch (PortalException portalException) {
 			_log.error(portalException);


### PR DESCRIPTION
Dear Team,

Could you please review this pull request?

Motivation
=======
[GroupItemSelectorProviderImpl._filterGroups](https://github.com/liferay/liferay-portal/blob/master/modules/apps/item-selector/item-selector-impl/src/main/java/com/liferay/item/selector/internal/provider/GroupItemSelectorProviderImpl.java#L123) filters out the Site that the User has no permission to view. The problem is that the pagination won't align with the modified list and thus won't display all Sites the User has still access to.

Proposed Solution
========
Taking the full list of Sites and performing the filtering on that list.

Steps to Verify
========
Please see the linked LPS for the reproduction steps.
https://issues.liferay.com/browse/LPS-181899

Thank you and best regards,
István