### PR TITLE
LPD-87226 Dates are not displayed properly in OOTB Collections for some locales

### DIFF
--- a/modules/apps/asset/asset-info-impl/src/main/java/com/liferay/asset/info/internal/item/provider/AssetEntryInfoItemFieldValuesProvider.java
+++ b/modules/apps/asset/asset-info-impl/src/main/java/com/liferay/asset/info/internal/item/provider/AssetEntryInfoItemFieldValuesProvider.java
@@ -23,14 +23,10 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.LocaleThreadLocal;
 import com.liferay.template.info.item.provider.TemplateInfoItemFieldSetProvider;
 
-import java.text.Format;
-
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 
@@ -80,13 +76,13 @@ public class AssetEntryInfoItemFieldValuesProvider
 				assetEntry.getUserName()),
 			new InfoFieldValue<>(
 				AssetEntryInfoItemFields.createDateInfoField,
-				_getDateValue(assetEntry.getCreateDate())),
+				assetEntry.getCreateDate()),
 			new InfoFieldValue<>(
 				AssetEntryInfoItemFields.modifiedDateInfoField,
-				_getDateValue(assetEntry.getModifiedDate())),
+				assetEntry.getModifiedDate()),
 			new InfoFieldValue<>(
 				AssetEntryInfoItemFields.expirationDateInfoField,
-				_getDateValue(assetEntry.getExpirationDate())),
+				assetEntry.getExpirationDate()),
 			new InfoFieldValue<>(
 				AssetEntryInfoItemFields.viewCountInfoField,
 				assetEntry::getViewCount),
@@ -98,18 +94,6 @@ public class AssetEntryInfoItemFieldValuesProvider
 			new InfoFieldValue<>(
 				AssetEntryInfoItemFields.userProfileImageInfoField,
 				_getUserNameProfileImage(assetEntry.getUserId())));
-	}
-
-	private String _getDateValue(Date date) {
-		if (date == null) {
-			return StringPool.BLANK;
-		}
-
-		Locale locale = LocaleThreadLocal.getThemeDisplayLocale();
-
-		Format dateTimeFormat = FastDateFormatFactoryUtil.getDateTime(locale);
-
-		return dateTimeFormat.format(date);
 	}
 
 	private String _getDisplayPageURL(AssetEntry assetEntry) {

--- a/modules/apps/asset/asset-info-test/src/testIntegration/java/com/liferay/asset/info/internal/item/provider/test/AssetEntryInfoItemFieldValuesProviderTest.java
+++ b/modules/apps/asset/asset-info-test/src/testIntegration/java/com/liferay/asset/info/internal/item/provider/test/AssetEntryInfoItemFieldValuesProviderTest.java
@@ -42,6 +42,8 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import jakarta.servlet.http.HttpServletRequest;
 
+import java.util.Date;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -68,6 +70,28 @@ public class AssetEntryInfoItemFieldValuesProviderTest {
 		_classNameId = _classNameLocalService.getClassNameId(
 			JournalArticle.class);
 		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	public void testGetInfoItemFieldValuesReturnsDateForDateFields()
+		throws Exception {
+
+		JournalArticle journalArticle = JournalTestUtil.addArticle(
+			_group.getGroupId(),
+			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID);
+
+		AssetEntry assetEntry = _assetEntryLocalService.fetchEntry(
+			_classNameId, journalArticle.getResourcePrimKey());
+
+		_setupServiceContext(_getThemeDisplay());
+
+		InfoItemFieldValues infoItemFieldValues =
+			_infoItemFieldValuesProvider.getInfoItemFieldValues(assetEntry);
+
+		_assertDateFieldValue(
+			assetEntry.getCreateDate(), infoItemFieldValues, "createDate");
+		_assertDateFieldValue(
+			assetEntry.getModifiedDate(), infoItemFieldValues, "modifiedDate");
 	}
 
 	@Test
@@ -110,6 +134,16 @@ public class AssetEntryInfoItemFieldValuesProviderTest {
 
 		_testGetInfoItemFieldValues(
 			journalArticle, JournalArticleConstants.CANONICAL_URL_SEPARATOR);
+	}
+
+	private void _assertDateFieldValue(
+		Date expectedDate, InfoItemFieldValues infoItemFieldValues,
+		String fieldName) {
+
+		InfoFieldValue<Object> infoFieldValue =
+			infoItemFieldValues.getInfoFieldValue(fieldName);
+
+		Assert.assertEquals(expectedDate, infoFieldValue.getValue());
 	}
 
 	private ThemeDisplay _getThemeDisplay() throws Exception {

--- a/modules/apps/asset/asset-info-test/src/testIntegration/java/com/liferay/asset/info/internal/item/provider/test/AssetEntryInfoItemFieldValuesProviderTest.java
+++ b/modules/apps/asset/asset-info-test/src/testIntegration/java/com/liferay/asset/info/internal/item/provider/test/AssetEntryInfoItemFieldValuesProviderTest.java
@@ -91,6 +91,9 @@ public class AssetEntryInfoItemFieldValuesProviderTest {
 		_assertDateFieldValue(
 			assetEntry.getCreateDate(), infoItemFieldValues, "createDate");
 		_assertDateFieldValue(
+			assetEntry.getExpirationDate(), infoItemFieldValues,
+			"expirationDate");
+		_assertDateFieldValue(
 			assetEntry.getModifiedDate(), infoItemFieldValues, "modifiedDate");
 	}
 


### PR DESCRIPTION
## Ticket

[LPD-87226](https://liferay.atlassian.net/browse/LPD-87226) — Dates are not displayed properly in OOTB Collections for some locales

## Problem

When a Collection Display fragment is backed by an OOTB **Recent Content** collection, date fields (`createDate`, `modifiedDate`, `expirationDate`) render incorrectly for users whose locale differs from the site default, and any custom `config.dateFormat` configured on the fragment editable is ignored.

Recent Content resolves to `AssetEntry` objects, whose fields are populated by `AssetEntryInfoItemFieldValuesProvider`. That provider was pre-formatting dates into a user-locale string via `FastDateFormatFactoryUtil.getDateTime(locale)` and returning it as the field value. The Fragment processor then hit `FragmentEntryProcessorHelperImpl.java:629-695` — the String branch for `DateInfoFieldType` — which tries to parse the incoming string with `_getShortTimeStylePattern(siteDefaultLocale)` and then `_getDefaultPattern(siteDefaultLocale)`. The pattern produced by `FastDateFormat.getDateTime` and the pattern produced by `DateTimeFormatterBuilder.getLocalizedDateTimePattern` don't always agree for a given locale, so parsing fails; the raw pre-formatted string is returned and the fragment's custom pattern is discarded.

## Fix

Return the raw `java.util.Date` objects directly from `AssetEntryInfoItemFieldValuesProvider._getAssetEntryInfoFieldValues` for `createDate`, `modifiedDate`, and `expirationDate`. This routes them into the Fragment processor's `Date` branch (`FragmentEntryProcessorHelperImpl.java:590-606`), which uses `fragmentEntryProcessorContext.getLocale()` (the viewer's locale) and honors the fragment's configured `config.dateFormat`.

## Why `_getDateValue` is no longer necessary

The private `_getDateValue(Date)` helper was introduced in [LPS-115840](https://liferay.atlassian.net/browse/LPS-115840) (2020-06-20) as part of a broader refactor that moved AssetEntry field-value logic into the new Information Framework provider. Its pre-formatting-to-String behavior was carried over from the legacy asset code, predating the convention that `DateInfoFieldType` values should be raw `Date` objects (which `JournalArticleInfoItemFieldValuesProvider` already follows). Now that the Fragment processor's Date path fully handles locale-aware formatting and custom date patterns, pre-formatting in the provider is unnecessary — and actively harmful, because it forces values into the brittle String-parse fallback. The helper is removed and the getter calls are inlined.

## Test plan

- New integration test `AssetEntryInfoItemFieldValuesProviderTest.testGetInfoItemFieldValuesReturnsDateForDateFields` verifies `createDate` and `modifiedDate` come back as raw `Date` objects equal to the `AssetEntry`'s dates. The test fails on master (returns e.g. `"4/23/26, 1:04 AM"`) and passes after the fix.

## Results
Before:
<img width="317" height="210" alt="image" src="https://github.com/user-attachments/assets/fb481a12-1b15-46ac-9d82-f856aae4515c" />

After:
<img width="1009" height="631" alt="image" src="https://github.com/user-attachments/assets/1f597447-a098-4a23-bda1-d9585870cce7" />
