### PR TITLE
LPS-165773 Search results are returned in the wrong order when searching for entry content

### DIFF
--- a/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/display/context/BlogsManagementToolbarDisplayContext.java
+++ b/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/display/context/BlogsManagementToolbarDisplayContext.java
@@ -113,7 +113,11 @@ public class BlogsManagementToolbarDisplayContext
 
 	@Override
 	public String getClearResultsURL() {
-		return getSearchActionURL();
+		return PortletURLBuilder.createRenderURL(
+			liferayPortletResponse
+		).setMVCRenderCommandName(
+			"/blogs/view"
+		).buildString();
 	}
 
 	@Override
@@ -174,30 +178,32 @@ public class BlogsManagementToolbarDisplayContext
 		).setNavigation(
 			ParamUtil.getString(httpServletRequest, "navigation", "entries")
 		).setParameter(
-			"orderByCol",
-			() -> {
-				String mvcRenderCommandName = ParamUtil.getString(
-					httpServletRequest, "mvcRenderCommandName");
-
-				if (mvcRenderCommandName.equals("/blogs/search")) {
-					return getOrderByCol();
-				}
-
-				return null;
-			}
+			"orderByCol", "relevance"
 		).setParameter(
-			"orderByType",
-			() -> {
-				String mvcRenderCommandName = ParamUtil.getString(
-					httpServletRequest, "mvcRenderCommandName");
-
-				if (mvcRenderCommandName.equals("/blogs/search")) {
-					return getOrderByType();
-				}
-
-				return null;
-			}
+			"orderByType", "desc"
 		).buildString();
+	}
+
+	@Override
+	public String getSortingURL() {
+		PortletURL sortingURL = getPortletURL();
+
+		String orderByCol = getOrderByCol();
+
+		if (Validator.isNotNull(orderByCol)) {
+			sortingURL.setParameter(getOrderByColParam(), orderByCol);
+		}
+
+		if (Objects.equals(orderByCol, "relevance")) {
+			sortingURL.setParameter(getOrderByTypeParam(), "desc");
+		}
+		else {
+			sortingURL.setParameter(
+				getOrderByTypeParam(),
+				Objects.equals(getOrderByType(), "asc") ? "desc" : "asc");
+		}
+
+		return sortingURL.toString();
 	}
 
 	@Override
@@ -270,7 +276,8 @@ public class BlogsManagementToolbarDisplayContext
 				dropdownItem.setActive(
 					Objects.equals(getOrderByCol(), "relevance"));
 				dropdownItem.setHref(
-					_getCurrentSortingURL(), "orderByCol", "relevance");
+					_getCurrentSortingURL(), "orderByCol", "relevance",
+					"orderByType", "desc");
 				dropdownItem.setLabel(
 					LanguageUtil.get(httpServletRequest, "relevance"));
 			}

--- a/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/display/context/BlogsViewEntriesDisplayContext.java
+++ b/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/display/context/BlogsViewEntriesDisplayContext.java
@@ -158,9 +158,14 @@ public class BlogsViewEntriesDisplayContext {
 			return _orderByCol;
 		}
 
-		_orderByCol = SearchOrderByUtil.getOrderByCol(
-			_httpServletRequest, BlogsPortletKeys.BLOGS_ADMIN,
-			"entries-order-by-col", _getDefaultOrderByCol());
+		if (_isOrderByColRelevance()) {
+			_orderByCol = "relevance";
+		}
+		else {
+			_orderByCol = SearchOrderByUtil.getOrderByCol(
+				_httpServletRequest, BlogsPortletKeys.BLOGS_ADMIN,
+				"entries-order-by-col", "title");
+		}
 
 		return _orderByCol;
 	}
@@ -170,9 +175,14 @@ public class BlogsViewEntriesDisplayContext {
 			return _orderByType;
 		}
 
-		_orderByType = SearchOrderByUtil.getOrderByType(
-			_httpServletRequest, BlogsPortletKeys.BLOGS_ADMIN,
-			"entries-order-by-type", "asc");
+		if (_isOrderByColRelevance()) {
+			_orderByType = "desc";
+		}
+		else {
+			_orderByType = SearchOrderByUtil.getOrderByType(
+				_httpServletRequest, BlogsPortletKeys.BLOGS_ADMIN,
+				"entries-order-by-type", "asc");
+		}
 
 		return _orderByType;
 	}
@@ -207,15 +217,17 @@ public class BlogsViewEntriesDisplayContext {
 		return entriesSearchContainer;
 	}
 
-	private String _getDefaultOrderByCol() {
-		String mvcRenderCommandName = ParamUtil.getString(
-			_httpServletRequest, "mvcRenderCommandName");
+	private boolean _isOrderByColRelevance() {
+		if (Objects.equals(
+				ParamUtil.getString(
+					_httpServletRequest,
+					SearchContainer.DEFAULT_ORDER_BY_COL_PARAM),
+				"relevance")) {
 
-		if (mvcRenderCommandName.equals("/blogs/search")) {
-			return "relevance";
+			return true;
 		}
 
-		return "title";
+		return false;
 	}
 
 	private void _populateResults(SearchContainer<BlogsEntry> searchContainer)
@@ -313,7 +325,7 @@ public class BlogsViewEntriesDisplayContext {
 					Field.DISPLAY_DATE, Sort.LONG_TYPE, !orderByAsc);
 			}
 			else if (Objects.equals(orderByCol, "relevance")) {
-				sort = new Sort(null, Sort.SCORE_TYPE, !orderByAsc);
+				sort = new Sort(null, Sort.SCORE_TYPE, false);
 			}
 			else {
 				sort = new Sort(orderByCol, !orderByAsc);


### PR DESCRIPTION
Steps for testing are in https://liferay.atlassian.net/browse/LPS-165773

Changes done are:

1.  Fixed the sort direction when searching: it was incorrectly set to be the opposite
2. When searching, the sort direction cannot be changed if sorting by relevance, it is always Descending
3. Relevance sorting is not saved in Portal Preferences, otherwise it used in non-search view where the "relevance" sort option doesn't apply
