### PR TITLE
LPS-202242 KB widgets do not show correctly

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/AdminPortlet.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/AdminPortlet.java
@@ -28,8 +28,6 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
-import com.liferay.trash.TrashHelper;
-import com.liferay.trash.util.TrashWebKeys;
 
 import java.io.IOException;
 
@@ -104,8 +102,6 @@ public class AdminPortlet extends BaseKBPortlet {
 				resourceRequest.setAttribute(
 					KBWebKeys.KNOWLEDGE_BASE_KB_FOLDERS,
 					_getKBFolders(httpServletRequest));
-				resourceRequest.setAttribute(
-					TrashWebKeys.TRASH_HELPER, _trashHelper);
 
 				PortletSession portletSession =
 					resourceRequest.getPortletSession();
@@ -222,7 +218,6 @@ public class AdminPortlet extends BaseKBPortlet {
 				KBWebKeys.KNOWLEDGE_BASE_KB_TEMPLATE, kbTemplate);
 
 			renderRequest.setAttribute(KBWebKeys.KNOWLEDGE_BASE_STATUS, status);
-			renderRequest.setAttribute(TrashWebKeys.TRASH_HELPER, _trashHelper);
 		}
 		catch (NoSuchArticleException | NoSuchFolderException |
 			   NoSuchTemplateException | PrincipalException exception) {
@@ -289,8 +284,5 @@ public class AdminPortlet extends BaseKBPortlet {
 		target = "(&(release.bundle.symbolic.name=com.liferay.knowledge.base.web)(&(release.schema.version>=1.2.0)(!(release.schema.version>=2.0.0))))"
 	)
 	private Release _release;
-
-	@Reference
-	private TrashHelper _trashHelper;
 
 }

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/BaseKBPortlet.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/BaseKBPortlet.java
@@ -42,6 +42,8 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.rss.util.RSSUtil;
+import com.liferay.trash.TrashHelper;
+import com.liferay.trash.util.TrashWebKeys;
 
 import java.io.IOException;
 
@@ -69,6 +71,8 @@ public abstract class BaseKBPortlet extends MVCPortlet {
 		if (Validator.isNotNull(cmd) && cmd.equals("compareVersions")) {
 			_compareVersions(renderRequest);
 		}
+
+		renderRequest.setAttribute(TrashWebKeys.TRASH_HELPER, trashHelper);
 
 		doRender(renderRequest, renderResponse);
 
@@ -224,6 +228,9 @@ public abstract class BaseKBPortlet extends MVCPortlet {
 
 	@Reference
 	protected Portal portal;
+
+	@Reference
+	protected TrashHelper trashHelper;
 
 	private void _compareVersions(RenderRequest renderRequest)
 		throws PortletException {


### PR DESCRIPTION
See https://liferay.atlassian.net/browse/LPS-202242

This PR only fixes the problem with KB portlets not showing correctly because of missing TrashHelper reference needed to correctly render the Delete action of the action dropdown.

To avoid showing deleted KB articles the recent PR #4926 should be taken into account.