### PR TITLE
Layouts for Blogs displayed on Content or Full Page Application pages not found with BasePortletLayoutFinder

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/portlet/BasePortletLayoutFinder.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/portlet/BasePortletLayoutFinder.java
@@ -239,15 +239,14 @@ public abstract class BasePortletLayoutFinder implements PortletLayoutFinder {
 			long groupId, long scopeGroupId, String portletId)
 		throws PortalException {
 
-		String[] portletTypes = {
-			LayoutConstants.TYPE_CONTENT,
-			LayoutConstants.TYPE_FULL_PAGE_APPLICATION,
-			LayoutConstants.TYPE_PORTLET
-		};
-
 		for (boolean privateLayout : Arrays.asList(false, true)) {
 			List<Layout> layouts = LayoutLocalServiceUtil.getLayouts(
-				groupId, privateLayout, portletTypes);
+				groupId, privateLayout,
+				new String[] {
+					LayoutConstants.TYPE_CONTENT,
+					LayoutConstants.TYPE_FULL_PAGE_APPLICATION,
+					LayoutConstants.TYPE_PORTLET
+				});
 
 			for (Layout layout : layouts) {
 				LayoutTypePortlet layoutTypePortlet =

--- a/portal-kernel/src/com/liferay/portal/kernel/portlet/BasePortletLayoutFinder.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/portlet/BasePortletLayoutFinder.java
@@ -239,9 +239,15 @@ public abstract class BasePortletLayoutFinder implements PortletLayoutFinder {
 			long groupId, long scopeGroupId, String portletId)
 		throws PortalException {
 
+		String[] portletTypes = {
+			LayoutConstants.TYPE_CONTENT,
+			LayoutConstants.TYPE_FULL_PAGE_APPLICATION,
+			LayoutConstants.TYPE_PORTLET
+		};
+
 		for (boolean privateLayout : Arrays.asList(false, true)) {
 			List<Layout> layouts = LayoutLocalServiceUtil.getLayouts(
-				groupId, privateLayout, LayoutConstants.TYPE_PORTLET);
+				groupId, privateLayout, portletTypes);
 
 			for (Layout layout : layouts) {
 				LayoutTypePortlet layoutTypePortlet =


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-182722

When a blog aggregator links to content on a Content or full page application type layout, those layouts are not found because the BasePortletLayoutFinder only retrieves Widget pages.

**Proposed Solution**
Add the other layout types that widgets can be placed on and scoped to.