### PR TITLE
LPD-86051 Modify shared content and notifications url to link to the new view asset

### DIFF
--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/asset/model/ObjectEntryAssetRenderer.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/asset/model/ObjectEntryAssetRenderer.java
@@ -32,15 +32,16 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
+import com.liferay.portal.kernel.portlet.PortletURLFactoryUtil;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
+import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.trash.TrashRenderer;
 import com.liferay.portal.kernel.util.Constants;
-import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
@@ -253,18 +254,24 @@ public class ObjectEntryAssetRenderer
 			return getURLViewInContext(themeDisplay, StringPool.BLANK);
 		}
 
-		String mode = Constants.READ;
+		PortletURL portletURL = PortletURLFactoryUtil.create(
+			themeDisplay.getRequest(), _getPortletDisplayId(themeDisplay),
+			PortletRequest.RENDER_PHASE);
 
 		if (editable) {
-			mode = Constants.EDIT;
+			return StringBundler.concat(
+				themeDisplay.getPortalURL(), themeDisplay.getPathMain(),
+				GroupConstants.CMS_FRIENDLY_URL,
+				"/edit_content_item?objectEntryId=",
+				_objectEntry.getObjectEntryId(), "&p_l_mode=", Constants.EDIT,
+				"&redirect=", portletURL);
 		}
 
 		return StringBundler.concat(
-			themeDisplay.getPortalURL(), themeDisplay.getPathMain(),
-			GroupConstants.CMS_FRIENDLY_URL,
-			"/edit_content_item?objectEntryId=",
-			_objectEntry.getObjectEntryId(), "&p_l_mode=", mode, "&redirect=",
-			HtmlUtil.escapeURL(themeDisplay.getURLCurrent()));
+			themeDisplay.getPortalURL(),
+			themeDisplay.getPathFriendlyURLPublic(),
+			GroupConstants.CMS_FRIENDLY_URL, "/view-asset?objectEntryId=",
+			_objectEntry.getObjectEntryId(), "&backURL=", portletURL);
 	}
 
 	@Override
@@ -394,6 +401,16 @@ public class ObjectEntryAssetRenderer
 		}
 
 		return permissionChecker;
+	}
+
+	private String _getPortletDisplayId(ThemeDisplay themeDisplay) {
+		PortletDisplay portletDisplay = themeDisplay.getPortletDisplay();
+
+		if (portletDisplay == null) {
+			return "com_liferay_notifications_web_portlet_NotificationsPortlet";
+		}
+
+		return portletDisplay.getId();
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/object/object-web/src/test/java/com/liferay/object/web/internal/asset/model/ObjectEntryAssetRendererTest.java
+++ b/modules/apps/object/object-web/src/test/java/com/liferay/object/web/internal/asset/model/ObjectEntryAssetRendererTest.java
@@ -28,16 +28,19 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
+import com.liferay.portal.kernel.portlet.LiferayPortletURL;
+import com.liferay.portal.kernel.portlet.PortletURLFactoryUtil;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HashMapBuilder;
-import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import jakarta.servlet.http.HttpServletRequest;
 
 import java.io.Serializable;
 
@@ -72,6 +75,7 @@ public class ObjectEntryAssetRendererTest {
 		_setUpObjectField();
 		_setUpObjectFieldLocalService();
 		_setUpObjectFieldUtilMockedStatic();
+		_setUpPortletURLFactoryUtilMockedStatic();
 	}
 
 	@Test
@@ -97,8 +101,12 @@ public class ObjectEntryAssetRendererTest {
 		);
 
 		Assert.assertEquals(
-			_getCMSFriendlyURL(themeDisplay),
+			_getCMSFriendlyURL(false, themeDisplay),
 			assetRenderer.getSharingEntryRowPortletURL(false, themeDisplay));
+
+		Assert.assertEquals(
+			_getCMSFriendlyURL(true, themeDisplay),
+			assetRenderer.getSharingEntryRowPortletURL(true, themeDisplay));
 	}
 
 	@Test
@@ -152,8 +160,12 @@ public class ObjectEntryAssetRendererTest {
 		ThemeDisplay themeDisplay = Mockito.mock(ThemeDisplay.class);
 
 		Assert.assertEquals(
-			_getCMSFriendlyURL(themeDisplay),
-			assetRenderer.getURLSharingNotification(themeDisplay));
+			_getCMSFriendlyURL(false, themeDisplay),
+			assetRenderer.getURLSharingNotification(false, themeDisplay));
+
+		Assert.assertEquals(
+			_getCMSFriendlyURL(true, themeDisplay),
+			assetRenderer.getURLSharingNotification(true, themeDisplay));
 	}
 
 	@Test
@@ -231,7 +243,15 @@ public class ObjectEntryAssetRendererTest {
 		Assert.assertTrue(assetRenderer.hasViewPermission(_permissionChecker));
 	}
 
-	private String _getCMSFriendlyURL(ThemeDisplay themeDisplay) {
+	private String _getCMSFriendlyURL(
+		boolean editable, ThemeDisplay themeDisplay) {
+
+		Mockito.when(
+			themeDisplay.getPathFriendlyURLPublic()
+		).thenReturn(
+			"/web"
+		);
+
 		String pathMain = StringPool.SLASH + RandomTestUtil.randomString();
 
 		Mockito.when(
@@ -248,12 +268,10 @@ public class ObjectEntryAssetRendererTest {
 			portalURL
 		);
 
-		String urlCurrent = RandomTestUtil.randomString();
-
 		Mockito.when(
-			themeDisplay.getURLCurrent()
+			themeDisplay.getRequest()
 		).thenReturn(
-			urlCurrent
+			Mockito.mock(HttpServletRequest.class)
 		);
 
 		long objectEntryId = RandomTestUtil.randomLong();
@@ -278,10 +296,18 @@ public class ObjectEntryAssetRendererTest {
 			depotEntry
 		);
 
+		if (editable) {
+			return StringBundler.concat(
+				portalURL, pathMain, GroupConstants.CMS_FRIENDLY_URL,
+				"/edit_content_item?objectEntryId=", objectEntryId,
+				"&p_l_mode=edit&redirect=", _LIFERAY_PORTLET_URL);
+		}
+
 		return StringBundler.concat(
-			portalURL, pathMain, GroupConstants.CMS_FRIENDLY_URL,
-			"/edit_content_item?objectEntryId=", objectEntryId,
-			"&p_l_mode=read&redirect=", HtmlUtil.escapeURL(urlCurrent));
+			themeDisplay.getPortalURL(),
+			themeDisplay.getPathFriendlyURLPublic(),
+			GroupConstants.CMS_FRIENDLY_URL, "/view-asset?objectEntryId=",
+			_objectEntry.getObjectEntryId(), "&backURL=", _LIFERAY_PORTLET_URL);
 	}
 
 	private String _getFriendlyURL(LiferayPortletRequest liferayPortletRequest)
@@ -405,12 +431,34 @@ public class ObjectEntryAssetRendererTest {
 		);
 	}
 
+	private void _setUpPortletURLFactoryUtilMockedStatic() {
+		LiferayPortletURL liferayPortletURL = Mockito.mock(
+			LiferayPortletURL.class);
+
+		Mockito.when(
+			liferayPortletURL.toString()
+		).thenReturn(
+			_LIFERAY_PORTLET_URL
+		);
+
+		_portletURLFactoryUtilMockedStatic.when(
+			() -> PortletURLFactoryUtil.create(
+				Mockito.any(HttpServletRequest.class),
+				Mockito.any(String.class), Mockito.any(String.class))
+		).thenReturn(
+			liferayPortletURL
+		);
+	}
+
 	private static final String _ATTACHMENT_DOWNLOAD_URL =
 		RandomTestUtil.randomString();
 
 	private static final long _FILE_ENTRY_ID = RandomTestUtil.randomLong();
 
 	private static final long _GROUP_ID = RandomTestUtil.randomLong();
+
+	private static final String _LIFERAY_PORTLET_URL =
+		"http://" + RandomTestUtil.randomString();
 
 	private static final String _OBJECT_DEFINITION_EXTERNAL_REFERENCE_CODE =
 		RandomTestUtil.randomString();
@@ -424,6 +472,9 @@ public class ObjectEntryAssetRendererTest {
 	private static final MockedStatic<ObjectFieldUtil>
 		_objectFieldUtilMockedStatic = Mockito.mockStatic(
 			ObjectFieldUtil.class);
+	private static final MockedStatic<PortletURLFactoryUtil>
+		_portletURLFactoryUtilMockedStatic = Mockito.mockStatic(
+			PortletURLFactoryUtil.class);
 
 	private final AssetDisplayPageFriendlyURLProvider
 		_assetDisplayPageFriendlyURLProvider = Mockito.mock(

--- a/modules/apps/sharing/sharing-notifications/src/test/java/com/liferay/sharing/notifications/internal/notifications/SharingUserNotificationHandlerTest.java
+++ b/modules/apps/sharing/sharing-notifications/src/test/java/com/liferay/sharing/notifications/internal/notifications/SharingUserNotificationHandlerTest.java
@@ -186,15 +186,19 @@ public class SharingUserNotificationHandlerTest {
 		_setUpAssetRendererFactoryRegistryUtil(
 			className, assetRenderer, classPK);
 
-		String mode = "read";
+		String expectedURL = null;
 
 		if (hasUpdatePermission) {
-			mode = "edit";
+			expectedURL = StringBundler.concat(
+				"http://localhost:8080/c/portal/cms",
+				"/edit_content_item?objectEntryId=", classPK,
+				"&p_l_mode=edit&redirect=http://localhost:8080");
 		}
-
-		String expectedURL = StringBundler.concat(
-			"http://localhost:8080/c/portal/cms",
-			"/edit_content_item?objectEntryId=", classPK, "&p_l_mode=", mode);
+		else {
+			expectedURL = StringBundler.concat(
+				"http://localhost:8080/web/cms/view-asset?objectEntryId=",
+				classPK, "&backURL=http://localhost:8080");
+		}
 
 		Mockito.when(
 			assetRenderer.getURLSharingNotification(

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewAssetDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewAssetDisplayContextTest.java
@@ -165,7 +165,7 @@ public class ViewAssetDisplayContextTest extends BaseDisplayContextTestCase {
 			StringBundler.concat(
 				themeDisplay.getPortalURL(), themeDisplay.getPathMain(),
 				GroupConstants.CMS_FRIENDLY_URL,
-				"/edit_content_item?&p_l_mode=read&p_p_state=",
+				"/edit_content_item?p_l_mode=read&p_p_state=",
 				LiferayWindowState.POP_UP, "&redirect=",
 				themeDisplay.getURLCurrent(), "&objectEntryId=",
 				objectEntry.getObjectEntryId())

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
@@ -193,8 +193,7 @@ public abstract class BaseSectionDisplayContext {
 				return collaboratorURLs;
 			}
 		).put(
-			"commentsProps",
-			CommentUtil.getCommentsProps(httpServletRequest, themeDisplay)
+			"commentsProps", CommentUtil.getCommentsProps(httpServletRequest)
 		).put(
 			"contentViewURL",
 			StringBundler.concat(

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewAssetDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewAssetDisplayContext.java
@@ -62,7 +62,7 @@ public class ViewAssetDisplayContext {
 			StringBundler.concat(
 				_themeDisplay.getPortalURL(), _themeDisplay.getPathMain(),
 				GroupConstants.CMS_FRIENDLY_URL,
-				"/edit_content_item?&p_l_mode=read&p_p_state=",
+				"/edit_content_item?p_l_mode=read&p_p_state=",
 				LiferayWindowState.POP_UP, "&redirect=",
 				_themeDisplay.getURLCurrent(), "&objectEntryId=",
 				_objectEntry.getObjectEntryId())

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewAssetDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewAssetDisplayContext.java
@@ -55,8 +55,7 @@ public class ViewAssetDisplayContext {
 		).put(
 			"className", _objectDefinition.getClassName()
 		).put(
-			"commentsProps",
-			CommentUtil.getCommentsProps(_httpServletRequest, _themeDisplay)
+			"commentsProps", CommentUtil.getCommentsProps(_httpServletRequest)
 		).put(
 			"contentViewURL",
 			StringBundler.concat(

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/util/CommentUtil.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/util/CommentUtil.java
@@ -95,7 +95,11 @@ public class CommentUtil {
 	}
 
 	public static Map<String, Object> getCommentsProps(
-		HttpServletRequest httpServletRequest, ThemeDisplay themeDisplay) {
+		HttpServletRequest httpServletRequest) {
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
 
 		return HashMapBuilder.<String, Object>put(
 			"addCommentURL",

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/view_asset/ViewAsset.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/view_asset/ViewAsset.tsx
@@ -137,7 +137,7 @@ export default function ViewAsset({
 								)}
 								borderless
 								className={classNames({
-									active: 'commentPanel',
+									active: openSidePanel,
 								})}
 								displayType="secondary"
 								onClick={handleClickComments}


### PR DESCRIPTION


Add view asset content page with new view asset fragment

# How am I fixing it?

The purpose of this PR is to modify the link to link to the view created in the other task : https://liferay.atlassian.net/browse/LPD-85354 that is already in brian repository ( see https://github.com/liferay-content-management/liferay-portal/pull/8047)

1. Modify the link to go the new view from the notifications
2. Modify the link to go the new view from the sharing content


This PR contains the change to add the view but that changes are not part of the PR, only I adding them for testing the whole solution.


# How can you verify that it works?

To test we have to follow these steps:

1. Deploy modules and initialize the cms with the new page with the configuration
3. Add a file and a content
4. Create a user to share the above assets
5. Go to file and content list and share the created file and content to the created user
6. If we share the file if we select download and view, the user would see and download the file, and if we select also comment the user would be able to add a comment to the asset. And, the same for the content but without the action of download.
7. Go to notifications and shared content applications and see when clicking on the item links to the new view. So, we will have to possibilities:

> 1. If the user has update permission for the shared entry we will link to the edit entry view

> 2. If the user does not have update permission for the shared entry we will link to the view entry view


Also, we can test that the PR works runniung created tests: 

1. Added frontend tests
3. Added backend integration tests
4. Added backend junit tests
