### PR TITLE
LPS-186176 the level can be retrieved from the config so we must put it before the assignation

### DIFF
--- a/portal-test/src/com/liferay/portal/test/log/LoggerTestUtil.java
+++ b/portal-test/src/com/liferay/portal/test/log/LoggerTestUtil.java
@@ -240,13 +240,13 @@ public class LoggerTestUtil {
 
 			_level = logger.getLevel();
 
+			Log4JUtil.setLevel(logger.getName(), priority, false);
+
 			_loggerConfig = logger.get();
 
 			_additive = _loggerConfig.isAdditive();
 
 			_loggerConfig.setAdditive(false);
-
-			Log4JUtil.setLevel(logger.getName(), priority, false);
 		}
 
 		private final boolean _additive;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-186176

On https://liferay.atlassian.net/browse/LPS-164317 the order of the creation and the  Log4JUtil.setLevel was changed to prevent  `OutOfMemoryError from ObjectEntryLocalServiceTest`



On Log4JUtil.setLevel logger is updated and the priority is set to the loggerConfig, and it seems that is from loggerConfig where we take the priority for logging.

If we made Log4JUtil.setLevel after _loggerConfig = logger.get() we are not putting the correct priority to the config so when we take the priority on the logCapture we are comparing with the previous log level (INFO) so the log is not captured if the priority is not the same.


To test it:

- stop server
- wait 5 mins
- start server
- go to `(your portal folder)/modules/apps/message-boards/message-boards-test`
- run ` gw tI --tests "*testDeleteAttachmentsWhenDeletingMessage*"`
