### PR TITLE
LPS-200623 Failed upgrade process for module com.liferay.document.library.service

### DIFF
--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/registry/DLServiceUpgradeStepRegistrator.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/registry/DLServiceUpgradeStepRegistrator.java
@@ -34,6 +34,7 @@ import com.liferay.portal.kernel.upgrade.MVCCVersionUpgradeProcess;
 import com.liferay.portal.kernel.upgrade.ViewCountUpgradeProcess;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 import com.liferay.subscription.service.SubscriptionLocalService;
+import com.liferay.view.count.service.ViewCountEntryLocalService;
 
 import org.osgi.service.cm.ConfigurationAdmin;
 import org.osgi.service.component.annotations.Component;
@@ -168,5 +169,8 @@ public class DLServiceUpgradeStepRegistrator implements UpgradeStepRegistrator {
 
 	@Reference
 	private SubscriptionLocalService _subscriptionLocalService;
+
+	@Reference
+	private ViewCountEntryLocalService _viewCountEntryLocalService;
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-200623

The upgrade process was failing because of a missing service dependence. It was incorrectly removed in https://github.com/liferay-lima/liferay-portal/pull/4816/commits/304dd0dfa991969ba23bb509c04cb6559346e794