### PR TITLE
LPS-204483 Avoid use the default folder in DL search

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminDisplayContext.java
@@ -1012,6 +1012,13 @@ public class DLAdminDisplayContext {
 			_searchFolderId = ParamUtil.getLong(
 				_httpServletRequest, "searchFolderId",
 				ParamUtil.getLong(_httpServletRequest, "folderId"));
+
+			if ((_rootFolderId != DLFolderConstants.DEFAULT_PARENT_FOLDER_ID) &&
+				(_searchFolderId ==
+					DLFolderConstants.DEFAULT_PARENT_FOLDER_ID)) {
+
+				_searchFolderId = _rootFolderId;
+			}
 		}
 
 		return _searchFolderId;

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/search_info.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/search_info.jsp
@@ -14,7 +14,7 @@ Folder folder = null;
 
 long folderId = ParamUtil.getLong(request, "folderId");
 
-if (folderId != dlAdminDisplayContext.getRootFolderId()) {
+if ((folderId != DLFolderConstants.DEFAULT_PARENT_FOLDER_ID) && (folderId != dlAdminDisplayContext.getRootFolderId())) {
 	folder = DLAppServiceUtil.getFolder(folderId);
 }
 


### PR DESCRIPTION
If the user configures a root folder we could not rely only on parameters the default folder id to be used in DL search.

The default folder Id in this cases (if the parameters do not have another value) should be the rootfolderId