### PR TITLE
LPD-85488: Let lastPostDate to be imported and preserve modification date at import

### DIFF
--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/exportimport/data/handler/WikiNodeStagedModelDataHandler.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/exportimport/data/handler/WikiNodeStagedModelDataHandler.java
@@ -130,6 +130,8 @@ public class WikiNodeStagedModelDataHandler
 		ServiceContext serviceContext = portletDataContext.createServiceContext(
 			node);
 
+		serviceContext.setAttribute("lastPostDate", node.getLastPostDate());
+
 		WikiNode importedNode = null;
 
 		WikiNode existingNode = fetchStagedModelByUuidAndGroupId(

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiNodeLocalServiceImpl.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiNodeLocalServiceImpl.java
@@ -7,6 +7,7 @@ package com.liferay.wiki.service.impl;
 
 import com.liferay.asset.kernel.service.AssetTagLocalService;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
+import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.aop.AopService;
@@ -136,6 +137,8 @@ public class WikiNodeLocalServiceImpl extends WikiNodeLocalServiceBaseImpl {
 		node.setUserName(user.getFullName());
 		node.setName(name);
 		node.setDescription(description);
+
+		_setLastPostDate(node, serviceContext);
 
 		try {
 			node = wikiNodePersistence.update(node);
@@ -512,7 +515,9 @@ public class WikiNodeLocalServiceImpl extends WikiNodeLocalServiceBaseImpl {
 		node.setName(name);
 		node.setDescription(description);
 
-		return wikiNodePersistence.update(node);
+		_setLastPostDate(node, serviceContext);
+
+		return wikiNodePersistence.update(node, serviceContext);
 	}
 
 	@Override
@@ -608,6 +613,22 @@ public class WikiNodeLocalServiceImpl extends WikiNodeLocalServiceBaseImpl {
 			}
 
 			_wikiPageLocalService.restorePageFromTrash(userId, page);
+		}
+	}
+
+	private void _setLastPostDate(
+		WikiNode node, ServiceContext serviceContext) {
+
+		if (!ExportImportThreadLocal.isImportInProcess() &&
+			!ExportImportThreadLocal.isStagingInProcess()) {
+
+			return;
+		}
+
+		Date lastPostDate = (Date)serviceContext.getAttribute("lastPostDate");
+
+		if (lastPostDate != null) {
+			node.setLastPostDate(lastPostDate);
 		}
 	}
 

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiPageLocalServiceImpl.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiPageLocalServiceImpl.java
@@ -17,6 +17,7 @@ import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.expando.kernel.model.ExpandoBridge;
 import com.liferay.expando.kernel.service.ExpandoRowLocalService;
 import com.liferay.expando.kernel.util.ExpandoBridgeUtil;
+import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
 import com.liferay.petra.function.transform.TransformUtil;
@@ -306,8 +307,7 @@ public class WikiPageLocalServiceImpl extends WikiPageLocalServiceBaseImpl {
 
 		// Node
 
-		wikiPageLocalService.updateLastPostDate(
-			node.getNodeId(), serviceContext.getModifiedDate(date));
+		_setLastPostDate(serviceContext.getModifiedDate(date), nodeId);
 
 		// Asset
 
@@ -3307,6 +3307,14 @@ public class WikiPageLocalServiceImpl extends WikiPageLocalServiceBaseImpl {
 		return page;
 	}
 
+	private void _setLastPostDate(Date date, long nodeId) {
+		if (!ExportImportThreadLocal.isImportInProcess() &&
+			!ExportImportThreadLocal.isStagingInProcess()) {
+
+			wikiPageLocalService.updateLastPostDate(nodeId, date);
+		}
+	}
+
 	private void _setParameter(
 		String name, StringBundler sb, ServiceContext serviceContext,
 		String value) {
@@ -3428,8 +3436,7 @@ public class WikiPageLocalServiceImpl extends WikiPageLocalServiceBaseImpl {
 
 		// Node
 
-		wikiPageLocalService.updateLastPostDate(
-			nodeId, serviceContext.getModifiedDate(date));
+		_setLastPostDate(serviceContext.getModifiedDate(date), nodeId);
 
 		// Asset
 

--- a/modules/apps/wiki/wiki-test/src/testIntegration/java/com/liferay/wiki/internal/exportimport/data/handler/test/WikiNodeStagedModelDataHandlerTest.java
+++ b/modules/apps/wiki/wiki-test/src/testIntegration/java/com/liferay/wiki/internal/exportimport/data/handler/test/WikiNodeStagedModelDataHandlerTest.java
@@ -13,6 +13,7 @@ import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.StagedModel;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.props.test.util.PropsTemporarySwapper;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -81,6 +82,48 @@ public class WikiNodeStagedModelDataHandlerTest
 		}
 	}
 
+	@Test
+	@TestInfo("LPD-85488")
+	public void testExportImportPreservesLastPostDate() throws Exception {
+		initExport();
+
+		Map<String, List<StagedModel>> dependentStagedModelsMap =
+			addDependentStagedModelsMap(stagingGroup);
+
+		StagedModel stagedModel = addStagedModel(
+			stagingGroup, dependentStagedModelsMap);
+
+		WikiNode wikiNode = (WikiNode)stagedModel;
+
+		wikiNode.setLastPostDate(new Date());
+
+		StagedModelDataHandlerUtil.exportStagedModel(
+			portletDataContext, stagedModel);
+
+		try (SafeCloseable safeCloseable = initImportWithSafeCloseable()) {
+			StagedModel exportedStagedModel = readExportedStagedModel(
+				stagedModel);
+
+			ExportImportThreadLocal.setLayoutImportInProcess(true);
+
+			StagedModelDataHandlerUtil.importStagedModel(
+				portletDataContext, exportedStagedModel);
+
+			StagedModel importedStagedModel = getStagedModel(
+				exportedStagedModel.getUuid(), liveGroup);
+
+			WikiNode exportedWikiNode = (WikiNode)exportedStagedModel;
+			WikiNode importedWikiNode = (WikiNode)importedStagedModel;
+
+			Assert.assertEquals(
+				exportedWikiNode.getLastPostDate(),
+				importedWikiNode.getLastPostDate());
+		}
+		finally {
+			ExportImportThreadLocal.setLayoutImportInProcess(false);
+		}
+	}
+
 	@Override
 	@Test
 	public void testExportImportWithDefaultData() throws Exception {
@@ -120,41 +163,6 @@ public class WikiNodeStagedModelDataHandlerTest
 
 				Assert.assertNull(exportedStagedModel);
 			}
-		}
-	}
-
-	@Test
-	public void testLastPostDate() throws Exception {
-		initExport();
-
-		Map<String, List<StagedModel>> dependentStagedModelsMap =
-			addDependentStagedModelsMap(stagingGroup);
-
-		StagedModel stagedModel = addStagedModel(
-			stagingGroup, dependentStagedModelsMap);
-
-		WikiNode wikiNode = (WikiNode)stagedModel;
-
-		wikiNode.setLastPostDate(new Date());
-
-		StagedModelDataHandlerUtil.exportStagedModel(
-			portletDataContext, stagedModel);
-
-		try (SafeCloseable safeCloseable = initImportWithSafeCloseable()) {
-			StagedModel exportedStagedModel = readExportedStagedModel(
-				stagedModel);
-
-			ExportImportThreadLocal.setLayoutImportInProcess(true);
-
-			StagedModelDataHandlerUtil.importStagedModel(
-				portletDataContext, exportedStagedModel);
-
-			validateImportedStagedModel(
-				exportedStagedModel,
-				getStagedModel(exportedStagedModel.getUuid(), liveGroup));
-		}
-		finally {
-			ExportImportThreadLocal.setLayoutImportInProcess(false);
 		}
 	}
 

--- a/modules/apps/wiki/wiki-test/src/testIntegration/java/com/liferay/wiki/internal/exportimport/data/handler/test/WikiNodeStagedModelDataHandlerTest.java
+++ b/modules/apps/wiki/wiki-test/src/testIntegration/java/com/liferay/wiki/internal/exportimport/data/handler/test/WikiNodeStagedModelDataHandlerTest.java
@@ -6,6 +6,7 @@
 package com.liferay.wiki.internal.exportimport.data.handler.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.exportimport.kernel.lar.StagedModelDataHandlerUtil;
 import com.liferay.exportimport.test.util.lar.BaseStagedModelDataHandlerTestCase;
 import com.liferay.petra.lang.SafeCloseable;
@@ -19,6 +20,7 @@ import com.liferay.wiki.model.WikiNode;
 import com.liferay.wiki.service.WikiNodeLocalServiceUtil;
 import com.liferay.wiki.test.util.WikiTestUtil;
 
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -118,6 +120,41 @@ public class WikiNodeStagedModelDataHandlerTest
 
 				Assert.assertNull(exportedStagedModel);
 			}
+		}
+	}
+
+	@Test
+	public void testLastPostDate() throws Exception {
+		initExport();
+
+		Map<String, List<StagedModel>> dependentStagedModelsMap =
+			addDependentStagedModelsMap(stagingGroup);
+
+		StagedModel stagedModel = addStagedModel(
+			stagingGroup, dependentStagedModelsMap);
+
+		WikiNode wikiNode = (WikiNode)stagedModel;
+
+		wikiNode.setLastPostDate(new Date());
+
+		StagedModelDataHandlerUtil.exportStagedModel(
+			portletDataContext, stagedModel);
+
+		try (SafeCloseable safeCloseable = initImportWithSafeCloseable()) {
+			StagedModel exportedStagedModel = readExportedStagedModel(
+				stagedModel);
+
+			ExportImportThreadLocal.setLayoutImportInProcess(true);
+
+			StagedModelDataHandlerUtil.importStagedModel(
+				portletDataContext, exportedStagedModel);
+
+			validateImportedStagedModel(
+				exportedStagedModel,
+				getStagedModel(exportedStagedModel.getUuid(), liveGroup));
+		}
+		finally {
+			ExportImportThreadLocal.setLayoutImportInProcess(false);
 		}
 	}
 

--- a/modules/apps/wiki/wiki-test/src/testIntegration/java/com/liferay/wiki/internal/exportimport/data/handler/test/WikiPageStagedModelDataHandlerTest.java
+++ b/modules/apps/wiki/wiki-test/src/testIntegration/java/com/liferay/wiki/internal/exportimport/data/handler/test/WikiPageStagedModelDataHandlerTest.java
@@ -29,10 +29,12 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.Constants;
+import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.wiki.attachments.test.WikiAttachmentsTest;
 import com.liferay.wiki.model.WikiNode;
 import com.liferay.wiki.model.WikiPage;
+import com.liferay.wiki.service.WikiNodeLocalService;
 import com.liferay.wiki.service.WikiNodeLocalServiceUtil;
 import com.liferay.wiki.service.WikiPageLocalServiceUtil;
 import com.liferay.wiki.service.WikiPageServiceUtil;
@@ -60,41 +62,6 @@ public class WikiPageStagedModelDataHandlerTest
 	@Rule
 	public static final AggregateTestRule aggregateTestRule =
 		new LiferayIntegrationTestRule();
-
-	@Test
-	public void testAtImportWikiNodePreservesLastPostDateWhenWikiPagesAdded()
-		throws Exception {
-
-		Map<String, List<StagedModel>> dependentStagedModelsMap =
-			addDependentStagedModelsMap(stagingGroup);
-
-		List<StagedModel> dependentStagedModels = dependentStagedModelsMap.get(
-			WikiNode.class.getSimpleName());
-
-		WikiNode wikiNode1 = (WikiNode)dependentStagedModels.get(0);
-
-		WikiPage wikiPage = WikiTestUtil.addPage(
-			TestPropsValues.getUserId(), wikiNode1.getNodeId(),
-			RandomTestUtil.randomString(), RandomTestUtil.randomString(), true,
-			ServiceContextTestUtil.getServiceContext(
-				stagingGroup.getGroupId()));
-
-		try {
-			ExportImportThreadLocal.setLayoutImportInProcess(true);
-
-			exportImportStagedModel(wikiPage);
-		}
-		finally {
-			ExportImportThreadLocal.setLayoutImportInProcess(false);
-		}
-
-		WikiNode wikiNode2 =
-			WikiNodeLocalServiceUtil.getWikiNodeByUuidAndGroupId(
-				wikiNode1.getUuid(), liveGroup.getGroupId());
-
-		Assert.assertEquals(
-			wikiNode1.getLastPostDate(), wikiNode2.getLastPostDate());
-	}
 
 	@Test
 	public void testDeleteAttachmentsFileEntry() throws Exception {
@@ -161,6 +128,41 @@ public class WikiPageStagedModelDataHandlerTest
 
 		Assert.assertEquals(
 			1, importedWikiPage.getAttachmentsFileEntriesCount());
+	}
+
+	@Test
+	public void testWikiNodePreservesLastPostDateOnImport() throws Exception {
+		Map<String, List<StagedModel>> dependentStagedModelsMap =
+			addDependentStagedModelsMap(stagingGroup);
+
+		List<StagedModel> dependentStagedModels = dependentStagedModelsMap.get(
+			WikiNode.class.getSimpleName());
+
+		WikiNode wikiNode1 = (WikiNode)dependentStagedModels.get(0);
+
+		WikiPage wikiPage = WikiTestUtil.addPage(
+			TestPropsValues.getUserId(), wikiNode1.getNodeId(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(), true,
+			ServiceContextTestUtil.getServiceContext(
+				stagingGroup.getGroupId()));
+
+		wikiNode1 = _wikiNodeLocalService.getWikiNode(wikiNode1.getNodeId());
+
+		try {
+			ExportImportThreadLocal.setLayoutImportInProcess(true);
+
+			exportImportStagedModel(wikiPage);
+		}
+		finally {
+			ExportImportThreadLocal.setLayoutImportInProcess(false);
+		}
+
+		WikiNode wikiNode2 =
+			WikiNodeLocalServiceUtil.getWikiNodeByUuidAndGroupId(
+				wikiNode1.getUuid(), liveGroup.getGroupId());
+
+		Assert.assertEquals(
+			wikiNode1.getLastPostDate(), wikiNode2.getLastPostDate());
 	}
 
 	@Override
@@ -402,5 +404,8 @@ public class WikiPageStagedModelDataHandlerTest
 		Assert.assertEquals(
 			page.getRedirectTitle(), importedPage.getRedirectTitle());
 	}
+
+	@Inject
+	private WikiNodeLocalService _wikiNodeLocalService;
 
 }

--- a/modules/apps/wiki/wiki-test/src/testIntegration/java/com/liferay/wiki/internal/exportimport/data/handler/test/WikiPageStagedModelDataHandlerTest.java
+++ b/modules/apps/wiki/wiki-test/src/testIntegration/java/com/liferay/wiki/internal/exportimport/data/handler/test/WikiPageStagedModelDataHandlerTest.java
@@ -11,6 +11,7 @@ import com.liferay.document.library.kernel.exception.NoSuchFolderException;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFolder;
 import com.liferay.exportimport.kernel.lar.ExportImportClassedModelUtil;
+import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.exportimport.kernel.lar.StagedModelDataHandler;
 import com.liferay.exportimport.kernel.lar.StagedModelDataHandlerRegistryUtil;
 import com.liferay.exportimport.test.util.lar.BaseWorkflowedStagedModelDataHandlerTestCase;
@@ -59,6 +60,41 @@ public class WikiPageStagedModelDataHandlerTest
 	@Rule
 	public static final AggregateTestRule aggregateTestRule =
 		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testAtImportWikiNodePreservesLastPostDateWhenWikiPagesAdded()
+		throws Exception {
+
+		Map<String, List<StagedModel>> dependentStagedModelsMap =
+			addDependentStagedModelsMap(stagingGroup);
+
+		List<StagedModel> dependentStagedModels = dependentStagedModelsMap.get(
+			WikiNode.class.getSimpleName());
+
+		WikiNode wikiNode1 = (WikiNode)dependentStagedModels.get(0);
+
+		WikiPage wikiPage = WikiTestUtil.addPage(
+			TestPropsValues.getUserId(), wikiNode1.getNodeId(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(), true,
+			ServiceContextTestUtil.getServiceContext(
+				stagingGroup.getGroupId()));
+
+		try {
+			ExportImportThreadLocal.setLayoutImportInProcess(true);
+
+			exportImportStagedModel(wikiPage);
+		}
+		finally {
+			ExportImportThreadLocal.setLayoutImportInProcess(false);
+		}
+
+		WikiNode wikiNode2 =
+			WikiNodeLocalServiceUtil.getWikiNodeByUuidAndGroupId(
+				wikiNode1.getUuid(), liveGroup.getGroupId());
+
+		Assert.assertEquals(
+			wikiNode1.getLastPostDate(), wikiNode2.getLastPostDate());
+	}
 
 	@Test
 	public void testDeleteAttachmentsFileEntry() throws Exception {

--- a/modules/apps/wiki/wiki-test/src/testIntegration/java/com/liferay/wiki/internal/exportimport/data/handler/test/WikiPageStagedModelDataHandlerTest.java
+++ b/modules/apps/wiki/wiki-test/src/testIntegration/java/com/liferay/wiki/internal/exportimport/data/handler/test/WikiPageStagedModelDataHandlerTest.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.service.RepositoryLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
@@ -131,6 +132,7 @@ public class WikiPageStagedModelDataHandlerTest
 	}
 
 	@Test
+	@TestInfo("LPD-85488")
 	public void testWikiNodePreservesLastPostDateOnImport() throws Exception {
 		Map<String, List<StagedModel>> dependentStagedModelsMap =
 			addDependentStagedModelsMap(stagingGroup);


### PR DESCRIPTION
- https://liferay.atlassian.net/browse/LPD-84210
  - https://liferay.atlassian.net/browse/LPD-86116
  - https://liferay.atlassian.net/browse/LPD-85488

These are based on the findings in [liferay.com testing epic](https://liferay.atlassian.net/browse/LPD-84210). Last post date was not imported and source modification date were locally overwritten at consecutive imports.