### PR TITLE
LPD-84446 Import of vocabularies fail when there are no valid types or subtypes in the destination

### DIFF
--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyVocabularyResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyVocabularyResourceImpl.java
@@ -32,6 +32,8 @@ import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Layout;
@@ -734,7 +736,7 @@ public class TaxonomyVocabularyResourceImpl
 		return Arrays.toString(assetTypes.toArray());
 	}
 
-	private long _getClassNameId(Long assetTypeId, String assetTypeType) {
+	private Long _getClassNameId(Long assetTypeId, String assetTypeType) {
 		if (Validator.isNull(assetTypeType)) {
 			if (assetTypeId == null) {
 				throw new BadRequestException("Invalid Vocabulary Asset Type");
@@ -770,18 +772,22 @@ public class TaxonomyVocabularyResourceImpl
 		}
 
 		if (className == null) {
-			throw new BadRequestException(
-				StringBundler.concat(
-					"Asset type ", assetTypeType,
-					" not available, the supported asset types are: ",
-					_getAvailableAssetTypes(
-						categorizableAssetRenderFactories)));
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					StringBundler.concat(
+						"Asset type ", assetTypeType,
+						" not available, the supported asset types are: ",
+						_getAvailableAssetTypes(
+							categorizableAssetRenderFactories)));
+			}
+
+			return null;
 		}
 
 		return _portal.getClassNameId(className);
 	}
 
-	private long _getClassTypePK(
+	private Long _getClassTypePK(
 		long classNameId, String subtype, long groupId) {
 
 		if (Objects.equals(subtype, "AllAssetSubtypes") ||
@@ -812,8 +818,11 @@ public class TaxonomyVocabularyResourceImpl
 			}
 		}
 
-		throw new BadRequestException(
-			"Invalid subtype " + subtype + " for this context");
+		if (_log.isDebugEnabled()) {
+			_log.debug("Invalid subtype " + subtype + " for this context");
+		}
+
+		return null;
 	}
 
 	private String _getModelResource(
@@ -860,21 +869,34 @@ public class TaxonomyVocabularyResourceImpl
 		}
 
 		long[] classNameIds = new long[assetTypes.length];
+
 		long[] classTypePKs = new long[assetTypes.length];
+
+		Arrays.fill(classTypePKs, AssetCategoryConstants.ALL_CLASS_TYPE_PK);
+
 		boolean[] requiredClassNameIds = new boolean[assetTypes.length];
 
 		for (int i = 0; i < assetTypes.length; i++) {
 			AssetType assetType = assetTypes[i];
 
-			long classNameId = _getClassNameId(
+			Long classNameId = _getClassNameId(
 				assetType.getTypeId(), assetType.getType());
+
+			if (classNameId == null) {
+				continue;
+			}
 
 			classNameIds[i] = classNameId;
 
-			classTypePKs[i] = _getClassTypePK(
+			Long classTypePK = _getClassTypePK(
 				classNameId, assetType.getSubtype(), groupId);
 
-			requiredClassNameIds[i] = assetType.getRequired();
+			if (classTypePK != null) {
+				classTypePKs[i] = classTypePK;
+
+				requiredClassNameIds[i] = GetterUtil.getBoolean(
+					assetType.getRequired());
+			}
 		}
 
 		assetVocabularySettingsHelper.setClassNameIdsAndClassTypePKs(
@@ -1109,6 +1131,9 @@ public class TaxonomyVocabularyResourceImpl
 				taxonomyVocabulary.getViewableByAsString()
 			).build());
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		TaxonomyVocabularyResourceImpl.class);
 
 	private static final Map<String, String> _assetTypeTypeToClassNames =
 		new HashMap<>();

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyVocabularyResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyVocabularyResourceImpl.java
@@ -736,7 +736,7 @@ public class TaxonomyVocabularyResourceImpl
 
 	private long _getClassNameId(Long assetTypeId, String assetTypeType) {
 		if (Validator.isNull(assetTypeType)) {
-			if (Validator.isNull(assetTypeId)) {
+			if (assetTypeId == null) {
 				throw new BadRequestException("Invalid Vocabulary Asset Type");
 			}
 

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyVocabularyResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyVocabularyResourceImpl.java
@@ -760,7 +760,9 @@ public class TaxonomyVocabularyResourceImpl
 		for (AssetRendererFactory<?> assetRendererFactory :
 				categorizableAssetRenderFactories) {
 
-			if (assetTypeType.equals(_getModelResource(assetRendererFactory))) {
+			if (Objects.equals(
+					assetTypeType, _getModelResource(assetRendererFactory))) {
+
 				className = assetRendererFactory.getClassName();
 
 				break;

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyVocabularyResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyVocabularyResourceImpl.java
@@ -58,6 +58,7 @@ import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.vulcan.aggregation.Aggregation;
 import com.liferay.portal.vulcan.dto.action.DTOActionProvider;
@@ -733,7 +734,15 @@ public class TaxonomyVocabularyResourceImpl
 		return Arrays.toString(assetTypes.toArray());
 	}
 
-	private long _getClassNameId(String assetTypeType) {
+	private long _getClassNameId(Long assetTypeId, String assetTypeType) {
+		if (Validator.isNull(assetTypeType)) {
+			if (Validator.isNull(assetTypeId)) {
+				throw new BadRequestException("Invalid Vocabulary Asset Type");
+			}
+
+			return assetTypeId;
+		}
+
 		if (Objects.equals(assetTypeType, "AllAssetTypes")) {
 			return AssetCategoryConstants.ALL_CLASS_NAME_ID;
 		}
@@ -803,7 +812,8 @@ public class TaxonomyVocabularyResourceImpl
 			}
 		}
 
-		throw new BadRequestException("Invalid subtype " + subtype);
+		throw new BadRequestException(
+			"Invalid subtype " + subtype + " for this context");
 	}
 
 	private String _getModelResource(
@@ -856,7 +866,8 @@ public class TaxonomyVocabularyResourceImpl
 		for (int i = 0; i < assetTypes.length; i++) {
 			AssetType assetType = assetTypes[i];
 
-			long classNameId = _getClassNameId(assetType.getType());
+			long classNameId = _getClassNameId(
+				assetType.getTypeId(), assetType.getType());
 
 			classNameIds[i] = classNameId;
 

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyVocabularyResourceTest.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyVocabularyResourceTest.java
@@ -43,6 +43,9 @@ import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LogEntry;
+import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 
@@ -251,18 +254,9 @@ public class TaxonomyVocabularyResourceTest
 	public void testPostSiteTaxonomyVocabulary() throws Exception {
 		super.testPostSiteTaxonomyVocabulary();
 
-		TaxonomyVocabulary randomTaxonomyVocabulary =
-			randomTaxonomyVocabulary();
-
-		randomTaxonomyVocabulary.setVisibilityType(
-			TaxonomyVocabulary.VisibilityType.EMPTY);
-
-		TaxonomyVocabulary postTaxonomyVocabulary =
-			testPostSiteTaxonomyVocabulary_addTaxonomyVocabulary(
-				randomTaxonomyVocabulary);
-
-		assertEquals(randomTaxonomyVocabulary, postTaxonomyVocabulary);
-		assertValid(postTaxonomyVocabulary);
+		_testPostSiteTaxonomyVocabulary();
+		_testPostSiteTaxonomyVocabularyInvalidAssetType();
+		_testPostSiteTaxonomyVocabularyInvalidAssetSubtype();
 	}
 
 	@Override
@@ -544,6 +538,122 @@ public class TaxonomyVocabularyResourceTest
 		Assert.assertNull(getTaxonomyVocabulary.getPermissions());
 	}
 
+	private void _testPostSiteTaxonomyVocabulary() throws Exception {
+		TaxonomyVocabulary randomTaxonomyVocabulary =
+			randomTaxonomyVocabulary();
+
+		randomTaxonomyVocabulary.setVisibilityType(
+			TaxonomyVocabulary.VisibilityType.EMPTY);
+
+		TaxonomyVocabulary postTaxonomyVocabulary =
+			testPostSiteTaxonomyVocabulary_addTaxonomyVocabulary(
+				randomTaxonomyVocabulary);
+
+		assertEquals(randomTaxonomyVocabulary, postTaxonomyVocabulary);
+		assertValid(postTaxonomyVocabulary);
+	}
+
+	private void _testPostSiteTaxonomyVocabularyInvalidAssetSubtype()
+		throws Exception {
+
+		String randomAssetSubtype = RandomTestUtil.randomString();
+
+		TaxonomyVocabulary randomTaxonomyVocabulary =
+			randomTaxonomyVocabulary();
+
+		randomTaxonomyVocabulary.setAssetTypes(
+			new AssetType[] {
+				new AssetType() {
+					{
+						required = true;
+						subtype = randomAssetSubtype;
+						type = "StructuredContent";
+					}
+				}
+			});
+
+		TaxonomyVocabulary postTaxonomyVocabulary = null;
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				_LOG_NAME, LoggerTestUtil.DEBUG)) {
+
+			postTaxonomyVocabulary =
+				testPostSiteTaxonomyVocabulary_addTaxonomyVocabulary(
+					randomTaxonomyVocabulary);
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			LogEntry logEntry = logEntries.get(0);
+
+			Assert.assertEquals(
+				StringBundler.concat(
+					"Invalid subtype ", randomAssetSubtype,
+					" for this context"),
+				logEntry.getMessage());
+		}
+
+		AssetType[] assetTypes = postTaxonomyVocabulary.getAssetTypes();
+
+		Assert.assertEquals(assetTypes.toString(), 1, assetTypes.length);
+
+		AssetType assetType = assetTypes[0];
+
+		Assert.assertEquals("AllAssetSubtypes", assetType.getSubtype());
+		Assert.assertEquals("StructuredContent", assetType.getType());
+		Assert.assertFalse(assetType.getRequired());
+	}
+
+	private void _testPostSiteTaxonomyVocabularyInvalidAssetType()
+		throws Exception {
+
+		String randomAssetType = RandomTestUtil.randomString();
+
+		TaxonomyVocabulary randomTaxonomyVocabulary =
+			randomTaxonomyVocabulary();
+
+		randomTaxonomyVocabulary.setAssetTypes(
+			new AssetType[] {
+				new AssetType() {
+					{
+						required = true;
+						subtype = RandomTestUtil.randomString();
+						type = randomAssetType;
+					}
+				}
+			});
+
+		TaxonomyVocabulary postTaxonomyVocabulary = null;
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				_LOG_NAME, LoggerTestUtil.DEBUG)) {
+
+			postTaxonomyVocabulary =
+				testPostSiteTaxonomyVocabulary_addTaxonomyVocabulary(
+					randomTaxonomyVocabulary);
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			LogEntry logEntry = logEntries.get(0);
+
+			Assert.assertTrue(
+				StringUtil.startsWith(
+					logEntry.getMessage(),
+					StringBundler.concat(
+						"Asset type ", randomAssetType,
+						" not available, the supported asset types are:")));
+		}
+
+		AssetType[] assetTypes = postTaxonomyVocabulary.getAssetTypes();
+
+		Assert.assertEquals(assetTypes.toString(), 1, assetTypes.length);
+
+		AssetType assetType = assetTypes[0];
+
+		Assert.assertEquals("AllAssetSubtypes", assetType.getSubtype());
+		Assert.assertEquals("AllAssetTypes", assetType.getType());
+		Assert.assertFalse(assetType.getRequired());
+	}
+
 	private void _testPutSiteTaxonomyVocabularyByExternalReferenceCodeExternalReferenceCode()
 		throws Exception {
 
@@ -672,6 +782,10 @@ public class TaxonomyVocabularyResourceTest
 			AssetVocabularyConstants.VISIBILITY_TYPE_PUBLIC,
 			assetVocabulary.getVisibilityType());
 	}
+
+	private static final String _LOG_NAME =
+		"com.liferay.headless.admin.taxonomy.internal.resource.v1_0." +
+			"TaxonomyVocabularyResourceImpl";
 
 	@Inject
 	private AssetVocabularyGroupRelLocalService


### PR DESCRIPTION
# What is this trying to solve?

[Link to ticket](https://issues.liferay.com/browse/LPD-84446)

Import of vocabularies fail when there are no valid types or subtypes in the destination

# How am I fixing it?

Don't throw the exceptions when the type or subtype cannot be found

# How can you verify that it works?

Follow the steps in the tickets or run the provided integration tests
