### PR TITLE
LPD-86105 Don't disable search bar when 0 results returned

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
@@ -443,11 +443,8 @@ public class DLAdminManagementToolbarDisplayContext
 
 	@Override
 	public Boolean isDisabled() {
-		if (searchContainer.getTotal() <= 0) {
-			return true;
-		}
-
-		return false;
+		return !_dlAdminDisplayContext.isSearch() &&
+			   (searchContainer.getTotal() == 0);
 	}
 
 	@Override

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/display/context/KBAdminManagementToolbarDisplayContext.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/display/context/KBAdminManagementToolbarDisplayContext.java
@@ -430,7 +430,11 @@ public class KBAdminManagementToolbarDisplayContext {
 	}
 
 	public boolean isDisabled() {
-		return !_searchContainer.hasResults();
+		if (!isSearch() && !_searchContainer.hasResults()) {
+			return true;
+		}
+
+		return false;
 	}
 
 	public boolean isSearch() {

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards_admin/view.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards_admin/view.jsp
@@ -65,7 +65,7 @@ String entriesNavigation = ParamUtil.getString(request, "entriesNavigation", "al
 	additionalProps="<%= mbEntriesManagementToolbarDisplayContext.getAdditionalProps() %>"
 	clearResultsURL="<%= mbEntriesManagementToolbarDisplayContext.getSearchActionURL() %>"
 	creationMenu="<%= mbEntriesManagementToolbarDisplayContext.getCreationMenu() %>"
-	disabled='<%= (entriesSearchContainer.getTotal() == 0) && (categoryId == MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID) && entriesNavigation.equals("all") %>'
+	disabled='<%= !mbAdminListDisplayContext.isShowSearch() && (entriesSearchContainer.getTotal() == 0) && (categoryId == MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID) && entriesNavigation.equals("all") %>'
 	filterDropdownItems="<%= mbEntriesManagementToolbarDisplayContext.getFilterDropdownItems() %>"
 	filterLabelItems="<%= mbEntriesManagementToolbarDisplayContext.getFilterLabelItems() %>"
 	itemsTotal="<%= entriesSearchContainer.getTotal() %>"

--- a/modules/test/playwright/tests/document-library-web/main/dmSearch.spec.ts
+++ b/modules/test/playwright/tests/document-library-web/main/dmSearch.spec.ts
@@ -5,12 +5,15 @@
 
 import {expect, mergeTests} from '@playwright/test';
 
+import {apiHelpersTest} from '../../../fixtures/apiHelpersTest';
 import {documentLibraryPagesTest} from '../../../fixtures/documentLibraryPages.fixtures';
 import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
 import {isolatedSiteTest} from '../../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../../fixtures/loginTest';
+import getRandomString from '../../../utils/getRandomString';
 
 const test = mergeTests(
+	apiHelpersTest,
 	documentLibraryPagesTest,
 	featureFlagsTest({
 		'LPD-11313': {enabled: true},
@@ -26,5 +29,22 @@ test(
 		await documentLibraryPage.goto(site.friendlyUrlPath);
 
 		await expect(page.getByPlaceholder('Search')).toBeVisible();
+	}
+);
+
+test(
+	'Search bar is not disabled after zero-result search',
+	{tag: '@LPD-86105'},
+	async ({apiHelpers, documentLibraryPage, page, site}) => {
+		await apiHelpers.headlessDelivery.postDocumentFolder(site.id);
+
+		await documentLibraryPage.goto(site.friendlyUrlPath);
+
+		const searchInput = page.getByRole('searchbox');
+
+		await searchInput.fill(getRandomString());
+		await searchInput.press('Enter');
+
+		await expect(searchInput).not.toBeDisabled();
 	}
 );

--- a/modules/test/playwright/tests/knowledge-base-web/main/knowledge-base-web.spec.ts
+++ b/modules/test/playwright/tests/knowledge-base-web/main/knowledge-base-web.spec.ts
@@ -261,3 +261,24 @@ test(
 		).not.toBeVisible();
 	}
 );
+
+test(
+	'Search bar is not disabled after zero-result search',
+	{tag: '@LPD-86105'},
+	async ({apiHelpers, knowledgeBasePage, page, site}) => {
+		await apiHelpers.headlessDelivery.postSiteKnowledgeBaseArticle({
+			articleBody: getRandomString(),
+			siteId: site.id,
+			title: getRandomString(),
+		});
+
+		await knowledgeBasePage.goto(site.friendlyUrlPath);
+
+		const searchInput = page.getByRole('searchbox');
+
+		await searchInput.fill(getRandomString());
+		await searchInput.press('Enter');
+
+		await expect(searchInput).not.toBeDisabled();
+	}
+);

--- a/modules/test/playwright/tests/message-boards-web/main/message-boards-web.spec.ts
+++ b/modules/test/playwright/tests/message-boards-web/main/message-boards-web.spec.ts
@@ -257,3 +257,24 @@ test(
 		await expect(heading).toHaveText('Add Category');
 	}
 );
+
+test(
+	'Search bar is not disabled after zero-result search',
+	{tag: '@LPD-86105'},
+	async ({apiHelpers, messageBoardsPage, page, site}) => {
+		await apiHelpers.headlessDelivery.postMessageBoardThread({
+			articleBody: getRandomString(),
+			headline: getRandomString(),
+			siteId: site.id,
+		});
+
+		await messageBoardsPage.goto(site.friendlyUrlPath);
+
+		const searchInput = page.getByRole('searchbox');
+
+		await searchInput.fill(getRandomString());
+		await searchInput.press('Enter');
+
+		await expect(searchInput).not.toBeDisabled();
+	}
+);


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-86105

In DM, KB and MB, the search bar is disabled after performing a search with a term that returns no results, preventing the users from doing additional searches.

# How am I fixing it?

By not disabling the search bar when the query terms are not empty (in addition to any other conditions previously present).

# How can you verify that it works?

Run the included playwright tests.