### PR TITLE
LPS-197315 use the fileName on the creation of the documents on Sharepoint Rest Repositories

### DIFF
--- a/modules/apps/document-library/document-library-repository-external-api/bnd.bnd
+++ b/modules/apps/document-library/document-library-repository-external-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Document Library Repository External API
 Bundle-SymbolicName: com.liferay.document.library.repository.external.api
-Bundle-Version: 8.0.4
+Bundle-Version: 9.0.0
 Export-Package:\
 	com.liferay.document.library.repository.external,\
 	com.liferay.document.library.repository.external.cache,\

--- a/modules/apps/document-library/document-library-repository-external-api/src/main/java/com/liferay/document/library/repository/external/ExtRepository.java
+++ b/modules/apps/document-library/document-library-repository-external-api/src/main/java/com/liferay/document/library/repository/external/ExtRepository.java
@@ -45,8 +45,9 @@ public interface ExtRepository {
 	 *
 	 * @param  extRepositoryParentFolderKey the primary key of the repository
 	 *         file entry's parent folder
+	 * @param  fileName the repository file entry's file name
 	 * @param  mimeType the repository file entry's MIME type
-	 * @param  title the repository file entry's name
+	 * @param  title the repository file entry's title
 	 * @param  description the repository file entry's description
 	 * @param  changeLog the repository file entry's version change log
 	 * @param  inputStream the repository file entry's data (optionally
@@ -56,8 +57,9 @@ public interface ExtRepository {
 	 *         found or if the repository file entry's information was invalid
 	 */
 	public ExtRepositoryFileEntry addExtRepositoryFileEntry(
-			String extRepositoryParentFolderKey, String mimeType, String title,
-			String description, String changeLog, InputStream inputStream)
+			String extRepositoryParentFolderKey, String fileName,
+			String mimeType, String title, String description, String changeLog,
+			InputStream inputStream)
 		throws PortalException;
 
 	/**

--- a/modules/apps/document-library/document-library-repository-external-api/src/main/java/com/liferay/document/library/repository/external/ExtRepositoryAdapter.java
+++ b/modules/apps/document-library/document-library-repository-external-api/src/main/java/com/liferay/document/library/repository/external/ExtRepositoryAdapter.java
@@ -77,27 +77,22 @@ public class ExtRepositoryAdapter extends BaseRepositoryImpl {
 	@Override
 	public FileEntry addFileEntry(
 			String externalReferenceCode, long userId, long folderId,
-			String sourceFileName, String mimeType, String title,
-			String urlTitle, String description, String changeLog,
-			InputStream inputStream, long size, Date expirationDate,
-			Date reviewDate, ServiceContext serviceContext)
+			String fileName, String mimeType, String title, String urlTitle,
+			String description, String changeLog, InputStream inputStream,
+			long size, Date expirationDate, Date reviewDate,
+			ServiceContext serviceContext)
 		throws PortalException {
 
-		String fileName = null;
-
 		if (Validator.isNull(title)) {
-			fileName = sourceFileName;
-		}
-		else {
-			fileName = title;
+			title = fileName;
 		}
 
 		String extRepositoryFolderKey = getExtRepositoryObjectKey(folderId);
 
 		ExtRepositoryFileEntry extRepositoryFileEntry =
 			_extRepository.addExtRepositoryFileEntry(
-				extRepositoryFolderKey, sourceFileName, mimeType, fileName,
-				description, changeLog, inputStream);
+				extRepositoryFolderKey, fileName, mimeType, title, description,
+				changeLog, inputStream);
 
 		return _toExtRepositoryObjectAdapter(
 			ExtRepositoryObjectAdapterType.FILE, extRepositoryFileEntry);

--- a/modules/apps/document-library/document-library-repository-external-api/src/main/java/com/liferay/document/library/repository/external/ExtRepositoryAdapter.java
+++ b/modules/apps/document-library/document-library-repository-external-api/src/main/java/com/liferay/document/library/repository/external/ExtRepositoryAdapter.java
@@ -96,8 +96,8 @@ public class ExtRepositoryAdapter extends BaseRepositoryImpl {
 
 		ExtRepositoryFileEntry extRepositoryFileEntry =
 			_extRepository.addExtRepositoryFileEntry(
-				extRepositoryFolderKey, mimeType, fileName, description,
-				changeLog, inputStream);
+				extRepositoryFolderKey, sourceFileName, mimeType, fileName,
+				description, changeLog, inputStream);
 
 		return _toExtRepositoryObjectAdapter(
 			ExtRepositoryObjectAdapterType.FILE, extRepositoryFileEntry);

--- a/modules/apps/document-library/document-library-repository-external-api/src/main/resources/com/liferay/document/library/repository/external/packageinfo
+++ b/modules/apps/document-library/document-library-repository-external-api/src/main/resources/com/liferay/document/library/repository/external/packageinfo
@@ -1,1 +1,1 @@
-version 6.0.0
+version 7.0.0

--- a/modules/dxp/apps/sharepoint-rest/sharepoint-rest-repository/src/main/java/com/liferay/sharepoint/rest/repository/internal/document/library/repository/external/SharepointCachingExtRepository.java
+++ b/modules/dxp/apps/sharepoint-rest/sharepoint-rest-repository/src/main/java/com/liferay/sharepoint/rest/repository/internal/document/library/repository/external/SharepointCachingExtRepository.java
@@ -38,8 +38,9 @@ public class SharepointCachingExtRepository implements ExtRepository {
 
 	@Override
 	public ExtRepositoryFileEntry addExtRepositoryFileEntry(
-			String extRepositoryParentFolderKey, String mimeType, String title,
-			String description, String changeLog, InputStream inputStream)
+			String extRepositoryParentFolderKey, String fileName,
+			String mimeType, String title, String description, String changeLog,
+			InputStream inputStream)
 		throws PortalException {
 
 		Map<String, List<ExtRepositoryObject>> extRepositoryObjectsCache =
@@ -49,8 +50,8 @@ public class SharepointCachingExtRepository implements ExtRepository {
 
 		ExtRepositoryFileEntry extRepositoryFileEntry =
 			_extRepository.addExtRepositoryFileEntry(
-				extRepositoryParentFolderKey, mimeType, title, description,
-				changeLog, inputStream);
+				extRepositoryParentFolderKey, fileName, mimeType, title,
+				description, changeLog, inputStream);
 
 		Map<String, ExtRepositoryObject> extRepositoryObjectCache =
 			_extRepositoryObjectCache.get();

--- a/modules/dxp/apps/sharepoint-rest/sharepoint-rest-repository/src/main/java/com/liferay/sharepoint/rest/repository/internal/document/library/repository/external/SharepointExtRepository.java
+++ b/modules/dxp/apps/sharepoint-rest/sharepoint-rest-repository/src/main/java/com/liferay/sharepoint/rest/repository/internal/document/library/repository/external/SharepointExtRepository.java
@@ -74,8 +74,9 @@ public class SharepointExtRepository implements ExtRepository {
 
 	@Override
 	public ExtRepositoryFileEntry addExtRepositoryFileEntry(
-			String extRepositoryParentFolderKey, String mimeType, String title,
-			String description, String changeLog, InputStream inputStream)
+			String extRepositoryParentFolderKey, String fileName,
+			String mimeType, String title, String description, String changeLog,
+			InputStream inputStream)
 		throws PortalException {
 
 		try {

--- a/modules/dxp/apps/sharepoint-rest/sharepoint-rest-repository/src/main/java/com/liferay/sharepoint/rest/repository/internal/document/library/repository/external/SharepointExtRepository.java
+++ b/modules/dxp/apps/sharepoint-rest/sharepoint-rest-repository/src/main/java/com/liferay/sharepoint/rest/repository/internal/document/library/repository/external/SharepointExtRepository.java
@@ -81,7 +81,7 @@ public class SharepointExtRepository implements ExtRepository {
 
 		try {
 			String url = _sharepointURLHelper.getAddFileURL(
-				extRepositoryParentFolderKey, title);
+				extRepositoryParentFolderKey, fileName);
 
 			JSONObject jsonObject = _post(url, inputStream);
 

--- a/modules/dxp/apps/sharepoint-soap/sharepoint-soap-repository/src/main/java/com/liferay/sharepoint/soap/repository/SharepointWSRepository.java
+++ b/modules/dxp/apps/sharepoint-soap/sharepoint-soap-repository/src/main/java/com/liferay/sharepoint/soap/repository/SharepointWSRepository.java
@@ -74,8 +74,9 @@ public class SharepointWSRepository
 
 	@Override
 	public ExtRepositoryFileEntry addExtRepositoryFileEntry(
-			String extRepositoryParentFolderKey, String mimeType, String title,
-			String description, String changeLog, InputStream inputStream)
+			String extRepositoryParentFolderKey, String fileName,
+			String mimeType, String title, String description, String changeLog,
+			InputStream inputStream)
 		throws PortalException {
 
 		String filePath = null;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-197315

Problems with Sharepoint: Uploading File as Drag and Drop will make the file lose the extension

This will use the file name field to create the file on Sharepoint Rest, so for it I added a new parameter (_fileName_) to the method `addExtRepositoryFileEntry`. **This new parameter has the same order that other add*FileEntry and same as the service of FIleEntry**

The side effect is that the title field when you create a file via the portal, not via drag and drop, will be ignored.
This issue should be treated separately and addressed with design / product team members


Steps for Replication

1. Install a Clean Bundle
2. Create a Sharepoint OAuth2 Connection in (System Settings > Documents and Media > Sharepoint OAuth2)
3. Access Documents & Medias
4. Create a new Liferay Repository using the Sharepoint OAuth2 Connection
5. Upload a File, if uploaded through drag & drop it will lose file extension, if using the Plus icon from Documents & Media, the extension will be kept as long as you type it on the title.




- LPS-197315 add new param to the addExtRepositoryFileEntry method with the fileName of the file Entry
- LPS-197315 baseline
- LPS-197315 on the creation of the file use the filename instead of the title
- LPS-197315 use the new method
