### PR TITLE
LPS-182347 Add asset Tag to the searching filter

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminDisplayContext.java
@@ -579,6 +579,8 @@ public class DLAdminDisplayContext {
 			_httpServletRequest, "fileEntryTypeId", -1);
 		String[] extensions = ParamUtil.getStringValues(
 			_httpServletRequest, "extension");
+		String[] assetTagIds = ParamUtil.getStringValues(
+			_httpServletRequest, "assetTagId");
 
 		int status = WorkflowConstants.STATUS_APPROVED;
 
@@ -626,8 +628,9 @@ public class DLAdminDisplayContext {
 		dlSearchContainer.setOrderByCol(getOrderByCol());
 		dlSearchContainer.setOrderByType(getOrderByType());
 
-		if ((fileEntryTypeId >= 0) || ArrayUtil.isNotEmpty(extensions) ||
-			navigation.equals("mine") || navigation.equals("recent")) {
+		if ((fileEntryTypeId >= 0) || ArrayUtil.isNotEmpty(assetTagIds) ||
+			ArrayUtil.isNotEmpty(extensions) || navigation.equals("mine") ||
+			navigation.equals("recent")) {
 
 			if (navigation.equals("recent")) {
 				dlSearchContainer.setOrderByCol("modifiedDate");
@@ -650,6 +653,10 @@ public class DLAdminDisplayContext {
 			searchContext.setAttribute("status", status);
 			searchContext.setBooleanClauses(
 				_getBooleanClauses(extensions, fileEntryTypeId, userId));
+
+			if (ArrayUtil.isNotEmpty(assetTagIds)) {
+				searchContext.setAssetTagNames(assetTagIds);
+			}
 
 			Indexer<?> indexer = IndexerRegistryUtil.getIndexer(
 				DLFileEntryConstants.getClassName());

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
@@ -375,10 +375,7 @@ public class DLAdminManagementToolbarDisplayContext
 				}
 
 				labelItem.setLabel(
-					String.format(
-						"%s: %s",
-						LanguageUtil.get(_httpServletRequest, "document-type"),
-						HtmlUtil.escape(fileEntryTypeName)));
+					_getLabel("document-type", fileEntryTypeName));
 			});
 
 		labelItemListWrapper.add(
@@ -397,11 +394,7 @@ public class DLAdminManagementToolbarDisplayContext
 
 				User user = _themeDisplay.getUser();
 
-				labelItem.setLabel(
-					String.format(
-						"%s: %s",
-						LanguageUtil.get(_httpServletRequest, "owner"),
-						HtmlUtil.escape(user.getFullName())));
+				labelItem.setLabel(_getLabel("owner", user.getFullName()));
 			});
 
 		labelItemListWrapper.add(
@@ -655,11 +648,7 @@ public class DLAdminManagementToolbarDisplayContext
 								},
 								String.class)));
 					labelItem.setCloseable(true);
-					labelItem.setLabel(
-						String.format(
-							"%s: %s",
-							LanguageUtil.get(_httpServletRequest, "tag"),
-							HtmlUtil.escape(assetTagId)));
+					labelItem.setLabel(_getLabel("tag", assetTagId));
 				});
 		}
 	}
@@ -684,11 +673,7 @@ public class DLAdminManagementToolbarDisplayContext
 
 					labelItem.setCloseable(true);
 
-					labelItem.setLabel(
-						String.format(
-							"%s: %s",
-							LanguageUtil.get(_httpServletRequest, "extension"),
-							HtmlUtil.escape(extension)));
+					labelItem.setLabel(_getLabel("extension", extension));
 				});
 		}
 	}
@@ -923,6 +908,12 @@ public class DLAdminManagementToolbarDisplayContext
 		}
 
 		return _dlAdminDisplayContext.getFolderId();
+	}
+
+	private String _getLabel(String key, String value) {
+		return String.format(
+			"%s: %s", LanguageUtil.get(_httpServletRequest, key),
+			HtmlUtil.escape(value));
 	}
 
 	private String _getNavigation() {

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
@@ -678,12 +678,9 @@ public class DLAdminManagementToolbarDisplayContext
 				labelItem -> {
 					labelItem.putData(
 						"removeLabelURL",
-						PortletURLBuilder.create(
-							PortletURLUtil.clone(
-								_currentURLObj, _liferayPortletResponse)
-						).setParameter(
-							"extension", ArrayUtil.remove(extensions, extension)
-						).buildString());
+						_getRemoveLabelURL(
+							"extension",
+							() -> ArrayUtil.remove(extensions, extension)));
 
 					labelItem.setCloseable(true);
 

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
@@ -790,12 +790,14 @@ public class DLAdminManagementToolbarDisplayContext
 		long fileEntryTypeId = _getFileEntryTypeId();
 		String navigation = ParamUtil.getString(
 			_httpServletRequest, "navigation", "home");
+		boolean selectedAssetTagIdsIsEmpty = SetUtil.isEmpty(
+			_getSelectedAssetTagIds(_httpServletRequest));
 
 		return DropdownItemListBuilder.add(
 			dropdownItem -> {
 				dropdownItem.setActive(
 					extensionsIsEmpty && (fileEntryTypeId == -1) &&
-					navigation.equals("home"));
+					navigation.equals("home") && selectedAssetTagIdsIsEmpty);
 				dropdownItem.setHref(
 					PortletURLBuilder.create(
 						PortletURLUtil.clone(
@@ -804,6 +806,8 @@ public class DLAdminManagementToolbarDisplayContext
 						"/document_library/view"
 					).setNavigation(
 						"home"
+					).setParameter(
+						"assetTagId", (String)null
 					).setParameter(
 						"browseBy", (String)null
 					).setParameter(
@@ -892,9 +896,7 @@ public class DLAdminManagementToolbarDisplayContext
 				dropdownItem.putData("action", "openTagsSelector");
 				dropdownItem.putData(
 					"tagsFilterURL", _getAssetTagSelectorURL());
-				dropdownItem.setActive(
-					SetUtil.isNotEmpty(
-						_getSelectedAssetTagIds(_httpServletRequest)));
+				dropdownItem.setActive(!selectedAssetTagIdsIsEmpty);
 				dropdownItem.setLabel(
 					LanguageUtil.get(_httpServletRequest, "tags") +
 						StringPool.TRIPLE_PERIOD);

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLViewDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLViewDisplayContext.java
@@ -180,6 +180,14 @@ public class DLViewDisplayContext {
 		).buildString();
 	}
 
+	public String getSelectAssetTagsURL() throws PortletException {
+		return PortletURLBuilder.create(
+			PortletURLUtil.clone(_getCurrentPortletURL(), _renderResponse)
+		).setParameter(
+			"assetTagId", (String)null
+		).buildString();
+	}
+
 	public String getSelectCategoriesURL()
 		throws PortalException, WindowStateException {
 

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/DLManagementToolbarPropsTransformer.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/DLManagementToolbarPropsTransformer.js
@@ -32,6 +32,7 @@ export default function propsTransformer({
 		editEntryURL,
 		folderConfiguration,
 		openViewMoreFileEntryTypesURL,
+		selectAssetTagsURL,
 		selectExtensionURL,
 		selectFileEntryTypeURL,
 		selectFolderURL,
@@ -225,6 +226,20 @@ export default function propsTransformer({
 			buttonAddLabel: Liferay.Language.get('select'),
 			height: '70vh',
 			multiple: true,
+			onSelect: (selectedItem) => {
+				if (selectedItem) {
+					const url = selectedItem.reduce(
+						(acc, item) =>
+							addParams(
+								`${portletNamespace}assetTagId=${item.value}`,
+								acc
+							),
+						selectAssetTagsURL
+					);
+
+					navigate(url);
+				}
+			},
 			selectEventName: `${portletNamespace}selectedAssetTag`,
 			size: 'lg',
 			title: Liferay.Language.get('filter-by-tags'),

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view.jsp
@@ -84,6 +84,8 @@ DLViewDisplayContext dlViewDisplayContext = new DLViewDisplayContext(dlAdminDisp
 				).put(
 					"openViewMoreFileEntryTypesURL", dlViewDisplayContext.getViewMoreFileEntryTypesURL()
 				).put(
+					"selectAssetTagsURL", dlViewDisplayContext.getSelectAssetTagsURL()
+				).put(
 					"selectExtensionURL", dlViewDisplayContext.getSelectExtensionURL()
 				).put(
 					"selectFileEntryTypeURL", dlViewDisplayContext.getSelectFileEntryTypeURL()


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-182347

It's under FF LPS-84424

To test :

1. Go to Documents & Media
2. Create files with some tags
3. You can see the tags from the group
4. Select tag from modal
5. only the documents with this tag are shown


https://user-images.githubusercontent.com/47524751/234052654-b698cc3a-d085-48f8-8081-aee40588fa7a.mp4




- LPS-182347 add action to the modal select
- LPS-182347 put the tags on the label item List
- LPS-182347 select all on the dropdown when the tags are empty and deselect the tag when you select all
- LPS-182347 add the assetTagIds to the search content
