### PR TITLE
LPD-86227 Issue trying to execute updateStrategy PARTIAL_UPDATE using structured-contents API PART II

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/StructuredContentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/StructuredContentResourceImpl.java
@@ -129,7 +129,6 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
@@ -494,21 +493,6 @@ public class StructuredContentResourceImpl
 
 		JournalArticle journalArticle = _journalArticleService.getLatestArticle(
 			structuredContentId);
-
-		if (!ArrayUtil.contains(
-				journalArticle.getAvailableLanguageIds(),
-				contextAcceptLanguage.getPreferredLanguageId())) {
-
-			throw new BadRequestException(
-				StringBundler.concat(
-					"Unable to patch structured content with language ",
-					LocaleUtil.toW3cLanguageId(
-						contextAcceptLanguage.getPreferredLanguageId()),
-					" because it is only available in the following languages ",
-					Arrays.toString(
-						LocaleUtil.toW3cLanguageIds(
-							journalArticle.getAvailableLanguageIds()))));
-		}
 
 		DDMStructure ddmStructure = journalArticle.getDDMStructure();
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/StructuredContentResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/StructuredContentResourceTest.java
@@ -134,6 +134,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.TreeMap;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -533,6 +534,7 @@ public class StructuredContentResourceTest
 
 		_testPatchStructuredContentWithDateExpired();
 		_testPatchStructuredContentWithLocalizedContentFields();
+		_testPatchStructuredContentWithNewLocale();
 		_testPatchStructuredContentWithRandomTitle();
 		_testPatchStructuredContentWithUnlocalizedContentFields();
 	}
@@ -2946,6 +2948,71 @@ public class StructuredContentResourceTest
 		_assertData(
 			patchContentFieldValue_I18n,
 			GetterUtil.getString(postFrenchData.get("data")), "fr-FR");
+	}
+
+	private void _testPatchStructuredContentWithNewLocale() throws Exception {
+		Locale locale = LocaleUtil.US;
+
+		StructuredContent structuredContent = _randomStructuredContent(
+			locale, true);
+
+		StructuredContent postStructuredContent =
+			structuredContentResource.postSiteStructuredContent(
+				testGroup.getGroupId(), structuredContent);
+
+		ContentField postContentField =
+			postStructuredContent.getContentFields()[0];
+
+		ContentFieldValue postContentFieldValue =
+			postContentField.getContentFieldValue();
+
+		String englishData = postContentFieldValue.getData();
+
+		String germanData = RandomTestUtil.randomString(10);
+
+		Map<String, ContentFieldValue> contentFieldValues = HashMapBuilder.put(
+			"de-DE",
+			(ContentFieldValue)new ContentFieldValue() {
+
+				{
+					data = germanData;
+				}
+			}
+		).build();
+
+		structuredContent.setContentFields(
+			new ContentField[] {
+				new ContentField() {
+					{
+						contentFieldValue = contentFieldValues.get("de-DE");
+						contentFieldValue_i18n = contentFieldValues;
+						fieldReference = "MyText";
+						name = "MyText";
+					}
+				}
+			});
+
+		StructuredContentResource germanStructuredContentResource =
+			_buildStructureContentResource(LocaleUtil.GERMANY);
+
+		StructuredContent patchStructuredContent =
+			germanStructuredContentResource.patchStructuredContent(
+				postStructuredContent.getId(), structuredContent);
+
+		ContentField patchContentField =
+			patchStructuredContent.getContentFields()[0];
+
+		Map<String, ContentFieldValue> patchContentFieldValue_I18n =
+			patchContentField.getContentFieldValue_i18n();
+
+		Map<String, ContentFieldValue> sortedContentFieldValues = new TreeMap<>(
+			patchContentFieldValue_I18n);
+
+		Assert.assertTrue(sortedContentFieldValues.containsKey("de-DE"));
+		Assert.assertTrue(sortedContentFieldValues.containsKey("en-US"));
+
+		_assertData(sortedContentFieldValues, germanData, "de-DE");
+		_assertData(sortedContentFieldValues, englishData, "en-US");
 	}
 
 	private void _testPatchStructuredContentWithRandomTitle() throws Exception {


### PR DESCRIPTION
### **What is this trying to solve?**

[https://liferay.atlassian.net/browse/LPD-86227](https://liferay.atlassian.net/browse/LPD-86227)

The o/headless-delivery/v1.0/structured-contents/batch?updateStrategy=PARTIAL_UPDATE endpoint does not work as expected when updating structured contents for a new language. As a result, partial updates to structured content fields are not applied correctly.

### **How am I fixing it?**

Remove the language validation check in patchStructuredContent that was preventing new language data from being added during updateStrategy=PARTIAL_UPDATE. This allows adding new language values while preserving existing content.

### **How can you verify that it works?**

Run the included automated tests. 