### PR TITLE
LPS 183824 1

### DIFF
--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/exportimport/data/handler/DLFileEntryTypeStagedModelDataHandler.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/exportimport/data/handler/DLFileEntryTypeStagedModelDataHandler.java
@@ -20,7 +20,6 @@ import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
 import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalService;
 import com.liferay.document.library.kernel.util.DLUtil;
 import com.liferay.document.library.util.DLFileEntryTypeUtil;
-import com.liferay.dynamic.data.mapping.kernel.DDMStructureManagerUtil;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
 import com.liferay.exportimport.data.handler.base.BaseStagedModelDataHandler;
@@ -463,8 +462,8 @@ public class DLFileEntryTypeStagedModelDataHandler
 		}
 
 		for (long ddmStructureId : ddmStructureIds) {
-			com.liferay.dynamic.data.mapping.kernel.DDMStructure ddmStructure =
-				DDMStructureManagerUtil.fetchStructure(ddmStructureId);
+			DDMStructure ddmStructure =
+				_ddmStructureLocalService.fetchStructure(ddmStructureId);
 
 			if (ddmStructure == null) {
 				throw new NoSuchMetadataSetException(

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/http/DLFileEntryTypeServiceHttp.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/http/DLFileEntryTypeServiceHttp.java
@@ -97,99 +97,6 @@ public class DLFileEntryTypeServiceHttp {
 		}
 	}
 
-	public static com.liferay.document.library.kernel.model.DLFileEntryType
-			addFileEntryType(
-				HttpPrincipal httpPrincipal, long groupId,
-				String fileEntryTypeKey,
-				java.util.Map<java.util.Locale, String> nameMap,
-				java.util.Map<java.util.Locale, String> descriptionMap,
-				long[] ddmStructureIds,
-				com.liferay.portal.kernel.service.ServiceContext serviceContext)
-		throws com.liferay.portal.kernel.exception.PortalException {
-
-		try {
-			MethodKey methodKey = new MethodKey(
-				DLFileEntryTypeServiceUtil.class, "addFileEntryType",
-				_addFileEntryTypeParameterTypes1);
-
-			MethodHandler methodHandler = new MethodHandler(
-				methodKey, groupId, fileEntryTypeKey, nameMap, descriptionMap,
-				ddmStructureIds, serviceContext);
-
-			Object returnObj = null;
-
-			try {
-				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
-			}
-			catch (Exception exception) {
-				if (exception instanceof
-						com.liferay.portal.kernel.exception.PortalException) {
-
-					throw (com.liferay.portal.kernel.exception.PortalException)
-						exception;
-				}
-
-				throw new com.liferay.portal.kernel.exception.SystemException(
-					exception);
-			}
-
-			return (com.liferay.document.library.kernel.model.DLFileEntryType)
-				returnObj;
-		}
-		catch (com.liferay.portal.kernel.exception.SystemException
-					systemException) {
-
-			_log.error(systemException, systemException);
-
-			throw systemException;
-		}
-	}
-
-	public static com.liferay.document.library.kernel.model.DLFileEntryType
-			addFileEntryType(
-				HttpPrincipal httpPrincipal, long groupId, String name,
-				String description, long[] ddmStructureIds,
-				com.liferay.portal.kernel.service.ServiceContext serviceContext)
-		throws com.liferay.portal.kernel.exception.PortalException {
-
-		try {
-			MethodKey methodKey = new MethodKey(
-				DLFileEntryTypeServiceUtil.class, "addFileEntryType",
-				_addFileEntryTypeParameterTypes2);
-
-			MethodHandler methodHandler = new MethodHandler(
-				methodKey, groupId, name, description, ddmStructureIds,
-				serviceContext);
-
-			Object returnObj = null;
-
-			try {
-				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
-			}
-			catch (Exception exception) {
-				if (exception instanceof
-						com.liferay.portal.kernel.exception.PortalException) {
-
-					throw (com.liferay.portal.kernel.exception.PortalException)
-						exception;
-				}
-
-				throw new com.liferay.portal.kernel.exception.SystemException(
-					exception);
-			}
-
-			return (com.liferay.document.library.kernel.model.DLFileEntryType)
-				returnObj;
-		}
-		catch (com.liferay.portal.kernel.exception.SystemException
-					systemException) {
-
-			_log.error(systemException, systemException);
-
-			throw systemException;
-		}
-	}
-
 	public static void deleteFileEntryType(
 			HttpPrincipal httpPrincipal, long fileEntryTypeId)
 		throws com.liferay.portal.kernel.exception.PortalException {
@@ -197,7 +104,7 @@ public class DLFileEntryTypeServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryTypeServiceUtil.class, "deleteFileEntryType",
-				_deleteFileEntryTypeParameterTypes3);
+				_deleteFileEntryTypeParameterTypes1);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, fileEntryTypeId);
@@ -233,7 +140,7 @@ public class DLFileEntryTypeServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryTypeServiceUtil.class, "getFileEntryType",
-				_getFileEntryTypeParameterTypes4);
+				_getFileEntryTypeParameterTypes2);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, fileEntryTypeId);
@@ -274,7 +181,7 @@ public class DLFileEntryTypeServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryTypeServiceUtil.class, "getFileEntryTypes",
-				_getFileEntryTypesParameterTypes5);
+				_getFileEntryTypesParameterTypes3);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupIds);
@@ -311,7 +218,7 @@ public class DLFileEntryTypeServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryTypeServiceUtil.class, "getFileEntryTypes",
-				_getFileEntryTypesParameterTypes6);
+				_getFileEntryTypesParameterTypes4);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupIds, start, end);
@@ -345,7 +252,7 @@ public class DLFileEntryTypeServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryTypeServiceUtil.class, "getFileEntryTypesCount",
-				_getFileEntryTypesCountParameterTypes7);
+				_getFileEntryTypesCountParameterTypes5);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupIds);
@@ -381,7 +288,7 @@ public class DLFileEntryTypeServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryTypeServiceUtil.class, "getFolderFileEntryTypes",
-				_getFolderFileEntryTypesParameterTypes8);
+				_getFolderFileEntryTypesParameterTypes6);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupIds, folderId, inherited);
@@ -427,7 +334,7 @@ public class DLFileEntryTypeServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryTypeServiceUtil.class, "search",
-				_searchParameterTypes9);
+				_searchParameterTypes7);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, folderId, groupIds, keywords,
@@ -475,7 +382,7 @@ public class DLFileEntryTypeServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryTypeServiceUtil.class, "search",
-				_searchParameterTypes10);
+				_searchParameterTypes8);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, groupIds, keywords,
@@ -517,7 +424,7 @@ public class DLFileEntryTypeServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryTypeServiceUtil.class, "search",
-				_searchParameterTypes11);
+				_searchParameterTypes9);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, groupIds, keywords,
@@ -554,7 +461,7 @@ public class DLFileEntryTypeServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryTypeServiceUtil.class, "searchCount",
-				_searchCountParameterTypes12);
+				_searchCountParameterTypes10);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, folderId, groupIds, keywords,
@@ -588,7 +495,7 @@ public class DLFileEntryTypeServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryTypeServiceUtil.class, "searchCount",
-				_searchCountParameterTypes13);
+				_searchCountParameterTypes11);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, groupIds, keywords,
@@ -622,7 +529,7 @@ public class DLFileEntryTypeServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryTypeServiceUtil.class, "searchCount",
-				_searchCountParameterTypes14);
+				_searchCountParameterTypes12);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, groupIds, keywords,
@@ -659,7 +566,7 @@ public class DLFileEntryTypeServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryTypeServiceUtil.class, "updateFileEntryType",
-				_updateFileEntryTypeParameterTypes15);
+				_updateFileEntryTypeParameterTypes13);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, fileEntryTypeId, nameMap, descriptionMap);
@@ -693,86 +600,6 @@ public class DLFileEntryTypeServiceHttp {
 		}
 	}
 
-	public static void updateFileEntryType(
-			HttpPrincipal httpPrincipal, long fileEntryTypeId,
-			java.util.Map<java.util.Locale, String> nameMap,
-			java.util.Map<java.util.Locale, String> descriptionMap,
-			long[] ddmStructureIds,
-			com.liferay.portal.kernel.service.ServiceContext serviceContext)
-		throws com.liferay.portal.kernel.exception.PortalException {
-
-		try {
-			MethodKey methodKey = new MethodKey(
-				DLFileEntryTypeServiceUtil.class, "updateFileEntryType",
-				_updateFileEntryTypeParameterTypes16);
-
-			MethodHandler methodHandler = new MethodHandler(
-				methodKey, fileEntryTypeId, nameMap, descriptionMap,
-				ddmStructureIds, serviceContext);
-
-			try {
-				TunnelUtil.invoke(httpPrincipal, methodHandler);
-			}
-			catch (Exception exception) {
-				if (exception instanceof
-						com.liferay.portal.kernel.exception.PortalException) {
-
-					throw (com.liferay.portal.kernel.exception.PortalException)
-						exception;
-				}
-
-				throw new com.liferay.portal.kernel.exception.SystemException(
-					exception);
-			}
-		}
-		catch (com.liferay.portal.kernel.exception.SystemException
-					systemException) {
-
-			_log.error(systemException, systemException);
-
-			throw systemException;
-		}
-	}
-
-	public static void updateFileEntryType(
-			HttpPrincipal httpPrincipal, long fileEntryTypeId, String name,
-			String description, long[] ddmStructureIds,
-			com.liferay.portal.kernel.service.ServiceContext serviceContext)
-		throws com.liferay.portal.kernel.exception.PortalException {
-
-		try {
-			MethodKey methodKey = new MethodKey(
-				DLFileEntryTypeServiceUtil.class, "updateFileEntryType",
-				_updateFileEntryTypeParameterTypes17);
-
-			MethodHandler methodHandler = new MethodHandler(
-				methodKey, fileEntryTypeId, name, description, ddmStructureIds,
-				serviceContext);
-
-			try {
-				TunnelUtil.invoke(httpPrincipal, methodHandler);
-			}
-			catch (Exception exception) {
-				if (exception instanceof
-						com.liferay.portal.kernel.exception.PortalException) {
-
-					throw (com.liferay.portal.kernel.exception.PortalException)
-						exception;
-				}
-
-				throw new com.liferay.portal.kernel.exception.SystemException(
-					exception);
-			}
-		}
-		catch (com.liferay.portal.kernel.exception.SystemException
-					systemException) {
-
-			_log.error(systemException, systemException);
-
-			throw systemException;
-		}
-	}
-
 	private static Log _log = LogFactoryUtil.getLog(
 		DLFileEntryTypeServiceHttp.class);
 
@@ -782,62 +609,42 @@ public class DLFileEntryTypeServiceHttp {
 			java.util.Map.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _addFileEntryTypeParameterTypes1 =
-		new Class[] {
-			long.class, String.class, java.util.Map.class, java.util.Map.class,
-			long[].class, com.liferay.portal.kernel.service.ServiceContext.class
-		};
-	private static final Class<?>[] _addFileEntryTypeParameterTypes2 =
-		new Class[] {
-			long.class, String.class, String.class, long[].class,
-			com.liferay.portal.kernel.service.ServiceContext.class
-		};
-	private static final Class<?>[] _deleteFileEntryTypeParameterTypes3 =
+	private static final Class<?>[] _deleteFileEntryTypeParameterTypes1 =
 		new Class[] {long.class};
-	private static final Class<?>[] _getFileEntryTypeParameterTypes4 =
+	private static final Class<?>[] _getFileEntryTypeParameterTypes2 =
 		new Class[] {long.class};
-	private static final Class<?>[] _getFileEntryTypesParameterTypes5 =
+	private static final Class<?>[] _getFileEntryTypesParameterTypes3 =
 		new Class[] {long[].class};
-	private static final Class<?>[] _getFileEntryTypesParameterTypes6 =
+	private static final Class<?>[] _getFileEntryTypesParameterTypes4 =
 		new Class[] {long[].class, int.class, int.class};
-	private static final Class<?>[] _getFileEntryTypesCountParameterTypes7 =
+	private static final Class<?>[] _getFileEntryTypesCountParameterTypes5 =
 		new Class[] {long[].class};
-	private static final Class<?>[] _getFolderFileEntryTypesParameterTypes8 =
+	private static final Class<?>[] _getFolderFileEntryTypesParameterTypes6 =
 		new Class[] {long[].class, long.class, boolean.class};
-	private static final Class<?>[] _searchParameterTypes9 = new Class[] {
+	private static final Class<?>[] _searchParameterTypes7 = new Class[] {
 		long.class, long.class, long[].class, String.class, boolean.class,
 		boolean.class, int.class, int.class
 	};
-	private static final Class<?>[] _searchParameterTypes10 = new Class[] {
+	private static final Class<?>[] _searchParameterTypes8 = new Class[] {
 		long.class, long[].class, String.class, boolean.class, int.class,
 		int.class, int.class,
 		com.liferay.portal.kernel.util.OrderByComparator.class
 	};
-	private static final Class<?>[] _searchParameterTypes11 = new Class[] {
+	private static final Class<?>[] _searchParameterTypes9 = new Class[] {
 		long.class, long[].class, String.class, boolean.class, int.class,
 		int.class, com.liferay.portal.kernel.util.OrderByComparator.class
 	};
-	private static final Class<?>[] _searchCountParameterTypes12 = new Class[] {
+	private static final Class<?>[] _searchCountParameterTypes10 = new Class[] {
 		long.class, long.class, long[].class, String.class, boolean.class,
 		boolean.class
 	};
-	private static final Class<?>[] _searchCountParameterTypes13 = new Class[] {
+	private static final Class<?>[] _searchCountParameterTypes11 = new Class[] {
 		long.class, long[].class, String.class, boolean.class
 	};
-	private static final Class<?>[] _searchCountParameterTypes14 = new Class[] {
+	private static final Class<?>[] _searchCountParameterTypes12 = new Class[] {
 		long.class, long[].class, String.class, boolean.class, int.class
 	};
-	private static final Class<?>[] _updateFileEntryTypeParameterTypes15 =
+	private static final Class<?>[] _updateFileEntryTypeParameterTypes13 =
 		new Class[] {long.class, java.util.Map.class, java.util.Map.class};
-	private static final Class<?>[] _updateFileEntryTypeParameterTypes16 =
-		new Class[] {
-			long.class, java.util.Map.class, java.util.Map.class, long[].class,
-			com.liferay.portal.kernel.service.ServiceContext.class
-		};
-	private static final Class<?>[] _updateFileEntryTypeParameterTypes17 =
-		new Class[] {
-			long.class, String.class, String.class, long[].class,
-			com.liferay.portal.kernel.service.ServiceContext.class
-		};
 
 }

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryTypeLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryTypeLocalServiceImpl.java
@@ -58,11 +58,9 @@ import com.liferay.portal.kernel.service.permission.ModelPermissionsFactory;
 import com.liferay.portal.kernel.service.persistence.UserPersistence;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.PortalUtil;
-import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.SortedArrayList;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -182,101 +180,6 @@ public class DLFileEntryTypeLocalServiceImpl
 			descriptionMap,
 			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_SCOPE_DEFAULT,
 			serviceContext);
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *             #addFileEntryType(long, long, String, Map, Map, long,
-	 *             ServiceContext)}
-	 */
-	@Deprecated
-	@Override
-	public DLFileEntryType addFileEntryType(
-			long userId, long groupId, String fileEntryTypeKey,
-			Map<Locale, String> nameMap, Map<Locale, String> descriptionMap,
-			long[] ddmStructureIds, ServiceContext serviceContext)
-		throws PortalException {
-
-		User user = _userPersistence.findByPrimaryKey(userId);
-
-		if (Validator.isNull(fileEntryTypeKey)) {
-			fileEntryTypeKey = String.valueOf(counterLocalService.increment());
-		}
-		else {
-			fileEntryTypeKey = StringUtil.toUpperCase(fileEntryTypeKey.trim());
-		}
-
-		String fileEntryTypeUuid = GetterUtil.getString(
-			serviceContext.getAttribute("fileEntryTypeUuid"));
-
-		if (Validator.isNull(fileEntryTypeUuid)) {
-			fileEntryTypeUuid = serviceContext.getUuid();
-
-			if (Validator.isNull(fileEntryTypeUuid)) {
-				fileEntryTypeUuid = PortalUUIDUtil.generate();
-			}
-		}
-
-		long fileEntryTypeId = counterLocalService.increment();
-
-		_validateFileEntryTypeKey(groupId, fileEntryTypeKey);
-
-		_validateDDMStructures(fileEntryTypeKey, ddmStructureIds);
-
-		DLFileEntryType dlFileEntryType = dlFileEntryTypePersistence.create(
-			fileEntryTypeId);
-
-		dlFileEntryType.setUuid(fileEntryTypeUuid);
-		dlFileEntryType.setGroupId(groupId);
-		dlFileEntryType.setCompanyId(user.getCompanyId());
-		dlFileEntryType.setUserId(user.getUserId());
-		dlFileEntryType.setUserName(user.getFullName());
-		dlFileEntryType.setDataDefinitionId(ddmStructureIds[0]);
-		dlFileEntryType.setFileEntryTypeKey(fileEntryTypeKey);
-		dlFileEntryType.setNameMap(nameMap);
-		dlFileEntryType.setDescriptionMap(descriptionMap);
-
-		dlFileEntryType = dlFileEntryTypePersistence.update(dlFileEntryType);
-
-		addDDMStructureLinks(
-			fileEntryTypeId, SetUtil.fromArray(ddmStructureIds));
-
-		if (serviceContext.isAddGroupPermissions() ||
-			serviceContext.isAddGuestPermissions()) {
-
-			addFileEntryTypeResources(
-				dlFileEntryType, serviceContext.isAddGroupPermissions(),
-				serviceContext.isAddGuestPermissions());
-		}
-		else {
-			addFileEntryTypeResources(
-				dlFileEntryType, serviceContext.getModelPermissions());
-		}
-
-		return dlFileEntryType;
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *             #addFileEntryType(long, long, String, Map, Map, long,
-	 *             ServiceContext)}
-	 */
-	@Deprecated
-	@Override
-	public DLFileEntryType addFileEntryType(
-			long userId, long groupId, String name, String description,
-			long[] ddmStructureIds, ServiceContext serviceContext)
-		throws PortalException {
-
-		return addFileEntryType(
-			userId, groupId, null,
-			HashMapBuilder.put(
-				LocaleUtil.getSiteDefault(), name
-			).build(),
-			HashMapBuilder.put(
-				LocaleUtil.getSiteDefault(), description
-			).build(),
-			ddmStructureIds, serviceContext);
 	}
 
 	@Override
@@ -589,55 +492,6 @@ public class DLFileEntryTypeLocalServiceImpl
 			DLVersionNumberIncrease.fromMajorVersion(false),
 			getDefaultFileEntryTypeId(folderId), null, null, null, 0, null,
 			null, serviceContext);
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *             #updateFileEntryType(long, Map, Map)}
-	 */
-	@Deprecated
-	@Override
-	public void updateFileEntryType(
-			long userId, long fileEntryTypeId, Map<Locale, String> nameMap,
-			Map<Locale, String> descriptionMap, long[] ddmStructureIds,
-			ServiceContext serviceContext)
-		throws PortalException {
-
-		DLFileEntryType dlFileEntryType =
-			dlFileEntryTypePersistence.findByPrimaryKey(fileEntryTypeId);
-
-		_validateDDMStructures(
-			dlFileEntryType.getFileEntryTypeKey(), ddmStructureIds);
-
-		dlFileEntryType.setNameMap(nameMap);
-		dlFileEntryType.setDescriptionMap(descriptionMap);
-
-		dlFileEntryTypePersistence.update(dlFileEntryType);
-
-		updateDDMStructureLinks(
-			fileEntryTypeId, SetUtil.fromArray(ddmStructureIds));
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *             #updateFileEntryType(long, Map, Map)}
-	 */
-	@Deprecated
-	@Override
-	public void updateFileEntryType(
-			long userId, long fileEntryTypeId, String name, String description,
-			long[] ddmStructureIds, ServiceContext serviceContext)
-		throws PortalException {
-
-		updateFileEntryType(
-			userId, fileEntryTypeId,
-			HashMapBuilder.put(
-				LocaleUtil.getSiteDefault(), name
-			).build(),
-			HashMapBuilder.put(
-				LocaleUtil.getSiteDefault(), description
-			).build(),
-			ddmStructureIds, serviceContext);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryTypeServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryTypeServiceImpl.java
@@ -29,9 +29,7 @@ import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermi
 import com.liferay.portal.kernel.security.permission.resource.PortletResourcePermission;
 import com.liferay.portal.kernel.security.permission.resource.PortletResourcePermissionFactory;
 import com.liferay.portal.kernel.service.ServiceContext;
-import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
-import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portlet.documentlibrary.constants.DLConstants;
 import com.liferay.portlet.documentlibrary.service.base.DLFileEntryTypeServiceBaseImpl;
@@ -63,50 +61,6 @@ public class DLFileEntryTypeServiceImpl extends DLFileEntryTypeServiceBaseImpl {
 		return dlFileEntryTypeLocalService.addFileEntryType(
 			getUserId(), groupId, dataDefinitionId, fileEntryTypeKey, nameMap,
 			descriptionMap, serviceContext);
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *             #addFileEntryType(long, String, Map, Map, long,
-	 *             ServiceContext)}
-	 */
-	@Deprecated
-	@Override
-	public DLFileEntryType addFileEntryType(
-			long groupId, String fileEntryTypeKey, Map<Locale, String> nameMap,
-			Map<Locale, String> descriptionMap, long[] ddmStructureIds,
-			ServiceContext serviceContext)
-		throws PortalException {
-
-		_portletResourcePermission.check(
-			getPermissionChecker(), groupId, ActionKeys.ADD_DOCUMENT_TYPE);
-
-		return dlFileEntryTypeLocalService.addFileEntryType(
-			getUserId(), groupId, fileEntryTypeKey, nameMap, descriptionMap,
-			ddmStructureIds, serviceContext);
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *             #addFileEntryType(long, String, Map, Map, long,
-	 *             ServiceContext)}
-	 */
-	@Deprecated
-	@Override
-	public DLFileEntryType addFileEntryType(
-			long groupId, String name, String description,
-			long[] ddmStructureIds, ServiceContext serviceContext)
-		throws PortalException {
-
-		return addFileEntryType(
-			groupId, null,
-			HashMapBuilder.put(
-				LocaleUtil.getSiteDefault(), name
-			).build(),
-			HashMapBuilder.put(
-				LocaleUtil.getSiteDefault(), description
-			).build(),
-			ddmStructureIds, serviceContext);
 	}
 
 	@Override
@@ -241,48 +195,6 @@ public class DLFileEntryTypeServiceImpl extends DLFileEntryTypeServiceBaseImpl {
 
 		return dlFileEntryTypeLocalService.updateFileEntryType(
 			fileEntryTypeId, nameMap, descriptionMap);
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *             #updateFileEntryType(long, Map, Map)}
-	 */
-	@Deprecated
-	@Override
-	public void updateFileEntryType(
-			long fileEntryTypeId, Map<Locale, String> nameMap,
-			Map<Locale, String> descriptionMap, long[] ddmStructureIds,
-			ServiceContext serviceContext)
-		throws PortalException {
-
-		_dlFileEntryTypeModelResourcePermission.check(
-			getPermissionChecker(), fileEntryTypeId, ActionKeys.UPDATE);
-
-		dlFileEntryTypeLocalService.updateFileEntryType(
-			getUserId(), fileEntryTypeId, nameMap, descriptionMap,
-			ddmStructureIds, serviceContext);
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *             #updateFileEntryType(long, Map, Map)}
-	 */
-	@Deprecated
-	@Override
-	public void updateFileEntryType(
-			long fileEntryTypeId, String name, String description,
-			long[] ddmStructureIds, ServiceContext serviceContext)
-		throws PortalException {
-
-		updateFileEntryType(
-			fileEntryTypeId,
-			HashMapBuilder.put(
-				LocaleUtil.getSiteDefault(), name
-			).build(),
-			HashMapBuilder.put(
-				LocaleUtil.getSiteDefault(), description
-			).build(),
-			ddmStructureIds, serviceContext);
 	}
 
 	protected List<DLFileEntryType> filterFileEntryTypes(

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryTypeLocalService.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryTypeLocalService.java
@@ -124,29 +124,6 @@ public interface DLFileEntryTypeLocalService
 			Map<Locale, String> descriptionMap, ServiceContext serviceContext)
 		throws PortalException;
 
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 #addFileEntryType(long, long, String, Map, Map, long,
-	 ServiceContext)}
-	 */
-	@Deprecated
-	public DLFileEntryType addFileEntryType(
-			long userId, long groupId, String fileEntryTypeKey,
-			Map<Locale, String> nameMap, Map<Locale, String> descriptionMap,
-			long[] ddmStructureIds, ServiceContext serviceContext)
-		throws PortalException;
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 #addFileEntryType(long, long, String, Map, Map, long,
-	 ServiceContext)}
-	 */
-	@Deprecated
-	public DLFileEntryType addFileEntryType(
-			long userId, long groupId, String name, String description,
-			long[] ddmStructureIds, ServiceContext serviceContext)
-		throws PortalException;
-
 	public void cascadeFileEntryTypes(long userId, DLFolder dlFolder)
 		throws PortalException;
 
@@ -514,27 +491,6 @@ public interface DLFileEntryTypeLocalService
 
 	public DLFileEntry updateFileEntryFileEntryType(
 			DLFileEntry dlFileEntry, ServiceContext serviceContext)
-		throws PortalException;
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 #updateFileEntryType(long, Map, Map)}
-	 */
-	@Deprecated
-	public void updateFileEntryType(
-			long userId, long fileEntryTypeId, Map<Locale, String> nameMap,
-			Map<Locale, String> descriptionMap, long[] ddmStructureIds,
-			ServiceContext serviceContext)
-		throws PortalException;
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 #updateFileEntryType(long, Map, Map)}
-	 */
-	@Deprecated
-	public void updateFileEntryType(
-			long userId, long fileEntryTypeId, String name, String description,
-			long[] ddmStructureIds, ServiceContext serviceContext)
 		throws PortalException;
 
 	public DLFileEntryType updateFileEntryType(

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryTypeLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryTypeLocalServiceUtil.java
@@ -122,42 +122,6 @@ public class DLFileEntryTypeLocalServiceUtil {
 			descriptionMap, serviceContext);
 	}
 
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 #addFileEntryType(long, long, String, Map, Map, long,
-	 ServiceContext)}
-	 */
-	@Deprecated
-	public static DLFileEntryType addFileEntryType(
-			long userId, long groupId, String fileEntryTypeKey,
-			Map<java.util.Locale, String> nameMap,
-			Map<java.util.Locale, String> descriptionMap,
-			long[] ddmStructureIds,
-			com.liferay.portal.kernel.service.ServiceContext serviceContext)
-		throws PortalException {
-
-		return getService().addFileEntryType(
-			userId, groupId, fileEntryTypeKey, nameMap, descriptionMap,
-			ddmStructureIds, serviceContext);
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 #addFileEntryType(long, long, String, Map, Map, long,
-	 ServiceContext)}
-	 */
-	@Deprecated
-	public static DLFileEntryType addFileEntryType(
-			long userId, long groupId, String name, String description,
-			long[] ddmStructureIds,
-			com.liferay.portal.kernel.service.ServiceContext serviceContext)
-		throws PortalException {
-
-		return getService().addFileEntryType(
-			userId, groupId, name, description, ddmStructureIds,
-			serviceContext);
-	}
-
 	public static void cascadeFileEntryTypes(
 			long userId,
 			com.liferay.document.library.kernel.model.DLFolder dlFolder)
@@ -666,40 +630,6 @@ public class DLFileEntryTypeLocalServiceUtil {
 
 		return getService().updateFileEntryFileEntryType(
 			dlFileEntry, serviceContext);
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 #updateFileEntryType(long, Map, Map)}
-	 */
-	@Deprecated
-	public static void updateFileEntryType(
-			long userId, long fileEntryTypeId,
-			Map<java.util.Locale, String> nameMap,
-			Map<java.util.Locale, String> descriptionMap,
-			long[] ddmStructureIds,
-			com.liferay.portal.kernel.service.ServiceContext serviceContext)
-		throws PortalException {
-
-		getService().updateFileEntryType(
-			userId, fileEntryTypeId, nameMap, descriptionMap, ddmStructureIds,
-			serviceContext);
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 #updateFileEntryType(long, Map, Map)}
-	 */
-	@Deprecated
-	public static void updateFileEntryType(
-			long userId, long fileEntryTypeId, String name, String description,
-			long[] ddmStructureIds,
-			com.liferay.portal.kernel.service.ServiceContext serviceContext)
-		throws PortalException {
-
-		getService().updateFileEntryType(
-			userId, fileEntryTypeId, name, description, ddmStructureIds,
-			serviceContext);
 	}
 
 	public static DLFileEntryType updateFileEntryType(

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryTypeLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryTypeLocalServiceWrapper.java
@@ -130,44 +130,6 @@ public class DLFileEntryTypeLocalServiceWrapper
 			descriptionMap, serviceContext);
 	}
 
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 #addFileEntryType(long, long, String, Map, Map, long,
-	 ServiceContext)}
-	 */
-	@Deprecated
-	@Override
-	public DLFileEntryType addFileEntryType(
-			long userId, long groupId, String fileEntryTypeKey,
-			java.util.Map<java.util.Locale, String> nameMap,
-			java.util.Map<java.util.Locale, String> descriptionMap,
-			long[] ddmStructureIds,
-			com.liferay.portal.kernel.service.ServiceContext serviceContext)
-		throws com.liferay.portal.kernel.exception.PortalException {
-
-		return _dlFileEntryTypeLocalService.addFileEntryType(
-			userId, groupId, fileEntryTypeKey, nameMap, descriptionMap,
-			ddmStructureIds, serviceContext);
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 #addFileEntryType(long, long, String, Map, Map, long,
-	 ServiceContext)}
-	 */
-	@Deprecated
-	@Override
-	public DLFileEntryType addFileEntryType(
-			long userId, long groupId, String name, String description,
-			long[] ddmStructureIds,
-			com.liferay.portal.kernel.service.ServiceContext serviceContext)
-		throws com.liferay.portal.kernel.exception.PortalException {
-
-		return _dlFileEntryTypeLocalService.addFileEntryType(
-			userId, groupId, name, description, ddmStructureIds,
-			serviceContext);
-	}
-
 	@Override
 	public void cascadeFileEntryTypes(
 			long userId,
@@ -774,42 +736,6 @@ public class DLFileEntryTypeLocalServiceWrapper
 
 		return _dlFileEntryTypeLocalService.updateFileEntryFileEntryType(
 			dlFileEntry, serviceContext);
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 #updateFileEntryType(long, Map, Map)}
-	 */
-	@Deprecated
-	@Override
-	public void updateFileEntryType(
-			long userId, long fileEntryTypeId,
-			java.util.Map<java.util.Locale, String> nameMap,
-			java.util.Map<java.util.Locale, String> descriptionMap,
-			long[] ddmStructureIds,
-			com.liferay.portal.kernel.service.ServiceContext serviceContext)
-		throws com.liferay.portal.kernel.exception.PortalException {
-
-		_dlFileEntryTypeLocalService.updateFileEntryType(
-			userId, fileEntryTypeId, nameMap, descriptionMap, ddmStructureIds,
-			serviceContext);
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 #updateFileEntryType(long, Map, Map)}
-	 */
-	@Deprecated
-	@Override
-	public void updateFileEntryType(
-			long userId, long fileEntryTypeId, String name, String description,
-			long[] ddmStructureIds,
-			com.liferay.portal.kernel.service.ServiceContext serviceContext)
-		throws com.liferay.portal.kernel.exception.PortalException {
-
-		_dlFileEntryTypeLocalService.updateFileEntryType(
-			userId, fileEntryTypeId, name, description, ddmStructureIds,
-			serviceContext);
 	}
 
 	@Override

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryTypeService.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryTypeService.java
@@ -63,29 +63,6 @@ public interface DLFileEntryTypeService extends BaseService {
 			ServiceContext serviceContext)
 		throws PortalException;
 
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 #addFileEntryType(long, String, Map, Map, long,
-	 ServiceContext)}
-	 */
-	@Deprecated
-	public DLFileEntryType addFileEntryType(
-			long groupId, String fileEntryTypeKey, Map<Locale, String> nameMap,
-			Map<Locale, String> descriptionMap, long[] ddmStructureIds,
-			ServiceContext serviceContext)
-		throws PortalException;
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 #addFileEntryType(long, String, Map, Map, long,
-	 ServiceContext)}
-	 */
-	@Deprecated
-	public DLFileEntryType addFileEntryType(
-			long groupId, String name, String description,
-			long[] ddmStructureIds, ServiceContext serviceContext)
-		throws PortalException;
-
 	public void deleteFileEntryType(long fileEntryTypeId)
 		throws PortalException;
 
@@ -152,27 +129,6 @@ public interface DLFileEntryTypeService extends BaseService {
 	public DLFileEntryType updateFileEntryType(
 			long fileEntryTypeId, Map<Locale, String> nameMap,
 			Map<Locale, String> descriptionMap)
-		throws PortalException;
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 #updateFileEntryType(long, Map, Map)}
-	 */
-	@Deprecated
-	public void updateFileEntryType(
-			long fileEntryTypeId, Map<Locale, String> nameMap,
-			Map<Locale, String> descriptionMap, long[] ddmStructureIds,
-			ServiceContext serviceContext)
-		throws PortalException;
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 #updateFileEntryType(long, Map, Map)}
-	 */
-	@Deprecated
-	public void updateFileEntryType(
-			long fileEntryTypeId, String name, String description,
-			long[] ddmStructureIds, ServiceContext serviceContext)
 		throws PortalException;
 
 }

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryTypeServiceUtil.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryTypeServiceUtil.java
@@ -52,41 +52,6 @@ public class DLFileEntryTypeServiceUtil {
 			descriptionMap, serviceContext);
 	}
 
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 #addFileEntryType(long, String, Map, Map, long,
-	 ServiceContext)}
-	 */
-	@Deprecated
-	public static DLFileEntryType addFileEntryType(
-			long groupId, String fileEntryTypeKey,
-			Map<java.util.Locale, String> nameMap,
-			Map<java.util.Locale, String> descriptionMap,
-			long[] ddmStructureIds,
-			com.liferay.portal.kernel.service.ServiceContext serviceContext)
-		throws PortalException {
-
-		return getService().addFileEntryType(
-			groupId, fileEntryTypeKey, nameMap, descriptionMap, ddmStructureIds,
-			serviceContext);
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 #addFileEntryType(long, String, Map, Map, long,
-	 ServiceContext)}
-	 */
-	@Deprecated
-	public static DLFileEntryType addFileEntryType(
-			long groupId, String name, String description,
-			long[] ddmStructureIds,
-			com.liferay.portal.kernel.service.ServiceContext serviceContext)
-		throws PortalException {
-
-		return getService().addFileEntryType(
-			groupId, name, description, ddmStructureIds, serviceContext);
-	}
-
 	public static void deleteFileEntryType(long fileEntryTypeId)
 		throws PortalException {
 
@@ -193,39 +158,6 @@ public class DLFileEntryTypeServiceUtil {
 
 		return getService().updateFileEntryType(
 			fileEntryTypeId, nameMap, descriptionMap);
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 #updateFileEntryType(long, Map, Map)}
-	 */
-	@Deprecated
-	public static void updateFileEntryType(
-			long fileEntryTypeId, Map<java.util.Locale, String> nameMap,
-			Map<java.util.Locale, String> descriptionMap,
-			long[] ddmStructureIds,
-			com.liferay.portal.kernel.service.ServiceContext serviceContext)
-		throws PortalException {
-
-		getService().updateFileEntryType(
-			fileEntryTypeId, nameMap, descriptionMap, ddmStructureIds,
-			serviceContext);
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 #updateFileEntryType(long, Map, Map)}
-	 */
-	@Deprecated
-	public static void updateFileEntryType(
-			long fileEntryTypeId, String name, String description,
-			long[] ddmStructureIds,
-			com.liferay.portal.kernel.service.ServiceContext serviceContext)
-		throws PortalException {
-
-		getService().updateFileEntryType(
-			fileEntryTypeId, name, description, ddmStructureIds,
-			serviceContext);
 	}
 
 	public static DLFileEntryTypeService getService() {

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryTypeServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryTypeServiceWrapper.java
@@ -50,43 +50,6 @@ public class DLFileEntryTypeServiceWrapper
 			descriptionMap, serviceContext);
 	}
 
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 #addFileEntryType(long, String, Map, Map, long,
-	 ServiceContext)}
-	 */
-	@Deprecated
-	@Override
-	public DLFileEntryType addFileEntryType(
-			long groupId, String fileEntryTypeKey,
-			java.util.Map<java.util.Locale, String> nameMap,
-			java.util.Map<java.util.Locale, String> descriptionMap,
-			long[] ddmStructureIds,
-			com.liferay.portal.kernel.service.ServiceContext serviceContext)
-		throws com.liferay.portal.kernel.exception.PortalException {
-
-		return _dlFileEntryTypeService.addFileEntryType(
-			groupId, fileEntryTypeKey, nameMap, descriptionMap, ddmStructureIds,
-			serviceContext);
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 #addFileEntryType(long, String, Map, Map, long,
-	 ServiceContext)}
-	 */
-	@Deprecated
-	@Override
-	public DLFileEntryType addFileEntryType(
-			long groupId, String name, String description,
-			long[] ddmStructureIds,
-			com.liferay.portal.kernel.service.ServiceContext serviceContext)
-		throws com.liferay.portal.kernel.exception.PortalException {
-
-		return _dlFileEntryTypeService.addFileEntryType(
-			groupId, name, description, ddmStructureIds, serviceContext);
-	}
-
 	@Override
 	public void deleteFileEntryType(long fileEntryTypeId)
 		throws com.liferay.portal.kernel.exception.PortalException {
@@ -210,42 +173,6 @@ public class DLFileEntryTypeServiceWrapper
 
 		return _dlFileEntryTypeService.updateFileEntryType(
 			fileEntryTypeId, nameMap, descriptionMap);
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 #updateFileEntryType(long, Map, Map)}
-	 */
-	@Deprecated
-	@Override
-	public void updateFileEntryType(
-			long fileEntryTypeId,
-			java.util.Map<java.util.Locale, String> nameMap,
-			java.util.Map<java.util.Locale, String> descriptionMap,
-			long[] ddmStructureIds,
-			com.liferay.portal.kernel.service.ServiceContext serviceContext)
-		throws com.liferay.portal.kernel.exception.PortalException {
-
-		_dlFileEntryTypeService.updateFileEntryType(
-			fileEntryTypeId, nameMap, descriptionMap, ddmStructureIds,
-			serviceContext);
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 #updateFileEntryType(long, Map, Map)}
-	 */
-	@Deprecated
-	@Override
-	public void updateFileEntryType(
-			long fileEntryTypeId, String name, String description,
-			long[] ddmStructureIds,
-			com.liferay.portal.kernel.service.ServiceContext serviceContext)
-		throws com.liferay.portal.kernel.exception.PortalException {
-
-		_dlFileEntryTypeService.updateFileEntryType(
-			fileEntryTypeId, name, description, ddmStructureIds,
-			serviceContext);
 	}
 
 	@Override

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/packageinfo
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/packageinfo
@@ -1,1 +1,1 @@
-version 11.4.0
+version 12.0.0


### PR DESCRIPTION
Motivation
----
Removes old dependencies to DDMStructure located in portal-kernel

Proposed Solution
----
Removes 7.3 deprecated method in DLFileEntryType services. Since deprecated methods are only used **DLFileEntryTypeStagedModelDataHandler** copy some logic to keep the same logic between new methods and deprecated methods, this logic is related to DDMStructureLinks and DDMStructures validation.

Please note that I removed some logic in [f6423b8](https://github.com/liferay-lima/liferay-portal/pull/4489/commits/f6423b832fe4597b03600bf714f00bb7d95e2d02) related to **serviceContext.getAttribute("ddmForm")** since it is not set, and also I've removed some old logic related with **AUTO_** prefix in DDMStructure keys in [1c0b345](https://github.com/liferay-lima/liferay-portal/pull/4489/commits/1c0b3458d62eacf538a73873b841d445a4377255), maybe we can remove more code or maybe it is wrong and we cannot delete it.

Please let me know if you have any question.