### PR TITLE
LPS-185879 Preview and thumbnails are not override when checkin with “Keep Current Version Number”

### DIFF
--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/model/listener/DLFileVersionModelListener.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/model/listener/DLFileVersionModelListener.java
@@ -83,15 +83,24 @@ public class DLFileVersionModelListener
 		throws ModelListenerException {
 
 		try {
+			dlFileVersion = _dlFileVersionLocalService.fetchDLFileVersion(
+				dlFileVersion.getFileVersionId());
+
+			if (dlFileVersion == null) {
+				return;
+			}
+
 			if (Objects.equals(
 					DLFileEntryConstants.PRIVATE_WORKING_COPY_VERSION,
 					dlFileVersion.getVersion())) {
 
 				DLFileVersion latestFileVersion =
-					_dlFileVersionLocalService.getLatestFileVersion(
+					_dlFileVersionLocalService.fetchLatestFileVersion(
 						dlFileVersion.getFileEntryId(), true);
 
-				_cleanUpFileVersion(latestFileVersion.getFileVersionId());
+				if (latestFileVersion != null) {
+					_cleanUpFileVersion(latestFileVersion.getFileVersionId());
+				}
 			}
 
 			_cleanUpFileVersion(dlFileVersion.getFileVersionId());

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/model/listener/DLFileVersionModelListener.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/model/listener/DLFileVersionModelListener.java
@@ -93,6 +93,8 @@ public class DLFileVersionModelListener
 
 				_cleanUpFileVersion(latestFileVersion.getFileVersionId());
 			}
+
+			_cleanUpFileVersion(dlFileVersion.getFileVersionId());
 		}
 		catch (PortalException portalException) {
 			_log.error(portalException);

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/model/listener/DLFileVersionModelListener.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/model/listener/DLFileVersionModelListener.java
@@ -22,6 +22,8 @@ import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
 import com.liferay.document.library.kernel.service.DLFileVersionLocalService;
 import com.liferay.document.library.kernel.store.DLStoreUtil;
 import com.liferay.document.library.kernel.util.DLProcessor;
+import com.liferay.document.library.model.DLFileVersionPreview;
+import com.liferay.document.library.service.DLFileVersionPreviewLocalService;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
 import com.liferay.portal.kernel.exception.ModelListenerException;
@@ -61,6 +63,15 @@ public class DLFileVersionModelListener
 					dlFileVersion.getStoreFileName());
 			}
 
+			DLFileVersionPreview dlFileVersionPreview =
+				_dlFileVersionPreviewLocalService.fetchDLFileVersionPreview(
+					dlFileVersion.getFileEntryId(),
+					dlFileVersion.getFileVersionId());
+
+			if (dlFileVersionPreview != null) {
+				_dlFileVersionPreviewLocalService.deleteDLFileVersionPreview(
+					dlFileVersionPreview);
+			}
 		}
 		catch (PortalException portalException) {
 			_log.error(portalException);
@@ -115,6 +126,9 @@ public class DLFileVersionModelListener
 
 	@Reference
 	private DLFileVersionLocalService _dlFileVersionLocalService;
+
+	@Reference
+	private DLFileVersionPreviewLocalService _dlFileVersionPreviewLocalService;
 
 	private ServiceTrackerMap<String, DLProcessor>
 		_dlProcessorServiceTrackerMap;

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/model/listener/DLFileVersionModelListener.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/model/listener/DLFileVersionModelListener.java
@@ -15,16 +15,27 @@
 package com.liferay.document.library.internal.model.listener;
 
 import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.document.library.kernel.model.DLFileEntryConstants;
 import com.liferay.document.library.kernel.model.DLFileVersion;
+import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
+import com.liferay.document.library.kernel.service.DLFileVersionLocalService;
 import com.liferay.document.library.kernel.store.DLStoreUtil;
+import com.liferay.document.library.kernel.util.DLProcessor;
+import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
+import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
 import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.ModelListener;
+import com.liferay.portal.kernel.repository.model.FileVersion;
 
+import java.util.Objects;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
@@ -49,16 +60,63 @@ public class DLFileVersionModelListener
 					dlFileEntry.getDataRepositoryId(), dlFileEntry.getName(),
 					dlFileVersion.getStoreFileName());
 			}
+
 		}
 		catch (PortalException portalException) {
 			_log.error(portalException);
 		}
 	}
 
+	@Override
+	public void onBeforeRemove(DLFileVersion dlFileVersion)
+		throws ModelListenerException {
+
+		try {
+			if (Objects.equals(
+					DLFileEntryConstants.PRIVATE_WORKING_COPY_VERSION,
+					dlFileVersion.getVersion())) {
+
+				DLFileVersion latestFileVersion =
+					_dlFileVersionLocalService.getLatestFileVersion(
+						dlFileVersion.getFileEntryId(), true);
+
+				FileVersion fileVersion = _dlAppLocalService.getFileVersion(
+					latestFileVersion.getFileVersionId());
+
+				for (DLProcessor dlProcessor :
+						_dlProcessorServiceTrackerMap.values()) {
+
+					if (dlProcessor.isSupported(fileVersion)) {
+						dlProcessor.cleanUp(fileVersion);
+					}
+				}
+			}
+		}
+		catch (PortalException portalException) {
+			_log.error(portalException);
+		}
+	}
+
+	@Activate
+	protected void activate(BundleContext bundleContext) {
+		_dlProcessorServiceTrackerMap =
+			ServiceTrackerMapFactory.openSingleValueMap(
+				bundleContext, DLProcessor.class, "type");
+	}
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		DLFileVersionModelListener.class);
 
 	@Reference
+	private DLAppLocalService _dlAppLocalService;
+
+	@Reference
 	private DLFileEntryLocalService _dlFileEntryLocalService;
+
+	@Reference
+	private DLFileVersionLocalService _dlFileVersionLocalService;
+
+	private ServiceTrackerMap<String, DLProcessor>
+		_dlProcessorServiceTrackerMap;
 
 }

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/model/listener/DLFileVersionModelListener.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/model/listener/DLFileVersionModelListener.java
@@ -91,16 +91,7 @@ public class DLFileVersionModelListener
 					_dlFileVersionLocalService.getLatestFileVersion(
 						dlFileVersion.getFileEntryId(), true);
 
-				FileVersion fileVersion = _dlAppLocalService.getFileVersion(
-					latestFileVersion.getFileVersionId());
-
-				for (DLProcessor dlProcessor :
-						_dlProcessorServiceTrackerMap.values()) {
-
-					if (dlProcessor.isSupported(fileVersion)) {
-						dlProcessor.cleanUp(fileVersion);
-					}
-				}
+				_cleanUpFileVersion(latestFileVersion.getFileVersionId());
 			}
 		}
 		catch (PortalException portalException) {
@@ -113,6 +104,19 @@ public class DLFileVersionModelListener
 		_dlProcessorServiceTrackerMap =
 			ServiceTrackerMapFactory.openSingleValueMap(
 				bundleContext, DLProcessor.class, "type");
+	}
+
+	private void _cleanUpFileVersion(long fileVersionId)
+		throws PortalException {
+
+		FileVersion fileVersion = _dlAppLocalService.getFileVersion(
+			fileVersionId);
+
+		for (DLProcessor dlProcessor : _dlProcessorServiceTrackerMap.values()) {
+			if (dlProcessor.isSupported(fileVersion)) {
+				dlProcessor.cleanUp(fileVersion);
+			}
+		}
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-185879


Steps to reproduce

It happens to with video (and I suppose that with audio/other preview)


1. Go to Content & Media > Documents and Media > “+” > File Upload
2. Select 1 PDF File which has Thumbnail and Publish
3. Select (⋮) button on it, and click “Checkout”
4. Select (⋮) button again and click “Edit”
5. Select PDF File (which is not include same Thumbnail with step3) and save
6. Note: Thumbnail is changed to New picture
7. Select (⋮) button, and click “Checkin”
8. Select “Keep Current Version Number” and Save

It happened that previews are no clean after the deletion of the fileversion



- LPS-185879 when you delete a file entry that is a PWC make a cleanup of the previous trusted version of the file to make it new previews and thumbnails with the content con the correct version
- LPS-185879 remove the dlFileVersionPreview when removing the dlFileVersion
- LPS-185879 extract method
- LPS-185879 clean up the deleted file version previews and thumbnails
