### PR TITLE
LPS-205549 replace ' because is inside of ''

### DIFF
--- a/portal-web/docroot/html/taglib/aui/button/init-ext.jspf
+++ b/portal-web/docroot/html/taglib/aui/button/init-ext.jspf
@@ -23,7 +23,8 @@ boolean dropdown = Validator.isNotNull(bodyContentString.trim());
 String escapedHREF = StringPool.BLANK;
 
 if (Validator.isNotNull(href)) {
-	escapedHREF = HtmlUtil.escapeAttribute(PortalUtil.escapeRedirect(href));
+	escapedHREF = href.replace("\'", "");
+	escapedHREF = HtmlUtil.escapeAttribute(PortalUtil.escapeRedirect(escapedHREF));
 }
 else if (onClick.startsWith(Http.HTTP_WITH_SLASH) || onClick.startsWith(Http.HTTPS_WITH_SLASH) || onClick.startsWith(StringPool.SLASH)) {
 	href = onClick;


### PR DESCRIPTION
- LPS-205549 cancel button will encapsulate url between '' so another '' will break the string and the insides of this second '' can be problematic.
