### PR TITLE
LPD-84137 Return null and add logging, instead of throwing exception

### DIFF
--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyVocabularyResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyVocabularyResourceImpl.java
@@ -73,7 +73,6 @@ import com.liferay.portlet.asset.service.permission.AssetCategoriesPermission;
 import com.liferay.portlet.asset.util.AssetVocabularySettingsHelper;
 
 import jakarta.ws.rs.BadRequestException;
-import jakarta.ws.rs.InternalServerErrorException;
 import jakarta.ws.rs.core.MultivaluedMap;
 
 import java.io.Serializable;
@@ -646,7 +645,12 @@ public class TaxonomyVocabularyResourceImpl
 							}
 						}
 
-						throw new InternalServerErrorException();
+						if (_log.isDebugEnabled()) {
+							_log.debug(
+								"Unable to get class type for " + classTypePK);
+						}
+
+						return null;
 					});
 				setType(
 					() -> {

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/bnd.bnd
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/bnd.bnd
@@ -1,7 +1,7 @@
 Bundle-Name: Liferay Headless Admin Taxonomy Test
 Bundle-SymbolicName: com.liferay.headless.admin.taxonomy.test
 Bundle-Version: 1.0.0
--includeresource: :\
+-includeresource:\
 	com.liferay.headless.admin.taxonomy.client.jar=com.liferay.headless.admin.taxonomy.client-*.jar;lib:=true,\
 	com.liferay.headless.batch.engine.client.jar=com.liferay.headless.batch.engine.client-*.jar;lib:=true,\
 	@jsonassert-[0-9.]*.jar

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/build.gradle
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/build.gradle
@@ -9,6 +9,8 @@ dependencies {
 	testIntegrationImplementation project(":apps:asset:asset-entry-rel-api")
 	testIntegrationImplementation project(":apps:asset:asset-test-util")
 	testIntegrationImplementation project(":apps:depot:depot-api")
+	testIntegrationImplementation project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")
+	testIntegrationImplementation project(":apps:dynamic-data-mapping:dynamic-data-mapping-test-util")
 	testIntegrationImplementation project(":apps:export-import:export-import-test-util")
 	testIntegrationImplementation project(":apps:headless:headless-admin-taxonomy:headless-admin-taxonomy-api")
 	testIntegrationImplementation project(":apps:headless:headless-admin-taxonomy:headless-admin-taxonomy-client")

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyVocabularyResourceTest.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyVocabularyResourceTest.java
@@ -13,6 +13,12 @@ import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
 import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.document.library.kernel.model.DLFileEntryConstants;
+import com.liferay.document.library.kernel.model.DLFileEntryMetadata;
+import com.liferay.document.library.kernel.model.DLFileEntryType;
+import com.liferay.document.library.kernel.service.DLFileEntryTypeService;
+import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.dynamic.data.mapping.test.util.DDMStructureTestUtil;
 import com.liferay.headless.admin.taxonomy.client.dto.v1_0.AssetLibrary;
 import com.liferay.headless.admin.taxonomy.client.dto.v1_0.AssetType;
 import com.liferay.headless.admin.taxonomy.client.dto.v1_0.TaxonomyVocabulary;
@@ -22,12 +28,14 @@ import com.liferay.headless.admin.taxonomy.client.problem.Problem;
 import com.liferay.headless.admin.taxonomy.client.resource.v1_0.TaxonomyVocabularyResource;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.lazy.referencing.LazyReferencingThreadLocal;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
@@ -43,12 +51,15 @@ import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LogEntry;
 import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -247,6 +258,7 @@ public class TaxonomyVocabularyResourceTest
 		super.testGetTaxonomyVocabulary();
 
 		_testGetTaxonomyVocabularyActions();
+		_testGetTaxonomyVocabularyWithoutClassTypePK();
 		_testGetTaxonomyVocabularyWithoutPermissionsAction();
 	}
 
@@ -498,6 +510,57 @@ public class TaxonomyVocabularyResourceTest
 					"method", "PATCH"
 				).build()
 			).build());
+	}
+
+	private void _testGetTaxonomyVocabularyWithoutClassTypePK()
+		throws Exception {
+
+		DDMStructure ddmStructure = DDMStructureTestUtil.addStructure(
+			testGroup.getGroupId(), DLFileEntryMetadata.class.getName());
+
+		DLFileEntryType dlFileEntryType =
+			_dlFileEntryTypeService.addFileEntryType(
+				null, testGroup.getGroupId(), ddmStructure.getStructureId(),
+				null,
+				Collections.singletonMap(LocaleUtil.US, "New File Entry Type"),
+				Collections.singletonMap(LocaleUtil.US, "New File Entry Type"),
+				ServiceContextTestUtil.getServiceContext(
+					testGroup, TestPropsValues.getUserId()));
+
+		long classNameId = _classNameLocalService.getClassNameId(
+			DLFileEntryConstants.getClassName());
+
+		UnicodeProperties unicodeProperties = UnicodePropertiesBuilder.create(
+			true
+		).put(
+			"selectedClassNameIds",
+			classNameId + StringPool.COLON +
+				dlFileEntryType.getFileEntryTypeId()
+		).build();
+
+		AssetVocabulary assetVocabulary =
+			_assetVocabularyLocalService.addVocabulary(
+				TestPropsValues.getUserId(), testGroup.getGroupId(),
+				RandomTestUtil.randomString(),
+				Collections.singletonMap(
+					LocaleUtil.getSiteDefault(), RandomTestUtil.randomString()),
+				null, unicodeProperties.toString(),
+				ServiceContextTestUtil.getServiceContext(
+					testGroup.getGroupId()));
+
+		_dlFileEntryTypeService.deleteFileEntryType(
+			dlFileEntryType.getFileEntryTypeId());
+
+		TaxonomyVocabulary taxonomyVocabulary =
+			taxonomyVocabularyResource.getTaxonomyVocabulary(
+				assetVocabulary.getVocabularyId());
+
+		Assert.assertNotNull(taxonomyVocabulary);
+
+		AssetType[] assetTypes = taxonomyVocabulary.getAssetTypes();
+
+		Assert.assertEquals(classNameId, (long)assetTypes[0].getTypeId());
+		Assert.assertNull(assetTypes[0].getSubtype());
 	}
 
 	private void _testGetTaxonomyVocabularyWithoutPermissionsAction()
@@ -789,7 +852,13 @@ public class TaxonomyVocabularyResourceTest
 	private AssetVocabularyLocalService _assetVocabularyLocalService;
 
 	@Inject
+	private ClassNameLocalService _classNameLocalService;
+
+	@Inject
 	private DepotEntryLocalService _depotEntryLocalService;
+
+	@Inject
+	private DLFileEntryTypeService _dlFileEntryTypeService;
 
 	@Inject
 	private ResourcePermissionLocalService _resourcePermissionLocalService;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-84137

What is this trying to solve?
When a DL file entry type is deleted, any asset vocabulary that was configured to filter by that specific type ends up with a empty reference.

How am I fixing it?
When a DL file entry type is deleted, we now find all asset vocabularies referencing it and reset their class type PK back to ALL_CLASS_TYPE_PK (the default).

How can you verify that it works?
gw testIntegration --tests=DLFileEntryTypeServiceTest.testDeleteFileEntryTypeSetsVocabularyClassTypePK

Rebased version of https://github.com/brianchandotcom/liferay-portal/pull/172846