### PR TITLE
LPD-27458 Success message appears more than once when clicking to copy a document's URL

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/js/document_library/InfoPanel.es.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/js/document_library/InfoPanel.es.js
@@ -17,7 +17,17 @@ class InfoPanel extends PortletBase {
 	 * @review
 	 */
 	attached() {
-		this._clipboard = new ClipboardJS('.dm-infopanel-copy-clipboard');
+		this._destroyClipboard();
+
+		const selector = '.dm-infopanel-copy-clipboard';
+
+		const container = this.rootNode;
+
+		if (!container) {
+			return;
+		}
+
+		this._clipboard = new ClipboardJS(container.querySelectorAll(selector));
 
 		this._clipboard.on('success', this._handleClipboardSuccess.bind(this));
 	}
@@ -28,8 +38,14 @@ class InfoPanel extends PortletBase {
 	 */
 	disposeInternal() {
 		super.disposeInternal();
+		this._destroyClipboard();
+	}
 
-		this._clipboard.destroy();
+	_destroyClipboard() {
+		if (this._clipboard) {
+			this._clipboard.destroy();
+			this._clipboard = null;
+		}
 	}
 
 	_handleClipboardSuccess() {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-27458

**How I fixed:** 
Refactored the ClipboardJS initialization in the InfoPanel component to prevent "copy to clipboard" events from registering multiple times when the component is attached/detached from the DOM.

The issue was caused by the mismatch between the component's lifecycle and ClipboardJS's global event delegation. By explicitly calling .destroy() before re-instantiating, we ensure the internal Emitter of the library is cleared. Using querySelectorAll on the rootNode ensures we only target elements belonging to this specific instance of the InfoPanel.