### PR TITLE
LPD-64573 Remove toolbar code from view folder since it has a breadcrumb

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewFolderSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewFolderSectionDisplayContext.java
@@ -18,7 +18,6 @@ import com.liferay.object.service.ObjectEntryFolderLocalService;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.language.Language;
@@ -288,38 +287,6 @@ public class ViewFolderSectionDisplayContext extends BaseSectionDisplayContext {
 			rootObjectEntryFolder.getExternalReferenceCode();
 
 		return _rootObjectEntryFolderExternalReferenceCode;
-	}
-
-	@Override
-	public Map<String, Object> getToolbarProps() throws PortalException {
-		return HashMapBuilder.<String, Object>putAll(
-			super.getToolbarProps()
-		).put(
-			"title",
-			() -> {
-				if (objectEntryFolder == null) {
-					return null;
-				}
-
-				String[] parts = StringUtil.split(
-					objectEntryFolder.getTreePath(), CharPool.SLASH);
-
-				if (parts.length == 0) {
-					return null;
-				}
-
-				ObjectEntryFolder rootObjectEntryFolder =
-					_objectEntryFolderLocalService.fetchObjectEntryFolder(
-						GetterUtil.getLong(parts[1]));
-
-				if (rootObjectEntryFolder == null) {
-					return null;
-				}
-
-				return rootObjectEntryFolder.getLabel(
-					themeDisplay.getLocale(), true);
-			}
-		).build();
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/view_folder.jsp
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/view_folder.jsp
@@ -14,13 +14,6 @@ ViewFolderSectionDisplayContext viewFolderSectionDisplayContext = (ViewFolderSec
 <div class="cms-section">
 	<div>
 		<react:component
-			module="{Toolbar} from site-cms-site-initializer"
-			props="<%= viewFolderSectionDisplayContext.getToolbarProps() %>"
-		/>
-	</div>
-
-	<div>
-		<react:component
 			module="{Breadcrumb} from site-cms-site-initializer"
 			props="<%= viewFolderSectionDisplayContext.getBreadcrumbProps() %>"
 		/>


### PR DESCRIPTION
### What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-62573

Remove toolbar code from view folder since it has a breadcrumb

### How am I fixing it?

Removing the code that adds the toolbar when there is a breadcrumb

### How can you verify that it works?

Follow this steps:

1. Go to a Space Homepage.
2. Click on View All Content/View All Files.

<img width="1783" height="319" alt="Captura de pantalla 2025-09-11 a las 10 18 09" src="https://github.com/user-attachments/assets/a2cc8448-cec5-473a-b2f8-d2df52f977f1" />
