### PR TITLE
LPD-71163 MessageBoardAttachment headless API creates attachments with incorrect encodingFormat

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardAttachmentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardAttachmentResourceImpl.java
@@ -182,7 +182,7 @@ public class MessageBoardAttachmentResourceImpl
 				MBMessage.class.getName(), mbMessage.getClassPK(),
 				MBConstants.SERVICE_NAME, folder.getFolderId(),
 				binaryFile.getInputStream(), binaryFile.getFileName(),
-				binaryFile.getFileName(), false));
+				binaryFile.getContentType(), false));
 	}
 
 	private Page<MessageBoardAttachment> _getMessageBoardAttachmentsPage(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/MessageBoardAttachmentResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/MessageBoardAttachmentResourceTest.java
@@ -16,6 +16,7 @@ import com.liferay.portal.kernel.test.constants.TestDataConstants;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.MimeTypesUtil;
 import com.liferay.portal.kernel.util.PropsValues;
 
 import java.io.File;
@@ -109,6 +110,60 @@ public class MessageBoardAttachmentResourceTest
 		throws Exception {
 
 		super.testGraphQLGetMessageBoardThreadMessageBoardAttachmentsPage();
+	}
+
+	@Override
+	@Test
+	public void testPostMessageBoardMessageMessageBoardAttachment()
+		throws Exception {
+
+		MessageBoardAttachment randomMessageBoardAttachment =
+			randomMessageBoardAttachment();
+
+		Map<String, File> multipartFiles = getMultipartFiles();
+
+		MessageBoardAttachment postMessageBoardAttachment =
+			testPostMessageBoardMessageMessageBoardAttachment_addMessageBoardAttachment(
+				randomMessageBoardAttachment, multipartFiles);
+
+		assertEquals(randomMessageBoardAttachment, postMessageBoardAttachment);
+		assertValid(postMessageBoardAttachment);
+
+		assertValid(postMessageBoardAttachment, multipartFiles);
+
+		File file = multipartFiles.get("file");
+
+		String mimeType = MimeTypesUtil.getContentType(file, file.getName());
+
+		Assert.assertEquals(
+			mimeType, postMessageBoardAttachment.getEncodingFormat());
+	}
+
+	@Override
+	@Test
+	public void testPostMessageBoardThreadMessageBoardAttachment()
+		throws Exception {
+
+		MessageBoardAttachment randomMessageBoardAttachment =
+			randomMessageBoardAttachment();
+
+		Map<String, File> multipartFiles = getMultipartFiles();
+
+		MessageBoardAttachment postMessageBoardAttachment =
+			testPostMessageBoardThreadMessageBoardAttachment_addMessageBoardAttachment(
+				randomMessageBoardAttachment, multipartFiles);
+
+		assertEquals(randomMessageBoardAttachment, postMessageBoardAttachment);
+		assertValid(postMessageBoardAttachment);
+
+		assertValid(postMessageBoardAttachment, multipartFiles);
+
+		File file = multipartFiles.get("file");
+
+		String mimeType = MimeTypesUtil.getContentType(file, file.getName());
+
+		Assert.assertEquals(
+			mimeType, postMessageBoardAttachment.getEncodingFormat());
 	}
 
 	@Override


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-71163

MessageBoardAttachments are erroneously using fileName for mimeType.

```
gw testIntegration --tests MessageBoardAttachmentResourceTest.testPostMessageBoardMessageMessageBoardAttachment
gw testIntegration --tests MessageBoardAttachmentResourceTest.testPostMessageBoardThreadMessageBoardAttachment
```