### PR TITLE
LPD-87240 Update Poshi locators for CK5 migration (toolbar + comments)

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/CKEditor.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/CKEditor.path
@@ -130,7 +130,7 @@
 </tr>
 <tr>
 	<td>TOOLBAR_VIDEO_BUTTON</td>
-	<td>//a[contains(@class,'cke_button') and contains(@class,'video')]</td>
+	<td>//button[contains(@class,'ck-button') and contains(@data-cke-tooltip-text,'Video')]</td>
 	<td></td>
 </tr>
 <tr>
@@ -256,12 +256,12 @@
 </tr>
 <tr>
 	<td>TOOLBAR_IMAGE_BUTTON</td>
-	<td>//a[contains(@class,'cke_button') and contains(@class,'image')]</td>
+	<td>//button[contains(@class,'ck-button') and contains(@data-cke-tooltip-text,'Image')]</td>
 	<td></td>
 </tr>
 <tr>
 	<td>TOOLBAR_IMAGE_BUTTON_2</td>
-	<td>xpath=(//a[contains(@class,'cke_button') and contains(@class,'image')])[2]</td>
+	<td>xpath=(//button[contains(@class,'ck-button') and contains(@data-cke-tooltip-text,'Image')])[2]</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/pageeditor/PageEditor.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/pageeditor/PageEditor.path
@@ -236,7 +236,7 @@
 </tr>
 <tr>
 	<td>FRAGMENT_SIDEBAR_COMMENTS</td>
-	<td>//div[contains(@class,'alloy-editor-container')]/div[contains(@data-placeholder,'Type your comment here.')]</td>
+	<td>//div[contains(@class,'ck-editor__editable_inline') and contains(@data-placeholder,'Type your comment here')]</td>
 	<td></td>
 </tr>
 <tr>
@@ -256,7 +256,7 @@
 </tr>
 <tr>
 	<td>FRAGMENT_SIDEBAR_COMMENT_ENTRY_INPUT</td>
-	<td>//div[contains(@class,'alloy-editor-container') and contains(@id,'ContentPageEditorPortlet')]/div[contains(@data-placeholder,'Type your comment here.')]/p[contains(.,'${fragmentComment}')]</td>
+	<td>//div[contains(@class,'ck-editor__editable_inline') and contains(@data-placeholder,'Type your comment here')]/p[contains(.,'${fragmentComment}')]</td>
 	<td></td>
 </tr>
 <tr>
@@ -286,7 +286,7 @@
 </tr>
 <tr>
 	<td>FRAGMENT_SIDEBAR_REPLY_COMMENTS_EDITOR</td>
-	<td>//div[contains(@class,'alloy-editor-container')]/div[contains(@id,'pageEditorCommentReplyEditor') and contains(@data-placeholder,'Type your comment here.')]</td>
+	<td>//article[contains(@class,'reply')]//div[contains(@class,'ck-editor__editable_inline') and contains(@data-placeholder,'Type your comment here')]</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-87240

**What is being fixed:** A large cluster of content-management Poshi failures traces back to stale locators that expect the CKEditor 4 DOM (`//a[cke_button]/[image|video]`) and the AlloyEditor-based page-editor comments panel (`alloy-editor-container`). Both have been replaced by CKEditor 5 — the `<a>` toolbar buttons are now `<button>` elements tagged by `data-cke-tooltip-text`, and the page-editor comments form now uses `CKEditor5BalloonEditor`, which renders `<div class="ck ck-editor__editable_inline" data-placeholder="Type your comment here.">`.

**How it is being fixed:** `CKEditor.path` — `TOOLBAR_IMAGE_BUTTON`, `TOOLBAR_IMAGE_BUTTON_2` and `TOOLBAR_VIDEO_BUTTON` are switched to `//button[@data-cke-tooltip-text='Image'|'Video']`, verified live via the CK5 "New Web Content" editor (one match per editor, clicking opens the Select Item modal as expected). `PageEditor.path` — the three fragment-comment locators swap `alloy-editor-container` for `ck-editor__editable_inline`, using `@data-placeholder='Type your comment here.'` for disambiguation. The reply-editor locator switches from the old React id (`pageEditorCommentReplyEditor`, gone under `useId()`) to a structural match under `article[contains(@class,'reply')]`, mirroring the pattern already used by `FRAGMENT_SIDEBAR_REPLY_COMMENTS_ENTRY_AUTHOR` in the same file.