### PR TITLE
[TS] LPS-203880 Make sure older UpgradeProcess dependency is completed first

### DIFF
--- a/modules/apps/image/image-impl/src/main/java/com/liferay/image/internal/upgrade/registry/ImageServiceUpgradeStepRegistrator.java
+++ b/modules/apps/image/image-impl/src/main/java/com/liferay/image/internal/upgrade/registry/ImageServiceUpgradeStepRegistrator.java
@@ -14,6 +14,7 @@ import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.LayoutSetBranch;
+import com.liferay.portal.kernel.model.Release;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.ImageLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
@@ -75,6 +76,11 @@ public class ImageServiceUpgradeStepRegistrator
 
 	@Reference
 	private LayoutSetLocalService _layoutSetLocalService;
+
+	@Reference(
+		target = "(&(release.bundle.symbolic.name=com.liferay.journal.service)(release.schema.version>=1.1.0))"
+	)
+	private Release _release;
 
 	@Reference(target = "(default=true)")
 	private Store _store;


### PR DESCRIPTION
[LPS-203880](https://liferay.atlassian.net/browse/LPS-203880)

Hi Team,
This looks like a possible race condition between `ImageTypeContentUpgradeProcess` and `ImageStorageUpgradeProcess`
Given that `ImageTypeContentUpgradeProcess` was created 5 years earlier, I'd like to introduce a hard dependency between these 2 steps

Cheers,
Balázs