### PR TITLE
[TECHNICAL SUPPORT] LPS-184947 Incorrect redirect when trying to access permission-protected page

### DIFF
--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
@@ -387,7 +387,9 @@ public class FriendlyURLServlet extends HttpServlet {
 					group, _normalizeFriendlyURL(layoutFriendlyURL));
 			}
 
-			if (exception instanceof NoSuchLayoutException) {
+			if (exception instanceof LayoutPermissionException ||
+				exception instanceof NoSuchLayoutException) {
+
 				if (Validator.isNotNull(
 						PropsValues.LAYOUT_FRIENDLY_URL_PAGE_NOT_FOUND)) {
 


### PR DESCRIPTION
Hey,

[LPS-184947](https://issues.liferay.com/browse/LPS-184947)
In case of permission error, we should redirect the user to the general page not found page according to [PTR-3906](https://issues.liferay.com/browse/PTR-3906).

Please review my changes,

Thanks
