### PR TITLE
LPD-85308 Migrate CM playwright tests to site admin headless helpers

### DIFF
--- a/modules/test/playwright/tests/announcements-web/main/announcements-web.spec.ts
+++ b/modules/test/playwright/tests/announcements-web/main/announcements-web.spec.ts
@@ -90,7 +90,7 @@ test(
 					name: 'Role' + getRandomString(),
 				});
 
-				const site1 = await apiHelpers.headlessSite.createSite({
+				const site1 = await apiHelpers.headlessAdminSite.postSite({
 					name: 'Site' + getRandomString(),
 				});
 

--- a/modules/test/playwright/tests/document-library-web/main/fileEntry.spec.ts
+++ b/modules/test/playwright/tests/document-library-web/main/fileEntry.spec.ts
@@ -891,7 +891,6 @@ test(
 		documentLibraryPage,
 		globalMenuPage,
 		page,
-		site,
 		siteSettingsLocalizationPage,
 	}) => {
 		const dTypeTitle = getRandomString();
@@ -900,6 +899,10 @@ test(
 			dTypeTitle,
 			'/global'
 		);
+
+		const site = await apiHelpers.headlessAdminSite.postSite({
+			name: getRandomString(),
+		});
 
 		await siteSettingsLocalizationPage.setCustomDefaultLanguage(
 			'Spanish (Spain)',

--- a/modules/test/playwright/tests/document-library-web/main/fileEntry.spec.ts
+++ b/modules/test/playwright/tests/document-library-web/main/fileEntry.spec.ts
@@ -926,7 +926,7 @@ test(
 		);
 
 		await globalMenuPage.goToSite('Global');
-		await apiHelpers.headlessSite.deleteSite(site.id);
+		await apiHelpers.headlessAdminSite.deleteSite(site.externalReferenceCode);
 		await documentLibraryPage.deleteDocumentType(dTypeTitle);
 
 		await waitForAlert(

--- a/modules/test/playwright/tests/document-library-web/main/fileEntry.spec.ts
+++ b/modules/test/playwright/tests/document-library-web/main/fileEntry.spec.ts
@@ -929,7 +929,9 @@ test(
 		);
 
 		await globalMenuPage.goToSite('Global');
-		await apiHelpers.headlessAdminSite.deleteSite(site.externalReferenceCode);
+		await apiHelpers.headlessAdminSite.deleteSite(
+			site.externalReferenceCode
+		);
 		await documentLibraryPage.deleteDocumentType(dTypeTitle);
 
 		await waitForAlert(

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/contentEditor.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/contentEditor.spec.ts
@@ -867,7 +867,7 @@ test.describe('Categorization Panel', () => {
 			const categoryName = getRandomString();
 			const vocabularyName = getRandomString();
 
-			const site = await apiHelpers.headlessSite.getSiteByERC('L_CMS');
+			const site = await apiHelpers.headlessAdminSite.getSite('L_CMS');
 
 			await createCategories({
 				apiHelpers,

--- a/modules/test/playwright/tests/trash-web/main/trash.spec.ts
+++ b/modules/test/playwright/tests/trash-web/main/trash.spec.ts
@@ -29,7 +29,7 @@ test(
 		let user;
 
 		await test.step('Create a new Site', async () => {
-			siteOne = await apiHelpers.headlessSite.createSite({
+			siteOne = await apiHelpers.headlessAdminSite.postSite({
 				name: siteOneName,
 			});
 		});
@@ -65,7 +65,7 @@ test(
 		});
 
 		await test.step('Create a new second Site', async () => {
-			siteTwo = await apiHelpers.headlessSite.createSite({
+			siteTwo = await apiHelpers.headlessAdminSite.postSite({
 				name: siteTwoName,
 			});
 		});
@@ -107,11 +107,19 @@ test(
 			const promises = [];
 
 			if (siteOne?.id) {
-				promises.push(apiHelpers.headlessSite.deleteSite(siteOne.id));
+				promises.push(
+					apiHelpers.headlessAdminSite.deleteSite(
+						siteOne.externalReferenceCode
+					)
+				);
 			}
 
 			if (siteTwo?.id) {
-				promises.push(apiHelpers.headlessSite.deleteSite(siteTwo.id));
+				promises.push(
+					apiHelpers.headlessAdminSite.deleteSite(
+						siteTwo.externalReferenceCode
+					)
+				);
 			}
 
 			if (user?.id) {

--- a/modules/test/playwright/tests/trash-web/main/trash.spec.ts
+++ b/modules/test/playwright/tests/trash-web/main/trash.spec.ts
@@ -102,33 +102,5 @@ test(
 				page.getByText('You do not have the required permissions')
 			).toBeVisible();
 		});
-
-		await test.step('Clean up', async () => {
-			const promises = [];
-
-			if (siteOne?.id) {
-				promises.push(
-					apiHelpers.headlessAdminSite.deleteSite(
-						siteOne.externalReferenceCode
-					)
-				);
-			}
-
-			if (siteTwo?.id) {
-				promises.push(
-					apiHelpers.headlessAdminSite.deleteSite(
-						siteTwo.externalReferenceCode
-					)
-				);
-			}
-
-			if (user?.id) {
-				promises.push(
-					apiHelpers.headlessAdminUser.deleteUserAccount(user.id)
-				);
-			}
-
-			await Promise.allSettled(promises);
-		});
 	}
 );


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-85308

After [LPD-82439](https://liferay.atlassian.net/browse/LPD-82439), playwright tests must use the new api helpers.  These changes update Content Management tests accordingly.

# How am I fixing it?

By changing references to the new api helper.

# How can you verify that it works?

Run the modified tests and see them pass.

Note that some CMS playwright tests will fail; those failures are not related to these changes.