### PR TITLE
LPD-86823: Fix fragment compositions getting lost during site export/import and staging

### DIFF
--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/data/handler/FragmentCompositionStagedModelDataHandler.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/data/handler/FragmentCompositionStagedModelDataHandler.java
@@ -1,0 +1,245 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.fragment.internal.exportimport.data.handler;
+
+import com.liferay.exportimport.data.handler.base.BaseStagedModelDataHandler;
+import com.liferay.exportimport.kernel.lar.ExportImportPathUtil;
+import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
+import com.liferay.exportimport.kernel.lar.PortletDataContext;
+import com.liferay.exportimport.kernel.lar.StagedModelDataHandler;
+import com.liferay.exportimport.kernel.lar.StagedModelDataHandlerUtil;
+import com.liferay.exportimport.staged.model.repository.StagedModelRepository;
+import com.liferay.fragment.model.FragmentCollection;
+import com.liferay.fragment.model.FragmentComposition;
+import com.liferay.fragment.service.FragmentCollectionLocalService;
+import com.liferay.fragment.service.FragmentCompositionLocalService;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.portletfilerepository.PortletFileRepositoryUtil;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.xml.Element;
+
+import java.util.Map;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Petteri Karttunen
+ */
+@Component(service = StagedModelDataHandler.class)
+public class FragmentCompositionStagedModelDataHandler
+	extends BaseStagedModelDataHandler<FragmentComposition> {
+
+	public static final String[] CLASS_NAMES = {
+		FragmentComposition.class.getName()
+	};
+
+	@Override
+	public void deleteStagedModel(FragmentComposition fragmentComposition)
+		throws PortalException {
+
+		_stagedModelRepository.deleteStagedModel(fragmentComposition);
+	}
+
+	@Override
+	public void deleteStagedModel(
+			String uuid, long groupId, String className, String extraData)
+		throws PortalException {
+
+		_stagedModelRepository.deleteStagedModel(
+			uuid, groupId, className, extraData);
+	}
+
+	@Override
+	public String[] getClassNames() {
+		return CLASS_NAMES;
+	}
+
+	@Override
+	public String getDisplayName(FragmentComposition fragmentComposition) {
+		return fragmentComposition.getName();
+	}
+
+	@Override
+	protected void doExportStagedModel(
+			PortletDataContext portletDataContext,
+			FragmentComposition fragmentComposition)
+		throws Exception {
+
+		if (fragmentComposition.isMarketplace() &&
+			!ExportImportThreadLocal.isStagingInProcess()) {
+
+			return;
+		}
+
+		FragmentCollection fragmentCollection =
+			_fragmentCollectionLocalService.fetchFragmentCollection(
+				fragmentComposition.getFragmentCollectionId());
+
+		if (fragmentCollection == null) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Unable to export fragment composition with key " +
+						fragmentComposition.getFragmentCompositionKey());
+			}
+
+			return;
+		}
+
+		StagedModelDataHandlerUtil.exportReferenceStagedModel(
+			portletDataContext, fragmentComposition, fragmentCollection,
+			PortletDataContext.REFERENCE_TYPE_PARENT);
+
+		if (fragmentComposition.getPreviewFileEntryId() > 0) {
+			try {
+				FileEntry fileEntry =
+					PortletFileRepositoryUtil.getPortletFileEntry(
+						fragmentComposition.getPreviewFileEntryId());
+
+				StagedModelDataHandlerUtil.exportReferenceStagedModel(
+					portletDataContext, fragmentComposition, fileEntry,
+					PortletDataContext.REFERENCE_TYPE_WEAK);
+			}
+			catch (PortalException portalException) {
+				if (_log.isWarnEnabled()) {
+					_log.warn(
+						"Unable to export file entry " +
+							fragmentComposition.getPreviewFileEntryId(),
+						portalException);
+				}
+			}
+		}
+
+		Element entryElement = portletDataContext.getExportDataElement(
+			fragmentComposition);
+
+		portletDataContext.addClassedModel(
+			entryElement,
+			ExportImportPathUtil.getModelPath(fragmentComposition),
+			fragmentComposition);
+	}
+
+	@Override
+	protected void doImportMissingReference(
+			PortletDataContext portletDataContext, String uuid, long groupId,
+			long fragmentCompositionId)
+		throws Exception {
+
+		FragmentComposition existingFragmentComposition = fetchMissingReference(
+			uuid, groupId);
+
+		if (existingFragmentComposition == null) {
+			return;
+		}
+
+		Map<Long, Long> fragmentCompositionIds =
+			(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
+				FragmentComposition.class);
+
+		fragmentCompositionIds.put(
+			fragmentCompositionId,
+			existingFragmentComposition.getFragmentCompositionId());
+	}
+
+	@Override
+	protected void doImportStagedModel(
+			PortletDataContext portletDataContext,
+			FragmentComposition fragmentComposition)
+		throws Exception {
+
+		Map<Long, Long> fragmentCollectionIds =
+			(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
+				FragmentCollection.class);
+
+		long fragmentCollectionId = MapUtil.getLong(
+			fragmentCollectionIds,
+			fragmentComposition.getFragmentCollectionId(),
+			fragmentComposition.getFragmentCollectionId());
+
+		FragmentComposition importedFragmentComposition =
+			(FragmentComposition)fragmentComposition.clone();
+
+		importedFragmentComposition.setGroupId(
+			portletDataContext.getScopeGroupId());
+		importedFragmentComposition.setFragmentCollectionId(
+			fragmentCollectionId);
+
+		FragmentComposition existingFragmentComposition =
+			_stagedModelRepository.fetchStagedModelByUuidAndGroupId(
+				fragmentComposition.getUuid(),
+				portletDataContext.getScopeGroupId());
+
+		if ((existingFragmentComposition == null) ||
+			!portletDataContext.isDataStrategyMirror()) {
+
+			importedFragmentComposition = _stagedModelRepository.addStagedModel(
+				portletDataContext, importedFragmentComposition);
+		}
+		else {
+			importedFragmentComposition.setMvccVersion(
+				existingFragmentComposition.getMvccVersion());
+			importedFragmentComposition.setFragmentCompositionId(
+				existingFragmentComposition.getFragmentCompositionId());
+
+			importedFragmentComposition =
+				_stagedModelRepository.updateStagedModel(
+					portletDataContext, importedFragmentComposition);
+		}
+
+		if ((fragmentComposition.getPreviewFileEntryId() == 0) &&
+			(importedFragmentComposition.getPreviewFileEntryId() > 0)) {
+
+			PortletFileRepositoryUtil.deletePortletFileEntry(
+				importedFragmentComposition.getPreviewFileEntryId());
+
+			importedFragmentComposition =
+				_fragmentCompositionLocalService.updateFragmentComposition(
+					importedFragmentComposition.getFragmentCompositionId(), 0);
+		}
+		else if (fragmentComposition.getPreviewFileEntryId() > 0) {
+			Map<Long, Long> fileEntryIds =
+				(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
+					FileEntry.class);
+
+			long previewFileEntryId = MapUtil.getLong(
+				fileEntryIds, fragmentComposition.getPreviewFileEntryId(), 0);
+
+			importedFragmentComposition =
+				_fragmentCompositionLocalService.updateFragmentComposition(
+					importedFragmentComposition.getFragmentCompositionId(),
+					previewFileEntryId);
+		}
+
+		portletDataContext.importClassedModel(
+			fragmentComposition, importedFragmentComposition);
+	}
+
+	@Override
+	protected StagedModelRepository<FragmentComposition>
+		getStagedModelRepository() {
+
+		return _stagedModelRepository;
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		FragmentCompositionStagedModelDataHandler.class);
+
+	@Reference
+	private FragmentCollectionLocalService _fragmentCollectionLocalService;
+
+	@Reference
+	private FragmentCompositionLocalService _fragmentCompositionLocalService;
+
+	@Reference(
+		target = "(model.class.name=com.liferay.fragment.model.FragmentComposition)",
+		unbind = "-"
+	)
+	private StagedModelRepository<FragmentComposition> _stagedModelRepository;
+
+}

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/data/handler/FragmentPortletDataHandler.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/data/handler/FragmentPortletDataHandler.java
@@ -20,6 +20,7 @@ import com.liferay.fragment.configuration.FragmentServiceConfiguration;
 import com.liferay.fragment.constants.FragmentConstants;
 import com.liferay.fragment.constants.FragmentPortletKeys;
 import com.liferay.fragment.model.FragmentCollection;
+import com.liferay.fragment.model.FragmentComposition;
 import com.liferay.fragment.model.FragmentEntry;
 import com.liferay.layout.util.LayoutServiceContextHelper;
 import com.liferay.portal.configuration.module.configuration.ConfigurationProvider;
@@ -76,6 +77,7 @@ public class FragmentPortletDataHandler extends BasePortletDataHandler {
 	protected void activate() {
 		setDeletionSystemEventStagedModelTypes(
 			new StagedModelType(FragmentCollection.class),
+			new StagedModelType(FragmentComposition.class),
 			new StagedModelType(FragmentEntry.class));
 		setExportPortletDataHandlerControls(
 			new PortletDataHandlerBoolean(
@@ -99,6 +101,8 @@ public class FragmentPortletDataHandler extends BasePortletDataHandler {
 		}
 
 		_fragmentEntryStagedModelRepository.deleteStagedModels(
+			portletDataContext);
+		_fragmentCompositionStagedModelRepository.deleteStagedModels(
 			portletDataContext);
 		_fragmentCollectionStagedModelRepository.deleteStagedModels(
 			portletDataContext);
@@ -129,6 +133,12 @@ public class FragmentPortletDataHandler extends BasePortletDataHandler {
 				getExportActionableDynamicQuery(portletDataContext);
 
 		fragmentCollectionExportActionableDynamicQuery.performActions();
+
+		ActionableDynamicQuery fragmentCompositionExportActionableDynamicQuery =
+			_fragmentCompositionStagedModelRepository.
+				getExportActionableDynamicQuery(portletDataContext);
+
+		fragmentCompositionExportActionableDynamicQuery.performActions();
 
 		ActionableDynamicQuery fragmentEntryActionableDynamicQuery =
 			_fragmentEntryStagedModelRepository.getExportActionableDynamicQuery(
@@ -169,38 +179,47 @@ public class FragmentPortletDataHandler extends BasePortletDataHandler {
 
 		List<Element> fragmentEntryElements = fragmentEntriesElement.elements();
 
-		if (ListUtil.isEmpty(fragmentEntryElements)) {
-			return null;
+		if (ListUtil.isNotEmpty(fragmentEntryElements)) {
+			FragmentServiceConfiguration fragmentServiceConfiguration =
+				_configurationProvider.getCompanyConfiguration(
+					FragmentServiceConfiguration.class,
+					portletDataContext.getCompanyId());
+
+			if (!fragmentServiceConfiguration.propagateChanges() ||
+				(ExportImportThreadLocal.isStagingInProcess() &&
+				 _stagingGroupHelper.isStagedPortlet(
+					 portletDataContext.getGroupId(),
+					 FragmentPortletKeys.FRAGMENT))) {
+
+				for (Element fragmentEntryElement : fragmentEntryElements) {
+					StagedModelDataHandlerUtil.importStagedModel(
+						portletDataContext, fragmentEntryElement);
+				}
+			}
+			else {
+				try (AutoCloseable autoCloseable =
+						_layoutServiceContextHelper.
+							getServiceContextAutoCloseable(
+								_companyLocalService.getCompany(
+									portletDataContext.getCompanyId()))) {
+
+					for (Element fragmentEntryElement : fragmentEntryElements) {
+						StagedModelDataHandlerUtil.importStagedModel(
+							portletDataContext, fragmentEntryElement);
+					}
+				}
+			}
 		}
 
-		FragmentServiceConfiguration fragmentServiceConfiguration =
-			_configurationProvider.getCompanyConfiguration(
-				FragmentServiceConfiguration.class,
-				portletDataContext.getCompanyId());
+		Element fragmentCompositionsElement =
+			portletDataContext.getImportDataGroupElement(
+				FragmentComposition.class);
 
-		if (!fragmentServiceConfiguration.propagateChanges() ||
-			(ExportImportThreadLocal.isStagingInProcess() &&
-			 _stagingGroupHelper.isStagedPortlet(
-				 portletDataContext.getGroupId(),
-				 FragmentPortletKeys.FRAGMENT))) {
+		for (Element fragmentCompositionElement :
+				fragmentCompositionsElement.elements()) {
 
-			for (Element fragmentEntryElement : fragmentEntryElements) {
-				StagedModelDataHandlerUtil.importStagedModel(
-					portletDataContext, fragmentEntryElement);
-			}
-
-			return null;
-		}
-
-		try (AutoCloseable autoCloseable =
-				_layoutServiceContextHelper.getServiceContextAutoCloseable(
-					_companyLocalService.getCompany(
-						portletDataContext.getCompanyId()))) {
-
-			for (Element fragmentEntryElement : fragmentEntryElements) {
-				StagedModelDataHandlerUtil.importStagedModel(
-					portletDataContext, fragmentEntryElement);
-			}
+			StagedModelDataHandlerUtil.importStagedModel(
+				portletDataContext, fragmentCompositionElement);
 		}
 
 		return null;
@@ -219,6 +238,7 @@ public class FragmentPortletDataHandler extends BasePortletDataHandler {
 				portletDataContext,
 				new StagedModelType[] {
 					new StagedModelType(FragmentCollection.class.getName()),
+					new StagedModelType(FragmentComposition.class.getName()),
 					new StagedModelType(FragmentEntry.class.getName())
 				});
 
@@ -230,6 +250,12 @@ public class FragmentPortletDataHandler extends BasePortletDataHandler {
 				getExportActionableDynamicQuery(portletDataContext);
 
 		fragmentCollectionExportActionableDynamicQuery.performCount();
+
+		ActionableDynamicQuery fragmentCompositionExportActionableDynamicQuery =
+			_fragmentCompositionStagedModelRepository.
+				getExportActionableDynamicQuery(portletDataContext);
+
+		fragmentCompositionExportActionableDynamicQuery.performCount();
 
 		ActionableDynamicQuery fragmentEntryExportActionableDynamicQuery =
 			_fragmentEntryStagedModelRepository.getExportActionableDynamicQuery(
@@ -250,6 +276,13 @@ public class FragmentPortletDataHandler extends BasePortletDataHandler {
 	)
 	private StagedModelRepository<FragmentCollection>
 		_fragmentCollectionStagedModelRepository;
+
+	@Reference(
+		target = "(model.class.name=com.liferay.fragment.model.FragmentComposition)",
+		unbind = "-"
+	)
+	private StagedModelRepository<FragmentComposition>
+		_fragmentCompositionStagedModelRepository;
 
 	@Reference(
 		target = "(model.class.name=com.liferay.fragment.model.FragmentEntry)",

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/staged/model/repository/FragmentCompositionStagedModelRepository.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/staged/model/repository/FragmentCompositionStagedModelRepository.java
@@ -1,0 +1,158 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.fragment.internal.exportimport.staged.model.repository;
+
+import com.liferay.exportimport.kernel.lar.PortletDataContext;
+import com.liferay.exportimport.kernel.lar.StagedModelModifiedDateComparator;
+import com.liferay.exportimport.staged.model.repository.StagedModelRepository;
+import com.liferay.exportimport.staged.model.repository.StagedModelRepositoryHelper;
+import com.liferay.fragment.model.FragmentComposition;
+import com.liferay.fragment.service.FragmentCompositionLocalService;
+import com.liferay.portal.kernel.dao.orm.ExportActionableDynamicQuery;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.service.ServiceContext;
+
+import java.util.List;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Petteri Karttunen
+ */
+@Component(
+	property = "model.class.name=com.liferay.fragment.model.FragmentComposition",
+	service = StagedModelRepository.class
+)
+public class FragmentCompositionStagedModelRepository
+	implements StagedModelRepository<FragmentComposition> {
+
+	@Override
+	public FragmentComposition addStagedModel(
+			PortletDataContext portletDataContext,
+			FragmentComposition fragmentComposition)
+		throws PortalException {
+
+		long userId = portletDataContext.getUserId(
+			fragmentComposition.getUserUuid());
+
+		ServiceContext serviceContext = portletDataContext.createServiceContext(
+			fragmentComposition);
+
+		if (portletDataContext.isDataStrategyMirror()) {
+			serviceContext.setUuid(fragmentComposition.getUuid());
+		}
+
+		return _fragmentCompositionLocalService.addFragmentComposition(
+			fragmentComposition.getExternalReferenceCode(), userId,
+			fragmentComposition.getGroupId(),
+			fragmentComposition.getFragmentCollectionId(),
+			fragmentComposition.getFragmentCompositionKey(),
+			fragmentComposition.getName(), fragmentComposition.getDescription(),
+			fragmentComposition.getData(),
+			fragmentComposition.getPreviewFileEntryId(),
+			fragmentComposition.getStatus(), serviceContext);
+	}
+
+	@Override
+	public void deleteStagedModel(FragmentComposition fragmentComposition)
+		throws PortalException {
+
+		_fragmentCompositionLocalService.deleteFragmentComposition(
+			fragmentComposition);
+	}
+
+	@Override
+	public void deleteStagedModel(
+			String uuid, long groupId, String className, String extraData)
+		throws PortalException {
+
+		FragmentComposition fragmentComposition =
+			fetchStagedModelByUuidAndGroupId(uuid, groupId);
+
+		if (fragmentComposition != null) {
+			deleteStagedModel(fragmentComposition);
+		}
+	}
+
+	@Override
+	public void deleteStagedModels(PortletDataContext portletDataContext)
+		throws PortalException {
+	}
+
+	@Override
+	public FragmentComposition fetchMissingReference(
+		String uuid, long groupId) {
+
+		return (FragmentComposition)
+			_stagedModelRepositoryHelper.fetchMissingReference(
+				uuid, groupId, this);
+	}
+
+	@Override
+	public FragmentComposition fetchStagedModelByUuidAndGroupId(
+		String uuid, long groupId) {
+
+		return _fragmentCompositionLocalService.
+			fetchFragmentCompositionByUuidAndGroupId(uuid, groupId);
+	}
+
+	@Override
+	public List<FragmentComposition> fetchStagedModelsByUuidAndCompanyId(
+		String uuid, long companyId) {
+
+		return _fragmentCompositionLocalService.
+			getFragmentCompositionsByUuidAndCompanyId(
+				uuid, companyId, QueryUtil.ALL_POS, QueryUtil.ALL_POS,
+				new StagedModelModifiedDateComparator<FragmentComposition>());
+	}
+
+	@Override
+	public ExportActionableDynamicQuery getExportActionableDynamicQuery(
+		PortletDataContext portletDataContext) {
+
+		return _fragmentCompositionLocalService.getExportActionableDynamicQuery(
+			portletDataContext);
+	}
+
+	@Override
+	public FragmentComposition getStagedModel(long id) throws PortalException {
+		return _fragmentCompositionLocalService.getFragmentComposition(id);
+	}
+
+	@Override
+	public FragmentComposition saveStagedModel(
+			FragmentComposition fragmentComposition)
+		throws PortalException {
+
+		return _fragmentCompositionLocalService.updateFragmentComposition(
+			fragmentComposition);
+	}
+
+	@Override
+	public FragmentComposition updateStagedModel(
+			PortletDataContext portletDataContext,
+			FragmentComposition fragmentComposition)
+		throws PortalException {
+
+		return _fragmentCompositionLocalService.updateFragmentComposition(
+			portletDataContext.getUserId(fragmentComposition.getUserUuid()),
+			fragmentComposition.getFragmentCompositionId(),
+			fragmentComposition.getFragmentCollectionId(),
+			fragmentComposition.getName(), fragmentComposition.getDescription(),
+			fragmentComposition.getData(),
+			fragmentComposition.getPreviewFileEntryId(),
+			fragmentComposition.getStatus());
+	}
+
+	@Reference
+	private FragmentCompositionLocalService _fragmentCompositionLocalService;
+
+	@Reference
+	private StagedModelRepositoryHelper _stagedModelRepositoryHelper;
+
+}

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/exportimport/data/handler/test/FragmentCompositionStagedModelDataHandlerTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/exportimport/data/handler/test/FragmentCompositionStagedModelDataHandlerTest.java
@@ -1,0 +1,249 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.fragment.internal.exportimport.data.handler.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.document.library.kernel.exception.NoSuchFileEntryException;
+import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
+import com.liferay.exportimport.test.util.lar.BaseStagedModelDataHandlerTestCase;
+import com.liferay.fragment.constants.FragmentPortletKeys;
+import com.liferay.fragment.model.FragmentCollection;
+import com.liferay.fragment.model.FragmentComposition;
+import com.liferay.fragment.service.FragmentCompositionLocalService;
+import com.liferay.fragment.test.util.FragmentTestUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Repository;
+import com.liferay.portal.kernel.model.StagedModel;
+import com.liferay.portal.kernel.portletfilerepository.PortletFileRepositoryUtil;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Petteri Karttunen
+ */
+@RunWith(Arquillian.class)
+public class FragmentCompositionStagedModelDataHandlerTest
+	extends BaseStagedModelDataHandlerTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+	}
+
+	@Test
+	public void testDeletePreviewFileEntryWithStagingEnabled()
+		throws Exception {
+
+		Map<String, List<StagedModel>> dependentStagedModelsMap =
+			addDependentStagedModelsMap(stagingGroup);
+
+		StagedModel stagedModel = addStagedModel(
+			stagingGroup, dependentStagedModelsMap);
+
+		FragmentComposition fragmentComposition =
+			(FragmentComposition)stagedModel;
+
+		Repository repository = PortletFileRepositoryUtil.addPortletRepository(
+			stagingGroup.getGroupId(), FragmentPortletKeys.FRAGMENT,
+			ServiceContextTestUtil.getServiceContext(
+				stagingGroup.getGroupId(), TestPropsValues.getUserId()));
+
+		Class<?> clazz = getClass();
+
+		ClassLoader classLoader = clazz.getClassLoader();
+
+		FileEntry fileEntry = PortletFileRepositoryUtil.addPortletFileEntry(
+			null, stagingGroup.getGroupId(), TestPropsValues.getUserId(),
+			FragmentComposition.class.getName(),
+			fragmentComposition.getFragmentCompositionId(),
+			FragmentPortletKeys.FRAGMENT, repository.getDlFolderId(),
+			classLoader.getResourceAsStream(
+				"com/liferay/fragment/dependencies/liferay.png"),
+			RandomTestUtil.randomString(), ContentTypes.IMAGE_PNG, false);
+
+		stagedModel =
+			_fragmentCompositionLocalService.updateFragmentComposition(
+				fragmentComposition.getFragmentCompositionId(),
+				fileEntry.getFileEntryId());
+
+		_exportImportStagedModel(stagedModel);
+
+		StagedModel importedStagedModel = getStagedModel(
+			stagedModel.getUuid(), liveGroup);
+
+		FragmentComposition importedFragmentComposition =
+			(FragmentComposition)importedStagedModel;
+
+		long importedPreviewFileEntryId =
+			importedFragmentComposition.getPreviewFileEntryId();
+
+		fileEntry = PortletFileRepositoryUtil.getPortletFileEntry(
+			importedPreviewFileEntryId);
+
+		Assert.assertNotNull(fileEntry);
+
+		PortletFileRepositoryUtil.deletePortletFileEntry(
+			fileEntry.getFileEntryId());
+
+		stagedModel =
+			_fragmentCompositionLocalService.updateFragmentComposition(
+				fragmentComposition.getFragmentCompositionId(), 0);
+
+		_exportImportStagedModel(stagedModel);
+
+		importedStagedModel = getStagedModel(stagedModel.getUuid(), liveGroup);
+
+		importedFragmentComposition = (FragmentComposition)importedStagedModel;
+
+		Assert.assertEquals(
+			0, importedFragmentComposition.getPreviewFileEntryId());
+
+		fileEntry = null;
+
+		try {
+			fileEntry = PortletFileRepositoryUtil.getPortletFileEntry(
+				importedPreviewFileEntryId);
+		}
+		catch (NoSuchFileEntryException noSuchFileEntryException) {
+			Assert.assertEquals(
+				StringBundler.concat(
+					"No FileEntry exists with the key {fileEntryId=",
+					importedPreviewFileEntryId, "}"),
+				noSuchFileEntryException.getMessage());
+		}
+
+		Assert.assertNull(fileEntry);
+	}
+
+	@Test
+	public void testImportRemapsFragmentCollectionId() throws Exception {
+		Map<String, List<StagedModel>> dependentStagedModelsMap =
+			addDependentStagedModelsMap(stagingGroup);
+
+		FragmentComposition fragmentComposition =
+			(FragmentComposition)addStagedModel(
+				stagingGroup, dependentStagedModelsMap);
+
+		_exportImportStagedModel(fragmentComposition);
+
+		FragmentComposition importedFragmentComposition =
+			(FragmentComposition)getStagedModel(
+				fragmentComposition.getUuid(), liveGroup);
+
+		Assert.assertNotEquals(
+			fragmentComposition.getFragmentCollectionId(),
+			importedFragmentComposition.getFragmentCollectionId());
+	}
+
+	@Override
+	protected StagedModel addStagedModel(
+			Group group,
+			Map<String, List<StagedModel>> dependentStagedModelsMap)
+		throws Exception {
+
+		FragmentCollection fragmentCollection =
+			FragmentTestUtil.addFragmentCollection(group.getGroupId());
+
+		return _fragmentCompositionLocalService.addFragmentComposition(
+			null, TestPropsValues.getUserId(), group.getGroupId(),
+			fragmentCollection.getFragmentCollectionId(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), _SAMPLE_DATA, 0,
+			WorkflowConstants.STATUS_APPROVED,
+			ServiceContextTestUtil.getServiceContext(
+				group.getGroupId(), TestPropsValues.getUserId()));
+	}
+
+	@Override
+	protected StagedModel getStagedModel(String uuid, Group group)
+		throws PortalException {
+
+		return _fragmentCompositionLocalService.
+			getFragmentCompositionByUuidAndGroupId(uuid, group.getGroupId());
+	}
+
+	@Override
+	protected Class<? extends StagedModel> getStagedModelClass() {
+		return FragmentComposition.class;
+	}
+
+	@Override
+	protected void validateImportedStagedModel(
+			StagedModel stagedModel, StagedModel importedStagedModel)
+		throws Exception {
+
+		super.validateImportedStagedModel(stagedModel, importedStagedModel);
+
+		FragmentComposition fragmentComposition =
+			(FragmentComposition)stagedModel;
+		FragmentComposition importedFragmentComposition =
+			(FragmentComposition)importedStagedModel;
+
+		Assert.assertEquals(
+			fragmentComposition.getName(),
+			importedFragmentComposition.getName());
+		Assert.assertEquals(
+			fragmentComposition.getDescription(),
+			importedFragmentComposition.getDescription());
+		Assert.assertEquals(
+			fragmentComposition.getData(),
+			importedFragmentComposition.getData());
+		Assert.assertEquals(
+			fragmentComposition.getFragmentCompositionKey(),
+			importedFragmentComposition.getFragmentCompositionKey());
+		Assert.assertEquals(
+			fragmentComposition.getStatus(),
+			importedFragmentComposition.getStatus());
+	}
+
+	private void _exportImportStagedModel(StagedModel... stagedModels)
+		throws Exception {
+
+		ExportImportThreadLocal.setPortletImportInProcess(true);
+
+		try {
+			for (StagedModel stagedModel : stagedModels) {
+				exportImportStagedModel(stagedModel);
+			}
+		}
+		finally {
+			ExportImportThreadLocal.setPortletImportInProcess(false);
+		}
+	}
+
+	private static final String _SAMPLE_DATA =
+		"{\"version\":1,\"items\":{\"root\":{\"children\":[],\"type\":" +
+			"\"root\"}},\"rootItems\":{\"main\":\"root\"}}";
+
+	@Inject
+	private FragmentCompositionLocalService _fragmentCompositionLocalService;
+
+}


### PR DESCRIPTION
- https://liferay.atlassian.net/browse/LPD-86823

This PR is  based on the findings in [liferay.com testing epic](https://liferay.atlassian.net/browse/LPD-84210). 

## Summary                                                                                                                                                                           
                      
`FragmentComposition` is a staged model but had no `StagedModelDataHandler` / `StagedModelRepository`, so site export, publication staging, and remote live staging silently dropped all fragment compositions.                                                                                                                   
                                                                                                                                                                                       
Batch engine / headless REST is the preferred long-term path, but `FragmentComposition` is not covered there today (the headless-admin-site endpoints for it were removed as unimplemented in LPD-74328).                                                                                                                                                                 
                                                                                                                                                                                       
## Changes                                                                                                                                                             
This PR add the staged model data handler and wires the compositions to LAR export-import.