### PR TITLE
LPS-181933 Disable SPA in Add Category button within Message Boards

### DIFF
--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view.jsp
@@ -232,6 +232,7 @@ request.setAttribute("view.jsp-viewCategory", Boolean.TRUE.toString());
 
 									<div class="btn-group-item">
 										<clay:link
+											data-senna-off="<%= true %>"
 											displayType="secondary"
 											href="<%= editCategoryURL %>"
 											label="add-category[message-board]"


### PR DESCRIPTION
Hey guys,

The first solution I sent for this LPS fixed the case... sometimes. 

It's hard to figure out  a pattern about when it is actually reproducible, but I managed to figure out disabling SPA is not happening anymore. Actually, I've seen we do the same in our Management Toolbar so that avoids cases like this in many occasions through our portal.

Thanks!