### PR TITLE
LPS-200202 Show "copy link" action even when sharing is disabled

### DIFF
--- a/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/display/context/util/SharingDropdownItemFactory.java
+++ b/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/display/context/util/SharingDropdownItemFactory.java
@@ -17,6 +17,9 @@ import javax.servlet.http.HttpServletRequest;
  */
 public interface SharingDropdownItemFactory {
 
+	public DropdownItem createCopyLinkDropdownItem(
+		String className, long classPK, HttpServletRequest httpServletRequest);
+
 	public DropdownItem createManageCollaboratorsDropdownItem(
 			String className, long classPK,
 			HttpServletRequest httpServletRequest)

--- a/modules/apps/sharing/sharing-document-library/src/main/java/com/liferay/sharing/document/library/internal/display/context/SharingDLDisplayContextFactory.java
+++ b/modules/apps/sharing/sharing-document-library/src/main/java/com/liferay/sharing/document/library/internal/display/context/SharingDLDisplayContextFactory.java
@@ -73,10 +73,6 @@ public class SharingDLDisplayContextFactory implements DLDisplayContextFactory {
 			SharingConfiguration sharingConfiguration =
 				_getSharingConfiguration(httpServletRequest);
 
-			if (!sharingConfiguration.isEnabled()) {
-				return parentDLViewFileVersionDisplayContext;
-			}
-
 			FileEntry fileEntry = null;
 
 			if (fileVersion != null) {

--- a/modules/apps/sharing/sharing-document-library/src/main/java/com/liferay/sharing/document/library/internal/display/context/SharingDLViewFileVersionDisplayContext.java
+++ b/modules/apps/sharing/sharing-document-library/src/main/java/com/liferay/sharing/document/library/internal/display/context/SharingDLViewFileVersionDisplayContext.java
@@ -10,11 +10,9 @@ import com.liferay.document.library.display.context.BaseDLViewFileVersionDisplay
 import com.liferay.document.library.display.context.DLUIItemKeys;
 import com.liferay.document.library.display.context.DLViewFileVersionDisplayContext;
 import com.liferay.document.library.kernel.model.DLFileEntryConstants;
-import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownContextItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownGroupItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemListBuilder;
-import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.repository.model.FileEntry;
@@ -136,53 +134,32 @@ public class SharingDLViewFileVersionDisplayContext
 
 		if (FeatureFlagManagerUtil.isEnabled("LPS-197477")) {
 			if (_isSharingEnabled()) {
-				UnsafeConsumer<DropdownContextItem, Exception> unsafeConsumer =
-					_sharingDropdownItemFactory.createShareActionUnsafeConsumer(
-						DLFileEntryConstants.getClassName(),
-						_fileEntry.getFileEntryId(), _httpServletRequest);
-
-				if (i >= dropdownItems.size()) {
-					dropdownItems.addAll(
-						DropdownItemListBuilder.addContext(
-							unsafeConsumer
-						).build());
-				}
-				else {
-					dropdownItems.addAll(
-						i,
-						DropdownItemListBuilder.addContext(
-							unsafeConsumer
-						).build());
-				}
+				dropdownItems.addAll(
+					Math.min(i, dropdownItems.size()),
+					DropdownItemListBuilder.addContext(
+						_sharingDropdownItemFactory.
+							createShareActionUnsafeConsumer(
+								DLFileEntryConstants.getClassName(),
+								_fileEntry.getFileEntryId(),
+								_httpServletRequest)
+					).build());
 			}
 			else {
-				DropdownItem copyLinkDropdownItem =
+				dropdownItems.add(
+					Math.min(i, dropdownItems.size()),
 					_sharingDropdownItemFactory.createCopyLinkDropdownItem(
 						DLFileEntryConstants.getClassName(),
-						_fileEntry.getFileEntryId(), _httpServletRequest);
-
-				if (i >= dropdownItems.size()) {
-					dropdownItems.add(copyLinkDropdownItem);
-				}
-				else {
-					dropdownItems.add(i, copyLinkDropdownItem);
-				}
+						_fileEntry.getFileEntryId(), _httpServletRequest));
 			}
 
 			return dropdownItems;
 		}
 
-		DropdownItem sharingDropdownItem =
+		dropdownItems.add(
+			Math.min(i, dropdownItems.size()),
 			_sharingDropdownItemFactory.createShareDropdownItem(
 				DLFileEntryConstants.getClassName(),
-				_fileEntry.getFileEntryId(), _httpServletRequest);
-
-		if (i >= dropdownItems.size()) {
-			dropdownItems.add(sharingDropdownItem);
-		}
-		else {
-			dropdownItems.add(i, sharingDropdownItem);
-		}
+				_fileEntry.getFileEntryId(), _httpServletRequest));
 
 		return dropdownItems;
 	}

--- a/modules/apps/sharing/sharing-document-library/src/main/java/com/liferay/sharing/document/library/internal/display/context/SharingDLViewFileVersionDisplayContext.java
+++ b/modules/apps/sharing/sharing-document-library/src/main/java/com/liferay/sharing/document/library/internal/display/context/SharingDLViewFileVersionDisplayContext.java
@@ -30,6 +30,7 @@ import com.liferay.sharing.display.context.util.SharingDropdownItemFactory;
 import com.liferay.sharing.security.permission.SharingPermission;
 import com.liferay.sharing.service.SharingEntryLocalService;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
@@ -71,6 +72,10 @@ public class SharingDLViewFileVersionDisplayContext
 	@Override
 	public List<DropdownItem> getActionDropdownItems() throws PortalException {
 		List<DropdownItem> dropdownItems = super.getActionDropdownItems();
+
+		if (dropdownItems == null) {
+			dropdownItems = new ArrayList<>();
+		}
 
 		return _addSharingDropdownItem(dropdownItems);
 	}

--- a/modules/apps/sharing/sharing-document-library/src/main/java/com/liferay/sharing/document/library/internal/display/context/SharingDLViewFileVersionDisplayContext.java
+++ b/modules/apps/sharing/sharing-document-library/src/main/java/com/liferay/sharing/document/library/internal/display/context/SharingDLViewFileVersionDisplayContext.java
@@ -74,10 +74,6 @@ public class SharingDLViewFileVersionDisplayContext
 	public List<DropdownItem> getActionDropdownItems() throws PortalException {
 		List<DropdownItem> dropdownItems = super.getActionDropdownItems();
 
-		if (!_isShowShareAction() || !_sharingConfiguration.isEnabled()) {
-			return dropdownItems;
-		}
-
 		return _addSharingDropdownItem(dropdownItems);
 	}
 
@@ -139,23 +135,38 @@ public class SharingDLViewFileVersionDisplayContext
 		}
 
 		if (FeatureFlagManagerUtil.isEnabled("LPS-197477")) {
-			UnsafeConsumer<DropdownContextItem, Exception> unsafeConsumer =
-				_sharingDropdownItemFactory.createShareActionUnsafeConsumer(
-					DLFileEntryConstants.getClassName(),
-					_fileEntry.getFileEntryId(), _httpServletRequest);
+			if (_isSharingEnabled()) {
+				UnsafeConsumer<DropdownContextItem, Exception> unsafeConsumer =
+					_sharingDropdownItemFactory.createShareActionUnsafeConsumer(
+						DLFileEntryConstants.getClassName(),
+						_fileEntry.getFileEntryId(), _httpServletRequest);
 
-			if (i >= dropdownItems.size()) {
-				dropdownItems.addAll(
-					DropdownItemListBuilder.addContext(
-						unsafeConsumer
-					).build());
+				if (i >= dropdownItems.size()) {
+					dropdownItems.addAll(
+						DropdownItemListBuilder.addContext(
+							unsafeConsumer
+						).build());
+				}
+				else {
+					dropdownItems.addAll(
+						i,
+						DropdownItemListBuilder.addContext(
+							unsafeConsumer
+						).build());
+				}
 			}
 			else {
-				dropdownItems.addAll(
-					i,
-					DropdownItemListBuilder.addContext(
-						unsafeConsumer
-					).build());
+				DropdownItem copyLinkDropdownItem =
+					_sharingDropdownItemFactory.createCopyLinkDropdownItem(
+						DLFileEntryConstants.getClassName(),
+						_fileEntry.getFileEntryId(), _httpServletRequest);
+
+				if (i >= dropdownItems.size()) {
+					dropdownItems.add(copyLinkDropdownItem);
+				}
+				else {
+					dropdownItems.add(i, copyLinkDropdownItem);
+				}
 			}
 
 			return dropdownItems;
@@ -204,15 +215,24 @@ public class SharingDLViewFileVersionDisplayContext
 
 		if (i < dropdownItems.size()) {
 			if (FeatureFlagManagerUtil.isEnabled("LPS-197477")) {
-				dropdownItems.addAll(
-					i,
-					DropdownItemListBuilder.addContext(
-						_sharingDropdownItemFactory.
-							createShareActionUnsafeConsumer(
-								DLFileEntryConstants.getClassName(),
-								_fileEntry.getFileEntryId(),
-								_httpServletRequest)
-					).build());
+				if (_isSharingEnabled()) {
+					dropdownItems.addAll(
+						i,
+						DropdownItemListBuilder.addContext(
+							_sharingDropdownItemFactory.
+								createShareActionUnsafeConsumer(
+									DLFileEntryConstants.getClassName(),
+									_fileEntry.getFileEntryId(),
+									_httpServletRequest)
+						).build());
+				}
+				else {
+					dropdownItems.add(
+						i,
+						_sharingDropdownItemFactory.createCopyLinkDropdownItem(
+							DLFileEntryConstants.getClassName(),
+							_fileEntry.getFileEntryId(), _httpServletRequest));
+				}
 			}
 			else {
 				dropdownItems.add(
@@ -226,6 +246,14 @@ public class SharingDLViewFileVersionDisplayContext
 		}
 
 		return false;
+	}
+
+	private boolean _isSharingEnabled() throws PortalException {
+		if (!_isShowShareAction() || !_sharingConfiguration.isEnabled()) {
+			return false;
+		}
+
+		return true;
 	}
 
 	private boolean _isShowActions() throws PortalException {

--- a/modules/apps/sharing/sharing-web/src/main/java/com/liferay/sharing/web/internal/display/context/util/SharingDropdownItemFactoryImpl.java
+++ b/modules/apps/sharing/sharing-web/src/main/java/com/liferay/sharing/web/internal/display/context/util/SharingDropdownItemFactoryImpl.java
@@ -27,6 +27,25 @@ public class SharingDropdownItemFactoryImpl
 	implements SharingDropdownItemFactory {
 
 	@Override
+	public DropdownItem createCopyLinkDropdownItem(
+		String className, long classPK, HttpServletRequest httpServletRequest) {
+
+		return DropdownItemBuilder.setHref(
+			() -> {
+				String copyLinkOnClickMethod =
+					_sharingJavaScriptFactory.createCopyLinkClickMethod(
+						className, classPK, httpServletRequest);
+
+				return "javascript:" + copyLinkOnClickMethod;
+			}
+		).setIcon(
+			"link"
+		).setLabel(
+			SharingItemFactoryUtil.getCopyLinkLabel(httpServletRequest)
+		).build();
+	}
+
+	@Override
 	public DropdownItem createManageCollaboratorsDropdownItem(
 			String className, long classPK,
 			HttpServletRequest httpServletRequest)
@@ -66,7 +85,7 @@ public class SharingDropdownItemFactoryImpl
 				DropdownItemListBuilder.add(
 					shareDropdownItem
 				).add(
-					_createCopyLinkDropdownItem(
+					createCopyLinkDropdownItem(
 						className, classPK, httpServletRequest)
 				).build());
 			dropdownContextItem.setIcon("share");
@@ -93,24 +112,6 @@ public class SharingDropdownItemFactoryImpl
 			"share"
 		).setLabel(
 			SharingItemFactoryUtil.getSharingLabel(httpServletRequest)
-		).build();
-	}
-
-	private DropdownItem _createCopyLinkDropdownItem(
-		String className, long classPK, HttpServletRequest httpServletRequest) {
-
-		return DropdownItemBuilder.setHref(
-			() -> {
-				String copyLinkOnClickMethod =
-					_sharingJavaScriptFactory.createCopyLinkClickMethod(
-						className, classPK, httpServletRequest);
-
-				return "javascript:" + copyLinkOnClickMethod;
-			}
-		).setIcon(
-			"link"
-		).setLabel(
-			SharingItemFactoryUtil.getCopyLinkLabel(httpServletRequest)
 		).build();
 	}
 

--- a/modules/apps/sharing/sharing-web/src/main/java/com/liferay/sharing/web/internal/display/context/util/SharingDropdownItemFactoryImpl.java
+++ b/modules/apps/sharing/sharing-web/src/main/java/com/liferay/sharing/web/internal/display/context/util/SharingDropdownItemFactoryImpl.java
@@ -10,7 +10,6 @@ import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemBuilder;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemListBuilder;
 import com.liferay.petra.function.UnsafeConsumer;
-import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.sharing.display.context.util.SharingDropdownItemFactory;
 import com.liferay.sharing.display.context.util.SharingJavaScriptFactory;
 
@@ -47,9 +46,7 @@ public class SharingDropdownItemFactoryImpl
 
 	@Override
 	public DropdownItem createManageCollaboratorsDropdownItem(
-			String className, long classPK,
-			HttpServletRequest httpServletRequest)
-		throws PortalException {
+		String className, long classPK, HttpServletRequest httpServletRequest) {
 
 		return DropdownItemBuilder.setHref(
 			() -> {
@@ -68,10 +65,9 @@ public class SharingDropdownItemFactoryImpl
 
 	@Override
 	public UnsafeConsumer<DropdownContextItem, Exception>
-			createShareActionUnsafeConsumer(
-				String className, long classPK,
-				HttpServletRequest httpServletRequest)
-		throws PortalException {
+		createShareActionUnsafeConsumer(
+			String className, long classPK,
+			HttpServletRequest httpServletRequest) {
 
 		DropdownItem shareDropdownItem = createShareDropdownItem(
 			className, classPK, httpServletRequest);
@@ -96,9 +92,7 @@ public class SharingDropdownItemFactoryImpl
 
 	@Override
 	public DropdownItem createShareDropdownItem(
-			String className, long classPK,
-			HttpServletRequest httpServletRequest)
-		throws PortalException {
+		String className, long classPK, HttpServletRequest httpServletRequest) {
 
 		return DropdownItemBuilder.setHref(
 			() -> {

--- a/modules/apps/sharing/sharing-web/src/main/java/com/liferay/sharing/web/internal/servlet/taglib/ui/SharingBottomJSPDynamicInclude.java
+++ b/modules/apps/sharing/sharing-web/src/main/java/com/liferay/sharing/web/internal/servlet/taglib/ui/SharingBottomJSPDynamicInclude.java
@@ -9,10 +9,6 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.servlet.taglib.BaseJSPDynamicInclude;
 import com.liferay.portal.kernel.servlet.taglib.DynamicInclude;
-import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.WebKeys;
-import com.liferay.sharing.configuration.SharingConfiguration;
-import com.liferay.sharing.configuration.SharingConfigurationFactory;
 import com.liferay.sharing.web.internal.util.SharingJavaScriptThreadLocal;
 
 import java.io.IOException;
@@ -45,17 +41,7 @@ public class SharingBottomJSPDynamicInclude extends BaseJSPDynamicInclude {
 			return;
 		}
 
-		ThemeDisplay themeDisplay =
-			(ThemeDisplay)httpServletRequest.getAttribute(
-				WebKeys.THEME_DISPLAY);
-
-		SharingConfiguration sharingConfiguration =
-			_sharingConfigurationFactory.getGroupSharingConfiguration(
-				themeDisplay.getScopeGroup());
-
-		if (sharingConfiguration.isEnabled()) {
-			super.include(httpServletRequest, httpServletResponse, key);
-		}
+		super.include(httpServletRequest, httpServletResponse, key);
 	}
 
 	@Override
@@ -78,8 +64,5 @@ public class SharingBottomJSPDynamicInclude extends BaseJSPDynamicInclude {
 
 	@Reference(target = "(osgi.web.symbolicname=com.liferay.sharing.web)")
 	private ServletContext _servletContext;
-
-	@Reference
-	private SharingConfigurationFactory _sharingConfigurationFactory;
 
 }


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPS-200202

When disabling sharing, the "copy link" action is omitted as well. We want to always show the copy action, no matter the state of sharing.

# How am I fixing it?

I had to move the logic that checks Sharing status around, and simply include the lone "Copy" action when disabled.

# How can you verify that it works?

1. Enable feature flag LPS-197477.
2. Upload a document and click on its dropdown actions. A "Share" group should be available, containing two actions: "Invite collaborators" and "Copy link".
3. Go to system settings > Sharing and disable sharing.
4. Go back to the same document, click in the dropdown actions and verify that only the "Copy Link" action is available.