### PR TITLE
LPD-87421 Null-guard missing "extensions" aggregation in ExtensionSelectionFDSFilter

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/ExtensionSelectionFDSFilter.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/ExtensionSelectionFDSFilter.java
@@ -28,6 +28,7 @@ import com.liferay.portal.search.searcher.SearchResponse;
 import com.liferay.portal.search.searcher.Searcher;
 import com.liferay.site.cms.site.initializer.internal.constants.CMSSiteInitializerFDSNames;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 
@@ -89,7 +90,7 @@ public class ExtensionSelectionFDSFilter extends BaseSelectionFDSFilter {
 				companyId, DepotConstants.TYPE_SPACE),
 			DepotEntry::getGroupId);
 
-		if ((groupIds != null) && ArrayUtil.isNotEmpty(groupIds)) {
+		if (ArrayUtil.isNotEmpty(groupIds)) {
 			searchContext.setGroupIds(groupIds);
 		}
 
@@ -118,6 +119,10 @@ public class ExtensionSelectionFDSFilter extends BaseSelectionFDSFilter {
 		TermsAggregationResult termsAggregationResult =
 			(TermsAggregationResult)searchResponse.getAggregationResult(
 				"extensions");
+
+		if (termsAggregationResult == null) {
+			return Collections.emptyList();
+		}
 
 		return TransformUtil.transform(
 			termsAggregationResult.getBuckets(), Bucket::getKey);

--- a/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/ExtensionSelectionFDSFilterTest.java
+++ b/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/ExtensionSelectionFDSFilterTest.java
@@ -1,0 +1,190 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.frontend.data.set.filter;
+
+import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.frontend.data.set.constants.FDSEntityFieldTypes;
+import com.liferay.frontend.data.set.filter.SelectionFDSFilterItem;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.search.aggregation.Aggregations;
+import com.liferay.portal.search.aggregation.bucket.Bucket;
+import com.liferay.portal.search.aggregation.bucket.TermsAggregation;
+import com.liferay.portal.search.aggregation.bucket.TermsAggregationResult;
+import com.liferay.portal.search.legacy.searcher.SearchRequestBuilderFactory;
+import com.liferay.portal.search.searcher.SearchRequestBuilder;
+import com.liferay.portal.search.searcher.SearchResponse;
+import com.liferay.portal.search.searcher.Searcher;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * @author Sam Ziemer
+ */
+public class ExtensionSelectionFDSFilterTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() throws Exception {
+		MockitoAnnotations.openMocks(this);
+
+		_extensionSelectionFDSFilter = new ExtensionSelectionFDSFilter();
+
+		ReflectionTestUtil.setFieldValue(
+			_extensionSelectionFDSFilter, "_aggregations", _aggregations);
+		ReflectionTestUtil.setFieldValue(
+			_extensionSelectionFDSFilter, "_depotEntryLocalService",
+			_depotEntryLocalService);
+		ReflectionTestUtil.setFieldValue(
+			_extensionSelectionFDSFilter, "_searcher", _searcher);
+		ReflectionTestUtil.setFieldValue(
+			_extensionSelectionFDSFilter, "_searchRequestBuilderFactory",
+			_searchRequestBuilderFactory);
+
+		Mockito.when(
+			_aggregations.terms(Mockito.anyString(), Mockito.anyString())
+		).thenReturn(
+			Mockito.mock(TermsAggregation.class)
+		);
+
+		Mockito.when(
+			_depotEntryLocalService.getDepotEntries(
+				Mockito.anyLong(), Mockito.anyInt())
+		).thenReturn(
+			Collections.emptyList()
+		);
+
+		Mockito.when(
+			_searcher.search(Mockito.any())
+		).thenReturn(
+			_searchResponse
+		);
+
+		SearchRequestBuilder searchRequestBuilder = Mockito.mock(
+			SearchRequestBuilder.class, Mockito.RETURNS_SELF);
+
+		Mockito.when(
+			_searchRequestBuilderFactory.builder(Mockito.any())
+		).thenReturn(
+			searchRequestBuilder
+		);
+	}
+
+	@Test
+	public void testGetProperties() {
+		Assert.assertEquals(
+			FDSEntityFieldTypes.STRING,
+			_extensionSelectionFDSFilter.getEntityFieldType());
+		Assert.assertEquals("extension", _extensionSelectionFDSFilter.getId());
+		Assert.assertEquals(
+			"extension", _extensionSelectionFDSFilter.getLabel());
+	}
+
+	@Test
+	public void testGetSelectionFDSFilterItemsReturnsEmptyListWhenAggregationIsNull() {
+		Mockito.when(
+			_searchResponse.getAggregationResult("extensions")
+		).thenReturn(
+			null
+		);
+
+		List<SelectionFDSFilterItem> selectionFDSFilterItems =
+			_extensionSelectionFDSFilter.getSelectionFDSFilterItems(_locale);
+
+		Assert.assertTrue(
+			selectionFDSFilterItems.toString(),
+			selectionFDSFilterItems.isEmpty());
+	}
+
+	@Test
+	public void testGetSelectionFDSFilterItemsReturnsItemsFromBuckets() {
+		Bucket pdfBucket = Mockito.mock(Bucket.class);
+
+		Mockito.when(
+			pdfBucket.getKey()
+		).thenReturn(
+			"pdf"
+		);
+
+		Bucket pngBucket = Mockito.mock(Bucket.class);
+
+		Mockito.when(
+			pngBucket.getKey()
+		).thenReturn(
+			"png"
+		);
+
+		TermsAggregationResult termsAggregationResult = Mockito.mock(
+			TermsAggregationResult.class);
+
+		Mockito.when(
+			termsAggregationResult.getBuckets()
+		).thenReturn(
+			List.of(pdfBucket, pngBucket)
+		);
+
+		Mockito.when(
+			_searchResponse.getAggregationResult("extensions")
+		).thenReturn(
+			termsAggregationResult
+		);
+
+		List<SelectionFDSFilterItem> selectionFDSFilterItems =
+			_extensionSelectionFDSFilter.getSelectionFDSFilterItems(_locale);
+
+		Assert.assertEquals(
+			selectionFDSFilterItems.toString(), 2,
+			selectionFDSFilterItems.size());
+
+		SelectionFDSFilterItem pdfSelectionFDSFilterItem =
+			selectionFDSFilterItems.get(0);
+
+		Assert.assertEquals("pdf", pdfSelectionFDSFilterItem.getLabel());
+		Assert.assertEquals("pdf", pdfSelectionFDSFilterItem.getValue());
+
+		SelectionFDSFilterItem pngSelectionFDSFilterItem =
+			selectionFDSFilterItems.get(1);
+
+		Assert.assertEquals("png", pngSelectionFDSFilterItem.getLabel());
+		Assert.assertEquals("png", pngSelectionFDSFilterItem.getValue());
+	}
+
+	@Mock
+	private Aggregations _aggregations;
+
+	@Mock
+	private DepotEntryLocalService _depotEntryLocalService;
+
+	private ExtensionSelectionFDSFilter _extensionSelectionFDSFilter;
+	private final Locale _locale = LocaleUtil.US;
+
+	@Mock
+	private Searcher _searcher;
+
+	@Mock
+	private SearchRequestBuilderFactory _searchRequestBuilderFactory;
+
+	@Mock
+	private SearchResponse _searchResponse;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-87421
On a fresh bundle, navigating to CMS → All or CMS → Files fails with "An unexpected error occurred." because the Extension filter NPEs when the ObjectEntry index has nothing to aggregate over. This fix keeps the page usable and the filter simply empty until files are indexed.
# How am I fixing it?                                                                                           
`ExtensionSelectionFDSFilter._getExistingFileExtensions` assumes the search response always carries an `extensions` terms aggregation, but when no `ObjectEntry` documents match the query the aggregation is absent and `getAggregationResult("extensions")` returns null. Guard the null and return an empty list, which is the correct UI state for "no indexed files" anyway.
# How can you verify that it works?                                                                             
Follow the steps described in https://liferay.atlassian.net/browse/LPD-87421.

I'm sending this on top of Brian's master since the regression only reproduces on top of recent ObjectEntry reindex changes that haven't synced to liferay-portal/master yet.