### PR TITLE
LPD-86074 Edit url for cms objects don't go to the cms

### DIFF
--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/asset/model/ObjectEntryAssetRenderer.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/asset/model/ObjectEntryAssetRenderer.java
@@ -7,9 +7,6 @@ package com.liferay.object.web.internal.asset.model;
 
 import com.liferay.asset.display.page.portlet.AssetDisplayPageFriendlyURLProvider;
 import com.liferay.asset.kernel.model.BaseJSPAssetRenderer;
-import com.liferay.depot.constants.DepotConstants;
-import com.liferay.depot.model.DepotEntry;
-import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.util.DLURLHelper;
 import com.liferay.info.item.ClassPKInfoItemIdentifier;
@@ -67,7 +64,6 @@ public class ObjectEntryAssetRenderer
 	public ObjectEntryAssetRenderer(
 			AssetDisplayPageFriendlyURLProvider
 				assetDisplayPageFriendlyURLProvider,
-			DepotEntryLocalService depotEntryLocalService,
 			DLAppLocalService dlAppLocalService, DLURLHelper dlURLHelper,
 			ObjectDefinition objectDefinition, ObjectEntry objectEntry,
 			ObjectEntryDisplayContextFactory objectEntryDisplayContextFactory,
@@ -77,7 +73,6 @@ public class ObjectEntryAssetRenderer
 
 		_assetDisplayPageFriendlyURLProvider =
 			assetDisplayPageFriendlyURLProvider;
-		_depotEntryLocalService = depotEntryLocalService;
 		_dlAppLocalService = dlAppLocalService;
 		_dlURLHelper = dlURLHelper;
 		_objectDefinition = objectDefinition;
@@ -204,7 +199,7 @@ public class ObjectEntryAssetRenderer
 	public PortletURL getURLEdit(HttpServletRequest httpServletRequest)
 		throws Exception {
 
-		if (_objectDefinition.isCMS() && _isSpaceDepotEntryObjectEntry()) {
+		if (_objectDefinition.isCMS()) {
 			ThemeDisplay themeDisplay =
 				(ThemeDisplay)httpServletRequest.getAttribute(
 					WebKeys.THEME_DISPLAY);
@@ -253,7 +248,7 @@ public class ObjectEntryAssetRenderer
 			String redirect)
 		throws Exception {
 
-		if (_objectDefinition.isCMS() && _isSpaceDepotEntryObjectEntry()) {
+		if (_objectDefinition.isCMS()) {
 			return getURLEdit(httpServletRequest);
 		}
 
@@ -277,7 +272,7 @@ public class ObjectEntryAssetRenderer
 			WindowState windowState, String redirect)
 		throws Exception {
 
-		if (_objectDefinition.isCMS() && _isSpaceDepotEntryObjectEntry()) {
+		if (_objectDefinition.isCMS()) {
 			return getURLEdit(
 				PortalUtil.getHttpServletRequest(liferayPortletRequest));
 		}
@@ -296,7 +291,7 @@ public class ObjectEntryAssetRenderer
 			return null;
 		}
 
-		if (!_isSpaceDepotEntryObjectEntry()) {
+		if (!_objectDefinition.isCMS()) {
 			return getURLViewInContext(themeDisplay, StringPool.BLANK);
 		}
 
@@ -447,25 +442,11 @@ public class ObjectEntryAssetRenderer
 		return permissionChecker;
 	}
 
-	private boolean _isSpaceDepotEntryObjectEntry() {
-		DepotEntry depotEntry = _depotEntryLocalService.fetchGroupDepotEntry(
-			_objectEntry.getGroupId());
-
-		if ((depotEntry == null) ||
-			(depotEntry.getType() != DepotConstants.TYPE_SPACE)) {
-
-			return false;
-		}
-
-		return true;
-	}
-
 	private static final Log _log = LogFactoryUtil.getLog(
 		ObjectEntryAssetRenderer.class);
 
 	private final AssetDisplayPageFriendlyURLProvider
 		_assetDisplayPageFriendlyURLProvider;
-	private final DepotEntryLocalService _depotEntryLocalService;
 	private final DLAppLocalService _dlAppLocalService;
 	private final DLURLHelper _dlURLHelper;
 	private final ObjectDefinition _objectDefinition;

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/asset/model/ObjectEntryAssetRenderer.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/asset/model/ObjectEntryAssetRenderer.java
@@ -30,8 +30,10 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.portlet.DummyPortletURL;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
+import com.liferay.portal.kernel.portlet.PortletURLWrapper;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
@@ -49,6 +51,7 @@ import com.liferay.portal.kernel.util.WebKeys;
 import jakarta.portlet.PortletRequest;
 import jakarta.portlet.PortletResponse;
 import jakarta.portlet.PortletURL;
+import jakarta.portlet.WindowState;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -201,6 +204,25 @@ public class ObjectEntryAssetRenderer
 	public PortletURL getURLEdit(HttpServletRequest httpServletRequest)
 		throws Exception {
 
+		if (_objectDefinition.isCMS() && _isSpaceDepotEntryObjectEntry()) {
+			ThemeDisplay themeDisplay =
+				(ThemeDisplay)httpServletRequest.getAttribute(
+					WebKeys.THEME_DISPLAY);
+
+			if (themeDisplay != null) {
+				String cmsEditURL = _getCMSURL(Constants.EDIT, themeDisplay);
+
+				return new PortletURLWrapper(DummyPortletURL.getInstance()) {
+
+					@Override
+					public String toString() {
+						return cmsEditURL;
+					}
+
+				};
+			}
+		}
+
 		Group group = GroupLocalServiceUtil.fetchGroup(
 			_objectEntry.getGroupId());
 
@@ -227,12 +249,42 @@ public class ObjectEntryAssetRenderer
 
 	@Override
 	public PortletURL getURLEdit(
+			HttpServletRequest httpServletRequest, WindowState windowState,
+			String redirect)
+		throws Exception {
+
+		if (_objectDefinition.isCMS() && _isSpaceDepotEntryObjectEntry()) {
+			return getURLEdit(httpServletRequest);
+		}
+
+		return super.getURLEdit(httpServletRequest, windowState, redirect);
+	}
+
+	@Override
+	public PortletURL getURLEdit(
 			LiferayPortletRequest liferayPortletRequest,
 			LiferayPortletResponse liferayPortletResponse)
 		throws Exception {
 
 		return getURLEdit(
 			PortalUtil.getHttpServletRequest(liferayPortletRequest));
+	}
+
+	@Override
+	public PortletURL getURLEdit(
+			LiferayPortletRequest liferayPortletRequest,
+			LiferayPortletResponse liferayPortletResponse,
+			WindowState windowState, String redirect)
+		throws Exception {
+
+		if (_objectDefinition.isCMS() && _isSpaceDepotEntryObjectEntry()) {
+			return getURLEdit(
+				PortalUtil.getHttpServletRequest(liferayPortletRequest));
+		}
+
+		return super.getURLEdit(
+			liferayPortletRequest, liferayPortletResponse, windowState,
+			redirect);
 	}
 
 	@Override
@@ -244,12 +296,7 @@ public class ObjectEntryAssetRenderer
 			return null;
 		}
 
-		DepotEntry depotEntry = _depotEntryLocalService.fetchGroupDepotEntry(
-			_objectEntry.getGroupId());
-
-		if ((depotEntry == null) ||
-			(depotEntry.getType() != DepotConstants.TYPE_SPACE)) {
-
+		if (!_isSpaceDepotEntryObjectEntry()) {
 			return getURLViewInContext(themeDisplay, StringPool.BLANK);
 		}
 
@@ -259,12 +306,7 @@ public class ObjectEntryAssetRenderer
 			mode = Constants.EDIT;
 		}
 
-		return StringBundler.concat(
-			themeDisplay.getPortalURL(), themeDisplay.getPathMain(),
-			GroupConstants.CMS_FRIENDLY_URL,
-			"/edit_content_item?objectEntryId=",
-			_objectEntry.getObjectEntryId(), "&p_l_mode=", mode, "&redirect=",
-			HtmlUtil.escapeURL(themeDisplay.getURLCurrent()));
+		return _getCMSURL(mode, themeDisplay);
 	}
 
 	@Override
@@ -385,6 +427,15 @@ public class ObjectEntryAssetRenderer
 		return _objectDefinition.isEnableComments();
 	}
 
+	private String _getCMSURL(String mode, ThemeDisplay themeDisplay) {
+		return StringBundler.concat(
+			themeDisplay.getPortalURL(), themeDisplay.getPathMain(),
+			GroupConstants.CMS_FRIENDLY_URL,
+			"/edit_content_item?objectEntryId=",
+			_objectEntry.getObjectEntryId(), "&p_l_mode=", mode, "&redirect=",
+			HtmlUtil.escapeURL(themeDisplay.getURLCurrent()));
+	}
+
 	private PermissionChecker _getPermissionChecker(ThemeDisplay themeDisplay) {
 		PermissionChecker permissionChecker =
 			PermissionThreadLocal.getPermissionChecker();
@@ -394,6 +445,19 @@ public class ObjectEntryAssetRenderer
 		}
 
 		return permissionChecker;
+	}
+
+	private boolean _isSpaceDepotEntryObjectEntry() {
+		DepotEntry depotEntry = _depotEntryLocalService.fetchGroupDepotEntry(
+			_objectEntry.getGroupId());
+
+		if ((depotEntry == null) ||
+			(depotEntry.getType() != DepotConstants.TYPE_SPACE)) {
+
+			return false;
+		}
+
+		return true;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/asset/model/ObjectEntryAssetRendererFactory.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/asset/model/ObjectEntryAssetRendererFactory.java
@@ -8,7 +8,6 @@ package com.liferay.object.web.internal.asset.model;
 import com.liferay.asset.display.page.portlet.AssetDisplayPageFriendlyURLProvider;
 import com.liferay.asset.kernel.model.AssetRenderer;
 import com.liferay.asset.kernel.model.BaseAssetRendererFactory;
-import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.util.DLURLHelper;
 import com.liferay.object.constants.ObjectDefinitionConstants;
@@ -44,7 +43,6 @@ public class ObjectEntryAssetRendererFactory
 
 	public ObjectEntryAssetRendererFactory(
 		AssetDisplayPageFriendlyURLProvider assetDisplayPageFriendlyURLProvider,
-		DepotEntryLocalService depotEntryLocalService,
 		DLAppLocalService dlAppLocalService, DLURLHelper dlURLHelper,
 		ObjectDefinition objectDefinition,
 		ObjectEntryDisplayContextFactory objectEntryDisplayContextFactory,
@@ -59,7 +57,6 @@ public class ObjectEntryAssetRendererFactory
 
 		_assetDisplayPageFriendlyURLProvider =
 			assetDisplayPageFriendlyURLProvider;
-		_depotEntryLocalService = depotEntryLocalService;
 		_dlAppLocalService = dlAppLocalService;
 		_dlURLHelper = dlURLHelper;
 		_objectDefinition = objectDefinition;
@@ -80,8 +77,8 @@ public class ObjectEntryAssetRendererFactory
 
 		ObjectEntryAssetRenderer objectEntryAssetRenderer =
 			new ObjectEntryAssetRenderer(
-				_assetDisplayPageFriendlyURLProvider, _depotEntryLocalService,
-				_dlAppLocalService, _dlURLHelper, _objectDefinition,
+				_assetDisplayPageFriendlyURLProvider, _dlAppLocalService,
+				_dlURLHelper, _objectDefinition,
 				_objectEntryLocalService.getObjectEntry(classPK),
 				_objectEntryDisplayContextFactory, _objectEntryService,
 				_objectFieldLocalService);
@@ -187,7 +184,6 @@ public class ObjectEntryAssetRendererFactory
 
 	private final AssetDisplayPageFriendlyURLProvider
 		_assetDisplayPageFriendlyURLProvider;
-	private final DepotEntryLocalService _depotEntryLocalService;
 	private final DLAppLocalService _dlAppLocalService;
 	private final DLURLHelper _dlURLHelper;
 	private final ObjectDefinition _objectDefinition;

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -12,7 +12,6 @@ import com.liferay.asset.kernel.service.AssetCategoryLocalService;
 import com.liferay.asset.kernel.service.AssetTagLocalService;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
 import com.liferay.asset.util.AssetHelper;
-import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.document.library.kernel.exception.FileExtensionException;
 import com.liferay.document.library.kernel.exception.FileSizeException;
 import com.liferay.document.library.kernel.exception.InvalidFileException;
@@ -248,11 +247,11 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 			_bundleContext.registerService(
 				AssetRendererFactory.class,
 				new ObjectEntryAssetRendererFactory(
-					_assetDisplayPageFriendlyURLProvider,
-					_depotEntryLocalService, _dlAppLocalService, _dlURLHelper,
-					objectDefinition, _objectEntryDisplayContextFactory,
-					_objectEntryLocalService, _objectEntryService,
-					_objectFieldLocalService, _servletContext),
+					_assetDisplayPageFriendlyURLProvider, _dlAppLocalService,
+					_dlURLHelper, objectDefinition,
+					_objectEntryDisplayContextFactory, _objectEntryLocalService,
+					_objectEntryService, _objectFieldLocalService,
+					_servletContext),
 				HashMapDictionaryBuilder.<String, Object>put(
 					"company.id", objectDefinition.getCompanyId()
 				).put(
@@ -769,9 +768,6 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 
 	@Reference(target = "(upload.response.handler.system.default=true)")
 	private UploadResponseHandler _defaultUploadResponseHandler;
-
-	@Reference
-	private DepotEntryLocalService _depotEntryLocalService;
 
 	@Reference(
 		target = "(info.item.capability.key=" + DisplayPageInfoItemCapability.KEY + ")"

--- a/modules/apps/object/object-web/src/test/java/com/liferay/object/web/internal/asset/model/ObjectEntryAssetRendererFactoryTest.java
+++ b/modules/apps/object/object-web/src/test/java/com/liferay/object/web/internal/asset/model/ObjectEntryAssetRendererFactoryTest.java
@@ -6,7 +6,6 @@
 package com.liferay.object.web.internal.asset.model;
 
 import com.liferay.asset.display.page.portlet.AssetDisplayPageFriendlyURLProvider;
-import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.util.DLURLHelper;
 import com.liferay.object.constants.ObjectDefinitionConstants;
@@ -49,8 +48,8 @@ public class ObjectEntryAssetRendererFactoryTest {
 		languageUtil.setLanguage(new LanguageImpl());
 
 		_objectEntryAssetRendererFactory = new ObjectEntryAssetRendererFactory(
-			_assetDisplayPageFriendlyURLProvider, _depotEntryLocalService,
-			_dlAppLocalService, _dlURLHelper, _objectDefinition,
+			_assetDisplayPageFriendlyURLProvider, _dlAppLocalService,
+			_dlURLHelper, _objectDefinition,
 			_objectEntryDisplayContextFactoryImpl, _objectEntryLocalService,
 			_objectEntryService, _objectFieldLocalService, _servletContext);
 
@@ -139,8 +138,6 @@ public class ObjectEntryAssetRendererFactoryTest {
 	private final AssetDisplayPageFriendlyURLProvider
 		_assetDisplayPageFriendlyURLProvider = Mockito.mock(
 			AssetDisplayPageFriendlyURLProvider.class);
-	private final DepotEntryLocalService _depotEntryLocalService = Mockito.mock(
-		DepotEntryLocalService.class);
 	private final DLAppLocalService _dlAppLocalService = Mockito.mock(
 		DLAppLocalService.class);
 	private final DLURLHelper _dlURLHelper = Mockito.mock(DLURLHelper.class);

--- a/modules/apps/object/object-web/src/test/java/com/liferay/object/web/internal/asset/model/ObjectEntryAssetRendererTest.java
+++ b/modules/apps/object/object-web/src/test/java/com/liferay/object/web/internal/asset/model/ObjectEntryAssetRendererTest.java
@@ -7,9 +7,6 @@ package com.liferay.object.web.internal.asset.model;
 
 import com.liferay.asset.display.page.portlet.AssetDisplayPageFriendlyURLProvider;
 import com.liferay.asset.kernel.model.AssetRenderer;
-import com.liferay.depot.constants.DepotConstants;
-import com.liferay.depot.model.DepotEntry;
-import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.util.DLURLHelper;
 import com.liferay.info.item.ClassPKInfoItemIdentifier;
@@ -299,18 +296,10 @@ public class ObjectEntryAssetRendererTest {
 			_objectEntry
 		).getObjectEntryId();
 
-		DepotEntry depotEntry = Mockito.mock(DepotEntry.class);
-
-		Mockito.doReturn(
-			DepotConstants.TYPE_SPACE
-		).when(
-			depotEntry
-		).getType();
-
 		Mockito.when(
-			_depotEntryLocalService.fetchGroupDepotEntry(Mockito.anyLong())
+			_objectDefinition.isCMS()
 		).thenReturn(
-			depotEntry
+			true
 		);
 
 		return StringBundler.concat(
@@ -358,8 +347,8 @@ public class ObjectEntryAssetRendererTest {
 		throws Exception {
 
 		return new ObjectEntryAssetRenderer(
-			_assetDisplayPageFriendlyURLProvider, _depotEntryLocalService,
-			_dlAppLocalService, _dlURLHelper, _objectDefinition, _objectEntry,
+			_assetDisplayPageFriendlyURLProvider, _dlAppLocalService,
+			_dlURLHelper, _objectDefinition, _objectEntry,
 			_objectEntryDisplayContextFactoryImpl, _objectEntryService,
 			_objectFieldLocalService);
 	}
@@ -463,8 +452,6 @@ public class ObjectEntryAssetRendererTest {
 	private final AssetDisplayPageFriendlyURLProvider
 		_assetDisplayPageFriendlyURLProvider = Mockito.mock(
 			AssetDisplayPageFriendlyURLProvider.class);
-	private final DepotEntryLocalService _depotEntryLocalService = Mockito.mock(
-		DepotEntryLocalService.class);
 	private final DLAppLocalService _dlAppLocalService = Mockito.mock(
 		DLAppLocalService.class);
 	private final DLURLHelper _dlURLHelper = Mockito.mock(DLURLHelper.class);

--- a/modules/apps/object/object-web/src/test/java/com/liferay/object/web/internal/asset/model/ObjectEntryAssetRendererTest.java
+++ b/modules/apps/object/object-web/src/test/java/com/liferay/object/web/internal/asset/model/ObjectEntryAssetRendererTest.java
@@ -33,11 +33,16 @@ import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import jakarta.portlet.PortletURL;
+
+import jakarta.servlet.http.HttpServletRequest;
 
 import java.io.Serializable;
 
@@ -97,7 +102,7 @@ public class ObjectEntryAssetRendererTest {
 		);
 
 		Assert.assertEquals(
-			_getCMSFriendlyURL(themeDisplay),
+			_getCMSFriendlyURL(Constants.READ, themeDisplay),
 			assetRenderer.getSharingEntryRowPortletURL(false, themeDisplay));
 	}
 
@@ -145,6 +150,36 @@ public class ObjectEntryAssetRendererTest {
 	}
 
 	@Test
+	public void testGetURLEdit() throws Exception {
+		Mockito.when(
+			_objectDefinition.isCMS()
+		).thenReturn(
+			true
+		);
+
+		AssetRenderer<ObjectEntry> assetRenderer =
+			_getObjectEntryAssetRenderer();
+
+		HttpServletRequest httpServletRequest = Mockito.mock(
+			HttpServletRequest.class);
+
+		ThemeDisplay themeDisplay = Mockito.mock(ThemeDisplay.class);
+
+		Mockito.when(
+			httpServletRequest.getAttribute(WebKeys.THEME_DISPLAY)
+		).thenReturn(
+			themeDisplay
+		);
+
+		String expectedURL = _getCMSFriendlyURL(Constants.EDIT, themeDisplay);
+
+		PortletURL editPortletURL = assetRenderer.getURLEdit(
+			httpServletRequest);
+
+		Assert.assertEquals(expectedURL, editPortletURL.toString());
+	}
+
+	@Test
 	public void testGetURLSharingNotification() throws Exception {
 		AssetRenderer<ObjectEntry> assetRenderer =
 			_getObjectEntryAssetRenderer();
@@ -152,7 +187,7 @@ public class ObjectEntryAssetRendererTest {
 		ThemeDisplay themeDisplay = Mockito.mock(ThemeDisplay.class);
 
 		Assert.assertEquals(
-			_getCMSFriendlyURL(themeDisplay),
+			_getCMSFriendlyURL(Constants.READ, themeDisplay),
 			assetRenderer.getURLSharingNotification(themeDisplay));
 	}
 
@@ -231,7 +266,7 @@ public class ObjectEntryAssetRendererTest {
 		Assert.assertTrue(assetRenderer.hasViewPermission(_permissionChecker));
 	}
 
-	private String _getCMSFriendlyURL(ThemeDisplay themeDisplay) {
+	private String _getCMSFriendlyURL(String mode, ThemeDisplay themeDisplay) {
 		String pathMain = StringPool.SLASH + RandomTestUtil.randomString();
 
 		Mockito.when(
@@ -280,8 +315,8 @@ public class ObjectEntryAssetRendererTest {
 
 		return StringBundler.concat(
 			portalURL, pathMain, GroupConstants.CMS_FRIENDLY_URL,
-			"/edit_content_item?objectEntryId=", objectEntryId,
-			"&p_l_mode=read&redirect=", HtmlUtil.escapeURL(urlCurrent));
+			"/edit_content_item?objectEntryId=", objectEntryId, "&p_l_mode=",
+			mode, "&redirect=", HtmlUtil.escapeURL(urlCurrent));
 	}
 
 	private String _getFriendlyURL(LiferayPortletRequest liferayPortletRequest)


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-86074

When trying to access the edit url of an object entry through the asset framework, objects created through the cms should redirect the user to the cms, not the generic object edit url.

# How am I fixing it?

By explicitly checking for cms-ness of objects, and redirecting to the corret page.

# How can you verify that it works?

Run the included unit tests.