### PR TITLE
[TS] LPS-181899 Item Selector won't show all Sites grouped to the paginated page

### DIFF
--- a/modules/apps/item-selector/item-selector-impl/src/main/java/com/liferay/item/selector/internal/GroupItemSelectorGroupUtil.java
+++ b/modules/apps/item-selector/item-selector-impl/src/main/java/com/liferay/item/selector/internal/GroupItemSelectorGroupUtil.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.item.selector.internal;
+
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.security.auth.GuestOrUserUtil;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
+import com.liferay.portal.kernel.service.GroupServiceUtil;
+import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
+import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
+import com.liferay.portal.kernel.util.ListUtil;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+
+/**
+ * @author István András Dézsi
+ */
+public class GroupItemSelectorGroupUtil {
+
+	public static List<Group> getGroups(
+			long companyId, long[] classNameIds, String keywords,
+			LinkedHashMap<String, Object> groupParams, int start, int end)
+		throws PortalException {
+
+		try {
+			List<Group> groups = GroupLocalServiceUtil.search(
+				companyId, classNameIds, keywords, groupParams, start, end,
+				null);
+
+			return _fillGroupsPage(
+				_filterGroups(groups), groups.size(), classNameIds, companyId,
+				keywords, groupParams, start, end);
+		}
+		catch (PortalException portalException) {
+			_log.error(portalException);
+
+			return Collections.emptyList();
+		}
+	}
+
+	public static int getGroupsCount(
+		long companyId, long[] classNameIds, String keywords) {
+
+		return GroupServiceUtil.searchCount(
+			companyId, classNameIds, keywords,
+			LinkedHashMapBuilder.<String, Object>put(
+				"actionId", ActionKeys.VIEW
+			).put(
+				"site", Boolean.TRUE
+			).build());
+	}
+
+	private static List<Group> _fillGroupsPage(
+			List<Group> groups, int pageSize, long[] classNameIds,
+			long companyId, String keywords,
+			LinkedHashMap<String, Object> groupParams, int start, int end)
+		throws PortalException {
+
+		int delta = end - start;
+
+		int groupsCount = getGroupsCount(companyId, classNameIds, keywords);
+
+		int pageCount =
+			(groupsCount / delta) + (((groupsCount % delta) == 0) ? 0 : 1);
+
+		int pageIndex = (int)Math.ceil((double)start / delta);
+
+		while ((groups.size() < pageSize) && (pageIndex < pageCount)) {
+			pageIndex++;
+
+			start += delta;
+			end += delta;
+
+			List<Group> remainigFilteredGroups = _filterGroups(
+				GroupLocalServiceUtil.search(
+					companyId, classNameIds, keywords, groupParams, start, end,
+					null));
+
+			int difference = pageSize - groups.size();
+
+			groups.addAll(
+				ListUtil.subList(remainigFilteredGroups, 0, difference));
+		}
+
+		return groups;
+	}
+
+	private static List<Group> _filterGroups(List<Group> groups)
+		throws PortalException {
+
+		List<Group> filteredGroups = new ArrayList<>();
+
+		PermissionChecker permissionChecker =
+			GuestOrUserUtil.getPermissionChecker();
+
+		for (Group group : groups) {
+			if (group.isCompany() ||
+				permissionChecker.isGroupAdmin(group.getGroupId()) ||
+				GroupPermissionUtil.contains(
+					permissionChecker, group, ActionKeys.VIEW)) {
+
+				filteredGroups.add(group);
+			}
+		}
+
+		return filteredGroups;
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		GroupItemSelectorGroupUtil.class);
+
+}

--- a/modules/apps/item-selector/item-selector-impl/src/main/java/com/liferay/item/selector/internal/provider/GroupItemSelectorProviderImpl.java
+++ b/modules/apps/item-selector/item-selector-impl/src/main/java/com/liferay/item/selector/internal/provider/GroupItemSelectorProviderImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.item.selector.internal.provider;
 
+import com.liferay.item.selector.internal.GroupItemSelectorGroupUtil;
 import com.liferay.item.selector.provider.GroupItemSelectorProvider;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
@@ -22,9 +23,6 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Organization;
-import com.liferay.portal.kernel.security.auth.GuestOrUserUtil;
-import com.liferay.portal.kernel.security.permission.ActionKeys;
-import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.GroupService;
@@ -32,7 +30,6 @@ import com.liferay.portal.kernel.service.permission.GroupPermission;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
 import com.liferay.portlet.usersadmin.search.GroupSearch;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -73,10 +70,8 @@ public class GroupItemSelectorProviderImpl
 			).build();
 
 		try {
-			return _filterGroups(
-				_groupLocalService.search(
-					companyId, _classNameIds, keywords, groupParams, start, end,
-					null));
+			return GroupItemSelectorGroupUtil.getGroups(
+				companyId, _classNameIds, keywords, groupParams, start, end);
 		}
 		catch (PortalException portalException) {
 			_log.error(portalException);
@@ -87,13 +82,8 @@ public class GroupItemSelectorProviderImpl
 
 	@Override
 	public int getGroupsCount(long companyId, long groupId, String keywords) {
-		return _groupService.searchCount(
-			companyId, _classNameIds, keywords,
-			LinkedHashMapBuilder.<String, Object>put(
-				"actionId", ActionKeys.VIEW
-			).put(
-				"site", Boolean.TRUE
-			).build());
+		return GroupItemSelectorGroupUtil.getGroupsCount(
+			companyId, _classNameIds, keywords);
 	}
 
 	@Override
@@ -118,27 +108,6 @@ public class GroupItemSelectorProviderImpl
 			_classNameLocalService.getClassNameId(Group.class),
 			_classNameLocalService.getClassNameId(Organization.class)
 		};
-	}
-
-	private List<Group> _filterGroups(List<Group> groups)
-		throws PortalException {
-
-		List<Group> filteredGroups = new ArrayList<>();
-
-		PermissionChecker permissionChecker =
-			GuestOrUserUtil.getPermissionChecker();
-
-		for (Group group : groups) {
-			if (group.isCompany() ||
-				permissionChecker.isGroupAdmin(group.getGroupId()) ||
-				_groupPermission.contains(
-					permissionChecker, group, ActionKeys.VIEW)) {
-
-				filteredGroups.add(group);
-			}
-		}
-
-		return filteredGroups;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(


### PR DESCRIPTION
Dear Team,

Could you please review this pull request?

Motivation
=======
[GroupItemSelectorProviderImpl._filterGroups](https://github.com/liferay/liferay-portal/blob/master/modules/apps/item-selector/item-selector-impl/src/main/java/com/liferay/item/selector/internal/provider/GroupItemSelectorProviderImpl.java#L123) filters out the Site that the User has no permission to view. The problem is that the pagination won't align with the modified list and thus won't display all Sites the User still has access to.

Proposed Solution
========
If the number of filtered groups ends up being less than that of original the original results in a paginated section, pad it with groups from the subsequent sections. This logic has been outsourced to the new class [GroupItemSelectorGroupUtil](https://github.com/liferay-lima/liferay-portal/commit/eaeeae7099ca6d11920ed845f4be0df4377c6afa), as agreed upon in https://github.com/liferay-lima/liferay-portal/pull/4221#discussion_r1175253005.

Steps to Verify
========
Please see the linked LPS for the reproduction steps.
https://issues.liferay.com/browse/LPS-181899

Thank you and best regards,
István