### PR TITLE
LPS-181652 Can't see Knowledge Base Article Child when Parent Article still pending

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/model/impl/KBArticleImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/model/impl/KBArticleImpl.java
@@ -164,7 +164,7 @@ public class KBArticleImpl extends KBArticleBaseImpl {
 		}
 
 		return KBArticleLocalServiceUtil.getLatestKBArticle(
-			parentResourcePrimKey, WorkflowConstants.STATUS_APPROVED);
+			parentResourcePrimKey, WorkflowConstants.STATUS_ANY);
 	}
 
 	@Override


### PR DESCRIPTION
Related issue: [LPS-181652](https://issues.liferay.com/browse/LPS-181652)

**Motivation:** when a user creates a child article where the parent doesn't have an approved status, it's not possible to see its content page. 

**Proposed solution:** This happens because when the `getParentKBArticle()` method is called, it requests the KBA by approved status only, so when the parent article isn't _approved_ it throws a `NoSuchArticleException`. To solve this problem, I proposed to change the status parameter from `WorkflowConstants.STATUS_APPROVED` to `WorkflowConstants.STATUS_ANY` so no that matter what the parent's status is, it will return the article.
