### PR TITLE
Add sourceFileName field for headless api to create document

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/Document.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/Document.java
@@ -759,6 +759,34 @@ public class Document implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long sizeInBytes;
 
+	@Schema(description = "The document's source file name.")
+	public String getSourceFileName() {
+		return sourceFileName;
+	}
+
+	public void setSourceFileName(String sourceFileName) {
+		this.sourceFileName = sourceFileName;
+	}
+
+	@JsonIgnore
+	public void setSourceFileName(
+		UnsafeSupplier<String, Exception> sourceFileNameUnsafeSupplier) {
+
+		try {
+			sourceFileName = sourceFileNameUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField(description = "The document's source file name.")
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String sourceFileName;
+
 	@Schema(description = "The categories associated with this document.")
 	@Valid
 	public TaxonomyCategoryBrief[] getTaxonomyCategoryBriefs() {
@@ -1241,6 +1269,20 @@ public class Document implements Serializable {
 			sb.append("\"sizeInBytes\": ");
 
 			sb.append(sizeInBytes);
+		}
+
+		if (sourceFileName != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"sourceFileName\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(sourceFileName));
+
+			sb.append("\"");
 		}
 
 		if (taxonomyCategoryBriefs != null) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/Document.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/Document.java
@@ -553,6 +553,34 @@ public class Document implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String fileExtension;
 
+	@Schema(description = "The document's file name.")
+	public String getFileName() {
+		return fileName;
+	}
+
+	public void setFileName(String fileName) {
+		this.fileName = fileName;
+	}
+
+	@JsonIgnore
+	public void setFileName(
+		UnsafeSupplier<String, Exception> fileNameUnsafeSupplier) {
+
+		try {
+			fileName = fileNameUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField(description = "The document's file name.")
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String fileName;
+
 	@Schema(description = "The document's ID.")
 	public Long getId() {
 		return id;
@@ -758,34 +786,6 @@ public class Document implements Serializable {
 	@GraphQLField(description = "The document's size in bytes.")
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long sizeInBytes;
-
-	@Schema(description = "The document's source file name.")
-	public String getSourceFileName() {
-		return sourceFileName;
-	}
-
-	public void setSourceFileName(String sourceFileName) {
-		this.sourceFileName = sourceFileName;
-	}
-
-	@JsonIgnore
-	public void setSourceFileName(
-		UnsafeSupplier<String, Exception> sourceFileNameUnsafeSupplier) {
-
-		try {
-			sourceFileName = sourceFileNameUnsafeSupplier.get();
-		}
-		catch (RuntimeException re) {
-			throw re;
-		}
-		catch (Exception e) {
-			throw new RuntimeException(e);
-		}
-	}
-
-	@GraphQLField(description = "The document's source file name.")
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
-	protected String sourceFileName;
 
 	@Schema(description = "The categories associated with this document.")
 	@Valid
@@ -1167,6 +1167,20 @@ public class Document implements Serializable {
 			sb.append("\"");
 		}
 
+		if (fileName != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"fileName\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(fileName));
+
+			sb.append("\"");
+		}
+
 		if (id != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -1269,20 +1283,6 @@ public class Document implements Serializable {
 			sb.append("\"sizeInBytes\": ");
 
 			sb.append(sizeInBytes);
-		}
-
-		if (sourceFileName != null) {
-			if (sb.length() > 1) {
-				sb.append(", ");
-			}
-
-			sb.append("\"sourceFileName\": ");
-
-			sb.append("\"");
-
-			sb.append(_escape(sourceFileName));
-
-			sb.append("\"");
 		}
 
 		if (taxonomyCategoryBriefs != null) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/StructuredContentUtil.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/StructuredContentUtil.java
@@ -27,7 +27,7 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import java.util.Locale;
 
 /**
- *@author Luis Miguel Barcos
+ * @author Luis Miguel Barcos
  */
 public class StructuredContentUtil {
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/Document.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/Document.java
@@ -374,6 +374,27 @@ public class Document implements Cloneable, Serializable {
 
 	protected String fileExtension;
 
+	public String getFileName() {
+		return fileName;
+	}
+
+	public void setFileName(String fileName) {
+		this.fileName = fileName;
+	}
+
+	public void setFileName(
+		UnsafeSupplier<String, Exception> fileNameUnsafeSupplier) {
+
+		try {
+			fileName = fileNameUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String fileName;
+
 	public Long getId() {
 		return id;
 	}
@@ -520,27 +541,6 @@ public class Document implements Cloneable, Serializable {
 	}
 
 	protected Long sizeInBytes;
-
-	public String getSourceFileName() {
-		return sourceFileName;
-	}
-
-	public void setSourceFileName(String sourceFileName) {
-		this.sourceFileName = sourceFileName;
-	}
-
-	public void setSourceFileName(
-		UnsafeSupplier<String, Exception> sourceFileNameUnsafeSupplier) {
-
-		try {
-			sourceFileName = sourceFileNameUnsafeSupplier.get();
-		}
-		catch (Exception e) {
-			throw new RuntimeException(e);
-		}
-	}
-
-	protected String sourceFileName;
 
 	public TaxonomyCategoryBrief[] getTaxonomyCategoryBriefs() {
 		return taxonomyCategoryBriefs;

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/Document.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/Document.java
@@ -521,6 +521,27 @@ public class Document implements Cloneable, Serializable {
 
 	protected Long sizeInBytes;
 
+	public String getSourceFileName() {
+		return sourceFileName;
+	}
+
+	public void setSourceFileName(String sourceFileName) {
+		this.sourceFileName = sourceFileName;
+	}
+
+	public void setSourceFileName(
+		UnsafeSupplier<String, Exception> sourceFileNameUnsafeSupplier) {
+
+		try {
+			sourceFileName = sourceFileNameUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String sourceFileName;
+
 	public TaxonomyCategoryBrief[] getTaxonomyCategoryBriefs() {
 		return taxonomyCategoryBriefs;
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/DocumentSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/DocumentSerDes.java
@@ -386,6 +386,20 @@ public class DocumentSerDes {
 			sb.append(document.getSizeInBytes());
 		}
 
+		if (document.getSourceFileName() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"sourceFileName\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(document.getSourceFileName()));
+
+			sb.append("\"");
+		}
+
 		if (document.getTaxonomyCategoryBriefs() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -660,6 +674,14 @@ public class DocumentSerDes {
 			map.put("sizeInBytes", String.valueOf(document.getSizeInBytes()));
 		}
 
+		if (document.getSourceFileName() == null) {
+			map.put("sourceFileName", null);
+		}
+		else {
+			map.put(
+				"sourceFileName", String.valueOf(document.getSourceFileName()));
+		}
+
 		if (document.getTaxonomyCategoryBriefs() == null) {
 			map.put("taxonomyCategoryBriefs", null);
 		}
@@ -885,6 +907,11 @@ public class DocumentSerDes {
 				if (jsonParserFieldValue != null) {
 					document.setSizeInBytes(
 						Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "sourceFileName")) {
+				if (jsonParserFieldValue != null) {
+					document.setSourceFileName((String)jsonParserFieldValue);
 				}
 			}
 			else if (Objects.equals(

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/DocumentSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/DocumentSerDes.java
@@ -282,6 +282,20 @@ public class DocumentSerDes {
 			sb.append("\"");
 		}
 
+		if (document.getFileName() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"fileName\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(document.getFileName()));
+
+			sb.append("\"");
+		}
+
 		if (document.getId() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -384,20 +398,6 @@ public class DocumentSerDes {
 			sb.append("\"sizeInBytes\": ");
 
 			sb.append(document.getSizeInBytes());
-		}
-
-		if (document.getSourceFileName() != null) {
-			if (sb.length() > 1) {
-				sb.append(", ");
-			}
-
-			sb.append("\"sourceFileName\": ");
-
-			sb.append("\"");
-
-			sb.append(_escape(document.getSourceFileName()));
-
-			sb.append("\"");
 		}
 
 		if (document.getTaxonomyCategoryBriefs() != null) {
@@ -619,6 +619,13 @@ public class DocumentSerDes {
 				"fileExtension", String.valueOf(document.getFileExtension()));
 		}
 
+		if (document.getFileName() == null) {
+			map.put("fileName", null);
+		}
+		else {
+			map.put("fileName", String.valueOf(document.getFileName()));
+		}
+
 		if (document.getId() == null) {
 			map.put("id", null);
 		}
@@ -672,14 +679,6 @@ public class DocumentSerDes {
 		}
 		else {
 			map.put("sizeInBytes", String.valueOf(document.getSizeInBytes()));
-		}
-
-		if (document.getSourceFileName() == null) {
-			map.put("sourceFileName", null);
-		}
-		else {
-			map.put(
-				"sourceFileName", String.valueOf(document.getSourceFileName()));
 		}
 
 		if (document.getTaxonomyCategoryBriefs() == null) {
@@ -848,6 +847,11 @@ public class DocumentSerDes {
 					document.setFileExtension((String)jsonParserFieldValue);
 				}
 			}
+			else if (Objects.equals(jsonParserFieldName, "fileName")) {
+				if (jsonParserFieldValue != null) {
+					document.setFileName((String)jsonParserFieldValue);
+				}
+			}
 			else if (Objects.equals(jsonParserFieldName, "id")) {
 				if (jsonParserFieldValue != null) {
 					document.setId(Long.valueOf((String)jsonParserFieldValue));
@@ -907,11 +911,6 @@ public class DocumentSerDes {
 				if (jsonParserFieldValue != null) {
 					document.setSizeInBytes(
 						Long.valueOf((String)jsonParserFieldValue));
-				}
-			}
-			else if (Objects.equals(jsonParserFieldName, "sourceFileName")) {
-				if (jsonParserFieldValue != null) {
-					document.setSourceFileName((String)jsonParserFieldValue);
 				}
 			}
 			else if (Objects.equals(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
@@ -1387,9 +1387,9 @@ components:
                     format: int64
                     readOnly: true
                     type: integer
-                sourceFileName:
+                fileName:
                     description:
-                        The document's source file name.
+                        The document's file name.
                     type: string
                 taxonomyCategoryBriefs:
                     # @review

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
@@ -1341,6 +1341,10 @@ components:
                         The document's file extension.
                     readOnly: true
                     type: string
+                fileName:
+                    description:
+                        The document's file name.
+                    type: string
                 id:
                     description:
                         The document's ID.
@@ -1387,10 +1391,6 @@ components:
                     format: int64
                     readOnly: true
                     type: integer
-                fileName:
-                    description:
-                        The document's file name.
-                    type: string
                 taxonomyCategoryBriefs:
                     # @review
                     description:

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
@@ -1387,6 +1387,10 @@ components:
                     format: int64
                     readOnly: true
                     type: integer
+                sourceFileName:
+                    description:
+                        The document's source file name.
+                    type: string
                 taxonomyCategoryBriefs:
                     # @review
                     description:

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/DocumentDTOConverter.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/DocumentDTOConverter.java
@@ -165,7 +165,7 @@ public class DocumentDTOConverter
 					dtoConverterContext.getLocale());
 				siteId = GroupUtil.getSiteId(group);
 				sizeInBytes = fileEntry.getSize();
-				sourceFileName = fileEntry.getFileName();
+				fileName = fileEntry.getFileName();
 				taxonomyCategoryBriefs = TransformUtil.transformToArray(
 					_assetCategoryLocalService.getCategories(
 						DLFileEntry.class.getName(),

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/DocumentDTOConverter.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/DocumentDTOConverter.java
@@ -150,6 +150,7 @@ public class DocumentDTOConverter
 				encodingFormat = fileEntry.getMimeType();
 				externalReferenceCode = fileEntry.getExternalReferenceCode();
 				fileExtension = fileEntry.getExtension();
+				fileName = fileEntry.getFileName();
 				id = fileEntry.getFileEntryId();
 				keywords = ListUtil.toArray(
 					_assetTagLocalService.getTags(
@@ -165,7 +166,6 @@ public class DocumentDTOConverter
 					dtoConverterContext.getLocale());
 				siteId = GroupUtil.getSiteId(group);
 				sizeInBytes = fileEntry.getSize();
-				fileName = fileEntry.getFileName();
 				taxonomyCategoryBriefs = TransformUtil.transformToArray(
 					_assetCategoryLocalService.getCategories(
 						DLFileEntry.class.getName(),

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/DocumentDTOConverter.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/DocumentDTOConverter.java
@@ -165,6 +165,7 @@ public class DocumentDTOConverter
 					dtoConverterContext.getLocale());
 				siteId = GroupUtil.getSiteId(group);
 				sizeInBytes = fileEntry.getSize();
+				sourceFileName = fileEntry.getFileName();
 				taxonomyCategoryBriefs = TransformUtil.transformToArray(
 					_assetCategoryLocalService.getCategories(
 						DLFileEntry.class.getName(),

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/query/v1_0/Query.java
@@ -1176,7 +1176,7 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {assetLibraryDocumentByExternalReferenceCode(assetLibraryId: ___, externalReferenceCode: ___){actions, adaptedImages, aggregateRating, assetLibraryKey, contentUrl, contentValue, creator, customFields, dateCreated, dateModified, description, documentFolderId, documentType, encodingFormat, externalReferenceCode, fileExtension, id, keywords, numberOfComments, relatedContents, renderedContents, siteId, sizeInBytes, taxonomyCategoryBriefs, taxonomyCategoryIds, title, viewableBy}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {assetLibraryDocumentByExternalReferenceCode(assetLibraryId: ___, externalReferenceCode: ___){actions, adaptedImages, aggregateRating, assetLibraryKey, contentUrl, contentValue, creator, customFields, dateCreated, dateModified, description, documentFolderId, documentType, encodingFormat, externalReferenceCode, fileExtension, id, keywords, numberOfComments, relatedContents, renderedContents, siteId, sizeInBytes, sourceFileName, taxonomyCategoryBriefs, taxonomyCategoryIds, title, viewableBy}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField(
 		description = "Retrieves the asset library's document by external reference code."
@@ -1269,7 +1269,7 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {document(documentId: ___){actions, adaptedImages, aggregateRating, assetLibraryKey, contentUrl, contentValue, creator, customFields, dateCreated, dateModified, description, documentFolderId, documentType, encodingFormat, externalReferenceCode, fileExtension, id, keywords, numberOfComments, relatedContents, renderedContents, siteId, sizeInBytes, taxonomyCategoryBriefs, taxonomyCategoryIds, title, viewableBy}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {document(documentId: ___){actions, adaptedImages, aggregateRating, assetLibraryKey, contentUrl, contentValue, creator, customFields, dateCreated, dateModified, description, documentFolderId, documentType, encodingFormat, externalReferenceCode, fileExtension, id, keywords, numberOfComments, relatedContents, renderedContents, siteId, sizeInBytes, sourceFileName, taxonomyCategoryBriefs, taxonomyCategoryIds, title, viewableBy}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField(description = "Retrieves the document.")
 	public Document document(@GraphQLName("documentId") Long documentId)
@@ -1373,7 +1373,7 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {documentByExternalReferenceCode(externalReferenceCode: ___, siteKey: ___){actions, adaptedImages, aggregateRating, assetLibraryKey, contentUrl, contentValue, creator, customFields, dateCreated, dateModified, description, documentFolderId, documentType, encodingFormat, externalReferenceCode, fileExtension, id, keywords, numberOfComments, relatedContents, renderedContents, siteId, sizeInBytes, taxonomyCategoryBriefs, taxonomyCategoryIds, title, viewableBy}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {documentByExternalReferenceCode(externalReferenceCode: ___, siteKey: ___){actions, adaptedImages, aggregateRating, assetLibraryKey, contentUrl, contentValue, creator, customFields, dateCreated, dateModified, description, documentFolderId, documentType, encodingFormat, externalReferenceCode, fileExtension, id, keywords, numberOfComments, relatedContents, renderedContents, siteId, sizeInBytes, sourceFileName, taxonomyCategoryBriefs, taxonomyCategoryIds, title, viewableBy}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField(
 		description = "Retrieves the site's document by external reference code."

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/query/v1_0/Query.java
@@ -1176,7 +1176,7 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {assetLibraryDocumentByExternalReferenceCode(assetLibraryId: ___, externalReferenceCode: ___){actions, adaptedImages, aggregateRating, assetLibraryKey, contentUrl, contentValue, creator, customFields, dateCreated, dateModified, description, documentFolderId, documentType, encodingFormat, externalReferenceCode, fileExtension, id, keywords, numberOfComments, relatedContents, renderedContents, siteId, sizeInBytes, sourceFileName, taxonomyCategoryBriefs, taxonomyCategoryIds, title, viewableBy}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {assetLibraryDocumentByExternalReferenceCode(assetLibraryId: ___, externalReferenceCode: ___){actions, adaptedImages, aggregateRating, assetLibraryKey, contentUrl, contentValue, creator, customFields, dateCreated, dateModified, description, documentFolderId, documentType, encodingFormat, externalReferenceCode, fileExtension, fileName, id, keywords, numberOfComments, relatedContents, renderedContents, siteId, sizeInBytes, taxonomyCategoryBriefs, taxonomyCategoryIds, title, viewableBy}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField(
 		description = "Retrieves the asset library's document by external reference code."
@@ -1269,7 +1269,7 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {document(documentId: ___){actions, adaptedImages, aggregateRating, assetLibraryKey, contentUrl, contentValue, creator, customFields, dateCreated, dateModified, description, documentFolderId, documentType, encodingFormat, externalReferenceCode, fileExtension, id, keywords, numberOfComments, relatedContents, renderedContents, siteId, sizeInBytes, sourceFileName, taxonomyCategoryBriefs, taxonomyCategoryIds, title, viewableBy}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {document(documentId: ___){actions, adaptedImages, aggregateRating, assetLibraryKey, contentUrl, contentValue, creator, customFields, dateCreated, dateModified, description, documentFolderId, documentType, encodingFormat, externalReferenceCode, fileExtension, fileName, id, keywords, numberOfComments, relatedContents, renderedContents, siteId, sizeInBytes, taxonomyCategoryBriefs, taxonomyCategoryIds, title, viewableBy}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField(description = "Retrieves the document.")
 	public Document document(@GraphQLName("documentId") Long documentId)
@@ -1373,7 +1373,7 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {documentByExternalReferenceCode(externalReferenceCode: ___, siteKey: ___){actions, adaptedImages, aggregateRating, assetLibraryKey, contentUrl, contentValue, creator, customFields, dateCreated, dateModified, description, documentFolderId, documentType, encodingFormat, externalReferenceCode, fileExtension, id, keywords, numberOfComments, relatedContents, renderedContents, siteId, sizeInBytes, sourceFileName, taxonomyCategoryBriefs, taxonomyCategoryIds, title, viewableBy}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {documentByExternalReferenceCode(externalReferenceCode: ___, siteKey: ___){actions, adaptedImages, aggregateRating, assetLibraryKey, contentUrl, contentValue, creator, customFields, dateCreated, dateModified, description, documentFolderId, documentType, encodingFormat, externalReferenceCode, fileExtension, fileName, id, keywords, numberOfComments, relatedContents, renderedContents, siteId, sizeInBytes, taxonomyCategoryBriefs, taxonomyCategoryIds, title, viewableBy}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField(
 		description = "Retrieves the site's document by external reference code."

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentResourceImpl.java
@@ -378,18 +378,18 @@ public class DocumentResourceImpl extends BaseDocumentResourceImpl {
 		existingFileEntry = _moveDocument(
 			documentId, document, existingFileEntry);
 
-		String sourceFileName = null;
+		String fileName = null;
 		String title = null;
 		String description = null;
 
 		if (document != null) {
-			sourceFileName = document.getSourceFileName();
+			fileName = document.getFileName();
 			title = document.getTitle();
 			description = document.getDescription();
 		}
 
-		if (sourceFileName == null) {
-			sourceFileName = binaryFile.getFileName();
+		if (fileName == null) {
+			fileName = binaryFile.getFileName();
 		}
 
 		if (title == null) {
@@ -402,7 +402,7 @@ public class DocumentResourceImpl extends BaseDocumentResourceImpl {
 
 		return _toDocument(
 			_dlAppService.updateFileEntry(
-				documentId, sourceFileName, binaryFile.getContentType(), title,
+				documentId, fileName, binaryFile.getContentType(), title,
 				null, description, null, DLVersionNumberIncrease.AUTOMATIC,
 				binaryFile.getInputStream(), binaryFile.getSize(),
 				existingFileEntry.getExpirationDate(),
@@ -549,28 +549,28 @@ public class DocumentResourceImpl extends BaseDocumentResourceImpl {
 			throw new BadRequestException("No file found in body");
 		}
 
-		String sourceFileName = null;
+		String fileName = null;
 		String title = null;
 		String description = null;
 
 		if (document != null) {
-			sourceFileName = document.getSourceFileName();
+			fileName = document.getFileName();
 			title = document.getTitle();
 			description = document.getDescription();
 		}
 
-		if (sourceFileName == null) {
-			sourceFileName = binaryFile.getFileName();
+		if (fileName == null) {
+			fileName = binaryFile.getFileName();
 		}
 
 		if (title == null) {
-			title = sourceFileName;
+			title = fileName;
 		}
 
 		return _toDocument(
 			_dlAppService.addFileEntry(
 				externalReferenceCode, repositoryId, documentFolderId,
-				sourceFileName, binaryFile.getContentType(), title, null,
+				fileName, binaryFile.getContentType(), title, null,
 				description, null, binaryFile.getInputStream(),
 				binaryFile.getSize(), null, null,
 				_createServiceContext(
@@ -962,18 +962,18 @@ public class DocumentResourceImpl extends BaseDocumentResourceImpl {
 		fileEntry = _moveDocument(
 			fileEntry.getFileEntryId(), document, fileEntry);
 
-		String sourceFileName = null;
+		String fileName = null;
 		String title = null;
 		String description = null;
 
 		if (document != null) {
-			sourceFileName = document.getSourceFileName();
+			fileName = document.getFileName();
 			title = document.getTitle();
 			description = document.getDescription();
 		}
 
-		if (sourceFileName == null) {
-			sourceFileName = binaryFile.getFileName();
+		if (fileName == null) {
+			fileName = binaryFile.getFileName();
 		}
 
 		if (title == null) {
@@ -982,7 +982,7 @@ public class DocumentResourceImpl extends BaseDocumentResourceImpl {
 
 		return _toDocument(
 			_dlAppService.updateFileEntry(
-				fileEntry.getFileEntryId(), sourceFileName,
+				fileEntry.getFileEntryId(), fileName,
 				binaryFile.getContentType(), title, null, description, null,
 				DLVersionNumberIncrease.AUTOMATIC, binaryFile.getInputStream(),
 				binaryFile.getSize(), fileEntry.getExpirationDate(),

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentResourceImpl.java
@@ -402,8 +402,8 @@ public class DocumentResourceImpl extends BaseDocumentResourceImpl {
 
 		return _toDocument(
 			_dlAppService.updateFileEntry(
-				documentId, fileName, binaryFile.getContentType(), title,
-				null, description, null, DLVersionNumberIncrease.AUTOMATIC,
+				documentId, fileName, binaryFile.getContentType(), title, null,
+				description, null, DLVersionNumberIncrease.AUTOMATIC,
 				binaryFile.getInputStream(), binaryFile.getSize(),
 				existingFileEntry.getExpirationDate(),
 				existingFileEntry.getReviewDate(),
@@ -569,10 +569,9 @@ public class DocumentResourceImpl extends BaseDocumentResourceImpl {
 
 		return _toDocument(
 			_dlAppService.addFileEntry(
-				externalReferenceCode, repositoryId, documentFolderId,
-				fileName, binaryFile.getContentType(), title, null,
-				description, null, binaryFile.getInputStream(),
-				binaryFile.getSize(), null, null,
+				externalReferenceCode, repositoryId, documentFolderId, fileName,
+				binaryFile.getContentType(), title, null, description, null,
+				binaryFile.getInputStream(), binaryFile.getSize(), null, null,
 				_createServiceContext(
 					Constants.ADD, () -> new Long[0], () -> new String[0],
 					documentFolderId, document, groupId)));

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentResourceImpl.java
@@ -378,12 +378,18 @@ public class DocumentResourceImpl extends BaseDocumentResourceImpl {
 		existingFileEntry = _moveDocument(
 			documentId, document, existingFileEntry);
 
+		String sourceFileName = null;
 		String title = null;
 		String description = null;
 
 		if (document != null) {
+			sourceFileName = document.getSourceFileName();
 			title = document.getTitle();
 			description = document.getDescription();
+		}
+
+		if (sourceFileName == null) {
+			sourceFileName = binaryFile.getFileName();
 		}
 
 		if (title == null) {
@@ -396,10 +402,10 @@ public class DocumentResourceImpl extends BaseDocumentResourceImpl {
 
 		return _toDocument(
 			_dlAppService.updateFileEntry(
-				documentId, binaryFile.getFileName(),
-				binaryFile.getContentType(), title, null, description, null,
-				DLVersionNumberIncrease.AUTOMATIC, binaryFile.getInputStream(),
-				binaryFile.getSize(), existingFileEntry.getExpirationDate(),
+				documentId, sourceFileName, binaryFile.getContentType(), title,
+				null, description, null, DLVersionNumberIncrease.AUTOMATIC,
+				binaryFile.getInputStream(), binaryFile.getSize(),
+				existingFileEntry.getExpirationDate(),
 				existingFileEntry.getReviewDate(),
 				_createServiceContext(
 					Constants.UPDATE,
@@ -543,23 +549,29 @@ public class DocumentResourceImpl extends BaseDocumentResourceImpl {
 			throw new BadRequestException("No file found in body");
 		}
 
+		String sourceFileName = null;
 		String title = null;
 		String description = null;
 
 		if (document != null) {
+			sourceFileName = document.getSourceFileName();
 			title = document.getTitle();
 			description = document.getDescription();
 		}
 
+		if (sourceFileName == null) {
+			sourceFileName = binaryFile.getFileName();
+		}
+
 		if (title == null) {
-			title = binaryFile.getFileName();
+			title = sourceFileName;
 		}
 
 		return _toDocument(
 			_dlAppService.addFileEntry(
 				externalReferenceCode, repositoryId, documentFolderId,
-				binaryFile.getFileName(), binaryFile.getContentType(), title,
-				null, description, null, binaryFile.getInputStream(),
+				sourceFileName, binaryFile.getContentType(), title, null,
+				description, null, binaryFile.getInputStream(),
 				binaryFile.getSize(), null, null,
 				_createServiceContext(
 					Constants.ADD, () -> new Long[0], () -> new String[0],
@@ -950,13 +962,18 @@ public class DocumentResourceImpl extends BaseDocumentResourceImpl {
 		fileEntry = _moveDocument(
 			fileEntry.getFileEntryId(), document, fileEntry);
 
+		String sourceFileName = null;
 		String title = null;
-
 		String description = null;
 
 		if (document != null) {
+			sourceFileName = document.getSourceFileName();
 			title = document.getTitle();
 			description = document.getDescription();
+		}
+
+		if (sourceFileName == null) {
+			sourceFileName = binaryFile.getFileName();
 		}
 
 		if (title == null) {
@@ -965,7 +982,7 @@ public class DocumentResourceImpl extends BaseDocumentResourceImpl {
 
 		return _toDocument(
 			_dlAppService.updateFileEntry(
-				fileEntry.getFileEntryId(), binaryFile.getFileName(),
+				fileEntry.getFileEntryId(), sourceFileName,
 				binaryFile.getContentType(), title, null, description, null,
 				DLVersionNumberIncrease.AUTOMATIC, binaryFile.getInputStream(),
 				binaryFile.getSize(), fileEntry.getExpirationDate(),

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/HeadlessDeliverySupportDifferentParametersDM.testcase
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/HeadlessDeliverySupportDifferentParametersDM.testcase
@@ -77,7 +77,7 @@ definition {
 
 			TestUtils.assertEquals(
 				actual = ${actualValue},
-				expected = "{title=Document_1.txt}");
+				expected = "{fileName=Document_1.txt, title=Document_1.txt}");
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/HeadlessDeliverySupportDifferentParametersDM.testcase
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/HeadlessDeliverySupportDifferentParametersDM.testcase
@@ -69,7 +69,7 @@ definition {
 			var response = DocumentAPI.getDocumentsByDifferentParameters(
 				documentId = ${documentId},
 				parameter = "restrictFields",
-				parameterValue = "actions,adaptedImages,assetLibraryKey,contentUrl,creator,customFields,dateCreated,dateModified,description,documentFolderId,documentType,encodingFormat,externalReferenceCode,fileExtension,id,keywords,numberOfComments,relatedContents,renderedContents,siteId,sizeInBytes,taxonomyCategoryBriefs");
+				parameterValue = "actions,adaptedImages,assetLibraryKey,contentUrl,creator,customFields,dateCreated,dateModified,description,documentFolderId,documentType,encodingFormat,externalReferenceCode,fileExtension,fileName,id,keywords,numberOfComments,relatedContents,renderedContents,siteId,sizeInBytes,taxonomyCategoryBriefs");
 		}
 
 		task ("Then in a response I receive a body with title field values only") {
@@ -77,7 +77,7 @@ definition {
 
 			TestUtils.assertEquals(
 				actual = ${actualValue},
-				expected = "{fileName=Document_1.txt, title=Document_1.txt}");
+				expected = "{title=Document_1.txt}");
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentResourceTestCase.java
@@ -214,6 +214,7 @@ public abstract class BaseDocumentResourceTestCase {
 		document.setEncodingFormat(regex);
 		document.setExternalReferenceCode(regex);
 		document.setFileExtension(regex);
+		document.setSourceFileName(regex);
 		document.setTitle(regex);
 
 		String json = DocumentSerDes.toJSON(document);
@@ -229,6 +230,7 @@ public abstract class BaseDocumentResourceTestCase {
 		Assert.assertEquals(regex, document.getEncodingFormat());
 		Assert.assertEquals(regex, document.getExternalReferenceCode());
 		Assert.assertEquals(regex, document.getFileExtension());
+		Assert.assertEquals(regex, document.getSourceFileName());
 		Assert.assertEquals(regex, document.getTitle());
 	}
 
@@ -2947,6 +2949,14 @@ public abstract class BaseDocumentResourceTestCase {
 				continue;
 			}
 
+			if (Objects.equals("sourceFileName", additionalAssertFieldName)) {
+				if (document.getSourceFileName() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals(
 					"taxonomyCategoryBriefs", additionalAssertFieldName)) {
 
@@ -3400,6 +3410,17 @@ public abstract class BaseDocumentResourceTestCase {
 				continue;
 			}
 
+			if (Objects.equals("sourceFileName", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						document1.getSourceFileName(),
+						document2.getSourceFileName())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals(
 					"taxonomyCategoryBriefs", additionalAssertFieldName)) {
 
@@ -3832,6 +3853,14 @@ public abstract class BaseDocumentResourceTestCase {
 				"Invalid entity field " + entityFieldName);
 		}
 
+		if (entityFieldName.equals("sourceFileName")) {
+			sb.append("'");
+			sb.append(String.valueOf(document.getSourceFileName()));
+			sb.append("'");
+
+			return sb.toString();
+		}
+
 		if (entityFieldName.equals("taxonomyCategoryBriefs")) {
 			throw new IllegalArgumentException(
 				"Invalid entity field " + entityFieldName);
@@ -3925,6 +3954,8 @@ public abstract class BaseDocumentResourceTestCase {
 				numberOfComments = RandomTestUtil.randomInt();
 				siteId = testGroup.getGroupId();
 				sizeInBytes = RandomTestUtil.randomLong();
+				sourceFileName = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
 				title = StringUtil.toLowerCase(RandomTestUtil.randomString());
 			}
 		};

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentResourceTestCase.java
@@ -214,7 +214,7 @@ public abstract class BaseDocumentResourceTestCase {
 		document.setEncodingFormat(regex);
 		document.setExternalReferenceCode(regex);
 		document.setFileExtension(regex);
-		document.setSourceFileName(regex);
+		document.setFileName(regex);
 		document.setTitle(regex);
 
 		String json = DocumentSerDes.toJSON(document);
@@ -230,7 +230,7 @@ public abstract class BaseDocumentResourceTestCase {
 		Assert.assertEquals(regex, document.getEncodingFormat());
 		Assert.assertEquals(regex, document.getExternalReferenceCode());
 		Assert.assertEquals(regex, document.getFileExtension());
-		Assert.assertEquals(regex, document.getSourceFileName());
+		Assert.assertEquals(regex, document.getFileName());
 		Assert.assertEquals(regex, document.getTitle());
 	}
 
@@ -2909,6 +2909,14 @@ public abstract class BaseDocumentResourceTestCase {
 				continue;
 			}
 
+			if (Objects.equals("fileName", additionalAssertFieldName)) {
+				if (document.getFileName() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals("keywords", additionalAssertFieldName)) {
 				if (document.getKeywords() == null) {
 					valid = false;
@@ -2943,14 +2951,6 @@ public abstract class BaseDocumentResourceTestCase {
 
 			if (Objects.equals("sizeInBytes", additionalAssertFieldName)) {
 				if (document.getSizeInBytes() == null) {
-					valid = false;
-				}
-
-				continue;
-			}
-
-			if (Objects.equals("sourceFileName", additionalAssertFieldName)) {
-				if (document.getSourceFileName() == null) {
 					valid = false;
 				}
 
@@ -3348,6 +3348,16 @@ public abstract class BaseDocumentResourceTestCase {
 				continue;
 			}
 
+			if (Objects.equals("fileName", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						document1.getFileName(), document2.getFileName())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals("id", additionalAssertFieldName)) {
 				if (!Objects.deepEquals(document1.getId(), document2.getId())) {
 					return false;
@@ -3403,17 +3413,6 @@ public abstract class BaseDocumentResourceTestCase {
 				if (!Objects.deepEquals(
 						document1.getSizeInBytes(),
 						document2.getSizeInBytes())) {
-
-					return false;
-				}
-
-				continue;
-			}
-
-			if (Objects.equals("sourceFileName", additionalAssertFieldName)) {
-				if (!Objects.deepEquals(
-						document1.getSourceFileName(),
-						document2.getSourceFileName())) {
 
 					return false;
 				}
@@ -3817,6 +3816,14 @@ public abstract class BaseDocumentResourceTestCase {
 			return sb.toString();
 		}
 
+		if (entityFieldName.equals("fileName")) {
+			sb.append("'");
+			sb.append(String.valueOf(document.getFileName()));
+			sb.append("'");
+
+			return sb.toString();
+		}
+
 		if (entityFieldName.equals("id")) {
 			throw new IllegalArgumentException(
 				"Invalid entity field " + entityFieldName);
@@ -3851,14 +3858,6 @@ public abstract class BaseDocumentResourceTestCase {
 		if (entityFieldName.equals("sizeInBytes")) {
 			throw new IllegalArgumentException(
 				"Invalid entity field " + entityFieldName);
-		}
-
-		if (entityFieldName.equals("sourceFileName")) {
-			sb.append("'");
-			sb.append(String.valueOf(document.getSourceFileName()));
-			sb.append("'");
-
-			return sb.toString();
 		}
 
 		if (entityFieldName.equals("taxonomyCategoryBriefs")) {
@@ -3950,12 +3949,12 @@ public abstract class BaseDocumentResourceTestCase {
 					RandomTestUtil.randomString());
 				fileExtension = StringUtil.toLowerCase(
 					RandomTestUtil.randomString());
+				fileName = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
 				id = RandomTestUtil.randomLong();
 				numberOfComments = RandomTestUtil.randomInt();
 				siteId = testGroup.getGroupId();
 				sizeInBytes = RandomTestUtil.randomLong();
-				sourceFileName = StringUtil.toLowerCase(
-					RandomTestUtil.randomString());
 				title = StringUtil.toLowerCase(RandomTestUtil.randomString());
 			}
 		};

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/DocumentResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/DocumentResourceTest.java
@@ -122,7 +122,7 @@ public class DocumentResourceTest extends BaseDocumentResourceTestCase {
 
 	@Override
 	protected String[] getAdditionalAssertFieldNames() {
-		return new String[] {"description", "sourceFileName", "title"};
+		return new String[] {"description", "fileName", "title"};
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/DocumentResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/DocumentResourceTest.java
@@ -122,7 +122,7 @@ public class DocumentResourceTest extends BaseDocumentResourceTestCase {
 
 	@Override
 	protected String[] getAdditionalAssertFieldNames() {
-		return new String[] {"description", "title"};
+		return new String[] {"description", "sourceFileName", "title"};
 	}
 
 	@Override


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-182040

To test it:

```
curl -X POST http://localhost:8080/o/headless-delivery/v1.0/sites/20119/documents \
{
    -u 'test@liferay.com:test' \
    -H 'Content-Type: multipart/form-data' \
    -F 'document={"title":"title", "fileName":"fileName.txt"}' \
    -F 'file=../Document_1.txt' 
}
```

- LPS-182040 add sourceFileName attribute to the Document declaration
- LPS-182040 buildRest
- LPS-182040 autoSF
- LPS-182040 add the sourceFileName on the DocumentDTOConverter
- LPS-182040 use the sourceFileName on the creation and update of the file
- LPS-182040 add the field to the test
- LPS-182040 add the new field to the tests
