### PR TITLE
LPS-194118  Copy Document Types in D&M - Test Creation

### DIFF
--- a/modules/apps/depot/depot-test/build.gradle
+++ b/modules/apps/depot/depot-test/build.gradle
@@ -5,6 +5,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:asset:asset-list-api")
 	testIntegrationImplementation project(":apps:depot:depot-api")
 	testIntegrationImplementation project(":apps:document-library:document-library-api")
+	testIntegrationImplementation project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")
 	testIntegrationImplementation project(":apps:export-import:export-import-api")
 	testIntegrationImplementation project(":apps:export-import:export-import-test-util")
 	testIntegrationImplementation project(":apps:friendly-url:friendly-url-api")

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/test/DepotEntryDLAppServiceWhenCopyingWithDocumentTypesTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/test/DepotEntryDLAppServiceWhenCopyingWithDocumentTypesTest.java
@@ -123,7 +123,7 @@ public class DepotEntryDLAppServiceWhenCopyingWithDocumentTypesTest {
 	}
 
 	@Test
-	public void testCopyFileShouldCopyDocumentTypeToRelatedGroupDDMStructuresAvailable()
+	public void testCopyFileShouldCopyDocumentTypeToRelatedGroupWhenDDMStructuresAvailable()
 		throws Exception {
 
 		_depotEntryGroupRelLocalService.addDepotEntryGroupRel(
@@ -160,7 +160,7 @@ public class DepotEntryDLAppServiceWhenCopyingWithDocumentTypesTest {
 	}
 
 	@Test
-	public void testCopyFileShouldNotCopyDocumentTypeFromRelatedGroupIfNotDDMStructuresAvailable()
+	public void testCopyFileShouldNotCopyDocumentTypeFromRelatedGroupUnlessDDMStructuresAvailable()
 		throws Exception {
 
 		_depotEntryGroupRelLocalService.addDepotEntryGroupRel(
@@ -251,7 +251,7 @@ public class DepotEntryDLAppServiceWhenCopyingWithDocumentTypesTest {
 	}
 
 	@Test
-	public void testCopyFileShouldNotCopyDocumentTypeToRelatedGroupIfNotDDMStructuresAvailable()
+	public void testCopyFileShouldNotCopyDocumentTypeToRelatedGroupUnlessDDMStructuresAvailable()
 		throws Exception {
 
 		_depotEntryGroupRelLocalService.addDepotEntryGroupRel(
@@ -338,7 +338,7 @@ public class DepotEntryDLAppServiceWhenCopyingWithDocumentTypesTest {
 	}
 
 	@Test(expected = InvalidFileEntryTypeException.class)
-	public void testCopyFileThrowsExceptionWhenCopyDocumentTypeFromRelatedGroupDDMStructuresAvailable()
+	public void testCopyFileThrowsExceptionWhenCopyDocumentTypeFromRelatedGroupWhenDDMStructuresAvailable()
 		throws Exception {
 
 		_depotEntryGroupRelLocalService.addDepotEntryGroupRel(

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/test/DepotEntryDLAppServiceWhenCopyingWithDocumentTypesTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/test/DepotEntryDLAppServiceWhenCopyingWithDocumentTypesTest.java
@@ -1,0 +1,406 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.depot.service.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.group.provider.SiteConnectedGroupGroupProvider;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryGroupRelLocalService;
+import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.document.library.kernel.exception.InvalidFileEntryTypeException;
+import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.document.library.kernel.model.DLFileEntryMetadata;
+import com.liferay.document.library.kernel.model.DLFileEntryType;
+import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
+import com.liferay.document.library.kernel.model.DLFolderConstants;
+import com.liferay.document.library.kernel.service.DLAppService;
+import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalService;
+import com.liferay.dynamic.data.mapping.constants.DDMStructureConstants;
+import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
+import com.liferay.dynamic.data.mapping.storage.StorageType;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.util.HashMap;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Alicia García
+ */
+@RunWith(Arquillian.class)
+public class DepotEntryDLAppServiceWhenCopyingWithDocumentTypesTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_depotEntry = _depotEntryLocalService.addDepotEntry(
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), "name"
+			).build(),
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), "description"
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		_depotGroup = _groupLocalService.getGroup(_depotEntry.getGroupId());
+
+		DDMStructure depotDDMStructure = _ddmStructureLocalService.addStructure(
+			_depotGroup.getCreatorUserId(), _depotGroup.getGroupId(),
+			DDMStructureConstants.DEFAULT_PARENT_STRUCTURE_ID,
+			PortalUtil.getClassNameId(DLFileEntryMetadata.class),
+			StringPool.BLANK,
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(),
+				DLFileEntryMetadata.class.getSimpleName()
+			).build(),
+			new HashMap<>(), StringPool.BLANK, StorageType.DEFAULT.toString(),
+			ServiceContextTestUtil.getServiceContext(_depotGroup.getGroupId()));
+
+		_depotDLFileEntryType = _dlFileEntryTypeLocalService.addFileEntryType(
+			_depotGroup.getCreatorUserId(), _depotGroup.getGroupId(),
+			depotDDMStructure.getStructureId(), null,
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()
+			).build(),
+			new HashMap<>(),
+			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_SCOPE_DEFAULT,
+			ServiceContextTestUtil.getServiceContext(_depotGroup.getGroupId()));
+
+		_group = GroupTestUtil.addGroup();
+
+		DDMStructure ddmStructure = _ddmStructureLocalService.addStructure(
+			_group.getCreatorUserId(), _group.getGroupId(),
+			DDMStructureConstants.DEFAULT_PARENT_STRUCTURE_ID,
+			PortalUtil.getClassNameId(DLFileEntryMetadata.class),
+			StringPool.BLANK,
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(),
+				DLFileEntryMetadata.class.getSimpleName()
+			).build(),
+			new HashMap<>(), StringPool.BLANK, StorageType.DEFAULT.toString(),
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		_dlFileEntryType = _dlFileEntryTypeLocalService.addFileEntryType(
+			_group.getCreatorUserId(), _group.getGroupId(),
+			ddmStructure.getStructureId(), null,
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()
+			).build(),
+			new HashMap<>(),
+			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_SCOPE_DEFAULT,
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+	}
+
+	@Test
+	public void testCopyFileShouldCopyDocumentTypeToRelatedGroupDDMStructuresAvailable()
+		throws Exception {
+
+		_depotEntryGroupRelLocalService.addDepotEntryGroupRel(
+			true, _depotEntry.getDepotEntryId(), _group.getGroupId(), false);
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(_depotGroup.getGroupId());
+
+		serviceContext.setAttribute(
+			"fileEntryTypeId", _depotDLFileEntryType.getFileEntryTypeId());
+
+		FileEntry fileEntry1 = _dlAppService.addFileEntry(
+			RandomTestUtil.randomString(), _depotGroup.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, _FILE_NAME,
+			ContentTypes.TEXT_PLAIN, _FILE_NAME, StringPool.BLANK,
+			StringPool.BLANK, StringPool.BLANK, new byte[0], null, null,
+			serviceContext);
+
+		FileEntry fileEntry2 = _dlAppService.copyFileEntry(
+			fileEntry1.getFileEntryId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, _group.getGroupId(),
+			_depotDLFileEntryType.getFileEntryTypeId(),
+			_siteConnectedGroupGroupProvider.
+				getCurrentAndAncestorSiteAndDepotGroupIds(_group.getGroupId()),
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		DLFileEntry dlFileEntry1 = (DLFileEntry)fileEntry1.getModel();
+
+		DLFileEntry dlFileEntry2 = (DLFileEntry)fileEntry2.getModel();
+
+		Assert.assertEquals(
+			dlFileEntry1.getFileEntryTypeId(),
+			dlFileEntry2.getFileEntryTypeId());
+	}
+
+	@Test
+	public void testCopyFileShouldNotCopyDocumentTypeFromRelatedGroupIfNotDDMStructuresAvailable()
+		throws Exception {
+
+		_depotEntryGroupRelLocalService.addDepotEntryGroupRel(
+			_depotEntry.getDepotEntryId(), _group.getGroupId());
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId());
+
+		serviceContext.setAttribute(
+			"fileEntryTypeId", _dlFileEntryType.getFileEntryTypeId());
+
+		FileEntry fileEntry1 = _dlAppService.addFileEntry(
+			RandomTestUtil.randomString(), _group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, _FILE_NAME,
+			ContentTypes.TEXT_PLAIN, _FILE_NAME, StringPool.BLANK,
+			StringPool.BLANK, StringPool.BLANK, new byte[0], null, null,
+			serviceContext);
+
+		DLFileEntry dlFileEntry1 = (DLFileEntry)fileEntry1.getModel();
+
+		Assert.assertEquals(
+			_dlFileEntryType.getFileEntryTypeId(),
+			dlFileEntry1.getFileEntryTypeId());
+
+		Assert.assertNotEquals(
+			DLFileEntryTypeConstants.COMPANY_ID_BASIC_DOCUMENT,
+			dlFileEntry1.getFileEntryTypeId());
+
+		FileEntry fileEntry2 = _dlAppService.copyFileEntry(
+			fileEntry1.getFileEntryId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			_depotGroup.getGroupId(),
+			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
+			_siteConnectedGroupGroupProvider.
+				getCurrentAndAncestorSiteAndDepotGroupIds(
+					_depotGroup.getGroupId()),
+			ServiceContextTestUtil.getServiceContext(_depotGroup.getGroupId()));
+
+		DLFileEntry dlFileEntry2 = (DLFileEntry)fileEntry2.getModel();
+
+		Assert.assertEquals(
+			DLFileEntryTypeConstants.COMPANY_ID_BASIC_DOCUMENT,
+			dlFileEntry2.getFileEntryTypeId());
+	}
+
+	@Test
+	public void testCopyFileShouldNotCopyDocumentTypeFromUnrelatedGroup()
+		throws Exception {
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId());
+
+		serviceContext.setAttribute(
+			"fileEntryTypeId", _dlFileEntryType.getFileEntryTypeId());
+
+		FileEntry fileEntry1 = _dlAppService.addFileEntry(
+			RandomTestUtil.randomString(), _group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, _FILE_NAME,
+			ContentTypes.TEXT_PLAIN, _FILE_NAME, StringPool.BLANK,
+			StringPool.BLANK, StringPool.BLANK, new byte[0], null, null,
+			serviceContext);
+
+		DLFileEntry dlFileEntry1 = (DLFileEntry)fileEntry1.getModel();
+
+		Assert.assertEquals(
+			_dlFileEntryType.getFileEntryTypeId(),
+			dlFileEntry1.getFileEntryTypeId());
+
+		Assert.assertNotEquals(
+			DLFileEntryTypeConstants.COMPANY_ID_BASIC_DOCUMENT,
+			dlFileEntry1.getFileEntryTypeId());
+
+		FileEntry fileEntry2 = _dlAppService.copyFileEntry(
+			fileEntry1.getFileEntryId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			_depotGroup.getGroupId(),
+			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
+			_siteConnectedGroupGroupProvider.
+				getCurrentAndAncestorSiteAndDepotGroupIds(
+					_depotGroup.getGroupId()),
+			ServiceContextTestUtil.getServiceContext(_depotGroup.getGroupId()));
+
+		DLFileEntry dlFileEntry2 = (DLFileEntry)fileEntry2.getModel();
+
+		Assert.assertEquals(
+			DLFileEntryTypeConstants.COMPANY_ID_BASIC_DOCUMENT,
+			dlFileEntry2.getFileEntryTypeId());
+	}
+
+	@Test
+	public void testCopyFileShouldNotCopyDocumentTypeToRelatedGroupIfNotDDMStructuresAvailable()
+		throws Exception {
+
+		_depotEntryGroupRelLocalService.addDepotEntryGroupRel(
+			_depotEntry.getDepotEntryId(), _group.getGroupId());
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(_depotGroup.getGroupId());
+
+		serviceContext.setAttribute(
+			"fileEntryTypeId", _depotDLFileEntryType.getFileEntryTypeId());
+
+		FileEntry fileEntry1 = _dlAppService.addFileEntry(
+			RandomTestUtil.randomString(), _depotGroup.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, _FILE_NAME,
+			ContentTypes.TEXT_PLAIN, _FILE_NAME, StringPool.BLANK,
+			StringPool.BLANK, StringPool.BLANK, new byte[0], null, null,
+			serviceContext);
+
+		DLFileEntry dlFileEntry1 = (DLFileEntry)fileEntry1.getModel();
+
+		Assert.assertEquals(
+			_depotDLFileEntryType.getFileEntryTypeId(),
+			dlFileEntry1.getFileEntryTypeId());
+
+		Assert.assertNotEquals(
+			DLFileEntryTypeConstants.COMPANY_ID_BASIC_DOCUMENT,
+			dlFileEntry1.getFileEntryTypeId());
+
+		FileEntry fileEntry2 = _dlAppService.copyFileEntry(
+			fileEntry1.getFileEntryId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, _group.getGroupId(),
+			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
+			_siteConnectedGroupGroupProvider.
+				getCurrentAndAncestorSiteAndDepotGroupIds(_group.getGroupId()),
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		DLFileEntry dlFileEntry2 = (DLFileEntry)fileEntry2.getModel();
+
+		Assert.assertEquals(
+			DLFileEntryTypeConstants.COMPANY_ID_BASIC_DOCUMENT,
+			dlFileEntry2.getFileEntryTypeId());
+	}
+
+	@Test
+	public void testCopyFileShouldNotCopyDocumentTypeToUnrelatedGroup()
+		throws Exception {
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(_depotGroup.getGroupId());
+
+		serviceContext.setAttribute(
+			"fileEntryTypeId", _depotDLFileEntryType.getFileEntryTypeId());
+
+		FileEntry fileEntry1 = _dlAppService.addFileEntry(
+			RandomTestUtil.randomString(), _depotGroup.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, _FILE_NAME,
+			ContentTypes.TEXT_PLAIN, _FILE_NAME, StringPool.BLANK,
+			StringPool.BLANK, StringPool.BLANK, new byte[0], null, null,
+			serviceContext);
+
+		DLFileEntry dlFileEntry1 = (DLFileEntry)fileEntry1.getModel();
+
+		Assert.assertEquals(
+			_depotDLFileEntryType.getFileEntryTypeId(),
+			dlFileEntry1.getFileEntryTypeId());
+
+		Assert.assertNotEquals(
+			DLFileEntryTypeConstants.COMPANY_ID_BASIC_DOCUMENT,
+			dlFileEntry1.getFileEntryTypeId());
+
+		FileEntry fileEntry2 = _dlAppService.copyFileEntry(
+			fileEntry1.getFileEntryId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, _group.getGroupId(),
+			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
+			_siteConnectedGroupGroupProvider.
+				getCurrentAndAncestorSiteAndDepotGroupIds(_group.getGroupId()),
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		DLFileEntry dlFileEntry2 = (DLFileEntry)fileEntry2.getModel();
+
+		Assert.assertEquals(
+			DLFileEntryTypeConstants.COMPANY_ID_BASIC_DOCUMENT,
+			dlFileEntry2.getFileEntryTypeId());
+	}
+
+	@Test(expected = InvalidFileEntryTypeException.class)
+	public void testCopyFileThrowsExceptionWhenCopyDocumentTypeFromRelatedGroupDDMStructuresAvailable()
+		throws Exception {
+
+		_depotEntryGroupRelLocalService.addDepotEntryGroupRel(
+			true, _depotEntry.getDepotEntryId(), _group.getGroupId(), false);
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId());
+
+		serviceContext.setAttribute(
+			"fileEntryTypeId", _dlFileEntryType.getFileEntryTypeId());
+
+		FileEntry fileEntry1 = _dlAppService.addFileEntry(
+			RandomTestUtil.randomString(), _group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, _FILE_NAME,
+			ContentTypes.TEXT_PLAIN, _FILE_NAME, StringPool.BLANK,
+			StringPool.BLANK, StringPool.BLANK, new byte[0], null, null,
+			serviceContext);
+
+		_dlAppService.copyFileEntry(
+			fileEntry1.getFileEntryId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			_depotGroup.getGroupId(), _dlFileEntryType.getFileEntryTypeId(),
+			_siteConnectedGroupGroupProvider.
+				getCurrentAndAncestorSiteAndDepotGroupIds(
+					_depotGroup.getGroupId()),
+			ServiceContextTestUtil.getServiceContext(_depotGroup.getGroupId()));
+	}
+
+	private static final String _FILE_NAME = "Title.txt";
+
+	@Inject
+	private static DLAppService _dlAppService;
+
+	@Inject
+	private static DLFileEntryTypeLocalService _dlFileEntryTypeLocalService;
+
+	@Inject
+	private DDMStructureLocalService _ddmStructureLocalService;
+
+	@DeleteAfterTestRun
+	private DLFileEntryType _depotDLFileEntryType;
+
+	private DepotEntry _depotEntry;
+
+	@Inject
+	private DepotEntryGroupRelLocalService _depotEntryGroupRelLocalService;
+
+	@Inject
+	private DepotEntryLocalService _depotEntryLocalService;
+
+	@DeleteAfterTestRun
+	private Group _depotGroup;
+
+	private DLFileEntryType _dlFileEntryType;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private GroupLocalService _groupLocalService;
+
+	@Inject
+	private SiteConnectedGroupGroupProvider _siteConnectedGroupGroupProvider;
+
+}

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenCopyingWithDocumentTypesTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenCopyingWithDocumentTypesTest.java
@@ -102,7 +102,7 @@ public class DLAppServiceWhenCopyingWithDocumentTypesTest
 	}
 
 	@Test
-	public void testCopyFileShouldCopyBasicDocumentTypeWhenCopyDocumentTypesDifferentGroup()
+	public void testCopyFileShouldCopyBasicDocumentTypeWhenCopyDocumentTypesInDifferentGroup()
 		throws Exception {
 
 		ServiceContext serviceContext =
@@ -141,7 +141,7 @@ public class DLAppServiceWhenCopyingWithDocumentTypesTest
 	}
 
 	@Test
-	public void testCopyFileShouldCopyDocumentTypesParentGroup()
+	public void testCopyFileShouldCopyDocumentTypesFromParentGroup()
 		throws Exception {
 
 		ServiceContext serviceContext =
@@ -179,7 +179,7 @@ public class DLAppServiceWhenCopyingWithDocumentTypesTest
 	}
 
 	@Test
-	public void testCopyFileShouldCopyDocumentTypesSameGroup()
+	public void testCopyFileShouldCopyDocumentTypesFromSameGroup()
 		throws Exception {
 
 		ServiceContext serviceContext =
@@ -218,7 +218,7 @@ public class DLAppServiceWhenCopyingWithDocumentTypesTest
 	}
 
 	@Test(expected = InvalidFileEntryTypeException.class)
-	public void testCopyFileThrowsExceptionWhenCopyDocumentTypesDifferentGroup()
+	public void testCopyFileThrowsExceptionWhenCopyDocumentTypesFromDifferentGroup()
 		throws Exception {
 
 		ServiceContext serviceContext =
@@ -251,7 +251,7 @@ public class DLAppServiceWhenCopyingWithDocumentTypesTest
 	}
 
 	@Test
-	public void testCopyFolderShouldCopyBasicDocumentTypeWhenCopyDocumentTypesDifferentGroup()
+	public void testCopyFolderShouldCopyBasicDocumentTypeWhenCopyDocumentTypesFromDifferentGroup()
 		throws Exception {
 
 		ServiceContext serviceContext =
@@ -294,7 +294,7 @@ public class DLAppServiceWhenCopyingWithDocumentTypesTest
 	}
 
 	@Test
-	public void testCopyFolderShouldCopyDocumentTypesParentGroup()
+	public void testCopyFolderShouldCopyDocumentTypesFromParentGroup()
 		throws Exception {
 
 		ServiceContext serviceContext =
@@ -337,7 +337,7 @@ public class DLAppServiceWhenCopyingWithDocumentTypesTest
 	}
 
 	@Test(expected = InvalidFileEntryTypeException.class)
-	public void testCopyFolderThrowsExceptionWhenCopyDocumentTypesDifferentGroup()
+	public void testCopyFolderThrowsExceptionWhenCopyDocumentTypesFromDifferentGroup()
 		throws Exception {
 
 		ServiceContext serviceContext =

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenCopyingWithDocumentTypesTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenCopyingWithDocumentTypesTest.java
@@ -280,7 +280,7 @@ public class DLAppServiceWhenCopyingWithDocumentTypesTest
 			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
 
 		List<FileEntry> fileEntries = _dlAppService.getFileEntries(
-			_childGroup.getGroupId(), folder.getFolderId());
+			targetGroup.getGroupId(), folder.getFolderId());
 
 		Assert.assertEquals(fileEntries.toString(), 1, fileEntries.size());
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenCopyingWithDocumentTypesTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenCopyingWithDocumentTypesTest.java
@@ -1,0 +1,384 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.document.library.app.service.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.document.library.kernel.exception.InvalidFileEntryTypeException;
+import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.document.library.kernel.model.DLFileEntryMetadata;
+import com.liferay.document.library.kernel.model.DLFileEntryType;
+import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
+import com.liferay.document.library.kernel.model.DLFolderConstants;
+import com.liferay.document.library.kernel.service.DLAppService;
+import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalService;
+import com.liferay.document.library.test.util.BaseDLAppTestCase;
+import com.liferay.dynamic.data.mapping.constants.DDMStructureConstants;
+import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
+import com.liferay.dynamic.data.mapping.storage.StorageType;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.repository.model.Folder;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.HashMap;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Alicia García
+ */
+@RunWith(Arquillian.class)
+public class DLAppServiceWhenCopyingWithDocumentTypesTest
+	extends BaseDLAppTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		super.setUp();
+
+		DDMStructure ddmStructure = _ddmStructureLocalService.addStructure(
+			group.getCreatorUserId(), group.getGroupId(),
+			DDMStructureConstants.DEFAULT_PARENT_STRUCTURE_ID,
+			PortalUtil.getClassNameId(DLFileEntryMetadata.class),
+			StringPool.BLANK,
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(),
+				DLFileEntryMetadata.class.getSimpleName()
+			).build(),
+			new HashMap<>(), StringPool.BLANK, StorageType.DEFAULT.toString(),
+			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
+
+		_dlFileEntryType = _dlFileEntryTypeLocalService.addFileEntryType(
+			group.getCreatorUserId(), group.getGroupId(),
+			ddmStructure.getStructureId(), null,
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()
+			).build(),
+			new HashMap<>(),
+			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_SCOPE_DEFAULT,
+			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
+
+		_childGroup = GroupTestUtil.addGroup(group.getGroupId());
+
+		_newParentFolder = _dlAppService.addFolder(
+			null, group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, "New Test Folder",
+			RandomTestUtil.randomString(),
+			ServiceContextTestUtil.getServiceContext(
+				group.getGroupId(), TestPropsValues.getUserId()));
+		_targetParentFolder = _dlAppService.addFolder(
+			null, targetGroup.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, "Target Test Folder",
+			RandomTestUtil.randomString(),
+			ServiceContextTestUtil.getServiceContext(
+				targetGroup.getGroupId(), TestPropsValues.getUserId()));
+	}
+
+	@Test
+	public void testCopyFileShouldCopyBasicDocumentTypeWhenCopyDocumentTypesDifferentGroup()
+		throws Exception {
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(group.getGroupId());
+
+		serviceContext.setAttribute(
+			"fileEntryTypeId", _dlFileEntryType.getFileEntryTypeId());
+
+		FileEntry fileEntry1 = _dlAppService.addFileEntry(
+			RandomTestUtil.randomString(), group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			DLAppServiceTestUtil.FILE_NAME, ContentTypes.TEXT_PLAIN,
+			DLAppServiceTestUtil.FILE_NAME, StringPool.BLANK, StringPool.BLANK,
+			StringPool.BLANK, BaseDLAppTestCase.CONTENT.getBytes(), null, null,
+			serviceContext);
+
+		DLFileEntry dlFileEntry1 = (DLFileEntry)fileEntry1.getModel();
+
+		Assert.assertEquals(
+			_dlFileEntryType.getFileEntryTypeId(),
+			dlFileEntry1.getFileEntryTypeId());
+
+		FileEntry fileEntry2 = _dlAppService.copyFileEntry(
+			fileEntry1.getFileEntryId(), _newParentFolder.getFolderId(),
+			_newParentFolder.getGroupId(),
+			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
+			new long[] {group.getGroupId()},
+			ServiceContextTestUtil.getServiceContext(
+				_newParentFolder.getGroupId()));
+
+		DLFileEntry dlFileEntry2 = (DLFileEntry)fileEntry2.getModel();
+
+		Assert.assertEquals(
+			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
+			dlFileEntry2.getFileEntryTypeId());
+	}
+
+	@Test
+	public void testCopyFileShouldCopyDocumentTypesParentGroup()
+		throws Exception {
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(group.getGroupId());
+
+		serviceContext.setAttribute(
+			"fileEntryTypeId", _dlFileEntryType.getFileEntryTypeId());
+
+		FileEntry fileEntry1 = _dlAppService.addFileEntry(
+			RandomTestUtil.randomString(), group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			DLAppServiceTestUtil.FILE_NAME, ContentTypes.TEXT_PLAIN,
+			DLAppServiceTestUtil.FILE_NAME, StringPool.BLANK, StringPool.BLANK,
+			StringPool.BLANK, BaseDLAppTestCase.CONTENT.getBytes(), null, null,
+			serviceContext);
+
+		DLFileEntry dlFileEntry1 = (DLFileEntry)fileEntry1.getModel();
+
+		Assert.assertEquals(
+			_dlFileEntryType.getFileEntryTypeId(),
+			dlFileEntry1.getFileEntryTypeId());
+
+		FileEntry fileEntry2 = _dlAppService.copyFileEntry(
+			fileEntry1.getFileEntryId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			_childGroup.getGroupId(), _dlFileEntryType.getFileEntryTypeId(),
+			new long[] {group.getGroupId()},
+			ServiceContextTestUtil.getServiceContext(_childGroup.getGroupId()));
+
+		DLFileEntry dlFileEntry2 = (DLFileEntry)fileEntry2.getModel();
+
+		Assert.assertEquals(
+			dlFileEntry1.getFileEntryTypeId(),
+			dlFileEntry2.getFileEntryTypeId());
+	}
+
+	@Test
+	public void testCopyFileShouldCopyDocumentTypesSameGroup()
+		throws Exception {
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(group.getGroupId());
+
+		serviceContext.setAttribute(
+			"fileEntryTypeId", _dlFileEntryType.getFileEntryTypeId());
+
+		FileEntry fileEntry1 = _dlAppService.addFileEntry(
+			RandomTestUtil.randomString(), group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			DLAppServiceTestUtil.FILE_NAME, ContentTypes.TEXT_PLAIN,
+			DLAppServiceTestUtil.FILE_NAME, StringPool.BLANK, StringPool.BLANK,
+			StringPool.BLANK, BaseDLAppTestCase.CONTENT.getBytes(), null, null,
+			serviceContext);
+
+		DLFileEntry dlFileEntry1 = (DLFileEntry)fileEntry1.getModel();
+
+		Assert.assertEquals(
+			_dlFileEntryType.getFileEntryTypeId(),
+			dlFileEntry1.getFileEntryTypeId());
+
+		FileEntry fileEntry2 = _dlAppService.copyFileEntry(
+			fileEntry1.getFileEntryId(), _newParentFolder.getFolderId(),
+			_newParentFolder.getGroupId(),
+			_dlFileEntryType.getFileEntryTypeId(),
+			new long[] {group.getGroupId()},
+			ServiceContextTestUtil.getServiceContext(
+				_newParentFolder.getGroupId()));
+
+		DLFileEntry dlFileEntry2 = (DLFileEntry)fileEntry2.getModel();
+
+		Assert.assertEquals(
+			dlFileEntry1.getFileEntryTypeId(),
+			dlFileEntry2.getFileEntryTypeId());
+	}
+
+	@Test(expected = InvalidFileEntryTypeException.class)
+	public void testCopyFileThrowsExceptionWhenCopyDocumentTypesDifferentGroup()
+		throws Exception {
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(group.getGroupId());
+
+		serviceContext.setAttribute(
+			"fileEntryTypeId", _dlFileEntryType.getFileEntryTypeId());
+
+		FileEntry fileEntry1 = _dlAppService.addFileEntry(
+			RandomTestUtil.randomString(), group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			DLAppServiceTestUtil.FILE_NAME, ContentTypes.TEXT_PLAIN,
+			DLAppServiceTestUtil.FILE_NAME, StringPool.BLANK, StringPool.BLANK,
+			StringPool.BLANK, BaseDLAppTestCase.CONTENT.getBytes(), null, null,
+			serviceContext);
+
+		DLFileEntry dlFileEntry1 = (DLFileEntry)fileEntry1.getModel();
+
+		Assert.assertEquals(
+			_dlFileEntryType.getFileEntryTypeId(),
+			dlFileEntry1.getFileEntryTypeId());
+
+		_dlAppService.copyFileEntry(
+			fileEntry1.getFileEntryId(), _targetParentFolder.getFolderId(),
+			_targetParentFolder.getGroupId(),
+			_dlFileEntryType.getFileEntryTypeId(),
+			new long[] {_targetParentFolder.getGroupId()},
+			ServiceContextTestUtil.getServiceContext(
+				_targetParentFolder.getGroupId()));
+	}
+
+	@Test
+	public void testCopyFolderShouldCopyBasicDocumentTypeWhenCopyDocumentTypesDifferentGroup()
+		throws Exception {
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(group.getGroupId());
+
+		serviceContext.setAttribute(
+			"fileEntryTypeId", _dlFileEntryType.getFileEntryTypeId());
+
+		FileEntry fileEntry1 = _dlAppService.addFileEntry(
+			RandomTestUtil.randomString(), group.getGroupId(),
+			parentFolder.getFolderId(), DLAppServiceTestUtil.FILE_NAME,
+			ContentTypes.TEXT_PLAIN, DLAppServiceTestUtil.FILE_NAME,
+			StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
+			BaseDLAppTestCase.CONTENT.getBytes(), null, null, serviceContext);
+
+		DLFileEntry dlFileEntry1 = (DLFileEntry)fileEntry1.getModel();
+
+		Assert.assertEquals(
+			_dlFileEntryType.getFileEntryTypeId(),
+			dlFileEntry1.getFileEntryTypeId());
+
+		Folder folder = _dlAppService.copyFolder(
+			group.getGroupId(), parentFolder.getFolderId(),
+			targetGroup.getGroupId(), _targetParentFolder.getFolderId(),
+			new HashMap<>(), new long[] {targetGroup.getGroupId()},
+			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
+
+		List<FileEntry> fileEntries = _dlAppService.getFileEntries(
+			_childGroup.getGroupId(), folder.getFolderId());
+
+		Assert.assertEquals(fileEntries.toString(), 1, fileEntries.size());
+
+		FileEntry fileEntry2 = fileEntries.get(0);
+
+		DLFileEntry dlFileEntry2 = (DLFileEntry)fileEntry2.getModel();
+
+		Assert.assertEquals(
+			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
+			dlFileEntry2.getFileEntryTypeId());
+	}
+
+	@Test
+	public void testCopyFolderShouldCopyDocumentTypesParentGroup()
+		throws Exception {
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(group.getGroupId());
+
+		serviceContext.setAttribute(
+			"fileEntryTypeId", _dlFileEntryType.getFileEntryTypeId());
+
+		FileEntry fileEntry1 = _dlAppService.addFileEntry(
+			RandomTestUtil.randomString(), group.getGroupId(),
+			parentFolder.getFolderId(), DLAppServiceTestUtil.FILE_NAME,
+			ContentTypes.TEXT_PLAIN, DLAppServiceTestUtil.FILE_NAME,
+			StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
+			BaseDLAppTestCase.CONTENT.getBytes(), null, null, serviceContext);
+
+		DLFileEntry dlFileEntry1 = (DLFileEntry)fileEntry1.getModel();
+
+		Folder folder = _dlAppService.copyFolder(
+			group.getGroupId(), parentFolder.getFolderId(),
+			_childGroup.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			HashMapBuilder.put(
+				dlFileEntry1.getFileEntryId(), dlFileEntry1.getFileEntryTypeId()
+			).build(),
+			new long[] {group.getGroupId()},
+			ServiceContextTestUtil.getServiceContext(_childGroup.getGroupId()));
+
+		List<FileEntry> fileEntries = _dlAppService.getFileEntries(
+			_childGroup.getGroupId(), folder.getFolderId());
+
+		Assert.assertEquals(fileEntries.toString(), 1, fileEntries.size());
+
+		FileEntry fileEntry2 = fileEntries.get(0);
+
+		DLFileEntry dlFileEntry2 = (DLFileEntry)fileEntry2.getModel();
+
+		Assert.assertEquals(
+			dlFileEntry1.getFileEntryTypeId(),
+			dlFileEntry2.getFileEntryTypeId());
+	}
+
+	@Test(expected = InvalidFileEntryTypeException.class)
+	public void testCopyFolderThrowsExceptionWhenCopyDocumentTypesDifferentGroup()
+		throws Exception {
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(group.getGroupId());
+
+		serviceContext.setAttribute(
+			"fileEntryTypeId", _dlFileEntryType.getFileEntryTypeId());
+
+		FileEntry fileEntry = _dlAppService.addFileEntry(
+			RandomTestUtil.randomString(), group.getGroupId(),
+			parentFolder.getFolderId(), DLAppServiceTestUtil.FILE_NAME,
+			ContentTypes.TEXT_PLAIN, DLAppServiceTestUtil.FILE_NAME,
+			StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
+			BaseDLAppTestCase.CONTENT.getBytes(), null, null, serviceContext);
+
+		DLFileEntry dlFileEntry = (DLFileEntry)fileEntry.getModel();
+
+		_dlAppService.copyFolder(
+			group.getGroupId(), parentFolder.getFolderId(),
+			targetGroup.getGroupId(), _targetParentFolder.getFolderId(),
+			HashMapBuilder.put(
+				dlFileEntry.getFileEntryId(), dlFileEntry.getFileEntryTypeId()
+			).build(),
+			new long[] {targetGroup.getGroupId()},
+			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
+	}
+
+	@Inject
+	private static DLAppService _dlAppService;
+
+	@Inject
+	private static DLFileEntryTypeLocalService _dlFileEntryTypeLocalService;
+
+	@DeleteAfterTestRun
+	private Group _childGroup;
+
+	@Inject
+	private DDMStructureLocalService _ddmStructureLocalService;
+
+	private DLFileEntryType _dlFileEntryType;
+	private Folder _newParentFolder;
+	private Folder _targetParentFolder;
+
+}


### PR DESCRIPTION
- LPS-194118 add test to check the copy between asset library and Site of Document types
- LPS-194118 add test to check the copy between sites of document types contained on files
