### PR TITLE
LPD-83024 Fix folder navigation in gallery and card views for space members

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/SectionDisplayContextHelper.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/SectionDisplayContextHelper.java
@@ -302,7 +302,7 @@ public class SectionDisplayContextHelper {
 				ActionUtil.getBaseViewFolderURL(themeDisplay) + "{embedded.id}",
 				"view", "actionLinkFolder",
 				LanguageUtil.get(httpServletRequest, "view-folder"), "get",
-				"update", null,
+				"get", null,
 				HashMapBuilder.<String, Object>put(
 					"entryClassName", ObjectEntryFolder.class.getName()
 				).build()),

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewRecycleBinSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewRecycleBinSectionDisplayContext.java
@@ -166,7 +166,7 @@ public class ViewRecycleBinSectionDisplayContext
 					"{embedded.id}",
 				"view", "actionLinkFolder",
 				LanguageUtil.get(httpServletRequest, "view-folder"), "get",
-				"update", null,
+				"get", null,
 				HashMapBuilder.<String, Object>put(
 					"entryClassName", ObjectEntryFolder.class.getName()
 				).build()),


### PR DESCRIPTION
### LPD: https://liferay.atlassian.net/browse/LPD-83024

# What is this solving?
Space members were unable to navigate into folders when using Gallery or Card views because the "View Folder" action was incorrectly restricted to users with update permissions in the backend.

During the fix, I explored a more robust frontend propagation, but it required extensive refactoring of legacy GalleryView tests due to new TypeScript constraints. Since the current backend fix leverages native FDS behavior to solve the issue, I've kept the changes minimal. 

# How is it fixed?
Updated `SectionDisplayContextHelper` and `ViewRecycleBinSectionDisplayContext` to use 'get' instead of 'update' as the `permissionKey` for the `actionLinkFolder` action. This ensures the action is correctly sent to the client for users with read-only permissions, allowing the FDS engine to automatically enable the kebab menu option and the title link.

# How to verify?
- Automated tests: idk (Backend permission change)
- Manual steps: https://liferay.atlassian.net/browse/LPD-83024

>[!NOTE]
> As a frontender, I am not entirely sure if adding additional tests is strictly required for this specific change or the best way to implement them in this context, so I'll leave it to your discretion if further verification logic is needed.

# Visual changes
## Before
#### No Action, no link
<img width="1916" height="1054" alt="image" src="https://github.com/user-attachments/assets/988d2d5c-f466-423f-94dd-432ac8ada3d7" />
<img width="1916" height="1046" alt="image" src="https://github.com/user-attachments/assets/c9621450-907b-416c-b0f3-da51eb461acd" />

## After
#### Action and link working

<img width="1916" height="1052" alt="image" src="https://github.com/user-attachments/assets/241283bb-11fe-4920-a591-b29cf922f6ef" />
<img width="1908" height="1045" alt="image" src="https://github.com/user-attachments/assets/597b4832-988b-4f7b-9aa7-014b6a107648" />