### PR TITLE
LPD-84631 Cannot enable CMS if default language is not English

### DIFF
--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/01_home/page.json
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/01_home/page.json
@@ -1,6 +1,7 @@
 {
 	"friendlyURL": "/home",
 	"hidden": false,
+	"name": "Home",
 	"name_i18n": {
 		"en_US": "Home"
 	},

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/02_dashboard/page.json
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/02_dashboard/page.json
@@ -1,6 +1,7 @@
 {
 	"friendlyURL": "/dashboard",
 	"hidden": false,
+	"name": "Dashboard",
 	"name_i18n": {
 		"en_US": "Dashboard"
 	},

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/03_assets/01_all/page.json
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/03_assets/01_all/page.json
@@ -1,6 +1,7 @@
 {
 	"friendlyURL": "/all",
 	"hidden": false,
+	"name": "All",
 	"name_i18n": {
 		"en_US": "All"
 	},

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/03_assets/02_contents/page.json
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/03_assets/02_contents/page.json
@@ -1,6 +1,7 @@
 {
 	"friendlyURL": "/contents",
 	"hidden": false,
+	"name": "Contents",
 	"name_i18n": {
 		"en_US": "Contents"
 	},

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/03_assets/03_files/page.json
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/03_assets/03_files/page.json
@@ -1,6 +1,7 @@
 {
 	"friendlyURL": "/files",
 	"hidden": false,
+	"name": "Files",
 	"name_i18n": {
 		"en_US": "Files"
 	},

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/03_assets/04_version_history/page.json
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/03_assets/04_version_history/page.json
@@ -1,6 +1,7 @@
 {
 	"friendlyURL": "/version-history",
 	"hidden": true,
+	"name": "Version History",
 	"name_i18n": {
 		"en_US": "Version History"
 	},

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/03_shared_with_me/page.json
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/03_shared_with_me/page.json
@@ -1,6 +1,7 @@
 {
 	"friendlyURL": "/shared-with-me",
 	"hidden": false,
+	"name": "Shared With Me",
 	"name_i18n": {
 		"en_US": "Shared With Me"
 	},

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/04_admin/01_structures/01_structure_builder/page.json
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/04_admin/01_structures/01_structure_builder/page.json
@@ -1,6 +1,7 @@
 {
 	"friendlyURL": "/structure-builder",
 	"hidden": true,
+	"name": "Structure Builder",
 	"name_i18n": {
 		"en_US": "Structure Builder"
 	},

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/04_admin/01_structures/02_structure_usages/page.json
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/04_admin/01_structures/02_structure_usages/page.json
@@ -1,6 +1,7 @@
 {
 	"friendlyURL": "/structure-usages",
 	"hidden": true,
+	"name": "Structure Usages",
 	"name_i18n": {
 		"en_US": "Structure Usages"
 	},

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/04_admin/01_structures/page.json
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/04_admin/01_structures/page.json
@@ -1,6 +1,7 @@
 {
 	"friendlyURL": "/structures",
 	"hidden": false,
+	"name": "Content Structures",
 	"name_i18n": {
 		"en_US": "Content Structures"
 	},

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/04_admin/02_categorization/01_vocabularies/01_add_vocabulary/page.json
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/04_admin/02_categorization/01_vocabularies/01_add_vocabulary/page.json
@@ -1,6 +1,7 @@
 {
 	"friendlyURL": "/categorization/new-vocabulary",
 	"hidden": false,
+	"name": "Vocabularies",
 	"name_i18n": {
 		"en_US": "Vocabularies"
 	},

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/04_admin/02_categorization/01_vocabularies/02_edit_vocabulary/page.json
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/04_admin/02_categorization/01_vocabularies/02_edit_vocabulary/page.json
@@ -1,6 +1,7 @@
 {
 	"friendlyURL": "/categorization/edit-vocabulary",
 	"hidden": false,
+	"name": "Vocabularies",
 	"name_i18n": {
 		"en_US": "Vocabularies"
 	},

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/04_admin/02_categorization/01_vocabularies/page.json
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/04_admin/02_categorization/01_vocabularies/page.json
@@ -1,6 +1,7 @@
 {
 	"friendlyURL": "/categorization/view-vocabularies",
 	"hidden": false,
+	"name": "Vocabularies",
 	"name_i18n": {
 		"en_US": "Vocabularies"
 	},

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/04_admin/02_categorization/02_tags/01_view_tag_usages/page.json
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/04_admin/02_categorization/02_tags/01_view_tag_usages/page.json
@@ -1,6 +1,7 @@
 {
 	"friendlyURL": "/categorization/view-tag-usages",
 	"hidden": false,
+	"name": "Tag Usages",
 	"name_i18n": {
 		"en_US": "Tag Usages"
 	},

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/04_admin/02_categorization/02_tags/page.json
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/04_admin/02_categorization/02_tags/page.json
@@ -1,6 +1,7 @@
 {
 	"friendlyURL": "/categorization/view-tags",
 	"hidden": false,
+	"name": "Tags",
 	"name_i18n": {
 		"en_US": "Tags"
 	},

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/04_admin/02_categorization/03_categories/01_add_category/page.json
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/04_admin/02_categorization/03_categories/01_add_category/page.json
@@ -1,6 +1,7 @@
 {
 	"friendlyURL": "/categorization/new-category",
 	"hidden": false,
+	"name": "Categories",
 	"name_i18n": {
 		"en_US": "Categories"
 	},

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/04_admin/02_categorization/03_categories/02_edit_category/page.json
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/04_admin/02_categorization/03_categories/02_edit_category/page.json
@@ -1,6 +1,7 @@
 {
 	"friendlyURL": "/categorization/edit-category",
 	"hidden": false,
+	"name": "Categories",
 	"name_i18n": {
 		"en_US": "Categories"
 	},

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/04_admin/02_categorization/03_categories/03_view_category_usages/page.json
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/04_admin/02_categorization/03_categories/03_view_category_usages/page.json
@@ -1,6 +1,7 @@
 {
 	"friendlyURL": "/categorization/view-category-usages",
 	"hidden": false,
+	"name": "Category Usages",
 	"name_i18n": {
 		"en_US": "Category Usages"
 	},

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/04_admin/02_categorization/03_categories/page.json
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/04_admin/02_categorization/03_categories/page.json
@@ -1,6 +1,7 @@
 {
 	"friendlyURL": "/categorization/view-categories",
 	"hidden": false,
+	"name": "Categories",
 	"name_i18n": {
 		"en_US": "Categories"
 	},

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/04_admin/02_categorization/page.json
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/04_admin/02_categorization/page.json
@@ -1,6 +1,7 @@
 {
 	"friendlyURL": "/categorization",
 	"hidden": false,
+	"name": "Categorization",
 	"name_i18n": {
 		"en_US": "Categorization"
 	},

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/04_admin/03_picklists/page.json
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/04_admin/03_picklists/page.json
@@ -1,6 +1,7 @@
 {
 	"friendlyURL": "/picklist-builder",
 	"hidden": true,
+	"name": "Picklist Builder",
 	"name_i18n": {
 		"en_US": "Picklist Builder"
 	},

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/04_admin/page.json
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/04_admin/page.json
@@ -1,6 +1,7 @@
 {
 	"friendlyURL": "/admin",
 	"hidden": false,
+	"name": "Admin",
 	"name_i18n": {
 		"en_US": "Admin"
 	},

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/05_spaces/page.json
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/05_spaces/page.json
@@ -1,6 +1,7 @@
 {
 	"friendlyURL": "/all-spaces",
 	"hidden": true,
+	"name": "All Spaces",
 	"name_i18n": {
 		"en_US": "All Spaces"
 	},

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/06_new_space/page.json
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/06_new_space/page.json
@@ -1,6 +1,7 @@
 {
 	"friendlyURL": "/new-space",
 	"hidden": true,
+	"name": "New Space",
 	"name_i18n": {
 		"en_US": "New Space"
 	},

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/07_add_members/page.json
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/07_add_members/page.json
@@ -1,6 +1,7 @@
 {
 	"friendlyURL": "/add-space-members",
 	"hidden": true,
+	"name": "Add Space Members",
 	"name_i18n": {
 		"en_US": "Add Space Members"
 	},

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/08_recycle_bin/page.json
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/08_recycle_bin/page.json
@@ -1,6 +1,7 @@
 {
 	"friendlyURL": "/recycle-bin",
 	"hidden": false,
+	"name": "Recycle Bin",
 	"name_i18n": {
 		"en_US": "Recycle Bin"
 	},

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/09_bulk_action_task_report/page.json
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/09_bulk_action_task_report/page.json
@@ -1,6 +1,7 @@
 {
 	"friendlyURL": "/bulk-action-task-report",
 	"hidden": true,
+	"name": "Bulk Action Task Report",
 	"name_i18n": {
 		"en_US": "Bulk Action Task Report"
 	},


### PR DESCRIPTION
# What is this trying to solve?

[Link to ticket](https://liferay.atlassian.net/browse/LPD-84631)

When instance is not in English, CMS cannot be activated

# How am I fixing it?

Adds name property as fallback in case the page name is not in the i18n map

# How can you verify that it works?

Follow the steps in the ticket or LPP
