### PR TITLE
LPS-184127 Refactor DLAMImageCounterTest so that it doesn't depend on the images of a site initializer

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-document-library-web-test/src/testIntegration/java/com/liferay/adaptive/media/document/library/web/internal/counter/test/DLAMImageCounterTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-document-library-web-test/src/testIntegration/java/com/liferay/adaptive/media/document/library/web/internal/counter/test/DLAMImageCounterTest.java
@@ -82,10 +82,8 @@ public class DLAMImageCounterTest {
 	public void testDLAMImageCounterOnlyCountsDefaultRepositoryImages()
 		throws Exception {
 
-		Assert.assertEquals(
-			_WELCOME_SITE_INITIALIZER_IMAGES_COUNT,
-			_amImageCounter.countExpectedAMImageEntries(
-				_company1.getCompanyId()));
+		int count = _amImageCounter.countExpectedAMImageEntries(
+			_company1.getCompanyId());
 
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(
@@ -105,7 +103,7 @@ public class DLAMImageCounterTest {
 			RandomTestUtil.randomString(), ContentTypes.IMAGE_JPEG, true);
 
 		Assert.assertEquals(
-			_WELCOME_SITE_INITIALIZER_IMAGES_COUNT + 1,
+			count + 1,
 			_amImageCounter.countExpectedAMImageEntries(
 				_company1.getCompanyId()));
 	}
@@ -114,14 +112,11 @@ public class DLAMImageCounterTest {
 	public void testDLAMImageCounterOnlyCountsDefaultRepositoryImagesPerCompany()
 		throws Exception {
 
-		Assert.assertEquals(
-			_WELCOME_SITE_INITIALIZER_IMAGES_COUNT,
-			_amImageCounter.countExpectedAMImageEntries(
-				_company1.getCompanyId()));
-		Assert.assertEquals(
-			_WELCOME_SITE_INITIALIZER_IMAGES_COUNT,
-			_amImageCounter.countExpectedAMImageEntries(
-				_company2.getCompanyId()));
+		int company1Count = _amImageCounter.countExpectedAMImageEntries(
+			_company1.getCompanyId());
+
+		int company2Count = _amImageCounter.countExpectedAMImageEntries(
+			_company2.getCompanyId());
 
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(
@@ -141,11 +136,11 @@ public class DLAMImageCounterTest {
 			RandomTestUtil.randomString(), ContentTypes.IMAGE_JPEG, true);
 
 		Assert.assertEquals(
-			_WELCOME_SITE_INITIALIZER_IMAGES_COUNT + 1,
+			company1Count + 1,
 			_amImageCounter.countExpectedAMImageEntries(
 				_company1.getCompanyId()));
 		Assert.assertEquals(
-			_WELCOME_SITE_INITIALIZER_IMAGES_COUNT,
+			company2Count,
 			_amImageCounter.countExpectedAMImageEntries(
 				_company2.getCompanyId()));
 	}
@@ -154,10 +149,8 @@ public class DLAMImageCounterTest {
 	public void testDLAMImageCounterOnlyCountsImagesNotInTrash()
 		throws Exception {
 
-		Assert.assertEquals(
-			_WELCOME_SITE_INITIALIZER_IMAGES_COUNT,
-			_amImageCounter.countExpectedAMImageEntries(
-				_company1.getCompanyId()));
+		int count = _amImageCounter.countExpectedAMImageEntries(
+			_company1.getCompanyId());
 
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(
@@ -170,7 +163,7 @@ public class DLAMImageCounterTest {
 			_getImageBytes(), null, null, serviceContext);
 
 		Assert.assertEquals(
-			_WELCOME_SITE_INITIALIZER_IMAGES_COUNT + 1,
+			count + 1,
 			_amImageCounter.countExpectedAMImageEntries(
 				_company1.getCompanyId()));
 
@@ -179,7 +172,7 @@ public class DLAMImageCounterTest {
 			fileEntry.getFileEntryId());
 
 		Assert.assertEquals(
-			_WELCOME_SITE_INITIALIZER_IMAGES_COUNT,
+			count,
 			_amImageCounter.countExpectedAMImageEntries(
 				_company1.getCompanyId()));
 	}
@@ -188,10 +181,8 @@ public class DLAMImageCounterTest {
 	public void testDLAMImageCounterOnlyCountsImagesWithSupportedMimeTypes()
 		throws Exception {
 
-		Assert.assertEquals(
-			_WELCOME_SITE_INITIALIZER_IMAGES_COUNT,
-			_amImageCounter.countExpectedAMImageEntries(
-				_company1.getCompanyId()));
+		int count = _amImageCounter.countExpectedAMImageEntries(
+			_company1.getCompanyId());
 
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(
@@ -211,7 +202,7 @@ public class DLAMImageCounterTest {
 			TestDataConstants.TEST_BYTE_ARRAY, null, null, serviceContext);
 
 		Assert.assertEquals(
-			_WELCOME_SITE_INITIALIZER_IMAGES_COUNT + 1,
+			count + 1,
 			_amImageCounter.countExpectedAMImageEntries(
 				_company1.getCompanyId()));
 	}
@@ -220,8 +211,6 @@ public class DLAMImageCounterTest {
 		return FileUtil.getBytes(
 			DLAMImageCounterTest.class, "dependencies/image.jpg");
 	}
-
-	private static final int _WELCOME_SITE_INITIALIZER_IMAGES_COUNT = 5;
 
 	@Inject(
 		filter = "adaptive.media.key=document-library",

--- a/modules/apps/adaptive-media/adaptive-media-document-library-web-test/src/testIntegration/java/com/liferay/adaptive/media/document/library/web/internal/counter/test/DLAMImageCounterTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-document-library-web-test/src/testIntegration/java/com/liferay/adaptive/media/document/library/web/internal/counter/test/DLAMImageCounterTest.java
@@ -107,12 +107,6 @@ public class DLAMImageCounterTest {
 
 		Company company2 = CompanyTestUtil.addCompany();
 
-		User user2 = UserTestUtil.getAdminUser(company2.getCompanyId());
-
-		Group group2 = GroupTestUtil.addGroup(
-			company2.getCompanyId(), user2.getUserId(),
-			GroupConstants.DEFAULT_PARENT_GROUP_ID);
-
 		try {
 			int company1Count = _amImageCounter.countExpectedAMImageEntries(
 				_company1.getCompanyId());


### PR DESCRIPTION
## Motivation

[Link to ticket](https://issues.liferay.com/browse/LPS-184127)

Dear Team, working on https://issues.liferay.com/browse/LPS-177408, and after sending the PR we noticed that we would need to change by hand the variable relating to the images in a site initializer in DLAMImageCounterTest. So to avoid this, I refactored the tests. This way we won't need to change the tests when we add the future utility pages.

We also noticed that the second company was created even though it's only used in a test, so I moved it there. The time of test execution has been reduced by around 50% because of this. Also, there's no need to create the group for the second company, a simple cound should do.

Please let me know what you think.

Thanks!

## Change summary:

* Don't depend on a fix amount of images in the group
* Move creating the second company to the test where it's used


## Test Scenario

* Just run DLAMImageCounterTest
