### PR TITLE
LPD-71875 putSiteStructuredContentByExternalReferenceCode does not save the updated values

### DIFF
--- a/modules/apps/headless/headless-admin-content/headless-admin-content-client/src/main/java/com/liferay/headless/admin/content/client/dto/v1_0/ContentField.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-client/src/main/java/com/liferay/headless/admin/content/client/dto/v1_0/ContentField.java
@@ -93,6 +93,27 @@ public class ContentField implements Cloneable, Serializable {
 
 	protected String dataType;
 
+	public String getFieldReference() {
+		return fieldReference;
+	}
+
+	public void setFieldReference(String fieldReference) {
+		this.fieldReference = fieldReference;
+	}
+
+	public void setFieldReference(
+		UnsafeSupplier<String, Exception> fieldReferenceUnsafeSupplier) {
+
+		try {
+			fieldReference = fieldReferenceUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String fieldReference;
+
 	public String getInputControl() {
 		return inputControl;
 	}

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-client/src/main/java/com/liferay/headless/admin/content/client/serdes/v1_0/ContentFieldSerDes.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-client/src/main/java/com/liferay/headless/admin/content/client/serdes/v1_0/ContentFieldSerDes.java
@@ -81,6 +81,20 @@ public class ContentFieldSerDes {
 			sb.append("\"");
 		}
 
+		if (contentField.getFieldReference() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"fieldReference\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(contentField.getFieldReference()));
+
+			sb.append("\"");
+		}
+
 		if (contentField.getInputControl() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -209,6 +223,15 @@ public class ContentFieldSerDes {
 			map.put("dataType", String.valueOf(contentField.getDataType()));
 		}
 
+		if (contentField.getFieldReference() == null) {
+			map.put("fieldReference", null);
+		}
+		else {
+			map.put(
+				"fieldReference",
+				String.valueOf(contentField.getFieldReference()));
+		}
+
 		if (contentField.getInputControl() == null) {
 			map.put("inputControl", null);
 		}
@@ -283,6 +306,9 @@ public class ContentFieldSerDes {
 			else if (Objects.equals(jsonParserFieldName, "dataType")) {
 				return false;
 			}
+			else if (Objects.equals(jsonParserFieldName, "fieldReference")) {
+				return false;
+			}
 			else if (Objects.equals(jsonParserFieldName, "inputControl")) {
 				return false;
 			}
@@ -330,6 +356,12 @@ public class ContentFieldSerDes {
 			else if (Objects.equals(jsonParserFieldName, "dataType")) {
 				if (jsonParserFieldValue != null) {
 					contentField.setDataType((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "fieldReference")) {
+				if (jsonParserFieldValue != null) {
+					contentField.setFieldReference(
+						(String)jsonParserFieldValue);
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "inputControl")) {

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-impl/rest-openapi.yaml
@@ -184,7 +184,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.headless.admin.content.client', and version '2.0.45'."
+        'com.liferay.headless.admin.content.client', and version '2.0.46'."
     license:
         name: Apache 2.0
         url: http://www.apache.org/licenses/LICENSE-2.0.html

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -42,7 +42,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.content.client', and version '2.0.45'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Admin Content", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.content.client', and version '2.0.46'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Admin Content", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-test/src/testIntegration/java/com/liferay/headless/admin/content/resource/v1_0/test/StructuredContentResourceTest.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-test/src/testIntegration/java/com/liferay/headless/admin/content/resource/v1_0/test/StructuredContentResourceTest.java
@@ -791,6 +791,7 @@ public class StructuredContentResourceTest
 						contentFieldValue = contentFieldValues.get(
 							w3cLanguageId);
 						contentFieldValue_i18n = contentFieldValues;
+						fieldReference = "MyText";
 						name = "MyText";
 					}
 				}

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/ContentField.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/ContentField.java
@@ -188,6 +188,51 @@ public class ContentField implements Serializable {
 	private Supplier<String> _dataTypeSupplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The field's friendly reference name. This is used by developers when referencing the field in custom implementations."
+	)
+	public String getFieldReference() {
+		if (_fieldReferenceSupplier != null) {
+			fieldReference = _fieldReferenceSupplier.get();
+
+			_fieldReferenceSupplier = null;
+		}
+
+		return fieldReference;
+	}
+
+	public void setFieldReference(String fieldReference) {
+		this.fieldReference = fieldReference;
+
+		_fieldReferenceSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setFieldReference(
+		UnsafeSupplier<String, Exception> fieldReferenceUnsafeSupplier) {
+
+		_fieldReferenceSupplier = () -> {
+			try {
+				return fieldReferenceUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(
+		description = "The field's friendly reference name. This is used by developers when referencing the field in custom implementations."
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String fieldReference;
+
+	@JsonIgnore
+	private Supplier<String> _fieldReferenceSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema(
 		description = "The field's control type (e.g., text, text area, etc.)."
 	)
 	public String getInputControl() {
@@ -519,6 +564,22 @@ public class ContentField implements Serializable {
 			sb.append("\"");
 
 			sb.append(_escape(dataType));
+
+			sb.append("\"");
+		}
+
+		String fieldReference = getFieldReference();
+
+		if (fieldReference != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"fieldReference\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(fieldReference));
 
 			sb.append("\"");
 		}

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/ContentStructureField.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/ContentStructureField.java
@@ -98,6 +98,51 @@ public class ContentStructureField implements Serializable {
 	private Supplier<String> _dataTypeSupplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The field's friendly reference name. This is used by developers when referencing the field in custom implementations."
+	)
+	public String getFieldReference() {
+		if (_fieldReferenceSupplier != null) {
+			fieldReference = _fieldReferenceSupplier.get();
+
+			_fieldReferenceSupplier = null;
+		}
+
+		return fieldReference;
+	}
+
+	public void setFieldReference(String fieldReference) {
+		this.fieldReference = fieldReference;
+
+		_fieldReferenceSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setFieldReference(
+		UnsafeSupplier<String, Exception> fieldReferenceUnsafeSupplier) {
+
+		_fieldReferenceSupplier = () -> {
+			try {
+				return fieldReferenceUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(
+		description = "The field's friendly reference name. This is used by developers when referencing the field in custom implementations."
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String fieldReference;
+
+	@JsonIgnore
+	private Supplier<String> _fieldReferenceSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema(
 		description = "The form field's input control type (e.g., text, textarea, select field, etc.)."
 	)
 	public String getInputControl() {
@@ -721,6 +766,22 @@ public class ContentStructureField implements Serializable {
 			sb.append("\"");
 
 			sb.append(_escape(dataType));
+
+			sb.append("\"");
+		}
+
+		String fieldReference = getFieldReference();
+
+		if (fieldReference != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"fieldReference\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(fieldReference));
 
 			sb.append("\"");
 		}

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/ContentFieldUtil.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/ContentFieldUtil.java
@@ -139,6 +139,7 @@ public class ContentFieldUtil {
 					});
 				setDataType(
 					() -> ContentStructureUtil.toDataType(ddmFormField));
+				setFieldReference(ddmFormField::getFieldReference);
 				setInputControl(
 					() -> ContentStructureUtil.toInputControl(ddmFormField));
 				setLabel(

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/ContentFieldUtil.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/ContentFieldUtil.java
@@ -148,7 +148,7 @@ public class ContentFieldUtil {
 					() -> LocalizedMapUtil.getI18nMap(
 						dtoConverterContext.isAcceptAllLanguages(),
 						localizedValue.getValues()));
-				setName(ddmFormField::getFieldReference);
+				setName(ddmFormField::getName);
 				setNestedContentFields(
 					() -> TransformUtil.transformToArray(
 						ddmFormFieldValue.getNestedDDMFormFieldValues(),

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/ContentStructureUtil.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/ContentStructureUtil.java
@@ -139,7 +139,7 @@ public class ContentStructureUtil {
 						acceptAllLanguage, labelLocalizedValue.getValues()));
 				setLocalizable(ddmFormField::isLocalizable);
 				setMultiple(ddmFormField::isMultiple);
-				setName(ddmFormField::getFieldReference);
+				setName(ddmFormField::getName);
 				setNestedContentStructureFields(
 					() -> TransformUtil.transformToArray(
 						ddmFormField.getNestedDDMFormFields(),

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/ContentStructureUtil.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/ContentStructureUtil.java
@@ -132,6 +132,7 @@ public class ContentStructureUtil {
 		return new ContentStructureField() {
 			{
 				setDataType(() -> toDataType(ddmFormField));
+				setFieldReference(ddmFormField::getFieldReference);
 				setInputControl(() -> toInputControl(ddmFormField));
 				setLabel(() -> _toString(labelLocalizedValue, locale));
 				setLabel_i18n(

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/DDMFormValuesUtil.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/DDMFormValuesUtil.java
@@ -163,11 +163,9 @@ public class DDMFormValuesUtil {
 		Map<String, List<ContentField>> contentFieldsMap = new HashMap<>();
 
 		for (ContentField contentField : contentFields) {
-			String contentFieldName = contentField.getName();
-
 			List<ContentField> contentFieldsList =
 				contentFieldsMap.computeIfAbsent(
-					contentFieldName, key -> new ArrayList<>());
+					contentField.getFieldReference(), key -> new ArrayList<>());
 
 			contentFieldsList.add(contentField);
 		}

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/resources/com/liferay/headless/delivery/dto/v1_0/packageinfo
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/resources/com/liferay/headless/delivery/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 35.2.1
+version 35.3.0

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/ContentField.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/ContentField.java
@@ -93,6 +93,27 @@ public class ContentField implements Cloneable, Serializable {
 
 	protected String dataType;
 
+	public String getFieldReference() {
+		return fieldReference;
+	}
+
+	public void setFieldReference(String fieldReference) {
+		this.fieldReference = fieldReference;
+	}
+
+	public void setFieldReference(
+		UnsafeSupplier<String, Exception> fieldReferenceUnsafeSupplier) {
+
+		try {
+			fieldReference = fieldReferenceUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String fieldReference;
+
 	public String getInputControl() {
 		return inputControl;
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/ContentStructureField.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/ContentStructureField.java
@@ -47,6 +47,27 @@ public class ContentStructureField implements Cloneable, Serializable {
 
 	protected String dataType;
 
+	public String getFieldReference() {
+		return fieldReference;
+	}
+
+	public void setFieldReference(String fieldReference) {
+		this.fieldReference = fieldReference;
+	}
+
+	public void setFieldReference(
+		UnsafeSupplier<String, Exception> fieldReferenceUnsafeSupplier) {
+
+		try {
+			fieldReference = fieldReferenceUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String fieldReference;
+
 	public String getInputControl() {
 		return inputControl;
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/ContentFieldSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/ContentFieldSerDes.java
@@ -81,6 +81,20 @@ public class ContentFieldSerDes {
 			sb.append("\"");
 		}
 
+		if (contentField.getFieldReference() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"fieldReference\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(contentField.getFieldReference()));
+
+			sb.append("\"");
+		}
+
 		if (contentField.getInputControl() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -210,6 +224,15 @@ public class ContentFieldSerDes {
 			map.put("dataType", String.valueOf(contentField.getDataType()));
 		}
 
+		if (contentField.getFieldReference() == null) {
+			map.put("fieldReference", null);
+		}
+		else {
+			map.put(
+				"fieldReference",
+				String.valueOf(contentField.getFieldReference()));
+		}
+
 		if (contentField.getInputControl() == null) {
 			map.put("inputControl", null);
 		}
@@ -284,6 +307,9 @@ public class ContentFieldSerDes {
 			else if (Objects.equals(jsonParserFieldName, "dataType")) {
 				return false;
 			}
+			else if (Objects.equals(jsonParserFieldName, "fieldReference")) {
+				return false;
+			}
 			else if (Objects.equals(jsonParserFieldName, "inputControl")) {
 				return false;
 			}
@@ -331,6 +357,12 @@ public class ContentFieldSerDes {
 			else if (Objects.equals(jsonParserFieldName, "dataType")) {
 				if (jsonParserFieldValue != null) {
 					contentField.setDataType((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "fieldReference")) {
+				if (jsonParserFieldValue != null) {
+					contentField.setFieldReference(
+						(String)jsonParserFieldValue);
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "inputControl")) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/ContentStructureFieldSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/ContentStructureFieldSerDes.java
@@ -61,6 +61,20 @@ public class ContentStructureFieldSerDes {
 			sb.append("\"");
 		}
 
+		if (contentStructureField.getFieldReference() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"fieldReference\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(contentStructureField.getFieldReference()));
+
+			sb.append("\"");
+		}
+
 		if (contentStructureField.getInputControl() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -269,6 +283,15 @@ public class ContentStructureFieldSerDes {
 				String.valueOf(contentStructureField.getDataType()));
 		}
 
+		if (contentStructureField.getFieldReference() == null) {
+			map.put("fieldReference", null);
+		}
+		else {
+			map.put(
+				"fieldReference",
+				String.valueOf(contentStructureField.getFieldReference()));
+		}
+
 		if (contentStructureField.getInputControl() == null) {
 			map.put("inputControl", null);
 		}
@@ -404,6 +427,9 @@ public class ContentStructureFieldSerDes {
 			if (Objects.equals(jsonParserFieldName, "dataType")) {
 				return false;
 			}
+			else if (Objects.equals(jsonParserFieldName, "fieldReference")) {
+				return false;
+			}
 			else if (Objects.equals(jsonParserFieldName, "inputControl")) {
 				return false;
 			}
@@ -459,6 +485,12 @@ public class ContentStructureFieldSerDes {
 			if (Objects.equals(jsonParserFieldName, "dataType")) {
 				if (jsonParserFieldValue != null) {
 					contentStructureField.setDataType(
+						(String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "fieldReference")) {
+				if (jsonParserFieldValue != null) {
+					contentStructureField.setFieldReference(
 						(String)jsonParserFieldValue);
 				}
 			}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
@@ -571,6 +571,12 @@ components:
                         The field type (e.g., image, text, etc.).
                     readOnly: true
                     type: string
+                fieldReference:
+                    # @review
+                    description:
+                        The field's friendly reference name. This is used by developers when referencing the field in
+                        custom implementations.
+                    type: string
                 inputControl:
                     description:
                         The field's control type (e.g., text, text area, etc.).
@@ -791,6 +797,13 @@ components:
                 dataType:
                     description:
                         The form field's type (e.g., date, geolocation, text, etc.).
+                    readOnly: true
+                    type: string
+                fieldReference:
+                    # @review
+                    description:
+                        The field's friendly reference name. This is used by developers when referencing the field in
+                        custom implementations.
                     readOnly: true
                     type: string
                 inputControl:

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/StructuredContentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/StructuredContentResourceImpl.java
@@ -20,7 +20,6 @@ import com.liferay.dynamic.data.mapping.model.DDMTemplate;
 import com.liferay.dynamic.data.mapping.model.Value;
 import com.liferay.dynamic.data.mapping.service.DDMStructureService;
 import com.liferay.dynamic.data.mapping.service.DDMTemplateLocalService;
-import com.liferay.dynamic.data.mapping.storage.DDMFormFieldValue;
 import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
 import com.liferay.dynamic.data.mapping.storage.Field;
 import com.liferay.dynamic.data.mapping.storage.Fields;
@@ -102,7 +101,6 @@ import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
@@ -1352,33 +1350,8 @@ public class StructuredContentResourceImpl
 			}
 		}
 
-		DDMFormValues ddmFormValues = DDMFormValuesUtil.toDDMFormValues(
-			SetUtil.fromArray(
-				LocaleUtil.fromLanguageIds(
-					journalArticle.getAvailableLanguageIds())),
-			contentFields, ddmStructure.getDDMForm(), _dlAppService,
-			journalArticle.getGroupId(), _journalArticleService,
-			_layoutLocalService, contextAcceptLanguage.getPreferredLocale(),
-			_getRootDDMFormFields(ddmStructure));
-
-		Map<String, DDMFormFieldValue> ddmFormFieldValuesMap = new HashMap<>();
-
-		for (DDMFormFieldValue ddmFormFieldValue :
-				ddmFormValues.getDDMFormFieldValues()) {
-
-			ddmFormFieldValuesMap.put(
-				ddmFormFieldValue.getFieldReference(), ddmFormFieldValue);
-		}
-
 		for (ContentField contentField : contentFields) {
-			DDMFormFieldValue ddmFormFieldValue = ddmFormFieldValuesMap.get(
-				contentField.getName());
-
-			if (ddmFormFieldValue == null) {
-				continue;
-			}
-
-			Field field = fields.get(ddmFormFieldValue.getName());
+			Field field = fields.get(contentField.getName());
 
 			Value value = DDMValueUtil.toDDMValue(
 				contentField,
@@ -1400,7 +1373,7 @@ public class StructuredContentResourceImpl
 			}
 		}
 
-		ddmFormValues = _fieldsToDDMFormValuesConverter.convert(
+		DDMFormValues ddmFormValues = _fieldsToDDMFormValuesConverter.convert(
 			ddmStructure, fields);
 
 		_ddmFormValuesValidator.validate(ddmFormValues);

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/StructuredContentResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/StructuredContentResourceTest.java
@@ -1318,7 +1318,8 @@ public class StructuredContentResourceTest
 							data = RandomTestUtil.randomString(10);
 						}
 					};
-					name = "Text";
+					fieldReference = "Text";
+					name = "Text91610572";
 				}
 			},
 			new ContentField() {
@@ -1339,7 +1340,8 @@ public class StructuredContentResourceTest
 								});
 						}
 					};
-					name = "SelectFromList";
+					fieldReference = "SelectFromList";
+					name = "SelectFromList43392010";
 				}
 			},
 			new ContentField() {
@@ -1360,7 +1362,8 @@ public class StructuredContentResourceTest
 								});
 						}
 					};
-					name = "SingleSelection";
+					fieldReference = "SingleSelection";
+					name = "SingleSelection90775749";
 				}
 			},
 			new ContentField() {
@@ -1385,7 +1388,8 @@ public class StructuredContentResourceTest
 								});
 						}
 					};
-					name = "MultipleSelection";
+					fieldReference = "MultipleSelection";
+					name = "MultipleSelection91429516";
 				}
 			},
 			new ContentField() {
@@ -1395,7 +1399,8 @@ public class StructuredContentResourceTest
 							data = _randomGrid();
 						}
 					};
-					name = "Grid";
+					fieldReference = "Grid";
+					name = "Grid61505317";
 				}
 			},
 			new ContentField() {
@@ -1405,12 +1410,14 @@ public class StructuredContentResourceTest
 							data = _randomDate();
 						}
 					};
-					name = "Date";
+					fieldReference = "Date";
+					name = "Date13994235";
 				}
 			},
 			new ContentField() {
 				{
-					name = "Fieldset";
+					fieldReference = "FieldSet";
+					name = "Fieldset39810423";
 				}
 			},
 			new ContentField() {
@@ -1420,7 +1427,8 @@ public class StructuredContentResourceTest
 							data = String.valueOf(RandomTestUtil.randomInt());
 						}
 					};
-					name = "Numeric";
+					fieldReference = "Numeric";
+					name = "Numeric90681086";
 				}
 			},
 			new ContentField() {
@@ -1434,7 +1442,8 @@ public class StructuredContentResourceTest
 							};
 						}
 					};
-					name = "Image";
+					fieldReference = "Image";
+					name = "Image09552700";
 				}
 			},
 			new ContentField() {
@@ -1444,7 +1453,8 @@ public class StructuredContentResourceTest
 							data = RandomTestUtil.randomString(500);
 						}
 					};
-					name = "RichText";
+					fieldReference = "RichText";
+					name = "RichText26302729";
 				}
 			},
 			new ContentField() {
@@ -1458,7 +1468,8 @@ public class StructuredContentResourceTest
 							};
 						}
 					};
-					name = "Upload";
+					fieldReference = "Upload";
+					name = "Upload59174863";
 				}
 			},
 			new ContentField() {
@@ -1468,7 +1479,8 @@ public class StructuredContentResourceTest
 							data = _randomColor();
 						}
 					};
-					name = "Color";
+					fieldReference = "Color";
+					name = "Color08878017";
 				}
 			},
 			new ContentField() {
@@ -1484,7 +1496,8 @@ public class StructuredContentResourceTest
 								};
 						}
 					};
-					name = "WebContent";
+					fieldReference = "WebContent";
+					name = "WebContent62525280";
 				}
 			},
 			new ContentField() {
@@ -1499,7 +1512,8 @@ public class StructuredContentResourceTest
 							};
 						}
 					};
-					name = "Geolocation";
+					fieldReference = "Geolocation";
+					name = "Geolocation12799577";
 				}
 			},
 			new ContentField() {
@@ -1509,7 +1523,8 @@ public class StructuredContentResourceTest
 							link = _layout.getFriendlyURL();
 						}
 					};
-					name = "LinkToPage";
+					fieldReference = "LinkToPage";
+					name = "LinkToPage24223121";
 				}
 			}
 		};
@@ -1585,6 +1600,7 @@ public class StructuredContentResourceTest
 						contentFieldValue = contentFieldValues.get(
 							w3cLanguageId);
 						contentFieldValue_i18n = contentFieldValues;
+						fieldReference = "MyText";
 						name = "MyText";
 					}
 				},
@@ -1608,6 +1624,7 @@ public class StructuredContentResourceTest
 							}
 						).build();
 						dataType = "document";
+						fieldReference = "MyDocument";
 						name = "MyDocument";
 					}
 				},
@@ -1631,6 +1648,7 @@ public class StructuredContentResourceTest
 							}
 						).build();
 						dataType = "image";
+						fieldReference = "MyImage";
 						name = "MyImage";
 					}
 				}
@@ -1697,7 +1715,8 @@ public class StructuredContentResourceTest
 								data = contentFieldValueData;
 							}
 						};
-						name = "Foo";
+						fieldReference = "Foo";
+						name = "MyText";
 					}
 				}
 			});
@@ -2163,7 +2182,7 @@ public class StructuredContentResourceTest
 		for (ContentField contentField :
 				getStructuredContent.getContentFields()) {
 
-			if (fieldName.equals(contentField.getName())) {
+			if (fieldName.equals(contentField.getFieldReference())) {
 				articleSelector = contentField;
 
 				break;
@@ -2853,6 +2872,7 @@ public class StructuredContentResourceTest
 								};
 							}
 						};
+						fieldReference = "image";
 						name = "image";
 					}
 				}

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/resources/com/liferay/headless/delivery/resource/v1_0/test/dependencies/test-journal-article-radio.xml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/resources/com/liferay/headless/delivery/resource/v1_0/test/dependencies/test-journal-article-radio.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <root available-locales="en_US" default-locale="en_US" version="1.0">
-	<dynamic-element field-reference="SingleSelection" index-type="keyword" instance-id="gTvjpM5x" name="SingleSelection" type="radio">
+	<dynamic-element field-reference="SingleSelection" index-type="keyword" instance-id="gTvjpM5x" name="SingleSelection90775749" type="radio">
 		<dynamic-content language-id="en_US"><![CDATA[[]]]></dynamic-content>
 	</dynamic-element>
 </root>


### PR DESCRIPTION
# What is this trying to solve?

[LPD-71875](https://liferay.atlassian.net/browse/LPD-71875)

When updating the Field Reference, the structured content cannot be updated through the Headless API.

# How am I fixing it?

A dedicated field is introduced for the Field Reference, while the existing name field continues to represent the original field name.

# How can you verify that it works?

Run the included automated tests.