### PR TITLE
[TS] LPS-186835 - truncating to solely the body when transforming AM HTML content can cause template content loss

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-image-content-transformer-backwards-compatibility/src/main/java/com/liferay/adaptive/media/image/content/transformer/backwards/compatibility/internal/AMBackwardsCompatibilityHtmlContentTransformer.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-content-transformer-backwards-compatibility/src/main/java/com/liferay/adaptive/media/image/content/transformer/backwards/compatibility/internal/AMBackwardsCompatibilityHtmlContentTransformer.java
@@ -87,9 +87,7 @@ public class AMBackwardsCompatibilityHtmlContentTransformer
 			imgElement.replaceWith(_parseNode(replacement));
 		}
 
-		Element body = document.body();
-
-		return body.html();
+		return document.html();
 	}
 
 	@Override

--- a/modules/apps/adaptive-media/adaptive-media-image-content-transformer-backwards-compatibility/src/main/java/com/liferay/adaptive/media/image/content/transformer/backwards/compatibility/internal/AMBackwardsCompatibilityHtmlContentTransformer.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-content-transformer-backwards-compatibility/src/main/java/com/liferay/adaptive/media/image/content/transformer/backwards/compatibility/internal/AMBackwardsCompatibilityHtmlContentTransformer.java
@@ -87,7 +87,13 @@ public class AMBackwardsCompatibilityHtmlContentTransformer
 			imgElement.replaceWith(_parseNode(replacement));
 		}
 
-		return document.html();
+		if (html.contains("<html>") || html.contains("<head>")) {
+			return document.html();
+		}
+
+		Element body = document.body();
+
+		return body.html();
 	}
 
 	@Override


### PR DESCRIPTION
Hi @liferay-lima!

https://issues.liferay.com/browse/LPP-49128
https://issues.liferay.com/browse/LPS-186835

I'm sending this specifically to you guys since this deals with partially reverting changes made in [LPS-148916](https://issues.liferay.com/browse/LPS-148916) - "Regex in AMBackwardsCompatibilityHtmlContentTransformer.java has exponential complexity". We have a client reporting that when they use the getArticleDisplay() API in JournalArticleLocalServiceUtil that they are not retrieving the full content of their template.

For example, if their template is:
```
<html>
<head>
</head>
<body>
<p> Group Id - ${groupId} - PRINT THIS PAGE AND BRING TO CENTER -</p>
<img alt="Logo graphic" src="${LogoUpdate.getData()}"/>
</body>
</html>
```

They're seeing only the `<p>` and `<img>` parts.

This is due to us specifically grabbing only the body of the document. I reverted this specific part of the change back to being the entire document so we don't lose non-body content. I did test using the reproduction steps in LPS-148916 and was not able to reproduce the issues reported, but please let me know if there's something I'm missing and I'll take a look. Thanks!