### PR TITLE
LPS-168067 HR_221 SR is not announcing "Open Graph Image" Dialog box

### DIFF
--- a/modules/apps/layout/layout-seo-web-test/src/testFunctional/macros/OpenGraph.macro
+++ b/modules/apps/layout/layout-seo-web-test/src/testFunctional/macros/OpenGraph.macro
@@ -55,7 +55,7 @@ definition {
 
 			AssertTextEquals(
 				locator1 = "Modal#HEADER",
-				value1 = "Open Graph Image");
+				value1 = "Select Image");
 
 			SelectFrame(locator1 = "IFrame#MODAL_BODY");
 

--- a/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/js/seo/openGraph.es.js
+++ b/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/js/seo/openGraph.es.js
@@ -65,7 +65,7 @@ export default function ({namespace, uploadOpenGraphImageURL}) {
 				}
 			},
 			selectEventName: `${namespace}openGraphImageSelectedItem`,
-			title: Liferay.Language.get('open-graph-image'),
+			title: Liferay.Language.get('select-image'),
 			url: uploadOpenGraphImageURL,
 		});
 	};


### PR DESCRIPTION
Issue https://issues.liferay.com/browse/LPS-168067

This is a sev2 but reopened by the client. What I get from the comments in the issue is that the speech history is correct, even if it is large, but that the modal title should match with the trigger button label.

So here is the fix, I would appreciate your opinion about if this is enough for the issue.
![image](https://github.com/liferay-lima/liferay-portal/assets/48118285/87aee3cf-8b7f-4d81-b0d4-dc110c9f0347)
