### PR TITLE
LPD-85940 Search results widget warnings triggered by folder navigation

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info_panel.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info_panel.jsp
@@ -82,6 +82,7 @@ List<Folder> folders = dlInfoPanelDisplayContext.getFolders();
 							</dd>
 
 							<%
+							request.setAttribute("info_panel_location.jsp-groupId", folder.getGroupId());
 							request.setAttribute("info_panel_location.jsp-parentFolder", folder.getParentFolder());
 							%>
 

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info_panel_file_entry.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info_panel_file_entry.jsp
@@ -396,6 +396,7 @@ long assetClassPK = DLAssetHelperUtil.getAssetClassPK(fileEntry, fileVersion);
 				</dd>
 
 				<%
+				request.setAttribute("info_panel_location.jsp-groupId", fileEntry.getGroupId());
 				request.setAttribute("info_panel_location.jsp-parentFolder", fileEntry.getFolder());
 				%>
 

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info_panel_location.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info_panel_location.jsp
@@ -20,7 +20,16 @@ long parentFolderId = (parentFolder == null) ? DLFolderConstants.DEFAULT_PARENT_
 	<dd class="sidebar-dd">
 
 		<%
-		PortletURL viewFolderURL = liferayPortletResponse.createRenderURL();
+		long groupId = GetterUtil.getLong(request.getAttribute("info_panel_location.jsp-groupId"));
+
+		PortletURL viewFolderURL = null;
+
+		if (groupId > 0) {
+			viewFolderURL = PortalUtil.getControlPanelPortletURL(request, GroupLocalServiceUtil.getGroup(groupId), PortletProviderUtil.getPortletId(Folder.class.getName(), PortletProvider.Action.MANAGE), groupId, 0, PortletRequest.RENDER_PHASE);
+		}
+		else {
+			viewFolderURL = liferayPortletResponse.createRenderURL();
+		}
 
 		if (parentFolderId == DLFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
 			viewFolderURL.setParameter("mvcRenderCommandName", "/document_library/view");

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/init.jsp
@@ -157,6 +157,8 @@ page import="com.liferay.portal.kernel.model.Portlet" %><%@
 page import="com.liferay.portal.kernel.model.Repository" %><%@
 page import="com.liferay.portal.kernel.model.User" %><%@
 page import="com.liferay.portal.kernel.portlet.LiferayWindowState" %><%@
+page import="com.liferay.portal.kernel.portlet.PortletProvider" %><%@
+page import="com.liferay.portal.kernel.portlet.PortletProviderUtil" %><%@
 page import="com.liferay.portal.kernel.portlet.PortletURLUtil" %><%@
 page import="com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder" %><%@
 page import="com.liferay.portal.kernel.repository.AuthenticationRepositoryException" %><%@
@@ -206,7 +208,8 @@ page import="com.liferay.taglib.search.ResultRow" %><%@
 page import="com.liferay.taglib.servlet.PipingServletResponseFactory" %><%@
 page import="com.liferay.trash.model.TrashEntry" %>
 
-<%@ page import="jakarta.portlet.PortletURL" %>
+<%@ page import="jakarta.portlet.PortletRequest" %><%@
+page import="jakarta.portlet.PortletURL" %>
 
 <%@ page import="java.text.DecimalFormatSymbols" %><%@
 page import="java.text.Format" %>

--- a/modules/test/playwright/tests/document-library-web/main/dmPreview.spec.ts
+++ b/modules/test/playwright/tests/document-library-web/main/dmPreview.spec.ts
@@ -8,6 +8,7 @@ import {expect, mergeTests} from '@playwright/test';
 import {documentLibraryPagesTest} from '../../../fixtures/documentLibraryPages.fixtures';
 import {isolatedSiteTest} from '../../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../../fixtures/loginTest';
+import getRandomString from '../../../utils/getRandomString';
 
 const test = mergeTests(
 	documentLibraryPagesTest,
@@ -19,7 +20,7 @@ test(
 	'DM Preview page has not a fixed navbar',
 	{tag: '@LPD-26290'},
 	async ({documentLibraryEditFilePage, documentLibraryPage, page, site}) => {
-		const title = 'DM File Entry title';
+		const title = getRandomString();
 
 		await documentLibraryEditFilePage.publishNewBasicFileEntry(
 			title,
@@ -41,5 +42,40 @@ test(
 		await expect(navItemPosition).not.toBe('fixed');
 
 		await documentLibraryPage.goto(site.friendlyUrlPath);
+	}
+);
+
+test(
+	'Verify location link from file info panel',
+	{tag: '@LPD-85940'},
+	async ({documentLibraryEditFilePage, page, site}) => {
+		const title = getRandomString();
+
+		await documentLibraryEditFilePage.publishNewBasicFileEntry(
+			title,
+			site.friendlyUrlPath
+		);
+
+		await page.getByRole('link', {name: title}).first().click();
+
+		const infoButton = page.locator('[data-qa-id="infoButton"]');
+
+		await expect(infoButton).toBeVisible();
+		await infoButton.click();
+
+		const sidebar = page.locator(
+			'#_com_liferay_document_library_web_portlet_DLAdminPortlet_ContextualSidebar.contextual-sidebar-visible'
+		);
+
+		await expect(sidebar).toBeVisible();
+
+		const locationLink = sidebar.locator('dt:has-text("Location") + dd a');
+
+		await expect(locationLink).toBeVisible();
+
+		await expect(locationLink).toHaveAttribute(
+			'href',
+			new RegExp(`/group${site.friendlyUrlPath}/~/control_panel/manage`)
+		);
 	}
 );


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-85940

The Search Results widget appears blank, and a warning message is displayed indicating either /document_library/view or /document_library/view_folder, depending on whether the file is stored in the default Documents and Media folder or within a subfolder.

# How am I fixing it?

Generate control panel url based on groupId

# How can you verify that it works?

Follow the steps described in https://liferay.atlassian.net/browse/LPD-85940