### PR TITLE
LPD-48271 Fix flaky Web Content POSHI tests

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/journal/structure/WebContentWithCustomStructures.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/journal/structure/WebContentWithCustomStructures.testcase
@@ -189,6 +189,12 @@ definition {
 				value1 = "Contenido web Contenido");
 
 			WebContent.publishExistingWCArticleWithPermissions();
+
+			LexiconEntry.changeDisplayStyle(displayStyle = "list");
+
+			AssertElementPresent(
+				key_webContentTitle = "Web Content Title",
+				locator1 = "WC#ENTRY_LIST_TITLE");
 		}
 
 		task ("View web content is shown in English") {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/journal/webcontentdisplay/WebContentDisplay.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/journal/webcontentdisplay/WebContentDisplay.testcase
@@ -525,6 +525,12 @@ Welcome to Liferay Community Edition Portal 7.4.0 CE GA1''';
 				navTab = "URL");
 
 			WebContent.publishExistingWCArticleWithPermissions();
+
+			LexiconEntry.changeDisplayStyle(displayStyle = "list");
+
+			AssertElementPresent(
+				key_webContentTitle = "Web Content Title",
+				locator1 = "WC#ENTRY_LIST_TITLE");
 		}
 
 		task ("Select the web content article in Web Content Display") {
@@ -568,6 +574,12 @@ Welcome to Liferay Community Edition Portal 7.4.0 CE GA1''';
 				uploadFileName = "Document_3.png");
 
 			WebContent.publishExistingWCArticleWithPermissions();
+
+			LexiconEntry.changeDisplayStyle(displayStyle = "list");
+
+			AssertElementPresent(
+				key_webContentTitle = "Web Content Title",
+				locator1 = "WC#ENTRY_LIST_TITLE");
 		}
 
 		task ("Select the web content article in Web Content Display") {


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-48271

Trying to fix flaky POSHI tests:

* LocalFile.WebContentDisplay#DisplayWebContentAudio
* LocalFile.WebContentDisplay#DisplayWebContentImage
* LocalFile.WebContentWithCustomStructures#AddTranslationsToRemovableFields

# How am I fixing it?

Locally I got a different error, but it seems related to the error we get in CI. What I did is giving some time after the update of the Web Content by asserting its existence. Without this time the WC changes don't seem to be saved.

# How can you verify that it works?

`ant -f build-test.xml run-selenium-test -Dtest.class=WebContentDisplay#DisplayWebContentImage`
`ant -f build-test.xml run-selenium-test -Dtest.class=WebContentDisplay#DisplayWebContentAudio`
`ant -f build-test.xml run-selenium-test -Dtest.class=WebContentWithCustomStructures#AddTranslationsToRemovableFields`
