### PR TITLE
LPS-190085 Notifications select all

### DIFF
--- a/modules/apps/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/js/NotificationsManagementToolbarPropsTransformer.js
+++ b/modules/apps/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/js/NotificationsManagementToolbarPropsTransformer.js
@@ -14,39 +14,19 @@ export default function propsTransformer({
 	portletNamespace,
 	...otherProps
 }) {
-	const deleteNotifications = () => {
+	const processAction = (url) => {
 		const form = document.getElementById(`${portletNamespace}fm`);
 
 		if (form) {
 			postForm(form, {
 				data: {
-					deleteEntryIds: getCheckedCheckboxes(
+					selectedEntryIds: getCheckedCheckboxes(
 						form,
 						`${portletNamespace}allRowIds`
 					),
 				},
-				url: deleteNotificationsURL,
+				url,
 			});
-		}
-	};
-
-	const markNotificationsAsRead = () => {
-		const form = document.getElementById(`${portletNamespace}fm`);
-
-		if (form) {
-			form.setAttribute('method', 'post');
-
-			submitForm(form, markNotificationsAsReadURL);
-		}
-	};
-
-	const markNotificationsAsUnread = () => {
-		const form = document.getElementById(`${portletNamespace}fm`);
-
-		if (form) {
-			form.setAttribute('method', 'post');
-
-			submitForm(form, markNotificationsAsUnreadURL);
 		}
 	};
 
@@ -56,13 +36,13 @@ export default function propsTransformer({
 			const action = item?.data?.action;
 
 			if (action === 'deleteNotifications') {
-				deleteNotifications();
+				processAction(deleteNotificationsURL);
 			}
 			else if (action === 'markNotificationsAsRead') {
-				markNotificationsAsRead();
+				processAction(markNotificationsAsReadURL);
 			}
 			else if (action === 'markNotificationsAsUnread') {
-				markNotificationsAsUnread();
+				processAction(markNotificationsAsUnreadURL);
 			}
 		},
 	};

--- a/modules/apps/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/js/NotificationsManagementToolbarPropsTransformer.js
+++ b/modules/apps/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/js/NotificationsManagementToolbarPropsTransformer.js
@@ -10,16 +10,26 @@ export default function propsTransformer({
 		deleteNotificationsURL,
 		markNotificationsAsReadURL,
 		markNotificationsAsUnreadURL,
+		searchContainerId,
 	},
 	portletNamespace,
 	...otherProps
 }) {
+	let searchContainer;
+
+	Liferay.componentReady(`${portletNamespace}${searchContainerId}`).then(
+		(searchContainerComponent) => {
+			searchContainer = searchContainerComponent;
+		}
+	);
+
 	const processAction = (url) => {
 		const form = document.getElementById(`${portletNamespace}fm`);
 
 		if (form) {
 			postForm(form, {
 				data: {
+					selectAll: searchContainer.select?.get('bulkSelection'),
 					selectedEntryIds: getCheckedCheckboxes(
 						form,
 						`${portletNamespace}allRowIds`

--- a/modules/apps/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/view.jsp
+++ b/modules/apps/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/view.jsp
@@ -86,6 +86,8 @@ if (Validator.isNotNull(backURL)) {
 			"markNotificationsAsReadURL", markNotificationsAsReadURL.toString()
 		).put(
 			"markNotificationsAsUnreadURL", markNotificationsAsUnreadURL.toString()
+		).put(
+			"searchContainerId", searchContainerId
 		).build()
 	%>'
 	clearResultsURL="<%= notificationsManagementToolbarDisplayContext.getClearResultsURL() %>"
@@ -106,6 +108,7 @@ if (Validator.isNotNull(backURL)) {
 <clay:container-fluid>
 	<aui:form action="<%= currentURL %>" method="get" name="fm">
 		<aui:input name="selectedEntryIds" type="hidden" />
+		<aui:input name="selectAll" type="hidden" value="<%= false %>" />
 
 		<div class="user-notifications">
 			<liferay-ui:search-container

--- a/modules/apps/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/view.jsp
+++ b/modules/apps/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/view.jsp
@@ -105,6 +105,8 @@ if (Validator.isNotNull(backURL)) {
 
 <clay:container-fluid>
 	<aui:form action="<%= currentURL %>" method="get" name="fm">
+		<aui:input name="selectedEntryIds" type="hidden" />
+
 		<div class="user-notifications">
 			<liferay-ui:search-container
 				rowChecker="<%= actionRequired ? null : new UserNotificationEventRowChecker(renderResponse) %>"


### PR DESCRIPTION
Issue https://liferay.atlassian.net/browse/LPS-190085
This is a partial fix, bulk process is still needed. As we saw by slack call, the backend process to delete, mark as read or unread all the notifications needs to be implemented.

@robertoDiaz Now you can get the `selectAll` parameter in your _NotificationPorlet.java_. The rest of the selected notifications could be get as before, via `rowIds` parameter, or `selectedEntryIds`. 