### PR TITLE
LPD-63735 Asset Library Connected Site Member should not appear in the roles dropdown

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/spaces/SpaceMembersWithList.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/spaces/SpaceMembersWithList.tsx
@@ -83,7 +83,7 @@ export function SpaceMembersWithList({
 							spaceId: assetLibraryId,
 						}),
 						AdminUserService.getUserRoles({
-							filter: 'type eq 5',
+							filter: "type eq 5 and name ne 'Asset Library Connected Site Member'",
 						}),
 					]);
 


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-63735

The role "Asset Library Connected Site Membe" should be excluded in roles dropdown from Space "View All Members" dialog

# How am I fixing it?

Exclude role in filter sent in `AdminUserService.getUserRoles()`

# How can you verify that it works?

Execute existing unit test SpaceMembersWithList.test.tsx