### PR TITLE
[TECHNICAL SUPPORT] LPS-200885 Private page of type "Link to URL" does not return 404 Page.

### DIFF
--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
@@ -358,7 +358,9 @@ public class FriendlyURLServlet extends HttpServlet {
 						LayoutConstants.DEFAULT_PARENT_LAYOUT_ID);
 
 					for (Layout layout : layouts) {
-						if (layout.matches(httpServletRequest, layoutFriendlyURL)) {
+						if (layout.matches(
+								httpServletRequest, layoutFriendlyURL)) {
+
 							redirectLayout = layout;
 
 							break;

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
@@ -348,28 +348,21 @@ public class FriendlyURLServlet extends HttpServlet {
 		catch (LayoutPermissionException | NoSuchLayoutException exception) {
 			Layout redirectLayout = null;
 
-			if (exception instanceof LayoutPermissionException) {
-				List<Layout> layouts = layoutService.getLayouts(
-					group.getGroupId(), _private,
-					LayoutConstants.DEFAULT_PARENT_LAYOUT_ID, 0, 1);
-
-				if (!layouts.isEmpty()) {
-					redirectLayout = layouts.get(0);
+			if (!(exception instanceof LayoutPermissionException)) {
+				if (layoutFriendlyURL == null) {
+					redirectLayout = defaultLayout;
 				}
-			}
-			else if (layoutFriendlyURL == null) {
-				redirectLayout = defaultLayout;
-			}
-			else {
-				List<Layout> layouts = layoutLocalService.getLayouts(
-					group.getGroupId(), _private,
-					LayoutConstants.DEFAULT_PARENT_LAYOUT_ID);
+				else {
+					List<Layout> layouts = layoutLocalService.getLayouts(
+						group.getGroupId(), _private,
+						LayoutConstants.DEFAULT_PARENT_LAYOUT_ID);
 
-				for (Layout layout : layouts) {
-					if (layout.matches(httpServletRequest, layoutFriendlyURL)) {
-						redirectLayout = layout;
+					for (Layout layout : layouts) {
+						if (layout.matches(httpServletRequest, layoutFriendlyURL)) {
+							redirectLayout = layout;
 
-						break;
+							break;
+						}
 					}
 				}
 			}


### PR DESCRIPTION
### 🐛  Issue

In case of a Regular and URL Page, if **User** has **no view permissions** they are redirected to the **Home Page** instead of **404 Page**.

### 📖  Content

- **LPS-200885**
Adjusted the logic in the `FriendlyURLServlet.getRedirect` method to maintain the value of the `redirectLayout` variable as `null` when a **User** lacks the permissions to view the requested page. This way, the **404 Page Not Found** layout will be returned to the **User**.

### 🧪  How To Test

1st case
- Add a page with Name=`URLPage`, Type=`Link to URL` and URL=`http://www.google.com`
- Uncheck all permissions except Owner on the page and save
- Sign out
- Enter the URL http://localhost:8080/group/guest/urlpage

2nd case
- Add a Blank page with Name=`BlankPage`
- Uncheck all permissions except Owner on the page and save
- Sign out
- Enter the URL http://localhost:8080/group/guest/blankpage

:white_check_mark: **Expected result**
If users do not have viewing permissions, they should see a 404 Page.