### PR TITLE
LPS-199427 Scheduled articles not exported

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/exportimport/data/handler/KBArticleStagedModelDataHandler.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/exportimport/data/handler/KBArticleStagedModelDataHandler.java
@@ -103,6 +103,14 @@ public class KBArticleStagedModelDataHandler
 	}
 
 	@Override
+	public int[] getExportableStatuses() {
+		return new int[] {
+			WorkflowConstants.STATUS_APPROVED,
+			WorkflowConstants.STATUS_SCHEDULED
+		};
+	}
+
+	@Override
 	protected boolean countStagedModel(
 		PortletDataContext portletDataContext, KBArticle kbArticle) {
 

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/exportimport/data/handler/KBArticleStagedModelDataHandler.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/exportimport/data/handler/KBArticleStagedModelDataHandler.java
@@ -505,7 +505,7 @@ public class KBArticleStagedModelDataHandler
 		}
 
 		return _kbArticleLocalService.getLatestKBArticle(
-			resourcePrimKey, WorkflowConstants.STATUS_APPROVED);
+			resourcePrimKey, kbArticle.getStatus());
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPS-199427

Only approved articles are exported from staged sites.

# How am I fixing it?

I simply added the scheduled status to the set of exportable statuses.

# How can you verify that it works?

Follow the steps described in https://liferay.atlassian.net/browse/LPS-199427.