### PR TITLE
LPS-195902 When publishing from Staging to Live, the FriendlyUrlEntryLocalization information is not correctly updated

### DIFF
--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/exportimport/data/handler/FriendlyURLEntryStagedModelDataHandler.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/exportimport/data/handler/FriendlyURLEntryStagedModelDataHandler.java
@@ -156,7 +156,7 @@ public class FriendlyURLEntryStagedModelDataHandler
 		}
 		else {
 			importedFriendlyURLEntry = _stagedModelRepository.updateStagedModel(
-				portletDataContext, existingFriendlyURLEntry);
+				portletDataContext, friendlyURLEntry);
 
 			boolean mainEntry = GetterUtil.getBoolean(
 				friendlyURLEntryElement.attributeValue("mainEntry"));

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/exportimport/staged/model/repository/FriendlyURLEntryStagedModelRepository.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/exportimport/staged/model/repository/FriendlyURLEntryStagedModelRepository.java
@@ -162,6 +162,10 @@ public class FriendlyURLEntryStagedModelRepository
 				friendlyURLEntry.getUuid(),
 				portletDataContext.getScopeGroupId());
 
+		if (existingFriendlyURLEntry == null) {
+			return null;
+		}
+
 		return _friendlyURLEntryLocalService.updateFriendlyURLEntry(
 			existingFriendlyURLEntry.getFriendlyURLEntryId(),
 			existingFriendlyURLEntry.getClassNameId(),

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/exportimport/staged/model/repository/FriendlyURLEntryStagedModelRepository.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/exportimport/staged/model/repository/FriendlyURLEntryStagedModelRepository.java
@@ -157,10 +157,16 @@ public class FriendlyURLEntryStagedModelRepository
 			FriendlyURLEntry friendlyURLEntry)
 		throws PortalException {
 
+		FriendlyURLEntry existingFriendlyURLEntry =
+			fetchStagedModelByUuidAndGroupId(
+				friendlyURLEntry.getUuid(),
+				portletDataContext.getScopeGroupId());
+
 		return _friendlyURLEntryLocalService.updateFriendlyURLEntry(
-			friendlyURLEntry.getFriendlyURLEntryId(),
-			friendlyURLEntry.getClassNameId(), friendlyURLEntry.getClassPK(),
-			friendlyURLEntry.getDefaultLanguageId(),
+			existingFriendlyURLEntry.getFriendlyURLEntryId(),
+			existingFriendlyURLEntry.getClassNameId(),
+			existingFriendlyURLEntry.getClassPK(),
+			existingFriendlyURLEntry.getDefaultLanguageId(),
 			_getLocalizationMap(portletDataContext, friendlyURLEntry));
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-195902

When publishing from Staging to Live, the FriendlyUrlEntryLocalization information is not correctly updated, this is only reproduced in case you end having a FriendlyUrlEntryLocalization entry in Live with a different value than the Staging value and you try publishing the content to fix the mismatch information

One cause of the mismatch information between Staging and Live is the bug, as it can cause inconsistent data, but you can end having this wrong information following the steps explained in the ticket description.

I didn't escalated this ticket to the Lima IPT as in the beginning I thought it was Staging issue and when I realized it belonged to Lima, I had already implemented the fix. 

Let me know if you have any question.

