### PR TITLE
LPS-191493 Cannot open document for editing in Office 365 from the details page of the document

### DIFF
--- a/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/src/main/java/com/liferay/document/library/opener/onedrive/web/internal/display/context/DLOpenerOneDriveDLViewFileVersionDisplayContext.java
+++ b/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/src/main/java/com/liferay/document/library/opener/onedrive/web/internal/display/context/DLOpenerOneDriveDLViewFileVersionDisplayContext.java
@@ -173,20 +173,6 @@ public class DLOpenerOneDriveDLViewFileVersionDisplayContext
 	private DropdownItem _createEditInOffice365DropdownItem(String cmd)
 		throws PortalException {
 
-		if (Objects.equals(
-				request.getParameter("mvcRenderCommandName"),
-				"/document_library/view_file_entry")) {
-
-			return DropdownItemBuilder.putData(
-				"senna-off", "true"
-			).setHref(
-				_getEditURL(
-					cmd, "/document_library/edit_in_one_drive_and_redirect")
-			).setLabel(
-				LanguageUtil.get(_resourceBundle, _getLabelKey())
-			).build();
-		}
-
 		return DropdownItemBuilder.putData(
 			"action", "editOfficeDocument"
 		).putData(

--- a/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/src/main/java/com/liferay/document/library/opener/onedrive/web/internal/servlet/taglib/OneDriveViewPostJSPDynamicInclude.java
+++ b/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/src/main/java/com/liferay/document/library/opener/onedrive/web/internal/servlet/taglib/OneDriveViewPostJSPDynamicInclude.java
@@ -39,6 +39,9 @@ public class OneDriveViewPostJSPDynamicInclude extends BaseJSPDynamicInclude {
 	public void register(DynamicIncludeRegistry dynamicIncludeRegistry) {
 		dynamicIncludeRegistry.register(
 			"com.liferay.document.library.web#/document_library/view.jsp#post");
+		dynamicIncludeRegistry.register(
+			"com.liferay.document.library.web#/document_library" +
+				"/view_file_entry.jsp#post");
 	}
 
 	@Override


### PR DESCRIPTION
Using same Props Transformer in Details page menu option "Edit in Office 365" as in menu option of item in DM folder view.
The inclusion of the component `DocumentLibraryOpener` was needed in this page also.

See: https://liferay.atlassian.net/browse/LPS-191493