### PR TITLE
LPD-64738 Cover image for blogs shouldn't be required

### DIFF
--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/com/liferay/site/initializer/cms/internal/batch/02-object-definition.batch-engine-data.json
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/com/liferay/site/initializer/cms/internal/batch/02-object-definition.batch-engine-data.json
@@ -274,7 +274,6 @@
 					],
 					"readOnly": "false",
 					"readOnlyConditionExpression": "",
-					"required": true,
 					"state": false,
 					"system": false,
 					"type": "Long",


### PR DESCRIPTION
Ticket: https://liferay.atlassian.net/browse/LPD-64738

1. Go to CMS
2. Create a new Blog 
3. Cover Image field should not be marked as required