### PR TITLE
LPD-83640 User added to a space via User Group has no access to the CMS in the User menu

### DIFF
--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
@@ -7,7 +7,6 @@ package com.liferay.friendly.url.internal.servlet;
 
 import com.liferay.depot.constants.DepotActionKeys;
 import com.liferay.depot.constants.DepotConstants;
-import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.friendly.url.configuration.FriendlyURLRedirectionConfiguration;
 import com.liferay.friendly.url.configuration.FriendlyURLRedirectionConfigurationProvider;
@@ -71,6 +70,7 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.JavaConstants;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -1276,21 +1276,11 @@ public class FriendlyURLServlet extends HttpServlet {
 		return user;
 	}
 
-	private boolean _hasDepotEntryTypeSpace(User user) throws PortalException {
-		for (Group group : user.getGroups()) {
-			if (!group.isDepot()) {
-				continue;
-			}
-
-			DepotEntry depotEntry = depotEntryLocalService.getGroupDepotEntry(
-				group.getGroupId());
-
-			if (depotEntry.getType() == DepotConstants.TYPE_SPACE) {
-				return true;
-			}
-		}
-
-		return false;
+	private boolean _hasDepotEntryTypeSpace(User user) {
+		return ListUtil.isNotEmpty(
+			depotEntryLocalService.getDepotEntryGroupIds(
+				user.getCompanyId(), user.getUserId(),
+				DepotConstants.TYPE_SPACE));
 	}
 
 	private boolean _isImpersonated(

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/product/navigation/personal/menu/test/CMSPersonalMenuEntryTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/product/navigation/personal/menu/test/CMSPersonalMenuEntryTest.java
@@ -11,18 +11,21 @@ import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.UserGroup;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.UserGroupLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.context.ContextUserReplace;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserGroupTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
@@ -77,6 +80,7 @@ public class CMSPersonalMenuEntryTest {
 		_testIsShowAdminUser();
 		_testIsShowCMSAdminRole();
 		_testIsShowDepotEntryMemberUser();
+		_testIsShowDepotEntryMemberUserGroup();
 		_testIsShowWithoutPermissions();
 	}
 
@@ -136,6 +140,33 @@ public class CMSPersonalMenuEntryTest {
 		}
 	}
 
+	private void _testIsShowDepotEntryMemberUserGroup() throws Exception {
+		User user = UserTestUtil.addUser();
+		UserGroup userGroup = UserGroupTestUtil.addUserGroup();
+
+		_userGroupLocalService.addGroupUserGroups(
+			_depotEntry.getGroupId(), new long[] {userGroup.getUserGroupId()});
+		_userGroupLocalService.addUserUserGroup(
+			user.getUserId(), userGroup.getUserGroupId());
+
+		PermissionChecker permissionChecker =
+			PermissionCheckerFactoryUtil.create(user);
+
+		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
+				user, permissionChecker)) {
+
+			Assert.assertTrue(
+				_personalMenuEntry.isShow(null, permissionChecker));
+		}
+		finally {
+			_userLocalService.deleteUser(user);
+
+			// Order matters, first the user, then the userGroup
+
+			_userGroupLocalService.deleteUserGroup(userGroup);
+		}
+	}
+
 	private void _testIsShowWithoutPermissions() throws Exception {
 		User user = UserTestUtil.addUser();
 
@@ -169,6 +200,9 @@ public class CMSPersonalMenuEntryTest {
 
 	@Inject
 	private RoleLocalService _roleLocalService;
+
+	@Inject
+	private UserGroupLocalService _userGroupLocalService;
 
 	@Inject
 	private UserLocalService _userLocalService;

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/product/navigation/personal/menu/CMSPersonalMenuEntry.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/product/navigation/personal/menu/CMSPersonalMenuEntry.java
@@ -59,10 +59,8 @@ public class CMSPersonalMenuEntry implements PersonalMenuEntry {
 			(ThemeDisplay)httpServletRequest.getAttribute(
 				WebKeys.THEME_DISPLAY);
 
-		Group group = _groupLocalService.getGroup(
-			themeDisplay.getCompanyId(), GroupConstants.CMS);
-
-		return group.getDisplayURL(themeDisplay);
+		return themeDisplay.getPathFriendlyURLPublic() +
+			GroupConstants.CMS_FRIENDLY_URL + "/home";
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/product/navigation/personal/menu/CMSPersonalMenuEntry.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/product/navigation/personal/menu/CMSPersonalMenuEntry.java
@@ -6,7 +6,6 @@
 package com.liferay.site.cms.site.initializer.internal.product.navigation.personal.menu;
 
 import com.liferay.depot.constants.DepotConstants;
-import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
@@ -21,6 +20,7 @@ import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.product.navigation.personal.menu.PersonalMenuEntry;
 
@@ -99,27 +99,10 @@ public class CMSPersonalMenuEntry implements PersonalMenuEntry {
 			return true;
 		}
 
-		List<Group> groups = user.getGroups();
-
-		for (Group curGroup : groups) {
-			if (!curGroup.isDepot()) {
-				continue;
-			}
-
-			DepotEntry depotEntry =
-				_depotEntryLocalService.fetchGroupDepotEntry(
-					curGroup.getGroupId());
-
-			if (depotEntry == null) {
-				continue;
-			}
-
-			if (depotEntry.getType() == DepotConstants.TYPE_SPACE) {
-				return true;
-			}
-		}
-
-		return false;
+		return ListUtil.isNotEmpty(
+			_depotEntryLocalService.getDepotEntryGroupIds(
+				user.getCompanyId(), user.getUserId(),
+				DepotConstants.TYPE_SPACE));
 	}
 
 	@Reference

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/home.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/home.spec.ts
@@ -10,6 +10,10 @@ import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
 import {loginTest} from '../../../fixtures/loginTest';
 import {workflowPagesTest} from '../../../fixtures/workflowPagesTest';
 import getRandomString from '../../../utils/getRandomString';
+import performLogin, {
+	performLogout,
+	userData,
+} from '../../../utils/performLogin';
 import {cmsPagesTest} from './fixtures/cmsPagesTest';
 import {DataSetPage} from './pages/DataSetPage';
 
@@ -529,5 +533,49 @@ test(
 				String(objectEntry2.id)
 			);
 		}
+	}
+);
+
+test(
+	'Can access the CMS when assigned to a Space via user group',
+	{tag: '@LPD-83640'},
+	async ({apiHelpers, page}) => {
+		const userGroup = await apiHelpers.headlessAdminUser.postUserGroup();
+
+		const user = await apiHelpers.headlessAdminUser.postUserAccount();
+
+		userData[user.alternateName] = {
+			name: user.givenName,
+			password: 'test',
+			surname: user.familyName,
+		};
+
+		await apiHelpers.headlessAdminUser.assignUsersToUserGroup(
+			userGroup.id,
+			[user.id]
+		);
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: `Space ${getRandomString()}`,
+			settings: {
+				logoColor: 'outline-3',
+				sharingEnabled: true,
+			},
+			type: 'Space',
+		});
+
+		await apiHelpers.jsonWebServicesUserGroup.assignUserGroupsToGroup(
+			String(space.siteId),
+			String(userGroup.id)
+		);
+
+		await performLogout(page);
+		await performLogin(page, user.alternateName);
+
+		await page.goto('/web/cms');
+
+		await expect(
+			page.getByRole('heading', {name: `Welcome, ${user.givenName}!`})
+		).toBeVisible();
 	}
 );


### PR DESCRIPTION
# What is this trying to solve?

[Link to ticket](https://issues.liferay.com/browse/LPD-83640)

User added to a space via User Group has no access to the CMS in the User menu, this is because user groups are not checked when handling the personal menu entry

# How am I fixing it?

We have a method in depotEntryLocalService that retrieves all groups for a given type of depot, so, the proposed solution is to call this method instead of iterating through all the groups of the user.

# Other notes

When a user that belongs to a user group navigated to the cms group friendly URL (http://localhost:8080/web/cms/) a 404 was shown. This is because in the servlet, we also didn't check for user groups

# How can you verify that it works?

I have added a new test to cover user groups in CMSPersonalMenuEntryTest called _testIsShowDepotEntryMemberUserGroup. All other tests also pass. It can also be checked manually by following the steps in the ticket
