### PR TITLE
LPS-191935 Mentions do not work when setting "message.boards.message.formats.default=html"

### DIFF
--- a/modules/apps/mentions/mentions-web/src/main/java/com/liferay/mentions/web/internal/editor/configuration/BlogsMentionsEditorConfigContributor.java
+++ b/modules/apps/mentions/mentions-web/src/main/java/com/liferay/mentions/web/internal/editor/configuration/BlogsMentionsEditorConfigContributor.java
@@ -25,7 +25,8 @@ import org.osgi.service.component.annotations.Component;
 @Component(
 	property = {
 		"editor.config.key=contentEditor", "editor.name=alloyeditor",
-		"editor.name=ckeditor", "javax.portlet.name=" + BlogsPortletKeys.BLOGS,
+		"editor.name=ckeditor", "editor.name=ckeditor_classic",
+		"javax.portlet.name=" + BlogsPortletKeys.BLOGS,
 		"javax.portlet.name=" + BlogsPortletKeys.BLOGS_ADMIN,
 		"service.ranking:Integer=10"
 	},

--- a/modules/apps/mentions/mentions-web/src/main/java/com/liferay/mentions/web/internal/editor/configuration/MBMentionsEditorConfigContributor.java
+++ b/modules/apps/mentions/mentions-web/src/main/java/com/liferay/mentions/web/internal/editor/configuration/MBMentionsEditorConfigContributor.java
@@ -26,7 +26,7 @@ import org.osgi.service.component.annotations.Component;
 	property = {
 		"editor.config.key=bodyEditor", "editor.config.key=replyMBEditor",
 		"editor.name=alloyeditor", "editor.name=alloyeditor_bbcode",
-		"editor.name=ckeditor", "editor.name=ckeditor_bbcode",
+		"editor.name=ckeditor_bbcode", "editor.name=ckeditor_classic",
 		"javax.portlet.name=" + MBPortletKeys.MESSAGE_BOARDS,
 		"javax.portlet.name=" + MBPortletKeys.MESSAGE_BOARDS_ADMIN,
 		"service.ranking:Integer=10"


### PR DESCRIPTION
The problem was that the Autocomplete javascript was not loading in the HTML editor because its name is not "ckeditor" but "ckeditor_classic".

Issue: https://liferay.atlassian.net/browse/LPS-191935