### PR TITLE
LPS-202501 Using KBArticle.resourcePrimKey as key to store in TrashHandler

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleLocalService.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleLocalService.java
@@ -459,6 +459,10 @@ public interface KBArticleLocalService
 		long groupId, long kbFolderId, int status);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public KBArticle getLatestKBArticle(long resourcePrimKey)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public KBArticle getLatestKBArticle(long resourcePrimKey, int status)
 		throws PortalException;
 

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleLocalService.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleLocalService.java
@@ -521,7 +521,7 @@ public interface KBArticleLocalService
 		throws PortalException;
 
 	public void moveDependentKBArticlesToTrash(
-			KBArticle parentKBArticle, long trashEntryId)
+			long parentResourcePrimKey, long trashEntryId)
 		throws PortalException;
 
 	public void moveDependentKBArticleToTrash(
@@ -534,20 +534,20 @@ public interface KBArticleLocalService
 		throws PortalException;
 
 	public void moveKBArticleFromTrash(
-			long userId, long kbArticleId, long parentResourceClassNameId,
+			long userId, long resourcePrimKey, long parentResourceClassNameId,
 			long parentResourcePrimKey)
 		throws PortalException;
 
-	public KBArticle moveKBArticleToTrash(long userId, long kbArticleId)
+	public KBArticle moveKBArticleToTrash(long userId, long resourcePrimKey)
 		throws PortalException;
 
 	public void restoreDependentKBArticleFromTrash(KBArticle kbArticle)
 		throws PortalException;
 
-	public void restoreDependentKBArticlesFromTrash(KBArticle parentKBArticle)
+	public void restoreDependentKBArticlesFromTrash(long parentResourcePrimKey)
 		throws PortalException;
 
-	public void restoreKBArticleFromTrash(long userId, long kbArticleId)
+	public void restoreKBArticleFromTrash(long userId, long resourcePrimKey)
 		throws PortalException;
 
 	public KBArticle revertKBArticle(

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleLocalServiceUtil.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleLocalServiceUtil.java
@@ -691,11 +691,11 @@ public class KBArticleLocalServiceUtil {
 	}
 
 	public static void moveDependentKBArticlesToTrash(
-			KBArticle parentKBArticle, long trashEntryId)
+			long parentResourcePrimKey, long trashEntryId)
 		throws PortalException {
 
 		getService().moveDependentKBArticlesToTrash(
-			parentKBArticle, trashEntryId);
+			parentResourcePrimKey, trashEntryId);
 	}
 
 	public static void moveDependentKBArticleToTrash(
@@ -716,19 +716,20 @@ public class KBArticleLocalServiceUtil {
 	}
 
 	public static void moveKBArticleFromTrash(
-			long userId, long kbArticleId, long parentResourceClassNameId,
+			long userId, long resourcePrimKey, long parentResourceClassNameId,
 			long parentResourcePrimKey)
 		throws PortalException {
 
 		getService().moveKBArticleFromTrash(
-			userId, kbArticleId, parentResourceClassNameId,
+			userId, resourcePrimKey, parentResourceClassNameId,
 			parentResourcePrimKey);
 	}
 
-	public static KBArticle moveKBArticleToTrash(long userId, long kbArticleId)
+	public static KBArticle moveKBArticleToTrash(
+			long userId, long resourcePrimKey)
 		throws PortalException {
 
-		return getService().moveKBArticleToTrash(userId, kbArticleId);
+		return getService().moveKBArticleToTrash(userId, resourcePrimKey);
 	}
 
 	public static void restoreDependentKBArticleFromTrash(KBArticle kbArticle)
@@ -738,16 +739,17 @@ public class KBArticleLocalServiceUtil {
 	}
 
 	public static void restoreDependentKBArticlesFromTrash(
-			KBArticle parentKBArticle)
+			long parentResourcePrimKey)
 		throws PortalException {
 
-		getService().restoreDependentKBArticlesFromTrash(parentKBArticle);
+		getService().restoreDependentKBArticlesFromTrash(parentResourcePrimKey);
 	}
 
-	public static void restoreKBArticleFromTrash(long userId, long kbArticleId)
+	public static void restoreKBArticleFromTrash(
+			long userId, long resourcePrimKey)
 		throws PortalException {
 
-		getService().restoreKBArticleFromTrash(userId, kbArticleId);
+		getService().restoreKBArticleFromTrash(userId, resourcePrimKey);
 	}
 
 	public static KBArticle revertKBArticle(

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleLocalServiceUtil.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleLocalServiceUtil.java
@@ -601,6 +601,12 @@ public class KBArticleLocalServiceUtil {
 			groupId, kbFolderId, status);
 	}
 
+	public static KBArticle getLatestKBArticle(long resourcePrimKey)
+		throws PortalException {
+
+		return getService().getLatestKBArticle(resourcePrimKey);
+	}
+
 	public static KBArticle getLatestKBArticle(long resourcePrimKey, int status)
 		throws PortalException {
 

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleLocalServiceWrapper.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleLocalServiceWrapper.java
@@ -786,11 +786,11 @@ public class KBArticleLocalServiceWrapper
 
 	@Override
 	public void moveDependentKBArticlesToTrash(
-			KBArticle parentKBArticle, long trashEntryId)
+			long parentResourcePrimKey, long trashEntryId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		_kbArticleLocalService.moveDependentKBArticlesToTrash(
-			parentKBArticle, trashEntryId);
+			parentResourcePrimKey, trashEntryId);
 	}
 
 	@Override
@@ -815,20 +815,21 @@ public class KBArticleLocalServiceWrapper
 
 	@Override
 	public void moveKBArticleFromTrash(
-			long userId, long kbArticleId, long parentResourceClassNameId,
+			long userId, long resourcePrimKey, long parentResourceClassNameId,
 			long parentResourcePrimKey)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		_kbArticleLocalService.moveKBArticleFromTrash(
-			userId, kbArticleId, parentResourceClassNameId,
+			userId, resourcePrimKey, parentResourceClassNameId,
 			parentResourcePrimKey);
 	}
 
 	@Override
-	public KBArticle moveKBArticleToTrash(long userId, long kbArticleId)
+	public KBArticle moveKBArticleToTrash(long userId, long resourcePrimKey)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
-		return _kbArticleLocalService.moveKBArticleToTrash(userId, kbArticleId);
+		return _kbArticleLocalService.moveKBArticleToTrash(
+			userId, resourcePrimKey);
 	}
 
 	@Override
@@ -839,18 +840,19 @@ public class KBArticleLocalServiceWrapper
 	}
 
 	@Override
-	public void restoreDependentKBArticlesFromTrash(KBArticle parentKBArticle)
+	public void restoreDependentKBArticlesFromTrash(long parentResourcePrimKey)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		_kbArticleLocalService.restoreDependentKBArticlesFromTrash(
-			parentKBArticle);
+			parentResourcePrimKey);
 	}
 
 	@Override
-	public void restoreKBArticleFromTrash(long userId, long kbArticleId)
+	public void restoreKBArticleFromTrash(long userId, long resourcePrimKey)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
-		_kbArticleLocalService.restoreKBArticleFromTrash(userId, kbArticleId);
+		_kbArticleLocalService.restoreKBArticleFromTrash(
+			userId, resourcePrimKey);
 	}
 
 	@Override

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleLocalServiceWrapper.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleLocalServiceWrapper.java
@@ -679,6 +679,13 @@ public class KBArticleLocalServiceWrapper
 	}
 
 	@Override
+	public KBArticle getLatestKBArticle(long resourcePrimKey)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _kbArticleLocalService.getLatestKBArticle(resourcePrimKey);
+	}
+
+	@Override
 	public KBArticle getLatestKBArticle(long resourcePrimKey, int status)
 		throws com.liferay.portal.kernel.exception.PortalException {
 

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleService.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleService.java
@@ -198,6 +198,10 @@ public interface KBArticleService extends BaseService {
 		long groupId, long resourcePrimKey, int status);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public KBArticle getLatestKBArticle(long resourcePrimKey)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public KBArticle getLatestKBArticle(long resourcePrimKey, int status)
 		throws PortalException;
 

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleServiceUtil.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleServiceUtil.java
@@ -283,6 +283,12 @@ public class KBArticleServiceUtil {
 			groupId, resourcePrimKey, status);
 	}
 
+	public static KBArticle getLatestKBArticle(long resourcePrimKey)
+		throws PortalException {
+
+		return getService().getLatestKBArticle(resourcePrimKey);
+	}
+
 	public static KBArticle getLatestKBArticle(long resourcePrimKey, int status)
 		throws PortalException {
 

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleServiceWrapper.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleServiceWrapper.java
@@ -318,6 +318,13 @@ public class KBArticleServiceWrapper
 	}
 
 	@Override
+	public KBArticle getLatestKBArticle(long resourcePrimKey)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _kbArticleService.getLatestKBArticle(resourcePrimKey);
+	}
+
+	@Override
 	public KBArticle getLatestKBArticle(long resourcePrimKey, int status)
 		throws com.liferay.portal.kernel.exception.PortalException {
 

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/util/KnowledgeBaseUtil.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/util/KnowledgeBaseUtil.java
@@ -58,11 +58,11 @@ import javax.portlet.PortletURL;
 public class KnowledgeBaseUtil {
 
 	public static String getKBArticleAbsolutePath(
-			PortletRequest portletRequest, long kbArticleId)
+			PortletRequest portletRequest, long resourcePrimKey)
 		throws PortalException {
 
-		KBArticle kbArticle = KBArticleLocalServiceUtil.getKBArticle(
-			kbArticleId);
+		KBArticle kbArticle = KBArticleLocalServiceUtil.getLatestKBArticle(
+			resourcePrimKey);
 
 		String kbFolderAbsolutePath = getKBFolderAbsolutePath(
 			portletRequest, kbArticle.getKbFolderId());

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/exportimport/data/handler/KBArticleStagedModelDataHandler.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/exportimport/data/handler/KBArticleStagedModelDataHandler.java
@@ -291,10 +291,10 @@ public class KBArticleStagedModelDataHandler
 		TrashHandler trashHandler = TrashHandlerRegistryUtil.getTrashHandler(
 			KBArticle.class.getName());
 
-		if (trashHandler.isRestorable(existingKBArticle.getKbArticleId())) {
+		if (trashHandler.isRestorable(existingKBArticle.getResourcePrimKey())) {
 			trashHandler.restoreTrashEntry(
 				portletDataContext.getUserId(kbArticle.getUserUuid()),
-				existingKBArticle.getKbArticleId());
+				existingKBArticle.getResourcePrimKey());
 		}
 	}
 

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/trash/KBArticleTrashHandler.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/trash/KBArticleTrashHandler.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermi
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.trash.TrashHandler;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.trash.TrashHelper;
 import com.liferay.trash.constants.TrashActionKeys;
 
@@ -40,9 +41,8 @@ public class KBArticleTrashHandler extends BaseKBTrashHandler {
 
 	@Override
 	public void deleteTrashEntry(long classPK) throws PortalException {
-		KBArticle kbArticle = _kbArticleLocalService.getKBArticle(classPK);
-
-		_kbArticleLocalService.deleteKBArticle(kbArticle.getResourcePrimKey());
+		_kbArticleLocalService.deleteKBArticle(
+			_kbArticleLocalService.getLatestKBArticle(classPK));
 	}
 
 	@Override
@@ -54,7 +54,8 @@ public class KBArticleTrashHandler extends BaseKBTrashHandler {
 	public ContainerModel getParentContainerModel(long classPK)
 		throws PortalException {
 
-		KBArticle kbArticle = _kbArticleLocalService.getKBArticle(classPK);
+		KBArticle kbArticle = _kbArticleLocalService.getLatestKBArticle(
+			classPK);
 
 		long parentKBFolderId = kbArticle.getKbFolderId();
 
@@ -79,7 +80,8 @@ public class KBArticleTrashHandler extends BaseKBTrashHandler {
 			PortletRequest portletRequest, long classPK)
 		throws PortalException {
 
-		KBArticle kbArticle = _kbArticleLocalService.getKBArticle(classPK);
+		KBArticle kbArticle = _kbArticleLocalService.getLatestKBArticle(
+			classPK);
 
 		if (!kbArticle.hasParentKBArticle()) {
 			return KnowledgeBaseUtil.getKBFolderControlPanelLink(
@@ -100,7 +102,8 @@ public class KBArticleTrashHandler extends BaseKBTrashHandler {
 
 	@Override
 	public TrashedModel getTrashedModel(long classPK) {
-		return _kbArticleLocalService.fetchKBArticle(classPK);
+		return _kbArticleLocalService.fetchLatestKBArticle(
+			classPK, WorkflowConstants.STATUS_ANY);
 	}
 
 	@Override
@@ -121,7 +124,8 @@ public class KBArticleTrashHandler extends BaseKBTrashHandler {
 
 	@Override
 	public boolean isMovable(long classPK) throws PortalException {
-		KBArticle kbArticle = _kbArticleLocalService.getKBArticle(classPK);
+		KBArticle kbArticle = _kbArticleLocalService.getLatestKBArticle(
+			classPK);
 
 		if (kbArticle.getKbFolderId() > 0) {
 			KBFolder parentKBFolder = kbFolderLocalService.fetchKBFolder(
@@ -137,7 +141,8 @@ public class KBArticleTrashHandler extends BaseKBTrashHandler {
 
 	@Override
 	public boolean isRestorable(long classPK) throws PortalException {
-		KBArticle kbArticle = _kbArticleLocalService.getKBArticle(classPK);
+		KBArticle kbArticle = _kbArticleLocalService.getLatestKBArticle(
+			classPK);
 
 		if (kbArticle.getKbFolderId() > 0) {
 			KBFolder bookmarksFolder = kbFolderLocalService.fetchKBFolder(
@@ -165,7 +170,8 @@ public class KBArticleTrashHandler extends BaseKBTrashHandler {
 			ServiceContext serviceContext)
 		throws PortalException {
 
-		KBArticle kbArticle = _kbArticleLocalService.getKBArticle(classPK);
+		KBArticle kbArticle = _kbArticleLocalService.getLatestKBArticle(
+			classPK);
 
 		_kbArticleLocalService.moveKBArticle(
 			userId, kbArticle.getResourcePrimKey(),
@@ -196,7 +202,8 @@ public class KBArticleTrashHandler extends BaseKBTrashHandler {
 
 	@Override
 	protected long getGroupId(long classPK) throws PortalException {
-		KBArticle kbArticle = _kbArticleLocalService.getKBArticle(classPK);
+		KBArticle kbArticle = _kbArticleLocalService.getLatestKBArticle(
+			classPK);
 
 		return kbArticle.getGroupId();
 	}
@@ -207,8 +214,8 @@ public class KBArticleTrashHandler extends BaseKBTrashHandler {
 		throws PortalException {
 
 		return _kbArticleModelResourcePermission.contains(
-			permissionChecker, _kbArticleLocalService.getKBArticle(classPK),
-			actionId);
+			permissionChecker,
+			_kbArticleLocalService.getLatestKBArticle(classPK), actionId);
 	}
 
 	@Reference

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/model/impl/KBArticleImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/model/impl/KBArticleImpl.java
@@ -206,6 +206,11 @@ public class KBArticleImpl extends KBArticleBaseImpl {
 	}
 
 	@Override
+	public long getTrashEntryClassPK() {
+		return getResourcePrimKey();
+	}
+
+	@Override
 	public long getViewCount() {
 		return ViewCountManagerUtil.getViewCount(
 			getCompanyId(),

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/http/KBArticleServiceHttp.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/http/KBArticleServiceHttp.java
@@ -1226,13 +1226,53 @@ public class KBArticleServiceHttp {
 	}
 
 	public static com.liferay.knowledge.base.model.KBArticle getLatestKBArticle(
-			HttpPrincipal httpPrincipal, long resourcePrimKey, int status)
+			HttpPrincipal httpPrincipal, long resourcePrimKey)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "getLatestKBArticle",
 				_getLatestKBArticleParameterTypes30);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, resourcePrimKey);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.knowledge.base.model.KBArticle)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
+	public static com.liferay.knowledge.base.model.KBArticle getLatestKBArticle(
+			HttpPrincipal httpPrincipal, long resourcePrimKey, int status)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				KBArticleServiceUtil.class, "getLatestKBArticle",
+				_getLatestKBArticleParameterTypes31);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, resourcePrimKey, status);
@@ -1275,7 +1315,7 @@ public class KBArticleServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class,
 				"getLatestKBArticleByExternalReferenceCode",
-				_getLatestKBArticleByExternalReferenceCodeParameterTypes31);
+				_getLatestKBArticleByExternalReferenceCodeParameterTypes32);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, externalReferenceCode);
@@ -1316,7 +1356,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "getPreviousAndNextKBArticles",
-				_getPreviousAndNextKBArticlesParameterTypes32);
+				_getPreviousAndNextKBArticlesParameterTypes33);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, kbArticleId);
@@ -1360,7 +1400,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "getSectionsKBArticles",
-				_getSectionsKBArticlesParameterTypes33);
+				_getSectionsKBArticlesParameterTypes34);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, sections, status, start, end,
@@ -1395,7 +1435,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "getSectionsKBArticlesCount",
-				_getSectionsKBArticlesCountParameterTypes34);
+				_getSectionsKBArticlesCountParameterTypes35);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, sections, status);
@@ -1428,7 +1468,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "getTempAttachmentNames",
-				_getTempAttachmentNamesParameterTypes35);
+				_getTempAttachmentNamesParameterTypes36);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, tempFolderName);
@@ -1470,7 +1510,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "moveKBArticle",
-				_moveKBArticleParameterTypes36);
+				_moveKBArticleParameterTypes37);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, resourcePrimKey, parentResourceClassNameId,
@@ -1508,7 +1548,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "moveKBArticleToTrash",
-				_moveKBArticleToTrashParameterTypes37);
+				_moveKBArticleToTrashParameterTypes38);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, resourcePrimKey);
@@ -1549,7 +1589,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "revertKBArticle",
-				_revertKBArticleParameterTypes38);
+				_revertKBArticleParameterTypes39);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, resourcePrimKey, version, serviceContext);
@@ -1589,7 +1629,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "subscribeGroupKBArticles",
-				_subscribeGroupKBArticlesParameterTypes39);
+				_subscribeGroupKBArticlesParameterTypes40);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, portletId);
@@ -1625,7 +1665,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "subscribeKBArticle",
-				_subscribeKBArticleParameterTypes40);
+				_subscribeKBArticleParameterTypes41);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, resourcePrimKey);
@@ -1661,7 +1701,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "unsubscribeGroupKBArticles",
-				_unsubscribeGroupKBArticlesParameterTypes41);
+				_unsubscribeGroupKBArticlesParameterTypes42);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, portletId);
@@ -1697,7 +1737,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "unsubscribeKBArticle",
-				_unsubscribeKBArticleParameterTypes42);
+				_unsubscribeKBArticleParameterTypes43);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, resourcePrimKey);
@@ -1738,7 +1778,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "updateKBArticle",
-				_updateKBArticleParameterTypes43);
+				_updateKBArticleParameterTypes44);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, resourcePrimKey, title, content, description,
@@ -1781,7 +1821,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBArticleServiceUtil.class, "updateKBArticlesPriorities",
-				_updateKBArticlesPrioritiesParameterTypes44);
+				_updateKBArticlesPrioritiesParameterTypes45);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, resourcePrimKeyToPriorityMap);
@@ -1921,45 +1961,47 @@ public class KBArticleServiceHttp {
 	private static final Class<?>[] _getKBArticleVersionsCountParameterTypes29 =
 		new Class[] {long.class, long.class, int.class};
 	private static final Class<?>[] _getLatestKBArticleParameterTypes30 =
+		new Class[] {long.class};
+	private static final Class<?>[] _getLatestKBArticleParameterTypes31 =
 		new Class[] {long.class, int.class};
 	private static final Class<?>[]
-		_getLatestKBArticleByExternalReferenceCodeParameterTypes31 =
+		_getLatestKBArticleByExternalReferenceCodeParameterTypes32 =
 			new Class[] {long.class, String.class};
 	private static final Class<?>[]
-		_getPreviousAndNextKBArticlesParameterTypes32 = new Class[] {
+		_getPreviousAndNextKBArticlesParameterTypes33 = new Class[] {
 			long.class
 		};
-	private static final Class<?>[] _getSectionsKBArticlesParameterTypes33 =
+	private static final Class<?>[] _getSectionsKBArticlesParameterTypes34 =
 		new Class[] {
 			long.class, String[].class, int.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
 	private static final Class<?>[]
-		_getSectionsKBArticlesCountParameterTypes34 = new Class[] {
+		_getSectionsKBArticlesCountParameterTypes35 = new Class[] {
 			long.class, String[].class, int.class
 		};
-	private static final Class<?>[] _getTempAttachmentNamesParameterTypes35 =
+	private static final Class<?>[] _getTempAttachmentNamesParameterTypes36 =
 		new Class[] {long.class, String.class};
-	private static final Class<?>[] _moveKBArticleParameterTypes36 =
+	private static final Class<?>[] _moveKBArticleParameterTypes37 =
 		new Class[] {long.class, long.class, long.class, double.class};
-	private static final Class<?>[] _moveKBArticleToTrashParameterTypes37 =
+	private static final Class<?>[] _moveKBArticleToTrashParameterTypes38 =
 		new Class[] {long.class};
-	private static final Class<?>[] _revertKBArticleParameterTypes38 =
+	private static final Class<?>[] _revertKBArticleParameterTypes39 =
 		new Class[] {
 			long.class, int.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _subscribeGroupKBArticlesParameterTypes39 =
+	private static final Class<?>[] _subscribeGroupKBArticlesParameterTypes40 =
 		new Class[] {long.class, String.class};
-	private static final Class<?>[] _subscribeKBArticleParameterTypes40 =
+	private static final Class<?>[] _subscribeKBArticleParameterTypes41 =
 		new Class[] {long.class, long.class};
 	private static final Class<?>[]
-		_unsubscribeGroupKBArticlesParameterTypes41 = new Class[] {
+		_unsubscribeGroupKBArticlesParameterTypes42 = new Class[] {
 			long.class, String.class
 		};
-	private static final Class<?>[] _unsubscribeKBArticleParameterTypes42 =
+	private static final Class<?>[] _unsubscribeKBArticleParameterTypes43 =
 		new Class[] {long.class};
-	private static final Class<?>[] _updateKBArticleParameterTypes43 =
+	private static final Class<?>[] _updateKBArticleParameterTypes44 =
 		new Class[] {
 			long.class, String.class, String.class, String.class,
 			String[].class, String.class, java.util.Date.class,
@@ -1967,7 +2009,7 @@ public class KBArticleServiceHttp {
 			long[].class, com.liferay.portal.kernel.service.ServiceContext.class
 		};
 	private static final Class<?>[]
-		_updateKBArticlesPrioritiesParameterTypes44 = new Class[] {
+		_updateKBArticlesPrioritiesParameterTypes45 = new Class[] {
 			long.class, java.util.Map.class
 		};
 

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
@@ -469,11 +469,11 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 
 		if (kbArticle.isInTrash()) {
 			TrashEntry trashEntry = _trashEntryLocalService.deleteEntry(
-				KBArticle.class.getName(), kbArticle.getKbArticleId());
+				KBArticle.class.getName(), kbArticle.getResourcePrimKey());
 
 			if (trashEntry == null) {
 				_trashVersionLocalService.deleteTrashVersion(
-					KBArticle.class.getName(), kbArticle.getKbArticleId());
+					KBArticle.class.getName(), kbArticle.getResourcePrimKey());
 			}
 		}
 
@@ -1057,12 +1057,11 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 
 	@Override
 	public void moveDependentKBArticlesToTrash(
-			KBArticle parentKBArticle, long trashEntryId)
+			long parentResourcePrimKey, long trashEntryId)
 		throws PortalException {
 
 		List<KBArticle> allDescendantKBArticles = getAllDescendantKBArticles(
-			parentKBArticle.getResourcePrimKey(), WorkflowConstants.STATUS_ANY,
-			null);
+			parentResourcePrimKey, WorkflowConstants.STATUS_ANY, null);
 
 		for (KBArticle descendantKBArticle : allDescendantKBArticles) {
 			_moveDependentKBArticleToTrash(descendantKBArticle, trashEntryId);
@@ -1076,7 +1075,8 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 
 		_moveDependentKBArticleToTrash(kbArticle, trashEntryId);
 
-		moveDependentKBArticlesToTrash(kbArticle, trashEntryId);
+		moveDependentKBArticlesToTrash(
+			kbArticle.getResourcePrimKey(), trashEntryId);
 	}
 
 	@Override
@@ -1172,11 +1172,11 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 
 	@Override
 	public void moveKBArticleFromTrash(
-			long userId, long kbArticleId, long parentResourceClassNameId,
+			long userId, long resourcePrimKey, long parentResourceClassNameId,
 			long parentResourcePrimKey)
 		throws PortalException {
 
-		KBArticle kbArticle = getKBArticle(kbArticleId);
+		KBArticle kbArticle = getLatestKBArticle(resourcePrimKey);
 
 		if (!kbArticle.isInTrash()) {
 			throw new RestoreEntryException(
@@ -1184,7 +1184,7 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 		}
 
 		if (_trashHelper.isInTrashExplicitly(kbArticle)) {
-			restoreKBArticleFromTrash(userId, kbArticleId);
+			restoreKBArticleFromTrash(userId, resourcePrimKey);
 		}
 		else {
 			restoreDependentKBArticleFromTrash(kbArticle);
@@ -1196,11 +1196,10 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 	}
 
 	@Override
-	public KBArticle moveKBArticleToTrash(long userId, long kbArticleId)
+	public KBArticle moveKBArticleToTrash(long userId, long resourcePrimKey)
 		throws PortalException {
 
-		KBArticle kbArticle = kbArticlePersistence.findByPrimaryKey(
-			kbArticleId);
+		KBArticle kbArticle = getLatestKBArticle(resourcePrimKey);
 
 		if (kbArticle.isInTrash()) {
 			throw new TrashEntryException();
@@ -1209,27 +1208,25 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 		int oldStatus = kbArticle.getStatus();
 
 		kbArticle = _updateStatus(
-			userId, kbArticle.getResourcePrimKey(),
-			WorkflowConstants.STATUS_IN_TRASH);
+			userId, kbArticle, WorkflowConstants.STATUS_IN_TRASH);
 
 		_assetEntryLocalService.updateVisible(
-			KBArticle.class.getName(), kbArticle.getResourcePrimKey(), false);
+			KBArticle.class.getName(), resourcePrimKey, false);
 
 		JSONObject extraDataJSONObject = JSONUtil.put(
 			"title", kbArticle.getTitle());
 
 		_socialActivityLocalService.addActivity(
 			userId, kbArticle.getGroupId(), KBArticle.class.getName(),
-			kbArticle.getResourcePrimKey(),
-			SocialActivityConstants.TYPE_MOVE_TO_TRASH,
+			resourcePrimKey, SocialActivityConstants.TYPE_MOVE_TO_TRASH,
 			extraDataJSONObject.toString(), 0);
 
 		TrashEntry trashEntry = _trashEntryLocalService.addTrashEntry(
 			userId, kbArticle.getGroupId(), KBArticle.class.getName(),
-			kbArticle.getKbArticleId(), kbArticle.getUuid(), null, oldStatus,
-			null, null);
+			resourcePrimKey, kbArticle.getUuid(), null, oldStatus, null, null);
 
-		moveDependentKBArticlesToTrash(kbArticle, trashEntry.getEntryId());
+		moveDependentKBArticlesToTrash(
+			resourcePrimKey, trashEntry.getEntryId());
 
 		return kbArticle;
 	}
@@ -1238,15 +1235,14 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 		throws PortalException {
 
 		_restoreDependentKBArticleFromTrash(kbArticle);
-		restoreDependentKBArticlesFromTrash(kbArticle);
+		restoreDependentKBArticlesFromTrash(kbArticle.getResourcePrimKey());
 	}
 
-	public void restoreDependentKBArticlesFromTrash(KBArticle parentKBArticle)
+	public void restoreDependentKBArticlesFromTrash(long parentResourcePrimKey)
 		throws PortalException {
 
 		List<KBArticle> allDescendantKBArticles = getAllDescendantKBArticles(
-			parentKBArticle.getResourcePrimKey(), WorkflowConstants.STATUS_ANY,
-			null);
+			parentResourcePrimKey, WorkflowConstants.STATUS_ANY, null);
 
 		for (KBArticle descendantKBArticle : allDescendantKBArticles) {
 			_restoreDependentKBArticleFromTrash(descendantKBArticle);
@@ -1254,11 +1250,10 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 	}
 
 	@Override
-	public void restoreKBArticleFromTrash(long userId, long kbArticleId)
+	public void restoreKBArticleFromTrash(long userId, long resourcePrimKey)
 		throws PortalException {
 
-		KBArticle kbArticle = kbArticlePersistence.findByPrimaryKey(
-			kbArticleId);
+		KBArticle kbArticle = getLatestKBArticle(resourcePrimKey);
 
 		if (!kbArticle.isInTrash()) {
 			throw new RestoreEntryException(
@@ -1266,15 +1261,13 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 		}
 
 		TrashEntry trashEntry = _trashEntryLocalService.getEntry(
-			KBArticle.class.getName(), kbArticleId);
+			KBArticle.class.getName(), resourcePrimKey);
 
-		kbArticle = _updateStatus(
-			userId, kbArticle.getResourcePrimKey(), trashEntry.getStatus());
+		kbArticle = _updateStatus(userId, kbArticle, trashEntry.getStatus());
 
 		if (kbArticle.isApproved()) {
 			_assetEntryLocalService.updateVisible(
-				KBArticle.class.getName(), kbArticle.getResourcePrimKey(),
-				true);
+				KBArticle.class.getName(), resourcePrimKey, true);
 		}
 
 		JSONObject extraDataJSONObject = JSONUtil.put(
@@ -1282,14 +1275,13 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 
 		_socialActivityLocalService.addActivity(
 			userId, kbArticle.getGroupId(), KBArticle.class.getName(),
-			kbArticle.getResourcePrimKey(),
-			SocialActivityConstants.TYPE_RESTORE_FROM_TRASH,
+			resourcePrimKey, SocialActivityConstants.TYPE_RESTORE_FROM_TRASH,
 			extraDataJSONObject.toString(), 0);
 
 		_trashEntryLocalService.deleteEntry(
-			KBArticle.class.getName(), kbArticleId);
+			KBArticle.class.getName(), resourcePrimKey);
 
-		restoreDependentKBArticlesFromTrash(kbArticle);
+		restoreDependentKBArticlesFromTrash(resourcePrimKey);
 	}
 
 	@Override
@@ -2352,7 +2344,7 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 		if (status != WorkflowConstants.STATUS_APPROVED) {
 			_trashVersionLocalService.addTrashVersion(
 				trashEntryId, KBArticle.class.getName(),
-				kbArticle.getKbArticleId(), status, null);
+				kbArticle.getResourcePrimKey(), status, null);
 		}
 
 		// Asset
@@ -2526,7 +2518,7 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 		}
 
 		TrashVersion trashVersion = _trashVersionLocalService.fetchVersion(
-			KBArticle.class.getName(), kbArticle.getKbArticleId());
+			KBArticle.class.getName(), kbArticle.getResourcePrimKey());
 
 		int oldStatus = WorkflowConstants.STATUS_APPROVED;
 
@@ -2647,13 +2639,10 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 	}
 
 	private KBArticle _updateStatus(
-			long userId, long resourcePrimKey, int status)
+			long userId, KBArticle kbArticle, int status)
 		throws PortalException {
 
 		User user = _userLocalService.getUser(userId);
-
-		KBArticle kbArticle = getLatestKBArticle(
-			resourcePrimKey, WorkflowConstants.STATUS_ANY);
 
 		kbArticle.setStatus(status);
 		kbArticle.setStatusByUserId(user.getUserId());

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
@@ -912,6 +912,14 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 	}
 
 	@Override
+	public KBArticle getLatestKBArticle(long resourcePrimKey)
+		throws PortalException {
+
+		return getLatestKBArticle(
+			resourcePrimKey, WorkflowConstants.STATUS_ANY);
+	}
+
+	@Override
 	public KBArticle getLatestKBArticle(long resourcePrimKey, int status)
 		throws PortalException {
 

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleServiceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleServiceImpl.java
@@ -617,6 +617,16 @@ public class KBArticleServiceImpl extends KBArticleServiceBaseImpl {
 	}
 
 	@Override
+	public KBArticle getLatestKBArticle(long resourcePrimKey)
+		throws PortalException {
+
+		_kbArticleModelResourcePermission.check(
+			getPermissionChecker(), resourcePrimKey, KBActionKeys.VIEW);
+
+		return kbArticleLocalService.getLatestKBArticle(resourcePrimKey);
+	}
+
+	@Override
 	public KBArticle getLatestKBArticle(long resourcePrimKey, int status)
 		throws PortalException {
 

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/AdminPortlet.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/AdminPortlet.java
@@ -28,6 +28,8 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.trash.TrashHelper;
+import com.liferay.trash.util.TrashWebKeys;
 
 import java.io.IOException;
 
@@ -102,6 +104,8 @@ public class AdminPortlet extends BaseKBPortlet {
 				resourceRequest.setAttribute(
 					KBWebKeys.KNOWLEDGE_BASE_KB_FOLDERS,
 					_getKBFolders(httpServletRequest));
+				resourceRequest.setAttribute(
+					TrashWebKeys.TRASH_HELPER, _trashHelper);
 
 				PortletSession portletSession =
 					resourceRequest.getPortletSession();
@@ -284,5 +288,8 @@ public class AdminPortlet extends BaseKBPortlet {
 		target = "(&(release.bundle.symbolic.name=com.liferay.knowledge.base.web)(&(release.schema.version>=1.2.0)(!(release.schema.version>=2.0.0))))"
 	)
 	private Release _release;
+
+	@Reference
+	private TrashHelper _trashHelper;
 
 }

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/action/DeleteKBArticleMVCActionCommand.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/action/DeleteKBArticleMVCActionCommand.java
@@ -21,7 +21,6 @@ import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
-import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
 import java.util.Objects;
 
@@ -58,9 +57,6 @@ public class DeleteKBArticleMVCActionCommand extends BaseMVCActionCommand {
 		long resourcePrimKey = ParamUtil.getLong(
 			actionRequest, "resourcePrimKey");
 
-		KBArticle kbArticle = _kbArticleService.getLatestKBArticle(
-			resourcePrimKey, WorkflowConstants.STATUS_ANY);
-
 		if (cmd.equals(Constants.MOVE_TO_TRASH) &&
 			FeatureFlagManagerUtil.isEnabled("LPS-188058")) {
 
@@ -70,7 +66,7 @@ public class DeleteKBArticleMVCActionCommand extends BaseMVCActionCommand {
 					"trashedModels",
 					ListUtil.toList(
 						(TrashedModel)_kbArticleService.moveKBArticleToTrash(
-							kbArticle.getKbArticleId()))
+							resourcePrimKey))
 				).build());
 		}
 		else {
@@ -83,6 +79,9 @@ public class DeleteKBArticleMVCActionCommand extends BaseMVCActionCommand {
 
 			ThemeDisplay themeDisplay =
 				(ThemeDisplay)actionRequest.getAttribute(WebKeys.THEME_DISPLAY);
+
+			KBArticle kbArticle = _kbArticleService.getLatestKBArticle(
+				resourcePrimKey);
 
 			LiferayPortletURL liferayPortletURL = PortletURLFactoryUtil.create(
 				actionRequest, _portal.getPortletId(actionRequest),

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/action/DeleteKBArticlesAndFoldersMVCActionCommand.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/action/DeleteKBArticlesAndFoldersMVCActionCommand.java
@@ -6,7 +6,6 @@
 package com.liferay.knowledge.base.web.internal.portlet.action;
 
 import com.liferay.knowledge.base.constants.KBPortletKeys;
-import com.liferay.knowledge.base.model.KBArticle;
 import com.liferay.knowledge.base.service.KBArticleService;
 import com.liferay.knowledge.base.service.KBFolderService;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
@@ -16,7 +15,6 @@ import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ParamUtil;
-import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -82,12 +80,9 @@ public class DeleteKBArticlesAndFoldersMVCActionCommand
 		List<TrashedModel> trashedModels = new ArrayList<>();
 
 		for (long kbArticleResourcePrimKey : kbArticleResourcePrimKeys) {
-			KBArticle kbArticle = _kbArticleService.getLatestKBArticle(
-				kbArticleResourcePrimKey, WorkflowConstants.STATUS_ANY);
-
 			trashedModels.add(
 				_kbArticleService.moveKBArticleToTrash(
-					kbArticle.getKbArticleId()));
+					kbArticleResourcePrimKey));
 		}
 
 		for (long kbFolderId : kbFolderIds) {


### PR DESCRIPTION
Now we are using `resourcePrimKey` instead of `kbArticleId` as the primary key when storing to the TrashHandler

See: https://liferay.atlassian.net/browse/LPS-202501
