### PR TITLE
LPS-197260

### DIFF
--- a/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/internal/model/listener/test/CompanyModelListenerTest.java
+++ b/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/internal/model/listener/test/CompanyModelListenerTest.java
@@ -16,7 +16,6 @@ import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
-import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.test.rule.Inject;
@@ -24,7 +23,6 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -43,45 +41,28 @@ public class CompanyModelListenerTest {
 			new LiferayIntegrationTestRule(),
 			PermissionCheckerMethodTestRule.INSTANCE);
 
-	@Before
-	public void setUp() throws Exception {
-		_company = CompanyTestUtil.addCompany();
-
-		_guestUser = _company.getGuestUser();
-
-		_accountEntry = AccountEntryTestUtil.addAccountEntry(
-			AccountEntryArgs.withOwner(_guestUser));
-	}
-
 	@Test
-	public void testCleanUpAccountEntries() throws Exception {
-		_deleteCompany();
+	public void testCleanUp() throws Exception {
+		Company company = CompanyTestUtil.addCompany();
+
+		User guestUser = company.getGuestUser();
+
+		AccountEntry accountEntry = AccountEntryTestUtil.addAccountEntry(
+			AccountEntryArgs.withOwner(guestUser));
+
+		AccountRole accountRole = _accountRoleLocalService.addAccountRole(
+			guestUser.getUserId(), accountEntry.getAccountEntryId(),
+			RandomTestUtil.randomString(), null, null);
+
+		_companyLocalService.deleteCompany(company);
 
 		Assert.assertNull(
 			_accountEntryLocalService.fetchAccountEntry(
-				_accountEntry.getAccountEntryId()));
-	}
-
-	@Test
-	public void testCleanUpAccountRoles() throws Exception {
-		AccountRole accountRole = _accountRoleLocalService.addAccountRole(
-			_guestUser.getUserId(), _accountEntry.getAccountEntryId(),
-			RandomTestUtil.randomString(), null, null);
-
-		_deleteCompany();
-
+				accountEntry.getAccountEntryId()));
 		Assert.assertNull(
 			_accountRoleLocalService.fetchAccountRole(
 				accountRole.getAccountRoleId()));
 	}
-
-	private void _deleteCompany() throws Exception {
-		_companyLocalService.deleteCompany(_company);
-
-		_company = null;
-	}
-
-	private AccountEntry _accountEntry;
 
 	@Inject
 	private AccountEntryLocalService _accountEntryLocalService;
@@ -89,12 +70,7 @@ public class CompanyModelListenerTest {
 	@Inject
 	private AccountRoleLocalService _accountRoleLocalService;
 
-	@DeleteAfterTestRun
-	private Company _company;
-
 	@Inject
 	private CompanyLocalService _companyLocalService;
-
-	private User _guestUser;
 
 }

--- a/modules/apps/adaptive-media/adaptive-media-blogs-web-test/src/testIntegration/java/com/liferay/adaptive/media/blogs/web/internal/counter/test/BlogsAMImageCounterTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-blogs-web-test/src/testIntegration/java/com/liferay/adaptive/media/blogs/web/internal/counter/test/BlogsAMImageCounterTest.java
@@ -13,8 +13,9 @@ import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -23,6 +24,7 @@ import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.FileUtil;
@@ -51,21 +53,7 @@ public class BlogsAMImageCounterTest {
 
 	@Before
 	public void setUp() throws Exception {
-		_company1 = CompanyTestUtil.addCompany();
-
-		_user1 = UserTestUtil.getAdminUser(_company1.getCompanyId());
-
-		_group1 = GroupTestUtil.addGroup(
-			_company1.getCompanyId(), _user1.getUserId(),
-			GroupConstants.DEFAULT_PARENT_GROUP_ID);
-
-		_company2 = CompanyTestUtil.addCompany();
-
-		_user2 = UserTestUtil.getAdminUser(_company2.getCompanyId());
-
-		_group2 = GroupTestUtil.addGroup(
-			_company2.getCompanyId(), _user2.getUserId(),
-			GroupConstants.DEFAULT_PARENT_GROUP_ID);
+		_group = GroupTestUtil.addGroup();
 	}
 
 	@Test
@@ -74,22 +62,22 @@ public class BlogsAMImageCounterTest {
 
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(
-				_group1, _user1.getUserId());
+				_group, TestPropsValues.getUserId());
 
 		_dlAppLocalService.addFileEntry(
-			null, _user1.getUserId(), _group1.getGroupId(),
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString() + ".jpg", ContentTypes.IMAGE_JPEG,
 			_getImageBytes(), null, null, serviceContext);
 
 		BlogsEntry blogsEntry = _blogsEntryLocalService.addEntry(
-			_user1.getUserId(), RandomTestUtil.randomString(),
+			TestPropsValues.getUserId(), RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(), new Date(), serviceContext);
 
 		Assert.assertEquals(
 			0,
 			_amImageCounter.countExpectedAMImageEntries(
-				_company1.getCompanyId()));
+				TestPropsValues.getCompanyId()));
 
 		ImageSelector imageSelector = new ImageSelector(
 			_getImageBytes(), RandomTestUtil.randomString() + ".jpg",
@@ -101,51 +89,66 @@ public class BlogsAMImageCounterTest {
 		Assert.assertEquals(
 			1,
 			_amImageCounter.countExpectedAMImageEntries(
-				_company1.getCompanyId()));
+				TestPropsValues.getCompanyId()));
 	}
 
 	@Test
 	public void testBlogsAMImageCounterOnlyCountsBlogsImagesPerCompany()
 		throws Exception {
 
-		ServiceContext serviceContext =
-			ServiceContextTestUtil.getServiceContext(
-				_group1, _user1.getUserId());
+		String originalName = PrincipalThreadLocal.getName();
 
-		_dlAppLocalService.addFileEntry(
-			null, _user1.getUserId(), _group1.getGroupId(),
-			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-			RandomTestUtil.randomString() + ".jpg", ContentTypes.IMAGE_JPEG,
-			_getImageBytes(), null, null, serviceContext);
+		Company company = CompanyTestUtil.addCompany();
 
-		BlogsEntry blogsEntry = _blogsEntryLocalService.addEntry(
-			_user1.getUserId(), RandomTestUtil.randomString(),
-			RandomTestUtil.randomString(), new Date(), serviceContext);
+		User user = UserTestUtil.getAdminUser(company.getCompanyId());
 
-		Assert.assertEquals(
-			0,
-			_amImageCounter.countExpectedAMImageEntries(
-				_company1.getCompanyId()));
-		Assert.assertEquals(
-			0,
-			_amImageCounter.countExpectedAMImageEntries(
-				_company2.getCompanyId()));
+		try {
+			PrincipalThreadLocal.setName(user.getUserId());
 
-		ImageSelector imageSelector = new ImageSelector(
-			_getImageBytes(), RandomTestUtil.randomString() + ".jpg",
-			ContentTypes.IMAGE_JPEG, IMAGE_CROP_REGION);
+			ServiceContext serviceContext =
+				ServiceContextTestUtil.getServiceContext(
+					_group, TestPropsValues.getUserId());
 
-		_blogsEntryLocalService.addCoverImage(
-			blogsEntry.getEntryId(), imageSelector);
+			_dlAppLocalService.addFileEntry(
+				null, TestPropsValues.getUserId(), _group.getGroupId(),
+				DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+				RandomTestUtil.randomString() + ".jpg", ContentTypes.IMAGE_JPEG,
+				_getImageBytes(), null, null, serviceContext);
 
-		Assert.assertEquals(
-			1,
-			_amImageCounter.countExpectedAMImageEntries(
-				_company1.getCompanyId()));
-		Assert.assertEquals(
-			0,
-			_amImageCounter.countExpectedAMImageEntries(
-				_company2.getCompanyId()));
+			BlogsEntry blogsEntry = _blogsEntryLocalService.addEntry(
+				TestPropsValues.getUserId(), RandomTestUtil.randomString(),
+				RandomTestUtil.randomString(), new Date(), serviceContext);
+
+			Assert.assertEquals(
+				0,
+				_amImageCounter.countExpectedAMImageEntries(
+					TestPropsValues.getCompanyId()));
+			Assert.assertEquals(
+				0,
+				_amImageCounter.countExpectedAMImageEntries(
+					company.getCompanyId()));
+
+			ImageSelector imageSelector = new ImageSelector(
+				_getImageBytes(), RandomTestUtil.randomString() + ".jpg",
+				ContentTypes.IMAGE_JPEG, IMAGE_CROP_REGION);
+
+			_blogsEntryLocalService.addCoverImage(
+				blogsEntry.getEntryId(), imageSelector);
+
+			Assert.assertEquals(
+				1,
+				_amImageCounter.countExpectedAMImageEntries(
+					TestPropsValues.getCompanyId()));
+			Assert.assertEquals(
+				0,
+				_amImageCounter.countExpectedAMImageEntries(
+					company.getCompanyId()));
+		}
+		finally {
+			_companyLocalService.deleteCompany(company);
+
+			PrincipalThreadLocal.setName(originalName);
+		}
 	}
 
 	protected static final String IMAGE_CROP_REGION =
@@ -162,18 +165,13 @@ public class BlogsAMImageCounterTest {
 	@Inject
 	private BlogsEntryLocalService _blogsEntryLocalService;
 
-	@DeleteAfterTestRun
-	private Company _company1;
-
-	@DeleteAfterTestRun
-	private Company _company2;
+	@Inject
+	private CompanyLocalService _companyLocalService;
 
 	@Inject
 	private DLAppLocalService _dlAppLocalService;
 
-	private Group _group1;
-	private Group _group2;
-	private User _user1;
-	private User _user2;
+	@DeleteAfterTestRun
+	private Group _group;
 
 }

--- a/modules/apps/adaptive-media/adaptive-media-blogs-web-test/src/testIntegration/java/com/liferay/adaptive/media/blogs/web/internal/optimizer/test/BlogsAMImageOptimizerTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-blogs-web-test/src/testIntegration/java/com/liferay/adaptive/media/blogs/web/internal/optimizer/test/BlogsAMImageOptimizerTest.java
@@ -19,6 +19,8 @@ import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -27,6 +29,7 @@ import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.FileUtil;
@@ -34,10 +37,8 @@ import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
-import java.util.Collection;
 import java.util.Date;
 
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -58,164 +59,200 @@ public class BlogsAMImageOptimizerTest {
 
 	@Before
 	public void setUp() throws Exception {
-		_company1 = CompanyTestUtil.addCompany();
-
-		_user1 = UserTestUtil.getAdminUser(_company1.getCompanyId());
-
-		_group1 = GroupTestUtil.addGroup(
-			_company1.getCompanyId(), _user1.getUserId(),
-			GroupConstants.DEFAULT_PARENT_GROUP_ID);
-
-		_company2 = CompanyTestUtil.addCompany();
-
-		_user2 = UserTestUtil.getAdminUser(_company2.getCompanyId());
-
-		_group2 = GroupTestUtil.addGroup(
-			_company2.getCompanyId(), _user2.getUserId(),
-			GroupConstants.DEFAULT_PARENT_GROUP_ID);
-	}
-
-	@After
-	public void tearDown() throws Exception {
-		_deleteAllAMImageConfigurationEntries(_company1.getCompanyId());
-		_deleteAllAMImageConfigurationEntries(_company2.getCompanyId());
+		_group = GroupTestUtil.addGroup();
 	}
 
 	@Test
 	public void testBlogsAMImageOptimizerOptimizesEveryAMImageConfigurationEntryInSpecificCompany()
 		throws Exception {
 
-		_addBlogEntryWithCoverImage(_user1.getUserId(), _group1.getGroupId());
+		_addBlogEntryWithCoverImage(
+			TestPropsValues.getUserId(), _group.getGroupId());
 
 		AMImageConfigurationEntry amImageConfigurationEntry1 =
-			_addAMImageConfigurationEntry(_company1.getCompanyId());
+			_addAMImageConfigurationEntry(TestPropsValues.getCompanyId());
 		AMImageConfigurationEntry amImageConfigurationEntry2 =
-			_addAMImageConfigurationEntry(_company1.getCompanyId());
+			_addAMImageConfigurationEntry(TestPropsValues.getCompanyId());
 
-		Assert.assertEquals(
-			0,
-			_amImageEntryLocalService.getAMImageEntriesCount(
-				_company1.getCompanyId(),
-				amImageConfigurationEntry1.getUUID()));
-		Assert.assertEquals(
-			0,
-			_amImageEntryLocalService.getAMImageEntriesCount(
-				_company1.getCompanyId(),
-				amImageConfigurationEntry2.getUUID()));
+		try {
+			Assert.assertEquals(
+				0,
+				_amImageEntryLocalService.getAMImageEntriesCount(
+					TestPropsValues.getCompanyId(),
+					amImageConfigurationEntry1.getUUID()));
+			Assert.assertEquals(
+				0,
+				_amImageEntryLocalService.getAMImageEntriesCount(
+					TestPropsValues.getCompanyId(),
+					amImageConfigurationEntry2.getUUID()));
 
-		_amImageOptimizer.optimize(_company1.getCompanyId());
+			_amImageOptimizer.optimize(TestPropsValues.getCompanyId());
 
-		Assert.assertEquals(
-			1,
-			_amImageEntryLocalService.getAMImageEntriesCount(
-				_company1.getCompanyId(),
-				amImageConfigurationEntry1.getUUID()));
-		Assert.assertEquals(
-			1,
-			_amImageEntryLocalService.getAMImageEntriesCount(
-				_company1.getCompanyId(),
-				amImageConfigurationEntry2.getUUID()));
+			Assert.assertEquals(
+				1,
+				_amImageEntryLocalService.getAMImageEntriesCount(
+					TestPropsValues.getCompanyId(),
+					amImageConfigurationEntry1.getUUID()));
+			Assert.assertEquals(
+				1,
+				_amImageEntryLocalService.getAMImageEntriesCount(
+					TestPropsValues.getCompanyId(),
+					amImageConfigurationEntry2.getUUID()));
+		}
+		finally {
+			_amImageConfigurationHelper.forceDeleteAMImageConfigurationEntry(
+				TestPropsValues.getCompanyId(),
+				amImageConfigurationEntry1.getUUID());
+			_amImageConfigurationHelper.forceDeleteAMImageConfigurationEntry(
+				TestPropsValues.getCompanyId(),
+				amImageConfigurationEntry2.getUUID());
+		}
 	}
 
 	@Test
 	public void testBlogsAMImageOptimizerOptimizesEveryAMImageConfigurationEntryOnlyInSpecificCompany()
 		throws Exception {
 
-		_addBlogEntryWithCoverImage(_user1.getUserId(), _group1.getGroupId());
-		_addBlogEntryWithCoverImage(_user2.getUserId(), _group2.getGroupId());
+		String originalName = PrincipalThreadLocal.getName();
 
-		AMImageConfigurationEntry amImageConfigurationEntry1 =
-			_addAMImageConfigurationEntry(_company1.getCompanyId());
-		AMImageConfigurationEntry amImageConfigurationEntry2 =
-			_addAMImageConfigurationEntry(_company2.getCompanyId());
+		Company company = CompanyTestUtil.addCompany();
 
-		Assert.assertEquals(
-			0,
-			_amImageEntryLocalService.getAMImageEntriesCount(
-				_company1.getCompanyId(),
-				amImageConfigurationEntry1.getUUID()));
-		Assert.assertEquals(
-			0,
-			_amImageEntryLocalService.getAMImageEntriesCount(
-				_company2.getCompanyId(),
-				amImageConfigurationEntry2.getUUID()));
+		User user = UserTestUtil.getAdminUser(company.getCompanyId());
 
-		_amImageOptimizer.optimize(_company1.getCompanyId());
+		Group group = GroupTestUtil.addGroup(
+			company.getCompanyId(), user.getUserId(),
+			GroupConstants.DEFAULT_PARENT_GROUP_ID);
 
-		Assert.assertEquals(
-			1,
-			_amImageEntryLocalService.getAMImageEntriesCount(
-				_company1.getCompanyId(),
-				amImageConfigurationEntry1.getUUID()));
-		Assert.assertEquals(
-			0,
-			_amImageEntryLocalService.getAMImageEntriesCount(
-				_company2.getCompanyId(),
-				amImageConfigurationEntry2.getUUID()));
+		try {
+			PrincipalThreadLocal.setName(user.getUserId());
 
-		_amImageOptimizer.optimize(_company2.getCompanyId());
+			_addBlogEntryWithCoverImage(
+				TestPropsValues.getUserId(), _group.getGroupId());
+			_addBlogEntryWithCoverImage(user.getUserId(), group.getGroupId());
 
-		Assert.assertEquals(
-			1,
-			_amImageEntryLocalService.getAMImageEntriesCount(
-				_company1.getCompanyId(),
-				amImageConfigurationEntry1.getUUID()));
-		Assert.assertEquals(
-			1,
-			_amImageEntryLocalService.getAMImageEntriesCount(
-				_company2.getCompanyId(),
-				amImageConfigurationEntry2.getUUID()));
+			AMImageConfigurationEntry amImageConfigurationEntry1 =
+				_addAMImageConfigurationEntry(TestPropsValues.getCompanyId());
+			AMImageConfigurationEntry amImageConfigurationEntry2 =
+				_addAMImageConfigurationEntry(company.getCompanyId());
+
+			try {
+				Assert.assertEquals(
+					0,
+					_amImageEntryLocalService.getAMImageEntriesCount(
+						TestPropsValues.getCompanyId(),
+						amImageConfigurationEntry1.getUUID()));
+				Assert.assertEquals(
+					0,
+					_amImageEntryLocalService.getAMImageEntriesCount(
+						company.getCompanyId(),
+						amImageConfigurationEntry2.getUUID()));
+
+				_amImageOptimizer.optimize(TestPropsValues.getCompanyId());
+
+				Assert.assertEquals(
+					1,
+					_amImageEntryLocalService.getAMImageEntriesCount(
+						TestPropsValues.getCompanyId(),
+						amImageConfigurationEntry1.getUUID()));
+				Assert.assertEquals(
+					0,
+					_amImageEntryLocalService.getAMImageEntriesCount(
+						company.getCompanyId(),
+						amImageConfigurationEntry2.getUUID()));
+
+				_amImageOptimizer.optimize(company.getCompanyId());
+
+				Assert.assertEquals(
+					1,
+					_amImageEntryLocalService.getAMImageEntriesCount(
+						TestPropsValues.getCompanyId(),
+						amImageConfigurationEntry1.getUUID()));
+				Assert.assertEquals(
+					1,
+					_amImageEntryLocalService.getAMImageEntriesCount(
+						company.getCompanyId(),
+						amImageConfigurationEntry2.getUUID()));
+			}
+			finally {
+				_amImageConfigurationHelper.
+					forceDeleteAMImageConfigurationEntry(
+						TestPropsValues.getCompanyId(),
+						amImageConfigurationEntry1.getUUID());
+				_amImageConfigurationHelper.
+					forceDeleteAMImageConfigurationEntry(
+						company.getCompanyId(),
+						amImageConfigurationEntry2.getUUID());
+			}
+		}
+		finally {
+			_companyLocalService.deleteCompany(company);
+
+			PrincipalThreadLocal.setName(originalName);
+		}
 	}
 
 	@Test
 	public void testBlogsAMImageOptimizerOptimizesForSpecificAMImageConfigurationEntry()
 		throws Exception {
 
-		_addBlogEntryWithCoverImage(_user1.getUserId(), _group1.getGroupId());
+		_addBlogEntryWithCoverImage(
+			TestPropsValues.getUserId(), _group.getGroupId());
 
 		AMImageConfigurationEntry amImageConfigurationEntry1 =
-			_addAMImageConfigurationEntry(_company1.getCompanyId());
+			_addAMImageConfigurationEntry(TestPropsValues.getCompanyId());
 		AMImageConfigurationEntry amImageConfigurationEntry2 =
-			_addAMImageConfigurationEntry(_company1.getCompanyId());
+			_addAMImageConfigurationEntry(TestPropsValues.getCompanyId());
 
-		Assert.assertEquals(
-			0,
-			_amImageEntryLocalService.getAMImageEntriesCount(
-				_company1.getCompanyId(),
-				amImageConfigurationEntry1.getUUID()));
-		Assert.assertEquals(
-			0,
-			_amImageEntryLocalService.getAMImageEntriesCount(
-				_company1.getCompanyId(),
-				amImageConfigurationEntry2.getUUID()));
+		try {
+			Assert.assertEquals(
+				0,
+				_amImageEntryLocalService.getAMImageEntriesCount(
+					TestPropsValues.getCompanyId(),
+					amImageConfigurationEntry1.getUUID()));
+			Assert.assertEquals(
+				0,
+				_amImageEntryLocalService.getAMImageEntriesCount(
+					TestPropsValues.getCompanyId(),
+					amImageConfigurationEntry2.getUUID()));
 
-		_amImageOptimizer.optimize(
-			_company1.getCompanyId(), amImageConfigurationEntry1.getUUID());
+			_amImageOptimizer.optimize(
+				TestPropsValues.getCompanyId(),
+				amImageConfigurationEntry1.getUUID());
 
-		Assert.assertEquals(
-			1,
-			_amImageEntryLocalService.getAMImageEntriesCount(
-				_company1.getCompanyId(),
-				amImageConfigurationEntry1.getUUID()));
-		Assert.assertEquals(
-			0,
-			_amImageEntryLocalService.getAMImageEntriesCount(
-				_company1.getCompanyId(),
-				amImageConfigurationEntry2.getUUID()));
+			Assert.assertEquals(
+				1,
+				_amImageEntryLocalService.getAMImageEntriesCount(
+					TestPropsValues.getCompanyId(),
+					amImageConfigurationEntry1.getUUID()));
+			Assert.assertEquals(
+				0,
+				_amImageEntryLocalService.getAMImageEntriesCount(
+					TestPropsValues.getCompanyId(),
+					amImageConfigurationEntry2.getUUID()));
 
-		_amImageOptimizer.optimize(
-			_company1.getCompanyId(), amImageConfigurationEntry2.getUUID());
+			_amImageOptimizer.optimize(
+				TestPropsValues.getCompanyId(),
+				amImageConfigurationEntry2.getUUID());
 
-		Assert.assertEquals(
-			1,
-			_amImageEntryLocalService.getAMImageEntriesCount(
-				_company1.getCompanyId(),
-				amImageConfigurationEntry1.getUUID()));
-		Assert.assertEquals(
-			1,
-			_amImageEntryLocalService.getAMImageEntriesCount(
-				_company1.getCompanyId(),
-				amImageConfigurationEntry2.getUUID()));
+			Assert.assertEquals(
+				1,
+				_amImageEntryLocalService.getAMImageEntriesCount(
+					TestPropsValues.getCompanyId(),
+					amImageConfigurationEntry1.getUUID()));
+			Assert.assertEquals(
+				1,
+				_amImageEntryLocalService.getAMImageEntriesCount(
+					TestPropsValues.getCompanyId(),
+					amImageConfigurationEntry2.getUUID()));
+		}
+		finally {
+			_amImageConfigurationHelper.forceDeleteAMImageConfigurationEntry(
+				TestPropsValues.getCompanyId(),
+				amImageConfigurationEntry1.getUUID());
+			_amImageConfigurationHelper.forceDeleteAMImageConfigurationEntry(
+				TestPropsValues.getCompanyId(),
+				amImageConfigurationEntry2.getUUID());
+		}
 	}
 
 	protected static final String IMAGE_CROP_REGION =
@@ -262,21 +299,6 @@ public class BlogsAMImageOptimizerTest {
 		return _blogsEntryLocalService.getEntry(blogsEntry.getEntryId());
 	}
 
-	private void _deleteAllAMImageConfigurationEntries(long companyId)
-		throws Exception {
-
-		Collection<AMImageConfigurationEntry> amImageConfigurationEntries =
-			_amImageConfigurationHelper.getAMImageConfigurationEntries(
-				companyId, amImageConfigurationEntry -> true);
-
-		for (AMImageConfigurationEntry amImageConfigurationEntry :
-				amImageConfigurationEntries) {
-
-			_amImageConfigurationHelper.forceDeleteAMImageConfigurationEntry(
-				companyId, amImageConfigurationEntry.getUUID());
-		}
-	}
-
 	private byte[] _getImageBytes() throws Exception {
 		return FileUtil.getBytes(
 			BlogsAMImageOptimizerTest.class, "dependencies/image.jpg");
@@ -294,18 +316,13 @@ public class BlogsAMImageOptimizerTest {
 	@Inject
 	private BlogsEntryLocalService _blogsEntryLocalService;
 
-	@DeleteAfterTestRun
-	private Company _company1;
-
-	@DeleteAfterTestRun
-	private Company _company2;
+	@Inject
+	private CompanyLocalService _companyLocalService;
 
 	@Inject
 	private DLAppLocalService _dlAppLocalService;
 
-	private Group _group1;
-	private Group _group2;
-	private User _user1;
-	private User _user2;
+	@DeleteAfterTestRun
+	private Group _group;
 
 }

--- a/modules/apps/adaptive-media/adaptive-media-image-test/src/testIntegration/java/com/liferay/adaptive/media/image/service/impl/test/AMImageEntryLocalServiceTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-test/src/testIntegration/java/com/liferay/adaptive/media/image/service/impl/test/AMImageEntryLocalServiceTest.java
@@ -20,11 +20,8 @@ import com.liferay.document.library.kernel.store.DLStoreUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.io.unsync.UnsyncByteArrayInputStream;
-import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.model.GroupConstants;
-import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.FileVersion;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
@@ -32,12 +29,10 @@ import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
-import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
-import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -404,10 +399,6 @@ public class AMImageEntryLocalServiceTest {
 
 	@Test
 	public void testGetExpectedAMImageEntriesCount() throws Exception {
-		String originalName = PrincipalThreadLocal.getName();
-
-		Company company = CompanyTestUtil.addCompany();
-
 		ServiceRegistration<AMImageCounter> amImageCounterServiceRegistration =
 			null;
 
@@ -421,7 +412,7 @@ public class AMImageEntryLocalServiceTest {
 
 			int expectedAMImageEntriesCount =
 				AMImageEntryLocalServiceUtil.getExpectedAMImageEntriesCount(
-					company.getCompanyId());
+					TestPropsValues.getCompanyId());
 
 			Assert.assertTrue(
 				String.valueOf(expectedAMImageEntriesCount),
@@ -429,20 +420,12 @@ public class AMImageEntryLocalServiceTest {
 		}
 		finally {
 			_unregisterAMImageCounter(amImageCounterServiceRegistration);
-
-			_companyLocalService.deleteCompany(company);
-
-			PrincipalThreadLocal.setName(originalName);
 		}
 	}
 
 	@Test
 	public void testGetExpectedAMImageEntriesCountSumsAllAMImageCounters()
 		throws Exception {
-
-		String originalName = PrincipalThreadLocal.getName();
-
-		Company company = CompanyTestUtil.addCompany();
 
 		ServiceRegistration<AMImageCounter> amImageCounterServiceRegistration1 =
 			null;
@@ -464,7 +447,7 @@ public class AMImageEntryLocalServiceTest {
 
 			int expectedAMImageEntriesCount =
 				AMImageEntryLocalServiceUtil.getExpectedAMImageEntriesCount(
-					company.getCompanyId());
+					TestPropsValues.getCompanyId());
 
 			Assert.assertTrue(
 				String.valueOf(expectedAMImageEntriesCount),
@@ -473,105 +456,79 @@ public class AMImageEntryLocalServiceTest {
 		finally {
 			_unregisterAMImageCounter(amImageCounterServiceRegistration1);
 			_unregisterAMImageCounter(amImageCounterServiceRegistration2);
-
-			_companyLocalService.deleteCompany(company);
-
-			PrincipalThreadLocal.setName(originalName);
 		}
 	}
 
 	@Test
 	public void testGetPercentage() throws Exception {
-		String originalName = PrincipalThreadLocal.getName();
-
-		Company company = CompanyTestUtil.addCompany();
-
-		User user = UserTestUtil.getAdminUser(company.getCompanyId());
-
-		Group group = GroupTestUtil.addGroup(
-			company.getCompanyId(), user.getUserId(),
-			GroupConstants.DEFAULT_PARENT_GROUP_ID);
-
 		AMImageConfigurationEntry amImageConfigurationEntry =
 			_addAMImageConfigurationEntry(
-				company.getCompanyId(), "uuid1", 100, 200);
+				TestPropsValues.getCompanyId(), "uuid1", 100, 200);
 
 		ServiceRegistration<AMImageCounter> amImageCounterServiceRegistration =
 			null;
 
 		try {
-			PrincipalThreadLocal.setName(user.getUserId());
+			PrincipalThreadLocal.setName(TestPropsValues.getUserId());
 
 			amImageCounterServiceRegistration = _registerAMImageCounter(
 				"test", 4);
 
 			ServiceContext serviceContext =
-				ServiceContextTestUtil.getServiceContext(group.getGroupId());
+				ServiceContextTestUtil.getServiceContext(_group.getGroupId());
 
 			byte[] bytes = _getImageBytes();
 
 			FileEntry fileEntry = _addFileEntry(
-				user.getUserId(), group.getGroupId(), bytes, serviceContext);
+				TestPropsValues.getUserId(), _group.getGroupId(), bytes,
+				serviceContext);
 
 			AMImageEntryLocalServiceUtil.addAMImageEntry(
 				amImageConfigurationEntry, fileEntry.getFileVersion(), 100, 200,
 				new UnsyncByteArrayInputStream(bytes), 12345);
 
 			int percentage = AMImageEntryLocalServiceUtil.getPercentage(
-				company.getCompanyId(), amImageConfigurationEntry.getUUID());
+				TestPropsValues.getCompanyId(),
+				amImageConfigurationEntry.getUUID());
 
 			Assert.assertTrue(String.valueOf(percentage), percentage <= 20);
 		}
 		finally {
 			_unregisterAMImageCounter(amImageCounterServiceRegistration);
-
-			_companyLocalService.deleteCompany(company);
-
-			PrincipalThreadLocal.setName(originalName);
 		}
 	}
 
 	@Test
 	public void testGetPercentageMax100() throws Exception {
-		String originalName = PrincipalThreadLocal.getName();
-
-		Company company = CompanyTestUtil.addCompany();
-
-		User user = UserTestUtil.getAdminUser(company.getCompanyId());
-
-		Group group = GroupTestUtil.addGroup(
-			company.getCompanyId(), user.getUserId(),
-			GroupConstants.DEFAULT_PARENT_GROUP_ID);
-
 		AMImageConfigurationEntry amImageConfigurationEntry =
 			_addAMImageConfigurationEntry(
-				company.getCompanyId(), "uuid1", 100, 200);
+				TestPropsValues.getCompanyId(), "uuid1", 100, 200);
 
 		ServiceRegistration<AMImageCounter> amImageCounterServiceRegistration =
 			null;
 
 		try {
-			PrincipalThreadLocal.setName(user.getUserId());
-
 			amImageCounterServiceRegistration = _registerAMImageCounter(
 				"test",
 				-AMImageEntryLocalServiceUtil.getExpectedAMImageEntriesCount(
-					company.getCompanyId()));
+					TestPropsValues.getCompanyId()));
 
 			ServiceContext serviceContext =
-				ServiceContextTestUtil.getServiceContext(group.getGroupId());
+				ServiceContextTestUtil.getServiceContext(_group.getGroupId());
 
 			byte[] bytes = _getImageBytes();
 
 			FileEntry fileEntry1 = _addFileEntry(
-				user.getUserId(), group.getGroupId(), bytes, serviceContext);
+				TestPropsValues.getUserId(), _group.getGroupId(), bytes,
+				serviceContext);
 
 			AMImageEntryLocalServiceUtil.addAMImageEntry(
 				amImageConfigurationEntry, fileEntry1.getFileVersion(), 100,
 				200, new UnsyncByteArrayInputStream(bytes), 12345);
 
 			FileEntry fileEntry2 = _addFileEntry(
-				user.getUserId(), group.getGroupId(), bytes, serviceContext);
+				TestPropsValues.getUserId(), _group.getGroupId(), bytes,
+				serviceContext);
 
 			AMImageEntryLocalServiceUtil.addAMImageEntry(
 				amImageConfigurationEntry, fileEntry2.getFileVersion(), 100,
@@ -580,42 +537,25 @@ public class AMImageEntryLocalServiceTest {
 			Assert.assertEquals(
 				100,
 				AMImageEntryLocalServiceUtil.getPercentage(
-					company.getCompanyId(),
+					TestPropsValues.getCompanyId(),
 					amImageConfigurationEntry.getUUID()));
 		}
 		finally {
 			_unregisterAMImageCounter(amImageCounterServiceRegistration);
-
-			_companyLocalService.deleteCompany(company);
-
-			PrincipalThreadLocal.setName(originalName);
 		}
 	}
 
 	@Test
 	public void testGetPercentageWhenNoImages() throws Exception {
-		String originalName = PrincipalThreadLocal.getName();
-
-		Company company = CompanyTestUtil.addCompany();
-
 		AMImageConfigurationEntry amImageConfigurationEntry1 =
 			_addAMImageConfigurationEntry(
-				company.getCompanyId(), "uuid1", 100, 200);
+				TestPropsValues.getCompanyId(), "uuid1", 100, 200);
 
-		try {
-			PrincipalThreadLocal.setName(TestPropsValues.getUserId());
-
-			Assert.assertEquals(
-				0,
-				AMImageEntryLocalServiceUtil.getPercentage(
-					company.getCompanyId(),
-					amImageConfigurationEntry1.getUUID()));
-		}
-		finally {
-			_companyLocalService.deleteCompany(company);
-
-			PrincipalThreadLocal.setName(originalName);
-		}
+		Assert.assertEquals(
+			0,
+			AMImageEntryLocalServiceUtil.getPercentage(
+				TestPropsValues.getCompanyId(),
+				amImageConfigurationEntry1.getUUID()));
 	}
 
 	@Test

--- a/modules/apps/portal-language/portal-language-test/src/testIntegration/java/com/liferay/portal/language/test/LanguageImplGetAvailableLocalesTest.java
+++ b/modules/apps/portal-language/portal-language-test/src/testIntegration/java/com/liferay/portal/language/test/LanguageImplGetAvailableLocalesTest.java
@@ -13,7 +13,6 @@ import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
-import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -26,7 +25,7 @@ import java.util.Locale;
 import java.util.Set;
 
 import org.junit.Assert;
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -43,8 +42,8 @@ public class LanguageImplGetAvailableLocalesTest {
 	public static final AggregateTestRule aggregateTestRule =
 		new LiferayIntegrationTestRule();
 
-	@Before
-	public void setUp() throws Exception {
+	@BeforeClass
+	public static void setUpClass() throws Exception {
 		_company = CompanyTestUtil.addCompany();
 	}
 
@@ -98,6 +97,8 @@ public class LanguageImplGetAvailableLocalesTest {
 			_company.getCompanyId(), _locales, LocaleUtil.US);
 	}
 
+	private static Company _company;
+
 	@Inject
 	private static GroupLocalService _groupLocalService;
 
@@ -108,8 +109,5 @@ public class LanguageImplGetAvailableLocalesTest {
 		Arrays.asList(
 			LocaleUtil.BRAZIL, LocaleUtil.HUNGARY, LocaleUtil.JAPAN,
 			LocaleUtil.US));
-
-	@DeleteAfterTestRun
-	private Company _company;
 
 }

--- a/modules/apps/sharing/sharing-test-util/src/main/java/com/liferay/sharing/test/util/BaseSharingTestCase.java
+++ b/modules/apps/sharing/sharing-test-util/src/main/java/com/liferay/sharing/test/util/BaseSharingTestCase.java
@@ -10,7 +10,6 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.ClassedModel;
-import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.ResourceConstants;
@@ -28,7 +27,6 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.context.ContextUserReplace;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
-import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -67,31 +65,25 @@ public abstract class BaseSharingTestCase<T extends ClassedModel> {
 
 	@Before
 	public void setUp() throws Exception {
-		_company = CompanyTestUtil.addCompany();
-
-		_user = UserTestUtil.addCompanyAdminUser(_company);
-
-		_group = GroupTestUtil.addGroup(
-			_company.getCompanyId(), _user.getUserId(),
-			GroupConstants.DEFAULT_PARENT_GROUP_ID);
+		_group = GroupTestUtil.addGroup();
 
 		_groupUser = UserTestUtil.addGroupUser(
 			_group, RoleConstants.POWER_USER);
 
 		_powerUserRole = _roleLocalService.getRole(
-			_company.getCompanyId(), RoleConstants.POWER_USER);
+			TestPropsValues.getCompanyId(), RoleConstants.POWER_USER);
 	}
 
 	@Test
 	public void testAdminCanShareWithAddDiscussion() throws Exception {
 		PermissionChecker permissionChecker =
-			PermissionCheckerFactoryUtil.create(_user);
+			PermissionCheckerFactoryUtil.create(TestPropsValues.getUser());
 
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
-				_user, permissionChecker)) {
+				TestPropsValues.getUser(), permissionChecker)) {
 
 			_assertContainsSharingPermission(
-				permissionChecker, getModel(_user, _group),
+				permissionChecker, getModel(TestPropsValues.getUser(), _group),
 				SharingEntryAction.ADD_DISCUSSION);
 		}
 	}
@@ -99,13 +91,13 @@ public abstract class BaseSharingTestCase<T extends ClassedModel> {
 	@Test
 	public void testAdminCanShareWithUpdate() throws Exception {
 		PermissionChecker permissionChecker =
-			PermissionCheckerFactoryUtil.create(_user);
+			PermissionCheckerFactoryUtil.create(TestPropsValues.getUser());
 
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
-				_user, permissionChecker)) {
+				TestPropsValues.getUser(), permissionChecker)) {
 
 			_assertContainsSharingPermission(
-				permissionChecker, getModel(_user, _group),
+				permissionChecker, getModel(TestPropsValues.getUser(), _group),
 				SharingEntryAction.UPDATE);
 		}
 	}
@@ -113,13 +105,13 @@ public abstract class BaseSharingTestCase<T extends ClassedModel> {
 	@Test
 	public void testAdminCanShareWithView() throws Exception {
 		PermissionChecker permissionChecker =
-			PermissionCheckerFactoryUtil.create(_user);
+			PermissionCheckerFactoryUtil.create(TestPropsValues.getUser());
 
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
-				_user, permissionChecker)) {
+				TestPropsValues.getUser(), permissionChecker)) {
 
 			_assertContainsSharingPermission(
-				permissionChecker, getModel(_user, _group),
+				permissionChecker, getModel(TestPropsValues.getUser(), _group),
 				SharingEntryAction.VIEW);
 		}
 	}
@@ -130,14 +122,14 @@ public abstract class BaseSharingTestCase<T extends ClassedModel> {
 
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), _user.getUserId());
+				_group.getGroupId(), TestPropsValues.getUserId());
 
-		T model = getModel(_user, _group);
+		T model = getModel(TestPropsValues.getUser(), _group);
 
 		long classPK = (Long)model.getPrimaryKeyObj();
 
 		_sharingEntryLocalService.addSharingEntry(
-			_user.getUserId(), _groupUser.getUserId(),
+			TestPropsValues.getUserId(), _groupUser.getUserId(),
 			_classNameLocalService.getClassNameId(model.getModelClassName()),
 			classPK, _group.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.UPDATE, SharingEntryAction.VIEW),
@@ -166,29 +158,29 @@ public abstract class BaseSharingTestCase<T extends ClassedModel> {
 
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), _user.getUserId());
+				_group.getGroupId(), TestPropsValues.getUserId());
 
-		T model1 = getModel(_user, _group);
+		T model1 = getModel(TestPropsValues.getUser(), _group);
 
 		long classNameId1 = _classNameLocalService.getClassNameId(
 			model1.getModelClassName());
 		long classPK1 = (Long)model1.getPrimaryKeyObj();
 
 		_sharingEntryLocalService.addSharingEntry(
-			_user.getUserId(), _groupUser.getUserId(), classNameId1, classPK1,
-			_group.getGroupId(), true,
+			TestPropsValues.getUserId(), _groupUser.getUserId(), classNameId1,
+			classPK1, _group.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.UPDATE, SharingEntryAction.VIEW),
 			null, serviceContext);
 
-		T model2 = getModel(_user, _group);
+		T model2 = getModel(TestPropsValues.getUser(), _group);
 
 		long classNameId2 = _classNameLocalService.getClassNameId(
 			model2.getModelClassName());
 		long classPK2 = (Long)model2.getPrimaryKeyObj();
 
 		SharingEntry sharingEntry = _sharingEntryLocalService.addSharingEntry(
-			_user.getUserId(), _groupUser.getUserId(), classNameId2, classPK2,
-			_group.getGroupId(), true,
+			TestPropsValues.getUserId(), _groupUser.getUserId(), classNameId2,
+			classPK2, _group.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.UPDATE, SharingEntryAction.VIEW),
 			null, serviceContext);
 
@@ -269,14 +261,14 @@ public abstract class BaseSharingTestCase<T extends ClassedModel> {
 
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), _user.getUserId());
+				_group.getGroupId(), TestPropsValues.getUserId());
 
-		T model = getModel(_user, _group);
+		T model = getModel(TestPropsValues.getUser(), _group);
 
 		long classPK = (Long)model.getPrimaryKeyObj();
 
 		_sharingEntryLocalService.addSharingEntry(
-			_user.getUserId(), _groupUser.getUserId(),
+			TestPropsValues.getUserId(), _groupUser.getUserId(),
 			_classNameLocalService.getClassNameId(model.getModelClassName()),
 			classPK, _group.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.UPDATE, SharingEntryAction.VIEW),
@@ -305,14 +297,14 @@ public abstract class BaseSharingTestCase<T extends ClassedModel> {
 
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), _user.getUserId());
+				_group.getGroupId(), TestPropsValues.getUserId());
 
-		T model = getModel(_user, _group);
+		T model = getModel(TestPropsValues.getUser(), _group);
 
 		long classPK = (Long)model.getPrimaryKeyObj();
 
 		_sharingEntryLocalService.addSharingEntry(
-			_user.getUserId(), _groupUser.getUserId(),
+			TestPropsValues.getUserId(), _groupUser.getUserId(),
 			_classNameLocalService.getClassNameId(model.getModelClassName()),
 			classPK, _group.getGroupId(), true,
 			Arrays.asList(
@@ -336,14 +328,14 @@ public abstract class BaseSharingTestCase<T extends ClassedModel> {
 
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), _user.getUserId());
+				_group.getGroupId(), TestPropsValues.getUserId());
 
-		T model = getModel(_user, _group);
+		T model = getModel(TestPropsValues.getUser(), _group);
 
 		long classPK = (Long)model.getPrimaryKeyObj();
 
 		_sharingEntryLocalService.addSharingEntry(
-			_user.getUserId(), _groupUser.getUserId(),
+			TestPropsValues.getUserId(), _groupUser.getUserId(),
 			_classNameLocalService.getClassNameId(model.getModelClassName()),
 			classPK, _group.getGroupId(), true,
 			Arrays.asList(
@@ -375,7 +367,7 @@ public abstract class BaseSharingTestCase<T extends ClassedModel> {
 				_groupUser, permissionChecker)) {
 
 			_assertNotContainsSharingPermission(
-				permissionChecker, getModel(_user, _group),
+				permissionChecker, getModel(TestPropsValues.getUser(), _group),
 				SharingEntryAction.UPDATE);
 		}
 	}
@@ -394,7 +386,7 @@ public abstract class BaseSharingTestCase<T extends ClassedModel> {
 				_groupUser, permissionChecker)) {
 
 			_assertNotContainsSharingPermission(
-				permissionChecker, getModel(_user, _group),
+				permissionChecker, getModel(TestPropsValues.getUser(), _group),
 				SharingEntryAction.VIEW);
 		}
 	}
@@ -413,7 +405,7 @@ public abstract class BaseSharingTestCase<T extends ClassedModel> {
 				_groupUser, permissionChecker)) {
 
 			_assertContainsSharingPermission(
-				permissionChecker, getModel(_user, _group),
+				permissionChecker, getModel(TestPropsValues.getUser(), _group),
 				SharingEntryAction.ADD_DISCUSSION);
 		}
 	}
@@ -429,7 +421,7 @@ public abstract class BaseSharingTestCase<T extends ClassedModel> {
 				_groupUser, permissionChecker)) {
 
 			_assertNotContainsSharingPermission(
-				permissionChecker, getModel(_user, _group),
+				permissionChecker, getModel(TestPropsValues.getUser(), _group),
 				SharingEntryAction.ADD_DISCUSSION);
 		}
 	}
@@ -445,7 +437,7 @@ public abstract class BaseSharingTestCase<T extends ClassedModel> {
 				_groupUser, permissionChecker)) {
 
 			_assertNotContainsPermission(
-				permissionChecker, getModel(_user, _group),
+				permissionChecker, getModel(TestPropsValues.getUser(), _group),
 				ActionKeys.ADD_DISCUSSION);
 		}
 	}
@@ -461,7 +453,8 @@ public abstract class BaseSharingTestCase<T extends ClassedModel> {
 				_groupUser, permissionChecker)) {
 
 			_assertNotContainsPermission(
-				permissionChecker, getModel(_user, _group), ActionKeys.VIEW);
+				permissionChecker, getModel(TestPropsValues.getUser(), _group),
+				ActionKeys.VIEW);
 		}
 	}
 
@@ -476,7 +469,7 @@ public abstract class BaseSharingTestCase<T extends ClassedModel> {
 				_groupUser, permissionChecker)) {
 
 			_assertNotContainsSharingPermission(
-				permissionChecker, getModel(_user, _group),
+				permissionChecker, getModel(TestPropsValues.getUser(), _group),
 				SharingEntryAction.UPDATE);
 		}
 	}
@@ -492,7 +485,8 @@ public abstract class BaseSharingTestCase<T extends ClassedModel> {
 				_groupUser, permissionChecker)) {
 
 			_assertNotContainsPermission(
-				permissionChecker, getModel(_user, _group), ActionKeys.UPDATE);
+				permissionChecker, getModel(TestPropsValues.getUser(), _group),
+				ActionKeys.UPDATE);
 		}
 	}
 
@@ -507,7 +501,7 @@ public abstract class BaseSharingTestCase<T extends ClassedModel> {
 				_groupUser, permissionChecker)) {
 
 			_assertNotContainsSharingPermission(
-				permissionChecker, getModel(_user, _group),
+				permissionChecker, getModel(TestPropsValues.getUser(), _group),
 				SharingEntryAction.VIEW);
 		}
 	}
@@ -523,7 +517,8 @@ public abstract class BaseSharingTestCase<T extends ClassedModel> {
 				_groupUser, permissionChecker)) {
 
 			_assertNotContainsPermission(
-				permissionChecker, getModel(_user, _group), ActionKeys.VIEW);
+				permissionChecker, getModel(TestPropsValues.getUser(), _group),
+				ActionKeys.VIEW);
 		}
 	}
 
@@ -533,14 +528,14 @@ public abstract class BaseSharingTestCase<T extends ClassedModel> {
 
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), _user.getUserId());
+				_group.getGroupId(), TestPropsValues.getUserId());
 
-		T model = getModel(_user, _group);
+		T model = getModel(TestPropsValues.getUser(), _group);
 
 		long classPK = (Long)model.getPrimaryKeyObj();
 
 		_sharingEntryLocalService.addSharingEntry(
-			_user.getUserId(), _groupUser.getUserId(),
+			TestPropsValues.getUserId(), _groupUser.getUserId(),
 			_classNameLocalService.getClassNameId(model.getModelClassName()),
 			classPK, _group.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.UPDATE, SharingEntryAction.VIEW),
@@ -563,14 +558,14 @@ public abstract class BaseSharingTestCase<T extends ClassedModel> {
 
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), _user.getUserId());
+				_group.getGroupId(), TestPropsValues.getUserId());
 
-		T model = getModel(_user, _group);
+		T model = getModel(TestPropsValues.getUser(), _group);
 
 		long classPK = (Long)model.getPrimaryKeyObj();
 
 		_sharingEntryLocalService.addSharingEntry(
-			_user.getUserId(), _groupUser.getUserId(),
+			TestPropsValues.getUserId(), _groupUser.getUserId(),
 			_classNameLocalService.getClassNameId(model.getModelClassName()),
 			classPK, _group.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.UPDATE, SharingEntryAction.VIEW),
@@ -601,7 +596,7 @@ public abstract class BaseSharingTestCase<T extends ClassedModel> {
 				_groupUser, permissionChecker)) {
 
 			_assertNotContainsSharingPermission(
-				permissionChecker, getModel(_user, _group),
+				permissionChecker, getModel(TestPropsValues.getUser(), _group),
 				SharingEntryAction.ADD_DISCUSSION);
 		}
 	}
@@ -620,7 +615,7 @@ public abstract class BaseSharingTestCase<T extends ClassedModel> {
 				_groupUser, permissionChecker)) {
 
 			_assertNotContainsSharingPermission(
-				permissionChecker, getModel(_user, _group),
+				permissionChecker, getModel(TestPropsValues.getUser(), _group),
 				SharingEntryAction.VIEW);
 		}
 	}
@@ -639,7 +634,7 @@ public abstract class BaseSharingTestCase<T extends ClassedModel> {
 				_groupUser, permissionChecker)) {
 
 			_assertContainsSharingPermission(
-				permissionChecker, getModel(_user, _group),
+				permissionChecker, getModel(TestPropsValues.getUser(), _group),
 				SharingEntryAction.UPDATE);
 		}
 	}
@@ -657,7 +652,7 @@ public abstract class BaseSharingTestCase<T extends ClassedModel> {
 				_groupUser, permissionChecker)) {
 
 			_assertNotContainsSharingPermission(
-				permissionChecker, getModel(_user, _group),
+				permissionChecker, getModel(TestPropsValues.getUser(), _group),
 				SharingEntryAction.ADD_DISCUSSION);
 		}
 	}
@@ -675,7 +670,7 @@ public abstract class BaseSharingTestCase<T extends ClassedModel> {
 				_groupUser, permissionChecker)) {
 
 			_assertNotContainsSharingPermission(
-				permissionChecker, getModel(_user, _group),
+				permissionChecker, getModel(TestPropsValues.getUser(), _group),
 				SharingEntryAction.UPDATE);
 		}
 	}
@@ -691,7 +686,7 @@ public abstract class BaseSharingTestCase<T extends ClassedModel> {
 				_groupUser, permissionChecker)) {
 
 			_assertContainsSharingPermission(
-				permissionChecker, getModel(_user, _group),
+				permissionChecker, getModel(TestPropsValues.getUser(), _group),
 				SharingEntryAction.VIEW);
 		}
 	}
@@ -702,14 +697,14 @@ public abstract class BaseSharingTestCase<T extends ClassedModel> {
 
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), _user.getUserId());
+				_group.getGroupId(), TestPropsValues.getUserId());
 
-		T model = getPendingModel(_user, _group);
+		T model = getPendingModel(TestPropsValues.getUser(), _group);
 
 		long classPK = (Long)model.getPrimaryKeyObj();
 
 		_sharingEntryLocalService.addSharingEntry(
-			_user.getUserId(), _groupUser.getUserId(),
+			TestPropsValues.getUserId(), _groupUser.getUserId(),
 			_classNameLocalService.getClassNameId(model.getModelClassName()),
 			classPK, _group.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.VIEW), null, serviceContext);
@@ -731,14 +726,14 @@ public abstract class BaseSharingTestCase<T extends ClassedModel> {
 
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), _user.getUserId());
+				_group.getGroupId(), TestPropsValues.getUserId());
 
-		T model = getModel(_user, _group);
+		T model = getModel(TestPropsValues.getUser(), _group);
 
 		long classPK = (Long)model.getPrimaryKeyObj();
 
 		_sharingEntryLocalService.addSharingEntry(
-			_user.getUserId(), _groupUser.getUserId(),
+			TestPropsValues.getUserId(), _groupUser.getUserId(),
 			_classNameLocalService.getClassNameId(model.getModelClassName()),
 			classPK, _group.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.VIEW), null, serviceContext);
@@ -835,9 +830,8 @@ public abstract class BaseSharingTestCase<T extends ClassedModel> {
 	private ClassNameLocalService _classNameLocalService;
 
 	@DeleteAfterTestRun
-	private Company _company;
-
 	private Group _group;
+
 	private User _groupUser;
 	private Role _powerUserRole;
 
@@ -849,8 +843,6 @@ public abstract class BaseSharingTestCase<T extends ClassedModel> {
 
 	@Inject
 	private SharingEntryLocalService _sharingEntryLocalService;
-
-	private User _user;
 
 	private class AddModelResourcePermission implements AutoCloseable {
 


### PR DESCRIPTION
Motivation
----
Speed up tests

Proposed solution
----
Create companies only when it is necessary:

* Use default company if it is possible.
* If we need to create a new company, create it only in the test that we need it.

You can find average of tests executions right here https://test-1-0.liferay.com/userContent/reports/master/test-duration-report/index.html