### PR TITLE
LPS-197123 use the getPreviewableProcessorMaxSize on the exception

### DIFF
--- a/modules/apps/document-library/document-library-preview-audio/src/main/java/com/liferay/document/library/preview/audio/internal/AudioDLPreviewRendererProvider.java
+++ b/modules/apps/document-library/document-library-preview-audio/src/main/java/com/liferay/document/library/preview/audio/internal/AudioDLPreviewRendererProvider.java
@@ -93,7 +93,8 @@ public class AudioDLPreviewRendererProvider
 
 		if (!_audioProcessor.hasAudio(fileVersion)) {
 			if (!DLProcessorRegistryUtil.isPreviewableSize(fileVersion)) {
-				throw new DLPreviewSizeException();
+				throw new DLPreviewSizeException(
+					DLProcessorRegistryUtil.getPreviewableProcessorMaxSize());
 			}
 
 			throw new DLPreviewGenerationInProcessException();

--- a/modules/apps/document-library/document-library-preview-document/src/main/java/com/liferay/document/library/preview/document/internal/DocumentPreviewRendererProvider.java
+++ b/modules/apps/document-library/document-library-preview-document/src/main/java/com/liferay/document/library/preview/document/internal/DocumentPreviewRendererProvider.java
@@ -85,7 +85,8 @@ public class DocumentPreviewRendererProvider
 
 		if (!PDFProcessorUtil.hasImages(fileVersion)) {
 			if (!DLProcessorRegistryUtil.isPreviewableSize(fileVersion)) {
-				throw new DLPreviewSizeException();
+				throw new DLPreviewSizeException(
+					DLProcessorRegistryUtil.getPreviewableProcessorMaxSize());
 			}
 
 			throw new DLPreviewGenerationInProcessException();

--- a/modules/apps/document-library/document-library-preview-image/src/main/java/com/liferay/document/library/preview/image/internal/ImageDLPreviewRendererProvider.java
+++ b/modules/apps/document-library/document-library-preview-image/src/main/java/com/liferay/document/library/preview/image/internal/ImageDLPreviewRendererProvider.java
@@ -90,7 +90,8 @@ public class ImageDLPreviewRendererProvider
 
 		if (!imageProcessor.hasImages(fileVersion)) {
 			if (!DLProcessorRegistryUtil.isPreviewableSize(fileVersion)) {
-				throw new DLPreviewSizeException();
+				throw new DLPreviewSizeException(
+					DLProcessorRegistryUtil.getPreviewableProcessorMaxSize());
 			}
 
 			throw new DLPreviewGenerationInProcessException();

--- a/modules/apps/document-library/document-library-video/src/main/java/com/liferay/document/library/video/internal/preview/DLVideoDLPreviewRendererProvider.java
+++ b/modules/apps/document-library/document-library-video/src/main/java/com/liferay/document/library/video/internal/preview/DLVideoDLPreviewRendererProvider.java
@@ -103,7 +103,8 @@ public class DLVideoDLPreviewRendererProvider
 
 		if (!_videoProcessor.hasVideo(fileVersion)) {
 			if (!DLProcessorRegistryUtil.isPreviewableSize(fileVersion)) {
-				throw new DLPreviewSizeException();
+				throw new DLPreviewSizeException(
+					DLProcessorRegistryUtil.getPreviewableProcessorMaxSize());
 			}
 
 			throw new DLPreviewGenerationInProcessException();


### PR DESCRIPTION
- LPS-197123 use the getPreviewableProcessorMaxSize on the exception

