### PR TITLE
LPS-200600 KB use the user timezone 

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/action/UpdateKBArticleMVCActionCommand.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/action/UpdateKBArticleMVCActionCommand.java
@@ -99,15 +99,16 @@ public class UpdateKBArticleMVCActionCommand
 		String content = ParamUtil.getString(actionRequest, "content");
 		String description = ParamUtil.getString(actionRequest, "description");
 		String sourceURL = ParamUtil.getString(actionRequest, "sourceURL");
-		Date displayDate = ParamUtil.getDate(
-			actionRequest, "displayDate",
-			DateFormatFactoryUtil.getSimpleDateFormat("yyyy-MM-dd HH:mm"));
 
 		ThemeDisplay themeDisplay = (ThemeDisplay)actionRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
 		User user = _userLocalService.getUser(themeDisplay.getUserId());
 
+		Date displayDate = ParamUtil.getDate(
+			actionRequest, "displayDate",
+			DateFormatFactoryUtil.getSimpleDateFormat(
+				"yyyy-MM-dd HH:mm", user.getTimeZone()));
 		Date expirationDate = _getExpirationDate(
 			actionRequest, true, user.getTimeZone());
 		Date reviewDate = _getReviewDate(

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_kb_article.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_kb_article.jsp
@@ -380,6 +380,8 @@ if (editKBArticleDisplayContext.isPortletTitleBasedNavigation()) {
 				"displayDate", editKBArticleDisplayContext.getDatePickerFormattedDisplayDate()
 			).put(
 				"scheduled", editKBArticleDisplayContext.isScheduled()
+			).put(
+				"timeZone", timeZone.getID()
 			).build()
 		%>'
 	/>

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/schedule_modal.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/schedule_modal.jsp
@@ -15,6 +15,8 @@
 				"displayDate", ParamUtil.getString(request, "displayDate")
 			).put(
 				"isScheduled", ParamUtil.getBoolean(request, "scheduled")
+			).put(
+				"timeZone", timeZone.getID()
 			).build()
 		%>'
 	/>

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/js/components/ScheduleKBArticle.js
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/js/components/ScheduleKBArticle.js
@@ -12,6 +12,7 @@ export default function ScheduleKBArticle({
 	displayDate,
 	portletNamespace,
 	scheduled,
+	timeZone,
 }) {
 	const [showModal, setShowModal] = useState();
 	const [callback, setCallback] = useState();
@@ -56,6 +57,7 @@ export default function ScheduleKBArticle({
 					observer={observer}
 					onModalClose={onClose}
 					scheduled={scheduled}
+					timeZone={timeZone}
 				/>
 			)}
 		</>

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/js/components/ScheduleModal.js
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/js/components/ScheduleModal.js
@@ -17,6 +17,7 @@ export default function ScheduleModal({
 	callback = noop,
 	displayDate: initialDisplayDate,
 	scheduled,
+	timeZone,
 	observer,
 	onModalClose = noop,
 }) {
@@ -70,6 +71,7 @@ export default function ScheduleModal({
 						onChange={setDisplayDate}
 						placeholder="YYYY-MM-DD HH:mm"
 						time
+						timeZone={timeZone}
 						value={displayDate}
 					/>
 				</div>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-200660

Way I tested it:

- Enable feature flag
- Go to instance settings> Localization> Time zone
- Change the time zone to “UTC-7“
- Go to user account settings> Preferences> Display Settings
- Change the time zone to “UTC-7“
- Go to Kb admin 
- Add a kb article and set the scheduled date and a expiration Date with the same date.

On database the date of both fields are the same



- LPS-200660 use the user timezone when saving the schedule date (display date)
