### PR TITLE
LPS-188418 Fallback into deleted area

### DIFF
--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/upgrade/v3_2_6/test/DeleteStalePWCVersionsUpgradeProcessTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/upgrade/v3_2_6/test/DeleteStalePWCVersionsUpgradeProcessTest.java
@@ -21,8 +21,9 @@ import com.liferay.document.library.kernel.model.DLFileVersion;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.model.DLVersionNumberIncrease;
 import com.liferay.document.library.kernel.service.DLAppService;
-import com.liferay.document.library.kernel.store.DLStoreRequest;
-import com.liferay.document.library.kernel.store.DLStoreUtil;
+import com.liferay.document.library.kernel.store.Store;
+import com.liferay.document.library.kernel.store.StoreArea;
+import com.liferay.petra.io.unsync.UnsyncByteArrayInputStream;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.repository.model.FileEntry;
@@ -135,14 +136,26 @@ public class DeleteStalePWCVersionsUpgradeProcessTest {
 
 		DLFileEntry dlFileEntry = (DLFileEntry)fileEntry.getModel();
 
-		DLStoreUtil.addFile(
-			DLStoreRequest.builder(
-				dlFileEntry.getCompanyId(), dlFileEntry.getRepositoryId(),
-				dlFileEntry.getName()
-			).versionLabel(
-				DLFileEntryConstants.PRIVATE_WORKING_COPY_VERSION
-			).build(),
-			new byte[0]);
+		_store.addFile(
+			dlFileEntry.getCompanyId(), dlFileEntry.getRepositoryId(),
+			dlFileEntry.getName(),
+			DLFileEntryConstants.PRIVATE_WORKING_COPY_VERSION,
+			new UnsyncByteArrayInputStream(new byte[0]));
+	}
+
+	private String _getStoreFileName(DLFileEntry dlFileEntry)
+		throws PortalException {
+
+		DLFileVersion dlFileVersion = dlFileEntry.getLatestFileVersion(true);
+
+		if (Objects.equals(
+				dlFileVersion.getVersion(),
+				DLFileEntryConstants.PRIVATE_WORKING_COPY_VERSION)) {
+
+			return dlFileVersion.getStoreFileName();
+		}
+
+		return DLFileEntryConstants.PRIVATE_WORKING_COPY_VERSION;
 	}
 
 	private UpgradeProcess _getUpgradeProcess() {
@@ -167,21 +180,11 @@ public class DeleteStalePWCVersionsUpgradeProcessTest {
 	private boolean _hasPWCVersion(FileEntry fileEntry) throws PortalException {
 		DLFileEntry dlFileEntry = (DLFileEntry)fileEntry.getModel();
 
-		DLFileVersion dlFileVersion = dlFileEntry.getLatestFileVersion(true);
-
-		if (Objects.equals(
-				dlFileVersion.getVersion(),
-				DLFileEntryConstants.PRIVATE_WORKING_COPY_VERSION)) {
-
-			return DLStoreUtil.hasFile(
+		return StoreArea.tryGetWithStoreAreas(
+			() -> _store.hasFile(
 				dlFileEntry.getCompanyId(), dlFileEntry.getRepositoryId(),
-				dlFileEntry.getName(), dlFileVersion.getStoreFileName());
-		}
-
-		return DLStoreUtil.hasFile(
-			dlFileEntry.getCompanyId(), dlFileEntry.getRepositoryId(),
-			dlFileEntry.getName(),
-			DLFileEntryConstants.PRIVATE_WORKING_COPY_VERSION);
+				dlFileEntry.getName(), _getStoreFileName(dlFileEntry)),
+			Boolean.TRUE::equals, false, StoreArea.LIVE, StoreArea.NEW);
 	}
 
 	private void _runUpgrade() throws UpgradeException {
@@ -208,5 +211,10 @@ public class DeleteStalePWCVersionsUpgradeProcessTest {
 
 	@DeleteAfterTestRun
 	private Group _group;
+
+	@Inject(
+		filter = "(&(objectClass=com.liferay.document.library.kernel.store.Store)(default=true))"
+	)
+	private Store _store;
 
 }

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -463,7 +463,7 @@ public class DLFileEntryLocalServiceImpl
 			dlFileEntry.getName(), oldStoreFileName,
 			latestDLFileVersion.getStoreFileName());
 
-		_registerPWCDeletionCallback(dlFileEntry);
+		_registerPWCDeletionCallback(dlFileEntry, oldStoreFileName);
 
 		unlockFileEntry(fileEntryId);
 	}
@@ -3238,13 +3238,15 @@ public class DLFileEntryLocalServiceImpl
 		_removeFileVersion(dlFileEntry, latestDLFileVersion);
 	}
 
-	private void _registerPWCDeletionCallback(DLFileEntry dlFileEntry) {
+	private void _registerPWCDeletionCallback(
+		DLFileEntry dlFileEntry, String storeFileName) {
+
 		TransactionCommitCallbackUtil.registerCallback(
 			() -> {
 				_deleteFile(
 					dlFileEntry.getCompanyId(),
 					dlFileEntry.getDataRepositoryId(), dlFileEntry.getName(),
-					DLFileEntryConstants.PRIVATE_WORKING_COPY_VERSION);
+					storeFileName);
 
 				return null;
 			});

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/store/DLStoreImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/store/DLStoreImpl.java
@@ -29,6 +29,7 @@ import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.io.ByteArrayFileInputStream;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.util.FileUtil;
@@ -107,7 +108,7 @@ public class DLStoreImpl implements DLStore {
 			String fromVersionLabel, String toVersionLabel)
 		throws PortalException {
 
-		if (_storeAreaProcessor != null) {
+		if (_isStoreAreaSupported()) {
 			StoreArea.tryRunWithStoreAreas(
 				sourceStoreArea -> _storeAreaProcessor.copy(
 					sourceStoreArea.getPath(
@@ -241,7 +242,7 @@ public class DLStoreImpl implements DLStore {
 				_wrappedStore.getFileVersions(
 					companyId, repositoryId, fileName)) {
 
-			if (_storeAreaProcessor != null) {
+			if (_isStoreAreaSupported()) {
 				StoreArea.tryRunWithStoreAreas(
 					sourceStoreArea -> _storeAreaProcessor.copy(
 						sourceStoreArea.getPath(
@@ -269,7 +270,7 @@ public class DLStoreImpl implements DLStore {
 			String fromVersionLabel, String toVersionLabel)
 		throws PortalException {
 
-		if (_storeAreaProcessor != null) {
+		if (_isStoreAreaSupported()) {
 			StoreArea.tryRunWithStoreAreas(
 				sourceStoreArea -> _storeAreaProcessor.copy(
 					sourceStoreArea.getPath(
@@ -328,6 +329,18 @@ public class DLStoreImpl implements DLStore {
 		}
 
 		return inputStream;
+	}
+
+	private boolean _isStoreAreaSupported() {
+		if (!FeatureFlagManagerUtil.isEnabled("LPS-174816")) {
+			return false;
+		}
+
+		if (_storeAreaProcessor != null) {
+			return true;
+		}
+
+		return false;
 	}
 
 	private void _validate(

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/store/DLStoreImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/store/DLStoreImpl.java
@@ -114,7 +114,7 @@ public class DLStoreImpl implements DLStore {
 						companyId, repositoryId, fileName, fromVersionLabel),
 					StoreArea.NEW.getPath(
 						companyId, repositoryId, fileName, toVersionLabel)),
-				StoreArea.LIVE, StoreArea.NEW);
+				StoreArea.LIVE, StoreArea.NEW, StoreArea.DELETED);
 		}
 		else {
 			_wrappedStore.addFile(
@@ -249,7 +249,7 @@ public class DLStoreImpl implements DLStore {
 						StoreArea.NEW.getPath(
 							companyId, newRepositoryId, fileName,
 							versionLabel)),
-					StoreArea.LIVE, StoreArea.NEW);
+					StoreArea.LIVE, StoreArea.NEW, StoreArea.DELETED);
 			}
 			else {
 				_wrappedStore.addFile(
@@ -276,7 +276,7 @@ public class DLStoreImpl implements DLStore {
 						companyId, repositoryId, fileName, fromVersionLabel),
 					StoreArea.NEW.getPath(
 						companyId, repositoryId, fileName, toVersionLabel)),
-				StoreArea.LIVE, StoreArea.NEW);
+				StoreArea.LIVE, StoreArea.NEW, StoreArea.DELETED);
 		}
 		else {
 			_wrappedStore.addFile(

--- a/portal-kernel/src/com/liferay/document/library/kernel/store/StoreAreaAwareStoreWrapper.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/store/StoreAreaAwareStoreWrapper.java
@@ -114,10 +114,12 @@ public class StoreAreaAwareStoreWrapper implements Store {
 						companyId, repositoryId, fileName, versionLabel)),
 				StoreArea.LIVE, StoreArea.NEW);
 
-			StoreArea.withStoreArea(
-				storeArea,
-				() -> store.deleteFile(
-					companyId, repositoryId, fileName, versionLabel));
+			if (storeArea != null) {
+				StoreArea.withStoreArea(
+					storeArea,
+					() -> store.deleteFile(
+						companyId, repositoryId, fileName, versionLabel));
+			}
 		}
 		else {
 			store.deleteFile(companyId, repositoryId, fileName, versionLabel);

--- a/portal-kernel/src/com/liferay/document/library/kernel/store/StoreAreaAwareStoreWrapper.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/store/StoreAreaAwareStoreWrapper.java
@@ -136,7 +136,8 @@ public class StoreAreaAwareStoreWrapper implements Store {
 			return StoreArea.tryGetWithStoreAreas(
 				() -> store.getFileAsStream(
 					companyId, repositoryId, fileName, versionLabel),
-				Objects::nonNull, null, StoreArea.LIVE, StoreArea.NEW);
+				Objects::nonNull, null, StoreArea.LIVE, StoreArea.NEW,
+				StoreArea.DELETED);
 		}
 
 		return store.getFileAsStream(
@@ -152,7 +153,7 @@ public class StoreAreaAwareStoreWrapper implements Store {
 		if (_isStoreAreaSupported()) {
 			String[] fileNames = StoreArea.mergeWithStoreAreas(
 				() -> store.getFileNames(companyId, repositoryId, dirName),
-				StoreArea.LIVE, StoreArea.NEW);
+				StoreArea.LIVE, StoreArea.NEW, StoreArea.DELETED);
 
 			Arrays.sort(fileNames);
 
@@ -174,7 +175,8 @@ public class StoreAreaAwareStoreWrapper implements Store {
 			return StoreArea.tryGetWithStoreAreas(
 				() -> store.getFileSize(
 					companyId, repositoryId, fileName, versionLabel),
-				Objects::nonNull, 0L, StoreArea.LIVE, StoreArea.NEW);
+				Objects::nonNull, 0L, StoreArea.LIVE, StoreArea.NEW,
+				StoreArea.DELETED);
 		}
 
 		return store.getFileSize(
@@ -190,7 +192,7 @@ public class StoreAreaAwareStoreWrapper implements Store {
 		if (_isStoreAreaSupported()) {
 			String[] fileVersions = StoreArea.mergeWithStoreAreas(
 				() -> store.getFileVersions(companyId, repositoryId, fileName),
-				StoreArea.LIVE, StoreArea.NEW);
+				StoreArea.LIVE, StoreArea.NEW, StoreArea.DELETED);
 
 			Arrays.sort(fileVersions, DLUtil::compareVersions);
 


### PR DESCRIPTION
# What is this about?

https://issues.liferay.com/browse/LPS-188418

This is a WIP. There are some failing tests in `document-library-test` that need some work. In particular, there are two problems:
  * `DeleteStalePWCVersionsUpgradeProcessTest` is failing.
  * `DLFileVersionHistoryTest` takes too long to run (performance issue).

Other tests in `document-library-test` may fail as well, so after these two issues are fixed, it could be a good idea to run a selection of those (not all; in particular, those involving the persistence can be skipped).

To reproduce these issues, remember that you have to:
  * Enable feature flag `LPS-174816`.
  * Configure and enable the GCS store.