### PR TITLE
LPS-202905 Avoid performance errors on file creation

### DIFF
--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/service/SubscriptionDLAppHelperLocalServiceWrapper.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/service/SubscriptionDLAppHelperLocalServiceWrapper.java
@@ -5,7 +5,6 @@
 
 package com.liferay.document.library.internal.service;
 
-import com.liferay.asset.display.page.constants.AssetDisplayPageConstants;
 import com.liferay.asset.display.page.portlet.AssetDisplayPageFriendlyURLProvider;
 import com.liferay.asset.display.page.service.AssetDisplayPageEntryLocalService;
 import com.liferay.document.library.internal.util.DLSubscriptionSender;
@@ -19,8 +18,6 @@ import com.liferay.document.library.kernel.service.DLAppHelperLocalServiceWrappe
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalService;
 import com.liferay.document.library.kernel.util.DLAppHelperThreadLocal;
-import com.liferay.info.item.ClassPKInfoItemIdentifier;
-import com.liferay.info.item.InfoItemReference;
 import com.liferay.portal.json.jabsorb.serializer.LiferayJSONDeserializationWhitelist;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
@@ -33,11 +30,9 @@ import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceWrapper;
 import com.liferay.portal.kernel.settings.LocalizedValuesMap;
-import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.EscapableLocalizableFunction;
 import com.liferay.portal.kernel.util.Localization;
-import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.SubscriptionSender;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
@@ -134,18 +129,6 @@ public class SubscriptionDLAppHelperLocalServiceWrapper
 		}
 	}
 
-	private boolean _hasAssetDisplayPage(ServiceContext serviceContext) {
-		int displayPageType = ParamUtil.getInteger(
-			serviceContext, "displayPageType",
-			AssetDisplayPageConstants.TYPE_DEFAULT);
-
-		if (displayPageType == AssetDisplayPageConstants.TYPE_NONE) {
-			return false;
-		}
-
-		return true;
-	}
-
 	private boolean _isEnabled(FileEntry fileEntry) {
 		if (!DLAppHelperThreadLocal.isEnabled() ||
 			RepositoryUtil.isExternalRepository(fileEntry.getRepositoryId())) {
@@ -172,27 +155,7 @@ public class SubscriptionDLAppHelperLocalServiceWrapper
 			ServiceContext serviceContext)
 		throws PortalException {
 
-		if (!fileVersion.isApproved()) {
-			return;
-		}
-
-		ThemeDisplay themeDisplay = serviceContext.getThemeDisplay();
-
-		if ((themeDisplay != null) && _hasAssetDisplayPage(serviceContext)) {
-			String friendlyURL =
-				_assetDisplayPageFriendlyURLProvider.getFriendlyURL(
-					new InfoItemReference(
-						FileEntry.class.getName(),
-						new ClassPKInfoItemIdentifier(
-							fileVersion.getFileEntryId())),
-					themeDisplay);
-
-			if (Validator.isNotNull(friendlyURL)) {
-				entryURL = friendlyURL;
-			}
-		}
-
-		if (Validator.isNull(entryURL)) {
+		if (!fileVersion.isApproved() || Validator.isNull(entryURL)) {
 			return;
 		}
 

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/util/DLImpl.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/util/DLImpl.java
@@ -5,6 +5,8 @@
 
 package com.liferay.document.library.internal.util;
 
+import com.liferay.asset.display.page.constants.AssetDisplayPageConstants;
+import com.liferay.asset.display.page.portlet.AssetDisplayPageFriendlyURLProvider;
 import com.liferay.document.library.kernel.exception.InvalidFolderException;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFileEntryConstants;
@@ -21,6 +23,8 @@ import com.liferay.document.library.kernel.util.comparator.RepositoryModelModifi
 import com.liferay.document.library.kernel.util.comparator.RepositoryModelReadCountComparator;
 import com.liferay.document.library.kernel.util.comparator.RepositoryModelSizeComparator;
 import com.liferay.document.library.kernel.util.comparator.RepositoryModelTitleComparator;
+import com.liferay.info.item.ClassPKInfoItemIdentifier;
+import com.liferay.info.item.InfoItemReference;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -58,6 +62,7 @@ import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
+import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PrefsPropsUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
@@ -810,6 +815,22 @@ public class DLImpl implements DL {
 				serviceContext.getCurrentURL();
 		}
 
+		ThemeDisplay themeDisplay = serviceContext.getThemeDisplay();
+
+		if ((themeDisplay != null) && _hasAssetDisplayPage(serviceContext)) {
+			String friendlyURL =
+				_assetDisplayPageFriendlyURLProvider.getFriendlyURL(
+					new InfoItemReference(
+						FileEntry.class.getName(),
+						new ClassPKInfoItemIdentifier(
+							dlFileVersion.getFileEntryId())),
+					themeDisplay);
+
+			if (Validator.isNotNull(friendlyURL)) {
+				return friendlyURL;
+			}
+		}
+
 		String entryURL = GetterUtil.getString(
 			serviceContext.getAttribute("entryURL"));
 
@@ -818,7 +839,6 @@ public class DLImpl implements DL {
 		}
 
 		HttpServletRequest httpServletRequest = serviceContext.getRequest();
-		ThemeDisplay themeDisplay = serviceContext.getThemeDisplay();
 
 		if ((httpServletRequest == null) || (themeDisplay == null)) {
 			return StringPool.BLANK;
@@ -933,6 +953,18 @@ public class DLImpl implements DL {
 		return true;
 	}
 
+	private boolean _hasAssetDisplayPage(ServiceContext serviceContext) {
+		int displayPageType = ParamUtil.getInteger(
+			serviceContext, "displayPageType",
+			AssetDisplayPageConstants.TYPE_DEFAULT);
+
+		if (displayPageType == AssetDisplayPageConstants.TYPE_NONE) {
+			return false;
+		}
+
+		return true;
+	}
+
 	private String _stripVersionSuffix(String version) {
 		int index = version.indexOf(CharPool.TILDE);
 
@@ -1040,6 +1072,10 @@ public class DLImpl implements DL {
 			_populateGenericNamesMap(genericName);
 		}
 	}
+
+	@Reference
+	private AssetDisplayPageFriendlyURLProvider
+		_assetDisplayPageFriendlyURLProvider;
 
 	@Reference
 	private DLAppLocalService _dlAppLocalService;

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/util/DLImpl.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/util/DLImpl.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-package com.liferay.portlet.documentlibrary.util;
+package com.liferay.document.library.internal.util;
 
 import com.liferay.document.library.kernel.exception.InvalidFolderException;
 import com.liferay.document.library.kernel.model.DLFileEntry;

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/util/DLImpl.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/util/DLImpl.java
@@ -13,8 +13,8 @@ import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
 import com.liferay.document.library.kernel.model.DLFileVersion;
 import com.liferay.document.library.kernel.model.DLFolder;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
-import com.liferay.document.library.kernel.service.DLAppLocalServiceUtil;
-import com.liferay.document.library.kernel.service.DLFolderLocalServiceUtil;
+import com.liferay.document.library.kernel.service.DLAppLocalService;
+import com.liferay.document.library.kernel.service.DLFolderLocalService;
 import com.liferay.document.library.kernel.util.DL;
 import com.liferay.document.library.kernel.util.comparator.RepositoryModelCreateDateComparator;
 import com.liferay.document.library.kernel.util.comparator.RepositoryModelModifiedDateComparator;
@@ -26,7 +26,7 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.configuration.Filter;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
@@ -44,7 +44,7 @@ import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Hits;
 import com.liferay.portal.kernel.service.ServiceContext;
-import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalServiceUtil;
+import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalService;
 import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.trash.helper.TrashHelper;
@@ -58,7 +58,7 @@ import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
-import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PrefsPropsUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
@@ -88,10 +88,14 @@ import javax.portlet.PortletURL;
 
 import javax.servlet.http.HttpServletRequest;
 
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
 /**
  * @author Brian Wing Shun Chan
  * @author Julio Camarero
  */
+@Component(service = DL.class)
 public class DLImpl implements DL {
 
 	@Override
@@ -142,12 +146,12 @@ public class DLImpl implements DL {
 			return themeDisplay.translate("home");
 		}
 
-		Folder folder = DLAppLocalServiceUtil.getFolder(folderId);
+		Folder folder = _dlAppLocalService.getFolder(folderId);
 
 		List<Folder> folders = folder.getAncestors();
 
 		if (rootFolderId != DLFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
-			Folder rootFolder = DLAppLocalServiceUtil.getFolder(rootFolderId);
+			Folder rootFolder = _dlAppLocalService.getFolder(rootFolderId);
 
 			if (!folders.contains(rootFolder)) {
 				throw new InvalidFolderException(
@@ -236,40 +240,40 @@ public class DLImpl implements DL {
 
 		return LinkedHashMapBuilder.put(
 			"[$COMPANY_ID$]",
-			LanguageUtil.get(
+			_language.get(
 				themeDisplay.getLocale(),
 				"the-company-id-associated-with-the-document")
 		).put(
 			"[$COMPANY_MX$]",
-			LanguageUtil.get(
+			_language.get(
 				themeDisplay.getLocale(),
 				"the-company-mx-associated-with-the-document")
 		).put(
 			"[$COMPANY_NAME$]",
-			LanguageUtil.get(
+			_language.get(
 				themeDisplay.getLocale(),
 				"the-company-name-associated-with-the-document")
 		).put(
 			"[$DOCUMENT_TITLE$]",
-			LanguageUtil.get(themeDisplay.getLocale(), "the-document-title")
+			_language.get(themeDisplay.getLocale(), "the-document-title")
 		).put(
 			"[$DOCUMENT_TYPE$]",
-			LanguageUtil.get(themeDisplay.getLocale(), "the-document-type")
+			_language.get(themeDisplay.getLocale(), "the-document-type")
 		).put(
 			"[$DOCUMENT_URL$]",
-			LanguageUtil.get(themeDisplay.getLocale(), "the-document-url")
+			_language.get(themeDisplay.getLocale(), "the-document-url")
 		).put(
 			"[$DOCUMENT_USER_ADDRESS$]",
-			LanguageUtil.get(
+			_language.get(
 				themeDisplay.getLocale(),
 				"the-email-address-of-the-user-who-added-the-document")
 		).put(
 			"[$DOCUMENT_USER_NAME$]",
-			LanguageUtil.get(
+			_language.get(
 				themeDisplay.getLocale(), "the-user-who-added-the-document")
 		).put(
 			"[$FOLDER_NAME$]",
-			LanguageUtil.get(
+			_language.get(
 				themeDisplay.getLocale(),
 				"the-folder-in-which-the-document-has-been-added")
 		).put(
@@ -293,16 +297,16 @@ public class DLImpl implements DL {
 			}
 		).put(
 			"[$SITE_NAME$]",
-			LanguageUtil.get(
+			_language.get(
 				themeDisplay.getLocale(),
 				"the-site-name-associated-with-the-document")
 		).put(
 			"[$TO_ADDRESS$]",
-			LanguageUtil.get(
+			_language.get(
 				themeDisplay.getLocale(), "the-address-of-the-email-recipient")
 		).put(
 			"[$TO_NAME$]",
-			LanguageUtil.get(
+			_language.get(
 				themeDisplay.getLocale(), "the-name-of-the-email-recipient")
 		).build();
 	}
@@ -317,31 +321,31 @@ public class DLImpl implements DL {
 
 		return LinkedHashMapBuilder.put(
 			"[$COMPANY_ID$]",
-			LanguageUtil.get(
+			_language.get(
 				themeDisplay.getLocale(),
 				"the-company-id-associated-with-the-document")
 		).put(
 			"[$COMPANY_MX$]",
-			LanguageUtil.get(
+			_language.get(
 				themeDisplay.getLocale(),
 				"the-company-mx-associated-with-the-document")
 		).put(
 			"[$COMPANY_NAME$]",
-			LanguageUtil.get(
+			_language.get(
 				themeDisplay.getLocale(),
 				"the-company-name-associated-with-the-document")
 		).put(
 			"[$DOCUMENT_STATUS_BY_USER_NAME$]",
-			LanguageUtil.get(
+			_language.get(
 				themeDisplay.getLocale(), "the-user-who-updated-the-document")
 		).put(
 			"[$DOCUMENT_USER_ADDRESS$]",
-			LanguageUtil.get(
+			_language.get(
 				themeDisplay.getLocale(),
 				"the-email-address-of-the-user-who-added-the-document")
 		).put(
 			"[$DOCUMENT_USER_NAME$]",
-			LanguageUtil.get(
+			_language.get(
 				themeDisplay.getLocale(), "the-user-who-added-the-document")
 		).put(
 			"[$PORTLET_NAME$]",
@@ -353,7 +357,7 @@ public class DLImpl implements DL {
 			}
 		).put(
 			"[$SITE_NAME$]",
-			LanguageUtil.get(
+			_language.get(
 				themeDisplay.getLocale(),
 				"the-site-name-associated-with-the-document")
 		).build();
@@ -368,7 +372,7 @@ public class DLImpl implements DL {
 				document.get(Field.ENTRY_CLASS_PK));
 
 			try {
-				entries.add(DLAppLocalServiceUtil.getFileEntry(fileEntryId));
+				entries.add(_dlAppLocalService.getFileEntry(fileEntryId));
 			}
 			catch (Exception exception) {
 				if (_log.isWarnEnabled()) {
@@ -451,7 +455,7 @@ public class DLImpl implements DL {
 			sb.append(themeDisplay.getPortalURL());
 		}
 
-		sb.append(PortalUtil.getPathContext());
+		sb.append(_portal.getPathContext());
 		sb.append("/documents/");
 		sb.append(fileEntry.getRepositoryId());
 		sb.append(StringPool.SLASH);
@@ -490,12 +494,12 @@ public class DLImpl implements DL {
 
 		if (themeDisplay != null) {
 			if (Validator.isNotNull(themeDisplay.getDoAsUserId())) {
-				previewURL = PortalUtil.addPreservedParameters(
+				previewURL = _portal.addPreservedParameters(
 					themeDisplay, previewURL, false, true);
 			}
 
 			if (themeDisplay.isAddSessionIdToURL()) {
-				previewURL = PortalUtil.getURLWithSessionId(
+				previewURL = _portal.getURLWithSessionId(
 					previewURL, themeDisplay.getSessionId());
 			}
 		}
@@ -706,8 +710,7 @@ public class DLImpl implements DL {
 		long companyId, long groupId, long folderId, long fileEntryTypeId) {
 
 		while (folderId != DLFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
-			DLFolder dlFolder = DLFolderLocalServiceUtil.fetchDLFolder(
-				folderId);
+			DLFolder dlFolder = _dlFolderLocalService.fetchDLFolder(folderId);
 
 			if (dlFolder == null) {
 				return false;
@@ -722,10 +725,10 @@ public class DLImpl implements DL {
 			folderId = dlFolder.getParentFolderId();
 		}
 
-		if (WorkflowDefinitionLinkLocalServiceUtil.hasWorkflowDefinitionLink(
+		if (_workflowDefinitionLinkLocalService.hasWorkflowDefinitionLink(
 				companyId, groupId, DLFolderConstants.getClassName(), folderId,
 				fileEntryTypeId) ||
-			WorkflowDefinitionLinkLocalServiceUtil.hasWorkflowDefinitionLink(
+			_workflowDefinitionLinkLocalService.hasWorkflowDefinitionLink(
 				companyId, groupId, DLFolderConstants.getClassName(), folderId,
 				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_ALL)) {
 
@@ -824,7 +827,7 @@ public class DLImpl implements DL {
 		PortletURL portletURL = null;
 
 		long plid = serviceContext.getPlid();
-		long controlPanelPlid = PortalUtil.getControlPanelPlid(
+		long controlPanelPlid = _portal.getControlPanelPlid(
 			serviceContext.getCompanyId());
 		String portletId = PortletProviderUtil.getPortletId(
 			FileEntry.class.getName(), PortletProvider.Action.VIEW);
@@ -846,7 +849,7 @@ public class DLImpl implements DL {
 		if ((plid == controlPanelPlid) ||
 			(plid == LayoutConstants.DEFAULT_PLID)) {
 
-			portletURL = PortalUtil.getControlPanelPortletURL(
+			portletURL = _portal.getControlPanelPortletURL(
 				httpServletRequest, portletId, PortletRequest.RENDER_PHASE);
 		}
 		else {
@@ -899,7 +902,7 @@ public class DLImpl implements DL {
 		long groupId, String extension, long folderId, String title) {
 
 		try {
-			DLAppLocalServiceUtil.getFileEntryByFileName(
+			_dlAppLocalService.getFileEntryByFileName(
 				groupId, folderId, getTitleWithExtension(title, extension));
 		}
 		catch (Exception exception) {
@@ -917,8 +920,7 @@ public class DLImpl implements DL {
 		long groupId, long folderId, String uniqueFileTitle) {
 
 		try {
-			DLAppLocalServiceUtil.getFileEntry(
-				groupId, folderId, uniqueFileTitle);
+			_dlAppLocalService.getFileEntry(groupId, folderId, uniqueFileTitle);
 		}
 		catch (Exception exception) {
 			if (_log.isDebugEnabled()) {
@@ -1038,5 +1040,21 @@ public class DLImpl implements DL {
 			_populateGenericNamesMap(genericName);
 		}
 	}
+
+	@Reference
+	private DLAppLocalService _dlAppLocalService;
+
+	@Reference
+	private DLFolderLocalService _dlFolderLocalService;
+
+	@Reference
+	private Language _language;
+
+	@Reference
+	private Portal _portal;
+
+	@Reference
+	private WorkflowDefinitionLinkLocalService
+		_workflowDefinitionLinkLocalService;
 
 }

--- a/portal-impl/src/META-INF/document-library-spring.xml
+++ b/portal-impl/src/META-INF/document-library-spring.xml
@@ -10,10 +10,5 @@
 	<bean class="com.liferay.document.library.kernel.store.DLStoreUtil">
 		<property name="store" ref="com.liferay.portlet.documentlibrary.store.DLStoreImpl" />
 	</bean>
-	<bean class="com.liferay.document.library.kernel.util.DLUtil">
-		<property name="DL">
-			<bean class="com.liferay.portlet.documentlibrary.util.DLImpl" destroy-method="destroy" />
-		</property>
-	</bean>
 	<bean class="com.liferay.portlet.documentlibrary.store.DLStoreImpl" id="com.liferay.portlet.documentlibrary.store.DLStoreImpl" />
 </beans>

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/util/packageinfo
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/util/packageinfo
@@ -1,1 +1,1 @@
-version 12.0.0
+version 13.0.0

--- a/portal-kernel/src/com/liferay/document/library/kernel/util/DLUtil.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/util/DLUtil.java
@@ -8,6 +8,7 @@ package com.liferay.document.library.kernel.util;
 import com.liferay.document.library.kernel.model.DLFileEntryType;
 import com.liferay.document.library.kernel.model.DLFileVersion;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.module.service.Snapshot;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.FileVersion;
 import com.liferay.portal.kernel.search.Hits;
@@ -29,51 +30,51 @@ import javax.portlet.RenderRequest;
 public class DLUtil {
 
 	public static int compareVersions(String version1, String version2) {
-		return _dl.compareVersions(version1, version2);
+		return getDL().compareVersions(version1, version2);
 	}
 
 	public static String getAbsolutePath(
 			PortletRequest portletRequest, long rootFolderId, long folderId)
 		throws PortalException {
 
-		return _dl.getAbsolutePath(portletRequest, rootFolderId, folderId);
+		return getDL().getAbsolutePath(portletRequest, rootFolderId, folderId);
 	}
 
 	public static Set<String> getAllMediaGalleryMimeTypes() {
-		return _dl.getAllMediaGalleryMimeTypes();
+		return getDL().getAllMediaGalleryMimeTypes();
 	}
 
 	public static String getDDMStructureKey(DLFileEntryType dlFileEntryType) {
-		return _dl.getDDMStructureKey(dlFileEntryType);
+		return getDL().getDDMStructureKey(dlFileEntryType);
 	}
 
 	public static String getDDMStructureKey(String fileEntryTypeUuid) {
-		return _dl.getDDMStructureKey(fileEntryTypeUuid);
+		return getDL().getDDMStructureKey(fileEntryTypeUuid);
 	}
 
 	public static String getDeprecatedDDMStructureKey(
 		DLFileEntryType dlFileEntryType) {
 
-		return _dl.getDeprecatedDDMStructureKey(dlFileEntryType);
+		return getDL().getDeprecatedDDMStructureKey(dlFileEntryType);
 	}
 
 	public static String getDeprecatedDDMStructureKey(long fileEntryTypeId) {
-		return _dl.getDeprecatedDDMStructureKey(fileEntryTypeId);
+		return getDL().getDeprecatedDDMStructureKey(fileEntryTypeId);
 	}
 
 	public static String getDividedPath(long id) {
-		return _dl.getDividedPath(id);
+		return getDL().getDividedPath(id);
 	}
 
 	public static DL getDL() {
-		return _dl;
+		return _dlSnapshot.get();
 	}
 
 	public static Map<String, String> getEmailDefinitionTerms(
 		RenderRequest renderRequest, String emailFromAddress,
 		String emailFromName) {
 
-		return _dl.getEmailDefinitionTerms(
+		return getDL().getEmailDefinitionTerms(
 			renderRequest, emailFromAddress, emailFromName);
 	}
 
@@ -81,30 +82,30 @@ public class DLUtil {
 		RenderRequest renderRequest, String emailFromAddress,
 		String emailFromName) {
 
-		return _dl.getEmailFromDefinitionTerms(
+		return getDL().getEmailFromDefinitionTerms(
 			renderRequest, emailFromAddress, emailFromName);
 	}
 
 	public static List<FileEntry> getFileEntries(Hits hits) {
-		return _dl.getFileEntries(hits);
+		return getDL().getFileEntries(hits);
 	}
 
 	public static String getFileEntryImage(
 		FileEntry fileEntry, ThemeDisplay themeDisplay) {
 
-		return _dl.getFileEntryImage(fileEntry, themeDisplay);
+		return getDL().getFileEntryImage(fileEntry, themeDisplay);
 	}
 
 	public static String getFileIcon(String extension) {
-		return _dl.getFileIcon(extension);
+		return getDL().getFileIcon(extension);
 	}
 
 	public static String getFileIconCssClass(String extension) {
-		return _dl.getFileIconCssClass(extension);
+		return getDL().getFileIconCssClass(extension);
 	}
 
 	public static String getGenericName(String extension) {
-		return _dl.getGenericName(extension);
+		return getDL().getGenericName(extension);
 	}
 
 	/**
@@ -117,7 +118,7 @@ public class DLUtil {
 		FileEntry fileEntry, FileVersion fileVersion, ThemeDisplay themeDisplay,
 		String queryString) {
 
-		return _dl.getPreviewURL(
+		return getDL().getPreviewURL(
 			fileEntry, fileVersion, themeDisplay, queryString);
 	}
 
@@ -132,7 +133,7 @@ public class DLUtil {
 		FileEntry fileEntry, FileVersion fileVersion, ThemeDisplay themeDisplay,
 		String queryString, boolean appendVersion, boolean absoluteURL) {
 
-		return _dl.getPreviewURL(
+		return getDL().getPreviewURL(
 			fileEntry, fileVersion, themeDisplay, queryString, appendVersion,
 			absoluteURL);
 	}
@@ -140,86 +141,87 @@ public class DLUtil {
 	public static <T> OrderByComparator<T> getRepositoryModelOrderByComparator(
 		String orderByCol, String orderByType) {
 
-		return _dl.getRepositoryModelOrderByComparator(orderByCol, orderByType);
+		return getDL().getRepositoryModelOrderByComparator(
+			orderByCol, orderByType);
 	}
 
 	public static <T> OrderByComparator<T> getRepositoryModelOrderByComparator(
 		String orderByCol, String orderByType, boolean orderByModel) {
 
-		return _dl.getRepositoryModelOrderByComparator(
+		return getDL().getRepositoryModelOrderByComparator(
 			orderByCol, orderByType, orderByModel);
 	}
 
 	public static String getSanitizedFileName(String title, String extension) {
-		return _dl.getSanitizedFileName(title, extension);
+		return getDL().getSanitizedFileName(title, extension);
 	}
 
 	public static String getTempFileId(long id, String version) {
-		return _dl.getTempFileId(id, version);
+		return getDL().getTempFileId(id, version);
 	}
 
 	public static String getTempFileId(
 		long id, String version, String languageId) {
 
-		return _dl.getTempFileId(id, version, languageId);
+		return getDL().getTempFileId(id, version, languageId);
 	}
 
 	public static String getThumbnailStyle() {
-		return _dl.getThumbnailStyle();
+		return getDL().getThumbnailStyle();
 	}
 
 	public static String getThumbnailStyle(boolean max, int margin) {
-		return _dl.getThumbnailStyle(max, margin);
+		return getDL().getThumbnailStyle(max, margin);
 	}
 
 	public static String getThumbnailStyle(
 		boolean max, int margin, int height, int width) {
 
-		return _dl.getThumbnailStyle(max, margin, height, width);
+		return getDL().getThumbnailStyle(max, margin, height, width);
 	}
 
 	public static String getTitleWithExtension(FileEntry fileEntry) {
-		return _dl.getTitleWithExtension(fileEntry);
+		return getDL().getTitleWithExtension(fileEntry);
 	}
 
 	public static String getTitleWithExtension(String title, String extension) {
-		return _dl.getTitleWithExtension(title, extension);
+		return getDL().getTitleWithExtension(title, extension);
 	}
 
 	public static String getUniqueFileName(
 		long groupId, long folderId, String fileName,
 		boolean ignoreDuplicateTitle) {
 
-		return _dl.getUniqueFileName(
+		return getDL().getUniqueFileName(
 			groupId, folderId, fileName, ignoreDuplicateTitle);
 	}
 
 	public static String getUniqueTitle(
 		long groupId, long folderId, String title) {
 
-		return _dl.getUniqueTitle(groupId, folderId, title);
+		return getDL().getUniqueTitle(groupId, folderId, title);
 	}
 
 	public static boolean hasWorkflowDefinitionLink(
 		long companyId, long groupId, long folderId, long fileEntryTypeId) {
 
-		return _dl.hasWorkflowDefinitionLink(
+		return getDL().hasWorkflowDefinitionLink(
 			companyId, groupId, folderId, fileEntryTypeId);
 	}
 
 	public static boolean isAutoGeneratedDLFileEntryTypeDDMStructureKey(
 		String ddmStructureKey) {
 
-		return _dl.isAutoGeneratedDLFileEntryTypeDDMStructureKey(
+		return getDL().isAutoGeneratedDLFileEntryTypeDDMStructureKey(
 			ddmStructureKey);
 	}
 
 	public static boolean isOfficeExtension(String extension) {
-		return _dl.isOfficeExtension(extension);
+		return getDL().isOfficeExtension(extension);
 	}
 
 	public static boolean isValidVersion(String version) {
-		return _dl.isValidVersion(version);
+		return getDL().isValidVersion(version);
 	}
 
 	public static void startWorkflowInstance(
@@ -227,14 +229,11 @@ public class DLUtil {
 			ServiceContext serviceContext)
 		throws PortalException {
 
-		_dl.startWorkflowInstance(
+		getDL().startWorkflowInstance(
 			userId, dlFileVersion, syncEventType, serviceContext);
 	}
 
-	public void setDL(DL dl) {
-		_dl = dl;
-	}
-
-	private static DL _dl;
+	private static final Snapshot<DL> _dlSnapshot = new Snapshot<>(
+		DLUtil.class, DL.class);
 
 }

--- a/portal-kernel/src/com/liferay/document/library/kernel/util/packageinfo
+++ b/portal-kernel/src/com/liferay/document/library/kernel/util/packageinfo
@@ -1,1 +1,1 @@
-version 13.0.0
+version 14.0.0


### PR DESCRIPTION
Currently when adding a new file we try to generate a link to it (it is used in the notifications).

To do so, we iterate over all the pages searching for a public DL portlet.

If we have too many pages it could take some minutes to iterate.

Taking this into account, since DLFileEntries have AssetDisplayPages, if its configured we could avoid iterate over all this pages and the performance issue is not reproducible.

To fix this I've moved DLImpl from portal-impl to DM modules so I could reach the tools to get this url as fast as possible in order to avoid this iterations over a ton of pages.