### PR TITLE
LPS-202909 check if the searchContainer has rowChecker, that is filled only if the user has permissions, to prevent NPE

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/search_resources.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/search_resources.jsp
@@ -148,16 +148,18 @@ entriesChecker.setRememberCheckBoxStateURLRegex("^(?!.*" + liferayPortletRespons
 											<div class="aspect-ratio card-item-first">
 												<div class="custom-checkbox custom-control">
 													<label>
+														<c:if test="<%= searchContainer.getRowChecker() != null %>">
 
-														<%
-														RowChecker rowChecker = searchContainer.getRowChecker();
+															<%
+															RowChecker rowChecker = searchContainer.getRowChecker();
 
-														rowChecker.setCssClass("custom-control-input");
-														%>
+															rowChecker.setCssClass("custom-control-input");
+															%>
 
-														<%= rowChecker.getRowCheckBox(request, row) %>
+															<%= rowChecker.getRowCheckBox(request, row) %>
 
-														<span class="custom-control-label"></span>
+															<span class="custom-control-label"></span>
+														</c:if>
 
 														<c:choose>
 															<c:when test="<%= dlViewFileVersionDisplayContext.hasCustomThumbnail() %>">


### PR DESCRIPTION

Steps to reproduce:

1. Add a new document. Call it 'whatever'
4. Add the DL portlet to a page.
5. Configure the cards view.
6. Search, inside the DL portlet, 'whatever'. - the doc is listed
7. Logout
8. Search again, in cards view, 'whatever' -