### PR TITLE
LPS-202581 RawMetadataProcessorMessageListener was moved, so before was on com.liferay.portlet.documentlibrary.messaging, that has WARN log level. Add the log level to the new package to maintain the same behavior

### DIFF
--- a/modules/apps/document-library/document-library-service/src/main/resources/META-INF/module-log4j.xml
+++ b/modules/apps/document-library/document-library-service/src/main/resources/META-INF/module-log4j.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+
+<Configuration strict="true">
+	<Loggers>
+		<Logger level="WARN" name="com.liferay.document.library.internal.messaging" />
+	</Loggers>
+</Configuration>


### PR DESCRIPTION
…as on com.liferay.portlet.documentlibrary.messaging, that has WARN log level.

Add the log level to the new package to maintain the same behavior


Now log appears on console

```2023-11-27 15:19:42.087 WARN  [liferay/document_library_raw_metadata_processor-2][RawMetadataProcessorMessageListener:69] Unable to save metadata for file version 32902
com.liferay.portal.kernel.exception.SystemException: java.io.IOException: org.apache.tika.exception.TikaException: TIKA-198: Illegal IOException from org.apache.tika.parser.mp3.Mp3Parser@1988f78c
	at com.liferay.portal.tika.internal.metadata.TikaRawMetadataProcessor._extractMetadata(TikaRawMetadataProcessor.java:233) ~[?:?]
	at com.liferay.portal.tika.internal.metadata.TikaRawMetadataProcessor.getRawMetadataMap(TikaRawMetadataProcessor.java:90) ~[?:?]
	at com.liferay.portal.kernel.metadata.RawMetadataProcessorUtil.getRawMetadataMap(RawMetadataProcessorUtil.java:36) ~[portal-kernel.jar:?]
	at com.liferay.document.library.internal.util.RawMetadataProcessorImpl.saveMetadata(RawMetadataProcessorImpl.java:130) ~[?:?]
	at com.liferay.document.library.kernel.util.RawMetadataProcessorUtil.saveMetadata(RawMetadataProcessorUtil.java:97) ~[portal-kernel.jar:?]
	at com.liferay.document.library.internal.messaging.RawMetadataProcessorMessageListener.doReceive(RawMetadataProcessorMessageListener.java:65) [bundleFile:?]
	at com.liferay.portal.kernel.messaging.BaseMessageListener.doReceive(BaseMessageListener.java:39) [portal-kernel.jar:?]
	at com.liferay.portal.kernel.messaging.BaseMessageListener.receive(BaseMessageListener.java:25) [portal-kernel.jar:?]
	at com.liferay.portal.kernel.messaging.InvokerMessageListener.receive(InvokerMessageListener.java:65) [portal-kernel.jar:?]
	at com.liferay.portal.messaging.internal.SerialDestination$1.run(SerialDestination.java:50) [bundleFile:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_311]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_311]
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_311]
Caused by: java.io.IOException: org.apache.tika.exception.TikaException: TIKA-198: Illegal IOException from org.apache.tika.parser.mp3.Mp3Parser@1988f78c
	at com.liferay.portal.tika.internal.metadata.TikaRawMetadataProcessor$ExtractMetadataProcessCallable._extractMetadata(TikaRawMetadataProcessor.java:341) ~[?:?]
	at com.liferay.portal.tika.internal.metadata.TikaRawMetadataProcessor$ExtractMetadataProcessCallable.access$100(TikaRawMetadataProcessor.java:304) ~[?:?]
	at com.liferay.portal.tika.internal.metadata.TikaRawMetadataProcessor._extractMetadata(TikaRawMetadataProcessor.java:229) ~[?:?]
	... 12 more
Caused by: org.apache.tika.exception.TikaException: TIKA-198: Illegal IOException from org.apache.tika.parser.mp3.Mp3Parser@1988f78c
	at org.apache.tika.parser.CompositeParser.parse(CompositeParser.java:287) ~[?:?]
	at org.apache.tika.parser.CompositeParser.parse(CompositeParser.java:281) ~[?:?]
	at org.apache.tika.parser.AutoDetectParser.parse(AutoDetectParser.java:143) ~[?:?]
	at com.liferay.portal.tika.internal.metadata.TikaRawMetadataProcessor$ExtractMetadataProcessCallable._extractMetadata(TikaRawMetadataProcessor.java:337) ~[?:?]
	at com.liferay.portal.tika.internal.metadata.TikaRawMetadataProcessor$ExtractMetadataProcessCallable.access$100(TikaRawMetadataProcessor.java:304) ~[?:?]
	at com.liferay.portal.tika.internal.metadata.TikaRawMetadataProcessor._extractMetadata(TikaRawMetadataProcessor.java:229) ~[?:?]
	... 12 more
Caused by: java.io.IOException: Record size (2147483647 bytes) is larger than the allowed record size: 1000000
	at org.apache.tika.parser.mp3.ID3v2Frame.readFully(ID3v2Frame.java:186) ~[?:?]
	at org.apache.tika.parser.mp3.ID3v2Frame.readFully(ID3v2Frame.java:181) ~[?:?]
	at org.apache.tika.parser.mp3.ID3v2Frame.<init>(ID3v2Frame.java:133) ~[?:?]
	at org.apache.tika.parser.mp3.ID3v2Frame.createFrameIfPresent(ID3v2Frame.java:91) ~[?:?]
	at org.apache.tika.parser.mp3.Mp3Parser.getAllTagHandlers(Mp3Parser.java:188) ~[?:?]
	at org.apache.tika.parser.mp3.Mp3Parser.parse(Mp3Parser.java:70) ~[?:?]
	at org.apache.tika.parser.CompositeParser.parse(CompositeParser.java:281) ~[?:?]
	at org.apache.tika.parser.CompositeParser.parse(CompositeParser.java:281) ~[?:?]
	at org.apache.tika.parser.AutoDetectParser.parse(AutoDetectParser.java:143) ~[?:?]
	at com.liferay.portal.tika.internal.metadata.TikaRawMetadataProcessor$ExtractMetadataProcessCallable._extractMetadata(TikaRawMetadataProcessor.java:337) ~[?:?]
	at com.liferay.portal.tika.internal.metadata.TikaRawMetadataProcessor$ExtractMetadataProcessCallable.access$100(TikaRawMetadataProcessor.java:304) ~[?:?]
	at com.liferay.portal.tika.internal.metadata.TikaRawMetadataProcessor._extractMetadata(TikaRawMetadataProcessor.java:229) ~[?:?]
	... 12 more
```