### PR TITLE
Lpd 86227

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/StructuredContentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/StructuredContentResourceImpl.java
@@ -129,7 +129,6 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
@@ -494,21 +493,6 @@ public class StructuredContentResourceImpl
 
 		JournalArticle journalArticle = _journalArticleService.getLatestArticle(
 			structuredContentId);
-
-		if (!ArrayUtil.contains(
-				journalArticle.getAvailableLanguageIds(),
-				contextAcceptLanguage.getPreferredLanguageId())) {
-
-			throw new BadRequestException(
-				StringBundler.concat(
-					"Unable to patch structured content with language ",
-					LocaleUtil.toW3cLanguageId(
-						contextAcceptLanguage.getPreferredLanguageId()),
-					" because it is only available in the following languages ",
-					Arrays.toString(
-						LocaleUtil.toW3cLanguageIds(
-							journalArticle.getAvailableLanguageIds()))));
-		}
 
 		DDMStructure ddmStructure = journalArticle.getDDMStructure();
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/StructuredContentResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/StructuredContentResourceTest.java
@@ -2751,6 +2751,7 @@ public class StructuredContentResourceTest
 		_testPatchStructuredContentWithDateExpiredExpire2();
 		_testPatchStructuredContentWithDateExpiredExpireBadRequest();
 		_testPatchStructuredContentWithDateExpiredNeverExpire();
+		_testPatchStructuredContentWithNewLocal();
 	}
 
 	private void _testPatchStructuredContentWithDateExpiredExpire1()
@@ -2946,6 +2947,54 @@ public class StructuredContentResourceTest
 		_assertData(
 			patchContentFieldValue_I18n,
 			GetterUtil.getString(postFrenchData.get("data")), "fr-FR");
+	}
+
+	private void _testPatchStructuredContentWithNewLocal() throws Exception {
+		StructuredContent structuredContent = _randomStructuredContent(
+			LocaleUtil.getDefault(), true);
+
+		StructuredContent postStructuredContent =
+			structuredContentResource.postSiteStructuredContent(
+				testGroup.getGroupId(), structuredContent);
+
+		String germanData = RandomTestUtil.randomString(10);
+
+		Map<String, ContentFieldValue> contentFieldValues = HashMapBuilder.put(
+			"de-DE",
+			(ContentFieldValue)new ContentFieldValue() {
+
+				{
+					data = germanData;
+				}
+			}
+		).build();
+
+		structuredContent.setContentFields(
+			new ContentField[] {
+				new ContentField() {
+					{
+						contentFieldValue = contentFieldValues.get("de-DE");
+						contentFieldValue_i18n = contentFieldValues;
+						fieldReference = "MyText";
+						name = "MyText";
+					}
+				}
+			});
+
+		StructuredContentResource structuredContentResource =
+			_buildStructureContentResource(LocaleUtil.GERMANY);
+
+		StructuredContent patchStructuredContent =
+			structuredContentResource.patchStructuredContent(
+				postStructuredContent.getId(), structuredContent);
+
+		ContentField patchContentField =
+			patchStructuredContent.getContentFields()[0];
+
+		Map<String, ContentFieldValue> patchContentFieldValue_I18n =
+			patchContentField.getContentFieldValue_i18n();
+
+		_assertData(patchContentFieldValue_I18n, germanData, "de-DE");
 	}
 
 	private void _testPatchStructuredContentWithRandomTitle() throws Exception {


### PR DESCRIPTION
The o/headless-delivery/v1.0/structured-contents/batch?updateStrategy=PARTIAL_UPDATE endpoint is not working as expected when updating structured contents using the Structured Contents API for a new language. As a result, partial updates to structured content fields are not applied correctly.

This change ensures that the PARTIAL_UPDATE strategy behaves correctly when updating structured contents.

The fix updates the handling of the updateStrategy=PARTIAL_UPDATE in the Structured Contents API to ensure partial updates are applied correctly.

Additionally, automated tests are added to validate the expected behavior and prevent regressions.