### PR TITLE
LPS-190337 - Check that document belongs to current company.

### DIFF
--- a/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
+++ b/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
@@ -1605,7 +1605,7 @@ public class WebServerServlet extends HttpServlet {
 
 		long companyId = PortalUtil.getCompanyId(httpServletRequest);
 
-		if (!(group.getCompanyId() == companyId)) {
+		if (group.getCompanyId() != companyId) {
 			if (_log.isDebugEnabled()) {
 				_log.debug(
 					StringBundler.concat(

--- a/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
+++ b/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
@@ -1549,6 +1549,8 @@ public class WebServerServlet extends HttpServlet {
 			return;
 		}
 
+		_checkInstanceGroupId(fileEntry.getGroupId(), httpServletRequest);
+
 		PermissionChecker permissionChecker = _getPermissionChecker(
 			httpServletRequest);
 
@@ -1583,6 +1585,35 @@ public class WebServerServlet extends HttpServlet {
 			throw new FileEntryExpiredException(
 				"The file entry " + fileEntry.getFileEntryId() +
 					" is expired and the user does not have review permission");
+		}
+	}
+
+	private void _checkInstanceGroupId(
+			long groupId, HttpServletRequest httpServletRequest)
+		throws Exception {
+
+		Group group = GroupLocalServiceUtil.fetchGroup(groupId);
+
+		if (group == null) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					StringBundler.concat("Group not found: ", groupId, "."));
+			}
+
+			throw new NoSuchFileEntryException("No file entry found");
+		}
+
+		long companyId = PortalUtil.getCompanyId(httpServletRequest);
+
+		if (!(group.getCompanyId() == companyId)) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					StringBundler.concat(
+						"Group ", groupId, " does not belong to company: ",
+						companyId, "."));
+			}
+
+			throw new NoSuchFileEntryException("No file entry found");
 		}
 	}
 


### PR DESCRIPTION
As previously mentioned, if someone acceded a file stored in a virtual instance using a URL based on the main instance the file was accessible. With this check if the file does not belong to the current instance a NoSuchFileEntryException exception is returned.

@robertoDiaz also has the full context.