### PR TITLE
LPD-82992 Empty body should be valid in Document API if file is present

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentResourceImpl.java
@@ -103,7 +103,6 @@ import com.liferay.ratings.kernel.service.RatingsEntryLocalService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.core.MultivaluedMap;
 
 import java.io.Serializable;
@@ -1081,10 +1080,6 @@ public class DocumentResourceImpl extends BaseDocumentResourceImpl {
 		Document document = multipartBody.getValueAsNullableInstance(
 			"document", Document.class);
 
-		if (document == null) {
-			throw new BadRequestException("Document not found in body");
-		}
-
 		BinaryFile binaryFile = multipartBody.getBinaryFile("file");
 
 		if (binaryFile == null) {
@@ -1096,37 +1091,62 @@ public class DocumentResourceImpl extends BaseDocumentResourceImpl {
 		fileEntry = _moveDocument(
 			fileEntry.getFileEntryId(), document, fileEntry);
 
-		String fileName = null;
-		String title = null;
-		String urlTitle = null;
+		String contentType = binaryFile.getContentType();
+
+		if (contentType == null) {
+			contentType = fileEntry.getMimeType();
+		}
+
 		String description = null;
 		Date displayDate = null;
 		Date expirationDate = null;
+		String fileName = null;
+		String title = null;
+		String urlTitle = null;
 
-		if (document != null) {
-			fileName = document.getFileName();
-			title = document.getTitle();
-			urlTitle = document.getFriendlyUrlPath();
+		if (document == null) {
+			description = fileEntry.getDescription();
+			displayDate = fileEntry.getDisplayDate();
+			expirationDate = fileEntry.getExpirationDate();
+
+			fileName = binaryFile.getFileName();
+
+			if (fileName == null) {
+				fileName = fileEntry.getFileName();
+			}
+
+			title = fileEntry.getTitle();
+		}
+		else {
 			description = document.getDescription();
 			displayDate = document.getDatePublished();
 			expirationDate = document.getDateExpired();
-		}
 
-		if (fileName == null) {
-			fileName = binaryFile.getFileName();
-		}
+			fileName = document.getFileName();
 
-		if (title == null) {
-			title = fileEntry.getTitle();
+			if (fileName == null) {
+				fileName = binaryFile.getFileName();
+			}
+
+			if (fileName == null) {
+				fileName = fileEntry.getFileName();
+			}
+
+			title = document.getTitle();
+
+			if (title == null) {
+				title = fileEntry.getTitle();
+			}
+
+			urlTitle = document.getFriendlyUrlPath();
 		}
 
 		return _toDocument(
 			_dlAppService.updateFileEntry(
-				fileEntry.getFileEntryId(), fileName,
-				binaryFile.getContentType(), title, urlTitle, description, null,
-				DLVersionNumberIncrease.AUTOMATIC, binaryFile.getInputStream(),
-				binaryFile.getSize(), displayDate, expirationDate,
-				fileEntry.getReviewDate(),
+				fileEntry.getFileEntryId(), fileName, contentType, title,
+				urlTitle, description, null, DLVersionNumberIncrease.AUTOMATIC,
+				binaryFile.getInputStream(), binaryFile.getSize(), displayDate,
+				expirationDate, fileEntry.getReviewDate(),
 				_createServiceContext(
 					Constants.UPDATE, () -> new Long[0], () -> new String[0],
 					_getDLFileEntryType(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentResourceImpl.java
@@ -1097,48 +1097,32 @@ public class DocumentResourceImpl extends BaseDocumentResourceImpl {
 			contentType = fileEntry.getMimeType();
 		}
 
-		String description = null;
-		Date displayDate = null;
-		Date expirationDate = null;
+		String description = fileEntry.getDescription();
+		Date displayDate = fileEntry.getDisplayDate();
+		Date expirationDate = fileEntry.getExpirationDate();
 		String fileName = null;
 		String title = null;
 		String urlTitle = null;
 
-		if (document == null) {
-			description = fileEntry.getDescription();
-			displayDate = fileEntry.getDisplayDate();
-			expirationDate = fileEntry.getExpirationDate();
-
-			fileName = binaryFile.getFileName();
-
-			if (fileName == null) {
-				fileName = fileEntry.getFileName();
-			}
-
-			title = fileEntry.getTitle();
-		}
-		else {
+		if (document != null) {
 			description = document.getDescription();
 			displayDate = document.getDatePublished();
 			expirationDate = document.getDateExpired();
-
 			fileName = document.getFileName();
-
-			if (fileName == null) {
-				fileName = binaryFile.getFileName();
-			}
-
-			if (fileName == null) {
-				fileName = fileEntry.getFileName();
-			}
-
 			title = document.getTitle();
-
-			if (title == null) {
-				title = fileEntry.getTitle();
-			}
-
 			urlTitle = document.getFriendlyUrlPath();
+		}
+
+		if (fileName == null) {
+			fileName = binaryFile.getFileName();
+		}
+
+		if (fileName == null) {
+			fileName = fileEntry.getFileName();
+		}
+
+		if (title == null) {
+			title = fileEntry.getTitle();
 		}
 
 		return _toDocument(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/DocumentResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/DocumentResourceTest.java
@@ -837,7 +837,6 @@ public class DocumentResourceTest extends BaseDocumentResourceTestCase {
 			postDocument.getDatePublished(), putDocument.getDatePublished());
 		Assert.assertEquals(
 			postDocument.getDescription(), putDocument.getDescription());
-		Assert.assertEquals(postDocument.getId(), putDocument.getId());
 		Assert.assertEquals(postDocument.getTitle(), putDocument.getTitle());
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/DocumentResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/DocumentResourceTest.java
@@ -269,6 +269,7 @@ public class DocumentResourceTest extends BaseDocumentResourceTestCase {
 	public void testPutDocument() throws Exception {
 		super.testPutDocument();
 
+		_testPutDocumentWithEmptyDocumentPartAndFileOnlyUpdate();
 		_testPutSiteDocumentByExternalReferenceCodeWithSameFolderId();
 		_testPutSiteDocumentWithFriendlyUrlPath();
 		_testPutSiteDocumentWithNoMultipartFiles();
@@ -816,6 +817,28 @@ public class DocumentResourceTest extends BaseDocumentResourceTestCase {
 		Assert.assertEquals(StringPool.BLANK, postDocument.getContentUrl());
 		Assert.assertEquals(
 			0, GetterUtil.getLong(postDocument.getSizeInBytes()));
+	}
+
+	private void _testPutDocumentWithEmptyDocumentPartAndFileOnlyUpdate()
+		throws Exception {
+
+		Document postDocument = testPutDocument_addDocument();
+
+		Document putDocument = documentResource.putDocument(
+			postDocument.getId(), null,
+			HashMapBuilder.<String, File>put(
+				"file",
+				() -> FileUtil.createTempFile("updated-content".getBytes())
+			).build());
+
+		Assert.assertEquals(
+			postDocument.getDateExpired(), putDocument.getDateExpired());
+		Assert.assertEquals(
+			postDocument.getDatePublished(), putDocument.getDatePublished());
+		Assert.assertEquals(
+			postDocument.getDescription(), putDocument.getDescription());
+		Assert.assertEquals(postDocument.getId(), putDocument.getId());
+		Assert.assertEquals(postDocument.getTitle(), putDocument.getTitle());
 	}
 
 	private void _testPutSiteDocumentByExternalReferenceCodeWithSameFolderId()

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/multipart/MultipartBody.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/multipart/MultipartBody.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import com.liferay.petra.io.StreamUtil;
 
+import com.liferay.portal.kernel.util.Validator;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.InternalServerErrorException;
 
@@ -47,14 +48,14 @@ public class MultipartBody {
 	public <T> T getValueAsInstance(String key, Class<T> clazz)
 		throws IOException {
 
-		String valueAsString = getValueAsString(key);
+		T value = getValueAsNullableInstance(key, clazz);
 
-		if (valueAsString == null) {
+		if (value == null) {
 			throw new BadRequestException(
 				"Missing JSON property with the key: " + key);
 		}
 
-		return _parseValue(valueAsString, clazz);
+		return value;
 	}
 
 	public <T> T getValueAsNullableInstance(String key, Class<T> clazz)
@@ -62,7 +63,7 @@ public class MultipartBody {
 
 		String valueAsString = getValueAsString(key);
 
-		if (valueAsString == null) {
+		if (Validator.isBlank(valueAsString)) {
 			return null;
 		}
 

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/multipart/MultipartBody.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/multipart/MultipartBody.java
@@ -8,8 +8,8 @@ package com.liferay.portal.vulcan.multipart;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import com.liferay.petra.io.StreamUtil;
-
 import com.liferay.portal.kernel.util.Validator;
+
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.InternalServerErrorException;
 

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/test/java/com/liferay/portal/vulcan/multipart/MultipartBodyTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/test/java/com/liferay/portal/vulcan/multipart/MultipartBodyTest.java
@@ -8,6 +8,7 @@ package com.liferay.portal.vulcan.multipart;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
 
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
@@ -125,35 +126,14 @@ public class MultipartBodyTest {
 	@Test
 	public void testGetValueAsNullableInstance() throws IOException {
 
-		// Present optional
+		// Blank optional
 
 		MultipartBody multipartBody = MultipartBody.of(
 			Collections.emptyMap(), __ -> _objectMapper,
-			Collections.singletonMap(
-				"key",
-				JSONUtil.put(
-					"list", Arrays.asList(1, 2, 3)
-				).put(
-					"number", 42
-				).put(
-					"string", "Hello"
-				).toString()));
+			Collections.singletonMap("key", StringPool.BLANK));
 
 		TestClass testClass = multipartBody.getValueAsNullableInstance(
 			"key", TestClass.class);
-
-		MatcherAssert.assertThat(testClass != null, Is.is(true));
-
-		MatcherAssert.assertThat(testClass.list, Matchers.contains(1, 2, 3));
-		MatcherAssert.assertThat(testClass.number, Is.is(42L));
-		MatcherAssert.assertThat(testClass.string, Is.is("Hello"));
-		MatcherAssert.assertThat(
-			testClass.testClass, Is.is(CoreMatchers.nullValue()));
-
-		// Null optional
-
-		testClass = multipartBody.getValueAsNullableInstance(
-			"null", TestClass.class);
 
 		MatcherAssert.assertThat(testClass != null, Is.is(false));
 
@@ -183,6 +163,38 @@ public class MultipartBodyTest {
 					CoreMatchers.instanceOf(
 						UnrecognizedPropertyException.class)));
 		}
+
+		// Null optional
+
+		testClass = multipartBody.getValueAsNullableInstance(
+			"null", TestClass.class);
+
+		MatcherAssert.assertThat(testClass != null, Is.is(false));
+
+		// Present optional
+
+		multipartBody = MultipartBody.of(
+			Collections.emptyMap(), __ -> _objectMapper,
+			Collections.singletonMap(
+				"key",
+				JSONUtil.put(
+					"list", Arrays.asList(1, 2, 3)
+				).put(
+					"number", 42
+				).put(
+					"string", "Hello"
+				).toString()));
+
+		testClass = multipartBody.getValueAsNullableInstance(
+			"key", TestClass.class);
+
+		MatcherAssert.assertThat(testClass != null, Is.is(true));
+
+		MatcherAssert.assertThat(testClass.list, Matchers.contains(1, 2, 3));
+		MatcherAssert.assertThat(testClass.number, Is.is(42L));
+		MatcherAssert.assertThat(testClass.string, Is.is("Hello"));
+		MatcherAssert.assertThat(
+			testClass.testClass, Is.is(CoreMatchers.nullValue()));
 	}
 
 	@Test


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-82992
The fix was reviewed by The headless team on: https://github.com/liferay-headless/liferay-portal/pull/3619 
I am opening this pr as the Content Mangement team is the code owner of Documents API. 

What is being fixed:
Uploading a file via the Documents Headless API fails with a 400 error when the document part of the multipart request is empty. The empty value is incorrectly parsed as JSON, causing a deserialization error (“Unable to map JSON path”). Additionally, PUT requests require a document body even when only updating the file, preventing valid file-only updates.

How it is being fixed:
Updating multipart handling to treat blank document values as null in MultipartBody.getValueAsNullableInstance(), avoiding unnecessary JSON parsing. Adjusting the document update logic to support file-only PUT requests by allowing a missing document body and preserving existing metadata when no metadata is provided, while keeping standard PUT behavior when document is present.