### PR TITLE
LPD-78887 Failing to upload files with same name but different extension

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/multiple_file_uploader/MultipleFileUploader.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/multiple_file_uploader/MultipleFileUploader.tsx
@@ -27,6 +27,37 @@ import {required, validate} from '../../common/components/forms/validations';
 import {AssetLibrary} from '../../common/types/AssetLibrary';
 import {Space} from '../../common/types/Space';
 import FailedFiles from './FailedFiles';
+
+function getBaseName(filename: string): string {
+	const pos = filename.lastIndexOf('.');
+
+	return pos > 0 ? filename.substring(0, pos) : filename;
+}
+
+function getUploadBatches(files: FileData[]): FileData[][] {
+	const uploadBatches: FileData[][] = [];
+	const uploadBatchBaseNames: Set<string>[] = [];
+
+	for (const fileData of files) {
+		const baseName = getBaseName(fileData.name);
+
+		const pos = uploadBatchBaseNames.findIndex(
+			(baseNames) => !baseNames.has(baseName)
+		);
+
+		if (pos === -1) {
+			uploadBatches.push([fileData]);
+			uploadBatchBaseNames.push(new Set([baseName]));
+		}
+		else {
+			uploadBatches[pos].push(fileData);
+			uploadBatchBaseNames[pos].add(baseName);
+		}
+	}
+
+	return uploadBatches;
+}
+
 export interface FileData {
 	errorMessage?: string;
 	failed?: boolean;
@@ -155,53 +186,53 @@ export default function MultipleFileUploader({
 			const failedFiles: FileData[] = [];
 			const uploadedFiles: string[] = [];
 
-			Promise.allSettled(
-				filesToUpload.map(async (fileData: FileData) => {
-					const response = await uploadRequest({
-						fileData,
-						groupId: String(values.groupId),
-					});
-
-					const {error} = response;
-
-					if (error) {
-						failedFiles.push({
-							...fileData,
-							errorMessage: error,
-							failed: true,
+			for (const uploadBatch of getUploadBatches(filesToUpload)) {
+				await Promise.allSettled(
+					uploadBatch.map(async (fileData: FileData) => {
+						const response = await uploadRequest({
+							fileData,
+							groupId: String(values.groupId),
 						});
-					}
-					else if (response.multipleErrors) {
-						response.errors.map((item: any) => {
+
+						const {error} = response;
+
+						if (error) {
 							failedFiles.push({
-								...item,
+								...fileData,
+								errorMessage: error,
 								failed: true,
 							});
-						});
-					}
-					else {
-						uploadedFiles.push(fileData.name);
-					}
+						}
+						else if (response.multipleErrors) {
+							response.errors.map((item: any) => {
+								failedFiles.push({
+									...item,
+									failed: true,
+								});
+							});
+						}
+						else {
+							uploadedFiles.push(fileData.name);
+						}
+					})
+				);
+			}
 
-					return true;
-				})
-			).then(() => {
-				setIsLoading(false);
+			setIsLoading(false);
 
-				setFilesToUpload([]);
-				setFiledFiles(failedFiles);
+			setFilesToUpload([]);
+			setFiledFiles(failedFiles);
 
-				if (onUploadComplete) {
-					onUploadComplete({
-						assetLibrary: assetLibraries
-							? findAssetLibrary(String(values.groupId)) ||
-								assetLibraries?.[0]
-							: null,
-						failedFiles: failedFiles.map((file) => file.name),
-						successFiles: uploadedFiles,
-					});
-				}
-			});
+			if (onUploadComplete) {
+				onUploadComplete({
+					assetLibrary: assetLibraries
+						? findAssetLibrary(String(values.groupId)) ||
+							assetLibraries?.[0]
+						: null,
+					failedFiles: failedFiles.map((file) => file.name),
+					successFiles: uploadedFiles,
+				});
+			}
 		},
 		validate: (values) =>
 			validate(

--- a/modules/apps/site/site-cms-site-initializer/test/js/content_editor/components/ContentEditorSidePanel.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/content_editor/components/ContentEditorSidePanel.test.tsx
@@ -18,8 +18,8 @@ jest.mock('frontend-js-web', () => ({
 	...(jest.requireActual('frontend-js-web') as object),
 	dateUtils: {
 		getFirstDayOfWeek: jest.fn(),
-		getMonthsLong: jest.fn(),
-		getWeekdaysShort: jest.fn(),
+		getMonthsLong: jest.fn().mockReturnValue([]),
+		getWeekdaysShort: jest.fn().mockReturnValue([]),
 	},
 }));
 

--- a/modules/apps/site/site-cms-site-initializer/test/js/content_editor/components/panels/SchedulePanel.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/content_editor/components/panels/SchedulePanel.test.tsx
@@ -20,8 +20,8 @@ jest.mock('frontend-js-web', () => ({
 	...(jest.requireActual('frontend-js-web') as object),
 	dateUtils: {
 		getFirstDayOfWeek: jest.fn(),
-		getMonthsLong: jest.fn(),
-		getWeekdaysShort: jest.fn(),
+		getMonthsLong: jest.fn().mockReturnValue([]),
+		getWeekdaysShort: jest.fn().mockReturnValue([]),
 	},
 }));
 

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/components/MultipleFileUploader.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/components/MultipleFileUploader.test.tsx
@@ -247,6 +247,128 @@ describe('MultipleFileUploader', () => {
 		});
 	});
 
+	describe('batch upload', () => {
+		it('uploads files with the same base name in separate sequential batches', async () => {
+			const callOrder: string[] = [];
+			let resolveFirstBatch!: () => void;
+
+			const mockBatchRequest = jest.fn().mockImplementation(
+				({fileData}: {fileData: {name: string}}) =>
+					new Promise<{error: boolean}>((resolve) => {
+						callOrder.push(fileData.name);
+
+						if (fileData.name === 'A.pdf') {
+							resolveFirstBatch = () => resolve({error: false});
+						}
+						else {
+							resolve({error: false});
+						}
+					})
+			);
+
+			const {container} = render(
+				<MultipleFileUploader
+					{...DEFAULT_PROPS}
+					assetLibraries={[
+						{
+							externalReferenceCode: 'erc-1',
+							groupId: 2,
+							name: 'Library A',
+						},
+					]}
+					uploadRequest={mockBatchRequest}
+				/>
+			);
+
+			const input =
+				container.querySelector<HTMLInputElement>(
+					'input[type="file"]'
+				)!;
+
+			fireEvent.change(input, {
+				target: {
+					files: [
+						createFile('A.pdf', 1024),
+						createFile('A.txt', 1024),
+					],
+				},
+			});
+
+			expect(await screen.findByText('A.pdf')).toBeInTheDocument();
+
+			fireEvent.click(screen.getByRole('button', {name: /upload/i}));
+
+			await waitFor(() => expect(callOrder).toContain('A.pdf'));
+
+			expect(callOrder).not.toContain('A.txt');
+
+			resolveFirstBatch();
+
+			await waitFor(() => expect(callOrder).toContain('A.txt'));
+
+			await waitFor(() => expect(mockUploadComplete).toHaveBeenCalled());
+		});
+
+		it('uploads files with different base names in parallel within the same batch', async () => {
+			const started: string[] = [];
+			let resolveFirst!: () => void;
+
+			const mockBatchRequest = jest.fn().mockImplementation(
+				({fileData}: {fileData: {name: string}}) =>
+					new Promise<{error: boolean}>((resolve) => {
+						started.push(fileData.name);
+
+						if (fileData.name === 'A.pdf') {
+							resolveFirst = () => resolve({error: false});
+						}
+						else {
+							resolve({error: false});
+						}
+					})
+			);
+
+			const {container} = render(
+				<MultipleFileUploader
+					{...DEFAULT_PROPS}
+					assetLibraries={[
+						{
+							externalReferenceCode: 'erc-1',
+							groupId: 2,
+							name: 'Library A',
+						},
+					]}
+					uploadRequest={mockBatchRequest}
+				/>
+			);
+
+			const input =
+				container.querySelector<HTMLInputElement>(
+					'input[type="file"]'
+				)!;
+
+			fireEvent.change(input, {
+				target: {
+					files: [
+						createFile('A.pdf', 1024),
+						createFile('B.pdf', 1024),
+					],
+				},
+			});
+
+			expect(await screen.findByText('A.pdf')).toBeInTheDocument();
+
+			fireEvent.click(screen.getByRole('button', {name: /upload/i}));
+
+			await waitFor(() => expect(started).toContain('A.pdf'));
+
+			expect(started).toContain('B.pdf');
+
+			resolveFirst();
+
+			await waitFor(() => expect(mockUploadComplete).toHaveBeenCalled());
+		});
+	});
+
 	it('shows files that failed to upload', async () => {
 		const mockUploadRequestFail = jest
 			.fn()


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-78887

When using the multiple uploader, it may fail to upload files with the same name but different extension.  By default, friendly urls are generated without taking into account the extension (this is configurable, though). As the multiple uploader uses a different server thread to upload each individual file, there's a chance that uploading files with the same name in parallel may fail due to a race condition.

# How am I fixing it?

Grouping the files to upload in groups, in a way such that there are no files with the same base name in the same group.  All files in each group are uploaded in parallel, but each groups is sent in sequence.  This prevents the race condition from occurring while maximizing upload parallelism.

# How can you verify that it works?

Run the included unit tests.