### PR TITLE
Pull request 162506 lpd 56872

### DIFF
--- a/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/constants/AssetCategoryDestinationNames.java
+++ b/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/constants/AssetCategoryDestinationNames.java
@@ -1,0 +1,16 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.asset.categories.internal.constants;
+
+/**
+ * @author Manuel Rives
+ */
+public class AssetCategoryDestinationNames {
+
+	public static final String ASSET_CATEGORY_ASSET_ENTRIES_REINDEX =
+		"liferay/asset_category_asset_entries_reindex";
+
+}

--- a/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/service/AssetEntryAssetCategoryRelAssetCategoryLocalServiceWrapper.java
+++ b/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/service/AssetEntryAssetCategoryRelAssetCategoryLocalServiceWrapper.java
@@ -5,6 +5,7 @@
 
 package com.liferay.asset.categories.internal.service;
 
+import com.liferay.asset.categories.internal.constants.AssetCategoryDestinationNames;
 import com.liferay.asset.categories.internal.util.comparator.AssetEntryAssetCategoryRelAssetCategoryIdComparator;
 import com.liferay.asset.entry.rel.model.AssetEntryAssetCategoryRel;
 import com.liferay.asset.entry.rel.service.AssetEntryAssetCategoryRelLocalService;
@@ -16,7 +17,6 @@ import com.liferay.asset.kernel.service.AssetEntryLocalService;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.messaging.DestinationNames;
 import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.messaging.MessageBus;
 import com.liferay.portal.kernel.model.ModelHintsUtil;
@@ -174,7 +174,8 @@ public class AssetEntryAssetCategoryRelAssetCategoryLocalServiceWrapper
 				message.put("categoryId", assetCategoryId);
 
 				_messageBus.sendMessage(
-					DestinationNames.ASSET_CATEGORY_ASSET_ENTRIES_REINDEX,
+					AssetCategoryDestinationNames.
+						ASSET_CATEGORY_ASSET_ENTRIES_REINDEX,
 					message);
 
 				return null;

--- a/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/service/messaging/AssetCategoryAssetEntriesReindexMessageListener.java
+++ b/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/service/messaging/AssetCategoryAssetEntriesReindexMessageListener.java
@@ -5,6 +5,7 @@
 
 package com.liferay.asset.categories.internal.service.messaging;
 
+import com.liferay.asset.categories.internal.constants.AssetCategoryDestinationNames;
 import com.liferay.asset.entry.rel.service.AssetEntryAssetCategoryRelLocalService;
 import com.liferay.asset.kernel.service.AssetEntryLocalService;
 import com.liferay.petra.function.transform.TransformUtil;
@@ -12,7 +13,6 @@ import com.liferay.portal.kernel.messaging.BaseMessageListener;
 import com.liferay.portal.kernel.messaging.Destination;
 import com.liferay.portal.kernel.messaging.DestinationConfiguration;
 import com.liferay.portal.kernel.messaging.DestinationFactory;
-import com.liferay.portal.kernel.messaging.DestinationNames;
 import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.messaging.MessageListener;
 import com.liferay.portal.kernel.util.MapUtil;
@@ -28,7 +28,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Manuel Rives
  */
 @Component(
-	property = "destination.name=" + DestinationNames.ASSET_CATEGORY_ASSET_ENTRIES_REINDEX,
+	property = "destination.name=" + AssetCategoryDestinationNames.ASSET_CATEGORY_ASSET_ENTRIES_REINDEX,
 	service = MessageListener.class
 )
 public class AssetCategoryAssetEntriesReindexMessageListener
@@ -39,7 +39,8 @@ public class AssetCategoryAssetEntriesReindexMessageListener
 		DestinationConfiguration destinationConfiguration =
 			new DestinationConfiguration(
 				DestinationConfiguration.DESTINATION_TYPE_SERIAL,
-				DestinationNames.ASSET_CATEGORY_ASSET_ENTRIES_REINDEX);
+				AssetCategoryDestinationNames.
+					ASSET_CATEGORY_ASSET_ENTRIES_REINDEX);
 
 		Destination destination = _destinationFactory.createDestination(
 			destinationConfiguration);

--- a/portal-kernel/src/com/liferay/portal/kernel/messaging/DestinationNames.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/messaging/DestinationNames.java
@@ -10,9 +10,6 @@ package com.liferay.portal.kernel.messaging;
  */
 public interface DestinationNames {
 
-	public static final String ASSET_CATEGORY_ASSET_ENTRIES_REINDEX =
-		"liferay/asset_category_asset_entries_reindex";
-
 	public static final String ASYNC_SERVICE = "liferay/async_service";
 
 	public static final String BACKGROUND_TASK = "liferay/background_task";

--- a/portal-test/src/com/liferay/portal/kernel/test/rule/SynchronousDestinationTestRule.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/SynchronousDestinationTestRule.java
@@ -171,8 +171,6 @@ public class SynchronousDestinationTestRule
 				BufferedIncrementThreadLocal.setForceSyncWithSafeCloseable(
 					true);
 
-			replaceDestination(
-				DestinationNames.ASSET_CATEGORY_ASSET_ENTRIES_REINDEX);
 			replaceDestination(DestinationNames.ASYNC_SERVICE);
 			replaceDestination(DestinationNames.BACKGROUND_TASK);
 			replaceDestination(DestinationNames.BACKGROUND_TASK_STATUS);
@@ -193,6 +191,7 @@ public class SynchronousDestinationTestRule
 			replaceDestination(DestinationNames.SUBSCRIPTION_SENDER);
 			replaceDestination("liferay/adaptive_media_processor");
 			replaceDestination("liferay/asset_auto_tagger");
+			replaceDestination("liferay/asset_category_asset_entries_reindex");
 			replaceDestination("liferay/ddm_structure_reindex");
 			replaceDestination("liferay/report_request");
 			replaceDestination("liferay/reports_admin");


### PR DESCRIPTION
This is a follow up of https://github.com/liferay-content-management/liferay-portal/pull/6703 with Brian requested changes.

### What is this trying to solve?
https://liferay.atlassian.net/browse/LPD-56872 Transfer Asset Reindex to a Message Listener to avoid unnecesary waits.
### How am I fixing it?
Transfering the reindexation of Assets to the background
### How can you verify that it works?
1. Create a category.
2. Create 300 Basic Contents that are assigned to that category.
3. Rename the category
### Why does this pull not include tests?
This cannot be observed reliably from a test. This is a performance change.