### PR TITLE
LPS-167607 HR_87 The basic web content template is not accessed from the template iframe by the keyboard 

### DIFF
--- a/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/view_item_selector_view_descriptor.jsp
+++ b/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/view_item_selector_view_descriptor.jsp
@@ -95,6 +95,8 @@ SearchContainer<Object> searchContainer = itemSelectorViewDescriptorRendererDisp
 
 							<liferay-ui:search-container-column-text>
 								<clay:vertical-card
+									role="button"
+									tabIndex="0"
 									verticalCard="<%= verticalCard %>"
 								/>
 							</liferay-ui:search-container-column-text>

--- a/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/view_item_selector_view_descriptor.jsp
+++ b/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/view_item_selector_view_descriptor.jsp
@@ -238,58 +238,74 @@ SearchContainer<Object> searchContainer = itemSelectorViewDescriptorRendererDisp
 		<aui:script require="frontend-js-web/index as frontendJsWeb">
 			var {delegate} = frontendJsWeb;
 
-			var selectItemHandler = delegate(
+			var selectItem = () => {
+				var activeCards = document.querySelectorAll('.form-check-card.active');
+
+				if (activeCards.length) {
+					activeCards.forEach((card) => {
+						card.classList.remove('active');
+					});
+				}
+
+				var target = event.delegateTarget;
+
+				var newSelectedCard = target.closest('.form-check-card');
+
+				if (newSelectedCard) {
+					newSelectedCard.classList.add('active');
+				}
+
+				var domElement = target.closest('li');
+
+				if (domElement == null) {
+					domElement = target.closest('tr');
+				}
+
+				if (domElement == null) {
+					domElement = target.closest('dd');
+				}
+
+				var itemValue = '';
+
+				if (domElement != null) {
+					itemValue = domElement.dataset.value;
+				}
+
+				Liferay.Util.getOpener().Liferay.fire(
+					'<%= itemSelectorViewDescriptorRendererDisplayContext.getItemSelectedEventName() %>',
+					{
+						data: {
+							returnType:
+								'<%= itemSelectorViewDescriptorRendererDisplayContext.getReturnType() %>',
+							value: itemValue,
+						},
+					}
+				);
+			};
+
+			var onClickHandler = delegate(
 				document.querySelector('#<portlet:namespace />entriesContainer'),
 				'click',
 				'.entry',
 				(event) => {
-					var activeCards = document.querySelectorAll('.form-check-card.active');
+					selectItem();
+				}
+			);
 
-					if (activeCards.length) {
-						activeCards.forEach((card) => {
-							card.classList.remove('active');
-						});
+			var onKeydownHandler = delegate(
+				document.querySelector('#<portlet:namespace />entriesContainer'),
+				'keydown',
+				'.entry',
+				(event) => {
+					if (event.code === 'Enter') {
+						selectItem();
 					}
-
-					var target = event.delegateTarget;
-
-					var newSelectedCard = target.closest('.form-check-card');
-
-					if (newSelectedCard) {
-						newSelectedCard.classList.add('active');
-					}
-
-					var domElement = target.closest('li');
-
-					if (domElement == null) {
-						domElement = target.closest('tr');
-					}
-
-					if (domElement == null) {
-						domElement = target.closest('dd');
-					}
-
-					var itemValue = '';
-
-					if (domElement != null) {
-						itemValue = domElement.dataset.value;
-					}
-
-					Liferay.Util.getOpener().Liferay.fire(
-						'<%= itemSelectorViewDescriptorRendererDisplayContext.getItemSelectedEventName() %>',
-						{
-							data: {
-								returnType:
-									'<%= itemSelectorViewDescriptorRendererDisplayContext.getReturnType() %>',
-								value: itemValue,
-							},
-						}
-					);
 				}
 			);
 
 			Liferay.on('destroyPortlet', function removeListener() {
-				selectItemHandler.dispose();
+				onClickHandler.dispose();
+				onKeydownHandler.dispose();
 
 				Liferay.detach('destroyPortlet', removeListener);
 			});

--- a/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/view_item_selector_view_descriptor.jsp
+++ b/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/view_item_selector_view_descriptor.jsp
@@ -95,6 +95,7 @@ SearchContainer<Object> searchContainer = itemSelectorViewDescriptorRendererDisp
 
 							<liferay-ui:search-container-column-text>
 								<clay:vertical-card
+									aria-label='<%= LanguageUtil.format(request, "select-x", verticalCard.getTitle()) %>'
 									role="button"
 									tabIndex="0"
 									verticalCard="<%= verticalCard %>"


### PR DESCRIPTION
Fixes https://issues.liferay.com/browse/LPS-167607

Hi guys! I send you a fix for this accessibility issue. The main problem is that the cards are not focusable elements and they don't have an associated keyboard event to select the item, so the following solution has been applied:
- Give a `role="button"` and `tabindex="0"` to the card.
- Add an `aria-label` to the card with the text `select-x` to have more context of the action to be carried out. For example,  the screen reader will read `Select Basic Web Content`.
- A new keyboard event has been created to select the item when it's pressed.

Let me know If you have any doubt! thanks in advance!