### PR TITLE
LPD-84874 Assets in subfolders cannot be searched

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
@@ -118,6 +118,8 @@ public abstract class BaseSectionDisplayContext {
 
 	public Map<String, Object> getAdditionalProps() {
 		return HashMapBuilder.<String, Object>put(
+			"additionalAPIURLParameters", getAdditionalAPIURLParameters()
+		).put(
 			"assetLibraries",
 			_sectionDisplayContextHelper.getDepotEntriesJSONArray(
 				httpServletRequest)
@@ -305,7 +307,7 @@ public abstract class BaseSectionDisplayContext {
 	}
 
 	public String getAPIURL() {
-		return "/o/search/v1.0/search?" + getAdditionalAPIURLParameters();
+		return "/o/search/v1.0/search";
 	}
 
 	public Map<String, Object> getBreadcrumbProps() throws PortalException {

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewFolderSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewFolderSectionDisplayContext.java
@@ -78,10 +78,20 @@ public class ViewFolderSectionDisplayContext extends BaseSectionDisplayContext {
 			getRootObjectEntryFolderExternalReferenceCode(),
 			ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS);
 
+		boolean rootFolder = false;
+
+		if (objectEntryFolder != null) {
+			rootFolder = Objects.equals(
+				objectEntryFolder.getExternalReferenceCode(),
+				getRootObjectEntryFolderExternalReferenceCode());
+		}
+
 		return new HashMapBuilder<>().putAll(
 			super.getAdditionalProps()
 		).put(
 			"galleryViewEnabled", !contentsFolder
+		).put(
+			"rootFolder", rootFolder
 		).put(
 			"rootObjectEntryFolderExternalReferenceCode",
 			getRootObjectEntryFolderExternalReferenceCode()

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/AssetsFDSPropsTransformer.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/AssetsFDSPropsTransformer.tsx
@@ -50,14 +50,18 @@ import transformViewsItemsProps from './utils/transformViewsItemProps';
 import GalleryView from './views/GalleryView';
 
 /**
- * Transforms additionalAPIURLParameters to remove cmsRoot filter when searching.
+ * Transforms additionalAPIURLParameters to remove folderId filter when searching at root folder.
  * Hoisted outside component to avoid recreation
  */
-const additionalAPIURLParametersTransformer = (loadDataArgs: {
+export interface AdditionalAPIURLParametersTransformerArgs {
 	additionalAPIURLParameters: string;
+	rootFolder?: boolean;
 	searchParam: string;
-}): string | undefined => {
-	const {additionalAPIURLParameters, searchParam} = loadDataArgs;
+}
+const additionalAPIURLParametersTransformer = (
+	args: AdditionalAPIURLParametersTransformerArgs
+): string | undefined => {
+	const {additionalAPIURLParameters, rootFolder, searchParam} = args;
 
 	if (!additionalAPIURLParameters) {
 		return additionalAPIURLParameters;
@@ -85,7 +89,17 @@ const additionalAPIURLParametersTransformer = (loadDataArgs: {
 	const cleanedFilters = filterContent
 		.split(/\s+and\s+/i)
 		.map((part) => part.trim())
-		.filter((part) => part !== 'cmsRoot eq true' && part !== '');
+		.filter((part) => {
+			if (part === 'cmsRoot eq true') {
+				return false;
+			}
+
+			if (rootFolder && part.startsWith('folderId eq')) {
+				return false;
+			}
+
+			return part !== '';
+		});
 
 	if (!cleanedFilters.length) {
 		const beforeFilter = additionalAPIURLParameters.substring(
@@ -120,6 +134,7 @@ export type AdditionalProps = {
 	objectEntryFolderExternalReferenceCode: string;
 	parentObjectEntryFolderExternalReferenceCode: string;
 	redirect: string;
+	rootFolder?: boolean;
 	rootObjectEntryFolderExternalReferenceCode: string;
 	showAdditionalItemInfo?: boolean;
 };
@@ -167,13 +182,22 @@ export default function AssetsFDSPropsTransformer({
 		mergedViews = [...nonDefaultViews, galleryViewRenderer];
 	}
 
-	const {additionalAPIURLParameters, ...remainingAdditionalProps} =
-		additionalProps || {};
+	const {
+		additionalAPIURLParameters,
+		rootFolder,
+		...remainingAdditionalProps
+	} = additionalProps || {};
 
 	return {
 		...otherProps,
 		additionalAPIURLParameters,
-		additionalAPIURLParametersTransformer,
+		additionalAPIURLParametersTransformer: (
+			args: AdditionalAPIURLParametersTransformerArgs
+		) =>
+			additionalAPIURLParametersTransformer({
+				...args,
+				rootFolder,
+			}),
 		additionalProps: remainingAdditionalProps,
 		creationMenu: {
 			...creationMenu,

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/AssetsFDSPropsTransformer.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/AssetsFDSPropsTransformer.tsx
@@ -49,7 +49,58 @@ import addOnClickToCreationMenuItems from './utils/addOnClickToCreationMenuItems
 import transformViewsItemsProps from './utils/transformViewsItemProps';
 import GalleryView from './views/GalleryView';
 
+/**
+ * Transforms additionalAPIURLParameters to remove cmsRoot filter when searching.
+ * Hoisted outside component to avoid recreation
+ */
+const additionalAPIURLParametersTransformer = (loadDataArgs: {
+	additionalAPIURLParameters: string;
+	searchParam: string;
+}): string | undefined => {
+	const {additionalAPIURLParameters, searchParam} = loadDataArgs;
+
+	if (!additionalAPIURLParameters) {
+		return additionalAPIURLParameters;
+	}
+
+	if (!searchParam || !searchParam.trim().length) {
+		return additionalAPIURLParameters;
+	}
+
+	const filterPrefix = 'filter=';
+	const startIndex = additionalAPIURLParameters.indexOf(filterPrefix);
+
+	if (startIndex === -1) {
+		return additionalAPIURLParameters;
+	}
+
+	const prefixPart = additionalAPIURLParameters.substring(
+		0,
+		startIndex + filterPrefix.length
+	);
+	const filterContent = additionalAPIURLParameters.substring(
+		startIndex + filterPrefix.length
+	);
+
+	const cleanedFilters = filterContent
+		.split(/\s+and\s+/i)
+		.map((part) => part.trim())
+		.filter((part) => part !== 'cmsRoot eq true' && part !== '');
+
+	if (!cleanedFilters.length) {
+		const beforeFilter = additionalAPIURLParameters.substring(
+			0,
+			startIndex
+		);
+
+		return beforeFilter.replace(/&$/, '').trim() || undefined;
+	}
+
+	return `${prefixPart}${cleanedFilters.join(' and ')}`.trim();
+};
+
 export type AdditionalProps = {
+	additionalAPIURLParameters: string | undefined;
 	assetLibraries: AssetLibrary[];
 	autocompleteURL: string;
 	availableExportFileFormats: any[];
@@ -116,8 +167,14 @@ export default function AssetsFDSPropsTransformer({
 		mergedViews = [...nonDefaultViews, galleryViewRenderer];
 	}
 
+	const {additionalAPIURLParameters, ...remainingAdditionalProps} =
+		additionalProps || {};
+
 	return {
 		...otherProps,
+		additionalAPIURLParameters,
+		additionalAPIURLParametersTransformer,
+		additionalProps: remainingAdditionalProps,
 		creationMenu: {
 			...creationMenu,
 			primaryItems: addOnClickToCreationMenuItems(


### PR DESCRIPTION
Close https://liferay.atlassian.net/browse/LPD-84145

The fix solution is to use the new `additionalAPIURLParameters` prop from FDS to remove the `cmsRoot eq true` filter on search.

 
[search-asset-2026-04-06_13.29.42.webm](https://github.com/user-attachments/assets/de0a9b8c-1dc9-41db-9526-9151a4ea69e6)
