### PR TITLE
LPS-196217 Avoid creating unnecessary companies for tests

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-document-library-web-test/src/testIntegration/java/com/liferay/adaptive/media/document/library/web/internal/counter/test/DLAMImageCounterTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-document-library-web-test/src/testIntegration/java/com/liferay/adaptive/media/document/library/web/internal/counter/test/DLAMImageCounterTest.java
@@ -14,8 +14,6 @@ import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.kernel.service.DLTrashLocalService;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.model.GroupConstants;
-import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.portletfilerepository.PortletFileRepository;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.service.CompanyLocalService;
@@ -27,7 +25,7 @@ import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
-import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.test.rule.Inject;
@@ -56,13 +54,7 @@ public class DLAMImageCounterTest {
 
 	@Before
 	public void setUp() throws Exception {
-		_company1 = CompanyTestUtil.addCompany();
-
-		_user1 = UserTestUtil.getAdminUser(_company1.getCompanyId());
-
-		_group1 = GroupTestUtil.addGroup(
-			_company1.getCompanyId(), _user1.getUserId(),
-			GroupConstants.DEFAULT_PARENT_GROUP_ID);
+		_group = GroupTestUtil.addGroup();
 	}
 
 	@Test
@@ -70,20 +62,20 @@ public class DLAMImageCounterTest {
 		throws Exception {
 
 		int count = _amImageCounter.countExpectedAMImageEntries(
-			_company1.getCompanyId());
+			TestPropsValues.getCompanyId());
 
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(
-				_group1, _user1.getUserId());
+				_group, TestPropsValues.getUserId());
 
 		_dlAppLocalService.addFileEntry(
-			null, _user1.getUserId(), _group1.getGroupId(),
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString() + ".jpg", ContentTypes.IMAGE_JPEG,
 			_getImageBytes(), null, null, serviceContext);
 
 		_portletFileRepository.addPortletFileEntry(
-			_group1.getGroupId(), _user1.getUserId(),
+			_group.getGroupId(), TestPropsValues.getUserId(),
 			BlogsEntry.class.getName(), RandomTestUtil.randomLong(),
 			BlogsConstants.SERVICE_NAME,
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, _getImageBytes(),
@@ -92,7 +84,7 @@ public class DLAMImageCounterTest {
 		Assert.assertEquals(
 			count + 1,
 			_amImageCounter.countExpectedAMImageEntries(
-				_company1.getCompanyId()));
+				TestPropsValues.getCompanyId()));
 	}
 
 	@Test
@@ -103,22 +95,22 @@ public class DLAMImageCounterTest {
 
 		try {
 			int company1Count = _amImageCounter.countExpectedAMImageEntries(
-				_company1.getCompanyId());
+				TestPropsValues.getCompanyId());
 			int company2Count = _amImageCounter.countExpectedAMImageEntries(
 				company2.getCompanyId());
 
 			ServiceContext serviceContext =
 				ServiceContextTestUtil.getServiceContext(
-					_group1, _user1.getUserId());
+					_group, TestPropsValues.getUserId());
 
 			_dlAppLocalService.addFileEntry(
-				null, _user1.getUserId(), _group1.getGroupId(),
+				null, TestPropsValues.getUserId(), _group.getGroupId(),
 				DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 				RandomTestUtil.randomString() + ".jpg", ContentTypes.IMAGE_JPEG,
 				_getImageBytes(), null, null, serviceContext);
 
 			_portletFileRepository.addPortletFileEntry(
-				_group1.getGroupId(), _user1.getUserId(),
+				_group.getGroupId(), TestPropsValues.getUserId(),
 				BlogsEntry.class.getName(), RandomTestUtil.randomLong(),
 				BlogsConstants.SERVICE_NAME,
 				DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, _getImageBytes(),
@@ -127,7 +119,7 @@ public class DLAMImageCounterTest {
 			Assert.assertEquals(
 				company1Count + 1,
 				_amImageCounter.countExpectedAMImageEntries(
-					_company1.getCompanyId()));
+					TestPropsValues.getCompanyId()));
 			Assert.assertEquals(
 				company2Count,
 				_amImageCounter.countExpectedAMImageEntries(
@@ -143,14 +135,14 @@ public class DLAMImageCounterTest {
 		throws Exception {
 
 		int count = _amImageCounter.countExpectedAMImageEntries(
-			_company1.getCompanyId());
+			TestPropsValues.getCompanyId());
 
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(
-				_group1, _user1.getUserId());
+				_group, TestPropsValues.getUserId());
 
 		FileEntry fileEntry = _dlAppLocalService.addFileEntry(
-			null, _user1.getUserId(), _group1.getGroupId(),
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString() + ".jpg", ContentTypes.IMAGE_JPEG,
 			_getImageBytes(), null, null, serviceContext);
@@ -158,16 +150,16 @@ public class DLAMImageCounterTest {
 		Assert.assertEquals(
 			count + 1,
 			_amImageCounter.countExpectedAMImageEntries(
-				_company1.getCompanyId()));
+				TestPropsValues.getCompanyId()));
 
 		_dlTrashLocalService.moveFileEntryToTrash(
-			_user1.getUserId(), _group1.getGroupId(),
+			TestPropsValues.getUserId(), _group.getGroupId(),
 			fileEntry.getFileEntryId());
 
 		Assert.assertEquals(
 			count,
 			_amImageCounter.countExpectedAMImageEntries(
-				_company1.getCompanyId()));
+				TestPropsValues.getCompanyId()));
 	}
 
 	@Test
@@ -175,20 +167,20 @@ public class DLAMImageCounterTest {
 		throws Exception {
 
 		int count = _amImageCounter.countExpectedAMImageEntries(
-			_company1.getCompanyId());
+			TestPropsValues.getCompanyId());
 
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(
-				_group1, _user1.getUserId());
+				_group, TestPropsValues.getUserId());
 
 		_dlAppLocalService.addFileEntry(
-			null, _user1.getUserId(), _group1.getGroupId(),
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString() + ".jpg", ContentTypes.IMAGE_JPEG,
 			_getImageBytes(), null, null, serviceContext);
 
 		_dlAppLocalService.addFileEntry(
-			null, _user1.getUserId(), _group1.getGroupId(),
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(),
 			ContentTypes.APPLICATION_OCTET_STREAM,
@@ -197,7 +189,7 @@ public class DLAMImageCounterTest {
 		Assert.assertEquals(
 			count + 1,
 			_amImageCounter.countExpectedAMImageEntries(
-				_company1.getCompanyId()));
+				TestPropsValues.getCompanyId()));
 	}
 
 	private byte[] _getImageBytes() throws Exception {
@@ -211,9 +203,6 @@ public class DLAMImageCounterTest {
 	)
 	private AMImageCounter _amImageCounter;
 
-	@DeleteAfterTestRun
-	private Company _company1;
-
 	@Inject
 	private CompanyLocalService _companyLocalService;
 
@@ -223,11 +212,10 @@ public class DLAMImageCounterTest {
 	@Inject
 	private DLTrashLocalService _dlTrashLocalService;
 
-	private Group _group1;
+	@DeleteAfterTestRun
+	private Group _group;
 
 	@Inject
 	private PortletFileRepository _portletFileRepository;
-
-	private User _user1;
 
 }

--- a/modules/apps/adaptive-media/adaptive-media-document-library-web-test/src/testIntegration/java/com/liferay/adaptive/media/document/library/web/internal/optimizer/test/DLAMImageOptimizerTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-document-library-web-test/src/testIntegration/java/com/liferay/adaptive/media/document/library/web/internal/optimizer/test/DLAMImageOptimizerTest.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.FileUtil;
@@ -37,7 +38,8 @@ import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
-import java.util.Collection;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -62,18 +64,12 @@ public class DLAMImageOptimizerTest {
 
 	@Before
 	public void setUp() throws Exception {
-		_company1 = CompanyTestUtil.addCompany();
-
-		_user1 = UserTestUtil.getAdminUser(_company1.getCompanyId());
-
-		_group1 = GroupTestUtil.addGroup(
-			_company1.getCompanyId(), _user1.getUserId(),
-			GroupConstants.DEFAULT_PARENT_GROUP_ID);
+		_group = GroupTestUtil.addGroup();
 	}
 
 	@After
 	public void tearDown() throws Exception {
-		_deleteAllAMImageConfigurationEntries(_company1.getCompanyId());
+		_deleteAllAMImageConfigurationEntries();
 	}
 
 	@Test
@@ -81,43 +77,43 @@ public class DLAMImageOptimizerTest {
 		throws Exception {
 
 		int count = _amImageCounter.countExpectedAMImageEntries(
-			_company1.getCompanyId());
+			TestPropsValues.getCompanyId());
 
 		_dlAppLocalService.addFileEntry(
-			null, _user1.getUserId(), _group1.getGroupId(),
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString() + ".jpg", ContentTypes.IMAGE_JPEG,
 			_getImageBytes(), null, null,
 			ServiceContextTestUtil.getServiceContext(
-				_group1.getGroupId(), _user1.getUserId()));
+				_group.getGroupId(), TestPropsValues.getUserId()));
 
 		AMImageConfigurationEntry amImageConfigurationEntry1 =
-			_addAMImageConfigurationEntry(_company1.getCompanyId());
+			_addAMImageConfigurationEntry(TestPropsValues.getCompanyId());
 		AMImageConfigurationEntry amImageConfigurationEntry2 =
-			_addAMImageConfigurationEntry(_company1.getCompanyId());
+			_addAMImageConfigurationEntry(TestPropsValues.getCompanyId());
 
 		Assert.assertEquals(
 			0,
 			_amImageEntryLocalService.getAMImageEntriesCount(
-				_company1.getCompanyId(),
+				TestPropsValues.getCompanyId(),
 				amImageConfigurationEntry1.getUUID()));
 		Assert.assertEquals(
 			0,
 			_amImageEntryLocalService.getAMImageEntriesCount(
-				_company1.getCompanyId(),
+				TestPropsValues.getCompanyId(),
 				amImageConfigurationEntry2.getUUID()));
 
-		_amImageOptimizer.optimize(_company1.getCompanyId());
+		_amImageOptimizer.optimize(TestPropsValues.getCompanyId());
 
 		Assert.assertEquals(
 			count + 1,
 			_amImageEntryLocalService.getAMImageEntriesCount(
-				_company1.getCompanyId(),
+				TestPropsValues.getCompanyId(),
 				amImageConfigurationEntry1.getUUID()));
 		Assert.assertEquals(
 			count + 1,
 			_amImageEntryLocalService.getAMImageEntriesCount(
-				_company1.getCompanyId(),
+				TestPropsValues.getCompanyId(),
 				amImageConfigurationEntry2.getUUID()));
 	}
 
@@ -135,17 +131,17 @@ public class DLAMImageOptimizerTest {
 
 		try {
 			int company1Count = _amImageCounter.countExpectedAMImageEntries(
-				_company1.getCompanyId());
+				TestPropsValues.getCompanyId());
 			int company2Count = _amImageCounter.countExpectedAMImageEntries(
 				company2.getCompanyId());
 
 			_dlAppLocalService.addFileEntry(
-				null, _user1.getUserId(), _group1.getGroupId(),
+				null, TestPropsValues.getUserId(), _group.getGroupId(),
 				DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 				RandomTestUtil.randomString() + ".jpg", ContentTypes.IMAGE_JPEG,
 				_getImageBytes(), null, null,
 				ServiceContextTestUtil.getServiceContext(
-					_group1.getGroupId(), _user1.getUserId()));
+					_group.getGroupId(), TestPropsValues.getUserId()));
 			_dlAppLocalService.addFileEntry(
 				null, user2.getUserId(), group2.getGroupId(),
 				DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
@@ -155,14 +151,14 @@ public class DLAMImageOptimizerTest {
 					group2.getGroupId(), user2.getUserId()));
 
 			AMImageConfigurationEntry amImageConfigurationEntry1 =
-				_addAMImageConfigurationEntry(_company1.getCompanyId());
+				_addAMImageConfigurationEntry(TestPropsValues.getCompanyId());
 			AMImageConfigurationEntry amImageConfigurationEntry2 =
 				_addAMImageConfigurationEntry(company2.getCompanyId());
 
 			Assert.assertEquals(
 				0,
 				_amImageEntryLocalService.getAMImageEntriesCount(
-					_company1.getCompanyId(),
+					TestPropsValues.getCompanyId(),
 					amImageConfigurationEntry1.getUUID()));
 			Assert.assertEquals(
 				0,
@@ -170,12 +166,12 @@ public class DLAMImageOptimizerTest {
 					company2.getCompanyId(),
 					amImageConfigurationEntry2.getUUID()));
 
-			_amImageOptimizer.optimize(_company1.getCompanyId());
+			_amImageOptimizer.optimize(TestPropsValues.getCompanyId());
 
 			Assert.assertEquals(
 				company1Count + 1,
 				_amImageEntryLocalService.getAMImageEntriesCount(
-					_company1.getCompanyId(),
+					TestPropsValues.getCompanyId(),
 					amImageConfigurationEntry1.getUUID()));
 			Assert.assertEquals(
 				0,
@@ -188,7 +184,7 @@ public class DLAMImageOptimizerTest {
 			Assert.assertEquals(
 				company1Count + 1,
 				_amImageEntryLocalService.getAMImageEntriesCount(
-					_company1.getCompanyId(),
+					TestPropsValues.getCompanyId(),
 					amImageConfigurationEntry1.getUUID()));
 			Assert.assertEquals(
 				company2Count + 1,
@@ -206,58 +202,60 @@ public class DLAMImageOptimizerTest {
 		throws Exception {
 
 		int count = _amImageCounter.countExpectedAMImageEntries(
-			_company1.getCompanyId());
+			TestPropsValues.getCompanyId());
 
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(
-				_group1.getGroupId(), _user1.getUserId());
+				_group.getGroupId(), TestPropsValues.getUserId());
 
 		_dlAppLocalService.addFileEntry(
-			null, _user1.getUserId(), _group1.getGroupId(),
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString() + ".jpg", ContentTypes.IMAGE_JPEG,
 			_getImageBytes(), null, null, serviceContext);
 
 		FileEntry fileEntry2 = _dlAppLocalService.addFileEntry(
-			null, _user1.getUserId(), _group1.getGroupId(),
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString() + ".jpg", ContentTypes.IMAGE_JPEG,
 			_getImageBytes(), null, null, serviceContext);
 
 		_dlTrashLocalService.moveFileEntryToTrash(
-			_user1.getUserId(), _group1.getGroupId(),
+			TestPropsValues.getUserId(), _group.getGroupId(),
 			fileEntry2.getFileEntryId());
 
 		AMImageConfigurationEntry amImageConfigurationEntry1 =
-			_addAMImageConfigurationEntry(_company1.getCompanyId());
+			_addAMImageConfigurationEntry(TestPropsValues.getCompanyId());
 
 		Assert.assertEquals(
 			0,
 			_amImageEntryLocalService.getAMImageEntriesCount(
-				_company1.getCompanyId(),
+				TestPropsValues.getCompanyId(),
 				amImageConfigurationEntry1.getUUID()));
 
 		_amImageOptimizer.optimize(
-			_company1.getCompanyId(), amImageConfigurationEntry1.getUUID());
+			TestPropsValues.getCompanyId(),
+			amImageConfigurationEntry1.getUUID());
 
 		Assert.assertEquals(
 			count + 1,
 			_amImageEntryLocalService.getAMImageEntriesCount(
-				_company1.getCompanyId(),
+				TestPropsValues.getCompanyId(),
 				amImageConfigurationEntry1.getUUID()));
 
 		_dlTrashLocalService.moveFileEntryFromTrash(
-			_user1.getUserId(), _group1.getGroupId(),
+			TestPropsValues.getUserId(), _group.getGroupId(),
 			fileEntry2.getFileEntryId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, serviceContext);
 
 		_amImageOptimizer.optimize(
-			_company1.getCompanyId(), amImageConfigurationEntry1.getUUID());
+			TestPropsValues.getCompanyId(),
+			amImageConfigurationEntry1.getUUID());
 
 		Assert.assertEquals(
 			count + 2,
 			_amImageEntryLocalService.getAMImageEntriesCount(
-				_company1.getCompanyId(),
+				TestPropsValues.getCompanyId(),
 				amImageConfigurationEntry1.getUUID()));
 	}
 
@@ -266,58 +264,60 @@ public class DLAMImageOptimizerTest {
 		throws Exception {
 
 		int count = _amImageCounter.countExpectedAMImageEntries(
-			_company1.getCompanyId());
+			TestPropsValues.getCompanyId());
 
 		_dlAppLocalService.addFileEntry(
-			null, _user1.getUserId(), _group1.getGroupId(),
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString() + ".jpg", ContentTypes.IMAGE_JPEG,
 			_getImageBytes(), null, null,
 			ServiceContextTestUtil.getServiceContext(
-				_group1.getGroupId(), _user1.getUserId()));
+				_group.getGroupId(), TestPropsValues.getUserId()));
 
 		AMImageConfigurationEntry amImageConfigurationEntry1 =
-			_addAMImageConfigurationEntry(_company1.getCompanyId());
+			_addAMImageConfigurationEntry(TestPropsValues.getCompanyId());
 		AMImageConfigurationEntry amImageConfigurationEntry2 =
-			_addAMImageConfigurationEntry(_company1.getCompanyId());
+			_addAMImageConfigurationEntry(TestPropsValues.getCompanyId());
 
 		Assert.assertEquals(
 			0,
 			_amImageEntryLocalService.getAMImageEntriesCount(
-				_company1.getCompanyId(),
+				TestPropsValues.getCompanyId(),
 				amImageConfigurationEntry1.getUUID()));
 		Assert.assertEquals(
 			0,
 			_amImageEntryLocalService.getAMImageEntriesCount(
-				_company1.getCompanyId(),
+				TestPropsValues.getCompanyId(),
 				amImageConfigurationEntry2.getUUID()));
 
 		_amImageOptimizer.optimize(
-			_company1.getCompanyId(), amImageConfigurationEntry1.getUUID());
+			TestPropsValues.getCompanyId(),
+			amImageConfigurationEntry1.getUUID());
 
 		Assert.assertEquals(
 			count + 1,
 			_amImageEntryLocalService.getAMImageEntriesCount(
-				_company1.getCompanyId(),
+				TestPropsValues.getCompanyId(),
 				amImageConfigurationEntry1.getUUID()));
 		Assert.assertEquals(
 			0,
 			_amImageEntryLocalService.getAMImageEntriesCount(
-				_company1.getCompanyId(),
+				TestPropsValues.getCompanyId(),
 				amImageConfigurationEntry2.getUUID()));
 
 		_amImageOptimizer.optimize(
-			_company1.getCompanyId(), amImageConfigurationEntry2.getUUID());
+			TestPropsValues.getCompanyId(),
+			amImageConfigurationEntry2.getUUID());
 
 		Assert.assertEquals(
 			count + 1,
 			_amImageEntryLocalService.getAMImageEntriesCount(
-				_company1.getCompanyId(),
+				TestPropsValues.getCompanyId(),
 				amImageConfigurationEntry1.getUUID()));
 		Assert.assertEquals(
 			count + 1,
 			_amImageEntryLocalService.getAMImageEntriesCount(
-				_company1.getCompanyId(),
+				TestPropsValues.getCompanyId(),
 				amImageConfigurationEntry2.getUUID()));
 	}
 
@@ -326,32 +326,33 @@ public class DLAMImageOptimizerTest {
 		throws Exception {
 
 		int count = _amImageCounter.countExpectedAMImageEntries(
-			_company1.getCompanyId());
+			TestPropsValues.getCompanyId());
 
 		AMImageConfigurationEntry amImageConfigurationEntry1 =
-			_addAMImageConfigurationEntry(_company1.getCompanyId());
+			_addAMImageConfigurationEntry(TestPropsValues.getCompanyId());
 
 		Assert.assertEquals(
 			0,
 			_amImageEntryLocalService.getAMImageEntriesCount(
-				_company1.getCompanyId(),
+				TestPropsValues.getCompanyId(),
 				amImageConfigurationEntry1.getUUID()));
 
 		_amImageOptimizer.optimize(
-			_company1.getCompanyId(), amImageConfigurationEntry1.getUUID());
+			TestPropsValues.getCompanyId(),
+			amImageConfigurationEntry1.getUUID());
 
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(
-				_group1.getGroupId(), _user1.getUserId());
+				_group.getGroupId(), TestPropsValues.getUserId());
 
 		_dlAppLocalService.addFileEntry(
-			null, _user1.getUserId(), _group1.getGroupId(),
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString() + ".jpg", ContentTypes.IMAGE_JPEG,
 			_getImageBytes(), null, null, serviceContext);
 
 		_dlAppLocalService.addFileEntry(
-			null, _user1.getUserId(), _group1.getGroupId(),
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(),
 			ContentTypes.APPLICATION_OCTET_STREAM,
@@ -360,7 +361,7 @@ public class DLAMImageOptimizerTest {
 		Assert.assertEquals(
 			count + 1,
 			_amImageEntryLocalService.getAMImageEntriesCount(
-				_company1.getCompanyId(),
+				TestPropsValues.getCompanyId(),
 				amImageConfigurationEntry1.getUUID()));
 	}
 
@@ -370,28 +371,28 @@ public class DLAMImageOptimizerTest {
 
 		String amImageConfigurationEntry1Name = RandomTestUtil.randomString();
 
-		return _amImageConfigurationHelper.addAMImageConfigurationEntry(
-			companyId, amImageConfigurationEntry1Name, StringPool.BLANK,
-			amImageConfigurationEntry1Name,
-			HashMapBuilder.put(
-				"max-height", String.valueOf(RandomTestUtil.randomLong())
-			).put(
-				"max-width", String.valueOf(RandomTestUtil.randomLong())
-			).build());
+		AMImageConfigurationEntry amImageConfigurationEntry =
+			_amImageConfigurationHelper.addAMImageConfigurationEntry(
+				companyId, amImageConfigurationEntry1Name, StringPool.BLANK,
+				amImageConfigurationEntry1Name,
+				HashMapBuilder.put(
+					"max-height", String.valueOf(RandomTestUtil.randomLong())
+				).put(
+					"max-width", String.valueOf(RandomTestUtil.randomLong())
+				).build());
+
+		_amImageConfigurationEntries.add(amImageConfigurationEntry);
+
+		return amImageConfigurationEntry;
 	}
 
-	private void _deleteAllAMImageConfigurationEntries(long companyId)
-		throws Exception {
-
-		Collection<AMImageConfigurationEntry> amImageConfigurationEntries =
-			_amImageConfigurationHelper.getAMImageConfigurationEntries(
-				companyId, amImageConfigurationEntry -> true);
-
+	private void _deleteAllAMImageConfigurationEntries() throws Exception {
 		for (AMImageConfigurationEntry amImageConfigurationEntry :
-				amImageConfigurationEntries) {
+				_amImageConfigurationEntries) {
 
 			_amImageConfigurationHelper.forceDeleteAMImageConfigurationEntry(
-				companyId, amImageConfigurationEntry.getUUID());
+				TestPropsValues.getCompanyId(),
+				amImageConfigurationEntry.getUUID());
 		}
 	}
 
@@ -399,6 +400,9 @@ public class DLAMImageOptimizerTest {
 		return FileUtil.getBytes(
 			DLAMImageOptimizerTest.class, "dependencies/image.jpg");
 	}
+
+	private final List<AMImageConfigurationEntry> _amImageConfigurationEntries =
+		new ArrayList<>();
 
 	@Inject
 	private AMImageConfigurationHelper _amImageConfigurationHelper;
@@ -418,9 +422,6 @@ public class DLAMImageOptimizerTest {
 	)
 	private AMImageOptimizer _amImageOptimizer;
 
-	@DeleteAfterTestRun
-	private Company _company1;
-
 	@Inject
 	private CompanyLocalService _companyLocalService;
 
@@ -430,7 +431,7 @@ public class DLAMImageOptimizerTest {
 	@Inject
 	private DLTrashLocalService _dlTrashLocalService;
 
-	private Group _group1;
-	private User _user1;
+	@DeleteAfterTestRun
+	private Group _group;
 
 }

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/servlet/taglib/test/DepotBreadcrumbEntryContributorTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/servlet/taglib/test/DepotBreadcrumbEntryContributorTest.java
@@ -9,17 +9,16 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.portal.kernel.language.Language;
-import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.servlet.PortletServlet;
 import com.liferay.portal.kernel.servlet.taglib.ui.BreadcrumbEntry;
 import com.liferay.portal.kernel.servlet.taglib.ui.BreadcrumbEntryContributorUtil;
 import com.liferay.portal.kernel.test.portlet.MockLiferayResourceRequest;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
-import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
@@ -63,8 +62,6 @@ public class DepotBreadcrumbEntryContributorTest {
 	public void setUp() throws Exception {
 		PermissionThreadLocal.setPermissionChecker(
 			PermissionCheckerFactoryUtil.create(TestPropsValues.getUser()));
-
-		_company = CompanyTestUtil.addCompany();
 	}
 
 	@Test
@@ -232,7 +229,8 @@ public class DepotBreadcrumbEntryContributorTest {
 	private ThemeDisplay _getThemeDisplay(Group group) throws Exception {
 		ThemeDisplay themeDisplay = new ThemeDisplay();
 
-		themeDisplay.setCompany(_company);
+		themeDisplay.setCompany(
+			_companyLocalService.fetchCompany(TestPropsValues.getCompanyId()));
 		themeDisplay.setLanguageId(group.getDefaultLanguageId());
 		themeDisplay.setPermissionChecker(
 			PermissionThreadLocal.getPermissionChecker());
@@ -243,8 +241,8 @@ public class DepotBreadcrumbEntryContributorTest {
 		return themeDisplay;
 	}
 
-	@DeleteAfterTestRun
-	private Company _company;
+	@Inject
+	private CompanyLocalService _companyLocalService;
 
 	@DeleteAfterTestRun
 	private final List<DepotEntry> _depotEntries = new ArrayList<>();

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryMetadataLocalServiceTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryMetadataLocalServiceTest.java
@@ -28,7 +28,6 @@ import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
 import com.liferay.dynamic.data.mapping.test.util.DDMFormTestUtil;
 import com.liferay.dynamic.data.mapping.test.util.DDMStructureTestUtil;
-import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.GroupLocalService;
@@ -36,7 +35,6 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.constants.TestDataConstants;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
-import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
@@ -80,8 +78,6 @@ public class DLFileEntryMetadataLocalServiceTest {
 
 	@Before
 	public void setUp() throws Exception {
-		_company = CompanyTestUtil.addCompany();
-
 		_group = GroupTestUtil.addGroup();
 
 		User user = TestPropsValues.getUser();
@@ -194,7 +190,7 @@ public class DLFileEntryMetadataLocalServiceTest {
 			_ddmStructure = _ddmStructureLocalService.fetchStructure(
 				_ddmStructure.getStructureId());
 
-			_ddmStructure.setCompanyId(_company.getCompanyId());
+			_ddmStructure.setCompanyId(0);
 
 			_ddmStructure = _ddmStructureLocalService.updateDDMStructure(
 				_ddmStructure);
@@ -322,9 +318,6 @@ public class DLFileEntryMetadataLocalServiceTest {
 
 	@Inject
 	private static GroupLocalService _groupLocalService;
-
-	@DeleteAfterTestRun
-	private Company _company;
 
 	@Inject(filter = "ddm.form.deserializer.type=xsd")
 	private DDMFormDeserializer _ddmFormDeserializer;

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/verify/test/DLServiceVerifyProcessTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/verify/test/DLServiceVerifyProcessTest.java
@@ -36,7 +36,6 @@ import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.service.DDMStructureLocalServiceUtil;
 import com.liferay.dynamic.data.mapping.test.util.DDMFormTestUtil;
 import com.liferay.dynamic.data.mapping.test.util.DDMStructureTestUtil;
-import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.repository.model.FileEntry;
@@ -46,7 +45,6 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.constants.TestDataConstants;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
-import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
@@ -96,8 +94,6 @@ public class DLServiceVerifyProcessTest extends BaseVerifyProcessTestCase {
 	public void setUp() throws Exception {
 		super.setUp();
 
-		_company = CompanyTestUtil.addCompany();
-
 		_group = GroupTestUtil.addGroup();
 	}
 
@@ -114,7 +110,7 @@ public class DLServiceVerifyProcessTest extends BaseVerifyProcessTestCase {
 
 		DDMStructure ddmStructure = ddmStructures.get(0);
 
-		ddmStructure.setCompanyId(_company.getCompanyId());
+		ddmStructure.setCompanyId(0);
 
 		try {
 			ddmStructure = DDMStructureLocalServiceUtil.updateDDMStructure(
@@ -500,9 +496,6 @@ public class DLServiceVerifyProcessTest extends BaseVerifyProcessTestCase {
 		type = VerifyProcess.class
 	)
 	private static VerifyProcess _verifyProcess;
-
-	@DeleteAfterTestRun
-	private Company _company;
 
 	@Inject(filter = "ddm.form.deserializer.type=xsd")
 	private DDMFormDeserializer _ddmFormDeserializer;

--- a/modules/apps/mentions/mentions-web-test/src/testIntegration/java/com/liferay/mentions/web/test/MentionsPortletTest.java
+++ b/modules/apps/mentions/mentions-web-test/src/testIntegration/java/com/liferay/mentions/web/test/MentionsPortletTest.java
@@ -11,21 +11,18 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
-import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
-import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.portlet.MockLiferayResourceRequest;
 import com.liferay.portal.kernel.test.portlet.MockLiferayResourceResponse;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
-import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
@@ -40,15 +37,10 @@ import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import javax.portlet.Portlet;
 
-import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -69,87 +61,87 @@ public class MentionsPortletTest {
 			new LiferayIntegrationTestRule(),
 			PermissionCheckerMethodTestRule.INSTANCE);
 
-	@BeforeClass
-	public static void setUpClass() throws Exception {
-		_company = CompanyTestUtil.addCompany();
-
-		_originalName = PrincipalThreadLocal.getName();
-
-		PrincipalThreadLocal.setName(TestPropsValues.getUserId());
-	}
-
-	@AfterClass
-	public static void tearDownClass() throws Exception {
-		_companyLocalService.deleteCompany(_company);
-
-		PrincipalThreadLocal.setName(_originalName);
-	}
-
 	@Before
 	public void setUp() throws Exception {
-		User adminUser = UserTestUtil.getAdminUser(_company.getCompanyId());
+		_group = GroupTestUtil.addGroup();
 
-		_group = GroupTestUtil.addGroup(
-			_company.getCompanyId(), adminUser.getUserId(),
-			GroupConstants.DEFAULT_PARENT_GROUP_ID);
-
-		_layout = _addLayout(_group.getGroupId(), adminUser.getUserId());
+		_layout = _addLayout(_group.getGroupId(), TestPropsValues.getUserId());
 	}
 
 	@Test
 	public void testServletResponseWithoutQuery() throws Exception {
-		_addUser("example");
+		User user = _addUser("example");
 
-		JSONArray jsonArray = _getServletResponseJSONArray(null);
+		try {
+			JSONArray jsonArray = _getServletResponseJSONArray(null);
 
-		Assert.assertEquals(1, jsonArray.length());
+			Assert.assertEquals(1, jsonArray.length());
 
-		JSONObject jsonObject = jsonArray.getJSONObject(0);
+			JSONObject jsonObject = jsonArray.getJSONObject(0);
 
-		Assert.assertEquals("example", jsonObject.getString("screenName"));
+			Assert.assertEquals("example", jsonObject.getString("screenName"));
+		}
+		finally {
+			_userLocalService.deleteUser(user);
+		}
 	}
 
 	@Test
 	public void testServletResponseWithQueryWithFullScreenName()
 		throws Exception {
 
-		_addUser("example");
+		User user = _addUser("example");
 
-		JSONArray jsonArray = _getServletResponseJSONArray("example");
+		try {
+			JSONArray jsonArray = _getServletResponseJSONArray("example");
 
-		Assert.assertEquals(1, jsonArray.length());
+			Assert.assertEquals(1, jsonArray.length());
 
-		JSONObject jsonObject = jsonArray.getJSONObject(0);
+			JSONObject jsonObject = jsonArray.getJSONObject(0);
 
-		Assert.assertEquals("example", jsonObject.getString("screenName"));
+			Assert.assertEquals("example", jsonObject.getString("screenName"));
+		}
+		finally {
+			_userLocalService.deleteUser(user);
+		}
 	}
 
 	@Test
 	public void testServletResponseWithQueryWithPartialScreenName()
 		throws Exception {
 
-		_addUser("example");
+		User user = _addUser("example");
 
-		JSONArray jsonArray = _getServletResponseJSONArray("exa");
+		try {
+			JSONArray jsonArray = _getServletResponseJSONArray("exa");
 
-		Assert.assertEquals(1, jsonArray.length());
+			Assert.assertEquals(1, jsonArray.length());
 
-		JSONObject jsonObject = jsonArray.getJSONObject(0);
+			JSONObject jsonObject = jsonArray.getJSONObject(0);
 
-		Assert.assertEquals("example", jsonObject.getString("screenName"));
+			Assert.assertEquals("example", jsonObject.getString("screenName"));
+		}
+		finally {
+			_userLocalService.deleteUser(user);
+		}
 	}
 
 	@Test
 	public void testServletResponseWithQueryWithWildard() throws Exception {
-		_addUser("example");
+		User user = _addUser("example");
 
-		JSONArray jsonArray = _getServletResponseJSONArray("");
+		try {
+			JSONArray jsonArray = _getServletResponseJSONArray("");
 
-		Assert.assertEquals(1, jsonArray.length());
+			Assert.assertEquals(1, jsonArray.length());
 
-		JSONObject jsonObject = jsonArray.getJSONObject(0);
+			JSONObject jsonObject = jsonArray.getJSONObject(0);
 
-		Assert.assertEquals("example", jsonObject.getString("screenName"));
+			Assert.assertEquals("example", jsonObject.getString("screenName"));
+		}
+		finally {
+			_userLocalService.deleteUser(user);
+		}
 	}
 
 	@Test
@@ -174,16 +166,13 @@ public class MentionsPortletTest {
 			ServiceContextTestUtil.getServiceContext());
 	}
 
-	private void _addUser(String screenName) throws Exception {
-		User adminUser = UserTestUtil.getAdminUser(_company.getCompanyId());
-
-		_users.add(
-			UserTestUtil.addUser(
-				_company.getCompanyId(), adminUser.getUserId(), screenName,
-				LocaleUtil.getDefault(), RandomTestUtil.randomString(),
-				RandomTestUtil.randomString(), new long[] {_group.getGroupId()},
-				ServiceContextTestUtil.getServiceContext(
-					_company.getGroupId())));
+	private User _addUser(String screenName) throws Exception {
+		return UserTestUtil.addUser(
+			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			screenName, LocaleUtil.getDefault(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), new long[] {_group.getGroupId()},
+			ServiceContextTestUtil.getServiceContext(
+				TestPropsValues.getGroupId()));
 	}
 
 	private MockLiferayResourceRequest _getMockLiferayResourceRequest(
@@ -233,22 +222,18 @@ public class MentionsPortletTest {
 	private ThemeDisplay _getThemeDisplay() throws Exception {
 		ThemeDisplay themeDisplay = new ThemeDisplay();
 
-		themeDisplay.setCompany(_company);
+		themeDisplay.setCompany(
+			_companyLocalService.fetchCompany(TestPropsValues.getCompanyId()));
 		themeDisplay.setLayout(_layout);
 		themeDisplay.setPpid(MentionsPortletKeys.MENTIONS);
 		themeDisplay.setSiteGroupId(_group.getGroupId());
-		themeDisplay.setUser(
-			UserTestUtil.getAdminUser(_company.getCompanyId()));
+		themeDisplay.setUser(TestPropsValues.getUser());
 
 		return themeDisplay;
 	}
 
-	private static Company _company;
-
 	@Inject
-	private static CompanyLocalService _companyLocalService;
-
-	private static String _originalName;
+	private CompanyLocalService _companyLocalService;
 
 	@DeleteAfterTestRun
 	private Group _group;
@@ -261,7 +246,7 @@ public class MentionsPortletTest {
 	@Inject(filter = "javax.portlet.name=" + MentionsPortletKeys.MENTIONS)
 	private Portlet _portlet;
 
-	@DeleteAfterTestRun
-	private final List<User> _users = new ArrayList<>();
+	@Inject
+	private UserLocalService _userLocalService;
 
 }

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/search/test/MBCategoryIndexerTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/search/test/MBCategoryIndexerTest.java
@@ -9,21 +9,18 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.message.boards.model.MBCategory;
 import com.liferay.message.boards.service.MBCategoryLocalServiceUtil;
 import com.liferay.petra.string.StringBundler;
-import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
-import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistryUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
-import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
-import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.search.test.util.SearchTestRule;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LogEntry;
@@ -58,10 +55,6 @@ public class MBCategoryIndexerTest {
 	@Before
 	public void setUp() throws Exception {
 		_indexer = IndexerRegistryUtil.getIndexer(MBCategory.class);
-
-		_company = CompanyTestUtil.addCompany();
-
-		_user = UserTestUtil.getAdminUser(_company.getCompanyId());
 	}
 
 	@Test
@@ -71,12 +64,12 @@ public class MBCategoryIndexerTest {
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
 				_LOG_NAME, LoggerTestUtil.DEBUG)) {
 
-			GroupTestUtil.addGroup(
-				_company.getCompanyId(), _user.getUserId(),
+			_group = GroupTestUtil.addGroup(
+				TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
 				GroupConstants.DEFAULT_PARENT_GROUP_ID);
 
 			_indexer.reindex(
-				new String[] {String.valueOf(_company.getCompanyId())});
+				new String[] {String.valueOf(TestPropsValues.getCompanyId())});
 
 			List<LogEntry> logEntries = logCapture.getLogEntries();
 
@@ -89,18 +82,18 @@ public class MBCategoryIndexerTest {
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
 				_LOG_NAME, LoggerTestUtil.DEBUG)) {
 
-			Group group = GroupTestUtil.addGroup(
-				_company.getCompanyId(), _user.getUserId(),
+			_group = GroupTestUtil.addGroup(
+				TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
 				GroupConstants.DEFAULT_PARENT_GROUP_ID);
 
 			MBCategory mbCategory = MBCategoryLocalServiceUtil.addCategory(
-				_user.getUserId(), 0, RandomTestUtil.randomString(),
+				TestPropsValues.getUserId(), 0, RandomTestUtil.randomString(),
 				RandomTestUtil.randomString(),
 				ServiceContextTestUtil.getServiceContext(
-					group.getGroupId(), _user.getUserId()));
+					_group.getGroupId(), TestPropsValues.getUserId()));
 
 			_indexer.reindex(
-				new String[] {String.valueOf(_company.getCompanyId())});
+				new String[] {String.valueOf(TestPropsValues.getCompanyId())});
 
 			List<LogEntry> logEntries = logCapture.getLogEntries();
 
@@ -112,7 +105,7 @@ public class MBCategoryIndexerTest {
 				StringBundler.concat(
 					"Reindexing message boards categories for category ID ",
 					mbCategory.getCategoryId(), " and group ID ",
-					group.getGroupId()),
+					_group.getGroupId()),
 				logEntry.getMessage());
 		}
 	}
@@ -125,9 +118,8 @@ public class MBCategoryIndexerTest {
 			"contributor.MBCategoryModelIndexerWriterContributor";
 
 	@DeleteAfterTestRun
-	private Company _company;
+	private Group _group;
 
 	private Indexer<MBCategory> _indexer;
-	private User _user;
 
 }

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/search/test/MBMessageIndexerTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/search/test/MBMessageIndexerTest.java
@@ -12,10 +12,8 @@ import com.liferay.message.boards.model.MBMessage;
 import com.liferay.message.boards.service.MBMessageLocalServiceUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.comment.CommentManagerUtil;
-import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
-import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistryUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -23,11 +21,10 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
-import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
-import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.ObjectValuePair;
 import com.liferay.portal.search.test.util.SearchTestRule;
 import com.liferay.portal.test.log.LogCapture;
@@ -66,10 +63,6 @@ public class MBMessageIndexerTest {
 	@Before
 	public void setUp() throws Exception {
 		_indexer = IndexerRegistryUtil.getIndexer(MBMessage.class);
-
-		_company1 = CompanyTestUtil.addCompany();
-
-		_user1 = UserTestUtil.getAdminUser(_company1.getCompanyId());
 	}
 
 	@Test
@@ -77,12 +70,12 @@ public class MBMessageIndexerTest {
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
 				_LOG_NAME, LoggerTestUtil.DEBUG)) {
 
-			GroupTestUtil.addGroup(
-				_company1.getCompanyId(), _user1.getUserId(),
+			_group = GroupTestUtil.addGroup(
+				TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
 				GroupConstants.DEFAULT_PARENT_GROUP_ID);
 
 			_indexer.reindex(
-				new String[] {String.valueOf(_company1.getCompanyId())});
+				new String[] {String.valueOf(TestPropsValues.getCompanyId())});
 
 			List<LogEntry> logEntries = logCapture.getLogEntries();
 
@@ -95,21 +88,21 @@ public class MBMessageIndexerTest {
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
 				_LOG_NAME, LoggerTestUtil.DEBUG)) {
 
-			Group group = GroupTestUtil.addGroup(
-				_company1.getCompanyId(), _user1.getUserId(),
+			_group = GroupTestUtil.addGroup(
+				TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
 				GroupConstants.DEFAULT_PARENT_GROUP_ID);
 
 			ServiceContext serviceContext =
 				ServiceContextTestUtil.getServiceContext(
-					group.getGroupId(), _user1.getUserId());
+					_group.getGroupId(), TestPropsValues.getUserId());
 
 			CommentManagerUtil.addComment(
-				_user1.getUserId(), group.getGroupId(),
+				TestPropsValues.getUserId(), _group.getGroupId(),
 				RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
 				RandomTestUtil.randomString(), s -> serviceContext);
 
 			_indexer.reindex(
-				new String[] {String.valueOf(_company1.getCompanyId())});
+				new String[] {String.valueOf(TestPropsValues.getCompanyId())});
 
 			List<LogEntry> logEntries = logCapture.getLogEntries();
 
@@ -121,7 +114,7 @@ public class MBMessageIndexerTest {
 				StringBundler.concat(
 					"Reindexing message boards messages for message board ",
 					"category ID ", MBCategoryConstants.DISCUSSION_CATEGORY_ID,
-					" and group ID ", group.getGroupId()),
+					" and group ID ", _group.getGroupId()),
 				logEntry.getMessage());
 		}
 	}
@@ -131,20 +124,20 @@ public class MBMessageIndexerTest {
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
 				_LOG_NAME, LoggerTestUtil.DEBUG)) {
 
-			Group group = GroupTestUtil.addGroup(
-				_company1.getCompanyId(), _user1.getUserId(),
+			_group = GroupTestUtil.addGroup(
+				TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
 				GroupConstants.DEFAULT_PARENT_GROUP_ID);
 
 			ServiceContext serviceContext =
 				ServiceContextTestUtil.getServiceContext(
-					group.getGroupId(), _user1.getUserId());
+					_group.getGroupId(), TestPropsValues.getUserId());
 
 			List<ObjectValuePair<String, InputStream>> inputStreamOVPs =
 				Collections.emptyList();
 
 			MBMessageLocalServiceUtil.addMessage(
-				_user1.getUserId(), RandomTestUtil.randomString(),
-				group.getGroupId(),
+				TestPropsValues.getUserId(), RandomTestUtil.randomString(),
+				_group.getGroupId(),
 				MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID, 0,
 				MBMessageConstants.DEFAULT_PARENT_MESSAGE_ID,
 				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
@@ -152,7 +145,7 @@ public class MBMessageIndexerTest {
 				false, serviceContext);
 
 			_indexer.reindex(
-				new String[] {String.valueOf(_company1.getCompanyId())});
+				new String[] {String.valueOf(TestPropsValues.getCompanyId())});
 
 			List<LogEntry> logEntries = logCapture.getLogEntries();
 
@@ -165,7 +158,7 @@ public class MBMessageIndexerTest {
 					"Reindexing message boards messages for message board ",
 					"category ID ",
 					MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
-					" and group ID ", group.getGroupId()),
+					" and group ID ", _group.getGroupId()),
 				logEntry.getMessage());
 		}
 	}
@@ -178,9 +171,8 @@ public class MBMessageIndexerTest {
 			"contributor.MBMessageModelIndexerWriterContributor";
 
 	@DeleteAfterTestRun
-	private Company _company1;
+	private Group _group;
 
 	private Indexer<MBMessage> _indexer;
-	private User _user1;
 
 }

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/search/test/MBThreadIndexerTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/search/test/MBThreadIndexerTest.java
@@ -12,10 +12,8 @@ import com.liferay.message.boards.model.MBThread;
 import com.liferay.message.boards.service.MBMessageLocalServiceUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.comment.CommentManagerUtil;
-import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
-import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistryUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -23,11 +21,10 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
-import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
-import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.ObjectValuePair;
 import com.liferay.portal.search.test.util.SearchTestRule;
 import com.liferay.portal.test.log.LogCapture;
@@ -66,10 +63,6 @@ public class MBThreadIndexerTest {
 	@Before
 	public void setUp() throws Exception {
 		_indexer = IndexerRegistryUtil.getIndexer(MBThread.class);
-
-		_company1 = CompanyTestUtil.addCompany();
-
-		_user1 = UserTestUtil.getAdminUser(_company1.getCompanyId());
 	}
 
 	@Test
@@ -77,12 +70,12 @@ public class MBThreadIndexerTest {
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
 				_LOG_NAME, LoggerTestUtil.DEBUG)) {
 
-			GroupTestUtil.addGroup(
-				_company1.getCompanyId(), _user1.getUserId(),
+			_group = GroupTestUtil.addGroup(
+				TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
 				GroupConstants.DEFAULT_PARENT_GROUP_ID);
 
 			_indexer.reindex(
-				new String[] {String.valueOf(_company1.getCompanyId())});
+				new String[] {String.valueOf(TestPropsValues.getCompanyId())});
 
 			List<LogEntry> logEntries = logCapture.getLogEntries();
 
@@ -95,21 +88,21 @@ public class MBThreadIndexerTest {
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
 				_LOG_NAME, LoggerTestUtil.DEBUG)) {
 
-			Group group = GroupTestUtil.addGroup(
-				_company1.getCompanyId(), _user1.getUserId(),
+			_group = GroupTestUtil.addGroup(
+				TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
 				GroupConstants.DEFAULT_PARENT_GROUP_ID);
 
 			ServiceContext serviceContext =
 				ServiceContextTestUtil.getServiceContext(
-					group.getGroupId(), _user1.getUserId());
+					_group.getGroupId(), TestPropsValues.getUserId());
 
 			CommentManagerUtil.addComment(
-				_user1.getUserId(), group.getGroupId(),
+				TestPropsValues.getUserId(), _group.getGroupId(),
 				RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
 				RandomTestUtil.randomString(), s -> serviceContext);
 
 			_indexer.reindex(
-				new String[] {String.valueOf(_company1.getCompanyId())});
+				new String[] {String.valueOf(TestPropsValues.getCompanyId())});
 
 			List<LogEntry> logEntries = logCapture.getLogEntries();
 
@@ -121,7 +114,7 @@ public class MBThreadIndexerTest {
 				StringBundler.concat(
 					"Reindexing message boards threads for message board ",
 					"category ID ", MBCategoryConstants.DISCUSSION_CATEGORY_ID,
-					" and group ID ", group.getGroupId()),
+					" and group ID ", _group.getGroupId()),
 				logEntry.getMessage());
 		}
 	}
@@ -131,20 +124,20 @@ public class MBThreadIndexerTest {
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
 				_LOG_NAME, LoggerTestUtil.DEBUG)) {
 
-			Group group = GroupTestUtil.addGroup(
-				_company1.getCompanyId(), _user1.getUserId(),
+			_group = GroupTestUtil.addGroup(
+				TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
 				GroupConstants.DEFAULT_PARENT_GROUP_ID);
 
 			ServiceContext serviceContext =
 				ServiceContextTestUtil.getServiceContext(
-					group.getGroupId(), _user1.getUserId());
+					_group.getGroupId(), TestPropsValues.getUserId());
 
 			List<ObjectValuePair<String, InputStream>> inputStreamOVPs =
 				Collections.emptyList();
 
 			MBMessageLocalServiceUtil.addMessage(
-				_user1.getUserId(), RandomTestUtil.randomString(),
-				group.getGroupId(),
+				TestPropsValues.getUserId(), RandomTestUtil.randomString(),
+				_group.getGroupId(),
 				MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID, 0,
 				MBMessageConstants.DEFAULT_PARENT_MESSAGE_ID,
 				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
@@ -152,7 +145,7 @@ public class MBThreadIndexerTest {
 				false, serviceContext);
 
 			_indexer.reindex(
-				new String[] {String.valueOf(_company1.getCompanyId())});
+				new String[] {String.valueOf(TestPropsValues.getCompanyId())});
 
 			List<LogEntry> logEntries = logCapture.getLogEntries();
 
@@ -165,7 +158,7 @@ public class MBThreadIndexerTest {
 					"Reindexing message boards threads for message board ",
 					"category ID ",
 					MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
-					" and group ID ", group.getGroupId()),
+					" and group ID ", _group.getGroupId()),
 				logEntry.getMessage());
 		}
 	}
@@ -178,9 +171,8 @@ public class MBThreadIndexerTest {
 			"contributor.MBThreadModelIndexerWriterContributor";
 
 	@DeleteAfterTestRun
-	private Company _company1;
+	private Group _group;
 
 	private Indexer<MBThread> _indexer;
-	private User _user1;
 
 }

--- a/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/internal/model/listener/test/GroupModelListenerTest.java
+++ b/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/internal/model/listener/test/GroupModelListenerTest.java
@@ -6,9 +6,7 @@
 package com.liferay.sharing.internal.model.listener.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
-import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
@@ -16,9 +14,9 @@ import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
-import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -54,13 +52,7 @@ public class GroupModelListenerTest {
 
 	@Before
 	public void setUp() throws Exception {
-		_company = CompanyTestUtil.addCompany();
-
-		_user = UserTestUtil.addCompanyAdminUser(_company);
-
-		_group = GroupTestUtil.addGroup(
-			_company.getCompanyId(), _user.getUserId(),
-			GroupConstants.DEFAULT_PARENT_GROUP_ID);
+		_group = GroupTestUtil.addGroup();
 
 		_groupUser = UserTestUtil.addGroupUser(
 			_group, RoleConstants.POWER_USER);
@@ -71,12 +63,12 @@ public class GroupModelListenerTest {
 		long classPK = _group.getGroupId();
 
 		_sharingEntryLocalService.addSharingEntry(
-			_user.getUserId(), _groupUser.getUserId(),
+			TestPropsValues.getUserId(), _groupUser.getUserId(),
 			_classNameLocalService.getClassNameId(Group.class.getName()),
 			classPK, _group.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.VIEW), null,
 			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), _user.getUserId()));
+				_group.getGroupId(), TestPropsValues.getUserId()));
 
 		List<SharingEntry> groupSharingEntries =
 			_sharingEntryLocalService.getGroupSharingEntries(
@@ -106,16 +98,16 @@ public class GroupModelListenerTest {
 
 			ServiceContext serviceContext =
 				ServiceContextTestUtil.getServiceContext(
-					_group.getGroupId(), _user.getUserId());
+					_group.getGroupId(), TestPropsValues.getUserId());
 
 			_sharingEntryLocalService.addSharingEntry(
-				_user.getUserId(), _groupUser.getUserId(), classNameId,
-				_group.getGroupId(), _group.getGroupId(), true,
+				TestPropsValues.getUserId(), _groupUser.getUserId(),
+				classNameId, _group.getGroupId(), _group.getGroupId(), true,
 				Arrays.asList(SharingEntryAction.VIEW), null, serviceContext);
 
 			_sharingEntryLocalService.addSharingEntry(
-				_user.getUserId(), _groupUser.getUserId(), classNameId,
-				group2.getGroupId(), group2.getGroupId(), true,
+				TestPropsValues.getUserId(), _groupUser.getUserId(),
+				classNameId, group2.getGroupId(), group2.getGroupId(), true,
 				Arrays.asList(SharingEntryAction.VIEW), null, serviceContext);
 
 			List<SharingEntry> groupSharingEntries1 =
@@ -161,8 +153,6 @@ public class GroupModelListenerTest {
 	private ClassNameLocalService _classNameLocalService;
 
 	@DeleteAfterTestRun
-	private Company _company;
-
 	private Group _group;
 
 	@Inject
@@ -172,7 +162,5 @@ public class GroupModelListenerTest {
 
 	@Inject
 	private SharingEntryLocalService _sharingEntryLocalService;
-
-	private User _user;
 
 }

--- a/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/internal/model/listener/test/UserModelListenerTest.java
+++ b/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/internal/model/listener/test/UserModelListenerTest.java
@@ -6,18 +6,16 @@
 package com.liferay.sharing.internal.model.listener.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
-import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
-import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -53,15 +51,11 @@ public class UserModelListenerTest {
 
 	@Before
 	public void setUp() throws Exception {
-		_company = CompanyTestUtil.addCompany();
+		_group = GroupTestUtil.addGroup();
 
-		_user = UserTestUtil.addCompanyAdminUser(_company);
-
-		_group = GroupTestUtil.addGroup(
-			_company.getCompanyId(), _user.getUserId(),
-			GroupConstants.DEFAULT_PARENT_GROUP_ID);
-
-		_groupUser = UserTestUtil.addGroupUser(
+		_groupUser1 = UserTestUtil.addGroupUser(
+			_group, RoleConstants.POWER_USER);
+		_groupUser2 = UserTestUtil.addGroupUser(
 			_group, RoleConstants.POWER_USER);
 	}
 
@@ -70,25 +64,25 @@ public class UserModelListenerTest {
 		long classPK = _group.getGroupId();
 
 		_sharingEntryLocalService.addSharingEntry(
-			_user.getUserId(), _groupUser.getUserId(),
+			TestPropsValues.getUserId(), _groupUser1.getUserId(),
 			_classNameLocalService.getClassNameId(Group.class.getName()),
 			classPK, _group.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.VIEW), null,
 			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), _user.getUserId()));
+				_group.getGroupId(), TestPropsValues.getUserId()));
 
 		List<SharingEntry> toUserSharingEntries =
 			_sharingEntryLocalService.getToUserSharingEntries(
-				_groupUser.getUserId());
+				_groupUser1.getUserId());
 
 		Assert.assertEquals(
 			toUserSharingEntries.toString(), 1, toUserSharingEntries.size());
 
-		_userLocalService.deleteUser(_groupUser.getUserId());
+		_userLocalService.deleteUser(_groupUser1.getUserId());
 
 		toUserSharingEntries =
 			_sharingEntryLocalService.getToUserSharingEntries(
-				_groupUser.getUserId());
+				_groupUser1.getUserId());
 
 		Assert.assertEquals(
 			toUserSharingEntries.toString(), 0, toUserSharingEntries.size());
@@ -101,25 +95,25 @@ public class UserModelListenerTest {
 		long classPK = _group.getGroupId();
 
 		_sharingEntryLocalService.addSharingEntry(
-			_user.getUserId(), _groupUser.getUserId(),
+			TestPropsValues.getUserId(), _groupUser1.getUserId(),
 			_classNameLocalService.getClassNameId(Group.class.getName()),
 			classPK, _group.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.VIEW), null,
 			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), _user.getUserId()));
+				_group.getGroupId(), TestPropsValues.getUserId()));
 
 		List<SharingEntry> toUserSharingEntries =
 			_sharingEntryLocalService.getToUserSharingEntries(
-				_groupUser.getUserId());
+				_groupUser1.getUserId());
 
 		Assert.assertEquals(
 			toUserSharingEntries.toString(), 1, toUserSharingEntries.size());
 
-		_userLocalService.deleteUser(_user.getUserId());
+		_userLocalService.deleteUser(_groupUser2.getUserId());
 
 		toUserSharingEntries =
 			_sharingEntryLocalService.getToUserSharingEntries(
-				_groupUser.getUserId());
+				_groupUser1.getUserId());
 
 		Assert.assertEquals(
 			toUserSharingEntries.toString(), 1, toUserSharingEntries.size());
@@ -129,15 +123,13 @@ public class UserModelListenerTest {
 	private ClassNameLocalService _classNameLocalService;
 
 	@DeleteAfterTestRun
-	private Company _company;
-
 	private Group _group;
-	private User _groupUser;
+
+	private User _groupUser1;
+	private User _groupUser2;
 
 	@Inject
 	private SharingEntryLocalService _sharingEntryLocalService;
-
-	private User _user;
 
 	@Inject
 	private UserLocalService _userLocalService;


### PR DESCRIPTION
Motivation
-----
Speed up tests

Proposed solution
----
Create companies only when it is necessary:

* Use default company if it is possible.
* If we need to create a new company, create it only in the test that we need it.

You can find average of tests executions right here https://test-1-0.liferay.com/userContent/reports/master/test-duration-report/index.html