### PR TITLE
LPD-83998 Asset vocabulary name not exported-imported

### DIFF
--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetVocabularyLocalServiceTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetVocabularyLocalServiceTest.java
@@ -23,7 +23,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapBuilder;
-import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.Inject;
@@ -31,7 +31,6 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
 import java.util.HashMap;
-import java.util.Locale;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -114,19 +113,21 @@ public class AssetVocabularyLocalServiceTest {
 			Assert.assertEquals(
 				WorkflowConstants.STATUS_EMPTY, vocabulary.getStatus());
 
-			Locale locale = _portal.getSiteDefaultLocale(_group.getGroupId());
 			String title = RandomTestUtil.randomString();
 
 			vocabulary = _assetVocabularyLocalService.updateVocabulary(
 				vocabulary.getExternalReferenceCode(),
 				vocabulary.getVocabularyId(),
 				HashMapBuilder.put(
-					locale, title
+					LocaleUtil.getDefault(), title
 				).build(),
 				null, vocabulary.getSettings(),
 				AssetVocabularyConstants.VISIBILITY_TYPE_INTERNAL);
 
-			Assert.assertEquals(title, vocabulary.getTitle(locale));
+			Assert.assertEquals(
+				title, vocabulary.getTitle(LocaleUtil.getDefault()));
+			Assert.assertEquals(
+				StringUtil.toLowerCase(title), vocabulary.getName());
 			Assert.assertEquals(
 				AssetVocabularyConstants.VISIBILITY_TYPE_INTERNAL,
 				vocabulary.getVisibilityType());
@@ -159,8 +160,5 @@ public class AssetVocabularyLocalServiceTest {
 
 	@DeleteAfterTestRun
 	private Group _group;
-
-	@Inject
-	private Portal _portal;
 
 }

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyLocalServiceImpl.java
@@ -52,6 +52,7 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -537,7 +538,12 @@ public class AssetVocabularyLocalServiceImpl
 			vocabulary.setExternalReferenceCode(externalReferenceCode);
 		}
 
-		vocabulary.setTitleMap(_getTrimmedTitleMap(titleMap));
+		Map<Locale, String> trimmedTitleMap = _getTrimmedTitleMap(titleMap);
+
+		vocabulary.setName(
+			_getAssetVocabularyName(trimmedTitleMap, vocabulary));
+		vocabulary.setTitleMap(trimmedTitleMap);
+
 		vocabulary.setDescriptionMap(descriptionMap);
 		vocabulary.setSettings(settings);
 		vocabulary.setVisibilityType(visibilityType);
@@ -568,7 +574,11 @@ public class AssetVocabularyLocalServiceImpl
 			vocabulary.setExternalReferenceCode(externalReferenceCode);
 		}
 
-		vocabulary.setTitleMap(_getTrimmedTitleMap(titleMap));
+		Map<Locale, String> trimmedTitleMap = _getTrimmedTitleMap(titleMap);
+
+		vocabulary.setName(
+			_getAssetVocabularyName(trimmedTitleMap, vocabulary));
+		vocabulary.setTitleMap(trimmedTitleMap);
 
 		if (Validator.isNotNull(title)) {
 			vocabulary.setTitle(title);
@@ -683,6 +693,24 @@ public class AssetVocabularyLocalServiceImpl
 
 			curVocabularyName = curVocabularyName + CharPool.DASH + count++;
 		}
+	}
+
+	private String _getAssetVocabularyName(
+			Map<Locale, String> titleMap, AssetVocabulary vocabulary)
+		throws PortalException {
+
+		if (vocabulary.getStatus() != WorkflowConstants.STATUS_EMPTY) {
+			return vocabulary.getName();
+		}
+
+		String title = titleMap.get(
+			PortalUtil.getSiteDefaultLocale(vocabulary.getGroupId()));
+
+		if (Validator.isNull(title)) {
+			return vocabulary.getName();
+		}
+
+		return _generateVocabularyName(vocabulary.getGroupId(), title);
 	}
 
 	private Map<Locale, String> _getTrimmedTitleMap(


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-83998

When creating an empty shell for a vocabulary, the name is initially set to its ERC. Later on, when the vocabulary is resolved, all its field are updated *expect* the name.

# How am I fixing it?

By updating the name only when the vocabulary is an empty shell.  This is done by invoking the logic to generate the name used when creating new vocabularies.

# How can you verify that it works?

Run the updated integration test.