### PR TITLE
LPD-86819: Handle null page element definition during page experience import

### DIFF
--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LayoutStructureUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LayoutStructureUtil.java
@@ -10,6 +10,8 @@ import com.liferay.headless.admin.site.internal.resource.v1_0.layout.structure.i
 import com.liferay.headless.admin.site.internal.resource.v1_0.layout.structure.item.importer.context.LayoutStructureItemImporterContext;
 import com.liferay.layout.util.structure.LayoutStructure;
 import com.liferay.layout.util.structure.LayoutStructureItem;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -39,6 +41,17 @@ public class LayoutStructureUtil {
 		}
 
 		for (PageElement childPageElement : pageElement.getPageElements()) {
+			if (childPageElement.getPageElementDefinition() == null) {
+				if (_log.isWarnEnabled()) {
+					_log.warn(
+						"Skipping page element " +
+							childPageElement.getExternalReferenceCode() +
+								" with null definition");
+				}
+
+				continue;
+			}
+
 			addLayoutStructureItem(
 				layoutStructure, layoutStructureItemImporterContext,
 				childPageElement);
@@ -59,5 +72,8 @@ public class LayoutStructureUtil {
 
 		return layoutStructure.getMainItemId();
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		LayoutStructureUtil.class);
 
 }

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/SegmentsExperienceUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/SegmentsExperienceUtil.java
@@ -16,6 +16,8 @@ import com.liferay.info.item.InfoItemServiceRegistry;
 import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalServiceUtil;
 import com.liferay.layout.util.structure.LayoutStructure;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
@@ -184,6 +186,17 @@ public class SegmentsExperienceUtil {
 				UserLocalServiceUtil.getUser(serviceContext.getUserId()));
 
 		for (PageElement pageElement : pageExperience.getPageElements()) {
+			if (pageElement.getPageElementDefinition() == null) {
+				if (_log.isWarnEnabled()) {
+					_log.warn(
+						"Skipping page element " +
+							pageElement.getExternalReferenceCode() +
+								" with null definition");
+				}
+
+				continue;
+			}
+
 			LayoutStructureUtil.addLayoutStructureItem(
 				layoutStructure, layoutStructureItemImporterContext,
 				pageElement);
@@ -228,6 +241,9 @@ public class SegmentsExperienceUtil {
 
 		return segmentsEntryReference;
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		SegmentsExperienceUtil.class);
 
 	private static class SegmentsEntryReference {
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/test/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LayoutStructureUtilTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/test/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LayoutStructureUtilTest.java
@@ -1,0 +1,232 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.site.internal.resource.v1_0.util;
+
+import com.liferay.headless.admin.site.dto.v1_0.BasicFragmentInstancePageElementDefinition;
+import com.liferay.headless.admin.site.dto.v1_0.PageElement;
+import com.liferay.headless.admin.site.dto.v1_0.PageElementDefinition;
+import com.liferay.headless.admin.site.internal.resource.v1_0.layout.structure.item.importer.LayoutStructureItemImporter;
+import com.liferay.headless.admin.site.internal.resource.v1_0.layout.structure.item.importer.context.LayoutStructureItemImporterContext;
+import com.liferay.layout.util.structure.LayoutStructure;
+import com.liferay.layout.util.structure.LayoutStructureItem;
+import com.liferay.osgi.util.ServiceTrackerFactory;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LogEntry;
+import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.List;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * @author Petteri Karttunen
+ */
+public class LayoutStructureUtilTest {
+
+	@ClassRule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_serviceTrackerFactoryMockedStatic = Mockito.mockStatic(
+			ServiceTrackerFactory.class);
+
+		_serviceTrackerFactoryMockedStatic.when(
+			() -> ServiceTrackerFactory.open(
+				Mockito.any(), Mockito.any(Class.class))
+		).thenReturn(
+			null
+		);
+
+		_layoutStructureItemImporterUtilMockedStatic = Mockito.mockStatic(
+			LayoutStructureItemImporterUtil.class);
+
+		_layoutStructureItemImporterUtilMockedStatic.when(
+			() ->
+				LayoutStructureItemImporterUtil.getLayoutStructureItemImporter(
+					Mockito.any(PageElementDefinition.class))
+		).thenReturn(
+			_layoutStructureItemImporter
+		);
+
+		Mockito.when(
+			_layoutStructureItemImporter.addLayoutStructureItem(
+				Mockito.any(LayoutStructure.class),
+				Mockito.any(LayoutStructureItemImporterContext.class),
+				Mockito.any(PageElement.class))
+		).thenReturn(
+			Mockito.mock(LayoutStructureItem.class)
+		);
+	}
+
+	@AfterClass
+	public static void tearDownClass() {
+		_layoutStructureItemImporterUtilMockedStatic.close();
+		_serviceTrackerFactoryMockedStatic.close();
+	}
+
+	@Before
+	public void setUp() {
+		Mockito.clearInvocations(_layoutStructureItemImporter);
+	}
+
+	@Test
+	public void testAddLayoutStructureItemSkipsAllNullDefinitionChildren()
+		throws Exception {
+
+		PageElement pageElement = _createPageElement(
+			"parent", _createPageElementDefinition());
+
+		pageElement.setPageElements(
+			new PageElement[] {
+				_createPageElement("child-null-1", null),
+				_createPageElement("child-null-2", null)
+			});
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				LayoutStructureUtil.class.getName(), LoggerTestUtil.WARN)) {
+
+			LayoutStructureUtil.addLayoutStructureItem(
+				Mockito.mock(LayoutStructure.class),
+				Mockito.mock(LayoutStructureItemImporterContext.class),
+				pageElement);
+
+			_assertLogEntries(logCapture, "child-null-1", "child-null-2");
+		}
+
+		Mockito.verify(
+			_layoutStructureItemImporter, Mockito.times(1)
+		).addLayoutStructureItem(
+			Mockito.any(), Mockito.any(), Mockito.any()
+		);
+	}
+
+	@Test
+	public void testAddLayoutStructureItemSkipsMixedNullAndValidChildren()
+		throws Exception {
+
+		PageElement pageElement = _createPageElement(
+			"parent", _createPageElementDefinition());
+
+		pageElement.setPageElements(
+			new PageElement[] {
+				_createPageElement(
+					"child-valid-1", _createPageElementDefinition()),
+				_createPageElement("child-null", null),
+				_createPageElement(
+					"child-valid-2", _createPageElementDefinition())
+			});
+
+		LayoutStructureItem layoutStructureItem = null;
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				LayoutStructureUtil.class.getName(), LoggerTestUtil.WARN)) {
+
+			layoutStructureItem = LayoutStructureUtil.addLayoutStructureItem(
+				Mockito.mock(LayoutStructure.class),
+				Mockito.mock(LayoutStructureItemImporterContext.class),
+				pageElement);
+
+			_assertLogEntries(logCapture, "child-null");
+		}
+
+		Assert.assertNotNull(layoutStructureItem);
+
+		Mockito.verify(
+			_layoutStructureItemImporter, Mockito.times(3)
+		).addLayoutStructureItem(
+			Mockito.any(), Mockito.any(), Mockito.any()
+		);
+	}
+
+	@Test
+	public void testAddLayoutStructureItemWithoutChildren() throws Exception {
+		PageElement pageElement = _createPageElement(
+			"parent", _createPageElementDefinition());
+
+		LayoutStructureItem layoutStructureItem = null;
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				LayoutStructureUtil.class.getName(), LoggerTestUtil.WARN)) {
+
+			layoutStructureItem = LayoutStructureUtil.addLayoutStructureItem(
+				Mockito.mock(LayoutStructure.class),
+				Mockito.mock(LayoutStructureItemImporterContext.class),
+				pageElement);
+
+			_assertLogEntries(logCapture);
+		}
+
+		Assert.assertNotNull(layoutStructureItem);
+
+		Mockito.verify(
+			_layoutStructureItemImporter, Mockito.times(1)
+		).addLayoutStructureItem(
+			Mockito.any(), Mockito.any(), Mockito.any()
+		);
+	}
+
+	private void _assertLogEntries(
+		LogCapture logCapture, String... externalReferenceCodes) {
+
+		List<LogEntry> logEntries = logCapture.getLogEntries();
+
+		Assert.assertEquals(
+			logEntries.toString(), externalReferenceCodes.length,
+			logEntries.size());
+
+		for (int i = 0; i < externalReferenceCodes.length; i++) {
+			LogEntry logEntry = logEntries.get(i);
+
+			Assert.assertEquals(LoggerTestUtil.WARN, logEntry.getPriority());
+			Assert.assertEquals(
+				"Skipping page element " + externalReferenceCodes[i] +
+					" with null definition",
+				logEntry.getMessage());
+		}
+	}
+
+	private PageElement _createPageElement(
+		String externalReferenceCode,
+		PageElementDefinition pageElementDefinition) {
+
+		PageElement pageElement = new PageElement();
+
+		pageElement.setExternalReferenceCode(externalReferenceCode);
+		pageElement.setPageElementDefinition(pageElementDefinition);
+
+		return pageElement;
+	}
+
+	private PageElementDefinition _createPageElementDefinition() {
+		BasicFragmentInstancePageElementDefinition pageElementDefinition =
+			new BasicFragmentInstancePageElementDefinition();
+
+		pageElementDefinition.setType(
+			PageElementDefinition.Type.BASIC_FRAGMENT);
+
+		return pageElementDefinition;
+	}
+
+	private static final LayoutStructureItemImporter
+		_layoutStructureItemImporter = Mockito.mock(
+			LayoutStructureItemImporter.class);
+	private static MockedStatic<LayoutStructureItemImporterUtil>
+		_layoutStructureItemImporterUtilMockedStatic;
+	private static MockedStatic<ServiceTrackerFactory>
+		_serviceTrackerFactoryMockedStatic;
+
+}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/test/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/SegmentsExperienceUtilTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/test/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/SegmentsExperienceUtilTest.java
@@ -1,0 +1,236 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.site.internal.resource.v1_0.util;
+
+import com.liferay.fragment.processor.FragmentEntryProcessorRegistry;
+import com.liferay.headless.admin.site.dto.v1_0.BasicFragmentInstancePageElementDefinition;
+import com.liferay.headless.admin.site.dto.v1_0.PageElement;
+import com.liferay.headless.admin.site.dto.v1_0.PageElementDefinition;
+import com.liferay.headless.admin.site.dto.v1_0.PageExperience;
+import com.liferay.headless.admin.site.internal.resource.v1_0.layout.structure.item.importer.context.LayoutStructureItemImporterContext;
+import com.liferay.info.item.InfoItemServiceRegistry;
+import com.liferay.layout.util.structure.LayoutStructure;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.UserLocalServiceUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LogEntry;
+import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.lang.reflect.Method;
+
+import java.util.List;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * @author Petteri Karttunen
+ */
+public class SegmentsExperienceUtilTest {
+
+	@ClassRule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_layoutStructureUtilMockedStatic = Mockito.mockStatic(
+			LayoutStructureUtil.class);
+
+		_layoutStructureUtilMockedStatic.when(
+			() -> LayoutStructureUtil.addLayoutStructureItem(
+				Mockito.any(LayoutStructure.class),
+				Mockito.any(LayoutStructureItemImporterContext.class),
+				Mockito.any(PageElement.class))
+		).thenReturn(
+			null
+		);
+
+		_userLocalServiceUtilMockedStatic = Mockito.mockStatic(
+			UserLocalServiceUtil.class);
+
+		_userLocalServiceUtilMockedStatic.when(
+			() -> UserLocalServiceUtil.getUser(Mockito.anyLong())
+		).thenReturn(
+			Mockito.mock(User.class)
+		);
+
+		_getDataMethod = SegmentsExperienceUtil.class.getDeclaredMethod(
+			"_getData", FragmentEntryProcessorRegistry.class,
+			InfoItemServiceRegistry.class, Layout.class, PageExperience.class,
+			long.class, ServiceContext.class);
+
+		_getDataMethod.setAccessible(true);
+	}
+
+	@AfterClass
+	public static void tearDownClass() {
+		_layoutStructureUtilMockedStatic.close();
+		_userLocalServiceUtilMockedStatic.close();
+	}
+
+	@Before
+	public void setUp() {
+		_layoutStructureUtilMockedStatic.clearInvocations();
+	}
+
+	@Test
+	public void testGetDataSkipsAllNullDefinitionPageElements()
+		throws Exception {
+
+		PageExperience pageExperience = new PageExperience();
+
+		pageExperience.setPageElements(
+			new PageElement[] {
+				_createPageElement("page-element-null-1", null),
+				_createPageElement("page-element-null-2", null)
+			});
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				SegmentsExperienceUtil.class.getName(), LoggerTestUtil.WARN)) {
+
+			_invokeGetData(pageExperience);
+
+			_assertLogEntries(
+				logCapture, "page-element-null-1", "page-element-null-2");
+		}
+
+		_layoutStructureUtilMockedStatic.verify(
+			() -> LayoutStructureUtil.addLayoutStructureItem(
+				Mockito.any(), Mockito.any(), Mockito.any()),
+			Mockito.never());
+	}
+
+	@Test
+	public void testGetDataSkipsMixedNullAndValidPageElements()
+		throws Exception {
+
+		PageExperience pageExperience = new PageExperience();
+
+		pageExperience.setPageElements(
+			new PageElement[] {
+				_createPageElement(
+					"page-element-valid-1", _createPageElementDefinition()),
+				_createPageElement("page-element-null", null),
+				_createPageElement(
+					"page-element-valid-2", _createPageElementDefinition())
+			});
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				SegmentsExperienceUtil.class.getName(), LoggerTestUtil.WARN)) {
+
+			_invokeGetData(pageExperience);
+
+			_assertLogEntries(logCapture, "page-element-null");
+		}
+
+		_layoutStructureUtilMockedStatic.verify(
+			() -> LayoutStructureUtil.addLayoutStructureItem(
+				Mockito.any(), Mockito.any(), Mockito.any()),
+			Mockito.times(2));
+	}
+
+	@Test
+	public void testGetDataWithEmptyPageElements() throws Exception {
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				SegmentsExperienceUtil.class.getName(), LoggerTestUtil.WARN)) {
+
+			_invokeGetData(new PageExperience());
+
+			_assertLogEntries(logCapture);
+		}
+
+		_layoutStructureUtilMockedStatic.verify(
+			() -> LayoutStructureUtil.addLayoutStructureItem(
+				Mockito.any(), Mockito.any(), Mockito.any()),
+			Mockito.never());
+	}
+
+	private void _assertLogEntries(
+		LogCapture logCapture, String... externalReferenceCodes) {
+
+		List<LogEntry> logEntries = logCapture.getLogEntries();
+
+		Assert.assertEquals(
+			logEntries.toString(), externalReferenceCodes.length,
+			logEntries.size());
+
+		for (int i = 0; i < externalReferenceCodes.length; i++) {
+			LogEntry logEntry = logEntries.get(i);
+
+			Assert.assertEquals(LoggerTestUtil.WARN, logEntry.getPriority());
+			Assert.assertEquals(
+				"Skipping page element " + externalReferenceCodes[i] +
+					" with null definition",
+				logEntry.getMessage());
+		}
+	}
+
+	private PageElement _createPageElement(
+		String externalReferenceCode,
+		PageElementDefinition pageElementDefinition) {
+
+		PageElement pageElement = new PageElement();
+
+		pageElement.setExternalReferenceCode(externalReferenceCode);
+		pageElement.setPageElementDefinition(pageElementDefinition);
+
+		return pageElement;
+	}
+
+	private PageElementDefinition _createPageElementDefinition() {
+		BasicFragmentInstancePageElementDefinition pageElementDefinition =
+			new BasicFragmentInstancePageElementDefinition();
+
+		pageElementDefinition.setType(
+			PageElementDefinition.Type.BASIC_FRAGMENT);
+
+		return pageElementDefinition;
+	}
+
+	private void _invokeGetData(PageExperience pageExperience)
+		throws Exception {
+
+		Layout layout = Mockito.mock(Layout.class);
+
+		Mockito.when(
+			layout.getGroupId()
+		).thenReturn(
+			RandomTestUtil.randomLong()
+		);
+
+		ServiceContext serviceContext = Mockito.mock(ServiceContext.class);
+
+		Mockito.when(
+			serviceContext.getCompanyId()
+		).thenReturn(
+			RandomTestUtil.randomLong()
+		);
+
+		_getDataMethod.invoke(
+			null, Mockito.mock(FragmentEntryProcessorRegistry.class),
+			Mockito.mock(InfoItemServiceRegistry.class), layout, pageExperience,
+			RandomTestUtil.randomLong(), serviceContext);
+	}
+
+	private static Method _getDataMethod;
+	private static MockedStatic<LayoutStructureUtil>
+		_layoutStructureUtilMockedStatic;
+	private static MockedStatic<UserLocalServiceUtil>
+		_userLocalServiceUtilMockedStatic;
+
+}


### PR DESCRIPTION
- https://liferay.atlassian.net/browse/LPD-86819

This PR is  based on the findings in [liferay.com testing epic](https://liferay.atlassian.net/browse/LPD-84210). 

 ## Summary                                                                                                                                                                           
                                                                                                                                                                                       
  - `SegmentsExperienceUtil._getData`: skip and warn-log top-level page elements with a null `pageElementDefinition` instead of NPE-ing on import.                                     
  - `LayoutStructureUtil.addLayoutStructureItem`: apply the same skip-and-warn-log in the recursive descent over child page elements so nested missing-fragment cases are handled  symmetrically.                                                                                                                                                                       
  - No API or DTO changes; behavior change is limited to the import path.                                                                                                              
                                                                                                                                                                                       
  ## Why                                                                                                                                                                               
                                                                                                                                                                                       
  An upstream change in this branch (export-side DTO converter) returns a null `pageElementDefinition` when the exported page references a fragment that no longer exists on the target   system (no matching `FragmentEntryLink`). Without this fix the import path NPE'd inside `LayoutStructureItemImporterUtil.getLayoutStructureItemImporter(...)` (it calls `.getType()`   on the null definition) and aborted the entire import.                                                                                                                              
                  
  ## Design notes

  The null check is deliberately **not** at the entry of the shared `LayoutStructureUtil.addLayoutStructureItem`, even though that would cover both call sites in one spot. That util   is also called from `PageElementResourceImpl._addOrUpdatePageElement`, which uses the return value (`layoutStructureItem.getItemId()`). Silently returning null there would mask
  malformed client input as a confusing downstream NPE, so the REST endpoints continue to fail loudly while the import path tolerates and skips.                                       
        