### PR TITLE
LPD-86516 Resizing the browser trigger a web content auto-save

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
@@ -331,6 +331,7 @@ export default function _JournalPortlet({
 		});
 	};
 
+	let formChangeListener;
 	let hasUnsavedChanges = false;
 
 	const submitAsyncForm = (
@@ -418,6 +419,8 @@ export default function _JournalPortlet({
 					lockHolder.lock?.unlock();
 					removeAlert();
 
+					formChangeListener?.refreshSnapshot();
+
 					if (hasUnsavedChanges) {
 						hasUnsavedChanges = false;
 
@@ -498,33 +501,33 @@ export default function _JournalPortlet({
 		hasSavePermission &&
 		(!classNameId || classNameId === '0')
 	) {
-		eventHandlers.push(
-			attachFormChangeListener({
-				acceptMutationRecord: (mutationRecord) => {
-					return [
-						mutationRecord.target,
-						...mutationRecord.addedNodes,
-						...mutationRecord.removedNodes,
-					].some(
-						(node) =>
-							node.name &&
-							node.name.startsWith(namespace) &&
-							node.name !== `${namespace}languageId`
-					);
-				},
-				callback: () => {
-					if (lockHolder.lock?.isLocked()) {
-						hasUnsavedChanges = true;
+		formChangeListener = attachFormChangeListener({
+			acceptMutationRecord: (mutationRecord) => {
+				return [
+					mutationRecord.target,
+					...mutationRecord.addedNodes,
+					...mutationRecord.removedNodes,
+				].some(
+					(node) =>
+						node.name &&
+						node.name.startsWith(namespace) &&
+						node.name !== `${namespace}languageId`
+				);
+			},
+			callback: () => {
+				if (lockHolder.lock?.isLocked()) {
+					hasUnsavedChanges = true;
 
-						return;
-					}
+					return;
+				}
 
-					handleAutoSave();
-				},
-				form,
-				namespace,
-			})
-		);
+				handleAutoSave();
+			},
+			form,
+			namespace,
+		});
+
+		eventHandlers.push(formChangeListener);
 	}
 
 	if (window.innerWidth > Liferay.BREAKPOINTS.PHONE) {
@@ -548,7 +551,52 @@ function attachFormChangeListener({
 	form,
 	namespace,
 }) {
+	const excludedSnapshotNames = new Set([
+		`${namespace}formDate`,
+		`${namespace}languageId`,
+	]);
+
+	const snapshotFormValues = () => {
+		const values = new Map();
+
+		for (const element of form.elements) {
+			if (
+				element.name &&
+				element.name.startsWith(namespace) &&
+				!excludedSnapshotNames.has(element.name)
+			) {
+				values.set(element.name, (element.value ?? '').trim());
+			}
+		}
+
+		return values;
+	};
+
+	const snapshotsDiffer = (a, b) => {
+		if (a.size !== b.size) {
+			return true;
+		}
+
+		for (const [name, value] of a) {
+			if (b.get(name) !== value) {
+				return true;
+			}
+		}
+
+		return false;
+	};
+
+	let lastKnownSnapshot = new Map();
+
 	const handleChange = debounce(() => {
+		const current = snapshotFormValues();
+
+		if (!snapshotsDiffer(current, lastKnownSnapshot)) {
+			return;
+		}
+
+		lastKnownSnapshot = current;
+
 		callback();
 	}, AUTO_SAVE_DELAY);
 
@@ -580,6 +628,8 @@ function attachFormChangeListener({
 	});
 
 	Liferay.componentReady(`${namespace}SelectAssetDisplayPage`).then(() => {
+		lastKnownSnapshot = snapshotFormValues();
+
 		mutationObserver.observe(form, {
 			attributeFilter: ['value'],
 			attributeOldValue: true,
@@ -595,6 +645,9 @@ function attachFormChangeListener({
 		detach() {
 			mutationObserver.disconnect();
 			form.removeEventListener('change', handleChange);
+		},
+		refreshSnapshot() {
+			lastKnownSnapshot = snapshotFormValues();
 		},
 	};
 }

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/LocaleChangedHandler.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/LocaleChangedHandler.es.js
@@ -119,22 +119,22 @@ class LocaleChangedHandler {
 
 				// LPS-92493
 
-				const eventHandler = AOP.before(
-					() => AOP.prevent(),
-					inputComponent,
-					'updateInputLanguage'
-				);
+				const eventHandler = inputComponent.get('editor')
+					? AOP.before(
+							() => AOP.prevent(),
+							inputComponent,
+							'updateInputLanguage'
+						)
+					: null;
 
 				inputComponent.selectFlag(selectedLanguageId);
 				inputComponent.updateInput(inputDefaultValue);
 
-				// setInterval declared in ckeditor.jsp is triggering
-				// the updateInputLanguage function, so with this
-				// we guarantee that this function is not called
-
-				setTimeout(() => {
-					eventHandler.detach();
-				}, 400);
+				if (eventHandler) {
+					setTimeout(() => {
+						eventHandler.detach();
+					}, 400);
+				}
 			}
 		}
 	}

--- a/modules/test/playwright/tests/journal-web/main/journalArticleAutosave.spec.ts
+++ b/modules/test/playwright/tests/journal-web/main/journalArticleAutosave.spec.ts
@@ -841,6 +841,85 @@ autosaveWithoutPermissionsTest(
 );
 
 autoSaveTest(
+	'Resizing the browser does not trigger autosave for an unmodified article',
+	{
+		tag: '@LPD-86516',
+	},
+	async ({journalEditArticlePage, page, site}) => {
+		await journalEditArticlePage.goto({siteUrl: site.friendlyUrlPath});
+
+		await journalEditArticlePage.propertiesTab.waitFor();
+
+		let autosaveRequestCount = 0;
+
+		page.on('request', (request) => {
+			if (request.url().includes('auto_save_article')) {
+				autosaveRequestCount++;
+			}
+		});
+
+		const viewportSizes = [
+			{height: 800, width: 1600},
+			{height: 800, width: 900},
+			{height: 800, width: 480},
+			{height: 800, width: 1600},
+		];
+
+		for (const size of viewportSizes) {
+			await page.setViewportSize(size);
+
+			// Wait past AUTO_SAVE_DELAY (1500 ms) so any spurious debounced
+			// save would have fired before we assert.
+
+			await page.waitForTimeout(2000);
+		}
+
+		expect(autosaveRequestCount).toBe(0);
+
+		await expect(journalEditArticlePage.changesSavedIndicator).toBeHidden();
+	}
+);
+
+autoSaveTest(
+	'Resizing the browser does not trigger autosave after the article has already been saved',
+	{
+		tag: '@LPD-86516',
+	},
+	async ({journalEditArticlePage, page, site}) => {
+		await journalEditArticlePage.goto({siteUrl: site.friendlyUrlPath});
+
+		await journalEditArticlePage.fillTitle(getRandomString());
+
+		await expect(
+			journalEditArticlePage.changesSavedIndicator
+		).toBeVisible();
+
+		let autosaveRequestCount = 0;
+
+		page.on('request', (request) => {
+			if (request.url().includes('auto_save_article')) {
+				autosaveRequestCount++;
+			}
+		});
+
+		const viewportSizes = [
+			{height: 800, width: 900},
+			{height: 800, width: 1600},
+			{height: 800, width: 480},
+			{height: 800, width: 1600},
+		];
+
+		for (const size of viewportSizes) {
+			await page.setViewportSize(size);
+
+			await page.waitForTimeout(2000);
+		}
+
+		expect(autosaveRequestCount).toBe(0);
+	}
+);
+
+autoSaveTest(
 	'Preview button is disabled until first autosave',
 	{
 		tag: '@LPD-72082',


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-86516

Resizing the browser triggers an auto-save of web content even if you haven't made any changes.

# How am I fixing it?

By keeping a snapshot of the whole form so that when an resize event happens, I can compare the state of the form and really know if any value has really changed.

# How can you verify that it works?

Run the included functional tests.