### PR TITLE
LPS-183482 add the asset tag filter with a must to the boolean clauses

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminDisplayContext.java
@@ -535,8 +535,24 @@ public class DLAdminDisplayContext {
 		}
 	}
 
+	private Filter _getAssetTagNamesFilter(String[] assetTagNames) {
+		if (ArrayUtil.isEmpty(assetTagNames)) {
+			return null;
+		}
+
+		BooleanFilter booleanFilter = new BooleanFilter();
+
+		for (String assetTagName : assetTagNames) {
+			booleanFilter.addTerm(
+				Field.ASSET_TAG_NAMES, assetTagName, BooleanClauseOccur.MUST);
+		}
+
+		return booleanFilter;
+	}
+
 	private BooleanClause<Query>[] _getBooleanClauses(
-		String[] extensions, long fileEntryTypeId, long userId) {
+		String[] assetTagNames, String[] extensions, long fileEntryTypeId,
+		long userId) {
 
 		BooleanFilter booleanFilter = new BooleanFilter();
 
@@ -549,6 +565,12 @@ public class DLAdminDisplayContext {
 		if (ArrayUtil.isNotEmpty(extensions)) {
 			booleanFilter.add(
 				_getExtensionsFilter(extensions), BooleanClauseOccur.MUST);
+		}
+
+		if (ArrayUtil.isNotEmpty(assetTagNames)) {
+			booleanFilter.add(
+				_getAssetTagNamesFilter(assetTagNames),
+				BooleanClauseOccur.MUST);
 		}
 
 		if (userId > 0) {
@@ -652,7 +674,8 @@ public class DLAdminDisplayContext {
 
 			searchContext.setAttribute("status", status);
 			searchContext.setBooleanClauses(
-				_getBooleanClauses(extensions, fileEntryTypeId, userId));
+				_getBooleanClauses(
+					assetTagIds, extensions, fileEntryTypeId, userId));
 
 			if (folderId != DLFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
 				searchContext.setFolderIds(new long[] {folderId});


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-183482

1. Enable FF (LPS-84424)
2. Create new 1 document  (document1) with tag: tag1
3. Create new 1 document (document2) with tags: tag1, tag2
4. search by tags select : tag1, tag2 


Expected results:

- only document2 is shown