### PR TITLE
LPS-203356 Do not allow show categories from other scopes

### DIFF
--- a/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/portlet/action/ActionUtil.java
+++ b/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/portlet/action/ActionUtil.java
@@ -5,6 +5,7 @@
 
 package com.liferay.message.boards.web.internal.portlet.action;
 
+import com.liferay.message.boards.exception.NoSuchCategoryException;
 import com.liferay.message.boards.exception.NoSuchMessageException;
 import com.liferay.message.boards.model.MBCategory;
 import com.liferay.message.boards.model.MBMessage;
@@ -16,6 +17,7 @@ import com.liferay.message.boards.service.MBMessageLocalServiceUtil;
 import com.liferay.message.boards.service.MBMessageServiceUtil;
 import com.liferay.message.boards.service.MBThreadLocalServiceUtil;
 import com.liferay.message.boards.web.internal.security.permission.MBResourcePermission;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
@@ -67,6 +69,13 @@ public class ActionUtil {
 
 		if (categoryId > 0) {
 			category = MBCategoryServiceUtil.getCategory(categoryId);
+
+			if (category.getGroupId() != themeDisplay.getScopeGroupId()) {
+				throw new NoSuchCategoryException(
+					StringBundler.concat(
+						"Unable to find Category with Id: ", categoryId,
+						" in group ", themeDisplay.getScopeGroupId()));
+			}
 		}
 		else {
 			MBResourcePermission.check(


### PR DESCRIPTION
I'm adding this restriction to avoid show categories from other sites in the web layer.

This is the smallest change needed.

I could use a different approach and create a new finder in the service if you find it more appropiate.