### PR TITLE
LPS-192614 Performance issues loading images - lot of DDM accesses

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/validator/AMImageValidatorImpl.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/validator/AMImageValidatorImpl.java
@@ -58,24 +58,21 @@ public class AMImageValidatorImpl implements AMImageValidator {
 	public <T> boolean isProcessingRequired(
 		AdaptiveMedia<T> adaptiveMedia, FileVersion fileVersion) {
 
-		if (!isProcessingSupported(fileVersion)) {
-			return false;
-		}
-
 		String configurationUuid = adaptiveMedia.getValue(
 			AMAttribute.getConfigurationUuidAMAttribute());
 
-		if (configurationUuid == null) {
-			return true;
-		}
-
-		if (_amImageEntryLocalService.hasAMImageEntryContent(
+		if ((configurationUuid != null) &&
+			_amImageEntryLocalService.hasAMImageEntryContent(
 				configurationUuid, fileVersion)) {
 
 			return false;
 		}
 
-		return true;
+		if (isProcessingSupported(fileVersion)) {
+			return true;
+		}
+
+		return false;
 	}
 
 	@Override


### PR DESCRIPTION
When accessing an image there a lot of DDM accesses to check the image size (method `AMImageValidatorImpl.isProcessingSupported()`), which is not needed if we already have the image. We need to know that only if no image exists and we need to create it (thumbnails).

See issue: https://liferay.atlassian.net/browse/LPS-192614