### PR TITLE
LPD-81794 fix web content feeds export import

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/content/processor/JournalFeedExportImportContentProcessor.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/content/processor/JournalFeedExportImportContentProcessor.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.xml.Element;
 
 import java.util.Arrays;
@@ -82,10 +83,6 @@ public class JournalFeedExportImportContentProcessor
 			feed.setTargetLayoutFriendlyUrl(targetLayoutFriendlyURL);
 		}
 
-		Group targetLayoutGroup = _groupLocalService.fetchFriendlyURLGroup(
-			portletDataContext.getCompanyId(),
-			StringPool.SLASH + oldGroupFriendlyURL);
-
 		boolean privateLayout = false;
 
 		if (!PropsValues.LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING.equals(
@@ -98,6 +95,10 @@ public class JournalFeedExportImportContentProcessor
 		String targetLayoutFriendlyURL = null;
 
 		if (friendlyURLParts.length > 3) {
+			Group targetLayoutGroup = _groupLocalService.fetchFriendlyURLGroup(
+				portletDataContext.getCompanyId(),
+				StringPool.SLASH + oldGroupFriendlyURL);
+
 			targetLayoutFriendlyURL = StringUtil.merge(
 				Arrays.copyOfRange(
 					friendlyURLParts, 3, friendlyURLParts.length),
@@ -133,9 +134,8 @@ public class JournalFeedExportImportContentProcessor
 
 		Element feedElement = portletDataContext.getExportDataElement(feed);
 
-		portletDataContext.addReferenceElement(
-			feed, feedElement, targetLayout,
-			PortletDataContext.REFERENCE_TYPE_DEPENDENCY, true);
+		feedElement.addAttribute(
+			"targetLayoutERC", targetLayout.getExternalReferenceCode());
 
 		return content;
 	}
@@ -148,38 +148,27 @@ public class JournalFeedExportImportContentProcessor
 
 		JournalFeed feed = (JournalFeed)stagedModel;
 
-		Group group = _groupLocalService.getGroup(
-			portletDataContext.getScopeGroupId());
+		Element feedElement =
+			portletDataContext.getImportDataStagedModelElement(feed);
 
-		String newGroupFriendlyURL = group.getFriendlyURL();
+		String targetLayoutERC = feedElement.attributeValue("targetLayoutERC");
 
-		newGroupFriendlyURL = newGroupFriendlyURL.substring(1);
+		if (Validator.isNotNull(targetLayoutERC)) {
+			Layout targetLayout =
+				_layoutLocalService.getLayoutByExternalReferenceCode(
+					targetLayoutERC, portletDataContext.getGroupId());
 
-		String newTargetLayoutFriendlyURL = StringUtil.replace(
-			feed.getTargetLayoutFriendlyUrl(), _DATA_HANDLER_GROUP_FRIENDLY_URL,
-			newGroupFriendlyURL);
+			Group targetLayoutGroup = _groupLocalService.getGroup(
+				targetLayout.getGroupId());
 
-		long plid = _portal.getPlidFromFriendlyURL(
-			portletDataContext.getCompanyId(), newTargetLayoutFriendlyURL);
+			String friendlyURLPath = targetLayout.isPrivateLayout() ?
+				_portal.getPathFriendlyURLPrivateGroup() :
+					_portal.getPathFriendlyURLPublic();
 
-		if (plid <= 0) {
-			Group oldGroup = _groupLocalService.fetchGroup(
-				portletDataContext.getSourceGroupId());
-
-			if (oldGroup == null) {
-				return content;
-			}
-
-			String oldGroupFriendlyURL = oldGroup.getFriendlyURL();
-
-			oldGroupFriendlyURL = oldGroupFriendlyURL.substring(1);
-
-			newTargetLayoutFriendlyURL = StringUtil.replace(
-				feed.getTargetLayoutFriendlyUrl(),
-				_DATA_HANDLER_GROUP_FRIENDLY_URL, oldGroupFriendlyURL);
+			feed.setTargetLayoutFriendlyUrl(
+				friendlyURLPath + targetLayoutGroup.getFriendlyURL() +
+					targetLayout.getFriendlyURL());
 		}
-
-		feed.setTargetLayoutFriendlyUrl(newTargetLayoutFriendlyURL);
 
 		return content;
 	}

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/content/processor/JournalFeedExportImportContentProcessor.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/content/processor/JournalFeedExportImportContentProcessor.java
@@ -137,6 +137,15 @@ public class JournalFeedExportImportContentProcessor
 		feedElement.addAttribute(
 			"targetLayoutERC", targetLayout.getExternalReferenceCode());
 
+		if (targetLayout.getGroupId() != feed.getGroupId()) {
+			Group targetLayoutGroup = _groupLocalService.getGroup(
+				targetLayout.getGroupId());
+
+			feedElement.addAttribute(
+				"targetLayoutGroupERC",
+				targetLayoutGroup.getExternalReferenceCode());
+		}
+
 		return content;
 	}
 
@@ -154,9 +163,25 @@ public class JournalFeedExportImportContentProcessor
 		String targetLayoutERC = feedElement.attributeValue("targetLayoutERC");
 
 		if (Validator.isNotNull(targetLayoutERC)) {
+			long targetLayoutGroupId = portletDataContext.getGroupId();
+
+			String targetLayoutGroupERC = feedElement.attributeValue(
+				"targetLayoutGroupERC");
+
+			if (Validator.isNotNull(targetLayoutGroupERC)) {
+				Group targetLayoutGroup =
+					_groupLocalService.fetchGroupByExternalReferenceCode(
+						targetLayoutGroupERC,
+						portletDataContext.getCompanyId());
+
+				if (targetLayoutGroup != null) {
+					targetLayoutGroupId = targetLayoutGroup.getGroupId();
+				}
+			}
+
 			Layout targetLayout =
 				_layoutLocalService.getLayoutByExternalReferenceCode(
-					targetLayoutERC, portletDataContext.getGroupId());
+					targetLayoutERC, targetLayoutGroupId);
 
 			Group targetLayoutGroup = _groupLocalService.getGroup(
 				targetLayout.getGroupId());

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/content/processor/JournalFeedExportImportContentProcessor.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/content/processor/JournalFeedExportImportContentProcessor.java
@@ -95,10 +95,6 @@ public class JournalFeedExportImportContentProcessor
 		String targetLayoutFriendlyURL = null;
 
 		if (friendlyURLParts.length > 3) {
-			Group targetLayoutGroup = _groupLocalService.fetchFriendlyURLGroup(
-				portletDataContext.getCompanyId(),
-				StringPool.SLASH + oldGroupFriendlyURL);
-
 			targetLayoutFriendlyURL = StringUtil.merge(
 				Arrays.copyOfRange(
 					friendlyURLParts, 3, friendlyURLParts.length),
@@ -106,6 +102,10 @@ public class JournalFeedExportImportContentProcessor
 
 			targetLayoutFriendlyURL =
 				StringPool.SLASH + targetLayoutFriendlyURL;
+
+			Group targetLayoutGroup = _groupLocalService.fetchFriendlyURLGroup(
+				portletDataContext.getCompanyId(),
+				StringPool.SLASH + oldGroupFriendlyURL);
 
 			targetLayout = _layoutLocalService.fetchLayoutByFriendlyURL(
 				targetLayoutGroup.getGroupId(), privateLayout,

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/exportimport/data/handler/test/JournalFeedStagedModelDataHandlerTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/exportimport/data/handler/test/JournalFeedStagedModelDataHandlerTest.java
@@ -34,6 +34,8 @@ import com.liferay.portal.kernel.service.PortalPreferencesLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.AssertUtils;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.PortalUtil;
@@ -272,6 +274,67 @@ public class JournalFeedStagedModelDataHandlerTest
 		}
 	}
 
+	@Test
+	public void testExportImportWithTargetLayoutFromAnotherGroup()
+		throws Exception {
+
+		_otherGroup = GroupTestUtil.addGroup();
+
+		Layout otherLayout = LayoutTestUtil.addTypePortletLayout(_otherGroup);
+
+		Map<String, List<StagedModel>> dependentStagedModelsMap =
+			addDependentStagedModelsMap(stagingGroup);
+
+		JournalFeed feed = (JournalFeed)addStagedModel(
+			stagingGroup, dependentStagedModelsMap);
+
+		String targetLayoutFriendlyURL =
+			PortalUtil.getPathFriendlyURLPublic() +
+				_otherGroup.getFriendlyURL() + otherLayout.getFriendlyURL();
+
+		feed.setTargetLayoutFriendlyUrl(targetLayoutFriendlyURL);
+
+		feed = JournalFeedLocalServiceUtil.updateJournalFeed(feed);
+
+		exportStagedModel(feed);
+
+		try (SafeCloseable safeCloseable = initImportWithSafeCloseable()) {
+			Element feedElement =
+				portletDataContext.getImportDataStagedModelElement(feed);
+
+			Assert.assertEquals(
+				otherLayout.getExternalReferenceCode(),
+				feedElement.attributeValue("targetLayoutERC"));
+			Assert.assertEquals(
+				_otherGroup.getExternalReferenceCode(),
+				feedElement.attributeValue("targetLayoutGroupERC"));
+
+			StagedModel exportedStagedModel = readExportedStagedModel(feed);
+
+			Assert.assertNotNull(exportedStagedModel);
+
+			ExportImportThreadLocal.setPortletImportInProcess(true);
+
+			try {
+				StagedModelDataHandlerUtil.importStagedModel(
+					portletDataContext, exportedStagedModel);
+			}
+			finally {
+				ExportImportThreadLocal.setPortletImportInProcess(false);
+			}
+
+			JournalFeed importedFeed =
+				JournalFeedLocalServiceUtil.fetchJournalFeedByUuidAndGroupId(
+					feed.getUuid(), liveGroup.getGroupId());
+
+			Assert.assertNotNull(importedFeed);
+
+			Assert.assertEquals(
+				targetLayoutFriendlyURL,
+				importedFeed.getTargetLayoutFriendlyUrl());
+		}
+	}
+
 	@Override
 	@Test
 	public void testStagedModelDataHandler() throws Exception {
@@ -422,5 +485,8 @@ public class JournalFeedStagedModelDataHandlerTest
 
 	private Layout _layout;
 	private String _originalPortalPreferencesXML;
+
+	@DeleteAfterTestRun
+	private Group _otherGroup;
 
 }

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/exportimport/data/handler/test/JournalFeedStagedModelDataHandlerTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/exportimport/data/handler/test/JournalFeedStagedModelDataHandlerTest.java
@@ -13,12 +13,16 @@ import com.liferay.dynamic.data.mapping.service.DDMTemplateLocalServiceUtil;
 import com.liferay.dynamic.data.mapping.test.util.DDMStructureTestUtil;
 import com.liferay.dynamic.data.mapping.test.util.DDMTemplateTestUtil;
 import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
+import com.liferay.exportimport.kernel.lar.PortletDataException;
+import com.liferay.exportimport.kernel.lar.StagedModelDataHandlerUtil;
 import com.liferay.exportimport.test.util.lar.BaseStagedModelDataHandlerTestCase;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.model.JournalFeed;
 import com.liferay.journal.service.JournalFeedLocalServiceUtil;
 import com.liferay.journal.test.util.JournalTestUtil;
 import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
@@ -28,11 +32,13 @@ import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.service.PortalPreferencesLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.AssertUtils;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PortletKeys;
+import com.liferay.portal.kernel.xml.Element;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LogEntry;
 import com.liferay.portal.test.log.LoggerTestUtil;
@@ -74,11 +80,11 @@ public class JournalFeedStagedModelDataHandlerTest
 		serviceContext.setUuid(_layout.getUuid());
 
 		LayoutLocalServiceUtil.addLayout(
-			null, TestPropsValues.getUserId(), liveGroup.getGroupId(),
-			_layout.isPrivateLayout(), _layout.getParentLayoutId(),
-			_layout.getName(), _layout.getTitle(), _layout.getDescription(),
-			_layout.getType(), _layout.isHidden(), _layout.getFriendlyURL(),
-			serviceContext);
+			_layout.getExternalReferenceCode(), TestPropsValues.getUserId(),
+			liveGroup.getGroupId(), _layout.isPrivateLayout(),
+			_layout.getParentLayoutId(), _layout.getName(), _layout.getTitle(),
+			_layout.getDescription(), _layout.getType(), _layout.isHidden(),
+			_layout.getFriendlyURL(), serviceContext);
 
 		serviceContext.setCompanyId(TestPropsValues.getCompanyId());
 
@@ -184,6 +190,85 @@ public class JournalFeedStagedModelDataHandlerTest
 				stagedModel.getUuid(), liveGroup);
 
 			Assert.assertNotNull(importedStagedModel);
+		}
+	}
+
+	@Test
+	public void testExportImport() throws Exception {
+		StagedModel stagedModel = addStagedModel(
+			stagingGroup, addDependentStagedModelsMap(stagingGroup));
+
+		exportStagedModel(stagedModel);
+
+		LayoutLocalServiceUtil.deleteLayout(
+			LayoutLocalServiceUtil.getLayoutByExternalReferenceCode(
+				_layout.getExternalReferenceCode(), liveGroup.getGroupId()));
+
+		try (SafeCloseable safeCloseable = initImportWithSafeCloseable()) {
+			Element feedElement =
+				portletDataContext.getImportDataStagedModelElement(stagedModel);
+
+			Assert.assertEquals(
+				_layout.getExternalReferenceCode(),
+				feedElement.attributeValue("targetLayoutERC"));
+
+			StagedModel exportedStagedModel = readExportedStagedModel(
+				stagedModel);
+
+			Assert.assertNotNull(exportedStagedModel);
+
+			ExportImportThreadLocal.setPortletImportInProcess(true);
+
+			try {
+				AssertUtils.assertFailure(
+					PortletDataException.class,
+					StringBundler.concat(
+						"No Layout exists with the key ",
+						"{externalReferenceCode=",
+						_layout.getExternalReferenceCode(), ", groupId=",
+						liveGroup.getGroupId(), "}"),
+					() -> StagedModelDataHandlerUtil.importStagedModel(
+						portletDataContext, exportedStagedModel));
+			}
+			finally {
+				ExportImportThreadLocal.setPortletImportInProcess(false);
+			}
+		}
+
+		ServiceContext serviceContext = new ServiceContext();
+
+		serviceContext.setUuid(_layout.getUuid());
+
+		LayoutLocalServiceUtil.addLayout(
+			_layout.getExternalReferenceCode(), TestPropsValues.getUserId(),
+			liveGroup.getGroupId(), _layout.isPrivateLayout(),
+			_layout.getParentLayoutId(), _layout.getName(), _layout.getTitle(),
+			_layout.getDescription(), _layout.getType(), _layout.isHidden(),
+			_layout.getFriendlyURL(), serviceContext);
+
+		try (SafeCloseable safeCloseable = initImportWithSafeCloseable()) {
+			StagedModel exportedStagedModel = readExportedStagedModel(
+				stagedModel);
+
+			Assert.assertNotNull(exportedStagedModel);
+
+			ExportImportThreadLocal.setPortletImportInProcess(true);
+
+			try {
+				StagedModelDataHandlerUtil.importStagedModel(
+					portletDataContext, exportedStagedModel);
+			}
+			finally {
+				ExportImportThreadLocal.setPortletImportInProcess(false);
+			}
+
+			JournalFeed importedFeed =
+				JournalFeedLocalServiceUtil.fetchJournalFeedByUuidAndGroupId(
+					stagedModel.getUuid(), liveGroup.getGroupId());
+
+			Assert.assertNotNull(importedFeed);
+
+			validateImportedStagedModel(stagedModel, importedFeed);
 		}
 	}
 


### PR DESCRIPTION
Jira Ticket: https://liferay.atlassian.net/browse/LPD-81794

Following the same approach as [LPD-80000](https://github.com/liferay-page-management/liferay-portal/pull/18178), this PR switches                                    
  JournalFeedExportImportContentProcessor to reference the feed's target Layout by its ERC writing a targetLayoutERC attribute on export and resolving the Layout by ERC on import. 

If no Layout with the matching ERC exists in the target group, the import fails with NoSuchLayoutException and the feed is not imported. 

https://github.com/user-attachments/assets/8b925442-9de3-4bdf-b52c-5c2c0a162315

