### PR TITLE
LPD-86256 Remove icons from “Add Category” and “View Categories” in the actions menu

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewCategoriesDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewCategoriesDisplayContext.java
@@ -179,7 +179,7 @@ public class ViewCategoriesDisplayContext {
 								_themeDisplay),
 							"parentCategoryId", "{id}", "vocabularyId",
 							"{taxonomyVocabularyId}"),
-						"plus", "add-subcategory",
+						null, "add-subcategory",
 						_language.get(_httpServletRequest, "add-subcategory"),
 						"get", "update", null),
 					new FDSActionDropdownItem(
@@ -191,7 +191,7 @@ public class ViewCategoriesDisplayContext {
 								_themeDisplay),
 							"categoryId", "{id}", "vocabularyId",
 							"{taxonomyVocabularyId}"),
-						"categories", "view-categories",
+						null, "view-categories",
 						_language.get(
 							_httpServletRequest, "view-subcategories"),
 						"get", null, null),

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewVocabulariesDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewVocabulariesDisplayContext.java
@@ -106,7 +106,7 @@ public class ViewVocabulariesDisplayContext {
 									"/categorization/new-category"),
 								_themeDisplay),
 							"vocabularyId", "{id}"),
-						"plus", "add-category",
+						null, "add-category",
 						LanguageUtil.get(_httpServletRequest, "add-category"),
 						"get", "update", null),
 					new FDSActionDropdownItem(
@@ -117,7 +117,7 @@ public class ViewVocabulariesDisplayContext {
 									"/categorization/view-categories"),
 								_themeDisplay),
 							"vocabularyId", "{id}"),
-						"categories", "view-categories",
+						null, "view-categories",
 						LanguageUtil.get(
 							_httpServletRequest, "view-categories"),
 						"get", null, null))


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-86256

When opening the actions menu for categories, the following options currently display icons:

- Add Category
- View Categories
- Add Subcategory
- View Subcategory

These options should not include any icons. 

# How am I fixing it?

Remove the icons from the related actions.

# How can you verify that it works?
<img width="270" height="342" alt="Screenshot from 2026-04-15 12-26-44" src="https://github.com/user-attachments/assets/6e3e6af5-1732-420b-bb9b-00f6a5ce458f" />
<img width="258" height="240" alt="Screenshot from 2026-04-15 12-26-02" src="https://github.com/user-attachments/assets/3234b837-cb8c-4682-8281-e0c6f05bf19b" />

