### PR TITLE
LPS 191041

### DIFF
--- a/modules/apps/asset/asset-browser-web/src/main/java/com/liferay/asset/browser/web/internal/item/selector/AssetEntryItemDescriptor.java
+++ b/modules/apps/asset/asset-browser-web/src/main/java/com/liferay/asset/browser/web/internal/item/selector/AssetEntryItemDescriptor.java
@@ -30,7 +30,6 @@ import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 
 import java.util.Date;
@@ -131,7 +130,7 @@ public class AssetEntryItemDescriptor
 
 	@Override
 	public String getTitle(Locale locale) {
-		return HtmlUtil.escape(_assetEntry.getTitle(locale));
+		return _assetEntry.getTitle(locale);
 	}
 
 	@Override

--- a/modules/apps/asset/asset-tags-item-selector-web/src/main/java/com/liferay/asset/tags/item/selector/web/internal/AssetTagsItemDescriptor.java
+++ b/modules/apps/asset/asset-tags-item-selector-web/src/main/java/com/liferay/asset/tags/item/selector/web/internal/AssetTagsItemDescriptor.java
@@ -18,7 +18,6 @@ import com.liferay.asset.kernel.model.AssetTag;
 import com.liferay.item.selector.ItemSelectorViewDescriptor;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONUtil;
-import com.liferay.portal.kernel.util.HtmlUtil;
 
 import java.util.Locale;
 
@@ -58,7 +57,7 @@ public class AssetTagsItemDescriptor
 
 	@Override
 	public String getTitle(Locale locale) {
-		return HtmlUtil.escape(_assetTag.getName());
+		return _assetTag.getName();
 	}
 
 	private final AssetTag _assetTag;

--- a/modules/apps/asset/asset-vocabulary-item-selector-web/src/main/java/com/liferay/asset/vocabulary/item/selector/web/internal/AssetVocabularyItemDescriptor.java
+++ b/modules/apps/asset/asset-vocabulary-item-selector-web/src/main/java/com/liferay/asset/vocabulary/item/selector/web/internal/AssetVocabularyItemDescriptor.java
@@ -26,7 +26,6 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 
 import java.util.Date;
@@ -95,9 +94,7 @@ public class AssetVocabularyItemDescriptor
 			(ThemeDisplay)_httpServletRequest.getAttribute(
 				WebKeys.THEME_DISPLAY);
 
-		sb.append(
-			HtmlUtil.escape(
-				_assetVocabulary.getTitle(themeDisplay.getLocale())));
+		sb.append(_assetVocabulary.getTitle(themeDisplay.getLocale()));
 
 		sb.append(StringPool.SPACE);
 		sb.append(StringPool.OPEN_PARENTHESIS);

--- a/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/item/selector/BlogsEntryItemSelectorView.java
+++ b/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/item/selector/BlogsEntryItemSelectorView.java
@@ -34,7 +34,6 @@ import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.portlet.SearchOrderByUtil;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
@@ -208,8 +207,7 @@ public class BlogsEntryItemSelectorView
 			return _language.format(
 				locale, "x-ago-by-x",
 				new Object[] {
-					modifiedDateDescription,
-					HtmlUtil.escape(_blogsEntry.getUserName())
+					modifiedDateDescription, _blogsEntry.getUserName()
 				});
 		}
 

--- a/modules/apps/commerce/commerce-order-content-web/src/main/java/com/liferay/commerce/order/content/web/internal/item/selector/CommerceOrderItemSelectorView.java
+++ b/modules/apps/commerce/commerce-order-content-web/src/main/java/com/liferay/commerce/order/content/web/internal/item/selector/CommerceOrderItemSelectorView.java
@@ -29,7 +29,6 @@ import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -188,7 +187,7 @@ public class CommerceOrderItemSelectorView
 						locale,
 						System.currentTimeMillis() - modifiedDate.getTime(),
 						true),
-					HtmlUtil.escape(_commerceOrder.getUserName())
+					_commerceOrder.getUserName()
 				});
 		}
 

--- a/modules/apps/commerce/commerce-product-content-web/src/main/java/com/liferay/commerce/product/content/web/internal/item/selector/CPDefinitionItemSelectorView.java
+++ b/modules/apps/commerce/commerce-product-content-web/src/main/java/com/liferay/commerce/product/content/web/internal/item/selector/CPDefinitionItemSelectorView.java
@@ -32,7 +32,6 @@ import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -186,7 +185,7 @@ public class CPDefinitionItemSelectorView
 						locale,
 						System.currentTimeMillis() - modifiedDate.getTime(),
 						true),
-					HtmlUtil.escape(_cpDefinition.getUserName())
+					_cpDefinition.getUserName()
 				});
 		}
 

--- a/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/item/selector/DepotGroupItemSelectorView.java
+++ b/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/item/selector/DepotGroupItemSelectorView.java
@@ -198,7 +198,7 @@ public class DepotGroupItemSelectorView
 
 		private String _getTitle(Locale locale) {
 			try {
-				return _html.escape(_group.getDescriptiveName(locale));
+				return _group.getDescriptiveName(locale);
 			}
 			catch (Exception exception) {
 				if (_log.isDebugEnabled()) {
@@ -206,7 +206,7 @@ public class DepotGroupItemSelectorView
 				}
 			}
 
-			return _html.escape(_group.getName(locale));
+			return _group.getName(locale);
 		}
 
 		private final Group _group;

--- a/modules/apps/item-selector/item-selector-web/src/main/java/com/liferay/item/selector/web/internal/DefaultTableItemView.java
+++ b/modules/apps/item-selector/item-selector-web/src/main/java/com/liferay/item/selector/web/internal/DefaultTableItemView.java
@@ -19,6 +19,7 @@ import com.liferay.item.selector.TableItemView;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.search.SearchEntry;
 import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.taglib.search.StatusSearchEntry;
 import com.liferay.taglib.search.TextSearchEntry;
 
@@ -62,7 +63,8 @@ public class DefaultTableItemView implements TableItemView {
 
 		titleTextSearchEntry.setCssClass(
 			"entry entry-selector table-cell-expand table-cell-minw-200");
-		titleTextSearchEntry.setName(_itemDescriptor.getTitle(locale));
+		titleTextSearchEntry.setName(
+			HtmlUtil.escape(_itemDescriptor.getTitle(locale)));
 
 		searchEntries.add(titleTextSearchEntry);
 

--- a/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/init.jsp
@@ -49,6 +49,7 @@ page import="com.liferay.portal.kernel.model.BaseModel" %><%@
 page import="com.liferay.portal.kernel.model.UserConstants" %><%@
 page import="com.liferay.portal.kernel.util.GetterUtil" %><%@
 page import="com.liferay.portal.kernel.util.HashMapBuilder" %><%@
+page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
 page import="com.liferay.portal.kernel.util.ParamUtil" %><%@
 page import="com.liferay.portal.kernel.util.StringUtil" %><%@
 page import="com.liferay.portal.kernel.util.Validator" %>

--- a/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/view_item_selector_view_descriptor.jsp
+++ b/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/view_item_selector_view_descriptor.jsp
@@ -162,11 +162,11 @@ SearchContainer<Object> searchContainer = itemSelectorViewDescriptorRendererDisp
 						</c:if>
 
 						<p class="font-weight-bold h5">
-							<%= itemDescriptor.getTitle(locale) %>
+							<%= HtmlUtil.escape(itemDescriptor.getTitle(locale)) %>
 						</p>
 
 						<p class="h6 text-default">
-							<%= itemDescriptor.getSubtitle(locale) %>
+							<%= HtmlUtil.escape(itemDescriptor.getSubtitle(locale)) %>
 						</p>
 
 						<c:if test="<%= itemDescriptor.getStatus() != null %>">

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/item/selector/KBArticleItemSelectorView.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/item/selector/KBArticleItemSelectorView.java
@@ -32,7 +32,6 @@ import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -206,7 +205,7 @@ public class KBArticleItemSelectorView
 						locale,
 						System.currentTimeMillis() - modifiedDate.getTime(),
 						true),
-					HtmlUtil.escape(_kbArticle.getUserName())
+					_kbArticle.getUserName()
 				});
 		}
 

--- a/modules/apps/layout/layout-page-template-item-selector-web/src/main/java/com/liferay/layout/page/template/item/selector/web/internal/LayoutPageTemplateEntryItemSelectorView.java
+++ b/modules/apps/layout/layout-page-template-item-selector-web/src/main/java/com/liferay/layout/page/template/item/selector/web/internal/LayoutPageTemplateEntryItemSelectorView.java
@@ -41,7 +41,6 @@ import com.liferay.portal.kernel.security.auth.AuthTokenUtil;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Constants;
-import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -296,7 +295,7 @@ public class LayoutPageTemplateEntryItemSelectorView
 
 		@Override
 		public String getTitle(Locale locale) {
-			return HtmlUtil.escape(_layoutPageTemplateEntry.getName());
+			return _layoutPageTemplateEntry.getName();
 		}
 
 		@Override

--- a/modules/apps/organizations/organizations-item-selector-web/src/main/java/com/liferay/organizations/item/selector/web/internal/OrganizationItemDescriptor.java
+++ b/modules/apps/organizations/organizations-item-selector-web/src/main/java/com/liferay/organizations/item/selector/web/internal/OrganizationItemDescriptor.java
@@ -21,7 +21,6 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.search.RowChecker;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.Organization;
-import com.liferay.portal.kernel.util.HtmlUtil;
 
 import java.util.Locale;
 
@@ -65,7 +64,7 @@ public class OrganizationItemDescriptor
 
 	@Override
 	public String getTitle(Locale locale) {
-		return HtmlUtil.escape(_organization.getName());
+		return _organization.getName();
 	}
 
 	@Override

--- a/modules/apps/segments/segments-item-selector-web/src/main/java/com/liferay/segments/item/selector/web/internal/SegmentsEntryItemDescriptor.java
+++ b/modules/apps/segments/segments-item-selector-web/src/main/java/com/liferay/segments/item/selector/web/internal/SegmentsEntryItemDescriptor.java
@@ -18,7 +18,6 @@ import com.liferay.item.selector.ItemSelectorViewDescriptor;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.segments.model.SegmentsEntry;
 
@@ -71,7 +70,7 @@ public class SegmentsEntryItemDescriptor
 
 	@Override
 	public String getTitle(Locale locale) {
-		return HtmlUtil.escape(_segmentsEntry.getName(locale));
+		return _segmentsEntry.getName(locale);
 	}
 
 	private final HttpServletRequest _httpServletRequest;

--- a/modules/apps/segments/segments-item-selector-web/src/main/java/com/liferay/segments/item/selector/web/internal/SegmentsExperienceItemDescriptor.java
+++ b/modules/apps/segments/segments-item-selector-web/src/main/java/com/liferay/segments/item/selector/web/internal/SegmentsExperienceItemDescriptor.java
@@ -18,7 +18,6 @@ import com.liferay.item.selector.ItemSelectorViewDescriptor;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.segments.model.SegmentsExperience;
 
@@ -77,7 +76,7 @@ public class SegmentsExperienceItemDescriptor
 
 	@Override
 	public String getTitle(Locale locale) {
-		return HtmlUtil.escape(_segmentsExperience.getName(locale));
+		return _segmentsExperience.getName(locale);
 	}
 
 	@Override

--- a/modules/apps/site/site-teams-item-selector-web/src/main/java/com/liferay/site/teams/item/selector/web/internal/SiteTeamsItemDescriptor.java
+++ b/modules/apps/site/site-teams-item-selector-web/src/main/java/com/liferay/site/teams/item/selector/web/internal/SiteTeamsItemDescriptor.java
@@ -18,7 +18,6 @@ import com.liferay.item.selector.ItemSelectorViewDescriptor;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.Team;
-import com.liferay.portal.kernel.util.HtmlUtil;
 
 import java.util.Date;
 import java.util.Locale;
@@ -64,7 +63,7 @@ public class SiteTeamsItemDescriptor
 
 	@Override
 	public String getTitle(Locale locale) {
-		return HtmlUtil.escape(_team.getName());
+		return _team.getName();
 	}
 
 	@Override

--- a/modules/apps/user-groups-admin/user-groups-admin-item-selector-web/src/main/java/com/liferay/user/groups/admin/item/selector/web/internal/UserGroupItemDescriptor.java
+++ b/modules/apps/user-groups-admin/user-groups-admin-item-selector-web/src/main/java/com/liferay/user/groups/admin/item/selector/web/internal/UserGroupItemDescriptor.java
@@ -75,7 +75,7 @@ public class UserGroupItemDescriptor
 
 	@Override
 	public String getTitle(Locale locale) {
-		return HtmlUtil.escape(_userGroup.getName());
+		return _userGroup.getName();
 	}
 
 	@Override

--- a/modules/apps/users-admin/users-admin-item-selector-web/src/main/java/com/liferay/users/admin/item/selector/web/internal/UserItemDescriptor.java
+++ b/modules/apps/users-admin/users-admin-item-selector-web/src/main/java/com/liferay/users/admin/item/selector/web/internal/UserItemDescriptor.java
@@ -21,7 +21,6 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.HtmlUtil;
 
 import java.util.Date;
 import java.util.Locale;
@@ -72,12 +71,12 @@ public class UserItemDescriptor
 
 	@Override
 	public String getSubtitle(Locale locale) {
-		return HtmlUtil.escape(_user.getScreenName());
+		return _user.getScreenName();
 	}
 
 	@Override
 	public String getTitle(Locale locale) {
-		return HtmlUtil.escape(_user.getFullName());
+		return _user.getFullName();
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(


### PR DESCRIPTION
Motivation
----
Since for cards we are already escaping title and subtitle, we should find a way to not double escaping those fields.

[Link to the issue
](https://liferay.atlassian.net/browse/LPS-191041)

Proposed solution
----
Removes escape from title and subtitle in **ItemSelectorViewDescriptor.ItemDescriptor** and add it to item selector table and descriptive view, in that way we are going to escape it only once.

Steps to reproduce
----

1. Add a new user with special characters in first name and last name
><script>alert(1)</script> and ><script>alert(2)</script>
2. Add a new site
3. Navigate to the Memberships admin
4. Open the Assign Users to This Site modal
5. Change the display style to list
6. The special characters are shown
7. Change the display style to cards