### PR TITLE
LPS-184698 Add the category to the filters

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminDisplayContext.java
@@ -535,6 +535,22 @@ public class DLAdminDisplayContext {
 		}
 	}
 
+	private Filter _getAssetCategoryIdsFilter(long[] assetCategoryIds) {
+		if (ArrayUtil.isEmpty(assetCategoryIds)) {
+			return null;
+		}
+
+		BooleanFilter booleanFilter = new BooleanFilter();
+
+		for (long assetCategoryId : assetCategoryIds) {
+			booleanFilter.addTerm(
+				Field.ASSET_CATEGORY_IDS, String.valueOf(assetCategoryId),
+				BooleanClauseOccur.MUST);
+		}
+
+		return booleanFilter;
+	}
+
 	private Filter _getAssetTagNamesFilter(String[] assetTagNames) {
 		if (ArrayUtil.isEmpty(assetTagNames)) {
 			return null;
@@ -552,12 +568,18 @@ public class DLAdminDisplayContext {
 	}
 
 	private BooleanClause<Query>[] _getBooleanClauses(
-		String[] assetTagNames, String[] extensions, long fileEntryTypeId,
-		long userId) {
+		long[] assetCategoryIds, String[] assetTagNames, String[] extensions,
+		long fileEntryTypeId, long userId) {
 
 		BooleanQuery booleanQuery = new BooleanQueryImpl();
 
 		BooleanFilter booleanFilter = new BooleanFilter();
+
+		if (ArrayUtil.isNotEmpty(assetCategoryIds)) {
+			booleanFilter.add(
+				_getAssetCategoryIdsFilter(assetCategoryIds),
+				BooleanClauseOccur.MUST);
+		}
 
 		if (ArrayUtil.isNotEmpty(assetTagNames)) {
 			booleanFilter.add(
@@ -598,6 +620,8 @@ public class DLAdminDisplayContext {
 			_httpServletRequest, "curFolder");
 		String deltaFolder = ParamUtil.getString(
 			_httpServletRequest, "deltaFolder");
+		long[] assetCategoryIds = ParamUtil.getLongValues(
+			_httpServletRequest, "assetCategoryId");
 		long fileEntryTypeId = ParamUtil.getLong(
 			_httpServletRequest, "fileEntryTypeId", -1);
 		String[] extensions = ParamUtil.getStringValues(
@@ -651,7 +675,8 @@ public class DLAdminDisplayContext {
 		dlSearchContainer.setOrderByCol(getOrderByCol());
 		dlSearchContainer.setOrderByType(getOrderByType());
 
-		if ((fileEntryTypeId >= 0) || ArrayUtil.isNotEmpty(assetTagIds) ||
+		if (ArrayUtil.isNotEmpty(assetCategoryIds) || (fileEntryTypeId >= 0) ||
+			ArrayUtil.isNotEmpty(assetTagIds) ||
 			ArrayUtil.isNotEmpty(extensions) || navigation.equals("mine") ||
 			navigation.equals("recent")) {
 
@@ -672,7 +697,8 @@ public class DLAdminDisplayContext {
 			searchContext.setAttribute("status", status);
 			searchContext.setBooleanClauses(
 				_getBooleanClauses(
-					assetTagIds, extensions, fileEntryTypeId, userId));
+					assetCategoryIds, assetTagIds, extensions, fileEntryTypeId,
+					userId));
 
 			if (folderId != DLFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
 				searchContext.setFolderIds(new long[] {folderId});

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
@@ -18,12 +18,12 @@ import com.liferay.asset.kernel.model.AssetCategory;
 import com.liferay.asset.kernel.model.AssetTag;
 import com.liferay.asset.kernel.model.AssetVocabulary;
 import com.liferay.asset.kernel.service.AssetCategoryServiceUtil;
-import com.liferay.asset.kernel.service.AssetVocabularyLocalServiceUtil;
 import com.liferay.asset.kernel.service.AssetVocabularyServiceUtil;
 import com.liferay.digital.signature.configuration.DigitalSignatureConfiguration;
 import com.liferay.digital.signature.configuration.DigitalSignatureConfigurationUtil;
 import com.liferay.document.library.constants.DLPortletKeys;
 import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.document.library.kernel.model.DLFileEntryConstants;
 import com.liferay.document.library.kernel.model.DLFileEntryType;
 import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
@@ -726,8 +726,10 @@ public class DLAdminManagementToolbarDisplayContext
 						WebKeys.THEME_DISPLAY);
 
 				return StringUtil.merge(
-					AssetVocabularyLocalServiceUtil.getCompanyVocabularies(
-						themeDisplay.getCompanyId()),
+					AssetVocabularyServiceUtil.getGroupsVocabularies(
+						PortalUtil.getCurrentAndAncestorSiteGroupIds(
+							themeDisplay.getScopeGroupId()),
+						DLFileEntryConstants.getClassName()),
 					assetVocabulary -> String.valueOf(
 						assetVocabulary.getVocabularyId()),
 					StringPool.COMMA);

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
@@ -883,6 +883,8 @@ public class DLAdminManagementToolbarDisplayContext
 					).setNavigation(
 						"home"
 					).setParameter(
+						"assetCategoryId", (String)null
+					).setParameter(
 						"assetTagId", (String)null
 					).setParameter(
 						"browseBy", (String)null

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
@@ -343,6 +343,8 @@ public class DLAdminManagementToolbarDisplayContext
 		LabelItemListBuilder.LabelItemListWrapper labelItemListWrapper =
 			new LabelItemListBuilder.LabelItemListWrapper();
 
+		_addAssetCategoriesFilterLabelItems(labelItemListWrapper);
+
 		_addExtensionFilterLabelItems(labelItemListWrapper);
 
 		_addAssetTagsFilterLabelItems(labelItemListWrapper);
@@ -646,6 +648,49 @@ public class DLAdminManagementToolbarDisplayContext
 		}
 
 		return false;
+	}
+
+	private void _addAssetCategoriesFilterLabelItems(
+		LabelItemListBuilder.LabelItemListWrapper labelItemListWrapper) {
+
+		Set<Long> assetCategoryIds = _getSelectedAssetCategoryIds(
+			_httpServletRequest);
+
+		for (Long assetCategoryId : assetCategoryIds) {
+			labelItemListWrapper.add(
+				labelItem -> {
+					labelItem.putData(
+						"removeLabelURL",
+						_getRemoveLabelURL(
+							"assetCategoryId",
+							() -> TransformUtil.transformToArray(
+								assetCategoryIds,
+								curAssetCategoryId -> {
+									if (Objects.equals(
+											assetCategoryId,
+											curAssetCategoryId)) {
+
+										return null;
+									}
+
+									return String.valueOf(curAssetCategoryId);
+								},
+								String.class)));
+					labelItem.setCloseable(true);
+
+					String title = StringPool.BLANK;
+
+					AssetCategory assetCategory =
+						AssetCategoryServiceUtil.fetchCategory(assetCategoryId);
+
+					if (assetCategory != null) {
+						title = assetCategory.getTitle(
+							_httpServletRequest.getLocale());
+					}
+
+					labelItem.setLabel(_getLabel("category", title));
+				});
+		}
 	}
 
 	private void _addAssetTagsFilterLabelItems(

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
@@ -918,7 +918,9 @@ public class DLAdminManagementToolbarDisplayContext
 			dropdownItem -> {
 				dropdownItem.setActive(
 					extensionsIsEmpty && (fileEntryTypeId == -1) &&
-					navigation.equals("home") && selectedAssetTagIdsIsEmpty);
+					navigation.equals("home") &&
+					selectedAssetCategoryIdsIsEmpty &&
+					selectedAssetTagIdsIsEmpty);
 				dropdownItem.setHref(
 					PortletURLBuilder.create(
 						PortletURLUtil.clone(

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
@@ -535,6 +535,18 @@ public class DLAdminManagementToolbarDisplayContext
 				return HtmlUtil.escapeJS(navigation);
 			}
 		).setParameter(
+			"assetCategoryId",
+			() -> {
+				long[] assetCategoryIds = ArrayUtil.toLongArray(
+					_getSelectedAssetCategoryIds(_httpServletRequest));
+
+				if (ArrayUtil.isNotEmpty(assetCategoryIds)) {
+					return ArrayUtil.toStringArray(assetCategoryIds);
+				}
+
+				return null;
+			}
+		).setParameter(
 			"assetTagId",
 			() -> {
 				String[] assetTagIds = ArrayUtil.toStringArray(

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
@@ -837,6 +837,15 @@ public class DLAdminManagementToolbarDisplayContext
 		}
 
 		sortingURL.setParameter("folderId", String.valueOf(folderId));
+
+		long[] assetCategoryIds = ArrayUtil.toLongArray(
+			_getSelectedAssetCategoryIds(_httpServletRequest));
+
+		if (ArrayUtil.isNotEmpty(assetCategoryIds)) {
+			sortingURL.setParameter(
+				"assetCategoryId", ArrayUtil.toStringArray(assetCategoryIds));
+		}
+
 		sortingURL.setParameter(
 			"fileEntryTypeId", String.valueOf(_getFileEntryTypeId()));
 

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLViewDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLViewDisplayContext.java
@@ -180,6 +180,14 @@ public class DLViewDisplayContext {
 		).buildString();
 	}
 
+	public String getSelectAssetCategoriesURL() throws PortletException {
+		return PortletURLBuilder.create(
+			PortletURLUtil.clone(_getCurrentPortletURL(), _renderResponse)
+		).setParameter(
+			"assetCategoryId", (String)null
+		).buildString();
+	}
+
 	public String getSelectAssetTagsURL() throws PortletException {
 		return PortletURLBuilder.create(
 			PortletURLUtil.clone(_getCurrentPortletURL(), _renderResponse)

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/DLManagementToolbarPropsTransformer.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/DLManagementToolbarPropsTransformer.js
@@ -32,6 +32,7 @@ export default function propsTransformer({
 		editEntryURL,
 		folderConfiguration,
 		openViewMoreFileEntryTypesURL,
+		selectAssetCategoriesURL,
 		selectAssetTagsURL,
 		selectExtensionURL,
 		selectFileEntryTypeURL,
@@ -183,6 +184,24 @@ export default function propsTransformer({
 			buttonAddLabel: Liferay.Language.get('select'),
 			height: '70vh',
 			multiple: true,
+			onSelect: (selectedItems) => {
+				if (selectedItems) {
+					const assetCategories = Object.keys(selectedItems).filter(
+						(key) => !selectedItems[key].unchecked
+					);
+
+					let url = selectAssetCategoriesURL;
+
+					assetCategories.forEach((assetCategory) => {
+						url = addParams(
+							`${portletNamespace}assetCategoryId=${assetCategory}`,
+							url
+						);
+					});
+
+					navigate(url);
+				}
+			},
 			selectEventName: `${portletNamespace}selectedAssetCategory`,
 			size: 'md',
 			title: Liferay.Language.get('filter-by-categories'),

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view.jsp
@@ -84,6 +84,8 @@ DLViewDisplayContext dlViewDisplayContext = new DLViewDisplayContext(dlAdminDisp
 				).put(
 					"openViewMoreFileEntryTypesURL", dlViewDisplayContext.getViewMoreFileEntryTypesURL()
 				).put(
+					"selectAssetCategoriesURL", dlViewDisplayContext.getSelectAssetCategoriesURL()
+				).put(
 					"selectAssetTagsURL", dlViewDisplayContext.getSelectAssetTagsURL()
 				).put(
 					"selectExtensionURL", dlViewDisplayContext.getSelectExtensionURL()


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-184698

It's under FF LPS-84424

To test :
- Create some Categories
- Go to Documents & Media
- Create a Document with those category/ies 
- Check the filter and order Dropdown
- You can see a modal with the categories of the site and global
- select the previous created category



https://github.com/liferay-lima/liferay-portal/assets/47524751/7319a500-bb25-4844-ae0a-54e8627ee84e





- LPS-184698 get only the categories that can be shown on the site and for the DLFileEntries
- LPS-184698 add onSelect action to the modal
- LPS-184698 clean categories on reload
- LPS-184698 put the category names on the label item List if selected
- LPS-184698 select all option when no categories
- LPS-184698 add the asset category ids to the filter of the searching
- LPS-184698 add the category filter to the sorting url in the same order that it appears on the dropdown filters
- LPS-184698  add as parameters the category filters to the displayStyleURL to persist the filters when changing the display view
