### PR TITLE
LPS-197416 | Correct misalignment of long titles on DDM and KB

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/legacy/DocumentLibraryUpload.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/legacy/DocumentLibraryUpload.js
@@ -98,14 +98,20 @@ AUI.add(
 
 		const TPL_ENTRIES_CONTAINER = '<dl class="{cssClass}"></dl>';
 
-		const TPL_ENTRY_ROW_TITLE = `<div class="table-title">
-			<span class="sticker sticker-rounded sticker-document sticker-secondary file-icon-color-0">
-				<span class="sticker-overlay">
-					${Liferay.Util.getLexiconIconTpl(STR_ICON_DEFAULT)}
-				</span>
-			</span>
-			<a>{0}</a>
-		</div>`;
+		const TPL_ENTRY_ROW_TITLE = `<div class="autofit-row">
+			<div class="autofit-col pr-1">
+				<span class="sticker sticker-rounded sticker-document sticker-secondary file-icon-color-0">
+					<span class="sticker-overlay">
+						${Liferay.Util.getLexiconIconTpl(STR_ICON_DEFAULT)}
+					</span>
+					</span>
+			</div>
+			<div class="autofit-col autofit-col-expand pl-1">
+				<div class="table-title">
+					<a>{0}</a>
+				</div>
+			</div>
+			</div>`;
 
 		const TPL_ENTRY_WRAPPER =
 			'<dd class="card-page-item card-page-item-asset" data-title="{title}"></dd>';

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/search_resources.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/search_resources.jsp
@@ -259,32 +259,38 @@ entriesChecker.setRememberCheckBoxStateURLRegex("^(?!.*" + liferayPortletRespons
 												cssClass="table-cell-expand table-cell-minw-200"
 												name="title"
 											>
-												<div class="table-title">
-													<liferay-document-library:mime-type-sticker
-														cssClass="sticker-secondary"
-														fileVersion="<%= latestFileVersion %>"
-													/>
+												<div class="autofit-row">
+													<div class="autofit-col pr-1">
+														<liferay-document-library:mime-type-sticker
+															cssClass="sticker-secondary"
+															fileVersion="<%= latestFileVersion %>"
+														/>
+													</div>
 
-													<clay:link
-														href="<%= dlViewEntriesDisplayContext.getViewFileEntryURL(fileEntry) %>"
-														label="<%= HtmlUtil.unescape(latestFileVersion.getTitle()) %>"
-													/>
-
-													<c:if test="<%= fileEntry.hasLock() || fileEntry.isCheckedOut() %>">
-														<span class="inline-item inline-item-after state-icon">
-															<clay:icon
-																symbol="lock"
+													<div class="autofit-col autofit-col-expand pl-1">
+														<div class="table-title">
+															<clay:link
+																href="<%= dlViewEntriesDisplayContext.getViewFileEntryURL(fileEntry) %>"
+																label="<%= HtmlUtil.unescape(latestFileVersion.getTitle()) %>"
 															/>
-														</span>
-													</c:if>
 
-													<c:if test="<%= dlViewFileVersionDisplayContext.isShared() %>">
-														<span class="inline-item inline-item-after lfr-portal-tooltip state-icon" title="<%= LanguageUtil.get(request, "shared") %>">
-															<clay:icon
-																symbol="users"
-															/>
-														</span>
-													</c:if>
+															<c:if test="<%= fileEntry.hasLock() || fileEntry.isCheckedOut() %>">
+																<span class="inline-item inline-item-after state-icon">
+																	<clay:icon
+																		symbol="lock"
+																	/>
+																</span>
+															</c:if>
+
+															<c:if test="<%= dlViewFileVersionDisplayContext.isShared() %>">
+																<span class="inline-item inline-item-after lfr-portal-tooltip state-icon" title="<%= LanguageUtil.get(request, "shared") %>">
+																	<clay:icon
+																		symbol="users"
+																	/>
+																</span>
+															</c:if>
+														</div>
+													</div>
 												</div>
 
 												<c:if test="<%= fileShortcut != null %>">
@@ -462,7 +468,7 @@ entriesChecker.setRememberCheckBoxStateURLRegex("^(?!.*" + liferayPortletRespons
 												name="name"
 											>
 												<div class="autofit-row">
-													<div class="autofit-col">
+													<div class="autofit-col pr-1">
 														<clay:sticker
 															cssClass="sticker-document"
 															displayType="secondary"
@@ -470,7 +476,7 @@ entriesChecker.setRememberCheckBoxStateURLRegex("^(?!.*" + liferayPortletRespons
 														/>
 													</div>
 
-													<div class="autofit-col autofit-col-expand">
+													<div class="autofit-col autofit-col-expand pl-1">
 														<div class="table-title">
 															<clay:link
 																href='<%=

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp
@@ -190,44 +190,50 @@ DLViewEntriesDisplayContext dlViewEntriesDisplayContext = new DLViewEntriesDispl
 											cssClass="table-cell-expand table-cell-minw-200"
 											name="title"
 										>
-											<div class="table-title">
-												<liferay-document-library:mime-type-sticker
-													cssClass="sticker-secondary"
-													fileVersion="<%= latestFileVersion %>"
-												/>
+											<div class="autofit-row">
+												<div class="autofit-col pr-1">
+													<liferay-document-library:mime-type-sticker
+														cssClass="sticker-secondary"
+														fileVersion="<%= latestFileVersion %>"
+													/>
+												</div>
 
-												<clay:link
-													href="<%= dlViewEntriesDisplayContext.getViewFileEntryURL(fileEntry) %>"
-													label="<%= HtmlUtil.unescape(latestFileVersion.getTitle()) %>"
-												/>
-
-												<c:if test="<%= fileEntry.hasLock() || fileEntry.isCheckedOut() %>">
-													<span class="inline-item inline-item-after state-icon">
-														<clay:icon
-															aria-label='<%= LanguageUtil.get(request, "locked") %>'
-															symbol="lock"
+												<div class="autofit-col autofit-col-expand pl-1">
+													<div class="table-title">
+														<clay:link
+															href="<%= dlViewEntriesDisplayContext.getViewFileEntryURL(fileEntry) %>"
+															label="<%= HtmlUtil.unescape(latestFileVersion.getTitle()) %>"
 														/>
-													</span>
-												</c:if>
 
-												<c:if test="<%= dlViewFileVersionDisplayContext.isShared() %>">
-													<span class="inline-item inline-item-after lfr-portal-tooltip state-icon" title="<%= LanguageUtil.get(request, "shared") %>">
-														<clay:icon
-															aria-label='<%= LanguageUtil.get(request, "shared") %>'
-															symbol="users"
-														/>
-													</span>
-												</c:if>
+														<c:if test="<%= fileEntry.hasLock() || fileEntry.isCheckedOut() %>">
+															<span class="inline-item inline-item-after state-icon">
+																<clay:icon
+																	aria-label='<%= LanguageUtil.get(request, "locked") %>'
+																	symbol="lock"
+																/>
+															</span>
+														</c:if>
 
-												<c:if test="<%= fileShortcut != null %>">
-													<span class="inline-item inline-item-after state-icon">
-														<clay:icon
-															aria-label='<%= LanguageUtil.get(request, "shortcut") %>'
-															symbol="shortcut"
-															title='<%= LanguageUtil.get(request, "shortcut") %>'
-														/>
-													</span>
-												</c:if>
+														<c:if test="<%= dlViewFileVersionDisplayContext.isShared() %>">
+															<span class="inline-item inline-item-after lfr-portal-tooltip state-icon" title="<%= LanguageUtil.get(request, "shared") %>">
+																<clay:icon
+																	aria-label='<%= LanguageUtil.get(request, "shared") %>'
+																	symbol="users"
+																/>
+															</span>
+														</c:if>
+
+														<c:if test="<%= fileShortcut != null %>">
+															<span class="inline-item inline-item-after state-icon">
+																<clay:icon
+																	aria-label='<%= LanguageUtil.get(request, "shortcut") %>'
+																	symbol="shortcut"
+																	title='<%= LanguageUtil.get(request, "shortcut") %>'
+																/>
+															</span>
+														</c:if>
+													</div>
+												</div>
 											</div>
 										</liferay-ui:search-container-column-text>
 									</c:when>
@@ -392,27 +398,33 @@ DLViewEntriesDisplayContext dlViewEntriesDisplayContext = new DLViewEntriesDispl
 											cssClass="table-cell-expand table-cell-minw-200"
 											name="name"
 										>
-											<div class="table-title">
-												<clay:sticker
-													cssClass="sticker-document"
-													displayType="secondary"
-													icon='<%= curFolder.isMountPoint() ? "repository" : "folder" %>'
-												/>
+											<div class="autofit-row">
+												<div class="autofit-col pr-1">
+													<clay:sticker
+														cssClass="sticker-document"
+														displayType="secondary"
+														icon='<%= curFolder.isMountPoint() ? "repository" : "folder" %>'
+													/>
+												</div>
 
-												<clay:link
-													href='<%=
-														PortletURLBuilder.createRenderURL(
-															liferayPortletResponse
-														).setMVCRenderCommandName(
-															"/document_library/view_folder"
-														).setRedirect(
-															currentURL
-														).setParameter(
-															"folderId", curFolder.getFolderId()
-														).buildString()
-													%>'
-													label="<%= HtmlUtil.unescape(curFolder.getName()) %>"
-												/>
+												<div class="autofit-col autofit-col-expand pl-1">
+													<div class="table-title">
+														<clay:link
+															href='<%=
+																PortletURLBuilder.createRenderURL(
+																	liferayPortletResponse
+																).setMVCRenderCommandName(
+																	"/document_library/view_folder"
+																).setRedirect(
+																	currentURL
+																).setParameter(
+																	"folderId", curFolder.getFolderId()
+																).buildString()
+															%>'
+															label="<%= HtmlUtil.unescape(curFolder.getName()) %>"
+														/>
+													</div>
+												</div>
 											</div>
 										</liferay-ui:search-container-column-text>
 									</c:when>

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/view_table.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/view_table.jsp
@@ -43,24 +43,35 @@ KBArticleViewDisplayContext kbArticleViewDisplayContext = new KBArticleViewDispl
 					cssClass="table-cell-expand"
 					name="title"
 				>
-					<clay:sticker
-						cssClass="sticker-secondary"
-						icon="folder"
-					/>
+					<clay:content-row>
+						<clay:content-col
+							cssClass="pr-1"
+						>
+							<clay:sticker
+								cssClass="sticker-secondary"
+								icon="folder"
+							/>
+						</clay:content-col>
 
-					<liferay-portlet:renderURL varImpl="rowURL">
-						<portlet:param name="mvcPath" value="/admin/view_kb_folders.jsp" />
-						<portlet:param name="redirect" value="<%= currentURL %>" />
-						<portlet:param name="parentResourceClassNameId" value="<%= String.valueOf(kbFolder.getClassNameId()) %>" />
-						<portlet:param name="parentResourcePrimKey" value="<%= String.valueOf(kbFolder.getKbFolderId()) %>" />
-						<portlet:param name="selectedItemId" value="<%= String.valueOf(kbFolder.getKbFolderId()) %>" />
-					</liferay-portlet:renderURL>
+						<clay:content-col
+							cssClass="pl-1"
+							expand="<%= true %>"
+						>
+							<liferay-portlet:renderURL varImpl="rowURL">
+								<portlet:param name="mvcPath" value="/admin/view_kb_folders.jsp" />
+								<portlet:param name="redirect" value="<%= currentURL %>" />
+								<portlet:param name="parentResourceClassNameId" value="<%= String.valueOf(kbFolder.getClassNameId()) %>" />
+								<portlet:param name="parentResourcePrimKey" value="<%= String.valueOf(kbFolder.getKbFolderId()) %>" />
+								<portlet:param name="selectedItemId" value="<%= String.valueOf(kbFolder.getKbFolderId()) %>" />
+							</liferay-portlet:renderURL>
 
-					<clay:link
-						aria-label="<%= HtmlUtil.escape(kbFolder.getName()) %>"
-						href="<%= rowURL.toString() %>"
-						label="<%= HtmlUtil.escape(kbFolder.getName()) %>"
-					/>
+							<clay:link
+								aria-label="<%= HtmlUtil.escape(kbFolder.getName()) %>"
+								href="<%= rowURL.toString() %>"
+								label="<%= HtmlUtil.escape(kbFolder.getName()) %>"
+							/>
+						</clay:content-col>
+					</clay:content-row>
 				</liferay-ui:search-container-column-text>
 
 				<liferay-ui:search-container-column-text
@@ -135,20 +146,32 @@ KBArticleViewDisplayContext kbArticleViewDisplayContext = new KBArticleViewDispl
 					cssClass="table-cell-expand"
 					name="title"
 				>
-					<clay:sticker
-						cssClass="sticker-secondary"
-						icon="document-text"
-					/>
+					<clay:content-row>
+						<clay:content-col
+							cssClass="pr-1"
+						>
+							<clay:sticker
+								cssClass="sticker-secondary"
+								icon="document-text"
+							/>
+						</clay:content-col>
 
-					<%
-					PortletURL viewURL = kbArticleURLHelper.createViewWithRedirectURL(kbArticle, currentURL);
-					%>
+						<clay:content-col
+							cssClass="pl-1"
+							expand="<%= true %>"
+						>
 
-					<clay:link
-						aria-label="<%= HtmlUtil.escape(kbArticle.getTitle()) %>"
-						href="<%= viewURL.toString() %>"
-						label="<%= HtmlUtil.escape(kbArticle.getTitle()) %>"
-					/>
+							<%
+							PortletURL viewURL = kbArticleURLHelper.createViewWithRedirectURL(kbArticle, currentURL);
+							%>
+
+							<clay:link
+								aria-label="<%= HtmlUtil.escape(kbArticle.getTitle()) %>"
+								href="<%= viewURL.toString() %>"
+								label="<%= HtmlUtil.escape(kbArticle.getTitle()) %>"
+							/>
+						</clay:content-col>
+					</clay:content-row>
 				</liferay-ui:search-container-column-text>
 
 				<liferay-ui:search-container-column-text


### PR DESCRIPTION
**Description:** Corrected misalignment found between icons and titles for items with long titles after  [LPS-196690](https://liferay.atlassian.net/browse/LPS-196690) 
![image](https://github.com/liferay-lima/liferay-portal/assets/40394495/f78eb3ea-e917-4022-b839-2fce0e0993bc)


**Jira Ticket:** https://liferay.atlassian.net/browse/LPS-197416