### PR TITLE
LPS-202025 Able to download file with no VIEW permission over folder

### DIFF
--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/security/permission/resource/DLFileEntryModelResourcePermissionWrapper.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/security/permission/resource/DLFileEntryModelResourcePermissionWrapper.java
@@ -130,10 +130,21 @@ public class DLFileEntryModelResourcePermissionWrapper
 					});
 
 				if (PropsValues.PERMISSIONS_VIEW_DYNAMIC_INHERITANCE) {
+					DynamicInheritancePermissionLogic<DLFileEntry, DLFolder>
+						permissionLogic =
+							new DynamicInheritancePermissionLogic<>(
+								_dlFolderModelResourcePermission,
+								_getFetchParentFunction(), true);
+
 					consumer.accept(
-						new DynamicInheritancePermissionLogic<>(
-							_dlFolderModelResourcePermission,
-							_getFetchParentFunction(), true));
+						(permissionChecker, name, model, actionId) -> {
+							if (actionId.equals(ActionKeys.DOWNLOAD)) {
+								actionId = ActionKeys.VIEW;
+							}
+
+							return permissionLogic.contains(
+								permissionChecker, name, model, actionId);
+						});
 				}
 			});
 	}


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPS-202025

With permission inheritance enabled, and no VIEW permission granted over the parent folders, it should not be possible to download documents (even if DOWNLOAD is granted on them).

# How can you verify that it works?

Follow the steps described in https://liferay.atlassian.net/browse/LPS-202025.