### PR TITLE
LPD-54189 Avoid random colors in space stickers

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/components/SpaceSticker.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/components/SpaceSticker.tsx
@@ -6,9 +6,9 @@
 import ClaySticker from '@clayui/sticker';
 import React from 'react';
 
-function getRandomDisplayType(): React.ComponentProps<
-	typeof ClaySticker
->['displayType'] {
+function getDisplayType(
+	char: string
+): React.ComponentProps<typeof ClaySticker>['displayType'] {
 	const validDisplayTypes: React.ComponentProps<
 		typeof ClaySticker
 	>['displayType'][] = [
@@ -24,13 +24,11 @@ function getRandomDisplayType(): React.ComponentProps<
 		'outline-9',
 	];
 
-	const randomIndex = Math.floor(Math.random() * validDisplayTypes.length);
-
-	return validDisplayTypes[randomIndex];
+	return validDisplayTypes[char.charCodeAt(0) % validDisplayTypes.length];
 }
 
 export default function SpaceSticker({
-	displayType = getRandomDisplayType(),
+	displayType,
 	name,
 	size,
 }: {
@@ -38,7 +36,10 @@ export default function SpaceSticker({
 } & Pick<React.ComponentProps<typeof ClaySticker>, 'displayType' | 'size'>) {
 	return (
 		<>
-			<ClaySticker displayType={displayType} size={size}>
+			<ClaySticker
+				displayType={displayType ?? getDisplayType(name)}
+				size={size}
+			>
 				{name.charAt(0).toUpperCase()}
 			</ClaySticker>
 


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-54189

Avoid random colors in space stickers

# How am I fixing it?

Implement a deterministic approach to calculate the sticker color based on the first letter of the space name. This way, the same space will always have the same color, improving user experience and consistency.

# Why doesn't this include any test?

This is just a visual tweak to make space sticker colors deterministic instead of random.