### PR TITLE
LPD-86119 Incorrect HTML Title in Display Pages when viewing different Web Content versions

### DIFF
--- a/modules/apps/asset/asset-display-page-api/src/main/java/com/liferay/asset/display/page/portlet/BaseAssetDisplayPageFriendlyURLResolver.java
+++ b/modules/apps/asset/asset-display-page-api/src/main/java/com/liferay/asset/display/page/portlet/BaseAssetDisplayPageFriendlyURLResolver.java
@@ -115,7 +115,8 @@ public abstract class BaseAssetDisplayPageFriendlyURLResolver
 			LayoutDisplayPageWebKeys.LAYOUT_DISPLAY_PAGE_PROVIDER,
 			layoutDisplayPageProvider);
 
-		AssetEntry assetEntry = _getAssetEntry(layoutDisplayPageObjectProvider);
+		AssetEntry assetEntry = _getAssetEntry(
+			infoItem, layoutDisplayPageObjectProvider);
 
 		httpServletRequest.setAttribute(WebKeys.LAYOUT_ASSET_ENTRY, assetEntry);
 
@@ -343,13 +344,14 @@ public abstract class BaseAssetDisplayPageFriendlyURLResolver
 	@Reference
 	protected Portal portal;
 
-	private AssetEntry _getAssetEntry(
+	private <T> AssetEntry _getAssetEntry(
+		T infoItem,
 		LayoutDisplayPageObjectProvider<?> layoutDisplayPageObjectProvider) {
 
 		String className = infoSearchClassMapperRegistry.getSearchClassName(
 			layoutDisplayPageObjectProvider.getClassName());
 
-		AssetRendererFactory<?> assetRendererFactory =
+		AssetRendererFactory<T> assetRendererFactory =
 			AssetRendererFactoryRegistryUtil.getAssetRendererFactoryByClassName(
 				className);
 
@@ -357,7 +359,11 @@ public abstract class BaseAssetDisplayPageFriendlyURLResolver
 			return null;
 		}
 
-		long classPK = layoutDisplayPageObjectProvider.getClassPK();
+		long classPK = assetRendererFactory.getAssetEntryClassPK(infoItem);
+
+		if (classPK == 0) {
+			return null;
+		}
 
 		try {
 			AssetEntry assetEntry = assetRendererFactory.getAssetEntry(

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/layout/display/page/JournalArticleLayoutDisplayPageObjectProvider.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/layout/display/page/JournalArticleLayoutDisplayPageObjectProvider.java
@@ -13,6 +13,9 @@ import com.liferay.asset.util.AssetHelper;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.layout.display.page.LayoutDisplayPageObjectProvider;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
 
 import java.util.Locale;
 
@@ -39,7 +42,11 @@ public class JournalArticleLayoutDisplayPageObjectProvider
 
 	@Override
 	public long getClassNameId() {
-		return _assetEntry.getClassNameId();
+		if (_assetEntry != null) {
+			return _assetEntry.getClassNameId();
+		}
+
+		return PortalUtil.getClassNameId(JournalArticle.class.getName());
 	}
 
 	@Override
@@ -49,12 +56,20 @@ public class JournalArticleLayoutDisplayPageObjectProvider
 
 	@Override
 	public long getClassTypeId() {
-		return _assetEntry.getClassTypeId();
+		if (_assetEntry != null) {
+			return _assetEntry.getClassTypeId();
+		}
+
+		return _article.getDDMStructureId();
 	}
 
 	@Override
 	public String getDescription(Locale locale) {
-		return _assetEntry.getDescription(locale);
+		if (_assetEntry != null) {
+			return _assetEntry.getDescription(locale);
+		}
+
+		return _article.getDescription(locale);
 	}
 
 	@Override
@@ -74,20 +89,43 @@ public class JournalArticleLayoutDisplayPageObjectProvider
 
 	@Override
 	public String getKeywords(Locale locale) {
+		if (_assetEntry != null) {
+			return _assetHelper.getAssetKeywords(
+				_assetEntry.getClassName(), _assetEntry.getClassPK(), locale);
+		}
+
 		return _assetHelper.getAssetKeywords(
-			_assetEntry.getClassName(), _assetEntry.getClassPK(), locale);
+			JournalArticle.class.getName(), _article.getResourcePrimKey(),
+			locale);
 	}
 
 	@Override
 	public String getTitle(Locale locale) {
-		return _assetEntry.getTitle(locale);
+		if (_assetEntry != null) {
+			return _assetEntry.getTitle(locale);
+		}
+
+		return _article.getTitle(locale);
 	}
 
 	@Override
 	public String getURLTitle(Locale locale) {
-		AssetRenderer<?> assetRenderer = _assetEntry.getAssetRenderer();
+		if (_assetEntry != null) {
+			AssetRenderer<?> assetRenderer = _assetEntry.getAssetRenderer();
 
-		return assetRenderer.getUrlTitle(locale);
+			return assetRenderer.getUrlTitle(locale);
+		}
+
+		try {
+			return _article.getUrlTitle(locale);
+		}
+		catch (PortalException portalException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(portalException);
+			}
+		}
+
+		return _article.getUrlTitle();
 	}
 
 	private AssetEntry _getAssetEntry(JournalArticle journalArticle)
@@ -107,6 +145,9 @@ public class JournalArticleLayoutDisplayPageObjectProvider
 		return assetRendererFactory.getAssetEntry(
 			JournalArticle.class.getName(), assetEntryClassPK);
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		JournalArticleLayoutDisplayPageObjectProvider.class.getName());
 
 	private final JournalArticle _article;
 	private final AssetEntry _assetEntry;

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/layout/display/page/JournalArticleLayoutDisplayPageObjectProvider.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/layout/display/page/JournalArticleLayoutDisplayPageObjectProvider.java
@@ -15,7 +15,7 @@ import com.liferay.layout.display.page.LayoutDisplayPageObjectProvider;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.Portal;
 
 import java.util.Locale;
 
@@ -26,11 +26,12 @@ public class JournalArticleLayoutDisplayPageObjectProvider
 	implements LayoutDisplayPageObjectProvider<JournalArticle> {
 
 	public JournalArticleLayoutDisplayPageObjectProvider(
-			JournalArticle article, AssetHelper assetHelper)
+			JournalArticle article, AssetHelper assetHelper, Portal portal)
 		throws PortalException {
 
 		_article = article;
 		_assetHelper = assetHelper;
+		_portal = portal;
 
 		_assetEntry = _getAssetEntry(article);
 	}
@@ -46,7 +47,7 @@ public class JournalArticleLayoutDisplayPageObjectProvider
 			return _assetEntry.getClassNameId();
 		}
 
-		return PortalUtil.getClassNameId(JournalArticle.class.getName());
+		return _portal.getClassNameId(JournalArticle.class.getName());
 	}
 
 	@Override
@@ -152,5 +153,6 @@ public class JournalArticleLayoutDisplayPageObjectProvider
 	private final JournalArticle _article;
 	private final AssetEntry _assetEntry;
 	private final AssetHelper _assetHelper;
+	private final Portal _portal;
 
 }

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/layout/display/page/JournalArticleLayoutDisplayPageObjectProvider.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/layout/display/page/JournalArticleLayoutDisplayPageObjectProvider.java
@@ -93,13 +93,13 @@ public class JournalArticleLayoutDisplayPageObjectProvider
 	private AssetEntry _getAssetEntry(JournalArticle journalArticle)
 		throws PortalException {
 
-		AssetRendererFactory<?> assetRendererFactory =
+		AssetRendererFactory<JournalArticle> assetRendererFactory =
 			AssetRendererFactoryRegistryUtil.getAssetRendererFactoryByClassName(
 				JournalArticle.class.getName());
 
 		return assetRendererFactory.getAssetEntry(
 			JournalArticle.class.getName(),
-			journalArticle.getResourcePrimKey());
+			assetRendererFactory.getAssetEntryClassPK(journalArticle));
 	}
 
 	private final JournalArticle _article;

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/layout/display/page/JournalArticleLayoutDisplayPageObjectProvider.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/layout/display/page/JournalArticleLayoutDisplayPageObjectProvider.java
@@ -97,9 +97,15 @@ public class JournalArticleLayoutDisplayPageObjectProvider
 			AssetRendererFactoryRegistryUtil.getAssetRendererFactoryByClassName(
 				JournalArticle.class.getName());
 
+		long assetEntryClassPK = assetRendererFactory.getAssetEntryClassPK(
+			journalArticle);
+
+		if (assetEntryClassPK == 0) {
+			return null;
+		}
+
 		return assetRendererFactory.getAssetEntry(
-			JournalArticle.class.getName(),
-			assetRendererFactory.getAssetEntryClassPK(journalArticle));
+			JournalArticle.class.getName(), assetEntryClassPK);
 	}
 
 	private final JournalArticle _article;

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/layout/display/page/JournalArticleLayoutDisplayPageProvider.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/layout/display/page/JournalArticleLayoutDisplayPageProvider.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.portlet.constants.FriendlyURLResolverConstants;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.Validator;
 
 import org.osgi.service.component.annotations.Component;
@@ -56,7 +57,7 @@ public class JournalArticleLayoutDisplayPageProvider
 			}
 
 			return new JournalArticleLayoutDisplayPageObjectProvider(
-				article, assetHelper);
+				article, assetHelper, portal);
 		}
 		catch (PortalException portalException) {
 			throw new RuntimeException(portalException);
@@ -75,7 +76,7 @@ public class JournalArticleLayoutDisplayPageProvider
 			}
 
 			return new JournalArticleLayoutDisplayPageObjectProvider(
-				article, assetHelper);
+				article, assetHelper, portal);
 		}
 		catch (PortalException portalException) {
 			throw new RuntimeException(portalException);
@@ -95,7 +96,7 @@ public class JournalArticleLayoutDisplayPageProvider
 			}
 
 			return new JournalArticleLayoutDisplayPageObjectProvider(
-				article, assetHelper);
+				article, assetHelper, portal);
 		}
 		catch (PortalException portalException) {
 			throw new RuntimeException(portalException);
@@ -149,7 +150,7 @@ public class JournalArticleLayoutDisplayPageProvider
 
 		try {
 			return new JournalArticleLayoutDisplayPageObjectProvider(
-				article, assetHelper);
+				article, assetHelper, portal);
 		}
 		catch (PortalException portalException) {
 			throw new RuntimeException(portalException);
@@ -161,6 +162,9 @@ public class JournalArticleLayoutDisplayPageProvider
 
 	@Reference
 	protected JournalArticleLocalService journalArticleLocalService;
+
+	@Reference
+	protected Portal portal;
 
 	@Reference
 	protected SiteConnectedGroupGroupProvider siteConnectedGroupGroupProvider;

--- a/modules/apps/portal/portal-util-test/build.gradle
+++ b/modules/apps/portal/portal-util-test/build.gradle
@@ -8,6 +8,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:info:info-api")
 	testIntegrationImplementation project(":apps:journal:journal-api")
 	testIntegrationImplementation project(":apps:journal:journal-test-util")
+	testIntegrationImplementation project(":apps:layout:layout-display-page-api")
 	testIntegrationImplementation project(":apps:layout:layout-page-template-api")
 	testIntegrationImplementation project(":apps:layout:layout-page-template-test-util")
 	testIntegrationImplementation project(":apps:layout:layout-test-util")

--- a/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalImplActualURLTest.java
+++ b/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalImplActualURLTest.java
@@ -6,6 +6,11 @@
 package com.liferay.portal.util.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.journal.test.util.JournalTestUtil;
+import com.liferay.layout.display.page.LayoutDisplayPageProvider;
+import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
+import com.liferay.layout.page.template.test.util.DisplayPageTemplateTestUtil;
 import com.liferay.layout.test.util.ContentLayoutTestUtil;
 import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.petra.string.StringBundler;
@@ -25,6 +30,7 @@ import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserGroupLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
@@ -35,15 +41,19 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
+import com.liferay.portal.kernel.util.ListMergeable;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.webdav.methods.Method;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 import org.junit.Assert;
@@ -116,6 +126,103 @@ public class PortalImplActualURLTest {
 				_log.debug(noSuchLayoutException);
 			}
 		}
+	}
+
+	@Test
+	@TestInfo("LPD-86119")
+	public void testGetActualURLWithDisplayPageTemplateAndVersion()
+		throws Exception {
+
+		Locale locale = _portal.getSiteDefaultLocale(_group);
+
+		JournalArticle firstVersionJournalArticle = JournalTestUtil.addArticle(
+			_group.getGroupId(), 0,
+			_portal.getClassNameId(JournalArticle.class),
+			RandomTestUtil.randomLocaleStringMap(),
+			RandomTestUtil.randomLocaleStringMap(),
+			RandomTestUtil.randomLocaleStringMap(), locale, true, true,
+			_serviceContext);
+
+		Assert.assertEquals(
+			0,
+			Double.compare(
+				Double.valueOf("1.0"),
+				firstVersionJournalArticle.getVersion()));
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_APPROVED,
+			firstVersionJournalArticle.getStatus());
+
+		JournalArticle secondVersionJournalArticle =
+			JournalTestUtil.updateArticle(
+				firstVersionJournalArticle,
+				RandomTestUtil.randomLocaleStringMap(),
+				firstVersionJournalArticle.getContent(), true, true,
+				_serviceContext);
+
+		Assert.assertEquals(
+			0,
+			Double.compare(
+				Double.valueOf("1.1"),
+				secondVersionJournalArticle.getVersion()));
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_APPROVED,
+			secondVersionJournalArticle.getStatus());
+
+		String firstVersionTitle = firstVersionJournalArticle.getTitle(locale);
+		String secondVersionTitle = secondVersionJournalArticle.getTitle(
+			locale);
+
+		Assert.assertNotEquals(firstVersionTitle, secondVersionTitle);
+
+		JournalArticle draftVersionJournalArticle =
+			JournalTestUtil.updateArticle(
+				secondVersionJournalArticle,
+				RandomTestUtil.randomLocaleStringMap(),
+				secondVersionJournalArticle.getContent(), true, false,
+				_serviceContext);
+
+		Assert.assertEquals(
+			0,
+			Double.compare(
+				Double.valueOf("1.2"),
+				draftVersionJournalArticle.getVersion()));
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_DRAFT,
+			draftVersionJournalArticle.getStatus());
+
+		String draftVersionTitle = draftVersionJournalArticle.getTitle(locale);
+
+		Assert.assertNotEquals(draftVersionTitle, secondVersionTitle);
+
+		LayoutPageTemplateEntry layoutPageTemplateEntry =
+			DisplayPageTemplateTestUtil.addDisplayPageTemplate(
+				_group.getGroupId(),
+				_portal.getClassNameId(JournalArticle.class.getName()),
+				firstVersionJournalArticle.getDDMStructureKey(), true,
+				WorkflowConstants.STATUS_APPROVED);
+
+		String friendlyURL =
+			_layoutDisplayPageProvider.getURLSeparator() +
+				secondVersionJournalArticle.getUrlTitle(locale);
+
+		_testGetActualURLWithDisplayPageTemplateAndVersion(
+			layoutPageTemplateEntry.getPlid(), firstVersionTitle, friendlyURL,
+			"1.0");
+
+		_testGetActualURLWithDisplayPageTemplateAndVersion(
+			layoutPageTemplateEntry.getPlid(), secondVersionTitle, friendlyURL,
+			"1.1");
+
+		_testGetActualURLWithDisplayPageTemplateAndVersion(
+			layoutPageTemplateEntry.getPlid(), draftVersionTitle, friendlyURL,
+			"1.2");
+
+		_testGetActualURLWithDisplayPageTemplateAndVersion(
+			layoutPageTemplateEntry.getPlid(), secondVersionTitle, friendlyURL,
+			null);
 	}
 
 	@Test
@@ -304,11 +411,56 @@ public class PortalImplActualURLTest {
 		}
 	}
 
+	private void _testGetActualURLWithDisplayPageTemplateAndVersion(
+			long expectedPlid, String expectedTitle, String friendlyURL,
+			String version)
+		throws Exception {
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest(Method.GET, "/");
+
+		Assert.assertEquals(
+			expectedPlid,
+			MapUtil.getLong(
+				HttpComponentsUtil.getParameterMap(
+					HttpComponentsUtil.getQueryString(
+						_portal.getActualURL(
+							_group.getGroupId(), false, Portal.PATH_MAIN,
+							friendlyURL,
+							HashMapBuilder.put(
+								"version",
+								() -> {
+									if (Validator.isNull(version)) {
+										return null;
+									}
+
+									return new String[] {version};
+								}
+							).build(),
+							HashMapBuilder.<String, Object>put(
+								"request", mockHttpServletRequest
+							).build()))),
+				"p_l_id"));
+
+		ListMergeable<String> titleListMergeable =
+			(ListMergeable<String>)mockHttpServletRequest.getAttribute(
+				WebKeys.PAGE_TITLE);
+
+		Assert.assertEquals(
+			expectedTitle, titleListMergeable.mergeToString(StringPool.COMMA));
+	}
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		PortalImplActualURLTest.class);
 
 	@DeleteAfterTestRun
 	private Group _group;
+
+	@Inject(
+		filter = "component.name=com.liferay.journal.web.internal.layout.display.page.JournalArticleLayoutDisplayPageProvider"
+	)
+	private LayoutDisplayPageProvider<JournalArticle>
+		_layoutDisplayPageProvider;
 
 	@Inject
 	private LayoutLocalService _layoutLocalService;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-86119

## Summary
This PR resolves **[LPD-86119](https://liferay.atlassian.net/browse/LPD-86119)**. The fix addresses issues in asset retrieval where the resource primary key was being incorrectly used as the asset entry classPK, and provides fallbacks for journal articles without asset entries.

## Proposed Solution
The logic has been refined to handle edge cases in asset mapping and versioning:

* **Correct ClassPK Retrieval:** Replaced the direct use of info item classPKs with `AssetRendererFactory.getAssetEntryClassPK()`. This ensures the correct ID is used when dealing with resource models where these two values can differ.
* **Handling Null Asset Entries:** Added fallbacks and null safety checks for cases where an article (particularly older versions) does not have a corresponding entry in the `AssetEntry` table.
* **Integration Testing:** Added a new integration test that reproduces the mismatch scenario to ensure long-term stability.