### PR TITLE
LPS-201182 video resolutions

### DIFF
--- a/modules/apps/fragment/fragment-video-streaming/bnd.bnd
+++ b/modules/apps/fragment/fragment-video-streaming/bnd.bnd
@@ -1,5 +1,5 @@
 Bundle-Name: Liferay Fragment Video Streaming
 Bundle-SymbolicName: com.liferay.fragment.video.streaming
-Bundle-Version: 1.0.2
+Bundle-Version: 1.0.0
 Web-ContextPath: /fragment-video-streaming
 -dsannotations-options: inherit

--- a/modules/apps/fragment/fragment-video-streaming/package.json
+++ b/modules/apps/fragment/fragment-video-streaming/package.json
@@ -8,5 +8,5 @@
 		"checkFormat": "liferay-npm-scripts check",
 		"format": "liferay-npm-scripts fix"
 	},
-	"version": "1.0.2"
+	"version": "1.0.0"
 }

--- a/modules/apps/fragment/fragment-video-streaming/src/main/resources/META-INF/resources/js/VideoStreaming.js
+++ b/modules/apps/fragment/fragment-video-streaming/src/main/resources/META-INF/resources/js/VideoStreaming.js
@@ -16,6 +16,14 @@ export default function VideoStreaming({
 
 	const configuration = {
 		autoplay,
+		html5: {
+			hls: {
+				overrideNative: true,
+			},
+			vhs: {
+				withCredentials: true,
+			},
+		},
 		loop,
 		muted,
 		playbackRates: [0.5, 1, 1.5, 2],
@@ -60,5 +68,10 @@ export default function VideoStreaming({
 				src: subtitles,
 			});
 		}
+
+		player.qualitySelectorHls({
+			displayCurrentQuality: true,
+			vjsIconClass: 'vjs-icon-cog',
+		});
 	});
 }

--- a/modules/apps/fragment/fragment-video-streaming/src/main/resources/META-INF/resources/js/VideoStreaming.js
+++ b/modules/apps/fragment/fragment-video-streaming/src/main/resources/META-INF/resources/js/VideoStreaming.js
@@ -7,6 +7,7 @@ export default function VideoStreaming({
 	autoplay,
 	loop,
 	muted,
+	src,
 	subtitles,
 	videoHeight,
 	videoWidth,
@@ -42,6 +43,8 @@ export default function VideoStreaming({
 
 	// eslint-disable-next-line no-undef
 	const player = videojs('fragmentVideoJsURL', configuration);
+
+	player.src(src);
 
 	player.ready(() => {
 		window.addEventListener('resize', resizeVideoJs);

--- a/modules/apps/fragment/fragment-video-streaming/src/main/resources/META-INF/resources/js/VideoStreaming.js
+++ b/modules/apps/fragment/fragment-video-streaming/src/main/resources/META-INF/resources/js/VideoStreaming.js
@@ -20,9 +20,6 @@ export default function VideoStreaming({
 			hls: {
 				overrideNative: true,
 			},
-			vhs: {
-				withCredentials: true,
-			},
 		},
 		loop,
 		muted,

--- a/modules/apps/fragment/fragment-video-streaming/src/main/resources/META-INF/resources/page.jsp
+++ b/modules/apps/fragment/fragment-video-streaming/src/main/resources/META-INF/resources/page.jsp
@@ -16,7 +16,6 @@
 <div style="display: flex; justify-content: flex-start; overflow: hidden;">
 	<div class="videojs-container">
 		<video class="video-js" controls id="fragmentVideoJsURL" preload="auto">
-			<source src="<%= (String)request.getAttribute(VideoStreamingWebKeys.VIDEO_STREAMING_SOURCE_URL) %>" type="video/mp4" />
 		</video>
 
 		<script src="https://vjs.zencdn.net/8.6.1/video.min.js"></script>
@@ -31,6 +30,8 @@
 			"loop", (Boolean)request.getAttribute(VideoStreamingWebKeys.VIDEO_STREAMING_LOOP)
 		).put(
 			"muted", (Boolean)request.getAttribute(VideoStreamingWebKeys.VIDEO_STREAMING_MUTED)
+		).put(
+			"src", (String)request.getAttribute(VideoStreamingWebKeys.VIDEO_STREAMING_SOURCE_URL)
 		).put(
 			"subtitles", (String)request.getAttribute(VideoStreamingWebKeys.VIDEO_STREAMING_SUBTITLES)
 		).put(

--- a/modules/apps/fragment/fragment-video-streaming/src/main/resources/META-INF/resources/page.jsp
+++ b/modules/apps/fragment/fragment-video-streaming/src/main/resources/META-INF/resources/page.jsp
@@ -13,7 +13,7 @@
 	<link href="https://vjs.zencdn.net/8.6.1/video-js.min.css" rel="stylesheet" type="text/css" />
 </liferay-util:html-top>
 
-<div style="display: flex; justify-content: flex-start;">
+<div style="display: flex; justify-content: flex-start; overflow: hidden;">
 	<div class="videojs-container">
 		<video class="video-js" controls id="fragmentVideoJsURL" preload="auto">
 			<source src="<%= (String)request.getAttribute(VideoStreamingWebKeys.VIDEO_STREAMING_SOURCE_URL) %>" type="video/mp4" />

--- a/modules/apps/fragment/fragment-video-streaming/src/main/resources/META-INF/resources/page.jsp
+++ b/modules/apps/fragment/fragment-video-streaming/src/main/resources/META-INF/resources/page.jsp
@@ -11,6 +11,7 @@
 	outputKey="vide_sctreaming_css"
 >
 	<link href="https://vjs.zencdn.net/8.6.1/video-js.min.css" rel="stylesheet" type="text/css" />
+	<link href="https://unpkg.com/videojs-quality-selector-hls@1.1.1/dist/videojs-quality-selector-hls.css" rel="stylesheet" type="text/css" />
 </liferay-util:html-top>
 
 <div style="display: flex; justify-content: flex-start; overflow: hidden;">
@@ -19,6 +20,7 @@
 		</video>
 
 		<script src="https://vjs.zencdn.net/8.6.1/video.min.js"></script>
+		<script src="https://unpkg.com/videojs-quality-selector-hls@1.1.1/dist/videojs-quality-selector-hls.js" type="text/javascript"></script>
 	</div>
 </div>
 


### PR DESCRIPTION
Added quality selector hls [plugin](https://www.npmjs.com/package/videojs-quality-selector-hls) for video.js 

![Screenshot 2023-11-22 at 13 09 11](https://github.com/liferay-lima/liferay-portal/assets/8373764/8cb229f5-4ec0-4804-ace5-08710471ab7e)

Video with resolutions for tests: https://storage.googleapis.com/sgad-demo/resolutions/manifest.mpd 


currently, there are no changes when a different resolution is selected, I can work on that on a different pull. 