### PR TITLE
LPS-186554 Do not translate Document Types

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/toolbar/contributor/helper/MenuItemProvider.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/toolbar/contributor/helper/MenuItemProvider.java
@@ -368,11 +368,9 @@ public class MenuItemProvider {
 			DLFileEntryType.class.getSimpleName() +
 				fileEntryType.getFileEntryTypeKey());
 		urlMenuItem.setLabel(
-			_language.get(
-				_portal.getHttpServletRequest(portletRequest),
-				fileEntryType.getUnambiguousName(
-					fileEntryTypes, themeDisplay.getScopeGroupId(),
-					themeDisplay.getLocale())));
+			fileEntryType.getUnambiguousName(
+				fileEntryTypes, themeDisplay.getScopeGroupId(),
+				themeDisplay.getLocale()));
 		urlMenuItem.setURL(
 			PortletURLBuilder.create(
 				_getPortletURL(themeDisplay, portletRequest)


### PR DESCRIPTION
Issue [LPS-186554](https://issues.liferay.com/browse/LPS-186554) The document type name will be escaped when the name is "a"

**Reason:** 
Document types were translated when creating the menu items for the add dropdown, and there is an ["a" key](https://github.com/liferay/liferay-portal/blame/master/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties#L58-L58) in language.properties.
```
a=%A
```

The only solution I see here is that maybe document types do not need to be translated.  

When language is set to English: 
![Screenshot 2023-06-08 at 14 59 58](https://github.com/liferay-lima/liferay-portal/assets/8373764/810a2cb1-7fcf-43f4-926a-4f9b890cb38d)

When language is set to Spanish: 
![Screenshot 2023-06-08 at 15 00 55](https://github.com/liferay-lima/liferay-portal/assets/8373764/362d3c8f-3aa1-4db7-927c-6782fefa9716)
