### PR TITLE
  LPD-86920 Expose reviewDate at the root of SearchResult                                                         

### DIFF
--- a/modules/apps/portal-search/portal-search-rest-api/bnd.bnd
+++ b/modules/apps/portal-search/portal-search-rest-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Search REST API
 Bundle-SymbolicName: com.liferay.portal.search.rest.api
-Bundle-Version: 6.2.2
+Bundle-Version: 6.3.0
 Export-Package:\
 	com.liferay.portal.search.rest.configuration,\
 	com.liferay.portal.search.rest.dto.v1_0,\

--- a/modules/apps/portal-search/portal-search-rest-api/src/main/java/com/liferay/portal/search/rest/dto/v1_0/SearchResult.java
+++ b/modules/apps/portal-search/portal-search-rest-api/src/main/java/com/liferay/portal/search/rest/dto/v1_0/SearchResult.java
@@ -183,6 +183,51 @@ public class SearchResult implements Serializable {
 	private Supplier<Date> _dateModifiedSupplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The time when the item should next be reviewed."
+	)
+	public Date getDateReview() {
+		if (_dateReviewSupplier != null) {
+			dateReview = _dateReviewSupplier.get();
+
+			_dateReviewSupplier = null;
+		}
+
+		return dateReview;
+	}
+
+	public void setDateReview(Date dateReview) {
+		this.dateReview = dateReview;
+
+		_dateReviewSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setDateReview(
+		UnsafeSupplier<Date, Exception> dateReviewUnsafeSupplier) {
+
+		_dateReviewSupplier = () -> {
+			try {
+				return dateReviewUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(
+		description = "The time when the item should next be reviewed."
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Date dateReview;
+
+	@JsonIgnore
+	private Supplier<Date> _dateReviewSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema(
 		description = "The item's description."
 	)
 	public String getDescription() {
@@ -512,6 +557,22 @@ public class SearchResult implements Serializable {
 			sb.append("\"");
 		}
 
+		Date dateReview = getDateReview();
+
+		if (dateReview != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"dateReview\": ");
+
+			sb.append("\"");
+
+			sb.append(liferayToJSONDateFormat.format(dateReview));
+
+			sb.append("\"");
+		}
+
 		String description = getDescription();
 
 		if (description != null) {
@@ -712,4 +773,4 @@ public class SearchResult implements Serializable {
 	private Map<String, Serializable> _extendedProperties;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1012760903
+// LIFERAY-REST-BUILDER-HASH:-613360104

--- a/modules/apps/portal-search/portal-search-rest-api/src/main/resources/com/liferay/portal/search/rest/dto/v1_0/packageinfo
+++ b/modules/apps/portal-search/portal-search-rest-api/src/main/resources/com/liferay/portal/search/rest/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 2.3.1
+version 2.4.0

--- a/modules/apps/portal-search/portal-search-rest-client/src/main/java/com/liferay/portal/search/rest/client/dto/v1_0/SearchResult.java
+++ b/modules/apps/portal-search/portal-search-rest-client/src/main/java/com/liferay/portal/search/rest/client/dto/v1_0/SearchResult.java
@@ -91,6 +91,27 @@ public class SearchResult implements Cloneable, Serializable {
 
 	protected Date dateModified;
 
+	public Date getDateReview() {
+		return dateReview;
+	}
+
+	public void setDateReview(Date dateReview) {
+		this.dateReview = dateReview;
+	}
+
+	public void setDateReview(
+		UnsafeSupplier<Date, Exception> dateReviewUnsafeSupplier) {
+
+		try {
+			dateReview = dateReviewUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Date dateReview;
+
 	public String getDescription() {
 		return description;
 	}
@@ -247,4 +268,4 @@ public class SearchResult implements Cloneable, Serializable {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:1397601127
+// LIFERAY-REST-BUILDER-HASH:-1090536072

--- a/modules/apps/portal-search/portal-search-rest-client/src/main/java/com/liferay/portal/search/rest/client/serdes/v1_0/SearchResultSerDes.java
+++ b/modules/apps/portal-search/portal-search-rest-client/src/main/java/com/liferay/portal/search/rest/client/serdes/v1_0/SearchResultSerDes.java
@@ -92,6 +92,21 @@ public class SearchResultSerDes {
 			sb.append("\"");
 		}
 
+		if (searchResult.getDateReview() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"dateReview\": ");
+
+			sb.append("\"");
+
+			sb.append(
+				liferayToJSONDateFormat.format(searchResult.getDateReview()));
+
+			sb.append("\"");
+		}
+
 		if (searchResult.getDescription() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -222,6 +237,15 @@ public class SearchResultSerDes {
 				liferayToJSONDateFormat.format(searchResult.getDateModified()));
 		}
 
+		if (searchResult.getDateReview() == null) {
+			map.put("dateReview", null);
+		}
+		else {
+			map.put(
+				"dateReview",
+				liferayToJSONDateFormat.format(searchResult.getDateReview()));
+		}
+
 		if (searchResult.getDescription() == null) {
 			map.put("description", null);
 		}
@@ -294,6 +318,9 @@ public class SearchResultSerDes {
 			else if (Objects.equals(jsonParserFieldName, "dateModified")) {
 				return false;
 			}
+			else if (Objects.equals(jsonParserFieldName, "dateReview")) {
+				return false;
+			}
 			else if (Objects.equals(jsonParserFieldName, "description")) {
 				return false;
 			}
@@ -336,6 +363,12 @@ public class SearchResultSerDes {
 			else if (Objects.equals(jsonParserFieldName, "dateModified")) {
 				if (jsonParserFieldValue != null) {
 					searchResult.setDateModified(
+						toDate((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "dateReview")) {
+				if (jsonParserFieldValue != null) {
+					searchResult.setDateReview(
 						toDate((String)jsonParserFieldValue));
 				}
 			}
@@ -452,4 +485,4 @@ public class SearchResultSerDes {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:731239514
+// LIFERAY-REST-BUILDER-HASH:2431910

--- a/modules/apps/portal-search/portal-search-rest-impl/rest-openapi.yaml
+++ b/modules/apps/portal-search/portal-search-rest-impl/rest-openapi.yaml
@@ -88,6 +88,11 @@ components:
                         The last time the item was changed.
                     format: date-time
                     type: string
+                dateReview:
+                    description:
+                        The time when the item should next be reviewed.
+                    format: date-time
+                    type: string
                 description:
                     description:
                         The item's description.

--- a/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/resource/v1_0/SearchResultResourceImpl.java
+++ b/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/resource/v1_0/SearchResultResourceImpl.java
@@ -445,6 +445,22 @@ public class SearchResultResourceImpl extends BaseSearchResultResourceImpl {
 		}
 	}
 
+	private void _setDateReview(
+		Document document, List<String> fields, SearchResult searchResult) {
+
+		if (!_isEmptyOrContains(fields, "dateReview")) {
+			return;
+		}
+
+		String reviewDate = document.getString(
+			com.liferay.portal.kernel.search.Field.REVIEW_DATE);
+
+		if (reviewDate != null) {
+			searchResult.setDateReview(
+				() -> _parseDateStringFieldValue(reviewDate));
+		}
+	}
+
 	private void _setDescription(
 		AssetRenderer<?> assetRenderer, List<String> fields,
 		SearchResult searchResult, Summary summary) {
@@ -643,6 +659,7 @@ public class SearchResultResourceImpl extends BaseSearchResultResourceImpl {
 				embedded, entryClassName, entryClassPK, fields, searchResult);
 			_setDateCreated(document, fields, searchResult);
 			_setDateModified(document, fields, searchResult);
+			_setDateReview(document, fields, searchResult);
 			_setScore(fields, searchHit, searchResult);
 
 			searchResults.add(searchResult);

--- a/modules/apps/portal-search/portal-search-rest-test/src/testIntegration/java/com/liferay/portal/search/rest/resource/v1_0/test/BaseSearchResultResourceTestCase.java
+++ b/modules/apps/portal-search/portal-search-rest-test/src/testIntegration/java/com/liferay/portal/search/rest/resource/v1_0/test/BaseSearchResultResourceTestCase.java
@@ -628,6 +628,14 @@ public abstract class BaseSearchResultResourceTestCase {
 				continue;
 			}
 
+			if (Objects.equals("dateReview", additionalAssertFieldName)) {
+				if (searchResult.getDateReview() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals("description", additionalAssertFieldName)) {
 				if (searchResult.getDescription() == null) {
 					valid = false;
@@ -821,6 +829,17 @@ public abstract class BaseSearchResultResourceTestCase {
 				if (!Objects.deepEquals(
 						searchResult1.getDateModified(),
 						searchResult2.getDateModified())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("dateReview", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						searchResult1.getDateReview(),
+						searchResult2.getDateReview())) {
 
 					return false;
 				}
@@ -1057,6 +1076,35 @@ public abstract class BaseSearchResultResourceTestCase {
 				sb.append(" ");
 
 				sb.append(_format.format(searchResult.getDateModified()));
+			}
+
+			return sb.toString();
+		}
+
+		if (entityFieldName.equals("dateReview")) {
+			if (operator.equals("between")) {
+				Date date = searchResult.getDateReview();
+
+				sb = new StringBundler();
+
+				sb.append("(");
+				sb.append(entityFieldName);
+				sb.append(" gt ");
+				sb.append(_format.format(date.getTime() - (2 * Time.SECOND)));
+				sb.append(" and ");
+				sb.append(entityFieldName);
+				sb.append(" lt ");
+				sb.append(_format.format(date.getTime() + (2 * Time.SECOND)));
+				sb.append(")");
+			}
+			else {
+				sb.append(entityFieldName);
+
+				sb.append(" ");
+				sb.append(operator);
+				sb.append(" ");
+
+				sb.append(_format.format(searchResult.getDateReview()));
 			}
 
 			return sb.toString();
@@ -1303,6 +1351,7 @@ public abstract class BaseSearchResultResourceTestCase {
 			{
 				dateCreated = RandomTestUtil.nextDate();
 				dateModified = RandomTestUtil.nextDate();
+				dateReview = RandomTestUtil.nextDate();
 				description = StringUtil.toLowerCase(
 					RandomTestUtil.randomString());
 				entryClassName = StringUtil.toLowerCase(
@@ -1533,4 +1582,4 @@ public abstract class BaseSearchResultResourceTestCase {
 		_searchResultResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1963226699
+// LIFERAY-REST-BUILDER-HASH:1145884918


### PR DESCRIPTION
  https://liferay.atlassian.net/browse/LPD-86920
                                                                                                                  
  Review date is already indexed and filterable, but it's only available nested                                   
  inside each search result's `embedded` object. The upcoming Review Date FDS
  column (LPD-79678) needs the value at the top level so the same `fieldName`                                     
  can drive both display and OData sort — `embedded.*` field names are known to          
  break sort.                                           
                                             
  # How am I fixing it?                                                                                           
  - Add `dateReview` to `SearchResult` in the `portal-search-rest` OpenAPI
    schema, alongside the existing `dateCreated`/`dateModified`.                                                  
  - Regenerate the API DTO, client DTO, SerDes, and base test case with                  
    `buildREST`.                                                                                                  
  - Populate `dateReview` in `SearchResultResourceImpl` from the indexed                                          
    `reviewDate` field, mirroring `_setDateModified`.                                                             
  - Bump the exported `dto/v1_0` package (additive minor: `2.3.1 → 2.4.0`) and                                    
    the bundle version.                                                                                           
                                                                                         
  # How can you verify that it works?                                                                             
  1. Enable the `LPD-17564` feature flag (the one that indexes review date on                                     
     object entries).                                                                                             
  3. Call the search endpoint and confirm the returned result includes                                            
     `dateReview` at the root of the row, formatted as ISO-8601.                                                  
  4. Issue `?filter=dateReview gt <yesterday>` and confirm the entry is                                           
     returned; `?sort=dateReview:asc` orders correctly.                                                           
                                                                                                                  
  # Why doesn't this include any test?                                                                            
  This surfaces an already-indexed value at the response root; the indexing                                       
  path and OData entity-model wiring are covered by existing tests, and                                           
  `dateReview` remains in `_IGNORED_ENTITY_FIELD_NAMES` alongside its sibling                                     
  feature-flagged dates (`dateDisplay`, `dateExpiration`, `datePublish`) for                                      
  consistency. End-to-end coverage of the new root-level exposure arrives                                         
  naturally with the consumer change on LPD-79678 — a broken binding would                                        
  surface there as an empty column.