### PR TITLE
Lps 159384 Reuse logic from PortalUtil in BasePortletLayoutFinder

### DIFF
--- a/portal-impl/src/com/liferay/portal/model/impl/LayoutTypePortletImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/LayoutTypePortletImpl.java
@@ -268,6 +268,39 @@ public class LayoutTypePortletImpl
 	}
 
 	@Override
+	public List<Portlet> getAllNonembeddedPortlets() {
+		List<Portlet> staticPortlets = getStaticPortlets(
+			PropsKeys.LAYOUT_STATIC_PORTLETS_ALL);
+
+		List<Portlet> explicitlyAddedPortlets = new ArrayList<>();
+
+		Layout layout = getLayout();
+
+		if (layout.isTypeAssetDisplay() || layout.isTypeContent()) {
+			List<com.liferay.portal.kernel.model.PortletPreferences>
+				portletPreferencesList =
+					PortletPreferencesLocalServiceUtil.
+						getPortletPreferencesByPlid(layout.getPlid());
+
+			for (com.liferay.portal.kernel.model.PortletPreferences
+					portletPreferences : portletPreferencesList) {
+
+				Portlet portlet = PortletLocalServiceUtil.getPortletById(
+					layout.getCompanyId(), portletPreferences.getPortletId());
+
+				if (portlet != null) {
+					explicitlyAddedPortlets.add(portlet);
+				}
+			}
+		}
+		else {
+			explicitlyAddedPortlets = getExplicitlyAddedPortlets(false);
+		}
+
+		return addStaticPortlets(explicitlyAddedPortlets, staticPortlets, null);
+	}
+
+	@Override
 	public List<Portlet> getAllPortlets() {
 		return addStaticPortlets(
 			getExplicitlyAddedPortlets(),

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -138,7 +138,6 @@ import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.service.LayoutSetLocalServiceUtil;
 import com.liferay.portal.kernel.service.OrganizationLocalServiceUtil;
 import com.liferay.portal.kernel.service.PortletLocalServiceUtil;
-import com.liferay.portal.kernel.service.PortletPreferencesLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalServiceUtil;
 import com.liferay.portal.kernel.service.TicketLocalServiceUtil;
@@ -8243,40 +8242,6 @@ public class PortalImpl implements Portal {
 		return i18nErrorPath.concat(redirect);
 	}
 
-	private List<Portlet> _getAllNonembeddedPortlets(
-		Layout layout, LayoutTypePortlet layoutTypePortlet) {
-
-		List<Portlet> staticPortlets = layoutTypePortlet.getStaticPortlets(
-			PropsKeys.LAYOUT_STATIC_PORTLETS_ALL);
-
-		List<Portlet> explicitlyAddedPortlets = new ArrayList<>();
-
-		if (layout.isTypeAssetDisplay() || layout.isTypeContent()) {
-			List<com.liferay.portal.kernel.model.PortletPreferences>
-				portletPreferencesList =
-					PortletPreferencesLocalServiceUtil.
-						getPortletPreferencesByPlid(layout.getPlid());
-
-			for (com.liferay.portal.kernel.model.PortletPreferences
-					portletPreferences : portletPreferencesList) {
-
-				Portlet portlet = PortletLocalServiceUtil.getPortletById(
-					layout.getCompanyId(), portletPreferences.getPortletId());
-
-				if (portlet != null) {
-					explicitlyAddedPortlets.add(portlet);
-				}
-			}
-		}
-		else {
-			explicitlyAddedPortlets =
-				layoutTypePortlet.getExplicitlyAddedPortlets(false);
-		}
-
-		return layoutTypePortlet.addStaticPortlets(
-			explicitlyAddedPortlets, staticPortlets, null);
-	}
-
 	private String _getDefaultVirtualHostname(Company company) {
 		if ((company != null) &&
 			Validator.isNotNull(company.getVirtualHostname())) {
@@ -8853,9 +8818,7 @@ public class PortalImpl implements Portal {
 		LayoutTypePortlet layoutTypePortlet =
 			(LayoutTypePortlet)layout.getLayoutType();
 
-		for (Portlet portlet :
-				_getAllNonembeddedPortlets(layout, layoutTypePortlet)) {
-
+		for (Portlet portlet : layoutTypePortlet.getAllNonembeddedPortlets()) {
 			if (portletId.equals(portlet.getPortletId()) ||
 				portletId.equals(portlet.getRootPortletId())) {
 

--- a/portal-kernel/src/com/liferay/portal/kernel/model/LayoutTypePortlet.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/LayoutTypePortlet.java
@@ -73,6 +73,8 @@ public interface LayoutTypePortlet extends LayoutType {
 
 	public String getAddedCustomPortletMode();
 
+	public List<Portlet> getAllNonembeddedPortlets();
+
 	public List<Portlet> getAllPortlets();
 
 	public List<Portlet> getAllPortlets(boolean includeSystem);

--- a/portal-kernel/src/com/liferay/portal/kernel/model/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/packageinfo
@@ -1,1 +1,1 @@
-version 29.2.0
+version 30.0.0

--- a/portal-kernel/src/com/liferay/portal/kernel/portlet/BasePortletLayoutFinder.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/portlet/BasePortletLayoutFinder.java
@@ -15,7 +15,6 @@
 package com.liferay.portal.kernel.portlet;
 
 import com.liferay.petra.string.StringBundler;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.NoSuchLayoutException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
@@ -24,20 +23,17 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.model.LayoutTypePortlet;
+import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
-import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.service.PortletPreferencesLocalServiceUtil;
 import com.liferay.portal.kernel.service.permission.LayoutPermissionUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.ObjectValuePair;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PortletKeys;
-import com.liferay.portal.kernel.util.Validator;
 import com.liferay.sites.kernel.util.SitesUtil;
 
-import java.util.Arrays;
 import java.util.List;
 
 import javax.portlet.PortletPreferences;
@@ -120,12 +116,14 @@ public abstract class BasePortletLayoutFinder implements PortletLayoutFinder {
 	protected String getPortletId(
 		LayoutTypePortlet layoutTypePortlet, String portletId) {
 
-		for (String curPortletId : layoutTypePortlet.getPortletIds()) {
+		for (Portlet curPortletId :
+				layoutTypePortlet.getAllNonembeddedPortlets()) {
+
 			String curRootPortletId = PortletIdCodec.decodePortletName(
-				curPortletId);
+				curPortletId.getPortletId());
 
 			if (portletId.equals(curRootPortletId)) {
-				return curPortletId;
+				return curPortletId.getPortletId();
 			}
 		}
 
@@ -185,31 +183,31 @@ public abstract class BasePortletLayoutFinder implements PortletLayoutFinder {
 
 		Object[] fallbackPlidAndPortletId = null;
 
-		for (String portletId : portletIds) {
-			ObjectValuePair<Long, String> plidAndPortletIdObjectValuePair =
-				_getPlidPortletIdObjectValuePair(groupId, portletId);
-
-			long plid = plidAndPortletIdObjectValuePair.getKey();
+		for (String curPortletId : portletIds) {
+			long plid = PortalUtil.getPlidFromPortletId(groupId, curPortletId);
 
 			if (plid == LayoutConstants.DEFAULT_PLID) {
 				continue;
 			}
+
+			Layout layout = LayoutLocalServiceUtil.getLayout(plid);
+
+			LayoutTypePortlet layoutTypePortlet =
+				(LayoutTypePortlet)layout.getLayoutType();
+
+			String portletId = getPortletId(layoutTypePortlet, curPortletId);
 
 			if (!LayoutPermissionUtil.contains(
 					permissionChecker, LayoutLocalServiceUtil.getLayout(plid),
 					ActionKeys.VIEW) &&
 				!permissionChecker.isSignedIn()) {
 
-				fallbackPlidAndPortletId = new Object[] {
-					plid, plidAndPortletIdObjectValuePair.getValue(), true
-				};
+				fallbackPlidAndPortletId = new Object[] {plid, portletId, true};
 
 				continue;
 			}
 
-			return new Object[] {
-				plid, plidAndPortletIdObjectValuePair.getValue(), false
-			};
+			return new Object[] {plid, portletId, false};
 		}
 
 		return fallbackPlidAndPortletId;
@@ -233,91 +231,6 @@ public abstract class BasePortletLayoutFinder implements PortletLayoutFinder {
 		sb.append("}");
 
 		return sb.toString();
-	}
-
-	private ObjectValuePair<Long, String> _getPlidPortletIdObjectValuePair(
-			long groupId, long scopeGroupId, String portletId)
-		throws PortalException {
-
-		for (boolean privateLayout : Arrays.asList(false, true)) {
-			List<Layout> layouts = LayoutLocalServiceUtil.getLayouts(
-				groupId, privateLayout,
-				new String[] {
-					LayoutConstants.TYPE_CONTENT,
-					LayoutConstants.TYPE_FULL_PAGE_APPLICATION,
-					LayoutConstants.TYPE_PORTLET
-				});
-
-			for (Layout layout : layouts) {
-				LayoutTypePortlet layoutTypePortlet =
-					(LayoutTypePortlet)layout.getLayoutType();
-
-				String candidatePortletId = getPortletId(
-					layoutTypePortlet, portletId);
-
-				if (Validator.isNotNull(candidatePortletId) &&
-					(_getScopeGroupId(layout, candidatePortletId) ==
-						scopeGroupId)) {
-
-					return new ObjectValuePair<>(
-						layout.getPlid(), candidatePortletId);
-				}
-			}
-		}
-
-		return new ObjectValuePair<>(
-			LayoutConstants.DEFAULT_PLID, StringPool.BLANK);
-	}
-
-	private ObjectValuePair<Long, String> _getPlidPortletIdObjectValuePair(
-			long scopeGroupId, String portletId)
-		throws PortalException {
-
-		Group group = GroupLocalServiceUtil.getGroup(scopeGroupId);
-
-		long groupId = group.getGroupId();
-
-		if (group.isLayout()) {
-			Layout scopeLayout = LayoutLocalServiceUtil.getLayout(
-				group.getClassPK());
-
-			groupId = scopeLayout.getGroupId();
-		}
-
-		return _getPlidPortletIdObjectValuePair(
-			groupId, scopeGroupId, portletId);
-	}
-
-	private long _getScopeGroupId(Layout layout, String portletId)
-		throws PortalException {
-
-		PortletPreferences portletSetup =
-			PortletPreferencesFactoryUtil.getStrictLayoutPortletSetup(
-				layout, portletId);
-
-		String scopeType = GetterUtil.getString(
-			portletSetup.getValue("lfrScopeType", null));
-
-		if (Validator.isNull(scopeType)) {
-			return layout.getGroupId();
-		}
-
-		if (scopeType.equals("company")) {
-			Group companyGroup = GroupLocalServiceUtil.getCompanyGroup(
-				layout.getCompanyId());
-
-			return companyGroup.getGroupId();
-		}
-
-		String scopeLayoutUuid = GetterUtil.getString(
-			portletSetup.getValue("lfrScopeLayoutUuid", null));
-
-		Layout scopeLayout = LayoutLocalServiceUtil.getLayoutByUuidAndGroupId(
-			scopeLayoutUuid, layout.getGroupId(), layout.isPrivateLayout());
-
-		Group scopeGroup = scopeLayout.getScopeGroup();
-
-		return scopeGroup.getGroupId();
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/portal-kernel/src/com/liferay/portal/kernel/service/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/packageinfo
@@ -1,1 +1,1 @@
-version 22.0.0
+version 23.0.0


### PR DESCRIPTION
Hi,
this pull fixes https://issues.liferay.com/browse/LPS-159384

**Reproduction steps:**

- Be sure that your bundle is connected to a fake SMTP server like [fakeSMTP](http://nilhcem.com/FakeSMTP/) or [MockMock](https://github.com/tweakers/MockMock) in order to view the email notifications
- Login with Test user
- Create new folder in Documents and Media
- Create a user 'usr1' and add it as a member of the site 'Guest'
- Create a content page in 'Guest' site
- Add the Documents and media widget to the page created in step 5
- Login or impersonate 'usr1' user
- Subscribe to the folder created in step 3 in order to receive notifications when a new upload is done inside this folder
- Login with Test user
- Add new file to this folder to send new notification to subscribed user

 

 **Expected behavior:**

Customer expect to receive the link using friendlyURL of the page
 

 **Actual behavior:**

The link sent in the email notification is generated for control panel (http://localhost:8080/group/guest/~/control_panel/)
 

**Additional information:**
Class com.liferay.portal.kernel.portlet.BasePortletLayoutFinder implemented its own logic to find portlets added to layouts and it was only compatible with widget pages. My idea was to use already existing logic in PortalUtil.getPlidFromPortletId to achieve this as it is also compatible with content pages.

I also had to move method getAllNonembeddedPortlets from PortlImpl to LayoutTypePortletImpl because all existing methods in this class are only compatible with widget pages so I needed a method compatible also with content pages. It also made sense looking at its logic.