### PR TITLE
LPS-191268 Change status to SCHEDULED if displayDate is on the future

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
@@ -2349,10 +2349,11 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 			throw new KBArticleDisplayDateException("Display date is null");
 		}
 
-		_validateExpirationReviewDate(displayDate, expirationDate, reviewDate);
+		_validateDisplayExpirationReviewDate(
+			displayDate, expirationDate, reviewDate);
 	}
 
-	private void _validateExpirationReviewDate(
+	private void _validateDisplayExpirationReviewDate(
 			Date displayDate, Date expirationDate, Date reviewDate)
 		throws PortalException {
 

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
@@ -1360,12 +1360,16 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 		boolean main = false;
 		Date date = new Date();
 
-		if (status == WorkflowConstants.STATUS_APPROVED) {
-			main = true;
-		}
-
 		KBArticle kbArticle = getLatestKBArticle(
 			resourcePrimKey, WorkflowConstants.STATUS_ANY);
+
+		if (status == WorkflowConstants.STATUS_APPROVED) {
+			main = true;
+
+			if (date.before(kbArticle.getDisplayDate())) {
+				status = WorkflowConstants.STATUS_SCHEDULED;
+			}
+		}
 
 		_validateParentStatus(
 			kbArticle.getParentResourceClassNameId(),

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
@@ -514,7 +514,9 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 		KBArticle kbArticle = getLatestKBArticle(
 			resourcePrimKey, WorkflowConstants.STATUS_ANY);
 
-		if (kbArticle.isDraft() || kbArticle.isPending()) {
+		if (kbArticle.isDraft() || kbArticle.isPending() ||
+			kbArticle.isScheduled()) {
+
 			return kbArticle;
 		}
 
@@ -1834,6 +1836,9 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 				).and(
 					KBArticleTable.INSTANCE.status.neq(
 						WorkflowConstants.STATUS_PENDING)
+				).and(
+					KBArticleTable.INSTANCE.status.neq(
+						WorkflowConstants.STATUS_SCHEDULED)
 				)
 			));
 	}

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
@@ -2358,12 +2358,18 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 
 		Date now = new Date();
 
-		if ((expirationDate != null) &&
-			(expirationDate.before(now) ||
-			 expirationDate.before(displayDate))) {
+		if (expirationDate != null) {
+			if (expirationDate.before(now)) {
+				throw new KBArticleExpirationDateException(
+					"Expiration date " + expirationDate + " is in the past");
+			}
 
-			throw new KBArticleExpirationDateException(
-				"Expiration date " + expirationDate + " is in the past");
+			if (expirationDate.before(displayDate)) {
+				throw new KBArticleExpirationDateException(
+					StringBundler.concat(
+						"Expiration date ", expirationDate,
+						" is prior to display date ", displayDate));
+			}
 		}
 
 		if ((reviewDate != null) && reviewDate.before(now)) {

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
@@ -2344,16 +2344,19 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 			throw new KBArticleDisplayDateException("Display date is null");
 		}
 
-		_validateExpirationReviewDate(expirationDate, reviewDate);
+		_validateExpirationReviewDate(displayDate, expirationDate, reviewDate);
 	}
 
 	private void _validateExpirationReviewDate(
-			Date expirationDate, Date reviewDate)
+			Date displayDate, Date expirationDate, Date reviewDate)
 		throws PortalException {
 
 		Date now = new Date();
 
-		if ((expirationDate != null) && expirationDate.before(now)) {
+		if ((expirationDate != null) &&
+			(expirationDate.before(now) ||
+			 expirationDate.before(displayDate))) {
+
 			throw new KBArticleExpirationDateException(
 				"Expiration date " + expirationDate + " is in the past");
 		}

--- a/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/test/KBArticleLocalServiceTest.java
+++ b/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/test/KBArticleLocalServiceTest.java
@@ -278,6 +278,42 @@ public class KBArticleLocalServiceTest {
 			_serviceContext);
 	}
 
+	@Test
+	public void testAddKBArticleDisplayDateKBArticleStatusScheduled()
+		throws Exception {
+
+		Date displayDate = DateUtils.addDays(RandomTestUtil.nextDate(), 2);
+
+		Date expirationDate = DateUtils.addDays(displayDate, 1);
+
+		KBArticle kbArticle = _kbArticleLocalService.addKBArticle(
+			null, _user.getUserId(), _kbFolderClassNameId,
+			KBFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			StringUtil.randomString(), StringUtil.randomString(),
+			StringUtil.randomString(), StringUtil.randomString(), null, null,
+			displayDate, expirationDate, null, null, _serviceContext);
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_SCHEDULED, kbArticle.getStatus());
+	}
+
+	@Test(expected = KBArticleExpirationDateException.class)
+	public void testAddKBArticleInvalidExpirationDateBeforeDisplayDateKBArticleExpirationDateException()
+		throws Exception {
+
+		Date displayDate = DateUtils.addDays(RandomTestUtil.nextDate(), 2);
+
+		Date expirationDate = DateUtils.addDays(displayDate, -1);
+
+		_kbArticleLocalService.addKBArticle(
+			null, _user.getUserId(), _kbFolderClassNameId,
+			KBFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			StringUtil.randomString(), StringUtil.randomString(),
+			StringUtil.randomString(), StringUtil.randomString(), null, null,
+			displayDate, expirationDate, RandomTestUtil.nextDate(), null,
+			_serviceContext);
+	}
+
 	@Test(expected = KBArticleExpirationDateException.class)
 	public void testAddKBArticleInvalidExpirationDateException()
 		throws Exception {


### PR DESCRIPTION
Adding the back functionallity to check if the display date is on the future and put the status

As we can not check it with the portal till the front is made, and not changing manually UpdateKBArticleMVCActionCommand I added some test to check the new behavior


