### PR TITLE
LPD-67552 Set current to false only when the field is updated manually.

### DIFF
--- a/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/translate/components/TranslateFieldSetEntries.js
+++ b/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/translate/components/TranslateFieldSetEntries.js
@@ -105,7 +105,9 @@ const TranslateFieldEditor = ({
 			editorRef.current.editor.setData(targetContent);
 			setContent(targetContent);
 		}
-		internalUpdateRef.current = false;
+		else {
+			internalUpdateRef.current = false;
+		}
 	}, [targetContent]);
 
 	return (


### PR DESCRIPTION
LPD-67552 Translate action sometimes fails to update the content of the field.

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-67552

The translate action sometimes fails to update the content of the field when clicking on Auto Translate.

# How am I fixing it?

Setting internalUpdateRef.current to false only when the field is updated manually avoiding race conditions when the field is marked as "edited manually" and the content is never updated after that.

# How can you verify that it works?

1. Enable one of the translators (Amazon, Google, Deepl, Microsof),
2. Create a Basic Web Content with any content.
3. Access the translation of that content (three dots -> Translate)
4. Try several times to remove the content of the translated content Field and click on Auto Translate

At some point the translation gets stuck and the translated field remains empty even after clicking Auto Translate.
