### PR TITLE
LPS-194217 Cannot change favicon from favicon extension

### DIFF
--- a/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/js/ViewItemSelectorViewDescriptor.ts
+++ b/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/js/ViewItemSelectorViewDescriptor.ts
@@ -20,11 +20,32 @@ export default function ({
 	itemSelectorSelectedEvent,
 	namespace,
 }: Props) {
-	const selectItem = (event: DelegatedEvent<KeyboardEvent | MouseEvent>) => {
+	const updateSelectedCard = (
+		event: DelegatedEvent<KeyboardEvent | MouseEvent>
+	) => {
+		document.querySelectorAll('.form-check-card.active').forEach((card) => {
+			card.classList.remove('active');
+		});
+
+		const newSelectedCard = event.delegateTarget.closest(
+			'.form-check-card'
+		);
+
+		if (newSelectedCard) {
+			newSelectedCard.classList.add('active');
+		}
+	};
+
+	const dispatchSelectEvent = (
+		event: DelegatedEvent<KeyboardEvent | MouseEvent>
+	) => {
+		const element = event.delegateTarget.closest('li, tr, dd');
+		const value = element instanceof HTMLElement && element.dataset.value;
+
 		getOpener().Liferay.fire(itemSelectorSelectedEvent, {
 			data: {
 				returnType: itemSelectorReturnType,
-				value: event.delegateTarget.dataset.value,
+				value: value || '',
 			},
 		});
 	};
@@ -34,7 +55,8 @@ export default function ({
 		'click',
 		'.entry',
 		(event: DelegatedEvent<MouseEvent>) => {
-			selectItem(event);
+			updateSelectedCard(event);
+			dispatchSelectEvent(event);
 		}
 	);
 
@@ -44,7 +66,8 @@ export default function ({
 		'.entry',
 		(event: DelegatedEvent<KeyboardEvent>) => {
 			if (event.code === 'Enter') {
-				selectItem(event);
+				updateSelectedCard(event);
+				dispatchSelectEvent(event);
 			}
 		}
 	);

--- a/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/js/ViewItemSelectorViewDescriptorMultiple.ts
+++ b/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/js/ViewItemSelectorViewDescriptorMultiple.ts
@@ -21,11 +21,11 @@ export default function ({
 
 	const searchContainer = Liferay.SearchContainer.get(`${namespace}entries`);
 
-	const searchContainerItems: HTMLElement[] = searchContainer.select
-		.getAllSelectedElements()
-		.getDOMNodes();
-
 	const searchContainerOnHandler = searchContainer.on('rowToggled', () => {
+		const searchContainerItems: HTMLElement[] = searchContainer.select
+			.getAllSelectedElements()
+			.getDOMNodes();
+
 		getOpener().Liferay.fire(itemSelectorSelectedEvent, {
 			data: {
 				returnType: itemSelectorReturnType,


### PR DESCRIPTION
## Motivation

[Link to ticket](https://liferay.atlassian.net/browse/LPS-194217)

Ey, @Liferay-lima !

 I’m sending you the fix for this blocker. 

 This also fix: 
- [LPS-194219](https://liferay.atlassian.net/browse/LPS-194219)
- [LPS-194221](https://liferay.atlassian.net/browse/LPS-194221)
- [LPS-194231](https://liferay.atlassian.net/browse/LPS-194231)

## Test Scenario 1

1. Add a theme favicon extension using https://www.google.com/favicon.ico
2. Add a new site
3. Add a widget page
4. Navigate to the Design section
5. Change the favicon to the favicon extension

<img width="870" alt="Screenshot 2023-08-23 at 11 45 52" src="https://github.com/liferay-lima/liferay-portal/assets/93203423/fc356d21-d94d-4852-a7f7-272b32212629">
