### PR TITLE
LPS-195737 Add configuration icon for "move" action

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/configuration/icon/DeleteKBFolderPortletConfigurationIcon.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/configuration/icon/DeleteKBFolderPortletConfigurationIcon.java
@@ -41,6 +41,11 @@ public class DeleteKBFolderPortletConfigurationIcon
 	extends BasePortletConfigurationIcon {
 
 	@Override
+	public String getIconCssClass() {
+		return "trash";
+	}
+
+	@Override
 	public String getMessage(PortletRequest portletRequest) {
 		return _language.get(getLocale(portletRequest), "delete");
 	}

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/configuration/icon/EditKBFolderPortletConfigurationIcon.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/configuration/icon/EditKBFolderPortletConfigurationIcon.java
@@ -41,6 +41,11 @@ public class EditKBFolderPortletConfigurationIcon
 	extends BasePortletConfigurationIcon {
 
 	@Override
+	public String getIconCssClass() {
+		return "pencil";
+	}
+
+	@Override
 	public String getMessage(PortletRequest portletRequest) {
 		return _language.get(getLocale(portletRequest), "edit");
 	}

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/configuration/icon/KBFolderPermissionsPortletConfigurationIcon.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/configuration/icon/KBFolderPermissionsPortletConfigurationIcon.java
@@ -42,6 +42,11 @@ public class KBFolderPermissionsPortletConfigurationIcon
 	extends BasePortletConfigurationIcon {
 
 	@Override
+	public String getIconCssClass() {
+		return "password-policies";
+	}
+
+	@Override
 	public String getMessage(PortletRequest portletRequest) {
 		return _language.get(getLocale(portletRequest), "permissions");
 	}

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/configuration/icon/MoveKBFolderPortletConfigurationIcon.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/configuration/icon/MoveKBFolderPortletConfigurationIcon.java
@@ -1,0 +1,143 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.knowledge.base.web.internal.portlet.configuration.icon;
+
+import com.liferay.knowledge.base.constants.KBActionKeys;
+import com.liferay.knowledge.base.constants.KBPortletKeys;
+import com.liferay.knowledge.base.model.KBFolder;
+import com.liferay.knowledge.base.web.internal.constants.KBWebKeys;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
+import com.liferay.portal.kernel.portlet.LiferayWindowState;
+import com.liferay.portal.kernel.portlet.configuration.icon.BasePortletConfigurationIcon;
+import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIcon;
+import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.JavaConstants;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.WebKeys;
+
+import java.util.Map;
+
+import javax.portlet.PortletRequest;
+import javax.portlet.PortletResponse;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Adolfo Pérez
+ */
+@Component(
+	property = {
+		"javax.portlet.name=" + KBPortletKeys.KNOWLEDGE_BASE_ADMIN,
+		"path=/admin/view_kb_folders.jsp"
+	},
+	service = PortletConfigurationIcon.class
+)
+public class MoveKBFolderPortletConfigurationIcon
+	extends BasePortletConfigurationIcon {
+
+	@Override
+	public Map<String, Object> getContext(PortletRequest portletRequest) {
+		KBFolder kbFolder = (KBFolder)portletRequest.getAttribute(
+			KBWebKeys.KNOWLEDGE_BASE_PARENT_KB_FOLDER);
+
+		return HashMapBuilder.<String, Object>put(
+			"action", "move"
+		).put(
+			"kbObjectClassNameId", kbFolder.getClassNameId()
+		).put(
+			"kbObjectId", kbFolder.getKbFolderId()
+		).put(
+			"kbObjectType", KBFolder.class.getSimpleName()
+		).put(
+			"moveKBObjectActionURL",
+			PortletURLBuilder.createActionURL(
+				_getLiferayPortletResponse(portletRequest)
+			).setActionName(
+				"/knowledge_base/move_kb_object"
+			).buildString()
+		).put(
+			"moveKBObjectModalURL",
+			PortletURLBuilder.createRenderURL(
+				_getLiferayPortletResponse(portletRequest)
+			).setMVCPath(
+				"/admin/common/move_kb_object_modal.jsp"
+			).setWindowState(
+				LiferayWindowState.POP_UP
+			).buildString()
+		).build();
+	}
+
+	@Override
+	public String getMessage(PortletRequest portletRequest) {
+		return _language.get(getLocale(portletRequest), "move");
+	}
+
+	@Override
+	public double getWeight() {
+		return 103;
+	}
+
+	@Override
+	public boolean isShow(PortletRequest portletRequest) {
+		try {
+			ThemeDisplay themeDisplay =
+				(ThemeDisplay)portletRequest.getAttribute(
+					WebKeys.THEME_DISPLAY);
+
+			KBFolder kbFolder = (KBFolder)portletRequest.getAttribute(
+				KBWebKeys.KNOWLEDGE_BASE_PARENT_KB_FOLDER);
+
+			return _kbFolderModelResourcePermission.contains(
+				themeDisplay.getPermissionChecker(), kbFolder,
+				KBActionKeys.MOVE_KB_FOLDER);
+		}
+		catch (PortalException portalException) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(portalException);
+			}
+
+			return false;
+		}
+	}
+
+	private LiferayPortletResponse _getLiferayPortletResponse(
+		PortletRequest portletRequest) {
+
+		HttpServletRequest httpServletRequest = _portal.getHttpServletRequest(
+			portletRequest);
+
+		PortletResponse portletResponse =
+			(PortletResponse)httpServletRequest.getAttribute(
+				JavaConstants.JAVAX_PORTLET_RESPONSE);
+
+		return _portal.getLiferayPortletResponse(portletResponse);
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		MoveKBFolderPortletConfigurationIcon.class);
+
+	@Reference(
+		target = "(model.class.name=com.liferay.knowledge.base.model.KBFolder)"
+	)
+	private ModelResourcePermission<KBFolder> _kbFolderModelResourcePermission;
+
+	@Reference
+	private Language _language;
+
+	@Reference
+	private Portal _portal;
+
+}

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/configuration/icon/MoveKBFolderPortletConfigurationIcon.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/configuration/icon/MoveKBFolderPortletConfigurationIcon.java
@@ -88,6 +88,11 @@ public class MoveKBFolderPortletConfigurationIcon
 	}
 
 	@Override
+	public String getIconCssClass() {
+		return "move-folder";
+	}
+
+	@Override
 	public String getJspPath() {
 		return "/configuration/icon/move_folder.jsp";
 	}

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/configuration/icon/MoveKBFolderPortletConfigurationIcon.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/configuration/icon/MoveKBFolderPortletConfigurationIcon.java
@@ -15,7 +15,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.LiferayWindowState;
-import com.liferay.portal.kernel.portlet.configuration.icon.BasePortletConfigurationIcon;
+import com.liferay.portal.kernel.portlet.configuration.icon.BaseJSPPortletConfigurationIcon;
 import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIcon;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
@@ -30,6 +30,7 @@ import java.util.Map;
 import javax.portlet.PortletRequest;
 import javax.portlet.PortletResponse;
 
+import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
 
 import org.osgi.service.component.annotations.Component;
@@ -46,7 +47,7 @@ import org.osgi.service.component.annotations.Reference;
 	service = PortletConfigurationIcon.class
 )
 public class MoveKBFolderPortletConfigurationIcon
-	extends BasePortletConfigurationIcon {
+	extends BaseJSPPortletConfigurationIcon {
 
 	@Override
 	public Map<String, Object> getContext(PortletRequest portletRequest) {
@@ -54,11 +55,15 @@ public class MoveKBFolderPortletConfigurationIcon
 			KBWebKeys.KNOWLEDGE_BASE_PARENT_KB_FOLDER);
 
 		return HashMapBuilder.<String, Object>put(
-			"action", "move"
+			"action", getNamespace(portletRequest) + "moveFolder"
+		).put(
+			"globalAction", true
 		).put(
 			"kbObjectClassNameId", kbFolder.getClassNameId()
 		).put(
 			"kbObjectId", kbFolder.getKbFolderId()
+		).put(
+			"kbObjectTitle", kbFolder.getName()
 		).put(
 			"kbObjectType", KBFolder.class.getSimpleName()
 		).put(
@@ -77,7 +82,14 @@ public class MoveKBFolderPortletConfigurationIcon
 			).setWindowState(
 				LiferayWindowState.POP_UP
 			).buildString()
+		).put(
+			"portletNamespace", getNamespace(portletRequest)
 		).build();
+	}
+
+	@Override
+	public String getJspPath() {
+		return "/configuration/icon/move_folder.jsp";
 	}
 
 	@Override
@@ -113,6 +125,11 @@ public class MoveKBFolderPortletConfigurationIcon
 		}
 	}
 
+	@Override
+	protected ServletContext getServletContext() {
+		return _servletContext;
+	}
+
 	private LiferayPortletResponse _getLiferayPortletResponse(
 		PortletRequest portletRequest) {
 
@@ -139,5 +156,10 @@ public class MoveKBFolderPortletConfigurationIcon
 
 	@Reference
 	private Portal _portal;
+
+	@Reference(
+		target = "(osgi.web.symbolicname=com.liferay.knowledge.base.web)"
+	)
+	private ServletContext _servletContext;
 
 }

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/js/MoveKBObject.js
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/js/MoveKBObject.js
@@ -1,0 +1,103 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {
+	addParams,
+	fetch,
+	objectToFormData,
+	openSelectionModal,
+	openToast,
+	sub,
+} from 'frontend-js-web';
+
+import showSuccessMessage from './utils/showSuccessMessage';
+
+const ITEM_TYPES = {
+	KBArticle: 'KBArticle',
+	KBFolder: 'KBFolder',
+};
+
+class MoveKBObject {
+	openModal({
+		kbObjectClassNameId,
+		kbObjectId,
+		kbObjectTitle,
+		kbObjectType,
+		moveKBObjectActionURL,
+		moveKBObjectModalURL,
+		portletNamespace,
+	}) {
+		openSelectionModal({
+			buttonAddLabel: Liferay.Language.get('save'),
+			height: '50vh',
+			iframeBodyCssClass: '',
+			multiple: true,
+			onSelect: ({destinationItem, index}) => {
+				if (
+					kbObjectType === ITEM_TYPES.KBFolder &&
+					destinationItem.type === ITEM_TYPES.KBArticle
+				) {
+					openToast({
+						message: Liferay.Language.get(
+							'folders-cannot-be-moved-into-articles'
+						),
+						type: 'danger',
+					});
+
+					return false;
+				}
+
+				fetch(moveKBObjectActionURL, {
+					body: objectToFormData({
+						[`${portletNamespace}dragAndDrop`]: true,
+						[`${portletNamespace}position`]: index?.next ?? -1,
+						[`${portletNamespace}resourceClassNameId`]: kbObjectClassNameId,
+						[`${portletNamespace}resourcePrimKey`]: kbObjectId,
+						[`${portletNamespace}parentResourceClassNameId`]: destinationItem.classNameId,
+						[`${portletNamespace}parentResourcePrimKey`]: destinationItem.id,
+					}),
+					method: 'POST',
+				})
+					.then((response) => {
+						if (!response.ok) {
+							throw new Error();
+						}
+
+						return response.json();
+					})
+					.then((response) => {
+						if (!response.success) {
+							throw new Error(response.errorMessage);
+						}
+
+						showSuccessMessage(portletNamespace);
+					})
+					.catch(
+						({
+							message = Liferay.Language.get(
+								'an-unexpected-error-occurred'
+							),
+						}) => {
+							openToast({
+								message,
+								type: 'danger',
+							});
+						}
+					);
+
+				return true;
+			},
+			selectEventName: `selectKBMoveFolder`,
+			size: 'md',
+			title: sub(Liferay.Language.get('move-x-to'), `"${kbObjectTitle}"`),
+			url: addParams(
+				`${portletNamespace}moveKBObjectId=${kbObjectId}&${portletNamespace}moveKBObjectClassName=${kbObjectType}`,
+				moveKBObjectModalURL
+			),
+		});
+	}
+}
+
+export default MoveKBObject;

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/configuration/icon/move_folder.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/configuration/icon/move_folder.jsp
@@ -1,0 +1,24 @@
+<%--
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+--%>
+
+<%@ include file="/init.jsp" %>
+
+<liferay-frontend:component
+	componentId="MoveKBObject"
+	module="admin/js/MoveKBObject"
+/>
+
+<aui:script>
+	Liferay.Util.setPortletConfigurationIconAction(
+		'<portlet:namespace />moveFolder',
+		(event, data) => {
+			Liferay.componentReady('MoveKBObject').then((component) => {
+				component.openModal(data);
+			});
+		}
+	);
+</aui:script>


### PR DESCRIPTION
# What is this trying to solve?

https://issues.liferay.com/browse/LPS-195737

The action was not migrated to the new modal, but was deleted when removing the feature flag. We need to bring back the action, as there are functional tests failing.

# How am I fixing it?

I've recreated the class, but instead of the old URL, I've replicated the same logic used for the dropdown buttons (the configuration actions are converted into dropdown icons).

@ambrinchaudhary This is a starting point, as it doesn't work. I need you to hook it up correctly to the frontend logic.


**Final result:** 

![Screenshot 2023-09-18 at 22 42 05](https://github.com/liferay-lima/liferay-portal/assets/8373764/7d977bf8-7cf9-4c9a-9ae4-23c5d4a93e78)
