### PR TITLE
LPD-48377 Fix POSHI tests for Web Content Autotagging

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/journal/JSONWebcontent.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/journal/JSONWebcontent.macro
@@ -72,11 +72,24 @@ definition {
 		var folderId = JSONWebcontentSetter.setFolderId(
 			folderName = ${folderName},
 			groupId = ${groupId});
-		var serviceContext = JSONWebcontentSetter.setServiceContext(
-			assetCategoryIds = ${assetCategoryIds},
-			assetTagNames = ${assetTagNames},
-			serviceContext = ${serviceContext},
-			workflowAction = ${workflowAction});
+
+		if (isSet(site) && (${site} == "false")) {
+			var serviceContext = JSONWebcontentSetter.setServiceContext(
+				assetCategoryIds = ${assetCategoryIds},
+				assetTagNames = ${assetTagNames},
+				groupName = ${groupName},
+				serviceContext = ${serviceContext},
+				site = ${site},
+				workflowAction = ${workflowAction});
+		}
+		else {
+			var serviceContext = JSONWebcontentSetter.setServiceContext(
+				assetCategoryIds = ${assetCategoryIds},
+				assetTagNames = ${assetTagNames},
+				serviceContext = ${serviceContext},
+				workflowAction = ${workflowAction});
+		}
+
 		var titleMap = JSONWebcontentSetter.setTitleMap(title = ${title});
 
 		JSONWebcontentAPI._addWebContent(

--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/journal/JSONWebcontentSetter.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/journal/JSONWebcontentSetter.macro
@@ -97,13 +97,15 @@ definition {
 	}
 
 	@summary = "Default summary"
-	macro setServiceContext(assetCategoryIds = null, assetTagNames = null, workflowAction = null) {
+	macro setServiceContext(assetCategoryIds = null, assetTagNames = null, groupName = null, site = null, workflowAction = null) {
 		if (!(isSet(serviceContext))) {
 			var serviceContext = JSONServiceContextUtil.setServiceContext(
 				addGroupPermissions = "true",
 				addGuestPermissions = "true",
 				assetCategoryIds = ${assetCategoryIds},
 				assetTagNames = ${assetTagNames},
+				groupName = ${groupName},
+				site = ${site},
 				workflowAction = ${workflowAction});
 		}
 


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-48377

Fix test `DepotAutoTagging#WebContentCanBeAutoTagged`

# How am I fixing it?

Add the `scopeGroupId` to the service context when creating a Web Content in an Asset Library, otherwise auto tagging doesn't work.

# How can you verify that it works?

`ant -f build-test.xml run-selenium-test -Dtest.class=DepotAutoTagging#WebContentCanBeAutoTagged`
