### PR TITLE
LPS-202876 Add KB trash handler tests for KB Folder (2nd PR)

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBFolderLocalService.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBFolderLocalService.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.dao.orm.Projection;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.model.PersistedModel;
+import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.search.Indexable;
 import com.liferay.portal.kernel.search.IndexableType;
 import com.liferay.portal.kernel.service.BaseLocalService;
@@ -25,6 +26,7 @@ import com.liferay.portal.kernel.service.PersistedModelLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.change.tracking.CTService;
 import com.liferay.portal.kernel.service.persistence.change.tracking.CTPersistence;
+import com.liferay.portal.kernel.systemevent.SystemEvent;
 import com.liferay.portal.kernel.transaction.Isolation;
 import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.Transactional;
@@ -109,6 +111,10 @@ public interface KBFolderLocalService
 	@Indexable(type = IndexableType.DELETE)
 	public KBFolder deleteKBFolder(KBFolder kbFolder) throws PortalException;
 
+	@SystemEvent(
+		action = SystemEventConstants.ACTION_SKIP,
+		type = SystemEventConstants.TYPE_DELETE
+	)
 	public KBFolder deleteKBFolder(
 			KBFolder kbFolder, boolean includeTrashedEntries)
 		throws PortalException;

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/resources/com/liferay/knowledge/base/service/packageinfo
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/resources/com/liferay/knowledge/base/service/packageinfo
@@ -1,1 +1,1 @@
-version 12.0.0
+version 12.0.1

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/security/permission/resource/KBFolderModelResourcePermissionWrapper.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/security/permission/resource/KBFolderModelResourcePermissionWrapper.java
@@ -77,8 +77,14 @@ public class KBFolderModelResourcePermissionWrapper
 
 			kbFolder = _kbFolderLocalService.fetchKBFolder(parentKBFolderId);
 
-			return _kbFolderModelResourcePermission.contains(
-				permissionChecker, kbFolder, actionId);
+			if ((kbFolder != null) &&
+				!_kbFolderModelResourcePermission.contains(
+					permissionChecker, kbFolder, actionId)) {
+
+				return false;
+			}
+
+			return null;
 		}
 
 		private KBFolderDynamicInheritanceModelResourcePermissionLogic(

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBFolderLocalServiceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBFolderLocalServiceImpl.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.dao.orm.QueryDefinition;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistryUtil;
@@ -30,6 +31,7 @@ import com.liferay.portal.kernel.service.ResourceLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.service.permission.ModelPermissions;
+import com.liferay.portal.kernel.systemevent.SystemEvent;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -118,10 +120,14 @@ public class KBFolderLocalServiceImpl extends KBFolderLocalServiceBaseImpl {
 
 	@Override
 	public KBFolder deleteKBFolder(KBFolder kbFolder) throws PortalException {
-		return deleteKBFolder(kbFolder, true);
+		return kbFolderLocalService.deleteKBFolder(kbFolder, true);
 	}
 
 	@Override
+	@SystemEvent(
+		action = SystemEventConstants.ACTION_SKIP,
+		type = SystemEventConstants.TYPE_DELETE
+	)
 	public KBFolder deleteKBFolder(
 			KBFolder kbFolder, boolean includeTrashedEntries)
 		throws PortalException {
@@ -171,7 +177,8 @@ public class KBFolderLocalServiceImpl extends KBFolderLocalServiceBaseImpl {
 
 		KBFolder kbFolder = kbFolderPersistence.findByPrimaryKey(kbFolderId);
 
-		return deleteKBFolder(kbFolder, includeTrashedEntries);
+		return kbFolderLocalService.deleteKBFolder(
+			kbFolder, includeTrashedEntries);
 	}
 
 	@Override

--- a/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/trash/test/KBFolderTrashHandlerTest.java
+++ b/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/trash/test/KBFolderTrashHandlerTest.java
@@ -1,0 +1,195 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.knowledge.base.trash.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.knowledge.base.constants.KBFolderConstants;
+import com.liferay.knowledge.base.model.KBFolder;
+import com.liferay.knowledge.base.service.KBFolderLocalServiceUtil;
+import com.liferay.knowledge.base.test.util.KBTestUtil;
+import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.ClassedModel;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.TrashedModel;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.trash.TrashHelper;
+import com.liferay.trash.test.util.BaseTrashHandlerTestCase;
+import com.liferay.trash.test.util.WhenHasGrandParent;
+import com.liferay.trash.test.util.WhenHasMyBaseModel;
+import com.liferay.trash.test.util.WhenIsMoveableFromTrashBaseModel;
+import com.liferay.trash.test.util.WhenIsRestorableBaseModel;
+import com.liferay.trash.test.util.WhenIsUpdatableBaseModel;
+import com.liferay.trash.test.util.WhenParentModelIsSameType;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Marco Galluzzi
+ */
+@FeatureFlags("LPS-188058")
+@RunWith(Arquillian.class)
+public class KBFolderTrashHandlerTest
+	extends BaseTrashHandlerTestCase
+	implements WhenHasGrandParent, WhenHasMyBaseModel,
+			   WhenIsMoveableFromTrashBaseModel, WhenIsRestorableBaseModel,
+			   WhenIsUpdatableBaseModel, WhenParentModelIsSameType {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Override
+	public int getMineBaseModelsCount(long groupId, long userId)
+		throws Exception {
+
+		return KBFolderLocalServiceUtil.getKBFoldersCount(
+			groupId, KBFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			WorkflowConstants.STATUS_APPROVED);
+	}
+
+	@Override
+	public String getParentBaseModelClassName() {
+		return KBFolder.class.getName();
+	}
+
+	@Override
+	public BaseModel<?> moveBaseModelFromTrash(
+			ClassedModel classedModel, Group group,
+			ServiceContext serviceContext)
+		throws Exception {
+
+		KBFolder kbFolder = (KBFolder)classedModel;
+
+		KBFolderLocalServiceUtil.moveKBFolderFromTrash(
+			kbFolder.getUserId(), kbFolder.getKbFolderId(),
+			kbFolder.getParentKBFolderId());
+
+		return KBFolderLocalServiceUtil.getKBFolder(
+			kbFolder.getParentKBFolderId());
+	}
+
+	@Override
+	public void moveParentBaseModelToTrash(long primaryKey) throws Exception {
+		KBFolder kbFolder = KBFolderLocalServiceUtil.getKBFolder(primaryKey);
+
+		KBFolderLocalServiceUtil.moveKBFolderToTrash(
+			kbFolder.getUserId(), primaryKey);
+	}
+
+	@Before
+	@Override
+	public void setUp() throws Exception {
+		UserTestUtil.setUser(TestPropsValues.getUser());
+
+		super.setUp();
+	}
+
+	@Override
+	public BaseModel<?> updateBaseModel(
+			long primaryKey, ServiceContext serviceContext)
+		throws Exception {
+
+		KBFolder kbFolder = KBFolderLocalServiceUtil.getKBFolder(primaryKey);
+
+		return KBFolderLocalServiceUtil.updateKBFolder(
+			kbFolder.getClassNameId(), kbFolder.getParentKBFolderId(),
+			kbFolder.getKbFolderId(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), serviceContext);
+	}
+
+	@Override
+	protected BaseModel<?> addBaseModelWithWorkflow(
+			BaseModel<?> parentBaseModel, ServiceContext serviceContext)
+		throws Exception {
+
+		KBFolder kbFolder = (KBFolder)parentBaseModel;
+
+		return KBTestUtil.addKBFolder(
+			kbFolder.getGroupId(), kbFolder.getKbFolderId(), serviceContext);
+	}
+
+	@Override
+	protected void deleteParentBaseModel(
+			BaseModel<?> parentBaseModel, boolean includeTrashedEntries)
+		throws Exception {
+
+		KBFolderLocalServiceUtil.deleteKBFolder(
+			(KBFolder)parentBaseModel, includeTrashedEntries);
+	}
+
+	@Override
+	protected BaseModel<?> getBaseModel(long primaryKey) throws Exception {
+		return KBFolderLocalServiceUtil.getKBFolder(primaryKey);
+	}
+
+	@Override
+	protected Class<?> getBaseModelClass() {
+		return KBFolder.class;
+	}
+
+	@Override
+	protected int getNotInTrashBaseModelsCount(BaseModel<?> parentBaseModel)
+		throws Exception {
+
+		KBFolder kbFolder = (KBFolder)parentBaseModel;
+
+		return KBFolderLocalServiceUtil.getKBFoldersCount(
+			kbFolder.getGroupId(), kbFolder.getKbFolderId(),
+			WorkflowConstants.STATUS_APPROVED);
+	}
+
+	@Override
+	protected BaseModel<?> getParentBaseModel(
+			Group group, long parentBaseModelId, ServiceContext serviceContext)
+		throws Exception {
+
+		return KBTestUtil.addKBFolder(
+			group.getGroupId(), parentBaseModelId, serviceContext);
+	}
+
+	@Override
+	protected BaseModel<?> getParentBaseModel(
+			Group group, ServiceContext serviceContext)
+		throws Exception {
+
+		return getParentBaseModel(
+			group, KBFolderConstants.DEFAULT_PARENT_FOLDER_ID, serviceContext);
+	}
+
+	@Override
+	protected String getUniqueTitle(BaseModel<?> baseModel) {
+		return null;
+	}
+
+	@Override
+	protected boolean isInTrashContainer(TrashedModel trashedModel) {
+		return _trashHelper.isInTrashContainer(trashedModel);
+	}
+
+	@Override
+	protected void moveBaseModelToTrash(long primaryKey) throws Exception {
+		KBFolder kbFolder = KBFolderLocalServiceUtil.getKBFolder(primaryKey);
+
+		KBFolderLocalServiceUtil.moveKBFolderToTrash(
+			kbFolder.getUserId(), kbFolder.getKbFolderId());
+	}
+
+	@Inject
+	private TrashHelper _trashHelper;
+
+}


### PR DESCRIPTION
This PR have a little fix for a problem caught by Brian in https://github.com/brianchandotcom/liferay-portal/pull/144687

* Checked that all calls to `deleteKBFolder(KBFolder, boolean)` should be done through interface this way: `kbFolderLocalService.deleteKBFolder()`

See: https://liferay.atlassian.net/browse/LPS-202876
