### PR TITLE
LPS-193423 A document in a folder stored in a depot can not be accessed from FTP mode

### DIFF
--- a/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
+++ b/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
@@ -103,6 +103,7 @@ import com.liferay.portal.kernel.util.ReleaseInfo;
 import com.liferay.portal.kernel.util.ServiceProxyFactory;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.URLCodec;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.Validator_IW;
@@ -203,7 +204,8 @@ public class WebServerServlet extends HttpServlet {
 				for (int i = 1; i < pathArray.length; i++) {
 					try {
 						Folder folder = DLAppLocalServiceUtil.getFolder(
-							groupId, folderId, pathArray[i]);
+							groupId, folderId,
+							URLCodec.decodeURL(pathArray[i]));
 
 						folderId = folder.getFolderId();
 					}
@@ -915,7 +917,7 @@ public class WebServerServlet extends HttpServlet {
 
 			try {
 				Folder folder = DLAppServiceUtil.getFolder(
-					groupId, folderId, name);
+					groupId, folderId, URLCodec.decodeURL(name));
 
 				folderId = folder.getFolderId();
 			}
@@ -926,7 +928,9 @@ public class WebServerServlet extends HttpServlet {
 
 				String title = name;
 
-				sendFile(httpServletResponse, user, groupId, folderId, title);
+				sendFile(
+					httpServletResponse, user, groupId, folderId,
+					URLCodec.decodeURL(title));
 
 				return;
 			}
@@ -986,7 +990,8 @@ public class WebServerServlet extends HttpServlet {
 			webServerEntries.add(webServerEntry);
 		}
 
-		sendHTML(httpServletResponse, path, webServerEntries);
+		sendHTML(
+			httpServletResponse, URLCodec.decodeURL(path), webServerEntries);
 	}
 
 	protected void sendFile(


### PR DESCRIPTION
Fixed access to:

* Files with empty spaces (thanks to @adolfopa)
* Folders with empty spaces (the method `hasFiles` was being called from `VirtualHostFilter`)

I also added a decode of the path to finally show the folder name encoded once, and not twice. Maybe it should be not enconded again in `sendHTML` ? This would show the name of the folder correctly, but I don't know if it is SAFE

See issue: https://liferay.atlassian.net/browse/LPS-193423