### PR TITLE
LPD-85299 DL Folder parent hierarchy incorrectly preserved during export/import when parent mapping is missing

### DIFF
--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/exportimport/data/handler/FolderStagedModelDataHandler.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/exportimport/data/handler/FolderStagedModelDataHandler.java
@@ -227,7 +227,8 @@ public class FolderStagedModelDataHandler
 				Folder.class);
 
 		long parentFolderId = MapUtil.getLong(
-			folderIds, folder.getParentFolderId(), folder.getParentFolderId());
+			folderIds, folder.getParentFolderId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID);
 
 		ServiceContext serviceContext = portletDataContext.createServiceContext(
 			folder, DLFolder.class);

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/exportimport/data/handler/test/FolderStagedModelDataHandlerTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/exportimport/data/handler/test/FolderStagedModelDataHandlerTest.java
@@ -118,6 +118,12 @@ public class FolderStagedModelDataHandlerTest
 
 			Assert.assertNotNull(exportedChildFolder);
 
+			Folder exportedParentFolder = (Folder)readExportedStagedModel(
+				parentFolder);
+
+			StagedModelDataHandlerUtil.importStagedModel(
+				portletDataContext, exportedParentFolder);
+
 			Map<Long, Long> folderIds =
 				(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
 					Folder.class);

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/exportimport/data/handler/test/FolderStagedModelDataHandlerTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/exportimport/data/handler/test/FolderStagedModelDataHandlerTest.java
@@ -64,6 +64,57 @@ public class FolderStagedModelDataHandlerTest
 		new LiferayIntegrationTestRule();
 
 	@Test
+	public void testImportChildFolderWithMissingParentMapping()
+		throws Exception {
+
+		initExport();
+
+		Folder parentFolder = DLAppServiceUtil.addFolder(
+			null, stagingGroup.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			ServiceContextTestUtil.getServiceContext(
+				stagingGroup.getGroupId(), TestPropsValues.getUserId()));
+
+		Folder childFolder = DLAppServiceUtil.addFolder(
+			null, stagingGroup.getGroupId(), parentFolder.getFolderId(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			ServiceContextTestUtil.getServiceContext(
+				stagingGroup.getGroupId(), TestPropsValues.getUserId()));
+
+		StagedModelDataHandlerUtil.exportStagedModel(
+			portletDataContext, childFolder);
+
+		try (SafeCloseable safeCloseable = initImportWithSafeCloseable()) {
+			Folder exportedChildFolder = (Folder)readExportedStagedModel(
+				childFolder);
+
+			Assert.assertNotNull(exportedChildFolder);
+
+			// Clear the parent folder mapping so the parent is "missing"
+
+			Map<Long, Long> folderIds =
+				(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
+					Folder.class);
+
+			folderIds.remove(parentFolder.getFolderId());
+
+			StagedModelDataHandlerUtil.importStagedModel(
+				portletDataContext, exportedChildFolder);
+
+			DLFolder importedDLFolder =
+				DLFolderLocalServiceUtil.getDLFolderByUuidAndGroupId(
+					childFolder.getUuid(), liveGroup.getGroupId());
+
+			Assert.assertEquals(
+				"When parent folder mapping is missing, the imported child " +
+					"folder should be placed at root level",
+				DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+				importedDLFolder.getParentFolderId());
+		}
+	}
+
+	@Test
 	public void testCompanyScopeDependencies() throws Exception {
 		initExport();
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/exportimport/data/handler/test/FolderStagedModelDataHandlerTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/exportimport/data/handler/test/FolderStagedModelDataHandlerTest.java
@@ -64,6 +64,33 @@ public class FolderStagedModelDataHandlerTest
 		new LiferayIntegrationTestRule();
 
 	@Test
+	public void testCompanyScopeDependencies() throws Exception {
+		initExport();
+
+		Map<String, List<StagedModel>> dependentStagedModelsMap =
+			addCompanyDependencies();
+
+		StagedModel stagedModel = addStagedModel(
+			stagingGroup, dependentStagedModelsMap);
+
+		StagedModelDataHandlerUtil.exportStagedModel(
+			portletDataContext, stagedModel);
+
+		try (SafeCloseable safeCloseable = initImportWithSafeCloseable()) {
+			StagedModel exportedStagedModel = readExportedStagedModel(
+				stagedModel);
+
+			Assert.assertNotNull(exportedStagedModel);
+
+			StagedModelDataHandlerUtil.importStagedModel(
+				portletDataContext, exportedStagedModel);
+
+			validateCompanyDependenciesImport(
+				dependentStagedModelsMap, liveGroup);
+		}
+	}
+
+	@Test
 	public void testImportChildFolderWithMissingParentMapping()
 		throws Exception {
 
@@ -111,33 +138,6 @@ public class FolderStagedModelDataHandlerTest
 					"folder should be placed at root level",
 				DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 				importedDLFolder.getParentFolderId());
-		}
-	}
-
-	@Test
-	public void testCompanyScopeDependencies() throws Exception {
-		initExport();
-
-		Map<String, List<StagedModel>> dependentStagedModelsMap =
-			addCompanyDependencies();
-
-		StagedModel stagedModel = addStagedModel(
-			stagingGroup, dependentStagedModelsMap);
-
-		StagedModelDataHandlerUtil.exportStagedModel(
-			portletDataContext, stagedModel);
-
-		try (SafeCloseable safeCloseable = initImportWithSafeCloseable()) {
-			StagedModel exportedStagedModel = readExportedStagedModel(
-				stagedModel);
-
-			Assert.assertNotNull(exportedStagedModel);
-
-			StagedModelDataHandlerUtil.importStagedModel(
-				portletDataContext, exportedStagedModel);
-
-			validateCompanyDependenciesImport(
-				dependentStagedModelsMap, liveGroup);
 		}
 	}
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/exportimport/data/handler/test/FolderStagedModelDataHandlerTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/exportimport/data/handler/test/FolderStagedModelDataHandlerTest.java
@@ -118,8 +118,6 @@ public class FolderStagedModelDataHandlerTest
 
 			Assert.assertNotNull(exportedChildFolder);
 
-			// Clear the parent folder mapping so the parent is "missing"
-
 			Map<Long, Long> folderIds =
 				(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
 					Folder.class);
@@ -134,8 +132,6 @@ public class FolderStagedModelDataHandlerTest
 					childFolder.getUuid(), liveGroup.getGroupId());
 
 			Assert.assertEquals(
-				"When parent folder mapping is missing, the imported child " +
-					"folder should be placed at root level",
 				DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 				importedDLFolder.getParentFolderId());
 		}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-85299

## Expected Results

When the parent folder is not found in the primary key mapping during import, `ChildFolder` should be placed at root level (`parentFolderId = 0`).

## Fix

Change the fallback value in `FolderStagedModelDataHandler.java` (line 229-230) from `folder.getParentFolderId()` to `DLFolderConstants.DEFAULT_PARENT_FOLDER_ID`:

An integration test (`testImportChildFolderWithMissingParentMapping`) has been written that confirms the bug