### PR TITLE
LPD-85991 Links to view all Content, Files and Connected Sites of a space are missing

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewSpaceContentsSummarySectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewSpaceContentsSummarySectionDisplayContext.java
@@ -10,6 +10,7 @@ import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectDefinitionService;
 import com.liferay.object.service.ObjectDefinitionSettingLocalService;
 import com.liferay.object.service.ObjectEntryFolderLocalService;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
@@ -81,9 +82,10 @@ public class ViewSpaceContentsSummarySectionDisplayContext
 					themeDisplay.getCompanyId());
 
 		return SpaceSummaryHeaderUtil.getSpaceSummaryHeaderProps(
-			getAPIURL(), getCreationMenu(), httpServletRequest,
-			"view-all-content", Collections.emptyMap(), Collections.emptyMap(),
-			"content",
+			getAPIURL() + StringPool.AMPERSAND +
+				getAdditionalAPIURLParameters(),
+			getCreationMenu(), httpServletRequest, "view-all-content",
+			Collections.emptyMap(), Collections.emptyMap(), "content",
 			ActionUtil.getBaseViewFolderURL(themeDisplay) +
 				objectEntryFolder.getObjectEntryFolderId());
 	}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewSpaceFilesSummarySectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewSpaceFilesSummarySectionDisplayContext.java
@@ -11,6 +11,7 @@ import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectDefinitionService;
 import com.liferay.object.service.ObjectDefinitionSettingLocalService;
 import com.liferay.object.service.ObjectEntryFolderLocalService;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
@@ -73,9 +74,10 @@ public class ViewSpaceFilesSummarySectionDisplayContext
 					themeDisplay.getCompanyId());
 
 		return SpaceSummaryHeaderUtil.getSpaceSummaryHeaderProps(
-			getAPIURL(), getCreationMenu(), httpServletRequest,
-			"view-all-files", Collections.emptyMap(), Collections.emptyMap(),
-			"files",
+			getAPIURL() + StringPool.AMPERSAND +
+				getAdditionalAPIURLParameters(),
+			getCreationMenu(), httpServletRequest, "view-all-files",
+			Collections.emptyMap(), Collections.emptyMap(), "files",
 			ActionUtil.getBaseViewFolderURL(themeDisplay) +
 				objectEntryFolder.getObjectEntryFolderId());
 	}

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/pages/DataSetPage.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/pages/DataSetPage.ts
@@ -82,6 +82,7 @@ export class DataSetPage {
 		await clickAndExpectToBeVisible({
 			autoClick: true,
 			target: this.page.getByRole('menuitem', {
+				exact: true,
 				name: action,
 			}),
 			timeout,

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/pages/SpaceSummaryPage.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/pages/SpaceSummaryPage.ts
@@ -46,7 +46,7 @@ export class SpaceSummaryPage {
 			name: 'View All Content',
 		});
 
-		this.viewAllFilesLink = this.page.getByRole('link', {
+		this.viewAllFilesLink = this.page.getByRole('button', {
 			name: 'View All Files',
 		});
 

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/spaceSummary.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/spaceSummary.spec.ts
@@ -119,6 +119,30 @@ test(
 );
 
 test(
+	'View All Files link is not rendered when there are no files',
+	{tag: '@LPD-85991'},
+	async ({apiHelpers, spaceSummaryPage}) => {
+		const spaceName = `Space ${getRandomString()}`;
+
+		await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			settings: {
+				logoColor: 'outline-3',
+			},
+			type: 'Space',
+		});
+
+		await spaceSummaryPage.goto(spaceName);
+
+		await expect(spaceSummaryPage.viewAllFilesLink).not.toBeVisible();
+
+		await spaceSummaryPage.createFileFolder('Folder' + getRandomInt());
+
+		await expect(spaceSummaryPage.viewAllFilesLink).toBeVisible();
+	}
+);
+
+test(
 	'Can view added files in the space summary page',
 	{tag: '@LPD-62706'},
 	async ({apiHelpers, page, spaceSummaryPage}) => {
@@ -165,6 +189,30 @@ test(
 
 		await expect(page.getByRole('link', {name: spaceName})).toBeVisible();
 		expect(page.getByRole('link', {name: 'Contents'})).toBeVisible();
+	}
+);
+
+test(
+	'View All Content link is not rendered when there is no content',
+	{tag: '@LPD-85991'},
+	async ({apiHelpers, spaceSummaryPage}) => {
+		const spaceName = `Space ${getRandomString()}`;
+
+		await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			settings: {
+				logoColor: 'outline-3',
+			},
+			type: 'Space',
+		});
+
+		await spaceSummaryPage.goto(spaceName);
+
+		await expect(spaceSummaryPage.viewAllContentLink).not.toBeVisible();
+
+		await spaceSummaryPage.createContentFolder('Folder' + getRandomInt());
+
+		await expect(spaceSummaryPage.viewAllContentLink).toBeVisible();
 	}
 );
 

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/spaceSummary.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/spaceSummary.spec.ts
@@ -260,7 +260,7 @@ test(
 
 		await spaceSummaryPage.goto(spaceName);
 
-		expect(page.getByText(file1Title)).toBeVisible();
+		await expect(page.getByRole('link', {name: file1Title})).toBeVisible();
 
 		await apiHelpers.objectEntry.deleteObjectEntry(
 			applicationName,


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-85991

The links to access the full listing of files/contents is never rendered.

# How am I fixing it?

The api url used to retrieve the results was incorrect, it was missing essential parameters and always returned zero results, so the component always behaved as if there never was any content.  Using the correct url by appending all necessary parameters fixes the issue.

# How can you verify that it works?

Run the included functional tests.