### PR TITLE
LPS-202232 Change Configuration view for Documents and Media

### DIFF
--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/configuration_browse.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/configuration_browse.jsp
@@ -46,9 +46,9 @@ portletDisplay.setURLBackTitle("blogs");
 		<clay:col
 			lg="9"
 		>
-			<h1>
+			<h2>
 				<%= blogsConfigurationDisplayContext.getTitle() %>
-			</h1>
+			</h2>
 
 			<liferay-portlet:actionURL portletConfiguration="<%= true %>" var="configurationActionURL">
 				<portlet:param name="navigation" value="<%= blogsConfigurationDisplayContext.getNavigation() %>" />
@@ -61,7 +61,7 @@ portletDisplay.setURLBackTitle("blogs");
 					cssClass="c-mb-4 c-mt-4 c-p-0"
 					size="full"
 				>
-					<h2 class="c-pl-4 c-pr-4 c-pt-4 sheet-title">
+					<h3 class="c-pl-4 c-pr-4 c-pt-4 sheet-title">
 						<clay:content-row
 							verticalAlign="center"
 						>
@@ -69,7 +69,7 @@ portletDisplay.setURLBackTitle("blogs");
 								<%= blogsConfigurationDisplayContext.getSubtitle() %>
 							</clay:content-col>
 						</clay:content-row>
-					</h2>
+					</h3>
 
 					<aui:input name="<%= Constants.CMD %>" type="hidden" value="<%= Constants.UPDATE %>" />
 					<aui:input name="redirect" type="hidden" value="<%= blogsConfigurationDisplayContext.getRedirect() %>" />

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLConfigurationDisplaycontext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLConfigurationDisplaycontext.java
@@ -5,13 +5,28 @@
 
 package com.liferay.document.library.web.internal.display.context;
 
+import com.liferay.document.library.constants.DLPortletKeys;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.VerticalNavItem;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.VerticalNavItemList;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.VerticalNavItemListBuilder;
+import com.liferay.petra.function.UnsafeConsumer;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactory;
+import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactoryUtil;
+import com.liferay.portal.kernel.portlet.constants.PortletPreferencesFactoryConstants;
+import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 
+import java.util.Objects;
+
+import javax.portlet.PortletURL;
 import javax.portlet.RenderRequest;
 import javax.portlet.RenderResponse;
-import javax.servlet.http.HttpServletRequest;
 
+import javax.servlet.http.HttpServletRequest;
 
 /**
  * @author Bárbara Cabrera
@@ -30,7 +45,102 @@ public class DLConfigurationDisplaycontext {
 			WebKeys.THEME_DISPLAY);
 	}
 
+	public String getBackURL() {
+		RequestBackedPortletURLFactory requestBackedPortletURLFactory =
+			RequestBackedPortletURLFactoryUtil.create(_httpServletRequest);
+
+		return PortletURLBuilder.create(
+			requestBackedPortletURLFactory.createControlPanelRenderURL(
+				DLPortletKeys.DOCUMENT_LIBRARY_ADMIN,
+				_themeDisplay.getScopeGroup(), 0, 0)
+		).buildString();
+	}
+
+	public String getNavigation() {
+		if (Validator.isNotNull(_navigation)) {
+			return _navigation;
+		}
+
+		_navigation = ParamUtil.getString(
+			_renderRequest, "navigation", "email-from");
+
+		return _navigation;
+	}
+
+	public VerticalNavItemList getNotificationsVerticalNavItemList() {
+		return VerticalNavItemListBuilder.add(
+			_getVerticalNavItemUnsafeConsumer("email-from")
+		).add(
+			_getVerticalNavItemUnsafeConsumer("document-added-email")
+		).add(
+			_getVerticalNavItemUnsafeConsumer("document-updated-email")
+		).add(
+			_getVerticalNavItemUnsafeConsumer("document-needs-review-email")
+		).add(
+			_getVerticalNavItemUnsafeConsumer("document-expired-email")
+		).build();
+	}
+
+	public PortletURL getPortletURL() {
+		if (_portletURL != null) {
+			return _portletURL;
+		}
+
+		_portletURL = PortletURLBuilder.createRenderURL(
+			_renderResponse
+		).setActionName(
+			"editConfiguration"
+		).setMVCPath(
+			"/edit_configuration.jsp"
+		).setPortletResource(
+			ParamUtil.getString(_httpServletRequest, "portletResource")
+		).setParameter(
+			"portletConfiguration", Boolean.TRUE
+		).setParameter(
+			"settingsScope",
+			PortletPreferencesFactoryConstants.SETTINGS_SCOPE_PORTLET_INSTANCE
+		).buildPortletURL();
+
+		return _portletURL;
+	}
+
+	public PortletURL getRedirect() {
+		return PortletURLBuilder.create(
+			getPortletURL()
+		).setNavigation(
+			getNavigation()
+		).buildPortletURL();
+	}
+
+	public String getSubtitle() {
+		return LanguageUtil.get(_httpServletRequest, "email");
+	}
+
+	public String getTitle() {
+		return LanguageUtil.get(_httpServletRequest, getNavigation());
+	}
+
+	private UnsafeConsumer<VerticalNavItem, Exception>
+		_getVerticalNavItemUnsafeConsumer(String key) {
+
+		return verticalNavItem -> {
+			String name = LanguageUtil.get(_httpServletRequest, key);
+
+			verticalNavItem.setActive(Objects.equals(getNavigation(), key));
+			verticalNavItem.setHref(
+				PortletURLBuilder.create(
+					getPortletURL()
+				).setNavigation(
+					key
+				).buildString());
+			verticalNavItem.setId(name);
+			verticalNavItem.setLabel(name);
+		};
+	}
+
 	private final HttpServletRequest _httpServletRequest;
+	private String _navigation;
+	private PortletURL _portletURL;
 	private final RenderRequest _renderRequest;
 	private final RenderResponse _renderResponse;
 	private final ThemeDisplay _themeDisplay;

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLConfigurationDisplaycontext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLConfigurationDisplaycontext.java
@@ -1,0 +1,38 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.document.library.web.internal.display.context;
+
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.WebKeys;
+
+import javax.portlet.RenderRequest;
+import javax.portlet.RenderResponse;
+import javax.servlet.http.HttpServletRequest;
+
+
+/**
+ * @author Bárbara Cabrera
+ */
+public class DLConfigurationDisplaycontext {
+
+	public DLConfigurationDisplaycontext(
+		HttpServletRequest httpServletRequest, RenderRequest renderRequest,
+		RenderResponse renderResponse) {
+
+		_httpServletRequest = httpServletRequest;
+		_renderRequest = renderRequest;
+		_renderResponse = renderResponse;
+
+		_themeDisplay = (ThemeDisplay)httpServletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+	}
+
+	private final HttpServletRequest _httpServletRequest;
+	private final RenderRequest _renderRequest;
+	private final RenderResponse _renderResponse;
+	private final ThemeDisplay _themeDisplay;
+
+}

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/DLAdminConfigurationAction.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/DLAdminConfigurationAction.java
@@ -7,6 +7,7 @@ package com.liferay.document.library.web.internal.portlet.action;
 
 import com.liferay.document.library.constants.DLPortletKeys;
 import com.liferay.item.selector.ItemSelector;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.portlet.BaseJSPSettingsConfigurationAction;
 import com.liferay.portal.kernel.portlet.ConfigurationAction;
 import com.liferay.portal.kernel.util.Constants;
@@ -36,6 +37,10 @@ public class DLAdminConfigurationAction
 
 	@Override
 	public String getJspPath(HttpServletRequest httpServletRequest) {
+		if (FeatureFlagManagerUtil.isEnabled("LPS-197692")) {
+			return "/document_library_admin/configuration_browse.jsp";
+		}
+
 		return "/document_library_admin/configuration.jsp";
 	}
 

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/DLAdminConfigurationAction.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/DLAdminConfigurationAction.java
@@ -74,7 +74,10 @@ public class DLAdminConfigurationAction
 	private void _validate(ActionRequest actionRequest) {
 		validateEmail(actionRequest, "emailFileEntryAdded");
 		validateEmail(actionRequest, "emailFileEntryUpdated");
-		validateEmailFrom(actionRequest);
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPS-197692")) {
+			validateEmailFrom(actionRequest);
+		}
 	}
 
 	@Reference

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library_admin/configuration_browse.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library_admin/configuration_browse.jsp
@@ -9,9 +9,11 @@
 
 <%
 DLConfigurationDisplaycontext dlConfigurationDisplaycontext = new DLConfigurationDisplaycontext(request, renderRequest, renderResponse);
+DLGroupServiceSettings dlGroupServiceSettings = DLGroupServiceSettings.getInstance(scopeGroupId, request.getParameterMap());
 
 portletDisplay.setShowBackIcon(true);
 portletDisplay.setURLBack(dlConfigurationDisplaycontext.getBackURL());
+portletDisplay.setURLBackTitle("documents-and-media");
 %>
 
 <clay:container-fluid
@@ -28,6 +30,116 @@ portletDisplay.setURLBack(dlConfigurationDisplaycontext.getBackURL());
 			<clay:vertical-nav
 				verticalNavItems="<%= dlConfigurationDisplaycontext.getNotificationsVerticalNavItemList() %>"
 			/>
+		</clay:col>
+
+		<clay:col
+			lg="9"
+		>
+			<h2>
+				<%= dlConfigurationDisplaycontext.getTitle() %>
+			</h2>
+
+			<liferay-portlet:actionURL portletConfiguration="<%= true %>" var="configurationActionURL">
+				<portlet:param name="navigation" value="<%= dlConfigurationDisplaycontext.getNavigation() %>" />
+				<portlet:param name="serviceName" value="<%= DLConstants.SERVICE_NAME %>" />
+				<portlet:param name="settingsScope" value="group" />
+			</liferay-portlet:actionURL>
+
+			<aui:form action="<%= configurationActionURL %>" method="post" name="fm">
+				<clay:sheet
+					cssClass="c-mb-4 c-mt-4 c-p-0"
+					size="full"
+				>
+					<h3 class="c-pl-4 c-pr-4 c-pt-4 sheet-title">
+						<clay:content-row
+							verticalAlign="center"
+						>
+							<clay:content-col>
+								<%= dlConfigurationDisplaycontext.getSubtitle() %>
+							</clay:content-col>
+						</clay:content-row>
+					</h3>
+
+					<aui:input name="<%= Constants.CMD %>" type="hidden" value="<%= Constants.UPDATE %>" />
+					<aui:input name="redirect" type="hidden" value="<%= configurationActionURL %>" />
+
+					<liferay-ui:error embed="<%= false %>" key="emailEntryAddedBody" message="please-enter-a-valid-body" />
+					<liferay-ui:error embed="<%= false %>" key="emailEntryAddedSubject" message="please-enter-a-valid-subject" />
+					<liferay-ui:error embed="<%= false %>" key="emailEntryUpdatedBody" message="please-enter-a-valid-body" />
+					<liferay-ui:error embed="<%= false %>" key="emailEntryUpdatedSubject" message="please-enter-a-valid-subject" />
+
+					<%
+					Map<String, String> emailDefinitionTerms = DLUtil.getEmailDefinitionTerms(renderRequest, dlGroupServiceSettings.getEmailFromAddress(), dlGroupServiceSettings.getEmailFromName());
+					%>
+
+					<c:choose>
+						<c:when test='<%= Objects.equals(dlConfigurationDisplaycontext.getNavigation(), "document-added-email") %>'>
+							<div class="c-px-4 panel-group-flush">
+								<liferay-frontend:email-notification-settings
+									emailBody="<%= dlGroupServiceSettings.getEmailFileEntryAddedBodyXml() %>"
+									emailDefinitionTerms="<%= emailDefinitionTerms %>"
+									emailEnabled="<%= dlGroupServiceSettings.isEmailFileEntryAddedEnabled() %>"
+									emailParam="emailFileEntryAdded"
+									emailSubject="<%= dlGroupServiceSettings.getEmailFileEntryAddedSubjectXml() %>"
+								/>
+							</div>
+						</c:when>
+						<c:when test='<%= Objects.equals(dlConfigurationDisplaycontext.getNavigation(), "document-updated-email") %>'>
+							<div class="c-px-4 panel-group-flush">
+								<liferay-frontend:email-notification-settings
+									emailBody="<%= dlGroupServiceSettings.getEmailFileEntryUpdatedBodyXml() %>"
+									emailDefinitionTerms="<%= emailDefinitionTerms %>"
+									emailEnabled="<%= dlGroupServiceSettings.isEmailFileEntryUpdatedEnabled() %>"
+									emailParam="emailFileEntryUpdated"
+									emailSubject="<%= dlGroupServiceSettings.getEmailFileEntryUpdatedSubjectXml() %>"
+								/>
+							</div>
+						</c:when>
+						<c:when test='<%= Objects.equals(dlConfigurationDisplaycontext.getNavigation(), "document-needs-review-email") %>'>
+							<div class="c-px-4 panel-group-flush">
+								<liferay-frontend:email-notification-settings
+									emailBody="<%= dlGroupServiceSettings.getEmailFileEntryReviewBodyXml() %>"
+									emailDefinitionTerms="<%= emailDefinitionTerms %>"
+									emailEnabled="<%= dlGroupServiceSettings.isEmailFileEntryReviewEnabled() %>"
+									emailParam="emailFileEntryReview"
+									emailSubject="<%= dlGroupServiceSettings.getEmailFileEntryReviewSubjectXml() %>"
+								/>
+							</div>
+						</c:when>
+						<c:when test='<%= Objects.equals(dlConfigurationDisplaycontext.getNavigation(), "document-expired-email") %>'>
+							<div class="c-px-4 panel-group-flush">
+								<liferay-frontend:email-notification-settings
+									emailBody="<%= dlGroupServiceSettings.getEmailFileEntryExpiredBodyXml() %>"
+									emailDefinitionTerms="<%= emailDefinitionTerms %>"
+									emailEnabled="<%= dlGroupServiceSettings.isEmailFileEntryExpiredEnabled() %>"
+									emailParam="emailFileEntryExpired"
+									emailSubject="<%= dlGroupServiceSettings.getEmailFileEntryExpiredSubjectXml() %>"
+								/>
+							</div>
+						</c:when>
+						<c:otherwise>
+							<div class="c-px-4">
+								<liferay-frontend:fieldset>
+									<aui:input cssClass="lfr-input-text-container" label="name" name="preferences--emailFromName--" value="<%= dlGroupServiceSettings.getEmailFromName() %>">
+										<aui:validator errorMessage="please-enter-a-valid-name" name="required" />
+									</aui:input>
+
+									<aui:input cssClass="lfr-input-text-container" label="address" name="preferences--emailFromAddress--" value="<%= dlGroupServiceSettings.getEmailFromAddress() %>">
+										<aui:validator errorMessage="please-enter-a-valid-email-address" name="required" />
+										<aui:validator name="email" />
+									</aui:input>
+								</liferay-frontend:fieldset>
+							</div>
+						</c:otherwise>
+					</c:choose>
+				</clay:sheet>
+
+				<aui:button-row>
+					<aui:button cssClass="c-mr-2" type="submit" />
+
+					<aui:button href="<%= dlConfigurationDisplaycontext.getBackURL() %>" type="cancel" />
+				</aui:button-row>
+			</aui:form>
 		</clay:col>
 	</clay:row>
 </clay:container-fluid>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library_admin/configuration_browse.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library_admin/configuration_browse.jsp
@@ -1,0 +1,33 @@
+<%--
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+--%>
+
+<%@ include file="/init.jsp" %>
+
+<%
+DLConfigurationDisplaycontext dlConfigurationDisplaycontext = new DLConfigurationDisplaycontext(request, renderRequest, renderResponse);
+
+portletDisplay.setShowBackIcon(true);
+portletDisplay.setURLBack(dlConfigurationDisplaycontext.getBackURL());
+%>
+
+<clay:container-fluid
+	cssClass="container-form-lg"
+>
+	<clay:row>
+		<clay:col
+			lg="3"
+		>
+			<p class="c-mb-1 sheet-tertiary-title text-2 text-secondary">
+				<liferay-ui:message key="notifications" />
+			</p>
+
+			<clay:vertical-nav
+				verticalNavItems="<%= dlConfigurationDisplaycontext.getNotificationsVerticalNavItemList() %>"
+			/>
+		</clay:col>
+	</clay:row>
+</clay:container-fluid>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/init.jsp
@@ -98,6 +98,7 @@ page import="com.liferay.document.library.web.internal.dao.search.IGResultRowSpl
 page import="com.liferay.document.library.web.internal.display.context.DLAdminDisplayContext" %><%@
 page import="com.liferay.document.library.web.internal.display.context.DLAdminManagementToolbarDisplayContext" %><%@
 page import="com.liferay.document.library.web.internal.display.context.DLAdminNavigationDisplayContext" %><%@
+page import="com.liferay.document.library.web.internal.display.context.DLConfigurationDisplaycontext" %><%@
 page import="com.liferay.document.library.web.internal.display.context.DLEditDDMStructureDisplayContext" %><%@
 page import="com.liferay.document.library.web.internal.display.context.DLSelectRestrictedFileEntryTypesDisplayContext" %><%@
 page import="com.liferay.document.library.web.internal.display.context.DLViewFileEntryMetadataSetsDisplayContext" %><%@

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/configuration_browse.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/configuration_browse.jsp
@@ -44,9 +44,9 @@ portletDisplay.setURLBackTitle("web-content");
 		<clay:col
 			lg="9"
 		>
-			<h1>
+			<h2>
 				<%= journalConfigurationDisplayContext.getTitle() %>
-			</h1>
+			</h2>
 
 			<liferay-portlet:actionURL portletConfiguration="<%= true %>" var="configurationActionURL">
 				<portlet:param name="navigation" value="<%= journalConfigurationDisplayContext.getNavigation() %>" />
@@ -59,7 +59,7 @@ portletDisplay.setURLBackTitle("web-content");
 					cssClass="c-mb-4 c-mt-4 c-p-0"
 					size="full"
 				>
-					<h2 class="c-pl-4 c-pr-4 c-pt-4 sheet-title">
+					<h3 class="c-pl-4 c-pr-4 c-pt-4 sheet-title">
 						<clay:content-row
 							verticalAlign="center"
 						>
@@ -67,7 +67,7 @@ portletDisplay.setURLBackTitle("web-content");
 								<%= journalConfigurationDisplayContext.getSubtitle() %>
 							</clay:content-col>
 						</clay:content-row>
-					</h2>
+					</h3>
 
 					<aui:input name="<%= Constants.CMD %>" type="hidden" value="<%= Constants.UPDATE %>" />
 					<aui:input name="redirect" type="hidden" value="<%= journalConfigurationDisplayContext.getRedirect() %>" />


### PR DESCRIPTION
## Motivation

Hey, @liferay-lima ! 
Continuing the epic of [Change "Configuration" view for all the apps inside Content & Data](https://liferay.atlassian.net/browse/LPS-197692) I am sending this pr to change the view of the Documents and media configuration. Let me know what you think. Thanks in advance! 😄 

[Link to ticket](https://liferay.atlassian.net/browse/LPS-202232)

## Changes

Change the configuration for Documents and Media because it should be open in a new page instead of a modal.

> [!NOTE]
> **You need to activate the LPS-197692 FF.**

## Test Scenario 1

1. Go to Documents and Media
2. Click on the kebab menu in the top right
3. Navigate to the sections to check the behaviour and styles


https://github.com/liferay-echo/liferay-portal/assets/93203423/d03b314e-090b-4916-94ee-dab2c414a74f


cc: @p2kmgcl @jkappler