### PR TITLE
LPS-197175 if the group is an asset lib show itshelf on the folder selector and the group selector

### DIFF
--- a/modules/apps/depot/depot-api/bnd.bnd
+++ b/modules/apps/depot/depot-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Depot API
 Bundle-SymbolicName: com.liferay.depot.api
-Bundle-Version: 4.4.2
+Bundle-Version: 4.5.0
 Export-Package:\
 	com.liferay.depot.application,\
 	com.liferay.depot.configuration,\

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/configuration/DepotConfiguration.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/configuration/DepotConfiguration.java
@@ -6,7 +6,7 @@
 package com.liferay.depot.configuration;
 
 /**
- * @author Alejandro Tardín
+ * @author     Alejandro Tardín
  * @deprecated As of Athanasius (7.3.x), with no direct replacement
  */
 @Deprecated

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryService.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryService.java
@@ -55,6 +55,11 @@ public interface DepotEntryService extends BaseService {
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<DepotEntry> getCurrentAndGroupConnectedDepotEntries(
+			long groupId, int start, int end)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public DepotEntry getDepotEntry(long depotEntryId) throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryServiceUtil.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryServiceUtil.java
@@ -46,6 +46,14 @@ public class DepotEntryServiceUtil {
 		return getService().deleteDepotEntry(depotEntryId);
 	}
 
+	public static List<DepotEntry> getCurrentAndGroupConnectedDepotEntries(
+			long groupId, int start, int end)
+		throws PortalException {
+
+		return getService().getCurrentAndGroupConnectedDepotEntries(
+			groupId, start, end);
+	}
+
 	public static DepotEntry getDepotEntry(long depotEntryId)
 		throws PortalException {
 

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryServiceWrapper.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryServiceWrapper.java
@@ -45,6 +45,16 @@ public class DepotEntryServiceWrapper
 	}
 
 	@Override
+	public java.util.List<com.liferay.depot.model.DepotEntry>
+			getCurrentAndGroupConnectedDepotEntries(
+				long groupId, int start, int end)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _depotEntryService.getCurrentAndGroupConnectedDepotEntries(
+			groupId, start, end);
+	}
+
+	@Override
 	public com.liferay.depot.model.DepotEntry getDepotEntry(long depotEntryId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 

--- a/modules/apps/depot/depot-api/src/main/resources/com/liferay/depot/service/packageinfo
+++ b/modules/apps/depot/depot-api/src/main/resources/com/liferay/depot/service/packageinfo
@@ -1,1 +1,1 @@
-version 1.11.0
+version 1.12.0

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/http/DepotEntryServiceHttp.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/http/DepotEntryServiceHttp.java
@@ -124,6 +124,49 @@ public class DepotEntryServiceHttp {
 		}
 	}
 
+	public static java.util.List<com.liferay.depot.model.DepotEntry>
+			getCurrentAndGroupConnectedDepotEntries(
+				HttpPrincipal httpPrincipal, long groupId, int start, int end)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				DepotEntryServiceUtil.class,
+				"getCurrentAndGroupConnectedDepotEntries",
+				_getCurrentAndGroupConnectedDepotEntriesParameterTypes2);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, groupId, start, end);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (java.util.List<com.liferay.depot.model.DepotEntry>)
+				returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
 	public static com.liferay.depot.model.DepotEntry getDepotEntry(
 			HttpPrincipal httpPrincipal, long depotEntryId)
 		throws com.liferay.portal.kernel.exception.PortalException {
@@ -131,7 +174,7 @@ public class DepotEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DepotEntryServiceUtil.class, "getDepotEntry",
-				_getDepotEntryParameterTypes2);
+				_getDepotEntryParameterTypes3);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, depotEntryId);
@@ -173,7 +216,7 @@ public class DepotEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DepotEntryServiceUtil.class, "getGroupConnectedDepotEntries",
-				_getGroupConnectedDepotEntriesParameterTypes3);
+				_getGroupConnectedDepotEntriesParameterTypes4);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, ddmStructuresAvailable, start, end);
@@ -215,7 +258,7 @@ public class DepotEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DepotEntryServiceUtil.class, "getGroupConnectedDepotEntries",
-				_getGroupConnectedDepotEntriesParameterTypes4);
+				_getGroupConnectedDepotEntriesParameterTypes5);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, start, end);
@@ -257,7 +300,7 @@ public class DepotEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				DepotEntryServiceUtil.class,
 				"getGroupConnectedDepotEntriesCount",
-				_getGroupConnectedDepotEntriesCountParameterTypes5);
+				_getGroupConnectedDepotEntriesCountParameterTypes6);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId);
 
@@ -296,7 +339,7 @@ public class DepotEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DepotEntryServiceUtil.class, "getGroupDepotEntry",
-				_getGroupDepotEntryParameterTypes6);
+				_getGroupDepotEntryParameterTypes7);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId);
 
@@ -341,7 +384,7 @@ public class DepotEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DepotEntryServiceUtil.class, "updateDepotEntry",
-				_updateDepotEntryParameterTypes7);
+				_updateDepotEntryParameterTypes8);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, depotEntryId, nameMap, descriptionMap,
@@ -386,23 +429,27 @@ public class DepotEntryServiceHttp {
 		};
 	private static final Class<?>[] _deleteDepotEntryParameterTypes1 =
 		new Class[] {long.class};
-	private static final Class<?>[] _getDepotEntryParameterTypes2 =
+	private static final Class<?>[]
+		_getCurrentAndGroupConnectedDepotEntriesParameterTypes2 = new Class[] {
+			long.class, int.class, int.class
+		};
+	private static final Class<?>[] _getDepotEntryParameterTypes3 =
 		new Class[] {long.class};
 	private static final Class<?>[]
-		_getGroupConnectedDepotEntriesParameterTypes3 = new Class[] {
+		_getGroupConnectedDepotEntriesParameterTypes4 = new Class[] {
 			long.class, boolean.class, int.class, int.class
 		};
 	private static final Class<?>[]
-		_getGroupConnectedDepotEntriesParameterTypes4 = new Class[] {
+		_getGroupConnectedDepotEntriesParameterTypes5 = new Class[] {
 			long.class, int.class, int.class
 		};
 	private static final Class<?>[]
-		_getGroupConnectedDepotEntriesCountParameterTypes5 = new Class[] {
+		_getGroupConnectedDepotEntriesCountParameterTypes6 = new Class[] {
 			long.class
 		};
-	private static final Class<?>[] _getGroupDepotEntryParameterTypes6 =
+	private static final Class<?>[] _getGroupDepotEntryParameterTypes7 =
 		new Class[] {long.class};
-	private static final Class<?>[] _updateDepotEntryParameterTypes7 =
+	private static final Class<?>[] _updateDepotEntryParameterTypes8 =
 		new Class[] {
 			long.class, java.util.Map.class, java.util.Map.class,
 			java.util.Map.class,

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/impl/DepotEntryServiceImpl.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/impl/DepotEntryServiceImpl.java
@@ -68,6 +68,24 @@ public class DepotEntryServiceImpl extends DepotEntryServiceBaseImpl {
 	}
 
 	@Override
+	public List<DepotEntry> getCurrentAndGroupConnectedDepotEntries(
+			long groupId, int start, int end)
+		throws PortalException {
+
+		List<DepotEntry> filteredDepotEntries = getGroupConnectedDepotEntries(
+			groupId, start, end);
+
+		DepotEntry depotEntry = depotEntryLocalService.fetchGroupDepotEntry(
+			groupId);
+
+		if (depotEntry != null) {
+			filteredDepotEntries.add(depotEntry);
+		}
+
+		return filteredDepotEntries;
+	}
+
+	@Override
 	public DepotEntry getDepotEntry(long depotEntryId) throws PortalException {
 		if (!_depotEntryModelResourcePermission.contains(
 				getPermissionChecker(), depotEntryId, ActionKeys.VIEW) &&

--- a/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/item/selector/provider/DepotGroupItemSelectorProvider.java
+++ b/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/item/selector/provider/DepotGroupItemSelectorProvider.java
@@ -59,7 +59,7 @@ public class DepotGroupItemSelectorProvider
 			List<Group> groups = new ArrayList<>();
 
 			for (DepotEntry depotEntry :
-					_depotEntryService.getGroupConnectedDepotEntries(
+					_depotEntryService.getCurrentAndGroupConnectedDepotEntries(
 						_getGroupId(groupId), start, end)) {
 
 				groups.add(depotEntry.getGroup());

--- a/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/folder/DLFolderItemSelectorView.java
+++ b/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/folder/DLFolderItemSelectorView.java
@@ -199,7 +199,7 @@ public class DLFolderItemSelectorView
 
 		try {
 			return ListUtil.toList(
-				_depotEntryService.getGroupConnectedDepotEntries(
+				_depotEntryService.getCurrentAndGroupConnectedDepotEntries(
 					themeDisplay.getRefererGroupId(), QueryUtil.ALL_POS,
 					QueryUtil.ALL_POS),
 				DepotEntry::getGroupId);


### PR DESCRIPTION



- LPS-197175 create a method that not only returns the depot entries connected to the group, but the current depot entry if the group is an asset library
- LPS-197175 buildService
- LPS-197175 baseline
- LPS-197175 show the current asset library folder selector, if the group selected is an asset library, show on the copy to field the folder name and let the user copy to a folder
- LPS-197175 show the current asset library on the group selector if the group selected is an asset library
