### PR TITLE
LPS-185580 Improve the error message on PDFPreview instance/site settings with 0 value entered

### DIFF
--- a/modules/apps/document-library/document-library-preview-pdf/src/main/java/com/liferay/document/library/preview/pdf/internal/configuration/admin/service/PDFPreviewManagedServiceFactory.java
+++ b/modules/apps/document-library/document-library-preview-pdf/src/main/java/com/liferay/document/library/preview/pdf/internal/configuration/admin/service/PDFPreviewManagedServiceFactory.java
@@ -320,9 +320,7 @@ public class PDFPreviewManagedServiceFactory implements ManagedServiceFactory {
 	}
 
 	private boolean _isMaxNumberOfPagesLimitExceeded(int limit, int value) {
-		if (((limit != 0) && (value != 0) && (limit < value)) ||
-			((limit != 0) && (value == 0))) {
-
+		if ((limit != 0) && ((value == 0) || (limit < value))) {
 			return true;
 		}
 

--- a/modules/apps/document-library/document-library-preview-pdf/src/main/java/com/liferay/document/library/preview/pdf/internal/configuration/admin/service/PDFPreviewManagedServiceFactory.java
+++ b/modules/apps/document-library/document-library-preview-pdf/src/main/java/com/liferay/document/library/preview/pdf/internal/configuration/admin/service/PDFPreviewManagedServiceFactory.java
@@ -200,9 +200,8 @@ public class PDFPreviewManagedServiceFactory implements ManagedServiceFactory {
 		if (scope.equals(
 				ExtendedObjectClassDefinition.Scope.COMPANY.getValue())) {
 
-			if (((systemMaxNumberOfPages != 0) && (maxNumberOfPages != 0) &&
-				 (systemMaxNumberOfPages < maxNumberOfPages)) ||
-				((systemMaxNumberOfPages != 0) && (maxNumberOfPages == 0))) {
+			if (_isMaxNumberOfPagesLimitExceeded(
+					systemMaxNumberOfPages, maxNumberOfPages)) {
 
 				throw new PDFPreviewException(systemMaxNumberOfPages);
 			}
@@ -212,9 +211,8 @@ public class PDFPreviewManagedServiceFactory implements ManagedServiceFactory {
 		else if (scope.equals(
 					ExtendedObjectClassDefinition.Scope.GROUP.getValue())) {
 
-			if (((systemMaxNumberOfPages != 0) && (maxNumberOfPages != 0) &&
-				 (systemMaxNumberOfPages < maxNumberOfPages)) ||
-				((systemMaxNumberOfPages != 0) && (maxNumberOfPages == 0))) {
+			if (_isMaxNumberOfPagesLimitExceeded(
+					systemMaxNumberOfPages, maxNumberOfPages)) {
 
 				throw new PDFPreviewException(systemMaxNumberOfPages);
 			}
@@ -224,9 +222,8 @@ public class PDFPreviewManagedServiceFactory implements ManagedServiceFactory {
 			int companyMaxNumberOfPages = _getCompanyMaxNumberOfPages(
 				group.getCompanyId());
 
-			if (((companyMaxNumberOfPages != 0) && (maxNumberOfPages != 0) &&
-				 (companyMaxNumberOfPages < maxNumberOfPages)) ||
-				((companyMaxNumberOfPages != 0) && (maxNumberOfPages == 0))) {
+			if (_isMaxNumberOfPagesLimitExceeded(
+					companyMaxNumberOfPages, maxNumberOfPages)) {
 
 				throw new PDFPreviewException(companyMaxNumberOfPages);
 			}
@@ -320,6 +317,16 @@ public class PDFPreviewManagedServiceFactory implements ManagedServiceFactory {
 
 	private int _getSystemMaxNumberOfPages() {
 		return _systemPDFPreviewConfiguration.maxNumberOfPages();
+	}
+
+	private boolean _isMaxNumberOfPagesLimitExceeded(int limit, int value) {
+		if (((limit != 0) && (value != 0) && (limit < value)) ||
+			((limit != 0) && (value == 0))) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 	private void _unmapPid(String pid) {

--- a/modules/apps/document-library/document-library-preview-pdf/src/main/java/com/liferay/document/library/preview/pdf/internal/configuration/admin/service/PDFPreviewManagedServiceFactory.java
+++ b/modules/apps/document-library/document-library-preview-pdf/src/main/java/com/liferay/document/library/preview/pdf/internal/configuration/admin/service/PDFPreviewManagedServiceFactory.java
@@ -200,8 +200,9 @@ public class PDFPreviewManagedServiceFactory implements ManagedServiceFactory {
 		if (scope.equals(
 				ExtendedObjectClassDefinition.Scope.COMPANY.getValue())) {
 
-			if ((systemMaxNumberOfPages != 0) && (maxNumberOfPages != 0) &&
-				(systemMaxNumberOfPages < maxNumberOfPages)) {
+			if (((systemMaxNumberOfPages != 0) && (maxNumberOfPages != 0) &&
+				 (systemMaxNumberOfPages < maxNumberOfPages)) ||
+				((systemMaxNumberOfPages != 0) && (maxNumberOfPages == 0))) {
 
 				throw new PDFPreviewException(systemMaxNumberOfPages);
 			}
@@ -211,8 +212,9 @@ public class PDFPreviewManagedServiceFactory implements ManagedServiceFactory {
 		else if (scope.equals(
 					ExtendedObjectClassDefinition.Scope.GROUP.getValue())) {
 
-			if ((systemMaxNumberOfPages != 0) && (maxNumberOfPages != 0) &&
-				(systemMaxNumberOfPages < maxNumberOfPages)) {
+			if (((systemMaxNumberOfPages != 0) && (maxNumberOfPages != 0) &&
+				 (systemMaxNumberOfPages < maxNumberOfPages)) ||
+				((systemMaxNumberOfPages != 0) && (maxNumberOfPages == 0))) {
 
 				throw new PDFPreviewException(systemMaxNumberOfPages);
 			}
@@ -222,8 +224,9 @@ public class PDFPreviewManagedServiceFactory implements ManagedServiceFactory {
 			int companyMaxNumberOfPages = _getCompanyMaxNumberOfPages(
 				group.getCompanyId());
 
-			if ((companyMaxNumberOfPages != 0) && (maxNumberOfPages != 0) &&
-				(companyMaxNumberOfPages < maxNumberOfPages)) {
+			if (((companyMaxNumberOfPages != 0) && (maxNumberOfPages != 0) &&
+				 (companyMaxNumberOfPages < maxNumberOfPages)) ||
+				((companyMaxNumberOfPages != 0) && (maxNumberOfPages == 0))) {
 
 				throw new PDFPreviewException(companyMaxNumberOfPages);
 			}

--- a/modules/apps/document-library/document-library-preview-pdf/src/main/resources/META-INF/resources/document_library_preview_pdf_settings/js/PDFPreviewLimit.js
+++ b/modules/apps/document-library/document-library-preview-pdf/src/main/resources/META-INF/resources/document_library_preview_pdf_settings/js/PDFPreviewLimit.js
@@ -26,10 +26,7 @@ const PDFPreviewLimit = ({maxLimitSize, namespace, scopeLabel, value}) => {
 
 		setInputValue(value);
 
-		setError(
-			(maxLimitSize > 0 && value > maxLimitSize) ||
-				(maxLimitSize > 0 && value === 0)
-		);
+		setError(maxLimitSize > 0 && (value > maxLimitSize || value === 0));
 	};
 
 	return (

--- a/modules/apps/document-library/document-library-preview-pdf/src/main/resources/META-INF/resources/document_library_preview_pdf_settings/js/PDFPreviewLimit.js
+++ b/modules/apps/document-library/document-library-preview-pdf/src/main/resources/META-INF/resources/document_library_preview_pdf_settings/js/PDFPreviewLimit.js
@@ -22,11 +22,14 @@ const PDFPreviewLimit = ({maxLimitSize, namespace, scopeLabel, value}) => {
 	const [inputValue, setInputValue] = useState(value);
 
 	const onChange = (event) => {
-		const value = event.target.value;
+		const value = parseInt(event.target.value, 10);
 
 		setInputValue(value);
 
-		setError(maxLimitSize > 0 && value > maxLimitSize);
+		setError(
+			(maxLimitSize > 0 && value > maxLimitSize) ||
+				(maxLimitSize > 0 && value === 0)
+		);
 	};
 
 	return (


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-185580


Steps to reproduce:

1. Go to System Settings -> Content and Data -> Documents and Media -> System Scope -> PDF Preview and define 3 for Maximum Number of Pages value
2. Go to Instance Settings -> Content and Data -> Documents and Media -> Virtual Instance Scope -> PDF Preview and define 0 for Maximum Number of Pages value. Save.
3. Go to Configuration > Site Settings -> Content and Data -> Documents and Media -> PDF Preview and define 0 for Maximum Number of Pages value. Save.

**Expected result**: error message is shown. You can not set a unlimited value when upper limit is set



https://github.com/liferay-lima/liferay-portal/assets/47524751/4a05af0c-67c7-4cb4-a036-caedf3db3665




- LPS-185580 if the maxNumberOfPages is 0 take it like is an unlimited value a throw error
- LPS-185580 extract method to know if the max is reached or not
- LPS-185580 error shown if the value is 0 and the maxLimitSize > 0 on js
