### PR TITLE
LPD-15353 Bring back DLStore.deleteFile method

### DIFF
--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryLocalServiceAdvancedFileSystemStoreTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryLocalServiceAdvancedFileSystemStoreTest.java
@@ -1,0 +1,105 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.document.library.service.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
+import com.liferay.document.library.kernel.model.DLFileVersion;
+import com.liferay.document.library.kernel.model.DLFolderConstants;
+import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
+import com.liferay.document.library.kernel.store.Store;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.AssumeTestRule;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.PropsUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.io.ByteArrayInputStream;
+
+import jodd.net.MimeTypes;
+
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Adolfo Pérez
+ */
+@RunWith(Arquillian.class)
+public class DLFileEntryLocalServiceAdvancedFileSystemStoreTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new AssumeTestRule("assume"), new LiferayIntegrationTestRule());
+
+	public static void assume() {
+		String storeClassName =
+			"com.liferay.portal.store.file.system.AdvancedFileSystemStore";
+		String dlStoreImpl = PropsUtil.get(PropsKeys.DL_STORE_IMPL);
+
+		Assume.assumeTrue(
+			StringBundler.concat(
+				"Property \"", PropsKeys.DL_STORE_IMPL, "\" is not set to \"",
+				storeClassName, "\""),
+			dlStoreImpl.equals(storeClassName));
+	}
+
+	@Test
+	public void testDeleteFileEntryDeletesStoreFile() throws Exception {
+		DLFileEntry dlFileEntry = _dlFileEntryLocalService.addFileEntry(
+			null, TestPropsValues.getUserId(), TestPropsValues.getGroupId(),
+			TestPropsValues.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, null,
+			MimeTypes.MIME_APPLICATION_OCTET_STREAM, StringUtil.randomString(),
+			null, null, null,
+			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT, null,
+			null, new ByteArrayInputStream(new byte[0]), 0, null, null,
+			ServiceContextTestUtil.getServiceContext());
+
+		DLFileVersion dlFileVersion = dlFileEntry.getFileVersion();
+
+		Assert.assertTrue(
+			StringBundler.concat(
+				"File with name ", dlFileEntry.getName(),
+				" and store file name ", dlFileVersion.getStoreFileName(),
+				" does not exist in the store."),
+			_store.hasFile(
+				TestPropsValues.getCompanyId(), TestPropsValues.getGroupId(),
+				dlFileEntry.getName(), dlFileVersion.getStoreFileName()));
+
+		_dlFileEntryLocalService.deleteFileEntry(dlFileEntry);
+
+		Assert.assertFalse(
+			StringBundler.concat(
+				"File with name ", dlFileEntry.getName(),
+				" and store file name ", dlFileVersion.getStoreFileName(),
+				" exists in the store."),
+			_store.hasFile(
+				TestPropsValues.getCompanyId(), TestPropsValues.getGroupId(),
+				dlFileEntry.getName(), dlFileVersion.getStoreFileName()));
+	}
+
+	@Inject
+	private DLFileEntryLocalService _dlFileEntryLocalService;
+
+	@Inject(
+		filter = "store.type=com.liferay.portal.store.file.system.AdvancedFileSystemStore",
+		type = Store.class
+	)
+	private Store _store;
+
+}

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/store/test/DLStoreStoreAreaTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/store/test/DLStoreStoreAreaTest.java
@@ -163,7 +163,7 @@ public class DLStoreStoreAreaTest {
 		_addFile(fileName, Store.VERSION_DEFAULT);
 		_addFile(fileName, "2.0");
 
-		DLStoreUtil.deleteDirectory(
+		DLStoreUtil.deleteFile(
 			TestPropsValues.getCompanyId(), TestPropsValues.getGroupId(),
 			fileName);
 

--- a/modules/apps/document-library/document-library-uad-test/src/testIntegration/java/com/liferay/document/library/uad/exporter/test/DLFileEntryUADExporterTest.java
+++ b/modules/apps/document-library/document-library-uad-test/src/testIntegration/java/com/liferay/document/library/uad/exporter/test/DLFileEntryUADExporterTest.java
@@ -85,7 +85,7 @@ public class DLFileEntryUADExporterTest
 	public void testExportAllWithMissingBinary() throws Exception {
 		DLFileEntry dlFileEntry = addBaseModel(user.getUserId());
 
-		DLStoreUtil.deleteDirectory(
+		DLStoreUtil.deleteFile(
 			dlFileEntry.getCompanyId(), dlFileEntry.getDataRepositoryId(),
 			dlFileEntry.getName());
 

--- a/modules/dxp/apps/antivirus/antivirus-async-store/src/main/java/com/liferay/antivirus/async/store/internal/AntivirusAsyncDLStore.java
+++ b/modules/dxp/apps/antivirus/antivirus-async-store/src/main/java/com/liferay/antivirus/async/store/internal/AntivirusAsyncDLStore.java
@@ -164,6 +164,19 @@ public class AntivirusAsyncDLStore implements DLStore {
 	}
 
 	@Override
+	public void deleteFile(long companyId, long repositoryId, String fileName)
+		throws PortalException {
+
+		_validate(fileName, null, null, false, StringPool.BLANK);
+
+		for (String versionLabel :
+				_store.getFileVersions(companyId, repositoryId, fileName)) {
+
+			_store.deleteFile(companyId, repositoryId, fileName, versionLabel);
+		}
+	}
+
+	@Override
 	public void deleteFile(
 			long companyId, long repositoryId, String fileName,
 			String versionLabel)

--- a/portal-impl/src/com/liferay/portal/upgrade/v6_2_0/BaseAttachmentsUpgradeProcess.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v6_2_0/BaseAttachmentsUpgradeProcess.java
@@ -603,7 +603,7 @@ public abstract class BaseAttachmentsUpgradeProcess extends UpgradeProcess {
 			}
 
 			try {
-				DLStoreUtil.deleteDirectory(
+				DLStoreUtil.deleteFile(
 					companyId, CompanyConstants.SYSTEM, attachment);
 			}
 			catch (Exception exception) {

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -772,7 +772,7 @@ public class DLFileEntryLocalServiceImpl
 		// File
 
 		try {
-			DLStoreUtil.deleteDirectory(
+			DLStoreUtil.deleteFile(
 				dlFileEntry.getCompanyId(), dlFileEntry.getDataRepositoryId(),
 				dlFileEntry.getName());
 		}

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/store/DLStoreImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/store/DLStoreImpl.java
@@ -143,6 +143,21 @@ public class DLStoreImpl implements DLStore {
 	}
 
 	@Override
+	public void deleteFile(long companyId, long repositoryId, String fileName)
+		throws PortalException {
+
+		_validate(fileName, null, null, false, StringPool.BLANK);
+
+		for (String versionLabel :
+				_wrappedStore.getFileVersions(
+					companyId, repositoryId, fileName)) {
+
+			_wrappedStore.deleteFile(
+				companyId, repositoryId, fileName, versionLabel);
+		}
+	}
+
+	@Override
 	public void deleteFile(
 			long companyId, long repositoryId, String fileName,
 			String versionLabel)

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/store/packageinfo
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/store/packageinfo
@@ -1,1 +1,1 @@
-version 9.0.0
+version 9.1.0

--- a/portal-kernel/bnd.bnd
+++ b/portal-kernel/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 133.1.0
+Bundle-Version: 134.0.0
 Export-Package:\
 	!com.liferay.portal.kernel.internal.*,\
 	!com.liferay.portal.kernel.module.util,\

--- a/portal-kernel/src/com/liferay/document/library/kernel/store/DLStore.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/store/DLStore.java
@@ -42,6 +42,9 @@ public interface DLStore {
 			long companyId, long repositoryId, String dirName)
 		throws PortalException;
 
+	public void deleteFile(long companyId, long repositoryId, String fileName)
+		throws PortalException;
+
 	public void deleteFile(
 			long companyId, long repositoryId, String fileName,
 			String versionLabel)

--- a/portal-kernel/src/com/liferay/document/library/kernel/store/DLStoreUtil.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/store/DLStoreUtil.java
@@ -107,6 +107,22 @@ public class DLStoreUtil {
 	}
 
 	/**
+	 * Deletes a file. If a file has multiple versions, all versions will be
+	 * deleted.
+	 *
+	 * @param companyId the primary key of the company
+	 * @param repositoryId the primary key of the data repository (optionally
+	 *        {@link com.liferay.portal.kernel.model.CompanyConstants#SYSTEM})
+	 * @param fileName the file's name
+	 */
+	public static void deleteFile(
+			long companyId, long repositoryId, String fileName)
+		throws PortalException {
+
+		_store.deleteFile(companyId, repositoryId, fileName);
+	}
+
+	/**
 	 * Deletes a file at a particular version.
 	 *
 	 * @param companyId the primary key of the company

--- a/portal-kernel/src/com/liferay/document/library/kernel/store/packageinfo
+++ b/portal-kernel/src/com/liferay/document/library/kernel/store/packageinfo
@@ -1,1 +1,1 @@
-version 9.0.0
+version 9.1.0


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-15353

Some usages of the `DLStore.deleteDirectory` method assume behavior that is not satisfied by the advanced file system store. This causes deletion to leave orphaned files in the file system.

# How am I fixing it?

By bringing back the old `DLStore.deleteFile` method.

# How can I verify that it works?

Automated tests are included in this same PR.

Additionaly, you may follow the manual steps described in https://liferay.atlassian.net/browse/LPD-15353.