### PR TITLE
LPD-85942 Live entries are not shown in asset publisher on staged site

### DIFF
--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/asset/model/test/DepotAssetRendererFactoryWrapperTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/asset/model/test/DepotAssetRendererFactoryWrapperTest.java
@@ -1,0 +1,194 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.depot.internal.asset.model.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.kernel.AssetRendererFactoryCustomizer;
+import com.liferay.asset.kernel.AssetRendererFactoryRegistryUtil;
+import com.liferay.asset.kernel.model.AssetRenderer;
+import com.liferay.asset.kernel.model.AssetRendererFactory;
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryGroupRelLocalService;
+import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
+import com.liferay.document.library.kernel.model.DLFolderConstants;
+import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
+import com.liferay.exportimport.kernel.service.StagingLocalService;
+import com.liferay.petra.function.UnsafeConsumer;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.test.constants.TestDataConstants;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.io.ByteArrayInputStream;
+
+import java.util.HashMap;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * @author Jürgen Kappler
+ */
+@RunWith(Arquillian.class)
+public class DepotAssetRendererFactoryWrapperTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Test
+	public void testGetAssetRenderer() throws Exception {
+		_testGetAssetRenderer(
+			assetRenderer -> Assert.assertNull(assetRenderer), false);
+		_testGetAssetRenderer(
+			assetRenderer -> Assert.assertNotNull(assetRenderer), true);
+	}
+
+	private DLFileEntry _addDLFileEntry(Group group) throws Exception {
+		byte[] bytes = TestDataConstants.TEST_BYTE_ARRAY;
+
+		return _dlFileEntryLocalService.addFileEntry(
+			null, TestPropsValues.getUserId(), group.getGroupId(),
+			group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			RandomTestUtil.randomString(),
+			ContentTypes.APPLICATION_OCTET_STREAM,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			StringPool.BLANK, StringPool.BLANK,
+			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT, null,
+			null, new ByteArrayInputStream(bytes), bytes.length, null, null,
+			null,
+			ServiceContextTestUtil.getServiceContext(
+				group.getGroupId(), TestPropsValues.getUserId()));
+	}
+
+	private Group _enableLocalStaging(Group group) throws Exception {
+		_stagingLocalService.enableLocalStaging(
+			TestPropsValues.getUserId(), group, false, false,
+			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
+
+		return group.getStagingGroup();
+	}
+
+	private ServiceContext _getServiceContext(Group group) throws Exception {
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext();
+
+		HttpServletRequest httpServletRequest = new MockHttpServletRequest();
+
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		themeDisplay.setScopeGroupId(group.getGroupId());
+
+		httpServletRequest.setAttribute(WebKeys.THEME_DISPLAY, themeDisplay);
+
+		serviceContext.setRequest(httpServletRequest);
+
+		return serviceContext;
+	}
+
+	private void _testGetAssetRenderer(
+			UnsafeConsumer<AssetRenderer<?>, Exception> unsafeConsumer,
+			boolean addDepotEntryGroupRel)
+		throws Exception {
+
+		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()
+			).build(),
+			new HashMap<>(), DepotConstants.TYPE_ASSET_LIBRARY,
+			ServiceContextTestUtil.getServiceContext());
+
+		Group group = GroupTestUtil.addGroup();
+
+		DLFileEntry dlFileEntry = _addDLFileEntry(depotEntry.getGroup());
+
+		_enableLocalStaging(depotEntry.getGroup());
+
+		if (addDepotEntryGroupRel) {
+			_depotEntryGroupRelLocalService.addDepotEntryGroupRel(
+				depotEntry.getDepotEntryId(), group.getGroupId());
+		}
+
+		Group stagedGroup = _enableLocalStaging(group);
+
+		AssetRendererFactory<Object> assetRendererFactory =
+			AssetRendererFactoryRegistryUtil.getAssetRendererFactoryByClassName(
+				DLFileEntry.class.getName());
+
+		AssetRendererFactory<?> customizedAssetRendererFactory =
+			_assetRendererFactory.customize(assetRendererFactory);
+
+		ServiceContextThreadLocal.pushServiceContext(
+			_getServiceContext(stagedGroup));
+
+		try {
+			unsafeConsumer.accept(
+				customizedAssetRendererFactory.getAssetRenderer(
+					dlFileEntry.getFileEntryId()));
+		}
+		finally {
+			ServiceContextThreadLocal.popServiceContext();
+
+			_stagingLocalService.disableStaging(
+				group, ServiceContextTestUtil.getServiceContext());
+
+			_groupLocalService.deleteGroup(group);
+
+			_stagingLocalService.disableStaging(
+				depotEntry.getGroup(),
+				ServiceContextTestUtil.getServiceContext());
+
+			_depotEntryLocalService.deleteDepotEntry(depotEntry);
+		}
+	}
+
+	@Inject
+	private AssetRendererFactoryCustomizer _assetRendererFactory;
+
+	@Inject
+	private DepotEntryGroupRelLocalService _depotEntryGroupRelLocalService;
+
+	@Inject
+	private DepotEntryLocalService _depotEntryLocalService;
+
+	@Inject
+	private DLFileEntryLocalService _dlFileEntryLocalService;
+
+	@Inject
+	private GroupLocalService _groupLocalService;
+
+	@Inject
+	private StagingLocalService _stagingLocalService;
+
+}

--- a/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/asset/model/DepotAssetRendererFactoryWrapper.java
+++ b/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/asset/model/DepotAssetRendererFactoryWrapper.java
@@ -32,6 +32,8 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.GroupThreadLocal;
+import com.liferay.staging.StagingGroupHelper;
+import com.liferay.staging.StagingGroupHelperUtil;
 
 import jakarta.portlet.PortletURL;
 import jakarta.portlet.WindowState;
@@ -105,14 +107,43 @@ public class DepotAssetRendererFactoryWrapper<T>
 			return null;
 		}
 
-		if (group.isControlPanel() ||
-			ArrayUtil.contains(
-				_siteConnectedGroupGroupProvider.
-					getCurrentAndAncestorSiteAndDepotGroupIds(
-						_getGroupId(group.getGroupId())),
-				groupId)) {
+		if (group.isControlPanel()) {
+			return assetRenderer;
+		}
+
+		long[] currentAndAncestorSiteAndDepotGroupIds =
+			_siteConnectedGroupGroupProvider.
+				getCurrentAndAncestorSiteAndDepotGroupIds(
+					_getGroupId(group.getGroupId()));
+
+		if (ArrayUtil.contains(
+				currentAndAncestorSiteAndDepotGroupIds, groupId)) {
 
 			return assetRenderer;
+		}
+
+		DepotEntry depotEntry = _depotEntryLocalService.fetchGroupDepotEntry(
+			groupId);
+
+		if (depotEntry != null) {
+			StagingGroupHelper stagingGroupHelper =
+				StagingGroupHelperUtil.getStagingGroupHelper();
+
+			Group depotEntryGroup = depotEntry.getGroup();
+
+			if (stagingGroupHelper.isLocalLiveGroup(depotEntryGroup) ||
+				stagingGroupHelper.isRemoteLiveGroup(depotEntryGroup)) {
+
+				Group stagedDepotEntryGroup = depotEntryGroup.getStagingGroup();
+
+				if ((stagedDepotEntryGroup != null) &&
+					ArrayUtil.contains(
+						currentAndAncestorSiteAndDepotGroupIds,
+						stagedDepotEntryGroup.getGroupId())) {
+
+					return assetRenderer;
+				}
+			}
 		}
 
 		if (!FeatureFlagManagerUtil.isEnabled(
@@ -121,10 +152,9 @@ public class DepotAssetRendererFactoryWrapper<T>
 			return null;
 		}
 
-		DepotEntry depotEntry = _depotEntryLocalService.getGroupDepotEntry(
-			groupId);
+		if ((depotEntry != null) &&
+			(depotEntry.getType() == DepotConstants.TYPE_SPACE)) {
 
-		if (depotEntry.getType() == DepotConstants.TYPE_SPACE) {
 			return assetRenderer;
 		}
 

--- a/modules/apps/depot/depot-web/src/test/java/com/liferay/depot/web/internal/asset/model/DepotAssetRendererFactoryWrapperTest.java
+++ b/modules/apps/depot/depot-web/src/test/java/com/liferay/depot/web/internal/asset/model/DepotAssetRendererFactoryWrapperTest.java
@@ -20,14 +20,19 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.GroupThreadLocal;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.staging.StagingGroupHelper;
+import com.liferay.staging.StagingGroupHelperUtil;
 
 import java.util.function.Consumer;
 
+import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 /**
@@ -39,6 +44,16 @@ public class DepotAssetRendererFactoryWrapperTest {
 	@Rule
 	public static final LiferayUnitTestRule liferayUnitTestRule =
 		LiferayUnitTestRule.INSTANCE;
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_setUpStagingGroupHelper();
+	}
+
+	@AfterClass
+	public static void tearDownClass() {
+		_stagingGroupHelperUtilMockedStatic.close();
+	}
 
 	@Test
 	public void testAssetRendererReturnsFallbackGroup() throws Exception {
@@ -235,7 +250,7 @@ public class DepotAssetRendererFactoryWrapperTest {
 		DepotEntry depotEntry = Mockito.mock(DepotEntry.class);
 
 		Mockito.when(
-			_depotEntryLocalService.getGroupDepotEntry(Mockito.anyLong())
+			_depotEntryLocalService.fetchGroupDepotEntry(Mockito.anyLong())
 		).thenReturn(
 			depotEntry
 		);
@@ -280,6 +295,32 @@ public class DepotAssetRendererFactoryWrapperTest {
 				depotAssetRendererFactoryWrapper.getAssetRenderer(
 					RandomTestUtil.randomLong()));
 		}
+	}
+
+	private static void _setUpStagingGroupHelper() {
+		_stagingGroupHelperUtilMockedStatic = Mockito.mockStatic(
+			StagingGroupHelperUtil.class);
+
+		StagingGroupHelper stagingGroupHelper = Mockito.mock(
+			StagingGroupHelper.class);
+
+		Mockito.when(
+			StagingGroupHelperUtil.getStagingGroupHelper()
+		).thenReturn(
+			stagingGroupHelper
+		);
+
+		Mockito.when(
+			stagingGroupHelper.isLocalLiveGroup(Mockito.any())
+		).thenReturn(
+			false
+		);
+
+		Mockito.when(
+			stagingGroupHelper.isRemoteLiveGroup(Mockito.any())
+		).thenReturn(
+			false
+		);
 	}
 
 	private long _setUpControlPanelGroup() throws Exception {
@@ -339,6 +380,9 @@ public class DepotAssetRendererFactoryWrapperTest {
 
 		return groupId;
 	}
+
+	private static MockedStatic<StagingGroupHelperUtil>
+		_stagingGroupHelperUtilMockedStatic;
 
 	private final AssetRendererFactory<Object> _assetRendererFactory =
 		Mockito.mock(AssetRendererFactory.class);

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/service/CMSObjectEntryFolderDepotEntryLocalServiceWrapper.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/service/CMSObjectEntryFolderDepotEntryLocalServiceWrapper.java
@@ -101,7 +101,10 @@ public class CMSObjectEntryFolderDepotEntryLocalServiceWrapper
 	public DepotEntry deleteDepotEntry(DepotEntry depotEntry)
 		throws PortalException {
 
-		if (depotEntry.getType() == DepotConstants.TYPE_SPACE) {
+		if (FeatureFlagManagerUtil.isEnabled(
+				depotEntry.getCompanyId(), "LPD-17564") &&
+			(depotEntry.getType() == DepotConstants.TYPE_SPACE)) {
+
 			ObjectEntryFolderUtil.deleteObjectEntryFolders(depotEntry);
 
 			_deleteCMSDefaultPermissions(depotEntry.getGroup());


### PR DESCRIPTION
Asset libraries entries are not shown correctly in a staged site in asset publisher

# What is this trying to solve?

[Link to ticket](https://issues.liferay.com/browse/LPD-85942)

When displaying an image for example in a staged site with a connected asset library, the later one is not shown

# How am I fixing it?

The connection is done through the staged site, so if we get a live item, we should also take it into account

# How can you verify that it works?

Follow the steps in the ticket or execute the provided test
