### PR TITLE
LPS205261 Create AI Images in DM:  show results as clay cards

### DIFF
--- a/modules/apps/ai-creator/ai-creator-openai-web/build.gradle
+++ b/modules/apps/ai-creator/ai-creator-openai-web/build.gradle
@@ -19,6 +19,7 @@ dependencies {
 	compileOnly project(":apps:portal-settings:portal-settings-api")
 	compileOnly project(":apps:site:site-api")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
+	compileOnly project(":apps:upload:upload-api")
 	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-sql-dsl-api")
 	compileOnly project(":core:petra:petra-string")

--- a/modules/apps/ai-creator/ai-creator-openai-web/src/main/java/com/liferay/ai/creator/openai/web/internal/display/context/AICreatorOpenAIDisplayContext.java
+++ b/modules/apps/ai-creator/ai-creator-openai-web/src/main/java/com/liferay/ai/creator/openai/web/internal/display/context/AICreatorOpenAIDisplayContext.java
@@ -57,6 +57,9 @@ public class AICreatorOpenAIDisplayContext {
 
 	public Map<String, Object> getGenerationsProps() {
 		return HashMapBuilder.<String, Object>put(
+			"eventName",
+			ParamUtil.getString(_httpServletRequest, "selectEventName")
+		).put(
 			"getGenerationsURL",
 			() -> {
 				RequestBackedPortletURLFactory requestBackedPortletURLFactory =

--- a/modules/apps/ai-creator/ai-creator-openai-web/src/main/java/com/liferay/ai/creator/openai/web/internal/display/context/AICreatorOpenAIDisplayContext.java
+++ b/modules/apps/ai-creator/ai-creator-openai-web/src/main/java/com/liferay/ai/creator/openai/web/internal/display/context/AICreatorOpenAIDisplayContext.java
@@ -84,7 +84,7 @@ public class AICreatorOpenAIDisplayContext {
 				return PortletURLBuilder.create(
 					requestBackedPortletURLFactory.createActionURL(
 						AICreatorOpenAIPortletKeys.AI_CREATOR_OPENAI)
-				).setMVCRenderCommandName(
+				).setActionName(
 					"/ai_creator_openai/upload_generations"
 				).setParameter(
 					"fileEntryTypeId",

--- a/modules/apps/ai-creator/ai-creator-openai-web/src/main/java/com/liferay/ai/creator/openai/web/internal/display/context/AICreatorOpenAIDisplayContext.java
+++ b/modules/apps/ai-creator/ai-creator-openai-web/src/main/java/com/liferay/ai/creator/openai/web/internal/display/context/AICreatorOpenAIDisplayContext.java
@@ -9,6 +9,7 @@ import com.liferay.ai.creator.openai.web.internal.constants.AICreatorOpenAIPortl
 import com.liferay.learn.LearnMessageUtil;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactory;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactoryUtil;
+import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.portlet.url.builder.ResourceURLBuilder;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -71,6 +72,20 @@ public class AICreatorOpenAIDisplayContext {
 		).put(
 			"learnResources",
 			LearnMessageUtil.getReactDataJSONObject("ai-creator-openai-web")
+		).put(
+			"uploadGenerationsURL",
+			() -> {
+				RequestBackedPortletURLFactory requestBackedPortletURLFactory =
+					RequestBackedPortletURLFactoryUtil.create(
+						_httpServletRequest);
+
+				return PortletURLBuilder.create(
+					requestBackedPortletURLFactory.createActionURL(
+						AICreatorOpenAIPortletKeys.AI_CREATOR_OPENAI)
+				).setMVCRenderCommandName(
+					"/ai_creator_openai/upload_generations"
+				).buildString();
+			}
 		).build();
 	}
 

--- a/modules/apps/ai-creator/ai-creator-openai-web/src/main/java/com/liferay/ai/creator/openai/web/internal/display/context/AICreatorOpenAIDisplayContext.java
+++ b/modules/apps/ai-creator/ai-creator-openai-web/src/main/java/com/liferay/ai/creator/openai/web/internal/display/context/AICreatorOpenAIDisplayContext.java
@@ -22,6 +22,8 @@ import javax.servlet.http.HttpServletRequest;
 
 /**
  * @author Lourdes Fernández Besada
+ * @author Roberto Díaz
+ * @author Ambrín Chaudhary
  */
 public class AICreatorOpenAIDisplayContext {
 
@@ -84,6 +86,15 @@ public class AICreatorOpenAIDisplayContext {
 						AICreatorOpenAIPortletKeys.AI_CREATOR_OPENAI)
 				).setMVCRenderCommandName(
 					"/ai_creator_openai/upload_generations"
+				).setParameter(
+					"fileEntryTypeId",
+					ParamUtil.getLong(_httpServletRequest, "fileEntryTypeId")
+				).setParameter(
+					"folderId",
+					ParamUtil.getLong(_httpServletRequest, "folderId")
+				).setParameter(
+					"repositoryId",
+					ParamUtil.getLong(_httpServletRequest, "repositoryId")
 				).buildString();
 			}
 		).build();

--- a/modules/apps/ai-creator/ai-creator-openai-web/src/main/java/com/liferay/ai/creator/openai/web/internal/portlet/action/UploadGenerationsMVCActionCommand.java
+++ b/modules/apps/ai-creator/ai-creator-openai-web/src/main/java/com/liferay/ai/creator/openai/web/internal/portlet/action/UploadGenerationsMVCActionCommand.java
@@ -1,0 +1,71 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ai.creator.openai.web.internal.portlet.action;
+
+import com.liferay.ai.creator.openai.web.internal.constants.AICreatorOpenAIPortletKeys;
+import com.liferay.ai.creator.openai.web.internal.upload.AICreatorOpenAIUploadFileEntryHandler;
+import com.liferay.document.library.kernel.service.DLAppService;
+import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCActionCommand;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
+import com.liferay.portal.kernel.util.File;
+import com.liferay.upload.UploadHandler;
+import com.liferay.upload.UploadResponseHandler;
+
+import java.util.Map;
+
+import javax.portlet.ActionRequest;
+import javax.portlet.ActionResponse;
+
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Modified;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Roberto Díaz
+ */
+@Component(
+	property = {
+		"javax.portlet.name=" + AICreatorOpenAIPortletKeys.AI_CREATOR_OPENAI,
+		"mvc.command.name=/ai_creator_openai/upload_generations"
+	},
+	service = MVCActionCommand.class
+)
+public class UploadGenerationsMVCActionCommand extends BaseMVCActionCommand {
+
+	@Activate
+	@Modified
+	protected void activate(Map<String, Object> properties) {
+		_aiCreatorOpenAIFileEntryHandler =
+			new AICreatorOpenAIUploadFileEntryHandler(_dlAppService, _file);
+	}
+
+	@Override
+	protected void doProcessAction(
+			ActionRequest actionRequest, ActionResponse actionResponse)
+		throws Exception {
+
+		_uploadHandler.upload(
+			_aiCreatorOpenAIFileEntryHandler, _defaultUploadResponseHandler,
+			actionRequest, actionResponse);
+	}
+
+	private volatile AICreatorOpenAIUploadFileEntryHandler
+		_aiCreatorOpenAIFileEntryHandler;
+
+	@Reference(target = "(upload.response.handler.system.default=true)")
+	private UploadResponseHandler _defaultUploadResponseHandler;
+
+	@Reference
+	private DLAppService _dlAppService;
+
+	@Reference
+	private File _file;
+
+	@Reference
+	private UploadHandler _uploadHandler;
+
+}

--- a/modules/apps/ai-creator/ai-creator-openai-web/src/main/java/com/liferay/ai/creator/openai/web/internal/upload/AICreatorOpenAIUploadFileEntryHandler.java
+++ b/modules/apps/ai-creator/ai-creator-openai-web/src/main/java/com/liferay/ai/creator/openai/web/internal/upload/AICreatorOpenAIUploadFileEntryHandler.java
@@ -1,0 +1,118 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ai.creator.openai.web.internal.upload;
+
+import com.liferay.document.library.kernel.model.DLFolderConstants;
+import com.liferay.document.library.kernel.service.DLAppService;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextFactory;
+import com.liferay.portal.kernel.upload.UploadPortletRequest;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.MimeTypesUtil;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.upload.UploadFileEntryHandler;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+
+import java.net.URL;
+import java.net.URLConnection;
+
+import java.util.Date;
+import java.util.Iterator;
+import java.util.Set;
+
+import javax.portlet.PortletRequest;
+
+/**
+ * @author Roberto Díaz
+ */
+public class AICreatorOpenAIUploadFileEntryHandler
+	implements UploadFileEntryHandler {
+
+	public AICreatorOpenAIUploadFileEntryHandler(
+		DLAppService dlAppService, com.liferay.portal.kernel.util.File file) {
+
+		_dlAppService = dlAppService;
+		_file = file;
+	}
+
+	@Override
+	public FileEntry upload(UploadPortletRequest uploadPortletRequest)
+		throws IOException, PortalException {
+
+		PortletRequest portletRequest =
+			uploadPortletRequest.getPortletRequest();
+
+		String urlPath = ParamUtil.getString(portletRequest, "urlPath");
+
+		if (Validator.isNull(urlPath)) {
+			return null;
+		}
+
+		URL url = new URL(urlPath);
+
+		InputStream inputStream = new BufferedInputStream(url.openStream());
+
+		String mimeType = URLConnection.guessContentTypeFromStream(inputStream);
+
+		Set<String> extensions = MimeTypesUtil.getExtensions(mimeType);
+
+		String extension = StringPool.BLANK;
+
+		if (!extensions.isEmpty()) {
+			Iterator<String> iterator = extensions.iterator();
+
+			extension = iterator.next();
+		}
+
+		File tempFile = _file.createTempFile(inputStream);
+
+		Date now = new Date();
+
+		String title = StringBundler.concat("image-", now.getTime(), extension);
+
+		File file = new File(tempFile.getParent(), title);
+
+		if (file.exists() && !file.delete()) {
+			throw new IOException();
+		}
+
+		if (!tempFile.renameTo(file)) {
+			file = tempFile;
+		}
+
+		long repositoryId = GetterUtil.getLong(
+			ParamUtil.getLong(portletRequest, "repositoryId"));
+
+		long folderId = GetterUtil.getLong(
+			ParamUtil.getLong(portletRequest, "folderId"),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID);
+
+		ServiceContext serviceContext = ServiceContextFactory.getInstance(
+			FileEntry.class.getName(), portletRequest);
+
+		serviceContext.setAttribute(
+			"fileEntryTypeId",
+			GetterUtil.getLong(
+				ParamUtil.getLong(portletRequest, "fileEntryTypeId")));
+
+		return _dlAppService.addFileEntry(
+			null, repositoryId, folderId, title, mimeType, title, title, null,
+			null, file, null, null, serviceContext);
+	}
+
+	private final DLAppService _dlAppService;
+	private final com.liferay.portal.kernel.util.File _file;
+
+}

--- a/modules/apps/ai-creator/ai-creator-openai-web/src/main/resources/META-INF/resources/ai_creator_modal/AICreatorImageModal.tsx
+++ b/modules/apps/ai-creator/ai-creator-openai-web/src/main/resources/META-INF/resources/ai_creator_modal/AICreatorImageModal.tsx
@@ -17,6 +17,7 @@ import {ImagesResult} from './ImagesResult';
 import {LoadingMessage} from './LoadingMessage';
 
 interface Props {
+	eventName?: string;
 	getGenerationsURL: string;
 	learnResources: AICreatorModalLearnResources;
 	portletNamespace: string;
@@ -40,6 +41,7 @@ type RequestStatus =
 	| {errorMessage: string; type: 'error'};
 
 export default function AICreatorImageModal({
+	eventName,
 	getGenerationsURL,
 	learnResources,
 	portletNamespace,
@@ -69,7 +71,9 @@ export default function AICreatorImageModal({
 					});
 				})
 			).then(() => {
-				closeModal();
+				const opener = Liferay.Util.getOpener();
+
+				opener.Liferay.fire(eventName, {selectedItems: selectedImages});
 			});
 		}
 	};

--- a/modules/apps/ai-creator/ai-creator-openai-web/src/main/resources/META-INF/resources/ai_creator_modal/AICreatorImageModal.tsx
+++ b/modules/apps/ai-creator/ai-creator-openai-web/src/main/resources/META-INF/resources/ai_creator_modal/AICreatorImageModal.tsx
@@ -183,6 +183,7 @@ export default function AICreatorImageModal({
 
 					<div className="d-flex flex-column flex-shrink-0">
 						<FormFooter
+							disabledAddButton={Boolean(!selectedImages?.length)}
 							onAdd={onAdd}
 							onClose={closeModal}
 							showAddButton={Boolean(imagesURL?.length)}

--- a/modules/apps/ai-creator/ai-creator-openai-web/src/main/resources/META-INF/resources/ai_creator_modal/AICreatorImageModal.tsx
+++ b/modules/apps/ai-creator/ai-creator-openai-web/src/main/resources/META-INF/resources/ai_creator_modal/AICreatorImageModal.tsx
@@ -52,12 +52,27 @@ export default function AICreatorImageModal({
 	const [status, setStatus] = useState<RequestStatus>({type: 'idle'});
 	const [imagesURL, setImagesURL] = useState<string[] | null>(null);
 
+	const [selectedImages, setSelectedImages] = useState<string[]>([]);
+
 	const onAdd = () => {
 		if (imagesURL) {
 			const opener = Liferay.Util.getOpener();
 
 			opener.Liferay.fire('closeModal', {imagesURL});
 		}
+	};
+
+	const onSelectedChange = (imageURL: string) => {
+		const newSelectedImages = [...selectedImages] || [];
+
+		if (newSelectedImages?.includes(imageURL)) {
+			newSelectedImages?.splice(newSelectedImages.indexOf(imageURL), 1);
+		}
+		else {
+			newSelectedImages?.push(imageURL);
+		}
+
+		setSelectedImages(newSelectedImages);
 	};
 
 	const onSubmit = (event: FormEvent) => {
@@ -131,7 +146,13 @@ export default function AICreatorImageModal({
 					>
 						<FormImage portletNamespace={portletNamespace} />
 
-						{imagesURL && <ImagesResult imagesURL={imagesURL} />}
+						{imagesURL && (
+							<ImagesResult
+								imagesURL={imagesURL}
+								onSelectedChange={onSelectedChange}
+								selectedImages={selectedImages}
+							/>
+						)}
 
 						<ClayForm.Group className="c-mb-0">
 							<LearnResourcesContext.Provider

--- a/modules/apps/ai-creator/ai-creator-openai-web/src/main/resources/META-INF/resources/ai_creator_modal/AICreatorImageModal.tsx
+++ b/modules/apps/ai-creator/ai-creator-openai-web/src/main/resources/META-INF/resources/ai_creator_modal/AICreatorImageModal.tsx
@@ -20,6 +20,7 @@ interface Props {
 	getGenerationsURL: string;
 	learnResources: AICreatorModalLearnResources;
 	portletNamespace: string;
+	uploadGenerationsURL: string;
 }
 
 type AICreatorModalLearnResources = {
@@ -42,6 +43,7 @@ export default function AICreatorImageModal({
 	getGenerationsURL,
 	learnResources,
 	portletNamespace,
+	uploadGenerationsURL,
 }: Props) {
 	const closeModal = () => {
 		const opener = Liferay.Util.getOpener();
@@ -55,10 +57,23 @@ export default function AICreatorImageModal({
 	const [selectedImages, setSelectedImages] = useState<string[]>([]);
 
 	const onAdd = () => {
-		if (imagesURL) {
-			const opener = Liferay.Util.getOpener();
+		if (selectedImages.length) {
+			Promise.all(
+				selectedImages.map((imageURL) => {
+					return fetch(uploadGenerationsURL, {
+						body: JSON.stringify(imageURL),
+						method: 'POST',
+					})
+						.then((response) => response.json())
+						.then((json) => {
+							console.log(json); // TODO
+						});
+				})
+			).then(() => {
+				const opener = Liferay.Util.getOpener();
 
-			opener.Liferay.fire('closeModal', {imagesURL});
+				opener.Liferay.fire('closeModal', {imagesURL});
+			});
 		}
 	};
 

--- a/modules/apps/ai-creator/ai-creator-openai-web/src/main/resources/META-INF/resources/ai_creator_modal/AICreatorImageModal.tsx
+++ b/modules/apps/ai-creator/ai-creator-openai-web/src/main/resources/META-INF/resources/ai_creator_modal/AICreatorImageModal.tsx
@@ -60,8 +60,11 @@ export default function AICreatorImageModal({
 		if (selectedImages.length) {
 			Promise.all(
 				selectedImages.map((imageURL) => {
+					const formData = new FormData();
+					formData.append(`${portletNamespace}urlPath`, imageURL);
+
 					return fetch(uploadGenerationsURL, {
-						body: JSON.stringify(imageURL),
+						body: formData,
 						method: 'POST',
 					})
 						.then((response) => response.json())
@@ -70,9 +73,7 @@ export default function AICreatorImageModal({
 						});
 				})
 			).then(() => {
-				const opener = Liferay.Util.getOpener();
-
-				opener.Liferay.fire('closeModal', {imagesURL});
+				closeModal();
 			});
 		}
 	};

--- a/modules/apps/ai-creator/ai-creator-openai-web/src/main/resources/META-INF/resources/ai_creator_modal/AICreatorImageModal.tsx
+++ b/modules/apps/ai-creator/ai-creator-openai-web/src/main/resources/META-INF/resources/ai_creator_modal/AICreatorImageModal.tsx
@@ -66,11 +66,7 @@ export default function AICreatorImageModal({
 					return fetch(uploadGenerationsURL, {
 						body: formData,
 						method: 'POST',
-					})
-						.then((response) => response.json())
-						.then((json) => {
-							console.log(json); // TODO
-						});
+					});
 				})
 			).then(() => {
 				closeModal();

--- a/modules/apps/ai-creator/ai-creator-openai-web/src/main/resources/META-INF/resources/ai_creator_modal/FormFooter.tsx
+++ b/modules/apps/ai-creator/ai-creator-openai-web/src/main/resources/META-INF/resources/ai_creator_modal/FormFooter.tsx
@@ -8,6 +8,7 @@ import ClayIcon from '@clayui/icon';
 import React from 'react';
 
 interface Props {
+	disabledAddButton?: boolean;
 	onAdd: () => void;
 	onClose: () => void;
 	showAddButton: boolean;
@@ -16,6 +17,7 @@ interface Props {
 }
 
 export function FormFooter({
+	disabledAddButton = false,
 	onAdd,
 	onClose,
 	showAddButton,
@@ -44,7 +46,12 @@ export function FormFooter({
 
 	if (showAddButton) {
 		children.push(
-			<ClayButton displayType="primary" key="add" onClick={onAdd}>
+			<ClayButton
+				disabled={disabledAddButton}
+				displayType="primary"
+				key="add"
+				onClick={onAdd}
+			>
 				{Liferay.Language.get('add')}
 			</ClayButton>
 		);

--- a/modules/apps/ai-creator/ai-creator-openai-web/src/main/resources/META-INF/resources/ai_creator_modal/ImagesResult.tsx
+++ b/modules/apps/ai-creator/ai-creator-openai-web/src/main/resources/META-INF/resources/ai_creator_modal/ImagesResult.tsx
@@ -4,22 +4,45 @@
  */
 
 import ClayCard from '@clayui/card';
+import {ClayCheckbox} from '@clayui/form';
 import React from 'react';
 
 interface Props {
 	imagesURL: string[];
+	onSelectedChange: Function;
+	selectedImages: string[];
 }
 
-export function ImagesResult({imagesURL}: Props) {
+export function ImagesResult({
+	imagesURL,
+	onSelectedChange,
+	selectedImages,
+}: Props) {
 	return (
 		<>
 			<label>{Liferay.Language.get('image-results')}</label>
 
 			<ul className="card-page card-page-equal-height">
 				{imagesURL.map((imageURL, index) => (
-					<li className="card-page-item mr-2" key={index}>
+					<li
+						className="card-page-item card-page-item-asset"
+						key={index}
+						role="menuitem"
+					>
 						<ClayCard displayType="image" selectable>
-							<img src={imageURL} style={{width: '200px'}} />
+							<ClayCheckbox
+								checked={
+									selectedImages.includes(imageURL) || false
+								}
+								onChange={() => onSelectedChange(imageURL)}
+							>
+								<ClayCard.AspectRatio className="card-item-first">
+									<img
+										className="aspect-ratio-item-center-middle aspect-ratio-item-fluid"
+										src={imageURL}
+									/>
+								</ClayCard.AspectRatio>
+							</ClayCheckbox>
 						</ClayCard>
 					</li>
 				))}

--- a/modules/apps/ai-creator/ai-creator-openai-web/types/src/main/resources/META-INF/resources/ai_creator_modal/AICreatorImageModal.d.ts
+++ b/modules/apps/ai-creator/ai-creator-openai-web/types/src/main/resources/META-INF/resources/ai_creator_modal/AICreatorImageModal.d.ts
@@ -6,6 +6,7 @@
 /// <reference types="react" />
 
 interface Props {
+	eventName?: string;
 	getGenerationsURL: string;
 	learnResources: AICreatorModalLearnResources;
 	portletNamespace: string;
@@ -22,6 +23,7 @@ declare type AICreatorModalLearnResources = {
 	};
 };
 export default function AICreatorImageModal({
+	eventName,
 	getGenerationsURL,
 	learnResources,
 	portletNamespace,

--- a/modules/apps/ai-creator/ai-creator-openai-web/types/src/main/resources/META-INF/resources/ai_creator_modal/AICreatorImageModal.d.ts
+++ b/modules/apps/ai-creator/ai-creator-openai-web/types/src/main/resources/META-INF/resources/ai_creator_modal/AICreatorImageModal.d.ts
@@ -9,6 +9,7 @@ interface Props {
 	getGenerationsURL: string;
 	learnResources: AICreatorModalLearnResources;
 	portletNamespace: string;
+	uploadGenerationsURL: string;
 }
 declare type AICreatorModalLearnResources = {
 	'ai-creator-openai-web': {
@@ -24,5 +25,6 @@ export default function AICreatorImageModal({
 	getGenerationsURL,
 	learnResources,
 	portletNamespace,
+	uploadGenerationsURL,
 }: Props): JSX.Element;
 export {};

--- a/modules/apps/ai-creator/ai-creator-openai-web/types/src/main/resources/META-INF/resources/ai_creator_modal/FormFooter.d.ts
+++ b/modules/apps/ai-creator/ai-creator-openai-web/types/src/main/resources/META-INF/resources/ai_creator_modal/FormFooter.d.ts
@@ -6,6 +6,7 @@
 /// <reference types="react" />
 
 interface Props {
+	disabledAddButton?: boolean;
 	onAdd: () => void;
 	onClose: () => void;
 	showAddButton: boolean;
@@ -13,6 +14,7 @@ interface Props {
 	showRetryButton: boolean;
 }
 export declare function FormFooter({
+	disabledAddButton,
 	onAdd,
 	onClose,
 	showAddButton,

--- a/modules/apps/ai-creator/ai-creator-openai-web/types/src/main/resources/META-INF/resources/ai_creator_modal/ImagesResult.d.ts
+++ b/modules/apps/ai-creator/ai-creator-openai-web/types/src/main/resources/META-INF/resources/ai_creator_modal/ImagesResult.d.ts
@@ -7,6 +7,12 @@
 
 interface Props {
 	imagesURL: string[];
+	onSelectedChange: Function;
+	selectedImages: string[];
 }
-export declare function ImagesResult({imagesURL}: Props): JSX.Element;
+export declare function ImagesResult({
+	imagesURL,
+	onSelectedChange,
+	selectedImages,
+}: Props): JSX.Element;
 export {};

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/DLManagementToolbarPropsTransformer.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/DLManagementToolbarPropsTransformer.js
@@ -5,6 +5,7 @@
 
 import {
 	addParams,
+	createPortletURL,
 	navigate,
 	openCategorySelectionModal,
 	openConfirmModal,
@@ -312,9 +313,17 @@ export default function propsTransformer({
 		else {
 			openSelectionModal({
 				height: '70vh',
+				onSelect: ({selectedItems}) => {
+					if (selectedItems) {
+						window.location.reload();
+					}
+				},
+				selectEventName: `${portletNamespace}selectAIImages`,
 				size: 'lg',
 				title: Liferay.Language.get('create-ai-image'),
-				url: aiImageCreatorURL,
+				url: createPortletURL(aiImageCreatorURL, {
+					selectEventName: `${portletNamespace}selectAIImages`,
+				}).toString(),
 			});
 		}
 	};


### PR DESCRIPTION
for testings purposes for @robertoDiaz 

- [x] Notes: check/uncheck to select images to add 
- [x] Reload DM page when added
- [ ] Add a loading while adding images to DM -> Not specified in story, will do in a different task

How to test it:
See https://liferay.atlassian.net/wiki/spaces/ENGECHO/pages/2413429012/How+to+use+the+OpenAI+mock+client for reference.

1. Enable mock Client via Gogo shell (scr:enable com.liferay.ai.creator.openai.web.internal.client.MockAICreatorOpenAIClient)
2. Set VALID_API_KEY as Apy key for AI Creator in Instance Settings
3. Go to D&M and click Create AI Image (from the + dropdown)
4. On Description, add USER_IMAGES_URL_ + an url that exists. i.e USER_IMAGES_URL_https://blogs.iadb.org/conocimiento-abierto/wp-content/uploads/sites/10/2014/06/New-Picture.png