### PR TITLE
  LPD-85999 Allow Space Administrator and Space Content Reviewer to create tags from the CMS info panel           

### DIFF
--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/instance/lifecycle/DepotRolesPortalInstanceLifecycleListener.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/instance/lifecycle/DepotRolesPortalInstanceLifecycleListener.java
@@ -26,7 +26,6 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 
 import java.util.List;
-import java.util.Objects;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -46,39 +45,50 @@ public class DepotRolesPortalInstanceLifecycleListener
 			company.getCompanyId(),
 			DepotRolesConstants.ASSET_LIBRARY_ADMINISTRATOR);
 
+		List<String> assetLibraryAdministratorResourceActions =
+			ResourceActionsUtil.getResourceActions(DepotEntry.class.getName());
+
+		assetLibraryAdministratorResourceActions.remove(
+			ActionKeys.ASSIGN_USER_ROLES);
+
+		_resourcePermissionLocalService.setResourcePermissions(
+			company.getCompanyId(), DepotEntry.class.getName(),
+			ResourceConstants.SCOPE_COMPANY,
+			String.valueOf(company.getCompanyId()),
+			assetLibraryAdministratorRole.getRoleId(),
+			assetLibraryAdministratorResourceActions.toArray(new String[0]));
+
+		_resourcePermissionLocalService.addResourcePermission(
+			company.getCompanyId(), _ASSET_TAGS_RESOURCE_NAME,
+			ResourceConstants.SCOPE_COMPANY,
+			String.valueOf(company.getCompanyId()),
+			assetLibraryAdministratorRole.getRoleId(), ActionKeys.MANAGE_TAG);
+
+		Role assetLibraryContentReviewerRole = _getOrCreateRole(
+			company.getCompanyId(),
+			DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER);
+
+		_resourcePermissionLocalService.addResourcePermission(
+			company.getCompanyId(), _ASSET_TAGS_RESOURCE_NAME,
+			ResourceConstants.SCOPE_COMPANY,
+			String.valueOf(company.getCompanyId()),
+			assetLibraryContentReviewerRole.getRoleId(), ActionKeys.MANAGE_TAG);
+
+		Role assetLibraryMemberRole = _getOrCreateRole(
+			company.getCompanyId(), DepotRolesConstants.ASSET_LIBRARY_MEMBER);
+
+		_resourcePermissionLocalService.addResourcePermission(
+			company.getCompanyId(), DepotEntry.class.getName(),
+			ResourceConstants.SCOPE_COMPANY,
+			String.valueOf(company.getCompanyId()),
+			assetLibraryMemberRole.getRoleId(), ActionKeys.VIEW);
+
 		for (String name : DepotRolesConstants.DEPOT_ROLE_NAMES) {
 			Role role = _getOrCreateRole(company.getCompanyId(), name);
 
 			_resourceLocalService.addResources(
 				company.getCompanyId(), 0, 0, Role.class.getName(),
 				role.getRoleId(), false, false, false);
-
-			if (Objects.equals(
-					DepotRolesConstants.ASSET_LIBRARY_ADMINISTRATOR,
-					role.getName())) {
-
-				List<String> resourceActions =
-					ResourceActionsUtil.getResourceActions(
-						DepotEntry.class.getName());
-
-				resourceActions.remove(ActionKeys.ASSIGN_USER_ROLES);
-
-				_resourcePermissionLocalService.setResourcePermissions(
-					company.getCompanyId(), DepotEntry.class.getName(),
-					ResourceConstants.SCOPE_COMPANY,
-					String.valueOf(company.getCompanyId()), role.getRoleId(),
-					resourceActions.toArray(new String[0]));
-			}
-			else if (Objects.equals(
-						DepotRolesConstants.ASSET_LIBRARY_MEMBER,
-						role.getName())) {
-
-				_resourcePermissionLocalService.addResourcePermission(
-					company.getCompanyId(), DepotEntry.class.getName(),
-					ResourceConstants.SCOPE_COMPANY,
-					String.valueOf(company.getCompanyId()), role.getRoleId(),
-					ActionKeys.VIEW);
-			}
 
 			_resourcePermissionLocalService.setResourcePermissions(
 				company.getCompanyId(), Role.class.getName(),
@@ -116,6 +126,9 @@ public class DepotRolesPortalInstanceLifecycleListener
 
 		return role;
 	}
+
+	private static final String _ASSET_TAGS_RESOURCE_NAME =
+		"com.liferay.asset.tags";
 
 	@Reference
 	private Language _language;

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/instance/lifecycle/test/DepotRolesPortalInstanceLifecycleListenerTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/instance/lifecycle/test/DepotRolesPortalInstanceLifecycleListenerTest.java
@@ -88,6 +88,15 @@ public class DepotRolesPortalInstanceLifecycleListenerTest {
 				DepotRolesConstants.ASSET_LIBRARY_MEMBER,
 				List.of(ActionKeys.VIEW));
 
+			_assertRoleResourcePermissions(
+				company.getCompanyId(), _ASSET_TAGS_RESOURCE_NAME,
+				DepotRolesConstants.ASSET_LIBRARY_ADMINISTRATOR,
+				List.of(ActionKeys.MANAGE_TAG));
+			_assertRoleResourcePermissions(
+				company.getCompanyId(), _ASSET_TAGS_RESOURCE_NAME,
+				DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER,
+				List.of(ActionKeys.MANAGE_TAG));
+
 			for (String name : DepotRolesConstants.DEPOT_ROLE_NAMES) {
 				_assertRoleResourcePermissions(
 					company.getCompanyId(), Role.class.getName(), name,
@@ -147,7 +156,9 @@ public class DepotRolesPortalInstanceLifecycleListenerTest {
 		Role role = _roleLocalService.getRole(companyId, roleName);
 
 		for (String actionId : actionIds) {
-			if (StringUtil.equals(resourceName, DepotEntry.class.getName())) {
+			if (StringUtil.equals(resourceName, DepotEntry.class.getName()) ||
+				StringUtil.equals(resourceName, _ASSET_TAGS_RESOURCE_NAME)) {
+
 				if (Objects.equals(actionId, ActionKeys.ASSIGN_USER_ROLES)) {
 					continue;
 				}
@@ -168,6 +179,9 @@ public class DepotRolesPortalInstanceLifecycleListenerTest {
 					administratorRole.getRoleId(), actionId));
 		}
 	}
+
+	private static final String _ASSET_TAGS_RESOURCE_NAME =
+		"com.liferay.asset.tags";
 
 	@Inject
 	private CompanyLocalService _companyLocalService;

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/KeywordResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/KeywordResourceImpl.java
@@ -33,6 +33,7 @@ import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -418,6 +419,39 @@ public class KeywordResourceImpl
 		return AssetTagsPermission.RESOURCE_NAME;
 	}
 
+	private AssetTag _addAssetTag(
+			String externalReferenceCode, Group group, Keyword keyword,
+			Long siteId)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled(
+				group.getCompanyId(), "LPD-17564") ||
+			!group.isCMS() || ArrayUtil.isEmpty(keyword.getAssetLibraries())) {
+
+			return _assetTagService.addTag(
+				externalReferenceCode, siteId, keyword.getName(),
+				new ServiceContext());
+		}
+
+		long[] assetLibraryGroupIds = TaxonomyGroupUtil.getAssetLibraryGroupIds(
+			keyword.getAssetLibraries(), group.getCompanyId());
+
+		for (long assetLibraryGroupId : assetLibraryGroupIds) {
+			AssetTagsPermission.check(
+				PermissionThreadLocal.getPermissionChecker(),
+				assetLibraryGroupId, ActionKeys.MANAGE_TAG);
+		}
+
+		AssetTag assetTag = _assetTagLocalService.addTag(
+			externalReferenceCode, contextUser.getUserId(), siteId,
+			keyword.getName(), new ServiceContext());
+
+		_assetTagGroupRelLocalService.setAssetTagGroupRels(
+			assetTag.getTagId(), assetLibraryGroupIds);
+
+		return assetTag;
+	}
+
 	private Page<Keyword> _getKeywordsPage(
 			Map<String, Map<String, String>> actions, Long groupId,
 			String search, Aggregation aggregation, Filter filter,
@@ -552,23 +586,10 @@ public class KeywordResourceImpl
 			String externalReferenceCode, Keyword keyword, Long siteId)
 		throws Exception {
 
-		AssetTag assetTag = _assetTagService.addTag(
-			externalReferenceCode, siteId, keyword.getName(),
-			new ServiceContext());
-
-		Group group = _groupLocalService.getGroup(siteId);
-
-		if (FeatureFlagManagerUtil.isEnabled(
-				group.getCompanyId(), "LPD-17564") &&
-			group.isCMS()) {
-
-			_assetTagGroupRelLocalService.setAssetTagGroupRels(
-				assetTag.getTagId(),
-				TaxonomyGroupUtil.getAssetLibraryGroupIds(
-					keyword.getAssetLibraries(), group.getCompanyId()));
-		}
-
-		return _toKeyword(assetTag);
+		return _toKeyword(
+			_addAssetTag(
+				externalReferenceCode, _groupLocalService.getGroup(siteId),
+				keyword, siteId));
 	}
 
 	private AssetTag _toAssetTag(Object[] assetTags) {

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/KeywordResourceTest.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/KeywordResourceTest.java
@@ -12,6 +12,7 @@ import com.liferay.asset.kernel.service.AssetTagGroupRelLocalService;
 import com.liferay.asset.kernel.service.AssetTagLocalServiceUtil;
 import com.liferay.asset.test.util.AssetTestUtil;
 import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.constants.DepotRolesConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.headless.admin.taxonomy.client.dto.v1_0.AssetLibrary;
@@ -24,8 +25,12 @@ import com.liferay.headless.admin.taxonomy.client.resource.v1_0.KeywordResource;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.UserGroupRoleLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.rule.DataGuard;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
@@ -476,6 +481,68 @@ public class KeywordResourceTest extends BaseKeywordResourceTestCase {
 		testGroup = originalTestGroup;
 	}
 
+	@FeatureFlag("LPD-17564")
+	@Test
+	public void testPostSiteKeywordAsSpaceContentReviewer() throws Exception {
+		Group originalTestGroup = testGroup;
+
+		testGroup = CMSTestUtil.getOrAddGroup(KeywordResourceTest.class);
+
+		DepotEntry space = _depotEntryLocalService.addDepotEntry(
+			RandomTestUtil.randomLocaleStringMap(), null,
+			DepotConstants.TYPE_SPACE,
+			ServiceContextTestUtil.getServiceContext(testGroup.getGroupId()));
+
+		Group spaceGroup = space.getGroup();
+
+		_spaceContentReviewerUser = UserTestUtil.addUser();
+
+		_userLocalService.updatePassword(
+			_spaceContentReviewerUser.getUserId(), "test", "test", false, true);
+
+		_groupLocalService.addUserGroup(
+			_spaceContentReviewerUser.getUserId(), spaceGroup);
+
+		Role contentReviewerRole = _roleLocalService.getRole(
+			testCompany.getCompanyId(),
+			DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER);
+
+		_userGroupRoleLocalService.addUserGroupRoles(
+			_spaceContentReviewerUser.getUserId(), spaceGroup.getGroupId(),
+			new long[] {contentReviewerRole.getRoleId()});
+
+		KeywordResource spaceContentReviewerKeywordResource =
+			KeywordResource.builder(
+			).authentication(
+				_spaceContentReviewerUser.getEmailAddress(), "test"
+			).endpoint(
+				testCompany.getVirtualHostname(), 8080, "http"
+			).locale(
+				LocaleUtil.getDefault()
+			).build();
+
+		Keyword randomKeyword = randomKeyword();
+
+		randomKeyword.setAssetLibraries(
+			new AssetLibrary[] {
+				new AssetLibrary() {
+					{
+						id = spaceGroup.getGroupId();
+						scopeKey = spaceGroup.getGroupKey();
+					}
+				}
+			});
+
+		Keyword postKeyword =
+			spaceContentReviewerKeywordResource.postSiteKeyword(
+				testGroup.getGroupId(), randomKeyword);
+
+		assertEquals(randomKeyword, postKeyword);
+		assertValid(postKeyword);
+
+		testGroup = originalTestGroup;
+	}
+
 	@Override
 	@Test
 	public void testPutAssetLibraryKeywordByExternalReferenceCode()
@@ -747,8 +814,20 @@ public class KeywordResourceTest extends BaseKeywordResourceTestCase {
 	@Inject
 	private DepotEntryLocalService _depotEntryLocalService;
 
+	@Inject
+	private GroupLocalService _groupLocalService;
+
 	@DeleteAfterTestRun
 	private User _regularUser;
+
+	@Inject
+	private RoleLocalService _roleLocalService;
+
+	@DeleteAfterTestRun
+	private User _spaceContentReviewerUser;
+
+	@Inject
+	private UserGroupRoleLocalService _userGroupRoleLocalService;
 
 	@Inject
 	private UserLocalService _userLocalService;


### PR DESCRIPTION
  # What is this trying to solve?                                                                                 
                                                                                                                  
  https://liferay.atlassian.net/browse/LPD-85999                                                                  
                                                                                                                  
  In a CMS space, users with the Space Administrator or Space Content Reviewer role couldn't add tags from the    
  content info panel — the "Create new tag" action silently failed with a 403. Only portal-level admins could     
  create tags, forcing space members to route every new tag through someone with broader authority than their role
   should require.                                                

  # How am I fixing it?

  The CMS tag-create endpoint receives the CMS site group in the URL but the space (asset library) group in the   
  body. `MANAGE_TAG` is now checked against the asset library group — where space-scoped roles actually live —
  instead of against the CMS group where those roles have no membership. Tag storage stays on the CMS group so    
  tags remain shareable across spaces. The portal-instance lifecycle listener also grants `MANAGE_TAG` on
  `com.liferay.asset.tags` to the Asset Library Administrator and Asset Library Content Reviewer roles at
  registration time, so the new permission check has something to resolve against.

  # How can you verify that it works?

  Run the included automated tests.