### PR TITLE
LPD-85299 DL Folder parent hierarchy incorrectly preserved during export/import when parent mapping is missing

### DIFF
--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/exportimport/data/handler/FolderStagedModelDataHandler.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/exportimport/data/handler/FolderStagedModelDataHandler.java
@@ -227,7 +227,8 @@ public class FolderStagedModelDataHandler
 				Folder.class);
 
 		long parentFolderId = MapUtil.getLong(
-			folderIds, folder.getParentFolderId(), folder.getParentFolderId());
+			folderIds, folder.getParentFolderId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID);
 
 		ServiceContext serviceContext = portletDataContext.createServiceContext(
 			folder, DLFolder.class);

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/exportimport/data/handler/test/FolderStagedModelDataHandlerTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/exportimport/data/handler/test/FolderStagedModelDataHandlerTest.java
@@ -118,6 +118,12 @@ public class FolderStagedModelDataHandlerTest
 
 			Assert.assertNotNull(exportedChildFolder);
 
+			Folder exportedParentFolder = (Folder)readExportedStagedModel(
+				parentFolder);
+
+			StagedModelDataHandlerUtil.importStagedModel(
+				portletDataContext, exportedParentFolder);
+
 			Map<Long, Long> folderIds =
 				(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
 					Folder.class);

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/exportimport/data/handler/test/FolderStagedModelDataHandlerTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/exportimport/data/handler/test/FolderStagedModelDataHandlerTest.java
@@ -91,9 +91,7 @@ public class FolderStagedModelDataHandlerTest
 	}
 
 	@Test
-	public void testImportChildFolderWithMissingParentMapping()
-		throws Exception {
-
+	public void testFolderWithoutParentFolder() throws Exception {
 		initExport();
 
 		Folder parentFolder = DLAppServiceUtil.addFolder(

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/exportimport/data/handler/test/FolderStagedModelDataHandlerTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/exportimport/data/handler/test/FolderStagedModelDataHandlerTest.java
@@ -64,6 +64,57 @@ public class FolderStagedModelDataHandlerTest
 		new LiferayIntegrationTestRule();
 
 	@Test
+	public void testImportChildFolderWithMissingParentMapping()
+		throws Exception {
+
+		initExport();
+
+		Folder parentFolder = DLAppServiceUtil.addFolder(
+			null, stagingGroup.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			ServiceContextTestUtil.getServiceContext(
+				stagingGroup.getGroupId(), TestPropsValues.getUserId()));
+
+		Folder childFolder = DLAppServiceUtil.addFolder(
+			null, stagingGroup.getGroupId(), parentFolder.getFolderId(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			ServiceContextTestUtil.getServiceContext(
+				stagingGroup.getGroupId(), TestPropsValues.getUserId()));
+
+		StagedModelDataHandlerUtil.exportStagedModel(
+			portletDataContext, childFolder);
+
+		try (SafeCloseable safeCloseable = initImportWithSafeCloseable()) {
+			Folder exportedChildFolder = (Folder)readExportedStagedModel(
+				childFolder);
+
+			Assert.assertNotNull(exportedChildFolder);
+
+			// Clear the parent folder mapping so the parent is "missing"
+
+			Map<Long, Long> folderIds =
+				(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
+					Folder.class);
+
+			folderIds.remove(parentFolder.getFolderId());
+
+			StagedModelDataHandlerUtil.importStagedModel(
+				portletDataContext, exportedChildFolder);
+
+			DLFolder importedDLFolder =
+				DLFolderLocalServiceUtil.getDLFolderByUuidAndGroupId(
+					childFolder.getUuid(), liveGroup.getGroupId());
+
+			Assert.assertEquals(
+				"When parent folder mapping is missing, the imported child " +
+					"folder should be placed at root level",
+				DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+				importedDLFolder.getParentFolderId());
+		}
+	}
+
+	@Test
 	public void testCompanyScopeDependencies() throws Exception {
 		initExport();
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/exportimport/data/handler/test/FolderStagedModelDataHandlerTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/exportimport/data/handler/test/FolderStagedModelDataHandlerTest.java
@@ -11,6 +11,7 @@ import com.liferay.document.library.kernel.model.DLFileEntryType;
 import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
 import com.liferay.document.library.kernel.model.DLFolder;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
+import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.kernel.service.DLAppServiceUtil;
 import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalServiceUtil;
 import com.liferay.document.library.kernel.service.DLFolderLocalServiceUtil;
@@ -38,6 +39,7 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.repository.liferayrepository.model.LiferayFolder;
+import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import java.util.Collections;
@@ -94,18 +96,19 @@ public class FolderStagedModelDataHandlerTest
 	public void testFolderWithoutParentFolder() throws Exception {
 		initExport();
 
-		Folder parentFolder = DLAppServiceUtil.addFolder(
-			null, stagingGroup.getGroupId(),
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(stagingGroup.getGroupId());
+
+		Folder parentFolder = _dlAppLocalService.addFolder(
+			null, TestPropsValues.getUserId(), stagingGroup.getGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-			ServiceContextTestUtil.getServiceContext(
-				stagingGroup.getGroupId(), TestPropsValues.getUserId()));
+			serviceContext);
 
-		Folder childFolder = DLAppServiceUtil.addFolder(
-			null, stagingGroup.getGroupId(), parentFolder.getFolderId(),
-			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-			ServiceContextTestUtil.getServiceContext(
-				stagingGroup.getGroupId(), TestPropsValues.getUserId()));
+		Folder childFolder = _dlAppLocalService.addFolder(
+			null, TestPropsValues.getUserId(), stagingGroup.getGroupId(),
+			parentFolder.getFolderId(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), serviceContext);
 
 		StagedModelDataHandlerUtil.exportStagedModel(
 			portletDataContext, childFolder);
@@ -131,13 +134,14 @@ public class FolderStagedModelDataHandlerTest
 			StagedModelDataHandlerUtil.importStagedModel(
 				portletDataContext, exportedChildFolder);
 
-			DLFolder importedDLFolder =
-				DLFolderLocalServiceUtil.getDLFolderByUuidAndGroupId(
-					childFolder.getUuid(), liveGroup.getGroupId());
+			Folder importedFolder =
+				_dlAppLocalService.getFolderByExternalReferenceCode(
+					childFolder.getExternalReferenceCode(),
+					liveGroup.getGroupId());
 
 			Assert.assertEquals(
 				DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-				importedDLFolder.getParentFolderId());
+				importedFolder.getParentFolderId());
 		}
 	}
 
@@ -425,5 +429,8 @@ public class FolderStagedModelDataHandlerTest
 		Assert.assertEquals(
 			folder.getDescription(), importedFolder.getDescription());
 	}
+
+	@Inject
+	private DLAppLocalService _dlAppLocalService;
 
 }

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/exportimport/data/handler/test/FolderStagedModelDataHandlerTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/exportimport/data/handler/test/FolderStagedModelDataHandlerTest.java
@@ -64,6 +64,33 @@ public class FolderStagedModelDataHandlerTest
 		new LiferayIntegrationTestRule();
 
 	@Test
+	public void testCompanyScopeDependencies() throws Exception {
+		initExport();
+
+		Map<String, List<StagedModel>> dependentStagedModelsMap =
+			addCompanyDependencies();
+
+		StagedModel stagedModel = addStagedModel(
+			stagingGroup, dependentStagedModelsMap);
+
+		StagedModelDataHandlerUtil.exportStagedModel(
+			portletDataContext, stagedModel);
+
+		try (SafeCloseable safeCloseable = initImportWithSafeCloseable()) {
+			StagedModel exportedStagedModel = readExportedStagedModel(
+				stagedModel);
+
+			Assert.assertNotNull(exportedStagedModel);
+
+			StagedModelDataHandlerUtil.importStagedModel(
+				portletDataContext, exportedStagedModel);
+
+			validateCompanyDependenciesImport(
+				dependentStagedModelsMap, liveGroup);
+		}
+	}
+
+	@Test
 	public void testImportChildFolderWithMissingParentMapping()
 		throws Exception {
 
@@ -111,33 +138,6 @@ public class FolderStagedModelDataHandlerTest
 					"folder should be placed at root level",
 				DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 				importedDLFolder.getParentFolderId());
-		}
-	}
-
-	@Test
-	public void testCompanyScopeDependencies() throws Exception {
-		initExport();
-
-		Map<String, List<StagedModel>> dependentStagedModelsMap =
-			addCompanyDependencies();
-
-		StagedModel stagedModel = addStagedModel(
-			stagingGroup, dependentStagedModelsMap);
-
-		StagedModelDataHandlerUtil.exportStagedModel(
-			portletDataContext, stagedModel);
-
-		try (SafeCloseable safeCloseable = initImportWithSafeCloseable()) {
-			StagedModel exportedStagedModel = readExportedStagedModel(
-				stagedModel);
-
-			Assert.assertNotNull(exportedStagedModel);
-
-			StagedModelDataHandlerUtil.importStagedModel(
-				portletDataContext, exportedStagedModel);
-
-			validateCompanyDependenciesImport(
-				dependentStagedModelsMap, liveGroup);
 		}
 	}
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/exportimport/data/handler/test/FolderStagedModelDataHandlerTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/exportimport/data/handler/test/FolderStagedModelDataHandlerTest.java
@@ -118,8 +118,6 @@ public class FolderStagedModelDataHandlerTest
 
 			Assert.assertNotNull(exportedChildFolder);
 
-			// Clear the parent folder mapping so the parent is "missing"
-
 			Map<Long, Long> folderIds =
 				(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
 					Folder.class);
@@ -134,8 +132,6 @@ public class FolderStagedModelDataHandlerTest
 					childFolder.getUuid(), liveGroup.getGroupId());
 
 			Assert.assertEquals(
-				"When parent folder mapping is missing, the imported child " +
-					"folder should be placed at root level",
 				DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 				importedDLFolder.getParentFolderId());
 		}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-85299

## Expected Results

When the parent folder is not found in the primary key mapping during import, `ChildFolder` should be placed at root level (`parentFolderId = 0`).

## Fix

Change the fallback value in `FolderStagedModelDataHandler.java` (line 229-230) from `folder.getParentFolderId()` to `DLFolderConstants.DEFAULT_PARENT_FOLDER_ID`:

An integration test (`testImportChildFolderWithMissingParentMapping`) has been written that confirms the bug