### PR TITLE
LPD-78864 Add YouTube thumbnail extraction as a client fallback for external videos

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/utils/transformViewsItemProps.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/utils/transformViewsItemProps.tsx
@@ -40,6 +40,24 @@ const getHrefLink = (item: any, props: Card) => {
 	return replaceTokens(selectedAction.href, item);
 };
 
+const getYouTubeVideoId = (videoURL: string) => {
+	try {
+		const url = new URL(videoURL);
+
+		if (['www.youtube.com', 'youtube.com'].includes(url.hostname)) {
+			return url.searchParams.get('v');
+		}
+		else if (['www.youtu.be', 'youtu.be'].includes(url.hostname)) {
+			return url.pathname.substring(1);
+		}
+	}
+	catch (_error) {
+		return null;
+	}
+
+	return null;
+};
+
 const getThumbnailProps = (item: any) => {
 	if (item.entryClassName === OBJECT_ENTRY_FOLDER_CLASS_NAME) {
 		return {symbol: 'folder'};
@@ -54,6 +72,16 @@ const getThumbnailProps = (item: any) => {
 		else {
 			return {symbol: 'documents-and-media'};
 		}
+	}
+
+	if (item.embedded.videoURL) {
+		const videoId = getYouTubeVideoId(item.embedded.videoURL);
+
+		if (videoId) {
+			return {imgProps: `https://img.youtube.com/vi/${videoId}/0.jpg`};
+		}
+
+		return {symbol: 'video'};
 	}
 
 	return {symbol: 'web-content'};

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/props_transformer/actions/transformItemCardView.test.ts
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/props_transformer/actions/transformItemCardView.test.ts
@@ -228,4 +228,76 @@ describe('transformItemCardView', () => {
 
 		expect(cardView.title).toBe('untitled-asset');
 	});
+
+	describe('External Video Thumbnail', () => {
+		it('External Video should show a thumbnail if it is a YouTube video (Standard URL)', () => {
+			const result = transformItemCardView(
+				{
+					embedded: {
+						systemProperties: {
+							objectDefinitionBrief: {
+								externalReferenceCode: 'L_CMS_EXTERNAL_VIDEO',
+							},
+						},
+						videoURL: 'https://www.youtube.com/watch?v=IqCSx3omX4o',
+					},
+				},
+				mockFileMimeTypeCssClasses,
+				mockFileMimeTypeIcons,
+				mockObjectDefinitionCssClasses,
+				mockObjectDefinitionIcons,
+				baseMockProps
+			);
+
+			expect(result.imgProps).toBe(
+				'https://img.youtube.com/vi/IqCSx3omX4o/0.jpg'
+			);
+		});
+
+		it('External Video should show a thumbnail if it is a YouTube video (Short URL)', () => {
+			const result = transformItemCardView(
+				{
+					embedded: {
+						systemProperties: {
+							objectDefinitionBrief: {
+								externalReferenceCode: 'L_CMS_EXTERNAL_VIDEO',
+							},
+						},
+						videoURL: 'https://youtu.be/IqCSx3omX4o',
+					},
+				},
+				mockFileMimeTypeCssClasses,
+				mockFileMimeTypeIcons,
+				mockObjectDefinitionCssClasses,
+				mockObjectDefinitionIcons,
+				baseMockProps
+			);
+
+			expect(result.imgProps).toBe(
+				'https://img.youtube.com/vi/IqCSx3omX4o/0.jpg'
+			);
+		});
+
+		it('External Video should show a video icon if it is not a YouTube video', () => {
+			const result = transformItemCardView(
+				{
+					embedded: {
+						systemProperties: {
+							objectDefinitionBrief: {
+								externalReferenceCode: 'L_CMS_EXTERNAL_VIDEO',
+							},
+						},
+						videoURL: 'https://vimeo.com/483035084',
+					},
+				},
+				mockFileMimeTypeCssClasses,
+				mockFileMimeTypeIcons,
+				mockObjectDefinitionCssClasses,
+				mockObjectDefinitionIcons,
+				baseMockProps
+			);
+
+			expect(result.symbol).toBe('video');
+		});
+	});
 });


### PR DESCRIPTION
### LPD: https://liferay.atlassian.net/browse/LPD-78864

# What is this solving?
In Site CMS, "External Video" assets created via YouTube URLs were not displaying thumbnails in FDS views (Cards, Gallery, etc.), falling back to a generic "Web Content" icon. This was inconsistent with the behavior in Documents & Media.

# How is it fixed?
- Implemented a client-side fallback in `transformViewsItemProps.tsx` to detect YouTube URLs.
- Added a utility to synchronously extract the YouTube Video ID from both standard and shortened URL formats.
- Generated the thumbnail URL using the official YouTube image service (`img.youtube.com`).
- Improved the default icon from "web-content" to "video" for non-supported external video providers.

# How to verify?
### Automated tests: 
Run 
```
cd modules/apps/site/site-cms-site-initializer
yarn test test/js/main_view/props_transformer/actions/transformItemCardView.test.ts
```
<img width="738" height="371" alt="image" src="https://github.com/user-attachments/assets/b5c76ea8-d031-4cb3-9832-b7125a070f96" />

### Manual steps:
#### Verify YouTube thumbnails
  1. Create an "External Video" in a CMS Space using a YouTube link (e.g., `https://www.youtube.com/watch?v=IqCSx3omX4o`).
  2. Navigate to the "Files" section.
  3. Verify that the thumbnail is correctly displayed in Card and Gallery views.

#### Verify the video icon fallback
  1. Create an "External Video" in a CMS Space using a non-YouTube link (e.g., a Vimeo or Twitch link).
  2. Navigate to the "Files" section.
  3. Verify that the generic "video" icon is displayed instead of the previous "web-content" (forms) icon.

# Visual changes
## Before
Displays the generic "Web Content" (forms) icon for YouTube links.
<img width="3788" height="2096" alt="image" src="https://github.com/user-attachments/assets/4a1792cb-dcee-477f-a9a6-8a419c0872da" />
<img width="1902" height="1048" alt="image" src="https://github.com/user-attachments/assets/b0480900-84e4-4297-8f46-56ffaacf765a" />

## After
Displays the actual YouTube video thumbnail.
<img width="3788" height="2098" alt="image" src="https://github.com/user-attachments/assets/650c1180-31fd-4e19-9198-1fc9a74cf725" />

<img width="3800" height="2099" alt="image" src="https://github.com/user-attachments/assets/2be932b1-e314-407e-be68-f6a87695e8bf" />
