### PR TITLE
LPS-202810 AMImageContentTransformerTest test failure

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-image-content-transformer-test/src/testIntegration/java/com/liferay/adaptive/media/image/content/transformer/test/AMImageContentTransformerTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-content-transformer-test/src/testIntegration/java/com/liferay/adaptive/media/image/content/transformer/test/AMImageContentTransformerTest.java
@@ -5,6 +5,7 @@
 
 package com.liferay.adaptive.media.image.content.transformer.test;
 
+import com.liferay.adaptive.media.content.transformer.ContentTransformer;
 import com.liferay.adaptive.media.content.transformer.ContentTransformerHandler;
 import com.liferay.adaptive.media.content.transformer.constants.ContentTransformerContentTypes;
 import com.liferay.adaptive.media.image.configuration.AMImageConfigurationEntry;
@@ -125,5 +126,12 @@ public class AMImageContentTransformerTest {
 
 	@DeleteAfterTestRun
 	private Group _group;
+
+	// See LPS-202810
+
+	@Inject(
+		filter = "component.name=com.liferay.adaptive.media.image.content.transformer.internal.HtmlContentTransformerImpl"
+	)
+	private ContentTransformer<String> _htmlContentTransformer;
 
 }


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPS-202810

There are intermitent test failures in the CI.

# How am I fixing it?

The only way I could reproduce it locally was to manually disable one
of the required components (the default HTML transformer). Adding an
explicit dependency for that service in the test should prevent it
from running until everything is ready.

# How can you verify that it works?

Follow the steps described in https://liferay.atlassian.net/browse/LPS-202810.