### PR TITLE
LPD-70966 Use real user login instead of doAsUserId

### DIFF
--- a/modules/test/playwright/tests/journal-web/main/journalFolder.spec.ts
+++ b/modules/test/playwright/tests/journal-web/main/journalFolder.spec.ts
@@ -12,6 +12,7 @@ import {loginTest} from '../../../fixtures/loginTest';
 import {productMenuPageTest} from '../../../fixtures/productMenuPageTest';
 import getRandomString from '../../../utils/getRandomString';
 import {openFieldset} from '../../../utils/openFieldset';
+import {performUserSwitch, userData} from '../../../utils/performLogin';
 import createSiteTemplate from '../../layout-set-prototype-web/main/utils/createSiteTemplate';
 import {journalPagesTest} from './fixtures/journalPagesTest';
 
@@ -83,11 +84,46 @@ test(
 	async ({apiHelpers, journalEditFolderPage, journalPage, page, site}) => {
 		const testUser = await apiHelpers.headlessAdminUser.postUserAccount();
 
-		const role =
+		userData[testUser.alternateName] = {
+			name: testUser.givenName,
+			password: 'test',
+			surname: testUser.familyName,
+		};
+
+		const company =
+			await apiHelpers.jsonWebServicesCompany.getCompanyByWebId(
+				'liferay.com'
+			);
+
+		const journalViewerRole = await apiHelpers.headlessAdminUser.postRole({
+			name: 'JournalViewer-' + getRandomString(),
+			rolePermissions: [
+				{
+					actionIds: ['VIEW'],
+					primaryKey: String(company.companyId),
+					resourceName: 'com.liferay.journal',
+					scope: 1,
+				},
+				{
+					actionIds: ['ACCESS_IN_CONTROL_PANEL'],
+					primaryKey: String(company.companyId),
+					resourceName:
+						'com_liferay_journal_web_portlet_JournalPortlet',
+					scope: 1,
+				},
+			],
+		});
+
+		await apiHelpers.headlessAdminUser.assignUserToRole(
+			journalViewerRole.externalReferenceCode,
+			testUser.id
+		);
+
+		const siteMemberRole =
 			await apiHelpers.headlessAdminUser.getRoleByName('Site Member');
 
 		await apiHelpers.headlessAdminUser.assignUserToSite(
-			String(role.id),
+			String(siteMemberRole.id),
 			site.id,
 			testUser.id
 		);
@@ -118,12 +154,16 @@ test(
 
 		await page.waitForURL(/edit_folder/);
 
-		const doAsUserIdURL = `${page.url()}&doAsUserId=${testUser.id}`;
+		const editFolderURL = page.url();
 
-		await page.goto(doAsUserIdURL);
+		await performUserSwitch(page, testUser.alternateName);
+
+		await page.goto(editFolderURL);
 
 		await expect(journalEditFolderPage.title).toBeDisabled();
 		await expect(journalEditFolderPage.structureRestricions).toBeVisible();
+
+		await performUserSwitch(page, 'test');
 
 		await journalPage.goto(site.friendlyUrlPath);
 		await journalEditFolderPage.gotToPermission(title);
@@ -140,9 +180,14 @@ test(
 
 		await permissionIframe.getByRole('button', {name: 'Save'}).click();
 
-		await page.getByLabel('Close', {exact: true}).click();
+		await page
+			.getByRole('dialog', {name: 'Permissions'})
+			.getByLabel('Close')
+			.click();
 
-		await page.goto(doAsUserIdURL);
+		await performUserSwitch(page, testUser.alternateName);
+
+		await page.goto(editFolderURL);
 
 		await expect(journalEditFolderPage.title).toBeEnabled();
 		await expect(journalEditFolderPage.structureRestricions).toBeHidden();


### PR DESCRIPTION
Use real user login instead of doAsUserId

https://liferay.atlassian.net/browse/LPD-71109

## Summary                                                        
                             
Rework of the @LPD-46006 Playwright test in modules/test/playwright/tests/journal-web/main/journalFolder.spec.ts to replace doAsUserId impersonation with real login via performUserSwitch.                                        
                                                         
## Changes

Dropped doAsUserId: the admin-with-impersonation URL (&doAsUserId=${testUser.id}) didn't reliably evaluate folder-level permissions for the impersonated user — the test was failing because the Name field never became disabled.