### PR TITLE
LPD-86501 View All Contents and View All Files link missing in Space Summary

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewSpaceContentsSummarySectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewSpaceContentsSummarySectionDisplayContext.java
@@ -80,8 +80,10 @@ public class ViewSpaceContentsSummarySectionDisplayContext
 	@Override
 	public String getAPIURL() {
 		return HttpComponentsUtil.addParameters(
-			super.getAPIURL(), "page", CMSSpaceConstants.SPACE_SUMMARY_PAGE,
-			"pageSize", CMSSpaceConstants.SPACE_SUMMARY_PAGE_SIZE, "sort",
+			super.getAPIURL(), "emptySearch", true, "filter",
+			getCMSSectionFilterString(), "page",
+			CMSSpaceConstants.SPACE_SUMMARY_PAGE, "pageSize",
+			CMSSpaceConstants.SPACE_SUMMARY_PAGE_SIZE, "sort",
 			"dateModified:desc");
 	}
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewSpaceFilesSummarySectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewSpaceFilesSummarySectionDisplayContext.java
@@ -80,8 +80,10 @@ public class ViewSpaceFilesSummarySectionDisplayContext
 	@Override
 	public String getAPIURL() {
 		return HttpComponentsUtil.addParameters(
-			super.getAPIURL(), "page", CMSSpaceConstants.SPACE_SUMMARY_PAGE,
-			"pageSize", CMSSpaceConstants.SPACE_SUMMARY_PAGE_SIZE, "sort",
+			super.getAPIURL(), "emptySearch", true, "filter",
+			getCMSSectionFilterString(), "page",
+			CMSSpaceConstants.SPACE_SUMMARY_PAGE, "pageSize",
+			CMSSpaceConstants.SPACE_SUMMARY_PAGE_SIZE, "sort",
 			"dateModified:desc");
 	}
 

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/spaceSummary.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/spaceSummary.spec.ts
@@ -228,6 +228,57 @@ test(
 );
 
 test(
+	'View All Content and View All Files links are shown when items exist in both sections',
+	{tag: '@LPD-86501'},
+	async ({apiHelpers, spaceSummaryPage}) => {
+		const spaceName = 'Default';
+
+		const contentApplicationName = 'cms/basic-web-contents';
+		const filesApplicationName = 'cms/basic-documents';
+
+		const contentObjectEntry = await apiHelpers.objectEntry.postObjectEntry(
+			{
+				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				title: `content ${getRandomString()}`,
+			},
+			contentApplicationName,
+			spaceName
+		);
+
+		const fileObjectEntry = await apiHelpers.objectEntry.postObjectEntry(
+			{
+				file: {
+					fileBase64: 'R0lGODlhAQABAAAAACw=',
+					name: `file_${getRandomString()}.png`,
+				},
+				objectEntryFolderExternalReferenceCode: 'L_FILES',
+				title: `file ${getRandomString()}`,
+			},
+			filesApplicationName,
+			spaceName
+		);
+
+		try {
+			await spaceSummaryPage.goto(spaceName);
+
+			await expect(spaceSummaryPage.viewAllContentLink).toBeVisible();
+			await expect(spaceSummaryPage.viewAllFilesLink).toBeVisible();
+		}
+		finally {
+			await apiHelpers.objectEntry.deleteObjectEntry(
+				contentApplicationName,
+				String(contentObjectEntry.id)
+			);
+
+			await apiHelpers.objectEntry.deleteObjectEntry(
+				filesApplicationName,
+				String(fileObjectEntry.id)
+			);
+		}
+	}
+);
+
+test(
 	'Can add and delete a user group as a member of the space',
 	{tag: '@LPD-61617'},
 	async ({apiHelpers, page, spaceSummaryPage}) => {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-86501

Failing tests that indicated the bug:

- site-cms-site-initializer/permissions/defaultPermissions.spec.ts > Can propagate Default Permissions to existing assets
- site-cms-site-initializer/permissions/defaultPermissions.spec.ts > Edit default permissions in bulk by role
- site-cms-site-initializer/permissions/defaultPermissions.spec.ts > Edit permissions in bulk by role
- site-cms-site-initializer/permissions/defaultPermissions.spec.ts > Reset permissions in bulk to the default permissions of the parent
- site-cms-site-initializer/permissions/defaultPermissions.spec.ts > Reset permissions to the default permissions of the parent
- site-cms-site-initializer/permissions/defaultPermissions.spec.ts > Space and folder contents inherit parent default permissions