### PR TITLE
Create a mechanism to allow get the proper Portlet Ratings classname

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/info/search/LiferayFileEntryInfoSearchClassMapper.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/info/search/LiferayFileEntryInfoSearchClassMapper.java
@@ -1,0 +1,26 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.document.library.web.internal.info.search;
+
+import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.info.search.InfoSearchClassMapper;
+import com.liferay.portal.repository.liferayrepository.model.LiferayFileEntry;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Roberto Díaz
+ */
+@Component(service = InfoSearchClassMapper.class)
+public class LiferayFileEntryInfoSearchClassMapper
+	implements InfoSearchClassMapper<LiferayFileEntry> {
+
+	@Override
+	public String getSearchClassName() {
+		return DLFileEntry.class.getName();
+	}
+
+}

--- a/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/renderer/BaseContentFragmentRenderer.java
+++ b/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/renderer/BaseContentFragmentRenderer.java
@@ -16,6 +16,7 @@ import com.liferay.info.item.InfoItemIdentifier;
 import com.liferay.info.item.InfoItemReference;
 import com.liferay.info.item.InfoItemServiceRegistry;
 import com.liferay.info.item.provider.InfoItemObjectProvider;
+import com.liferay.info.search.InfoSearchClassMapperRegistry;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -54,7 +55,8 @@ public abstract class BaseContentFragmentRenderer implements FragmentRenderer {
 			jsonObject.has("classPK")) {
 
 			return new Tuple(
-				jsonObject.getString("className"),
+				infoSearchClassMapperRegistry.getSearchClassName(
+					jsonObject.getString("className")),
 				jsonObject.getLong("classPK"));
 		}
 
@@ -86,7 +88,9 @@ public abstract class BaseContentFragmentRenderer implements FragmentRenderer {
 							AssetEntry.class.getName())) {
 
 						return new Tuple(
-							classedModel.getModelClassName(), primaryKeyObj);
+							infoSearchClassMapperRegistry.getSearchClassName(
+								classedModel.getModelClassName()),
+							primaryKeyObj);
 					}
 
 					AssetEntry assetEntry =
@@ -95,7 +99,9 @@ public abstract class BaseContentFragmentRenderer implements FragmentRenderer {
 
 					if (assetEntry != null) {
 						return new Tuple(
-							portal.getClassName(assetEntry.getClassNameId()),
+							infoSearchClassMapperRegistry.getSearchClassName(
+								portal.getClassName(
+									assetEntry.getClassNameId())),
 							assetEntry.getClassPK());
 					}
 				}
@@ -127,6 +133,9 @@ public abstract class BaseContentFragmentRenderer implements FragmentRenderer {
 
 	@Reference
 	protected InfoItemServiceRegistry infoItemServiceRegistry;
+
+	@Reference
+	protected InfoSearchClassMapperRegistry infoSearchClassMapperRegistry;
 
 	@Reference
 	protected Portal portal;


### PR DESCRIPTION
Hi @liferay-lima 

About the solution:

The problem here is that in some cases the ratings tag is been called with alternative file entry names (in this case LiferayFileEntry).

In this use case I see that it this was the caller: https://github.com/liferay/liferay-portal/blob/6ce0b9eb049e99a50285a324a3bd4afd76d340ab/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/renderer/BaseContentFragmentRenderer.java#L61-L79

When the file entry is rendered following the jira ticket steps the ClassedModel in the infoItem is the mentioned LiferayFileEntry (and I assume that change that could be a little bit tricky).

The only questions I have is about the naming of the new interface an the package (I do not like the className particle) but I haven't found better patters or option to that.

Do you have any alternative?

Thanks!