### PR TITLE
LPS-182018 Ratings from API

### DIFF
--- a/modules/apps/ratings/ratings-taglib/src/main/resources/META-INF/resources/js/components/RatingsSelectStars.js
+++ b/modules/apps/ratings/ratings-taglib/src/main/resources/META-INF/resources/js/components/RatingsSelectStars.js
@@ -67,7 +67,10 @@ export default function RatingsSelectStars({
 							value={score}
 						>
 							<span className="inline-item inline-item-before">
-								<ClayIcon symbol={score ? 'star' : 'star-o'} />
+								<ClayIcon
+									aria-label={Liferay.Language.get('votes')}
+									symbol={score ? 'star' : 'star-o'}
+								/>
 							</span>
 
 							<span className="inline-item ratings-stars-button-text">
@@ -138,6 +141,7 @@ export default function RatingsSelectStars({
 				<span className="ratings-stars-average">
 					<span className="inline-item inline-item-before">
 						<ClayIcon
+							aria-label={Liferay.Language.get('average')}
 							className="ratings-stars-average-icon"
 							symbol="star"
 						/>

--- a/modules/apps/ratings/ratings-taglib/src/main/resources/META-INF/resources/js/components/RatingsStackedStars.js
+++ b/modules/apps/ratings/ratings-taglib/src/main/resources/META-INF/resources/js/components/RatingsStackedStars.js
@@ -43,6 +43,7 @@ export default function RatingsStackedStars({
 
 						return (
 							<ClayIcon
+								aria-label={score}
 								className="ratings-stars-average-icon"
 								key={score}
 								symbol={symbol}
@@ -135,6 +136,7 @@ export default function RatingsStackedStars({
 						title={Liferay.Language.get('delete')}
 					>
 						<ClayIcon
+							aria-label={Liferay.Language.get('delete')}
 							className="lexicon-icon-vertical-align"
 							symbol="times-circle"
 						/>

--- a/modules/apps/ratings/ratings-taglib/src/main/resources/META-INF/resources/js/components/RatingsStars.js
+++ b/modules/apps/ratings/ratings-taglib/src/main/resources/META-INF/resources/js/components/RatingsStars.js
@@ -56,7 +56,7 @@ const RatingsStars = ({
 		(score) => {
 			let starScore = starScores.find(({value}) => score === value);
 
-			if (!starScore) {
+			if (score > 0 && !starScore) {
 				starScore = findClosestScore(score);
 			}
 

--- a/modules/apps/ratings/ratings-taglib/src/main/resources/META-INF/resources/js/components/RatingsStars.js
+++ b/modules/apps/ratings/ratings-taglib/src/main/resources/META-INF/resources/js/components/RatingsStars.js
@@ -34,13 +34,35 @@ const RatingsStars = ({
 		};
 	});
 
+	const findClosestScore = useCallback(
+		(score) => {
+			let closestScore = {label: 0, value: 0};
+
+			starScores.forEach((item) => {
+				if (
+					Math.abs(item.value - score) <=
+					Math.abs(closestScore.value - score)
+				) {
+					closestScore = item;
+				}
+			});
+
+			return closestScore;
+		},
+		[starScores]
+	);
+
 	const getLabelScore = useCallback(
 		(score) => {
-			const starScore = starScores.find(({value}) => score === value);
+			let starScore = starScores.find(({value}) => score === value);
+
+			if (!starScore) {
+				starScore = findClosestScore(score);
+			}
 
 			return (starScore && starScore.label) || 0;
 		},
-		[starScores]
+		[findClosestScore, starScores]
 	);
 
 	const formatAverageScore = useCallback(

--- a/modules/apps/ratings/ratings-taglib/src/main/resources/META-INF/resources/js/components/RatingsStars.js
+++ b/modules/apps/ratings/ratings-taglib/src/main/resources/META-INF/resources/js/components/RatingsStars.js
@@ -40,8 +40,8 @@ const RatingsStars = ({
 
 			starScores.forEach((item) => {
 				if (
-					Math.abs(item.value - score) <=
-					Math.abs(closestScore.value - score)
+					Math.abs((item.value - score).toFixed(1)) <=
+					Math.abs((closestScore.value - score).toFixed(1))
 				) {
 					closestScore = item;
 				}

--- a/modules/apps/ratings/ratings-taglib/test/components/RatingsSelectStars.js
+++ b/modules/apps/ratings/ratings-taglib/test/components/RatingsSelectStars.js
@@ -284,4 +284,15 @@ describe('RatingsSelectStars', () => {
 			});
 		});
 	});
+
+	describe('when a decimal score is set from the API', () => {
+		it('it rounds the score to the nearest valid rating', () => {
+			const result = renderComponent({
+				userScore: 0.5,
+			});
+			const starsDropdownToggle = result.getAllByRole('button')[0];
+
+			expect(starsDropdownToggle.value).toBe('3');
+		});
+	});
 });


### PR DESCRIPTION
Currently we have this values: 
0 -> no vote 
0.2 -> 1 star
0.4 -> 2 stars
0.6 -> 3 stars
0.8 -> 4 stars
1 -> 5 stars

From the UI only those values can be selected. But from the API you could vote from 0 to 1. So 0.5 rating should be valid, and now it is translated to 3 stars. 
See https://liferay.atlassian.net/browse/LPS-182018 for more details. 

