### PR TITLE
LPS-184925 add the extension and tag filter to the sorting url in the same order that it appears on the dropdown filters

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
@@ -732,6 +732,19 @@ public class DLAdminManagementToolbarDisplayContext
 		sortingURL.setParameter(
 			"fileEntryTypeId", String.valueOf(_getFileEntryTypeId()));
 
+		String[] extensions = _getExtensions(_httpServletRequest);
+
+		if (ArrayUtil.isNotEmpty(extensions)) {
+			sortingURL.setParameter("extension", extensions);
+		}
+
+		String[] assetTagIds = ArrayUtil.toStringArray(
+			_getSelectedAssetTagIds(_httpServletRequest));
+
+		if (ArrayUtil.isNotEmpty(assetTagIds)) {
+			sortingURL.setParameter("assetTagId", assetTagIds);
+		}
+
 		return sortingURL;
 	}
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-184925

Steps to reproduce:

1. Add FF
2. Add four files to DM and apply the same tag to two of them (tag1)
3. Click Filter and Order > Tags... (same happening with extension)
4. Select and filter by tag1
5. Assert two files are displayed by the filter
6. Click Filter and Order again
7. Order by anything (Size, Downloads, Modified Date, Create Date, Name)