### PR TITLE
LPS-186856 The Office 365 window can not pop up when adding a file in DM admin for first time

### DIFF
--- a/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/src/main/java/com/liferay/document/library/opener/onedrive/web/internal/oauth/OAuth2ControllerFactory.java
+++ b/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/src/main/java/com/liferay/document/library/opener/onedrive/web/internal/oauth/OAuth2ControllerFactory.java
@@ -32,6 +32,9 @@ import java.util.function.Function;
 import javax.portlet.PortletRequest;
 import javax.portlet.PortletResponse;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
@@ -40,6 +43,9 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(service = OAuth2ControllerFactory.class)
 public class OAuth2ControllerFactory {
+
+	public static final String REDIRECTING_OAUTH2_ATTRIBUTE_NAME =
+		"REDIRECTING_OAUTH2_ATTRIBUTE_NAME";
 
 	public OAuth2Controller getJSONOAuth2Controller(
 		Function<PortletRequest, String> function) {
@@ -248,16 +254,23 @@ public class OAuth2ControllerFactory {
 				throw portalException;
 			}
 
-			JSONObject jsonObject = oAuth2Result.getResponseJSONObject();
-
-			for (String fieldName : jsonObject.keySet()) {
-				portletRequest.setAttribute(
-					fieldName, jsonObject.getString(fieldName));
-			}
-
 			String url = oAuth2Result.getRedirectURL();
 
 			if (url == null) {
+				JSONObject jsonObject = oAuth2Result.getResponseJSONObject();
+
+				if (jsonObject.length() > 0) {
+					HttpServletRequest httpServletRequest =
+						_portal.getOriginalServletRequest(
+							_portal.getHttpServletRequest(portletRequest));
+
+					HttpSession httpSession = httpServletRequest.getSession();
+
+					httpSession.setAttribute(
+						REDIRECTING_OAUTH2_ATTRIBUTE_NAME,
+						oAuth2Result.getResponseJSONObject());
+				}
+
 				url = _getRenderURL(portletRequest);
 			}
 

--- a/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/src/main/java/com/liferay/document/library/opener/onedrive/web/internal/servlet/taglib/OneDriveViewPostJSPDynamicInclude.java
+++ b/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/src/main/java/com/liferay/document/library/opener/onedrive/web/internal/servlet/taglib/OneDriveViewPostJSPDynamicInclude.java
@@ -5,12 +5,20 @@
 
 package com.liferay.document.library.opener.onedrive.web.internal.servlet.taglib;
 
+import com.liferay.document.library.opener.onedrive.web.internal.oauth.OAuth2ControllerFactory;
+import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.servlet.taglib.BaseJSPDynamicInclude;
 import com.liferay.portal.kernel.servlet.taglib.DynamicInclude;
+import com.liferay.portal.kernel.util.Portal;
+
+import java.io.IOException;
 
 import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -24,6 +32,17 @@ public class OneDriveViewPostJSPDynamicInclude extends BaseJSPDynamicInclude {
 	@Override
 	public ServletContext getServletContext() {
 		return _servletContext;
+	}
+
+	@Override
+	public void include(
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse, String key)
+		throws IOException {
+
+		_setRedirectingOAuth2RequestAttributes(httpServletRequest);
+
+		super.include(httpServletRequest, httpServletResponse, key);
 	}
 
 	@Override
@@ -45,8 +64,33 @@ public class OneDriveViewPostJSPDynamicInclude extends BaseJSPDynamicInclude {
 		return _log;
 	}
 
+	private void _setRedirectingOAuth2RequestAttributes(
+		HttpServletRequest httpServletRequest) {
+
+		HttpServletRequest originalHttpServletRequest =
+			_portal.getOriginalServletRequest(httpServletRequest);
+
+		HttpSession httpSession = originalHttpServletRequest.getSession();
+
+		JSONObject jsonObject = (JSONObject)httpSession.getAttribute(
+			OAuth2ControllerFactory.REDIRECTING_OAUTH2_ATTRIBUTE_NAME);
+
+		if (jsonObject != null) {
+			httpSession.removeAttribute(
+				OAuth2ControllerFactory.REDIRECTING_OAUTH2_ATTRIBUTE_NAME);
+
+			for (String fieldName : jsonObject.keySet()) {
+				httpServletRequest.setAttribute(
+					fieldName, jsonObject.getString(fieldName));
+			}
+		}
+	}
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		OneDriveViewPostJSPDynamicInclude.class);
+
+	@Reference
+	private Portal _portal;
 
 	@Reference(
 		target = "(osgi.web.symbolicname=com.liferay.document.library.opener.onedrive.web)"

--- a/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/src/test/java/com/liferay/document/library/opener/onedrive/web/internal/oauth/OAuth2ControllerTest.java
+++ b/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/src/test/java/com/liferay/document/library/opener/onedrive/web/internal/oauth/OAuth2ControllerTest.java
@@ -200,7 +200,7 @@ public class OAuth2ControllerTest {
 		MockHttpServletResponse mockHttpServletResponse =
 			new MockHttpServletResponse();
 
-		JSONObject jsonObject = JSONUtil.put("key", "value");
+		JSONObject jsonObject1 = JSONUtil.put("key", "value");
 
 		OAuth2Controller oAuth2Controller =
 			_oAuth2ControllerFactory.getRedirectingOAuth2Controller();
@@ -208,14 +208,21 @@ public class OAuth2ControllerTest {
 		oAuth2Controller.execute(
 			_getMockPortletRequest(mockHttpServletRequest),
 			_getMockPortletResponse(mockHttpServletResponse),
-			portletRequest -> jsonObject);
+			portletRequest -> jsonObject1);
 
 		Assert.assertEquals(
 			_liferayPortletURL.toString(),
 			mockHttpServletRequest.getAttribute(WebKeys.REDIRECT));
 
-		Assert.assertEquals(
-			mockHttpServletRequest.getAttribute("key"), jsonObject.get("key"));
+		HttpSession httpSession = mockHttpServletRequest.getSession();
+
+		Assert.assertNotNull(httpSession);
+
+		JSONObject jsonObject2 = (JSONObject)httpSession.getAttribute(
+			OAuth2ControllerFactory.REDIRECTING_OAUTH2_ATTRIBUTE_NAME);
+
+		Assert.assertNotNull(jsonObject2);
+		Assert.assertEquals(jsonObject2.get("key"), jsonObject1.get("key"));
 	}
 
 	@Test


### PR DESCRIPTION
The problem was affecting both the creation and the edition of an Office file. A new tab should always open when:

* Creating an Office file
* Selecting "Edit in Office365" option

However sometimes it doesn't. This happens when the OAuth2Manager.getAccessToken() returns null, this is when accessing Office365 for the first time or when the token has been invalidated (or something similar).

The problem was that we were passing request attributes and trying to read them in the JSP file "dynamic_include/view_post.jsp", having a redirection in between. This is not possible because the redirect action creates a new request, and previously set attributes are lost. So, solution is to set a *session* attribute and read it after the redirection, during the rendering phase. Once read, the session attribute is removed and used as request attribute to be available to the JSP file.

See issue: https://liferay.atlassian.net/browse/LPS-186856