### PR TITLE
LPD-63302 AI Creator editor config contributor ignores showAICreator attribute

### DIFF
--- a/modules/apps/ai-creator/ai-creator-openai-web/src/main/java/com/liferay/ai/creator/openai/web/internal/editor/configuration/AICreatorOpenAIEditorConfigContributor.java
+++ b/modules/apps/ai-creator/ai-creator-openai-web/src/main/java/com/liferay/ai/creator/openai/web/internal/editor/configuration/AICreatorOpenAIEditorConfigContributor.java
@@ -17,6 +17,7 @@ import com.liferay.portal.kernel.portlet.LiferayWindowState;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactory;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -47,7 +48,8 @@ public class AICreatorOpenAIEditorConfigContributor
 		RequestBackedPortletURLFactory requestBackedPortletURLFactory) {
 
 		if (!_isAICreatorChatGPTGroupEnabled(
-				themeDisplay.getCompanyId(), themeDisplay.getScopeGroupId())) {
+				themeDisplay.getCompanyId(), themeDisplay.getScopeGroupId()) ||
+			!_isShowAICreator(inputEditorTaglibAttributes)) {
 
 			return;
 		}
@@ -111,6 +113,14 @@ public class AICreatorOpenAIEditorConfigContributor
 		}
 
 		return false;
+	}
+
+	private boolean _isShowAICreator(
+		Map<String, Object> inputEditorTaglibAttributes) {
+
+		return GetterUtil.getBoolean(
+			inputEditorTaglibAttributes.get(
+				"liferay-ui:input-editor:showAICreator"));
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-63302

The ai creator editor config contributor wasn't taking into account the value of the "showAICreator" attribute (used to show/hide AI controls independently of the configuration).

# How am I fixing it?

By checking the value of the attribute and doing nothing if it is `false`.

# How can you verify that it works?

This was caught by `AICreatorOpenAIEditorConfigurationTest.testAICreatorToolbarCompanyAndGroupEnabledWithAPIKeyNoJournalPortlet` in the `ai-creator-openai-test` module. These changes make the test green again.