### PR TITLE
LPS-186343 Redirect to 404 page instead of throwing error, this preve…

### DIFF
--- a/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
+++ b/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
@@ -1177,7 +1177,12 @@ public class WebServerServlet extends HttpServlet {
 		}
 
 		if (converted && (contentLength == 0)) {
-			throw new NoSuchFileException("The converted file is empty");
+			PortalUtil.sendError(
+				HttpServletResponse.SC_NOT_FOUND,
+				new NoSuchFileException("The converted file is empty"),
+				httpServletRequest, httpServletResponse);
+
+			return;
 		}
 
 		// Determine proper content type


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-186343

This change prevents transactions from being canceled when an adaptive media image does not exist but needs to be generated.