### PR TITLE
LPD-78615 “Approved” status label is visible for folders in CMS

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/AssetsFDSPropsTransformer.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/AssetsFDSPropsTransformer.tsx
@@ -174,7 +174,16 @@ export default function AssetsFDSPropsTransformer({
 					type: 'internal',
 				} as IInternalRenderer,
 				{
-					component: ({value}) => StatusLabel(value),
+					component: ({itemData, value}) => {
+						if (
+							itemData?.entryClassName ===
+							OBJECT_ENTRY_FOLDER_CLASS_NAME
+						) {
+							return '--';
+						}
+
+						return StatusLabel(value);
+					},
 					name: 'statusTableCellRenderer',
 					type: 'internal',
 				} as IInternalRenderer,

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/folders.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/folders.spec.ts
@@ -61,6 +61,31 @@ test(
 );
 
 test(
+	'Folders should not show status',
+	{tag: '@LPD-78615'},
+	async ({apiHelpers, assetsPage, page}) => {
+		const folderTitle = getRandomString();
+
+		await apiHelpers.objectFolder.createObjectEntryFolder({
+			scopeKey: 'Default',
+			title: folderTitle,
+		});
+
+		await assetsPage.gotoFiles();
+
+		await assetsPage.changeVisualizationMode('Table');
+
+		const row = page
+			.getByRole('row')
+			.filter({has: page.getByRole('link', {name: folderTitle})});
+
+		await expect(
+			row.getByRole('cell', {exact: true, name: '--'})
+		).toBeVisible();
+	}
+);
+
+test(
 	'Folders have View Folder action, but not View',
 	{tag: '@LPD-58720'},
 	async ({apiHelpers, assetsPage, page}) => {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-78615

Status should not be visible for folders, it should show "--"