### PR TITLE
LPS-200560 Mock static util to avoid NPE

### DIFF
--- a/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/src/test/java/com/liferay/document/library/opener/onedrive/web/internal/oauth/AccessTokenStoreUtilTest.java
+++ b/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/src/test/java/com/liferay/document/library/opener/onedrive/web/internal/oauth/AccessTokenStoreUtilTest.java
@@ -7,13 +7,19 @@ package com.liferay.document.library.opener.onedrive.web.internal.oauth;
 
 import com.github.scribejava.core.model.OAuth2AccessToken;
 
+import com.liferay.portal.kernel.cluster.ClusterExecutorUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
+import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 /**
  * @author Cristina González
@@ -24,6 +30,20 @@ public class AccessTokenStoreUtilTest {
 	@Rule
 	public static final LiferayUnitTestRule liferayUnitTestRule =
 		LiferayUnitTestRule.INSTANCE;
+
+	@BeforeClass
+	public static void setUpClass() {
+		Mockito.when(
+			ClusterExecutorUtil.isEnabled()
+		).thenReturn(
+			false
+		);
+	}
+
+	@AfterClass
+	public static void tearDownClass() {
+		_clusterExecutorUtilMockedStatic.close();
+	}
 
 	@Test
 	public void testAdd() {
@@ -65,5 +85,9 @@ public class AccessTokenStoreUtilTest {
 			AccessTokenStoreUtil.getAccessToken(
 				RandomTestUtil.randomInt(), RandomTestUtil.randomInt()));
 	}
+
+	private static final MockedStatic<ClusterExecutorUtil>
+		_clusterExecutorUtilMockedStatic = Mockito.mockStatic(
+			ClusterExecutorUtil.class);
 
 }


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPS-200560

The cluster execution util depends on the OSGi runtime. To prevent NPE when running unit tests, mock this static class to simulate a non-clustered run.

# How can you verify that it works?

Follow the steps described in https://liferay.atlassian.net/browse/LPS-200560.