### PR TITLE
LPD-1943 Guest users get a 200 OK page when accessing `/manage`

### DIFF
--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
@@ -814,8 +814,15 @@ public class FriendlyURLServlet extends HttpServlet {
 			layoutFriendlyURLLocalService.fetchFirstLayoutFriendlyURL(
 				groupId, _private, friendlyURL);
 
-		if (layoutFriendlyURL != null) {
-			return layoutLocalService.fetchLayout(layoutFriendlyURL.getPlid());
+		if (layoutFriendlyURL == null) {
+			return null;
+		}
+
+		Layout layout = layoutLocalService.fetchLayout(
+			layoutFriendlyURL.getPlid());
+
+		if ((layout != null) && !layout.isSystem()) {
+			return layout;
 		}
 
 		return null;


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-1943

The `/manage` page should always return a 404 for guest users, no matter any permissions assigned to that page.

# How am I fixing it?

The original implementation used `LayoutLocalService.getLayouts()`, which only returns non-system layouts; this fix emulates that behavior by ignoring a system layout that matches the friendly URL.

# How can you verify that it works?

Follow the steps described in https://liferay.atlassian.net/browse/LPD-1943.