### PR TITLE
LPS-194510 Publish article when displayDate is on past and SchedulerJobConfiguration launch the task of checkArticles

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
@@ -69,6 +69,7 @@ import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.dao.orm.RestrictionsFactoryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.log.Log;
@@ -1369,7 +1370,9 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 		if (status == WorkflowConstants.STATUS_APPROVED) {
 			main = true;
 
-			if (date.before(kbArticle.getDisplayDate())) {
+			if (FeatureFlagManagerUtil.isEnabled("LPS-188060") &&
+				date.before(kbArticle.getDisplayDate())) {
+
 				status = WorkflowConstants.STATUS_SCHEDULED;
 			}
 		}

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
@@ -350,7 +350,6 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 
 	@Override
 	public void checkKBArticles(long companyId) throws PortalException {
-
 		Company company = _companyLocalService.getCompany(companyId);
 
 		Date date = new Date();
@@ -1694,8 +1693,9 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 			_log.debug(
 				StringBundler.concat(
 					"Sending review notification for articles with review ",
-					"date between ", _dates.get(company.getCompanyId()), " and ", reviewDate,
-					" for company ", company.getCompanyId()));
+					"date between ", _dates.get(company.getCompanyId()),
+					" and ", reviewDate, " for company ",
+					company.getCompanyId()));
 		}
 
 		List<KBArticle> kbArticles = _getKBArticlesByCompanyIdAndReviewDate(

--- a/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/test/KBArticleLocalServiceTest.java
+++ b/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/test/KBArticleLocalServiceTest.java
@@ -49,6 +49,7 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.ratings.kernel.service.RatingsEntryLocalServiceUtil;
@@ -278,6 +279,7 @@ public class KBArticleLocalServiceTest {
 			_serviceContext);
 	}
 
+	@FeatureFlags("LPS-188060")
 	@Test
 	public void testAddKBArticleDisplayDateKBArticleStatusScheduled()
 		throws Exception {

--- a/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/web/internal/scheduler/test/CheckKBArticleSchedulerJobConfigurationTest.java
+++ b/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/web/internal/scheduler/test/CheckKBArticleSchedulerJobConfigurationTest.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
@@ -41,6 +42,7 @@ import org.junit.runner.RunWith;
 /**
  * @author Alicia García
  */
+@FeatureFlags("LPS-188060")
 @RunWith(Arquillian.class)
 @Sync
 public class CheckKBArticleSchedulerJobConfigurationTest {

--- a/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/web/internal/scheduler/test/CheckKBArticleSchedulerJobConfigurationTest.java
+++ b/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/web/internal/scheduler/test/CheckKBArticleSchedulerJobConfigurationTest.java
@@ -63,7 +63,7 @@ public class CheckKBArticleSchedulerJobConfigurationTest {
 	}
 
 	@Test
-	public void testDoNotExpireFileEntryIfKBArticleIsScheduled()
+	public void testDoNotExpireKBArticleIfKBArticleIsScheduled()
 		throws Exception {
 
 		Date displayDate = DateUtils.addDays(RandomTestUtil.nextDate(), 1);
@@ -94,7 +94,7 @@ public class CheckKBArticleSchedulerJobConfigurationTest {
 	}
 
 	@Test
-	public void testExpireFileEntry() throws Exception {
+	public void testExpireKBArticle() throws Exception {
 		Date expirationDate = new Date(
 			System.currentTimeMillis() + (Time.MINUTE * 5));
 

--- a/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/web/internal/scheduler/test/CheckKBArticleSchedulerJobConfigurationTest.java
+++ b/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/web/internal/scheduler/test/CheckKBArticleSchedulerJobConfigurationTest.java
@@ -121,6 +121,37 @@ public class CheckKBArticleSchedulerJobConfigurationTest {
 			WorkflowConstants.STATUS_EXPIRED, kbArticle.getStatus());
 	}
 
+	@Test
+	public void testPublishKBArticleIfKBArticleIsScheduled() throws Exception {
+		Date displayDate = new Date(
+			System.currentTimeMillis() + (Time.MINUTE * 10));
+
+		KBArticle kbArticle = _kbArticleLocalService.addKBArticle(
+			null, UserLocalServiceUtil.getGuestUserId(_group.getCompanyId()),
+			PortalUtil.getClassNameId(KBFolder.class.getName()), 0,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(), null,
+			null, displayDate, null, null, null,
+			ServiceContextTestUtil.getServiceContext(
+				_group, _user.getUserId()));
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_SCHEDULED, kbArticle.getStatus());
+
+		kbArticle.setDisplayDate(
+			new Date(System.currentTimeMillis() - (Time.MINUTE * 10)));
+
+		kbArticle = _kbArticleLocalService.updateKBArticle(kbArticle);
+
+		_kbArticleLocalService.checkKBArticles(_group.getCompanyId());
+
+		kbArticle = _kbArticleLocalService.getLatestKBArticle(
+			kbArticle.getResourcePrimKey(), WorkflowConstants.STATUS_ANY);
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_APPROVED, kbArticle.getStatus());
+	}
+
 	@DeleteAfterTestRun
 	private Group _group;
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-194510
How to test it:

_FF: LPS-188060_

since you can not select the display date on the edition of the KB Article, the only way to test this now is or modifying the _UpdateKBArticleMVCActionCommand.java_ or changing the date on the database



- LPS-194510 only schedule the article if the FF is active
- LPS-194510 find the articles marked as scheduled every time the interval of the service is checked, and  publish them if the time is previous to now
- LPS-194510 put the scheduled test under the FF
- LPS-194510 add test to check the publication of a scheduled article
- LPS-194510 rename tests
