### PR TITLE
LPS-149669 Fix some error messages in item selector related with size and extensions

### DIFF
--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/util/DLValidatorImpl.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/util/DLValidatorImpl.java
@@ -71,15 +71,22 @@ public final class DLValidatorImpl implements DLValidator {
 
 	@Override
 	public long getMaxAllowableSize(long groupId, String mimeType) {
+		return getMaxAllowableSize(groupId, mimeType, 0);
+	}
+
+	@Override
+	public long getMaxAllowableSize(long groupId, String mimeType, long limit) {
 		long companyId = _getCompanyId(groupId);
 
 		return _min(
-			_getGlobalMaxAllowableSize(companyId, groupId),
+			limit,
 			_min(
-				_dlSizeLimitConfigurationHelper.getCompanyMimeTypeSizeLimit(
-					companyId, mimeType),
-				_dlSizeLimitConfigurationHelper.getGroupMimeTypeSizeLimit(
-					groupId, mimeType)));
+				_getGlobalMaxAllowableSize(companyId, groupId),
+				_min(
+					_dlSizeLimitConfigurationHelper.getCompanyMimeTypeSizeLimit(
+						companyId, mimeType),
+					_dlSizeLimitConfigurationHelper.getGroupMimeTypeSizeLimit(
+						groupId, mimeType))));
 	}
 
 	@Override
@@ -198,7 +205,7 @@ public final class DLValidatorImpl implements DLValidator {
 		if (bytes == null) {
 			throw new FileSizeException(
 				"File size is zero for " + fileName,
-				getMaxAllowableSize(groupId, mimeType));
+				getMaxAllowableSize(groupId, mimeType, 0));
 		}
 
 		validateFileSize(groupId, fileName, mimeType, bytes.length);
@@ -212,7 +219,7 @@ public final class DLValidatorImpl implements DLValidator {
 		if (file == null) {
 			throw new FileSizeException(
 				"File is null for " + fileName,
-				getMaxAllowableSize(groupId, mimeType));
+				getMaxAllowableSize(groupId, mimeType, 0));
 		}
 
 		validateFileSize(groupId, fileName, mimeType, file.length());
@@ -228,7 +235,7 @@ public final class DLValidatorImpl implements DLValidator {
 			if (inputStream == null) {
 				throw new FileSizeException(
 					"Input stream is null for " + fileName,
-					getMaxAllowableSize(groupId, mimeType));
+					getMaxAllowableSize(groupId, mimeType, 0));
 			}
 
 			validateFileSize(
@@ -244,7 +251,7 @@ public final class DLValidatorImpl implements DLValidator {
 			long groupId, String fileName, String mimeType, long size)
 		throws FileSizeException {
 
-		long maxSize = getMaxAllowableSize(groupId, mimeType);
+		long maxSize = getMaxAllowableSize(groupId, mimeType, 0);
 
 		if ((maxSize > 0) && (size > maxSize)) {
 			throw new FileSizeException(

--- a/modules/apps/knowledge-base/knowledge-base-editor-configuration/src/main/java/com/liferay/knowledge/base/editor/configuration/internal/KBAttachmentEditorConfigContributor.java
+++ b/modules/apps/knowledge-base/knowledge-base-editor-configuration/src/main/java/com/liferay/knowledge/base/editor/configuration/internal/KBAttachmentEditorConfigContributor.java
@@ -5,6 +5,7 @@
 
 package com.liferay.knowledge.base.editor.configuration.internal;
 
+import com.liferay.document.library.kernel.util.DLValidator;
 import com.liferay.item.selector.ItemSelector;
 import com.liferay.item.selector.ItemSelectorCriterion;
 import com.liferay.item.selector.ItemSelectorReturnType;
@@ -141,6 +142,9 @@ public class KBAttachmentEditorConfigContributor
 		return UploadItemSelectorCriterion.builder(
 		).desiredItemSelectorReturnTypes(
 			new FileEntryItemSelectorReturnType()
+		).maxFileSize(
+			_dlValidator.getMaxAllowableSize(
+				themeDisplay.getScopeGroupId(), null)
 		).mimeTypeRestriction(
 			ItemSelectorCriterionConstants.MIME_TYPE_RESTRICTION_IMAGE
 		).repositoryName(
@@ -167,6 +171,9 @@ public class KBAttachmentEditorConfigContributor
 
 		return itemSelectorCriterion;
 	}
+
+	@Reference
+	private DLValidator _dlValidator;
 
 	@Reference
 	private ItemSelector _itemSelector;

--- a/modules/apps/wiki/wiki-editor-configuration/src/main/java/com/liferay/wiki/editor/configuration/internal/BaseWikiAttachmentImageEditorConfigContributor.java
+++ b/modules/apps/wiki/wiki-editor-configuration/src/main/java/com/liferay/wiki/editor/configuration/internal/BaseWikiAttachmentImageEditorConfigContributor.java
@@ -5,6 +5,8 @@
 
 package com.liferay.wiki.editor.configuration.internal;
 
+import com.liferay.document.library.kernel.util.DLValidator;
+import com.liferay.document.library.kernel.util.DLValidatorUtil;
 import com.liferay.item.selector.ItemSelectorCriterion;
 import com.liferay.item.selector.ItemSelectorReturnType;
 import com.liferay.item.selector.constants.ItemSelectorCriterionConstants;
@@ -22,6 +24,7 @@ import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.MimeTypesUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.util.PropsValues;
 import com.liferay.wiki.configuration.WikiFileUploadConfiguration;
@@ -127,9 +130,20 @@ public abstract class BaseWikiAttachmentImageEditorConfigContributor
 		WikiFileUploadConfiguration wikiFileUploadConfiguration =
 			getWikiFileUploadConfiguration();
 
+		String[] attachmentMimeTypes =
+			wikiFileUploadConfiguration.attachmentMimeTypes();
+
+		List<String> extensions = new ArrayList<>();
+
+		for (String attachmentMimeType : attachmentMimeTypes) {
+			extensions.addAll(MimeTypesUtil.getExtensions(attachmentMimeType));
+		}
+
 		return UploadItemSelectorCriterion.builder(
 		).desiredItemSelectorReturnTypes(
 			new FileEntryItemSelectorReturnType()
+		).extensions(
+			extensions.toArray(new String[extensions.size()])
 		).maxFileSize(
 			wikiFileUploadConfiguration.attachmentMaxSize()
 		).mimeTypeRestriction(

--- a/modules/apps/wiki/wiki-editor-configuration/src/main/java/com/liferay/wiki/editor/configuration/internal/BaseWikiAttachmentImageEditorConfigContributor.java
+++ b/modules/apps/wiki/wiki-editor-configuration/src/main/java/com/liferay/wiki/editor/configuration/internal/BaseWikiAttachmentImageEditorConfigContributor.java
@@ -124,9 +124,14 @@ public abstract class BaseWikiAttachmentImageEditorConfigContributor
 		long wikiPageResourcePrimKey, ThemeDisplay themeDisplay,
 		RequestBackedPortletURLFactory requestBackedPortletURLFactory) {
 
+		WikiFileUploadConfiguration wikiFileUploadConfiguration =
+			getWikiFileUploadConfiguration();
+
 		return UploadItemSelectorCriterion.builder(
 		).desiredItemSelectorReturnTypes(
 			new FileEntryItemSelectorReturnType()
+		).maxFileSize(
+			wikiFileUploadConfiguration.attachmentMaxSize()
 		).mimeTypeRestriction(
 			ItemSelectorCriterionConstants.MIME_TYPE_RESTRICTION_IMAGE
 		).portletId(

--- a/modules/apps/wiki/wiki-editor-configuration/src/main/java/com/liferay/wiki/editor/configuration/internal/BaseWikiAttachmentImageEditorConfigContributor.java
+++ b/modules/apps/wiki/wiki-editor-configuration/src/main/java/com/liferay/wiki/editor/configuration/internal/BaseWikiAttachmentImageEditorConfigContributor.java
@@ -6,7 +6,7 @@
 package com.liferay.wiki.editor.configuration.internal;
 
 import com.liferay.document.library.kernel.util.DLValidator;
-import com.liferay.document.library.kernel.util.DLValidatorUtil;
+import com.liferay.item.selector.ItemSelector;
 import com.liferay.item.selector.ItemSelectorCriterion;
 import com.liferay.item.selector.ItemSelectorReturnType;
 import com.liferay.item.selector.constants.ItemSelectorCriterionConstants;
@@ -16,6 +16,7 @@ import com.liferay.item.selector.criteria.image.criterion.ImageItemSelectorCrite
 import com.liferay.item.selector.criteria.upload.criterion.UploadItemSelectorCriterion;
 import com.liferay.item.selector.criteria.url.criterion.URLItemSelectorCriterion;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.editor.configuration.BaseEditorConfigContributor;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.language.LanguageUtil;
@@ -34,6 +35,10 @@ import com.liferay.wiki.item.selector.criterion.WikiAttachmentItemSelectorCriter
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Modified;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Sergio González
@@ -106,6 +111,13 @@ public abstract class BaseWikiAttachmentImageEditorConfigContributor
 		);
 	}
 
+	@Activate
+	@Modified
+	protected void activate(Map<String, Object> properties) {
+		wikiFileUploadConfiguration = ConfigurableUtil.createConfigurable(
+			WikiFileUploadConfiguration.class, properties);
+	}
+
 	protected ItemSelectorCriterion getImageItemSelectorCriterion(
 		ItemSelectorReturnType... desiredItemSelectorReturnTypes) {
 
@@ -127,9 +139,6 @@ public abstract class BaseWikiAttachmentImageEditorConfigContributor
 		long wikiPageResourcePrimKey, ThemeDisplay themeDisplay,
 		RequestBackedPortletURLFactory requestBackedPortletURLFactory) {
 
-		WikiFileUploadConfiguration wikiFileUploadConfiguration =
-			getWikiFileUploadConfiguration();
-
 		String[] attachmentMimeTypes =
 			wikiFileUploadConfiguration.attachmentMimeTypes();
 
@@ -143,9 +152,11 @@ public abstract class BaseWikiAttachmentImageEditorConfigContributor
 		).desiredItemSelectorReturnTypes(
 			new FileEntryItemSelectorReturnType()
 		).extensions(
-			extensions.toArray(new String[extensions.size()])
+			extensions.toArray(new String[0])
 		).maxFileSize(
-			wikiFileUploadConfiguration.attachmentMaxSize()
+			dlValidator.getMaxAllowableSize(
+				themeDisplay.getScopeGroupId(), null,
+				wikiFileUploadConfiguration.attachmentMaxSize())
 		).mimeTypeRestriction(
 			ItemSelectorCriterionConstants.MIME_TYPE_RESTRICTION_IMAGE
 		).portletId(
@@ -190,15 +201,17 @@ public abstract class BaseWikiAttachmentImageEditorConfigContributor
 		return itemSelectorCriterion;
 	}
 
-	protected abstract WikiFileUploadConfiguration
-		getWikiFileUploadConfiguration();
+	@Reference
+	protected DLValidator dlValidator;
+
+	@Reference
+	protected ItemSelector itemSelector;
+
+	protected volatile WikiFileUploadConfiguration wikiFileUploadConfiguration;
 
 	private String[] _getMimeTypes() {
 		String[] dlFileEntryPreviewImageMimeTypes =
 			PropsValues.DL_FILE_ENTRY_PREVIEW_IMAGE_MIME_TYPES;
-
-		WikiFileUploadConfiguration wikiFileUploadConfiguration =
-			getWikiFileUploadConfiguration();
 
 		List<String> wikiAttachmentMimeTypes = ListUtil.fromArray(
 			wikiFileUploadConfiguration.attachmentMimeTypes());

--- a/modules/apps/wiki/wiki-editor-configuration/src/main/java/com/liferay/wiki/editor/configuration/internal/WikiAttachmentImageCreoleEditorConfigContributor.java
+++ b/modules/apps/wiki/wiki-editor-configuration/src/main/java/com/liferay/wiki/editor/configuration/internal/WikiAttachmentImageCreoleEditorConfigContributor.java
@@ -5,22 +5,14 @@
 
 package com.liferay.wiki.editor.configuration.internal;
 
-import com.liferay.item.selector.ItemSelector;
 import com.liferay.item.selector.ItemSelectorCriterion;
 import com.liferay.item.selector.criteria.FileEntryItemSelectorReturnType;
-import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.editor.configuration.EditorConfigContributor;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactory;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.wiki.configuration.WikiFileUploadConfiguration;
 import com.liferay.wiki.constants.WikiPortletKeys;
 
-import java.util.Map;
-
-import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Modified;
-import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Ambrín Chaudhary
@@ -40,13 +32,6 @@ import org.osgi.service.component.annotations.Reference;
 public class WikiAttachmentImageCreoleEditorConfigContributor
 	extends BaseWikiAttachmentImageEditorConfigContributor {
 
-	@Activate
-	@Modified
-	protected void activate(Map<String, Object> properties) {
-		_wikiFileUploadConfiguration = ConfigurableUtil.createConfigurable(
-			WikiFileUploadConfiguration.class, properties);
-	}
-
 	@Override
 	protected String getItemSelectorURL(
 		RequestBackedPortletURLFactory requestBackedPortletURLFactory,
@@ -55,7 +40,7 @@ public class WikiAttachmentImageCreoleEditorConfigContributor
 
 		if (wikiPageResourcePrimKey == 0) {
 			return String.valueOf(
-				_itemSelector.getItemSelectorURL(
+				itemSelector.getItemSelectorURL(
 					requestBackedPortletURLFactory, itemSelectedEventName,
 					getURLItemSelectorCriterion()));
 		}
@@ -70,26 +55,10 @@ public class WikiAttachmentImageCreoleEditorConfigContributor
 				requestBackedPortletURLFactory);
 
 		return String.valueOf(
-			_itemSelector.getItemSelectorURL(
+			itemSelector.getItemSelectorURL(
 				requestBackedPortletURLFactory, itemSelectedEventName,
 				attachmentItemSelectorCriterion, getURLItemSelectorCriterion(),
 				uploadItemSelectorCriterion));
 	}
-
-	@Override
-	protected WikiFileUploadConfiguration getWikiFileUploadConfiguration() {
-		return _wikiFileUploadConfiguration;
-	}
-
-	protected void setWikiFileUploadConfiguration(
-		WikiFileUploadConfiguration wikiFileUploadConfiguration) {
-
-		_wikiFileUploadConfiguration = wikiFileUploadConfiguration;
-	}
-
-	@Reference
-	private ItemSelector _itemSelector;
-
-	private volatile WikiFileUploadConfiguration _wikiFileUploadConfiguration;
 
 }

--- a/modules/apps/wiki/wiki-editor-configuration/src/main/java/com/liferay/wiki/editor/configuration/internal/WikiAttachmentImageHTMLEditorConfigContributor.java
+++ b/modules/apps/wiki/wiki-editor-configuration/src/main/java/com/liferay/wiki/editor/configuration/internal/WikiAttachmentImageHTMLEditorConfigContributor.java
@@ -5,22 +5,14 @@
 
 package com.liferay.wiki.editor.configuration.internal;
 
-import com.liferay.item.selector.ItemSelector;
 import com.liferay.item.selector.ItemSelectorCriterion;
 import com.liferay.item.selector.criteria.FileEntryItemSelectorReturnType;
-import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.editor.configuration.EditorConfigContributor;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactory;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.wiki.configuration.WikiFileUploadConfiguration;
 import com.liferay.wiki.constants.WikiPortletKeys;
 
-import java.util.Map;
-
-import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Modified;
-import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Ambrín Chaudhary
@@ -39,13 +31,6 @@ import org.osgi.service.component.annotations.Reference;
 public class WikiAttachmentImageHTMLEditorConfigContributor
 	extends BaseWikiAttachmentImageEditorConfigContributor {
 
-	@Activate
-	@Modified
-	protected void activate(Map<String, Object> properties) {
-		_wikiFileUploadConfiguration = ConfigurableUtil.createConfigurable(
-			WikiFileUploadConfiguration.class, properties);
-	}
-
 	@Override
 	protected String getItemSelectorURL(
 		RequestBackedPortletURLFactory requestBackedPortletURLFactory,
@@ -58,7 +43,7 @@ public class WikiAttachmentImageHTMLEditorConfigContributor
 
 		if (wikiPageResourcePrimKey == 0) {
 			return String.valueOf(
-				_itemSelector.getItemSelectorURL(
+				itemSelector.getItemSelectorURL(
 					requestBackedPortletURLFactory, itemSelectedEventName,
 					imageItemSelectorCriterion, getURLItemSelectorCriterion()));
 		}
@@ -73,26 +58,10 @@ public class WikiAttachmentImageHTMLEditorConfigContributor
 				requestBackedPortletURLFactory);
 
 		return String.valueOf(
-			_itemSelector.getItemSelectorURL(
+			itemSelector.getItemSelectorURL(
 				requestBackedPortletURLFactory, itemSelectedEventName,
 				attachmentItemSelectorCriterion, imageItemSelectorCriterion,
 				getURLItemSelectorCriterion(), uploadItemSelectorCriterion));
 	}
-
-	@Override
-	protected WikiFileUploadConfiguration getWikiFileUploadConfiguration() {
-		return _wikiFileUploadConfiguration;
-	}
-
-	protected void setWikiFileUploadConfiguration(
-		WikiFileUploadConfiguration wikiFileUploadConfiguration) {
-
-		_wikiFileUploadConfiguration = wikiFileUploadConfiguration;
-	}
-
-	@Reference
-	private ItemSelector _itemSelector;
-
-	private volatile WikiFileUploadConfiguration _wikiFileUploadConfiguration;
 
 }

--- a/portal-impl/src/com/liferay/portal/upgrade/v6_2_0/util/DLValidatorImpl.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v6_2_0/util/DLValidatorImpl.java
@@ -62,6 +62,11 @@ public final class DLValidatorImpl implements DLValidator {
 	}
 
 	@Override
+	public long getMaxAllowableSize(long groupId, String mimeType, long limit) {
+		return 104857600;
+	}
+
+	@Override
 	public Map<String, Long> getMimeTypeSizeLimit(long groupId) {
 		return Collections.emptyMap();
 	}

--- a/portal-kernel/src/com/liferay/document/library/kernel/util/DLValidator.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/util/DLValidator.java
@@ -29,6 +29,8 @@ public interface DLValidator {
 
 	public long getMaxAllowableSize(long groupId, String mimeType);
 
+	public long getMaxAllowableSize(long groupId, String mimeType, long limit);
+
 	public Map<String, Long> getMimeTypeSizeLimit(long groupId);
 
 	public boolean isValidName(String name);

--- a/portal-kernel/src/com/liferay/document/library/kernel/util/DLValidatorUtil.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/util/DLValidatorUtil.java
@@ -29,6 +29,12 @@ public class DLValidatorUtil {
 		return _dlValidator.getMaxAllowableSize(groupId, mimeType);
 	}
 
+	public static long getMaxAllowableSize(
+		long groupId, String mimeType, long limit) {
+
+		return _dlValidator.getMaxAllowableSize(groupId, mimeType, limit);
+	}
+
 	public static boolean isValidName(String name) {
 		return _dlValidator.isValidName(name);
 	}


### PR DESCRIPTION
Backend also takes into account general limits, so I've created a new method to retrieve the maxAllowable size of all the possible cases.

I've changed some cases or wrong error messages that I've identify, but we could have more.

Example of the fix:

Before:
<img width="1524" alt="Captura de pantalla 2023-10-02 a las 17 50 55" src="https://github.com/liferay-lima/liferay-portal/assets/2728470/0c6ecb47-268a-491e-b6e9-6777409daf6d">

After:

<img width="1494" alt="Captura de pantalla 2023-10-02 a las 17 49 46" src="https://github.com/liferay-lima/liferay-portal/assets/2728470/6f57eaa7-2a41-41d0-a85a-ebed97132540">