### PR TITLE
LPS-195201 Use setURLBackTitle parameter to indicate the title in the knowledge-base-web module

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/compare_versions.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/compare_versions.jsp
@@ -22,6 +22,7 @@ boolean portletTitleBasedNavigation = GetterUtil.getBoolean(portletConfig.getIni
 if (portletTitleBasedNavigation) {
 	portletDisplay.setShowBackIcon(true);
 	portletDisplay.setURLBack(backURL);
+	portletDisplay.setURLBackTitle(kbArticle.getTitle());
 
 	renderResponse.setTitle(LanguageUtil.get(resourceBundle, "compare-versions"));
 }

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_kb_article.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_kb_article.jsp
@@ -11,8 +11,11 @@
 EditKBArticleDisplayContext editKBArticleDisplayContext = new EditKBArticleDisplayContext(kbGroupServiceConfiguration, liferayPortletRequest, liferayPortletResponse, portletConfig);
 
 if (editKBArticleDisplayContext.isPortletTitleBasedNavigation()) {
+	KBArticle kbArticle = editKBArticleDisplayContext.getKBArticle();
+
 	portletDisplay.setShowBackIcon(true);
 	portletDisplay.setURLBack(editKBArticleDisplayContext.getRedirect());
+	portletDisplay.setURLBackTitle(kbArticle.getTitle());
 
 	renderResponse.setTitle(editKBArticleDisplayContext.getHeaderTitle());
 }

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_kb_folder.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_kb_folder.jsp
@@ -26,6 +26,7 @@ long parentResourcePrimKey = ParamUtil.getLong(request, "parentResourcePrimKey",
 
 portletDisplay.setShowBackIcon(true);
 portletDisplay.setURLBack(redirect);
+portletDisplay.setURLBackTitle(portletDisplay.getTitle());
 
 renderResponse.setTitle((kbFolder == null) ? LanguageUtil.get(resourceBundle, "new-folder") : kbFolder.getName());
 %>

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_kb_template.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_kb_template.jsp
@@ -17,6 +17,7 @@ String content = BeanParamUtil.getString(kbTemplate, request, "content");
 
 portletDisplay.setShowBackIcon(true);
 portletDisplay.setURLBack(redirect);
+portletDisplay.setURLBackTitle(portletDisplay.getTitle());
 
 renderResponse.setTitle((kbTemplate == null) ? LanguageUtil.get(request, "new-template") : kbTemplate.getTitle());
 %>

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/error.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/error.jsp
@@ -22,6 +22,7 @@ if (portletTitleBasedNavigation) {
 	}
 
 	portletDisplay.setURLBack(backURL);
+	portletDisplay.setURLBackTitle(portletDisplay.getTitle());
 
 	renderResponse.setTitle(LanguageUtil.get(resourceBundle, "error"));
 }

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/kb_history.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/kb_history.jsp
@@ -23,6 +23,7 @@ boolean portletTitleBasedNavigation = GetterUtil.getBoolean(portletConfig.getIni
 if (portletTitleBasedNavigation) {
 	portletDisplay.setShowBackIcon(true);
 	portletDisplay.setURLBack(redirect);
+	portletDisplay.setURLBackTitle(portletDisplay.getTitle());
 
 	renderResponse.setTitle(kbArticle.getTitle());
 }

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/move_object.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/move_object.jsp
@@ -45,6 +45,7 @@ boolean portletTitleBasedNavigation = GetterUtil.getBoolean(portletConfig.getIni
 if (portletTitleBasedNavigation) {
 	portletDisplay.setShowBackIcon(true);
 	portletDisplay.setURLBack(redirect);
+	portletDisplay.setURLBackTitle(portletDisplay.getTitle());
 
 	renderResponse.setTitle(title);
 }

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/view_kb_article.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/view_kb_article.jsp
@@ -41,6 +41,7 @@ boolean portletTitleBasedNavigation = GetterUtil.getBoolean(portletConfig.getIni
 if (portletTitleBasedNavigation) {
 	portletDisplay.setShowBackIcon(true);
 	portletDisplay.setURLBack(redirect);
+	portletDisplay.setURLBackTitle(portletDisplay.getTitle());
 
 	renderResponse.setTitle(kbArticle.getTitle());
 }

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/view_kb_suggestion.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/view_kb_suggestion.jsp
@@ -12,6 +12,7 @@ ViewKBSuggestionDisplayContext viewKBSuggestionDisplayContext = new ViewKBSugges
 
 portletDisplay.setShowBackIcon(true);
 portletDisplay.setURLBack(viewKBSuggestionDisplayContext.getRedirect());
+portletDisplay.setURLBackTitle(portletDisplay.getTitle());
 
 renderResponse.setTitle(viewKBSuggestionDisplayContext.getKBCommentTitle());
 %>

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/import.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/import.jsp
@@ -12,6 +12,7 @@ long parentKBFolderId = ParamUtil.getLong(request, "parentKBFolderId");
 
 portletDisplay.setShowBackIcon(true);
 portletDisplay.setURLBack(redirect);
+portletDisplay.setURLBackTitle(portletDisplay.getTitle());
 
 renderResponse.setTitle(LanguageUtil.get(resourceBundle, "import"));
 %>

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/view_kb_template.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/view_kb_template.jsp
@@ -18,6 +18,7 @@
 
 	if (Validator.isNotNull(backURL)) {
 		portletDisplay.setURLBack(backURL);
+		portletDisplay.setURLBackTitle(portletDisplay.getTitle());
 	}
 
 	boolean portletTitleBasedNavigation = GetterUtil.getBoolean(portletConfig.getInitParameter("portlet-title-based-navigation"));
@@ -25,6 +26,7 @@
 	if (portletTitleBasedNavigation) {
 		portletDisplay.setShowBackIcon(true);
 		portletDisplay.setURLBack(redirect);
+		portletDisplay.setURLBackTitle(portletDisplay.getTitle());
 
 		renderResponse.setTitle(kbTemplate.getTitle());
 	}


### PR DESCRIPTION
Motivation
=======
The motivation behind this ticket is to use setURLBackTitle method for setting the name of the page when hovering over the back button to give the user more context.

Proposed Solution
========
What I did to solve this problem is to use the new setURLBackTitle in the PortletDisplay class for setting this parameter.

Steps to Verify
========
1. Go to Knowledge Base -> Create a KB and go to the View and Edit views and. check the back title.
2. Repeat the same with folders, sugestions and templates.
<img width="1792" alt="Screenshot 2023-09-05 at 15 37 48" src="https://github.com/liferay-lima/liferay-portal/assets/91207948/8859bd6a-e40f-47d0-aa12-7f9ceb0e95e6">



