### PR TITLE
LPS-205929 Site applications show up in the Asset Libraries

### DIFF
--- a/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/application/list/DepotPanelAppController.java
+++ b/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/application/list/DepotPanelAppController.java
@@ -7,17 +7,13 @@ package com.liferay.depot.web.internal.application.list;
 
 import com.liferay.application.list.PanelApp;
 import com.liferay.application.list.PanelAppRegistry;
-import com.liferay.application.list.PanelAppShowFilter;
 import com.liferay.application.list.PanelCategoryRegistry;
 import com.liferay.application.list.display.context.logic.PanelCategoryHelper;
 import com.liferay.depot.web.internal.application.controller.DepotApplicationController;
 import com.liferay.depot.web.internal.constants.DepotPortletKeys;
 
-import org.osgi.framework.BundleContext;
-import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 
 /**
@@ -45,28 +41,9 @@ public class DepotPanelAppController {
 	}
 
 	@Activate
-	protected void activate(BundleContext bundleContext) {
+	protected void activate() {
 		_panelCategoryHelper = new PanelCategoryHelper(
 			_panelAppRegistry, _panelCategoryRegistry);
-
-		_serviceRegistration = bundleContext.registerService(
-			PanelAppShowFilter.class,
-			(panelApp, permissionChecker, group) -> {
-				if (group.isDepot() &&
-					!DepotPanelAppController.this.isShow(
-						panelApp, group.getGroupId())) {
-
-					return false;
-				}
-
-				return panelApp.isShow(permissionChecker, group);
-			},
-			null);
-	}
-
-	@Deactivate
-	protected void deactivate() {
-		_serviceRegistration.unregister();
 	}
 
 	private boolean _isAlwaysShow(String portletId) {
@@ -91,7 +68,5 @@ public class DepotPanelAppController {
 
 	@Reference
 	private PanelCategoryRegistry _panelCategoryRegistry;
-
-	private ServiceRegistration<?> _serviceRegistration;
 
 }

--- a/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/application/list/DepotPanelAppShowFilter.java
+++ b/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/application/list/DepotPanelAppShowFilter.java
@@ -1,0 +1,40 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.depot.web.internal.application.list;
+
+import com.liferay.application.list.PanelApp;
+import com.liferay.application.list.PanelAppShowFilter;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Adolfo Pérez
+ */
+@Component(service = PanelAppShowFilter.class)
+public class DepotPanelAppShowFilter implements PanelAppShowFilter {
+
+	@Override
+	public boolean isShow(
+			PanelApp panelApp, PermissionChecker permissionChecker, Group group)
+		throws PortalException {
+
+		if (group.isDepot() &&
+			!_depotPanelAppController.isShow(panelApp, group.getGroupId())) {
+
+			return false;
+		}
+
+		return panelApp.isShow(permissionChecker, group);
+	}
+
+	@Reference
+	private DepotPanelAppController _depotPanelAppController;
+
+}


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPS-205929

Extra (unsupported) applications show up in the depot dashboard.

# How am I fixing it?

By making the panel app filter a regular DS component. Depending on
the `activate` lifecycle method of the controller is not reliable as
the component is not immediate.

# How can you verify that it works?

Follow the steps described in https://liferay.atlassian.net/browse/LPS-205929.