### PR TITLE
LPS-198648 XSS vulnerability with KB attachments

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/js/EditKBArticle.js
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/js/EditKBArticle.js
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import {escapeHTML} from 'frontend-js-web';
+
 function attachListener(element, eventType, callback) {
 	element?.addEventListener(eventType, callback);
 
@@ -93,7 +95,7 @@ export default function EditKBArticle({kbArticle, namespace, publishAction}) {
 				`<input id="${namespace}selectedFileName${i}"
 					name="${namespace}selectedFileName"
 					type="hidden"
-					value="${filesChecked[i].value}"
+					value="${escapeHTML(filesChecked[i].value)}"
 				/>`
 			);
 		}


### PR DESCRIPTION
Issue https://liferay.atlassian.net/browse/LPS-198648. 

> updateMultipleKBArticleAttachments in EditKBArticle  uses user supplied data filesChecked[i].value without encoding the value. Please encode filesChecked[i].value before using it in the <input> tag.


I followed what it is done in Message Boards: https://github.com/liferay/liferay-portal/blob/master/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/js/MBPortlet.es.js#L275