### PR TITLE
LPD-83779 Importing Vocabulary with Category in CMS results in incorrect breadcrumb

### DIFF
--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetVocabularyLocalServiceTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetVocabularyLocalServiceTest.java
@@ -126,6 +126,8 @@ public class AssetVocabularyLocalServiceTest {
 				null, vocabulary.getSettings(),
 				AssetVocabularyConstants.VISIBILITY_TYPE_INTERNAL);
 
+			Assert.assertEquals(
+				StringUtil.toLowerCase(title), vocabulary.getName());
 			Assert.assertEquals(title, vocabulary.getTitle(locale));
 			Assert.assertEquals(
 				AssetVocabularyConstants.VISIBILITY_TYPE_INTERNAL,

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyLocalServiceImpl.java
@@ -704,7 +704,7 @@ public class AssetVocabularyLocalServiceImpl
 				return curVocabularyName;
 			}
 
-			curVocabularyName = curVocabularyName + CharPool.DASH + count++;
+			curVocabularyName = vocabularyName + CharPool.DASH + count++;
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyLocalServiceImpl.java
@@ -178,12 +178,12 @@ public class AssetVocabularyLocalServiceImpl
 
 		if (Validator.isNull(name)) {
 			name = _generateVocabularyName(
-				groupId, trimmedTitleMap.get(LocaleUtil.getSiteDefault()));
+				0, groupId, trimmedTitleMap.get(LocaleUtil.getSiteDefault()));
 		}
 
 		name = _getVocabularyName(name);
 
-		validate(groupId, name);
+		validate(0, groupId, name);
 
 		_validateVisibilityType(visibilityType);
 
@@ -537,7 +537,17 @@ public class AssetVocabularyLocalServiceImpl
 			vocabulary.setExternalReferenceCode(externalReferenceCode);
 		}
 
-		vocabulary.setTitleMap(_getTrimmedTitleMap(titleMap));
+		Map<Locale, String> trimmedTitleMap = _getTrimmedTitleMap(titleMap);
+
+		String name = _generateVocabularyName(
+			vocabularyId, vocabulary.getGroupId(),
+			trimmedTitleMap.get(LocaleUtil.getSiteDefault()));
+
+		validate(vocabularyId, vocabulary.getGroupId(), name);
+
+		vocabulary.setName(name);
+
+		vocabulary.setTitleMap(trimmedTitleMap);
 		vocabulary.setDescriptionMap(descriptionMap);
 		vocabulary.setSettings(settings);
 		vocabulary.setVisibilityType(visibilityType);
@@ -568,7 +578,17 @@ public class AssetVocabularyLocalServiceImpl
 			vocabulary.setExternalReferenceCode(externalReferenceCode);
 		}
 
-		vocabulary.setTitleMap(_getTrimmedTitleMap(titleMap));
+		Map<Locale, String> trimmedTitleMap = _getTrimmedTitleMap(titleMap);
+
+		String name = _generateVocabularyName(
+			vocabularyId, vocabulary.getGroupId(),
+			trimmedTitleMap.get(LocaleUtil.getSiteDefault()));
+
+		validate(vocabularyId, vocabulary.getGroupId(), name);
+
+		vocabulary.setName(name);
+
+		vocabulary.setTitleMap(trimmedTitleMap);
 
 		if (Validator.isNotNull(title)) {
 			vocabulary.setTitle(title);
@@ -620,14 +640,6 @@ public class AssetVocabularyLocalServiceImpl
 		return searchContext;
 	}
 
-	protected boolean hasVocabulary(long groupId, String name) {
-		if (assetVocabularyPersistence.countByG_N(groupId, name) == 0) {
-			return false;
-		}
-
-		return true;
-	}
-
 	protected BaseModelSearchResult<AssetVocabulary> searchVocabularies(
 			SearchContext searchContext)
 		throws PortalException {
@@ -650,20 +662,29 @@ public class AssetVocabularyLocalServiceImpl
 			"Unable to fix the search index after 10 attempts");
 	}
 
-	protected void validate(long groupId, String name) throws PortalException {
+	protected void validate(long vocabularyId, long groupId, String name)
+		throws PortalException {
+
 		if (Validator.isNull(name)) {
 			throw new VocabularyNameException(
 				"Category vocabulary name cannot be null for group " + groupId);
 		}
 
-		if (hasVocabulary(groupId, name)) {
+		AssetVocabulary vocabulary = assetVocabularyPersistence.fetchByG_N(
+			groupId, name);
+
+		if ((vocabulary != null) &&
+			(vocabulary.getVocabularyId() != vocabularyId)) {
+
 			throw new DuplicateVocabularyException(
 				"A category vocabulary with the name " + name +
 					" already exists");
 		}
 	}
 
-	private String _generateVocabularyName(long groupId, String name) {
+	private String _generateVocabularyName(
+		long vocabularyId, long groupId, String name) {
+
 		String vocabularyName = _getVocabularyName(name);
 
 		vocabularyName = StringUtil.replace(
@@ -677,7 +698,9 @@ public class AssetVocabularyLocalServiceImpl
 			AssetVocabulary vocabulary = assetVocabularyPersistence.fetchByG_N(
 				groupId, curVocabularyName);
 
-			if (vocabulary == null) {
+			if ((vocabulary == null) ||
+				(vocabulary.getVocabularyId() == vocabularyId)) {
+
 				return curVocabularyName;
 			}
 


### PR DESCRIPTION
   # What is this trying to solve?
   [https://liferay.atlassian.net/browse/LPD-83779](https://liferay.atlassian.net/browse/LPD-83779)

   # How am I fixing it?
   When an `AssetVocabulary` is initially created as a placeholder (e.g., during a partial import where a category is imported before its parent vocabulary), the External Reference Code (ERC) is used as a temporary name and title. Previously, subsequent updates with the actual vocabulary data only updated the
   localized `title`, leaving the stable `name` field as the ERC. Since breadcrumb generation in the CMS relies on `assetVocabulary.getName()`, the UI incorrectly displayed the ERC instead of the readable name.

   I updated `AssetVocabularyLocalServiceImpl.java` to:
   1.  **Synchronize Name on Update**: Explicitly derive and set the `name` field from the site's default locale title during all `updateVocabulary` operations.
   2.  **ID-Aware Validation**: Modernized the `validate` method to accept a `vocabularyId`, allowing it to ignore the current record during uniqueness checks. This prevents incorrect `DuplicateVocabularyException` failures when a vocabulary is updated without changing its name.
   3.  **Uniqueness Resolution**: Updated the internal `_generateVocabularyName` method to correctly handle name collision resolution by excluding the current vocabulary's ID from the database lookup.
   4.  **Fix Name Generation Bug**: Corrected the collision resolution logic to always append suffixes to the base name rather than the running result, preventing "infinite dash" suffixes (e.g., `name-0-1-2`).
   5.  **Clean up**: Removed the redundant `hasVocabulary` method in favor of the more robust `validate` logic.

   # How can you verify that it works?
   In `modules/apps/asset/asset-categories-test` run `gw testIntegration --tests *.AssetVocabularyLocalServiceTest`
