### PR TITLE
LPD-62783 - Fix CMS Dropdowns

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/css/components/AssetTaskStatus.scss
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/css/components/AssetTaskStatus.scss
@@ -1,11 +1,5 @@
 @import 'atlas-variables';
 
-.dropdown-menu {
-	max-height: none;
-	max-width: none;
-	padding: 0;
-}
-
 .task-status {
 	margin: 0;
 	max-height: 36.25rem !important;
@@ -56,6 +50,12 @@
 }
 
 .task-status-dropdown {
+	&.dropdown-menu {
+		max-height: none;
+		max-width: none;
+		padding: 0;
+	}
+
 	.dropdown-toggle {
 		border-bottom-left-radius: unset;
 		border-left: unset;


### PR DESCRIPTION
It fixes the global Dropdown overwrite and specifies that class is only appliying when we are using a `task-status-dropdown`, a dropdown that was commited in the same PR and is present in `liferay-portal/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/task_status/TaskStatusManager.tsx`

cc @monaco-fabio

<img width="1609" height="634" alt="image" src="https://github.com/user-attachments/assets/6456745d-e92f-429f-a519-de5a7694b47d" />
