### PR TITLE
LPS-196180 KB DatePicker overflows the modal

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-web/package.json
+++ b/modules/apps/knowledge-base/knowledge-base-web/package.json
@@ -11,6 +11,7 @@
 		"@clayui/link": "3.88.0",
 		"@clayui/list": "3.104.0",
 		"@clayui/loading-indicator": "3.60.0",
+		"@clayui/modal": "^3.104.0",
 		"classnames": "2.3.1",
 		"date-fns": "2.29.3",
 		"frontend-js-web": "*",

--- a/modules/apps/knowledge-base/knowledge-base-web/package.json
+++ b/modules/apps/knowledge-base/knowledge-base-web/package.json
@@ -11,7 +11,7 @@
 		"@clayui/link": "3.88.0",
 		"@clayui/list": "3.104.0",
 		"@clayui/loading-indicator": "3.60.0",
-		"@clayui/modal": "^3.104.0",
+		"@clayui/modal": "3.104.0",
 		"classnames": "2.3.1",
 		"date-fns": "2.29.3",
 		"frontend-js-web": "*",

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_kb_article.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_kb_article.jsp
@@ -377,3 +377,16 @@ if (editKBArticleDisplayContext.isPortletTitleBasedNavigation()) {
 	%>'
 	module="admin/js/EditKBArticle"
 />
+
+<div>
+	<react:component
+		module="admin/js/components/ScheduleKBArticle"
+		props='<%=
+			HashMapBuilder.<String, Object>put(
+				"displayDate", editKBArticleDisplayContext.getDatePickerFormattedDisplayDate()
+			).put(
+				"isScheduled", String.valueOf(editKBArticleDisplayContext.isScheduled())
+			).build()
+		%>'
+	/>
+</div>

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_kb_article.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_kb_article.jsp
@@ -377,7 +377,7 @@ if (editKBArticleDisplayContext.isPortletTitleBasedNavigation()) {
 			HashMapBuilder.<String, Object>put(
 				"displayDate", editKBArticleDisplayContext.getDatePickerFormattedDisplayDate()
 			).put(
-				"isScheduled", editKBArticleDisplayContext.isScheduled()
+				"scheduled", editKBArticleDisplayContext.isScheduled()
 			).build()
 		%>'
 	/>

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_kb_article.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_kb_article.jsp
@@ -359,20 +359,12 @@ if (editKBArticleDisplayContext.isPortletTitleBasedNavigation()) {
 	</div>
 </aui:form>
 
-<portlet:renderURL var="scheduleModalURL" windowState="<%= LiferayWindowState.POP_UP.toString() %>">
-	<portlet:param name="mvcPath" value="/admin/common/schedule_modal.jsp" />
-	<portlet:param name="displayDate" value="<%= editKBArticleDisplayContext.getDatePickerFormattedDisplayDate() %>" />
-	<portlet:param name="scheduled" value="<%= String.valueOf(editKBArticleDisplayContext.isScheduled()) %>" />
-</portlet:renderURL>
-
 <liferay-frontend:component
 	context='<%=
 		HashMapBuilder.<String, Object>put(
 			"kbArticle", editKBArticleDisplayContext.getKBArticle()
 		).put(
 			"publishAction", WorkflowConstants.ACTION_PUBLISH
-		).put(
-			"scheduleModalURL", scheduleModalURL.toString()
 		).build()
 	%>'
 	module="admin/js/EditKBArticle"
@@ -385,7 +377,7 @@ if (editKBArticleDisplayContext.isPortletTitleBasedNavigation()) {
 			HashMapBuilder.<String, Object>put(
 				"displayDate", editKBArticleDisplayContext.getDatePickerFormattedDisplayDate()
 			).put(
-				"isScheduled", String.valueOf(editKBArticleDisplayContext.isScheduled())
+				"isScheduled", editKBArticleDisplayContext.isScheduled()
 			).build()
 		%>'
 	/>

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/css/_admin.scss
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/css/_admin.scss
@@ -267,10 +267,4 @@ $toolbarZIndex: 971;
 	.management-bar .navbar-nav {
 		column-gap: 0.25rem;
 	}
-
-	.schedule-modal .modal-footer {
-		bottom: 0;
-		position: absolute;
-		width: 100%;
-	}
 }

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/js/EditKBArticle.js
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/js/EditKBArticle.js
@@ -48,7 +48,14 @@ export default function EditKBArticle({kbArticle, namespace, publishAction}) {
 	const openScheduleModal = () => {
 		Liferay.componentReady(`${namespace}ScheduleKBArticleComponent`).then(
 			(component) => {
-				component.open();
+				component.open((displayDate) => {
+					const displayDateInput = document.getElementById(
+						`${namespace}displayDate`
+					);
+					displayDateInput.value = displayDate;
+
+					publishButtonOnClick();
+				});
 			}
 		);
 	};

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/js/EditKBArticle.js
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/js/EditKBArticle.js
@@ -61,31 +61,11 @@ export default function EditKBArticle({
 	};
 
 	const openScheduleModal = (modalTitle) => {
-		const modalEventHandlers = [];
-
-		openModal({
-			height: '65vh',
-			id: 'scheduleKBArticleDialog',
-			iframeBodyCssClass: '',
-			onClose: () => {
-				modalEventHandlers.forEach((eventHandler) => {
-					eventHandler.detach();
-				});
-
-				modalEventHandlers.splice(0, modalEventHandlers.length);
-			},
-			onOpen: () => {
-				const scheduleEventHandler = Liferay.on(
-					'scheduleKBArticle',
-					publishButtonOnClick
-				);
-
-				modalEventHandlers.push(scheduleEventHandler);
-			},
-			size: 'md',
-			title: modalTitle,
-			url: scheduleModalURL,
-		});
+		Liferay.componentReady(`${namespace}ScheduleKBArticleComponent`).then(
+			(component) => {
+				component.open();
+			}
+		);
 	};
 
 	const form = document.getElementById(`${namespace}fm`);

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/js/EditKBArticle.js
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/js/EditKBArticle.js
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openModal} from 'frontend-js-web';
-
 function attachListener(element, eventType, callback) {
 	element?.addEventListener(eventType, callback);
 
@@ -15,12 +13,7 @@ function attachListener(element, eventType, callback) {
 	};
 }
 
-export default function EditKBArticle({
-	kbArticle,
-	namespace,
-	publishAction,
-	scheduleModalURL,
-}) {
+export default function EditKBArticle({kbArticle, namespace, publishAction}) {
 	const contextualSidebarButton = document.getElementById(
 		`${namespace}contextualSidebarButton`
 	);
@@ -52,15 +45,7 @@ export default function EditKBArticle({
 		event.currentTarget.dataset.customUrl = urlTitleInput.value !== '';
 	};
 
-	const scheduleItemOnClick = () => {
-		openScheduleModal(Liferay.Language.get('schedule-publication'));
-	};
-
-	const scheduledButtonOnClick = () => {
-		openScheduleModal(Liferay.Language.get('edit-scheduled-publication'));
-	};
-
-	const openScheduleModal = (modalTitle) => {
+	const openScheduleModal = () => {
 		Liferay.componentReady(`${namespace}ScheduleKBArticleComponent`).then(
 			(component) => {
 				component.open();
@@ -154,10 +139,10 @@ export default function EditKBArticle({
 
 	if (Liferay.FeatureFlags['LPS-188060']) {
 		eventHandlers.push(
-			attachListener(scheduleItem, 'click', scheduleItemOnClick)
+			attachListener(scheduleItem, 'click', openScheduleModal)
 		);
 		eventHandlers.push(
-			attachListener(scheduledButton, 'click', scheduledButtonOnClick)
+			attachListener(scheduledButton, 'click', openScheduleModal)
 		);
 	}
 

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/js/components/ScheduleKBArticle.js
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/js/components/ScheduleKBArticle.js
@@ -1,0 +1,58 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {useModal} from '@clayui/modal';
+import React, {useEffect, useState} from 'react';
+
+import ScheduleModal from './ScheduleModal';
+
+function ScheduleKBArticle(props) {
+	const [showModal, setShowModal] = useState();
+	const namespace = props.portletNamespace;
+
+	const handleOnClose = () => {
+		setShowModal(false);
+	};
+
+	const {observer, onClose} = useModal({
+		onClose: handleOnClose,
+	});
+
+	useEffect(() => {
+		const bridgeComponentId = `${namespace}ScheduleKBArticleComponent`;
+
+		if (!Liferay.component(bridgeComponentId)) {
+			Liferay.component(
+				bridgeComponentId,
+				{
+					open: () => {
+						setShowModal(true);
+					},
+				},
+				{
+					destroyOnNavigate: true,
+				}
+			);
+		}
+
+		return () => {
+			Liferay.destroyComponent(bridgeComponentId);
+		};
+	}, [namespace]);
+
+	return (
+		<>
+			{showModal && (
+				<ScheduleModal
+					{...props}
+					observer={observer}
+					onModalClose={onClose}
+				/>
+			)}
+		</>
+	);
+}
+
+export default ScheduleKBArticle;

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/js/components/ScheduleKBArticle.js
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/js/components/ScheduleKBArticle.js
@@ -10,6 +10,8 @@ import ScheduleModal from './ScheduleModal';
 
 function ScheduleKBArticle(props) {
 	const [showModal, setShowModal] = useState();
+	const [callback, setCallback] = useState();
+
 	const namespace = props.portletNamespace;
 
 	const handleOnClose = () => {
@@ -27,7 +29,8 @@ function ScheduleKBArticle(props) {
 			Liferay.component(
 				bridgeComponentId,
 				{
-					open: () => {
+					open: (callback) => {
+						setCallback(() => callback);
 						setShowModal(true);
 					},
 				},
@@ -47,6 +50,7 @@ function ScheduleKBArticle(props) {
 			{showModal && (
 				<ScheduleModal
 					{...props}
+					callback={callback}
 					observer={observer}
 					onModalClose={onClose}
 				/>

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/js/components/ScheduleModal.js
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/js/components/ScheduleModal.js
@@ -16,12 +16,12 @@ const noop = () => {};
 export default function ScheduleModal({
 	callback = noop,
 	displayDate: initialDisplayDate,
-	isScheduled,
+	scheduled,
 	observer,
 	onModalClose = noop,
 }) {
 	const [displayDate, setDisplayDate] = useState(
-		isScheduled ? initialDisplayDate : ''
+		scheduled ? initialDisplayDate : ''
 	);
 	const [invalidDate, setInvalidDate] = useState(false);
 
@@ -47,14 +47,14 @@ export default function ScheduleModal({
 	return (
 		<ClayModal observer={observer} size="md">
 			<ClayModal.Header>
-				{isScheduled
+				{scheduled
 					? Liferay.Language.get('edit-scheduled-publication')
 					: Liferay.Language.get('schedule-publication')}
 			</ClayModal.Header>
 
 			<ClayModal.Body>
 				<p className="text-secondary">
-					{isScheduled
+					{scheduled
 						? Liferay.Language.get(
 								'this-article-is-set-to-publish-later'
 						  )
@@ -98,7 +98,7 @@ export default function ScheduleModal({
 							{Liferay.Language.get('cancel')}
 						</ClayButton>
 
-						{isScheduled && (
+						{scheduled && (
 							<ClayButton
 								displayType="secondary"
 								onClick={publisNowButtonOnClick}
@@ -124,7 +124,7 @@ export default function ScheduleModal({
 ScheduleModal.propTypes = {
 	callback: PropTypes.func,
 	displayDate: PropTypes.string,
-	isScheduled: PropTypes.bool,
 	observer: PropTypes.object.isRequired,
 	onModalClose: PropTypes.func,
+	scheduled: PropTypes.bool,
 };

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/js/components/ScheduleModal.js
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/js/components/ScheduleModal.js
@@ -6,6 +6,7 @@
 import ClayAlert from '@clayui/alert';
 import ClayButton from '@clayui/button';
 import ClayDatePicker from '@clayui/date-picker';
+import ClayModal from '@clayui/modal';
 import classnames from 'classnames';
 import {isAfter} from 'date-fns';
 import {getOpener} from 'frontend-js-web';
@@ -17,6 +18,8 @@ export default function ScheduleModal({
 	displayDate: initialDisplayDate,
 	isScheduled,
 	portletNamespace,
+	observer,
+	onModalClose = () => {},
 }) {
 	const [displayDate, setDisplayDate] = useState(
 		isScheduled ? initialDisplayDate : null
@@ -56,8 +59,14 @@ export default function ScheduleModal({
 	}, [displayDate]);
 
 	return (
-		<div className="schedule-modal">
-			<div className="container-fluid p-4">
+		<ClayModal observer={observer} size="md">
+			<ClayModal.Header>
+				{isScheduled
+					? Liferay.Language.get('edit-scheduled-publication')
+					: Liferay.Language.get('schedule-publication')}
+			</ClayModal.Header>
+
+			<ClayModal.Body>
 				<p className="text-secondary">
 					{isScheduled
 						? Liferay.Language.get(
@@ -90,10 +99,10 @@ export default function ScheduleModal({
 						</ClayAlert>
 					</div>
 				)}
-			</div>
+			</ClayModal.Body>
 
-			<div className="modal-footer">
-				<div className="modal-item-last">
+			<ClayModal.Footer
+				last={
 					<ClayButton.Group spaced>
 						<ClayButton
 							borderless="<%= true %>"
@@ -120,9 +129,9 @@ export default function ScheduleModal({
 							{Liferay.Language.get('schedule')}
 						</ClayButton>
 					</ClayButton.Group>
-				</div>
-			</div>
-		</div>
+				}
+			/>
+		</ClayModal>
 	);
 }
 

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/js/components/ScheduleModal.js
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/js/components/ScheduleModal.js
@@ -9,44 +9,30 @@ import ClayDatePicker from '@clayui/date-picker';
 import ClayModal from '@clayui/modal';
 import classnames from 'classnames';
 import {isAfter} from 'date-fns';
-import {getOpener} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useEffect, useState} from 'react';
 
-const SCHEDULE_EVENT_NAME = 'scheduleKBArticle';
+const noop = () => {};
 export default function ScheduleModal({
+	callback = noop,
 	displayDate: initialDisplayDate,
 	isScheduled,
-	portletNamespace,
 	observer,
-	onModalClose = () => {},
+	onModalClose = noop,
 }) {
 	const [displayDate, setDisplayDate] = useState(
-		isScheduled ? initialDisplayDate : null
+		isScheduled ? initialDisplayDate : ''
 	);
 	const [invalidDate, setInvalidDate] = useState(false);
 
-	const closeModal = () => {
-		getOpener().Liferay.fire('closeModal', {
-			id: 'scheduleKBArticleDialog',
-		});
-	};
-
 	const handleScheduleButtonOnClick = () => {
-		const openerWindow = getOpener();
-
-		const displayDateInput = openerWindow.document.getElementById(
-			`${portletNamespace}displayDate`
-		);
-		displayDateInput.value = displayDate;
-
-		openerWindow.Liferay.fire(SCHEDULE_EVENT_NAME);
-		closeModal();
+		onModalClose();
+		callback(displayDate);
 	};
 
 	const publisNowButtonOnClick = () => {
-		getOpener().Liferay.fire(SCHEDULE_EVENT_NAME);
-		closeModal();
+		onModalClose();
+		callback('');
 	};
 
 	useEffect(() => {
@@ -107,7 +93,7 @@ export default function ScheduleModal({
 						<ClayButton
 							borderless="<%= true %>"
 							displayType="secondary"
-							onClick={closeModal}
+							onClick={onModalClose}
 						>
 							{Liferay.Language.get('cancel')}
 						</ClayButton>
@@ -136,7 +122,9 @@ export default function ScheduleModal({
 }
 
 ScheduleModal.propTypes = {
+	callback: PropTypes.func,
 	displayDate: PropTypes.string,
 	isScheduled: PropTypes.bool,
-	portletNamespace: PropTypes.string.isRequired,
+	observer: PropTypes.object.isRequired,
+	onModalClose: PropTypes.func,
 };


### PR DESCRIPTION
**Before:** 

![Screenshot 2023-09-14 at 13 53 38](https://github.com/liferay-lima/liferay-portal/assets/8373764/98fcc943-1b73-408d-a895-d4fbdfdd5e6a)

**Now:** 

![Screenshot 2023-09-20 at 10 43 19](https://github.com/liferay-lima/liferay-portal/assets/8373764/3fb39066-bc17-4dd4-a911-b948bc4e6f3b)

The problem was that `openModal()` renders the modal as an iframe, so the content could never overflow the Iframe. As suggested by PEDS team, and also for accessibility rules, it is better to render directly a `ClayModal` and avoid the Iframe. 

I would like to add some unit tests, but in the meantime this pull could be reviewed. 