### PR TITLE
LPS-202905 Check if the file has a friendly URL in order to avoid iterate all the pages

### DIFF
--- a/modules/apps/asset/asset-display-page-api/bnd.bnd
+++ b/modules/apps/asset/asset-display-page-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Asset Display Page API
 Bundle-SymbolicName: com.liferay.asset.display.page.api
-Bundle-Version: 14.1.2
+Bundle-Version: 15.0.0
 Export-Package:\
 	com.liferay.asset.display.page.configuration,\
 	com.liferay.asset.display.page.constants,\

--- a/modules/apps/asset/asset-display-page-api/src/main/java/com/liferay/asset/display/page/portlet/AssetDisplayPageEntryFormProcessor.java
+++ b/modules/apps/asset/asset-display-page-api/src/main/java/com/liferay/asset/display/page/portlet/AssetDisplayPageEntryFormProcessor.java
@@ -6,16 +6,28 @@
 package com.liferay.asset.display.page.portlet;
 
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.service.ServiceContext;
 
 import javax.portlet.PortletRequest;
 
 /**
  * @author Alejandro Tardín
+ * @author Roberto Díaz
  */
 public interface AssetDisplayPageEntryFormProcessor {
 
 	public void process(
+			long userId, long groupId, String className, long classPK,
+			int displayPageType, String layoutUuid, long assetDisplayPageId,
+			ServiceContext serviceContext)
+		throws PortalException;
+
+	public void process(
 			String className, long classPK, PortletRequest portletRequest)
+		throws PortalException;
+
+	public void process(
+			String className, long classPK, ServiceContext serviceContext)
 		throws PortalException;
 
 }

--- a/modules/apps/asset/asset-display-page-api/src/main/resources/com/liferay/asset/display/page/portlet/packageinfo
+++ b/modules/apps/asset/asset-display-page-api/src/main/resources/com/liferay/asset/display/page/portlet/packageinfo
@@ -1,1 +1,1 @@
-version 8.0.0
+version 9.0.0

--- a/modules/apps/document-library/document-library-service/build.gradle
+++ b/modules/apps/document-library/document-library-service/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 	compileOnly project(":apps:export-import:export-import-api")
 	compileOnly project(":apps:friendly-url:friendly-url-api")
 	compileOnly project(":apps:info:info-api")
+	compileOnly project(":apps:layout:layout-page-template-api")
 	compileOnly project(":apps:portal-configuration:portal-configuration-module-configuration-api")
 	compileOnly project(":apps:portal-configuration:portal-configuration-upgrade-api")
 	compileOnly project(":apps:portal-search:portal-search-api")

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/DLAssetDisplayPageUtil.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/DLAssetDisplayPageUtil.java
@@ -1,0 +1,56 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.document.library.internal;
+
+import com.liferay.asset.display.page.constants.AssetDisplayPageConstants;
+import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
+import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
+import com.liferay.layout.page.template.service.LayoutPageTemplateEntryServiceUtil;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+
+/**
+ * @author Roberto Díaz
+ */
+public class DLAssetDisplayPageUtil {
+
+	public static boolean hasAssetDisplayPage(ServiceContext serviceContext) {
+		int displayPageType = ParamUtil.getInteger(
+			serviceContext, "displayPageType",
+			AssetDisplayPageConstants.TYPE_DEFAULT);
+
+		if (displayPageType == AssetDisplayPageConstants.TYPE_DEFAULT) {
+			long fileEntryTypeId = ParamUtil.getLong(
+				serviceContext, "fileEntryTypeId",
+				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT);
+
+			LayoutPageTemplateEntry layoutPageTemplateEntry =
+				LayoutPageTemplateEntryServiceUtil.
+					fetchDefaultLayoutPageTemplateEntry(
+						serviceContext.getScopeGroupId(),
+						PortalUtil.getClassNameId(FileEntry.class),
+						fileEntryTypeId);
+
+			if (layoutPageTemplateEntry == null) {
+				return false;
+			}
+		}
+		else if (displayPageType == AssetDisplayPageConstants.TYPE_NONE) {
+			return false;
+		}
+		else if ((displayPageType == AssetDisplayPageConstants.TYPE_SPECIFIC) &&
+				 (ParamUtil.getLong(serviceContext, "assetDisplayPageId") ==
+					 0)) {
+
+			return false;
+		}
+
+		return true;
+	}
+
+}

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/service/SubscriptionDLAppHelperLocalServiceWrapper.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/service/SubscriptionDLAppHelperLocalServiceWrapper.java
@@ -5,7 +5,6 @@
 
 package com.liferay.document.library.internal.service;
 
-import com.liferay.asset.display.page.constants.AssetDisplayPageConstants;
 import com.liferay.asset.display.page.portlet.AssetDisplayPageFriendlyURLProvider;
 import com.liferay.asset.display.page.service.AssetDisplayPageEntryLocalService;
 import com.liferay.document.library.internal.util.DLSubscriptionSender;
@@ -36,8 +35,8 @@ import com.liferay.portal.kernel.settings.LocalizedValuesMap;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.EscapableLocalizableFunction;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Localization;
-import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.SubscriptionSender;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
@@ -134,18 +133,6 @@ public class SubscriptionDLAppHelperLocalServiceWrapper
 		}
 	}
 
-	private boolean _hasAssetDisplayPage(ServiceContext serviceContext) {
-		int displayPageType = ParamUtil.getInteger(
-			serviceContext, "displayPageType",
-			AssetDisplayPageConstants.TYPE_DEFAULT);
-
-		if (displayPageType == AssetDisplayPageConstants.TYPE_NONE) {
-			return false;
-		}
-
-		return true;
-	}
-
 	private boolean _isEnabled(FileEntry fileEntry) {
 		if (!DLAppHelperThreadLocal.isEnabled() ||
 			RepositoryUtil.isExternalRepository(fileEntry.getRepositoryId())) {
@@ -178,7 +165,10 @@ public class SubscriptionDLAppHelperLocalServiceWrapper
 
 		ThemeDisplay themeDisplay = serviceContext.getThemeDisplay();
 
-		if ((themeDisplay != null) && _hasAssetDisplayPage(serviceContext)) {
+		boolean hasAssetDisplayPage = GetterUtil.getBoolean(
+			serviceContext.getAttribute("hasAssetDisplayPage"));
+
+		if ((themeDisplay != null) && hasAssetDisplayPage) {
 			String friendlyURL =
 				_assetDisplayPageFriendlyURLProvider.getFriendlyURL(
 					new InfoItemReference(

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/service/SubscriptionDLAppHelperLocalServiceWrapper.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/service/SubscriptionDLAppHelperLocalServiceWrapper.java
@@ -5,6 +5,7 @@
 
 package com.liferay.document.library.internal.service;
 
+import com.liferay.asset.display.page.portlet.AssetDisplayPageEntryFormProcessor;
 import com.liferay.asset.display.page.portlet.AssetDisplayPageFriendlyURLProvider;
 import com.liferay.asset.display.page.service.AssetDisplayPageEntryLocalService;
 import com.liferay.document.library.internal.util.DLSubscriptionSender;
@@ -18,6 +19,7 @@ import com.liferay.document.library.kernel.service.DLAppHelperLocalServiceWrappe
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalService;
 import com.liferay.document.library.kernel.util.DLAppHelperThreadLocal;
+import com.liferay.friendly.url.service.FriendlyURLEntryLocalService;
 import com.liferay.info.item.ClassPKInfoItemIdentifier;
 import com.liferay.info.item.InfoItemReference;
 import com.liferay.portal.json.jabsorb.serializer.LiferayJSONDeserializationWhitelist;
@@ -37,6 +39,7 @@ import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.EscapableLocalizableFunction;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Localization;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.SubscriptionSender;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
@@ -103,6 +106,12 @@ public class SubscriptionDLAppHelperLocalServiceWrapper
 		super.updateStatus(
 			userId, fileEntry, latestFileVersion, oldStatus, newStatus,
 			serviceContext, workflowContext);
+
+		// DisplayPage
+
+		_assetDisplayPageEntryFormProcessor.process(
+			FileEntry.class.getName(), fileEntry.getFileEntryId(),
+			serviceContext);
 
 		if ((newStatus == WorkflowConstants.STATUS_APPROVED) &&
 			(oldStatus != WorkflowConstants.STATUS_IN_TRASH) &&
@@ -332,6 +341,10 @@ public class SubscriptionDLAppHelperLocalServiceWrapper
 
 		subscriptionSender.flushNotificationsAsync();
 	}
+
+	@Reference
+	private AssetDisplayPageEntryFormProcessor
+		_assetDisplayPageEntryFormProcessor;
 
 	@Reference
 	private AssetDisplayPageEntryLocalService

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/service/SubscriptionDLAppLocalServiceWrapper.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/service/SubscriptionDLAppLocalServiceWrapper.java
@@ -12,11 +12,14 @@ import com.liferay.document.library.kernel.model.DLFolder;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.model.DLVersionNumberIncrease;
 import com.liferay.document.library.kernel.service.DLAppLocalServiceWrapper;
+import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
+import com.liferay.layout.page.template.service.LayoutPageTemplateEntryService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceWrapper;
 import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.subscription.service.SubscriptionLocalService;
 
 import java.io.File;
@@ -223,12 +226,39 @@ public class SubscriptionDLAppLocalServiceWrapper
 			serviceContext, "displayPageType",
 			AssetDisplayPageConstants.TYPE_DEFAULT);
 
-		if (displayPageType == AssetDisplayPageConstants.TYPE_NONE) {
+		if (displayPageType == AssetDisplayPageConstants.TYPE_DEFAULT) {
+			long fileEntryTypeId = ParamUtil.getLong(
+				serviceContext, "fileEntryTypeId",
+				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT);
+
+			LayoutPageTemplateEntry layoutPageTemplateEntry =
+				_layoutPageTemplateEntryService.
+					fetchDefaultLayoutPageTemplateEntry(
+						serviceContext.getScopeGroupId(),
+						_portal.getClassNameId(FileEntry.class),
+						fileEntryTypeId);
+
+			if (layoutPageTemplateEntry == null) {
+				return false;
+			}
+		}
+		else if (displayPageType == AssetDisplayPageConstants.TYPE_NONE) {
 			return false;
+		}
+		else if (displayPageType == AssetDisplayPageConstants.TYPE_SPECIFIC) {
+			if (ParamUtil.getLong(serviceContext, "assetDisplayPageId") == 0) {
+				return false;
+			}
 		}
 
 		return true;
 	}
+
+	@Reference
+	private LayoutPageTemplateEntryService _layoutPageTemplateEntryService;
+
+	@Reference
+	private Portal _portal;
 
 	@Reference
 	private SubscriptionLocalService _subscriptionLocalService;

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/service/SubscriptionDLAppLocalServiceWrapper.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/service/SubscriptionDLAppLocalServiceWrapper.java
@@ -5,14 +5,24 @@
 
 package com.liferay.document.library.internal.service;
 
+import com.liferay.asset.display.page.constants.AssetDisplayPageConstants;
 import com.liferay.document.library.kernel.model.DLFileEntryType;
 import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
 import com.liferay.document.library.kernel.model.DLFolder;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
+import com.liferay.document.library.kernel.model.DLVersionNumberIncrease;
 import com.liferay.document.library.kernel.service.DLAppLocalServiceWrapper;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceWrapper;
+import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.subscription.service.SubscriptionLocalService;
+
+import java.io.File;
+import java.io.InputStream;
+
+import java.util.Date;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -23,6 +33,74 @@ import org.osgi.service.component.annotations.Reference;
 @Component(service = ServiceWrapper.class)
 public class SubscriptionDLAppLocalServiceWrapper
 	extends DLAppLocalServiceWrapper {
+
+	@Override
+	public FileEntry addFileEntry(
+			String externalReferenceCode, long userId, long repositoryId,
+			long folderId, String sourceFileName, String mimeType, byte[] bytes,
+			Date expirationDate, Date reviewDate, ServiceContext serviceContext)
+		throws PortalException {
+
+		serviceContext.setAttribute(
+			"hasAssetDisplayPage", _hasAssetDisplayPage(serviceContext));
+
+		return super.addFileEntry(
+			externalReferenceCode, userId, repositoryId, folderId,
+			sourceFileName, mimeType, bytes, expirationDate, reviewDate,
+			serviceContext);
+	}
+
+	@Override
+	public FileEntry addFileEntry(
+			String externalReferenceCode, long userId, long repositoryId,
+			long folderId, String sourceFileName, String mimeType, String title,
+			String urlTitle, String description, String changeLog, byte[] bytes,
+			Date expirationDate, Date reviewDate, ServiceContext serviceContext)
+		throws PortalException {
+
+		serviceContext.setAttribute(
+			"hasAssetDisplayPage", _hasAssetDisplayPage(serviceContext));
+
+		return super.addFileEntry(
+			externalReferenceCode, userId, repositoryId, folderId,
+			sourceFileName, mimeType, title, urlTitle, description, changeLog,
+			bytes, expirationDate, reviewDate, serviceContext);
+	}
+
+	@Override
+	public FileEntry addFileEntry(
+			String externalReferenceCode, long userId, long repositoryId,
+			long folderId, String sourceFileName, String mimeType, String title,
+			String urlTitle, String description, String changeLog, File file,
+			Date expirationDate, Date reviewDate, ServiceContext serviceContext)
+		throws PortalException {
+
+		serviceContext.setAttribute(
+			"hasAssetDisplayPage", _hasAssetDisplayPage(serviceContext));
+
+		return super.addFileEntry(
+			externalReferenceCode, userId, repositoryId, folderId,
+			sourceFileName, mimeType, title, urlTitle, description, changeLog,
+			file, expirationDate, reviewDate, serviceContext);
+	}
+
+	@Override
+	public FileEntry addFileEntry(
+			String externalReferenceCode, long userId, long repositoryId,
+			long folderId, String sourceFileName, String mimeType, String title,
+			String urlTitle, String description, String changeLog,
+			InputStream inputStream, long size, Date expirationDate,
+			Date reviewDate, ServiceContext serviceContext)
+		throws PortalException {
+
+		serviceContext.setAttribute(
+			"hasAssetDisplayPage", _hasAssetDisplayPage(serviceContext));
+
+		return super.addFileEntry(
+			externalReferenceCode, userId, repositoryId, folderId,
+			sourceFileName, mimeType, title, urlTitle, description, changeLog,
+			inputStream, size, expirationDate, reviewDate, serviceContext);
+	}
 
 	@Override
 	public void subscribeFileEntryType(
@@ -84,6 +162,72 @@ public class SubscriptionDLAppLocalServiceWrapper
 
 		_subscriptionLocalService.deleteSubscription(
 			userId, DLFolder.class.getName(), folderId);
+	}
+
+	@Override
+	public FileEntry updateFileEntry(
+			long userId, long fileEntryId, String sourceFileName,
+			String mimeType, String title, String urlTitle, String description,
+			String changeLog, DLVersionNumberIncrease dlVersionNumberIncrease,
+			byte[] bytes, Date expirationDate, Date reviewDate,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		serviceContext.setAttribute(
+			"hasAssetDisplayPage", _hasAssetDisplayPage(serviceContext));
+
+		return super.updateFileEntry(
+			userId, fileEntryId, sourceFileName, mimeType, title, urlTitle,
+			description, changeLog, dlVersionNumberIncrease, bytes,
+			expirationDate, reviewDate, serviceContext);
+	}
+
+	@Override
+	public FileEntry updateFileEntry(
+			long userId, long fileEntryId, String sourceFileName,
+			String mimeType, String title, String urlTitle, String description,
+			String changeLog, DLVersionNumberIncrease dlVersionNumberIncrease,
+			File file, Date expirationDate, Date reviewDate,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		serviceContext.setAttribute(
+			"hasAssetDisplayPage", _hasAssetDisplayPage(serviceContext));
+
+		return super.updateFileEntry(
+			userId, fileEntryId, sourceFileName, mimeType, title, urlTitle,
+			description, changeLog, dlVersionNumberIncrease, file,
+			expirationDate, reviewDate, serviceContext);
+	}
+
+	@Override
+	public FileEntry updateFileEntry(
+			long userId, long fileEntryId, String sourceFileName,
+			String mimeType, String title, String urlTitle, String description,
+			String changeLog, DLVersionNumberIncrease dlVersionNumberIncrease,
+			InputStream inputStream, long size, Date expirationDate,
+			Date reviewDate, ServiceContext serviceContext)
+		throws PortalException {
+
+		serviceContext.setAttribute(
+			"hasAssetDisplayPage", _hasAssetDisplayPage(serviceContext));
+
+		return super.updateFileEntry(
+			userId, fileEntryId, sourceFileName, mimeType, title, urlTitle,
+			description, changeLog, dlVersionNumberIncrease, inputStream, size,
+			expirationDate, reviewDate, serviceContext);
+	}
+
+	private boolean _hasAssetDisplayPage(ServiceContext serviceContext) {
+		int displayPageType = ParamUtil.getInteger(
+			serviceContext, "displayPageType",
+			AssetDisplayPageConstants.TYPE_DEFAULT);
+
+		if (displayPageType == AssetDisplayPageConstants.TYPE_NONE) {
+			return false;
+		}
+
+		return true;
 	}
 
 	@Reference

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/service/SubscriptionDLAppLocalServiceWrapper.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/service/SubscriptionDLAppLocalServiceWrapper.java
@@ -5,21 +5,17 @@
 
 package com.liferay.document.library.internal.service;
 
-import com.liferay.asset.display.page.constants.AssetDisplayPageConstants;
+import com.liferay.document.library.internal.DLAssetDisplayPageUtil;
 import com.liferay.document.library.kernel.model.DLFileEntryType;
 import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
 import com.liferay.document.library.kernel.model.DLFolder;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.model.DLVersionNumberIncrease;
 import com.liferay.document.library.kernel.service.DLAppLocalServiceWrapper;
-import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
-import com.liferay.layout.page.template.service.LayoutPageTemplateEntryService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceWrapper;
-import com.liferay.portal.kernel.util.ParamUtil;
-import com.liferay.portal.kernel.util.Portal;
 import com.liferay.subscription.service.SubscriptionLocalService;
 
 import java.io.File;
@@ -45,7 +41,8 @@ public class SubscriptionDLAppLocalServiceWrapper
 		throws PortalException {
 
 		serviceContext.setAttribute(
-			"hasAssetDisplayPage", _hasAssetDisplayPage(serviceContext));
+			"hasAssetDisplayPage",
+			DLAssetDisplayPageUtil.hasAssetDisplayPage(serviceContext));
 
 		return super.addFileEntry(
 			externalReferenceCode, userId, repositoryId, folderId,
@@ -62,7 +59,8 @@ public class SubscriptionDLAppLocalServiceWrapper
 		throws PortalException {
 
 		serviceContext.setAttribute(
-			"hasAssetDisplayPage", _hasAssetDisplayPage(serviceContext));
+			"hasAssetDisplayPage",
+			DLAssetDisplayPageUtil.hasAssetDisplayPage(serviceContext));
 
 		return super.addFileEntry(
 			externalReferenceCode, userId, repositoryId, folderId,
@@ -79,7 +77,8 @@ public class SubscriptionDLAppLocalServiceWrapper
 		throws PortalException {
 
 		serviceContext.setAttribute(
-			"hasAssetDisplayPage", _hasAssetDisplayPage(serviceContext));
+			"hasAssetDisplayPage",
+			DLAssetDisplayPageUtil.hasAssetDisplayPage(serviceContext));
 
 		return super.addFileEntry(
 			externalReferenceCode, userId, repositoryId, folderId,
@@ -97,7 +96,8 @@ public class SubscriptionDLAppLocalServiceWrapper
 		throws PortalException {
 
 		serviceContext.setAttribute(
-			"hasAssetDisplayPage", _hasAssetDisplayPage(serviceContext));
+			"hasAssetDisplayPage",
+			DLAssetDisplayPageUtil.hasAssetDisplayPage(serviceContext));
 
 		return super.addFileEntry(
 			externalReferenceCode, userId, repositoryId, folderId,
@@ -177,7 +177,8 @@ public class SubscriptionDLAppLocalServiceWrapper
 		throws PortalException {
 
 		serviceContext.setAttribute(
-			"hasAssetDisplayPage", _hasAssetDisplayPage(serviceContext));
+			"hasAssetDisplayPage",
+			DLAssetDisplayPageUtil.hasAssetDisplayPage(serviceContext));
 
 		return super.updateFileEntry(
 			userId, fileEntryId, sourceFileName, mimeType, title, urlTitle,
@@ -195,7 +196,8 @@ public class SubscriptionDLAppLocalServiceWrapper
 		throws PortalException {
 
 		serviceContext.setAttribute(
-			"hasAssetDisplayPage", _hasAssetDisplayPage(serviceContext));
+			"hasAssetDisplayPage",
+			DLAssetDisplayPageUtil.hasAssetDisplayPage(serviceContext));
 
 		return super.updateFileEntry(
 			userId, fileEntryId, sourceFileName, mimeType, title, urlTitle,
@@ -213,52 +215,14 @@ public class SubscriptionDLAppLocalServiceWrapper
 		throws PortalException {
 
 		serviceContext.setAttribute(
-			"hasAssetDisplayPage", _hasAssetDisplayPage(serviceContext));
+			"hasAssetDisplayPage",
+			DLAssetDisplayPageUtil.hasAssetDisplayPage(serviceContext));
 
 		return super.updateFileEntry(
 			userId, fileEntryId, sourceFileName, mimeType, title, urlTitle,
 			description, changeLog, dlVersionNumberIncrease, inputStream, size,
 			expirationDate, reviewDate, serviceContext);
 	}
-
-	private boolean _hasAssetDisplayPage(ServiceContext serviceContext) {
-		int displayPageType = ParamUtil.getInteger(
-			serviceContext, "displayPageType",
-			AssetDisplayPageConstants.TYPE_DEFAULT);
-
-		if (displayPageType == AssetDisplayPageConstants.TYPE_DEFAULT) {
-			long fileEntryTypeId = ParamUtil.getLong(
-				serviceContext, "fileEntryTypeId",
-				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT);
-
-			LayoutPageTemplateEntry layoutPageTemplateEntry =
-				_layoutPageTemplateEntryService.
-					fetchDefaultLayoutPageTemplateEntry(
-						serviceContext.getScopeGroupId(),
-						_portal.getClassNameId(FileEntry.class),
-						fileEntryTypeId);
-
-			if (layoutPageTemplateEntry == null) {
-				return false;
-			}
-		}
-		else if (displayPageType == AssetDisplayPageConstants.TYPE_NONE) {
-			return false;
-		}
-		else if (displayPageType == AssetDisplayPageConstants.TYPE_SPECIFIC) {
-			if (ParamUtil.getLong(serviceContext, "assetDisplayPageId") == 0) {
-				return false;
-			}
-		}
-
-		return true;
-	}
-
-	@Reference
-	private LayoutPageTemplateEntryService _layoutPageTemplateEntryService;
-
-	@Reference
-	private Portal _portal;
 
 	@Reference
 	private SubscriptionLocalService _subscriptionLocalService;

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/service/SubscriptionDLAppServiceWrapper.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/service/SubscriptionDLAppServiceWrapper.java
@@ -6,13 +6,17 @@
 package com.liferay.document.library.internal.service;
 
 import com.liferay.asset.display.page.constants.AssetDisplayPageConstants;
+import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
 import com.liferay.document.library.kernel.model.DLVersionNumberIncrease;
 import com.liferay.document.library.kernel.service.DLAppServiceWrapper;
+import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
+import com.liferay.layout.page.template.service.LayoutPageTemplateEntryService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceWrapper;
 import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.Portal;
 
 import java.io.File;
 import java.io.InputStream;
@@ -20,6 +24,7 @@ import java.io.InputStream;
 import java.util.Date;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Roberto Díaz
@@ -136,11 +141,38 @@ public class SubscriptionDLAppServiceWrapper extends DLAppServiceWrapper {
 			serviceContext, "displayPageType",
 			AssetDisplayPageConstants.TYPE_DEFAULT);
 
-		if (displayPageType == AssetDisplayPageConstants.TYPE_NONE) {
+		if (displayPageType == AssetDisplayPageConstants.TYPE_DEFAULT) {
+			long fileEntryTypeId = ParamUtil.getLong(
+				serviceContext, "fileEntryTypeId",
+				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT);
+
+			LayoutPageTemplateEntry layoutPageTemplateEntry =
+				_layoutPageTemplateEntryService.
+					fetchDefaultLayoutPageTemplateEntry(
+						serviceContext.getScopeGroupId(),
+						_portal.getClassNameId(FileEntry.class),
+						fileEntryTypeId);
+
+			if (layoutPageTemplateEntry == null) {
+				return false;
+			}
+		}
+		else if (displayPageType == AssetDisplayPageConstants.TYPE_NONE) {
 			return false;
+		}
+		else if (displayPageType == AssetDisplayPageConstants.TYPE_SPECIFIC) {
+			if (ParamUtil.getLong(serviceContext, "assetDisplayPageId") == 0) {
+				return false;
+			}
 		}
 
 		return true;
 	}
+
+	@Reference
+	private LayoutPageTemplateEntryService _layoutPageTemplateEntryService;
+
+	@Reference
+	private Portal _portal;
 
 }

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/service/SubscriptionDLAppServiceWrapper.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/service/SubscriptionDLAppServiceWrapper.java
@@ -5,17 +5,14 @@
 
 package com.liferay.document.library.internal.service;
 
-import com.liferay.asset.display.page.constants.AssetDisplayPageConstants;
-import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
+import com.liferay.document.library.internal.DLAssetDisplayPageUtil;
 import com.liferay.document.library.kernel.model.DLVersionNumberIncrease;
 import com.liferay.document.library.kernel.service.DLAppServiceWrapper;
-import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceWrapper;
-import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 
 import java.io.File;
@@ -41,7 +38,8 @@ public class SubscriptionDLAppServiceWrapper extends DLAppServiceWrapper {
 		throws PortalException {
 
 		serviceContext.setAttribute(
-			"hasAssetDisplayPage", _hasAssetDisplayPage(serviceContext));
+			"hasAssetDisplayPage",
+			DLAssetDisplayPageUtil.hasAssetDisplayPage(serviceContext));
 
 		return super.addFileEntry(
 			externalReferenceCode, repositoryId, folderId, sourceFileName,
@@ -58,7 +56,8 @@ public class SubscriptionDLAppServiceWrapper extends DLAppServiceWrapper {
 		throws PortalException {
 
 		serviceContext.setAttribute(
-			"hasAssetDisplayPage", _hasAssetDisplayPage(serviceContext));
+			"hasAssetDisplayPage",
+			DLAssetDisplayPageUtil.hasAssetDisplayPage(serviceContext));
 
 		return super.addFileEntry(
 			externalReferenceCode, repositoryId, folderId, sourceFileName,
@@ -76,7 +75,8 @@ public class SubscriptionDLAppServiceWrapper extends DLAppServiceWrapper {
 		throws PortalException {
 
 		serviceContext.setAttribute(
-			"hasAssetDisplayPage", _hasAssetDisplayPage(serviceContext));
+			"hasAssetDisplayPage",
+			DLAssetDisplayPageUtil.hasAssetDisplayPage(serviceContext));
 
 		return super.addFileEntry(
 			externalReferenceCode, repositoryId, folderId, sourceFileName,
@@ -93,7 +93,8 @@ public class SubscriptionDLAppServiceWrapper extends DLAppServiceWrapper {
 		throws PortalException {
 
 		serviceContext.setAttribute(
-			"hasAssetDisplayPage", _hasAssetDisplayPage(serviceContext));
+			"hasAssetDisplayPage",
+			DLAssetDisplayPageUtil.hasAssetDisplayPage(serviceContext));
 
 		return super.updateFileEntry(
 			fileEntryId, sourceFileName, mimeType, title, urlTitle, description,
@@ -110,7 +111,8 @@ public class SubscriptionDLAppServiceWrapper extends DLAppServiceWrapper {
 		throws PortalException {
 
 		serviceContext.setAttribute(
-			"hasAssetDisplayPage", _hasAssetDisplayPage(serviceContext));
+			"hasAssetDisplayPage",
+			DLAssetDisplayPageUtil.hasAssetDisplayPage(serviceContext));
 
 		return super.updateFileEntry(
 			fileEntryId, sourceFileName, mimeType, title, urlTitle, description,
@@ -128,45 +130,13 @@ public class SubscriptionDLAppServiceWrapper extends DLAppServiceWrapper {
 		throws PortalException {
 
 		serviceContext.setAttribute(
-			"hasAssetDisplayPage", _hasAssetDisplayPage(serviceContext));
+			"hasAssetDisplayPage",
+			DLAssetDisplayPageUtil.hasAssetDisplayPage(serviceContext));
 
 		return super.updateFileEntry(
 			fileEntryId, sourceFileName, mimeType, title, urlTitle, description,
 			changeLog, dlVersionNumberIncrease, inputStream, size,
 			expirationDate, reviewDate, serviceContext);
-	}
-
-	private boolean _hasAssetDisplayPage(ServiceContext serviceContext) {
-		int displayPageType = ParamUtil.getInteger(
-			serviceContext, "displayPageType",
-			AssetDisplayPageConstants.TYPE_DEFAULT);
-
-		if (displayPageType == AssetDisplayPageConstants.TYPE_DEFAULT) {
-			long fileEntryTypeId = ParamUtil.getLong(
-				serviceContext, "fileEntryTypeId",
-				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT);
-
-			LayoutPageTemplateEntry layoutPageTemplateEntry =
-				_layoutPageTemplateEntryService.
-					fetchDefaultLayoutPageTemplateEntry(
-						serviceContext.getScopeGroupId(),
-						_portal.getClassNameId(FileEntry.class),
-						fileEntryTypeId);
-
-			if (layoutPageTemplateEntry == null) {
-				return false;
-			}
-		}
-		else if (displayPageType == AssetDisplayPageConstants.TYPE_NONE) {
-			return false;
-		}
-		else if (displayPageType == AssetDisplayPageConstants.TYPE_SPECIFIC) {
-			if (ParamUtil.getLong(serviceContext, "assetDisplayPageId") == 0) {
-				return false;
-			}
-		}
-
-		return true;
 	}
 
 	@Reference

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/service/SubscriptionDLAppServiceWrapper.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/service/SubscriptionDLAppServiceWrapper.java
@@ -1,0 +1,146 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.document.library.internal.service;
+
+import com.liferay.asset.display.page.constants.AssetDisplayPageConstants;
+import com.liferay.document.library.kernel.model.DLVersionNumberIncrease;
+import com.liferay.document.library.kernel.service.DLAppServiceWrapper;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceWrapper;
+import com.liferay.portal.kernel.util.ParamUtil;
+
+import java.io.File;
+import java.io.InputStream;
+
+import java.util.Date;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Roberto Díaz
+ */
+@Component(service = ServiceWrapper.class)
+public class SubscriptionDLAppServiceWrapper extends DLAppServiceWrapper {
+
+	@Override
+	public FileEntry addFileEntry(
+			String externalReferenceCode, long repositoryId, long folderId,
+			String sourceFileName, String mimeType, String title,
+			String urlTitle, String description, String changeLog, byte[] bytes,
+			Date expirationDate, Date reviewDate, ServiceContext serviceContext)
+		throws PortalException {
+
+		serviceContext.setAttribute(
+			"hasAssetDisplayPage", _hasAssetDisplayPage(serviceContext));
+
+		return super.addFileEntry(
+			externalReferenceCode, repositoryId, folderId, sourceFileName,
+			mimeType, title, urlTitle, description, changeLog, bytes,
+			expirationDate, reviewDate, serviceContext);
+	}
+
+	@Override
+	public FileEntry addFileEntry(
+			String externalReferenceCode, long repositoryId, long folderId,
+			String sourceFileName, String mimeType, String title,
+			String urlTitle, String description, String changeLog, File file,
+			Date expirationDate, Date reviewDate, ServiceContext serviceContext)
+		throws PortalException {
+
+		serviceContext.setAttribute(
+			"hasAssetDisplayPage", _hasAssetDisplayPage(serviceContext));
+
+		return super.addFileEntry(
+			externalReferenceCode, repositoryId, folderId, sourceFileName,
+			mimeType, title, urlTitle, description, changeLog, file,
+			expirationDate, reviewDate, serviceContext);
+	}
+
+	@Override
+	public FileEntry addFileEntry(
+			String externalReferenceCode, long repositoryId, long folderId,
+			String sourceFileName, String mimeType, String title,
+			String urlTitle, String description, String changeLog,
+			InputStream inputStream, long size, Date expirationDate,
+			Date reviewDate, ServiceContext serviceContext)
+		throws PortalException {
+
+		serviceContext.setAttribute(
+			"hasAssetDisplayPage", _hasAssetDisplayPage(serviceContext));
+
+		return super.addFileEntry(
+			externalReferenceCode, repositoryId, folderId, sourceFileName,
+			mimeType, title, urlTitle, description, changeLog, inputStream,
+			size, expirationDate, reviewDate, serviceContext);
+	}
+
+	@Override
+	public FileEntry updateFileEntry(
+			long fileEntryId, String sourceFileName, String mimeType,
+			String title, String urlTitle, String description, String changeLog,
+			DLVersionNumberIncrease dlVersionNumberIncrease, byte[] bytes,
+			Date expirationDate, Date reviewDate, ServiceContext serviceContext)
+		throws PortalException {
+
+		serviceContext.setAttribute(
+			"hasAssetDisplayPage", _hasAssetDisplayPage(serviceContext));
+
+		return super.updateFileEntry(
+			fileEntryId, sourceFileName, mimeType, title, urlTitle, description,
+			changeLog, dlVersionNumberIncrease, bytes, expirationDate,
+			reviewDate, serviceContext);
+	}
+
+	@Override
+	public FileEntry updateFileEntry(
+			long fileEntryId, String sourceFileName, String mimeType,
+			String title, String urlTitle, String description, String changeLog,
+			DLVersionNumberIncrease dlVersionNumberIncrease, File file,
+			Date expirationDate, Date reviewDate, ServiceContext serviceContext)
+		throws PortalException {
+
+		serviceContext.setAttribute(
+			"hasAssetDisplayPage", _hasAssetDisplayPage(serviceContext));
+
+		return super.updateFileEntry(
+			fileEntryId, sourceFileName, mimeType, title, urlTitle, description,
+			changeLog, dlVersionNumberIncrease, file, expirationDate,
+			reviewDate, serviceContext);
+	}
+
+	@Override
+	public FileEntry updateFileEntry(
+			long fileEntryId, String sourceFileName, String mimeType,
+			String title, String urlTitle, String description, String changeLog,
+			DLVersionNumberIncrease dlVersionNumberIncrease,
+			InputStream inputStream, long size, Date expirationDate,
+			Date reviewDate, ServiceContext serviceContext)
+		throws PortalException {
+
+		serviceContext.setAttribute(
+			"hasAssetDisplayPage", _hasAssetDisplayPage(serviceContext));
+
+		return super.updateFileEntry(
+			fileEntryId, sourceFileName, mimeType, title, urlTitle, description,
+			changeLog, dlVersionNumberIncrease, inputStream, size,
+			expirationDate, reviewDate, serviceContext);
+	}
+
+	private boolean _hasAssetDisplayPage(ServiceContext serviceContext) {
+		int displayPageType = ParamUtil.getInteger(
+			serviceContext, "displayPageType",
+			AssetDisplayPageConstants.TYPE_DEFAULT);
+
+		if (displayPageType == AssetDisplayPageConstants.TYPE_NONE) {
+			return false;
+		}
+
+		return true;
+	}
+
+}

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/EditFileEntryMVCActionCommand.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/EditFileEntryMVCActionCommand.java
@@ -5,7 +5,6 @@
 
 package com.liferay.document.library.web.internal.portlet.action;
 
-import com.liferay.asset.display.page.portlet.AssetDisplayPageEntryFormProcessor;
 import com.liferay.asset.kernel.exception.AssetCategoryException;
 import com.liferay.asset.kernel.exception.AssetTagException;
 import com.liferay.asset.kernel.model.AssetVocabulary;
@@ -465,16 +464,12 @@ public class EditFileEntryMVCActionCommand extends BaseMVCActionCommand {
 				tempFileEntry.getGroupId(), folderId,
 				FileUtil.stripExtension(originalSelectedFileName));
 
-			FileEntry fileEntry = _dlAppService.addFileEntry(
+			_dlAppService.addFileEntry(
 				null, repositoryId, folderId, uniqueFileName,
 				tempFileEntry.getMimeType(), uniqueFileTitle, StringPool.BLANK,
 				description, changeLog, tempFileEntry.getContentStream(),
 				tempFileEntry.getSize(), expirationDate, reviewDate,
 				serviceContext);
-
-			_assetDisplayPageEntryFormProcessor.process(
-				FileEntry.class.getName(), fileEntry.getFileEntryId(),
-				actionRequest);
 
 			validFileNameKVPs.add(
 				new KeyValuePair(uniqueFileName, selectedFileName));
@@ -1378,10 +1373,6 @@ public class EditFileEntryMVCActionCommand extends BaseMVCActionCommand {
 				}
 			}
 
-			_assetDisplayPageEntryFormProcessor.process(
-				FileEntry.class.getName(), fileEntry.getFileEntryId(),
-				actionRequest);
-
 			String portletResource = ParamUtil.getString(
 				actionRequest, "portletResource");
 
@@ -1415,10 +1406,6 @@ public class EditFileEntryMVCActionCommand extends BaseMVCActionCommand {
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		EditFileEntryMVCActionCommand.class);
-
-	@Reference
-	private AssetDisplayPageEntryFormProcessor
-		_assetDisplayPageEntryFormProcessor;
 
 	@Reference
 	private ClassNameLocalService _classNameLocalService;

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-asset-display/src/main/java/com/liferay/layout/type/controller/asset/display/internal/portlet/AssetDisplayPageFormProcessorImpl.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-asset-display/src/main/java/com/liferay/layout/type/controller/asset/display/internal/portlet/AssetDisplayPageFormProcessorImpl.java
@@ -25,10 +25,53 @@ import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Alejandro Tardín
+ * @author Roberto Díaz
  */
 @Component(service = AssetDisplayPageEntryFormProcessor.class)
 public class AssetDisplayPageFormProcessorImpl
 	implements AssetDisplayPageEntryFormProcessor {
+
+	@Override
+	public void process(
+			long userId, long groupId, String className, long classPK,
+			int displayPageType, String layoutUuid, long assetDisplayPageId,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		long classNameId = _portal.getClassNameId(className);
+
+		AssetDisplayPageEntry assetDisplayPageEntry =
+			_assetDisplayPageEntryLocalService.fetchAssetDisplayPageEntry(
+				groupId, classNameId, classPK);
+
+		if ((displayPageType == AssetDisplayPageConstants.TYPE_DEFAULT) ||
+			((displayPageType == AssetDisplayPageConstants.TYPE_SPECIFIC) &&
+			 Validator.isNotNull(layoutUuid))) {
+
+			if (assetDisplayPageEntry != null) {
+				_assetDisplayPageEntryLocalService.deleteAssetDisplayPageEntry(
+					groupId, classNameId, classPK);
+			}
+
+			return;
+		}
+
+		if (displayPageType == AssetDisplayPageConstants.TYPE_NONE) {
+			assetDisplayPageId = 0;
+		}
+
+		if (assetDisplayPageEntry == null) {
+			_assetDisplayPageEntryLocalService.addAssetDisplayPageEntry(
+				userId, groupId, classNameId, classPK, assetDisplayPageId,
+				displayPageType, serviceContext);
+
+			return;
+		}
+
+		_assetDisplayPageEntryLocalService.updateAssetDisplayPageEntry(
+			assetDisplayPageEntry.getAssetDisplayPageEntryId(),
+			assetDisplayPageId, displayPageType);
+	}
 
 	@Override
 	public void process(
@@ -38,29 +81,11 @@ public class AssetDisplayPageFormProcessorImpl
 		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
-		long classNameId = _portal.getClassNameId(className);
-
-		AssetDisplayPageEntry assetDisplayPageEntry =
-			_assetDisplayPageEntryLocalService.fetchAssetDisplayPageEntry(
-				themeDisplay.getScopeGroupId(), classNameId, classPK);
-
 		int displayPageType = ParamUtil.getInteger(
 			portletRequest, "displayPageType",
 			AssetDisplayPageConstants.TYPE_DEFAULT);
 
 		String layoutUuid = ParamUtil.getString(portletRequest, "layoutUuid");
-
-		if ((displayPageType == AssetDisplayPageConstants.TYPE_DEFAULT) ||
-			((displayPageType == AssetDisplayPageConstants.TYPE_SPECIFIC) &&
-			 Validator.isNotNull(layoutUuid))) {
-
-			if (assetDisplayPageEntry != null) {
-				_assetDisplayPageEntryLocalService.deleteAssetDisplayPageEntry(
-					themeDisplay.getScopeGroupId(), classNameId, classPK);
-			}
-
-			return;
-		}
 
 		long assetDisplayPageId = ParamUtil.getLong(
 			portletRequest, "assetDisplayPageId");
@@ -69,21 +94,37 @@ public class AssetDisplayPageFormProcessorImpl
 			assetDisplayPageId = 0;
 		}
 
-		if (assetDisplayPageEntry == null) {
-			ServiceContext serviceContext = ServiceContextFactory.getInstance(
-				portletRequest);
+		ServiceContext serviceContext = ServiceContextFactory.getInstance(
+			portletRequest);
 
-			_assetDisplayPageEntryLocalService.addAssetDisplayPageEntry(
-				themeDisplay.getUserId(), themeDisplay.getScopeGroupId(),
-				classNameId, classPK, assetDisplayPageId, displayPageType,
-				serviceContext);
+		process(
+			themeDisplay.getUserId(), themeDisplay.getScopeGroupId(), className,
+			classPK, displayPageType, layoutUuid, assetDisplayPageId,
+			serviceContext);
+	}
 
-			return;
+	@Override
+	public void process(
+			String className, long classPK, ServiceContext serviceContext)
+		throws PortalException {
+
+		int displayPageType = ParamUtil.getInteger(
+			serviceContext, "displayPageType",
+			AssetDisplayPageConstants.TYPE_DEFAULT);
+
+		String layoutUuid = ParamUtil.getString(serviceContext, "layoutUuid");
+
+		long assetDisplayPageId = ParamUtil.getLong(
+			serviceContext, "assetDisplayPageId");
+
+		if (displayPageType == AssetDisplayPageConstants.TYPE_NONE) {
+			assetDisplayPageId = 0;
 		}
 
-		_assetDisplayPageEntryLocalService.updateAssetDisplayPageEntry(
-			assetDisplayPageEntry.getAssetDisplayPageEntryId(),
-			assetDisplayPageId, displayPageType);
+		process(
+			serviceContext.getUserId(), serviceContext.getScopeGroupId(),
+			className, classPK, displayPageType, layoutUuid, assetDisplayPageId,
+			serviceContext);
 	}
 
 	@Reference

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/util/DLImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/util/DLImpl.java
@@ -814,6 +814,13 @@ public class DLImpl implements DL {
 			return entryURL;
 		}
 
+		boolean hasAssetDisplayPage = GetterUtil.getBoolean(
+			serviceContext.getAttribute("hasAssetDisplayPage"));
+
+		if (hasAssetDisplayPage) {
+			return StringPool.BLANK;
+		}
+
 		HttpServletRequest httpServletRequest = serviceContext.getRequest();
 		ThemeDisplay themeDisplay = serviceContext.getThemeDisplay();
 


### PR DESCRIPTION
Solves https://liferay.atlassian.net/browse/LPS-202905

I've changed the previous approach to avoid having to change a ton of calls that are been made to DLUtil (and avoid NPE)

In this case I check if the file has a friendlyURL and add it to the service builder, so the page iteration is not done in DLImpl.

Anyway friendly logic should remain in notifySubscribers because in some cases the friendlyURL is not the final one until the file entry is approved (specificly wheb adding the file entry).

The initial getEntryURL is used, somehow, as a flag to do not iterate.

Contact me if you have any question.