### PR TITLE
LPD-65862 Fix test failures in fileEntry.spec.ts > A non-localizable field in a Document Type cannot be entered if accessed from a site that does not use t

### DIFF
--- a/modules/test/playwright/pages/site-admin-web/SiteSettingsLocalizationPage.ts
+++ b/modules/test/playwright/pages/site-admin-web/SiteSettingsLocalizationPage.ts
@@ -74,11 +74,11 @@ export class SiteSettingsLocalizationPage {
 	async disableAllLanguagesExceptSp(siteUrl?: Site['friendlyUrlPath']) {
 		await this.goto(siteUrl);
 
-		await this.page.getByLabel('Transfer Item Left to Right').click();
+		await this.page.getByLabel('Transfer Item Right to Left').click();
 
 		await this.page
 			.getByRole('listbox')
-			.first()
+			.nth(1)
 			.selectOption([
 				'en_US',
 				'ar_SA',
@@ -94,7 +94,7 @@ export class SiteSettingsLocalizationPage {
 				'sv_SE',
 			]);
 
-		await this.page.getByLabel('Transfer Item Left to Right').click();
+		await this.page.getByLabel('Transfer Item Right to Left').click();
 
 		await this.siteSettingsPage.saveConfiguration();
 	}


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-65862

Test in `fileEntry.spec.ts` is failing.

# How am I fixing it?

The languages should be selected from the right listbox and moved into the left one (opposite direction)

# How can you verify that it works?

`npm run playwright -- test -g 'A non-localizable field in a Document Type'`
