### PR TITLE
LPS-190935 Translation destroys html structure/text data

### DIFF
--- a/modules/apps/translation/translation-api/bnd.bnd
+++ b/modules/apps/translation/translation-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Translation API
 Bundle-SymbolicName: com.liferay.translation.api
-Bundle-Version: 10.0.1
+Bundle-Version: 10.1.0
 Export-Package:\
 	com.liferay.translation.constants,\
 	com.liferay.translation.exception,\

--- a/modules/apps/translation/translation-api/src/main/java/com/liferay/translation/translator/JSONTranslatorPacket.java
+++ b/modules/apps/translation/translation-api/src/main/java/com/liferay/translation/translator/JSONTranslatorPacket.java
@@ -40,14 +40,6 @@ public class JSONTranslatorPacket implements TranslatorPacket {
 		}
 	}
 
-	private Boolean _getHtml(String key, JSONObject htmlJSONObject) {
-		if (htmlJSONObject == null) {
-			return null;
-		}
-
-		return htmlJSONObject.getBoolean(key);
-	}
-
 	@Override
 	public long getCompanyId() {
 		return _companyId;
@@ -71,6 +63,14 @@ public class JSONTranslatorPacket implements TranslatorPacket {
 	@Override
 	public String getTargetLanguageId() {
 		return _targetLanguageId;
+	}
+
+	private Boolean _getHtml(String key, JSONObject htmlJSONObject) {
+		if (htmlJSONObject == null) {
+			return null;
+		}
+
+		return htmlJSONObject.getBoolean(key);
 	}
 
 	private final long _companyId;

--- a/modules/apps/translation/translation-api/src/main/java/com/liferay/translation/translator/JSONTranslatorPacket.java
+++ b/modules/apps/translation/translation-api/src/main/java/com/liferay/translation/translator/JSONTranslatorPacket.java
@@ -35,15 +35,17 @@ public class JSONTranslatorPacket implements TranslatorPacket {
 		JSONObject htmlJSONObject = jsonObject.getJSONObject("html");
 
 		for (String key : fieldsJSONObject.keySet()) {
-			Boolean html = null;
-
-			if (htmlJSONObject != null) {
-				html = htmlJSONObject.getBoolean(key);
-			}
-
 			_fieldsMap.put(key, fieldsJSONObject.getString(key));
-			_htmlMap.put(key, html);
+			_htmlMap.put(key, _getHtml(key, htmlJSONObject));
 		}
+	}
+
+	private Boolean _getHtml(String key, JSONObject htmlJSONObject) {
+		if (htmlJSONObject == null) {
+			return null;
+		}
+
+		return htmlJSONObject.getBoolean(key);
 	}
 
 	@Override

--- a/modules/apps/translation/translation-api/src/main/java/com/liferay/translation/translator/JSONTranslatorPacket.java
+++ b/modules/apps/translation/translation-api/src/main/java/com/liferay/translation/translator/JSONTranslatorPacket.java
@@ -32,9 +32,17 @@ public class JSONTranslatorPacket implements TranslatorPacket {
 		_targetLanguageId = jsonObject.getString("targetLanguageId");
 
 		JSONObject fieldsJSONObject = jsonObject.getJSONObject("fields");
+		JSONObject htmlJSONObject = jsonObject.getJSONObject("html");
 
 		for (String key : fieldsJSONObject.keySet()) {
+			Boolean html = null;
+
+			if (htmlJSONObject != null) {
+				html = htmlJSONObject.getBoolean(key);
+			}
+
 			_fieldsMap.put(key, fieldsJSONObject.getString(key));
+			_htmlMap.put(key, html);
 		}
 	}
 
@@ -49,6 +57,11 @@ public class JSONTranslatorPacket implements TranslatorPacket {
 	}
 
 	@Override
+	public Map<String, Boolean> getHtmlMap() {
+		return _htmlMap;
+	}
+
+	@Override
 	public String getSourceLanguageId() {
 		return _sourceLanguageId;
 	}
@@ -60,6 +73,7 @@ public class JSONTranslatorPacket implements TranslatorPacket {
 
 	private final long _companyId;
 	private final Map<String, String> _fieldsMap = new LinkedHashMap<>();
+	private final Map<String, Boolean> _htmlMap = new LinkedHashMap<>();
 	private final String _sourceLanguageId;
 	private final String _targetLanguageId;
 

--- a/modules/apps/translation/translation-api/src/main/java/com/liferay/translation/translator/TranslatorPacket.java
+++ b/modules/apps/translation/translation-api/src/main/java/com/liferay/translation/translator/TranslatorPacket.java
@@ -19,6 +19,8 @@ public interface TranslatorPacket {
 
 	public Map<String, String> getFieldsMap();
 
+	public Map<String, Boolean> getHtmlMap();
+
 	public String getSourceLanguageId();
 
 	public String getTargetLanguageId();

--- a/modules/apps/translation/translation-api/src/main/resources/com/liferay/translation/translator/packageinfo
+++ b/modules/apps/translation/translation-api/src/main/resources/com/liferay/translation/translator/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 2.1.0

--- a/modules/apps/translation/translation-translator-aws/src/main/java/com/liferay/translation/translator/aws/internal/translator/AWSTranslator.java
+++ b/modules/apps/translation/translation-translator-aws/src/main/java/com/liferay/translation/translator/aws/internal/translator/AWSTranslator.java
@@ -99,6 +99,11 @@ public class AWSTranslator implements Translator {
 			}
 
 			@Override
+			public Map<String, Boolean> getHtmlMap() {
+				return null;
+			}
+
+			@Override
 			public String getSourceLanguageId() {
 				return translatorPacket.getSourceLanguageId();
 			}

--- a/modules/apps/translation/translation-translator-azure/src/main/java/com/liferay/translation/translator/azure/internal/AzureTranslator.java
+++ b/modules/apps/translation/translation-translator-azure/src/main/java/com/liferay/translation/translator/azure/internal/AzureTranslator.java
@@ -118,6 +118,11 @@ public class AzureTranslator implements Translator {
 				}
 
 				@Override
+				public Map<String, Boolean> getHtmlMap() {
+					return null;
+				}
+
+				@Override
 				public String getSourceLanguageId() {
 					return translatorPacket.getSourceLanguageId();
 				}

--- a/modules/apps/translation/translation-translator-deepl/src/main/java/com/liferay/translation/translator/deepl/internal/translator/DeepLTranslator.java
+++ b/modules/apps/translation/translation-translator-deepl/src/main/java/com/liferay/translation/translator/deepl/internal/translator/DeepLTranslator.java
@@ -87,6 +87,7 @@ public class DeepLTranslator implements Translator {
 
 		Map<String, String> translatedFieldsMap = _translate(
 			deepLTranslatorConfiguration, translatorPacket.getFieldsMap(),
+			translatorPacket.getHtmlMap(),
 			_getLanguageCode(translatorPacket.getSourceLanguageId()),
 			targetLanguageCode);
 
@@ -100,6 +101,11 @@ public class DeepLTranslator implements Translator {
 			@Override
 			public Map<String, String> getFieldsMap() {
 				return translatedFieldsMap;
+			}
+
+			@Override
+			public Map<String, Boolean> getHtmlMap() {
+				return translatorPacket.getHtmlMap();
 			}
 
 			@Override
@@ -171,18 +177,20 @@ public class DeepLTranslator implements Translator {
 
 	private Map<String, String> _translate(
 			DeepLTranslatorConfiguration deepLTranslatorConfiguration,
-			Map<String, String> fieldsMap, String sourceLanguageCode,
-			String targetLanguageCode)
+			Map<String, String> fieldsMap, Map<String, Boolean> htmlMap,
+			String sourceLanguageCode, String targetLanguageCode)
 		throws PortalException {
 
 		Map<String, String> translatedFieldsMap = new HashMap<>();
 
 		for (Map.Entry<String, String> entry : fieldsMap.entrySet()) {
+			Boolean html = htmlMap.get(entry.getKey());
+
 			translatedFieldsMap.put(
 				entry.getKey(),
 				_translate(
 					deepLTranslatorConfiguration, sourceLanguageCode,
-					targetLanguageCode, entry.getValue()));
+					targetLanguageCode, entry.getValue(), html));
 		}
 
 		return translatedFieldsMap;
@@ -190,7 +198,8 @@ public class DeepLTranslator implements Translator {
 
 	private String _translate(
 			DeepLTranslatorConfiguration deepLTranslatorConfiguration,
-			String sourceLanguageCode, String targetLanguageCode, String text)
+			String sourceLanguageCode, String targetLanguageCode, String text,
+			Boolean html)
 		throws PortalException {
 
 		if (Validator.isBlank(text)) {
@@ -202,6 +211,11 @@ public class DeepLTranslator implements Translator {
 		options.addHeader(
 			HttpHeaders.AUTHORIZATION,
 			"DeepL-Auth-Key " + deepLTranslatorConfiguration.authKey());
+
+		if ((html != null) && html) {
+			options.addPart("tag_handling", "html");
+		}
+
 		options.addPart("source_lang", sourceLanguageCode);
 		options.addPart("target_lang", targetLanguageCode);
 		options.addPart("text", text);

--- a/modules/apps/translation/translation-translator-deepl/src/main/java/com/liferay/translation/translator/deepl/internal/translator/DeepLTranslator.java
+++ b/modules/apps/translation/translation-translator-deepl/src/main/java/com/liferay/translation/translator/deepl/internal/translator/DeepLTranslator.java
@@ -151,9 +151,6 @@ public class DeepLTranslator implements Translator {
 
 		options.addHeader(
 			HttpHeaders.AUTHORIZATION, "DeepL-Auth-Key " + authKey);
-		options.addHeader(
-			HttpHeaders.CONTENT_TYPE,
-			ContentTypes.APPLICATION_X_WWW_FORM_URLENCODED);
 		options.setLocation(url);
 
 		try {
@@ -206,19 +203,30 @@ public class DeepLTranslator implements Translator {
 			return text;
 		}
 
+		JSONObject requestJSONObject = _jsonFactory.createJSONObject();
+
+		if ((html != null) && html) {
+			requestJSONObject.put("tag_handling", "html");
+		}
+
+		requestJSONObject.put(
+			"source_lang", sourceLanguageCode
+		).put(
+			"target_lang", targetLanguageCode
+		).put(
+			"text", new String[] {text}
+		);
+
+		Http.Body body = new Http.Body(
+			requestJSONObject.toString(), ContentTypes.APPLICATION_JSON,
+			"UTF-8");
+
 		Http.Options options = new Http.Options();
 
 		options.addHeader(
-			HttpHeaders.AUTHORIZATION,
-			"DeepL-Auth-Key " + deepLTranslatorConfiguration.authKey());
+			HttpHeaders.CONTENT_TYPE, ContentTypes.APPLICATION_JSON);
 
-		if ((html != null) && html) {
-			options.addPart("tag_handling", "html");
-		}
-
-		options.addPart("source_lang", sourceLanguageCode);
-		options.addPart("target_lang", targetLanguageCode);
-		options.addPart("text", text);
+		options.setBody(body);
 		options.setMethod(Http.Method.POST);
 
 		JSONObject jsonObject = _jsonFactory.createJSONObject(

--- a/modules/apps/translation/translation-translator-google-cloud/src/main/java/com/liferay/translation/translator/google/cloud/internal/translator/GoogleCloudTranslator.java
+++ b/modules/apps/translation/translation-translator-google-cloud/src/main/java/com/liferay/translation/translator/google/cloud/internal/translator/GoogleCloudTranslator.java
@@ -127,6 +127,11 @@ public class GoogleCloudTranslator implements Translator {
 			}
 
 			@Override
+			public Map<String, Boolean> getHtmlMap() {
+				return null;
+			}
+
+			@Override
 			public String getSourceLanguageId() {
 				return translatorPacket.getSourceLanguageId();
 			}

--- a/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/servlet/AutoTranslateServlet.java
+++ b/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/servlet/AutoTranslateServlet.java
@@ -102,10 +102,10 @@ public class AutoTranslateServlet extends HttpServlet {
 		}
 	}
 
-	private JSONObject _getFieldsJSONObject(Map<String, String> fieldsMap) {
+	private JSONObject _getFieldsJSONObject(Map<String, ?> fieldsMap) {
 		JSONObject jsonObject = _jsonFactory.createJSONObject();
 
-		for (Map.Entry<String, String> entry : fieldsMap.entrySet()) {
+		for (Map.Entry<String, ?> entry : fieldsMap.entrySet()) {
 			jsonObject.put(entry.getKey(), entry.getValue());
 		}
 
@@ -115,6 +115,8 @@ public class AutoTranslateServlet extends HttpServlet {
 	private String _toJSON(TranslatorPacket translatorPacket) {
 		return JSONUtil.put(
 			"fields", _getFieldsJSONObject(translatorPacket.getFieldsMap())
+		).put(
+			"html", _getFieldsJSONObject(translatorPacket.getHtmlMap())
 		).put(
 			"sourceLanguageId", translatorPacket.getSourceLanguageId()
 		).put(


### PR DESCRIPTION

https://liferay.atlassian.net/browse/LPS-190935

Steps to reproduce:


Language: German

Timezone: Central European Summertime 

 

    2. Configure DeepL Translator with a free token
    3. Go to "Inhalte" ("Contents & Data") -> "Webcontent" ("Web Content")
    4. Create a "Basic Web Content" with German content:
		title: `"Hallo & Welt"`

		content:
```

		<h4 style="margin-left: 40px;">Vergünstigungen in der Mensa</h4>
		<p style="margin-left: 40px;">In allen <strong>gastronomischen Einrichtungen</strong> des Studierendenwerks XYZ können Sie sich ganz einfach mit XXXXXX-M in der YYY-App ausweisen, um die vergünstigten Tarife für Mitarbeitende zu erhalten.</p>
		<h4 style="margin-left: 40px;">Bibliothek</h4>
		<p style="margin-left: 40px;">Sie können XXXXXX-M nutzen, um Medien in der Bibliothek auszuleihen.</p>
		<h4 style="margin-left: 40px;">XYZ-Bahn-Nutzung</h4>
		<p style="margin-left: 40px;">Zusammen mit einem amtlichen Lichtbildausweis kann XXXXXXId-M als Berechtigung zur Nutzung der XYZ-Bahn genutzt werden.</p>
		<p style="margin-left: 40px;">Warnung vom 26. Juli 2023 – IT-Sicherheit</p>
```

		The content should be entered when editor is switch to "Source" view, the quote characters should not be entered, HTML editor needs to be switch to preview mode before "publish", else the content is lost



   5. Choose "Übersetzen" from the Contextmenu of webcontent and request translation to en-US




- LPS-190935 Translation destroys html structure/text data
- LPS-190935 semver
- LPS-190935 use JSON object instead fields to prevent miss encoding
- LPS-190935 extract method
- LPS-190935 autoSF


//cc // @matthiasblaesing @ambrinchaudhary and @austinchiang