### PR TITLE
LPS-170286 | Refactor method to get fragment resource title properly

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/HorizontalCardTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/HorizontalCardTag.java
@@ -63,20 +63,14 @@ public class HorizontalCardTag extends BaseCardTag {
 	}
 
 	public String getTitle() {
-		String title = _title;
-
 		HorizontalCard horizontalCard = getHorizontalCard();
 
 		if ((_title == null) && (horizontalCard != null)) {
-			title = horizontalCard.getTitle();
+			return horizontalCard.getTitle();
 		}
 
-		if (_isTranslated()) {
-			title = LanguageUtil.get(
-				TagResourceBundleUtil.getResourceBundle(pageContext), title);
-		}
-
-		return title;
+		return LanguageUtil.get(
+			TagResourceBundleUtil.getResourceBundle(pageContext), _title);
 	}
 
 	public void setHorizontalCard(HorizontalCard horizontalCard) {


### PR DESCRIPTION
**Descripción**: Modify method `getTitle()` from `HorizontalCardTag.java` to make same as the one in `VerticalCardTag.java` and avoid escaping lowercase **a** to **%A**
![image](https://github.com/liferay/liferay-portal/assets/40394495/d6a1ac16-06fe-4999-b67e-a329f9f2b57b)

**Jira Ticket**: https://liferay.atlassian.net/browse/LPS-170286