### PR TITLE
LPS-182018 The vote option cannot manually delete the rating when the ratingValue is decimal

### DIFF
--- a/modules/apps/ratings/ratings-taglib/src/main/resources/META-INF/resources/js/components/RatingsSelectStars.js
+++ b/modules/apps/ratings/ratings-taglib/src/main/resources/META-INF/resources/js/components/RatingsSelectStars.js
@@ -15,6 +15,7 @@ const ID_PREFIX = 'rsd_';
 
 export default function RatingsSelectStars({
 	averageScore,
+	disableDelete,
 	disabled,
 	getSrAverageMessage,
 	getTitle,
@@ -116,7 +117,7 @@ export default function RatingsSelectStars({
 						})}
 
 						<ClayDropDown.Item
-							disabled={score === 0}
+							disabled={disableDelete}
 							id={`${ID_PREFIX}${Liferay.Language.get('delete')}`}
 							onClick={handleOnClick}
 							onFocus={() => {

--- a/modules/apps/ratings/ratings-taglib/src/main/resources/META-INF/resources/js/components/RatingsStackedStars.js
+++ b/modules/apps/ratings/ratings-taglib/src/main/resources/META-INF/resources/js/components/RatingsStackedStars.js
@@ -12,6 +12,7 @@ import Lang from '../utils/lang';
 
 export default function RatingsStackedStars({
 	averageScore,
+	disableDelete,
 	disabled,
 	getSrAverageMessage,
 	getTitle,
@@ -126,7 +127,7 @@ export default function RatingsStackedStars({
 					</div>
 				</fieldset>
 
-				{score !== 0 && (
+				{!disableDelete && (
 					<ClayButton
 						className="ratings-stacked-stars-delete"
 						disabled={disabled}

--- a/modules/apps/ratings/ratings-taglib/src/main/resources/META-INF/resources/js/components/RatingsStars.js
+++ b/modules/apps/ratings/ratings-taglib/src/main/resources/META-INF/resources/js/components/RatingsStars.js
@@ -49,6 +49,9 @@ const RatingsStars = ({
 	);
 
 	const [score, setScore] = useState(getLabelScore(userScore));
+	const [disableDelete, setDisableDelete] = useState(
+		score === 0 && userScore <= 0
+	);
 	const [averageScore, setAverageScore] = useState(
 		formatAverageScore(initialAverageScore)
 	);
@@ -67,7 +70,9 @@ const RatingsStars = ({
 					) {
 						setTotalEntries(totalEntries);
 						setAverageScore(formatAverageScore(averageScore));
-						setScore(getLabelScore(score));
+						const label = getLabelScore(score);
+						setScore(label);
+						setDisableDelete(label === 0);
 					}
 				}
 			);
@@ -90,6 +95,7 @@ const RatingsStars = ({
 		}
 
 		setScore(label);
+		setDisableDelete(label === 0);
 		handleSendVoteRequest(value);
 	};
 
@@ -136,6 +142,7 @@ const RatingsStars = ({
 
 	return RatingsStarsUI({
 		averageScore,
+		disableDelete,
 		disabled,
 		getSrAverageMessage,
 		getTitle,


### PR DESCRIPTION
If rating value has been set externally, i.e. from the API, and not from UI then the value can be valid (between 1 and 5) but not a specific value (0, 1, 2, 3, 4 or 5 stars). In those cases the deletion should be enabled.

For testing info see: https://liferay.atlassian.net/browse/LPS-182018

❗ I'm not sure if there is simpler way in JS/React to do the work but it looks OK to me.