### PR TITLE
Lps 159384 Reuse logic from PortalUtil in BasePortletLayoutFinder

### DIFF
--- a/portal-impl/src/com/liferay/portal/model/impl/LayoutTypePortletImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/LayoutTypePortletImpl.java
@@ -268,6 +268,39 @@ public class LayoutTypePortletImpl
 	}
 
 	@Override
+	public List<Portlet> getAllNonembeddedPortlets() {
+		List<Portlet> staticPortlets = getStaticPortlets(
+			PropsKeys.LAYOUT_STATIC_PORTLETS_ALL);
+
+		List<Portlet> explicitlyAddedPortlets = new ArrayList<>();
+
+		Layout layout = getLayout();
+
+		if (layout.isTypeAssetDisplay() || layout.isTypeContent()) {
+			List<com.liferay.portal.kernel.model.PortletPreferences>
+				portletPreferencesList =
+					PortletPreferencesLocalServiceUtil.
+						getPortletPreferencesByPlid(layout.getPlid());
+
+			for (com.liferay.portal.kernel.model.PortletPreferences
+					portletPreferences : portletPreferencesList) {
+
+				Portlet portlet = PortletLocalServiceUtil.getPortletById(
+					layout.getCompanyId(), portletPreferences.getPortletId());
+
+				if (portlet != null) {
+					explicitlyAddedPortlets.add(portlet);
+				}
+			}
+		}
+		else {
+			explicitlyAddedPortlets = getExplicitlyAddedPortlets(false);
+		}
+
+		return addStaticPortlets(explicitlyAddedPortlets, staticPortlets, null);
+	}
+
+	@Override
 	public List<Portlet> getAllPortlets() {
 		return addStaticPortlets(
 			getExplicitlyAddedPortlets(),

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -138,7 +138,6 @@ import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.service.LayoutSetLocalServiceUtil;
 import com.liferay.portal.kernel.service.OrganizationLocalServiceUtil;
 import com.liferay.portal.kernel.service.PortletLocalServiceUtil;
-import com.liferay.portal.kernel.service.PortletPreferencesLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalServiceUtil;
 import com.liferay.portal.kernel.service.TicketLocalServiceUtil;
@@ -8243,40 +8242,6 @@ public class PortalImpl implements Portal {
 		return i18nErrorPath.concat(redirect);
 	}
 
-	private List<Portlet> _getAllNonembeddedPortlets(
-		Layout layout, LayoutTypePortlet layoutTypePortlet) {
-
-		List<Portlet> staticPortlets = layoutTypePortlet.getStaticPortlets(
-			PropsKeys.LAYOUT_STATIC_PORTLETS_ALL);
-
-		List<Portlet> explicitlyAddedPortlets = new ArrayList<>();
-
-		if (layout.isTypeAssetDisplay() || layout.isTypeContent()) {
-			List<com.liferay.portal.kernel.model.PortletPreferences>
-				portletPreferencesList =
-					PortletPreferencesLocalServiceUtil.
-						getPortletPreferencesByPlid(layout.getPlid());
-
-			for (com.liferay.portal.kernel.model.PortletPreferences
-					portletPreferences : portletPreferencesList) {
-
-				Portlet portlet = PortletLocalServiceUtil.getPortletById(
-					layout.getCompanyId(), portletPreferences.getPortletId());
-
-				if (portlet != null) {
-					explicitlyAddedPortlets.add(portlet);
-				}
-			}
-		}
-		else {
-			explicitlyAddedPortlets =
-				layoutTypePortlet.getExplicitlyAddedPortlets(false);
-		}
-
-		return layoutTypePortlet.addStaticPortlets(
-			explicitlyAddedPortlets, staticPortlets, null);
-	}
-
 	private String _getDefaultVirtualHostname(Company company) {
 		if ((company != null) &&
 			Validator.isNotNull(company.getVirtualHostname())) {
@@ -8853,9 +8818,7 @@ public class PortalImpl implements Portal {
 		LayoutTypePortlet layoutTypePortlet =
 			(LayoutTypePortlet)layout.getLayoutType();
 
-		for (Portlet portlet :
-				_getAllNonembeddedPortlets(layout, layoutTypePortlet)) {
-
+		for (Portlet portlet : layoutTypePortlet.getAllNonembeddedPortlets()) {
 			if (portletId.equals(portlet.getPortletId()) ||
 				portletId.equals(portlet.getRootPortletId())) {
 

--- a/portal-kernel/src/com/liferay/portal/kernel/model/LayoutTypePortlet.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/LayoutTypePortlet.java
@@ -73,6 +73,8 @@ public interface LayoutTypePortlet extends LayoutType {
 
 	public String getAddedCustomPortletMode();
 
+	public List<Portlet> getAllNonembeddedPortlets();
+
 	public List<Portlet> getAllPortlets();
 
 	public List<Portlet> getAllPortlets(boolean includeSystem);

--- a/portal-kernel/src/com/liferay/portal/kernel/model/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/packageinfo
@@ -1,1 +1,1 @@
-version 29.2.0
+version 30.0.0


### PR DESCRIPTION
Previous pr: #4341 
Resent because of merge conflicts with packageinfo files

Hi,
this pull fixes https://issues.liferay.com/browse/LPS-159384

**Reproduction steps:**

- Be sure that your bundle is connected to a fake SMTP server like [fakeSMTP](http://nilhcem.com/FakeSMTP/) or [MockMock](https://github.com/tweakers/MockMock) in order to view the email notifications
- Login with Test user
- Create new folder in Documents and Media
- Create a user 'usr1' and add it as a member of the site 'Guest'
- Create a content page in 'Guest' site
- Add the Documents and media widget to the page created in step 5
- Login or impersonate 'usr1' user
- Subscribe to the folder created in step 3 in order to receive notifications when a new upload is done inside this folder
- Login with Test user
- Add new file to this folder to send new notification to subscribed user

**Expected behavior:**

Customer expect to receive the link using friendlyURL of the page

**Actual behavior:**

The link sent in the email notification is generated for control panel (http://localhost:8080/group/guest/~/control_panel/)

**Additional information:**
Class com.liferay.portal.kernel.portlet.BasePortletLayoutFinder implemented its own logic to find portlets added to layouts and it was only compatible with widget pages. My idea was to use already existing logic in PortalUtil.getPlidFromPortletId to achieve this as it is also compatible with content pages.

I also had to move method getAllNonembeddedPortlets from PortlImpl to LayoutTypePortletImpl because all existing methods in this class are only compatible with widget pages so I needed a method compatible also with content pages. It also made sense looking at its logic.