### PR TITLE
LPS-185122 Filter by tags & extensions modals display items from sites/asset libraries the user does not have permissions to

### DIFF
--- a/modules/apps/content-dashboard/content-dashboard-document-library-impl/src/main/java/com/liferay/content/dashboard/document/library/internal/item/selector/ContentDashboardFileExtensionItemSelectorView.java
+++ b/modules/apps/content-dashboard/content-dashboard-document-library-impl/src/main/java/com/liferay/content/dashboard/document/library/internal/item/selector/ContentDashboardFileExtensionItemSelectorView.java
@@ -114,13 +114,14 @@ public class ContentDashboardFileExtensionItemSelectorView
 				getName(),
 			new ContentDashboardFileExtensionItemSelectorViewDisplayContext(
 				_getContentDashboardFileExtensionGroupsJSONArray(
-					servletRequest),
+					fileExtensionItemSelectorCriterion, servletRequest),
 				itemSelectedEventName));
 
 		requestDispatcher.include(servletRequest, servletResponse);
 	}
 
 	private JSONArray _getContentDashboardFileExtensionGroupsJSONArray(
+		FileExtensionItemSelectorCriterion fileExtensionItemSelectorCriterion,
 		ServletRequest servletRequest) {
 
 		ThemeDisplay themeDisplay = (ThemeDisplay)servletRequest.getAttribute(
@@ -131,7 +132,7 @@ public class ContentDashboardFileExtensionItemSelectorView
 				_fileExtensionGroupsProvider.getFileExtensionGroups();
 
 		List<String> existingFileExtensions = _getExistingFileExtensions(
-			themeDisplay.getRequest());
+			fileExtensionItemSelectorCriterion, themeDisplay.getRequest());
 
 		Set<String> otherFileExtensions = SetUtil.fromList(
 			ListUtil.filter(
@@ -148,12 +149,21 @@ public class ContentDashboardFileExtensionItemSelectorView
 	}
 
 	private List<String> _getExistingFileExtensions(
+		FileExtensionItemSelectorCriterion fileExtensionItemSelectorCriterion,
 		HttpServletRequest httpServletRequest) {
 
 		SearchContext searchContext = SearchContextFactory.getInstance(
 			httpServletRequest);
 
-		searchContext.setGroupIds(new long[0]);
+		long[] selectedGroupIds =
+			fileExtensionItemSelectorCriterion.getSelectedGroupIds();
+
+		if (selectedGroupIds != null) {
+			searchContext.setGroupIds(selectedGroupIds);
+		}
+		else {
+			searchContext.setGroupIds(new long[0]);
+		}
 
 		SearchRequestBuilder searchRequestBuilder =
 			_searchRequestBuilderFactory.builder(

--- a/modules/apps/content-dashboard/content-dashboard-document-library-test/src/testIntegration/java/com/liferay/content/dashboard/document/library/internal/item/selector/test/ContentDashboardFileExtensionItemSelectorViewTest.java
+++ b/modules/apps/content-dashboard/content-dashboard-document-library-test/src/testIntegration/java/com/liferay/content/dashboard/document/library/internal/item/selector/test/ContentDashboardFileExtensionItemSelectorViewTest.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
+import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.portlet.MockLiferayPortletRenderRequest;
 import com.liferay.portal.kernel.test.portlet.MockLiferayPortletRenderResponse;
@@ -131,6 +132,36 @@ public class ContentDashboardFileExtensionItemSelectorViewTest {
 			fileExtensionGroupsJSONArray.getJSONObject(9));
 
 		Assert.assertNotNull(data.get("itemSelectorSaveEvent"));
+	}
+
+	@Test
+	public void testGetDataSelectedGroup() throws Exception {
+		_addFileEntry(_group, "java");
+		_addFileEntry(_group, "liferay");
+
+		Group group2 = GroupTestUtil.addGroup();
+
+		try {
+			Map<String, Object> data = _getData(group2);
+
+			JSONArray fileExtensionGroupsJSONArray = (JSONArray)data.get(
+				"fileExtensionGroups");
+
+			Assert.assertEquals(0, fileExtensionGroupsJSONArray.length());
+
+			_addFileEntry(group2, "xls");
+			_addFileEntry(group2, "zip");
+
+			data = _getData(group2);
+
+			fileExtensionGroupsJSONArray = (JSONArray)data.get(
+				"fileExtensionGroups");
+
+			Assert.assertEquals(2, fileExtensionGroupsJSONArray.length());
+		}
+		finally {
+			_groupLocalService.deleteGroup(group2);
+		}
 	}
 
 	private FileEntry _addFileEntry(Group group, String fileExtension)
@@ -240,5 +271,8 @@ public class ContentDashboardFileExtensionItemSelectorViewTest {
 
 	@DeleteAfterTestRun
 	private Group _group;
+
+	@Inject
+	private GroupLocalService _groupLocalService;
 
 }

--- a/modules/apps/content-dashboard/content-dashboard-document-library-test/src/testIntegration/java/com/liferay/content/dashboard/document/library/internal/item/selector/test/ContentDashboardFileExtensionItemSelectorViewTest.java
+++ b/modules/apps/content-dashboard/content-dashboard-document-library-test/src/testIntegration/java/com/liferay/content/dashboard/document/library/internal/item/selector/test/ContentDashboardFileExtensionItemSelectorViewTest.java
@@ -19,6 +19,7 @@ import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLAppLocalServiceUtil;
 import com.liferay.item.selector.ItemSelectorCriterion;
 import com.liferay.item.selector.ItemSelectorView;
+import com.liferay.item.selector.criteria.file.criterion.FileExtensionItemSelectorCriterion;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.model.Group;
@@ -191,7 +192,8 @@ public class ContentDashboardFileExtensionItemSelectorViewTest {
 			WebKeys.THEME_DISPLAY, themeDisplay);
 
 		_contentDashboardFileExtensionItemSelectorView.renderHTML(
-			mockHttpServletRequest, new MockHttpServletResponse(), null,
+			mockHttpServletRequest, new MockHttpServletResponse(),
+			new FileExtensionItemSelectorCriterion(),
 			new MockLiferayPortletURL(), RandomTestUtil.randomString(), true);
 
 		Object contentDashboardFileExtensionItemSelectorViewDisplayContext =

--- a/modules/apps/content-dashboard/content-dashboard-document-library-test/src/testIntegration/java/com/liferay/content/dashboard/document/library/internal/item/selector/test/ContentDashboardFileExtensionItemSelectorViewTest.java
+++ b/modules/apps/content-dashboard/content-dashboard-document-library-test/src/testIntegration/java/com/liferay/content/dashboard/document/library/internal/item/selector/test/ContentDashboardFileExtensionItemSelectorViewTest.java
@@ -81,18 +81,18 @@ public class ContentDashboardFileExtensionItemSelectorViewTest {
 
 	@Test
 	public void testGetData() throws Exception {
-		_addFileEntry("java");
-		_addFileEntry("liferay");
-		_addFileEntry("mp3");
-		_addFileEntry("mp4");
-		_addFileEntry("pdf");
-		_addFileEntry("png");
-		_addFileEntry("ppt");
-		_addFileEntry("txt");
-		_addFileEntry("xls");
-		_addFileEntry("zip");
+		_addFileEntry(_group, "java");
+		_addFileEntry(_group, "liferay");
+		_addFileEntry(_group, "mp3");
+		_addFileEntry(_group, "mp4");
+		_addFileEntry(_group, "pdf");
+		_addFileEntry(_group, "png");
+		_addFileEntry(_group, "ppt");
+		_addFileEntry(_group, "txt");
+		_addFileEntry(_group, "xls");
+		_addFileEntry(_group, "zip");
 
-		Map<String, Object> data = _getData();
+		Map<String, Object> data = _getData(null);
 
 		JSONArray fileExtensionGroupsJSONArray = (JSONArray)data.get(
 			"fileExtensionGroups");
@@ -133,14 +133,16 @@ public class ContentDashboardFileExtensionItemSelectorViewTest {
 		Assert.assertNotNull(data.get("itemSelectorSaveEvent"));
 	}
 
-	private FileEntry _addFileEntry(String fileExtension) throws Exception {
+	private FileEntry _addFileEntry(Group group, String fileExtension)
+		throws Exception {
+
 		return DLAppLocalServiceUtil.addFileEntry(
 			RandomTestUtil.randomString(), TestPropsValues.getUserId(),
-			_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString() + "." + fileExtension,
 			MimeTypesUtil.getExtensionContentType(fileExtension), new byte[0],
 			null, null,
-			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
 	}
 
 	private void _assertExtensionGroupJSONObject(
@@ -165,7 +167,7 @@ public class ContentDashboardFileExtensionItemSelectorViewTest {
 			fileExtensionJSONObject.getString("fileExtension"));
 	}
 
-	private Map<String, Object> _getData() throws Exception {
+	private Map<String, Object> _getData(Group group) throws Exception {
 		MockHttpServletRequest mockHttpServletRequest =
 			new MockHttpServletRequest();
 
@@ -191,10 +193,18 @@ public class ContentDashboardFileExtensionItemSelectorViewTest {
 		mockHttpServletRequest.setAttribute(
 			WebKeys.THEME_DISPLAY, themeDisplay);
 
+		FileExtensionItemSelectorCriterion fileExtensionItemSelectorCriterion =
+			new FileExtensionItemSelectorCriterion();
+
+		if (group != null) {
+			fileExtensionItemSelectorCriterion.setSelectedGroupIds(
+				new long[] {group.getGroupId()});
+		}
+
 		_contentDashboardFileExtensionItemSelectorView.renderHTML(
 			mockHttpServletRequest, new MockHttpServletResponse(),
-			new FileExtensionItemSelectorCriterion(),
-			new MockLiferayPortletURL(), RandomTestUtil.randomString(), true);
+			fileExtensionItemSelectorCriterion, new MockLiferayPortletURL(),
+			RandomTestUtil.randomString(), true);
 
 		Object contentDashboardFileExtensionItemSelectorViewDisplayContext =
 			mockHttpServletRequest.getAttribute(

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
@@ -776,20 +776,14 @@ public class DLAdminManagementToolbarDisplayContext
 			"singleSelect", false
 		).setParameter(
 			"vocabularyIds",
-			() -> {
-				ThemeDisplay themeDisplay =
-					(ThemeDisplay)_liferayPortletRequest.getAttribute(
-						WebKeys.THEME_DISPLAY);
-
-				return StringUtil.merge(
-					AssetVocabularyServiceUtil.getGroupsVocabularies(
-						PortalUtil.getCurrentAndAncestorSiteGroupIds(
-							themeDisplay.getScopeGroupId()),
-						DLFileEntryConstants.getClassName()),
-					assetVocabulary -> String.valueOf(
-						assetVocabulary.getVocabularyId()),
-					StringPool.COMMA);
-			}
+			StringUtil.merge(
+				AssetVocabularyServiceUtil.getGroupsVocabularies(
+					PortalUtil.getCurrentAndAncestorSiteGroupIds(
+						_themeDisplay.getScopeGroupId()),
+					DLFileEntryConstants.getClassName()),
+				assetVocabulary -> String.valueOf(
+					assetVocabulary.getVocabularyId()),
+				StringPool.COMMA)
 		).setWindowState(
 			LiferayWindowState.POP_UP
 		).buildString();
@@ -805,16 +799,10 @@ public class DLAdminManagementToolbarDisplayContext
 			_liferayPortletResponse.getNamespace() + "selectedAssetTag"
 		).setParameter(
 			"groupIds",
-			() -> {
-				ThemeDisplay themeDisplay =
-					(ThemeDisplay)_liferayPortletRequest.getAttribute(
-						WebKeys.THEME_DISPLAY);
-
-				return StringUtil.merge(
-					PortalUtil.getCurrentAndAncestorSiteGroupIds(
-						themeDisplay.getScopeGroupId()),
-					StringPool.COMMA);
-			}
+			StringUtil.merge(
+				PortalUtil.getCurrentAndAncestorSiteGroupIds(
+					_themeDisplay.getScopeGroupId()),
+				StringPool.COMMA)
 		).setParameter(
 			"selectedTagNames",
 			StringUtil.merge(
@@ -900,12 +888,8 @@ public class DLAdminManagementToolbarDisplayContext
 		fileExtensionItemSelectorCriterion.setDesiredItemSelectorReturnTypes(
 			Collections.singletonList(new UUIDItemSelectorReturnType()));
 
-		ThemeDisplay themeDisplay =
-			(ThemeDisplay)_liferayPortletRequest.getAttribute(
-				WebKeys.THEME_DISPLAY);
-
 		fileExtensionItemSelectorCriterion.setSelectedGroupIds(
-			new long[] {themeDisplay.getScopeGroupId()});
+			new long[] {_themeDisplay.getScopeGroupId()});
 
 		PortletResponse portletResponse =
 			(PortletResponse)_httpServletRequest.getAttribute(

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
@@ -537,7 +537,7 @@ public class DLAdminManagementToolbarDisplayContext
 			"assetCategoryId",
 			() -> {
 				long[] assetCategoryIds = ArrayUtil.toLongArray(
-					_getSelectedAssetCategoryIds(_httpServletRequest));
+					_getSelectedAssetCategoryIds());
 
 				if (ArrayUtil.isNotEmpty(assetCategoryIds)) {
 					return ArrayUtil.toStringArray(assetCategoryIds);
@@ -549,7 +549,7 @@ public class DLAdminManagementToolbarDisplayContext
 			"assetTagId",
 			() -> {
 				String[] assetTagIds = ArrayUtil.toStringArray(
-					_getSelectedAssetTagIds(_httpServletRequest));
+					_getSelectedAssetTagIds());
 
 				if (ArrayUtil.isNotEmpty(assetTagIds)) {
 					return assetTagIds;
@@ -584,7 +584,7 @@ public class DLAdminManagementToolbarDisplayContext
 		).setParameter(
 			"extension",
 			() -> {
-				String[] extensions = _getExtensions(_httpServletRequest);
+				String[] extensions = _getExtensions();
 
 				if (ArrayUtil.isNotEmpty(extensions)) {
 					return extensions;
@@ -664,8 +664,7 @@ public class DLAdminManagementToolbarDisplayContext
 	private void _addAssetCategoriesFilterLabelItems(
 		LabelItemListBuilder.LabelItemListWrapper labelItemListWrapper) {
 
-		Set<Long> assetCategoryIds = _getSelectedAssetCategoryIds(
-			_httpServletRequest);
+		Set<Long> assetCategoryIds = _getSelectedAssetCategoryIds();
 
 		for (Long assetCategoryId : assetCategoryIds) {
 			labelItemListWrapper.add(
@@ -707,7 +706,7 @@ public class DLAdminManagementToolbarDisplayContext
 	private void _addAssetTagsFilterLabelItems(
 		LabelItemListBuilder.LabelItemListWrapper labelItemListWrapper) {
 
-		Set<String> assetTagIds = _getSelectedAssetTagIds(_httpServletRequest);
+		Set<String> assetTagIds = _getSelectedAssetTagIds();
 
 		for (String assetTagId : assetTagIds) {
 			labelItemListWrapper.add(
@@ -737,7 +736,7 @@ public class DLAdminManagementToolbarDisplayContext
 	private void _addExtensionFilterLabelItems(
 		LabelItemListBuilder.LabelItemListWrapper labelItemListWrapper) {
 
-		String[] extensions = _getExtensions(_httpServletRequest);
+		String[] extensions = _getExtensions();
 
 		if (ArrayUtil.isEmpty(extensions)) {
 			return;
@@ -767,9 +766,7 @@ public class DLAdminManagementToolbarDisplayContext
 			_liferayPortletResponse.getNamespace() + "selectedAssetCategory"
 		).setParameter(
 			"selectedCategories",
-			StringUtil.merge(
-				_getSelectedAssetCategoryIds(_httpServletRequest),
-				StringPool.COMMA)
+			StringUtil.merge(_getSelectedAssetCategoryIds(), StringPool.COMMA)
 		).setParameter(
 			"showSelectedCounter", true
 		).setParameter(
@@ -805,8 +802,7 @@ public class DLAdminManagementToolbarDisplayContext
 				StringPool.COMMA)
 		).setParameter(
 			"selectedTagNames",
-			StringUtil.merge(
-				_getSelectedAssetTagIds(_httpServletRequest), StringPool.COMMA)
+			StringUtil.merge(_getSelectedAssetTagIds(), StringPool.COMMA)
 		).setWindowState(
 			LiferayWindowState.POP_UP
 		).buildString();
@@ -839,14 +835,14 @@ public class DLAdminManagementToolbarDisplayContext
 		sortingURL.setParameter(
 			"fileEntryTypeId", String.valueOf(_getFileEntryTypeId()));
 
-		String[] extensions = _getExtensions(_httpServletRequest);
+		String[] extensions = _getExtensions();
 
 		if (ArrayUtil.isNotEmpty(extensions)) {
 			sortingURL.setParameter("extension", extensions);
 		}
 
 		long[] assetCategoryIds = ArrayUtil.toLongArray(
-			_getSelectedAssetCategoryIds(_httpServletRequest));
+			_getSelectedAssetCategoryIds());
 
 		if (ArrayUtil.isNotEmpty(assetCategoryIds)) {
 			sortingURL.setParameter(
@@ -854,7 +850,7 @@ public class DLAdminManagementToolbarDisplayContext
 		}
 
 		String[] assetTagIds = ArrayUtil.toStringArray(
-			_getSelectedAssetTagIds(_httpServletRequest));
+			_getSelectedAssetTagIds());
 
 		if (ArrayUtil.isNotEmpty(assetTagIds)) {
 			sortingURL.setParameter("assetTagId", assetTagIds);
@@ -874,8 +870,8 @@ public class DLAdminManagementToolbarDisplayContext
 		return dlPortletInstanceSettings.getDisplayViews();
 	}
 
-	private String[] _getExtensions(HttpServletRequest httpServletRequest) {
-		return ParamUtil.getStringValues(httpServletRequest, "extension");
+	private String[] _getExtensions() {
+		return ParamUtil.getStringValues(_httpServletRequest, "extension");
 	}
 
 	private String _getExtensionsItemSelectorURL() {
@@ -905,7 +901,7 @@ public class DLAdminManagementToolbarDisplayContext
 				portletResponse.getNamespace() + "selectedFileExtension",
 				fileExtensionItemSelectorCriterion)
 		).setParameter(
-			"checkedFileExtensions", () -> _getExtensions(httpServletRequest)
+			"checkedFileExtensions", () -> _getExtensions()
 		).buildString();
 	}
 
@@ -914,15 +910,14 @@ public class DLAdminManagementToolbarDisplayContext
 	}
 
 	private List<DropdownItem> _getFilterNavigationDropdownItems() {
-		boolean extensionsIsEmpty = ArrayUtil.isEmpty(
-			_getExtensions(_httpServletRequest));
+		boolean extensionsIsEmpty = ArrayUtil.isEmpty(_getExtensions());
 		long fileEntryTypeId = _getFileEntryTypeId();
 		String navigation = ParamUtil.getString(
 			_httpServletRequest, "navigation", "home");
 		boolean selectedAssetCategoryIdsIsEmpty = SetUtil.isEmpty(
-			_getSelectedAssetCategoryIds(_httpServletRequest));
+			_getSelectedAssetCategoryIds());
 		boolean selectedAssetTagIdsIsEmpty = SetUtil.isEmpty(
-			_getSelectedAssetTagIds(_httpServletRequest));
+			_getSelectedAssetTagIds());
 
 		return DropdownItemListBuilder.add(
 			dropdownItem -> {
@@ -1137,28 +1132,24 @@ public class DLAdminManagementToolbarDisplayContext
 		return _dlAdminDisplayContext.getRepositoryId();
 	}
 
-	private Set<Long> _getSelectedAssetCategoryIds(
-		HttpServletRequest httpServletRequest) {
-
+	private Set<Long> _getSelectedAssetCategoryIds() {
 		if (_assetCategoryIds != null) {
 			return _assetCategoryIds;
 		}
 
 		_assetCategoryIds = SetUtil.fromArray(
-			ParamUtil.getLongValues(httpServletRequest, "assetCategoryId"));
+			ParamUtil.getLongValues(_httpServletRequest, "assetCategoryId"));
 
 		return _assetCategoryIds;
 	}
 
-	private Set<String> _getSelectedAssetTagIds(
-		HttpServletRequest httpServletRequest) {
-
+	private Set<String> _getSelectedAssetTagIds() {
 		if (_assetTagIds != null) {
 			return _assetTagIds;
 		}
 
 		_assetTagIds = SetUtil.fromArray(
-			ParamUtil.getStringValues(httpServletRequest, "assetTagId"));
+			ParamUtil.getStringValues(_httpServletRequest, "assetTagId"));
 
 		return _assetTagIds;
 	}

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
@@ -900,6 +900,13 @@ public class DLAdminManagementToolbarDisplayContext
 		fileExtensionItemSelectorCriterion.setDesiredItemSelectorReturnTypes(
 			Collections.singletonList(new UUIDItemSelectorReturnType()));
 
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)_liferayPortletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		fileExtensionItemSelectorCriterion.setSelectedGroupIds(
+			new long[] {themeDisplay.getScopeGroupId()});
+
 		PortletResponse portletResponse =
 			(PortletResponse)_httpServletRequest.getAttribute(
 				JavaConstants.JAVAX_PORTLET_RESPONSE);

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
@@ -67,7 +67,6 @@ import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactoryUtil;
 import com.liferay.portal.kernel.portlet.toolbar.contributor.PortletToolbarContributor;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.service.ClassNameLocalServiceUtil;
-import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.servlet.taglib.ui.Menu;
 import com.liferay.portal.kernel.servlet.taglib.ui.URLMenuItem;
 import com.liferay.portal.kernel.theme.PortletDisplay;
@@ -812,8 +811,8 @@ public class DLAdminManagementToolbarDisplayContext
 						WebKeys.THEME_DISPLAY);
 
 				return StringUtil.merge(
-					GroupLocalServiceUtil.getGroupIds(
-						themeDisplay.getCompanyId(), true),
+					PortalUtil.getCurrentAndAncestorSiteGroupIds(
+						themeDisplay.getScopeGroupId()),
 					StringPool.COMMA);
 			}
 		).setParameter(

--- a/modules/apps/item-selector/item-selector-criteria-api/bnd.bnd
+++ b/modules/apps/item-selector/item-selector-criteria-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Item Selector Criteria API
 Bundle-SymbolicName: com.liferay.item.selector.criteria.api
-Bundle-Version: 10.2.1
+Bundle-Version: 10.3.0
 Export-Package:\
 	com.liferay.item.selector.criteria,\
 	com.liferay.item.selector.criteria.asset.criterion,\

--- a/modules/apps/item-selector/item-selector-criteria-api/src/main/java/com/liferay/item/selector/criteria/file/criterion/FileExtensionItemSelectorCriterion.java
+++ b/modules/apps/item-selector/item-selector-criteria-api/src/main/java/com/liferay/item/selector/criteria/file/criterion/FileExtensionItemSelectorCriterion.java
@@ -21,4 +21,15 @@ import com.liferay.item.selector.BaseItemSelectorCriterion;
  */
 public class FileExtensionItemSelectorCriterion
 	extends BaseItemSelectorCriterion {
+
+	public long[] getSelectedGroupIds() {
+		return _selectedGroupIds;
+	}
+
+	public void setSelectedGroupIds(long[] selectedGroupIds) {
+		_selectedGroupIds = selectedGroupIds;
+	}
+
+	private long[] _selectedGroupIds;
+
 }

--- a/modules/apps/item-selector/item-selector-criteria-api/src/main/resources/com/liferay/item/selector/criteria/file/criterion/packageinfo
+++ b/modules/apps/item-selector/item-selector-criteria-api/src/main/resources/com/liferay/item/selector/criteria/file/criterion/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 1.2.0


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-185122


How to test

Enable the feature flag "LPS-84424"

tags:

1. Create on site Global : globalTag1 , globalTag2
2. Create on site Liferay : tag1 , tag2
3. Add a new site (site2)
4. Create on site2 : tagSite2_1 , tagSite2_2
5. Go to Liferay Site
6. Go to Documents and Media
7. Go to Filter and Order > Tags

- Only   globalTag1 , globalTag2, tag1 and tag2 is shown


extensions:

1. Create on site Global new Document : Document.css
2. Create on site Liferay : document.png
3. Add a new site (site2) (if not created)
4. Create on site2 new Document : Document.doc
5. Go to Liferay Site
6. Go to Documents and Media
7. Go to Filter and Order > Extension

- only png extension is shown





- LPS-185122 show only the tags for the current group and Ancestors (Global)
- LPS-185122 add selectedGroupId to FileExtensionItemSelectorCriterion to filter the groups
- LPS-185122 baseline
- LPS-185122 add the new field of groups to the search content
- LPS-185122 add the current scoped group to the fileExtensionItemSelectorCriterion to filter only the extension for the group that I'm currently. On this case we only will see the scoped group not the ancestors because we only show Documents of the groups and for the local repositories.
