### PR TITLE
LPD-78887 Failing to upload files with same name but different extension (2)

### DIFF
--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/multiple_file_uploader/MultipleFileUploader.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/multiple_file_uploader/MultipleFileUploader.tsx
@@ -65,12 +65,12 @@ function getBaseName(filename: string): string {
 }
 
 function getUploadBatches(files: FileData[]): FileData[][] {
-	const batches: { baseNames: Set<string>; files: FileData[] }[] = [];
+	const batches: {baseNames: Set<string>; files: FileData[]}[] = [];
 
 	for (const fileData of files) {
 		const baseName = getBaseName(fileData.name);
 
-		const batch = batches.find(batch => !batch.baseNames.has(baseName));
+		const batch = batches.find((batch) => !batch.baseNames.has(baseName));
 
 		if (batch) {
 			batch.files.push(fileData);
@@ -84,7 +84,7 @@ function getUploadBatches(files: FileData[]): FileData[][] {
 		}
 	}
 
-	return batches.map(batch => batch.files);
+	return batches.map((batch) => batch.files);
 }
 
 export default function MultipleFileUploader({
@@ -225,62 +225,62 @@ export default function MultipleFileUploader({
 		const uploadedFiles: string[] = [];
 
 		for (const uploadBatch of getUploadBatches(filesToUpload)) {
-		await Promise.allSettled(
-			uploadBatch.map(async (fileData: FileData) => {
-				try {
-					const response = await uploadRequest({fileData});
+			await Promise.allSettled(
+				uploadBatch.map(async (fileData: FileData) => {
+					try {
+						const response = await uploadRequest({fileData});
 
-					if (
-						'error' in response &&
-						typeof response.error === 'string'
-					) {
+						if (
+							'error' in response &&
+							typeof response.error === 'string'
+						) {
+							failedFiles.push({
+								...fileData,
+								errorMessage: response.error,
+								failed: true,
+							});
+						}
+						else if ('multipleErrors' in response) {
+							response.errors.map((item) => {
+								failedFiles.push({
+									...item,
+									failed: true,
+								});
+							});
+						}
+						else {
+							uploadedFiles.push(fileData.name);
+						}
+					}
+					catch (error) {
+						let errorMessage = Liferay.Language.get(
+							'there-was-an-unknown-error'
+						);
+
+						if (error instanceof Error) {
+							errorMessage = error.message;
+						}
+
 						failedFiles.push({
 							...fileData,
-							errorMessage: response.error,
+							errorMessage,
 							failed: true,
 						});
 					}
-					else if ('multipleErrors' in response) {
-						response.errors.map((item) => {
-							failedFiles.push({
-								...item,
-								failed: true,
-							});
-						});
-					}
-					else {
-						uploadedFiles.push(fileData.name);
-					}
-				}
-				catch (error) {
-					let errorMessage = Liferay.Language.get(
-						'there-was-an-unknown-error'
-					);
+				})
+			).then(() => {
+				setIsLoading(false);
 
-					if (error instanceof Error) {
-						errorMessage = error.message;
-					}
+				setFilesToUpload([]);
+				setFailedFiles(failedFiles);
 
-					failedFiles.push({
-						...fileData,
-						errorMessage,
-						failed: true,
+				if (onUploadComplete) {
+					onUploadComplete({
+						failedFiles: failedFiles.map((file) => file.name),
+						successFiles: uploadedFiles,
 					});
 				}
-			})
-		).then(() => {
-			setIsLoading(false);
-
-			setFilesToUpload([]);
-			setFailedFiles(failedFiles);
-
-			if (onUploadComplete) {
-				onUploadComplete({
-					failedFiles: failedFiles.map((file) => file.name),
-					successFiles: uploadedFiles,
-				});
-			}
-		});
+			});
 		}
 	};
 

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/multiple_file_uploader/MultipleFileUploader.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/multiple_file_uploader/MultipleFileUploader.tsx
@@ -58,6 +58,35 @@ interface MultipleFileUploaderProps {
 	validExtensions?: string;
 }
 
+function getBaseName(filename: string): string {
+	const index = filename.lastIndexOf('.');
+
+	return index > 0 ? filename.substring(0, index) : filename;
+}
+
+function getUploadBatches(files: FileData[]): FileData[][] {
+	const batches: { baseNames: Set<string>; files: FileData[] }[] = [];
+
+	for (const fileData of files) {
+		const baseName = getBaseName(fileData.name);
+
+		const batch = batches.find(batch => !batch.baseNames.has(baseName));
+
+		if (batch) {
+			batch.files.push(fileData);
+			batch.baseNames.add(baseName);
+		}
+		else {
+			batches.push({
+				baseNames: new Set([baseName]),
+				files: [fileData],
+			});
+		}
+	}
+
+	return batches.map(batch => batch.files);
+}
+
 export default function MultipleFileUploader({
 	buttonLabel,
 	description,
@@ -195,8 +224,9 @@ export default function MultipleFileUploader({
 		const failedFiles: FailedFile[] = [];
 		const uploadedFiles: string[] = [];
 
-		Promise.allSettled(
-			filesToUpload.map(async (fileData: FileData) => {
+		for (const uploadBatch of getUploadBatches(filesToUpload)) {
+		await Promise.allSettled(
+			uploadBatch.map(async (fileData: FileData) => {
 				try {
 					const response = await uploadRequest({fileData});
 
@@ -251,6 +281,7 @@ export default function MultipleFileUploader({
 				});
 			}
 		});
+		}
 	};
 
 	return (

--- a/modules/apps/frontend-js/frontend-js-components-web/test/multiple_file_uploader/MultipleFileUploader.test.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/test/multiple_file_uploader/MultipleFileUploader.test.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {render, screen, waitFor} from '@testing-library/react';
+import {fireEvent, render, screen, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
@@ -433,5 +433,113 @@ describe('MultipleFileUploader', () => {
 		).toBeInTheDocument();
 
 		expect(getByRole('button', {name: 'upload-(1)'})).toBeInTheDocument();
+	});
+
+	describe('batch upload', () => {
+		it('uploads files with the same base name in separate sequential batches', async () => {
+			const callOrder: string[] = [];
+			let resolveFirstBatch!: () => void;
+
+			const mockBatchRequest = jest.fn().mockImplementation(
+				({fileData}: {fileData: {name: string}}) =>
+					new Promise<{error: boolean}>((resolve) => {
+						callOrder.push(fileData.name);
+
+						if (fileData.name === 'A.pdf') {
+							resolveFirstBatch = () => resolve({error: false});
+						}
+						else {
+							resolve({error: false});
+						}
+					})
+			);
+
+			const {container} = render(
+				<MultipleFileUploader
+					{...DEFAULT_PROPS}
+					uploadRequest={mockBatchRequest}
+				/>
+			);
+
+			const input =
+				container.querySelector<HTMLInputElement>(
+					'input[type="file"]'
+				)!;
+
+			fireEvent.change(input, {
+				target: {
+					files: [
+						createFile('A.pdf', 1024),
+						createFile('A.txt', 1024),
+					],
+				},
+			});
+
+			expect(await screen.findByText('A.pdf')).toBeInTheDocument();
+
+			fireEvent.click(screen.getByRole('button', {name: /upload/i}));
+
+			await waitFor(() => expect(callOrder).toContain('A.pdf'));
+
+			expect(callOrder).not.toContain('A.txt');
+
+			resolveFirstBatch();
+
+			await waitFor(() => expect(callOrder).toContain('A.txt'));
+
+			await waitFor(() => expect(mockUploadComplete).toHaveBeenCalled());
+		});
+
+		it('uploads files with different base names in parallel within the same batch', async () => {
+			const started: string[] = [];
+			let resolveFirst!: () => void;
+
+			const mockBatchRequest = jest.fn().mockImplementation(
+				({fileData}: {fileData: {name: string}}) =>
+					new Promise<{error: boolean}>((resolve) => {
+						started.push(fileData.name);
+
+						if (fileData.name === 'A.pdf') {
+							resolveFirst = () => resolve({error: false});
+						}
+						else {
+							resolve({error: false});
+						}
+					})
+			);
+
+			const {container} = render(
+				<MultipleFileUploader
+					{...DEFAULT_PROPS}
+					uploadRequest={mockBatchRequest}
+				/>
+			);
+
+			const input =
+				container.querySelector<HTMLInputElement>(
+					'input[type="file"]'
+				)!;
+
+			fireEvent.change(input, {
+				target: {
+					files: [
+						createFile('A.pdf', 1024),
+						createFile('B.pdf', 1024),
+					],
+				},
+			});
+
+			expect(await screen.findByText('A.pdf')).toBeInTheDocument();
+
+			fireEvent.click(screen.getByRole('button', {name: /upload/i}));
+
+			await waitFor(() => expect(started).toContain('A.pdf'));
+
+			expect(started).toContain('B.pdf');
+
+			resolveFirst();
+
+			await waitFor(() => expect(mockUploadComplete).toHaveBeenCalled());
+		});
 	});
 });

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/modal/MultipleFilesUploadModalContent.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/modal/MultipleFilesUploadModalContent.tsx
@@ -56,7 +56,7 @@ export default function MultipleFilesUploadModalContent({
 
 	const getAssetLibraryLink = () => {
 		const assetLibrary = assetLibraries?.find(
-			(assetLibrary) => Number(assetLibrary.groupId) === groupId
+			(assetLibrary) => Number(assetLibrary.groupId) === Number(groupId)
 		);
 
 		return `<a href="${baseAssetLibraryViewURL}${assetLibrary?.groupId}" class="alert-link lead"><strong>${assetLibrary?.name}</strong></a>`;

--- a/modules/apps/site/site-cms-site-initializer/test/js/content_editor/components/ContentEditorSidePanel.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/content_editor/components/ContentEditorSidePanel.test.tsx
@@ -18,8 +18,8 @@ jest.mock('frontend-js-web', () => ({
 	...(jest.requireActual('frontend-js-web') as object),
 	dateUtils: {
 		getFirstDayOfWeek: jest.fn(),
-		getMonthsLong: jest.fn(),
-		getWeekdaysShort: jest.fn(),
+		getMonthsLong: jest.fn().mockReturnValue([]),
+		getWeekdaysShort: jest.fn().mockReturnValue([]),
 	},
 }));
 

--- a/modules/apps/site/site-cms-site-initializer/test/js/content_editor/components/panels/SchedulePanel.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/content_editor/components/panels/SchedulePanel.test.tsx
@@ -20,8 +20,8 @@ jest.mock('frontend-js-web', () => ({
 	...(jest.requireActual('frontend-js-web') as object),
 	dateUtils: {
 		getFirstDayOfWeek: jest.fn(),
-		getMonthsLong: jest.fn(),
-		getWeekdaysShort: jest.fn(),
+		getMonthsLong: jest.fn().mockReturnValue([]),
+		getWeekdaysShort: jest.fn().mockReturnValue([]),
 	},
 }));
 

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/default_permission/DefaultPermissionFormContainer.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/default_permission/DefaultPermissionFormContainer.test.tsx
@@ -466,7 +466,7 @@ describe('DefaultPermissionFormContainer', () => {
 		});
 	});
 
-	it.skip('Handle the onChange parameter', async () => {
+	it('Handle the onChange parameter', async () => {
 		let data = {};
 
 		const onChangeFn = jest.fn((callbackData) => {


### PR DESCRIPTION
Continuation of https://github.com/liferay-content-management/liferay-portal/pull/8024. Should be tested when https://github.com/brianchandotcom/liferay-portal/pull/172809#issuecomment-4215619937 changes are merged in master 

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-78887

When using the multiple uploader, it may fail to upload files with the same name but different extension.  By default, friendly urls are generated without taking into account the extension (this is configurable, though). As the multiple uploader uses a different server thread to upload each individual file, there's a chance that uploading files with the same name in parallel may fail due to a race condition.

# How am I fixing it?

Grouping the files to upload in groups, in a way such that there are no files with the same base name in the same group.  All files in each group are uploaded in parallel, but each groups is sent in sequence.  This prevents the race condition from occurring while maximizing upload parallelism.

# How can you verify that it works?

Run the included unit tests.