### PR TITLE
LPS-182336 Adaptive Media's Adapt Remaining feature with S3 store seems to be leaking HTTP connections

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-image-impl/build.gradle
+++ b/modules/apps/adaptive-media/adaptive-media-image-impl/build.gradle
@@ -19,6 +19,7 @@ dependencies {
 	compileOnly project(":core:osgi-service-tracker-collections")
 	compileOnly project(":core:petra:petra-concurrent")
 	compileOnly project(":core:petra:petra-function")
+	compileOnly project(":core:petra:petra-io")
 	compileOnly project(":core:petra:petra-process")
 	compileOnly project(":core:petra:petra-sql-dsl-api")
 	compileOnly project(":core:petra:petra-string")

--- a/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/util/RenderedImageUtil.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/util/RenderedImageUtil.java
@@ -15,6 +15,7 @@
 package com.liferay.adaptive.media.image.internal.util;
 
 import com.liferay.adaptive.media.exception.AMRuntimeException;
+import com.liferay.petra.io.StreamUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.exception.ImageResolutionException;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -105,6 +106,8 @@ public class RenderedImageUtil {
 				if (imageReader != null) {
 					imageReader.dispose();
 				}
+
+				StreamUtil.cleanUp(imageInputStream, inputStream);
 			}
 		}
 


### PR DESCRIPTION
Dear Team,

Could you please review this pull request?

Motivation
=======
During the "Adapt Remaining" process, `InputStream`s are not closed after usage leading to a congestion of connection resources when using a remote repository like S3. This is caused by the `ImageReader` object whose `dispose()` method does not close the `InputStream` handed to it.

Proposed Solution
========
Adding logic in the `finally` clause that closes the `InputStream`. Please note that closing the `imageInputStream` object won't automatically close the `inputStream`, so it has to be closed explicitly.

Steps to Verify
========
Please see the linked LPS for the reproduction steps.
https://issues.liferay.com/browse/LPS-182336

Thank you and best regards,
István