### PR TITLE
LPS-182911 Don't modify λ param to avoid PMD parsing errors

### DIFF
--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/security/permission/resource/DLFileEntryModelResourcePermissionWrapper.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/security/permission/resource/DLFileEntryModelResourcePermissionWrapper.java
@@ -111,15 +111,14 @@ public class DLFileEntryModelResourcePermissionWrapper
 							return null;
 						}
 
-						if (actionId.equals(ActionKeys.DOWNLOAD)) {
-							actionId = ActionKeys.VIEW;
-						}
+						String relatedModelActionId = _getRelatedModelActionId(
+							actionId);
 
 						Boolean hasResourcePermission =
 							ResourcePermissionCheckerUtil.
 								containsResourcePermission(
 									permissionChecker, className, classPK,
-									actionId);
+									relatedModelActionId);
 
 						if ((hasResourcePermission != null) &&
 							!hasResourcePermission) {
@@ -131,7 +130,7 @@ public class DLFileEntryModelResourcePermissionWrapper
 							BaseModelPermissionCheckerUtil.
 								containsBaseModelPermission(
 									permissionChecker, fileEntry.getGroupId(),
-									className, classPK, actionId);
+									className, classPK, relatedModelActionId);
 
 						if ((hasBaseModelPermission != null) &&
 							!hasBaseModelPermission) {
@@ -167,6 +166,14 @@ public class DLFileEntryModelResourcePermissionWrapper
 
 			return _dlFolderLocalService.getFolder(folderId);
 		};
+	}
+
+	private String _getRelatedModelActionId(String actionId) {
+		if (actionId.equals(ActionKeys.DOWNLOAD)) {
+			return ActionKeys.VIEW;
+		}
+
+		return actionId;
 	}
 
 	@Reference


### PR DESCRIPTION
# What is this about?

https://issues.liferay.com/browse/LPS-182911

PMD gets confused and fails with a parse error if a lambda parameter is assigned directly.  This is a minor refactor to work around that.

# How do I test it?

Follow the steps described in https://issues.liferay.com/browse/LPS-182911.