### PR TITLE
LPD-66410 Sharing in Space settings should be enabled by default

### DIFF
--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/AssetLibraryResourceImpl.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/AssetLibraryResourceImpl.java
@@ -51,6 +51,7 @@ import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 import com.liferay.portal.vulcan.util.SearchUtil;
+import com.liferay.sharing.constants.SharingConfigurationConstants;
 
 import jakarta.ws.rs.core.MultivaluedMap;
 
@@ -609,7 +610,9 @@ public class AssetLibraryResourceImpl extends BaseAssetLibraryResourceImpl {
 			GetterUtil.getString(settings.getLogoColor(), "outline-0")
 		).put(
 			"sharingEnabled",
-			GetterUtil.getBoolean(settings.getSharingEnabled())
+			GetterUtil.getBoolean(
+				settings.getSharingEnabled(),
+				SharingConfigurationConstants.SHARING_ENABLED_DEFAULT)
 		).put(
 			"trashEnabled",
 			GetterUtil.getBoolean(settings.getTrashEnabled(), true)

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/AssetLibraryResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/AssetLibraryResourceTest.java
@@ -28,6 +28,7 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.odata.entity.EntityField;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
+import com.liferay.sharing.constants.SharingConfigurationConstants;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -563,8 +564,9 @@ public class AssetLibraryResourceTest extends BaseAssetLibraryResourceTestCase {
 
 		_assertSettings(
 			assetLibrary, autoTaggingEnabled, availableLanguageIds,
-			defaultLanguageId, "outline-0", new MimeTypeLimit[0], false,
-			trashEnabled, trashEntriesMaxAge, useCustomLanguages);
+			defaultLanguageId, "outline-0", new MimeTypeLimit[0],
+			SharingConfigurationConstants.SHARING_ENABLED_DEFAULT, trashEnabled,
+			trashEntriesMaxAge, useCustomLanguages);
 	}
 
 	@Inject


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-66410 

The "Sharing Enabled" flag in Space Settings should be `true` by default.

# How am I fixing it?

This setting was already working correctly after changes in LPD-63428. After some investigation I found the solution: reverting a change invadvertly done in LPD-55828.

# How can you verify that it works?

Run integration test from module: `headless/headless-asset-library/headless-asset-library-test`

`gw tI --tests "AssetLibraryResourceTest.testPutAssetLibraryByExternalReferenceCode"`
