### PR TITLE
LPD-15182 use escaped value

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/notifications/AssetPublisherUserNotificationHandler.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/notifications/AssetPublisherUserNotificationHandler.java
@@ -58,7 +58,7 @@ public class AssetPublisherUserNotificationHandler
 		JSONObject assetEntriesJSONObject = contextJSONObject.getJSONObject(
 			"[$ASSET_ENTRIES$]");
 
-		return assetEntriesJSONObject.getString("originalValue");
+		return assetEntriesJSONObject.getString("escapedValue");
 	}
 
 	protected String getTitle(

--- a/modules/apps/flags/flags-test/build.gradle
+++ b/modules/apps/flags/flags-test/build.gradle
@@ -1,4 +1,6 @@
 dependencies {
 	testIntegrationImplementation project(":apps:flags:flags-api")
+	testIntegrationImplementation project(":apps:flags:flags-web")
+	testIntegrationImplementation project(":apps:message-boards:message-boards-api")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/flags/flags-test/src/testIntegration/java/com/liferay/flags/web/internal/notifications/test/FlagsUserNotificationHandlerTest.java
+++ b/modules/apps/flags/flags-test/src/testIntegration/java/com/liferay/flags/web/internal/notifications/test/FlagsUserNotificationHandlerTest.java
@@ -1,0 +1,193 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.flags.web.internal.notifications.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.message.boards.constants.MBCategoryConstants;
+import com.liferay.message.boards.constants.MBMessageConstants;
+import com.liferay.message.boards.model.MBMessage;
+import com.liferay.message.boards.model.MBThread;
+import com.liferay.message.boards.service.MBMessageLocalServiceUtil;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.model.UserNotificationEvent;
+import com.liferay.portal.kernel.notifications.UserNotificationDefinition;
+import com.liferay.portal.kernel.notifications.UserNotificationFeedEntry;
+import com.liferay.portal.kernel.notifications.UserNotificationHandler;
+import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.HtmlEscapableObject;
+import com.liferay.portal.kernel.util.HtmlUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.model.impl.UserNotificationEventImpl;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Alicia García
+ */
+@RunWith(Arquillian.class)
+public class FlagsUserNotificationHandlerTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testBodyShouldBeEscaped() throws Exception {
+		long groupId = TestPropsValues.getGroupId();
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(groupId);
+
+		String userName = "'\"></option><img src=x onerror=alert(userName)>";
+		String content = "'\"></option><img src=x onerror=alert(content)>";
+		String siteName = "'\"></option><img src=x onerror=alert(siteName)>";
+
+		MBMessage mbMessage = MBMessageLocalServiceUtil.addMessage(
+			null, TestPropsValues.getUserId(), userName, groupId,
+			MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID, 0L,
+			MBMessageConstants.DEFAULT_PARENT_MESSAGE_ID,
+			StringUtil.randomString(), content,
+			MBMessageConstants.DEFAULT_FORMAT, null, false, 0.0, false,
+			serviceContext);
+
+		MBThread mbThread = mbMessage.getThread();
+
+		UserNotificationEvent userNotificationEvent =
+			new UserNotificationEventImpl();
+
+		JSONObject jsonObject = JSONFactoryUtil.createJSONObject();
+
+		userNotificationEvent.setPayload(
+			jsonObject.put(
+				"className", MBThread.class.getName()
+			).put(
+				"classPK", mbThread.getThreadId()
+			).put(
+				"context",
+				_getContext(
+					content,
+					ResourceActionsUtil.getModelResource(
+						serviceContext.getLocale(), MBThread.class.getName()),
+					siteName, userName)
+			).put(
+				"notificationType",
+				UserNotificationDefinition.NOTIFICATION_TYPE_ADD_ENTRY
+			).put(
+				"portletId", "com_liferay_flags_web_portlet_FlagsPortlet"
+			).toString());
+
+		UserNotificationFeedEntry userNotificationFeedEntry =
+			_userNotificationHandler.interpret(
+				userNotificationEvent, serviceContext);
+
+		String body = userNotificationFeedEntry.getBody();
+
+		Assert.assertTrue(
+			String.format("%s should be escaped", userName),
+			body.contains(HtmlUtil.escape(userName)));
+		Assert.assertTrue(
+			String.format("%s should be escaped", content),
+			body.contains(HtmlUtil.escape(content)));
+		Assert.assertTrue(
+			String.format("%s should be escaped", siteName),
+			body.contains(HtmlUtil.escape(siteName)));
+	}
+
+	@Test
+	public void testGetBody() throws Exception {
+		long groupId = TestPropsValues.getGroupId();
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(groupId);
+
+		String content = "#63;";
+
+		MBMessage mbMessage = MBMessageLocalServiceUtil.addMessage(
+			null, TestPropsValues.getUserId(), StringUtil.randomString(),
+			groupId, MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID, 0L,
+			MBMessageConstants.DEFAULT_PARENT_MESSAGE_ID,
+			StringUtil.randomString(), content,
+			MBMessageConstants.DEFAULT_FORMAT, null, false, 0.0, false,
+			serviceContext);
+
+		MBThread mbThread = mbMessage.getThread();
+
+		UserNotificationEvent userNotificationEvent =
+			new UserNotificationEventImpl();
+
+		JSONObject jsonObject = JSONFactoryUtil.createJSONObject();
+
+		userNotificationEvent.setPayload(
+			jsonObject.put(
+				"className", MBThread.class.getName()
+			).put(
+				"classPK", mbThread.getThreadId()
+			).put(
+				"context",
+				_getContext(
+					content,
+					ResourceActionsUtil.getModelResource(
+						serviceContext.getLocale(), MBThread.class.getName()),
+					StringUtil.randomString(), StringUtil.randomString())
+			).put(
+				"notificationType",
+				UserNotificationDefinition.NOTIFICATION_TYPE_ADD_ENTRY
+			).put(
+				"portletId", "com_liferay_flags_web_portlet_FlagsPortlet"
+			).toString());
+
+		UserNotificationFeedEntry userNotificationFeedEntry =
+			_userNotificationHandler.interpret(
+				userNotificationEvent, serviceContext);
+
+		String body = userNotificationFeedEntry.getBody();
+
+		Assert.assertTrue(
+			String.format("%s should contain %s", body, content),
+			body.contains(content));
+	}
+
+	private Map<String, HtmlEscapableObject<String>> _getContext(
+		String content, String contentType, String siteName, String userName) {
+
+		return HashMapBuilder.<String, HtmlEscapableObject<String>>put(
+			"[$CONTENT_TITLE$]", new HtmlEscapableObject<>(content)
+		).put(
+			"[$CONTENT_TYPE$]", new HtmlEscapableObject<>(contentType)
+		).put(
+			"[$CONTENT_URL$]",
+			new HtmlEscapableObject<>(StringUtil.randomString())
+		).put(
+			"[$REASON|uri$]",
+			new HtmlEscapableObject<>(StringUtil.randomString())
+		).put(
+			"[$REPORTER_USER_NAME$]", new HtmlEscapableObject<>(userName)
+		).put(
+			"[$SITE_NAME$]", new HtmlEscapableObject<>(siteName)
+		).build();
+	}
+
+	@Inject(
+		filter = "javax.portlet.name=com_liferay_flags_web_portlet_FlagsPortlet"
+	)
+	private UserNotificationHandler _userNotificationHandler;
+
+}

--- a/modules/apps/flags/flags-web/src/main/java/com/liferay/flags/web/internal/notifications/FlagsUserNotificationHandler.java
+++ b/modules/apps/flags/flags-web/src/main/java/com/liferay/flags/web/internal/notifications/FlagsUserNotificationHandler.java
@@ -85,7 +85,7 @@ public class FlagsUserNotificationHandler extends BaseUserNotificationHandler {
 	}
 
 	private String _getOriginalValue(JSONObject jsonObject) {
-		return jsonObject.getString("originalValue");
+		return jsonObject.getString("escapedValue");
 	}
 
 	@Reference

--- a/modules/apps/flags/flags-web/src/main/java/com/liferay/flags/web/internal/notifications/FlagsUserNotificationHandler.java
+++ b/modules/apps/flags/flags-web/src/main/java/com/liferay/flags/web/internal/notifications/FlagsUserNotificationHandler.java
@@ -49,22 +49,22 @@ public class FlagsUserNotificationHandler extends BaseUserNotificationHandler {
 					serviceContext.getLocale(),
 					"a-x-named-x-was-flagged-as-x-by-x",
 					new String[] {
-						_getOriginalValue(
+						_getEscapedValue(
 							contextJSONObject.getJSONObject(
 								"[$CONTENT_TYPE$]")),
-						_getOriginalValue(
+						_getEscapedValue(
 							contextJSONObject.getJSONObject(
 								"[$CONTENT_TITLE$]")),
-						_getOriginalValue(
+						_getEscapedValue(
 							contextJSONObject.getJSONObject("[$REASON|uri$]")),
-						_getOriginalValue(
+						_getEscapedValue(
 							contextJSONObject.getJSONObject(
 								"[$REPORTER_USER_NAME$]"))
 					}),
 				_language.format(
 					serviceContext.getLocale(),
 					"inappropriate-content-flagged-in-x",
-					_getOriginalValue(
+					_getEscapedValue(
 						contextJSONObject.getJSONObject("[$SITE_NAME$]")))
 			});
 	}
@@ -80,11 +80,11 @@ public class FlagsUserNotificationHandler extends BaseUserNotificationHandler {
 
 		JSONObject contextJSONObject = jsonObject.getJSONObject("context");
 
-		return _getOriginalValue(
+		return _getEscapedValue(
 			contextJSONObject.getJSONObject("[$CONTENT_URL$]"));
 	}
 
-	private String _getOriginalValue(JSONObject jsonObject) {
+	private String _getEscapedValue(JSONObject jsonObject) {
 		return jsonObject.getString("escapedValue");
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-15182


how to test it: 

--

1. Change User First Name to `'"></option><img src=x onerror=alert(111)>`
2. Create a page with the following name: `'"></option><img src=x onerror=alert(222)>`
3. Add a Page Flags widget to the page created in step 2
4. Click "Flag This Page"
5. Select "Other Reason" as the reason
6. In the Other Reason field, enter `'"></option><img src=x onerror=alert(333)>`
7. Click the Report button
8. Profile Menu > Notifications



--

1. Change User First Name to `'"></option><img src=x onerror=alert(444)>`
2. Add a Message Board thread with the following subject `'"></option><img src=x onerror=alert(555)>`
3. View the message added in step 2
4. Click the Report flag
5. Select "Other Reason" as the reason
6. In the Other Reason field, enter `'"></option><img src=x onerror=alert(666)>`
7. Click the Report button
8. Profile Menu > Notifications 
9. Vulnerable Result: JavaScript is executed (three times)
10. Fixed Result: JavaScript is encoded and is not executed

![image](https://github.com/liferay-lima/liferay-portal/assets/47524751/ee4653ef-e557-45b2-bc45-f2d78de5842e)



- LPD-15182 use the escaped value
- LPD-15182 rename method
- LPD-15182 add test to check the body of the message on flags notification
