### PR TITLE
LPS-201372 Autotag Upgrade from 7.3.10 fails

### DIFF
--- a/modules/apps/asset/asset-auto-tagger-service/src/main/java/com/liferay/asset/auto/tagger/internal/osgi/commands/AssetAutoTaggerOSGiCommands.java
+++ b/modules/apps/asset/asset-auto-tagger-service/src/main/java/com/liferay/asset/auto/tagger/internal/osgi/commands/AssetAutoTaggerOSGiCommands.java
@@ -15,10 +15,12 @@ import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.asset.kernel.service.AssetEntryLocalService;
 import com.liferay.osgi.util.osgi.commands.OSGiCommands;
 import com.liferay.petra.function.UnsafeConsumer;
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -143,7 +145,14 @@ public class AssetAutoTaggerOSGiCommands implements OSGiCommands {
 			}
 
 			actionableDynamicQuery.setPerformActionMethod(
-				(AssetEntry assetEntry) -> consumer.accept(assetEntry));
+				(AssetEntry assetEntry) -> {
+					try (SafeCloseable safeCloseable =
+							CompanyThreadLocal.setWithSafeCloseable(
+								assetEntry.getCompanyId())) {
+
+						consumer.accept(assetEntry);
+					}
+				});
 
 			actionableDynamicQuery.performActions();
 		}


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPS-201372

The auto tag OSGi commands don't set the context company ID correctly. Thus, anything depending on the value of CompanyThreadLocal.getCompanyId() will always get SYSTEM as a result.

# How am I fixing it?

Setting the context company ID to that of the current asset entry before invoking the underlying logic.

# How can you verify that it works?

Follow the steps described in https://liferay.atlassian.net/browse/LPS-201372.