### PR TITLE
LPS-176476 Hide redirect button from view if displayed with asset taglib

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry.jsp
@@ -33,7 +33,9 @@ if (addPortletBreadcrumbEntries) {
 
 boolean portletTitleBasedNavigation = GetterUtil.getBoolean(portletConfig.getInitParameter("portlet-title-based-navigation"));
 
-if (portletTitleBasedNavigation) {
+boolean showBackButton = Objects.equals(dlRequestHelper.getResourcePortletName(), DLPortletKeys.DOCUMENT_LIBRARY_ADMIN);
+
+if (portletTitleBasedNavigation && showBackButton) {
 	portletDisplay.setShowBackIcon(true);
 	portletDisplay.setURLBack(dlViewFileEntryDisplayContext.getRedirect());
 
@@ -94,15 +96,17 @@ if (portletTitleBasedNavigation) {
 				<div class="file-entry-actions management-bar management-bar-light navbar navbar-expand-md">
 					<ul class="navbar-nav navbar-nav-expand">
 						<li class="nav-item nav-item-expand">
-							<clay:link
-								aria-label='<%= LanguageUtil.get(request, "back") %>'
-								borderless="<%= true %>"
-								displayType="secondary"
-								href="<%= dlViewFileEntryDisplayContext.getRedirect() %>"
-								icon="angle-left"
-								monospaced="<%= true %>"
-								type="button"
-							/>
+							<c:if test="<%= showBackButton %>">
+								<clay:link
+									aria-label='<%= LanguageUtil.get(request, "back") %>'
+									borderless="<%= true %>"
+									displayType="secondary"
+									href="<%= dlViewFileEntryDisplayContext.getRedirect() %>"
+									icon="angle-left"
+									monospaced="<%= true %>"
+									type="button"
+								/>
+							</c:if>
 
 							<h3 class="mb-1 text-secondary"><%= dlViewFileEntryDisplayContext.getDocumentTitle() %></h3>
 						</li>


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-176476 - Search Results details page back button removes search results for certain asset types

For some context, the document is rendered with the [asset taglib](https://github.com/liferay/liferay-portal/blob/0119142f5d9c3e9f9fc94cfd8d0f9b5cced2a013/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/view_content.jsp#L77C1-L82) on our search results view. When clicking on the redirect link of a document from the search results, it actually shows this error:

`2023-05-10 18:13:00.729 WARN  [http-nio-8080-exec-2][MVCPortlet:299] No render mappings found for MVC render command name "/document_library/view_folder" for portlet com_liferay_portal_search_web_search_results_portlet_SearchResultsPortlet_INSTANCE_4ocauBtVmcWC `

It seems like most asset types just decide not to show that back button, so these changes just add an extra parameter `showBackButton` that is set to false when the resource portlet name is not the DOCUMENT_LIBRARY_ADMIN.

Hopefully that is straightforward enough, please let me know what you think, thanks!