### PR TITLE
LPS-200203 Change the Share label when it comes from a dropdown.

### DIFF
--- a/modules/apps/sharing/sharing-web/src/main/java/com/liferay/sharing/web/internal/display/context/util/SharingDropdownItemFactoryImpl.java
+++ b/modules/apps/sharing/sharing-web/src/main/java/com/liferay/sharing/web/internal/display/context/util/SharingDropdownItemFactoryImpl.java
@@ -49,15 +49,22 @@ public class SharingDropdownItemFactoryImpl
 
 	@Override
 	public UnsafeConsumer<DropdownContextItem, Exception>
-		createShareActionUnsafeConsumer(
-			String className, long classPK,
-			HttpServletRequest httpServletRequest) {
+			createShareActionUnsafeConsumer(
+				String className, long classPK,
+				HttpServletRequest httpServletRequest)
+		throws PortalException {
+
+		DropdownItem shareDropdownItem = createShareDropdownItem(
+			className, classPK, httpServletRequest);
+
+		shareDropdownItem.setLabel(
+			SharingItemFactoryUtil.getInviteToCollaborateLabel(
+				httpServletRequest));
 
 		return dropdownContextItem -> {
 			dropdownContextItem.setDropdownItems(
 				DropdownItemListBuilder.add(
-					createShareDropdownItem(
-						className, classPK, httpServletRequest)
+					shareDropdownItem
 				).add(
 					dropdownItem -> {
 						dropdownItem.putData("action", "copyLink");

--- a/modules/apps/sharing/sharing-web/src/main/java/com/liferay/sharing/web/internal/display/context/util/SharingItemFactoryUtil.java
+++ b/modules/apps/sharing/sharing-web/src/main/java/com/liferay/sharing/web/internal/display/context/util/SharingItemFactoryUtil.java
@@ -21,6 +21,12 @@ public class SharingItemFactoryUtil {
 		return _getLabel("copy-link", httpServletRequest);
 	}
 
+	public static String getInviteToCollaborateLabel(
+		HttpServletRequest httpServletRequest) {
+
+		return _getLabel("invite-to-collaborate", httpServletRequest);
+	}
+
 	public static String getManageCollaboratorsLabel(
 		HttpServletRequest httpServletRequest) {
 


### PR DESCRIPTION
Issue https://liferay.atlassian.net/browse/LPS-200203

In DM, where there is a dropdown for Share with two options, the current Share action is renamed to Invite to Collaborate:
![Screenshot 2023-10-30 at 10 46 02](https://github.com/liferay-lima/liferay-portal/assets/8373764/f731456f-814b-4af2-87c3-e4cd00f8a7ef)

This doesn't affect to other Share actions like in Blogs: 
![Screenshot 2023-10-30 at 11 29 08](https://github.com/liferay-lima/liferay-portal/assets/8373764/dc125235-b1ba-4381-be48-1e3f655d628f)
