### PR TITLE
LPD-85998 Fix failing js unit tests for translations and bulk actions

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/bulk_action_task/util/index.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/bulk_action_task/util/index.test.tsx
@@ -106,7 +106,7 @@ describe('Bulk Actions Monitor Utils', () => {
 			);
 
 			expect(taskUrl).toBe(
-				`${Liferay.ThemeDisplay.getPortalURL()}/o/cms/translations?type=ExportTranslationBulkAction&emptySearch=true&filter=cmsRoot eq true and cmsSection eq 'contents' and status in (0, 2, 3) and folderId eq 123 and groupIds/any(g:g in (456))`
+				`${Liferay.ThemeDisplay.getPortalURL()}/o/cms/translations?type=ExportTranslationBulkAction&emptySearch=true&filter=cmsRoot+eq+true+and+cmsSection+eq+%27contents%27+and+status+in+%280%2C+2%2C+3%29+and+folderId+eq+123+and+groupIds%2Fany%28g%3Ag+in+%28456%29%29`
 			);
 		});
 	});

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/modal/ExportTranslationModalContent.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/modal/ExportTranslationModalContent.test.tsx
@@ -12,7 +12,7 @@ import {fetch} from 'frontend-js-web';
 import React from 'react';
 
 import ExportTranslationModalContent from '../../../../src/main/resources/META-INF/resources/js/main_view/modal/ExportTranslationModalContent';
-import exportTranslationBulkAction from '../../../../src/main/resources/META-INF/resources/js/main_view/props_transformer/actions/exportTranslationBulkAction';
+import {exportTranslationBulkActionRequest} from '../../../../src/main/resources/META-INF/resources/js/main_view/props_transformer/actions/exportTranslationBulkActionRequest';
 
 const mockCloseModal = jest.fn();
 
@@ -21,10 +21,9 @@ jest.mock('frontend-js-components-web', () => ({
 }));
 
 jest.mock(
-	'../../../../src/main/resources/META-INF/resources/js/main_view/props_transformer/actions/exportTranslationBulkAction',
+	'../../../../src/main/resources/META-INF/resources/js/main_view/props_transformer/actions/exportTranslationBulkActionRequest',
 	() => ({
-		__esModule: true,
-		default: jest.fn(() => Promise.resolve()),
+		exportTranslationBulkActionRequest: jest.fn(() => Promise.resolve()),
 	})
 );
 
@@ -99,10 +98,8 @@ const renderComponent = (
 	return render(<ExportTranslationModalContent {...props} />);
 };
 
-(global as any).URL = {
-	createObjectURL: jest.fn(() => 'blob:mock/url-string'),
-	revokeObjectURL: jest.fn(),
-};
+global.URL.createObjectURL = jest.fn(() => 'blob:mock/url-string') as any;
+global.URL.revokeObjectURL = jest.fn() as any;
 
 describe('ExportTranslationModalContent', () => {
 	afterEach(() => {
@@ -196,7 +193,7 @@ describe('ExportTranslationModalContent', () => {
 		});
 	});
 
-	it('calls exportTranslationBulkAction when selectedData is provided and the export button is clicked', async () => {
+	it('calls exportTranslationBulkActionRequest when selectedData is provided and the export button is clicked', async () => {
 		const selectedData = {items: [], selectAll: true};
 		const {getByLabelText, getByText} = renderComponent({
 			...DEFAULT_PROPS,
@@ -210,16 +207,18 @@ describe('ExportTranslationModalContent', () => {
 		fireEvent.click(getByText('export'));
 
 		await waitFor(() => {
-			expect(exportTranslationBulkAction).toHaveBeenCalledWith({
-				apiURL: '/api/test',
-				keyValues: {
-					sourceLanguageId: 'en_US',
-					targetLanguageIds: ['es_ES', 'fr_FR'],
-					xliffMimeType: 'application/xliff+xml',
-				},
-				selectedData,
-				type: 'ExportTranslationBulkAction',
-			});
+			expect(exportTranslationBulkActionRequest).toHaveBeenCalledWith(
+				expect.objectContaining({
+					apiURL: '/api/test',
+					keyValues: {
+						sourceLanguageId: 'en_US',
+						targetLanguageIds: ['es_ES', 'fr_FR'],
+						xliffMimeType: 'application/xliff+xml',
+					},
+					selectedData,
+					type: 'ExportTranslationBulkAction',
+				})
+			);
 		});
 	});
 });


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-85998

Some js unit test failures are failing upstream.

# How am I fixing it?

By updating the tests to reflect the changes made in LPD-82595.

# How can you verify that it works?

Run all site-cms-site-initializer js unit tests: `yarn test`.