### PR TITLE
LPD-85077 Cross-Site template selection when a web content structure is created in an Asset Library

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/info/item/provider/DDMTemplateInfoItemFieldSetProvider.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/info/item/provider/DDMTemplateInfoItemFieldSetProvider.java
@@ -17,7 +17,7 @@ import com.liferay.info.field.InfoFieldSet;
 @ProviderType
 public interface DDMTemplateInfoItemFieldSetProvider {
 
-	public InfoFieldSet getInfoItemFieldSet(long ddmStructureId)
+	public InfoFieldSet getInfoItemFieldSet(long ddmStructureId, long groupId)
 		throws NoSuchStructureException;
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web-test/build.gradle
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web-test/build.gradle
@@ -8,6 +8,7 @@ dependencies {
 	testImplementation project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")
 	testImplementation project(":apps:dynamic-data-mapping:dynamic-data-mapping-web")
 	testIntegrationImplementation group: "org.osgi", name: "org.osgi.service.cm", version: "1.6.0"
+	testIntegrationImplementation project(":apps:depot:depot-api")
 	testIntegrationImplementation project(":apps:dynamic-data-mapping:dynamic-data-mapping-test-util")
 	testIntegrationImplementation project(":apps:export-import:export-import-api")
 	testIntegrationImplementation project(":apps:export-import:export-import-test-util")

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/web/internal/info/item/provider/test/DDMTemplateInfoItemFieldSetProviderImplTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/web/internal/info/item/provider/test/DDMTemplateInfoItemFieldSetProviderImplTest.java
@@ -1,0 +1,131 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.dynamic.data.mapping.web.internal.info.item.provider.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.model.DepotEntryGroupRel;
+import com.liferay.depot.service.DepotEntryGroupRelLocalService;
+import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.dynamic.data.mapping.info.item.provider.DDMTemplateInfoItemFieldSetProvider;
+import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.dynamic.data.mapping.test.util.DDMStructureTestUtil;
+import com.liferay.dynamic.data.mapping.test.util.DDMTemplateTestUtil;
+import com.liferay.info.field.InfoField;
+import com.liferay.info.field.InfoFieldSet;
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Akhash Ramprakash
+ */
+@RunWith(Arquillian.class)
+public class DDMTemplateInfoItemFieldSetProviderImplTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testGetInfoItemFieldSet() throws Exception {
+		Group group1 = GroupTestUtil.addGroup();
+
+		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
+			HashMapBuilder.put(
+				LocaleUtil.US, RandomTestUtil.randomString()
+			).build(),
+			HashMapBuilder.put(
+				LocaleUtil.US, RandomTestUtil.randomString()
+			).build(),
+			DepotConstants.TYPE_ASSET_LIBRARY,
+			ServiceContextTestUtil.getServiceContext(
+				group1, TestPropsValues.getUserId()));
+
+		_addDepotEntryGroupRel(depotEntry, group1);
+
+		Group group2 = GroupTestUtil.addGroup();
+
+		_addDepotEntryGroupRel(depotEntry, group2);
+
+		DDMStructure ddmStructure = DDMStructureTestUtil.addStructure(
+			depotEntry.getGroupId(), JournalArticle.class.getName());
+
+		DDMTemplateTestUtil.addTemplate(
+			group1.getGroupId(), ddmStructure.getStructureId(),
+			PortalUtil.getClassNameId(JournalArticle.class));
+
+		_assertInfoFieldsCount(0, ddmStructure, group2.getGroupId());
+
+		DDMTemplateTestUtil.addTemplate(
+			group2.getGroupId(), ddmStructure.getStructureId(),
+			PortalUtil.getClassNameId(JournalArticle.class));
+
+		_assertInfoFieldsCount(1, ddmStructure, group2.getGroupId());
+
+		DDMTemplateTestUtil.addTemplate(
+			depotEntry.getGroupId(), ddmStructure.getStructureId(),
+			PortalUtil.getClassNameId(JournalArticle.class));
+
+		_assertInfoFieldsCount(2, ddmStructure, group2.getGroupId());
+	}
+
+	private void _addDepotEntryGroupRel(DepotEntry depotEntry, Group site)
+		throws Exception {
+
+		DepotEntryGroupRel depotEntryGroupRel =
+			_depotEntryGroupRelLocalService.addDepotEntryGroupRel(
+				depotEntry.getDepotEntryId(), site.getGroupId());
+
+		depotEntryGroupRel.setDdmStructuresAvailable(true);
+
+		_depotEntryGroupRelLocalService.updateDepotEntryGroupRel(
+			depotEntryGroupRel);
+	}
+
+	private void _assertInfoFieldsCount(
+			int count, DDMStructure ddmStructure, long groupId)
+		throws Exception {
+
+		InfoFieldSet infoFieldSet =
+			_ddmTemplateInfoItemFieldSetProvider.getInfoItemFieldSet(
+				ddmStructure.getStructureId(), groupId);
+
+		List<InfoField<?>> infoFields = infoFieldSet.getAllInfoFields();
+
+		Assert.assertEquals(infoFields.toString(), count, infoFields.size());
+	}
+
+	@Inject
+	private DDMTemplateInfoItemFieldSetProvider
+		_ddmTemplateInfoItemFieldSetProvider;
+
+	@Inject
+	private DepotEntryGroupRelLocalService _depotEntryGroupRelLocalService;
+
+	@Inject
+	private DepotEntryLocalService _depotEntryLocalService;
+
+}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/info/item/provider/DDMTemplateInfoItemFieldSetProviderImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/info/item/provider/DDMTemplateInfoItemFieldSetProviderImpl.java
@@ -10,6 +10,7 @@ import com.liferay.dynamic.data.mapping.info.item.provider.DDMTemplateInfoItemFi
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.model.DDMTemplate;
 import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
+import com.liferay.dynamic.data.mapping.service.DDMTemplateLocalService;
 import com.liferay.info.field.InfoField;
 import com.liferay.info.field.InfoFieldSet;
 import com.liferay.info.field.type.TextInfoFieldType;
@@ -18,6 +19,8 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.util.LocaleThreadLocal;
 import com.liferay.portlet.display.template.PortletDisplayTemplate;
+
+import java.util.List;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -31,19 +34,18 @@ public class DDMTemplateInfoItemFieldSetProviderImpl
 	implements DDMTemplateInfoItemFieldSetProvider {
 
 	@Override
-	public InfoFieldSet getInfoItemFieldSet(long ddmStructureId)
+	public InfoFieldSet getInfoItemFieldSet(long ddmStructureId, long groupId)
 		throws NoSuchStructureException {
 
 		try {
-			DDMStructure ddmStructure =
-				_ddmStructureLocalService.getDDMStructure(ddmStructureId);
+			List<DDMTemplate> ddmTemplates = _getTemplates(
+				_ddmStructureLocalService.getDDMStructure(ddmStructureId),
+				groupId);
 
 			return InfoFieldSet.builder(
 			).infoFieldSetEntry(
 				unsafeConsumer -> {
-					for (DDMTemplate ddmTemplate :
-							ddmStructure.getTemplates()) {
-
+					for (DDMTemplate ddmTemplate : ddmTemplates) {
 						unsafeConsumer.accept(
 							InfoField.builder(
 							).infoFieldType(
@@ -83,7 +85,22 @@ public class DDMTemplateInfoItemFieldSetProviderImpl
 			templateKey.replaceAll("\\W", "_");
 	}
 
+	private List<DDMTemplate> _getTemplates(
+		DDMStructure ddmStructure, long groupId) {
+
+		if (groupId == 0) {
+			return ddmStructure.getTemplates();
+		}
+
+		return _ddmTemplateLocalService.getTemplatesByClassPK(
+			new long[] {ddmStructure.getGroupId(), groupId},
+			ddmStructure.getStructureId());
+	}
+
 	@Reference
 	private DDMStructureLocalService _ddmStructureLocalService;
+
+	@Reference
+	private DDMTemplateLocalService _ddmTemplateLocalService;
 
 }

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/info/item/provider/JournalArticleInfoItemFormProvider.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/info/item/provider/JournalArticleInfoItemFormProvider.java
@@ -60,7 +60,8 @@ public class JournalArticleInfoItemFormProvider
 					JournalArticle.class.getName()),
 				displayPageInfoItemFieldSetProvider.getInfoFieldSet(
 					JournalArticle.class.getName(), StringPool.BLANK,
-					JournalArticle.class.getSimpleName(), 0));
+					JournalArticle.class.getSimpleName(), 0),
+				0);
 		}
 		catch (NoSuchFormVariationException noSuchFormVariationException) {
 			throw new RuntimeException(noSuchFormVariationException);
@@ -83,7 +84,8 @@ public class JournalArticleInfoItemFormProvider
 				displayPageInfoItemFieldSetProvider.getInfoFieldSet(
 					JournalArticle.class.getName(),
 					String.valueOf(ddmStructureId),
-					JournalArticle.class.getSimpleName(), 0));
+					JournalArticle.class.getSimpleName(), 0),
+				0);
 		}
 		catch (NoSuchClassTypeException noSuchClassTypeException) {
 			throw new RuntimeException(
@@ -110,7 +112,8 @@ public class JournalArticleInfoItemFormProvider
 				GetterUtil.getLong(formVariationKey), groupId),
 			displayPageInfoItemFieldSetProvider.getInfoFieldSet(
 				JournalArticle.class.getName(), formVariationKey,
-				JournalArticle.class.getSimpleName(), groupId));
+				JournalArticle.class.getSimpleName(), groupId),
+			groupId);
 	}
 
 	@Reference
@@ -184,7 +187,7 @@ public class JournalArticleInfoItemFormProvider
 
 	private InfoForm _getInfoForm(
 			String formVariationKey, InfoFieldSet assetEntryInfoFieldSet,
-			InfoFieldSet displayPageInfoFieldSet)
+			InfoFieldSet displayPageInfoFieldSet, long groupId)
 		throws NoSuchFormVariationException {
 
 		try {
@@ -205,7 +208,7 @@ public class JournalArticleInfoItemFormProvider
 
 						unsafeConsumer.accept(
 							ddmTemplateInfoItemFieldSetProvider.
-								getInfoItemFieldSet(ddmStructureId));
+								getInfoItemFieldSet(ddmStructureId, groupId));
 					}
 				}
 			).infoFieldSetEntry(

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/info/item/provider/JournalArticleInfoItemFormProvider.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/info/item/provider/JournalArticleInfoItemFormProvider.java
@@ -55,13 +55,12 @@ public class JournalArticleInfoItemFormProvider
 	public InfoForm getInfoForm() {
 		try {
 			return _getInfoForm(
-				StringPool.BLANK,
 				assetEntryInfoItemFieldSetProvider.getInfoFieldSet(
 					JournalArticle.class.getName()),
 				displayPageInfoItemFieldSetProvider.getInfoFieldSet(
 					JournalArticle.class.getName(), StringPool.BLANK,
 					JournalArticle.class.getSimpleName(), 0),
-				0);
+				StringPool.BLANK, 0);
 		}
 		catch (NoSuchFormVariationException noSuchFormVariationException) {
 			throw new RuntimeException(noSuchFormVariationException);
@@ -76,7 +75,6 @@ public class JournalArticleInfoItemFormProvider
 
 		try {
 			return _getInfoForm(
-				String.valueOf(ddmStructureId),
 				assetEntryInfoItemFieldSetProvider.getInfoFieldSet(
 					assetEntryLocalService.getEntry(
 						JournalArticle.class.getName(),
@@ -85,7 +83,7 @@ public class JournalArticleInfoItemFormProvider
 					JournalArticle.class.getName(),
 					String.valueOf(ddmStructureId),
 					JournalArticle.class.getSimpleName(), 0),
-				0);
+				String.valueOf(ddmStructureId), 0);
 		}
 		catch (NoSuchClassTypeException noSuchClassTypeException) {
 			throw new RuntimeException(
@@ -106,14 +104,13 @@ public class JournalArticleInfoItemFormProvider
 		throws NoSuchFormVariationException {
 
 		return _getInfoForm(
-			formVariationKey,
 			assetEntryInfoItemFieldSetProvider.getInfoFieldSet(
 				JournalArticle.class.getName(),
 				GetterUtil.getLong(formVariationKey), groupId),
 			displayPageInfoItemFieldSetProvider.getInfoFieldSet(
 				JournalArticle.class.getName(), formVariationKey,
 				JournalArticle.class.getSimpleName(), groupId),
-			groupId);
+			formVariationKey, groupId);
 	}
 
 	@Reference
@@ -186,8 +183,9 @@ public class JournalArticleInfoItemFormProvider
 	}
 
 	private InfoForm _getInfoForm(
-			String formVariationKey, InfoFieldSet assetEntryInfoFieldSet,
-			InfoFieldSet displayPageInfoFieldSet, long groupId)
+			InfoFieldSet assetEntryInfoFieldSet,
+			InfoFieldSet displayPageInfoFieldSet, String formVariationKey,
+			long groupId)
 		throws NoSuchFormVariationException {
 
 		try {


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-85077

When managing and displaying the web contents, during template configuration, templates from other sites are listed, allowing users to select them.

# How am I fixing it?

Restrict template fetching to only include templates belonging to the current site, and conditionally include the structure’s site only when it differs.

# How can you verify that it works?

Run the included automated tests.