### PR TITLE
LPS-192636 add background support on deletion of directories

### DIFF
--- a/modules/apps/portal-store/portal-store-gcs-test/src/testIntegration/java/com/liferay/portal/store/gcs/test/GCSStoreStoreAreaProcessorTest.java
+++ b/modules/apps/portal-store/portal-store-gcs-test/src/testIntegration/java/com/liferay/portal/store/gcs/test/GCSStoreStoreAreaProcessorTest.java
@@ -34,6 +34,7 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import java.time.Duration;
 
 import java.util.Arrays;
+import java.util.Dictionary;
 
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -80,6 +81,10 @@ public class GCSStoreStoreAreaProcessorTest {
 			"com.liferay.portal.store.gcs.configuration.GCSStoreConfiguration",
 			StringPool.QUESTION);
 
+		if (_configuration != null) {
+			_originalProperties = _configuration.getProperties();
+		}
+
 		ConfigurationTestUtil.saveConfiguration(
 			_configuration,
 			HashMapDictionaryBuilder.<String, Object>put(
@@ -109,8 +114,13 @@ public class GCSStoreStoreAreaProcessorTest {
 
 	@AfterClass
 	public static void tearDownClass() throws Exception {
-		ConfigurationTestUtil.deleteConfiguration(_configuration);
+		if (_originalProperties == null) {
 			ConfigurationTestUtil.deleteConfiguration(_configuration);
+		}
+		else {
+			_configuration.update(_originalProperties);
+		}
+
 		_companyLocalService.deleteCompany(_company);
 	}
 
@@ -408,6 +418,8 @@ public class GCSStoreStoreAreaProcessorTest {
 
 	@Inject
 	private static ConfigurationAdmin _configurationAdmin;
+
+	private static Dictionary<String, Object> _originalProperties;
 
 	@DeleteAfterTestRun
 	private Group _group;

--- a/modules/apps/portal-store/portal-store-gcs-test/src/testIntegration/java/com/liferay/portal/store/gcs/test/GCSStoreStoreAreaProcessorTest.java
+++ b/modules/apps/portal-store/portal-store-gcs-test/src/testIntegration/java/com/liferay/portal/store/gcs/test/GCSStoreStoreAreaProcessorTest.java
@@ -13,10 +13,13 @@ import com.liferay.petra.io.unsync.UnsyncByteArrayInputStream;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.test.util.ConfigurationTestUtil;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.AssumeTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
@@ -71,6 +74,8 @@ public class GCSStoreStoreAreaProcessorTest {
 
 	@BeforeClass
 	public static void setUpClass() throws Exception {
+		_company = CompanyTestUtil.addCompany();
+
 		_configuration = _configurationAdmin.getConfiguration(
 			"com.liferay.portal.store.gcs.configuration.GCSStoreConfiguration",
 			StringPool.QUESTION);
@@ -105,11 +110,13 @@ public class GCSStoreStoreAreaProcessorTest {
 	@AfterClass
 	public static void tearDownClass() throws Exception {
 		ConfigurationTestUtil.deleteConfiguration(_configuration);
+			ConfigurationTestUtil.deleteConfiguration(_configuration);
+		_companyLocalService.deleteCompany(_company);
 	}
 
 	@Before
 	public void setUp() throws Exception {
-		_group = GroupTestUtil.addGroup();
+		_group = GroupTestUtil.addGroupToCompany(_company.getCompanyId());
 	}
 
 	@Test
@@ -120,25 +127,25 @@ public class GCSStoreStoreAreaProcessorTest {
 				String fileName = StringUtil.randomString();
 
 				_store.addFile(
-					_group.getCompanyId(), _group.getGroupId(), fileName,
+					_company.getCompanyId(), _group.getGroupId(), fileName,
 					Store.VERSION_DEFAULT,
 					new UnsyncByteArrayInputStream(new byte[0]));
 
 				Assert.assertTrue(
 					_store.hasFile(
-						_group.getCompanyId(), _group.getGroupId(), fileName,
+						_company.getCompanyId(), _group.getGroupId(), fileName,
 						Store.VERSION_DEFAULT));
 
 				StoreAreaProcessor storeAreaProcessor =
 					(StoreAreaProcessor)_store;
 
 				storeAreaProcessor.cleanUpDeletedStoreArea(
-					_group.getCompanyId(), 1, name -> true, StringPool.BLANK,
+					_company.getCompanyId(), 1, name -> true, StringPool.BLANK,
 					Duration.ofDays(1));
 
 				Assert.assertTrue(
 					_store.hasFile(
-						_group.getCompanyId(), _group.getGroupId(), fileName,
+						_company.getCompanyId(), _group.getGroupId(), fileName,
 						Store.VERSION_DEFAULT));
 			});
 	}
@@ -152,7 +159,7 @@ public class GCSStoreStoreAreaProcessorTest {
 			() -> {
 				for (String fileName : RandomTestUtil.randomStrings(4)) {
 					_store.addFile(
-						_group.getCompanyId(), _group.getGroupId(), fileName,
+						_company.getCompanyId(), _group.getGroupId(), fileName,
 						Store.VERSION_DEFAULT,
 						new UnsyncByteArrayInputStream(new byte[0]));
 				}
@@ -166,7 +173,7 @@ public class GCSStoreStoreAreaProcessorTest {
 
 				do {
 					startOffset = storeAreaProcessor.cleanUpDeletedStoreArea(
-						_group.getCompanyId(), 1, name -> true, startOffset,
+						_company.getCompanyId(), 1, name -> true, startOffset,
 						Duration.ofDays(-1));
 
 					runCount++;
@@ -176,7 +183,7 @@ public class GCSStoreStoreAreaProcessorTest {
 				Assert.assertTrue(runCount > 1);
 
 				String[] fileNames = _store.getFileNames(
-					_group.getCompanyId(), _group.getGroupId(),
+					_company.getCompanyId(), _group.getGroupId(),
 					StringPool.BLANK);
 
 				Assert.assertEquals(
@@ -192,25 +199,25 @@ public class GCSStoreStoreAreaProcessorTest {
 				String fileName = StringUtil.randomString();
 
 				_store.addFile(
-					_group.getCompanyId(), _group.getGroupId(), fileName,
+					_company.getCompanyId(), _group.getGroupId(), fileName,
 					Store.VERSION_DEFAULT,
 					new UnsyncByteArrayInputStream(new byte[0]));
 
 				Assert.assertTrue(
 					_store.hasFile(
-						_group.getCompanyId(), _group.getGroupId(), fileName,
+						_company.getCompanyId(), _group.getGroupId(), fileName,
 						Store.VERSION_DEFAULT));
 
 				StoreAreaProcessor storeAreaProcessor =
 					(StoreAreaProcessor)_store;
 
 				storeAreaProcessor.cleanUpDeletedStoreArea(
-					_group.getCompanyId(), 1, name -> true, StringPool.BLANK,
+					_company.getCompanyId(), 1, name -> true, StringPool.BLANK,
 					Duration.ofDays(-1));
 
 				Assert.assertFalse(
 					_store.hasFile(
-						_group.getCompanyId(), _group.getGroupId(), fileName,
+						_company.getCompanyId(), _group.getGroupId(), fileName,
 						Store.VERSION_DEFAULT));
 			});
 	}
@@ -223,25 +230,25 @@ public class GCSStoreStoreAreaProcessorTest {
 				String fileName = StringUtil.randomString();
 
 				_store.addFile(
-					_group.getCompanyId(), _group.getGroupId(), fileName,
+					_company.getCompanyId(), _group.getGroupId(), fileName,
 					Store.VERSION_DEFAULT,
 					new UnsyncByteArrayInputStream(new byte[0]));
 
 				Assert.assertTrue(
 					_store.hasFile(
-						_group.getCompanyId(), _group.getGroupId(), fileName,
+						_company.getCompanyId(), _group.getGroupId(), fileName,
 						Store.VERSION_DEFAULT));
 
 				StoreAreaProcessor storeAreaProcessor =
 					(StoreAreaProcessor)_store;
 
 				storeAreaProcessor.cleanUpNewStoreArea(
-					_group.getCompanyId(), 1, name -> false, StringPool.BLANK,
+					_company.getCompanyId(), 1, name -> false, StringPool.BLANK,
 					Duration.ofDays(1));
 
 				Assert.assertTrue(
 					_store.hasFile(
-						_group.getCompanyId(), _group.getGroupId(), fileName,
+						_company.getCompanyId(), _group.getGroupId(), fileName,
 						Store.VERSION_DEFAULT));
 			});
 	}
@@ -255,7 +262,7 @@ public class GCSStoreStoreAreaProcessorTest {
 			() -> {
 				for (String fileName : RandomTestUtil.randomStrings(4)) {
 					_store.addFile(
-						_group.getCompanyId(), _group.getGroupId(), fileName,
+						_company.getCompanyId(), _group.getGroupId(), fileName,
 						Store.VERSION_DEFAULT,
 						new UnsyncByteArrayInputStream(new byte[0]));
 				}
@@ -269,7 +276,7 @@ public class GCSStoreStoreAreaProcessorTest {
 
 				do {
 					startOffset = storeAreaProcessor.cleanUpNewStoreArea(
-						_group.getCompanyId(), 1, name -> false, startOffset,
+						_company.getCompanyId(), 1, name -> false, startOffset,
 						Duration.ofDays(-1));
 
 					runCount++;
@@ -279,7 +286,7 @@ public class GCSStoreStoreAreaProcessorTest {
 				Assert.assertTrue(runCount > 1);
 
 				String[] fileNames = _store.getFileNames(
-					_group.getCompanyId(), _group.getGroupId(),
+					_company.getCompanyId(), _group.getGroupId(),
 					StringPool.BLANK);
 
 				Assert.assertEquals(
@@ -290,7 +297,7 @@ public class GCSStoreStoreAreaProcessorTest {
 			StoreArea.LIVE,
 			() -> {
 				String[] fileNames = _store.getFileNames(
-					_group.getCompanyId(), _group.getGroupId(),
+					_company.getCompanyId(), _group.getGroupId(),
 					StringPool.BLANK);
 
 				Assert.assertEquals(
@@ -306,25 +313,25 @@ public class GCSStoreStoreAreaProcessorTest {
 			StoreArea.NEW,
 			() -> {
 				_store.addFile(
-					_group.getCompanyId(), _group.getGroupId(), fileName,
+					_company.getCompanyId(), _group.getGroupId(), fileName,
 					Store.VERSION_DEFAULT,
 					new UnsyncByteArrayInputStream(new byte[0]));
 
 				Assert.assertTrue(
 					_store.hasFile(
-						_group.getCompanyId(), _group.getGroupId(), fileName,
+						_company.getCompanyId(), _group.getGroupId(), fileName,
 						Store.VERSION_DEFAULT));
 
 				StoreAreaProcessor storeAreaProcessor =
 					(StoreAreaProcessor)_store;
 
 				storeAreaProcessor.cleanUpNewStoreArea(
-					_group.getCompanyId(), 1, name -> false, StringPool.BLANK,
+					_company.getCompanyId(), 1, name -> false, StringPool.BLANK,
 					Duration.ofDays(-1));
 
 				Assert.assertFalse(
 					_store.hasFile(
-						_group.getCompanyId(), _group.getGroupId(), fileName,
+						_company.getCompanyId(), _group.getGroupId(), fileName,
 						Store.VERSION_DEFAULT));
 			});
 
@@ -332,7 +339,7 @@ public class GCSStoreStoreAreaProcessorTest {
 			StoreArea.LIVE,
 			() -> Assert.assertTrue(
 				_store.hasFile(
-					_group.getCompanyId(), _group.getGroupId(), fileName,
+					_company.getCompanyId(), _group.getGroupId(), fileName,
 					Store.VERSION_DEFAULT)));
 	}
 
@@ -341,31 +348,31 @@ public class GCSStoreStoreAreaProcessorTest {
 		String fileName = StringUtil.randomString();
 
 		_store.addFile(
-			_group.getCompanyId(), _group.getGroupId(), fileName,
+			_company.getCompanyId(), _group.getGroupId(), fileName,
 			Store.VERSION_DEFAULT, new UnsyncByteArrayInputStream(new byte[0]));
 
 		StoreArea.withStoreArea(
 			StoreArea.LIVE,
 			() -> Assert.assertTrue(
 				_store.hasFile(
-					_group.getCompanyId(), _group.getGroupId(), fileName,
+					_company.getCompanyId(), _group.getGroupId(), fileName,
 					Store.VERSION_DEFAULT)));
 
 		StoreArea.withStoreArea(
 			StoreArea.DELETED,
 			() -> Assert.assertFalse(
 				_store.hasFile(
-					_group.getCompanyId(), _group.getGroupId(), fileName,
+					_company.getCompanyId(), _group.getGroupId(), fileName,
 					Store.VERSION_DEFAULT)));
 
 		StoreAreaProcessor storeAreaProcessor = (StoreAreaProcessor)_store;
 
 		boolean copied = storeAreaProcessor.copy(
 			StoreArea.LIVE.getPath(
-				_group.getCompanyId(), _group.getGroupId(), fileName,
+				_company.getCompanyId(), _group.getGroupId(), fileName,
 				Store.VERSION_DEFAULT),
 			StoreArea.DELETED.getPath(
-				_group.getCompanyId(), _group.getGroupId(), fileName,
+				_company.getCompanyId(), _group.getGroupId(), fileName,
 				Store.VERSION_DEFAULT));
 
 		Assert.assertTrue(copied);
@@ -374,7 +381,7 @@ public class GCSStoreStoreAreaProcessorTest {
 			StoreArea.DELETED,
 			() -> Assert.assertTrue(
 				_store.hasFile(
-					_group.getCompanyId(), _group.getGroupId(), fileName,
+					_company.getCompanyId(), _group.getGroupId(), fileName,
 					Store.VERSION_DEFAULT)));
 	}
 
@@ -385,12 +392,17 @@ public class GCSStoreStoreAreaProcessorTest {
 		Assert.assertFalse(
 			storeAreaProcessor.copy(
 				StoreArea.LIVE.getPath(
-					_group.getCompanyId(), _group.getGroupId(),
+					_company.getCompanyId(), _group.getGroupId(),
 					StringUtil.randomString(), Store.VERSION_DEFAULT),
 				StoreArea.LIVE.getPath(
-					_group.getCompanyId(), _group.getGroupId(),
+					_company.getCompanyId(), _group.getGroupId(),
 					StringUtil.randomString(), Store.VERSION_DEFAULT)));
 	}
+
+	private static Company _company;
+
+	@Inject
+	private static CompanyLocalService _companyLocalService;
 
 	private static Configuration _configuration;
 

--- a/modules/apps/portal-store/portal-store-gcs-test/src/testIntegration/java/com/liferay/portal/store/gcs/test/GCSStoreTest.java
+++ b/modules/apps/portal-store/portal-store-gcs-test/src/testIntegration/java/com/liferay/portal/store/gcs/test/GCSStoreTest.java
@@ -19,6 +19,8 @@ import com.liferay.portal.store.test.util.BaseStoreTestCase;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
+import java.util.Dictionary;
+
 import org.junit.AfterClass;
 import org.junit.Assume;
 import org.junit.BeforeClass;
@@ -58,6 +60,10 @@ public class GCSStoreTest extends BaseStoreTestCase {
 			"com.liferay.portal.store.gcs.configuration.GCSStoreConfiguration",
 			StringPool.QUESTION);
 
+		if (_configuration != null) {
+			_originalProperties = _configuration.getProperties();
+		}
+
 		ConfigurationTestUtil.saveConfiguration(
 			_configuration,
 			HashMapDictionaryBuilder.<String, Object>put(
@@ -87,7 +93,12 @@ public class GCSStoreTest extends BaseStoreTestCase {
 
 	@AfterClass
 	public static void tearDownClass() throws Exception {
-		ConfigurationTestUtil.deleteConfiguration(_configuration);
+		if (_originalProperties == null) {
+			ConfigurationTestUtil.deleteConfiguration(_configuration);
+		}
+		else {
+			_configuration.update(_originalProperties);
+		}
 	}
 
 	@Override
@@ -99,6 +110,8 @@ public class GCSStoreTest extends BaseStoreTestCase {
 
 	@Inject
 	private static ConfigurationAdmin _configurationAdmin;
+
+	private static Dictionary<String, Object> _originalProperties;
 
 	@Inject(
 		filter = "store.type=com.liferay.portal.store.gcs.GCSStore",

--- a/portal-kernel/bnd.bnd
+++ b/portal-kernel/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 119.0.1
+Bundle-Version: 120.0.0
 Export-Package:\
 	!com.liferay.portal.kernel.internal.*,\
 	!com.liferay.portal.kernel.module.util,\

--- a/portal-kernel/src/com/liferay/document/library/kernel/store/StoreAreaAwareStoreWrapper.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/store/StoreAreaAwareStoreWrapper.java
@@ -8,6 +8,7 @@ package com.liferay.document.library.kernel.store;
 import com.liferay.document.library.kernel.util.DLUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
 
 import java.io.InputStream;
 
@@ -63,9 +64,9 @@ public class StoreAreaAwareStoreWrapper implements Store {
 				companyId, repositoryId, dirName, _SOURCE_STORE_AREAS,
 				StoreArea.DELETED);
 
-			StoreArea.runWithStoreAreas(
-				() -> store.deleteDirectory(companyId, repositoryId, dirName),
-				StoreArea.LIVE, StoreArea.NEW);
+			_registerDeleteDirectoryCallback(
+				companyId, repositoryId, dirName, store);
+			}
 		}
 		else {
 			store.deleteDirectory(companyId, repositoryId, dirName);
@@ -229,6 +230,20 @@ public class StoreAreaAwareStoreWrapper implements Store {
 		}
 
 		return false;
+	}
+
+	private void _registerDeleteDirectoryCallback(
+		long companyId, long repositoryId, String dirName, Store store) {
+
+		TransactionCommitCallbackUtil.registerCallback(
+			() -> {
+				StoreArea.runWithStoreAreas(
+					() -> store.deleteDirectory(
+						companyId, repositoryId, dirName),
+					StoreArea.LIVE, StoreArea.NEW);
+
+				return null;
+			});
 	}
 
 	private static final StoreArea[] _SOURCE_STORE_AREAS = {

--- a/portal-kernel/src/com/liferay/document/library/kernel/store/StoreAreaAwareStoreWrapper.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/store/StoreAreaAwareStoreWrapper.java
@@ -60,12 +60,12 @@ public class StoreAreaAwareStoreWrapper implements Store {
 			StoreAreaProcessor storeAreaProcessor =
 				_storeAreaProcessorSupplier.get();
 
-			storeAreaProcessor.copyDirectory(
-				companyId, repositoryId, dirName, _SOURCE_STORE_AREAS,
-				StoreArea.DELETED);
+			if (storeAreaProcessor.copyDirectory(
+					companyId, repositoryId, dirName, _SOURCE_STORE_AREAS,
+					StoreArea.DELETED)) {
 
-			_registerDeleteDirectoryCallback(
-				companyId, repositoryId, dirName, store);
+				_registerDeleteDirectoryCallback(
+					companyId, repositoryId, dirName, store);
 			}
 		}
 		else {


### PR DESCRIPTION
- LPS-192636 add the deletion of the directory to the transaction callback
- LPS-192636 delete the directory only if was copied
- LPS-192636 better create a company because cleanUpDeletedStoreArea and similar will try to delete from actual company and this can be wrong
- LPS-192636 if configuration exists save it and restore it
- LPS-192636 semver
