### PR TITLE
LPD-65313  A user without role added to the Space cannot access the Space if is the first time

### DIFF
--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/UserAccountResourceImpl.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/UserAccountResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.CalendarFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.security.permission.PermissionCacheUtil;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
 import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
@@ -301,7 +302,7 @@ public class UserAccountResourceImpl extends BaseUserAccountResourceImpl {
 		ServiceContext serviceContext = ServiceContextFactory.getInstance(
 			User.class.getName(), contextHttpServletRequest);
 
-		return _userService.updateUser(
+		user = _userService.updateUser(
 			user.getUserId(), user.getPassword(), null, null,
 			user.isPasswordReset(), null, null, user.getScreenName(),
 			user.getEmailAddress(), user.getLanguageId(), user.getTimeZoneId(),
@@ -315,6 +316,10 @@ public class UserAccountResourceImpl extends BaseUserAccountResourceImpl {
 			_getUserGroupIds(user, assetLibraryId, add),
 			user.getOrganizationIds(), null, null, user.getUserGroupIds(),
 			serviceContext);
+
+		PermissionCacheUtil.clearCache(user.getUserId());
+
+		return user;
 	}
 
 	@Reference


### PR DESCRIPTION
LPD-65313  A user without role added to the Space cannot access the Space if is the first time

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-65313

Clear the cache when modifying the user account


# How can you verify that it works?

Reproduction steps

1. Create new User without any role
2. Create a new Space
3. Add the new User to the new Space
4. Log in as the new User
5. Click on the notification with the invitation that gives access to the CSM Space




# Commits

LPD-65313 clear user permission cache to allow the user get the real permissions right after the membership to a Space