### PR TITLE
LPD-85725 Sort content by modified date

### DIFF
--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/BaseSectionDisplayContextTestCase.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/BaseSectionDisplayContextTestCase.java
@@ -300,6 +300,17 @@ public abstract class BaseSectionDisplayContextTestCase
 	}
 
 	@Test
+	public void testGetAdditionalAPIURLParameters() throws Exception {
+		String additionalAPIURLParameters = ReflectionTestUtil.invoke(
+			getSectionDisplayContext(getMockHttpServletRequest()),
+			"getAdditionalAPIURLParameters", new Class<?>[0]);
+
+		Assert.assertTrue(
+			additionalAPIURLParameters,
+			additionalAPIURLParameters.contains("sort=dateModified:desc"));
+	}
+
+	@Test
 	public void testGetAdditionalProps() throws Exception {
 		DepotEntry depotEntry = addDepotEntry(
 			StringUtil.randomString(), TestPropsValues.getUserId());
@@ -704,7 +715,7 @@ public abstract class BaseSectionDisplayContextTestCase
 			"&nestedFields=embedded,embeddedTaxonomyCategory,",
 			"file.metadata,file.previewURL,file.thumbnailURL,",
 			"numberOfObjectEntries,numberOfObjectEntryFolders,",
-			"systemProperties.objectDefinitionBrief");
+			"systemProperties.objectDefinitionBrief&sort=dateModified:desc");
 	}
 
 	protected String getCMSSectionFilterString(Object displayContext) {

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewAllSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewAllSectionDisplayContextTest.java
@@ -11,10 +11,12 @@ import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.constants.ObjectFolderConstants;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
@@ -23,6 +25,7 @@ import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
 import jakarta.servlet.http.HttpServletRequest;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.Assert;
@@ -47,6 +50,28 @@ public class ViewAllSectionDisplayContextTest
 		new AggregateTestRule(
 			new LiferayIntegrationTestRule(),
 			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Override
+	public HashMap<String, Object> getBaseAdditionalProps() throws Exception {
+		return new HashMapBuilder<>().putAll(
+			super.getBaseAdditionalProps()
+		).put(
+			"breadcrumbProps",
+			HashMapBuilder.<String, Object>put(
+				"breadcrumbItems",
+				JSONUtil.putAll(
+					JSONUtil.put(
+						"active", false
+					).put(
+						"href", (String)null
+					).put(
+						"label", "test"
+					))
+			).put(
+				"hideSpace", true
+			).build()
+		).build();
+	}
 
 	@Override
 	protected String getCMSSectionFilterString(Object displayContext) {

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewAllSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewAllSectionDisplayContextTest.java
@@ -31,8 +31,10 @@ import java.util.Map;
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Rule;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
 /**
@@ -71,6 +73,28 @@ public class ViewAllSectionDisplayContextTest
 				"hideSpace", true
 			).build()
 		).build();
+	}
+
+	@Test
+	public void testGetAdditionalAPIURLParametersWithSearchQuery()
+		throws Exception {
+
+		MockHttpServletRequest mockHttpServletRequest =
+			getMockHttpServletRequest();
+
+		mockHttpServletRequest.setParameter("q", "test-query");
+
+		String additionalAPIURLParameters = ReflectionTestUtil.invoke(
+			getSectionDisplayContext(mockHttpServletRequest),
+			"getAdditionalAPIURLParameters", new Class<?>[0]);
+
+		Assert.assertFalse(
+			additionalAPIURLParameters,
+			additionalAPIURLParameters.contains(StringPool.QUESTION));
+
+		Assert.assertTrue(
+			additionalAPIURLParameters,
+			additionalAPIURLParameters.contains("&search=test-query"));
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewContentsSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewContentsSectionDisplayContextTest.java
@@ -14,6 +14,7 @@ import com.liferay.object.constants.ObjectFolderConstants;
 import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -25,6 +26,7 @@ import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
 import jakarta.servlet.http.HttpServletRequest;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -51,6 +53,28 @@ public class ViewContentsSectionDisplayContextTest
 		new AggregateTestRule(
 			new LiferayIntegrationTestRule(),
 			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Override
+	public HashMap<String, Object> getBaseAdditionalProps() throws Exception {
+		return new HashMapBuilder<>().putAll(
+			super.getBaseAdditionalProps()
+		).put(
+			"breadcrumbProps",
+			HashMapBuilder.<String, Object>put(
+				"breadcrumbItems",
+				JSONUtil.putAll(
+					JSONUtil.put(
+						"active", false
+					).put(
+						"href", (String)null
+					).put(
+						"label", "test"
+					))
+			).put(
+				"hideSpace", true
+			).build()
+		).build();
+	}
 
 	@Test
 	public void testGetFDSActionDropdownItems() throws Exception {

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewFilesSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewFilesSectionDisplayContextTest.java
@@ -11,6 +11,7 @@ import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.constants.ObjectFolderConstants;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -52,6 +53,21 @@ public class ViewFilesSectionDisplayContextTest
 	public HashMap<String, Object> getBaseAdditionalProps() throws Exception {
 		return new HashMapBuilder<>().putAll(
 			super.getBaseAdditionalProps()
+		).put(
+			"breadcrumbProps",
+			HashMapBuilder.<String, Object>put(
+				"breadcrumbItems",
+				JSONUtil.putAll(
+					JSONUtil.put(
+						"active", false
+					).put(
+						"href", (String)null
+					).put(
+						"label", "test"
+					))
+			).put(
+				"hideSpace", true
+			).build()
 		).put(
 			"galleryViewEnabled", true
 		).build();

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewRelatedAssetsSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewRelatedAssetsSectionDisplayContextTest.java
@@ -93,24 +93,18 @@ public class ViewRelatedAssetsSectionDisplayContextTest
 	}
 
 	@Test
-	public void testGetAdditionalProps() throws Exception {
-		HashMap<String, Object> additionalProps = ReflectionTestUtil.invoke(
+	public void testGetAdditionalAPIURLParameters() throws Exception {
+		String additionalAPIURLParameters = ReflectionTestUtil.invoke(
 			_getViewRelatedAssetsSectionDisplayContext(mockHttpServletRequest),
-			"getAdditionalProps", new Class<?>[0]);
-
-		Assert.assertEquals(
-			_objectDefinition.getExternalReferenceCode() + _KEYWORD_SUFFIX,
-			additionalProps.get("keywords"));
-	}
-
-	@Test
-	public void testGetAPIURL() throws Exception {
-		String apiURL = ReflectionTestUtil.invoke(
-			_getViewRelatedAssetsSectionDisplayContext(mockHttpServletRequest),
-			"getAPIURL", new Class<?>[0]);
+			"getAdditionalAPIURLParameters", new Class<?>[0]);
 
 		Assert.assertTrue(
-			apiURL.contains(
+			additionalAPIURLParameters,
+			additionalAPIURLParameters.contains("sort=dateModified:desc"));
+
+		Assert.assertTrue(
+			additionalAPIURLParameters,
+			additionalAPIURLParameters.contains(
 				StringBundler.concat(
 					"(cmsSection eq 'contents' or cmsSection eq 'files') and ",
 					"keywords/any(k:k in ('",
@@ -122,14 +116,26 @@ public class ViewRelatedAssetsSectionDisplayContextTest
 			_objectDefinition.getObjectDefinitionId(), 0, null,
 			Collections.emptyMap(), ServiceContextTestUtil.getServiceContext());
 
-		apiURL = ReflectionTestUtil.invoke(
+		additionalAPIURLParameters = ReflectionTestUtil.invoke(
 			_getViewRelatedAssetsSectionDisplayContext(mockHttpServletRequest),
-			"getAPIURL", new Class<?>[0]);
+			"getAdditionalAPIURLParameters", new Class<?>[0]);
 
 		Assert.assertTrue(
-			apiURL.contains(
+			additionalAPIURLParameters,
+			additionalAPIURLParameters.contains(
 				"(cmsSection eq 'contents' or cmsSection eq 'files') and " +
 					"keywords/any(k:k in (''))"));
+	}
+
+	@Test
+	public void testGetAdditionalProps() throws Exception {
+		HashMap<String, Object> additionalProps = ReflectionTestUtil.invoke(
+			_getViewRelatedAssetsSectionDisplayContext(mockHttpServletRequest),
+			"getAdditionalProps", new Class<?>[0]);
+
+		Assert.assertEquals(
+			_objectDefinition.getExternalReferenceCode() + _KEYWORD_SUFFIX,
+			additionalProps.get("keywords"));
 	}
 
 	@Test

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewSharedWithMeSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewSharedWithMeSectionDisplayContextTest.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.portlet.LiferayWindowState;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactoryUtil;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -65,6 +66,16 @@ public class ViewSharedWithMeSectionDisplayContextTest
 		new AggregateTestRule(
 			new LiferayIntegrationTestRule(),
 			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Override
+	@Test
+	public void testGetAdditionalAPIURLParameters() throws Exception {
+		String apiURL = ReflectionTestUtil.invoke(
+			getSectionDisplayContext(getMockHttpServletRequest()), "getAPIURL",
+			new Class<?>[0]);
+
+		Assert.assertTrue(apiURL, apiURL.contains("sort=dateModified:desc"));
+	}
 
 	@Override
 	@Test

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/SectionDisplayContextHelper.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/SectionDisplayContextHelper.java
@@ -141,7 +141,7 @@ public class SectionDisplayContextHelper {
 			httpServletRequest.getAttribute(InfoDisplayWebKeys.INFO_ITEM),
 			rootObjectEntryFolderExternalReferenceCode);
 
-		StringBundler sb = new StringBundler(10);
+		StringBundler sb = new StringBundler(11);
 
 		sb.append("emptySearch=true&filter=");
 
@@ -169,6 +169,7 @@ public class SectionDisplayContextHelper {
 		sb.append("file.metadata,file.previewURL,file.thumbnailURL,");
 		sb.append("numberOfObjectEntries,numberOfObjectEntryFolders,");
 		sb.append("systemProperties.objectDefinitionBrief");
+		sb.append("&sort=dateModified:desc");
 
 		return sb.toString();
 	}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewHomeRecentAssetsSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewHomeRecentAssetsSectionDisplayContext.java
@@ -18,7 +18,6 @@ import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermi
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
-import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.translation.exporter.TranslationInfoItemFieldValuesExporterRegistry;
@@ -52,12 +51,6 @@ public class ViewHomeRecentAssetsSectionDisplayContext
 			objectDefinitionSettingLocalService,
 			objectEntryFolderModelResourcePermission, portal,
 			translationInfoItemFieldValuesExporterRegistry);
-	}
-
-	@Override
-	public String getAPIURL() {
-		return HttpComponentsUtil.addParameters(
-			super.getAPIURL(), "sort", "dateModified:desc");
 	}
 
 	public String getAssetsAllURL() throws PortalException {

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewSharedWithMeSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewSharedWithMeSectionDisplayContext.java
@@ -142,7 +142,7 @@ public class ViewSharedWithMeSectionDisplayContext {
 	public String getAPIURL() {
 		return "/o/headless-admin-user/v1.0/my-user-account/shared-assets" +
 			"/shared-with-me?filter=(spaceDepotEntry eq true)" +
-				"&nestedFields=file";
+				"&nestedFields=file&sort=dateModified:desc";
 	}
 
 	public Map<String, Object> getBreadcrumbProps() throws PortalException {

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewSpaceContentsSummarySectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewSpaceContentsSummarySectionDisplayContext.java
@@ -10,6 +10,7 @@ import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectDefinitionService;
 import com.liferay.object.service.ObjectDefinitionSettingLocalService;
 import com.liferay.object.service.ObjectEntryFolderLocalService;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
@@ -17,7 +18,6 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
-import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.site.cms.site.initializer.internal.constants.CMSSpaceConstants;
 import com.liferay.site.cms.site.initializer.internal.util.ActionUtil;
@@ -60,6 +60,14 @@ public class ViewSpaceContentsSummarySectionDisplayContext
 	}
 
 	@Override
+	public String getAdditionalAPIURLParameters() {
+		return StringBundler.concat(
+			super.getAdditionalAPIURLParameters(), "&page=",
+			CMSSpaceConstants.SPACE_SUMMARY_PAGE, "&pageSize=",
+			CMSSpaceConstants.SPACE_SUMMARY_PAGE_SIZE);
+	}
+
+	@Override
 	public Map<String, Object> getAdditionalProps() {
 		Map<String, Object> additionalProps = super.getAdditionalProps();
 
@@ -75,14 +83,6 @@ public class ViewSpaceContentsSummarySectionDisplayContext
 		additionalProps.put("showAdditionalItemInfo", true);
 
 		return additionalProps;
-	}
-
-	@Override
-	public String getAPIURL() {
-		return HttpComponentsUtil.addParameters(
-			super.getAPIURL(), "page", CMSSpaceConstants.SPACE_SUMMARY_PAGE,
-			"pageSize", CMSSpaceConstants.SPACE_SUMMARY_PAGE_SIZE, "sort",
-			"dateModified:desc");
 	}
 
 	public Map<String, Object> getHeaderProps() throws Exception {

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewSpaceFilesSummarySectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewSpaceFilesSummarySectionDisplayContext.java
@@ -11,6 +11,7 @@ import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectDefinitionService;
 import com.liferay.object.service.ObjectDefinitionSettingLocalService;
 import com.liferay.object.service.ObjectEntryFolderLocalService;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
@@ -18,7 +19,6 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
-import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.site.cms.site.initializer.internal.constants.CMSSpaceConstants;
 import com.liferay.site.cms.site.initializer.internal.util.ActionUtil;
@@ -62,6 +62,14 @@ public class ViewSpaceFilesSummarySectionDisplayContext
 	}
 
 	@Override
+	public String getAdditionalAPIURLParameters() {
+		return StringBundler.concat(
+			super.getAdditionalAPIURLParameters(), "&page=",
+			CMSSpaceConstants.SPACE_SUMMARY_PAGE, "&pageSize=",
+			CMSSpaceConstants.SPACE_SUMMARY_PAGE_SIZE);
+	}
+
+	@Override
 	public Map<String, Object> getAdditionalProps() {
 		Map<String, Object> additionalProps = super.getAdditionalProps();
 
@@ -75,14 +83,6 @@ public class ViewSpaceFilesSummarySectionDisplayContext
 		}
 
 		return additionalProps;
-	}
-
-	@Override
-	public String getAPIURL() {
-		return HttpComponentsUtil.addParameters(
-			super.getAPIURL(), "page", CMSSpaceConstants.SPACE_SUMMARY_PAGE,
-			"pageSize", CMSSpaceConstants.SPACE_SUMMARY_PAGE_SIZE, "sort",
-			"dateModified:desc");
 	}
 
 	public Map<String, Object> getHeaderProps() throws Exception {

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/ViewAllSectionSystemFDSEntry.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/ViewAllSectionSystemFDSEntry.java
@@ -9,11 +9,12 @@ import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.frontend.data.set.SystemFDSEntry;
 import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectDefinitionSettingLocalService;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
-import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.URLCodec;
 import com.liferay.site.cms.site.initializer.internal.constants.CMSSiteInitializerFDSNames;
 import com.liferay.site.cms.site.initializer.internal.display.context.SectionDisplayContextHelper;
 
@@ -43,15 +44,19 @@ public class ViewAllSectionSystemFDSEntry implements SystemFDSEntry {
 					"cmsSection eq 'files')",
 				httpServletRequest));
 
-		if (httpServletRequest.getParameter("q") != null) {
-			return HttpComponentsUtil.addParameters(
-				_sectionDisplayContextHelper.getAdditionalAPIURLParameters(
-					filterString, httpServletRequest, null),
-				"search", httpServletRequest.getParameter("q"));
+		String additionalAPIURLParameters =
+			_sectionDisplayContextHelper.getAdditionalAPIURLParameters(
+				filterString, httpServletRequest, null);
+
+		String searchQuery = httpServletRequest.getParameter("q");
+
+		if (searchQuery != null) {
+			return StringBundler.concat(
+				additionalAPIURLParameters, "&search=",
+				URLCodec.encodeURL(searchQuery));
 		}
 
-		return _sectionDisplayContextHelper.getAdditionalAPIURLParameters(
-			filterString, httpServletRequest, null);
+		return additionalAPIURLParameters;
 	}
 
 	@Override

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/all.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/all.spec.ts
@@ -3556,3 +3556,66 @@ test(
 		}
 	}
 );
+
+test(
+	'All section places most recently modified content at the top',
+	{tag: '@LPD-85725'},
+	async ({apiHelpers, assetsPage, page}) => {
+		const applicationName = 'cms/basic-web-contents';
+		const spaceName = 'Default';
+		const firstTitle = getRandomString();
+		const secondTitle = getRandomString();
+		const thirdTitle = getRandomString();
+
+		let firstEntry;
+		let secondEntry;
+		let thirdEntry;
+
+		try {
+			firstEntry = await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: firstTitle,
+				},
+				applicationName,
+				spaceName
+			);
+
+			secondEntry = await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: secondTitle,
+				},
+				applicationName,
+				spaceName
+			);
+
+			thirdEntry = await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: thirdTitle,
+				},
+				applicationName,
+				spaceName
+			);
+
+			await expect(async () => {
+				await assetsPage.gotoAll();
+
+				await expect(page.locator('tbody tr').first()).toContainText(
+					thirdTitle
+				);
+			}).toPass();
+		}
+		finally {
+			for (const entry of [firstEntry, secondEntry, thirdEntry]) {
+				if (entry) {
+					await apiHelpers.objectEntry.deleteObjectEntry(
+						applicationName,
+						String(entry.id)
+					);
+				}
+			}
+		}
+	}
+);

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/contents.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/contents.spec.ts
@@ -563,3 +563,66 @@ test(
 		});
 	}
 );
+
+test(
+	'Contents section places most recently modified content at the top',
+	{tag: '@LPD-85725'},
+	async ({apiHelpers, contentsPage, page}) => {
+		const applicationName = 'cms/basic-web-contents';
+		const spaceName = 'Default';
+		const firstTitle = getRandomString();
+		const secondTitle = getRandomString();
+		const thirdTitle = getRandomString();
+
+		let firstEntry;
+		let secondEntry;
+		let thirdEntry;
+
+		try {
+			firstEntry = await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: firstTitle,
+				},
+				applicationName,
+				spaceName
+			);
+
+			secondEntry = await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: secondTitle,
+				},
+				applicationName,
+				spaceName
+			);
+
+			thirdEntry = await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: thirdTitle,
+				},
+				applicationName,
+				spaceName
+			);
+
+			await expect(async () => {
+				await contentsPage.goto();
+
+				await expect(page.locator('tbody tr').first()).toContainText(
+					thirdTitle
+				);
+			}).toPass();
+		}
+		finally {
+			for (const entry of [firstEntry, secondEntry, thirdEntry]) {
+				if (entry) {
+					await apiHelpers.objectEntry.deleteObjectEntry(
+						applicationName,
+						String(entry.id)
+					);
+				}
+			}
+		}
+	}
+);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-85725
Content views are not sorted by modified date.
# How am I fixing it?
By appending the modified date sort to the api URL for content views. Also fix some pre existing failing tests in site-cms-site-initializer that prevented my tests from passing.
# How can you verify that it works?
Run the tests in site-cms-site-initializer-test and the playwright tests.