### PR TITLE
LPS-189476 Copy Categories, Tags in D&M when coping a File

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/CopyFileEntryMVCActionCommand.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/CopyFileEntryMVCActionCommand.java
@@ -26,6 +26,7 @@ import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.document.library.constants.DLPortletKeys;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.service.DLAppService;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONUtil;
@@ -47,6 +48,7 @@ import com.liferay.portal.kernel.util.WebKeys;
 
 import java.io.IOException;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -231,6 +233,38 @@ public class CopyFileEntryMVCActionCommand extends BaseMVCActionCommand {
 		}
 
 		return false;
+	}
+
+	private List<Long> _relatedGroupIds(
+			List<Long> currentAndAncestorSiteGroupsIds, Group group)
+		throws PortalException {
+
+		DepotEntry groupDepotEntry =
+			_depotEntryLocalService.fetchGroupDepotEntry(group.getGroupId());
+
+		if (groupDepotEntry != null) {
+			return currentAndAncestorSiteGroupsIds;
+		}
+
+		List<DepotEntryGroupRel> depotEntryGroupRels =
+			_depotEntryGroupRelLocalService.getDepotEntryGroupRels(
+				group.getGroupId(), QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+
+		if (ListUtil.isEmpty(depotEntryGroupRels)) {
+			return currentAndAncestorSiteGroupsIds;
+		}
+
+		List<Long> relatedGroupIds = new ArrayList<>(
+			currentAndAncestorSiteGroupsIds);
+
+		for (DepotEntryGroupRel depotEntryGroupRel : depotEntryGroupRels) {
+			DepotEntry depotEntry = _depotEntryLocalService.getDepotEntry(
+				depotEntryGroupRel.getDepotEntryId());
+
+			relatedGroupIds.add(depotEntry.getGroupId());
+		}
+
+		return relatedGroupIds;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/CopyFileEntryMVCActionCommand.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/CopyFileEntryMVCActionCommand.java
@@ -17,8 +17,10 @@ package com.liferay.document.library.web.internal.portlet.action;
 import com.liferay.asset.kernel.exception.NoSuchEntryException;
 import com.liferay.asset.kernel.model.AssetCategory;
 import com.liferay.asset.kernel.model.AssetEntry;
+import com.liferay.asset.kernel.model.AssetTag;
 import com.liferay.asset.kernel.service.AssetCategoryService;
 import com.liferay.asset.kernel.service.AssetEntryService;
+import com.liferay.asset.kernel.service.AssetTagLocalService;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.model.DepotEntryGroupRel;
 import com.liferay.depot.service.DepotEntryGroupRelLocalService;
@@ -175,7 +177,15 @@ public class CopyFileEntryMVCActionCommand extends BaseMVCActionCommand {
 			serviceContext.setAssetCategoryIds(
 				ArrayUtil.toLongArray(categoryIds));
 
-			serviceContext.setAssetTagNames(assetEntry.getTagNames());
+			Set<String> tagNames = new HashSet<>();
+
+			for (String tagName : assetEntry.getTagNames()) {
+				if (_isTagNameAllowed(groupIds, tagName)) {
+					tagNames.add(tagName);
+				}
+			}
+
+			serviceContext.setAssetTagNames(ArrayUtil.toStringArray(tagNames));
 		}
 		catch (PortalException portalException) {
 			if (!(portalException instanceof NoSuchEntryException)) {
@@ -223,14 +233,16 @@ public class CopyFileEntryMVCActionCommand extends BaseMVCActionCommand {
 		return false;
 	}
 
-		DepotEntryGroupRel depotEntryGroupRel =
-			_depotEntryGroupRelLocalService.
-				fetchDepotEntryGroupRelByDepotEntryIdToGroupId(
-					assetCategoryGroupDepotEntry.getDepotEntryId(),
-					group.getGroupId());
+	private boolean _isTagNameAllowed(
+		List<Long> groupIds, String tagName) {
 
-		if (depotEntryGroupRel != null) {
-			return true;
+		for (Long groupId : groupIds) {
+			AssetTag assetTag = _assetTagLocalService.fetchTag(
+				groupId, tagName);
+
+			if (assetTag != null) {
+				return true;
+			}
 		}
 
 		return false;
@@ -276,6 +288,9 @@ public class CopyFileEntryMVCActionCommand extends BaseMVCActionCommand {
 
 	@Reference
 	private AssetEntryService _assetEntryService;
+
+	@Reference
+	private AssetTagLocalService _assetTagLocalService;
 
 	@Reference
 	private DepotEntryGroupRelLocalService _depotEntryGroupRelLocalService;

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/CopyFileEntryMVCActionCommand.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/CopyFileEntryMVCActionCommand.java
@@ -148,44 +148,20 @@ public class CopyFileEntryMVCActionCommand extends BaseMVCActionCommand {
 			DLFileEntry.class.getName(), actionRequest);
 
 		try {
+			AssetEntry assetEntry = _assetEntryService.getEntry(
+				DLFileEntry.class.getName(), fileEntryId);
+
 			List<Long> currentAndAncestorSiteGroupsIds = ListUtil.fromArray(
 				_portal.getCurrentAndAncestorSiteGroupIds(group.getGroupId()));
 
 			List<Long> groupIds = _relatedGroupIds(
 				currentAndAncestorSiteGroupsIds, group);
 
-			DepotEntry groupDepotEntry = null;
-
-			if (group.isDepot()) {
-				groupDepotEntry = _depotEntryLocalService.fetchGroupDepotEntry(
-					group.getGroupId());
-			}
-
-			Set<Long> categoryIds = new HashSet<>();
-
-			AssetEntry assetEntry = _assetEntryService.getEntry(
-				DLFileEntry.class.getName(), fileEntryId);
-
-			for (long categoryId : assetEntry.getCategoryIds()) {
-				if (_isCategoryIdAllowed(
-						categoryId, groupIds, group, groupDepotEntry)) {
-
-					categoryIds.add(categoryId);
-				}
-			}
-
 			serviceContext.setAssetCategoryIds(
-				ArrayUtil.toLongArray(categoryIds));
+				_getAssetCategoryIds(assetEntry, group, groupIds));
 
-			Set<String> tagNames = new HashSet<>();
-
-			for (String tagName : assetEntry.getTagNames()) {
-				if (_isTagNameAllowed(groupIds, tagName)) {
-					tagNames.add(tagName);
-				}
-			}
-
-			serviceContext.setAssetTagNames(ArrayUtil.toStringArray(tagNames));
+			serviceContext.setAssetTagNames(
+				_getAssetTagNames(assetEntry, groupIds));
 		}
 		catch (PortalException portalException) {
 			if (!(portalException instanceof NoSuchEntryException)) {
@@ -194,6 +170,39 @@ public class CopyFileEntryMVCActionCommand extends BaseMVCActionCommand {
 		}
 
 		return serviceContext;
+	}
+
+	private long[] _getAssetCategoryIds(
+			AssetEntry assetEntry, Group group, List<Long> groupIds)
+		throws PortalException {
+
+		Set<Long> categoryIds = new HashSet<>();
+
+		for (long categoryId : assetEntry.getCategoryIds()) {
+			if (_isCategoryIdAllowed(
+					categoryId, groupIds, group,
+					_depotEntryLocalService.fetchGroupDepotEntry(
+						group.getGroupId()))) {
+
+				categoryIds.add(categoryId);
+			}
+		}
+
+		return ArrayUtil.toLongArray(categoryIds);
+	}
+
+	private String[] _getAssetTagNames(
+		AssetEntry assetEntry, List<Long> groupIds) {
+
+		Set<String> tagNames = new HashSet<>();
+
+		for (String tagName : assetEntry.getTagNames()) {
+			if (_isTagNameAllowed(groupIds, tagName)) {
+				tagNames.add(tagName);
+			}
+		}
+
+		return ArrayUtil.toStringArray(tagNames);
 	}
 
 	private boolean _isCategoryIdAllowed(
@@ -233,9 +242,7 @@ public class CopyFileEntryMVCActionCommand extends BaseMVCActionCommand {
 		return false;
 	}
 
-	private boolean _isTagNameAllowed(
-		List<Long> groupIds, String tagName) {
-
+	private boolean _isTagNameAllowed(List<Long> groupIds, String tagName) {
 		for (Long groupId : groupIds) {
 			AssetTag assetTag = _assetTagLocalService.fetchTag(
 				groupId, tagName);

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/CopyFileEntryMVCActionCommand.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/CopyFileEntryMVCActionCommand.java
@@ -15,7 +15,9 @@
 package com.liferay.document.library.web.internal.portlet.action;
 
 import com.liferay.asset.kernel.exception.NoSuchEntryException;
+import com.liferay.asset.kernel.model.AssetCategory;
 import com.liferay.asset.kernel.model.AssetEntry;
+import com.liferay.asset.kernel.service.AssetCategoryService;
 import com.liferay.asset.kernel.service.AssetEntryService;
 import com.liferay.document.library.constants.DLPortletKeys;
 import com.liferay.document.library.kernel.model.DLFileEntry;
@@ -33,10 +35,17 @@ import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextFactory;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
 
 import java.io.IOException;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 import javax.portlet.ActionRequest;
 import javax.portlet.ActionResponse;
@@ -73,10 +82,8 @@ public class CopyFileEntryMVCActionCommand extends BaseMVCActionCommand {
 		}
 	}
 
-	private void _checkDestinationRepository(long repositoryId)
+	private void _checkDestinationRepository(Group group)
 		throws PortalException {
-
-		Group group = _groupLocalService.fetchGroup(repositoryId);
 
 		if ((group != null) && group.isStaged() && !group.isStagingGroup()) {
 			throw new PortalException(
@@ -98,10 +105,13 @@ public class CopyFileEntryMVCActionCommand extends BaseMVCActionCommand {
 			actionRequest, "destinationRepositoryId");
 
 		try {
-			_checkDestinationRepository(destinationRepositoryId);
+			Group group = _groupLocalService.fetchGroup(
+				destinationRepositoryId);
+
+			_checkDestinationRepository(group);
 
 			ServiceContext serviceContext = _createServiceContext(
-				actionRequest, fileEntryId);
+				actionRequest, fileEntryId, group);
 
 			_dlAppService.copyFileEntry(
 				fileEntryId, destinationFolderId, destinationRepositoryId,
@@ -123,17 +133,34 @@ public class CopyFileEntryMVCActionCommand extends BaseMVCActionCommand {
 	}
 
 	private ServiceContext _createServiceContext(
-			ActionRequest actionRequest, long fileEntryId)
+			ActionRequest actionRequest, long fileEntryId, Group group)
 		throws PortalException {
 
 		ServiceContext serviceContext = ServiceContextFactory.getInstance(
 			DLFileEntry.class.getName(), actionRequest);
 
 		try {
+			List<Long> currentAndAncestorSiteGroupsIds = ListUtil.fromArray(
+				_portal.getCurrentAndAncestorSiteGroupIds(group.getGroupId()));
+			Set<Long> categoryIds = new HashSet<>();
+
 			AssetEntry assetEntry = _assetEntryService.getEntry(
 				DLFileEntry.class.getName(), fileEntryId);
 
-			serviceContext.setAssetCategoryIds(assetEntry.getCategoryIds());
+			for (long categoryId : assetEntry.getCategoryIds()) {
+				AssetCategory assetCategory =
+					_assetCategoryService.fetchCategory(categoryId);
+
+				if (currentAndAncestorSiteGroupsIds.contains(
+						assetCategory.getGroupId())) {
+
+					categoryIds.add(categoryId);
+				}
+			}
+
+			serviceContext.setAssetCategoryIds(
+				ArrayUtil.toLongArray(categoryIds));
+
 			serviceContext.setAssetTagNames(assetEntry.getTagNames());
 		}
 		catch (PortalException portalException) {
@@ -149,6 +176,9 @@ public class CopyFileEntryMVCActionCommand extends BaseMVCActionCommand {
 		CopyFileEntryMVCActionCommand.class);
 
 	@Reference
+	private AssetCategoryService _assetCategoryService;
+
+	@Reference
 	private AssetEntryService _assetEntryService;
 
 	@Reference
@@ -159,5 +189,8 @@ public class CopyFileEntryMVCActionCommand extends BaseMVCActionCommand {
 
 	@Reference
 	private JSONFactory _jsonFactory;
+
+	@Reference
+	private Portal _portal;
 
 }

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/CopyFileEntryMVCActionCommand.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/CopyFileEntryMVCActionCommand.java
@@ -19,6 +19,10 @@ import com.liferay.asset.kernel.model.AssetCategory;
 import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.asset.kernel.service.AssetCategoryService;
 import com.liferay.asset.kernel.service.AssetEntryService;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.model.DepotEntryGroupRel;
+import com.liferay.depot.service.DepotEntryGroupRelLocalService;
+import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.document.library.constants.DLPortletKeys;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.service.DLAppService;
@@ -138,6 +142,8 @@ public class CopyFileEntryMVCActionCommand extends BaseMVCActionCommand {
 
 		ServiceContext serviceContext = ServiceContextFactory.getInstance(
 			DLFileEntry.class.getName(), actionRequest);
+		DepotEntry groupDepotEntry =
+			_depotEntryLocalService.fetchGroupDepotEntry(group.getGroupId());
 
 		try {
 			List<Long> currentAndAncestorSiteGroupsIds = ListUtil.fromArray(
@@ -148,11 +154,9 @@ public class CopyFileEntryMVCActionCommand extends BaseMVCActionCommand {
 				DLFileEntry.class.getName(), fileEntryId);
 
 			for (long categoryId : assetEntry.getCategoryIds()) {
-				AssetCategory assetCategory =
-					_assetCategoryService.fetchCategory(categoryId);
-
-				if (currentAndAncestorSiteGroupsIds.contains(
-						assetCategory.getGroupId())) {
+				if (_isCategoryIdAllowed(
+						categoryId, currentAndAncestorSiteGroupsIds, group,
+						groupDepotEntry)) {
 
 					categoryIds.add(categoryId);
 				}
@@ -172,6 +176,63 @@ public class CopyFileEntryMVCActionCommand extends BaseMVCActionCommand {
 		return serviceContext;
 	}
 
+	private boolean _isCategoryIdAllowed(
+			long categoryId, List<Long> currentAndAncestorSiteGroupsIds,
+			Group group, DepotEntry groupDepotEntry)
+		throws PortalException {
+
+		AssetCategory assetCategory = _assetCategoryService.fetchCategory(
+			categoryId);
+
+		if (assetCategory == null) {
+			return false;
+		}
+
+		if (currentAndAncestorSiteGroupsIds.contains(
+				assetCategory.getGroupId())) {
+
+			return true;
+		}
+
+		if (group.isDepot()) {
+			if (groupDepotEntry == null) {
+				return false;
+			}
+
+			DepotEntryGroupRel depotEntryGroupRel =
+				_depotEntryGroupRelLocalService.
+					fetchDepotEntryGroupRelByDepotEntryIdToGroupId(
+						groupDepotEntry.getDepotEntryId(),
+						assetCategory.getGroupId());
+
+			if (depotEntryGroupRel != null) {
+				return true;
+			}
+
+			return false;
+		}
+
+		DepotEntry assetCategoryGroupDepotEntry =
+			_depotEntryLocalService.fetchGroupDepotEntry(
+				assetCategory.getGroupId());
+
+		if (assetCategoryGroupDepotEntry == null) {
+			return false;
+		}
+
+		DepotEntryGroupRel depotEntryGroupRel =
+			_depotEntryGroupRelLocalService.
+				fetchDepotEntryGroupRelByDepotEntryIdToGroupId(
+					assetCategoryGroupDepotEntry.getDepotEntryId(),
+					group.getGroupId());
+
+		if (depotEntryGroupRel != null) {
+			return true;
+		}
+
+		return false;
+	}
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		CopyFileEntryMVCActionCommand.class);
 
@@ -180,6 +241,12 @@ public class CopyFileEntryMVCActionCommand extends BaseMVCActionCommand {
 
 	@Reference
 	private AssetEntryService _assetEntryService;
+
+	@Reference
+	private DepotEntryGroupRelLocalService _depotEntryGroupRelLocalService;
+
+	@Reference
+	private DepotEntryLocalService _depotEntryLocalService;
 
 	@Reference
 	private DLAppService _dlAppService;

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/CopyFileEntryMVCActionCommand.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/CopyFileEntryMVCActionCommand.java
@@ -144,12 +144,21 @@ public class CopyFileEntryMVCActionCommand extends BaseMVCActionCommand {
 
 		ServiceContext serviceContext = ServiceContextFactory.getInstance(
 			DLFileEntry.class.getName(), actionRequest);
-		DepotEntry groupDepotEntry =
-			_depotEntryLocalService.fetchGroupDepotEntry(group.getGroupId());
 
 		try {
 			List<Long> currentAndAncestorSiteGroupsIds = ListUtil.fromArray(
 				_portal.getCurrentAndAncestorSiteGroupIds(group.getGroupId()));
+
+			List<Long> groupIds = _relatedGroupIds(
+				currentAndAncestorSiteGroupsIds, group);
+
+			DepotEntry groupDepotEntry = null;
+
+			if (group.isDepot()) {
+				groupDepotEntry = _depotEntryLocalService.fetchGroupDepotEntry(
+					group.getGroupId());
+			}
+
 			Set<Long> categoryIds = new HashSet<>();
 
 			AssetEntry assetEntry = _assetEntryService.getEntry(
@@ -157,8 +166,7 @@ public class CopyFileEntryMVCActionCommand extends BaseMVCActionCommand {
 
 			for (long categoryId : assetEntry.getCategoryIds()) {
 				if (_isCategoryIdAllowed(
-						categoryId, currentAndAncestorSiteGroupsIds, group,
-						groupDepotEntry)) {
+						categoryId, groupIds, group, groupDepotEntry)) {
 
 					categoryIds.add(categoryId);
 				}
@@ -179,8 +187,8 @@ public class CopyFileEntryMVCActionCommand extends BaseMVCActionCommand {
 	}
 
 	private boolean _isCategoryIdAllowed(
-			long categoryId, List<Long> currentAndAncestorSiteGroupsIds,
-			Group group, DepotEntry groupDepotEntry)
+			long categoryId, List<Long> groupsIds, Group group,
+			DepotEntry groupDepotEntry)
 		throws PortalException {
 
 		AssetCategory assetCategory = _assetCategoryService.fetchCategory(
@@ -190,9 +198,7 @@ public class CopyFileEntryMVCActionCommand extends BaseMVCActionCommand {
 			return false;
 		}
 
-		if (currentAndAncestorSiteGroupsIds.contains(
-				assetCategory.getGroupId())) {
-
+		if (groupsIds.contains(assetCategory.getGroupId())) {
 			return true;
 		}
 
@@ -214,13 +220,8 @@ public class CopyFileEntryMVCActionCommand extends BaseMVCActionCommand {
 			return false;
 		}
 
-		DepotEntry assetCategoryGroupDepotEntry =
-			_depotEntryLocalService.fetchGroupDepotEntry(
-				assetCategory.getGroupId());
-
-		if (assetCategoryGroupDepotEntry == null) {
-			return false;
-		}
+		return false;
+	}
 
 		DepotEntryGroupRel depotEntryGroupRel =
 			_depotEntryGroupRelLocalService.

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/CopyFileEntryMVCActionCommand.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/CopyFileEntryMVCActionCommand.java
@@ -14,8 +14,11 @@
 
 package com.liferay.document.library.web.internal.portlet.action;
 
+import com.liferay.asset.kernel.exception.NoSuchEntryException;
+import com.liferay.asset.kernel.model.AssetEntry;
+import com.liferay.asset.kernel.service.AssetEntryService;
 import com.liferay.document.library.constants.DLPortletKeys;
-import com.liferay.document.library.kernel.model.DLFileShortcut;
+import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.service.DLAppService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONFactory;
@@ -27,6 +30,7 @@ import com.liferay.portal.kernel.portlet.JSONPortletResponseUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCActionCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextFactory;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -96,10 +100,12 @@ public class CopyFileEntryMVCActionCommand extends BaseMVCActionCommand {
 		try {
 			_checkDestinationRepository(destinationRepositoryId);
 
+			ServiceContext serviceContext = _createServiceContext(
+				actionRequest, fileEntryId);
+
 			_dlAppService.copyFileEntry(
 				fileEntryId, destinationFolderId, destinationRepositoryId,
-				ServiceContextFactory.getInstance(
-					DLFileShortcut.class.getName(), actionRequest));
+				serviceContext);
 
 			JSONPortletResponseUtil.writeJSON(
 				actionRequest, actionResponse, _jsonFactory.createJSONObject());
@@ -116,8 +122,34 @@ public class CopyFileEntryMVCActionCommand extends BaseMVCActionCommand {
 		}
 	}
 
+	private ServiceContext _createServiceContext(
+			ActionRequest actionRequest, long fileEntryId)
+		throws PortalException {
+
+		ServiceContext serviceContext = ServiceContextFactory.getInstance(
+			DLFileEntry.class.getName(), actionRequest);
+
+		try {
+			AssetEntry assetEntry = _assetEntryService.getEntry(
+				DLFileEntry.class.getName(), fileEntryId);
+
+			serviceContext.setAssetCategoryIds(assetEntry.getCategoryIds());
+			serviceContext.setAssetTagNames(assetEntry.getTagNames());
+		}
+		catch (PortalException portalException) {
+			if (!(portalException instanceof NoSuchEntryException)) {
+				throw portalException;
+			}
+		}
+
+		return serviceContext;
+	}
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		CopyFileEntryMVCActionCommand.class);
+
+	@Reference
+	private AssetEntryService _assetEntryService;
 
 	@Reference
 	private DLAppService _dlAppService;

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/CopyFileEntryMVCActionCommand.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/CopyFileEntryMVCActionCommand.java
@@ -90,9 +90,7 @@ public class CopyFileEntryMVCActionCommand extends BaseMVCActionCommand {
 		}
 	}
 
-	private void _checkDestinationRepository(Group group)
-		throws PortalException {
-
+	private void _checkDestinationGroup(Group group) throws PortalException {
 		if ((group != null) && group.isStaged() && !group.isStagingGroup()) {
 			throw new PortalException(
 				"cannot-copy-file-entries-to-the-live-version-of-a-group");
@@ -116,7 +114,7 @@ public class CopyFileEntryMVCActionCommand extends BaseMVCActionCommand {
 			Group group = _groupLocalService.fetchGroup(
 				destinationRepositoryId);
 
-			_checkDestinationRepository(group);
+			_checkDestinationGroup(group);
 
 			ServiceContext serviceContext = _createServiceContext(
 				actionRequest, fileEntryId, group);
@@ -151,11 +149,11 @@ public class CopyFileEntryMVCActionCommand extends BaseMVCActionCommand {
 			AssetEntry assetEntry = _assetEntryService.getEntry(
 				DLFileEntry.class.getName(), fileEntryId);
 
-			List<Long> currentAndAncestorSiteGroupsIds = ListUtil.fromArray(
-				_portal.getCurrentAndAncestorSiteGroupIds(group.getGroupId()));
-
-			List<Long> groupIds = _relatedGroupIds(
-				currentAndAncestorSiteGroupsIds, group);
+			List<Long> groupIds = _getGroupIds(
+				ListUtil.fromArray(
+					_portal.getCurrentAndAncestorSiteGroupIds(
+						group.getGroupId())),
+				group);
 
 			serviceContext.setAssetCategoryIds(
 				_getAssetCategoryIds(assetEntry, group, groupIds));
@@ -205,57 +203,7 @@ public class CopyFileEntryMVCActionCommand extends BaseMVCActionCommand {
 		return ArrayUtil.toStringArray(tagNames);
 	}
 
-	private boolean _isCategoryIdAllowed(
-			long categoryId, List<Long> groupsIds, Group group,
-			DepotEntry groupDepotEntry)
-		throws PortalException {
-
-		AssetCategory assetCategory = _assetCategoryService.fetchCategory(
-			categoryId);
-
-		if (assetCategory == null) {
-			return false;
-		}
-
-		if (groupsIds.contains(assetCategory.getGroupId())) {
-			return true;
-		}
-
-		if (group.isDepot()) {
-			if (groupDepotEntry == null) {
-				return false;
-			}
-
-			DepotEntryGroupRel depotEntryGroupRel =
-				_depotEntryGroupRelLocalService.
-					fetchDepotEntryGroupRelByDepotEntryIdToGroupId(
-						groupDepotEntry.getDepotEntryId(),
-						assetCategory.getGroupId());
-
-			if (depotEntryGroupRel != null) {
-				return true;
-			}
-
-			return false;
-		}
-
-		return false;
-	}
-
-	private boolean _isTagNameAllowed(List<Long> groupIds, String tagName) {
-		for (Long groupId : groupIds) {
-			AssetTag assetTag = _assetTagLocalService.fetchTag(
-				groupId, tagName);
-
-			if (assetTag != null) {
-				return true;
-			}
-		}
-
-		return false;
-	}
-
-	private List<Long> _relatedGroupIds(
+	private List<Long> _getGroupIds(
 			List<Long> currentAndAncestorSiteGroupsIds, Group group)
 		throws PortalException {
 
@@ -274,17 +222,62 @@ public class CopyFileEntryMVCActionCommand extends BaseMVCActionCommand {
 			return currentAndAncestorSiteGroupsIds;
 		}
 
-		List<Long> relatedGroupIds = new ArrayList<>(
-			currentAndAncestorSiteGroupsIds);
+		List<Long> groupIds = new ArrayList<>(currentAndAncestorSiteGroupsIds);
 
 		for (DepotEntryGroupRel depotEntryGroupRel : depotEntryGroupRels) {
 			DepotEntry depotEntry = _depotEntryLocalService.getDepotEntry(
 				depotEntryGroupRel.getDepotEntryId());
 
-			relatedGroupIds.add(depotEntry.getGroupId());
+			groupIds.add(depotEntry.getGroupId());
 		}
 
-		return relatedGroupIds;
+		return groupIds;
+	}
+
+	private boolean _isCategoryIdAllowed(
+			long categoryId, List<Long> groupsIds, Group group,
+			DepotEntry groupDepotEntry)
+		throws PortalException {
+
+		AssetCategory assetCategory = _assetCategoryService.fetchCategory(
+			categoryId);
+
+		if (assetCategory == null) {
+			return false;
+		}
+
+		if (groupsIds.contains(assetCategory.getGroupId())) {
+			return true;
+		}
+
+		if (!group.isDepot() || (groupDepotEntry == null)) {
+			return false;
+		}
+
+		DepotEntryGroupRel depotEntryGroupRel =
+			_depotEntryGroupRelLocalService.
+				fetchDepotEntryGroupRelByDepotEntryIdToGroupId(
+					groupDepotEntry.getDepotEntryId(),
+					assetCategory.getGroupId());
+
+		if (depotEntryGroupRel != null) {
+			return true;
+		}
+
+		return false;
+	}
+
+	private boolean _isTagNameAllowed(List<Long> groupIds, String tagName) {
+		for (Long groupId : groupIds) {
+			AssetTag assetTag = _assetTagLocalService.fetchTag(
+				groupId, tagName);
+
+			if (assetTag != null) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-189476


To test it :
For all:  Enable FF: LPS-182512

1. Go to global site
2. On this create a category and a tag
3. Create a Document with created category and tag
4. Go to document > dropdown > copy to 
5. copy to Liferay site (home)
6. Go to Liferay site > Documents and Media
7. check document copied from global (edit) has the tag and the category


other test

1. Create an Asset Library
2. Connect to Liferay Site
3. On the asset library create a category and a tag
4. Create a Document with created category and tag
5. Go to document > dropdown > copy to 
6. copy to Liferay site (home)
7. Go to Liferay site > Documents and Media
8. check document copied from asset library has the tag and the category

note : if copy between sites not related, only common categories and tags (from global or an common ancestor) is copied

- LPS-189476 populate the service context with the tags and categories from the original asset entry and let the system work as expected
- LPS-189476 only copy categories on  current and ancestor site
- LPS-189476 add the categories of the related assetLibrary if is it
- LPS-189476 get the related groups ids of the destination group
- LPS-189476 check the categories with the groups related to the destination group
- LPS-189476 check if the tags are contained of groups related to the destination group
- LPS-189476 extract method to better readability
- LPS-189476 rename
