### PR TITLE
LPS-190095 Fix wrong URL usage in DeepL Translator

### DIFF
--- a/modules/apps/translation/translation-translator-deepl/src/main/java/com/liferay/translation/translator/deepl/internal/translator/DeepLTranslator.java
+++ b/modules/apps/translation/translation-translator-deepl/src/main/java/com/liferay/translation/translator/deepl/internal/translator/DeepLTranslator.java
@@ -141,24 +141,23 @@ public class DeepLTranslator implements Translator {
 
 		return JSONUtil.toList(
 			_jsonFactory.createJSONArray(
-				_invoke(deepLTranslatorConfiguration, options)),
+				_invoke(
+					options, deepLTranslatorConfiguration.validateLanguageURL(),
+					deepLTranslatorConfiguration.authKey())),
 			jsonObject -> jsonObject.getString("language"), _log);
 	}
 
-	private String _invoke(
-			DeepLTranslatorConfiguration deepLTranslatorConfiguration,
-			Http.Options options)
+	private String _invoke(Http.Options options, String url, String authKey)
 		throws PortalException {
 
 		String json = null;
 
 		options.addHeader(
-			HttpHeaders.AUTHORIZATION,
-			"DeepL-Auth-Key " + deepLTranslatorConfiguration.authKey());
+			HttpHeaders.AUTHORIZATION, "DeepL-Auth-Key " + authKey);
 		options.addHeader(
 			HttpHeaders.CONTENT_TYPE,
 			ContentTypes.APPLICATION_X_WWW_FORM_URLENCODED);
-		options.setLocation(deepLTranslatorConfiguration.validateLanguageURL());
+		options.setLocation(url);
 
 		try {
 			json = _http.URLtoString(options);
@@ -218,7 +217,9 @@ public class DeepLTranslator implements Translator {
 		options.setMethod(Http.Method.POST);
 
 		JSONObject jsonObject = _jsonFactory.createJSONObject(
-			_invoke(deepLTranslatorConfiguration, options));
+			_invoke(
+				options, deepLTranslatorConfiguration.url(),
+				deepLTranslatorConfiguration.authKey()));
 
 		JSONArray jsonArray = jsonObject.getJSONArray("translations");
 


### PR DESCRIPTION

https://issues.liferay.com/browse/LPS-190095

As described in https://liferay.dev/ask/questions/development/reply-for-lps-183137-lps-187034-breaks-deepl the fix for LPS-187034 introduces an issue for DeepL:

The refactoring of the DeepL translator code to use the company configuration as basis for requests (LPS-187034) breaks translations because the wrong URL is used to create translation requests. There are two different URLs used by the DeepL translator. One is used to fetch the valid languages (validatedLanguageUrl) and the second to do the translation (url). After the refactoring for both cases `validatedLanguageUrl` is used, which breaks the translation call.

In LPS-183137 a user with name Austin pinged me for this. I can't access the JIRA anymore, so there is neither a tracking issue, nor can I answer this person. If required, please create an issue, I can update the commit message accordingly.

The fix was coded against 7.4.3.83 and tested in our staging environment, I rebased it onto current master for inclusion in mainline.