### PR TITLE
LPS-196697 Show error of File too big to preview for videos and audios

### DIFF
--- a/modules/apps/document-library/document-library-preview-audio/src/main/java/com/liferay/document/library/preview/audio/internal/AudioDLPreviewRendererProvider.java
+++ b/modules/apps/document-library/document-library-preview-audio/src/main/java/com/liferay/document/library/preview/audio/internal/AudioDLPreviewRendererProvider.java
@@ -53,7 +53,7 @@ public class AudioDLPreviewRendererProvider
 		FileVersion fileVersion) {
 
 		if (!_audioProcessor.hasAudio(fileVersion) &&
-			!_audioProcessor.isAudioSupported(fileVersion)) {
+			!_audioProcessor.isAudioSupported(fileVersion.getMimeType())) {
 
 			return null;
 		}

--- a/modules/apps/document-library/document-library-video/src/main/java/com/liferay/document/library/video/internal/preview/DLVideoDLPreviewRendererProvider.java
+++ b/modules/apps/document-library/document-library-video/src/main/java/com/liferay/document/library/video/internal/preview/DLVideoDLPreviewRendererProvider.java
@@ -5,10 +5,17 @@
 
 package com.liferay.document.library.video.internal.preview;
 
+import com.liferay.document.library.constants.DLFileVersionPreviewConstants;
+import com.liferay.document.library.kernel.util.DLProcessorRegistryUtil;
 import com.liferay.document.library.kernel.util.VideoProcessor;
 import com.liferay.document.library.preview.DLPreviewRenderer;
 import com.liferay.document.library.preview.DLPreviewRendererProvider;
+import com.liferay.document.library.preview.exception.DLFileEntryPreviewGenerationException;
+import com.liferay.document.library.preview.exception.DLPreviewGenerationInProcessException;
+import com.liferay.document.library.preview.exception.DLPreviewSizeException;
+import com.liferay.document.library.service.DLFileVersionPreviewLocalService;
 import com.liferay.document.library.video.renderer.DLVideoRenderer;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.repository.model.FileVersion;
 import com.liferay.portal.kernel.util.ContentTypes;
 
@@ -45,6 +52,8 @@ public class DLVideoDLPreviewRendererProvider
 		FileVersion fileVersion) {
 
 		return (request, response) -> {
+			_checkForPreviewGenerationExceptions(fileVersion);
+
 			RequestDispatcher requestDispatcher =
 				_servletContext.getRequestDispatcher("/preview.jsp");
 
@@ -62,6 +71,28 @@ public class DLVideoDLPreviewRendererProvider
 
 		return null;
 	}
+
+	private void _checkForPreviewGenerationExceptions(FileVersion fileVersion)
+		throws PortalException {
+
+		if (_dlFileVersionPreviewLocalService.hasDLFileVersionPreview(
+				fileVersion.getFileEntryId(), fileVersion.getFileVersionId(),
+				DLFileVersionPreviewConstants.STATUS_FAILURE)) {
+
+			throw new DLFileEntryPreviewGenerationException();
+		}
+
+		if (!_videoProcessor.hasVideo(fileVersion)) {
+			if (!DLProcessorRegistryUtil.isPreviewableSize(fileVersion)) {
+				throw new DLPreviewSizeException();
+			}
+
+			throw new DLPreviewGenerationInProcessException();
+		}
+	}
+
+	@Reference
+	private DLFileVersionPreviewLocalService _dlFileVersionPreviewLocalService;
 
 	@Reference
 	private DLVideoRenderer _dlVideoRenderer;

--- a/modules/apps/document-library/document-library-video/src/main/java/com/liferay/document/library/video/internal/preview/DLVideoDLPreviewRendererProvider.java
+++ b/modules/apps/document-library/document-library-video/src/main/java/com/liferay/document/library/video/internal/preview/DLVideoDLPreviewRendererProvider.java
@@ -51,6 +51,12 @@ public class DLVideoDLPreviewRendererProvider
 	public DLPreviewRenderer getPreviewDLPreviewRenderer(
 		FileVersion fileVersion) {
 
+		if (!_videoProcessor.hasVideo(fileVersion) &&
+			!_videoProcessor.isVideoSupported(fileVersion.getMimeType())) {
+
+			return null;
+		}
+
 		return (request, response) -> {
 			_checkForPreviewGenerationExceptions(fileVersion);
 

--- a/modules/apps/document-library/document-library-video/src/main/java/com/liferay/document/library/video/internal/preview/DLVideoDLPreviewRendererProvider.java
+++ b/modules/apps/document-library/document-library-video/src/main/java/com/liferay/document/library/video/internal/preview/DLVideoDLPreviewRendererProvider.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.repository.model.FileVersion;
 import com.liferay.portal.kernel.util.ContentTypes;
 
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
 import javax.servlet.RequestDispatcher;
@@ -51,7 +52,11 @@ public class DLVideoDLPreviewRendererProvider
 	public DLPreviewRenderer getPreviewDLPreviewRenderer(
 		FileVersion fileVersion) {
 
-		if (!_videoProcessor.hasVideo(fileVersion) &&
+		if ((fileVersion != null) && !_videoProcessor.hasVideo(fileVersion) &&
+			!Objects.equals(
+				fileVersion.getMimeType(),
+				ContentTypes.
+					APPLICATION_VND_LIFERAY_VIDEO_EXTERNAL_SHORTCUT_HTML) &&
 			!_videoProcessor.isVideoSupported(fileVersion.getMimeType())) {
 
 			return null;
@@ -80,6 +85,14 @@ public class DLVideoDLPreviewRendererProvider
 
 	private void _checkForPreviewGenerationExceptions(FileVersion fileVersion)
 		throws PortalException {
+
+		if (Objects.equals(
+				fileVersion.getMimeType(),
+				ContentTypes.
+					APPLICATION_VND_LIFERAY_VIDEO_EXTERNAL_SHORTCUT_HTML)) {
+
+			return;
+		}
 
 		if (_dlFileVersionPreviewLocalService.hasDLFileVersionPreview(
 				fileVersion.getFileEntryId(), fileVersion.getFileVersionId(),


### PR DESCRIPTION

How to test it

1. Enable previews for Video/Audio
2. Go to : System Settings > D&M > File Entries >  Previewable Processor Maximum Size)
3. change the value and update
4. Upload a video/audio with a side bigger than the value introduced

<img width="1263" alt="image" src="https://github.com/liferay-lima/liferay-portal/assets/47524751/84ee9fd7-31f1-40dd-9c0e-8ea5fa8c85b5">



- LPS-196697 check for preview generation exceptions on video preview
- LPS-196697 if video is not supported and has no video preview, fail fast
- LPS-196697 show message of file big for audio checking the support of the mimeType for the generation of the audio.
