### PR TITLE
LPS - 191375

### DIFF
--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/helper/DLURLHelperImpl.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/helper/DLURLHelperImpl.java
@@ -517,7 +517,7 @@ public class DLURLHelperImpl implements DLURLHelper {
 			fileName = _trashHelper.getOriginalTitle(fileEntry.getFileName());
 		}
 
-		sb.append(URLCodec.encodeURL(_html.unescape(fileName), true));
+		sb.append(URLCodec.encodeURL(_html.unescape(fileName)));
 
 		sb.append(StringPool.SLASH);
 		sb.append(URLCodec.encodeURL(fileEntry.getUuid()));

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/webserver/test/WebServerFriendlyURLTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/webserver/test/WebServerFriendlyURLTest.java
@@ -80,6 +80,58 @@ public class WebServerFriendlyURLTest extends BaseWebServerTestCase {
 	}
 
 	@Test
+	public void testHasFilesWithFileEntryNameHasPlusSign() throws Exception {
+		String nameBase = RandomTestUtil.randomString();
+
+		String fileURL = nameBase + "%2B.txt";
+		String fileName = nameBase + "+.txt";
+
+		Assert.assertFalse(
+			WebServerServlet.hasFiles(
+				_createMockHttpServletRequest(
+					String.format("/%s/0/%s", group.getGroupId(), fileURL))));
+
+		_addFileEntry(fileName, RandomTestUtil.randomString());
+
+		Assert.assertTrue(
+			WebServerServlet.hasFiles(
+				_createMockHttpServletRequest(
+					String.format("/%s/0/%s", group.getGroupId(), fileURL))));
+
+		Assert.assertFalse(
+			WebServerServlet.hasFiles(
+				_createMockHttpServletRequest(
+					String.format("/%s/0/%s", group.getGroupId(), fileName))));
+	}
+
+	@Test
+	public void testHasFilesWithFileEntryNameHasSpaces() throws Exception {
+		String nameBase = RandomTestUtil.randomString();
+
+		String fileURL = nameBase + "+.txt";
+		String alternativeFileURL = nameBase + "%20.txt";
+		String fileName = nameBase + " .txt";
+
+		Assert.assertFalse(
+			WebServerServlet.hasFiles(
+				_createMockHttpServletRequest(
+					String.format("/%s/0/%s", group.getGroupId(), fileURL))));
+
+		_addFileEntry(fileName, RandomTestUtil.randomString());
+
+		Assert.assertTrue(
+			WebServerServlet.hasFiles(
+				_createMockHttpServletRequest(
+					String.format("/%s/0/%s", group.getGroupId(), fileURL))));
+
+		Assert.assertTrue(
+			WebServerServlet.hasFiles(
+				_createMockHttpServletRequest(
+					String.format(
+						"/%s/0/%s", group.getGroupId(), alternativeFileURL))));
+	}
+
+	@Test
 	public void testHasFilesWithFileEntryNameHasSpecialChars()
 		throws Exception {
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/webserver/test/WebServerFriendlyURLTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/webserver/test/WebServerFriendlyURLTest.java
@@ -28,6 +28,7 @@ import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.webdav.methods.Method;
@@ -82,14 +83,16 @@ public class WebServerFriendlyURLTest extends BaseWebServerTestCase {
 	public void testHasFilesWithFileEntryNameHasSpecialChars()
 		throws Exception {
 
-		String fileName = RandomTestUtil.randomString() + "+ .txt";
+		String fileName = RandomTestUtil.randomString() + "%2B .txt";
 
 		Assert.assertFalse(
 			WebServerServlet.hasFiles(
 				_createMockHttpServletRequest(
 					String.format("/%s/0/%s", group.getGroupId(), fileName))));
 
-		_addFileEntry(fileName, RandomTestUtil.randomString());
+		_addFileEntry(
+			HttpComponentsUtil.decodeURL(fileName),
+			RandomTestUtil.randomString());
 
 		Assert.assertTrue(
 			WebServerServlet.hasFiles(

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/webserver/test/WebServerRangeTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/webserver/test/WebServerRangeTest.java
@@ -195,7 +195,7 @@ public class WebServerRangeTest extends BaseWebServerTestCase {
 				group.getGroupId(), TestPropsValues.getUserId()));
 
 		String path = StringBundler.concat(
-			fileEntry.getGroupId(), "/", fileEntry.getFolderId(), "/",
+			"/", fileEntry.getGroupId(), "/", fileEntry.getFolderId(), "/",
 			fileEntry.getTitle());
 
 		Map<String, String> headers = new HashMap<>();

--- a/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
+++ b/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
@@ -1688,8 +1688,7 @@ public class WebServerServlet extends HttpServlet {
 		HttpServletResponse httpServletResponse, User user) {
 
 		return () -> {
-			String path = HttpComponentsUtil.fixPath(
-				httpServletRequest.getPathInfo());
+			String path = _getRawPathInfo(httpServletRequest);
 
 			String[] pathArray = StringUtil.split(path, CharPool.SLASH);
 

--- a/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
+++ b/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
@@ -175,8 +175,7 @@ public class WebServerServlet extends HttpServlet {
 					PortalUtil.getUserPassword(httpServletRequest));
 			}
 
-			String path = HttpComponentsUtil.fixPath(
-				httpServletRequest.getPathInfo());
+			String path = _getRawPathInfo(httpServletRequest);
 
 			String[] pathArray = StringUtil.split(path, CharPool.SLASH);
 
@@ -720,8 +719,7 @@ public class WebServerServlet extends HttpServlet {
 				modifiedDate = image.getModifiedDate();
 			}
 			else {
-				String path = HttpComponentsUtil.fixPath(
-					httpServletRequest.getPathInfo());
+				String path = _getRawPathInfo(httpServletRequest);
 
 				String[] pathArray = StringUtil.split(path, CharPool.SLASH);
 
@@ -1486,6 +1484,20 @@ public class WebServerServlet extends HttpServlet {
 		return user.getGroup();
 	}
 
+	private static String _getRawPathInfo(
+		HttpServletRequest httpServletRequest) {
+
+		String path = httpServletRequest.getRequestURI();
+
+		String location = httpServletRequest.getServletPath();
+
+		if (location.isEmpty()) {
+			location = httpServletRequest.getContextPath();
+		}
+
+		return path.substring(location.length() + 1);
+	}
+
 	private static User _getUser(HttpServletRequest httpServletRequest)
 		throws Exception {
 
@@ -1622,8 +1634,7 @@ public class WebServerServlet extends HttpServlet {
 			HttpServletResponse httpServletResponse)
 		throws Exception {
 
-		String path = HttpComponentsUtil.fixPath(
-			httpServletRequest.getPathInfo());
+		String path = _getRawPathInfo(httpServletRequest);
 
 		String[] pathArray = StringUtil.split(path, CharPool.SLASH);
 

--- a/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
+++ b/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
@@ -1322,7 +1322,8 @@ public class WebServerServlet extends HttpServlet {
 			return;
 		}
 
-		String fileName = HtmlUtil.escape(pathArray[2]);
+		String fileName = HttpComponentsUtil.decodeURL(
+			HtmlUtil.escape(pathArray[2]));
 
 		if (Validator.isNull(fileName)) {
 			throw new NoSuchFileEntryException("Invalid path " + path);
@@ -1425,7 +1426,7 @@ public class WebServerServlet extends HttpServlet {
 		else if (pathArray.length == 3) {
 			long groupId = GetterUtil.getLong(pathArray[0]);
 			long folderId = GetterUtil.getLong(pathArray[1]);
-			String fileName = pathArray[2];
+			String fileName = HttpComponentsUtil.decodeURL(pathArray[2]);
 
 			try {
 				try {
@@ -1829,7 +1830,7 @@ public class WebServerServlet extends HttpServlet {
 			long groupId = GetterUtil.getLong(pathArray[0]);
 			long folderId = GetterUtil.getLong(pathArray[1]);
 
-			String fileName = pathArray[2];
+			String fileName = HttpComponentsUtil.decodeURL(pathArray[2]);
 
 			if (fileName.contains(StringPool.QUESTION)) {
 				fileName = fileName.substring(


### PR DESCRIPTION
Allow the use of ascii chars in URLs in order to be able to access files with '+' in their names, while keeping working legacy URLs using '+' as ' '.