### PR TITLE
LPS-188080 Avoiding NPE by verifying if user has a group

### DIFF
--- a/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/model/listener/UserModelListener.java
+++ b/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/model/listener/UserModelListener.java
@@ -8,6 +8,8 @@ package com.liferay.calendar.internal.model.listener;
 import com.liferay.calendar.model.CalendarResource;
 import com.liferay.calendar.service.CalendarResourceLocalService;
 import com.liferay.portal.kernel.exception.ModelListenerException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.ModelListener;
@@ -49,13 +51,27 @@ public class UserModelListener extends BaseModelListener<User> {
 				return;
 			}
 
+			long groupId = 0;
+
+			try {
+				groupId = user.getGroupId();
+			}
+			catch (Exception exception) {
+				_log.error(
+					"User " + user.getUserId() +
+						" is not related to any groups");
+				_log.error(exception.toString());
+
+				return;
+			}
+
 			calendarResource.setNameMap(
 				_localization.populateLocalizationMap(
 					HashMapBuilder.put(
 						LocaleUtil.getSiteDefault(), user.getFullName()
 					).build(),
 					LocaleUtil.toLanguageId(LocaleUtil.getSiteDefault()),
-					user.getGroupId()));
+					groupId));
 
 			_calendarResourceLocalService.updateCalendarResource(
 				calendarResource);
@@ -64,6 +80,9 @@ public class UserModelListener extends BaseModelListener<User> {
 			throw new ModelListenerException(exception);
 		}
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		UserModelListener.class);
 
 	@Reference
 	private CalendarResourceLocalService _calendarResourceLocalService;


### PR DESCRIPTION
Opening this ticket on this repository based on this comment: https://github.com/liferay-core-infra/liferay-portal/pull/5098#issuecomment-1656508280

Let me know if you need any update here. 

No regressions found: https://github.com/liferay-core-infra/liferay-portal/pull/5098#issuecomment-1652582929

Thanks in advance,
Richard.

====

Hi team! I faced a problem in the customer's database where a change made by a customer in the control panel was not persisting. Debugging, I found that given the customer data, we faced a problem in our code due to a different role configuration. So I added more specific handling with validating the groups associated with a user when checked by the changed listener. According to the customer, it solved his problem.

Cause:

When the configuration changes tried to be committed, an error in the server log appeared and consequently the changes did not propagate.

`build-267 liferay[liferay-64cd75ddfc-mblw9] [dxp] ERROR [http-nio2-8080-exec-38][PortletServlet:118] Unable to process portlet com_liferay_configuration_admin_web_portlet_InstanceSettingsPortlet: com.liferay.portal.kernel.exception.ModelListenerException: java .lang.NullPointerException`

The client also informed that the changes are not saved, even after restarting the environment or clearing the cache, what was supposed to be recorded does not display as marked, which affects precisely another functionality which depends on updating the authentication configuration.

A part of the ticket was worked on the link below.

https://liferay.atlassian.net/browse/LPP-49289