### PR TITLE
LPD-87149 Consolidate breadcrumbProps in BaseSectionDisplayContext

### DIFF
--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/ExpiredAssetResourceImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/ExpiredAssetResourceImpl.java
@@ -85,7 +85,7 @@ public class ExpiredAssetResourceImpl extends BaseExpiredAssetResourceImpl {
 							_portal.getPortalURL(contextHttpServletRequest),
 							_portal.getPathMain(),
 							GroupConstants.CMS_FRIENDLY_URL,
-							"/edit_content_item?&p_l_mode=read&p_p_state=",
+							"/edit_content_item?p_l_mode=read&p_p_state=",
 							LiferayWindowState.POP_UP, "&objectEntryId=",
 							objectEntryId));
 

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/ExpiredAssetResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/ExpiredAssetResourceTest.java
@@ -175,7 +175,7 @@ public class ExpiredAssetResourceTest extends BaseExpiredAssetResourceTestCase {
 			() -> StringBundler.concat(
 				_themeDisplay.getPortalURL(), _portal.getPathMain(),
 				GroupConstants.CMS_FRIENDLY_URL,
-				"/edit_content_item?&p_l_mode=read&p_p_state=",
+				"/edit_content_item?p_l_mode=read&p_p_state=",
 				LiferayWindowState.POP_UP, "&objectEntryId=",
 				objectEntry.getObjectEntryId()));
 

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/AssetUsageResourceImpl.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/AssetUsageResourceImpl.java
@@ -380,7 +380,7 @@ public class AssetUsageResourceImpl extends BaseAssetUsageResourceImpl {
 										contextHttpServletRequest),
 									_portal.getPathMain(),
 									GroupConstants.CMS_FRIENDLY_URL,
-									"/edit_content_item?&p_l_mode=read&",
+									"/edit_content_item?p_l_mode=read&",
 									"p_p_state=", LiferayWindowState.POP_UP,
 									"&objectEntryId=",
 									objectEntry.getObjectEntryId()));

--- a/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/AssetUsageResourceTest.java
+++ b/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/AssetUsageResourceTest.java
@@ -164,7 +164,7 @@ public class AssetUsageResourceTest extends BaseAssetUsageResourceTestCase {
 			() -> StringBundler.concat(
 				_themeDisplay.getPortalURL(), _portal.getPathMain(),
 				GroupConstants.CMS_FRIENDLY_URL,
-				"/edit_content_item?&p_l_mode=read&p_p_state=",
+				"/edit_content_item?p_l_mode=read&p_p_state=",
 				LiferayWindowState.POP_UP, "&objectEntryId=",
 				objectEntry.getObjectEntryId()));
 

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/BaseSectionDisplayContextTestCase.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/BaseSectionDisplayContextTestCase.java
@@ -247,7 +247,7 @@ public abstract class BaseSectionDisplayContextTestCase
 			StringBundler.concat(
 				themeDisplay.getPortalURL(), themeDisplay.getPathMain(),
 				GroupConstants.CMS_FRIENDLY_URL,
-				"/edit_content_item?&p_l_mode=read&p_p_state=",
+				"/edit_content_item?p_l_mode=read&p_p_state=",
 				LiferayWindowState.POP_UP, "&redirect=",
 				themeDisplay.getURLCurrent(), "&objectEntryId={embedded.id}")
 		).put(

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/BaseSectionDisplayContextTestCase.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/BaseSectionDisplayContextTestCase.java
@@ -158,6 +158,8 @@ public abstract class BaseSectionDisplayContextTestCase
 				_portal.getClassNameId(ObjectEntryFolder.class),
 				StringPool.SLASH)
 		).put(
+			"breadcrumbProps", _getBreadcrumbProps(mockHttpServletRequest)
+		).put(
 			"brokenLinksCheckerEnabled",
 			GetterUtil.getBoolean(
 				PropsUtil.get(PropsKeys.CMS_BROKEN_LINKS_CHECKER_ENABLED))

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewAssetDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewAssetDisplayContextTest.java
@@ -165,7 +165,7 @@ public class ViewAssetDisplayContextTest extends BaseDisplayContextTestCase {
 			StringBundler.concat(
 				themeDisplay.getPortalURL(), themeDisplay.getPathMain(),
 				GroupConstants.CMS_FRIENDLY_URL,
-				"/edit_content_item?&p_l_mode=read&p_p_state=",
+				"/edit_content_item?p_l_mode=read&p_p_state=",
 				LiferayWindowState.POP_UP, "&redirect=",
 				themeDisplay.getURLCurrent(), "&objectEntryId=",
 				objectEntry.getObjectEntryId())

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewSharedWithMeSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewSharedWithMeSectionDisplayContextTest.java
@@ -151,7 +151,7 @@ public class ViewSharedWithMeSectionDisplayContextTest
 				StringBundler.concat(
 					themeDisplay.getPortalURL(), themeDisplay.getPathMain(),
 					GroupConstants.CMS_FRIENDLY_URL,
-					"/edit_content_item?&p_l_mode=read&p_p_state=",
+					"/edit_content_item?p_l_mode=read&p_p_state=",
 					LiferayWindowState.POP_UP, "&redirect=",
 					themeDisplay.getURLCurrent(),
 					"&objectEntryId={embedded.id}")

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseRelatedAssetsSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseRelatedAssetsSectionDisplayContext.java
@@ -95,7 +95,7 @@ public abstract class BaseRelatedAssetsSectionDisplayContext
 				StringBundler.concat(
 					themeDisplay.getPortalURL(), themeDisplay.getPathMain(),
 					GroupConstants.CMS_FRIENDLY_URL,
-					"/edit_content_item?&p_l_mode=read&p_p_state=",
+					"/edit_content_item?p_l_mode=read&p_p_state=",
 					LiferayWindowState.POP_UP, "&redirect=",
 					themeDisplay.getURLCurrent(),
 					"&objectEntryId={embedded.id}"),

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
@@ -200,7 +200,7 @@ public abstract class BaseSectionDisplayContext {
 			StringBundler.concat(
 				themeDisplay.getPortalURL(), themeDisplay.getPathMain(),
 				GroupConstants.CMS_FRIENDLY_URL,
-				"/edit_content_item?&p_l_mode=read&p_p_state=",
+				"/edit_content_item?p_l_mode=read&p_p_state=",
 				LiferayWindowState.POP_UP, "&redirect=",
 				themeDisplay.getURLCurrent(), "&objectEntryId={embedded.id}")
 		).put(

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
@@ -143,6 +143,20 @@ public abstract class BaseSectionDisplayContext {
 		).put(
 			"baseFolderViewURL", ActionUtil.getBaseViewFolderURL(themeDisplay)
 		).put(
+			"breadcrumbProps",
+			() -> {
+				try {
+					return getBreadcrumbProps();
+				}
+				catch (PortalException portalException) {
+					if (_log.isDebugEnabled()) {
+						_log.debug(portalException);
+					}
+				}
+
+				return null;
+			}
+		).put(
 			"brokenLinksCheckerEnabled",
 			GetterUtil.getBoolean(
 				PropsUtil.get(PropsKeys.CMS_BROKEN_LINKS_CHECKER_ENABLED))

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
@@ -149,8 +149,10 @@ public abstract class BaseSectionDisplayContext {
 					return getBreadcrumbProps();
 				}
 				catch (PortalException portalException) {
-					if (_log.isDebugEnabled()) {
-						_log.debug(portalException);
+					if (_log.isWarnEnabled()) {
+						_log.warn(
+							"Unable to resolve breadcrumbProps",
+							portalException);
 					}
 				}
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/SectionDisplayContextHelper.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/SectionDisplayContextHelper.java
@@ -345,7 +345,7 @@ public class SectionDisplayContextHelper {
 				StringBundler.concat(
 					themeDisplay.getPortalURL(), themeDisplay.getPathMain(),
 					GroupConstants.CMS_FRIENDLY_URL,
-					"/edit_content_item?&p_l_mode=read&p_p_state=",
+					"/edit_content_item?p_l_mode=read&p_p_state=",
 					LiferayWindowState.POP_UP, "&redirect=",
 					themeDisplay.getURLCurrent(),
 					"&objectEntryId={embedded.id}"),

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewAllSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewAllSectionDisplayContext.java
@@ -18,11 +18,8 @@ import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectDefinitionService;
 import com.liferay.object.service.ObjectDefinitionSettingLocalService;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.language.LanguageUtil;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -71,22 +68,6 @@ public class ViewAllSectionDisplayContext extends BaseSectionDisplayContext {
 	public String getAdditionalAPIURLParameters() {
 		return _viewAllSectionSystemFDSEntry.getAdditionalAPIURLParameters(
 			httpServletRequest);
-	}
-
-	@Override
-	public Map<String, Object> getAdditionalProps() {
-		Map<String, Object> additionalProps = super.getAdditionalProps();
-
-		try {
-			additionalProps.put("breadcrumbProps", getBreadcrumbProps());
-		}
-		catch (PortalException portalException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(portalException);
-			}
-		}
-
-		return additionalProps;
 	}
 
 	@Override
@@ -236,9 +217,6 @@ public class ViewAllSectionDisplayContext extends BaseSectionDisplayContext {
 		throw new UnsupportedOperationException(
 			"ViewAllSectionSystemFDSEntry must calculate this");
 	}
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		ViewAllSectionDisplayContext.class);
 
 	private final HttpServletRequest _httpServletRequest;
 	private final FDSCreationMenu _viewAllSectionFDSCreationMenu;

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewAssetDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewAssetDisplayContext.java
@@ -62,7 +62,7 @@ public class ViewAssetDisplayContext {
 			StringBundler.concat(
 				_themeDisplay.getPortalURL(), _themeDisplay.getPathMain(),
 				GroupConstants.CMS_FRIENDLY_URL,
-				"/edit_content_item?&p_l_mode=read&p_p_state=",
+				"/edit_content_item?p_l_mode=read&p_p_state=",
 				LiferayWindowState.POP_UP, "&redirect=",
 				_themeDisplay.getURLCurrent(), "&objectEntryId=",
 				_objectEntry.getObjectEntryId())

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewContentsSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewContentsSectionDisplayContext.java
@@ -11,11 +11,8 @@ import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectDefinitionService;
 import com.liferay.object.service.ObjectDefinitionSettingLocalService;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.language.LanguageUtil;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -52,22 +49,6 @@ public class ViewContentsSectionDisplayContext
 			objectDefinitionSettingLocalService,
 			objectEntryFolderModelResourcePermission, portal,
 			translationInfoItemFieldValuesExporterRegistry);
-	}
-
-	@Override
-	public Map<String, Object> getAdditionalProps() {
-		Map<String, Object> additionalProps = super.getAdditionalProps();
-
-		try {
-			additionalProps.put("breadcrumbProps", getBreadcrumbProps());
-		}
-		catch (PortalException portalException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(portalException);
-			}
-		}
-
-		return additionalProps;
 	}
 
 	@Override
@@ -109,8 +90,5 @@ public class ViewContentsSectionDisplayContext
 	protected String getEmptyStateDescriptionKey() {
 		return "click-new-to-create-your-first-piece-of-content";
 	}
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		ViewContentsSectionDisplayContext.class);
 
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewFilesSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewFilesSectionDisplayContext.java
@@ -12,11 +12,8 @@ import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectDefinitionService;
 import com.liferay.object.service.ObjectDefinitionSettingLocalService;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.language.LanguageUtil;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -58,15 +55,6 @@ public class ViewFilesSectionDisplayContext
 	@Override
 	public Map<String, Object> getAdditionalProps() {
 		Map<String, Object> additionalProps = super.getAdditionalProps();
-
-		try {
-			additionalProps.put("breadcrumbProps", getBreadcrumbProps());
-		}
-		catch (PortalException portalException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(portalException);
-			}
-		}
 
 		additionalProps.put("galleryViewEnabled", true);
 
@@ -112,8 +100,5 @@ public class ViewFilesSectionDisplayContext
 	protected String getEmptyStateDescriptionKey() {
 		return "click-new-or-drag-and-drop-your-files-here";
 	}
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		ViewFilesSectionDisplayContext.class);
 
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewFolderSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewFolderSectionDisplayContext.java
@@ -89,8 +89,6 @@ public class ViewFolderSectionDisplayContext extends BaseSectionDisplayContext {
 		return new HashMapBuilder<>().putAll(
 			super.getAdditionalProps()
 		).put(
-			"breadcrumbProps", getBreadcrumbProps()
-		).put(
 			"galleryViewEnabled", !contentsFolder
 		).put(
 			"rootFolder", rootFolder

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewSharedWithMeSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewSharedWithMeSectionDisplayContext.java
@@ -133,7 +133,7 @@ public class ViewSharedWithMeSectionDisplayContext {
 			StringBundler.concat(
 				_themeDisplay.getPortalURL(), _themeDisplay.getPathMain(),
 				GroupConstants.CMS_FRIENDLY_URL,
-				"/edit_content_item?&p_l_mode=read&p_p_state=",
+				"/edit_content_item?p_l_mode=read&p_p_state=",
 				LiferayWindowState.POP_UP, "&redirect=",
 				_themeDisplay.getURLCurrent(), "&objectEntryId={embedded.id}")
 		).build();
@@ -198,7 +198,7 @@ public class ViewSharedWithMeSectionDisplayContext {
 				StringBundler.concat(
 					_themeDisplay.getPortalURL(), _themeDisplay.getPathMain(),
 					GroupConstants.CMS_FRIENDLY_URL,
-					"/edit_content_item?&p_l_mode=read&p_p_state=",
+					"/edit_content_item?p_l_mode=read&p_p_state=",
 					LiferayWindowState.POP_UP, "&redirect=",
 					_themeDisplay.getURLCurrent(), "&objectEntryId={classPK}"),
 				"view", "view-content",

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewSpaceContentsSummarySectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewSpaceContentsSummarySectionDisplayContext.java
@@ -11,10 +11,7 @@ import com.liferay.object.service.ObjectDefinitionService;
 import com.liferay.object.service.ObjectDefinitionSettingLocalService;
 import com.liferay.object.service.ObjectEntryFolderLocalService;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
@@ -63,15 +60,6 @@ public class ViewSpaceContentsSummarySectionDisplayContext
 	public Map<String, Object> getAdditionalProps() {
 		Map<String, Object> additionalProps = super.getAdditionalProps();
 
-		try {
-			additionalProps.put("breadcrumbProps", getBreadcrumbProps());
-		}
-		catch (PortalException portalException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(portalException);
-			}
-		}
-
 		additionalProps.put("showAdditionalItemInfo", true);
 
 		return additionalProps;
@@ -113,9 +101,6 @@ public class ViewSpaceContentsSummarySectionDisplayContext
 	protected String getEmptyStateDescriptionKey() {
 		return "create-and-manage-content-within-this-space";
 	}
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		ViewSpaceContentsSummarySectionDisplayContext.class);
 
 	private final long _groupId;
 	private final ObjectEntryFolderLocalService _objectEntryFolderLocalService;

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewSpaceFilesSummarySectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewSpaceFilesSummarySectionDisplayContext.java
@@ -12,10 +12,7 @@ import com.liferay.object.service.ObjectDefinitionService;
 import com.liferay.object.service.ObjectDefinitionSettingLocalService;
 import com.liferay.object.service.ObjectEntryFolderLocalService;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
@@ -62,22 +59,6 @@ public class ViewSpaceFilesSummarySectionDisplayContext
 	}
 
 	@Override
-	public Map<String, Object> getAdditionalProps() {
-		Map<String, Object> additionalProps = super.getAdditionalProps();
-
-		try {
-			additionalProps.put("breadcrumbProps", getBreadcrumbProps());
-		}
-		catch (PortalException portalException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(portalException);
-			}
-		}
-
-		return additionalProps;
-	}
-
-	@Override
 	public String getAPIURL() {
 		return HttpComponentsUtil.addParameters(
 			super.getAPIURL(), "page", CMSSpaceConstants.SPACE_SUMMARY_PAGE,
@@ -113,9 +94,6 @@ public class ViewSpaceFilesSummarySectionDisplayContext
 	protected String getEmptyStateDescriptionKey() {
 		return "create-and-manage-files-within-this-space";
 	}
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		ViewSpaceFilesSummarySectionDisplayContext.class);
 
 	private final long _groupId;
 	private final ObjectEntryFolderLocalService _objectEntryFolderLocalService;


### PR DESCRIPTION
## Summary

- Move the `breadcrumbProps` wrapping (try/catch around `getBreadcrumbProps()`) from five subclasses into `BaseSectionDisplayContext#getAdditionalProps`. Subclasses now inherit it automatically and only override `getAdditionalProps` when they add other props.
- `ViewFolderSectionDisplayContext` keeps its folder-specific breadcrumbs because `getBreadcrumbProps` is still resolved polymorphically.
- Extend `BaseSectionDisplayContextTestCase.getBaseAdditionalProps` with a `breadcrumbProps` entry so `testGetAdditionalProps` verifies the refactored delegation. The expected value delegates to `_getBreadcrumbProps` on the same instance under test, so subclasses that override `getBreadcrumbProps` (e.g. `ViewRecycleBinSectionDisplayContext`) do not need a test-specific fixture.

## Test plan

- [x] `ViewAssetDisplayContextTest`
- [x] `ViewAllSectionDisplayContextTest`
- [x] `ViewContentsSectionDisplayContextTest`
- [x] `ViewFilesSectionDisplayContextTest`
- [x] `ViewRecycleBinSectionDisplayContextTest`
- [x] `ViewSharedWithMeSectionDisplayContextTest`