### PR TITLE
LPS-191937 Replace custom code by clay:vertical-nav for the item-selector-web module

### DIFF
--- a/modules/apps/item-selector/item-selector-web/src/main/java/com/liferay/item/selector/web/internal/portlet/LocalizedItemSelectorRendering.java
+++ b/modules/apps/item-selector/item-selector-web/src/main/java/com/liferay/item/selector/web/internal/portlet/LocalizedItemSelectorRendering.java
@@ -16,9 +16,11 @@ package com.liferay.item.selector.web.internal.portlet;
 
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.NavigationItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.NavigationItemList;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.VerticalNavItemList;
 import com.liferay.item.selector.ItemSelectorRendering;
 import com.liferay.item.selector.ItemSelectorView;
 import com.liferay.item.selector.ItemSelectorViewRenderer;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.util.HashMap;
@@ -82,13 +84,14 @@ public class LocalizedItemSelectorRendering {
 
 					navigationItem.setActive(true);
 
+					_activeNavigationItem = navigationItem;
 					_selectedNavigationItemLabel = title;
 				}
 			});
 	}
 
-	public String getItemSelectedEventName() {
-		return _itemSelectorRendering.getItemSelectedEventName();
+	public NavigationItem getActiveNavigationItem() {
+		return _activeNavigationItem;
 	}
 
 	public List<NavigationItem> getNavigationItems() {
@@ -125,6 +128,7 @@ public class LocalizedItemSelectorRendering {
 			LocalizedItemSelectorRendering.class.getName(), this);
 	}
 
+	private NavigationItem _activeNavigationItem;
 	private final ItemSelectorRendering _itemSelectorRendering;
 	private final Map<String, ItemSelectorViewRenderer>
 		_itemSelectorViewRenderers = new HashMap<>();

--- a/modules/apps/item-selector/item-selector-web/src/main/java/com/liferay/item/selector/web/internal/portlet/LocalizedItemSelectorRendering.java
+++ b/modules/apps/item-selector/item-selector-web/src/main/java/com/liferay/item/selector/web/internal/portlet/LocalizedItemSelectorRendering.java
@@ -99,6 +99,27 @@ public class LocalizedItemSelectorRendering {
 		return _itemSelectorViewRenderers.get(_selectedNavigationItemLabel);
 	}
 
+	public VerticalNavItemList getVerticalNavItemList() {
+		VerticalNavItemList verticalNavItemList = new VerticalNavItemList();
+
+		for (NavigationItem navigationItem : getNavigationItems()) {
+			verticalNavItemList.add(
+				verticalNavItem -> {
+					String name = GetterUtil.getString(
+						navigationItem.get("label"));
+
+					verticalNavItem.setActive(
+						GetterUtil.getBoolean(navigationItem.get("active")));
+					verticalNavItem.setHref(
+						GetterUtil.getString(navigationItem.get("href")));
+					verticalNavItem.setLabel(name);
+					verticalNavItem.setId(name);
+				});
+		}
+
+		return verticalNavItemList;
+	}
+
 	public void store(PortletRequest portletRequest) {
 		portletRequest.setAttribute(
 			LocalizedItemSelectorRendering.class.getName(), this);

--- a/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/view.jsp
@@ -63,28 +63,9 @@ List<NavigationItem> navigationItems = localizedItemSelectorRendering.getNavigat
 								<clay:col
 									lg="3"
 								>
-									<nav class="menubar menubar-transparent menubar-vertical-expand-lg">
-										<ul class="mb-2 nav nav-stacked">
-
-											<%
-											for (NavigationItem navigationItem : navigationItems) {
-												if (GetterUtil.getBoolean(navigationItem.get("active"))) {
-													activeNavigationItem = navigationItem;
-												}
-											%>
-
-												<li class="nav-item">
-													<a class="d-flex nav-link <%= GetterUtil.getBoolean(navigationItem.get("active")) ? "active" : StringPool.BLANK %>" href="<%= GetterUtil.getString(navigationItem.get("href")) %>">
-														<span class="text-truncate"><%= GetterUtil.getString(navigationItem.get("label")) %></span>
-													</a>
-												</li>
-
-											<%
-											}
-											%>
-
-										</ul>
-									</nav>
+									<clay:vertical-nav
+										verticalNavItems="<%= localizedItemSelectorRendering.getVerticalNavItemList() %>"
+									/>
 								</clay:col>
 
 								<clay:col

--- a/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/view.jsp
@@ -51,11 +51,6 @@ List<NavigationItem> navigationItems = localizedItemSelectorRendering.getNavigat
 						<liferay-util:include page="/view_item_selector.jsp" servletContext="<%= application %>" />
 					</c:when>
 					<c:otherwise>
-
-						<%
-						NavigationItem activeNavigationItem = null;
-						%>
-
 						<clay:container-fluid
 							cssClass="container-view"
 						>
@@ -74,6 +69,11 @@ List<NavigationItem> navigationItems = localizedItemSelectorRendering.getNavigat
 									<clay:sheet
 										size="full"
 									>
+
+										<%
+										NavigationItem activeNavigationItem = localizedItemSelectorRendering.getActiveNavigationItem();
+										%>
+
 										<c:if test="<%= activeNavigationItem != null %>">
 											<h2 class="sheet-title">
 												<clay:content-row


### PR DESCRIPTION
Motivation
=======
The motivation behind this ticket is to use the clay:vertical-nav tag in order to standarize the usage of vertical navigation elements.
[LPS-191937](https://liferay.atlassian.net/browse/LPS-191937)
[LPS-188310](https://liferay.atlassian.net/browse/LPS-188310)

Proposed Solution
========
The proposed solution consists in creating a list of verticalNavItemList and pass it to the clay:vertical-nav.

Steps to Verify
========
1. Enter the Edit mode of a Content Page.
2. Add a fragment of type Content Display by dragging it from the left panel in the Edit Mode. 
3. Click over the fragment and then go to the right panel.
4. In the right panel -> General tab -> Click over Select Item input -> a modal is oppened
5. Check in the modal that the navigation list is displayed correctly and also the titles for every view in the modal.

<img width="1792" alt="Screenshot 2023-07-27 at 15 29 10" src="https://github.com/liferay-echo/liferay-portal/assets/91207948/6fbcd3ac-7a48-425f-ae9a-7aaa4c5a968a">
