### PR TITLE
LPS-201919 Make the horizontal card a focusable element

### DIFF
--- a/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/view_item_selector_view_descriptor.jsp
+++ b/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/view_item_selector_view_descriptor.jsp
@@ -74,7 +74,10 @@ SearchContainer<Object> searchContainer = itemSelectorViewDescriptorRendererDisp
 
 							<liferay-ui:search-container-column-text>
 								<clay:horizontal-card
+									aria-label='<%= LanguageUtil.format(request, "select-x", horizontalCard.getTitle()) %>'
 									horizontalCard="<%= horizontalCard %>"
+									role="button"
+									tabIndex="0"
 								/>
 							</liferay-ui:search-container-column-text>
 						</c:when>


### PR DESCRIPTION
Issue https://liferay.atlassian.net/browse/LPS-201919 Shared Content modal options inaccessible with keyboard

Now the Asset Types' modal is accesible by keyboard
![Screenshot 2023-11-20 at 13 22 40](https://github.com/liferay-lima/liferay-portal/assets/8373764/78e7d032-2fcd-4790-8e80-dea30b9185c8)
