### PR TITLE
LPD-67395 Using "Clear All" when removing categories from Web Content does not remove categories

### DIFF
--- a/modules/apps/asset/asset-categories-item-selector-web/src/main/resources/META-INF/resources/js/AssetCategoryTree.js
+++ b/modules/apps/asset/asset-categories-item-selector-web/src/main/resources/META-INF/resources/js/AssetCategoryTree.js
@@ -94,11 +94,9 @@ export function AssetCategoryTree({
 		}
 
 		requestAnimationFrame(() => {
-			if (Object.keys(selectedItems).length) {
-				getOpener().Liferay.fire(itemSelectedEventName, {
-					data: selectedItems,
-				});
-			}
+			getOpener().Liferay.fire(itemSelectedEventName, {
+				data: selectedItems,
+			});
 		});
 	}, [
 		selectedKeys,


### PR DESCRIPTION
### Problem
When using "Clear All" or manually deselecting all categories in the Web Content category selector, the categories are not removed. The `AssetCategoryTree` component was not firing the selection event when `selectedItems` became empty, so the parent component was never notified of the change.
### Solution
Removed the conditional check if (`Object.keys(selectedItems).length`) that prevented the event from firing with empty selection data. The component now always fires the event, allowing the parent to properly handle cleared selections.
### Testing
Should this be covered with unit tests, integration tests, or both? What would be the appropriate test strategy for this change?

Thank you and best regards,
István