### PR TITLE
LPD-64517 CMS Site is listed as connected site in the Default space

### DIFF
--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
@@ -38,7 +38,6 @@ import com.liferay.data.engine.rest.dto.v2_0.DataDefinition;
 import com.liferay.data.engine.rest.resource.v2_0.DataDefinitionResource;
 import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
-import com.liferay.depot.service.DepotEntryGroupRelLocalService;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFileEntryType;
@@ -289,7 +288,6 @@ public class BundleSiteInitializer implements SiteInitializer {
 		DDMStructureLocalService ddmStructureLocalService,
 		DDMTemplateLocalService ddmTemplateLocalService,
 		DefaultDDMStructureHelper defaultDDMStructureHelper,
-		DepotEntryGroupRelLocalService depotEntryGroupRelLocalService,
 		DepotEntryLocalService depotEntryLocalService,
 		DLFileEntryTypeLocalService dlFileEntryTypeLocalService,
 		DLURLHelper dlURLHelper,
@@ -380,7 +378,6 @@ public class BundleSiteInitializer implements SiteInitializer {
 		_ddmStructureLocalService = ddmStructureLocalService;
 		_ddmTemplateLocalService = ddmTemplateLocalService;
 		_defaultDDMStructureHelper = defaultDDMStructureHelper;
-		_depotEntryGroupRelLocalService = depotEntryGroupRelLocalService;
 		_depotEntryLocalService = depotEntryLocalService;
 		_dlFileEntryTypeLocalService = dlFileEntryTypeLocalService;
 		_dlURLHelper = dlURLHelper;
@@ -2003,11 +2000,6 @@ public class BundleSiteInitializer implements SiteInitializer {
 						true)
 				).build(),
 				unicodeProperties, serviceContext);
-
-			_depotEntryGroupRelLocalService.addDepotEntryGroupRel(
-				(group != null) ? group.getClassPK() :
-					depotEntry.getDepotEntryId(),
-				serviceContext.getScopeGroupId());
 		}
 	}
 
@@ -6049,8 +6041,6 @@ public class BundleSiteInitializer implements SiteInitializer {
 	private final DDMStructureLocalService _ddmStructureLocalService;
 	private final DDMTemplateLocalService _ddmTemplateLocalService;
 	private final DefaultDDMStructureHelper _defaultDDMStructureHelper;
-	private final DepotEntryGroupRelLocalService
-		_depotEntryGroupRelLocalService;
 	private final DepotEntryLocalService _depotEntryLocalService;
 	private boolean _dialectThemeDetected;
 	private final DLFileEntryTypeLocalService _dlFileEntryTypeLocalService;

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/SiteInitializerExtender.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/SiteInitializerExtender.java
@@ -17,7 +17,6 @@ import com.liferay.asset.list.service.AssetListEntryLocalService;
 import com.liferay.client.extension.service.ClientExtensionEntryLocalService;
 import com.liferay.client.extension.type.manager.CETManager;
 import com.liferay.data.engine.rest.resource.v2_0.DataDefinitionResource;
-import com.liferay.depot.service.DepotEntryGroupRelLocalService;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalService;
 import com.liferay.document.library.util.DLURLHelper;
@@ -152,12 +151,11 @@ public class SiteInitializerExtender
 				_configurationProvider, _dataDefinitionResourceFactory,
 				_ddmStructureLocalService, _ddmTemplateLocalService,
 				_defaultDDMStructureHelper, _dependencyManager,
-				_depotEntryGroupRelLocalService, _depotEntryLocalService,
-				_dlFileEntryTypeLocalService, _dlURLHelper,
-				_documentFolderResourceFactory, _documentResourceFactory,
-				_expandoValueLocalService, _fragmentEntryLinkLocalService,
-				_fragmentsImporter, _groupLocalService,
-				_journalArticleLocalService, _jsonFactory,
+				_depotEntryLocalService, _dlFileEntryTypeLocalService,
+				_dlURLHelper, _documentFolderResourceFactory,
+				_documentResourceFactory, _expandoValueLocalService,
+				_fragmentEntryLinkLocalService, _fragmentsImporter,
+				_groupLocalService, _journalArticleLocalService, _jsonFactory,
 				_keywordResourceFactory, _knowledgeBaseArticleResourceFactory,
 				_knowledgeBaseFolderResourceFactory, _layoutLocalService,
 				_layoutPageTemplateEntryLocalService,
@@ -274,12 +272,11 @@ public class SiteInitializerExtender
 				_configurationProvider, _dataDefinitionResourceFactory,
 				_ddmStructureLocalService, _ddmTemplateLocalService,
 				_defaultDDMStructureHelper, _dependencyManager,
-				_depotEntryGroupRelLocalService, _depotEntryLocalService,
-				_dlFileEntryTypeLocalService, _dlURLHelper,
-				_documentFolderResourceFactory, _documentResourceFactory,
-				_expandoValueLocalService, _fragmentEntryLinkLocalService,
-				_fragmentsImporter, _groupLocalService,
-				_journalArticleLocalService, _jsonFactory,
+				_depotEntryLocalService, _dlFileEntryTypeLocalService,
+				_dlURLHelper, _documentFolderResourceFactory,
+				_documentResourceFactory, _expandoValueLocalService,
+				_fragmentEntryLinkLocalService, _fragmentsImporter,
+				_groupLocalService, _journalArticleLocalService, _jsonFactory,
 				_keywordResourceFactory, _knowledgeBaseArticleResourceFactory,
 				_knowledgeBaseFolderResourceFactory, _layoutLocalService,
 				_layoutPageTemplateEntryLocalService,
@@ -394,9 +391,6 @@ public class SiteInitializerExtender
 	private DefaultDDMStructureHelper _defaultDDMStructureHelper;
 
 	private DependencyManager _dependencyManager;
-
-	@Reference
-	private DepotEntryGroupRelLocalService _depotEntryGroupRelLocalService;
 
 	@Reference
 	private DepotEntryLocalService _depotEntryLocalService;

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/SiteInitializerExtension.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/SiteInitializerExtension.java
@@ -17,7 +17,6 @@ import com.liferay.asset.list.service.AssetListEntryLocalService;
 import com.liferay.client.extension.service.ClientExtensionEntryLocalService;
 import com.liferay.client.extension.type.manager.CETManager;
 import com.liferay.data.engine.rest.resource.v2_0.DataDefinitionResource;
-import com.liferay.depot.service.DepotEntryGroupRelLocalService;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalService;
 import com.liferay.document.library.util.DLURLHelper;
@@ -128,7 +127,6 @@ public class SiteInitializerExtension {
 		DDMTemplateLocalService ddmTemplateLocalService,
 		DefaultDDMStructureHelper defaultDDMStructureHelper,
 		DependencyManager dependencyManager,
-		DepotEntryGroupRelLocalService depotEntryGroupRelLocalService,
 		DepotEntryLocalService depotEntryLocalService,
 		DLFileEntryTypeLocalService dlFileEntryTypeLocalService,
 		DLURLHelper dlURLHelper,
@@ -213,8 +211,8 @@ public class SiteInitializerExtension {
 			clientExtensionEntryLocalService, companyLocalService,
 			configurationProvider, dataDefinitionResourceFactory,
 			ddmStructureLocalService, ddmTemplateLocalService,
-			defaultDDMStructureHelper, depotEntryGroupRelLocalService,
-			depotEntryLocalService, dlFileEntryTypeLocalService, dlURLHelper,
+			defaultDDMStructureHelper, depotEntryLocalService,
+			dlFileEntryTypeLocalService, dlURLHelper,
 			documentFolderResourceFactory, documentResourceFactory,
 			expandoValueLocalService, fragmentEntryLinkLocalService,
 			fragmentsImporter, groupLocalService, journalArticleLocalService,

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/SiteInitializerFactoryImpl.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/SiteInitializerFactoryImpl.java
@@ -17,7 +17,6 @@ import com.liferay.asset.list.service.AssetListEntryLocalService;
 import com.liferay.client.extension.service.ClientExtensionEntryLocalService;
 import com.liferay.client.extension.type.manager.CETManager;
 import com.liferay.data.engine.rest.resource.v2_0.DataDefinitionResource;
-import com.liferay.depot.service.DepotEntryGroupRelLocalService;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalService;
 import com.liferay.document.library.util.DLURLHelper;
@@ -138,8 +137,8 @@ public class SiteInitializerFactoryImpl implements SiteInitializerFactory {
 			_clientExtensionEntryLocalService, _companyLocalService,
 			_configurationProvider, _dataDefinitionResourceFactory,
 			_ddmStructureLocalService, _ddmTemplateLocalService,
-			_defaultDDMStructureHelper, _depotEntryGroupRelLocalService,
-			_depotEntryLocalService, _dlFileEntryTypeLocalService, _dlURLHelper,
+			_defaultDDMStructureHelper, _depotEntryLocalService,
+			_dlFileEntryTypeLocalService, _dlURLHelper,
 			_documentFolderResourceFactory, _documentResourceFactory,
 			_expandoValueLocalService, _fragmentEntryLinkLocalService,
 			_fragmentsImporter, _groupLocalService, _journalArticleLocalService,
@@ -255,9 +254,6 @@ public class SiteInitializerFactoryImpl implements SiteInitializerFactory {
 
 	@Reference
 	private DefaultDDMStructureHelper _defaultDDMStructureHelper;
-
-	@Reference
-	private DepotEntryGroupRelLocalService _depotEntryGroupRelLocalService;
 
 	@Reference
 	private DepotEntryLocalService _depotEntryLocalService;


### PR DESCRIPTION
### What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-64517

CMS Site is listed as connected site in the Default space

### How am I fixing it?

Removing the code that adds the DepotEntryGroupRel

### How can you verify that it works?

Follow this steps:

1. Start CMS
2. Go to the Default space
3. Check the Connected sites list

This is what should appear in the Connected Sites list:

<img width="786" height="457" alt="Captura de pantalla 2025-09-11 a las 11 48 57" src="https://github.com/user-attachments/assets/f21d61df-8df7-4a57-968f-ddb571d4d550" />


