### PR TITLE
LPD-84213 Fix the height of the info document and media preview panel…

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/css/document_library_preview.scss
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/css/document_library_preview.scss
@@ -32,6 +32,7 @@
 		}
 
 		&.contextual-sidebar {
+			min-height: 100vh;
 			overflow-y: scroll;
 			top: auto;
 			z-index: 1;


### PR DESCRIPTION
# What is this trying to solve?
[LPD-84213](https://liferay.atlassian.net/browse/LPD-84213)

Fix the height of the info document and media preview panel when the preview is disabled

# How am I fixing it?

By setting sidebar height to view-port height 

# How can you verify that it works?

Follow the steps described in [LPP-63439](https://liferay.atlassian.net/browse/LPP-63439)

Please refer screenshots for reference 

<img width="1914" height="1020" alt="2026-04-02_16-35" src="https://github.com/user-attachments/assets/f4067ebe-c54e-4fa9-b540-e641160e7a78" />
<img width="1900" height="988" alt="2026-04-02_16-39" src="https://github.com/user-attachments/assets/682bc462-5a3e-4f55-83ea-5a7c7d2a9038" />
<img width="1903" height="1027" alt="2026-04-02_16-40" src="https://github.com/user-attachments/assets/45fb7edc-139c-4a3c-b998-32e6822eb0ed" />
<img width="1895" height="1027" alt="2026-04-02_16-41" src="https://github.com/user-attachments/assets/cc21a0f0-cee8-4376-8775-64f64b071ff4" />
<img width="1878" height="1037" alt="2026-04-02_17-25" src="https://github.com/user-attachments/assets/92711244-f911-4319-b918-aa16c26f3a83" />
<img width="1878" height="1025" alt="2026-04-02_17-26" src="https://github.com/user-attachments/assets/b91b3699-0759-4344-a4a7-2a8228a9e7cd" />

