### PR TITLE
LPS-194502 show tooltip with the scheduled date/time

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/display/context/KBArticleViewDisplayContext.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/display/context/KBArticleViewDisplayContext.java
@@ -113,7 +113,8 @@ public class KBArticleViewDisplayContext {
 		Date expirationDate = kbArticle.getExpirationDate();
 
 		if (kbArticle.isDraft() || kbArticle.isExpired() ||
-			kbArticle.isPending() || (expirationDate == null)) {
+			kbArticle.isPending() || kbArticle.isScheduled() ||
+			(expirationDate == null)) {
 
 			return false;
 		}

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/view_descriptive.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/view_descriptive.jsp
@@ -131,29 +131,45 @@ KBArticleViewDisplayContext kbArticleViewDisplayContext = new KBArticleViewDispl
 					</c:if>
 
 					<span class="text-default">
+						<c:choose>
+							<c:when test='<%= FeatureFlagManagerUtil.isEnabled("LPS-188060") && kbArticle.isScheduled() %>'>
 
-						<%
-						String expirationDateString = StringPool.BLANK;
+								<%
+								String displayDateString = StringPool.BLANK;
 
-						if (kbArticle.getExpirationDate() != null) {
-							expirationDateString = dateFormatDateTime.format(kbArticle.getExpirationDate());
-						}
-						%>
+								if (kbArticle.getDisplayDate() != null) {
+									displayDateString = dateFormatDateTime.format(kbArticle.getDisplayDate());
+								}
+								%>
 
-						<aui:workflow-status helpMessage="<%= kbArticle.isExpired() ? expirationDateString : StringPool.BLANK %>" markupView="lexicon" showHelpMessage="<%= kbArticle.isExpired() %>" showIcon="<%= false %>" showLabel="<%= false %>" status="<%= kbArticle.getStatus() %>" />
+								<aui:workflow-status helpMessage="<%= kbArticle.isScheduled() ? displayDateString : StringPool.BLANK %>" markupView="lexicon" showHelpMessage="<%= kbArticle.isScheduled() %>" showIcon="<%= false %>" showLabel="<%= false %>" status="<%= kbArticle.getStatus() %>" />
+							</c:when>
+							<c:otherwise>
 
-						<c:if test="<%= kbArticleViewDisplayContext.isExpiringSoon(kbArticle) %>">
-							<span class="label label-warning">
-								<span class="label-item label-item-expand"><liferay-ui:message key="expiring-soon" /></span>
-							</span>
+								<%
+								String expirationDateString = StringPool.BLANK;
 
-							<clay:icon
-								aria-label="<%= expirationDateString %>"
-								cssClass="lfr-portal-tooltip"
-								symbol="question-circle-full"
-								title="<%= expirationDateString %>"
-							/>
-						</c:if>
+								if (kbArticle.getExpirationDate() != null) {
+									expirationDateString = dateFormatDateTime.format(kbArticle.getExpirationDate());
+								}
+								%>
+
+								<aui:workflow-status helpMessage="<%= kbArticle.isExpired() ? expirationDateString : StringPool.BLANK %>" markupView="lexicon" showHelpMessage="<%= kbArticle.isExpired() %>" showIcon="<%= false %>" showLabel="<%= false %>" status="<%= kbArticle.getStatus() %>" />
+
+								<c:if test="<%= kbArticleViewDisplayContext.isExpiringSoon(kbArticle) %>">
+									<span class="label label-warning">
+										<span class="label-item label-item-expand"><liferay-ui:message key="expiring-soon" /></span>
+									</span>
+
+									<clay:icon
+										aria-label="<%= expirationDateString %>"
+										cssClass="lfr-portal-tooltip"
+										symbol="question-circle-full"
+										title="<%= expirationDateString %>"
+									/>
+								</c:if>
+							</c:otherwise>
+						</c:choose>
 					</span>
 				</liferay-ui:search-container-column-text>
 

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/view_table.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/view_table.jsp
@@ -193,29 +193,45 @@ KBArticleViewDisplayContext kbArticleViewDisplayContext = new KBArticleViewDispl
 				<liferay-ui:search-container-column-text
 					name="status"
 				>
+					<c:choose>
+						<c:when test='<%= FeatureFlagManagerUtil.isEnabled("LPS-188060") && kbArticle.isScheduled() %>'>
 
-					<%
-					String expirationDateString = StringPool.BLANK;
+							<%
+							String displayDateString = StringPool.BLANK;
 
-					if (kbArticle.getExpirationDate() != null) {
-						expirationDateString = dateFormatDateTime.format(kbArticle.getExpirationDate());
-					}
-					%>
+							if (kbArticle.getDisplayDate() != null) {
+								displayDateString = dateFormatDateTime.format(kbArticle.getDisplayDate());
+							}
+							%>
 
-					<aui:workflow-status helpMessage="<%= kbArticle.isExpired() ? expirationDateString : StringPool.BLANK %>" markupView="lexicon" showHelpMessage="<%= kbArticle.isExpired() %>" showIcon="<%= false %>" showLabel="<%= false %>" status="<%= kbArticle.getStatus() %>" />
+							<aui:workflow-status helpMessage="<%= kbArticle.isScheduled() ? displayDateString : StringPool.BLANK %>" markupView="lexicon" showHelpMessage="<%= kbArticle.isScheduled() %>" showIcon="<%= false %>" showLabel="<%= false %>" status="<%= kbArticle.getStatus() %>" />
+						</c:when>
+						<c:otherwise>
 
-					<c:if test="<%= kbArticleViewDisplayContext.isExpiringSoon(kbArticle) %>">
-						<span class="label label-warning">
-							<span class="label-item label-item-expand"><liferay-ui:message key="expiring-soon" /></span>
-						</span>
+							<%
+							String expirationDateString = StringPool.BLANK;
 
-						<clay:icon
-							aria-label="<%= expirationDateString %>"
-							cssClass="lfr-portal-tooltip"
-							symbol="question-circle-full"
-							title="<%= expirationDateString %>"
-						/>
-					</c:if>
+							if (kbArticle.getExpirationDate() != null) {
+								expirationDateString = dateFormatDateTime.format(kbArticle.getExpirationDate());
+							}
+							%>
+
+							<aui:workflow-status helpMessage="<%= kbArticle.isExpired() ? expirationDateString : StringPool.BLANK %>" markupView="lexicon" showHelpMessage="<%= kbArticle.isExpired() %>" showIcon="<%= false %>" showLabel="<%= false %>" status="<%= kbArticle.getStatus() %>" />
+
+							<c:if test="<%= kbArticleViewDisplayContext.isExpiringSoon(kbArticle) %>">
+								<span class="label label-warning">
+									<span class="label-item label-item-expand"><liferay-ui:message key="expiring-soon" /></span>
+								</span>
+
+								<clay:icon
+									aria-label="<%= expirationDateString %>"
+									cssClass="lfr-portal-tooltip"
+									symbol="question-circle-full"
+									title="<%= expirationDateString %>"
+								/>
+							</c:if>
+						</c:otherwise>
+					</c:choose>
 				</liferay-ui:search-container-column-text>
 
 				<liferay-ui:search-container-column-text


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-194502

How to test it:

FF: LPS-188060

since you can not select the display date on the edition of the KB Article, the only way to test this now is or modifying the UpdateKBArticleMVCActionCommand.java or changing the date on the database

Result: 
<img width="682" alt="image" src="https://github.com/liferay-lima/liferay-portal/assets/47524751/51fda3d8-a76a-4f27-bd17-038cd3d4066f">



- LPS-194502 add the tooltip if the article is scheduled
- LPS-194502 expiring soon if the article is not scheduled
