### PR TITLE
[TS] LPS-205128 Questions: Accepting an answer under workflow subjects that answer to workflow again

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-api/bnd.bnd
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless Delivery API
 Bundle-SymbolicName: com.liferay.headless.delivery.api
-Bundle-Version: 49.3.3
+Bundle-Version: 49.4.0
 Export-Package:\
 	com.liferay.headless.delivery.dto.v1_0,\
 	com.liferay.headless.delivery.dto.v1_0.util,\

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/MessageBoardMessageResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/MessageBoardMessageResource.java
@@ -72,6 +72,9 @@ public interface MessageBoardMessageResource {
 			String callbackURL, Object object)
 		throws Exception;
 
+	public void putMessageBoardMessageMarkAsAnswer(Long messageBoardMessageId)
+		throws Exception;
+
 	public void deleteMessageBoardMessageMyRating(Long messageBoardMessageId)
 		throws Exception;
 
@@ -98,6 +101,9 @@ public interface MessageBoardMessageResource {
 		throws Exception;
 
 	public void putMessageBoardMessageSubscribe(Long messageBoardMessageId)
+		throws Exception;
+
+	public void putMessageBoardMessageUnmarkAsAnswer(Long messageBoardMessageId)
 		throws Exception;
 
 	public void putMessageBoardMessageUnsubscribe(Long messageBoardMessageId)

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/resources/com/liferay/headless/delivery/resource/v1_0/packageinfo
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/resources/com/liferay/headless/delivery/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 18.2.0
+version 18.3.0

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/MessageBoardMessageResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/MessageBoardMessageResource.java
@@ -85,6 +85,14 @@ public interface MessageBoardMessageResource {
 			String callbackURL, Object object)
 		throws Exception;
 
+	public void putMessageBoardMessageMarkAsAnswer(Long messageBoardMessageId)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse
+			putMessageBoardMessageMarkAsAnswerHttpResponse(
+				Long messageBoardMessageId)
+		throws Exception;
+
 	public void deleteMessageBoardMessageMyRating(Long messageBoardMessageId)
 		throws Exception;
 
@@ -139,6 +147,14 @@ public interface MessageBoardMessageResource {
 
 	public HttpInvoker.HttpResponse putMessageBoardMessageSubscribeHttpResponse(
 			Long messageBoardMessageId)
+		throws Exception;
+
+	public void putMessageBoardMessageUnmarkAsAnswer(Long messageBoardMessageId)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse
+			putMessageBoardMessageUnmarkAsAnswerHttpResponse(
+				Long messageBoardMessageId)
 		throws Exception;
 
 	public void putMessageBoardMessageUnsubscribe(Long messageBoardMessageId)
@@ -1045,6 +1061,114 @@ public interface MessageBoardMessageResource {
 			return httpInvoker.invoke();
 		}
 
+		public void putMessageBoardMessageMarkAsAnswer(
+				Long messageBoardMessageId)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				putMessageBoardMessageMarkAsAnswerHttpResponse(
+					messageBoardMessageId);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return;
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				putMessageBoardMessageMarkAsAnswerHttpResponse(
+					Long messageBoardMessageId)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body("[]", "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.PUT);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-delivery/v1.0/message-board-messages/{messageBoardMessageId}/mark-as-answer");
+
+			httpInvoker.path("messageBoardMessageId", messageBoardMessageId);
+
+			httpInvoker.userNameAndPassword(
+				_builder._login + ":" + _builder._password);
+
+			return httpInvoker.invoke();
+		}
+
 		public void deleteMessageBoardMessageMyRating(
 				Long messageBoardMessageId)
 			throws Exception {
@@ -1794,6 +1918,114 @@ public interface MessageBoardMessageResource {
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
 						"/o/headless-delivery/v1.0/message-board-messages/{messageBoardMessageId}/subscribe");
+
+			httpInvoker.path("messageBoardMessageId", messageBoardMessageId);
+
+			httpInvoker.userNameAndPassword(
+				_builder._login + ":" + _builder._password);
+
+			return httpInvoker.invoke();
+		}
+
+		public void putMessageBoardMessageUnmarkAsAnswer(
+				Long messageBoardMessageId)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				putMessageBoardMessageUnmarkAsAnswerHttpResponse(
+					messageBoardMessageId);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return;
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				putMessageBoardMessageUnmarkAsAnswerHttpResponse(
+					Long messageBoardMessageId)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body("[]", "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.PUT);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-delivery/v1.0/message-board-messages/{messageBoardMessageId}/unmark-as-answer");
 
 			httpInvoker.path("messageBoardMessageId", messageBoardMessageId);
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
@@ -9824,6 +9824,22 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/MessageBoardMessage"
             tags: ["MessageBoardMessage"]
+    "/message-board-messages/{messageBoardMessageId}/mark-as-answer":
+        put:
+            operationId: putMessageBoardMessageMarkAsAnswer
+            parameters:
+                - in: path
+                  name: messageBoardMessageId
+                  required: true
+                  schema:
+                      format: int64
+                      type: integer
+            responses:
+                204:
+                    content:
+                        application/json: {}
+                        application/xml: {}
+            tags: ["MessageBoardMessage"]
     "/message-board-messages/{messageBoardMessageId}/message-board-attachments":
         get:
             description:
@@ -10056,6 +10072,22 @@ paths:
     "/message-board-messages/{messageBoardMessageId}/subscribe":
         put:
             operationId: putMessageBoardMessageSubscribe
+            parameters:
+                - in: path
+                  name: messageBoardMessageId
+                  required: true
+                  schema:
+                      format: int64
+                      type: integer
+            responses:
+                204:
+                    content:
+                        application/json: {}
+                        application/xml: {}
+            tags: ["MessageBoardMessage"]
+    "/message-board-messages/{messageBoardMessageId}/unmark-as-answer":
+        put:
+            operationId: putMessageBoardMessageUnmarkAsAnswer
             parameters:
                 - in: path
                   name: messageBoardMessageId

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/mutation/v1_0/Mutation.java
@@ -3123,6 +3123,21 @@ public class Mutation {
 					callbackURL, object));
 	}
 
+	@GraphQLField
+	public boolean updateMessageBoardMessageMarkAsAnswer(
+			@GraphQLName("messageBoardMessageId") Long messageBoardMessageId)
+		throws Exception {
+
+		_applyVoidComponentServiceObjects(
+			_messageBoardMessageResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			messageBoardMessageResource ->
+				messageBoardMessageResource.putMessageBoardMessageMarkAsAnswer(
+					messageBoardMessageId));
+
+		return true;
+	}
+
 	@GraphQLField(
 		description = "Deletes the message board message's rating and returns a 204 if the operation succeeds."
 	)
@@ -3206,6 +3221,22 @@ public class Mutation {
 			messageBoardMessageResource ->
 				messageBoardMessageResource.putMessageBoardMessageSubscribe(
 					messageBoardMessageId));
+
+		return true;
+	}
+
+	@GraphQLField
+	public boolean updateMessageBoardMessageUnmarkAsAnswer(
+			@GraphQLName("messageBoardMessageId") Long messageBoardMessageId)
+		throws Exception {
+
+		_applyVoidComponentServiceObjects(
+			_messageBoardMessageResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			messageBoardMessageResource ->
+				messageBoardMessageResource.
+					putMessageBoardMessageUnmarkAsAnswer(
+						messageBoardMessageId));
 
 		return true;
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -982,6 +982,11 @@ public class ServletDataImpl implements ServletData {
 							MessageBoardMessageResourceImpl.class,
 							"putMessageBoardMessageBatch"));
 					put(
+						"mutation#updateMessageBoardMessageMarkAsAnswer",
+						new ObjectValuePair<>(
+							MessageBoardMessageResourceImpl.class,
+							"putMessageBoardMessageMarkAsAnswer"));
+					put(
 						"mutation#deleteMessageBoardMessageMyRating",
 						new ObjectValuePair<>(
 							MessageBoardMessageResourceImpl.class,
@@ -1006,6 +1011,11 @@ public class ServletDataImpl implements ServletData {
 						new ObjectValuePair<>(
 							MessageBoardMessageResourceImpl.class,
 							"putMessageBoardMessageSubscribe"));
+					put(
+						"mutation#updateMessageBoardMessageUnmarkAsAnswer",
+						new ObjectValuePair<>(
+							MessageBoardMessageResourceImpl.class,
+							"putMessageBoardMessageUnmarkAsAnswer"));
 					put(
 						"mutation#updateMessageBoardMessageUnsubscribe",
 						new ObjectValuePair<>(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardMessageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardMessageResourceImpl.java
@@ -424,6 +424,40 @@ public abstract class BaseMessageBoardMessageResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
+	 * curl -X 'PUT' 'http://localhost:8080/o/headless-delivery/v1.0/message-board-messages/{messageBoardMessageId}/mark-as-answer'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "messageBoardMessageId"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(
+				name = "MessageBoardMessage"
+			)
+		}
+	)
+	@javax.ws.rs.Path(
+		"/message-board-messages/{messageBoardMessageId}/mark-as-answer"
+	)
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@javax.ws.rs.PUT
+	@Override
+	public void putMessageBoardMessageMarkAsAnswer(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("messageBoardMessageId")
+			Long messageBoardMessageId)
+		throws Exception {
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
 	 * curl -X 'DELETE' 'http://localhost:8080/o/headless-delivery/v1.0/message-board-messages/{messageBoardMessageId}/my-rating'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
@@ -760,6 +794,40 @@ public abstract class BaseMessageBoardMessageResourceImpl
 	@javax.ws.rs.PUT
 	@Override
 	public void putMessageBoardMessageSubscribe(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("messageBoardMessageId")
+			Long messageBoardMessageId)
+		throws Exception {
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'PUT' 'http://localhost:8080/o/headless-delivery/v1.0/message-board-messages/{messageBoardMessageId}/unmark-as-answer'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "messageBoardMessageId"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(
+				name = "MessageBoardMessage"
+			)
+		}
+	)
+	@javax.ws.rs.Path(
+		"/message-board-messages/{messageBoardMessageId}/unmark-as-answer"
+	)
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@javax.ws.rs.PUT
+	@Override
+	public void putMessageBoardMessageUnmarkAsAnswer(
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@javax.validation.constraints.NotNull
 			@javax.ws.rs.PathParam("messageBoardMessageId")

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardMessageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardMessageResourceImpl.java
@@ -419,6 +419,13 @@ public class MessageBoardMessageResourceImpl
 	}
 
 	@Override
+	public void putMessageBoardMessageMarkAsAnswer(Long messageBoardMessageId)
+		throws Exception {
+
+		_mbMessageService.updateAnswer(messageBoardMessageId, true, false);
+	}
+
+	@Override
 	public Rating putMessageBoardMessageMyRating(
 			Long messageBoardMessageId, Rating rating)
 		throws Exception {
@@ -434,6 +441,13 @@ public class MessageBoardMessageResourceImpl
 		throws Exception {
 
 		_mbMessageService.subscribeMessage(messageBoardMessageId);
+	}
+
+	@Override
+	public void putMessageBoardMessageUnmarkAsAnswer(Long messageBoardMessageId)
+		throws Exception {
+
+		_mbMessageService.updateAnswer(messageBoardMessageId, false, false);
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardMessageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardMessageResourceTestCase.java
@@ -416,6 +416,32 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 	}
 
 	@Test
+	public void testPutMessageBoardMessageMarkAsAnswer() throws Exception {
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		MessageBoardMessage messageBoardMessage =
+			testPutMessageBoardMessageMarkAsAnswer_addMessageBoardMessage();
+
+		assertHttpResponseStatusCode(
+			204,
+			messageBoardMessageResource.
+				putMessageBoardMessageMarkAsAnswerHttpResponse(
+					messageBoardMessage.getId()));
+
+		assertHttpResponseStatusCode(
+			404,
+			messageBoardMessageResource.
+				putMessageBoardMessageMarkAsAnswerHttpResponse(0L));
+	}
+
+	protected MessageBoardMessage
+			testPutMessageBoardMessageMarkAsAnswer_addMessageBoardMessage()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Test
 	public void testDeleteMessageBoardMessageMyRating() throws Exception {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		MessageBoardMessage messageBoardMessage =
@@ -534,6 +560,32 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 
 	protected MessageBoardMessage
 			testPutMessageBoardMessageSubscribe_addMessageBoardMessage()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Test
+	public void testPutMessageBoardMessageUnmarkAsAnswer() throws Exception {
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		MessageBoardMessage messageBoardMessage =
+			testPutMessageBoardMessageUnmarkAsAnswer_addMessageBoardMessage();
+
+		assertHttpResponseStatusCode(
+			204,
+			messageBoardMessageResource.
+				putMessageBoardMessageUnmarkAsAnswerHttpResponse(
+					messageBoardMessage.getId()));
+
+		assertHttpResponseStatusCode(
+			404,
+			messageBoardMessageResource.
+				putMessageBoardMessageUnmarkAsAnswerHttpResponse(0L));
+	}
+
+	protected MessageBoardMessage
+			testPutMessageBoardMessageUnmarkAsAnswer_addMessageBoardMessage()
 		throws Exception {
 
 		throw new UnsupportedOperationException(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/MessageBoardMessageResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/MessageBoardMessageResourceTest.java
@@ -326,6 +326,14 @@ public class MessageBoardMessageResourceTest
 
 	@Override
 	protected MessageBoardMessage
+			testPutMessageBoardMessageMarkAsAnswer_addMessageBoardMessage()
+		throws Exception {
+
+		return _addMessageBoardMessage();
+	}
+
+	@Override
+	protected MessageBoardMessage
 			testPutMessageBoardMessagePermissionsPage_addMessageBoardMessage()
 		throws Exception {
 
@@ -335,6 +343,14 @@ public class MessageBoardMessageResourceTest
 	@Override
 	protected MessageBoardMessage
 			testPutMessageBoardMessageSubscribe_addMessageBoardMessage()
+		throws Exception {
+
+		return _addMessageBoardMessage();
+	}
+
+	@Override
+	protected MessageBoardMessage
+			testPutMessageBoardMessageUnmarkAsAnswer_addMessageBoardMessage()
 		throws Exception {
 
 		return _addMessageBoardMessage();

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/Answer.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/Answer.es.js
@@ -16,6 +16,7 @@ import FlagsContainer from '../pages/questions/components/FlagsContainer';
 import {
 	deleteMessageQuery,
 	markAsAnswerMessageBoardMessageQuery,
+	unMarkAsAnswerMessageBoardMessageQuery,
 } from '../utils/client.es';
 import ArticleBodyRenderer from './ArticleBodyRenderer.es';
 import Comments from './Comments.es';
@@ -59,6 +60,14 @@ export default withRouter(
 		const [markAsAnswerMessageBoardMessage] = useMutation(
 			markAsAnswerMessageBoardMessageQuery
 		);
+
+		const [unMarkAsAnswerMessageBoardMessage] = useMutation(
+			unMarkAsAnswerMessageBoardMessageQuery
+		);
+
+		const markAsAnswerFunction = showAsAnswer
+			? unMarkAsAnswerMessageBoardMessage
+			: markAsAnswerMessageBoardMessage;
 
 		useEffect(() => {
 			setShowAsAnswer(answer.showAsAnswer);
@@ -300,15 +309,12 @@ export default withRouter(
 													data-testid="mark-as-answer-button"
 													displayType="secondary"
 													onClick={() => {
-														markAsAnswerMessageBoardMessage(
-															{
-																variables: {
-																	messageBoardMessageId:
-																		answer.id,
-																	showAsAnswer: !showAsAnswer,
-																},
-															}
-														).then(() => {
+														markAsAnswerFunction({
+															variables: {
+																messageBoardMessageId:
+																	answer.id,
+															},
+														}).then(() => {
 															setShowAsAnswer(
 																!showAsAnswer
 															);

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/questions/Question.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/questions/Question.es.js
@@ -45,8 +45,8 @@ import {
 	getSubscriptionsQuery,
 	getThread,
 	getUserActivityQuery,
-	markAsAnswerMessageBoardMessageQuery,
 	subscribeQuery,
+	unMarkAsAnswerMessageBoardMessageQuery,
 } from '../../utils/client.es';
 import {ALL_SECTIONS_ID} from '../../utils/contants.es';
 import lang from '../../utils/lang.es';
@@ -306,8 +306,8 @@ const Question = ({
 		[answers]
 	);
 
-	const [markAsAnswerMessageBoardMessage] = useMutation(
-		markAsAnswerMessageBoardMessageQuery
+	const [unMarkAsAnswerMessageBoardMessage] = useMutation(
+		unMarkAsAnswerMessageBoardMessageQuery
 	);
 
 	const answerChange = useCallback(
@@ -317,17 +317,16 @@ const Question = ({
 			);
 
 			if (answer) {
-				markAsAnswerMessageBoardMessage({
+				unMarkAsAnswerMessageBoardMessage({
 					variables: {
 						messageBoardMessageId: answer.id,
-						showAsAnswer: false,
 					},
 				}).then(() => {
 					fetchMessages();
 				});
 			}
 		},
-		[markAsAnswerMessageBoardMessage, answers.items, fetchMessages]
+		[unMarkAsAnswerMessageBoardMessage, answers.items, fetchMessages]
 	);
 
 	useEffect(() => {

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/utils/client.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/utils/client.es.js
@@ -905,17 +905,18 @@ export const getUserActivityQuery = `
 `;
 
 export const markAsAnswerMessageBoardMessageQuery = `
-	mutation patchMessageBoardMessage(
-		$messageBoardMessageId: Long!
-		$showAsAnswer: Boolean!
-	) {
-		patchMessageBoardMessage(
-			messageBoardMessage: {showAsAnswer: $showAsAnswer}
+	mutation updateMessageBoardMessageMarkAsAnswer($messageBoardMessageId: Long!) {
+		updateMessageBoardMessageMarkAsAnswer(
 			messageBoardMessageId: $messageBoardMessageId
-		) {
-			id
-			showAsAnswer
-		}
+		)
+	}
+`;
+
+export const unMarkAsAnswerMessageBoardMessageQuery = `
+	mutation updateMessageBoardMessageUnmarkAsAnswer($messageBoardMessageId: Long!) {
+		updateMessageBoardMessageUnmarkAsAnswer(
+			messageBoardMessageId: $messageBoardMessageId
+		)
 	}
 `;
 

--- a/modules/apps/questions/questions-web/test/js/components/Answer.es.js
+++ b/modules/apps/questions/questions-web/test/js/components/Answer.es.js
@@ -11,7 +11,7 @@ import '@testing-library/jest-dom/extend-expect';
 import {waitForElementToBeRemoved} from '@testing-library/dom';
 import {cleanup} from '@testing-library/react';
 
-import {markAsAnswerMessageBoardMessageQuery} from '../../../src/main/resources/META-INF/resources/js/utils/client.es';
+import {unMarkAsAnswerMessageBoardMessageQuery} from '../../../src/main/resources/META-INF/resources/js/utils/client.es';
 import {renderComponent} from '../../helpers.es';
 
 const mockAnswer = {
@@ -72,10 +72,9 @@ const mockAnswer = {
 const apolloMocks = [
 	{
 		request: {
-			query: markAsAnswerMessageBoardMessageQuery,
+			query: unMarkAsAnswerMessageBoardMessageQuery,
 			variables: {
 				messageBoardMessageId: mockAnswer.id,
-				showAsAnswer: false,
 			},
 		},
 		result: {


### PR DESCRIPTION
Dear Team,

Could you please review this pull request?

Motivation
=======
When questions/answers are subject to the built-in Message-Board workflow, the acceptance of an answer by an unprivileged user causes the answer to disappear (assuming: because it has been edited) and to be subject to the workflow again.

Setting a message as an answer will trigger a `patchMessageBoardMessage` mutation API call which will eventually call [MessageBoardMessageResourceImpl._updateMessageBoardMessage](https://github.com/liferay/liferay-portal/blob/master/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardMessageResourceImpl.java#L762C30-L792).

The call to
```
		mbMessage = _mbMessageService.updateDiscussionMessage(
			mbMessage.getClassName(), mbMessage.getClassPK(),
			mbMessage.getMessageId(), headline,
			messageBoardMessage.getArticleBody(),
			_createServiceContext(mbMessage.getGroupId(), messageBoardMessage));
```
will cause a workflow status change on the message.

Proposed Solution
========
In order to avoid the status change, an API method could be introduced that only sets the `answer` field of the `mbMessage`
To avoid passing a boolean as a parameter in the REST URL, I chose to add two methods:

- `putMessageBoardMessageMarkAsAnswer` that sets the `answer` field to `true`
- `putMessageBoardMessageUnmarkAsAnswer` that sets the `answer` field to `false`

Steps to Verify
========
Please see the linked LPS for the reproduction steps.
https://liferay.atlassian.net/browse/LPS-205128

Thank you and best regards,
István