### PR TITLE
LPS-189740 DM Versions

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/file_entry_history.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/file_entry_history.jsp
@@ -80,7 +80,7 @@
 	}
 	%>
 
-	<c:if test='<%= FeatureFlagManagerUtil.isEnabled("LPS-175915") && (end > 0 && fileEntry.getFileVersionsCount(status) >= end) %>'>
+	<c:if test='<%= FeatureFlagManagerUtil.isEnabled("LPS-175915") && (end > 0) && (fileEntry.getFileVersionsCount(status) >= end) %>'>
 		<portlet:renderURL var="viewMoreURL">
 			<portlet:param name="mvcRenderCommandName" value="/document_library/view_file_entry_history" />
 			<portlet:param name="backURL" value="<%= currentURL %>" />

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/file_entry_history.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/file_entry_history.jsp
@@ -81,10 +81,16 @@
 	%>
 
 	<c:if test='<%= FeatureFlagManagerUtil.isEnabled("LPS-175915") && (index >= fileVersionsLimit) %>'>
+		<portlet:renderURL var="viewMoreURL">
+			<portlet:param name="mvcRenderCommandName" value="/document_library/view_file_entry_history" />
+			<portlet:param name="backURL" value="<%= currentURL %>" />
+			<portlet:param name="fileEntryId" value="<%= String.valueOf(fileEntry.getFileEntryId()) %>" />
+		</portlet:renderURL>
+
 		<div class="m-4 text-center">
 			<clay:link
 				displayType="secondary"
-				href="#"
+				href="<%= viewMoreURL %>"
 				label="view-more"
 				small="<%= true %>"
 				type="button"

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/file_entry_history.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/file_entry_history.jsp
@@ -27,14 +27,15 @@
 		status = WorkflowConstants.STATUS_ANY;
 	}
 
-	int fileVersionsLimit = 10;
+	int start = QueryUtil.ALL_POS;
+	int end = QueryUtil.ALL_POS;
 
-	int index = 0;
+	if (FeatureFlagManagerUtil.isEnabled("LPS-175915")) {
+		start = 0;
+		end = 10;
+	}
 
-	for (FileVersion fileVersion : fileEntry.getFileVersions(status)) {
-		if (FeatureFlagManagerUtil.isEnabled("LPS-175915") && (index >= fileVersionsLimit)) {
-			break;
-		}
+	for (FileVersion fileVersion : fileEntry.getFileVersions(status, start, end)) {
 	%>
 
 		<li class="list-group-item list-group-item-flex">
@@ -76,11 +77,10 @@
 		</li>
 
 	<%
-		index++;
 	}
 	%>
 
-	<c:if test='<%= FeatureFlagManagerUtil.isEnabled("LPS-175915") && (index >= fileVersionsLimit) %>'>
+	<c:if test='<%= FeatureFlagManagerUtil.isEnabled("LPS-175915") && (end > 0 && fileEntry.getFileVersionsCount(status) >= end) %>'>
 		<portlet:renderURL var="viewMoreURL">
 			<portlet:param name="mvcRenderCommandName" value="/document_library/view_file_entry_history" />
 			<portlet:param name="backURL" value="<%= currentURL %>" />

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/file_entry_history.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/file_entry_history.jsp
@@ -81,6 +81,14 @@
 	%>
 
 	<c:if test='<%= FeatureFlagManagerUtil.isEnabled("LPS-175915") && (index >= fileVersionsLimit) %>'>
-		<span>View More</span>
+		<div class="m-4 text-center">
+			<clay:link
+				displayType="secondary"
+				href="#"
+				label="view-more"
+				small="<%= true %>"
+				type="button"
+			/>
+		</div>
 	</c:if>
 </ul>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/file_entry_history.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/file_entry_history.jsp
@@ -27,7 +27,14 @@
 		status = WorkflowConstants.STATUS_ANY;
 	}
 
+	int fileVersionsLimit = 10;
+
+	int index = 0;
+
 	for (FileVersion fileVersion : fileEntry.getFileVersions(status)) {
+		if (FeatureFlagManagerUtil.isEnabled("LPS-175915") && (index >= fileVersionsLimit)) {
+			break;
+		}
 	%>
 
 		<li class="list-group-item list-group-item-flex">
@@ -69,7 +76,11 @@
 		</li>
 
 	<%
+		index++;
 	}
 	%>
 
+	<c:if test='<%= FeatureFlagManagerUtil.isEnabled("LPS-175915") && (index >= fileVersionsLimit) %>'>
+		<span>View More</span>
+	</c:if>
 </ul>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/init.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/init.jsp
@@ -59,6 +59,7 @@ page import="com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemLi
 page import="com.liferay.item.selector.ItemSelector" %><%@
 page import="com.liferay.item.selector.criteria.FolderItemSelectorReturnType" %><%@
 page import="com.liferay.item.selector.criteria.folder.criterion.FolderItemSelectorCriterion" %><%@
+page import="com.liferay.portal.kernel.dao.orm.QueryUtil" %><%@
 page import="com.liferay.portal.kernel.dao.search.RowChecker" %><%@
 page import="com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil" %><%@
 page import="com.liferay.portal.kernel.lock.Lock" %><%@


### PR DESCRIPTION
This pull completes stories https://liferay.atlassian.net/browse/LPS-175916 and https://liferay.atlassian.net/browse/LPS-175922 

Added a View More button when there are more than 10 versions of a file entry (from the info panel):

Screenshots with limit of 3 versions for simplicity: 
<img width="1051" alt="Screenshot 2023-07-06 at 12 24 42" src="https://github.com/liferay-lima/liferay-portal/assets/8373764/2f44dd49-44da-4631-a069-5f915099d9a2">

<img width="1051" alt="Screenshot 2023-07-06 at 12 24 55" src="https://github.com/liferay-lima/liferay-portal/assets/8373764/3575df97-7162-49a0-a616-9eb17df6f59a">

