### PR TITLE
LPS-198164 default max file size to be copied should be 50 MB

### DIFF
--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/configuration/DLSizeLimitConfiguration.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/configuration/DLSizeLimitConfiguration.java
@@ -31,7 +31,7 @@ public interface DLSizeLimitConfiguration {
 	@Meta.AD(deflt = "", name = "mime-type-size-limit-name", required = false)
 	public String[] mimeTypeSizeLimit();
 
-	@Meta.AD(deflt = "0", name = "max-size-to-copy", required = false)
+	@Meta.AD(deflt = "52428800", name = "max-size-to-copy", required = false)
 	public long maxSizeToCopy();
 
 }

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/verify/DLServiceVerifyProcess.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/verify/DLServiceVerifyProcess.java
@@ -67,9 +67,9 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
 /**
- * @author     Raymond Augé
- * @author     Douglas Wong
- * @author     Alexander Chow
+ * @author Raymond Augé
+ * @author Douglas Wong
+ * @author Alexander Chow
  */
 @Component(service = VerifyProcess.class)
 public class DLServiceVerifyProcess extends VerifyProcess {


### PR DESCRIPTION

![image](https://github.com/liferay-lima/liferay-portal/assets/47524751/856071ea-0a71-4348-bf79-774f503d0615)



- LPS-198164 default max file size to be copied should be 50 MB
- LPS-198164 autoSF
