### PR TITLE
LPS-185222 Add new files to the 'new' area instead of 'live'

### DIFF
--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/store/test/DLStoreStoreAreaTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/store/test/DLStoreStoreAreaTest.java
@@ -115,7 +115,7 @@ public class DLStoreStoreAreaTest {
 				fileName, Store.VERSION_DEFAULT));
 
 		StoreArea.withStoreArea(
-			StoreArea.LIVE,
+			StoreArea.NEW,
 			() -> _assertHasStoreFile(fileName, Store.VERSION_DEFAULT));
 	}
 
@@ -238,6 +238,8 @@ public class DLStoreStoreAreaTest {
 		StoreArea.withStoreArea(
 			StoreArea.DELETED,
 			() -> _assertHasStoreFile(fileName, Store.VERSION_DEFAULT));
+		StoreArea.withStoreArea(
+			StoreArea.NEW, () -> _assertHasStoreFile(fileName, "2.0"));
 	}
 
 	private void _addFile(String fileName, String version) throws Exception {

--- a/modules/apps/portal-store/portal-store-gcs-test/src/testIntegration/java/com/liferay/portal/store/gcs/test/GCSStoreStoreAreaProcessorTest.java
+++ b/modules/apps/portal-store/portal-store-gcs-test/src/testIntegration/java/com/liferay/portal/store/gcs/test/GCSStoreStoreAreaProcessorTest.java
@@ -248,7 +248,7 @@ public class GCSStoreStoreAreaProcessorTest {
 
 		StoreAreaProcessor storeAreaProcessor = (StoreAreaProcessor)_store;
 
-		storeAreaProcessor.copy(
+		boolean copied = storeAreaProcessor.copy(
 			StoreArea.LIVE.getPath(
 				_group.getCompanyId(), _group.getGroupId(), fileName,
 				Store.VERSION_DEFAULT),
@@ -256,12 +256,28 @@ public class GCSStoreStoreAreaProcessorTest {
 				_group.getCompanyId(), _group.getGroupId(), fileName,
 				Store.VERSION_DEFAULT));
 
+		Assert.assertTrue(copied);
+
 		StoreArea.withStoreArea(
 			StoreArea.DELETED,
 			() -> Assert.assertTrue(
 				_store.hasFile(
 					_group.getCompanyId(), _group.getGroupId(), fileName,
 					Store.VERSION_DEFAULT)));
+	}
+
+	@Test
+	public void testCopyNonexistantFile() throws Exception {
+		StoreAreaProcessor storeAreaProcessor = (StoreAreaProcessor)_store;
+
+		Assert.assertFalse(
+			storeAreaProcessor.copy(
+				StoreArea.LIVE.getPath(
+					_group.getCompanyId(), _group.getGroupId(),
+					StringUtil.randomString(), Store.VERSION_DEFAULT),
+				StoreArea.LIVE.getPath(
+					_group.getCompanyId(), _group.getGroupId(),
+					StringUtil.randomString(), Store.VERSION_DEFAULT)));
 	}
 
 	private static Configuration _configuration;

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/store/DLStoreImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/store/DLStoreImpl.java
@@ -111,11 +111,13 @@ public class DLStoreImpl implements DLStore {
 		throws PortalException {
 
 		if (_storeAreaProcessor != null) {
-			_storeAreaProcessor.copy(
-				StoreArea.LIVE.getPath(
-					companyId, repositoryId, fileName, fromVersionLabel),
-				StoreArea.LIVE.getPath(
-					companyId, repositoryId, fileName, toVersionLabel));
+			StoreArea.tryRunWithStoreAreas(
+				sourceStoreArea -> _storeAreaProcessor.copy(
+					sourceStoreArea.getPath(
+						companyId, repositoryId, fileName, fromVersionLabel),
+					StoreArea.NEW.getPath(
+						companyId, repositoryId, fileName, toVersionLabel)),
+				StoreArea.LIVE, StoreArea.NEW);
 		}
 		else {
 			_wrappedStore.addFile(
@@ -298,11 +300,14 @@ public class DLStoreImpl implements DLStore {
 					companyId, repositoryId, fileName)) {
 
 			if (_storeAreaProcessor != null) {
-				_storeAreaProcessor.copy(
-					StoreArea.LIVE.getPath(
-						companyId, repositoryId, fileName, versionLabel),
-					StoreArea.LIVE.getPath(
-						companyId, newRepositoryId, fileName, versionLabel));
+				StoreArea.tryRunWithStoreAreas(
+					sourceStoreArea -> _storeAreaProcessor.copy(
+						sourceStoreArea.getPath(
+							companyId, repositoryId, fileName, versionLabel),
+						StoreArea.NEW.getPath(
+							companyId, newRepositoryId, fileName,
+							versionLabel)),
+					StoreArea.LIVE, StoreArea.NEW);
 			}
 			else {
 				_wrappedStore.addFile(
@@ -323,11 +328,13 @@ public class DLStoreImpl implements DLStore {
 		throws PortalException {
 
 		if (_storeAreaProcessor != null) {
-			_storeAreaProcessor.copy(
-				StoreArea.LIVE.getPath(
-					companyId, repositoryId, fileName, fromVersionLabel),
-				StoreArea.LIVE.getPath(
-					companyId, repositoryId, fileName, toVersionLabel));
+			StoreArea.tryRunWithStoreAreas(
+				sourceStoreArea -> _storeAreaProcessor.copy(
+					sourceStoreArea.getPath(
+						companyId, repositoryId, fileName, fromVersionLabel),
+					StoreArea.NEW.getPath(
+						companyId, repositoryId, fileName, toVersionLabel)),
+				StoreArea.LIVE, StoreArea.NEW);
 		}
 		else {
 			_wrappedStore.addFile(

--- a/portal-kernel/src/com/liferay/document/library/kernel/store/StoreArea.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/store/StoreArea.java
@@ -21,6 +21,8 @@ import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringUtil;
 
+import java.util.function.Predicate;
+
 /**
  * @author Adolfo Pérez
  */
@@ -34,6 +36,18 @@ public enum StoreArea {
 		StoreArea storeArea = _storeAreaThreadLocal.get();
 
 		return storeArea.getPath(companyId, repositoryId, path);
+	}
+
+	public static StoreArea tryRunWithStoreAreas(
+		Predicate<StoreArea> predicate, StoreArea... storeAreas) {
+
+		for (StoreArea storeArea : storeAreas) {
+			if (predicate.test(storeArea)) {
+				return storeArea;
+			}
+		}
+
+		return null;
 	}
 
 	public static <T extends Throwable> void withStoreArea(

--- a/portal-kernel/src/com/liferay/document/library/kernel/store/StoreArea.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/store/StoreArea.java
@@ -22,6 +22,9 @@ import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringUtil;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.function.Predicate;
 
 /**
@@ -37,6 +40,23 @@ public enum StoreArea {
 		StoreArea storeArea = _storeAreaThreadLocal.get();
 
 		return storeArea.getPath(companyId, repositoryId, path);
+	}
+
+	public static <E extends Exception> String[] mergeWithStoreAreas(
+			UnsafeSupplier<String[], E> supplier, StoreArea... storeAreas)
+		throws E {
+
+		List<String> list = new ArrayList<>();
+
+		for (StoreArea storeArea : storeAreas) {
+			String[] strings = StoreArea.withStoreArea(storeArea, supplier);
+
+			if (strings != null) {
+				Collections.addAll(list, strings);
+			}
+		}
+
+		return list.toArray(new String[0]);
 	}
 
 	public static <T extends Exception> void runWithStoreAreas(

--- a/portal-kernel/src/com/liferay/document/library/kernel/store/StoreArea.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/store/StoreArea.java
@@ -38,6 +38,15 @@ public enum StoreArea {
 		return storeArea.getPath(companyId, repositoryId, path);
 	}
 
+	public static <T extends Exception> void runWithStoreAreas(
+			UnsafeRunnable<T> unsafeRunnable, StoreArea... storeAreas)
+		throws T {
+
+		for (StoreArea storeArea : storeAreas) {
+			StoreArea.withStoreArea(storeArea, unsafeRunnable);
+		}
+	}
+
 	public static StoreArea tryRunWithStoreAreas(
 		Predicate<StoreArea> predicate, StoreArea... storeAreas) {
 

--- a/portal-kernel/src/com/liferay/document/library/kernel/store/StoreArea.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/store/StoreArea.java
@@ -26,7 +26,7 @@ import com.liferay.portal.kernel.util.StringUtil;
  */
 public enum StoreArea {
 
-	DELETED("_deleted"), LIVE(StringPool.BLANK);
+	DELETED("_deleted"), LIVE(StringPool.BLANK), NEW("_new");
 
 	public static String getCurrentStoreAreaPath(
 		long companyId, long repositoryId, String... path) {

--- a/portal-kernel/src/com/liferay/document/library/kernel/store/StoreArea.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/store/StoreArea.java
@@ -69,18 +69,19 @@ public enum StoreArea {
 	}
 
 	public static <T, E extends Exception> T tryGetWithStoreAreas(
-			UnsafeSupplier<T, E> unsafeSupplier, StoreArea... storeAreas)
+			UnsafeSupplier<T, E> unsafeSupplier, Predicate<T> predicate,
+			T defaultValue, StoreArea... storeAreas)
 		throws E {
 
 		for (StoreArea storeArea : storeAreas) {
 			T result = StoreArea.withStoreArea(storeArea, unsafeSupplier);
 
-			if (result != null) {
+			if (predicate.test(result)) {
 				return result;
 			}
 		}
 
-		return null;
+		return defaultValue;
 	}
 
 	public static StoreArea tryRunWithStoreAreas(

--- a/portal-kernel/src/com/liferay/document/library/kernel/store/StoreAreaAwareStoreWrapper.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/store/StoreAreaAwareStoreWrapper.java
@@ -68,11 +68,15 @@ public class StoreAreaAwareStoreWrapper implements Store {
 						store.getFileVersions(
 							companyId, repositoryId, fileName)) {
 
-					storeAreaProcessor.copy(
-						StoreArea.LIVE.getPath(
-							companyId, repositoryId, fileName, versionLabel),
-						StoreArea.DELETED.getPath(
-							companyId, repositoryId, fileName, versionLabel));
+					StoreArea.tryRunWithStoreAreas(
+						sourceStoreArea -> storeAreaProcessor.copy(
+							sourceStoreArea.getPath(
+								companyId, repositoryId, fileName,
+								versionLabel),
+							StoreArea.DELETED.getPath(
+								companyId, repositoryId, fileName,
+								versionLabel)),
+						StoreArea.LIVE, StoreArea.NEW);
 				}
 			}
 		}
@@ -89,11 +93,13 @@ public class StoreAreaAwareStoreWrapper implements Store {
 			StoreAreaProcessor storeAreaProcessor =
 				_storeAreaProcessorSupplier.get();
 
-			storeAreaProcessor.copy(
-				StoreArea.LIVE.getPath(
-					companyId, repositoryId, fileName, versionLabel),
-				StoreArea.DELETED.getPath(
-					companyId, repositoryId, fileName, versionLabel));
+			StoreArea.tryRunWithStoreAreas(
+				sourceStoreArea -> storeAreaProcessor.copy(
+					sourceStoreArea.getPath(
+						companyId, repositoryId, fileName, versionLabel),
+					StoreArea.DELETED.getPath(
+						companyId, repositoryId, fileName, versionLabel)),
+				StoreArea.LIVE, StoreArea.NEW);
 		}
 
 		Store store = _storeSupplier.get();

--- a/portal-kernel/src/com/liferay/document/library/kernel/store/StoreAreaAwareStoreWrapper.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/store/StoreAreaAwareStoreWrapper.java
@@ -58,18 +58,15 @@ public class StoreAreaAwareStoreWrapper implements Store {
 	public void deleteDirectory(
 		long companyId, long repositoryId, String dirName) {
 
-		Store store = _storeSupplier.get();
-
 		if (_isStoreAreaSupported()) {
 			StoreAreaProcessor storeAreaProcessor =
 				_storeAreaProcessorSupplier.get();
 
 			for (String fileName :
-					store.getFileNames(companyId, repositoryId, dirName)) {
+					getFileNames(companyId, repositoryId, dirName)) {
 
 				for (String versionLabel :
-						store.getFileVersions(
-							companyId, repositoryId, fileName)) {
+						getFileVersions(companyId, repositoryId, fileName)) {
 
 					StoreArea.tryRunWithStoreAreas(
 						sourceStoreArea -> storeAreaProcessor.copy(
@@ -83,6 +80,8 @@ public class StoreAreaAwareStoreWrapper implements Store {
 				}
 			}
 		}
+
+		Store store = _storeSupplier.get();
 
 		StoreArea.runWithStoreAreas(
 			() -> store.deleteDirectory(companyId, repositoryId, dirName),

--- a/portal-kernel/src/com/liferay/document/library/kernel/store/StoreAreaAwareStoreWrapper.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/store/StoreAreaAwareStoreWrapper.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import java.io.InputStream;
 
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.function.Supplier;
 
 /**
@@ -129,7 +130,7 @@ public class StoreAreaAwareStoreWrapper implements Store {
 		return StoreArea.tryGetWithStoreAreas(
 			() -> store.getFileAsStream(
 				companyId, repositoryId, fileName, versionLabel),
-			StoreArea.LIVE, StoreArea.NEW);
+			Objects::nonNull, null, StoreArea.LIVE, StoreArea.NEW);
 	}
 
 	@Override
@@ -158,7 +159,7 @@ public class StoreAreaAwareStoreWrapper implements Store {
 		return StoreArea.tryGetWithStoreAreas(
 			() -> store.getFileSize(
 				companyId, repositoryId, fileName, versionLabel),
-			StoreArea.LIVE, StoreArea.NEW);
+			Objects::nonNull, 0L, StoreArea.LIVE, StoreArea.NEW);
 	}
 
 	@Override
@@ -186,7 +187,7 @@ public class StoreAreaAwareStoreWrapper implements Store {
 		return StoreArea.tryGetWithStoreAreas(
 			() -> store.hasFile(
 				companyId, repositoryId, fileName, versionLabel),
-			StoreArea.LIVE, StoreArea.NEW);
+			Boolean.TRUE::equals, false, StoreArea.LIVE, StoreArea.NEW);
 	}
 
 	private boolean _isStoreAreaSupported() {

--- a/portal-kernel/src/com/liferay/document/library/kernel/store/StoreAreaAwareStoreWrapper.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/store/StoreAreaAwareStoreWrapper.java
@@ -136,7 +136,9 @@ public class StoreAreaAwareStoreWrapper implements Store {
 
 		Store store = _storeSupplier.get();
 
-		return store.getFileNames(companyId, repositoryId, dirName);
+		return StoreArea.mergeWithStoreAreas(
+			() -> store.getFileNames(companyId, repositoryId, dirName),
+			StoreArea.LIVE, StoreArea.NEW);
 	}
 
 	@Override
@@ -159,7 +161,9 @@ public class StoreAreaAwareStoreWrapper implements Store {
 
 		Store store = _storeSupplier.get();
 
-		return store.getFileVersions(companyId, repositoryId, fileName);
+		return StoreArea.mergeWithStoreAreas(
+			() -> store.getFileVersions(companyId, repositoryId, fileName),
+			StoreArea.LIVE, StoreArea.NEW);
 	}
 
 	@Override

--- a/portal-kernel/src/com/liferay/document/library/kernel/store/StoreAreaAwareStoreWrapper.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/store/StoreAreaAwareStoreWrapper.java
@@ -124,8 +124,10 @@ public class StoreAreaAwareStoreWrapper implements Store {
 
 		Store store = _storeSupplier.get();
 
-		return store.getFileAsStream(
-			companyId, repositoryId, fileName, versionLabel);
+		return StoreArea.tryGetWithStoreAreas(
+			() -> store.getFileAsStream(
+				companyId, repositoryId, fileName, versionLabel),
+			StoreArea.LIVE, StoreArea.NEW);
 	}
 
 	@Override
@@ -145,8 +147,10 @@ public class StoreAreaAwareStoreWrapper implements Store {
 
 		Store store = _storeSupplier.get();
 
-		return store.getFileSize(
-			companyId, repositoryId, fileName, versionLabel);
+		return StoreArea.tryGetWithStoreAreas(
+			() -> store.getFileSize(
+				companyId, repositoryId, fileName, versionLabel),
+			StoreArea.LIVE, StoreArea.NEW);
 	}
 
 	@Override
@@ -165,7 +169,10 @@ public class StoreAreaAwareStoreWrapper implements Store {
 
 		Store store = _storeSupplier.get();
 
-		return store.hasFile(companyId, repositoryId, fileName, versionLabel);
+		return StoreArea.tryGetWithStoreAreas(
+			() -> store.hasFile(
+				companyId, repositoryId, fileName, versionLabel),
+			StoreArea.LIVE, StoreArea.NEW);
 	}
 
 	private boolean _isStoreAreaSupported() {

--- a/portal-kernel/src/com/liferay/document/library/kernel/store/StoreAreaAwareStoreWrapper.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/store/StoreAreaAwareStoreWrapper.java
@@ -14,11 +14,13 @@
 
 package com.liferay.document.library.kernel.store;
 
+import com.liferay.document.library.kernel.util.DLUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 
 import java.io.InputStream;
 
+import java.util.Arrays;
 import java.util.function.Supplier;
 
 /**
@@ -136,9 +138,13 @@ public class StoreAreaAwareStoreWrapper implements Store {
 
 		Store store = _storeSupplier.get();
 
-		return StoreArea.mergeWithStoreAreas(
+		String[] fileNames = StoreArea.mergeWithStoreAreas(
 			() -> store.getFileNames(companyId, repositoryId, dirName),
 			StoreArea.LIVE, StoreArea.NEW);
+
+		Arrays.sort(fileNames);
+
+		return fileNames;
 	}
 
 	@Override
@@ -161,9 +167,13 @@ public class StoreAreaAwareStoreWrapper implements Store {
 
 		Store store = _storeSupplier.get();
 
-		return StoreArea.mergeWithStoreAreas(
+		String[] fileVersions = StoreArea.mergeWithStoreAreas(
 			() -> store.getFileVersions(companyId, repositoryId, fileName),
 			StoreArea.LIVE, StoreArea.NEW);
+
+		Arrays.sort(fileVersions, DLUtil::compareVersions);
+
+		return fileVersions;
 	}
 
 	@Override

--- a/portal-kernel/src/com/liferay/document/library/kernel/store/StoreAreaAwareStoreWrapper.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/store/StoreAreaAwareStoreWrapper.java
@@ -40,10 +40,15 @@ public class StoreAreaAwareStoreWrapper implements Store {
 			String versionLabel, InputStream inputStream)
 		throws PortalException {
 
-		Store store = _storeSupplier.get();
+		StoreArea.withStoreArea(
+			StoreArea.NEW,
+			() -> {
+				Store store = _storeSupplier.get();
 
-		store.addFile(
-			companyId, repositoryId, fileName, versionLabel, inputStream);
+				store.addFile(
+					companyId, repositoryId, fileName, versionLabel,
+					inputStream);
+			});
 	}
 
 	@Override

--- a/portal-kernel/src/com/liferay/document/library/kernel/store/StoreAreaProcessor.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/store/StoreAreaProcessor.java
@@ -25,6 +25,6 @@ public interface StoreAreaProcessor {
 		long companyId, int deletionQuota, TemporalAmount temporalAmount,
 		String startOffset);
 
-	public void copy(String sourceFileName, String destinationFileName);
+	public boolean copy(String sourceFileName, String destinationFileName);
 
 }

--- a/portal-kernel/src/com/liferay/document/library/kernel/store/packageinfo
+++ b/portal-kernel/src/com/liferay/document/library/kernel/store/packageinfo
@@ -1,1 +1,1 @@
-version 5.0.0
+version 6.0.0


### PR DESCRIPTION
# What is this about?

https://issues.liferay.com/browse/LPS-185222

Instead of adding new files to the 'live' area, add them to a new 'new' area.

The use case that makes this necessary is the following:
1. Add file A.
2. Take a DB snapshot.
3. Add file B.
4. Restore DB snapshot.

At this point, file B is an orphan, there's no reference in the database pointing to it and so it cannot be easily removed.  To avoid leaking storage space each time a backup is restored, we need a way of detecting these files that doesn't involve scanning the whole store.

By adding new files to the 'new' area, we can implement a background process (which I'll send in a followup pr) that will scan the 'new' area looking for unreferenced content. As the 'new' area will be much smaller than 'live', this process will consume less time and resources than if it had to scan the whole store.

Note that files in 'new' will be promoted to 'live' after 31 days (by default), as we won't support "going back in time" for periods longer that the configured value. That job will be performed by the same background process that cleans up 'new'. It will work similarly to the one we already have for the 'deleted' area.