### PR TITLE
LPD-86108 When a file is shared the user can not see the selected permissions

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/actions/shareAction.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/actions/shareAction.ts
@@ -40,7 +40,10 @@ export default async function shareAction({
 		const initialCollaborators: Collaborator[] = items.reverse().map(
 			({actionIds, dateExpired, id, name, portrait, share, type}) =>
 				({
-					actionIds: actionIds.sort().join(','),
+					actionIds: actionIds
+						.filter((actionId) => actionId !== 'DOWNLOAD')
+						.sort()
+						.join(','),
 					dateExpired,
 					share,
 					type,

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/props_transformer/actions/shareAction.test.ts
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/props_transformer/actions/shareAction.test.ts
@@ -1,0 +1,110 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import CollaboratorService from '../../../../../src/main/resources/META-INF/resources/js/common/services/CollaboratorService';
+import {openCMSModal} from '../../../../../src/main/resources/META-INF/resources/js/common/utils/openCMSModal';
+import ShareModalContent from '../../../../../src/main/resources/META-INF/resources/js/main_view/modal/share_modal_content/ShareModalContent';
+import shareAction from '../../../../../src/main/resources/META-INF/resources/js/main_view/props_transformer/actions/shareAction';
+
+jest.mock(
+	'../../../../../src/main/resources/META-INF/resources/js/common/services/CollaboratorService',
+	() => ({
+		__esModule: true,
+		default: {
+			getCollaborators: jest.fn(),
+		},
+	})
+);
+
+jest.mock(
+	'../../../../../src/main/resources/META-INF/resources/js/common/utils/openCMSModal',
+	() => ({
+		openCMSModal: jest.fn(),
+	})
+);
+
+jest.mock(
+	'../../../../../src/main/resources/META-INF/resources/js/main_view/modal/share_modal_content/ShareModalContent',
+	() => jest.fn()
+);
+
+jest.mock('frontend-js-components-web', () => ({
+	openToast: jest.fn(),
+}));
+
+const DEFAULT_ARGS = {
+	autocompleteURL: '/search',
+	collaboratorURL: '/o/cms/basic-documents/{objectEntryId}/collaborators',
+	creator: {
+		contentType: 'UserAccount',
+		id: 1,
+		name: 'Owner User',
+	},
+	entryClassName: '11111-className',
+	itemId: 20,
+	title: 'Test Document',
+};
+
+const baseItem = {
+	dateExpired: undefined,
+	id: 2,
+	name: 'Test2 Test2',
+	portrait: undefined,
+	share: false,
+	type: 'User',
+};
+
+const getInitialCollaborators = () => {
+	const mockShareModalContent = ShareModalContent as unknown as jest.Mock;
+
+	const openCMSModalArgs = (openCMSModal as jest.Mock).mock.calls[0][0];
+
+	openCMSModalArgs.contentComponent({closeModal: jest.fn()});
+
+	return mockShareModalContent.mock.calls[0][0].initialCollaborators;
+};
+
+describe('shareAction', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it.each([
+		[['VIEW'], 'VIEW'],
+		[['DOWNLOAD', 'VIEW'], 'VIEW'],
+		[['ADD_DISCUSSION', 'DOWNLOAD', 'VIEW'], 'ADD_DISCUSSION,VIEW'],
+		[
+			['ADD_DISCUSSION', 'DOWNLOAD', 'UPDATE', 'VIEW'],
+			'ADD_DISCUSSION,UPDATE,VIEW',
+		],
+		[['UPDATE', 'VIEW'], 'UPDATE,VIEW'],
+	])(
+		'maps API actionIds %j to initialCollaborator actionIds %j',
+		async (apiActionIds, expectedActionIds) => {
+			(
+				CollaboratorService.getCollaborators as jest.Mock
+			).mockResolvedValue([{...baseItem, actionIds: apiActionIds}]);
+
+			await shareAction(DEFAULT_ARGS);
+
+			const [{actionIds}] = getInitialCollaborators();
+
+			expect(actionIds).toBe(expectedActionIds);
+		}
+	);
+
+	it('strips DOWNLOAD so the picker matches a permission option', async () => {
+		(CollaboratorService.getCollaborators as jest.Mock).mockResolvedValue([
+			{...baseItem, actionIds: ['DOWNLOAD', 'VIEW']},
+		]);
+
+		await shareAction(DEFAULT_ARGS);
+
+		const [collaborator] = getInitialCollaborators();
+
+		expect(collaborator.actionIds).not.toContain('DOWNLOAD');
+		expect(collaborator.actionIds).toBe('VIEW');
+	});
+});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-86108

## Problem 

Sharing a CMS file with View/Download/Comment and reopening the share dialog → the permission picker renders empty for that user.                    

## Root cause   

ObjectEntrySharingEntryServiceWrapper auto-adds DOWNLOAD for file-type entries. The collaborator REST endpoint returns e.g. ["ADD_DISCUSSION","DOWNLOAD","VIEW"]. shareAction.ts joined that into "ADD_DISCUSSION,DOWNLOAD,VIEW", which matches none of the Picker option values (the UI enum has no DOWNLOAD; it's treated as implicit with VIEW). Result: <Picker selectedKey> matches nothing → blank.                                              
                  

## Fix

Strip DOWNLOAD from actionIds before sort().join(',') in shareAction.ts. Four-line change.                                                               

## Tests
New shareAction.test.ts covering five action-id combinations including the DOWNLOAD-stripping case. All 14 share-related tests pass; full suite shows 587 pass, 14 fail in 4 unrelated suites that were already broken on master (AssetNavigationModalContent, CommentsPanel, CategorizationSpaces, ShortcutManager — all clay-breadcrumb items.filter on undefined).                                                                                                             
                  
## Verified live

Redeployed module (gradlew deploy -a -x :yarnInstall), confirmed picker now reads "View, Download, and Comment" for an existing shared user.