### PR TITLE
LPD-66929 Adjust No Results and Empty state margins

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/css/main.css
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/css/main.css
@@ -1,7 +1,3 @@
-.cms-section.custom-empty-state .c-empty-state-title {
-	margin-top: 0;
-}
-
 .cms-fds-fluid .container-fluid {
 	padding: 0;
 }


### PR DESCRIPTION
Resending https://github.com/brianchandotcom/liferay-portal/pull/166220#issuecomment-3358183825
Previous PR https://github.com/liferay-content-management/liferay-portal/pull/7204


# What is this trying to solve?

[LPD-66929](https://liferay.atlassian.net/browse/LPD-66929)

Fix no result state margins.
Please see the [slack thread](https://liferay.slack.com/archives/C080GFGC598/p1759235011092679) for more details about the solution.

# How am I fixing it?

Removing the class override in empty state title.

# How can you verify that it works?

Navigating between CMS pages with empty content.

**Before**
<img width="1095" height="729" alt="Screenshot from 2025-10-01 10-54-24" src="https://github.com/user-attachments/assets/409bf7f8-5f5b-483b-9065-d12baedf9340" />
<img width="1095" height="729" alt="Screenshot from 2025-10-01 10-54-41" src="https://github.com/user-attachments/assets/26f44396-59fb-4d42-be24-7ef8bcfea478" />


**After**
<img width="1095" height="729" alt="Screenshot from 2025-10-01 10-54-51" src="https://github.com/user-attachments/assets/f47be051-6074-4b36-8973-5048150fdb98" />
<img width="1095" height="729" alt="Screenshot from 2025-10-01 10-55-03" src="https://github.com/user-attachments/assets/32532073-a4ab-4087-96b7-547d6e2ede71" />

