### PR TITLE
LPS-202875 Upgrade Google Translator dependencies to address security vulnerabilities

### DIFF
--- a/modules/apps/translation/translation-translator-google-cloud/build.gradle
+++ b/modules/apps/translation/translation-translator-google-cloud/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
 	compileIncludePlatform group: "com.google.cloud", name: "google-cloud-translate"
-	compileIncludePlatform platform("com.google.cloud:libraries-bom:26.1.5")
+	compileIncludePlatform platform("com.google.cloud:libraries-bom:26.4.0")
 
 	compileOnly group: "com.liferay", name: "biz.aQute.bnd.annotation", version: "4.2.0.LIFERAY-PATCHED-2"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"

--- a/modules/apps/translation/translation-translator-google-cloud/build.gradle
+++ b/modules/apps/translation/translation-translator-google-cloud/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-	compileIncludePlatform group: "com.google.cloud", name: "google-cloud-translate"
+	compileIncludePlatform group: "com.google.cloud", name: "google-cloud-translate", version: "2.20.0"
 	compileIncludePlatform platform("com.google.cloud:libraries-bom:26.4.0")
 
 	compileOnly group: "com.liferay", name: "biz.aQute.bnd.annotation", version: "4.2.0.LIFERAY-PATCHED-2"


### PR DESCRIPTION
Ticket: [LPS-202875](https://liferay.atlassian.net/browse/LPS-202875)

Liferay Translation Translator Google Cloud specifies a dependency on Google Cloud Platform Supported Libraries 26.1.5 ([master](https://github.com/liferay/liferay-portal-ee/blob/master/modules/apps/translation/translation-translator-google-cloud/build.gradle#L9)) which has the following indirect vulnerabilities:

- [CVE-2023-32732](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-32732)
- [CVE-2023-32731](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-32731)
- [CVE-2023-2976](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2976)
- [CVE-2023-1428](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-1428)
- [CVE-2020-8908](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-8908)

Please upgrade to Google Cloud Platform Supported Libraries 26.4.0 or above.