### PR TITLE
LPS-204497 Adds guest and group permissions when we are adding documents to the repository

### DIFF
--- a/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/servlet/RepositoryBrowserServlet.java
+++ b/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/servlet/RepositoryBrowserServlet.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextFactory;
 import com.liferay.portal.kernel.servlet.ServletResponseUtil;
 import com.liferay.portal.kernel.servlet.SessionErrors;
@@ -192,12 +193,17 @@ public class RepositoryBrowserServlet extends HttpServlet {
 
 				String title = FileUtil.stripExtension(sourceFileName);
 
+				ServiceContext serviceContext =
+					ServiceContextFactory.getInstance(
+						FileEntry.class.getName(), httpServletRequest);
+
+				serviceContext.setAddGroupPermissions(true);
+				serviceContext.setAddGuestPermissions(true);
+
 				_dlAppService.addFileEntry(
 					null, repositoryId, parentFolderId, sourceFileName,
 					uploadServletRequest.getContentType("file"), title, null,
-					null, null, file, null, null,
-					ServiceContextFactory.getInstance(
-						FileEntry.class.getName(), httpServletRequest));
+					null, null, file, null, null, serviceContext);
 
 				SessionMessages.add(httpServletRequest, "requestProcessed");
 


### PR DESCRIPTION
Motivation
-----
Fix the following issue [LPS-204497](https://liferay.atlassian.net/browse/LPS-204497)

Proposed solution
-----
Adds guest and group permission when we are adding a new document through RepositoryBrowserServlet.java, in order to see the document for guest users, since it is not possible to change the permissions.

Steps to reproduce
-----

1. Create a new fragment collection
3. Upload a new resource for the fragment collection
5. Create a new fragment, and use the resource in the HTML code like this: <img src="[resources:resourcename]">
7. Create a new content page and add the fragment to it
9. Publish the page
11. Log out and navigate to the page

Additional notes
-----
I'm not completely sure about the solution, since adding those permissions means that all documents upload by this taglib are going to have guest permissions, but in the other hand we cannot change permissions. For the moment this taglib is only used in Fragments and Blogs, and in fragments we want to allow guest user to see the documents.

Please let me know if you have any question.

Thanks!!