### PR TITLE
LPD-85632 Use headless-admin-site API in site-cms-site-initializer

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/services/ConnectedSiteService.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/services/ConnectedSiteService.ts
@@ -36,7 +36,7 @@ async function getConnectedSitesFromSpace(externalReferenceCode: string) {
 
 async function getAllSites() {
 	return await ApiHelper.get<{items: Site[]}>(
-		`/o/headless-site/v1.0/sites?active=true`
+		`/o/headless-admin-site/v1.0/sites?active=true`
 	);
 }
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/spaces/SpaceConnectedSitesModal.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/spaces/SpaceConnectedSitesModal.tsx
@@ -181,7 +181,7 @@ const SitesSelector = ({
 					</label>
 
 					<ItemSelector
-						apiURL={`${location.origin}/o/headless-site/v1.0/sites?active=true`}
+						apiURL={`${location.origin}/o/headless-admin-site/v1.0/sites?active=true`}
 						id="siteSelector"
 						items={site ? [site] : []}
 						onItemsChange={(items: Site[]) => {


### PR DESCRIPTION
# What is this trying to solve?
   https://liferay.atlassian.net/browse/LPD-85632

   # How am I fixing it?
   I have removed the usages of the legacy and deprecated `headless-site` API within the Content Management (CMS) Site Initializer module. I updated the following files to use the current `headless-admin-site` API instead:
   - `ConnectedSiteService.ts`: Updated the `getAllSites` function to use `/o/headless-admin-site/v1.0/sites`.
   - `SpaceConnectedSitesModal.tsx`: Updated the `apiURL` passed to the `ItemSelector` component.

   # How can you verify that it works?
   In `modules/test/playwright`, run:
   `npm run playwright -- test modules/test/playwright/tests/site-cms-site-initializer/main/spaces/allspaces.spec.ts`