### PR TITLE
[TS] LPS-203124 Set the model's defaultLanguageId as languageId if it exists

### DIFF
--- a/modules/apps/friendly-url/friendly-url-taglib/src/main/java/com/liferay/friendly/url/taglib/servlet/taglib/InputTag.java
+++ b/modules/apps/friendly-url/friendly-url-taglib/src/main/java/com/liferay/friendly/url/taglib/servlet/taglib/InputTag.java
@@ -209,8 +209,13 @@ public class InputTag extends IncludeTag {
 				return urlTitle;
 			}
 
-			String languageId = LanguageUtil.getLanguageId(
-				LocaleUtil.getDefault());
+			String languageId = BeanPropertiesUtil.getString(
+				_getModel(), "defaultLanguageId");
+
+			if (languageId == null) {
+				languageId = LanguageUtil.getLanguageId(
+					LocaleUtil.getDefault());
+			}
 
 			return LocalizationUtil.getXml(
 				HashMapBuilder.put(


### PR DESCRIPTION
Hi Team,
https://liferay.atlassian.net/browse/LPS-203124

Issue:
If web contents are missing their friendlyURL (missing from the DB), the friendlyURL has to be generated on the fly. This is only an issue when the web content has a different defaultLanguage than the Site's defaultLanguage. Because the code uses the Site's defaultLanguage during this process, the friendlyURL is generated under the wrong language flag.
In the original ticket, it happened after upgrading from DXP 7.0 to DXP 7.4.

Solution:
I added a fix that uses the web content's default language ID if it finds any. If it does not have a default language ID, it works the same way as before.

I tested this solution in my local environment on master and it worked as expected.

Please review my PR!

Additional info: the web content still has the wrong language flag after opening it, but at least the friendlyURL is correctly generated. I created another LPS for this issue: https://liferay.atlassian.net/browse/LPS-203385
Feel free to discard this PR, if only this other LPS needs to be fixed instead.

Best regards,
Évi