### PR TITLE
LPS-192780 Wiki toolbar dissapears after search. 

### DIFF
--- a/modules/apps/wiki/wiki-web/src/main/java/com/liferay/wiki/web/internal/display/context/WikiPagesManagementToolbarDisplayContext.java
+++ b/modules/apps/wiki/wiki-web/src/main/java/com/liferay/wiki/web/internal/display/context/WikiPagesManagementToolbarDisplayContext.java
@@ -179,6 +179,12 @@ public class WikiPagesManagementToolbarDisplayContext {
 	}
 
 	public List<DropdownItem> getFilterDropdownItems() {
+		if (Validator.isNotNull(
+				ParamUtil.getString(_httpServletRequest, "keywords"))) {
+
+			return null;
+		}
+
 		return DropdownItemListBuilder.addGroup(
 			dropdownGroupItem -> {
 				dropdownGroupItem.setDropdownItems(
@@ -188,8 +194,6 @@ public class WikiPagesManagementToolbarDisplayContext {
 						_httpServletRequest, "filter-by-navigation"));
 			}
 		).addGroup(
-			() -> Validator.isNull(
-				ParamUtil.getString(_httpServletRequest, "keywords")),
 			dropdownGroupItem -> {
 				dropdownGroupItem.setDropdownItems(_getOrderByDropdownItems());
 				dropdownGroupItem.setLabel(
@@ -294,12 +298,6 @@ public class WikiPagesManagementToolbarDisplayContext {
 
 	private List<DropdownItem> _getFilterNavigationDropdownItems()
 		throws PortletException {
-
-		String keywords = ParamUtil.getString(_httpServletRequest, "keywords");
-
-		if (Validator.isNotNull(keywords)) {
-			return null;
-		}
 
 		return new DropdownItemList() {
 			{


### PR DESCRIPTION
Issue https://liferay.atlassian.net/browse/LPS-192780. 

It was working on **7.4 DXP U75**. I checked this version and this was the result of the Filter and order dropdown while search is active: 

<img width="1335" alt="Screenshot 2023-08-11 at 14 29 18" src="https://github.com/liferay-lima/liferay-portal/assets/8373764/96f902fd-1f07-4aa3-812a-00b5ffd11985">

Now something must have changed in the Clay Management Toolbar component, that when the filter items are null it fails. As this is an empty dropdown, I decided to set it to null while search is active, so now that dropdown does not appear. 

**Master - default page:** 
<img width="1048" alt="Screenshot 2023-08-11 at 14 21 37" src="https://github.com/liferay-lima/liferay-portal/assets/8373764/41739380-3c43-4f9e-9cff-18daa596699d">

**Master - on Search:** 

<img width="1323" alt="Screenshot 2023-08-11 at 14 36 25" src="https://github.com/liferay-lima/liferay-portal/assets/8373764/a365e929-7391-4350-b615-ea386a9d03a3">
