### PR TITLE
LPS-170286 | Avoid traduction for folder titles in fragment resources

### DIFF
--- a/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/repository_browser/page.jsp
+++ b/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/repository_browser/page.jsp
@@ -93,6 +93,7 @@ RepositoryBrowserTagDisplayContext repositoryBrowserTagDisplayContext = (Reposit
 							<c:otherwise>
 								<clay:horizontal-card
 									horizontalCard="<%= repositoryBrowserTagDisplayContext.getHorizontalCard(repositoryEntry) %>"
+									translated="<%= false %>"
 								/>
 							</c:otherwise>
 						</c:choose>


### PR DESCRIPTION
**Description:** Add `translated=false` property to the horizontal card to avoid traduction of folder titles in fragment resources. As suggested on https://github.com/liferay-frontend/liferay-portal/pull/3590
![image](https://github.com/liferay/liferay-portal/assets/40394495/d6a1ac16-06fe-4999-b67e-a329f9f2b57b)

**Jira Ticket:** https://liferay.atlassian.net/browse/LPS-170286