### PR TITLE
LPS-194119 Copy Document Types when coping a file and folders on D&M

### DIFF
--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/test/DepotEntryDLAppServiceWhenCopyingWithAssetCategoriesAndAssetTagsTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/test/DepotEntryDLAppServiceWhenCopyingWithAssetCategoriesAndAssetTagsTest.java
@@ -16,6 +16,7 @@ import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryGroupRelLocalService;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.document.library.kernel.model.DLFileEntryConstants;
+import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLAppService;
 import com.liferay.petra.string.StringPool;
@@ -40,6 +41,7 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 
 import org.junit.Assert;
@@ -126,6 +128,7 @@ public class
 		FileEntry fileEntry2 = _dlAppService.copyFileEntry(
 			fileEntry1.getFileEntryId(), _groupParentFolder.getFolderId(),
 			_groupParentFolder.getGroupId(),
+			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
 			_siteConnectedGroupGroupProvider.
 				getCurrentAndAncestorSiteAndDepotGroupIds(
 					_groupParentFolder.getGroupId()),
@@ -172,6 +175,7 @@ public class
 		FileEntry fileEntry2 = _dlAppService.copyFileEntry(
 			fileEntry1.getFileEntryId(), _groupParentFolder.getFolderId(),
 			_groupParentFolder.getGroupId(),
+			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
 			_siteConnectedGroupGroupProvider.
 				getCurrentAndAncestorSiteAndDepotGroupIds(
 					_groupParentFolder.getGroupId()),
@@ -212,6 +216,7 @@ public class
 		FileEntry fileEntry2 = _dlAppService.copyFileEntry(
 			fileEntry1.getFileEntryId(), _groupParentFolder.getFolderId(),
 			_groupParentFolder.getGroupId(),
+			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
 			_siteConnectedGroupGroupProvider.
 				getCurrentAndAncestorSiteAndDepotGroupIds(
 					_groupParentFolder.getGroupId()),
@@ -254,6 +259,7 @@ public class
 		FileEntry fileEntry2 = _dlAppService.copyFileEntry(
 			fileEntry1.getFileEntryId(), _groupParentFolder.getFolderId(),
 			_groupParentFolder.getGroupId(),
+			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
 			_siteConnectedGroupGroupProvider.
 				getCurrentAndAncestorSiteAndDepotGroupIds(
 					_groupParentFolder.getGroupId()),
@@ -295,6 +301,7 @@ public class
 		Folder folder = _dlAppService.copyFolder(
 			_depotGroup.getGroupId(), _depotParentFolder.getFolderId(),
 			_group.getGroupId(), _groupParentFolder.getFolderId(),
+			new HashMap<>(),
 			_siteConnectedGroupGroupProvider.
 				getCurrentAndAncestorSiteAndDepotGroupIds(
 					_groupParentFolder.getGroupId()),
@@ -348,6 +355,7 @@ public class
 		Folder folder = _dlAppService.copyFolder(
 			_depotGroup.getGroupId(), _depotParentFolder.getFolderId(),
 			_group.getGroupId(), _groupParentFolder.getFolderId(),
+			new HashMap<>(),
 			_siteConnectedGroupGroupProvider.
 				getCurrentAndAncestorSiteAndDepotGroupIds(
 					_groupParentFolder.getGroupId()),

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenCopyingAFileEntryTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenCopyingAFileEntryTest.java
@@ -7,6 +7,7 @@ package com.liferay.document.library.app.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.document.library.kernel.exception.DuplicateFileEntryException;
+import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLAppServiceUtil;
 import com.liferay.document.library.test.util.BaseDLAppTestCase;
@@ -154,7 +155,8 @@ public class DLAppServiceWhenCopyingAFileEntryTest extends BaseDLAppTestCase {
 			sourceGroupId, sourceFolderId);
 
 		DLAppServiceUtil.copyFileEntry(
-			fileEntry.getFileEntryId(), targetFolderId, targetGroupId, null,
+			fileEntry.getFileEntryId(), targetFolderId, targetGroupId,
+			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT, null,
 			ServiceContextTestUtil.getServiceContext(
 				targetParentFolder.getGroupId()));
 	}

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenCopyingAFolderTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenCopyingAFolderTest.java
@@ -94,8 +94,8 @@ public class DLAppServiceWhenCopyingAFolderTest extends BaseDLAppTestCase {
 		try {
 			DLAppServiceUtil.copyFolder(
 				group.getGroupId(), parentFolder.getFolderId(),
-				group.getGroupId(), parentFolder.getFolderId(), null,
-				serviceContext);
+				group.getGroupId(), parentFolder.getFolderId(), new HashMap<>(),
+				null, serviceContext);
 
 			Assert.fail();
 		}
@@ -128,7 +128,8 @@ public class DLAppServiceWhenCopyingAFolderTest extends BaseDLAppTestCase {
 		try {
 			DLAppServiceUtil.copyFolder(
 				group.getGroupId(), parentFolder.getFolderId(),
-				group.getGroupId(), folder.getFolderId(), null, serviceContext);
+				group.getGroupId(), folder.getFolderId(), new HashMap<>(), null,
+				serviceContext);
 
 			Assert.fail();
 		}
@@ -153,7 +154,7 @@ public class DLAppServiceWhenCopyingAFolderTest extends BaseDLAppTestCase {
 
 		DLAppServiceUtil.copyFolder(
 			group.getGroupId(), parentFolder.getFolderId(), group.getGroupId(),
-			parentFolder.getParentFolderId(), null,
+			parentFolder.getParentFolderId(), new HashMap<>(), null,
 			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
 	}
 
@@ -169,7 +170,8 @@ public class DLAppServiceWhenCopyingAFolderTest extends BaseDLAppTestCase {
 		Folder folder = DLAppServiceUtil.copyFolder(
 			group.getGroupId(), parentFolder.getFolderId(),
 			targetGroup.getGroupId(),
-			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, null, serviceContext);
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, new HashMap<>(), null,
+			serviceContext);
 
 		Assert.assertEquals(parentFolder.getName(), folder.getName());
 		AssertUtils.assertEquals(fileNamesMap, _getFileNamesMap(folder));

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenCopyingWithAssetCategoriesRatingsEntriesAndAssetTagsTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenCopyingWithAssetCategoriesRatingsEntriesAndAssetTagsTest.java
@@ -13,6 +13,7 @@ import com.liferay.asset.kernel.service.AssetTagLocalService;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
 import com.liferay.asset.test.util.AssetTestUtil;
 import com.liferay.document.library.kernel.model.DLFileEntryConstants;
+import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLAppService;
 import com.liferay.document.library.test.util.BaseDLAppTestCase;
@@ -35,6 +36,7 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.ratings.kernel.model.RatingsEntry;
 import com.liferay.ratings.kernel.service.RatingsEntryLocalService;
 
+import java.util.HashMap;
 import java.util.List;
 
 import org.junit.Assert;
@@ -114,7 +116,9 @@ public class
 		FileEntry fileEntry2 = _dlAppService.copyFileEntry(
 			fileEntry1.getFileEntryId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-			_childGroup.getGroupId(), new long[] {group.getGroupId()},
+			_childGroup.getGroupId(),
+			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
+			new long[] {group.getGroupId()},
 			ServiceContextTestUtil.getServiceContext(_childGroup.getGroupId()));
 
 		Assert.assertArrayEquals(
@@ -151,7 +155,9 @@ public class
 
 		FileEntry fileEntry2 = _dlAppService.copyFileEntry(
 			fileEntry1.getFileEntryId(), _newParentFolder.getFolderId(),
-			_newParentFolder.getGroupId(), new long[] {group.getGroupId()},
+			_newParentFolder.getGroupId(),
+			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
+			new long[] {group.getGroupId()},
 			ServiceContextTestUtil.getServiceContext(
 				_newParentFolder.getGroupId()));
 
@@ -191,7 +197,9 @@ public class
 		FileEntry fileEntry2 = _dlAppService.copyFileEntry(
 			fileEntry1.getFileEntryId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-			_childGroup.getGroupId(), new long[] {group.getGroupId()},
+			_childGroup.getGroupId(),
+			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
+			new long[] {group.getGroupId()},
 			ServiceContextTestUtil.getServiceContext(_childGroup.getGroupId()));
 
 		Assert.assertArrayEquals(
@@ -229,7 +237,9 @@ public class
 
 		FileEntry fileEntry2 = _dlAppService.copyFileEntry(
 			fileEntry1.getFileEntryId(), _newParentFolder.getFolderId(),
-			_newParentFolder.getGroupId(), new long[] {group.getGroupId()},
+			_newParentFolder.getGroupId(),
+			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
+			new long[] {group.getGroupId()},
 			ServiceContextTestUtil.getServiceContext(
 				_newParentFolder.getGroupId()));
 
@@ -273,7 +283,9 @@ public class
 
 		FileEntry fileEntry2 = _dlAppService.copyFileEntry(
 			fileEntry1.getFileEntryId(), _newParentFolder.getFolderId(),
-			_newParentFolder.getGroupId(), new long[] {group.getGroupId()},
+			_newParentFolder.getGroupId(),
+			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
+			new long[] {group.getGroupId()},
 			ServiceContextTestUtil.getServiceContext(
 				_newParentFolder.getGroupId()));
 
@@ -317,6 +329,7 @@ public class
 		FileEntry fileEntry2 = _dlAppService.copyFileEntry(
 			fileEntry1.getFileEntryId(), _targetParentFolder.getFolderId(),
 			_targetParentFolder.getGroupId(),
+			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
 			new long[] {_targetParentFolder.getGroupId()},
 			ServiceContextTestUtil.getServiceContext(
 				_targetParentFolder.getGroupId()));
@@ -358,6 +371,7 @@ public class
 		FileEntry fileEntry2 = _dlAppService.copyFileEntry(
 			fileEntry1.getFileEntryId(), _targetParentFolder.getFolderId(),
 			_targetParentFolder.getGroupId(),
+			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
 			new long[] {_targetParentFolder.getGroupId()},
 			ServiceContextTestUtil.getServiceContext(
 				_targetParentFolder.getGroupId()));
@@ -394,7 +408,7 @@ public class
 		Folder folder = _dlAppService.copyFolder(
 			group.getGroupId(), parentFolder.getFolderId(),
 			_childGroup.getGroupId(),
-			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, new HashMap<>(),
 			new long[] {group.getGroupId()},
 			ServiceContextTestUtil.getServiceContext(_childGroup.getGroupId()));
 
@@ -443,7 +457,8 @@ public class
 
 		Folder folder = _dlAppService.copyFolder(
 			group.getGroupId(), parentFolder.getFolderId(), group.getGroupId(),
-			_newParentFolder.getFolderId(), new long[] {group.getGroupId()},
+			_newParentFolder.getFolderId(), new HashMap<>(),
+			new long[] {group.getGroupId()},
 			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
 
 		List<FileEntry> fileEntries = _dlAppService.getFileEntries(
@@ -502,7 +517,8 @@ public class
 
 		Folder folder = _dlAppService.copyFolder(
 			group.getGroupId(), parentFolder.getFolderId(), group.getGroupId(),
-			_newParentFolder.getFolderId(), new long[] {group.getGroupId()},
+			_newParentFolder.getFolderId(), new HashMap<>(),
+			new long[] {group.getGroupId()},
 			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
 
 		List<FileEntry> fileEntries = _dlAppService.getFileEntries(
@@ -549,7 +565,8 @@ public class
 
 		Folder folder = _dlAppService.copyFolder(
 			group.getGroupId(), parentFolder.getFolderId(), group.getGroupId(),
-			_newParentFolder.getFolderId(), new long[] {group.getGroupId()},
+			_newParentFolder.getFolderId(), new HashMap<>(),
+			new long[] {group.getGroupId()},
 			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
 
 		List<RatingsEntry> ratingsEntries2 =
@@ -590,7 +607,7 @@ public class
 		Folder folder = _dlAppService.copyFolder(
 			group.getGroupId(), parentFolder.getFolderId(),
 			targetGroup.getGroupId(), _targetParentFolder.getFolderId(),
-			new long[] {targetGroup.getGroupId()},
+			new HashMap<>(), new long[] {targetGroup.getGroupId()},
 			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
 
 		List<FileEntry> fileEntries = _dlAppService.getFileEntries(

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/http/DLAppServiceHttp.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/http/DLAppServiceHttp.java
@@ -613,7 +613,7 @@ public class DLAppServiceHttp {
 			copyFileEntry(
 				HttpPrincipal httpPrincipal, long fileEntryId,
 				long destinationFolderId, long destinationRepositoryId,
-				long[] groupIds,
+				long fileEntryTypeId, long[] groupIds,
 				com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
@@ -624,7 +624,8 @@ public class DLAppServiceHttp {
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, fileEntryId, destinationFolderId,
-				destinationRepositoryId, groupIds, serviceContext);
+				destinationRepositoryId, fileEntryTypeId, groupIds,
+				serviceContext);
 
 			Object returnObj = null;
 
@@ -703,7 +704,8 @@ public class DLAppServiceHttp {
 	public static com.liferay.portal.kernel.repository.model.Folder copyFolder(
 			HttpPrincipal httpPrincipal, long sourceRepositoryId,
 			long sourceFolderId, long destinationRepositoryId,
-			long destinationParentFolderId, long[] groupIds,
+			long destinationParentFolderId,
+			java.util.Map<Long, Long> fileEntryTypeIds, long[] groupIds,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
@@ -714,8 +716,8 @@ public class DLAppServiceHttp {
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, sourceRepositoryId, sourceFolderId,
-				destinationRepositoryId, destinationParentFolderId, groupIds,
-				serviceContext);
+				destinationRepositoryId, destinationParentFolderId,
+				fileEntryTypeIds, groupIds, serviceContext);
 
 			Object returnObj = null;
 
@@ -4790,7 +4792,7 @@ public class DLAppServiceHttp {
 		};
 	private static final Class<?>[] _copyFileEntryParameterTypes13 =
 		new Class[] {
-			long.class, long.class, long.class, long[].class,
+			long.class, long.class, long.class, long.class, long[].class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
 	private static final Class<?>[] _copyFileShortcutParameterTypes14 =
@@ -4799,8 +4801,8 @@ public class DLAppServiceHttp {
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
 	private static final Class<?>[] _copyFolderParameterTypes15 = new Class[] {
-		long.class, long.class, long.class, long.class, long[].class,
-		com.liferay.portal.kernel.service.ServiceContext.class
+		long.class, long.class, long.class, long.class, java.util.Map.class,
+		long[].class, com.liferay.portal.kernel.service.ServiceContext.class
 	};
 	private static final Class<?>[] _copyFolderParameterTypes16 = new Class[] {
 		long.class, long.class, long.class, String.class, String.class,

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppServiceImpl.java
@@ -726,7 +726,7 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 	@Override
 	public FileEntry copyFileEntry(
 			long fileEntryId, long destinationFolderId,
-			long destinationRepositoryId, long[] groupIds,
+			long destinationRepositoryId, long fileEntryTypeId, long[] groupIds,
 			ServiceContext serviceContext)
 		throws PortalException {
 
@@ -736,8 +736,7 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 		return copyFileEntry(
 			getRepository(destinationRepositoryId),
 			sourceRepository.getFileEntry(fileEntryId), destinationFolderId,
-			ParamUtil.getLong(serviceContext, "fileEntryTypeId"), groupIds,
-			serviceContext);
+			fileEntryTypeId, groupIds, serviceContext);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -1305,6 +1305,40 @@ public class DLFileEntryLocalServiceImpl
 	}
 
 	@Override
+	public Map<Long, Long> getFileEntryTypeIds(
+		long companyId, long groupId, String treePath) {
+
+		List<Object[]> results = dslQuery(
+			DSLQueryFactoryUtil.select(
+				DLFileEntryTable.INSTANCE.fileEntryId,
+				DLFileEntryTable.INSTANCE.fileEntryTypeId
+			).from(
+				DLFileEntryTable.INSTANCE
+			).where(
+				DLFileEntryTable.INSTANCE.companyId.eq(
+					companyId
+				).and(
+					DLFileEntryTable.INSTANCE.groupId.eq(groupId)
+				).and(
+					DLFileEntryTable.INSTANCE.fileEntryTypeId.neq(
+						DLFileEntryTypeConstants.
+							FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT)
+				).and(
+					DLFileEntryTable.INSTANCE.treePath.like(
+						treePath.concat(StringPool.PERCENT))
+				)
+			));
+
+		Map<Long, Long> fileEntryTypeIds = new HashMap<>();
+
+		for (Object[] result : results) {
+			fileEntryTypeIds.put((Long)result[0], (Long)result[1]);
+		}
+
+		return fileEntryTypeIds;
+	}
+
+	@Override
 	public List<DLFileEntry> getGroupFileEntries(
 		long groupId, int start, int end) {
 

--- a/portal-kernel/bnd.bnd
+++ b/portal-kernel/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 121.1.0
+Bundle-Version: 122.0.0
 Export-Package:\
 	!com.liferay.portal.kernel.internal.*,\
 	!com.liferay.portal.kernel.module.util,\

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppService.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppService.java
@@ -33,6 +33,7 @@ import java.io.InputStream;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 import org.osgi.annotation.versioning.ProviderType;
 
@@ -454,7 +455,7 @@ public interface DLAppService extends BaseService {
 
 	public FileEntry copyFileEntry(
 			long fileEntryId, long destinationFolderId,
-			long destinationRepositoryId, long[] groupIds,
+			long destinationRepositoryId, long fileEntryTypeId, long[] groupIds,
 			ServiceContext serviceContext)
 		throws PortalException;
 
@@ -466,7 +467,8 @@ public interface DLAppService extends BaseService {
 	public Folder copyFolder(
 			long sourceRepositoryId, long sourceFolderId,
 			long destinationRepositoryId, long destinationParentFolderId,
-			long[] groupIds, ServiceContext serviceContext)
+			Map<Long, Long> fileEntryTypeIds, long[] groupIds,
+			ServiceContext serviceContext)
 		throws PortalException;
 
 	/**

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppServiceUtil.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppServiceUtil.java
@@ -11,6 +11,7 @@ import com.liferay.portal.kernel.util.OrderByComparator;
 import java.io.InputStream;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * Provides the remote service utility for DLApp. This utility wraps
@@ -501,13 +502,14 @@ public class DLAppServiceUtil {
 	public static com.liferay.portal.kernel.repository.model.FileEntry
 			copyFileEntry(
 				long fileEntryId, long destinationFolderId,
-				long destinationRepositoryId, long[] groupIds,
+				long destinationRepositoryId, long fileEntryTypeId,
+				long[] groupIds,
 				com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {
 
 		return getService().copyFileEntry(
-			fileEntryId, destinationFolderId, destinationRepositoryId, groupIds,
-			serviceContext);
+			fileEntryId, destinationFolderId, destinationRepositoryId,
+			fileEntryTypeId, groupIds, serviceContext);
 	}
 
 	public static com.liferay.portal.kernel.repository.model.FileShortcut
@@ -525,13 +527,14 @@ public class DLAppServiceUtil {
 	public static com.liferay.portal.kernel.repository.model.Folder copyFolder(
 			long sourceRepositoryId, long sourceFolderId,
 			long destinationRepositoryId, long destinationParentFolderId,
-			long[] groupIds,
+			Map<Long, Long> fileEntryTypeIds, long[] groupIds,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {
 
 		return getService().copyFolder(
 			sourceRepositoryId, sourceFolderId, destinationRepositoryId,
-			destinationParentFolderId, groupIds, serviceContext);
+			destinationParentFolderId, fileEntryTypeIds, groupIds,
+			serviceContext);
 	}
 
 	/**

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppServiceWrapper.java
@@ -504,13 +504,13 @@ public class DLAppServiceWrapper
 	@Override
 	public com.liferay.portal.kernel.repository.model.FileEntry copyFileEntry(
 			long fileEntryId, long destinationFolderId,
-			long destinationRepositoryId, long[] groupIds,
+			long destinationRepositoryId, long fileEntryTypeId, long[] groupIds,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _dlAppService.copyFileEntry(
-			fileEntryId, destinationFolderId, destinationRepositoryId, groupIds,
-			serviceContext);
+			fileEntryId, destinationFolderId, destinationRepositoryId,
+			fileEntryTypeId, groupIds, serviceContext);
 	}
 
 	@Override
@@ -530,13 +530,14 @@ public class DLAppServiceWrapper
 	public com.liferay.portal.kernel.repository.model.Folder copyFolder(
 			long sourceRepositoryId, long sourceFolderId,
 			long destinationRepositoryId, long destinationParentFolderId,
-			long[] groupIds,
+			java.util.Map<Long, Long> fileEntryTypeIds, long[] groupIds,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _dlAppService.copyFolder(
 			sourceRepositoryId, sourceFolderId, destinationRepositoryId,
-			destinationParentFolderId, groupIds, serviceContext);
+			destinationParentFolderId, fileEntryTypeIds, groupIds,
+			serviceContext);
 	}
 
 	/**

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryLocalService.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryLocalService.java
@@ -537,6 +537,10 @@ public interface DLFileEntryLocalService
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public Map<Long, Long> getFileEntryTypeIds(
+		long companyId, long groupId, String treePath);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<DLFileEntry> getGroupFileEntries(
 		long groupId, int start, int end);
 

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryLocalServiceUtil.java
@@ -720,6 +720,12 @@ public class DLFileEntryLocalServiceUtil {
 		return getService().getFileEntryByUuidAndGroupId(uuid, groupId);
 	}
 
+	public static Map<Long, Long> getFileEntryTypeIds(
+		long companyId, long groupId, String treePath) {
+
+		return getService().getFileEntryTypeIds(companyId, groupId, treePath);
+	}
+
 	public static List<DLFileEntry> getGroupFileEntries(
 		long groupId, int start, int end) {
 

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryLocalServiceWrapper.java
@@ -818,6 +818,14 @@ public class DLFileEntryLocalServiceWrapper
 	}
 
 	@Override
+	public java.util.Map<Long, Long> getFileEntryTypeIds(
+		long companyId, long groupId, String treePath) {
+
+		return _dlFileEntryLocalService.getFileEntryTypeIds(
+			companyId, groupId, treePath);
+	}
+
+	@Override
 	public java.util.List<DLFileEntry> getGroupFileEntries(
 		long groupId, int start, int end) {
 

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/packageinfo
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/packageinfo
@@ -1,1 +1,1 @@
-version 14.0.0
+version 15.0.0


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-194119


How to test it:

1. create a Document Type on Global Site (it works the same with a Parent site)
2. Create a document with previous Document Type - file 1
3. Create a Folder on Global Site
4. Create a document with the Document Type inside the folder
5. Copy file 1 to Site
6. - the file copied has the document type of global site
7. Copy folder to Site
8. - the file inside of the folder has the document type of global site


Other test

1. create a Document Type on a Asset Library (it works the same with a Parent site)
2. Create a document with previous Document Type - file 1
3. Create a Folder on Asset Library
4. Create a document with the Document Type inside the folder
5. Copy file 1 to Site
6. -  the file copied DOES NOT HAVE document type
7. Copy folder to Site
8. -  the file inside of the folder DOES NOT HAVE document type
9. connect site to asset library and make Structures available
10. delete the copied file and folder on Site (or copy on another folder)
11. Copy file 1 to Site
12. - the file copied has the document type
13. Copy folder to Site
14. - the file inside of the folder has the document type



- LPS-194119 add the file Type id to the copy of the file in the case that we have access to the structures from the source group
- LPS-194119 create a method to obtain the relation between file id and file type id on a treePath
- LPS-194119 add the map of the fileEntryTypeIds to the copy of the folder to add it on the copy of each file inside of the folder
- LPS-194119 add the fileEntryTypeId on the copy of the file entry
- LPS-194119 buildService
- LPS-194119 fix test
