### PR TITLE
LPS-182691 Set the AMImageMagickImageScaler as default

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-image-api/bnd.bnd
+++ b/modules/apps/adaptive-media/adaptive-media-image-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Adaptive Media Image API
 Bundle-SymbolicName: com.liferay.adaptive.media.image.api
-Bundle-Version: 11.0.1
+Bundle-Version: 11.1.0
 Export-Package:\
 	com.liferay.adaptive.media.image.configuration,\
 	com.liferay.adaptive.media.image.counter,\

--- a/modules/apps/adaptive-media/adaptive-media-image-api/src/main/java/com/liferay/adaptive/media/image/scaler/AMImageScaler.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-api/src/main/java/com/liferay/adaptive/media/image/scaler/AMImageScaler.java
@@ -53,6 +53,17 @@ public interface AMImageScaler {
 	}
 
 	/**
+	 * Returns <code>true</code> if the image type is supported by the  image
+	 * scaler.
+	 *
+	 * @return <code>true</code> if the image type is supported by the  image
+	 * scaler.
+	 */
+	public default boolean isSupportedMimeType(String mimeType) {
+		return true;
+	}
+
+	/**
 	 * Generates a scaled image for the file version that fits the
 	 * characteristics specified by the image configuration entry.
 	 *

--- a/modules/apps/adaptive-media/adaptive-media-image-api/src/main/resources/com/liferay/adaptive/media/image/scaler/packageinfo
+++ b/modules/apps/adaptive-media/adaptive-media-image-api/src/main/resources/com/liferay/adaptive/media/image/scaler/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 2.1.0

--- a/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/scaler/AMImageMagickImageScaler.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/scaler/AMImageMagickImageScaler.java
@@ -50,7 +50,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Roberto Díaz
  */
 @Component(
-	property = {"mime.type=*", "service.ranking:Integer=101"},
+	property = {"mime.type=*", "service.ranking:Integer=100"},
 	service = AMImageScaler.class
 )
 public class AMImageMagickImageScaler implements AMImageScaler {

--- a/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/scaler/AMImageMagickImageScaler.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/scaler/AMImageMagickImageScaler.java
@@ -19,13 +19,17 @@ import com.liferay.adaptive.media.image.configuration.AMImageConfigurationEntry;
 import com.liferay.adaptive.media.image.scaler.AMImageScaledImage;
 import com.liferay.adaptive.media.image.scaler.AMImageScaler;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.image.ImageBag;
 import com.liferay.portal.kernel.image.ImageMagick;
 import com.liferay.portal.kernel.image.ImageTool;
 import com.liferay.portal.kernel.repository.model.FileVersion;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.PrefsProps;
+import com.liferay.portal.kernel.util.PropsKeys;
 
 import java.awt.image.RenderedImage;
 
@@ -43,12 +47,10 @@ import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Eric Yan
+ * @author Roberto Díaz
  */
 @Component(
-	property = {
-		"mime.type=image/gif", "mime.type=image/heic", "mime.type=image/tiff",
-		"mime.type=image/webp"
-	},
+	property = {"mime.type=*", "service.ranking:Integer=101"},
 	service = AMImageScaler.class
 )
 public class AMImageMagickImageScaler implements AMImageScaler {
@@ -60,6 +62,15 @@ public class AMImageMagickImageScaler implements AMImageScaler {
 		}
 
 		return false;
+	}
+
+	@Override
+	public boolean isSupportedMimeType(String mimeType) {
+		return ArrayUtil.contains(
+			_prefsProps.getStringArray(
+				PropsKeys.IMAGEMAGICK_ADAPTIVE_MEDIA_SUPPORTED_MIME_TYPES,
+				StringPool.COMMA),
+			mimeType);
 	}
 
 	@Override
@@ -167,5 +178,8 @@ public class AMImageMagickImageScaler implements AMImageScaler {
 
 	@Reference
 	private ImageTool _imageTool;
+
+	@Reference
+	private PrefsProps _prefsProps;
 
 }

--- a/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/scaler/AMImageScalerRegistryImpl.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/scaler/AMImageScalerRegistryImpl.java
@@ -54,7 +54,9 @@ public class AMImageScalerRegistryImpl implements AMImageScalerRegistry {
 
 		if (ListUtil.isNotEmpty(amImageScalers)) {
 			for (AMImageScaler amImageScaler : amImageScalers) {
-				if (amImageScaler.isEnabled()) {
+				if (amImageScaler.isEnabled() &&
+					amImageScaler.isSupportedMimeType(mimeType)) {
+
 					return amImageScaler;
 				}
 			}

--- a/portal-impl/bnd.bnd
+++ b/portal-impl/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 75.0.2
+Bundle-Version: 76.0.0
 Export-Package:\
 	com.liferay.portal.bean,\
 	com.liferay.portal.dao.orm.hibernate,\

--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -917,6 +917,10 @@ public class PropsValues {
 	public static final long IMAGE_TOOL_IMAGE_MAX_WIDTH = GetterUtil.getLong(
 		PropsUtil.get(PropsKeys.IMAGE_TOOL_IMAGE_MAX_WIDTH));
 
+	public static final String[]
+		IMAGEMAGICK_ADAPTIVE_MEDIA_SUPPORTED_MIME_TYPES = PropsUtil.getArray(
+			PropsKeys.IMAGEMAGICK_ADAPTIVE_MEDIA_SUPPORTED_MIME_TYPES);
+
 	public static final boolean IMAGEMAGICK_ENABLED = GetterUtil.getBoolean(
 		PropsUtil.get(PropsKeys.IMAGEMAGICK_ENABLED));
 

--- a/portal-impl/src/com/liferay/portal/util/packageinfo
+++ b/portal-impl/src/com/liferay/portal/util/packageinfo
@@ -1,1 +1,1 @@
-version 47.1.0
+version 47.2.0

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -6780,6 +6780,17 @@
 ##
 
     #
+    # Env: LIFERAY_IMAGEMAGICK_PERIOD_ADAPTIVE_PERIOD_MEDIA_PERIOD_SUPPORTED_PERIOD_MIME_PERIOD_TYPES
+    #
+
+    imagemagick.adaptive.media.supported.mime.types=\
+        image/avif,\
+        image/gif,\
+        image/heic,\
+        image/tiff,\
+        image/webp
+
+    #
     # Set this to true to enable ImageMagick. You must install Ghostscript and
     # Imagemagick. See http://www.ghostscript.com and http://www.imagemagick.org
     # for more information.

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -1095,6 +1095,9 @@ public interface PropsKeys {
 	public static final String IMAGE_TOOL_IMAGE_MAX_WIDTH =
 		"image.tool.image.max.width";
 
+	public static final String IMAGEMAGICK_ADAPTIVE_MEDIA_SUPPORTED_MIME_TYPES =
+		"imagemagick.adaptive.media.supported.mime.types";
+
 	public static final String IMAGEMAGICK_ENABLED = "imagemagick.enabled";
 
 	public static final String IMAGEMAGICK_GLOBAL_SEARCH_PATH =

--- a/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
@@ -1,1 +1,1 @@
-version 58.0.0
+version 58.1.0


### PR DESCRIPTION
We have a ton of cases related with AM supported image types that were solved the same way: ImageMagickImageScaler

With current implementation we have to be reactive and add a new mime type to the service component with every customer new issue.

I've change the way it is registered and add new logic to allow customers add new image types if needed with a property.

Thanks @SamZiemer for helping me testing this fix asserting the all the current mime types work as expected