### PR TITLE
LPS-188637 Avoid calling `store.getFileVersions` when getting AM content

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-image-service/src/main/java/com/liferay/adaptive/media/image/internal/storage/ImageStorage.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-service/src/main/java/com/liferay/adaptive/media/image/internal/storage/ImageStorage.java
@@ -16,7 +16,6 @@ package com.liferay.adaptive.media.image.internal.storage;
 
 import com.liferay.adaptive.media.exception.AMRuntimeException;
 import com.liferay.document.library.kernel.store.Store;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.repository.model.FileVersion;

--- a/modules/apps/adaptive-media/adaptive-media-image-service/src/main/java/com/liferay/adaptive/media/image/internal/storage/ImageStorage.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-service/src/main/java/com/liferay/adaptive/media/image/internal/storage/ImageStorage.java
@@ -53,7 +53,7 @@ public class ImageStorage {
 
 			return _store.getFileAsStream(
 				fileVersion.getCompanyId(), CompanyConstants.SYSTEM,
-				fileVersionPath, StringPool.BLANK);
+				fileVersionPath, Store.VERSION_DEFAULT);
 		}
 		catch (PortalException portalException) {
 			throw new AMRuntimeException.IOException(portalException);


### PR DESCRIPTION
# What is this about?

https://issues.liferay.com/browse/LPS-188637

AM files are always saved as version Store.DEFAULT_VERSION; by passing that directly we can avoid an internal extra call to `store.getFileVersions` when requesting specific AM files.