### PR TITLE
LPS-189072 Message Boards: problem with dropdowns when click on More Messages 

### DIFF
--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_message_content.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_message_content.jsp
@@ -346,8 +346,6 @@ if (portletTitleBasedNavigation) {
 								.createContextualFragment(response)
 						);
 
-						runScriptsInElement(messageContainer.parentElement);
-
 						var replyContainer = document.querySelector(
 							'#<portlet:namespace />messageContainer > .reply-container'
 						);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-189072
No need to run scripts, otherwise dropdowns are registered twice. 

When `<liferay-ui:icon-menu>` is added to the markup (this is done for new replies loaded when you click on More Messages button), this automatically registers the "dropdown", so there is no need to call `runScriptsInElement()` fn, otherwise, the dropdown shows and hides inmediatelly. 
One possible solution could be to call runScriptsInElement for the last elements, 
```
runScriptsInElement(messageContainer.lastChild);
```
but I think there are no other scripts that need to be loaded and every button/feature works as expected, that is why I prefer to remove the call. 