### PR TITLE
LPS-193971 extract before shorten because short first can cause the deletion of the end of a html tag

### DIFF
--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/impl/BlogsEntryLocalServiceImpl.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/impl/BlogsEntryLocalServiceImpl.java
@@ -1089,8 +1089,8 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 			visible = true;
 		}
 
-		String summary = _htmlParser.extractText(
-			StringUtil.shorten(entry.getContent(), 500));
+		String summary = StringUtil.shorten(
+			_htmlParser.extractText(entry.getContent()), 500);
 
 		AssetEntry assetEntry = _assetEntryLocalService.updateEntry(
 			userId, entry.getGroupId(), entry.getCreateDate(),


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-193971

How to test it:

run  IntegrationTest: AMBlogsEntryStagedModelDataHandlerTest.testExportImportContentWithMultipleStaticReferences

no error message on console.