### PR TITLE
LPS-157775 on some cases the steps needed for upgrading the configuration are not fulfilled due the version so re-upgrade it again

### DIFF
--- a/modules/apps/document-library/document-library-service/bnd.bnd
+++ b/modules/apps/document-library/document-library-service/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Document Library Service
 Bundle-SymbolicName: com.liferay.document.library.service
 Bundle-Version: 6.0.115
-Liferay-Require-SchemaVersion: 3.2.8
+Liferay-Require-SchemaVersion: 3.2.9
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/helper/DLConfigurationUpgradeHelper.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/helper/DLConfigurationUpgradeHelper.java
@@ -9,11 +9,14 @@ import com.liferay.document.library.configuration.DLConfiguration;
 import com.liferay.document.library.configuration.DLFileEntryConfiguration;
 import com.liferay.document.library.constants.DLFileEntryConfigurationConstants;
 import com.liferay.document.library.internal.configuration.DLSizeLimitConfiguration;
+import com.liferay.document.library.internal.constants.LegacyDLKeys;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
 import com.liferay.portal.configuration.module.configuration.ConfigurationProvider;
 import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.kernel.util.PrefsProps;
+import com.liferay.portal.kernel.util.Validator;
 
 import java.util.Dictionary;
 
@@ -60,6 +63,64 @@ public class DLConfigurationUpgradeHelper {
 		}
 
 		return configurations[0];
+	}
+
+	public boolean hasConfigurationChanges() throws Exception {
+		Configuration dlSizeLimitConfiguration = getSystemConfiguration(
+			DLSizeLimitConfiguration.class.getName());
+
+		if (dlSizeLimitConfiguration != null) {
+			Dictionary<String, Object> dictionary =
+				dlSizeLimitConfiguration.getProperties();
+
+			if (dictionary != null) {
+				Long fileMaxSize = (Long)dictionary.get("fileMaxSize");
+
+				if ((fileMaxSize != null) && (fileMaxSize != 0)) {
+					return false;
+				}
+			}
+		}
+
+		Configuration dlFileEntryConfiguration = getSystemConfiguration(
+			DLConfigurationUpgradeHelper.
+				CLASS_NAME_DL_FILE_ENTRY_CONFIGURATION);
+
+		if (dlFileEntryConfiguration != null) {
+			Dictionary<String, Object> dictionary =
+				dlFileEntryConfiguration.getProperties();
+
+			if (dictionary != null) {
+				Long previewableProcessorMaxSize = (Long)dictionary.get(
+					"previewableProcessorMaxSize");
+
+				if ((previewableProcessorMaxSize != null) &&
+					(previewableProcessorMaxSize !=
+						DLFileEntryConfigurationConstants.
+							PREVIEWABLE_PROCESSOR_MAX_SIZE_DEFAULT)) {
+
+					return false;
+				}
+			}
+		}
+
+		return true;
+	}
+
+	public boolean hasLegacyProps() throws Exception {
+		if (Validator.isNull(
+				_prefsProps.getString(LegacyDLKeys.DL_FILE_EXTENSIONS, null)) &&
+			Validator.isNull(
+				_prefsProps.getString(LegacyDLKeys.DL_FILE_MAX_SIZE, null)) &&
+			Validator.isNull(
+				_prefsProps.getString(
+					LegacyDLKeys.DL_FILE_ENTRY_PREVIEWABLE_PROCESSOR_MAX_SIZE,
+					null))) {
+
+			return false;
+		}
+
+		return true;
 	}
 
 	public void updateDLSizeLimitConfiguration() throws Exception {
@@ -234,5 +295,8 @@ public class DLConfigurationUpgradeHelper {
 
 	@Reference
 	private ConfigurationProvider _configurationProvider;
+
+	@Reference
+	private PrefsProps _prefsProps;
 
 }

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/helper/DLConfigurationUpgradeHelper.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/helper/DLConfigurationUpgradeHelper.java
@@ -1,0 +1,238 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.document.library.internal.upgrade.helper;
+
+import com.liferay.document.library.configuration.DLConfiguration;
+import com.liferay.document.library.configuration.DLFileEntryConfiguration;
+import com.liferay.document.library.constants.DLFileEntryConfigurationConstants;
+import com.liferay.document.library.internal.configuration.DLSizeLimitConfiguration;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
+import com.liferay.portal.configuration.module.configuration.ConfigurationProvider;
+import com.liferay.portal.kernel.util.HashMapDictionary;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+
+import java.util.Dictionary;
+
+import org.osgi.framework.Constants;
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Alicia García
+ */
+@Component(service = DLConfigurationUpgradeHelper.class)
+public class DLConfigurationUpgradeHelper {
+
+	public static final String CLASS_NAME_DL_FILE_ENTRY_CONFIGURATION =
+		"com.liferay.document.library.configuration.DLFileEntryConfiguration";
+
+	public static final String CLASS_NAME_PDF_PREVIEW_CONFIGURATION =
+		"com.liferay.document.library.preview.pdf.internal.configuration." +
+			"PDFPreviewConfiguration";
+
+	public void deleteConfigurations(String className) throws Exception {
+		Configuration[] configurations = _configurationAdmin.listConfigurations(
+			String.format("(%s=%s*)", Constants.SERVICE_PID, className));
+
+		if (configurations == null) {
+			return;
+		}
+
+		for (Configuration configuration : configurations) {
+			configuration.delete();
+		}
+	}
+
+	public Configuration getSystemConfiguration(String className)
+		throws Exception {
+
+		Configuration[] configurations = _configurationAdmin.listConfigurations(
+			String.format("(%s=%s)", Constants.SERVICE_PID, className));
+
+		if (configurations == null) {
+			return null;
+		}
+
+		return configurations[0];
+	}
+
+	public void updateDLSizeLimitConfiguration() throws Exception {
+		long fileMaxSize = _updateDLConfiguration();
+
+		if (fileMaxSize > 0) {
+			_updateDLSizeLimitConfiguration(fileMaxSize);
+		}
+	}
+
+	public void updateScopedConfigurations(
+			long systemPreviewableProcessorMaxSize)
+		throws Exception {
+
+		Configuration[] configurations = _getScopedConfigurations(
+			CLASS_NAME_PDF_PREVIEW_CONFIGURATION);
+
+		for (Configuration configuration : configurations) {
+			Dictionary<String, Object> dictionary =
+				_createDLFileEntryConfigurationDictionary(
+					_getAttributeValue(
+						configuration, "maxNumberOfPages",
+						DLFileEntryConfigurationConstants.
+							MAX_NUMBER_OF_PAGES_DEFAULT),
+					Math.max(
+						DLFileEntryConfigurationConstants.
+							PREVIEWABLE_PROCESSOR_MAX_SIZE_DEFAULT,
+						systemPreviewableProcessorMaxSize));
+
+			long companyId = _getAttributeValue(
+				configuration,
+				ExtendedObjectClassDefinition.Scope.COMPANY.getPropertyKey(),
+				0L);
+
+			if (companyId != 0) {
+				_configurationProvider.saveCompanyConfiguration(
+					DLFileEntryConfiguration.class, companyId, dictionary);
+
+				continue;
+			}
+
+			long groupId = _getAttributeValue(
+				configuration,
+				ExtendedObjectClassDefinition.Scope.GROUP.getPropertyKey(), 0L);
+
+			if (groupId != 0) {
+				_configurationProvider.saveGroupConfiguration(
+					DLFileEntryConfiguration.class, groupId, dictionary);
+			}
+		}
+	}
+
+	public long updateSystemConfiguration() throws Exception {
+		Configuration dlFileEntryConfiguration = getSystemConfiguration(
+			CLASS_NAME_DL_FILE_ENTRY_CONFIGURATION);
+		Configuration pdfPreviewConfiguration = getSystemConfiguration(
+			CLASS_NAME_PDF_PREVIEW_CONFIGURATION);
+
+		if ((dlFileEntryConfiguration != null) ||
+			(pdfPreviewConfiguration != null)) {
+
+			int maxNumberOfPages = _getAttributeValue(
+				pdfPreviewConfiguration, "maxNumberOfPages",
+				DLFileEntryConfigurationConstants.MAX_NUMBER_OF_PAGES_DEFAULT);
+
+			long previewableProcessorMaxSize = _getAttributeValue(
+				dlFileEntryConfiguration, "previewableProcessorMaxSize",
+				DLFileEntryConfigurationConstants.
+					PREVIEWABLE_PROCESSOR_MAX_SIZE_DEFAULT);
+
+			_configurationProvider.saveSystemConfiguration(
+				DLFileEntryConfiguration.class,
+				_createDLFileEntryConfigurationDictionary(
+					maxNumberOfPages, previewableProcessorMaxSize));
+
+			return previewableProcessorMaxSize;
+		}
+
+		return DLFileEntryConfigurationConstants.
+			PREVIEWABLE_PROCESSOR_MAX_SIZE_DEFAULT;
+	}
+
+	private HashMapDictionary<String, Object>
+		_createDLFileEntryConfigurationDictionary(
+			int maxNumberOfPages, long previewableProcessorMaxSize) {
+
+		return HashMapDictionaryBuilder.<String, Object>put(
+			"maxNumberOfPages", maxNumberOfPages
+		).put(
+			"previewableProcessorMaxSize", previewableProcessorMaxSize
+		).build();
+	}
+
+	private <T> T _getAttributeValue(
+		Configuration configuration, String attributeName, T defaultValue) {
+
+		if (configuration == null) {
+			return defaultValue;
+		}
+
+		Dictionary<String, Object> dictionary = configuration.getProperties();
+
+		if (dictionary == null) {
+			return defaultValue;
+		}
+
+		T value = (T)dictionary.get(attributeName);
+
+		if (value == null) {
+			return defaultValue;
+		}
+
+		return value;
+	}
+
+	private Configuration[] _getScopedConfigurations(String className)
+		throws Exception {
+
+		Configuration[] configurations = _configurationAdmin.listConfigurations(
+			String.format(
+				"(%s=%s.scoped)", ConfigurationAdmin.SERVICE_FACTORYPID,
+				className));
+
+		if (configurations == null) {
+			return new Configuration[0];
+		}
+
+		return configurations;
+	}
+
+	private long _updateDLConfiguration() throws Exception {
+		Configuration configuration = getSystemConfiguration(
+			DLConfiguration.class.getName());
+
+		if (configuration == null) {
+			return 0;
+		}
+
+		Dictionary<String, Object> dictionary = configuration.getProperties();
+
+		if (dictionary == null) {
+			return 0;
+		}
+
+		Long fileMaxSize = (Long)dictionary.get("fileMaxSize");
+
+		if (fileMaxSize == null) {
+			return 0;
+		}
+
+		dictionary.remove("fileMaxSize");
+
+		configuration.update(dictionary);
+
+		return fileMaxSize;
+	}
+
+	private void _updateDLSizeLimitConfiguration(long fileMaxSize)
+		throws Exception {
+
+		Configuration configuration = _configurationAdmin.getConfiguration(
+			DLSizeLimitConfiguration.class.getName(), StringPool.QUESTION);
+
+		configuration.update(
+			HashMapDictionaryBuilder.put(
+				"fileMaxSize", fileMaxSize
+			).build());
+	}
+
+	@Reference
+	private ConfigurationAdmin _configurationAdmin;
+
+	@Reference
+	private ConfigurationProvider _configurationProvider;
+
+}

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/helper/DLConfigurationUpgradeHelper.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/helper/DLConfigurationUpgradeHelper.java
@@ -128,10 +128,10 @@ public class DLConfigurationUpgradeHelper {
 	}
 
 	public void updateDLSizeLimitConfiguration() throws Exception {
-		long fileMaxSize = _updateDLConfiguration();
+		long fileMaxSize = _updateDLConfigurationFileMaxSize();
 
 		if (fileMaxSize > 0) {
-			_updateDLSizeLimitConfiguration(fileMaxSize);
+			_updateDLSizeLimitConfigurationFileMaxSize(fileMaxSize);
 		}
 	}
 
@@ -255,7 +255,7 @@ public class DLConfigurationUpgradeHelper {
 		return configurations;
 	}
 
-	private long _updateDLConfiguration() throws Exception {
+	private long _updateDLConfigurationFileMaxSize() throws Exception {
 		Configuration configuration = getSystemConfiguration(
 			DLConfiguration.class.getName());
 
@@ -282,7 +282,7 @@ public class DLConfigurationUpgradeHelper {
 		return fileMaxSize;
 	}
 
-	private void _updateDLSizeLimitConfiguration(long fileMaxSize)
+	private void _updateDLSizeLimitConfigurationFileMaxSize(long fileMaxSize)
 		throws Exception {
 
 		Configuration configuration = _configurationAdmin.getConfiguration(

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/helper/DLConfigurationUpgradeHelper.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/helper/DLConfigurationUpgradeHelper.java
@@ -52,6 +52,23 @@ public class DLConfigurationUpgradeHelper {
 		}
 	}
 
+	public long getDLFileEntryConfigurationPreviewableProcessorMaxSize()
+		throws Exception {
+
+		Configuration dlFileEntryConfiguration = getSystemConfiguration(
+			CLASS_NAME_DL_FILE_ENTRY_CONFIGURATION);
+
+		if (dlFileEntryConfiguration != null) {
+			return _getAttributeValue(
+				dlFileEntryConfiguration, "previewableProcessorMaxSize",
+				DLFileEntryConfigurationConstants.
+					PREVIEWABLE_PROCESSOR_MAX_SIZE_DEFAULT);
+		}
+
+		return DLFileEntryConfigurationConstants.
+			PREVIEWABLE_PROCESSOR_MAX_SIZE_DEFAULT;
+	}
+
 	public Configuration getSystemConfiguration(String className)
 		throws Exception {
 
@@ -127,6 +144,29 @@ public class DLConfigurationUpgradeHelper {
 		return true;
 	}
 
+	public void updateDLFileEntryConfigurationSystemConfiguration(
+			long previewableProcessorMaxSize)
+		throws Exception {
+
+		Configuration dlFileEntryConfiguration = getSystemConfiguration(
+			CLASS_NAME_DL_FILE_ENTRY_CONFIGURATION);
+		Configuration pdfPreviewConfiguration = getSystemConfiguration(
+			CLASS_NAME_PDF_PREVIEW_CONFIGURATION);
+
+		if ((dlFileEntryConfiguration != null) ||
+			(pdfPreviewConfiguration != null)) {
+
+			_configurationProvider.saveSystemConfiguration(
+				DLFileEntryConfiguration.class,
+				_createDLFileEntryConfigurationDictionary(
+					_getAttributeValue(
+						pdfPreviewConfiguration, "maxNumberOfPages",
+						DLFileEntryConfigurationConstants.
+							MAX_NUMBER_OF_PAGES_DEFAULT),
+					previewableProcessorMaxSize));
+		}
+	}
+
 	public void updateDLSizeLimitConfiguration() throws Exception {
 		long fileMaxSize = _updateDLConfigurationFileMaxSize();
 
@@ -175,36 +215,6 @@ public class DLConfigurationUpgradeHelper {
 					DLFileEntryConfiguration.class, groupId, dictionary);
 			}
 		}
-	}
-
-	public long updateSystemConfiguration() throws Exception {
-		Configuration dlFileEntryConfiguration = getSystemConfiguration(
-			CLASS_NAME_DL_FILE_ENTRY_CONFIGURATION);
-		Configuration pdfPreviewConfiguration = getSystemConfiguration(
-			CLASS_NAME_PDF_PREVIEW_CONFIGURATION);
-
-		if ((dlFileEntryConfiguration != null) ||
-			(pdfPreviewConfiguration != null)) {
-
-			int maxNumberOfPages = _getAttributeValue(
-				pdfPreviewConfiguration, "maxNumberOfPages",
-				DLFileEntryConfigurationConstants.MAX_NUMBER_OF_PAGES_DEFAULT);
-
-			long previewableProcessorMaxSize = _getAttributeValue(
-				dlFileEntryConfiguration, "previewableProcessorMaxSize",
-				DLFileEntryConfigurationConstants.
-					PREVIEWABLE_PROCESSOR_MAX_SIZE_DEFAULT);
-
-			_configurationProvider.saveSystemConfiguration(
-				DLFileEntryConfiguration.class,
-				_createDLFileEntryConfigurationDictionary(
-					maxNumberOfPages, previewableProcessorMaxSize));
-
-			return previewableProcessorMaxSize;
-		}
-
-		return DLFileEntryConfigurationConstants.
-			PREVIEWABLE_PROCESSOR_MAX_SIZE_DEFAULT;
 	}
 
 	private HashMapDictionary<String, Object>

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/helper/DLConfigurationUpgradeHelper.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/helper/DLConfigurationUpgradeHelper.java
@@ -65,23 +65,7 @@ public class DLConfigurationUpgradeHelper {
 		return configurations[0];
 	}
 
-	public boolean hasConfigurationChanges() throws Exception {
-		Configuration dlSizeLimitConfiguration = getSystemConfiguration(
-			DLSizeLimitConfiguration.class.getName());
-
-		if (dlSizeLimitConfiguration != null) {
-			Dictionary<String, Object> dictionary =
-				dlSizeLimitConfiguration.getProperties();
-
-			if (dictionary != null) {
-				Long fileMaxSize = (Long)dictionary.get("fileMaxSize");
-
-				if ((fileMaxSize != null) && (fileMaxSize != 0)) {
-					return false;
-				}
-			}
-		}
-
+	public boolean hasDLFileEntryConfigurationChanges() throws Exception {
 		Configuration dlFileEntryConfiguration = getSystemConfiguration(
 			DLConfigurationUpgradeHelper.
 				CLASS_NAME_DL_FILE_ENTRY_CONFIGURATION);
@@ -99,6 +83,26 @@ public class DLConfigurationUpgradeHelper {
 						DLFileEntryConfigurationConstants.
 							PREVIEWABLE_PROCESSOR_MAX_SIZE_DEFAULT)) {
 
+					return false;
+				}
+			}
+		}
+
+		return true;
+	}
+
+	public boolean hasDLSizeLimitConfigurationChanges() throws Exception {
+		Configuration dlSizeLimitConfiguration = getSystemConfiguration(
+			DLSizeLimitConfiguration.class.getName());
+
+		if (dlSizeLimitConfiguration != null) {
+			Dictionary<String, Object> dictionary =
+				dlSizeLimitConfiguration.getProperties();
+
+			if (dictionary != null) {
+				Long fileMaxSize = (Long)dictionary.get("fileMaxSize");
+
+				if ((fileMaxSize != null) && (fileMaxSize != 0)) {
 					return false;
 				}
 			}

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/registry/DLServiceUpgradeStepRegistrator.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/registry/DLServiceUpgradeStepRegistrator.java
@@ -143,7 +143,7 @@ public class DLServiceUpgradeStepRegistrator implements UpgradeStepRegistrator {
 		registry.register(
 			"3.2.8", "3.2.9",
 			new DLLegacyConfigurationUpgradeProcess(
-				_dlConfigurationUpgradeHelper, _prefsProps,
+				_dlConfigurationUpgradeHelper,
 				_prefsPropsToConfigurationUpgradeHelper));
 	}
 

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/registry/DLServiceUpgradeStepRegistrator.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/registry/DLServiceUpgradeStepRegistrator.java
@@ -20,7 +20,6 @@ import com.liferay.document.library.internal.upgrade.v3_2_4.DLSizeLimitConfigura
 import com.liferay.document.library.internal.upgrade.v3_2_5.DLFileEntryTypesDDMStructureUpgradeProcess;
 import com.liferay.document.library.internal.upgrade.v3_2_6.DeleteStalePWCVersionsUpgradeProcess;
 import com.liferay.document.library.internal.upgrade.v3_2_7.DownloadViewActionResourcePermissionUpgradeProcess;
-import com.liferay.document.library.internal.upgrade.v3_2_9.DLLegacyConfigurationUpgradeProcess;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.store.Store;
 import com.liferay.dynamic.data.mapping.security.permission.DDMPermissionSupport;
@@ -33,7 +32,6 @@ import com.liferay.portal.kernel.upgrade.CTModelUpgradeProcess;
 import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
 import com.liferay.portal.kernel.upgrade.MVCCVersionUpgradeProcess;
 import com.liferay.portal.kernel.upgrade.ViewCountUpgradeProcess;
-import com.liferay.portal.kernel.util.PrefsProps;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 import com.liferay.subscription.service.SubscriptionLocalService;
 import com.liferay.view.count.service.ViewCountEntryLocalService;
@@ -142,9 +140,17 @@ public class DLServiceUpgradeStepRegistrator implements UpgradeStepRegistrator {
 
 		registry.register(
 			"3.2.8", "3.2.9",
-			new DLLegacyConfigurationUpgradeProcess(
-				_dlConfigurationUpgradeHelper,
-				_prefsPropsToConfigurationUpgradeHelper));
+			new com.liferay.document.library.internal.upgrade.v3_2_9.
+				DLConfigurationUpgradeProcess(
+					_dlConfigurationUpgradeHelper,
+					_prefsPropsToConfigurationUpgradeHelper),
+			new com.liferay.document.library.internal.upgrade.v3_2_9.
+				DLFileEntryConfigurationUpgradeProcess(
+					_dlConfigurationUpgradeHelper,
+					_prefsPropsToConfigurationUpgradeHelper),
+			new com.liferay.document.library.internal.upgrade.v3_2_9.
+				DLSizeLimitConfigurationUpgradeProcess(
+					_dlConfigurationUpgradeHelper));
 	}
 
 	@Reference
@@ -155,9 +161,6 @@ public class DLServiceUpgradeStepRegistrator implements UpgradeStepRegistrator {
 
 	@Reference
 	private DLConfigurationUpgradeHelper _dlConfigurationUpgradeHelper;
-
-	@Reference
-	private PrefsProps _prefsProps;
 
 	@Reference
 	private PrefsPropsToConfigurationUpgradeHelper

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/registry/DLServiceUpgradeStepRegistrator.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/registry/DLServiceUpgradeStepRegistrator.java
@@ -6,6 +6,7 @@
 package com.liferay.document.library.internal.upgrade.registry;
 
 import com.liferay.comment.upgrade.DiscussionSubscriptionClassNameUpgradeProcess;
+import com.liferay.document.library.internal.upgrade.helper.DLConfigurationUpgradeHelper;
 import com.liferay.document.library.internal.upgrade.v1_0_0.DocumentLibraryUpgradeProcess;
 import com.liferay.document.library.internal.upgrade.v1_0_1.DLConfigurationUpgradeProcess;
 import com.liferay.document.library.internal.upgrade.v1_0_1.DLFileEntryConfigurationUpgradeProcess;
@@ -19,10 +20,10 @@ import com.liferay.document.library.internal.upgrade.v3_2_4.DLSizeLimitConfigura
 import com.liferay.document.library.internal.upgrade.v3_2_5.DLFileEntryTypesDDMStructureUpgradeProcess;
 import com.liferay.document.library.internal.upgrade.v3_2_6.DeleteStalePWCVersionsUpgradeProcess;
 import com.liferay.document.library.internal.upgrade.v3_2_7.DownloadViewActionResourcePermissionUpgradeProcess;
+import com.liferay.document.library.internal.upgrade.v3_2_9.DLLegacyConfigurationUpgradeProcess;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.store.Store;
 import com.liferay.dynamic.data.mapping.security.permission.DDMPermissionSupport;
-import com.liferay.portal.configuration.module.configuration.ConfigurationProvider;
 import com.liferay.portal.configuration.upgrade.PrefsPropsToConfigurationUpgradeHelper;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
@@ -32,11 +33,11 @@ import com.liferay.portal.kernel.upgrade.CTModelUpgradeProcess;
 import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
 import com.liferay.portal.kernel.upgrade.MVCCVersionUpgradeProcess;
 import com.liferay.portal.kernel.upgrade.ViewCountUpgradeProcess;
+import com.liferay.portal.kernel.util.PrefsProps;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 import com.liferay.subscription.service.SubscriptionLocalService;
 import com.liferay.view.count.service.ViewCountEntryLocalService;
 
-import org.osgi.service.cm.ConfigurationAdmin;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
@@ -117,7 +118,8 @@ public class DLServiceUpgradeStepRegistrator implements UpgradeStepRegistrator {
 
 		registry.register(
 			"3.2.3", "3.2.4",
-			new DLSizeLimitConfigurationUpgradeProcess(_configurationAdmin));
+			new DLSizeLimitConfigurationUpgradeProcess(
+				_dlConfigurationUpgradeHelper));
 
 		registry.register(
 			"3.2.4", "3.2.5",
@@ -136,20 +138,26 @@ public class DLServiceUpgradeStepRegistrator implements UpgradeStepRegistrator {
 			"3.2.7", "3.2.8",
 			new com.liferay.document.library.internal.upgrade.v3_2_8.
 				DLFileEntryConfigurationUpgradeProcess(
-					_configurationAdmin, _configurationProvider));
+					_dlConfigurationUpgradeHelper));
+
+		registry.register(
+			"3.2.8", "3.2.9",
+			new DLLegacyConfigurationUpgradeProcess(
+				_dlConfigurationUpgradeHelper, _prefsProps,
+				_prefsPropsToConfigurationUpgradeHelper));
 	}
 
 	@Reference
 	private ClassNameLocalService _classNameLocalService;
 
 	@Reference
-	private ConfigurationAdmin _configurationAdmin;
-
-	@Reference
-	private ConfigurationProvider _configurationProvider;
-
-	@Reference
 	private DDMPermissionSupport _ddmPermissionSupport;
+
+	@Reference
+	private DLConfigurationUpgradeHelper _dlConfigurationUpgradeHelper;
+
+	@Reference
+	private PrefsProps _prefsProps;
 
 	@Reference
 	private PrefsPropsToConfigurationUpgradeHelper

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/v3_2_4/DLSizeLimitConfigurationUpgradeProcess.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/v3_2_4/DLSizeLimitConfigurationUpgradeProcess.java
@@ -5,16 +5,8 @@
 
 package com.liferay.document.library.internal.upgrade.v3_2_4;
 
-import com.liferay.document.library.configuration.DLConfiguration;
-import com.liferay.document.library.internal.configuration.DLSizeLimitConfiguration;
-import com.liferay.petra.string.StringPool;
+import com.liferay.document.library.internal.upgrade.helper.DLConfigurationUpgradeHelper;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
-import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
-
-import java.util.Dictionary;
-
-import org.osgi.service.cm.Configuration;
-import org.osgi.service.cm.ConfigurationAdmin;
 
 /**
  * @author Adolfo Pérez
@@ -22,59 +14,16 @@ import org.osgi.service.cm.ConfigurationAdmin;
 public class DLSizeLimitConfigurationUpgradeProcess extends UpgradeProcess {
 
 	public DLSizeLimitConfigurationUpgradeProcess(
-		ConfigurationAdmin configurationAdmin) {
+		DLConfigurationUpgradeHelper dlConfigurationUpgradeHelper) {
 
-		_configurationAdmin = configurationAdmin;
+		_dlConfigurationUpgradeHelper = dlConfigurationUpgradeHelper;
 	}
 
 	@Override
 	protected void doUpgrade() throws Exception {
-		long fileMaxSize = _updateDLConfiguration();
-
-		if (fileMaxSize > 0) {
-			_updateDLSizeLimitConfiguration(fileMaxSize);
-		}
+		_dlConfigurationUpgradeHelper.updateDLSizeLimitConfiguration();
 	}
 
-	private long _updateDLConfiguration() throws Exception {
-		Configuration[] configurations = _configurationAdmin.listConfigurations(
-			"(service.pid=" + DLConfiguration.class.getName() + ")");
-
-		if (configurations == null) {
-			return 0;
-		}
-
-		Configuration configuration = configurations[0];
-
-		Dictionary<String, Object> dictionary = configuration.getProperties();
-
-		if (dictionary == null) {
-			return 0;
-		}
-
-		Long fileMaxSize = (Long)dictionary.remove("fileMaxSize");
-
-		if (fileMaxSize == null) {
-			return 0;
-		}
-
-		configuration.update(dictionary);
-
-		return fileMaxSize;
-	}
-
-	private void _updateDLSizeLimitConfiguration(long fileMaxSize)
-		throws Exception {
-
-		Configuration configuration = _configurationAdmin.getConfiguration(
-			DLSizeLimitConfiguration.class.getName(), StringPool.QUESTION);
-
-		configuration.update(
-			HashMapDictionaryBuilder.put(
-				"fileMaxSize", fileMaxSize
-			).build());
-	}
-
-	private final ConfigurationAdmin _configurationAdmin;
+	private final DLConfigurationUpgradeHelper _dlConfigurationUpgradeHelper;
 
 }

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/v3_2_8/DLFileEntryConfigurationUpgradeProcess.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/v3_2_8/DLFileEntryConfigurationUpgradeProcess.java
@@ -5,19 +5,8 @@
 
 package com.liferay.document.library.internal.upgrade.v3_2_8;
 
-import com.liferay.document.library.configuration.DLFileEntryConfiguration;
-import com.liferay.document.library.constants.DLFileEntryConfigurationConstants;
-import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
-import com.liferay.portal.configuration.module.configuration.ConfigurationProvider;
+import com.liferay.document.library.internal.upgrade.helper.DLConfigurationUpgradeHelper;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
-import com.liferay.portal.kernel.util.HashMapDictionary;
-import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
-
-import java.util.Dictionary;
-
-import org.osgi.framework.Constants;
-import org.osgi.service.cm.Configuration;
-import org.osgi.service.cm.ConfigurationAdmin;
 
 /**
  * @author Marco Galluzzi
@@ -25,174 +14,23 @@ import org.osgi.service.cm.ConfigurationAdmin;
 public class DLFileEntryConfigurationUpgradeProcess extends UpgradeProcess {
 
 	public DLFileEntryConfigurationUpgradeProcess(
-		ConfigurationAdmin configurationAdmin,
-		ConfigurationProvider configurationProvider) {
+		DLConfigurationUpgradeHelper dlConfigurationUpgradeHelper) {
 
-		_configurationAdmin = configurationAdmin;
-		_configurationProvider = configurationProvider;
+		_dlConfigurationUpgradeHelper = dlConfigurationUpgradeHelper;
 	}
 
 	@Override
 	protected void doUpgrade() throws Exception {
-		long systemPreviewableProcessorMaxSize = _updateSystemConfiguration();
+		long systemPreviewableProcessorMaxSize =
+			_dlConfigurationUpgradeHelper.updateSystemConfiguration();
 
-		_updateScopedConfigurations(systemPreviewableProcessorMaxSize);
+		_dlConfigurationUpgradeHelper.updateScopedConfigurations(
+			systemPreviewableProcessorMaxSize);
 
-		_deleteConfigurations(_CLASS_NAME_PDF_PREVIEW_CONFIGURATION);
+		_dlConfigurationUpgradeHelper.deleteConfigurations(
+			DLConfigurationUpgradeHelper.CLASS_NAME_PDF_PREVIEW_CONFIGURATION);
 	}
 
-	private HashMapDictionary<String, Object> _createDictionary(
-		int maxNumberOfPages, long previewableProcessorMaxSize) {
-
-		return HashMapDictionaryBuilder.<String, Object>put(
-			"maxNumberOfPages", maxNumberOfPages
-		).put(
-			"previewableProcessorMaxSize", previewableProcessorMaxSize
-		).build();
-	}
-
-	private void _deleteConfigurations(String className) throws Exception {
-		Configuration[] configurations = _configurationAdmin.listConfigurations(
-			String.format("(%s=%s*)", Constants.SERVICE_PID, className));
-
-		if (configurations == null) {
-			return;
-		}
-
-		for (Configuration configuration : configurations) {
-			configuration.delete();
-		}
-	}
-
-	private <T> T _getAttributeValue(
-		Configuration configuration, String attributeName, T defaultValue) {
-
-		if (configuration == null) {
-			return defaultValue;
-		}
-
-		Dictionary<String, Object> dictionary = configuration.getProperties();
-
-		if (dictionary == null) {
-			return defaultValue;
-		}
-
-		T value = (T)dictionary.get(attributeName);
-
-		if (value == null) {
-			return defaultValue;
-		}
-
-		return value;
-	}
-
-	private Configuration[] _getScopedConfigurations(String className)
-		throws Exception {
-
-		Configuration[] configurations = _configurationAdmin.listConfigurations(
-			String.format(
-				"(%s=%s.scoped)", ConfigurationAdmin.SERVICE_FACTORYPID,
-				className));
-
-		if (configurations == null) {
-			return new Configuration[0];
-		}
-
-		return configurations;
-	}
-
-	private Configuration _getSystemConfiguration(String className)
-		throws Exception {
-
-		Configuration[] configurations = _configurationAdmin.listConfigurations(
-			String.format("(%s=%s)", Constants.SERVICE_PID, className));
-
-		if (configurations == null) {
-			return null;
-		}
-
-		return configurations[0];
-	}
-
-	private void _updateScopedConfigurations(
-			long systemPreviewableProcessorMaxSize)
-		throws Exception {
-
-		Configuration[] configurations = _getScopedConfigurations(
-			_CLASS_NAME_PDF_PREVIEW_CONFIGURATION);
-
-		for (Configuration configuration : configurations) {
-			Dictionary<String, Object> dictionary = _createDictionary(
-				_getAttributeValue(
-					configuration, "maxNumberOfPages",
-					DLFileEntryConfigurationConstants.
-						MAX_NUMBER_OF_PAGES_DEFAULT),
-				Math.max(
-					DLFileEntryConfigurationConstants.
-						PREVIEWABLE_PROCESSOR_MAX_SIZE_DEFAULT,
-					systemPreviewableProcessorMaxSize));
-
-			long companyId = _getAttributeValue(
-				configuration,
-				ExtendedObjectClassDefinition.Scope.COMPANY.getPropertyKey(),
-				0L);
-
-			if (companyId != 0) {
-				_configurationProvider.saveCompanyConfiguration(
-					DLFileEntryConfiguration.class, companyId, dictionary);
-
-				continue;
-			}
-
-			long groupId = _getAttributeValue(
-				configuration,
-				ExtendedObjectClassDefinition.Scope.GROUP.getPropertyKey(), 0L);
-
-			if (groupId != 0) {
-				_configurationProvider.saveGroupConfiguration(
-					DLFileEntryConfiguration.class, groupId, dictionary);
-			}
-		}
-	}
-
-	private long _updateSystemConfiguration() throws Exception {
-		Configuration dlFileEntryConfiguration = _getSystemConfiguration(
-			_CLASS_NAME_DL_FILE_ENTRY_CONFIGURATION);
-		Configuration pdfPreviewConfiguration = _getSystemConfiguration(
-			_CLASS_NAME_PDF_PREVIEW_CONFIGURATION);
-
-		if ((dlFileEntryConfiguration != null) ||
-			(pdfPreviewConfiguration != null)) {
-
-			int maxNumberOfPages = _getAttributeValue(
-				pdfPreviewConfiguration, "maxNumberOfPages",
-				DLFileEntryConfigurationConstants.MAX_NUMBER_OF_PAGES_DEFAULT);
-
-			long previewableProcessorMaxSize = _getAttributeValue(
-				dlFileEntryConfiguration, "previewableProcessorMaxSize",
-				DLFileEntryConfigurationConstants.
-					PREVIEWABLE_PROCESSOR_MAX_SIZE_DEFAULT);
-
-			_configurationProvider.saveSystemConfiguration(
-				DLFileEntryConfiguration.class,
-				_createDictionary(
-					maxNumberOfPages, previewableProcessorMaxSize));
-
-			return previewableProcessorMaxSize;
-		}
-
-		return DLFileEntryConfigurationConstants.
-			PREVIEWABLE_PROCESSOR_MAX_SIZE_DEFAULT;
-	}
-
-	private static final String _CLASS_NAME_DL_FILE_ENTRY_CONFIGURATION =
-		"com.liferay.document.library.configuration.DLFileEntryConfiguration";
-
-	private static final String _CLASS_NAME_PDF_PREVIEW_CONFIGURATION =
-		"com.liferay.document.library.preview.pdf.internal.configuration." +
-			"PDFPreviewConfiguration";
-
-	private final ConfigurationAdmin _configurationAdmin;
-	private final ConfigurationProvider _configurationProvider;
+	private final DLConfigurationUpgradeHelper _dlConfigurationUpgradeHelper;
 
 }

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/v3_2_8/DLFileEntryConfigurationUpgradeProcess.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/v3_2_8/DLFileEntryConfigurationUpgradeProcess.java
@@ -22,7 +22,12 @@ public class DLFileEntryConfigurationUpgradeProcess extends UpgradeProcess {
 	@Override
 	protected void doUpgrade() throws Exception {
 		long systemPreviewableProcessorMaxSize =
-			_dlConfigurationUpgradeHelper.updateSystemConfiguration();
+			_dlConfigurationUpgradeHelper.
+				getDLFileEntryConfigurationPreviewableProcessorMaxSize();
+
+		_dlConfigurationUpgradeHelper.
+			updateDLFileEntryConfigurationSystemConfiguration(
+				systemPreviewableProcessorMaxSize);
 
 		_dlConfigurationUpgradeHelper.updateScopedConfigurations(
 			systemPreviewableProcessorMaxSize);

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/v3_2_9/DLConfigurationUpgradeProcess.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/v3_2_9/DLConfigurationUpgradeProcess.java
@@ -1,0 +1,56 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.document.library.internal.upgrade.v3_2_9;
+
+import com.liferay.document.library.configuration.DLConfiguration;
+import com.liferay.document.library.internal.configuration.DLSizeLimitConfiguration;
+import com.liferay.document.library.internal.constants.LegacyDLKeys;
+import com.liferay.document.library.internal.upgrade.helper.DLConfigurationUpgradeHelper;
+import com.liferay.portal.configuration.upgrade.PrefsPropsToConfigurationUpgradeHelper;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.KeyValuePair;
+
+/**
+ * @author Drew Brokke
+ * @author Alicia García
+ */
+public class DLConfigurationUpgradeProcess extends UpgradeProcess {
+
+	public DLConfigurationUpgradeProcess(
+		DLConfigurationUpgradeHelper dlConfigurationUpgradeHelper,
+		PrefsPropsToConfigurationUpgradeHelper
+			prefsPropsToConfigurationUpgradeHelper) {
+
+		_dlConfigurationUpgradeHelper = dlConfigurationUpgradeHelper;
+		_prefsPropsToConfigurationUpgradeHelper =
+			prefsPropsToConfigurationUpgradeHelper;
+	}
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		if (!_dlConfigurationUpgradeHelper.hasLegacyProps()) {
+			return;
+		}
+
+		_upgradeConfiguration();
+	}
+
+	private void _upgradeConfiguration() throws Exception {
+		_prefsPropsToConfigurationUpgradeHelper.mapConfigurations(
+			DLConfiguration.class,
+			new KeyValuePair(
+				LegacyDLKeys.DL_FILE_EXTENSIONS, "fileExtensions"));
+
+		_prefsPropsToConfigurationUpgradeHelper.mapConfigurations(
+			DLSizeLimitConfiguration.class,
+			new KeyValuePair(LegacyDLKeys.DL_FILE_MAX_SIZE, "fileMaxSize"));
+	}
+
+	private final DLConfigurationUpgradeHelper _dlConfigurationUpgradeHelper;
+	private final PrefsPropsToConfigurationUpgradeHelper
+		_prefsPropsToConfigurationUpgradeHelper;
+
+}

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/v3_2_9/DLFileEntryConfigurationUpgradeProcess.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/v3_2_9/DLFileEntryConfigurationUpgradeProcess.java
@@ -41,11 +41,6 @@ public class DLFileEntryConfigurationUpgradeProcess extends UpgradeProcess {
 	}
 
 	private void _upgradeConfiguration() throws Exception {
-		if (!_dlConfigurationUpgradeHelper.hasLegacyProps() ||
-			!_dlConfigurationUpgradeHelper.hasConfigurationChanges()) {
-
-			return;
-		}
 
 		_prefsPropsToConfigurationUpgradeHelper.mapConfigurations(
 			DLFileEntryConfiguration.class,

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/v3_2_9/DLFileEntryConfigurationUpgradeProcess.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/v3_2_9/DLFileEntryConfigurationUpgradeProcess.java
@@ -32,7 +32,10 @@ public class DLFileEntryConfigurationUpgradeProcess extends UpgradeProcess {
 	@Override
 	protected void doUpgrade() throws Exception {
 		if (!_dlConfigurationUpgradeHelper.hasLegacyProps() ||
-			!_dlConfigurationUpgradeHelper.hasConfigurationChanges()) {
+			!_dlConfigurationUpgradeHelper.
+				hasDLSizeLimitConfigurationChanges() ||
+			!_dlConfigurationUpgradeHelper.
+				hasDLFileEntryConfigurationChanges()) {
 
 			return;
 		}

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/v3_2_9/DLFileEntryConfigurationUpgradeProcess.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/v3_2_9/DLFileEntryConfigurationUpgradeProcess.java
@@ -44,7 +44,6 @@ public class DLFileEntryConfigurationUpgradeProcess extends UpgradeProcess {
 	}
 
 	private void _upgradeConfiguration() throws Exception {
-
 		_prefsPropsToConfigurationUpgradeHelper.mapConfigurations(
 			DLFileEntryConfiguration.class,
 			new KeyValuePair(
@@ -52,7 +51,12 @@ public class DLFileEntryConfigurationUpgradeProcess extends UpgradeProcess {
 				"previewableProcessorMaxSize"));
 
 		long systemPreviewableProcessorMaxSize =
-			_dlConfigurationUpgradeHelper.updateSystemConfiguration();
+			_dlConfigurationUpgradeHelper.
+				getDLFileEntryConfigurationPreviewableProcessorMaxSize();
+
+		_dlConfigurationUpgradeHelper.
+			updateDLFileEntryConfigurationSystemConfiguration(
+				systemPreviewableProcessorMaxSize);
 
 		_dlConfigurationUpgradeHelper.updateScopedConfigurations(
 			systemPreviewableProcessorMaxSize);

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/v3_2_9/DLFileEntryConfigurationUpgradeProcess.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/v3_2_9/DLFileEntryConfigurationUpgradeProcess.java
@@ -5,9 +5,7 @@
 
 package com.liferay.document.library.internal.upgrade.v3_2_9;
 
-import com.liferay.document.library.configuration.DLConfiguration;
 import com.liferay.document.library.configuration.DLFileEntryConfiguration;
-import com.liferay.document.library.internal.configuration.DLSizeLimitConfiguration;
 import com.liferay.document.library.internal.constants.LegacyDLKeys;
 import com.liferay.document.library.internal.upgrade.helper.DLConfigurationUpgradeHelper;
 import com.liferay.portal.configuration.upgrade.PrefsPropsToConfigurationUpgradeHelper;
@@ -15,11 +13,13 @@ import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.KeyValuePair;
 
 /**
+ * @author Drew Brokke
+ * @author Marco Galluzzi
  * @author Alicia García
  */
-public class DLLegacyConfigurationUpgradeProcess extends UpgradeProcess {
+public class DLFileEntryConfigurationUpgradeProcess extends UpgradeProcess {
 
-	public DLLegacyConfigurationUpgradeProcess(
+	public DLFileEntryConfigurationUpgradeProcess(
 		DLConfigurationUpgradeHelper dlConfigurationUpgradeHelper,
 		PrefsPropsToConfigurationUpgradeHelper
 			prefsPropsToConfigurationUpgradeHelper) {
@@ -37,22 +37,21 @@ public class DLLegacyConfigurationUpgradeProcess extends UpgradeProcess {
 			return;
 		}
 
-		_prefsPropsToConfigurationUpgradeHelper.mapConfigurations(
-			DLConfiguration.class,
-			new KeyValuePair(
-				LegacyDLKeys.DL_FILE_EXTENSIONS, "fileExtensions"));
+		_upgradeConfiguration();
+	}
 
-		_prefsPropsToConfigurationUpgradeHelper.mapConfigurations(
-			DLSizeLimitConfiguration.class,
-			new KeyValuePair(LegacyDLKeys.DL_FILE_MAX_SIZE, "fileMaxSize"));
+	private void _upgradeConfiguration() throws Exception {
+		if (!_dlConfigurationUpgradeHelper.hasLegacyProps() ||
+			!_dlConfigurationUpgradeHelper.hasConfigurationChanges()) {
+
+			return;
+		}
 
 		_prefsPropsToConfigurationUpgradeHelper.mapConfigurations(
 			DLFileEntryConfiguration.class,
 			new KeyValuePair(
 				LegacyDLKeys.DL_FILE_ENTRY_PREVIEWABLE_PROCESSOR_MAX_SIZE,
 				"previewableProcessorMaxSize"));
-
-		_dlConfigurationUpgradeHelper.updateDLSizeLimitConfiguration();
 
 		long systemPreviewableProcessorMaxSize =
 			_dlConfigurationUpgradeHelper.updateSystemConfiguration();

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/v3_2_9/DLLegacyConfigurationUpgradeProcess.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/v3_2_9/DLLegacyConfigurationUpgradeProcess.java
@@ -40,6 +40,58 @@ public class DLLegacyConfigurationUpgradeProcess extends UpgradeProcess {
 
 	@Override
 	protected void doUpgrade() throws Exception {
+		if (Validator.isNull(
+				_prefsProps.getString(LegacyDLKeys.DL_FILE_EXTENSIONS, null)) &&
+			Validator.isNull(
+				_prefsProps.getString(LegacyDLKeys.DL_FILE_MAX_SIZE, null)) &&
+			Validator.isNull(
+				_prefsProps.getString(
+					LegacyDLKeys.DL_FILE_ENTRY_PREVIEWABLE_PROCESSOR_MAX_SIZE,
+					null))) {
+
+			return;
+		}
+
+		Configuration dlSizeLimitConfiguration =
+			_dlConfigurationUpgradeHelper.getSystemConfiguration(
+				DLSizeLimitConfiguration.class.getName());
+
+		if (dlSizeLimitConfiguration != null) {
+			Dictionary<String, Object> dictionary =
+				dlSizeLimitConfiguration.getProperties();
+
+			if (dictionary != null) {
+				Long fileMaxSize = (Long)dictionary.get("fileMaxSize");
+
+				if ((fileMaxSize != null) && (fileMaxSize != 0)) {
+					return;
+				}
+			}
+		}
+
+		Configuration dlFileEntryConfiguration =
+			_dlConfigurationUpgradeHelper.getSystemConfiguration(
+				DLConfigurationUpgradeHelper.
+					CLASS_NAME_DL_FILE_ENTRY_CONFIGURATION);
+
+		if (dlFileEntryConfiguration != null) {
+			Dictionary<String, Object> dictionary =
+				dlFileEntryConfiguration.getProperties();
+
+			if (dictionary != null) {
+				Long previewableProcessorMaxSize = (Long)dictionary.get(
+					"previewableProcessorMaxSize");
+
+				if ((previewableProcessorMaxSize != null) &&
+					(previewableProcessorMaxSize !=
+						DLFileEntryConfigurationConstants.
+							PREVIEWABLE_PROCESSOR_MAX_SIZE_DEFAULT)) {
+
+					return;
+				}
+			}
+		}
+
 		_prefsPropsToConfigurationUpgradeHelper.mapConfigurations(
 			DLConfiguration.class,
 			new KeyValuePair(

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/v3_2_9/DLLegacyConfigurationUpgradeProcess.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/v3_2_9/DLLegacyConfigurationUpgradeProcess.java
@@ -7,19 +7,12 @@ package com.liferay.document.library.internal.upgrade.v3_2_9;
 
 import com.liferay.document.library.configuration.DLConfiguration;
 import com.liferay.document.library.configuration.DLFileEntryConfiguration;
-import com.liferay.document.library.constants.DLFileEntryConfigurationConstants;
 import com.liferay.document.library.internal.configuration.DLSizeLimitConfiguration;
 import com.liferay.document.library.internal.constants.LegacyDLKeys;
 import com.liferay.document.library.internal.upgrade.helper.DLConfigurationUpgradeHelper;
 import com.liferay.portal.configuration.upgrade.PrefsPropsToConfigurationUpgradeHelper;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.KeyValuePair;
-import com.liferay.portal.kernel.util.PrefsProps;
-import com.liferay.portal.kernel.util.Validator;
-
-import java.util.Dictionary;
-
-import org.osgi.service.cm.Configuration;
 
 /**
  * @author Alicia García
@@ -28,19 +21,19 @@ public class DLLegacyConfigurationUpgradeProcess extends UpgradeProcess {
 
 	public DLLegacyConfigurationUpgradeProcess(
 		DLConfigurationUpgradeHelper dlConfigurationUpgradeHelper,
-		PrefsProps prefsProps,
 		PrefsPropsToConfigurationUpgradeHelper
 			prefsPropsToConfigurationUpgradeHelper) {
 
 		_dlConfigurationUpgradeHelper = dlConfigurationUpgradeHelper;
-		_prefsProps = prefsProps;
 		_prefsPropsToConfigurationUpgradeHelper =
 			prefsPropsToConfigurationUpgradeHelper;
 	}
 
 	@Override
 	protected void doUpgrade() throws Exception {
-		if (!_hasLegacyProps() || !_hasConfigurationChanges()) {
+		if (!_dlConfigurationUpgradeHelper.hasLegacyProps() ||
+			!_dlConfigurationUpgradeHelper.hasConfigurationChanges()) {
+
 			return;
 		}
 
@@ -71,68 +64,7 @@ public class DLLegacyConfigurationUpgradeProcess extends UpgradeProcess {
 			DLConfigurationUpgradeHelper.CLASS_NAME_PDF_PREVIEW_CONFIGURATION);
 	}
 
-	private boolean _hasConfigurationChanges() throws Exception {
-		Configuration dlSizeLimitConfiguration =
-			_dlConfigurationUpgradeHelper.getSystemConfiguration(
-				DLSizeLimitConfiguration.class.getName());
-
-		if (dlSizeLimitConfiguration != null) {
-			Dictionary<String, Object> dictionary =
-				dlSizeLimitConfiguration.getProperties();
-
-			if (dictionary != null) {
-				Long fileMaxSize = (Long)dictionary.get("fileMaxSize");
-
-				if ((fileMaxSize != null) && (fileMaxSize != 0)) {
-					return false;
-				}
-			}
-		}
-
-		Configuration dlFileEntryConfiguration =
-			_dlConfigurationUpgradeHelper.getSystemConfiguration(
-				DLConfigurationUpgradeHelper.
-					CLASS_NAME_DL_FILE_ENTRY_CONFIGURATION);
-
-		if (dlFileEntryConfiguration != null) {
-			Dictionary<String, Object> dictionary =
-				dlFileEntryConfiguration.getProperties();
-
-			if (dictionary != null) {
-				Long previewableProcessorMaxSize = (Long)dictionary.get(
-					"previewableProcessorMaxSize");
-
-				if ((previewableProcessorMaxSize != null) &&
-					(previewableProcessorMaxSize !=
-						DLFileEntryConfigurationConstants.
-							PREVIEWABLE_PROCESSOR_MAX_SIZE_DEFAULT)) {
-
-					return false;
-				}
-			}
-		}
-
-		return true;
-	}
-
-	private boolean _hasLegacyProps() throws Exception {
-		if (Validator.isNull(
-				_prefsProps.getString(LegacyDLKeys.DL_FILE_EXTENSIONS, null)) &&
-			Validator.isNull(
-				_prefsProps.getString(LegacyDLKeys.DL_FILE_MAX_SIZE, null)) &&
-			Validator.isNull(
-				_prefsProps.getString(
-					LegacyDLKeys.DL_FILE_ENTRY_PREVIEWABLE_PROCESSOR_MAX_SIZE,
-					null))) {
-
-			return false;
-		}
-
-		return true;
-	}
-
 	private final DLConfigurationUpgradeHelper _dlConfigurationUpgradeHelper;
-	private final PrefsProps _prefsProps;
 	private final PrefsPropsToConfigurationUpgradeHelper
 		_prefsPropsToConfigurationUpgradeHelper;
 

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/v3_2_9/DLLegacyConfigurationUpgradeProcess.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/v3_2_9/DLLegacyConfigurationUpgradeProcess.java
@@ -1,0 +1,75 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.document.library.internal.upgrade.v3_2_9;
+
+import com.liferay.document.library.configuration.DLConfiguration;
+import com.liferay.document.library.configuration.DLFileEntryConfiguration;
+import com.liferay.document.library.constants.DLFileEntryConfigurationConstants;
+import com.liferay.document.library.internal.configuration.DLSizeLimitConfiguration;
+import com.liferay.document.library.internal.constants.LegacyDLKeys;
+import com.liferay.document.library.internal.upgrade.helper.DLConfigurationUpgradeHelper;
+import com.liferay.portal.configuration.upgrade.PrefsPropsToConfigurationUpgradeHelper;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.KeyValuePair;
+import com.liferay.portal.kernel.util.PrefsProps;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.util.Dictionary;
+
+import org.osgi.service.cm.Configuration;
+
+/**
+ * @author Alicia García
+ */
+public class DLLegacyConfigurationUpgradeProcess extends UpgradeProcess {
+
+	public DLLegacyConfigurationUpgradeProcess(
+		DLConfigurationUpgradeHelper dlConfigurationUpgradeHelper,
+		PrefsProps prefsProps,
+		PrefsPropsToConfigurationUpgradeHelper
+			prefsPropsToConfigurationUpgradeHelper) {
+
+		_dlConfigurationUpgradeHelper = dlConfigurationUpgradeHelper;
+		_prefsProps = prefsProps;
+		_prefsPropsToConfigurationUpgradeHelper =
+			prefsPropsToConfigurationUpgradeHelper;
+	}
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		_prefsPropsToConfigurationUpgradeHelper.mapConfigurations(
+			DLConfiguration.class,
+			new KeyValuePair(
+				LegacyDLKeys.DL_FILE_EXTENSIONS, "fileExtensions"));
+
+		_prefsPropsToConfigurationUpgradeHelper.mapConfigurations(
+			DLSizeLimitConfiguration.class,
+			new KeyValuePair(LegacyDLKeys.DL_FILE_MAX_SIZE, "fileMaxSize"));
+
+		_prefsPropsToConfigurationUpgradeHelper.mapConfigurations(
+			DLFileEntryConfiguration.class,
+			new KeyValuePair(
+				LegacyDLKeys.DL_FILE_ENTRY_PREVIEWABLE_PROCESSOR_MAX_SIZE,
+				"previewableProcessorMaxSize"));
+
+		_dlConfigurationUpgradeHelper.updateDLSizeLimitConfiguration();
+
+		long systemPreviewableProcessorMaxSize =
+			_dlConfigurationUpgradeHelper.updateSystemConfiguration();
+
+		_dlConfigurationUpgradeHelper.updateScopedConfigurations(
+			systemPreviewableProcessorMaxSize);
+
+		_dlConfigurationUpgradeHelper.deleteConfigurations(
+			DLConfigurationUpgradeHelper.CLASS_NAME_PDF_PREVIEW_CONFIGURATION);
+	}
+
+	private final DLConfigurationUpgradeHelper _dlConfigurationUpgradeHelper;
+	private final PrefsProps _prefsProps;
+	private final PrefsPropsToConfigurationUpgradeHelper
+		_prefsPropsToConfigurationUpgradeHelper;
+
+}

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/v3_2_9/DLLegacyConfigurationUpgradeProcess.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/v3_2_9/DLLegacyConfigurationUpgradeProcess.java
@@ -40,56 +40,8 @@ public class DLLegacyConfigurationUpgradeProcess extends UpgradeProcess {
 
 	@Override
 	protected void doUpgrade() throws Exception {
-		if (Validator.isNull(
-				_prefsProps.getString(LegacyDLKeys.DL_FILE_EXTENSIONS, null)) &&
-			Validator.isNull(
-				_prefsProps.getString(LegacyDLKeys.DL_FILE_MAX_SIZE, null)) &&
-			Validator.isNull(
-				_prefsProps.getString(
-					LegacyDLKeys.DL_FILE_ENTRY_PREVIEWABLE_PROCESSOR_MAX_SIZE,
-					null))) {
-
+		if (!_hasLegacyProps() || !_hasConfigurationChanges()) {
 			return;
-		}
-
-		Configuration dlSizeLimitConfiguration =
-			_dlConfigurationUpgradeHelper.getSystemConfiguration(
-				DLSizeLimitConfiguration.class.getName());
-
-		if (dlSizeLimitConfiguration != null) {
-			Dictionary<String, Object> dictionary =
-				dlSizeLimitConfiguration.getProperties();
-
-			if (dictionary != null) {
-				Long fileMaxSize = (Long)dictionary.get("fileMaxSize");
-
-				if ((fileMaxSize != null) && (fileMaxSize != 0)) {
-					return;
-				}
-			}
-		}
-
-		Configuration dlFileEntryConfiguration =
-			_dlConfigurationUpgradeHelper.getSystemConfiguration(
-				DLConfigurationUpgradeHelper.
-					CLASS_NAME_DL_FILE_ENTRY_CONFIGURATION);
-
-		if (dlFileEntryConfiguration != null) {
-			Dictionary<String, Object> dictionary =
-				dlFileEntryConfiguration.getProperties();
-
-			if (dictionary != null) {
-				Long previewableProcessorMaxSize = (Long)dictionary.get(
-					"previewableProcessorMaxSize");
-
-				if ((previewableProcessorMaxSize != null) &&
-					(previewableProcessorMaxSize !=
-						DLFileEntryConfigurationConstants.
-							PREVIEWABLE_PROCESSOR_MAX_SIZE_DEFAULT)) {
-
-					return;
-				}
-			}
 		}
 
 		_prefsPropsToConfigurationUpgradeHelper.mapConfigurations(
@@ -117,6 +69,66 @@ public class DLLegacyConfigurationUpgradeProcess extends UpgradeProcess {
 
 		_dlConfigurationUpgradeHelper.deleteConfigurations(
 			DLConfigurationUpgradeHelper.CLASS_NAME_PDF_PREVIEW_CONFIGURATION);
+	}
+
+	private boolean _hasConfigurationChanges() throws Exception {
+		Configuration dlSizeLimitConfiguration =
+			_dlConfigurationUpgradeHelper.getSystemConfiguration(
+				DLSizeLimitConfiguration.class.getName());
+
+		if (dlSizeLimitConfiguration != null) {
+			Dictionary<String, Object> dictionary =
+				dlSizeLimitConfiguration.getProperties();
+
+			if (dictionary != null) {
+				Long fileMaxSize = (Long)dictionary.get("fileMaxSize");
+
+				if ((fileMaxSize != null) && (fileMaxSize != 0)) {
+					return false;
+				}
+			}
+		}
+
+		Configuration dlFileEntryConfiguration =
+			_dlConfigurationUpgradeHelper.getSystemConfiguration(
+				DLConfigurationUpgradeHelper.
+					CLASS_NAME_DL_FILE_ENTRY_CONFIGURATION);
+
+		if (dlFileEntryConfiguration != null) {
+			Dictionary<String, Object> dictionary =
+				dlFileEntryConfiguration.getProperties();
+
+			if (dictionary != null) {
+				Long previewableProcessorMaxSize = (Long)dictionary.get(
+					"previewableProcessorMaxSize");
+
+				if ((previewableProcessorMaxSize != null) &&
+					(previewableProcessorMaxSize !=
+						DLFileEntryConfigurationConstants.
+							PREVIEWABLE_PROCESSOR_MAX_SIZE_DEFAULT)) {
+
+					return false;
+				}
+			}
+		}
+
+		return true;
+	}
+
+	private boolean _hasLegacyProps() throws Exception {
+		if (Validator.isNull(
+				_prefsProps.getString(LegacyDLKeys.DL_FILE_EXTENSIONS, null)) &&
+			Validator.isNull(
+				_prefsProps.getString(LegacyDLKeys.DL_FILE_MAX_SIZE, null)) &&
+			Validator.isNull(
+				_prefsProps.getString(
+					LegacyDLKeys.DL_FILE_ENTRY_PREVIEWABLE_PROCESSOR_MAX_SIZE,
+					null))) {
+
+			return false;
+		}
+
+		return true;
 	}
 
 	private final DLConfigurationUpgradeHelper _dlConfigurationUpgradeHelper;

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/v3_2_9/DLSizeLimitConfigurationUpgradeProcess.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/v3_2_9/DLSizeLimitConfigurationUpgradeProcess.java
@@ -22,7 +22,10 @@ public class DLSizeLimitConfigurationUpgradeProcess extends UpgradeProcess {
 	@Override
 	protected void doUpgrade() throws Exception {
 		if (!_dlConfigurationUpgradeHelper.hasLegacyProps() ||
-			!_dlConfigurationUpgradeHelper.hasConfigurationChanges()) {
+			!_dlConfigurationUpgradeHelper.
+				hasDLSizeLimitConfigurationChanges() ||
+			!_dlConfigurationUpgradeHelper.
+				hasDLFileEntryConfigurationChanges()) {
 
 			return;
 		}

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/v3_2_9/DLSizeLimitConfigurationUpgradeProcess.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/v3_2_9/DLSizeLimitConfigurationUpgradeProcess.java
@@ -1,0 +1,35 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.document.library.internal.upgrade.v3_2_9;
+
+import com.liferay.document.library.internal.upgrade.helper.DLConfigurationUpgradeHelper;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+
+/**
+ * @author Adolfo Pérez
+ */
+public class DLSizeLimitConfigurationUpgradeProcess extends UpgradeProcess {
+
+	public DLSizeLimitConfigurationUpgradeProcess(
+		DLConfigurationUpgradeHelper dlConfigurationUpgradeHelper) {
+
+		_dlConfigurationUpgradeHelper = dlConfigurationUpgradeHelper;
+	}
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		if (!_dlConfigurationUpgradeHelper.hasLegacyProps() ||
+			!_dlConfigurationUpgradeHelper.hasConfigurationChanges()) {
+
+			return;
+		}
+
+		_dlConfigurationUpgradeHelper.updateDLSizeLimitConfiguration();
+	}
+
+	private final DLConfigurationUpgradeHelper _dlConfigurationUpgradeHelper;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-157775


- LPS-157775 extract methods of upgrade dl configurations processes to reuse several times
- LPS-157775 add new step because sometimes the configuration is not correctly upgraded, so we must redo it
- LPS-157775 only do the upgrade if there was not user changes on the new properties or the old ones are still with data
- LPS-157775 semver
- LPS-157775 extract methods to clarification
