### PR TITLE
LPD-65918 Filter vocabulary exports to just the particular site being exported

### DIFF
--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyVocabularyResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyVocabularyResourceImpl.java
@@ -40,6 +40,7 @@ import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.BooleanFilter;
 import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.search.filter.TermsFilter;
 import com.liferay.portal.kernel.search.generic.BooleanQueryImpl;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
@@ -67,6 +68,8 @@ import com.liferay.portlet.asset.util.AssetVocabularySettingsHelper;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.InternalServerErrorException;
 import jakarta.ws.rs.core.MultivaluedMap;
+
+import java.io.Serializable;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -185,6 +188,33 @@ public class TaxonomyVocabularyResourceImpl
 			).build());
 
 		return _toTaxonomyVocabulary(assetVocabulary);
+	}
+
+	@Override
+	public Page<TaxonomyVocabulary> read(
+			Filter filter, Pagination pagination, Sort[] sorts,
+			Map<String, Serializable> parameters, String search)
+		throws Exception {
+
+		if (parameters.containsKey("siteId")) {
+			TermsFilter siteFilter = new TermsFilter(Field.GROUP_ID);
+
+			siteFilter.addValue(String.valueOf(parameters.get("siteId")));
+
+			if (filter != null) {
+				BooleanFilter booleanFilter = new BooleanFilter();
+
+				booleanFilter.add(filter, BooleanClauseOccur.MUST);
+				booleanFilter.add(siteFilter, BooleanClauseOccur.MUST);
+
+				filter = booleanFilter;
+			}
+			else {
+				filter = siteFilter;
+			}
+		}
+
+		return super.read(filter, pagination, sorts, parameters, search);
 	}
 
 	@Override


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-65918

Context from [original PR](https://github.com/liferay-headless/liferay-portal/pull/3128)

> **Problem** - ResourceImpl Page return methods, such as [BaseTaxonomyVocabularyResourceImpl#getSiteTaxonomyVocabulariesPage](https://github.com/liferay/liferay-portal/blob/92343bff7607f7346fcf1aef53da6bac0266f6d4/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyVocabularyResourceImpl.java#L577), don't necessarily return only assets with the Site's Id, but also Assets available to the site. The causes extra assets to be exported and imported. (See Reproductions steps on [LPD-65918](https://liferay.atlassian.net/browse/LPD-65918))
> 
> In this case [TaxonomyVocabularyResourceImpl#_getTaxonomyVocabulariesPage adds groups returned from SiteConnectedGroupGroupProviderUtil#getCurrentAndAncestorSiteAndDepotGroupIds](https://github.com/liferay/liferay-portal/blob/21dcfdd8f3675590cc7020636d279c98a00ceea7/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyVocabularyResourceImpl.java#L832-L834). I believe this behavior needs to remain.
> 
> The fix being suggested here is to add a filter clause to enforce the assets to come from only the site being exported. There's a lot to consider here, such as how this will effect all different assets types using the BatchEngine framework and also if it works from different scopes. I have low confidence this is the ultimate solution, but wanted to provide it as a demonstration of how to address the issue.

[Danniel's response](https://github.com/liferay-headless/liferay-portal/pull/3128#issuecomment-3319693088)

> In my opinion, this should not be generalized to the BatchEnginePortletDataHandler. The behavior of including other groups beyond the current one is custom to this resource, so the issue belongs strictly to TaxonomyVocabularyResourceImpl.
> 
> The better approach would be to override the read method (the one used during export) in TaxonomyVocabularyResourceImpl and introduce a filter to explicitly limit results to the given siteId. This way the API keeps its current behavior for normal usage, while export can enforce stricter filtering when needed—without introducing global changes in the export/import framework.
> ...
> This keeps the fix localized to the vocabulary resource, avoids side effects for other resources, and gives export the stricter filtering it needs.
