### PR TITLE
LPS-195610 allow the fileEntryTypes of the groups allowed 

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/CopyFileEntryMVCActionCommand.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/CopyFileEntryMVCActionCommand.java
@@ -161,17 +161,16 @@ public class CopyFileEntryMVCActionCommand extends BaseMVCActionCommand {
 
 		DLFileEntry dlFileEntry = (DLFileEntry)fileEntry.getModel();
 
-		long fileEntryTypeId = dlFileEntry.getFileEntryTypeId();
-
 		if (ArrayUtil.contains(groupIds, fileEntry.getGroupId())) {
-			return fileEntryTypeId;
+			return dlFileEntry.getFileEntryTypeId();
 		}
 
 		DLFileEntryType fileEntryType =
-			_dlFileEntryTypeService.getFileEntryType(fileEntryTypeId);
+			_dlFileEntryTypeService.getFileEntryType(
+				dlFileEntry.getFileEntryTypeId());
 
 		if (ArrayUtil.contains(groupIds, fileEntryType.getGroupId())) {
-			return fileEntryTypeId;
+			return dlFileEntry.getFileEntryTypeId();
 		}
 
 		return DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT;

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/CopyFolderMVCActionCommand.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/CopyFolderMVCActionCommand.java
@@ -150,20 +150,18 @@ public class CopyFolderMVCActionCommand extends BaseMVCActionCommand {
 	private Map<Long, Long> _getFileEntryTypeIds(long groupId, long folderId)
 		throws PortalException {
 
-		DLFolder folder = _dlFolderService.getFolder(folderId);
-
 		long[] groupIds =
 			_siteConnectedGroupGroupProvider.
 				getCurrentAndAncestorSiteAndDepotGroupIds(groupId, true);
 
-		if (ArrayUtil.isEmpty(groupIds) ||
-			!ArrayUtil.contains(groupIds, folder.getGroupId())) {
-
+		if (ArrayUtil.isEmpty(groupIds)) {
 			return new HashMap<>();
 		}
 
+		DLFolder folder = _dlFolderService.getFolder(folderId);
+
 		return _dlFileEntryLocalService.getFileEntryTypeIds(
-			folder.getCompanyId(), folder.getGroupId(), folder.getTreePath());
+			folder.getCompanyId(), groupIds, folder.getTreePath());
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -23,6 +23,7 @@ import com.liferay.document.library.kernel.model.DLFileEntryMetadata;
 import com.liferay.document.library.kernel.model.DLFileEntryTable;
 import com.liferay.document.library.kernel.model.DLFileEntryType;
 import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
+import com.liferay.document.library.kernel.model.DLFileEntryTypeTable;
 import com.liferay.document.library.kernel.model.DLFileVersion;
 import com.liferay.document.library.kernel.model.DLFolder;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
@@ -1306,7 +1307,7 @@ public class DLFileEntryLocalServiceImpl
 
 	@Override
 	public Map<Long, Long> getFileEntryTypeIds(
-		long companyId, long groupId, String treePath) {
+		long companyId, long[] groupIds, String treePath) {
 
 		List<Object[]> results = dslQuery(
 			DSLQueryFactoryUtil.select(
@@ -1314,11 +1315,23 @@ public class DLFileEntryLocalServiceImpl
 				DLFileEntryTable.INSTANCE.fileEntryTypeId
 			).from(
 				DLFileEntryTable.INSTANCE
+			).innerJoinON(
+				DLFileEntryTypeTable.INSTANCE,
+				DLFileEntryTypeTable.INSTANCE.fileEntryTypeId.eq(
+					DLFileEntryTable.INSTANCE.fileEntryTypeId
+				).and(
+					DLFileEntryTypeTable.INSTANCE.companyId.eq(companyId)
+				).and(
+					DLFileEntryTypeTable.INSTANCE.groupId.in(
+						ArrayUtil.toLongArray(groupIds))
+				).and(
+					DLFileEntryTypeTable.INSTANCE.fileEntryTypeId.neq(
+						DLFileEntryTypeConstants.
+							FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT)
+				)
 			).where(
 				DLFileEntryTable.INSTANCE.companyId.eq(
 					companyId
-				).and(
-					DLFileEntryTable.INSTANCE.groupId.eq(groupId)
 				).and(
 					DLFileEntryTable.INSTANCE.fileEntryTypeId.neq(
 						DLFileEntryTypeConstants.

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryLocalService.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryLocalService.java
@@ -538,7 +538,7 @@ public interface DLFileEntryLocalService
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public Map<Long, Long> getFileEntryTypeIds(
-		long companyId, long groupId, String treePath);
+		long companyId, long[] groupIds, String treePath);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<DLFileEntry> getGroupFileEntries(

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryLocalServiceUtil.java
@@ -721,9 +721,9 @@ public class DLFileEntryLocalServiceUtil {
 	}
 
 	public static Map<Long, Long> getFileEntryTypeIds(
-		long companyId, long groupId, String treePath) {
+		long companyId, long[] groupIds, String treePath) {
 
-		return getService().getFileEntryTypeIds(companyId, groupId, treePath);
+		return getService().getFileEntryTypeIds(companyId, groupIds, treePath);
 	}
 
 	public static List<DLFileEntry> getGroupFileEntries(

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryLocalServiceWrapper.java
@@ -819,10 +819,10 @@ public class DLFileEntryLocalServiceWrapper
 
 	@Override
 	public java.util.Map<Long, Long> getFileEntryTypeIds(
-		long companyId, long groupId, String treePath) {
+		long companyId, long[] groupIds, String treePath) {
 
 		return _dlFileEntryLocalService.getFileEntryTypeIds(
-			companyId, groupId, treePath);
+			companyId, groupIds, treePath);
 	}
 
 	@Override

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/packageinfo
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/packageinfo
@@ -1,1 +1,1 @@
-version 15.0.0
+version 16.0.0


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-195610

Steps to reproduce:

1.  Enable Feature Flag
2.  Create a document type in global site
3.  Create a document in local site with this global document type
4.  Copy this document to a new site

With Asset libraries:

1. Enable Feature Flag
2.  Create a document type in Asset library site
3.  Connect Liferay and New site
4.  Create a document in Liferay site with this document type
5.  Copy this document to a new site



Commits:
- LPS-195610 on the copy of a file, check too if the group of the fileEntryType is on the groups that are allowed to be copied not only if the file group is on this groups
- LPS-195610 allow to obtain the fileEntryTypes from several groups ids
- LPS-195610 buildService
- LPS-195610 baseline
- LPS-195610 add all the allowed groups to the search of the fileEntryTypes.
