### PR TITLE
LPS-180179 Blog/DM with a DPT can not be accessed through the old friendly URL

### DIFF
--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
@@ -191,15 +191,19 @@ public class FriendlyURLServlet extends HttpServlet {
 					String friendlyURL =
 						layoutFriendlyURLSeparatorComposite.getFriendlyURL();
 
-					String redirectURL = StringBundler.concat(
-						PortalUtil.getPathContext(),
-						PropsValues.LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING,
-						path.substring(0, pos), friendlyURL);
+					String redirectURL = null;
 
 					if (friendlyURLPos > 0) {
 						redirectURL =
 							requestURL.substring(0, friendlyURLPos) +
 								friendlyURL;
+					}
+					else {
+						redirectURL = StringBundler.concat(
+							PortalUtil.getPathContext(),
+							PropsValues.
+								LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING,
+							path.substring(0, pos), friendlyURL);
 					}
 
 					String queryString = HttpComponentsUtil.getQueryString(

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
@@ -65,6 +65,7 @@ import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -182,20 +183,18 @@ public class FriendlyURLServlet extends HttpServlet {
 					layoutFriendlyURLSeparatorComposite.getURLSeparator());
 
 				if (pos != 1) {
-					HttpServletRequest originalHttpServletRequest =
-						portal.getOriginalServletRequest(httpServletRequest);
-
-					String requestURL = HttpComponentsUtil.getRequestURL(
-						originalHttpServletRequest);
+					String requestURL = PortalUtil.getCurrentCompleteURL(
+						httpServletRequest);
 
 					int friendlyURLPos = requestURL.indexOf(layoutFriendlyURL);
 
 					String friendlyURL =
 						layoutFriendlyURLSeparatorComposite.getFriendlyURL();
 
-					String redirectURL =
-						PropsValues.LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING +
-							path.substring(0, pos) + friendlyURL;
+					String redirectURL = StringBundler.concat(
+						PortalUtil.getPathContext(),
+						PropsValues.LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING,
+						path.substring(0, pos), friendlyURL);
 
 					if (friendlyURLPos > 0) {
 						redirectURL =
@@ -204,7 +203,7 @@ public class FriendlyURLServlet extends HttpServlet {
 					}
 
 					String queryString = HttpComponentsUtil.getQueryString(
-						originalHttpServletRequest);
+						portal.getOriginalServletRequest(httpServletRequest));
 
 					if (Validator.isNotNull(queryString)) {
 						redirectURL += StringPool.QUESTION + queryString;


### PR DESCRIPTION
# What is this about?

https://issues.liferay.com/browse/LPS-180179
https://issues.liferay.com/browse/LPS-180047

This fixes two bugs related to the context path. When using a proxy (or changing the ROOT context path), friendly url redirection wouldn't include it and the redirection would fail.

# How do I test it?

Follow the steps described in https://issues.liferay.com/browse/LPS-180179.