### PR TITLE
LPD-86111 Don't show manage collaborators UI when no update permission present

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/modal/share_modal_content/ShareModalContent.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/modal/share_modal_content/ShareModalContent.tsx
@@ -43,6 +43,7 @@ export interface Collaborator {
 
 function CollaboratorListItem({
 	actionIds,
+	canManageCollaborators = true,
 	dateExpired,
 	entryClassName,
 	error,
@@ -54,6 +55,7 @@ function CollaboratorListItem({
 	user,
 }: {
 	actionIds: string;
+	canManageCollaborators?: boolean;
 	dateExpired?: string;
 	entryClassName: string;
 	error?: string;
@@ -148,63 +150,66 @@ function CollaboratorListItem({
 				)}
 			</div>
 
-			<div className="autofit-col p-0">
-				<div className="d-flex">
-					<ExpirationDateSelector
-						dateExpired={dateExpired}
-						onChange={handleChangeUserProperties}
-					/>
+			{canManageCollaborators && (
+				<div className="autofit-col p-0">
+					<div className="d-flex">
+						<ExpirationDateSelector
+							dateExpired={dateExpired}
+							onChange={handleChangeUserProperties}
+						/>
 
-					<ClayDropDown
-						hasLeftSymbols={true}
-						trigger={
-							<ClayButtonWithIcon
-								aria-label={Liferay.Language.get(
-									'more-options'
-								)}
-								borderless
-								displayType="secondary"
-								monospaced
-								size="xs"
-								symbol="ellipsis-v"
-							/>
-						}
-					>
-						<ClayDropDown.ItemList>
-							<ClayDropDown.Item
-								aria-label={Liferay.Language.get(
-									'allow-resharing'
-								)}
-								key={`share-${user.id}`}
-								onClick={() =>
-									handleChangeUserProperties({
-										share: !share,
-									})
-								}
-								symbolLeft={share ? 'check-small' : ''}
-							>
-								{Liferay.Language.get('allow-resharing')}
-							</ClayDropDown.Item>
+						<ClayDropDown
+							hasLeftSymbols={true}
+							trigger={
+								<ClayButtonWithIcon
+									aria-label={Liferay.Language.get(
+										'more-options'
+									)}
+									borderless
+									displayType="secondary"
+									monospaced
+									size="xs"
+									symbol="ellipsis-v"
+								/>
+							}
+						>
+							<ClayDropDown.ItemList>
+								<ClayDropDown.Item
+									aria-label={Liferay.Language.get(
+										'allow-resharing'
+									)}
+									key={`share-${user.id}`}
+									onClick={() =>
+										handleChangeUserProperties({
+											share: !share,
+										})
+									}
+									symbolLeft={share ? 'check-small' : ''}
+								>
+									{Liferay.Language.get('allow-resharing')}
+								</ClayDropDown.Item>
 
-							<ClayDropDown.Item
-								aria-label={Liferay.Language.get(
-									'remove-access'
-								)}
-								key={`remove-${user.id}`}
-								onClick={() => onRemoveUser(user)}
-							>
-								{Liferay.Language.get('remove-access')}
-							</ClayDropDown.Item>
-						</ClayDropDown.ItemList>
-					</ClayDropDown>
+								<ClayDropDown.Item
+									aria-label={Liferay.Language.get(
+										'remove-access'
+									)}
+									key={`remove-${user.id}`}
+									onClick={() => onRemoveUser(user)}
+								>
+									{Liferay.Language.get('remove-access')}
+								</ClayDropDown.Item>
+							</ClayDropDown.ItemList>
+						</ClayDropDown>
+					</div>
 				</div>
-			</div>
+			)}
 		</li>
 	);
 }
 
 export default function ShareModalContent({
 	autocompleteURL = '',
+	canManageCollaborators = true,
 	closeModal,
 	collaboratorURL = '',
 	creator,
@@ -214,6 +219,7 @@ export default function ShareModalContent({
 	title = '',
 }: {
 	autocompleteURL: string;
+	canManageCollaborators?: boolean;
 	closeModal: () => void;
 	collaboratorURL: string;
 	creator: {
@@ -493,6 +499,9 @@ export default function ShareModalContent({
 							<ul className="c-mb-0 list-group">
 								{collaborators.map((item) => (
 									<CollaboratorListItem
+										canManageCollaborators={
+											canManageCollaborators
+										}
 										entryClassName={entryClassName}
 										key={`listItem-${item.type}-${item.user.id}`}
 										onChangeUser={handleChangeUser}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/SharedWithMeFDSPropsTransformer.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/SharedWithMeFDSPropsTransformer.ts
@@ -154,6 +154,8 @@ export default function SharedWithMeFDSPropsTransformer({
 
 				shareAction({
 					autocompleteURL,
+					canManageCollaborators:
+						itemData?.actionIds?.includes('UPDATE'),
 					collaboratorURL: collaboratorURLs[itemData.className],
 					creator: itemData.creator,
 					entryClassName: itemData.className,

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/actions/shareAction.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/actions/shareAction.ts
@@ -13,6 +13,7 @@ import ShareModalContent, {
 
 export default async function shareAction({
 	autocompleteURL,
+	canManageCollaborators = true,
 	collaboratorURL,
 	creator,
 	entryClassName,
@@ -20,6 +21,7 @@ export default async function shareAction({
 	title,
 }: {
 	autocompleteURL: string;
+	canManageCollaborators?: boolean;
 	collaboratorURL: string;
 	creator: {
 		contentType: string;
@@ -57,6 +59,7 @@ export default async function shareAction({
 			contentComponent: ({closeModal}: {closeModal: () => void}) =>
 				ShareModalContent({
 					autocompleteURL,
+					canManageCollaborators,
 					closeModal,
 					collaboratorURL,
 					creator: {...creator, id: creator.id.toString()},

--- a/modules/test/playwright/helpers/HeadlessAssetLibraryApiHelper.ts
+++ b/modules/test/playwright/helpers/HeadlessAssetLibraryApiHelper.ts
@@ -22,7 +22,7 @@ export class HeadlessAssetLibraryApiHelper {
 	}: {
 		description?: string;
 		name: string;
-		settings: any;
+		settings?: any;
 		type: string;
 	}) {
 		const data = JSON.stringify({

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/sharingPermissions.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/sharingPermissions.spec.ts
@@ -1,0 +1,235 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
+import {loginTest} from '../../../fixtures/loginTest';
+import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisible';
+import getRandomString from '../../../utils/getRandomString';
+import {performUserSwitch, userData} from '../../../utils/performLogin';
+import {cmsPagesTest} from './fixtures/cmsPagesTest';
+
+const test = mergeTests(
+	cmsPagesTest,
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+	}),
+	loginTest()
+);
+
+test(
+	'User with Reshare permission should not see Allow Resharing or Remove Access actions',
+	{tag: '@LPD-86111'},
+	async ({apiHelpers, page, sharedWithMePage}) => {
+		const spaceName = `Space ${getRandomString()}`;
+		let space = null;
+
+		await test.step('Create a new space', async () => {
+			space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+				name: spaceName,
+				type: 'Space',
+			});
+		});
+
+		const objectEntryTitle = `Content ${getRandomString()}`;
+		let objectEntry = null;
+
+		await test.step('Create a content in the space', async () => {
+			objectEntry = await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: objectEntryTitle,
+				},
+				'cms/basic-web-contents',
+				spaceName
+			);
+		});
+
+		let user = null;
+
+		await test.step('Create a user and add as space member', async () => {
+			user = await apiHelpers.headlessAdminUser.postUserAccount();
+
+			userData[user.alternateName] = {
+				name: user.givenName,
+				password: 'test',
+				surname: user.familyName,
+			};
+
+			await apiHelpers.jsonWebServicesUser.agreeToTermsOfUse(user.id);
+			await apiHelpers.jsonWebServicesUser.answerReminderQuery(user.id);
+
+			await apiHelpers.jsonWebServicesUser.addGroupUsers(space.siteId, [
+				user.id,
+			]);
+		});
+
+		await test.step('Share the content with the user with VIEW + Reshare enabled', async () => {
+			await apiHelpers.objectEntry.postObjectEntryCollaborators(
+				[
+					{
+						actionIds: ['VIEW'],
+						id: user.id,
+						share: true,
+						type: 'User',
+					},
+				],
+				'cms/basic-web-contents',
+				objectEntry.id
+			);
+		});
+
+		await test.step('Switch to the user and open the Share modal', async () => {
+			await performUserSwitch(page, user.alternateName);
+
+			await sharedWithMePage.goto();
+
+			const assetRow = page.getByRole('row', {name: objectEntryTitle});
+
+			await expect(assetRow).toBeVisible();
+
+			const actionsButton = assetRow.getByRole('button', {
+				name: `${objectEntryTitle} Actions`,
+			});
+
+			await clickAndExpectToBeVisible({
+				autoClick: true,
+				target: page.getByRole('menuitem', {
+					exact: true,
+					name: 'Share',
+				}),
+				trigger: actionsButton,
+			});
+		});
+
+		await test.step('Verify the share modal is open', async () => {
+			await expect(
+				page.getByText(`Share "${objectEntryTitle}"`)
+			).toBeVisible();
+		});
+
+		await test.step('Verify Allow Resharing and Remove Access are not available', async () => {
+			await expect(page.getByLabel('More Options')).not.toBeVisible();
+
+			await expect(page.getByLabel('Allow Resharing')).not.toBeVisible();
+
+			await expect(page.getByLabel('Remove Access')).not.toBeVisible();
+		});
+
+		await test.step('Verify the user can still add new collaborators', async () => {
+			await expect(
+				page.getByText('Add People to Collaborate')
+			).toBeVisible();
+		});
+	}
+);
+
+test(
+	'User with Reshare and Update permission should see Allow Resharing and Remove Access actions',
+	{tag: '@LPD-86111'},
+	async ({apiHelpers, page, sharedWithMePage}) => {
+		const spaceName = `Space ${getRandomString()}`;
+		let space = null;
+
+		await test.step('Create a new space', async () => {
+			space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+				name: spaceName,
+				type: 'Space',
+			});
+		});
+
+		const objectEntryTitle = `Content ${getRandomString()}`;
+		let objectEntry = null;
+
+		await test.step('Create a content in the space', async () => {
+			objectEntry = await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: objectEntryTitle,
+				},
+				'cms/basic-web-contents',
+				spaceName
+			);
+		});
+
+		let user = null;
+
+		await test.step('Create a user and add as space member', async () => {
+			user = await apiHelpers.headlessAdminUser.postUserAccount();
+
+			userData[user.alternateName] = {
+				name: user.givenName,
+				password: 'test',
+				surname: user.familyName,
+			};
+
+			await apiHelpers.jsonWebServicesUser.agreeToTermsOfUse(user.id);
+			await apiHelpers.jsonWebServicesUser.answerReminderQuery(user.id);
+
+			await apiHelpers.jsonWebServicesUser.addGroupUsers(space.siteId, [
+				user.id,
+			]);
+		});
+
+		await test.step('Share the content with the user with VIEW + UPDATE + Reshare enabled', async () => {
+			await apiHelpers.objectEntry.postObjectEntryCollaborators(
+				[
+					{
+						actionIds: ['UPDATE', 'VIEW'],
+						id: user.id,
+						share: true,
+						type: 'User',
+					},
+				],
+				'cms/basic-web-contents',
+				objectEntry.id
+			);
+		});
+
+		await test.step('Switch to the user and open the Share modal', async () => {
+			await performUserSwitch(page, user.alternateName);
+
+			await sharedWithMePage.goto();
+
+			const assetRow = page.getByRole('row', {name: objectEntryTitle});
+
+			await expect(assetRow).toBeVisible();
+
+			const actionsButton = assetRow.getByRole('button', {
+				name: `${objectEntryTitle} Actions`,
+			});
+
+			await clickAndExpectToBeVisible({
+				autoClick: true,
+				target: page.getByRole('menuitem', {
+					exact: true,
+					name: 'Share',
+				}),
+				trigger: actionsButton,
+			});
+		});
+
+		await test.step('Verify the share modal is open', async () => {
+			await expect(
+				page.getByText(`Share "${objectEntryTitle}"`)
+			).toBeVisible();
+		});
+
+		await test.step('Verify Allow Resharing and Remove Access are available', async () => {
+			const moreOptionsButton = page.getByLabel('More Options');
+
+			await expect(moreOptionsButton).toBeVisible();
+
+			await moreOptionsButton.click();
+
+			await expect(page.getByLabel('Allow Resharing')).toBeVisible();
+
+			await expect(page.getByLabel('Remove Access')).toBeVisible();
+		});
+	}
+);


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-86111

The manage collaborators UI should be dislayed only to users that have the update permission.

# How am I fixing it?

By passing a boolean as a prop indicating if the UI has to be rendered.

# How can you verify that it works?

Run the included functional tests.