### PR TITLE
LPS-185165 Disable copy of documents from External Repositories

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/helper/FileEntryDisplayContextHelper.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/helper/FileEntryDisplayContextHelper.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.util.RepositoryUtil;
 
 /**
  * @author Iván Zaera
@@ -180,7 +181,9 @@ public class FileEntryDisplayContextHelper {
 	}
 
 	public boolean isCopyActionAvailable() throws PortalException {
-		if (hasViewPermission() && hasDownloadPermission()) {
+		if (hasViewPermission() && hasDownloadPermission() &&
+			!_isExternalRepository()) {
+
 			return true;
 		}
 
@@ -258,6 +261,16 @@ public class FileEntryDisplayContextHelper {
 		}
 
 		if (_fileEntry.getFileVersionsCount(WorkflowConstants.STATUS_ANY) > 1) {
+			return true;
+		}
+
+		return false;
+	}
+
+	private boolean _isExternalRepository() {
+		if ((_fileEntry != null) &&
+			RepositoryUtil.isExternalRepository(_fileEntry.getRepositoryId())) {
+
 			return true;
 		}
 

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/helper/FileShortcutDisplayContextHelper.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/helper/FileShortcutDisplayContextHelper.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.repository.model.FileShortcut;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
+import com.liferay.portal.util.RepositoryUtil;
 
 /**
  * @author IL (Brian) Kim
@@ -85,7 +86,11 @@ public class FileShortcutDisplayContextHelper {
 	}
 
 	public boolean isCopyActionAvailable() throws PortalException {
-		return hasViewPermission();
+		if (hasViewPermission() && !_isExternalRepository()) {
+			return true;
+		}
+
+		return false;
 	}
 
 	public boolean isDLFileShortcut() {
@@ -119,6 +124,17 @@ public class FileShortcutDisplayContextHelper {
 
 	public boolean isUpdatable() throws PortalException {
 		return hasUpdatePermission();
+	}
+
+	private boolean _isExternalRepository() {
+		if ((_fileShortcut != null) &&
+			RepositoryUtil.isExternalRepository(
+				_fileShortcut.getRepositoryId())) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 	private void _setValuesForNullFileShortcut() {


### PR DESCRIPTION
The copy of documents is not allowed from External Repositories. Disabling this option.
For folders it was already disabled.