### PR TITLE
LPS-205263 Change calendar events URL separator

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/portlet/constants/FriendlyURLResolverConstants.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/portlet/constants/FriendlyURLResolverConstants.java
@@ -16,7 +16,7 @@ public class FriendlyURLResolverConstants {
 
 	public static final String URL_SEPARATOR_BLOGS_ENTRY = "/b/";
 
-	public static final String URL_SEPARATOR_CALENDAR_BOOKING = "/g/";
+	public static final String URL_SEPARATOR_CALENDAR_BOOKING = "/h/";
 
 	public static final String URL_SEPARATOR_FILE_ENTRY = "/d/";
 

--- a/portal-kernel/src/com/liferay/portal/kernel/portlet/constants/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/portlet/constants/packageinfo
@@ -1,1 +1,1 @@
-version 1.5.0
+version 1.5.1


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPS-205263

The separator `/g` is already taken (see `CPFriendlyURLConfiguration`).