### PR TITLE
[TS] LPS-203255 Friendly url input is not loaded correctly when web content's language is different from site's language

### DIFF
--- a/modules/apps/friendly-url/friendly-url-taglib/bnd.bnd
+++ b/modules/apps/friendly-url/friendly-url-taglib/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Friendly URL Taglib
 Bundle-SymbolicName: com.liferay.friendly.url.taglib
-Bundle-Version: 1.4.6
+Bundle-Version: 1.5.0
 Export-Package: com.liferay.friendly.url.taglib.servlet.taglib
 Provide-Capability:\
 	osgi.extender;\

--- a/modules/apps/friendly-url/friendly-url-taglib/package.json
+++ b/modules/apps/friendly-url/friendly-url-taglib/package.json
@@ -22,5 +22,5 @@
 		"format": "liferay-npm-scripts fix",
 		"test": "liferay-npm-scripts test"
 	},
-	"version": "1.4.6"
+	"version": "1.5.0"
 }

--- a/modules/apps/friendly-url/friendly-url-taglib/src/main/java/com/liferay/friendly/url/taglib/servlet/taglib/InputTag.java
+++ b/modules/apps/friendly-url/friendly-url-taglib/src/main/java/com/liferay/friendly/url/taglib/servlet/taglib/InputTag.java
@@ -47,6 +47,10 @@ public class InputTag extends IncludeTag {
 		return _classPK;
 	}
 
+	public String getDefaultLanguageId() {
+		return _defaultLanguageId;
+	}
+
 	public String getHelpMessage() {
 		return _helpMessage;
 	}
@@ -81,6 +85,10 @@ public class InputTag extends IncludeTag {
 
 	public void setClassPK(long classPK) {
 		_classPK = classPK;
+	}
+
+	public void setDefaultLanguageId(String defaultLanguageId) {
+		_defaultLanguageId = defaultLanguageId;
 	}
 
 	public void setDisabled(boolean disabled) {
@@ -124,6 +132,7 @@ public class InputTag extends IncludeTag {
 
 		_className = null;
 		_classPK = 0;
+		_defaultLanguageId = null;
 		_disabled = false;
 		_helpMessage = null;
 		_inputAddon = null;
@@ -146,6 +155,9 @@ public class InputTag extends IncludeTag {
 			"liferay-friendly-url:input:className", getClassName());
 		httpServletRequest.setAttribute(
 			"liferay-friendly-url:input:classPK", getClassPK());
+		httpServletRequest.setAttribute(
+			"liferay-friendly-url:input:defaultLanguageId",
+			getDefaultLanguageId());
 		httpServletRequest.setAttribute(
 			"liferay-friendly-url:input:disabled", isDisabled());
 		httpServletRequest.setAttribute(
@@ -295,6 +307,7 @@ public class InputTag extends IncludeTag {
 
 	private String _className;
 	private long _classPK;
+	private String _defaultLanguageId;
 	private boolean _disabled;
 	private String _helpMessage;
 	private String _inputAddon;

--- a/modules/apps/friendly-url/friendly-url-taglib/src/main/resources/META-INF/liferay-friendly-url.tld
+++ b/modules/apps/friendly-url/friendly-url-taglib/src/main/resources/META-INF/liferay-friendly-url.tld
@@ -55,6 +55,11 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
+			<name>defaultLanguageId</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
 			<name>disabled</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>

--- a/modules/apps/friendly-url/friendly-url-taglib/src/main/resources/META-INF/resources/input/page.jsp
+++ b/modules/apps/friendly-url/friendly-url-taglib/src/main/resources/META-INF/resources/input/page.jsp
@@ -8,11 +8,16 @@
 <%@ include file="/input/init.jsp" %>
 
 <%
+String defaultLanguageId = (String)request.getAttribute("liferay-friendly-url:input:defaultLanguageId");
 boolean disabled = (boolean)request.getAttribute("liferay-friendly-url:input:disabled");
 int friendlyURLMaxLength = (int)request.getAttribute("liferay-friendly-url:input:friendlyURLMaxLength");
 boolean localizable = (boolean)request.getAttribute("liferay-friendly-url:input:localizable");
 String name = (String)request.getAttribute("liferay-friendly-url:input:name");
 String value = (String)request.getAttribute("liferay-friendly-url:input:value");
+
+if (defaultLanguageId == null) {
+	defaultLanguageId = LocaleUtil.toLanguageId(themeDisplay.getSiteDefaultLocale());
+}
 %>
 
 <c:if test='<%= (boolean)request.getAttribute("liferay-friendly-url:input:showHistory") %>'>
@@ -37,7 +42,7 @@ String value = (String)request.getAttribute("liferay-friendly-url:input:value");
 	<c:choose>
 		<c:when test="<%= localizable %>">
 			<liferay-ui:input-localized
-				defaultLanguageId="<%= LocaleUtil.toLanguageId(themeDisplay.getSiteDefaultLocale()) %>"
+				defaultLanguageId="<%= defaultLanguageId %>"
 				disabled="<%= disabled %>"
 				helpMessage='<%= (String)request.getAttribute("liferay-friendly-url:input:helpMessage") %>'
 				ignoreRequestValue="<%= SessionErrors.isEmpty(request) %>"

--- a/modules/apps/friendly-url/friendly-url-taglib/src/main/resources/com/liferay/friendly/url/taglib/servlet/taglib/packageinfo
+++ b/modules/apps/friendly-url/friendly-url-taglib/src/main/resources/com/liferay/friendly/url/taglib/servlet/taglib/packageinfo
@@ -1,1 +1,1 @@
-version 1.4.0
+version 1.5.0

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/article/friendly_url.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/article/friendly_url.jsp
@@ -28,6 +28,7 @@ JournalEditArticleDisplayContext journalEditArticleDisplayContext = new JournalE
 <liferay-friendly-url:input
 	className="<%= JournalArticle.class.getName() %>"
 	classPK="<%= (article == null) || (article.getPrimaryKey() == 0) ? 0 : article.getResourcePrimKey() %>"
+	defaultLanguageId="<%= journalEditArticleDisplayContext.getDefaultArticleLanguageId() %>"
 	inputAddon="<%= journalEditArticleDisplayContext.getFriendlyURLBase() %>"
 	name="friendlyURL"
 	showHistory="<%= false %>"


### PR DESCRIPTION
Friendly url input's language is not loaded correctly when web content's language is different from site's language. 
Please check:
- https://liferay.atlassian.net/browse/LPS-203255

Lima needs to check [taglib extension](https://github.com/liferay-echo/liferay-portal/pull/14606#issuecomment-1838819322) 