### PR TITLE
Translation destroys html structure/text data

### DIFF
--- a/modules/apps/translation/translation-api/src/main/java/com/liferay/translation/translator/JSONTranslatorPacket.java
+++ b/modules/apps/translation/translation-api/src/main/java/com/liferay/translation/translator/JSONTranslatorPacket.java
@@ -41,9 +41,17 @@ public class JSONTranslatorPacket implements TranslatorPacket {
 		_targetLanguageId = jsonObject.getString("targetLanguageId");
 
 		JSONObject fieldsJSONObject = jsonObject.getJSONObject("fields");
+		JSONObject htmlJSONObject = jsonObject.getJSONObject("html");
 
 		for (String key : fieldsJSONObject.keySet()) {
+			Boolean html = null;
+
+			if (htmlJSONObject != null) {
+				html = htmlJSONObject.getBoolean(key);
+			}
+
 			_fieldsMap.put(key, fieldsJSONObject.getString(key));
+			_htmlMap.put(key, html);
 		}
 	}
 
@@ -58,6 +66,11 @@ public class JSONTranslatorPacket implements TranslatorPacket {
 	}
 
 	@Override
+	public Map<String, Boolean> getHtmlMap() {
+		return _htmlMap;
+	}
+
+	@Override
 	public String getSourceLanguageId() {
 		return _sourceLanguageId;
 	}
@@ -69,6 +82,7 @@ public class JSONTranslatorPacket implements TranslatorPacket {
 
 	private final long _companyId;
 	private final Map<String, String> _fieldsMap = new LinkedHashMap<>();
+	private final Map<String, Boolean> _htmlMap = new LinkedHashMap<>();
 	private final String _sourceLanguageId;
 	private final String _targetLanguageId;
 

--- a/modules/apps/translation/translation-api/src/main/java/com/liferay/translation/translator/TranslatorPacket.java
+++ b/modules/apps/translation/translation-api/src/main/java/com/liferay/translation/translator/TranslatorPacket.java
@@ -28,6 +28,8 @@ public interface TranslatorPacket {
 
 	public Map<String, String> getFieldsMap();
 
+	public Map<String, Boolean> getHtmlMap();
+
 	public String getSourceLanguageId();
 
 	public String getTargetLanguageId();

--- a/modules/apps/translation/translation-translator-aws/src/main/java/com/liferay/translation/translator/aws/internal/translator/AWSTranslator.java
+++ b/modules/apps/translation/translation-translator-aws/src/main/java/com/liferay/translation/translator/aws/internal/translator/AWSTranslator.java
@@ -108,6 +108,11 @@ public class AWSTranslator implements Translator {
 			}
 
 			@Override
+			public Map<String, Boolean> getHtmlMap() {
+				return null;
+			}
+
+			@Override
 			public String getSourceLanguageId() {
 				return translatorPacket.getSourceLanguageId();
 			}

--- a/modules/apps/translation/translation-translator-azure/src/main/java/com/liferay/translation/translator/azure/internal/AzureTranslator.java
+++ b/modules/apps/translation/translation-translator-azure/src/main/java/com/liferay/translation/translator/azure/internal/AzureTranslator.java
@@ -127,6 +127,11 @@ public class AzureTranslator implements Translator {
 				}
 
 				@Override
+				public Map<String, Boolean> getHtmlMap() {
+					return null;
+				}
+
+				@Override
 				public String getSourceLanguageId() {
 					return translatorPacket.getSourceLanguageId();
 				}

--- a/modules/apps/translation/translation-translator-deepl/src/main/java/com/liferay/translation/translator/deepl/internal/translator/DeepLTranslator.java
+++ b/modules/apps/translation/translation-translator-deepl/src/main/java/com/liferay/translation/translator/deepl/internal/translator/DeepLTranslator.java
@@ -96,6 +96,7 @@ public class DeepLTranslator implements Translator {
 
 		Map<String, String> translatedFieldsMap = _translate(
 			deepLTranslatorConfiguration, translatorPacket.getFieldsMap(),
+			translatorPacket.getHtmlMap(),
 			_getLanguageCode(translatorPacket.getSourceLanguageId()),
 			targetLanguageCode);
 
@@ -109,6 +110,11 @@ public class DeepLTranslator implements Translator {
 			@Override
 			public Map<String, String> getFieldsMap() {
 				return translatedFieldsMap;
+			}
+
+			@Override
+			public Map<String, Boolean> getHtmlMap() {
+				return translatorPacket.getHtmlMap();
 			}
 
 			@Override
@@ -180,18 +186,20 @@ public class DeepLTranslator implements Translator {
 
 	private Map<String, String> _translate(
 			DeepLTranslatorConfiguration deepLTranslatorConfiguration,
-			Map<String, String> fieldsMap, String sourceLanguageCode,
-			String targetLanguageCode)
+			Map<String, String> fieldsMap, Map<String, Boolean> htmlMap,
+			String sourceLanguageCode, String targetLanguageCode)
 		throws PortalException {
 
 		Map<String, String> translatedFieldsMap = new HashMap<>();
 
 		for (Map.Entry<String, String> entry : fieldsMap.entrySet()) {
+			Boolean html = htmlMap.get(entry.getKey());
+
 			translatedFieldsMap.put(
 				entry.getKey(),
 				_translate(
 					deepLTranslatorConfiguration, sourceLanguageCode,
-					targetLanguageCode, entry.getValue()));
+					targetLanguageCode, entry.getValue(), html));
 		}
 
 		return translatedFieldsMap;
@@ -199,7 +207,8 @@ public class DeepLTranslator implements Translator {
 
 	private String _translate(
 			DeepLTranslatorConfiguration deepLTranslatorConfiguration,
-			String sourceLanguageCode, String targetLanguageCode, String text)
+			String sourceLanguageCode, String targetLanguageCode, String text,
+			Boolean html)
 		throws PortalException {
 
 		if (Validator.isBlank(text)) {
@@ -211,6 +220,11 @@ public class DeepLTranslator implements Translator {
 		options.addHeader(
 			HttpHeaders.AUTHORIZATION,
 			"DeepL-Auth-Key " + deepLTranslatorConfiguration.authKey());
+
+		if ((html != null) && html) {
+			options.addPart("tag_handling", "html");
+		}
+
 		options.addPart("source_lang", sourceLanguageCode);
 		options.addPart("target_lang", targetLanguageCode);
 		options.addPart("text", text);

--- a/modules/apps/translation/translation-translator-google-cloud/src/main/java/com/liferay/translation/translator/google/cloud/internal/translator/GoogleCloudTranslator.java
+++ b/modules/apps/translation/translation-translator-google-cloud/src/main/java/com/liferay/translation/translator/google/cloud/internal/translator/GoogleCloudTranslator.java
@@ -136,6 +136,11 @@ public class GoogleCloudTranslator implements Translator {
 			}
 
 			@Override
+			public Map<String, Boolean> getHtmlMap() {
+				return null;
+			}
+
+			@Override
 			public String getSourceLanguageId() {
 				return translatorPacket.getSourceLanguageId();
 			}

--- a/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/servlet/AutoTranslateServlet.java
+++ b/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/servlet/AutoTranslateServlet.java
@@ -111,10 +111,10 @@ public class AutoTranslateServlet extends HttpServlet {
 		}
 	}
 
-	private JSONObject _getFieldsJSONObject(Map<String, String> fieldsMap) {
+	private JSONObject _getFieldsJSONObject(Map<String, ?> fieldsMap) {
 		JSONObject jsonObject = _jsonFactory.createJSONObject();
 
-		for (Map.Entry<String, String> entry : fieldsMap.entrySet()) {
+		for (Map.Entry<String, ?> entry : fieldsMap.entrySet()) {
 			jsonObject.put(entry.getKey(), entry.getValue());
 		}
 
@@ -124,6 +124,8 @@ public class AutoTranslateServlet extends HttpServlet {
 	private String _toJSON(TranslatorPacket translatorPacket) {
 		return JSONUtil.put(
 			"fields", _getFieldsJSONObject(translatorPacket.getFieldsMap())
+		).put(
+			"html", _getFieldsJSONObject(translatorPacket.getHtmlMap())
 		).put(
 			"sourceLanguageId", translatorPacket.getSourceLanguageId()
 		).put(

--- a/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/translate/Translate.js
+++ b/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/translate/Translate.js
@@ -36,11 +36,14 @@ const getInfoFields = (infoFieldSetEntries = []) => {
 	const targetFields = {};
 
 	infoFieldSetEntries.forEach(({fields}) => {
-		fields.forEach(({id: idSet, sourceContent, targetContent}) => {
+		fields.forEach(({html, id: idSet, sourceContent, targetContent}) => {
 			sourceContent.forEach((content, index) => {
 				const id = `${idSet}${index}`;
 
-				sourceFields[id] = content;
+				sourceFields[id] = {
+					content,
+					html,
+				};
 				targetFields[id] = {
 					content: targetContent[index],
 					message: '',
@@ -163,7 +166,12 @@ const Translate = ({
 	const fetchAutoTranslation = ({fields}) =>
 		fetch(getAutoTranslateURL, {
 			body: JSON.stringify({
-				fields,
+				fields: Object.fromEntries(
+					Object.entries(fields).map((a) => [a[0], a[1].content])
+				),
+				html: Object.fromEntries(
+					Object.entries(fields).map((a) => [a[0], a[1].html])
+				),
 				sourceLanguageId,
 				targetLanguageId,
 			}),
@@ -179,7 +187,7 @@ const Translate = ({
 		});
 
 		fetchAutoTranslation({fields: sourceFields})
-			.then(({error, fields}) => {
+			.then(({error, fields, html}) => {
 				if (error) {
 					throw error;
 				}
@@ -188,8 +196,18 @@ const Translate = ({
 					dispatch({
 						payload: Object.entries(fields).reduce(
 							(acc, [id, content]) => {
+								let contentData;
+								if (
+									html &&
+									sourceFields[id].html === html[id]
+								) {
+									contentData = content;
+								}
+								else {
+									contentData = unescapeHTML(content);
+								}
 								acc[id] = {
-									content: unescapeHTML(content),
+									content: contentData,
 								};
 
 								return acc;
@@ -238,7 +256,15 @@ const Translate = ({
 		fetchAutoTranslation({
 			fields: {[fieldId]: sourceFields[fieldId]},
 		})
-			.then(({error, fields}) => {
+			.then(({error, fields, html}) => {
+				let contentData;
+				if (html && sourceFields[fieldId].html === html[fieldId]) {
+					contentData = fields[fieldId];
+				}
+				else {
+					contentData = unescapeHTML(fields[fieldId]);
+				}
+
 				if (error) {
 					throw error;
 				}
@@ -247,7 +273,7 @@ const Translate = ({
 					dispatch({
 						payload: {
 							field: {
-								content: unescapeHTML(fields[fieldId]),
+								content: contentData,
 								message: Liferay.Language.get(
 									'field-translated'
 								),


### PR DESCRIPTION
While testing the DeepL translator we noticed a strange behavior of the translation system. Seemingly trivial paragraphs looked strange after translation. Investigating the problem I could hunt this down into the way the DeepL API is called.

DeepL needs to know whether plain text or HTML is translated. In many cases using the "text" format works ok, but in our "corner cases", translation is only well usable if DeepL is told, that HTML is translated. We noticed for example, that DeepL inserted fullstops  outside the expected tags, damaging the HTML structure.

While investigating I also noticed, that plain text is ran through "unescapeHTML", although not HTML is provided, basicly destroying text, that contains "\&amp;" (yeah worst case scenario).

To fix both issues frontend and backend both need to take into account, in which format is used in a field. The approach taken here only fixes the codepath for DeepL, ensuring that the old codepath can still be used by the other translators. The information, whether HTML or plain text is transfered in a field is send is encoded in a map alongside the existing "fields" entry. That way unmodified callers can ignore that codepath, while fixed callers can use this improved path.