### PR TITLE
[TECHNICAL SUPPORT] LPS-186154 Can't create web content with certain image names

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/DLReferencesExportImportContentProcessor.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/DLReferencesExportImportContentProcessor.java
@@ -871,7 +871,7 @@ public class DLReferencesExportImportContentProcessor
 
 	private static final Pattern _uuidPattern = Pattern.compile(
 		"[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-" +
-			"[a-fA-F0-9]{12}");
+			"[a-fA-F0-9]{12}(?=[&,?]|$)");
 
 	@Reference
 	private CompanyLocalService _companyLocalService;


### PR DESCRIPTION
Hey,

[LPS-186154](https://issues.liferay.com/browse/LPS-186154),

We matched any part of the url that matches the uuid pattern, however this also includes filenams that follows the 8-4-4-12 character pattern. I modified the uuid pattern matching, to only match uuid if its the end of the string or followeb by a valid separator.

Please review it,

Thanks