### PR TITLE
LPS-199428 XMATLAB case has to be handled in the metadata processor to avoid set wrong ContentTypes

### DIFF
--- a/modules/apps/portal/portal-tika/src/main/java/com/liferay/portal/tika/internal/metadata/TikaRawMetadataProcessor.java
+++ b/modules/apps/portal/portal-tika/src/main/java/com/liferay/portal/tika/internal/metadata/TikaRawMetadataProcessor.java
@@ -247,6 +247,18 @@ public class TikaRawMetadataProcessor implements RawMetadataProcessor {
 			}
 		}
 
+		if (mimeType.endsWith(ContentTypes.APPLICATION_JAVASCRIPT)) {
+			String contentType = metadata.get(HttpHeaders.CONTENT_TYPE);
+
+			if (contentType.startsWith(ContentTypes.TEXT_XMATLAB)) {
+				metadata.set(
+					HttpHeaders.CONTENT_TYPE,
+					StringUtil.replace(
+						contentType, ContentTypes.TEXT_XMATLAB,
+						ContentTypes.APPLICATION_JAVASCRIPT));
+			}
+		}
+
 		if (_log.isDebugEnabled()) {
 			_log.debug("Extracted metadata: " + metadata);
 		}

--- a/modules/apps/portal/portal-tika/src/main/resources/com/liferay/portal/tika/internal/mime/dependencies/custom-mimetypes.xml
+++ b/modules/apps/portal/portal-tika/src/main/resources/com/liferay/portal/tika/internal/mime/dependencies/custom-mimetypes.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0"?>
 
 <mime-info>
+	<mime-type type="application/javascript">
+		<glob pattern="*.js" />
+	</mime-type>
 	<mime-type type="application/zip">
 		<glob pattern="*.lar" />
 	</mime-type>

--- a/portal-kernel/src/com/liferay/portal/kernel/util/ContentTypes.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/ContentTypes.java
@@ -112,6 +112,8 @@ public interface ContentTypes {
 
 	public static final String TEXT_X_JSP = "text/x-jsp";
 
+	public static final String TEXT_XMATLAB = "text/x-matlab";
+
 	public static final String TEXT_XML = "text/xml";
 
 	public static final String TEXT_XML_UTF8 = "text/xml; charset=UTF-8";


### PR DESCRIPTION
This is a followup for https://github.com/liferay-lima/liferay-portal/pull/4801

It seems that the wrong mime type is also appearing in the content type of the metadata extracted