### PR TITLE
LPS-196743 show File too big to preview on previewable documents

### DIFF
--- a/modules/apps/document-library/document-library-preview-document/src/main/java/com/liferay/document/library/preview/document/internal/DocumentPreviewRendererProvider.java
+++ b/modules/apps/document-library/document-library-preview-document/src/main/java/com/liferay/document/library/preview/document/internal/DocumentPreviewRendererProvider.java
@@ -45,7 +45,11 @@ public class DocumentPreviewRendererProvider
 	public DLPreviewRenderer getPreviewDLPreviewRenderer(
 		FileVersion fileVersion) {
 
-		if (!PDFProcessorUtil.isDocumentSupported(fileVersion)) {
+		if ((fileVersion == null) || (fileVersion.getSize() == 0) ||
+			(!PDFProcessorUtil.hasImages(fileVersion) &&
+			 !PDFProcessorUtil.isDocumentSupported(
+				 fileVersion.getMimeType()))) {
+
 			return null;
 		}
 

--- a/modules/apps/document-library/document-library-preview-image/src/main/java/com/liferay/document/library/preview/image/internal/ImageDLPreviewRendererProvider.java
+++ b/modules/apps/document-library/document-library-preview-image/src/main/java/com/liferay/document/library/preview/image/internal/ImageDLPreviewRendererProvider.java
@@ -43,14 +43,9 @@ public class ImageDLPreviewRendererProvider
 	public DLPreviewRenderer getPreviewDLPreviewRenderer(
 		FileVersion fileVersion) {
 
-		if (!DLProcessorRegistryUtil.isPreviewableSize(fileVersion)) {
-			return (httpServletRequest, httpServletResponse) -> {
-				throw new DLPreviewSizeException();
-			};
-		}
-
-		if (!_imageProcessor.hasImages(fileVersion) &&
-			!_imageProcessor.isImageSupported(fileVersion)) {
+		if ((fileVersion == null) || (fileVersion.getSize() == 0) ||
+			(!_imageProcessor.hasImages(fileVersion) &&
+			 !_imageProcessor.isImageSupported(fileVersion.getMimeType()))) {
 
 			return null;
 		}
@@ -86,6 +81,10 @@ public class ImageDLPreviewRendererProvider
 		}
 
 		if (!_imageProcessor.hasImages(fileVersion)) {
+			if (!DLProcessorRegistryUtil.isPreviewableSize(fileVersion)) {
+				throw new DLPreviewSizeException();
+			}
+
 			throw new DLPreviewGenerationInProcessException();
 		}
 	}


### PR DESCRIPTION
2. Go to : System Settings > D&M > File Entries >  Previewable Processor Maximum Size)
3. change the value and update
4. Upload a pdf with a side bigger than the value introduced

<img width="1263" alt="image" src="https://github.com/liferay-lima/liferay-portal/assets/47524751/84ee9fd7-31f1-40dd-9c0e-8ea5fa8c85b5">

- LPS-196743 show preview size message on document preview. For this as we check the size on the method _checkForPreviewGenerationExceptions we should skip it previous this.
- LPS-196743 unify steps on behavior of image rendere with other rendered providers
