### PR TITLE
LPS-204979 BUG DM image editor zoom small images

### DIFF
--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/image_editor/ImageEditor.js
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/image_editor/ImageEditor.js
@@ -148,17 +148,22 @@ function ImageEditor({
 
 			const handleZoomChange = (event) => {
 				const zoom = event.detail.ratio * 100;
+				const zoomDirection =
+					event.detail.ratio > event.detail.oldRatio ? 1 : -1;
+				const nextZoom = zoom * (1 + zoomDirection * ZOOM_CONFIG.step);
 
-				if (zoom < ZOOM_CONFIG.min) {
+				if (zoom < ZOOM_CONFIG.min || zoom > ZOOM_CONFIG.max) {
 					event.preventDefault();
+				}
+
+				if (nextZoom < ZOOM_CONFIG.min) {
 					setDisabledZoomOut(true);
 				}
 				else {
 					setDisabledZoomOut(false);
 				}
 
-				if (zoom > ZOOM_CONFIG.max) {
-					event.preventDefault();
+				if (nextZoom > ZOOM_CONFIG.max) {
 					setDisabledZoomIn(true);
 				}
 				else {

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/image_editor/ImageEditor.js
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/image_editor/ImageEditor.js
@@ -41,7 +41,11 @@ const ratios = [
 	},
 ];
 
-const zoomSteps = [12.5, 25, 50, 100, 150, 200];
+const ZOOM_CONFIG = {
+	max: 200,
+	min: 12.5,
+	step: 0.5,
+};
 
 const noop = () => {};
 
@@ -55,7 +59,8 @@ function ImageEditor({
 }) {
 	const ref = useRef();
 
-	const [currentZoom, setCurrentZoom] = useState(100);
+	const [disabledZoomIn, setDisabledZoomIn] = useState(false);
+	const [disabledZoomOut, setDisabledZoomOut] = useState(false);
 
 	const handleAspectRationChange = (event) => {
 		const value = event.target.value;
@@ -94,29 +99,23 @@ function ImageEditor({
 	};
 
 	const handleZoomIn = () => {
-		const newZoomValue = zoomSteps.reduce((a, b) => {
-			return currentZoom < a ? a : b;
-		});
-
-		ref.current?.cropper?.zoomTo(newZoomValue / 100);
+		ref.current?.cropper?.zoom(ZOOM_CONFIG.step);
 	};
 
 	const handleZoomOut = () => {
-		const newZoomValue = zoomSteps.reduce((a, b) => {
-			return currentZoom > b ? b : a;
-		});
-
 		const cropBoxDdata = ref.current?.cropper?.getCropBoxData();
 		const imageData = ref.current?.cropper?.getImageData();
 
 		if (
-			imageData.width <= cropBoxDdata.width ||
-			imageData.height <= cropBoxDdata.height
+			Math.round(imageData.width) <= Math.round(cropBoxDdata.width) ||
+			Math.round(imageData.height) <= Math.round(cropBoxDdata.height)
 		) {
+			setDisabledZoomOut(true);
+
 			return;
 		}
 
-		ref.current?.cropper?.zoomTo(newZoomValue / 100);
+		ref.current?.cropper?.zoom(-ZOOM_CONFIG.step);
 	};
 
 	useEffect(() => {
@@ -140,39 +139,31 @@ function ImageEditor({
 			const handleCropReady = () => {
 				const imageData = imageElement?.cropper?.getImageData();
 
-				if (imageData.width < imageData.naturalWidth) {
-					const currentZoom =
-						(imageData.width * 100) / imageData.naturalWidth;
-
-					setCurrentZoom(parseFloat(currentZoom.toFixed(1)));
-				}
-				else {
+				if (imageData.width > imageData.naturalWidth) {
 					imageElement?.cropper?.zoomTo(1);
-
-					setCurrentZoom(100);
 				}
 
 				imageElement?.cropper?.crop();
 			};
 
 			const handleZoomChange = (event) => {
-				const newZoomValue = event.detail.ratio * 100;
+				const zoom = event.detail.ratio * 100;
 
-				if (newZoomValue > zoomSteps[zoomSteps.length - 1]) {
+				if (zoom < ZOOM_CONFIG.min) {
 					event.preventDefault();
-
-					return imageElement?.cropper?.zoomTo(
-						zoomSteps[zoomSteps.length - 1] / 100
-					);
+					setDisabledZoomOut(true);
+				}
+				else {
+					setDisabledZoomOut(false);
 				}
 
-				if (newZoomValue < zoomSteps[0]) {
+				if (zoom > ZOOM_CONFIG.max) {
 					event.preventDefault();
-
-					return imageElement?.cropper?.zoomTo(zoomSteps[0] / 100);
+					setDisabledZoomIn(true);
 				}
-
-				setCurrentZoom(parseFloat(newZoomValue.toFixed(1)));
+				else {
+					setDisabledZoomIn(false);
+				}
 			};
 
 			imageElement.addEventListener('ready', handleCropReady);
@@ -238,16 +229,14 @@ function ImageEditor({
 						<ClayToolbar.Section>
 							<ClayButton.Group spaced>
 								<ClayButtonWithIcon
+									disabled={disabledZoomOut}
 									displayType={null}
 									onClick={handleZoomOut}
 									symbol="hr"
 								/>
 
-								<span className="zoom-percent">
-									{currentZoom}%
-								</span>
-
 								<ClayButtonWithIcon
+									disabled={disabledZoomIn}
 									displayType={null}
 									onClick={handleZoomIn}
 									symbol="plus"

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/image_editor/ImageEditor.js
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/image_editor/ImageEditor.js
@@ -124,7 +124,7 @@ function ImageEditor({
 
 		if (imageElement !== null) {
 			new Cropper(imageElement, {
-				autoCrop: true,
+				autoCrop: false,
 				autoCropArea: 1,
 				background: false,
 				center: false,
@@ -135,16 +135,24 @@ function ImageEditor({
 				scaleX: 1,
 				scaleY: 1,
 				viewMode: 1,
-				zoomTo: 0,
 			});
 
 			const handleCropReady = () => {
 				const imageData = imageElement?.cropper?.getImageData();
 
-				const currentZoom =
-					(imageData.width * 100) / imageData.naturalWidth;
+				if (imageData.width < imageData.naturalWidth) {
+					const currentZoom =
+						(imageData.width * 100) / imageData.naturalWidth;
 
-				setCurrentZoom(parseFloat(currentZoom.toFixed(1)));
+					setCurrentZoom(parseFloat(currentZoom.toFixed(1)));
+				}
+				else {
+					imageElement?.cropper?.zoomTo(1);
+
+					setCurrentZoom(100);
+				}
+
+				imageElement?.cropper?.crop();
 			};
 
 			const handleZoomChange = (event) => {


### PR DESCRIPTION
# LPS: https://liferay.atlassian.net/browse/LPS-204979

## Implementation

First I limited the first render zoom to 100% of the image 58d98b167ccbe3cab56a05bff2377a4dfcccde89 allowing manual zoom after it.

After a conversation with Maria Martins we decided to hide the zoom percentage. We decided that because in some cases we are showing not the real zoom (the crop size is limited by the image size).

After I move from fixed zoom values to min, max and step config.


## Before the PR
![image](https://github.com/liferay-lima/liferay-portal/assets/67901/fed18bcf-58d1-4607-bcfa-5cca0f9460b1)

## After the PR
![image](https://github.com/liferay-lima/liferay-portal/assets/67901/1a3fca4c-6c67-44b5-bd33-73f00d44231f)