### PR TITLE
LPS-197738 Use Group settings instead of Company settings

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-blogs-web-test/src/testIntegration/java/com/liferay/adaptive/media/blogs/web/internal/counter/test/BlogsAMImageCounterTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-blogs-web-test/src/testIntegration/java/com/liferay/adaptive/media/blogs/web/internal/counter/test/BlogsAMImageCounterTest.java
@@ -16,6 +16,7 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -53,6 +54,8 @@ public class BlogsAMImageCounterTest {
 
 	@Before
 	public void setUp() throws Exception {
+		_count = _amImageCounter.countExpectedAMImageEntries(
+			TestPropsValues.getCompanyId());
 		_group = GroupTestUtil.addGroup();
 	}
 
@@ -60,34 +63,17 @@ public class BlogsAMImageCounterTest {
 	public void testBlogsAMImageCounterOnlyCountsBlogsImages()
 		throws Exception {
 
-		ServiceContext serviceContext =
-			ServiceContextTestUtil.getServiceContext(
-				_group, TestPropsValues.getUserId());
-
-		_dlAppLocalService.addFileEntry(
-			null, TestPropsValues.getUserId(), _group.getGroupId(),
-			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-			RandomTestUtil.randomString() + ".jpg", ContentTypes.IMAGE_JPEG,
-			_getImageBytes(), null, null, serviceContext);
-
-		BlogsEntry blogsEntry = _blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), RandomTestUtil.randomString(),
-			RandomTestUtil.randomString(), new Date(), serviceContext);
+		BlogsEntry blogsEntry = _addBlogsEntry();
 
 		Assert.assertEquals(
-			0,
+			_count,
 			_amImageCounter.countExpectedAMImageEntries(
 				TestPropsValues.getCompanyId()));
 
-		ImageSelector imageSelector = new ImageSelector(
-			_getImageBytes(), RandomTestUtil.randomString() + ".jpg",
-			ContentTypes.IMAGE_JPEG, IMAGE_CROP_REGION);
-
-		_blogsEntryLocalService.addCoverImage(
-			blogsEntry.getEntryId(), imageSelector);
+		_addCoverImage(blogsEntry);
 
 		Assert.assertEquals(
-			1,
+			_count + 1,
 			_amImageCounter.countExpectedAMImageEntries(
 				TestPropsValues.getCompanyId()));
 	}
@@ -105,22 +91,10 @@ public class BlogsAMImageCounterTest {
 		try {
 			PrincipalThreadLocal.setName(user.getUserId());
 
-			ServiceContext serviceContext =
-				ServiceContextTestUtil.getServiceContext(
-					_group, TestPropsValues.getUserId());
-
-			_dlAppLocalService.addFileEntry(
-				null, TestPropsValues.getUserId(), _group.getGroupId(),
-				DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-				RandomTestUtil.randomString() + ".jpg", ContentTypes.IMAGE_JPEG,
-				_getImageBytes(), null, null, serviceContext);
-
-			BlogsEntry blogsEntry = _blogsEntryLocalService.addEntry(
-				TestPropsValues.getUserId(), RandomTestUtil.randomString(),
-				RandomTestUtil.randomString(), new Date(), serviceContext);
+			BlogsEntry blogsEntry = _addBlogsEntry();
 
 			Assert.assertEquals(
-				0,
+				_count,
 				_amImageCounter.countExpectedAMImageEntries(
 					TestPropsValues.getCompanyId()));
 			Assert.assertEquals(
@@ -128,15 +102,10 @@ public class BlogsAMImageCounterTest {
 				_amImageCounter.countExpectedAMImageEntries(
 					company.getCompanyId()));
 
-			ImageSelector imageSelector = new ImageSelector(
-				_getImageBytes(), RandomTestUtil.randomString() + ".jpg",
-				ContentTypes.IMAGE_JPEG, IMAGE_CROP_REGION);
-
-			_blogsEntryLocalService.addCoverImage(
-				blogsEntry.getEntryId(), imageSelector);
+			_addCoverImage(blogsEntry);
 
 			Assert.assertEquals(
-				1,
+				_count + 1,
 				_amImageCounter.countExpectedAMImageEntries(
 					TestPropsValues.getCompanyId()));
 			Assert.assertEquals(
@@ -151,8 +120,71 @@ public class BlogsAMImageCounterTest {
 		}
 	}
 
+	@Test
+	public void testBlogsAMImageCounterOnlyCountsBlogsImagesWithMultipleGroups()
+		throws Exception {
+
+		BlogsEntry blogsEntry1 = _addBlogsEntry();
+
+		Assert.assertEquals(
+			_count,
+			_amImageCounter.countExpectedAMImageEntries(
+				TestPropsValues.getCompanyId()));
+
+		_addCoverImage(blogsEntry1);
+
+		Group group = GroupTestUtil.addGroup();
+
+		try {
+			BlogsEntry blogsEntry2 = _addBlogsEntry(group);
+
+			Assert.assertEquals(
+				_count + 1,
+				_amImageCounter.countExpectedAMImageEntries(
+					TestPropsValues.getCompanyId()));
+
+			_addCoverImage(blogsEntry2);
+
+			Assert.assertEquals(
+				_count + 2,
+				_amImageCounter.countExpectedAMImageEntries(
+					TestPropsValues.getCompanyId()));
+		}
+		finally {
+			_groupLocalService.deleteGroup(group);
+		}
+	}
+
 	protected static final String IMAGE_CROP_REGION =
 		"{\"height\": 0, \"width\": 00, \"x\": 0, \"y\": 0}";
+
+	private BlogsEntry _addBlogsEntry() throws Exception {
+		return _addBlogsEntry(_group);
+	}
+
+	private BlogsEntry _addBlogsEntry(Group group) throws Exception {
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				group, TestPropsValues.getUserId());
+
+		_dlAppLocalService.addFileEntry(
+			null, TestPropsValues.getUserId(), group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			RandomTestUtil.randomString() + ".jpg", ContentTypes.IMAGE_JPEG,
+			_getImageBytes(), null, null, serviceContext);
+
+		return _blogsEntryLocalService.addEntry(
+			TestPropsValues.getUserId(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), new Date(), serviceContext);
+	}
+
+	private void _addCoverImage(BlogsEntry blogsEntry) throws Exception {
+		_blogsEntryLocalService.addCoverImage(
+			blogsEntry.getEntryId(),
+			new ImageSelector(
+				_getImageBytes(), RandomTestUtil.randomString() + ".jpg",
+				ContentTypes.IMAGE_JPEG, IMAGE_CROP_REGION));
+	}
 
 	private byte[] _getImageBytes() throws Exception {
 		return FileUtil.getBytes(
@@ -168,10 +200,15 @@ public class BlogsAMImageCounterTest {
 	@Inject
 	private CompanyLocalService _companyLocalService;
 
+	private int _count;
+
 	@Inject
 	private DLAppLocalService _dlAppLocalService;
 
 	@DeleteAfterTestRun
 	private Group _group;
+
+	@Inject
+	private GroupLocalService _groupLocalService;
 
 }

--- a/modules/apps/adaptive-media/adaptive-media-blogs-web-test/src/testIntegration/java/com/liferay/adaptive/media/blogs/web/internal/optimizer/test/BlogsAMImageOptimizerTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-blogs-web-test/src/testIntegration/java/com/liferay/adaptive/media/blogs/web/internal/optimizer/test/BlogsAMImageOptimizerTest.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -37,8 +38,11 @@ import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -62,19 +66,63 @@ public class BlogsAMImageOptimizerTest {
 		_group = GroupTestUtil.addGroup();
 	}
 
+	@After
+	public void tearDown() throws Exception {
+		_deleteAllAMImageConfigurationEntries();
+	}
+
 	@Test
 	public void testBlogsAMImageOptimizerOptimizesEveryAMImageConfigurationEntryInSpecificCompany()
 		throws Exception {
 
-		_addBlogEntryWithCoverImage(
-			TestPropsValues.getUserId(), _group.getGroupId());
+		_addBlogEntryWithCoverImage();
 
 		AMImageConfigurationEntry amImageConfigurationEntry1 =
 			_addAMImageConfigurationEntry(TestPropsValues.getCompanyId());
 		AMImageConfigurationEntry amImageConfigurationEntry2 =
 			_addAMImageConfigurationEntry(TestPropsValues.getCompanyId());
 
+		Assert.assertEquals(
+			0,
+			_amImageEntryLocalService.getAMImageEntriesCount(
+				TestPropsValues.getCompanyId(),
+				amImageConfigurationEntry1.getUUID()));
+		Assert.assertEquals(
+			0,
+			_amImageEntryLocalService.getAMImageEntriesCount(
+				TestPropsValues.getCompanyId(),
+				amImageConfigurationEntry2.getUUID()));
+
+		_amImageOptimizer.optimize(TestPropsValues.getCompanyId());
+
+		Assert.assertEquals(
+			1,
+			_amImageEntryLocalService.getAMImageEntriesCount(
+				TestPropsValues.getCompanyId(),
+				amImageConfigurationEntry1.getUUID()));
+		Assert.assertEquals(
+			1,
+			_amImageEntryLocalService.getAMImageEntriesCount(
+				TestPropsValues.getCompanyId(),
+				amImageConfigurationEntry2.getUUID()));
+	}
+
+	@Test
+	public void testBlogsAMImageOptimizerOptimizesEveryAMImageConfigurationEntryInSpecificCompanyWithMultipleGroups()
+		throws Exception {
+
+		Group group = GroupTestUtil.addGroup();
+
 		try {
+			_addBlogEntryWithCoverImage();
+			_addBlogEntryWithCoverImage(
+				TestPropsValues.getUserId(), group.getGroupId());
+
+			AMImageConfigurationEntry amImageConfigurationEntry1 =
+				_addAMImageConfigurationEntry(TestPropsValues.getCompanyId());
+			AMImageConfigurationEntry amImageConfigurationEntry2 =
+				_addAMImageConfigurationEntry(TestPropsValues.getCompanyId());
+
 			Assert.assertEquals(
 				0,
 				_amImageEntryLocalService.getAMImageEntriesCount(
@@ -89,23 +137,18 @@ public class BlogsAMImageOptimizerTest {
 			_amImageOptimizer.optimize(TestPropsValues.getCompanyId());
 
 			Assert.assertEquals(
-				1,
+				2,
 				_amImageEntryLocalService.getAMImageEntriesCount(
 					TestPropsValues.getCompanyId(),
 					amImageConfigurationEntry1.getUUID()));
 			Assert.assertEquals(
-				1,
+				2,
 				_amImageEntryLocalService.getAMImageEntriesCount(
 					TestPropsValues.getCompanyId(),
 					amImageConfigurationEntry2.getUUID()));
 		}
 		finally {
-			_amImageConfigurationHelper.forceDeleteAMImageConfigurationEntry(
-				TestPropsValues.getCompanyId(),
-				amImageConfigurationEntry1.getUUID());
-			_amImageConfigurationHelper.forceDeleteAMImageConfigurationEntry(
-				TestPropsValues.getCompanyId(),
-				amImageConfigurationEntry2.getUUID());
+			_groupLocalService.deleteGroup(group);
 		}
 	}
 
@@ -126,8 +169,7 @@ public class BlogsAMImageOptimizerTest {
 		try {
 			PrincipalThreadLocal.setName(user.getUserId());
 
-			_addBlogEntryWithCoverImage(
-				TestPropsValues.getUserId(), _group.getGroupId());
+			_addBlogEntryWithCoverImage();
 			_addBlogEntryWithCoverImage(user.getUserId(), group.getGroupId());
 
 			AMImageConfigurationEntry amImageConfigurationEntry1 =
@@ -135,54 +177,42 @@ public class BlogsAMImageOptimizerTest {
 			AMImageConfigurationEntry amImageConfigurationEntry2 =
 				_addAMImageConfigurationEntry(company.getCompanyId());
 
-			try {
-				Assert.assertEquals(
-					0,
-					_amImageEntryLocalService.getAMImageEntriesCount(
-						TestPropsValues.getCompanyId(),
-						amImageConfigurationEntry1.getUUID()));
-				Assert.assertEquals(
-					0,
-					_amImageEntryLocalService.getAMImageEntriesCount(
-						company.getCompanyId(),
-						amImageConfigurationEntry2.getUUID()));
+			Assert.assertEquals(
+				0,
+				_amImageEntryLocalService.getAMImageEntriesCount(
+					TestPropsValues.getCompanyId(),
+					amImageConfigurationEntry1.getUUID()));
+			Assert.assertEquals(
+				0,
+				_amImageEntryLocalService.getAMImageEntriesCount(
+					company.getCompanyId(),
+					amImageConfigurationEntry2.getUUID()));
 
-				_amImageOptimizer.optimize(TestPropsValues.getCompanyId());
+			_amImageOptimizer.optimize(TestPropsValues.getCompanyId());
 
-				Assert.assertEquals(
-					1,
-					_amImageEntryLocalService.getAMImageEntriesCount(
-						TestPropsValues.getCompanyId(),
-						amImageConfigurationEntry1.getUUID()));
-				Assert.assertEquals(
-					0,
-					_amImageEntryLocalService.getAMImageEntriesCount(
-						company.getCompanyId(),
-						amImageConfigurationEntry2.getUUID()));
+			Assert.assertEquals(
+				1,
+				_amImageEntryLocalService.getAMImageEntriesCount(
+					TestPropsValues.getCompanyId(),
+					amImageConfigurationEntry1.getUUID()));
+			Assert.assertEquals(
+				0,
+				_amImageEntryLocalService.getAMImageEntriesCount(
+					company.getCompanyId(),
+					amImageConfigurationEntry2.getUUID()));
 
-				_amImageOptimizer.optimize(company.getCompanyId());
+			_amImageOptimizer.optimize(company.getCompanyId());
 
-				Assert.assertEquals(
-					1,
-					_amImageEntryLocalService.getAMImageEntriesCount(
-						TestPropsValues.getCompanyId(),
-						amImageConfigurationEntry1.getUUID()));
-				Assert.assertEquals(
-					1,
-					_amImageEntryLocalService.getAMImageEntriesCount(
-						company.getCompanyId(),
-						amImageConfigurationEntry2.getUUID()));
-			}
-			finally {
-				_amImageConfigurationHelper.
-					forceDeleteAMImageConfigurationEntry(
-						TestPropsValues.getCompanyId(),
-						amImageConfigurationEntry1.getUUID());
-				_amImageConfigurationHelper.
-					forceDeleteAMImageConfigurationEntry(
-						company.getCompanyId(),
-						amImageConfigurationEntry2.getUUID());
-			}
+			Assert.assertEquals(
+				1,
+				_amImageEntryLocalService.getAMImageEntriesCount(
+					TestPropsValues.getCompanyId(),
+					amImageConfigurationEntry1.getUUID()));
+			Assert.assertEquals(
+				1,
+				_amImageEntryLocalService.getAMImageEntriesCount(
+					company.getCompanyId(),
+					amImageConfigurationEntry2.getUUID()));
 		}
 		finally {
 			_companyLocalService.deleteCompany(company);
@@ -195,64 +225,53 @@ public class BlogsAMImageOptimizerTest {
 	public void testBlogsAMImageOptimizerOptimizesForSpecificAMImageConfigurationEntry()
 		throws Exception {
 
-		_addBlogEntryWithCoverImage(
-			TestPropsValues.getUserId(), _group.getGroupId());
+		_addBlogEntryWithCoverImage();
 
 		AMImageConfigurationEntry amImageConfigurationEntry1 =
 			_addAMImageConfigurationEntry(TestPropsValues.getCompanyId());
 		AMImageConfigurationEntry amImageConfigurationEntry2 =
 			_addAMImageConfigurationEntry(TestPropsValues.getCompanyId());
 
-		try {
-			Assert.assertEquals(
-				0,
-				_amImageEntryLocalService.getAMImageEntriesCount(
-					TestPropsValues.getCompanyId(),
-					amImageConfigurationEntry1.getUUID()));
-			Assert.assertEquals(
-				0,
-				_amImageEntryLocalService.getAMImageEntriesCount(
-					TestPropsValues.getCompanyId(),
-					amImageConfigurationEntry2.getUUID()));
-
-			_amImageOptimizer.optimize(
+		Assert.assertEquals(
+			0,
+			_amImageEntryLocalService.getAMImageEntriesCount(
 				TestPropsValues.getCompanyId(),
-				amImageConfigurationEntry1.getUUID());
-
-			Assert.assertEquals(
-				1,
-				_amImageEntryLocalService.getAMImageEntriesCount(
-					TestPropsValues.getCompanyId(),
-					amImageConfigurationEntry1.getUUID()));
-			Assert.assertEquals(
-				0,
-				_amImageEntryLocalService.getAMImageEntriesCount(
-					TestPropsValues.getCompanyId(),
-					amImageConfigurationEntry2.getUUID()));
-
-			_amImageOptimizer.optimize(
+				amImageConfigurationEntry1.getUUID()));
+		Assert.assertEquals(
+			0,
+			_amImageEntryLocalService.getAMImageEntriesCount(
 				TestPropsValues.getCompanyId(),
-				amImageConfigurationEntry2.getUUID());
+				amImageConfigurationEntry2.getUUID()));
 
-			Assert.assertEquals(
-				1,
-				_amImageEntryLocalService.getAMImageEntriesCount(
-					TestPropsValues.getCompanyId(),
-					amImageConfigurationEntry1.getUUID()));
-			Assert.assertEquals(
-				1,
-				_amImageEntryLocalService.getAMImageEntriesCount(
-					TestPropsValues.getCompanyId(),
-					amImageConfigurationEntry2.getUUID()));
-		}
-		finally {
-			_amImageConfigurationHelper.forceDeleteAMImageConfigurationEntry(
+		_amImageOptimizer.optimize(
+			TestPropsValues.getCompanyId(),
+			amImageConfigurationEntry1.getUUID());
+
+		Assert.assertEquals(
+			1,
+			_amImageEntryLocalService.getAMImageEntriesCount(
 				TestPropsValues.getCompanyId(),
-				amImageConfigurationEntry1.getUUID());
-			_amImageConfigurationHelper.forceDeleteAMImageConfigurationEntry(
+				amImageConfigurationEntry1.getUUID()));
+		Assert.assertEquals(
+			0,
+			_amImageEntryLocalService.getAMImageEntriesCount(
 				TestPropsValues.getCompanyId(),
-				amImageConfigurationEntry2.getUUID());
-		}
+				amImageConfigurationEntry2.getUUID()));
+
+		_amImageOptimizer.optimize(
+			TestPropsValues.getCompanyId(),
+			amImageConfigurationEntry2.getUUID());
+
+		Assert.assertEquals(
+			1,
+			_amImageEntryLocalService.getAMImageEntriesCount(
+				TestPropsValues.getCompanyId(),
+				amImageConfigurationEntry1.getUUID()));
+		Assert.assertEquals(
+			1,
+			_amImageEntryLocalService.getAMImageEntriesCount(
+				TestPropsValues.getCompanyId(),
+				amImageConfigurationEntry2.getUUID()));
 	}
 
 	protected static final String IMAGE_CROP_REGION =
@@ -262,16 +281,26 @@ public class BlogsAMImageOptimizerTest {
 			long companyId)
 		throws Exception {
 
-		String amImageConfigurationEntry1Name = RandomTestUtil.randomString();
+		String amImageConfigurationEntryName = RandomTestUtil.randomString();
 
-		return _amImageConfigurationHelper.addAMImageConfigurationEntry(
-			companyId, amImageConfigurationEntry1Name, StringPool.BLANK,
-			amImageConfigurationEntry1Name,
-			HashMapBuilder.put(
-				"max-height", String.valueOf(RandomTestUtil.randomLong())
-			).put(
-				"max-width", String.valueOf(RandomTestUtil.randomLong())
-			).build());
+		AMImageConfigurationEntry amImageConfigurationEntry =
+			_amImageConfigurationHelper.addAMImageConfigurationEntry(
+				companyId, amImageConfigurationEntryName, StringPool.BLANK,
+				amImageConfigurationEntryName,
+				HashMapBuilder.put(
+					"max-height", String.valueOf(RandomTestUtil.randomLong())
+				).put(
+					"max-width", String.valueOf(RandomTestUtil.randomLong())
+				).build());
+
+		_amImageConfigurationEntries.add(amImageConfigurationEntry);
+
+		return amImageConfigurationEntry;
+	}
+
+	private BlogsEntry _addBlogEntryWithCoverImage() throws Exception {
+		return _addBlogEntryWithCoverImage(
+			TestPropsValues.getUserId(), _group.getGroupId());
 	}
 
 	private BlogsEntry _addBlogEntryWithCoverImage(long userId, long groupId)
@@ -289,20 +318,32 @@ public class BlogsAMImageOptimizerTest {
 			userId, RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(), new Date(), serviceContext);
 
-		ImageSelector imageSelector = new ImageSelector(
-			_getImageBytes(), RandomTestUtil.randomString() + ".jpg",
-			ContentTypes.IMAGE_JPEG, IMAGE_CROP_REGION);
-
 		_blogsEntryLocalService.addCoverImage(
-			blogsEntry.getEntryId(), imageSelector);
+			blogsEntry.getEntryId(),
+			new ImageSelector(
+				_getImageBytes(), RandomTestUtil.randomString() + ".jpg",
+				ContentTypes.IMAGE_JPEG, IMAGE_CROP_REGION));
 
 		return _blogsEntryLocalService.getEntry(blogsEntry.getEntryId());
+	}
+
+	private void _deleteAllAMImageConfigurationEntries() throws Exception {
+		for (AMImageConfigurationEntry amImageConfigurationEntry :
+				_amImageConfigurationEntries) {
+
+			_amImageConfigurationHelper.forceDeleteAMImageConfigurationEntry(
+				TestPropsValues.getCompanyId(),
+				amImageConfigurationEntry.getUUID());
+		}
 	}
 
 	private byte[] _getImageBytes() throws Exception {
 		return FileUtil.getBytes(
 			BlogsAMImageOptimizerTest.class, "dependencies/image.jpg");
 	}
+
+	private final List<AMImageConfigurationEntry> _amImageConfigurationEntries =
+		new ArrayList<>();
 
 	@Inject
 	private AMImageConfigurationHelper _amImageConfigurationHelper;
@@ -324,5 +365,8 @@ public class BlogsAMImageOptimizerTest {
 
 	@DeleteAfterTestRun
 	private Group _group;
+
+	@Inject
+	private GroupLocalService _groupLocalService;
 
 }

--- a/modules/apps/adaptive-media/adaptive-media-blogs-web/src/main/java/com/liferay/adaptive/media/blogs/web/internal/counter/BlogsAMImageCounter.java
+++ b/modules/apps/adaptive-media/adaptive-media-blogs-web/src/main/java/com/liferay/adaptive/media/blogs/web/internal/counter/BlogsAMImageCounter.java
@@ -10,6 +10,7 @@ import com.liferay.adaptive.media.image.mime.type.AMImageMimeTypeProvider;
 import com.liferay.adaptive.media.image.validator.AMImageValidator;
 import com.liferay.blogs.model.BlogsEntry;
 import com.liferay.document.library.configuration.DLFileEntryConfigurationProvider;
+import com.liferay.document.library.constants.DLFileEntryConfigurationConstants;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.dao.orm.Property;
@@ -52,12 +53,18 @@ public class BlogsAMImageCounter implements AMImageCounter {
 					_amImageMimeTypeProvider.getSupportedMimeTypes(),
 					_amImageValidator::isProcessingSupported)));
 
-		Property sizeProperty = PropertyFactoryUtil.forName("size");
+		long previewableProcessorMaxSize =
+			_dlFileEntryConfigurationProvider.
+				getCompanyPreviewableProcessorMaxSize(companyId);
 
-		dynamicQuery.add(
-			sizeProperty.le(
-				_dlFileEntryConfigurationProvider.
-					getCompanyPreviewableProcessorMaxSize(companyId)));
+		if (previewableProcessorMaxSize !=
+				DLFileEntryConfigurationConstants.
+					PREVIEWABLE_PROCESSOR_MAX_SIZE_UNLIMITED) {
+
+			Property sizeProperty = PropertyFactoryUtil.forName("size");
+
+			dynamicQuery.add(sizeProperty.le(previewableProcessorMaxSize));
+		}
 
 		return (int)_dlFileEntryLocalService.dynamicQueryCount(dynamicQuery);
 	}

--- a/modules/apps/adaptive-media/adaptive-media-blogs-web/src/main/java/com/liferay/adaptive/media/blogs/web/internal/counter/BlogsAMImageCounter.java
+++ b/modules/apps/adaptive-media/adaptive-media-blogs-web/src/main/java/com/liferay/adaptive/media/blogs/web/internal/counter/BlogsAMImageCounter.java
@@ -6,17 +6,15 @@
 package com.liferay.adaptive.media.blogs.web.internal.counter;
 
 import com.liferay.adaptive.media.image.counter.AMImageCounter;
-import com.liferay.adaptive.media.image.mime.type.AMImageMimeTypeProvider;
-import com.liferay.adaptive.media.image.validator.AMImageValidator;
+import com.liferay.adaptive.media.image.counter.BaseAMImageCounter;
 import com.liferay.blogs.model.BlogsEntry;
 import com.liferay.document.library.configuration.DLFileEntryConfigurationProvider;
-import com.liferay.document.library.constants.DLFileEntryConfigurationConstants;
+import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
-import com.liferay.portal.kernel.dao.orm.DynamicQuery;
-import com.liferay.portal.kernel.dao.orm.Property;
-import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
-import com.liferay.portal.kernel.util.ArrayUtil;
+
+import java.util.function.Consumer;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -27,53 +25,21 @@ import org.osgi.service.component.annotations.Reference;
 @Component(
 	property = "adaptive.media.key=blogs", service = AMImageCounter.class
 )
-public class BlogsAMImageCounter implements AMImageCounter {
+public class BlogsAMImageCounter extends BaseAMImageCounter {
 
 	@Override
-	public int countExpectedAMImageEntries(long companyId) {
-		DynamicQuery dynamicQuery = _dlFileEntryLocalService.dynamicQuery();
+	protected void forEachFileEntry(
+			long companyId, Consumer<DLFileEntry> consumer)
+		throws PortalException {
 
-		Property companyIdProperty = PropertyFactoryUtil.forName("companyId");
-
-		dynamicQuery.add(companyIdProperty.eq(companyId));
-
-		Property classNameIdProperty = PropertyFactoryUtil.forName(
-			"classNameId");
-
-		dynamicQuery.add(
-			classNameIdProperty.eq(
-				_classNameLocalService.getClassNameId(
-					BlogsEntry.class.getName())));
-
-		Property mimeTypeProperty = PropertyFactoryUtil.forName("mimeType");
-
-		dynamicQuery.add(
-			mimeTypeProperty.in(
-				ArrayUtil.filter(
-					_amImageMimeTypeProvider.getSupportedMimeTypes(),
-					_amImageValidator::isProcessingSupported)));
-
-		long previewableProcessorMaxSize =
+		_dlFileEntryLocalService.forEachFileEntry(
+			companyId,
+			_classNameLocalService.getClassNameId(BlogsEntry.class.getName()),
+			consumer,
 			_dlFileEntryConfigurationProvider.
-				getCompanyPreviewableProcessorMaxSize(companyId);
-
-		if (previewableProcessorMaxSize !=
-				DLFileEntryConfigurationConstants.
-					PREVIEWABLE_PROCESSOR_MAX_SIZE_UNLIMITED) {
-
-			Property sizeProperty = PropertyFactoryUtil.forName("size");
-
-			dynamicQuery.add(sizeProperty.le(previewableProcessorMaxSize));
-		}
-
-		return (int)_dlFileEntryLocalService.dynamicQueryCount(dynamicQuery);
+				getCompanyPreviewableProcessorMaxSize(companyId),
+			getMimeTypes());
 	}
-
-	@Reference
-	private AMImageMimeTypeProvider _amImageMimeTypeProvider;
-
-	@Reference
-	private AMImageValidator _amImageValidator;
 
 	@Reference
 	private ClassNameLocalService _classNameLocalService;

--- a/modules/apps/adaptive-media/adaptive-media-blogs-web/src/main/java/com/liferay/adaptive/media/blogs/web/internal/optimizer/BlogsAMImageOptimizer.java
+++ b/modules/apps/adaptive-media/adaptive-media-blogs-web/src/main/java/com/liferay/adaptive/media/blogs/web/internal/optimizer/BlogsAMImageOptimizer.java
@@ -5,35 +5,17 @@
 
 package com.liferay.adaptive.media.blogs.web.internal.optimizer;
 
-import com.liferay.adaptive.media.constants.AMOptimizeImagesBackgroundTaskConstants;
-import com.liferay.adaptive.media.image.configuration.AMImageConfigurationEntry;
-import com.liferay.adaptive.media.image.configuration.AMImageConfigurationHelper;
 import com.liferay.adaptive.media.image.counter.AMImageCounter;
-import com.liferay.adaptive.media.image.mime.type.AMImageMimeTypeProvider;
 import com.liferay.adaptive.media.image.optimizer.AMImageOptimizer;
-import com.liferay.adaptive.media.processor.AMProcessor;
+import com.liferay.adaptive.media.image.optimizer.BaseAMImageOptimizer;
 import com.liferay.blogs.model.BlogsEntry;
 import com.liferay.document.library.configuration.DLFileEntryConfigurationProvider;
-import com.liferay.document.library.constants.DLFileEntryConfigurationConstants;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
-import com.liferay.portal.kernel.backgroundtask.BackgroundTaskStatusMessageSender;
-import com.liferay.portal.kernel.backgroundtask.BackgroundTaskThreadLocal;
-import com.liferay.portal.kernel.backgroundtask.constants.BackgroundTaskConstants;
-import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
-import com.liferay.portal.kernel.dao.orm.Property;
-import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.messaging.Message;
-import com.liferay.portal.kernel.repository.model.FileEntry;
-import com.liferay.portal.kernel.repository.model.FileVersion;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
-import com.liferay.portal.repository.liferayrepository.model.LiferayFileEntry;
 
-import java.util.Collection;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -44,160 +26,29 @@ import org.osgi.service.component.annotations.Reference;
 @Component(
 	property = "adaptive.media.key=blogs", service = AMImageOptimizer.class
 )
-public class BlogsAMImageOptimizer implements AMImageOptimizer {
+public class BlogsAMImageOptimizer extends BaseAMImageOptimizer {
 
 	@Override
-	public void optimize(long companyId) {
-		Collection<AMImageConfigurationEntry> amImageConfigurationEntries =
-			_amImageConfigurationHelper.getAMImageConfigurationEntries(
-				companyId);
-
-		int count = _amImageCounter.countExpectedAMImageEntries(companyId);
-
-		int total = count * amImageConfigurationEntries.size();
-
-		AtomicInteger successCounter = new AtomicInteger(0);
-		AtomicInteger errorCounter = new AtomicInteger(0);
-
-		for (AMImageConfigurationEntry amImageConfigurationEntry :
-				amImageConfigurationEntries) {
-
-			_optimize(
-				companyId, amImageConfigurationEntry.getUUID(), total,
-				successCounter, errorCounter);
-		}
+	protected int countExpectedAMImageEntries(long companyId) {
+		return _amImageCounter.countExpectedAMImageEntries(companyId);
 	}
 
 	@Override
-	public void optimize(long companyId, String configurationEntryUuid) {
-		int total = _amImageCounter.countExpectedAMImageEntries(companyId);
+	protected void forEachFileEntry(
+			long companyId, Consumer<DLFileEntry> consumer)
+		throws PortalException {
 
-		AtomicInteger successCounter = new AtomicInteger(0);
-		AtomicInteger errorCounter = new AtomicInteger(0);
-
-		_optimize(
-			companyId, configurationEntryUuid, total, successCounter,
-			errorCounter);
+		_dlFileEntryLocalService.forEachFileEntry(
+			companyId,
+			_classNameLocalService.getClassNameId(BlogsEntry.class.getName()),
+			consumer,
+			_dlFileEntryConfigurationProvider.
+				getCompanyPreviewableProcessorMaxSize(companyId),
+			getMimeTypes());
 	}
-
-	private void _optimize(
-		long companyId, String configurationEntryUuid, int total,
-		AtomicInteger successCounter, AtomicInteger errorCounter) {
-
-		ActionableDynamicQuery actionableDynamicQuery =
-			_dlFileEntryLocalService.getActionableDynamicQuery();
-
-		actionableDynamicQuery.setAddCriteriaMethod(
-			dynamicQuery -> {
-				Property companyIdProperty = PropertyFactoryUtil.forName(
-					"companyId");
-
-				dynamicQuery.add(companyIdProperty.eq(companyId));
-
-				Property classNameIdProperty = PropertyFactoryUtil.forName(
-					"classNameId");
-
-				dynamicQuery.add(
-					classNameIdProperty.eq(
-						_classNameLocalService.getClassNameId(
-							BlogsEntry.class.getName())));
-
-				Property mimeTypeProperty = PropertyFactoryUtil.forName(
-					"mimeType");
-
-				dynamicQuery.add(
-					mimeTypeProperty.in(
-						_amImageMimeTypeProvider.getSupportedMimeTypes()));
-
-				long previewableProcessorMaxSize =
-					_dlFileEntryConfigurationProvider.
-						getCompanyPreviewableProcessorMaxSize(companyId);
-
-				if (previewableProcessorMaxSize !=
-						DLFileEntryConfigurationConstants.
-							PREVIEWABLE_PROCESSOR_MAX_SIZE_UNLIMITED) {
-
-					Property sizeProperty = PropertyFactoryUtil.forName("size");
-
-					dynamicQuery.add(
-						sizeProperty.le(previewableProcessorMaxSize));
-				}
-			});
-		actionableDynamicQuery.setPerformActionMethod(
-			(DLFileEntry dlFileEntry) -> {
-				FileEntry fileEntry = new LiferayFileEntry(dlFileEntry);
-
-				try {
-					_amProcessor.process(
-						fileEntry.getFileVersion(), configurationEntryUuid);
-
-					_sendStatusMessage(
-						successCounter.incrementAndGet(), errorCounter.get(),
-						total);
-				}
-				catch (Exception exception) {
-					if (_log.isWarnEnabled()) {
-						_log.warn(
-							"Unable to process file entry " +
-								fileEntry.getFileEntryId(),
-							exception);
-					}
-
-					_sendStatusMessage(
-						successCounter.get(), errorCounter.incrementAndGet(),
-						total);
-				}
-			});
-
-		try {
-			actionableDynamicQuery.performActions();
-		}
-		catch (PortalException portalException) {
-			_log.error(portalException);
-		}
-	}
-
-	private void _sendStatusMessage(int count, int errors, int total) {
-		Message message = new Message();
-
-		message.put(
-			BackgroundTaskConstants.BACKGROUND_TASK_ID,
-			BackgroundTaskThreadLocal.getBackgroundTaskId());
-
-		Class<? extends BlogsAMImageOptimizer> clazz = getClass();
-
-		message.put(
-			AMOptimizeImagesBackgroundTaskConstants.CLASS_NAME,
-			clazz.getName());
-
-		message.put(AMOptimizeImagesBackgroundTaskConstants.COUNT, count);
-		message.put(AMOptimizeImagesBackgroundTaskConstants.ERRORS, errors);
-		message.put(AMOptimizeImagesBackgroundTaskConstants.TOTAL, total);
-
-		message.put("status", BackgroundTaskConstants.STATUS_IN_PROGRESS);
-
-		_backgroundTaskStatusMessageSender.sendBackgroundTaskStatusMessage(
-			message);
-	}
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		BlogsAMImageOptimizer.class);
-
-	@Reference
-	private AMImageConfigurationHelper _amImageConfigurationHelper;
 
 	@Reference(target = "(adaptive.media.key=blogs)")
 	private AMImageCounter _amImageCounter;
-
-	@Reference
-	private AMImageMimeTypeProvider _amImageMimeTypeProvider;
-
-	@Reference
-	private AMProcessor<FileVersion> _amProcessor;
-
-	@Reference
-	private BackgroundTaskStatusMessageSender
-		_backgroundTaskStatusMessageSender;
 
 	@Reference
 	private ClassNameLocalService _classNameLocalService;

--- a/modules/apps/adaptive-media/adaptive-media-blogs-web/src/main/java/com/liferay/adaptive/media/blogs/web/internal/optimizer/BlogsAMImageOptimizer.java
+++ b/modules/apps/adaptive-media/adaptive-media-blogs-web/src/main/java/com/liferay/adaptive/media/blogs/web/internal/optimizer/BlogsAMImageOptimizer.java
@@ -14,6 +14,7 @@ import com.liferay.adaptive.media.image.optimizer.AMImageOptimizer;
 import com.liferay.adaptive.media.processor.AMProcessor;
 import com.liferay.blogs.model.BlogsEntry;
 import com.liferay.document.library.configuration.DLFileEntryConfigurationProvider;
+import com.liferay.document.library.constants.DLFileEntryConfigurationConstants;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTaskStatusMessageSender;
@@ -108,12 +109,19 @@ public class BlogsAMImageOptimizer implements AMImageOptimizer {
 					mimeTypeProperty.in(
 						_amImageMimeTypeProvider.getSupportedMimeTypes()));
 
-				Property sizeProperty = PropertyFactoryUtil.forName("size");
+				long previewableProcessorMaxSize =
+					_dlFileEntryConfigurationProvider.
+						getCompanyPreviewableProcessorMaxSize(companyId);
 
-				dynamicQuery.add(
-					sizeProperty.le(
-						_dlFileEntryConfigurationProvider.
-							getCompanyPreviewableProcessorMaxSize(companyId)));
+				if (previewableProcessorMaxSize !=
+						DLFileEntryConfigurationConstants.
+							PREVIEWABLE_PROCESSOR_MAX_SIZE_UNLIMITED) {
+
+					Property sizeProperty = PropertyFactoryUtil.forName("size");
+
+					dynamicQuery.add(
+						sizeProperty.le(previewableProcessorMaxSize));
+				}
 			});
 		actionableDynamicQuery.setPerformActionMethod(
 			(DLFileEntry dlFileEntry) -> {

--- a/modules/apps/adaptive-media/adaptive-media-document-library-web-test/src/testIntegration/java/com/liferay/adaptive/media/document/library/web/internal/counter/test/DLAMImageCounterTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-document-library-web-test/src/testIntegration/java/com/liferay/adaptive/media/document/library/web/internal/counter/test/DLAMImageCounterTest.java
@@ -17,6 +17,7 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.portletfilerepository.PortletFileRepository;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.constants.TestDataConstants;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -54,35 +55,47 @@ public class DLAMImageCounterTest {
 
 	@Before
 	public void setUp() throws Exception {
+		_count = _amImageCounter.countExpectedAMImageEntries(
+			TestPropsValues.getCompanyId());
 		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	public void testDLAMImageCounterCountsImagesWithMultipleGroups()
+		throws Exception {
+
+		_addFileEntry();
+
+		Assert.assertEquals(
+			_count + 1,
+			_amImageCounter.countExpectedAMImageEntries(
+				TestPropsValues.getCompanyId()));
+
+		Group group = GroupTestUtil.addGroup();
+
+		try {
+			_addFileEntry(group);
+
+			Assert.assertEquals(
+				_count + 2,
+				_amImageCounter.countExpectedAMImageEntries(
+					TestPropsValues.getCompanyId()));
+		}
+		finally {
+			_groupLocalService.deleteGroup(group);
+		}
 	}
 
 	@Test
 	public void testDLAMImageCounterOnlyCountsDefaultRepositoryImages()
 		throws Exception {
 
-		int count = _amImageCounter.countExpectedAMImageEntries(
-			TestPropsValues.getCompanyId());
+		_addFileEntry();
 
-		ServiceContext serviceContext =
-			ServiceContextTestUtil.getServiceContext(
-				_group, TestPropsValues.getUserId());
-
-		_dlAppLocalService.addFileEntry(
-			null, TestPropsValues.getUserId(), _group.getGroupId(),
-			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-			RandomTestUtil.randomString() + ".jpg", ContentTypes.IMAGE_JPEG,
-			_getImageBytes(), null, null, serviceContext);
-
-		_portletFileRepository.addPortletFileEntry(
-			_group.getGroupId(), TestPropsValues.getUserId(),
-			BlogsEntry.class.getName(), RandomTestUtil.randomLong(),
-			BlogsConstants.SERVICE_NAME,
-			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, _getImageBytes(),
-			RandomTestUtil.randomString(), ContentTypes.IMAGE_JPEG, true);
+		_addPortletFileEntry();
 
 		Assert.assertEquals(
-			count + 1,
+			_count + 1,
 			_amImageCounter.countExpectedAMImageEntries(
 				TestPropsValues.getCompanyId()));
 	}
@@ -91,42 +104,27 @@ public class DLAMImageCounterTest {
 	public void testDLAMImageCounterOnlyCountsDefaultRepositoryImagesPerCompany()
 		throws Exception {
 
-		Company company2 = CompanyTestUtil.addCompany();
+		Company company = CompanyTestUtil.addCompany();
 
 		try {
-			int company1Count = _amImageCounter.countExpectedAMImageEntries(
-				TestPropsValues.getCompanyId());
-			int company2Count = _amImageCounter.countExpectedAMImageEntries(
-				company2.getCompanyId());
+			int count = _amImageCounter.countExpectedAMImageEntries(
+				company.getCompanyId());
 
-			ServiceContext serviceContext =
-				ServiceContextTestUtil.getServiceContext(
-					_group, TestPropsValues.getUserId());
+			_addFileEntry();
 
-			_dlAppLocalService.addFileEntry(
-				null, TestPropsValues.getUserId(), _group.getGroupId(),
-				DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-				RandomTestUtil.randomString() + ".jpg", ContentTypes.IMAGE_JPEG,
-				_getImageBytes(), null, null, serviceContext);
-
-			_portletFileRepository.addPortletFileEntry(
-				_group.getGroupId(), TestPropsValues.getUserId(),
-				BlogsEntry.class.getName(), RandomTestUtil.randomLong(),
-				BlogsConstants.SERVICE_NAME,
-				DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, _getImageBytes(),
-				RandomTestUtil.randomString(), ContentTypes.IMAGE_JPEG, true);
+			_addPortletFileEntry();
 
 			Assert.assertEquals(
-				company1Count + 1,
+				_count + 1,
 				_amImageCounter.countExpectedAMImageEntries(
 					TestPropsValues.getCompanyId()));
 			Assert.assertEquals(
-				company2Count,
+				count,
 				_amImageCounter.countExpectedAMImageEntries(
-					company2.getCompanyId()));
+					company.getCompanyId()));
 		}
 		finally {
-			_companyLocalService.deleteCompany(company2);
+			_companyLocalService.deleteCompany(company);
 		}
 	}
 
@@ -134,21 +132,10 @@ public class DLAMImageCounterTest {
 	public void testDLAMImageCounterOnlyCountsImagesNotInTrash()
 		throws Exception {
 
-		int count = _amImageCounter.countExpectedAMImageEntries(
-			TestPropsValues.getCompanyId());
-
-		ServiceContext serviceContext =
-			ServiceContextTestUtil.getServiceContext(
-				_group, TestPropsValues.getUserId());
-
-		FileEntry fileEntry = _dlAppLocalService.addFileEntry(
-			null, TestPropsValues.getUserId(), _group.getGroupId(),
-			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-			RandomTestUtil.randomString() + ".jpg", ContentTypes.IMAGE_JPEG,
-			_getImageBytes(), null, null, serviceContext);
+		FileEntry fileEntry = _addFileEntry();
 
 		Assert.assertEquals(
-			count + 1,
+			_count + 1,
 			_amImageCounter.countExpectedAMImageEntries(
 				TestPropsValues.getCompanyId()));
 
@@ -157,7 +144,7 @@ public class DLAMImageCounterTest {
 			fileEntry.getFileEntryId());
 
 		Assert.assertEquals(
-			count,
+			_count,
 			_amImageCounter.countExpectedAMImageEntries(
 				TestPropsValues.getCompanyId()));
 	}
@@ -166,30 +153,46 @@ public class DLAMImageCounterTest {
 	public void testDLAMImageCounterOnlyCountsImagesWithSupportedMimeTypes()
 		throws Exception {
 
-		int count = _amImageCounter.countExpectedAMImageEntries(
-			TestPropsValues.getCompanyId());
-
-		ServiceContext serviceContext =
-			ServiceContextTestUtil.getServiceContext(
-				_group, TestPropsValues.getUserId());
-
-		_dlAppLocalService.addFileEntry(
-			null, TestPropsValues.getUserId(), _group.getGroupId(),
-			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-			RandomTestUtil.randomString() + ".jpg", ContentTypes.IMAGE_JPEG,
-			_getImageBytes(), null, null, serviceContext);
+		_addFileEntry();
 
 		_dlAppLocalService.addFileEntry(
 			null, TestPropsValues.getUserId(), _group.getGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(),
 			ContentTypes.APPLICATION_OCTET_STREAM,
-			TestDataConstants.TEST_BYTE_ARRAY, null, null, serviceContext);
+			TestDataConstants.TEST_BYTE_ARRAY, null, null,
+			ServiceContextTestUtil.getServiceContext(
+				_group, TestPropsValues.getUserId()));
 
 		Assert.assertEquals(
-			count + 1,
+			_count + 1,
 			_amImageCounter.countExpectedAMImageEntries(
 				TestPropsValues.getCompanyId()));
+	}
+
+	private FileEntry _addFileEntry() throws Exception {
+		return _addFileEntry(_group);
+	}
+
+	private FileEntry _addFileEntry(Group group) throws Exception {
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				group, TestPropsValues.getUserId());
+
+		return _dlAppLocalService.addFileEntry(
+			null, TestPropsValues.getUserId(), group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			RandomTestUtil.randomString() + ".jpg", ContentTypes.IMAGE_JPEG,
+			_getImageBytes(), null, null, serviceContext);
+	}
+
+	private void _addPortletFileEntry() throws Exception {
+		_portletFileRepository.addPortletFileEntry(
+			_group.getGroupId(), TestPropsValues.getUserId(),
+			BlogsEntry.class.getName(), RandomTestUtil.randomLong(),
+			BlogsConstants.SERVICE_NAME,
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, _getImageBytes(),
+			RandomTestUtil.randomString(), ContentTypes.IMAGE_JPEG, true);
 	}
 
 	private byte[] _getImageBytes() throws Exception {
@@ -206,6 +209,8 @@ public class DLAMImageCounterTest {
 	@Inject
 	private CompanyLocalService _companyLocalService;
 
+	private int _count;
+
 	@Inject
 	private DLAppLocalService _dlAppLocalService;
 
@@ -214,6 +219,9 @@ public class DLAMImageCounterTest {
 
 	@DeleteAfterTestRun
 	private Group _group;
+
+	@Inject
+	private GroupLocalService _groupLocalService;
 
 	@Inject
 	private PortletFileRepository _portletFileRepository;

--- a/modules/apps/adaptive-media/adaptive-media-document-library-web-test/src/testIntegration/java/com/liferay/adaptive/media/document/library/web/internal/optimizer/test/DLAMImageOptimizerTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-document-library-web-test/src/testIntegration/java/com/liferay/adaptive/media/document/library/web/internal/optimizer/test/DLAMImageOptimizerTest.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.constants.TestDataConstants;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -65,6 +66,9 @@ public class DLAMImageOptimizerTest {
 	@Before
 	public void setUp() throws Exception {
 		_group = GroupTestUtil.addGroup();
+
+		_serviceContext = ServiceContextTestUtil.getServiceContext(
+			_group.getGroupId(), TestPropsValues.getUserId());
 	}
 
 	@After
@@ -79,13 +83,7 @@ public class DLAMImageOptimizerTest {
 		int count = _amImageCounter.countExpectedAMImageEntries(
 			TestPropsValues.getCompanyId());
 
-		_dlAppLocalService.addFileEntry(
-			null, TestPropsValues.getUserId(), _group.getGroupId(),
-			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-			RandomTestUtil.randomString() + ".jpg", ContentTypes.IMAGE_JPEG,
-			_getImageBytes(), null, null,
-			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), TestPropsValues.getUserId()));
+		_addFileEntry();
 
 		AMImageConfigurationEntry amImageConfigurationEntry1 =
 			_addAMImageConfigurationEntry(TestPropsValues.getCompanyId());
@@ -118,42 +116,22 @@ public class DLAMImageOptimizerTest {
 	}
 
 	@Test
-	public void testDLAMImageOptimizerOptimizesEveryAMImageConfigurationEntryOnlyInSpecificCompany()
+	public void testDLAMImageOptimizerOptimizesEveryAMImageConfigurationEntryInSpecificCompanyWithMultipleGroups()
 		throws Exception {
 
-		Company company2 = CompanyTestUtil.addCompany();
-
-		User user2 = UserTestUtil.getAdminUser(company2.getCompanyId());
-
-		Group group2 = GroupTestUtil.addGroup(
-			company2.getCompanyId(), user2.getUserId(),
-			GroupConstants.DEFAULT_PARENT_GROUP_ID);
+		Group group = GroupTestUtil.addGroup();
 
 		try {
-			int company1Count = _amImageCounter.countExpectedAMImageEntries(
+			int count = _amImageCounter.countExpectedAMImageEntries(
 				TestPropsValues.getCompanyId());
-			int company2Count = _amImageCounter.countExpectedAMImageEntries(
-				company2.getCompanyId());
 
-			_dlAppLocalService.addFileEntry(
-				null, TestPropsValues.getUserId(), _group.getGroupId(),
-				DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-				RandomTestUtil.randomString() + ".jpg", ContentTypes.IMAGE_JPEG,
-				_getImageBytes(), null, null,
-				ServiceContextTestUtil.getServiceContext(
-					_group.getGroupId(), TestPropsValues.getUserId()));
-			_dlAppLocalService.addFileEntry(
-				null, user2.getUserId(), group2.getGroupId(),
-				DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-				RandomTestUtil.randomString() + ".jpg", ContentTypes.IMAGE_JPEG,
-				_getImageBytes(), null, null,
-				ServiceContextTestUtil.getServiceContext(
-					group2.getGroupId(), user2.getUserId()));
+			_addFileEntry();
+			_addFileEntry(TestPropsValues.getUserId(), group.getGroupId());
 
 			AMImageConfigurationEntry amImageConfigurationEntry1 =
 				_addAMImageConfigurationEntry(TestPropsValues.getCompanyId());
 			AMImageConfigurationEntry amImageConfigurationEntry2 =
-				_addAMImageConfigurationEntry(company2.getCompanyId());
+				_addAMImageConfigurationEntry(TestPropsValues.getCompanyId());
 
 			Assert.assertEquals(
 				0,
@@ -163,7 +141,63 @@ public class DLAMImageOptimizerTest {
 			Assert.assertEquals(
 				0,
 				_amImageEntryLocalService.getAMImageEntriesCount(
-					company2.getCompanyId(),
+					TestPropsValues.getCompanyId(),
+					amImageConfigurationEntry2.getUUID()));
+
+			_amImageOptimizer.optimize(TestPropsValues.getCompanyId());
+
+			Assert.assertEquals(
+				count + 2,
+				_amImageEntryLocalService.getAMImageEntriesCount(
+					TestPropsValues.getCompanyId(),
+					amImageConfigurationEntry1.getUUID()));
+			Assert.assertEquals(
+				count + 2,
+				_amImageEntryLocalService.getAMImageEntriesCount(
+					TestPropsValues.getCompanyId(),
+					amImageConfigurationEntry2.getUUID()));
+		}
+		finally {
+			_groupLocalService.deleteGroup(group);
+		}
+	}
+
+	@Test
+	public void testDLAMImageOptimizerOptimizesEveryAMImageConfigurationEntryOnlyInSpecificCompany()
+		throws Exception {
+
+		Company company = CompanyTestUtil.addCompany();
+
+		User user = UserTestUtil.getAdminUser(company.getCompanyId());
+
+		Group group = GroupTestUtil.addGroup(
+			company.getCompanyId(), user.getUserId(),
+			GroupConstants.DEFAULT_PARENT_GROUP_ID);
+
+		try {
+			int company1Count = _amImageCounter.countExpectedAMImageEntries(
+				TestPropsValues.getCompanyId());
+			int company2Count = _amImageCounter.countExpectedAMImageEntries(
+				company.getCompanyId());
+
+			_addFileEntry();
+
+			_addFileEntry(user.getUserId(), group.getGroupId());
+
+			AMImageConfigurationEntry amImageConfigurationEntry1 =
+				_addAMImageConfigurationEntry(TestPropsValues.getCompanyId());
+			AMImageConfigurationEntry amImageConfigurationEntry2 =
+				_addAMImageConfigurationEntry(company.getCompanyId());
+
+			Assert.assertEquals(
+				0,
+				_amImageEntryLocalService.getAMImageEntriesCount(
+					TestPropsValues.getCompanyId(),
+					amImageConfigurationEntry1.getUUID()));
+			Assert.assertEquals(
+				0,
+				_amImageEntryLocalService.getAMImageEntriesCount(
+					company.getCompanyId(),
 					amImageConfigurationEntry2.getUUID()));
 
 			_amImageOptimizer.optimize(TestPropsValues.getCompanyId());
@@ -176,10 +210,10 @@ public class DLAMImageOptimizerTest {
 			Assert.assertEquals(
 				0,
 				_amImageEntryLocalService.getAMImageEntriesCount(
-					company2.getCompanyId(),
+					company.getCompanyId(),
 					amImageConfigurationEntry2.getUUID()));
 
-			_amImageOptimizer.optimize(company2.getCompanyId());
+			_amImageOptimizer.optimize(company.getCompanyId());
 
 			Assert.assertEquals(
 				company1Count + 1,
@@ -189,11 +223,11 @@ public class DLAMImageOptimizerTest {
 			Assert.assertEquals(
 				company2Count + 1,
 				_amImageEntryLocalService.getAMImageEntriesCount(
-					company2.getCompanyId(),
+					company.getCompanyId(),
 					amImageConfigurationEntry2.getUUID()));
 		}
 		finally {
-			_companyLocalService.deleteCompany(company2);
+			_companyLocalService.deleteCompany(company);
 		}
 	}
 
@@ -204,25 +238,13 @@ public class DLAMImageOptimizerTest {
 		int count = _amImageCounter.countExpectedAMImageEntries(
 			TestPropsValues.getCompanyId());
 
-		ServiceContext serviceContext =
-			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), TestPropsValues.getUserId());
+		_addFileEntry();
 
-		_dlAppLocalService.addFileEntry(
-			null, TestPropsValues.getUserId(), _group.getGroupId(),
-			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-			RandomTestUtil.randomString() + ".jpg", ContentTypes.IMAGE_JPEG,
-			_getImageBytes(), null, null, serviceContext);
-
-		FileEntry fileEntry2 = _dlAppLocalService.addFileEntry(
-			null, TestPropsValues.getUserId(), _group.getGroupId(),
-			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-			RandomTestUtil.randomString() + ".jpg", ContentTypes.IMAGE_JPEG,
-			_getImageBytes(), null, null, serviceContext);
+		FileEntry fileEntry = _addFileEntry();
 
 		_dlTrashLocalService.moveFileEntryToTrash(
 			TestPropsValues.getUserId(), _group.getGroupId(),
-			fileEntry2.getFileEntryId());
+			fileEntry.getFileEntryId());
 
 		AMImageConfigurationEntry amImageConfigurationEntry1 =
 			_addAMImageConfigurationEntry(TestPropsValues.getCompanyId());
@@ -245,8 +267,8 @@ public class DLAMImageOptimizerTest {
 
 		_dlTrashLocalService.moveFileEntryFromTrash(
 			TestPropsValues.getUserId(), _group.getGroupId(),
-			fileEntry2.getFileEntryId(),
-			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, serviceContext);
+			fileEntry.getFileEntryId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, _serviceContext);
 
 		_amImageOptimizer.optimize(
 			TestPropsValues.getCompanyId(),
@@ -266,13 +288,7 @@ public class DLAMImageOptimizerTest {
 		int count = _amImageCounter.countExpectedAMImageEntries(
 			TestPropsValues.getCompanyId());
 
-		_dlAppLocalService.addFileEntry(
-			null, TestPropsValues.getUserId(), _group.getGroupId(),
-			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-			RandomTestUtil.randomString() + ".jpg", ContentTypes.IMAGE_JPEG,
-			_getImageBytes(), null, null,
-			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), TestPropsValues.getUserId()));
+		_addFileEntry();
 
 		AMImageConfigurationEntry amImageConfigurationEntry1 =
 			_addAMImageConfigurationEntry(TestPropsValues.getCompanyId());
@@ -341,22 +357,14 @@ public class DLAMImageOptimizerTest {
 			TestPropsValues.getCompanyId(),
 			amImageConfigurationEntry1.getUUID());
 
-		ServiceContext serviceContext =
-			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), TestPropsValues.getUserId());
-
-		_dlAppLocalService.addFileEntry(
-			null, TestPropsValues.getUserId(), _group.getGroupId(),
-			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-			RandomTestUtil.randomString() + ".jpg", ContentTypes.IMAGE_JPEG,
-			_getImageBytes(), null, null, serviceContext);
+		_addFileEntry();
 
 		_dlAppLocalService.addFileEntry(
 			null, TestPropsValues.getUserId(), _group.getGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(),
 			ContentTypes.APPLICATION_OCTET_STREAM,
-			TestDataConstants.TEST_BYTE_ARRAY, null, null, serviceContext);
+			TestDataConstants.TEST_BYTE_ARRAY, null, null, _serviceContext);
 
 		Assert.assertEquals(
 			count + 1,
@@ -369,12 +377,12 @@ public class DLAMImageOptimizerTest {
 			long companyId)
 		throws Exception {
 
-		String amImageConfigurationEntry1Name = RandomTestUtil.randomString();
+		String amImageConfigurationEntryName = RandomTestUtil.randomString();
 
 		AMImageConfigurationEntry amImageConfigurationEntry =
 			_amImageConfigurationHelper.addAMImageConfigurationEntry(
-				companyId, amImageConfigurationEntry1Name, StringPool.BLANK,
-				amImageConfigurationEntry1Name,
+				companyId, amImageConfigurationEntryName, StringPool.BLANK,
+				amImageConfigurationEntryName,
 				HashMapBuilder.put(
 					"max-height", String.valueOf(RandomTestUtil.randomLong())
 				).put(
@@ -386,6 +394,31 @@ public class DLAMImageOptimizerTest {
 		return amImageConfigurationEntry;
 	}
 
+	private FileEntry _addFileEntry() throws Exception {
+		return _addFileEntry(
+			TestPropsValues.getUserId(), _group.getGroupId(), _serviceContext);
+	}
+
+	private FileEntry _addFileEntry(long userId, long groupId)
+		throws Exception {
+
+		return _addFileEntry(
+			userId, groupId,
+			ServiceContextTestUtil.getServiceContext(groupId, userId));
+	}
+
+	private FileEntry _addFileEntry(
+			long userId, long groupId, ServiceContext serviceContext)
+		throws Exception {
+
+		return _dlAppLocalService.addFileEntry(
+			null, userId, groupId, DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			RandomTestUtil.randomString() + ".jpg", ContentTypes.IMAGE_JPEG,
+			FileUtil.getBytes(
+				DLAMImageOptimizerTest.class, "dependencies/image.jpg"),
+			null, null, serviceContext);
+	}
+
 	private void _deleteAllAMImageConfigurationEntries() throws Exception {
 		for (AMImageConfigurationEntry amImageConfigurationEntry :
 				_amImageConfigurationEntries) {
@@ -394,11 +427,6 @@ public class DLAMImageOptimizerTest {
 				TestPropsValues.getCompanyId(),
 				amImageConfigurationEntry.getUUID());
 		}
-	}
-
-	private byte[] _getImageBytes() throws Exception {
-		return FileUtil.getBytes(
-			DLAMImageOptimizerTest.class, "dependencies/image.jpg");
 	}
 
 	private final List<AMImageConfigurationEntry> _amImageConfigurationEntries =
@@ -433,5 +461,10 @@ public class DLAMImageOptimizerTest {
 
 	@DeleteAfterTestRun
 	private Group _group;
+
+	@Inject
+	private GroupLocalService _groupLocalService;
+
+	private ServiceContext _serviceContext;
 
 }

--- a/modules/apps/adaptive-media/adaptive-media-document-library-web/src/main/java/com/liferay/adaptive/media/document/library/web/internal/counter/DLAMImageCounter.java
+++ b/modules/apps/adaptive-media/adaptive-media-document-library-web/src/main/java/com/liferay/adaptive/media/document/library/web/internal/counter/DLAMImageCounter.java
@@ -6,18 +6,13 @@
 package com.liferay.adaptive.media.document.library.web.internal.counter;
 
 import com.liferay.adaptive.media.image.counter.AMImageCounter;
-import com.liferay.adaptive.media.image.mime.type.AMImageMimeTypeProvider;
-import com.liferay.adaptive.media.image.validator.AMImageValidator;
+import com.liferay.adaptive.media.image.counter.BaseAMImageCounter;
 import com.liferay.document.library.configuration.DLFileEntryConfigurationProvider;
-import com.liferay.document.library.constants.DLFileEntryConfigurationConstants;
+import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
-import com.liferay.document.library.kernel.service.DLFileVersionLocalService;
-import com.liferay.portal.kernel.dao.orm.DynamicQuery;
-import com.liferay.portal.kernel.dao.orm.ProjectionFactoryUtil;
-import com.liferay.portal.kernel.dao.orm.Property;
-import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
-import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.kernel.exception.PortalException;
+
+import java.util.function.Consumer;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -29,101 +24,24 @@ import org.osgi.service.component.annotations.Reference;
 	property = "adaptive.media.key=document-library",
 	service = AMImageCounter.class
 )
-public class DLAMImageCounter implements AMImageCounter {
+public class DLAMImageCounter extends BaseAMImageCounter {
 
 	@Override
-	public int countExpectedAMImageEntries(long companyId) {
-		return _getFileEntriesCount(companyId) -
-			_getTrashedFileEntriesCount(companyId);
-	}
+	protected void forEachFileEntry(
+			long companyId, Consumer<DLFileEntry> consumer)
+		throws PortalException {
 
-	private int _getFileEntriesCount(long companyId) {
-		DynamicQuery dlFileEntryEntryDynamicQuery =
-			_dlFileEntryLocalService.dynamicQuery();
-
-		Property companyIdProperty = PropertyFactoryUtil.forName("companyId");
-
-		dlFileEntryEntryDynamicQuery.add(companyIdProperty.eq(companyId));
-
-		Property groupIdProperty = PropertyFactoryUtil.forName("groupId");
-		Property repositoryIdProperty = PropertyFactoryUtil.forName(
-			"repositoryId");
-
-		dlFileEntryEntryDynamicQuery.add(
-			groupIdProperty.eqProperty(repositoryIdProperty));
-
-		Property mimeTypeProperty = PropertyFactoryUtil.forName("mimeType");
-
-		dlFileEntryEntryDynamicQuery.add(
-			mimeTypeProperty.in(
-				ArrayUtil.filter(
-					_amImageMimeTypeProvider.getSupportedMimeTypes(),
-					_amImageValidator::isProcessingSupported)));
-
-		long previewableProcessorMaxSize =
+		_dlFileEntryLocalService.forEachFileEntry(
+			companyId, consumer,
 			_dlFileEntryConfigurationProvider.
-				getCompanyPreviewableProcessorMaxSize(companyId);
-
-		if (previewableProcessorMaxSize !=
-				DLFileEntryConfigurationConstants.
-					PREVIEWABLE_PROCESSOR_MAX_SIZE_UNLIMITED) {
-
-			Property sizeProperty = PropertyFactoryUtil.forName("size");
-
-			dlFileEntryEntryDynamicQuery.add(
-				sizeProperty.le(previewableProcessorMaxSize));
-		}
-
-		return (int)_dlFileEntryLocalService.dynamicQueryCount(
-			dlFileEntryEntryDynamicQuery);
+				getCompanyPreviewableProcessorMaxSize(companyId),
+			getMimeTypes());
 	}
-
-	private int _getTrashedFileEntriesCount(long companyId) {
-		DynamicQuery dlFileVersionDynamicQuery =
-			_dlFileVersionLocalService.dynamicQuery();
-
-		dlFileVersionDynamicQuery.setProjection(
-			ProjectionFactoryUtil.countDistinct("fileEntryId"));
-
-		Property companyIdProperty = PropertyFactoryUtil.forName("companyId");
-
-		dlFileVersionDynamicQuery.add(companyIdProperty.eq(companyId));
-
-		Property groupIdProperty = PropertyFactoryUtil.forName("groupId");
-		Property repositoryIdProperty = PropertyFactoryUtil.forName(
-			"repositoryId");
-
-		dlFileVersionDynamicQuery.add(
-			groupIdProperty.eqProperty(repositoryIdProperty));
-
-		Property mimeTypeProperty = PropertyFactoryUtil.forName("mimeType");
-
-		dlFileVersionDynamicQuery.add(
-			mimeTypeProperty.in(
-				_amImageMimeTypeProvider.getSupportedMimeTypes()));
-
-		Property statusProperty = PropertyFactoryUtil.forName("status");
-
-		dlFileVersionDynamicQuery.add(
-			statusProperty.eq(WorkflowConstants.STATUS_IN_TRASH));
-
-		return (int)_dlFileEntryLocalService.dynamicQueryCount(
-			dlFileVersionDynamicQuery);
-	}
-
-	@Reference
-	private AMImageMimeTypeProvider _amImageMimeTypeProvider;
-
-	@Reference
-	private AMImageValidator _amImageValidator;
 
 	@Reference
 	private DLFileEntryConfigurationProvider _dlFileEntryConfigurationProvider;
 
 	@Reference
 	private DLFileEntryLocalService _dlFileEntryLocalService;
-
-	@Reference
-	private DLFileVersionLocalService _dlFileVersionLocalService;
 
 }

--- a/modules/apps/adaptive-media/adaptive-media-document-library-web/src/main/java/com/liferay/adaptive/media/document/library/web/internal/counter/DLAMImageCounter.java
+++ b/modules/apps/adaptive-media/adaptive-media-document-library-web/src/main/java/com/liferay/adaptive/media/document/library/web/internal/counter/DLAMImageCounter.java
@@ -9,6 +9,7 @@ import com.liferay.adaptive.media.image.counter.AMImageCounter;
 import com.liferay.adaptive.media.image.mime.type.AMImageMimeTypeProvider;
 import com.liferay.adaptive.media.image.validator.AMImageValidator;
 import com.liferay.document.library.configuration.DLFileEntryConfigurationProvider;
+import com.liferay.document.library.constants.DLFileEntryConfigurationConstants;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
 import com.liferay.document.library.kernel.service.DLFileVersionLocalService;
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
@@ -59,12 +60,19 @@ public class DLAMImageCounter implements AMImageCounter {
 					_amImageMimeTypeProvider.getSupportedMimeTypes(),
 					_amImageValidator::isProcessingSupported)));
 
-		Property sizeProperty = PropertyFactoryUtil.forName("size");
+		long previewableProcessorMaxSize =
+			_dlFileEntryConfigurationProvider.
+				getCompanyPreviewableProcessorMaxSize(companyId);
 
-		dlFileEntryEntryDynamicQuery.add(
-			sizeProperty.le(
-				_dlFileEntryConfigurationProvider.
-					getCompanyPreviewableProcessorMaxSize(companyId)));
+		if (previewableProcessorMaxSize !=
+				DLFileEntryConfigurationConstants.
+					PREVIEWABLE_PROCESSOR_MAX_SIZE_UNLIMITED) {
+
+			Property sizeProperty = PropertyFactoryUtil.forName("size");
+
+			dlFileEntryEntryDynamicQuery.add(
+				sizeProperty.le(previewableProcessorMaxSize));
+		}
 
 		return (int)_dlFileEntryLocalService.dynamicQueryCount(
 			dlFileEntryEntryDynamicQuery);

--- a/modules/apps/adaptive-media/adaptive-media-document-library-web/src/main/java/com/liferay/adaptive/media/document/library/web/internal/optimizer/DLAMImageOptimizer.java
+++ b/modules/apps/adaptive-media/adaptive-media-document-library-web/src/main/java/com/liferay/adaptive/media/document/library/web/internal/optimizer/DLAMImageOptimizer.java
@@ -5,38 +5,15 @@
 
 package com.liferay.adaptive.media.document.library.web.internal.optimizer;
 
-import com.liferay.adaptive.media.constants.AMOptimizeImagesBackgroundTaskConstants;
-import com.liferay.adaptive.media.image.configuration.AMImageConfigurationEntry;
-import com.liferay.adaptive.media.image.configuration.AMImageConfigurationHelper;
 import com.liferay.adaptive.media.image.counter.AMImageCounter;
-import com.liferay.adaptive.media.image.mime.type.AMImageMimeTypeProvider;
 import com.liferay.adaptive.media.image.optimizer.AMImageOptimizer;
-import com.liferay.adaptive.media.image.validator.AMImageValidator;
-import com.liferay.adaptive.media.processor.AMProcessor;
+import com.liferay.adaptive.media.image.optimizer.BaseAMImageOptimizer;
 import com.liferay.document.library.configuration.DLFileEntryConfigurationProvider;
-import com.liferay.document.library.constants.DLFileEntryConfigurationConstants;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
-import com.liferay.document.library.kernel.service.DLFileVersionLocalService;
-import com.liferay.portal.kernel.backgroundtask.BackgroundTaskStatusMessageSender;
-import com.liferay.portal.kernel.backgroundtask.BackgroundTaskThreadLocal;
-import com.liferay.portal.kernel.backgroundtask.constants.BackgroundTaskConstants;
-import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
-import com.liferay.portal.kernel.dao.orm.DynamicQuery;
-import com.liferay.portal.kernel.dao.orm.ProjectionFactoryUtil;
-import com.liferay.portal.kernel.dao.orm.Property;
-import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.messaging.Message;
-import com.liferay.portal.kernel.repository.model.FileEntry;
-import com.liferay.portal.kernel.repository.model.FileVersion;
-import com.liferay.portal.kernel.workflow.WorkflowConstants;
-import com.liferay.portal.repository.liferayrepository.model.LiferayFileEntry;
 
-import java.util.Collection;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -48,201 +25,32 @@ import org.osgi.service.component.annotations.Reference;
 	property = "adaptive.media.key=document-library",
 	service = AMImageOptimizer.class
 )
-public class DLAMImageOptimizer implements AMImageOptimizer {
+public class DLAMImageOptimizer extends BaseAMImageOptimizer {
 
 	@Override
-	public void optimize(long companyId) {
-		Collection<AMImageConfigurationEntry> amImageConfigurationEntries =
-			_amImageConfigurationHelper.getAMImageConfigurationEntries(
-				companyId);
-
-		int count = _amImageCounter.countExpectedAMImageEntries(companyId);
-
-		int total = count * amImageConfigurationEntries.size();
-
-		AtomicInteger successCounter = new AtomicInteger(0);
-		AtomicInteger errorCounter = new AtomicInteger(0);
-
-		for (AMImageConfigurationEntry amImageConfigurationEntry :
-				amImageConfigurationEntries) {
-
-			_optimize(
-				companyId, amImageConfigurationEntry.getUUID(), total,
-				successCounter, errorCounter);
-		}
+	protected int countExpectedAMImageEntries(long companyId) {
+		return _amImageCounter.countExpectedAMImageEntries(companyId);
 	}
 
 	@Override
-	public void optimize(long companyId, String configurationEntryUuid) {
-		int total = _amImageCounter.countExpectedAMImageEntries(companyId);
+	protected void forEachFileEntry(
+			long companyId, Consumer<DLFileEntry> consumer)
+		throws PortalException {
 
-		AtomicInteger successCounter = new AtomicInteger(0);
-		AtomicInteger errorCounter = new AtomicInteger(0);
-
-		_optimize(
-			companyId, configurationEntryUuid, total, successCounter,
-			errorCounter);
+		_dlFileEntryLocalService.forEachFileEntry(
+			companyId, consumer,
+			_dlFileEntryConfigurationProvider.
+				getCompanyPreviewableProcessorMaxSize(companyId),
+			getMimeTypes());
 	}
-
-	private void _optimize(
-		long companyId, String configurationEntryUuid, int total,
-		AtomicInteger successCounter, AtomicInteger errorCounter) {
-
-		ActionableDynamicQuery actionableDynamicQuery =
-			_dlFileEntryLocalService.getActionableDynamicQuery();
-
-		actionableDynamicQuery.setAddCriteriaMethod(
-			dynamicQuery -> {
-				Property companyIdProperty = PropertyFactoryUtil.forName(
-					"companyId");
-
-				dynamicQuery.add(companyIdProperty.eq(companyId));
-
-				Property groupIdProperty = PropertyFactoryUtil.forName(
-					"groupId");
-				Property repositoryIdProperty = PropertyFactoryUtil.forName(
-					"repositoryId");
-
-				dynamicQuery.add(
-					groupIdProperty.eqProperty(repositoryIdProperty));
-
-				Property mimeTypeProperty = PropertyFactoryUtil.forName(
-					"mimeType");
-
-				dynamicQuery.add(
-					mimeTypeProperty.in(
-						_amImageMimeTypeProvider.getSupportedMimeTypes()));
-
-				long previewableProcessorMaxSize =
-					_dlFileEntryConfigurationProvider.
-						getCompanyPreviewableProcessorMaxSize(companyId);
-
-				if (previewableProcessorMaxSize !=
-						DLFileEntryConfigurationConstants.
-							PREVIEWABLE_PROCESSOR_MAX_SIZE_UNLIMITED) {
-
-					Property sizeProperty = PropertyFactoryUtil.forName("size");
-
-					dynamicQuery.add(
-						sizeProperty.le(previewableProcessorMaxSize));
-				}
-
-				DynamicQuery dlFileVersionDynamicQuery =
-					_dlFileVersionLocalService.dynamicQuery();
-
-				dlFileVersionDynamicQuery.setProjection(
-					ProjectionFactoryUtil.distinct(
-						ProjectionFactoryUtil.property("fileEntryId")));
-
-				dlFileVersionDynamicQuery.add(companyIdProperty.eq(companyId));
-
-				dlFileVersionDynamicQuery.add(
-					groupIdProperty.eqProperty(repositoryIdProperty));
-
-				dlFileVersionDynamicQuery.add(
-					mimeTypeProperty.in(
-						_amImageMimeTypeProvider.getSupportedMimeTypes()));
-
-				Property statusProperty = PropertyFactoryUtil.forName("status");
-
-				dlFileVersionDynamicQuery.add(
-					statusProperty.eq(WorkflowConstants.STATUS_IN_TRASH));
-
-				Property fileEntryIdProperty = PropertyFactoryUtil.forName(
-					"fileEntryId");
-
-				dynamicQuery.add(
-					fileEntryIdProperty.notIn(dlFileVersionDynamicQuery));
-			});
-		actionableDynamicQuery.setPerformActionMethod(
-			(DLFileEntry dlFileEntry) -> {
-				FileEntry fileEntry = new LiferayFileEntry(dlFileEntry);
-
-				try {
-					_amProcessor.process(
-						fileEntry.getFileVersion(), configurationEntryUuid);
-
-					_sendStatusMessage(
-						successCounter.incrementAndGet(), errorCounter.get(),
-						total);
-				}
-				catch (Exception exception) {
-					if (_log.isWarnEnabled()) {
-						_log.warn(
-							"Unable to process file entry " +
-								fileEntry.getFileEntryId());
-					}
-
-					if (_log.isDebugEnabled()) {
-						_log.debug(exception);
-					}
-
-					_sendStatusMessage(
-						successCounter.get(), errorCounter.incrementAndGet(),
-						total);
-				}
-			});
-
-		try {
-			actionableDynamicQuery.performActions();
-		}
-		catch (PortalException portalException) {
-			_log.error(portalException);
-		}
-	}
-
-	private void _sendStatusMessage(int count, int errors, int total) {
-		Message message = new Message();
-
-		message.put(
-			BackgroundTaskConstants.BACKGROUND_TASK_ID,
-			BackgroundTaskThreadLocal.getBackgroundTaskId());
-
-		Class<? extends DLAMImageOptimizer> clazz = getClass();
-
-		message.put(
-			AMOptimizeImagesBackgroundTaskConstants.CLASS_NAME,
-			clazz.getName());
-
-		message.put(AMOptimizeImagesBackgroundTaskConstants.COUNT, count);
-		message.put(AMOptimizeImagesBackgroundTaskConstants.ERRORS, errors);
-		message.put(AMOptimizeImagesBackgroundTaskConstants.TOTAL, total);
-
-		message.put("status", BackgroundTaskConstants.STATUS_IN_PROGRESS);
-
-		_backgroundTaskStatusMessageSender.sendBackgroundTaskStatusMessage(
-			message);
-	}
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		DLAMImageOptimizer.class);
-
-	@Reference
-	private AMImageConfigurationHelper _amImageConfigurationHelper;
 
 	@Reference(target = "(adaptive.media.key=document-library)")
 	private AMImageCounter _amImageCounter;
-
-	@Reference
-	private AMImageMimeTypeProvider _amImageMimeTypeProvider;
-
-	@Reference
-	private AMImageValidator _amImageValidator;
-
-	@Reference
-	private AMProcessor<FileVersion> _amProcessor;
-
-	@Reference
-	private BackgroundTaskStatusMessageSender
-		_backgroundTaskStatusMessageSender;
 
 	@Reference
 	private DLFileEntryConfigurationProvider _dlFileEntryConfigurationProvider;
 
 	@Reference
 	private DLFileEntryLocalService _dlFileEntryLocalService;
-
-	@Reference
-	private DLFileVersionLocalService _dlFileVersionLocalService;
 
 }

--- a/modules/apps/adaptive-media/adaptive-media-document-library-web/src/main/java/com/liferay/adaptive/media/document/library/web/internal/optimizer/DLAMImageOptimizer.java
+++ b/modules/apps/adaptive-media/adaptive-media-document-library-web/src/main/java/com/liferay/adaptive/media/document/library/web/internal/optimizer/DLAMImageOptimizer.java
@@ -14,6 +14,7 @@ import com.liferay.adaptive.media.image.optimizer.AMImageOptimizer;
 import com.liferay.adaptive.media.image.validator.AMImageValidator;
 import com.liferay.adaptive.media.processor.AMProcessor;
 import com.liferay.document.library.configuration.DLFileEntryConfigurationProvider;
+import com.liferay.document.library.constants.DLFileEntryConfigurationConstants;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
 import com.liferay.document.library.kernel.service.DLFileVersionLocalService;
@@ -112,12 +113,19 @@ public class DLAMImageOptimizer implements AMImageOptimizer {
 					mimeTypeProperty.in(
 						_amImageMimeTypeProvider.getSupportedMimeTypes()));
 
-				Property sizeProperty = PropertyFactoryUtil.forName("size");
+				long previewableProcessorMaxSize =
+					_dlFileEntryConfigurationProvider.
+						getCompanyPreviewableProcessorMaxSize(companyId);
 
-				dynamicQuery.add(
-					sizeProperty.le(
-						_dlFileEntryConfigurationProvider.
-							getCompanyPreviewableProcessorMaxSize(companyId)));
+				if (previewableProcessorMaxSize !=
+						DLFileEntryConfigurationConstants.
+							PREVIEWABLE_PROCESSOR_MAX_SIZE_UNLIMITED) {
+
+					Property sizeProperty = PropertyFactoryUtil.forName("size");
+
+					dynamicQuery.add(
+						sizeProperty.le(previewableProcessorMaxSize));
+				}
 
 				DynamicQuery dlFileVersionDynamicQuery =
 					_dlFileVersionLocalService.dynamicQuery();

--- a/modules/apps/adaptive-media/adaptive-media-image-api/bnd.bnd
+++ b/modules/apps/adaptive-media/adaptive-media-image-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Adaptive Media Image API
 Bundle-SymbolicName: com.liferay.adaptive.media.image.api
-Bundle-Version: 13.0.1
+Bundle-Version: 13.1.0
 Export-Package:\
 	com.liferay.adaptive.media.image.configuration,\
 	com.liferay.adaptive.media.image.counter,\

--- a/modules/apps/adaptive-media/adaptive-media-image-api/build.gradle
+++ b/modules/apps/adaptive-media/adaptive-media-image-api/build.gradle
@@ -1,8 +1,11 @@
 dependencies {
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "org.osgi", name: "org.osgi.annotation.versioning", version: "1.1.0"
+	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:adaptive-media:adaptive-media-api")
+	compileOnly project(":apps:document-library:document-library-api")
 	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-sql-dsl-api")
 }

--- a/modules/apps/adaptive-media/adaptive-media-image-api/src/main/java/com/liferay/adaptive/media/image/counter/BaseAMImageCounter.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-api/src/main/java/com/liferay/adaptive/media/image/counter/BaseAMImageCounter.java
@@ -1,0 +1,98 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.adaptive.media.image.counter;
+
+import com.liferay.adaptive.media.image.mime.type.AMImageMimeTypeProvider;
+import com.liferay.adaptive.media.image.validator.AMImageValidator;
+import com.liferay.document.library.configuration.DLFileEntryConfigurationProvider;
+import com.liferay.document.library.constants.DLFileEntryConfigurationConstants;
+import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Marco Galluzzi
+ */
+public abstract class BaseAMImageCounter implements AMImageCounter {
+
+	@Override
+	public int countExpectedAMImageEntries(long companyId) {
+		long previewableProcessorMaxSize =
+			dlFileEntryConfigurationProvider.
+				getCompanyPreviewableProcessorMaxSize(companyId);
+
+		if (previewableProcessorMaxSize == 0) {
+			return 0;
+		}
+
+		AtomicInteger counter = new AtomicInteger(0);
+
+		try {
+			forEachFileEntry(companyId, _getCountDlFileEntryConsumer(counter));
+		}
+		catch (PortalException portalException) {
+			_log.error(portalException);
+
+			return 0;
+		}
+
+		return counter.get();
+	}
+
+	protected abstract void forEachFileEntry(
+			long companyId, Consumer<DLFileEntry> consumer)
+		throws PortalException;
+
+	protected String[] getMimeTypes() {
+		return ArrayUtil.filter(
+			amImageMimeTypeProvider.getSupportedMimeTypes(),
+			amImageValidator::isProcessingSupported);
+	}
+
+	@Reference
+	protected AMImageMimeTypeProvider amImageMimeTypeProvider;
+
+	@Reference
+	protected AMImageValidator amImageValidator;
+
+	@Reference
+	protected DLFileEntryConfigurationProvider dlFileEntryConfigurationProvider;
+
+	private Consumer<DLFileEntry> _getCountDlFileEntryConsumer(
+		AtomicInteger counter) {
+
+		Map<Long, Long> groupPreviewableProcessorMaxSizeMap =
+			dlFileEntryConfigurationProvider.
+				getGroupPreviewableProcessorMaxSizeMap();
+
+		return dlFileEntry -> {
+			Long previewableProcessorMaxSize =
+				groupPreviewableProcessorMaxSizeMap.get(
+					dlFileEntry.getGroupId());
+
+			if ((previewableProcessorMaxSize == null) ||
+				(previewableProcessorMaxSize ==
+					DLFileEntryConfigurationConstants.
+						PREVIEWABLE_PROCESSOR_MAX_SIZE_UNLIMITED) ||
+				(dlFileEntry.getSize() <= previewableProcessorMaxSize)) {
+
+				counter.incrementAndGet();
+			}
+		};
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		BaseAMImageCounter.class);
+
+}

--- a/modules/apps/adaptive-media/adaptive-media-image-api/src/main/java/com/liferay/adaptive/media/image/optimizer/BaseAMImageOptimizer.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-api/src/main/java/com/liferay/adaptive/media/image/optimizer/BaseAMImageOptimizer.java
@@ -1,0 +1,228 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.adaptive.media.image.optimizer;
+
+import com.liferay.adaptive.media.constants.AMOptimizeImagesBackgroundTaskConstants;
+import com.liferay.adaptive.media.image.configuration.AMImageConfigurationEntry;
+import com.liferay.adaptive.media.image.configuration.AMImageConfigurationHelper;
+import com.liferay.adaptive.media.image.mime.type.AMImageMimeTypeProvider;
+import com.liferay.adaptive.media.image.validator.AMImageValidator;
+import com.liferay.adaptive.media.processor.AMProcessor;
+import com.liferay.document.library.configuration.DLFileEntryConfigurationProvider;
+import com.liferay.document.library.constants.DLFileEntryConfigurationConstants;
+import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.portal.kernel.backgroundtask.BackgroundTaskStatusMessageSender;
+import com.liferay.portal.kernel.backgroundtask.BackgroundTaskThreadLocal;
+import com.liferay.portal.kernel.backgroundtask.constants.BackgroundTaskConstants;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.messaging.Message;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.repository.model.FileVersion;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.repository.liferayrepository.model.LiferayFileEntry;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Marco Galluzzi
+ */
+public abstract class BaseAMImageOptimizer implements AMImageOptimizer {
+
+	@Override
+	public void optimize(long companyId) {
+		long previewableProcessorMaxSize =
+			dlFileEntryConfigurationProvider.
+				getCompanyPreviewableProcessorMaxSize(companyId);
+
+		if (previewableProcessorMaxSize == 0) {
+			return;
+		}
+
+		Collection<AMImageConfigurationEntry> amImageConfigurationEntries =
+			amImageConfigurationHelper.getAMImageConfigurationEntries(
+				companyId);
+
+		int count = countExpectedAMImageEntries(companyId);
+
+		if (count == 0) {
+			return;
+		}
+
+		int total = count * amImageConfigurationEntries.size();
+
+		AtomicInteger successCounter = new AtomicInteger(0);
+		AtomicInteger errorCounter = new AtomicInteger(0);
+
+		for (AMImageConfigurationEntry amImageConfigurationEntry :
+				amImageConfigurationEntries) {
+
+			_optimize(
+				companyId, amImageConfigurationEntry.getUUID(), total,
+				successCounter, errorCounter);
+		}
+	}
+
+	@Override
+	public void optimize(long companyId, String configurationEntryUuid) {
+		long previewableProcessorMaxSize =
+			dlFileEntryConfigurationProvider.
+				getCompanyPreviewableProcessorMaxSize(companyId);
+
+		if (previewableProcessorMaxSize == 0) {
+			return;
+		}
+
+		int total = countExpectedAMImageEntries(companyId);
+
+		if (total == 0) {
+			return;
+		}
+
+		AtomicInteger successCounter = new AtomicInteger(0);
+		AtomicInteger errorCounter = new AtomicInteger(0);
+
+		_optimize(
+			companyId, configurationEntryUuid, total, successCounter,
+			errorCounter);
+	}
+
+	protected abstract int countExpectedAMImageEntries(long companyId);
+
+	protected abstract void forEachFileEntry(
+			long companyId, Consumer<DLFileEntry> consumer)
+		throws PortalException;
+
+	protected String[] getMimeTypes() {
+		return ArrayUtil.filter(
+			amImageMimeTypeProvider.getSupportedMimeTypes(),
+			amImageValidator::isProcessingSupported);
+	}
+
+	@Reference
+	protected AMImageConfigurationHelper amImageConfigurationHelper;
+
+	@Reference
+	protected AMImageMimeTypeProvider amImageMimeTypeProvider;
+
+	@Reference
+	protected AMImageValidator amImageValidator;
+
+	@Reference
+	protected AMProcessor<FileVersion> amProcessor;
+
+	@Reference
+	protected BackgroundTaskStatusMessageSender
+		backgroundTaskStatusMessageSender;
+
+	@Reference
+	protected DLFileEntryConfigurationProvider dlFileEntryConfigurationProvider;
+
+	private Consumer<DLFileEntry> _getProcessDLFileEntryConsumer(
+		String configurationEntryUuid, int total, AtomicInteger successCounter,
+		AtomicInteger errorCounter) {
+
+		Map<Long, Long> groupPreviewableProcessorMaxSizeMap =
+			dlFileEntryConfigurationProvider.
+				getGroupPreviewableProcessorMaxSizeMap();
+
+		return dlFileEntry -> {
+			Long previewableProcessorMaxSize =
+				groupPreviewableProcessorMaxSizeMap.get(
+					dlFileEntry.getGroupId());
+
+			if ((previewableProcessorMaxSize == null) ||
+				(previewableProcessorMaxSize ==
+					DLFileEntryConfigurationConstants.
+						PREVIEWABLE_PROCESSOR_MAX_SIZE_UNLIMITED) ||
+				(dlFileEntry.getSize() <= previewableProcessorMaxSize)) {
+
+				_processDLFileEntry(
+					configurationEntryUuid, total, successCounter, errorCounter,
+					dlFileEntry);
+			}
+		};
+	}
+
+	private void _optimize(
+		long companyId, String configurationEntryUuid, int total,
+		AtomicInteger successCounter, AtomicInteger errorCounter) {
+
+		try {
+			forEachFileEntry(
+				companyId,
+				_getProcessDLFileEntryConsumer(
+					configurationEntryUuid, total, successCounter,
+					errorCounter));
+		}
+		catch (PortalException portalException) {
+			_log.error(portalException);
+		}
+	}
+
+	private void _processDLFileEntry(
+		String configurationEntryUuid, int total, AtomicInteger successCounter,
+		AtomicInteger errorCounter, DLFileEntry dlFileEntry) {
+
+		FileEntry fileEntry = new LiferayFileEntry(dlFileEntry);
+
+		try {
+			amProcessor.process(
+				fileEntry.getFileVersion(), configurationEntryUuid);
+
+			_sendStatusMessage(
+				successCounter.incrementAndGet(), errorCounter.get(), total);
+		}
+		catch (Exception exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Unable to process file entry " +
+						fileEntry.getFileEntryId(),
+					exception);
+			}
+
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
+
+			_sendStatusMessage(
+				successCounter.get(), errorCounter.incrementAndGet(), total);
+		}
+	}
+
+	private void _sendStatusMessage(int count, int errors, int total) {
+		Message message = new Message();
+
+		message.put(
+			BackgroundTaskConstants.BACKGROUND_TASK_ID,
+			BackgroundTaskThreadLocal.getBackgroundTaskId());
+
+		Class<?> clazz = getClass();
+
+		message.put(
+			AMOptimizeImagesBackgroundTaskConstants.CLASS_NAME,
+			clazz.getName());
+
+		message.put(AMOptimizeImagesBackgroundTaskConstants.COUNT, count);
+		message.put(AMOptimizeImagesBackgroundTaskConstants.ERRORS, errors);
+		message.put(AMOptimizeImagesBackgroundTaskConstants.TOTAL, total);
+
+		message.put("status", BackgroundTaskConstants.STATUS_IN_PROGRESS);
+
+		backgroundTaskStatusMessageSender.sendBackgroundTaskStatusMessage(
+			message);
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		BaseAMImageOptimizer.class);
+
+}

--- a/modules/apps/adaptive-media/adaptive-media-image-api/src/main/resources/com/liferay/adaptive/media/image/counter/packageinfo
+++ b/modules/apps/adaptive-media/adaptive-media-image-api/src/main/resources/com/liferay/adaptive/media/image/counter/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/modules/apps/adaptive-media/adaptive-media-image-api/src/main/resources/com/liferay/adaptive/media/image/optimizer/packageinfo
+++ b/modules/apps/adaptive-media/adaptive-media-image-api/src/main/resources/com/liferay/adaptive/media/image/optimizer/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.1
+version 2.1.0

--- a/modules/apps/document-library/document-library-api/src/main/java/com/liferay/document/library/configuration/DLFileEntryConfigurationProvider.java
+++ b/modules/apps/document-library/document-library-api/src/main/java/com/liferay/document/library/configuration/DLFileEntryConfigurationProvider.java
@@ -7,6 +7,8 @@ package com.liferay.document.library.configuration;
 
 import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
 
+import java.util.Map;
+
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
@@ -22,6 +24,8 @@ public interface DLFileEntryConfigurationProvider {
 	public int getGroupMaxNumberOfPages(long groupId);
 
 	public long getGroupPreviewableProcessorMaxSize(long groupId);
+
+	public Map<Long, Long> getGroupPreviewableProcessorMaxSizeMap();
 
 	public int getMaxNumberOfPages(
 		ExtendedObjectClassDefinition.Scope scope, long scopePK);

--- a/modules/apps/document-library/document-library-preview-api/src/main/java/com/liferay/document/library/preview/background/task/BasePreviewBackgroundTaskExecutor.java
+++ b/modules/apps/document-library/document-library-preview-api/src/main/java/com/liferay/document/library/preview/background/task/BasePreviewBackgroundTaskExecutor.java
@@ -6,6 +6,7 @@
 package com.liferay.document.library.preview.background.task;
 
 import com.liferay.document.library.configuration.DLFileEntryConfigurationProvider;
+import com.liferay.document.library.constants.DLFileEntryConfigurationConstants;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTask;
@@ -86,12 +87,19 @@ public abstract class BasePreviewBackgroundTaskExecutor
 
 				dynamicQuery.add(mimeTypeProperty.in(getMimeTypes()));
 
-				Property sizeProperty = PropertyFactoryUtil.forName("size");
+				long previewableProcessorMaxSize =
+					dlFileEntryConfigurationProvider.
+						getCompanyPreviewableProcessorMaxSize(companyId);
 
-				dynamicQuery.add(
-					sizeProperty.le(
-						dlFileEntryConfigurationProvider.
-							getCompanyPreviewableProcessorMaxSize(companyId)));
+				if (previewableProcessorMaxSize !=
+						DLFileEntryConfigurationConstants.
+							PREVIEWABLE_PROCESSOR_MAX_SIZE_UNLIMITED) {
+
+					Property sizeProperty = PropertyFactoryUtil.forName("size");
+
+					dynamicQuery.add(
+						sizeProperty.le(previewableProcessorMaxSize));
+				}
 			});
 		actionableDynamicQuery.setPerformActionMethod(
 			(DLFileEntry dlFileEntry) -> {

--- a/modules/apps/document-library/document-library-preview-api/src/main/java/com/liferay/document/library/preview/background/task/BasePreviewBackgroundTaskExecutor.java
+++ b/modules/apps/document-library/document-library-preview-api/src/main/java/com/liferay/document/library/preview/background/task/BasePreviewBackgroundTaskExecutor.java
@@ -14,9 +14,6 @@ import com.liferay.portal.kernel.backgroundtask.BackgroundTaskExecutor;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTaskResult;
 import com.liferay.portal.kernel.backgroundtask.BaseBackgroundTaskExecutor;
 import com.liferay.portal.kernel.backgroundtask.display.BackgroundTaskDisplay;
-import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
-import com.liferay.portal.kernel.dao.orm.Property;
-import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -28,6 +25,7 @@ import com.liferay.portal.repository.liferayrepository.model.LiferayFileEntry;
 import java.io.Serializable;
 
 import java.util.Map;
+import java.util.function.Consumer;
 
 import org.osgi.service.component.annotations.Reference;
 
@@ -72,53 +70,17 @@ public abstract class BasePreviewBackgroundTaskExecutor
 		throws Exception;
 
 	protected void generatePreviews(long companyId) throws PortalException {
-		ActionableDynamicQuery actionableDynamicQuery =
-			dlFileEntryLocalService.getActionableDynamicQuery();
+		long previewableProcessorMaxSize =
+			dlFileEntryConfigurationProvider.
+				getCompanyPreviewableProcessorMaxSize(companyId);
 
-		actionableDynamicQuery.setAddCriteriaMethod(
-			dynamicQuery -> {
-				Property companyIdProperty = PropertyFactoryUtil.forName(
-					"companyId");
+		if (previewableProcessorMaxSize == 0) {
+			return;
+		}
 
-				dynamicQuery.add(companyIdProperty.eq(companyId));
-
-				Property mimeTypeProperty = PropertyFactoryUtil.forName(
-					"mimeType");
-
-				dynamicQuery.add(mimeTypeProperty.in(getMimeTypes()));
-
-				long previewableProcessorMaxSize =
-					dlFileEntryConfigurationProvider.
-						getCompanyPreviewableProcessorMaxSize(companyId);
-
-				if (previewableProcessorMaxSize !=
-						DLFileEntryConfigurationConstants.
-							PREVIEWABLE_PROCESSOR_MAX_SIZE_UNLIMITED) {
-
-					Property sizeProperty = PropertyFactoryUtil.forName("size");
-
-					dynamicQuery.add(
-						sizeProperty.le(previewableProcessorMaxSize));
-				}
-			});
-		actionableDynamicQuery.setPerformActionMethod(
-			(DLFileEntry dlFileEntry) -> {
-				FileEntry fileEntry = new LiferayFileEntry(dlFileEntry);
-
-				try {
-					generatePreview(fileEntry.getLatestFileVersion());
-				}
-				catch (Exception exception) {
-					if (_log.isWarnEnabled()) {
-						_log.warn(
-							"Unable to process file entry " +
-								fileEntry.getFileEntryId(),
-							exception);
-					}
-				}
-			});
-
-		actionableDynamicQuery.performActions();
+		dlFileEntryLocalService.forEachFileEntry(
+			companyId, 0, _getProcessDlFileEntryConsumer(),
+			previewableProcessorMaxSize, getMimeTypes());
 	}
 
 	protected abstract String[] getMimeTypes();
@@ -128,6 +90,43 @@ public abstract class BasePreviewBackgroundTaskExecutor
 
 	@Reference
 	protected DLFileEntryLocalService dlFileEntryLocalService;
+
+	private Consumer<DLFileEntry> _getProcessDlFileEntryConsumer() {
+		Map<Long, Long> groupPreviewableProcessorMaxSizeMap =
+			dlFileEntryConfigurationProvider.
+				getGroupPreviewableProcessorMaxSizeMap();
+
+		return dlFileEntry -> {
+			Long previewableProcessorMaxSize =
+				groupPreviewableProcessorMaxSizeMap.get(
+					dlFileEntry.getGroupId());
+
+			if ((previewableProcessorMaxSize == null) ||
+				(previewableProcessorMaxSize ==
+					DLFileEntryConfigurationConstants.
+						PREVIEWABLE_PROCESSOR_MAX_SIZE_UNLIMITED) ||
+				(dlFileEntry.getSize() <= previewableProcessorMaxSize)) {
+
+				_processDlFileEntry(dlFileEntry);
+			}
+		};
+	}
+
+	private void _processDlFileEntry(DLFileEntry dlFileEntry) {
+		FileEntry fileEntry = new LiferayFileEntry(dlFileEntry);
+
+		try {
+			generatePreview(fileEntry.getLatestFileVersion());
+		}
+		catch (Exception exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Unable to process file entry " +
+						fileEntry.getFileEntryId(),
+					exception);
+			}
+		}
+	}
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		BasePreviewBackgroundTaskExecutor.class);

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/configuration/DLFileEntryConfigurationProviderImpl.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/configuration/DLFileEntryConfigurationProviderImpl.java
@@ -17,6 +17,8 @@ import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -78,6 +80,28 @@ public class DLFileEntryConfigurationProviderImpl
 				getCompanyPreviewableProcessorMaxSize(group.getCompanyId()),
 			_dlFileEntryConfigurationHelper.
 				getSystemPreviewableProcessorMaxSize());
+	}
+
+	@Override
+	public Map<Long, Long> getGroupPreviewableProcessorMaxSizeMap() {
+		Map<Long, Long> map = new HashMap<>();
+
+		for (long groupId : _dlFileEntryConfigurationHelper.getGroupIds()) {
+			long previewableProcessorMaxSize =
+				getGroupPreviewableProcessorMaxSize(groupId);
+
+			Group group = _groupLocalService.fetchGroup(groupId);
+
+			if ((group != null) &&
+				(previewableProcessorMaxSize !=
+					getCompanyPreviewableProcessorMaxSize(
+						group.getCompanyId()))) {
+
+				map.put(groupId, previewableProcessorMaxSize);
+			}
+		}
+
+		return map;
 	}
 
 	@Override

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/configuration/helper/DLFileEntryConfigurationHelper.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/configuration/helper/DLFileEntryConfigurationHelper.java
@@ -13,6 +13,7 @@ import com.liferay.portal.kernel.service.GroupLocalService;
 
 import java.util.Dictionary;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 
@@ -42,6 +43,10 @@ public class DLFileEntryConfigurationHelper {
 			_getCompanyDLFileEntryConfiguration(companyId);
 
 		return dlFileEntryConfiguration.previewableProcessorMaxSize();
+	}
+
+	public Set<Long> getGroupIds() {
+		return _groupConfigurationBeans.keySet();
 	}
 
 	public int getGroupMaxNumberOfPages(long groupId) {

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -63,7 +63,9 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.bean.BeanReference;
 import com.liferay.portal.kernel.comment.CommentManagerUtil;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
+import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.dao.orm.IndexableActionableDynamicQuery;
+import com.liferay.portal.kernel.dao.orm.ProjectionFactoryUtil;
 import com.liferay.portal.kernel.dao.orm.Property;
 import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
 import com.liferay.portal.kernel.dao.orm.QueryDefinition;
@@ -165,6 +167,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -1072,6 +1075,89 @@ public class DLFileEntryLocalServiceImpl
 		long groupId, long folderId, String name) {
 
 		return dlFileEntryPersistence.fetchByG_F_N(groupId, folderId, name);
+	}
+
+	@Override
+	public void forEachFileEntry(
+			long companyId, Consumer<DLFileEntry> consumer, long maximumSize,
+			String[] mimeTypes)
+		throws PortalException {
+
+		_performDynamicQueryActions(
+			consumer,
+			dynamicQuery -> {
+				Property companyIdProperty = PropertyFactoryUtil.forName(
+					"companyId");
+				Property fileEntryIdProperty = PropertyFactoryUtil.forName(
+					"fileEntryId");
+				Property groupIdProperty = PropertyFactoryUtil.forName(
+					"groupId");
+				Property mimeTypeProperty = PropertyFactoryUtil.forName(
+					"mimeType");
+				Property repositoryIdProperty = PropertyFactoryUtil.forName(
+					"repositoryId");
+				Property statusProperty = PropertyFactoryUtil.forName("status");
+
+				dynamicQuery.add(companyIdProperty.eq(companyId));
+				dynamicQuery.add(
+					groupIdProperty.eqProperty(repositoryIdProperty));
+				dynamicQuery.add(mimeTypeProperty.in(mimeTypes));
+
+				if (maximumSize >= 0) {
+					Property sizeProperty = PropertyFactoryUtil.forName("size");
+
+					dynamicQuery.add(sizeProperty.le(maximumSize));
+				}
+
+				DynamicQuery dlFileVersionDynamicQuery =
+					_dlFileVersionLocalService.dynamicQuery();
+
+				dlFileVersionDynamicQuery.setProjection(
+					ProjectionFactoryUtil.distinct(
+						ProjectionFactoryUtil.property("fileEntryId")));
+
+				dlFileVersionDynamicQuery.add(companyIdProperty.eq(companyId));
+				dlFileVersionDynamicQuery.add(
+					groupIdProperty.eqProperty(repositoryIdProperty));
+				dlFileVersionDynamicQuery.add(mimeTypeProperty.in(mimeTypes));
+				dlFileVersionDynamicQuery.add(
+					statusProperty.eq(WorkflowConstants.STATUS_IN_TRASH));
+
+				dynamicQuery.add(
+					fileEntryIdProperty.notIn(dlFileVersionDynamicQuery));
+			});
+	}
+
+	@Override
+	public void forEachFileEntry(
+			long companyId, long classNameId, Consumer<DLFileEntry> consumer,
+			long maximumSize, String[] mimeTypes)
+		throws PortalException {
+
+		_performDynamicQueryActions(
+			consumer,
+			dynamicQuery -> {
+				Property companyIdProperty = PropertyFactoryUtil.forName(
+					"companyId");
+				Property mimeTypeProperty = PropertyFactoryUtil.forName(
+					"mimeType");
+
+				dynamicQuery.add(companyIdProperty.eq(companyId));
+				dynamicQuery.add(mimeTypeProperty.in(mimeTypes));
+
+				if (classNameId > 0) {
+					Property classNameIdProperty = PropertyFactoryUtil.forName(
+						"classNameId");
+
+					dynamicQuery.add(classNameIdProperty.eq(classNameId));
+				}
+
+				if (maximumSize >= 0) {
+					Property sizeProperty = PropertyFactoryUtil.forName("size");
+
+					dynamicQuery.add(sizeProperty.le(maximumSize));
+				}
+			});
 	}
 
 	@Override
@@ -3290,6 +3376,21 @@ public class DLFileEntryLocalServiceImpl
 		// Latest file version
 
 		_removeFileVersion(dlFileEntry, latestDLFileVersion);
+	}
+
+	private void _performDynamicQueryActions(
+			Consumer<DLFileEntry> actionMethod,
+			Consumer<DynamicQuery> criteriaMethod)
+		throws PortalException {
+
+		ActionableDynamicQuery actionableDynamicQuery =
+			getActionableDynamicQuery();
+
+		actionableDynamicQuery.setAddCriteriaMethod(criteriaMethod::accept);
+		actionableDynamicQuery.setPerformActionMethod(
+			(DLFileEntry dlFileEntry) -> actionMethod.accept(dlFileEntry));
+
+		actionableDynamicQuery.performActions();
 	}
 
 	private void _registerPWCDeletionCallback(

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryLocalService.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryLocalService.java
@@ -46,6 +46,7 @@ import java.io.Serializable;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 
 import org.osgi.annotation.versioning.ProviderType;
 
@@ -351,6 +352,16 @@ public interface DLFileEntryLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public DLFileEntry fetchFileEntryByName(
 		long groupId, long folderId, String name);
+
+	public void forEachFileEntry(
+			long companyId, Consumer<DLFileEntry> consumer, long maximumSize,
+			String[] mimeTypes)
+		throws PortalException;
+
+	public void forEachFileEntry(
+			long companyId, long classNameId, Consumer<DLFileEntry> consumer,
+			long maximumSize, String[] mimeTypes)
+		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public ActionableDynamicQuery getActionableDynamicQuery();

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryLocalServiceUtil.java
@@ -436,6 +436,25 @@ public class DLFileEntryLocalServiceUtil {
 		return getService().fetchFileEntryByName(groupId, folderId, name);
 	}
 
+	public static void forEachFileEntry(
+			long companyId, java.util.function.Consumer<DLFileEntry> consumer,
+			long maximumSize, String[] mimeTypes)
+		throws PortalException {
+
+		getService().forEachFileEntry(
+			companyId, consumer, maximumSize, mimeTypes);
+	}
+
+	public static void forEachFileEntry(
+			long companyId, long classNameId,
+			java.util.function.Consumer<DLFileEntry> consumer, long maximumSize,
+			String[] mimeTypes)
+		throws PortalException {
+
+		getService().forEachFileEntry(
+			companyId, classNameId, consumer, maximumSize, mimeTypes);
+	}
+
 	public static com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery
 		getActionableDynamicQuery() {
 

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryLocalServiceWrapper.java
@@ -489,6 +489,27 @@ public class DLFileEntryLocalServiceWrapper
 	}
 
 	@Override
+	public void forEachFileEntry(
+			long companyId, java.util.function.Consumer<DLFileEntry> consumer,
+			long maximumSize, String[] mimeTypes)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		_dlFileEntryLocalService.forEachFileEntry(
+			companyId, consumer, maximumSize, mimeTypes);
+	}
+
+	@Override
+	public void forEachFileEntry(
+			long companyId, long classNameId,
+			java.util.function.Consumer<DLFileEntry> consumer, long maximumSize,
+			String[] mimeTypes)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		_dlFileEntryLocalService.forEachFileEntry(
+			companyId, classNameId, consumer, maximumSize, mimeTypes);
+	}
+
+	@Override
 	public com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery
 		getActionableDynamicQuery() {
 

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/packageinfo
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/packageinfo
@@ -1,1 +1,1 @@
-version 16.0.1
+version 16.1.0


### PR DESCRIPTION
# Description

The group configuration settings should be used when processing file entries, when they do exist, instead of the company settings.

Related issue: https://liferay.atlassian.net/browse/LPS-197738

NOTE: this PR was already reviewed in #4774. I've only made a change requested by @adolfopa changing the method name `forEachFileEntryInTrash`.
