### PR TITLE
LPS-200205 Remove Saved content Entries when deleting Asset entries or Users

### DIFF
--- a/modules/apps/saved-content/saved-content-api/src/main/java/com/liferay/saved/content/service/SavedContentEntryLocalService.java
+++ b/modules/apps/saved-content/saved-content-api/src/main/java/com/liferay/saved/content/service/SavedContentEntryLocalService.java
@@ -103,6 +103,11 @@ public interface SavedContentEntryLocalService
 	public PersistedModel deletePersistedModel(PersistedModel persistedModel)
 		throws PortalException;
 
+	public void deleteSavedContentEntries(
+		long groupId, long classNameId, long classPK);
+
+	public void deleteSavedContentEntriesByUserId(long userId);
+
 	/**
 	 * Deletes the saved content entry with the primary key from the database. Also notifies the appropriate model listeners.
 	 *

--- a/modules/apps/saved-content/saved-content-api/src/main/java/com/liferay/saved/content/service/SavedContentEntryLocalServiceUtil.java
+++ b/modules/apps/saved-content/saved-content-api/src/main/java/com/liferay/saved/content/service/SavedContentEntryLocalServiceUtil.java
@@ -92,6 +92,16 @@ public class SavedContentEntryLocalServiceUtil {
 		return getService().deletePersistedModel(persistedModel);
 	}
 
+	public static void deleteSavedContentEntries(
+		long groupId, long classNameId, long classPK) {
+
+		getService().deleteSavedContentEntries(groupId, classNameId, classPK);
+	}
+
+	public static void deleteSavedContentEntriesByUserId(long userId) {
+		getService().deleteSavedContentEntriesByUserId(userId);
+	}
+
 	/**
 	 * Deletes the saved content entry with the primary key from the database. Also notifies the appropriate model listeners.
 	 *

--- a/modules/apps/saved-content/saved-content-api/src/main/java/com/liferay/saved/content/service/SavedContentEntryLocalServiceWrapper.java
+++ b/modules/apps/saved-content/saved-content-api/src/main/java/com/liferay/saved/content/service/SavedContentEntryLocalServiceWrapper.java
@@ -96,6 +96,20 @@ public class SavedContentEntryLocalServiceWrapper
 			persistedModel);
 	}
 
+	@Override
+	public void deleteSavedContentEntries(
+		long groupId, long classNameId, long classPK) {
+
+		_savedContentEntryLocalService.deleteSavedContentEntries(
+			groupId, classNameId, classPK);
+	}
+
+	@Override
+	public void deleteSavedContentEntriesByUserId(long userId) {
+		_savedContentEntryLocalService.deleteSavedContentEntriesByUserId(
+			userId);
+	}
+
 	/**
 	 * Deletes the saved content entry with the primary key from the database. Also notifies the appropriate model listeners.
 	 *

--- a/modules/apps/saved-content/saved-content-service/src/main/java/com/liferay/saved/content/internal/model/listener/AssetEntryModelListener.java
+++ b/modules/apps/saved-content/saved-content-service/src/main/java/com/liferay/saved/content/internal/model/listener/AssetEntryModelListener.java
@@ -1,0 +1,40 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.saved.content.internal.model.listener;
+
+import com.liferay.asset.kernel.model.AssetEntry;
+import com.liferay.portal.kernel.exception.ModelListenerException;
+import com.liferay.portal.kernel.model.BaseModelListener;
+import com.liferay.portal.kernel.model.ModelListener;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.saved.content.service.SavedContentEntryLocalService;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Alicia García
+ */
+@Component(service = ModelListener.class)
+public class AssetEntryModelListener extends BaseModelListener<AssetEntry> {
+
+	@Override
+	public void onBeforeRemove(AssetEntry assetEntry)
+		throws ModelListenerException {
+
+		_savedContentEntryLocalService.deleteSavedContentEntries(
+			assetEntry.getGroupId(),
+			_classNameLocalService.getClassNameId(assetEntry.getClassName()),
+			assetEntry.getClassPK());
+	}
+
+	@Reference
+	private ClassNameLocalService _classNameLocalService;
+
+	@Reference
+	private SavedContentEntryLocalService _savedContentEntryLocalService;
+
+}

--- a/modules/apps/saved-content/saved-content-service/src/main/java/com/liferay/saved/content/internal/model/listener/UserModelListener.java
+++ b/modules/apps/saved-content/saved-content-service/src/main/java/com/liferay/saved/content/internal/model/listener/UserModelListener.java
@@ -1,0 +1,31 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.saved.content.internal.model.listener;
+
+import com.liferay.portal.kernel.exception.ModelListenerException;
+import com.liferay.portal.kernel.model.BaseModelListener;
+import com.liferay.portal.kernel.model.ModelListener;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.saved.content.service.SavedContentEntryLocalService;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Alicia García
+ */
+@Component(service = ModelListener.class)
+public class UserModelListener extends BaseModelListener<User> {
+
+	public void onBeforeRemove(User user) throws ModelListenerException {
+		_savedContentEntryLocalService.deleteSavedContentEntriesByUserId(
+			user.getUserId());
+	}
+
+	@Reference
+	private SavedContentEntryLocalService _savedContentEntryLocalService;
+
+}

--- a/modules/apps/saved-content/saved-content-service/src/main/java/com/liferay/saved/content/service/impl/SavedContentEntryLocalServiceImpl.java
+++ b/modules/apps/saved-content/saved-content-service/src/main/java/com/liferay/saved/content/service/impl/SavedContentEntryLocalServiceImpl.java
@@ -88,6 +88,19 @@ public class SavedContentEntryLocalServiceImpl
 	}
 
 	@Override
+	public void deleteSavedContentEntries(
+		long groupId, long classNameId, long classPK) {
+
+		savedContentEntryPersistence.removeByG_C_C(
+			groupId, classNameId, classPK);
+	}
+
+	@Override
+	public void deleteSavedContentEntriesByUserId(long userId) {
+		savedContentEntryPersistence.removeByUserId(userId);
+	}
+
+	@Override
 	public SavedContentEntry fetchSavedContentEntry(
 		long userId, long groupId, String className, long classPK) {
 

--- a/modules/apps/saved-content/saved-content-taglib/src/main/java/com/liferay/saved/content/taglib/servlet/taglib/SavedContentTag.java
+++ b/modules/apps/saved-content/saved-content-taglib/src/main/java/com/liferay/saved/content/taglib/servlet/taglib/SavedContentTag.java
@@ -129,6 +129,7 @@ public class SavedContentTag extends IncludeTag {
 			httpServletRequest.setAttribute(
 				"liferay-saved-content:saved-content:label",
 				_getLabel(httpServletRequest, themeDisplay));
+
 			httpServletRequest.setAttribute(
 				"liferay-saved-content:saved-content:saved", _saved);
 		}


### PR DESCRIPTION

How to test it:

- Activate FF (LPS-197909)
- edit Home Page
- add Asset Publisher widget
- select dynamic > Document
- Publish
- create Display Page template for basic documents with new Saved Content taglib and mark as default
- Create new document

For asset entry (docs on this example)
- Go to home
- See created document > save content (new register should be created on database)
- delete created document (from recycle bin too)
- the register on database should not longer be present


For user
- Create new user and add it as site member
- impersonate it
- Go to home
- See created document > save content (new register should be created on database with the new user)
- remove user (first deactivate, after filter by deactivated, and remove the created user)
- the register on database should not longer be present

