### PR TITLE
LPS-191931 check if message is null

### DIFF
--- a/modules/dxp/apps/sharepoint-soap/sharepoint-soap-repository/src/main/java/com/liferay/sharepoint/soap/repository/connector/internal/util/RemoteExceptionSharepointExceptionMapper.java
+++ b/modules/dxp/apps/sharepoint-soap/sharepoint-soap-repository/src/main/java/com/liferay/sharepoint/soap/repository/connector/internal/util/RemoteExceptionSharepointExceptionMapper.java
@@ -27,7 +27,9 @@ public class RemoteExceptionSharepointExceptionMapper {
 
 			String faultMessage = axisFault.getMessage();
 
-			if (faultMessage.endsWith("401 Error: Unauthorized")) {
+			if ((faultMessage != null) &&
+				faultMessage.endsWith("401 Error: Unauthorized")) {
+
 				throw new AuthenticationRepositoryException(remoteException);
 			}
 		}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-191931

```
com.liferay.sharepoint.soap.repository.connector.SharepointConnectionTest > testGetSharepointObjectsByFileName STARTED
     [exec] 
     [exec] com.liferay.sharepoint.soap.repository.connector.SharepointConnectionTest > testGetSharepointObjectsByFileName FAILED
     [exec]     java.lang.NullPointerException
     [exec]         at com.liferay.sharepoint.soap.repository.connector.internal.util.RemoteExceptionSharepointExceptionMapper.map(RemoteExceptionSharepointExceptionMapper.java:30)
     [exec]         a
```