### PR TITLE
LPD-85323 exported content shows null title when viewing in a non default language without translations

### DIFF
--- a/modules/apps/object/object-info-api/src/main/java/com/liferay/object/info/item/provider/util/ObjectEntryInfoItemValuesProviderUtil.java
+++ b/modules/apps/object/object-info-api/src/main/java/com/liferay/object/info/item/provider/util/ObjectEntryInfoItemValuesProviderUtil.java
@@ -63,6 +63,7 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -109,7 +110,8 @@ public class ObjectEntryInfoItemValuesProviderUtil {
 	}
 
 	public static List<InfoFieldValue<Object>> getInfoFieldValues(
-			DLAppLocalService dlAppLocalService, DLURLHelper dlURLHelper,
+			String defaultLanguageId, DLAppLocalService dlAppLocalService,
+			DLURLHelper dlURLHelper,
 			FriendlyURLEntryLocalService friendlyURLEntryLocalService,
 			ListTypeEntryLocalService listTypeEntryLocalService,
 			ObjectActionLocalService objectActionLocalService,
@@ -140,8 +142,9 @@ public class ObjectEntryInfoItemValuesProviderUtil {
 			}
 
 			_addInfoFieldValue(
-				dlAppLocalService, dlURLHelper, infoFieldValues,
-				listTypeEntryLocalService, objectEntryLocalService, objectField,
+				defaultLanguageId, dlAppLocalService, dlURLHelper,
+				infoFieldValues, listTypeEntryLocalService,
+				objectEntryLocalService, objectField,
 				objectFieldInfoFieldConverter,
 				ObjectField.class.getSimpleName(),
 				objectRelationshipLocalService, themeDisplay, value);
@@ -194,11 +197,11 @@ public class ObjectEntryInfoItemValuesProviderUtil {
 				}
 
 				_addInfoFieldValue(
-					dlAppLocalService, dlURLHelper, infoFieldValues,
-					listTypeEntryLocalService, objectEntryLocalService,
-					relatedObjectField, objectFieldInfoFieldConverter,
-					namespace, objectRelationshipLocalService, themeDisplay,
-					value);
+					defaultLanguageId, dlAppLocalService, dlURLHelper,
+					infoFieldValues, listTypeEntryLocalService,
+					objectEntryLocalService, relatedObjectField,
+					objectFieldInfoFieldConverter, namespace,
+					objectRelationshipLocalService, themeDisplay, value);
 
 				infoFieldValues.add(
 					new InfoFieldValue<>(
@@ -302,7 +305,8 @@ public class ObjectEntryInfoItemValuesProviderUtil {
 	}
 
 	private static void _addInfoFieldValue(
-			DLAppLocalService dlAppLocalService, DLURLHelper dlURLHelper,
+			String defaultLanguageId, DLAppLocalService dlAppLocalService,
+			DLURLHelper dlURLHelper,
 			List<InfoFieldValue<Object>> infoFieldValues,
 			ListTypeEntryLocalService listTypeEntryLocalService,
 			ObjectEntryLocalService objectEntryLocalService,
@@ -334,9 +338,15 @@ public class ObjectEntryInfoItemValuesProviderUtil {
 		if (objectField.isLocalized() && (value instanceof Map)) {
 			Map<String, Object> map = (Map<String, Object>)value;
 
+			Locale defaultLocale = null;
+
+			if (Validator.isNotNull(defaultLanguageId)) {
+				defaultLocale = LocaleUtil.fromLanguageId(defaultLanguageId);
+			}
+
 			infoFieldValue = InfoLocalizedValue.builder(
 			).defaultLocale(
-				LocaleUtil.fromLanguageId(objectField.getDefaultLanguageId())
+				defaultLocale
 			).value(
 				consumer -> {
 					for (Map.Entry<String, Object> entry : map.entrySet()) {

--- a/modules/apps/object/object-info-api/src/main/java/com/liferay/object/info/item/provider/util/ObjectEntryInfoItemValuesProviderUtil.java
+++ b/modules/apps/object/object-info-api/src/main/java/com/liferay/object/info/item/provider/util/ObjectEntryInfoItemValuesProviderUtil.java
@@ -155,8 +155,6 @@ public class ObjectEntryInfoItemValuesProviderUtil {
 				continue;
 			}
 
-			Map<String, Object> properties = new HashMap<>();
-
 			ObjectRelationship objectRelationship =
 				objectRelationshipLocalService.
 					fetchObjectRelationshipByObjectFieldId2(
@@ -173,8 +171,13 @@ public class ObjectEntryInfoItemValuesProviderUtil {
 					GetterUtil.getLong(values.get(objectField.getName()))),
 				themeDisplay);
 
+			Map<String, Object> properties = new HashMap<>();
+			String relatedObjectEntryDefaultLanguageId = defaultLanguageId;
+
 			if (objectEntry != null) {
 				properties = objectEntry.getProperties();
+				relatedObjectEntryDefaultLanguageId =
+					objectEntry.getDefaultLanguageId();
 			}
 
 			for (ObjectField relatedObjectField :
@@ -197,8 +200,8 @@ public class ObjectEntryInfoItemValuesProviderUtil {
 				}
 
 				_addInfoFieldValue(
-					defaultLanguageId, dlAppLocalService, dlURLHelper,
-					infoFieldValues, listTypeEntryLocalService,
+					relatedObjectEntryDefaultLanguageId, dlAppLocalService,
+					dlURLHelper, infoFieldValues, listTypeEntryLocalService,
 					objectEntryLocalService, relatedObjectField,
 					objectFieldInfoFieldConverter, namespace,
 					objectRelationshipLocalService, themeDisplay, value);

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/system/info/item/provider/SystemObjectEntryInfoItemFieldValuesProvider.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/system/info/item/provider/SystemObjectEntryInfoItemFieldValuesProvider.java
@@ -226,11 +226,12 @@ public class SystemObjectEntryInfoItemFieldValuesProvider
 
 		infoFieldValues.addAll(
 			ObjectEntryInfoItemValuesProviderUtil.getInfoFieldValues(
-				_dlAppLocalService, _dlURLHelper, _friendlyURLEntryLocalService,
-				_listTypeEntryLocalService, _objectActionLocalService,
-				_objectDefinition, _objectDefinitionLocalService,
-				_objectEntryLocalService, _objectEntryManagerRegistry,
-				_objectFieldInfoFieldConverter, _objectFieldLocalService,
+				null, _dlAppLocalService, _dlURLHelper,
+				_friendlyURLEntryLocalService, _listTypeEntryLocalService,
+				_objectActionLocalService, _objectDefinition,
+				_objectDefinitionLocalService, _objectEntryLocalService,
+				_objectEntryManagerRegistry, _objectFieldInfoFieldConverter,
+				_objectFieldLocalService,
 				_objectFieldLocalService.getObjectFields(
 					_objectDefinition.getObjectDefinitionId()),
 				_objectRelationshipLocalService, _objectScopeProviderRegistry,

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFieldValuesProvider.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFieldValuesProvider.java
@@ -255,7 +255,8 @@ public class ObjectEntryInfoItemFieldValuesProvider
 
 		objectEntryFieldValues.addAll(
 			ObjectEntryInfoItemValuesProviderUtil.getInfoFieldValues(
-				_dlAppLocalService, _dlURLHelper, _friendlyURLEntryLocalService,
+				objectEntry.getDefaultLanguageId(), _dlAppLocalService,
+				_dlURLHelper, _friendlyURLEntryLocalService,
 				_listTypeEntryLocalService, _objectActionLocalService,
 				_objectDefinition, _objectDefinitionLocalService,
 				_objectEntryLocalService, _objectEntryManagerRegistry,
@@ -367,7 +368,8 @@ public class ObjectEntryInfoItemFieldValuesProvider
 				objectEntry.getReviewDate()));
 		objectEntryFieldValues.addAll(
 			ObjectEntryInfoItemValuesProviderUtil.getInfoFieldValues(
-				_dlAppLocalService, _dlURLHelper, _friendlyURLEntryLocalService,
+				objectEntry.getDefaultLanguageId(), _dlAppLocalService,
+				_dlURLHelper, _friendlyURLEntryLocalService,
 				_listTypeEntryLocalService, _objectActionLocalService,
 				_objectDefinition, _objectDefinitionLocalService,
 				_objectEntryLocalService, _objectEntryManagerRegistry,

--- a/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/helper/InfoItemHelper.java
+++ b/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/helper/InfoItemHelper.java
@@ -114,8 +114,13 @@ public class InfoItemHelper {
 				return stringValue;
 			}
 
-			return (String)infoLocalizedValue.getValue(
-				infoLocalizedValue.getDefaultLocale());
+			Locale defaultLocale = infoLocalizedValue.getDefaultLocale();
+
+			if (defaultLocale == null) {
+				return null;
+			}
+
+			return (String)infoLocalizedValue.getValue(defaultLocale);
 		}
 
 		return (String)value;

--- a/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/helper/InfoItemHelper.java
+++ b/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/helper/InfoItemHelper.java
@@ -11,12 +11,14 @@ import com.liferay.info.item.InfoItemReference;
 import com.liferay.info.item.InfoItemServiceRegistry;
 import com.liferay.info.item.provider.InfoItemFieldValuesProvider;
 import com.liferay.info.item.provider.InfoItemObjectProvider;
+import com.liferay.info.localized.InfoLocalizedValue;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.util.ObjectValuePair;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.segments.model.SegmentsExperience;
 import com.liferay.segments.service.SegmentsExperienceLocalServiceUtil;
 
@@ -97,6 +99,28 @@ public class InfoItemHelper {
 				StringPool.CLOSE_PARENTHESIS));
 	}
 
+	private String _getStringValue(
+		InfoFieldValue<Object> infoFieldValue, Locale locale) {
+
+		Object value = infoFieldValue.getValue();
+
+		if (value instanceof InfoLocalizedValue) {
+			InfoLocalizedValue<Object> infoLocalizedValue =
+				(InfoLocalizedValue<Object>)value;
+
+			String stringValue = (String)infoLocalizedValue.getValue(locale);
+
+			if (Validator.isNotNull(stringValue)) {
+				return stringValue;
+			}
+
+			return (String)infoLocalizedValue.getValue(
+				infoLocalizedValue.getDefaultLocale());
+		}
+
+		return (String)value;
+	}
+
 	private String _getTitle(String className, Object object, Locale locale) {
 		InfoItemFieldValuesProvider<Object> infoItemFieldValuesProvider =
 			_infoItemServiceRegistry.getFirstInfoItemService(
@@ -106,13 +130,21 @@ public class InfoItemHelper {
 			infoItemFieldValuesProvider.getInfoFieldValue(object, "title");
 
 		if (titleInfoFieldValue != null) {
-			return (String)titleInfoFieldValue.getValue(locale);
+			String value = _getStringValue(titleInfoFieldValue, locale);
+
+			if (Validator.isNotNull(value)) {
+				return value;
+			}
 		}
 
 		InfoFieldValue<Object> nameInfoFieldValue =
 			infoItemFieldValuesProvider.getInfoFieldValue(object, "name");
 
-		return (String)nameInfoFieldValue.getValue(locale);
+		if (nameInfoFieldValue != null) {
+			return _getStringValue(nameInfoFieldValue, locale);
+		}
+
+		return null;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(InfoItemHelper.class);

--- a/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/manager/TranslationManagerImpl.java
+++ b/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/manager/TranslationManagerImpl.java
@@ -220,7 +220,7 @@ public class TranslationManagerImpl implements TranslationManager {
 
 		String title = getTitle(className, classPK, locale);
 
-		if (title == null) {
+		if (Validator.isNull(title)) {
 			title =
 				_language.get(locale, "model.resource." + className) +
 					StringPool.SPACE + classPK;

--- a/modules/apps/translation/translation-test/build.gradle
+++ b/modules/apps/translation/translation-test/build.gradle
@@ -8,6 +8,8 @@ dependencies {
 	testIntegrationImplementation project(":apps:journal:journal-api")
 	testIntegrationImplementation project(":apps:journal:journal-test-util")
 	testIntegrationImplementation project(":apps:layout:layout-test-util")
+	testIntegrationImplementation project(":apps:object:object-api")
+	testIntegrationImplementation project(":apps:object:object-test-util")
 	testIntegrationImplementation project(":apps:segments:segments-api")
 	testIntegrationImplementation project(":apps:translation:translation-api")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")

--- a/modules/apps/translation/translation-test/src/testIntegration/java/com/liferay/translation/manager/test/TranslationManagerTest.java
+++ b/modules/apps/translation/translation-test/src/testIntegration/java/com/liferay/translation/manager/test/TranslationManagerTest.java
@@ -10,12 +10,25 @@ import com.liferay.dynamic.data.mapping.io.DDMFormDeserializer;
 import com.liferay.journal.constants.JournalFolderConstants;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.test.util.JournalTestUtil;
+import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.field.builder.TextObjectFieldBuilder;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.test.util.ObjectDefinitionTestUtil;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -29,10 +42,13 @@ import com.liferay.translation.test.util.TranslationTestUtil;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
+import java.io.Serializable;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
@@ -92,6 +108,45 @@ public class TranslationManagerTest {
 
 		_testGetXLIFFFile("test-journal-article-v12.xlf", _MIMETYPE_XLIFF_1_2);
 		_testGetXLIFFFile("test-journal-article.xlf", _MIMETYPE_XLIFF_2_0);
+	}
+
+	@Test
+	@TestInfo("LPD-85323")
+	public void testObjectEntryGetTitle() throws Exception {
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition(
+				Collections.singletonList(
+					new TextObjectFieldBuilder(
+					).labelMap(
+						Collections.singletonMap(
+							LocaleUtil.getDefault(), "Title")
+					).localized(
+						true
+					).name(
+						"title"
+					).build()),
+				ObjectDefinitionConstants.SCOPE_SITE);
+
+		String spanishTitle = RandomTestUtil.randomString();
+
+		Map<String, String> titles = HashMapBuilder.put(
+			"es_ES", spanishTitle
+		).build();
+
+		_testObjectEntryGetTitle(
+			"es_ES", spanishTitle, LocaleUtil.US, objectDefinition, titles);
+		_testObjectEntryGetTitle(
+			"es_ES", spanishTitle, LocaleUtil.SPAIN, objectDefinition, titles);
+
+		String englishTitle = RandomTestUtil.randomString();
+
+		titles.put("en_US", englishTitle);
+
+		_testObjectEntryGetTitle(
+			"es_ES", englishTitle, LocaleUtil.US, objectDefinition, titles);
+
+		_testObjectEntryGetTitle(
+			"es_ES", spanishTitle, LocaleUtil.SPAIN, objectDefinition, titles);
 	}
 
 	@Test
@@ -198,6 +253,38 @@ public class TranslationManagerTest {
 		}
 	}
 
+	private void _testObjectEntryGetTitle(
+			String defaultLangueId, String expectedTitle, Locale locale,
+			ObjectDefinition objectDefinition, Map<String, String> titles)
+		throws Exception {
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId());
+
+		ObjectEntry objectEntry = _objectEntryLocalService.addObjectEntry(
+			_group.getGroupId(), TestPropsValues.getUserId(),
+			objectDefinition.getObjectDefinitionId(),
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			defaultLangueId,
+			HashMapBuilder.put(
+				"title_i18n", (Serializable)titles
+			).build(),
+			serviceContext);
+
+		ServiceContextThreadLocal.pushServiceContext(serviceContext);
+
+		try {
+			Assert.assertEquals(
+				expectedTitle,
+				_translationManager.getTitle(
+					objectDefinition.getClassName(),
+					objectEntry.getObjectEntryId(), locale));
+		}
+		finally {
+			ServiceContextThreadLocal.popServiceContext();
+		}
+	}
+
 	private void _testProcessXLIFFTranslationFailureWithSingleFile(
 			File xliffFile)
 		throws Exception {
@@ -297,6 +384,9 @@ public class TranslationManagerTest {
 	private Group _group;
 
 	private JournalArticle _journalArticle;
+
+	@Inject
+	private ObjectEntryLocalService _objectEntryLocalService;
 
 	@Inject
 	private TranslationManager _translationManager;


### PR DESCRIPTION
:warning: This PR has already passed the review of BPM team here: https://github.com/liferay-bpm/liferay-portal/pull/5943

I've just added the missing test

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-85323

Getting the title of an asset to name the file from Export Translation should use the asset default language if the display language is not available.

# How am I fixing it?

1. In method `ObjectEntryInfoItemValuesProviderUtil.getInfoFieldValues`, use the object entry default language instead of the object definition default language used for the name of the field. I think it was a mistake.
2. In method `InfoItemHelper._getTitle`, if the value for the input locale is missing use the default language locale. I don't know if this change can directly be included in `InfoFieldValue` as a new method like `getValueOrDefaultLocale` or something like that.

# How can you verify that it works?

`cd modules/apps/translation/translation-test`
`gw tI --tests "TranslationManagerTest.testObjectEntryGetTitle"`
