### PR TITLE
[TS] LPS-184468 If the file cannot be found then update the file entry (bring back the behavior of LPS-53033)

### DIFF
--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/exportimport/data/handler/FileEntryStagedModelDataHandler.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/exportimport/data/handler/FileEntryStagedModelDataHandler.java
@@ -539,6 +539,8 @@ public class FileEntryStagedModelDataHandler
 							if (_log.isDebugEnabled()) {
 								_log.debug(exception);
 							}
+
+							updateFileEntry = true;
 						}
 					}
 


### PR DESCRIPTION
This is how the portal behaved as a result of https://issues.liferay.com/browse/LPS-53033 but was broken by the changes made in https://issues.liferay.com/browse/LPS-110426. This is bringing back the functionality that was lost.

If there are any questions or concerns please let me know.

This has already been reviewed by the Staging team - https://github.com/liferay-staging/liferay-portal/pull/306