### PR TITLE
LPS-182299 Sharepoint connection problems

### DIFF
--- a/modules/dxp/apps/sharepoint-soap/sharepoint-soap-repository/src/main/java/com/liferay/sharepoint/soap/repository/connector/SharepointConnectionImpl.java
+++ b/modules/dxp/apps/sharepoint-soap/sharepoint-soap-repository/src/main/java/com/liferay/sharepoint/soap/repository/connector/SharepointConnectionImpl.java
@@ -348,6 +348,7 @@ public class SharepointConnectionImpl implements SharepointConnection {
 		HttpTransportPropertiesImpl.Authenticator authenticator =
 			new HttpTransportPropertiesImpl.Authenticator();
 
+		authenticator.setAllowedRetry(true);
 		authenticator.setAuthSchemes(
 			Collections.singletonList(AuthSchemes.NTLM));
 		authenticator.setDomain(url.getHost());


### PR DESCRIPTION
This fix should solve some connection problems like:

* https://liferay.atlassian.net/browse/LPS-182299
* https://liferay.atlassian.net/browse/LPS-158050

What I've found after deep research is that Axis2 doesn't seem to support Preemptive Authentication (see this [search](https://github.com/search?q=repo%3Aapache%2Faxis-axis2-java-core%20preemptive&type=code) on Github repo) because of security concerns. So, even if we set the authentication to be Preemptive this option is ignored. This means that a retry mechanism is needed because the first attempt to connect to the server will respond with the authentication methods supported, and only after that, repeating the request would work.