### PR TITLE
LPD-83779 Importing Vocabulary with Category in CMS results in incorrect breadcrumb

### DIFF
--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewCategoriesDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewCategoriesDisplayContextTest.java
@@ -1,0 +1,187 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.display.context.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.kernel.model.AssetCategory;
+import com.liferay.asset.kernel.model.AssetVocabulary;
+import com.liferay.asset.kernel.service.AssetCategoryLocalService;
+import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
+import com.liferay.fragment.renderer.FragmentRenderer;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.Sync;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.util.Collections;
+import java.util.Locale;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/**
+ * @author Adolfo Pérez
+ */
+@FeatureFlag("LPD-17564")
+@RunWith(Arquillian.class)
+@Sync
+public class ViewCategoriesDisplayContextTest
+	extends BaseDisplayContextTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+
+		String assetVocabularyTitle = RandomTestUtil.randomString();
+
+		_assetVocabulary = _assetVocabularyLocalService.addVocabulary(
+			TestPropsValues.getUserId(), group.getGroupId(),
+			RandomTestUtil.randomString(), assetVocabularyTitle,
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), assetVocabularyTitle
+			).put(
+				LocaleUtil.FRANCE, RandomTestUtil.randomString()
+			).build(),
+			Collections.emptyMap(), null,
+			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
+
+		_assetCategory = _assetCategoryLocalService.addCategory(
+			null, TestPropsValues.getUserId(), group.getGroupId(), 0,
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()
+			).put(
+				LocaleUtil.FRANCE, RandomTestUtil.randomString()
+			).build(),
+			Collections.emptyMap(), _assetVocabulary.getVocabularyId(),
+			new String[0],
+			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
+	}
+
+	@Test
+	@TestInfo("LPD-83779")
+	public void testGetBreadcrumbProps() throws Exception {
+		_testGetBreadcrumbPropsUsesCategoryTitle();
+		_testGetBreadcrumbPropsUsesVocabularyTitle();
+	}
+
+	private MockHttpServletRequest _getMockHttpServletRequest(
+			long categoryId, Locale locale, long vocabularyId)
+		throws Exception {
+
+		MockHttpServletRequest mockHttpServletRequest =
+			getMockHttpServletRequest();
+
+		mockHttpServletRequest.setParameter(
+			"categoryId", String.valueOf(categoryId));
+
+		if (vocabularyId != 0) {
+			mockHttpServletRequest.setParameter(
+				"vocabularyId", String.valueOf(vocabularyId));
+		}
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)mockHttpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		themeDisplay.setLocale(locale);
+
+		return mockHttpServletRequest;
+	}
+
+	private Object _getViewCategoriesDisplayContext(
+			HttpServletRequest httpServletRequest)
+		throws Exception {
+
+		_viewCategoriesFragmentRenderer.render(
+			null, httpServletRequest, new MockHttpServletResponse());
+
+		return httpServletRequest.getAttribute(
+			"com.liferay.site.cms.site.initializer.internal.display.context." +
+				"ViewCategoriesDisplayContext");
+	}
+
+	private void _testGetBreadcrumbPropsUsesCategoryTitle() throws Exception {
+		HttpServletRequest httpServletRequest = _getMockHttpServletRequest(
+			_assetCategory.getCategoryId(), LocaleUtil.FRANCE,
+			_assetVocabulary.getVocabularyId());
+
+		Map<String, Object> breadcrumbProps = ReflectionTestUtil.invoke(
+			_getViewCategoriesDisplayContext(httpServletRequest),
+			"getBreadcrumbProps", new Class<?>[0]);
+
+		JSONArray jsonArray = (JSONArray)breadcrumbProps.get("breadcrumbItems");
+
+		JSONObject jsonObject = jsonArray.getJSONObject(jsonArray.length() - 1);
+
+		Assert.assertEquals(
+			_assetCategory.getTitle(LocaleUtil.FRANCE),
+			jsonObject.getString("label"));
+	}
+
+	private void _testGetBreadcrumbPropsUsesVocabularyTitle() throws Exception {
+		HttpServletRequest httpServletRequest = _getMockHttpServletRequest(
+			0, LocaleUtil.getDefault(), _assetVocabulary.getVocabularyId());
+
+		Map<String, Object> breadcrumbProps = ReflectionTestUtil.invoke(
+			_getViewCategoriesDisplayContext(httpServletRequest),
+			"getBreadcrumbProps", new Class<?>[0]);
+
+		JSONArray jsonArray = (JSONArray)breadcrumbProps.get("breadcrumbItems");
+
+		JSONObject jsonObject = jsonArray.getJSONObject(jsonArray.length() - 1);
+
+		Assert.assertEquals(
+			_assetVocabulary.getTitle(LocaleUtil.getDefault()),
+			jsonObject.getString("label"));
+	}
+
+	private AssetCategory _assetCategory;
+
+	@Inject
+	private AssetCategoryLocalService _assetCategoryLocalService;
+
+	private AssetVocabulary _assetVocabulary;
+
+	@Inject
+	private AssetVocabularyLocalService _assetVocabularyLocalService;
+
+	@Inject(
+		filter = "component.name=com.liferay.site.cms.site.initializer.internal.fragment.renderer.ViewCategoriesJSPSectionFragmentRenderer"
+	)
+	private FragmentRenderer _viewCategoriesFragmentRenderer;
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/util/CategorizationBreadcrumbUtil.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/util/CategorizationBreadcrumbUtil.java
@@ -44,7 +44,7 @@ public class CategorizationBreadcrumbUtil {
 			JSONUtil.put(
 				"active", true
 			).put(
-				"label", assetCategory.getName()
+				"label", assetCategory.getTitle(themeDisplay.getLocale())
 			)
 		);
 	}
@@ -65,7 +65,7 @@ public class CategorizationBreadcrumbUtil {
 				"label",
 				LanguageUtil.format(
 					themeDisplay.getLocale(), "x-usages",
-					assetCategory.getName())
+					assetCategory.getTitle(themeDisplay.getLocale()))
 			)
 		);
 	}
@@ -96,7 +96,7 @@ public class CategorizationBreadcrumbUtil {
 						"vocabularyId", category.getVocabularyId(),
 						"categoryId", category.getCategoryId())
 				).put(
-					"label", category.getName()
+					"label", category.getTitle(themeDisplay.getLocale())
 				));
 		}
 
@@ -146,7 +146,7 @@ public class CategorizationBreadcrumbUtil {
 						"vocabularyId", assetVocabularyId);
 				}
 			).put(
-				"label", assetVocabulary.getName()
+				"label", assetVocabulary.getTitle(themeDisplay.getLocale())
 			));
 	}
 


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-83779

After importing a vocabulary, its ERC is used as part of the breadcrumb.

# How am I fixing it?

Instead of its name, use the vocabulary title in the current locale.

# How can you verify that it works?

Run the included integration test.