### PR TITLE
LPS-199197 KB Schedule modal: redundant space

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/js/components/ScheduleModal.js
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/js/components/ScheduleModal.js
@@ -89,9 +89,10 @@ export default function ScheduleModal({
 
 			<ClayModal.Footer
 				last={
-					<ClayButton.Group spaced>
+					<>
 						<ClayButton
 							borderless="<%= true %>"
+							className="mr-3"
 							displayType="secondary"
 							onClick={onModalClose}
 						>
@@ -100,6 +101,7 @@ export default function ScheduleModal({
 
 						{scheduled && (
 							<ClayButton
+								className="mr-3"
 								displayType="secondary"
 								onClick={publisNowButtonOnClick}
 							>
@@ -114,7 +116,7 @@ export default function ScheduleModal({
 						>
 							{Liferay.Language.get('schedule')}
 						</ClayButton>
-					</ClayButton.Group>
+					</>
 				}
 			/>
 		</ClayModal>


### PR DESCRIPTION
Issue https://liferay.atlassian.net/browse/LPS-199197 A redundant cursor is displayed on the “Schedule Publication“ modal

Even if I don't see that cursor (could be browser dependant?), it is true that there were an extra space between buttons where the cursor appears (as the attached video shows). 
### Before: 
![Screenshot 2023-11-06 at 11 49 46](https://github.com/liferay-lima/liferay-portal/assets/8373764/d5e17ed9-fe7b-4e7d-bcc9-c0a2d9c5c641)

### After: 
![Screenshot 2023-11-06 at 11 47 49](https://github.com/liferay-lima/liferay-portal/assets/8373764/88f4cbb0-1935-41b9-be6a-9d4b6c395c4f)
