### PR TITLE
LPD-86323 Use structure key when creating a display page template

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/ddmstructure/JSONDDMstructureAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/ddmstructure/JSONDDMstructureAPI.macro
@@ -91,4 +91,32 @@ definition {
 		return ${structureIds};
 	}
 
+	@summary = "Default summary"
+	macro _getStructureKey(structureName = null, groupId = null, classNameId = null) {
+		Variables.assertDefined(parameterList = "${classNameId},${groupId},${structureName}");
+
+		var portalURL = JSONCompany.getPortalURL();
+		var companyId = JSONCompany.getCompanyId();
+		var userLoginInfo = JSONUtil2.formatJSONUser();
+
+		var curl = '''
+			${portalURL}/api/jsonws/ddm.ddmstructure/get-structures \
+				-u ${userLoginInfo} \
+				-d companyId=${companyId} \
+				-d groupIds=[${groupId}] \
+				-d classNameId=${classNameId} \
+				-d "start=-1" \
+				-d "end=-1" \
+				-d -orderByComparator=
+		''';
+
+		var structureKey = JSONCurlUtil.post(${curl}, "$.[?(@['nameCurrentValue'] == '${structureName}')]['structureKey']");
+
+		if (${structureKey} == "") {
+			fail("FAIL. Cannot find structureKey.");
+		}
+
+		return ${structureKey};
+	}
+
 }

--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/layoutpagetemplate/JSONLayoutpagetemplateSetter.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/layoutpagetemplate/JSONLayoutpagetemplateSetter.macro
@@ -38,7 +38,7 @@ definition {
 	macro setClassTypeKey(structureName = null, groupId = null, classNameId = null) {
 		Variables.assertDefined(parameterList = "${classNameId},${groupId},${structureName}");
 
-		var classTypeKey = JSONDDMstructureAPI._getStructureId(
+		var classTypeKey = JSONDDMstructureAPI._getStructureKey(
 			classNameId = ${classNameId},
 			groupId = ${groupId},
 			structureName = ${structureName});


### PR DESCRIPTION
There are some failing tests because we are trying to create a display page template using the structrureId as the classTypeKey instead of the structureKey. 

The tests detected that fail due to this are:

https://testray.liferay.com/#/testflow/466210152/subtasks/466210162 and https://testray.liferay.com/#/testflow/466210152/subtasks/466210160 