### PR TITLE
LPS-193726 Duplicate Asset type when trying to select a Related Asset

### DIFF
--- a/modules/apps/document-library/document-library-api/src/main/java/com/liferay/document/library/asset/model/DLFileEntryClassTypeReader.java
+++ b/modules/apps/document-library/document-library-api/src/main/java/com/liferay/document/library/asset/model/DLFileEntryClassTypeReader.java
@@ -31,8 +31,6 @@ public class DLFileEntryClassTypeReader implements ClassTypeReader {
 
 		List<ClassType> classTypes = new ArrayList<>();
 
-		classTypes.add(getBasicDocumentClassType(locale));
-
 		String languageId = LocaleUtil.toLanguageId(locale);
 
 		List<DLFileEntryType> dlFileEntryTypes =


### PR DESCRIPTION
## Motivation

[Link to ticket](https://liferay.atlassian.net/browse/LPS-193726)

Ey, @Liferay-lima ! 😄 

I opened this bug and I’m sending you the fix. What do you think?	

## Proposed solution

Remove unnecessary add for Basic Document type because it is already include in dlFileEntryTypes.

## Test Scenario 1

1. Navigate to Content and Data
2. Add a web content
3. Go to Related Assets
4. Try to select an Asset type

## Result:
<img width="249" alt="261562592-1649c51f-5016-4d69-b41e-0dcc4730dd9d" src="https://github.com/liferay-lima/liferay-portal/assets/93203423/79d55a03-faf0-4aa2-8ad7-9bf4a821a99e">
