### PR TITLE
LPS-189775 copy tags and categories on shortcut

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info_panel.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info_panel.jsp
@@ -265,6 +265,37 @@ List<Folder> folders = dlInfoPanelDisplayContext.getFolders();
 						<dd class="sidebar-dd">
 							<%= HtmlUtil.escape(fileEntry.getMimeType()) %>
 						</dd>
+
+						<liferay-asset:asset-tags-available
+							className="<%= DLFileShortcutConstants.getClassName() %>"
+							classPK="<%= fileShortcut.getFileShortcutId() %>"
+						>
+							<dt class="sidebar-dt">
+								<liferay-ui:message key="tags" />
+							</dt>
+							<dd class="sidebar-dd">
+								<liferay-asset:asset-tags-summary
+									className="<%= DLFileShortcutConstants.getClassName() %>"
+									classPK="<%= fileShortcut.getFileShortcutId() %>"
+								/>
+							</dd>
+						</liferay-asset:asset-tags-available>
+
+						<liferay-asset:asset-categories-available
+							className="<%= DLFileShortcutConstants.getClassName() %>"
+							classPK="<%= fileShortcut.getFileShortcutId() %>"
+						>
+							<dt class="sidebar-dt">
+								<liferay-ui:message key="categories" />
+							</dt>
+							<dd class="sidebar-dd">
+								<liferay-asset:asset-categories-summary
+									className="<%= DLFileShortcutConstants.getClassName() %>"
+									classPK="<%= fileShortcut.getFileShortcutId() %>"
+									displayStyle="simple-category"
+								/>
+							</dd>
+						</liferay-asset:asset-categories-available>
 					</dl>
 				</liferay-ui:section>
 			</liferay-ui:tabs>

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileShortcutLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileShortcutLocalServiceImpl.java
@@ -17,6 +17,7 @@ package com.liferay.portlet.documentlibrary.service.impl;
 import com.liferay.asset.kernel.service.AssetEntryLocalService;
 import com.liferay.asset.kernel.service.AssetTagLocalService;
 import com.liferay.document.library.kernel.exception.NoSuchFileEntryException;
+import com.liferay.document.library.kernel.model.DLFileEntryConstants;
 import com.liferay.document.library.kernel.model.DLFileShortcut;
 import com.liferay.document.library.kernel.model.DLFileShortcutConstants;
 import com.liferay.document.library.kernel.model.DLFolder;
@@ -461,7 +462,7 @@ public class DLFileShortcutLocalServiceImpl
 		throws PortalException {
 
 		String[] assetTagNames = _assetTagLocalService.getTagNames(
-			FileEntry.class.getName(), fileEntry.getFileEntryId());
+			DLFileEntryConstants.getClassName(), fileEntry.getFileEntryId());
 
 		_assetTagLocalService.checkTags(
 			serviceContext.getUserId(), serviceContext.getScopeGroupId(),

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileShortcutLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileShortcutLocalServiceImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portlet.documentlibrary.service.impl;
 
+import com.liferay.asset.kernel.service.AssetCategoryLocalService;
 import com.liferay.asset.kernel.service.AssetEntryLocalService;
 import com.liferay.asset.kernel.service.AssetTagLocalService;
 import com.liferay.document.library.kernel.exception.NoSuchFileEntryException;
@@ -115,11 +116,15 @@ public class DLFileShortcutLocalServiceImpl
 
 		// Asset
 
-		copyAssetTags(
-			_dlAppLocalService.getFileEntry(toFileEntryId), serviceContext);
+		FileEntry fileEntry = _dlAppLocalService.getFileEntry(toFileEntryId);
+
+		copyAssetTags(fileEntry, serviceContext);
 
 		updateAsset(
-			userId, fileShortcut, serviceContext.getAssetCategoryIds(),
+			userId, fileShortcut,
+			_assetCategoryLocalService.getCategoryIds(
+				DLFileEntryConstants.getClassName(),
+				fileEntry.getFileEntryId()),
 			serviceContext.getAssetTagNames());
 
 		return fileShortcut;
@@ -402,11 +407,15 @@ public class DLFileShortcutLocalServiceImpl
 
 		// Asset
 
-		copyAssetTags(
-			_dlAppLocalService.getFileEntry(toFileEntryId), serviceContext);
+		FileEntry fileEntry = _dlAppLocalService.getFileEntry(toFileEntryId);
+
+		copyAssetTags(fileEntry, serviceContext);
 
 		updateAsset(
-			userId, fileShortcut, serviceContext.getAssetCategoryIds(),
+			userId, fileShortcut,
+			_assetCategoryLocalService.getCategoryIds(
+				DLFileEntryConstants.getClassName(),
+				fileEntry.getFileEntryId()),
 			serviceContext.getAssetTagNames());
 
 		return fileShortcut;
@@ -502,6 +511,9 @@ public class DLFileShortcutLocalServiceImpl
 		ServiceProxyFactory.newServiceTrackedInstance(
 			TrashHelper.class, DLFileShortcutLocalServiceImpl.class,
 			"_trashHelper", false);
+
+	@BeanReference(type = AssetCategoryLocalService.class)
+	private AssetCategoryLocalService _assetCategoryLocalService;
 
 	@BeanReference(type = AssetEntryLocalService.class)
 	private AssetEntryLocalService _assetEntryLocalService;


### PR DESCRIPTION
On this PR I want to solve 2 things

the tags were not copied on the shortcut because the class was incorrect
the categories never were obtained from the file

additionally I added the tag/category taglib to the info_panel to show them. This maybe will cause some poshi failures.




- LPS-189775 use DLFileEntryConstants.getClassName to get the tags
- LPS-189775 copy asset categories to the new shortcut
- LPS-189775 show the categories and the tags on the info panel
