### PR TITLE
LPS-199428 XMATLAB case has to be handled in the metadata processor to avoid set wrong ContentTypes

### DIFF
--- a/modules/apps/portal/portal-tika/src/main/java/com/liferay/portal/tika/internal/metadata/TikaRawMetadataProcessor.java
+++ b/modules/apps/portal/portal-tika/src/main/java/com/liferay/portal/tika/internal/metadata/TikaRawMetadataProcessor.java
@@ -247,6 +247,18 @@ public class TikaRawMetadataProcessor implements RawMetadataProcessor {
 			}
 		}
 
+		if (mimeType.endsWith(ContentTypes.APPLICATION_JAVASCRIPT)) {
+			String contentType = metadata.get(HttpHeaders.CONTENT_TYPE);
+
+			if (contentType.startsWith(ContentTypes.TEXT_XMATLAB)) {
+				metadata.set(
+					HttpHeaders.CONTENT_TYPE,
+					StringUtil.replace(
+						contentType, ContentTypes.TEXT_XMATLAB,
+						ContentTypes.APPLICATION_JAVASCRIPT));
+			}
+		}
+
 		if (_log.isDebugEnabled()) {
 			_log.debug("Extracted metadata: " + metadata);
 		}

--- a/modules/apps/portal/portal-tika/src/main/java/com/liferay/portal/tika/internal/metadata/TikaRawMetadataProcessor.java
+++ b/modules/apps/portal/portal-tika/src/main/java/com/liferay/portal/tika/internal/metadata/TikaRawMetadataProcessor.java
@@ -242,7 +242,7 @@ public class TikaRawMetadataProcessor implements RawMetadataProcessor {
 				metadata.set(
 					HttpHeaders.CONTENT_TYPE,
 					StringUtil.replace(
-						mimeType, ContentTypes.TEXT_PLAIN,
+						contentType, ContentTypes.TEXT_PLAIN,
 						ContentTypes.IMAGE_SVG_XML));
 			}
 		}

--- a/portal-kernel/bnd.bnd
+++ b/portal-kernel/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 128.0.0
+Bundle-Version: 128.0.1
 Export-Package:\
 	!com.liferay.portal.kernel.internal.*,\
 	!com.liferay.portal.kernel.module.util,\

--- a/portal-kernel/src/com/liferay/portal/kernel/util/ContentTypes.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/ContentTypes.java
@@ -112,6 +112,8 @@ public interface ContentTypes {
 
 	public static final String TEXT_X_JSP = "text/x-jsp";
 
+	public static final String TEXT_XMATLAB = "text/x-matlab";
+
 	public static final String TEXT_XML = "text/xml";
 
 	public static final String TEXT_XML_UTF8 = "text/xml; charset=UTF-8";

--- a/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
@@ -1,1 +1,1 @@
-version 69.0.0
+version 69.1.0


### PR DESCRIPTION
This is a followup for https://github.com/liferay-lima/liferay-portal/pull/4801

It seems that the wrong mime type is also appearing in the content type of the metadata extracted

@adolfopa I've added [LPS-199428 We want to replace part of the extracted contentType not o…](https://github.com/liferay-lima/liferay-portal/pull/4813/commits/cf14c72650058ed7cac69aa452b7edaa419d58a9) since it seems to be a bug (I see it while reviewing the previous pull - https://github.com/liferay-lima/liferay-portal/pull/4808)