### PR TITLE
LPD-86385 Filter Home Recent Assets by CMS contents and files sections

### DIFF
--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewHomeRecentAssetsSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewHomeRecentAssetsSectionDisplayContextTest.java
@@ -1,0 +1,196 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.display.context.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotRolesConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.fragment.renderer.FragmentRenderer;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu;
+import com.liferay.object.constants.ObjectFolderConstants;
+import com.liferay.object.model.ObjectEntryFolder;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.UserGroupRoleLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.Sync;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/**
+ * @author Mikel Lorza
+ */
+@FeatureFlag("LPD-17564")
+@RunWith(Arquillian.class)
+@Sync
+public class ViewHomeRecentAssetsSectionDisplayContextTest
+	extends BaseFilesSectionDisplayContextTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Test
+	public void testGetAdditionalAPIURLParameters() throws Exception {
+		_testGetAdditionalAPIURLParametersWithDepotRole(
+			DepotRolesConstants.ASSET_LIBRARY_ADMINISTRATOR);
+		_testGetAdditionalAPIURLParametersWithDepotRole(
+			DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER);
+		_testGetAdditionalAPIURLParametersWithDepotRole(
+			DepotRolesConstants.ASSET_LIBRARY_MEMBER);
+	}
+
+	@Override
+	@Test
+	public void testGetCreationMenu() throws Exception {
+	}
+
+	@Override
+	protected String getCMSSectionFilterString(Object displayContext) {
+		return ReflectionTestUtil.invoke(
+			displayContext, "getAdditionalAPIURLParameters", new Class<?>[0],
+			new Object[0]);
+	}
+
+	@Override
+	protected CreationMenu getCreationMenu(ObjectEntryFolder objectEntryFolder)
+		throws Exception {
+
+		return null;
+	}
+
+	@Override
+	protected Map<String, String> getExpectedCreationMenuItems() {
+		return new HashMap<>();
+	}
+
+	@Override
+	protected String getFilterString() {
+		return "cmsKind eq 'object' and (cmsSection eq 'contents' or " +
+			"cmsSection eq 'files')";
+	}
+
+	@Override
+	protected String getObjectFolderExternalReferenceCode() {
+		if (RandomTestUtil.randomBoolean()) {
+			return ObjectFolderConstants.
+				EXTERNAL_REFERENCE_CODE_CONTENT_STRUCTURES;
+		}
+
+		return ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_FILE_TYPES;
+	}
+
+	@Override
+	protected String[] getObjectFolderExternalReferenceCodes() {
+		return new String[] {
+			ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENT_STRUCTURES,
+			ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_FILE_TYPES
+		};
+	}
+
+	@Override
+	protected Object getSectionDisplayContext(
+			HttpServletRequest httpServletRequest)
+		throws Exception {
+
+		_fragmentRenderer.render(
+			null, httpServletRequest, new MockHttpServletResponse());
+
+		Object viewHomeRecentAssetsSectionDisplayContext =
+			httpServletRequest.getAttribute(
+				"com.liferay.site.cms.site.initializer.internal.display." +
+					"context.ViewHomeRecentAssetsSectionDisplayContext");
+
+		Assert.assertNotNull(viewHomeRecentAssetsSectionDisplayContext);
+
+		return viewHomeRecentAssetsSectionDisplayContext;
+	}
+
+	private void _testGetAdditionalAPIURLParametersWithDepotRole(
+			String depotRoleName)
+		throws Exception {
+
+		DepotEntry depotEntry = addDepotEntry(
+			StringUtil.randomString(), TestPropsValues.getUserId());
+
+		User user = UserTestUtil.addUser();
+
+		groupLocalService.addUserGroup(
+			user.getUserId(), depotEntry.getGroupId());
+
+		Role depotRole = _roleLocalService.getRole(
+			depotEntry.getCompanyId(), depotRoleName);
+
+		_userGroupRoleLocalService.addUserGroupRoles(
+			user.getUserId(), depotEntry.getGroupId(),
+			new long[] {depotRole.getRoleId()});
+
+		setUser(user);
+
+		String additionalAPIURLParameters = getCMSSectionFilterString(
+			getSectionDisplayContext(getMockHttpServletRequest(user)));
+
+		Assert.assertTrue(
+			additionalAPIURLParameters,
+			additionalAPIURLParameters.contains(
+				"filter=cmsKind eq 'object' and (cmsSection eq 'contents' or " +
+					"cmsSection eq 'files')"));
+		Assert.assertTrue(
+			additionalAPIURLParameters,
+			additionalAPIURLParameters.contains(
+				"groupIds/any(g:g in (" + depotEntry.getGroupId() + "))"));
+
+		setUser(adminUser);
+
+		_depotEntryLocalService.deleteDepotEntry(depotEntry);
+
+		_userLocalService.deleteUser(user);
+	}
+
+	@Inject
+	private DepotEntryLocalService _depotEntryLocalService;
+
+	@Inject(
+		filter = "component.name=com.liferay.site.cms.site.initializer.internal.fragment.renderer.ViewHomeRecentAssetsJSPSectionFragmentRenderer"
+	)
+	private FragmentRenderer _fragmentRenderer;
+
+	@Inject
+	private RoleLocalService _roleLocalService;
+
+	@Inject
+	private UserGroupRoleLocalService _userGroupRoleLocalService;
+
+	@Inject
+	private UserLocalService _userLocalService;
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
@@ -369,6 +369,11 @@ public abstract class BaseSectionDisplayContext {
 		return _sectionDisplayContextHelper.appendStatus(filterString);
 	}
 
+	protected String getAdditionalAPIURLParameters(String filterString) {
+		return _sectionDisplayContextHelper.getAdditionalAPIURLParameters(
+			filterString);
+	}
+
 	protected abstract String getCMSSectionFilterString();
 
 	protected String[] getObjectFolderExternalReferenceCodes() {

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/SectionDisplayContextHelper.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/SectionDisplayContextHelper.java
@@ -128,6 +128,15 @@ public class SectionDisplayContextHelper {
 			")");
 	}
 
+	public String getAdditionalAPIURLParameters(String filterString) {
+		return StringBundler.concat(
+			"emptySearch=true&filter=", filterString,
+			"&nestedFields=embedded,embeddedTaxonomyCategory,",
+			"file.metadata,file.previewURL,file.thumbnailURL,",
+			"numberOfObjectEntries,numberOfObjectEntryFolders,",
+			"systemProperties.objectDefinitionBrief");
+	}
+
 	public String getAdditionalAPIURLParameters(
 		String filterString, HttpServletRequest httpServletRequest,
 		String rootObjectEntryFolderExternalReferenceCode) {

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewHomeRecentAssetsSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewHomeRecentAssetsSectionDisplayContext.java
@@ -55,6 +55,11 @@ public class ViewHomeRecentAssetsSectionDisplayContext
 	}
 
 	@Override
+	public String getAdditionalAPIURLParameters() {
+		return getAdditionalAPIURLParameters(getCMSSectionFilterString());
+	}
+
+	@Override
 	public String getAPIURL() {
 		return HttpComponentsUtil.addParameters(
 			super.getAPIURL(), "sort", "dateModified:desc");

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/HomeRecentAssetsFDSPropsTransformer.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/HomeRecentAssetsFDSPropsTransformer.tsx
@@ -31,8 +31,13 @@ export default function HomeRecentAssetsFDSPropsTransformer({
 	itemsActions?: any[];
 	otherProps: any;
 }) {
+	const {additionalAPIURLParameters, ...remainingAdditionalProps} =
+		additionalProps || {};
+
 	return {
 		...otherProps,
+		additionalAPIURLParameters,
+		additionalProps: remainingAdditionalProps,
 		customRenderers: {
 			tableCell: [
 				{

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/props_transformer/HomeRecentAssetsFDSPropsTransformer.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/props_transformer/HomeRecentAssetsFDSPropsTransformer.test.tsx
@@ -1,0 +1,169 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import '@testing-library/jest-dom';
+
+import HomeRecentAssetsFDSPropsTransformer from '../../../../src/main/resources/META-INF/resources/js/main_view/props_transformer/HomeRecentAssetsFDSPropsTransformer';
+
+jest.mock('@liferay/frontend-data-set-web', () => ({
+	replaceTokens: jest.fn(),
+}));
+
+jest.mock('frontend-js-web', () => ({
+	sub: jest.fn(),
+}));
+
+jest.mock(
+	'../../../../src/main/resources/META-INF/resources/js/common/components/asset_usage/utils',
+	() => ({
+		openAssetUsageListModal: jest.fn(),
+	})
+);
+
+jest.mock(
+	'../../../../src/main/resources/META-INF/resources/js/common/utils/constants',
+	() => ({
+		OBJECT_ENTRY_FOLDER_CLASS_NAME:
+			'com.liferay.portal.kernel.repository.model.Folder',
+	})
+);
+
+jest.mock(
+	'../../../../src/main/resources/META-INF/resources/js/common/utils/openCMSModal',
+	() => ({
+		openCMSModal: jest.fn(),
+	})
+);
+
+jest.mock(
+	'../../../../src/main/resources/META-INF/resources/js/main_view/default_permission/DefaultPermissionModalContent',
+	() => ({
+		__esModule: true,
+		default: jest.fn(),
+	})
+);
+
+jest.mock(
+	'../../../../src/main/resources/META-INF/resources/js/main_view/default_permission/ResetPermissionModalContent',
+	() => ({
+		__esModule: true,
+		default: jest.fn(),
+	})
+);
+
+jest.mock(
+	'../../../../src/main/resources/META-INF/resources/js/main_view/modal/ExportTranslationModalContent',
+	() => ({
+		__esModule: true,
+		default: jest.fn(),
+	})
+);
+
+jest.mock(
+	'../../../../src/main/resources/META-INF/resources/js/main_view/modal/asset_navigation_view/AssetNavigationModalContent',
+	() => ({
+		__esModule: true,
+		default: jest.fn(),
+	})
+);
+
+jest.mock(
+	'../../../../src/main/resources/META-INF/resources/js/main_view/props_transformer/AssetsFDSPropsTransformer',
+	() => ({
+		__esModule: true,
+		default: jest.fn(),
+	})
+);
+
+jest.mock(
+	'../../../../src/main/resources/META-INF/resources/js/main_view/props_transformer/actions/creationMenuActions',
+	() => ({
+		__esModule: true,
+		default: {importTranslation: jest.fn()},
+	})
+);
+
+jest.mock(
+	'../../../../src/main/resources/META-INF/resources/js/main_view/props_transformer/actions/deleteItemAction',
+	() => ({
+		__esModule: true,
+		default: jest.fn(),
+	})
+);
+
+jest.mock(
+	'../../../../src/main/resources/META-INF/resources/js/main_view/props_transformer/actions/openFolderItemSelectorAction',
+	() => ({
+		__esModule: true,
+		default: jest.fn(),
+	})
+);
+
+jest.mock(
+	'../../../../src/main/resources/META-INF/resources/js/main_view/props_transformer/actions/shareAction',
+	() => ({
+		__esModule: true,
+		default: jest.fn(),
+	})
+);
+
+jest.mock(
+	'../../../../src/main/resources/META-INF/resources/js/main_view/props_transformer/cell_renderers/AssetRenderer',
+	() => ({
+		__esModule: true,
+		default: jest.fn(),
+	})
+);
+
+describe('HomeRecentAssetsFDSPropsTransformer', () => {
+	it('hoist additionalAPIURLParameters to the top level so FrontendDataSet forwards it to loadData', () => {
+		const additionalAPIURLParameters =
+			"emptySearch=true&filter=cmsKind eq 'object' and " +
+			"(cmsSection eq 'contents' or cmsSection eq 'files')";
+
+		const result = HomeRecentAssetsFDSPropsTransformer({
+			additionalProps: {
+				additionalAPIURLParameters,
+				contentViewURL: 'https://example.com/view',
+			} as any,
+			otherProps: {},
+		} as any);
+
+		expect(result.additionalAPIURLParameters).toBe(
+			additionalAPIURLParameters
+		);
+		expect(result.additionalProps).not.toHaveProperty(
+			'additionalAPIURLParameters'
+		);
+		expect(result.additionalProps).toEqual({
+			contentViewURL: 'https://example.com/view',
+		});
+	});
+
+	it('forward other top-level props untouched', () => {
+		const result = HomeRecentAssetsFDSPropsTransformer({
+			additionalProps: {
+				additionalAPIURLParameters: 'foo=bar',
+			} as any,
+			apiURL: '/o/search/v1.0/search',
+		} as any);
+
+		expect(result).toMatchObject({
+			additionalAPIURLParameters: 'foo=bar',
+			apiURL: '/o/search/v1.0/search',
+			hideManagementBarInEmptyState: true,
+		});
+	});
+
+	it('handle missing additionalProps without throwing', () => {
+		const result = HomeRecentAssetsFDSPropsTransformer({
+			additionalProps: undefined,
+			otherProps: {},
+		} as any);
+
+		expect(result.additionalAPIURLParameters).toBeUndefined();
+		expect(result.additionalProps).toEqual({});
+	});
+});


### PR DESCRIPTION
## Summary
- Introduce a filter-only `getAdditionalAPIURLParameters` overload in `SectionDisplayContextHelper`, expose it via `BaseSectionDisplayContext`, and override it in `ViewHomeRecentAssetsSectionDisplayContext` to restrict results to `cmsKind eq 'object'` and `cmsSection in ('contents', 'files')`.
- Hoist `additionalAPIURLParameters` to the top level in `HomeRecentAssetsFDSPropsTransformer` so `FrontendDataSet` forwards it to `loadData` (mirrors `AssetsFDSPropsTransformer`) — without this, the CMS section filter was silently dropped.
- Add integration coverage in `ViewHomeRecentAssetsSectionDisplayContextTest` for each depot-scoped CMS role (Asset Library Administrator, Content Reviewer, Member).
- Add a frontend unit test guarding the hoisting behavior.

## Test plan
- [ ] `ViewHomeRecentAssetsSectionDisplayContextTest` passes
- [ ] `npm test -- HomeRecentAssetsFDSPropsTransformer` passes
- [ ] Manually verify the Home Recent Assets widget only lists items from the `contents`/`files` CMS sections