### PR TITLE
[TS] LPS-194926 Also handle Integer values since this is the type when sent across the cluster via the background task

### DIFF
--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/bulk/selection/action/EditCategoriesBulkSelectionAction.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/bulk/selection/action/EditCategoriesBulkSelectionAction.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.util.SetUtil;
 
 import java.io.Serializable;
 
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -68,8 +69,8 @@ public class EditCategoriesBulkSelectionAction
 					long[] newCategoryIds = new long[0];
 
 					if (SetUtil.isNotEmpty(toAddCategoryIdsSet)) {
-						newCategoryIds = _getLongArray(
-							inputMap, "toAddCategoryIds");
+						newCategoryIds = ArrayUtil.toLongArray(
+							toAddCategoryIdsSet);
 					}
 
 					if (MapUtil.getBoolean(inputMap, "append")) {
@@ -97,14 +98,21 @@ public class EditCategoriesBulkSelectionAction
 			});
 	}
 
-	private long[] _getLongArray(Map<String, Serializable> map, String key) {
-		return ArrayUtil.toArray((Long[])map.getOrDefault(key, new Long[0]));
-	}
-
 	private Set<Long> _toLongSet(Map<String, Serializable> map, String key) {
 		try {
-			return SetUtil.fromArray(
-				(Long[])map.getOrDefault(key, new Long[0]));
+			Serializable values = map.get(key);
+
+			if (values instanceof Long[]) {
+				return SetUtil.fromArray((Long[])values);
+			}
+
+			Set<Long> set = new HashSet<>();
+
+			for (Integer value : (Integer[])values) {
+				set.add(value.longValue());
+			}
+
+			return set;
 		}
 		catch (Exception exception) {
 			if (_log.isDebugEnabled()) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-194926

When updating a file's category in a single node setup or on the master node then the IDs are sent as _long_ values as expected. However, when clustering is used and this update occurs on a secondary node the _BackgroundTask_ table is leveraged. When the task is read by the master node the values are interpreted as _Integer_ values. Here is an example of the JSON stored in the _BackgroundTask_ table:

```
"bulkSelectionActionInputMap": {
  "javaClass": "java.util.HashMap",
  "map": {
    "com.liferay.bulk.selection.BulkSelection#assetEntryBulkSelection": true,
    "toAddCategoryIds": [
      33720
    ],
    "toRemoveCategoryIds": [],
    "append": true
  }
}
```

There is nothing to denote that these ID values should be _long_s. Due to this I decided to handle _Integer_ values as well as _Long_ values.

If there are any issues with the changes or there is a better approach please let me know.