### PR TITLE
LPD-84446 Import of vocabularies fail when there are no valid types or subtypes in the destination

### DIFF
--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyVocabularyResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyVocabularyResourceImpl.java
@@ -32,6 +32,8 @@ import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Layout;
@@ -733,7 +735,7 @@ public class TaxonomyVocabularyResourceImpl
 		return Arrays.toString(assetTypes.toArray());
 	}
 
-	private long _getClassNameId(String assetTypeType) {
+	private Long _getClassNameId(String assetTypeType) {
 		if (Objects.equals(assetTypeType, "AllAssetTypes")) {
 			return AssetCategoryConstants.ALL_CLASS_NAME_ID;
 		}
@@ -761,18 +763,22 @@ public class TaxonomyVocabularyResourceImpl
 		}
 
 		if (className == null) {
-			throw new BadRequestException(
-				StringBundler.concat(
-					"Asset type ", assetTypeType,
-					" not available, the supported asset types are: ",
-					_getAvailableAssetTypes(
-						categorizableAssetRenderFactories)));
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					StringBundler.concat(
+						"Asset type ", assetTypeType,
+						" not available, the supported asset types are: ",
+						_getAvailableAssetTypes(
+							categorizableAssetRenderFactories)));
+			}
+
+			return null;
 		}
 
 		return _portal.getClassNameId(className);
 	}
 
-	private long _getClassTypePK(
+	private Long _getClassTypePK(
 		long classNameId, String subtype, long groupId) {
 
 		if (Objects.equals(subtype, "AllAssetSubtypes") ||
@@ -803,7 +809,11 @@ public class TaxonomyVocabularyResourceImpl
 			}
 		}
 
-		throw new BadRequestException("Invalid subtype " + subtype);
+		if (_log.isDebugEnabled()) {
+			_log.debug("Invalid subtype " + subtype);
+		}
+
+		return null;
 	}
 
 	private String _getModelResource(
@@ -850,20 +860,33 @@ public class TaxonomyVocabularyResourceImpl
 		}
 
 		long[] classNameIds = new long[assetTypes.length];
+
 		long[] classTypePKs = new long[assetTypes.length];
+
+		Arrays.fill(classTypePKs, AssetCategoryConstants.ALL_CLASS_TYPE_PK);
+
 		boolean[] requiredClassNameIds = new boolean[assetTypes.length];
 
 		for (int i = 0; i < assetTypes.length; i++) {
 			AssetType assetType = assetTypes[i];
 
-			long classNameId = _getClassNameId(assetType.getType());
+			Long classNameId = _getClassNameId(assetType.getType());
+
+			if (classNameId == null) {
+				continue;
+			}
 
 			classNameIds[i] = classNameId;
 
-			classTypePKs[i] = _getClassTypePK(
+			Long classTypePK = _getClassTypePK(
 				classNameId, assetType.getSubtype(), groupId);
 
-			requiredClassNameIds[i] = assetType.getRequired();
+			if (classTypePK != null) {
+				classTypePKs[i] = classTypePK;
+
+				requiredClassNameIds[i] = GetterUtil.getBoolean(
+					assetType.getRequired());
+			}
 		}
 
 		assetVocabularySettingsHelper.setClassNameIdsAndClassTypePKs(
@@ -1098,6 +1121,9 @@ public class TaxonomyVocabularyResourceImpl
 				taxonomyVocabulary.getViewableByAsString()
 			).build());
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		TaxonomyVocabularyResourceImpl.class);
 
 	private static final Map<String, String> _assetTypeTypeToClassNames =
 		new HashMap<>();

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyVocabularyResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyVocabularyResourceImpl.java
@@ -79,7 +79,6 @@ import jakarta.ws.rs.core.MultivaluedMap;
 import java.io.Serializable;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -714,27 +713,6 @@ public class TaxonomyVocabularyResourceImpl
 		return assetTypes;
 	}
 
-	private String _getAvailableAssetTypes(
-		List<AssetRendererFactory<?>> categorizableAssetRenderFactories) {
-
-		List<String> assetTypes = ListUtil.concat(
-			transform(
-				categorizableAssetRenderFactories,
-				assetRenderedFactory -> {
-					String assetTypeType = _classNameToAssetTypeTypes.get(
-						assetRenderedFactory.getClassName());
-
-					if (assetTypeType != null) {
-						return assetTypeType;
-					}
-
-					return _getModelResource(assetRenderedFactory);
-				}),
-			Collections.singletonList("AllAssetTypes"));
-
-		return Arrays.toString(assetTypes.toArray());
-	}
-
 	private Long _getClassNameId(String assetTypeType) {
 		if (Objects.equals(assetTypeType, "AllAssetTypes")) {
 			return AssetCategoryConstants.ALL_CLASS_NAME_ID;
@@ -764,12 +742,7 @@ public class TaxonomyVocabularyResourceImpl
 
 		if (className == null) {
 			if (_log.isDebugEnabled()) {
-				_log.debug(
-					StringBundler.concat(
-						"Asset type ", assetTypeType,
-						" not available, the supported asset types are: ",
-						_getAvailableAssetTypes(
-							categorizableAssetRenderFactories)));
+				_log.debug("Invalid asset type type " + assetTypeType);
 			}
 
 			return null;
@@ -810,7 +783,7 @@ public class TaxonomyVocabularyResourceImpl
 		}
 
 		if (_log.isDebugEnabled()) {
-			_log.debug("Invalid subtype " + subtype);
+			_log.debug("Invalid asset type subtype " + subtype);
 		}
 
 		return null;

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyVocabularyResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyVocabularyResourceImpl.java
@@ -729,7 +729,9 @@ public class TaxonomyVocabularyResourceImpl
 		for (AssetRendererFactory<?> assetRendererFactory :
 				categorizableAssetRenderFactories) {
 
-			if (assetTypeType.equals(_getModelResource(assetRendererFactory))) {
+			if (Objects.equals(
+					assetTypeType, _getModelResource(assetRendererFactory))) {
+
 				className = assetRendererFactory.getClassName();
 
 				break;

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyVocabularyResourceTest.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyVocabularyResourceTest.java
@@ -43,6 +43,9 @@ import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LogEntry;
+import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 
@@ -251,18 +254,9 @@ public class TaxonomyVocabularyResourceTest
 	public void testPostSiteTaxonomyVocabulary() throws Exception {
 		super.testPostSiteTaxonomyVocabulary();
 
-		TaxonomyVocabulary randomTaxonomyVocabulary =
-			randomTaxonomyVocabulary();
-
-		randomTaxonomyVocabulary.setVisibilityType(
-			TaxonomyVocabulary.VisibilityType.EMPTY);
-
-		TaxonomyVocabulary postTaxonomyVocabulary =
-			testPostSiteTaxonomyVocabulary_addTaxonomyVocabulary(
-				randomTaxonomyVocabulary);
-
-		assertEquals(randomTaxonomyVocabulary, postTaxonomyVocabulary);
-		assertValid(postTaxonomyVocabulary);
+		_testPostSiteTaxonomyVocabulary();
+		_testPostSiteTaxonomyVocabularyInvalidAssetTypeType();
+		_testPostSiteTaxonomyVocabularyInvalidAssetTypeSubtype();
 	}
 
 	@Override
@@ -544,6 +538,116 @@ public class TaxonomyVocabularyResourceTest
 		Assert.assertNull(getTaxonomyVocabulary.getPermissions());
 	}
 
+	private void _testPostSiteTaxonomyVocabulary() throws Exception {
+		TaxonomyVocabulary randomTaxonomyVocabulary =
+			randomTaxonomyVocabulary();
+
+		randomTaxonomyVocabulary.setVisibilityType(
+			TaxonomyVocabulary.VisibilityType.EMPTY);
+
+		TaxonomyVocabulary postTaxonomyVocabulary =
+			testPostSiteTaxonomyVocabulary_addTaxonomyVocabulary(
+				randomTaxonomyVocabulary);
+
+		assertEquals(randomTaxonomyVocabulary, postTaxonomyVocabulary);
+		assertValid(postTaxonomyVocabulary);
+	}
+
+	private void _testPostSiteTaxonomyVocabularyInvalidAssetTypeSubtype()
+		throws Exception {
+
+		String randomSubtype = RandomTestUtil.randomString();
+
+		TaxonomyVocabulary randomTaxonomyVocabulary =
+			randomTaxonomyVocabulary();
+
+		randomTaxonomyVocabulary.setAssetTypes(
+			new AssetType[] {
+				new AssetType() {
+					{
+						required = true;
+						subtype = randomSubtype;
+						type = "StructuredContent";
+					}
+				}
+			});
+
+		TaxonomyVocabulary postTaxonomyVocabulary = null;
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				_LOG_NAME, LoggerTestUtil.DEBUG)) {
+
+			postTaxonomyVocabulary =
+				testPostSiteTaxonomyVocabulary_addTaxonomyVocabulary(
+					randomTaxonomyVocabulary);
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			LogEntry logEntry = logEntries.get(0);
+
+			Assert.assertEquals(
+				"Invalid asset type subtype " + randomSubtype,
+				logEntry.getMessage());
+		}
+
+		AssetType[] assetTypes = postTaxonomyVocabulary.getAssetTypes();
+
+		Assert.assertEquals(assetTypes.toString(), 1, assetTypes.length);
+
+		AssetType assetType = assetTypes[0];
+
+		Assert.assertEquals("AllAssetSubtypes", assetType.getSubtype());
+		Assert.assertEquals("StructuredContent", assetType.getType());
+		Assert.assertFalse(assetType.getRequired());
+	}
+
+	private void _testPostSiteTaxonomyVocabularyInvalidAssetTypeType()
+		throws Exception {
+
+		String randomType = RandomTestUtil.randomString();
+
+		TaxonomyVocabulary randomTaxonomyVocabulary =
+			randomTaxonomyVocabulary();
+
+		randomTaxonomyVocabulary.setAssetTypes(
+			new AssetType[] {
+				new AssetType() {
+					{
+						required = true;
+						subtype = RandomTestUtil.randomString();
+						type = randomType;
+					}
+				}
+			});
+
+		TaxonomyVocabulary postTaxonomyVocabulary = null;
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				_LOG_NAME, LoggerTestUtil.DEBUG)) {
+
+			postTaxonomyVocabulary =
+				testPostSiteTaxonomyVocabulary_addTaxonomyVocabulary(
+					randomTaxonomyVocabulary);
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			LogEntry logEntry = logEntries.get(0);
+
+			Assert.assertEquals(
+				"Invalid asset type type " + randomType, logEntry.getMessage());
+		}
+
+		AssetType[] assetTypes = postTaxonomyVocabulary.getAssetTypes();
+
+		Assert.assertEquals(assetTypes.toString(), 1, assetTypes.length);
+
+		AssetType assetType = assetTypes[0];
+
+		Assert.assertEquals("AllAssetSubtypes", assetType.getSubtype());
+		Assert.assertEquals("AllAssetTypes", assetType.getType());
+		Assert.assertFalse(assetType.getRequired());
+	}
+
 	private void _testPutSiteTaxonomyVocabularyByExternalReferenceCodeExternalReferenceCode()
 		throws Exception {
 
@@ -672,6 +776,10 @@ public class TaxonomyVocabularyResourceTest
 			AssetVocabularyConstants.VISIBILITY_TYPE_PUBLIC,
 			assetVocabulary.getVisibilityType());
 	}
+
+	private static final String _LOG_NAME =
+		"com.liferay.headless.admin.taxonomy.internal.resource.v1_0." +
+			"TaxonomyVocabularyResourceImpl";
 
 	@Inject
 	private AssetVocabularyGroupRelLocalService


### PR DESCRIPTION
Follow up to: https://github.com/brianchandotcom/liferay-portal/pull/172794

# What is this trying to solve?

[Link to ticket](https://issues.liferay.com/browse/LPD-84446)

Import of vocabularies fail when there are no valid types or subtypes in the destination

# How am I fixing it?

Don't throw the exceptions when the type or subtype cannot be found

# How can you verify that it works?

Follow the steps in the tickets or run the provided integration tests