### PR TITLE
  LPD-79678 Add Review Date column to CMS asset list views

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/view/table/BaseContentsSectionCMSTableFDSView.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/view/table/BaseContentsSectionCMSTableFDSView.java
@@ -46,6 +46,13 @@ public abstract class BaseContentsSectionCMSTableFDSView
 		).add(
 			addDateFDSTableSchemaField("dateModified", "modified")
 		).add(
+			"dateReview", "review-date",
+			fdsTableSchemaField -> fdsTableSchemaField.setContentRenderer(
+				"reviewDateTableCellRenderer"
+			).setSortable(
+				true
+			)
+		).add(
 			"embedded.status", "status",
 			fdsTableSchemaField -> fdsTableSchemaField.setContentRenderer(
 				"statusTableCellRenderer")

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/AssetsFDSPropsTransformer.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/AssetsFDSPropsTransformer.tsx
@@ -48,6 +48,7 @@ import shareAction from './actions/shareAction';
 import {triggerAssetDownloadBulkAction} from './actions/triggerAssetDownloadBulkAction';
 import AdditionalItemInfoRenderer from './cell_renderers/AdditionalItemInfoRenderer';
 import AuthorRenderer from './cell_renderers/AuthorRenderer';
+import ReviewDateRenderer from './cell_renderers/ReviewDateRenderer';
 import SimpleActionLinkRenderer from './cell_renderers/SimpleActionLinkRenderer';
 import SpaceRendererWithCache from './cell_renderers/SpaceRendererWithCache';
 import TypeRenderer from './cell_renderers/TypeRenderer';
@@ -286,6 +287,11 @@ export default function AssetsFDSPropsTransformer({
 				{
 					component: TypeRenderer,
 					name: 'typeTableCellRenderer',
+					type: 'internal',
+				} as IInternalRenderer,
+				{
+					component: ReviewDateRenderer,
+					name: 'reviewDateTableCellRenderer',
 					type: 'internal',
 				} as IInternalRenderer,
 				{

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/cell_renderers/ReviewDateRenderer.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/cell_renderers/ReviewDateRenderer.tsx
@@ -1,0 +1,71 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import React, {useMemo} from 'react';
+
+const DATE_OPTIONS: Intl.DateTimeFormatOptions = {
+	day: 'numeric',
+	month: 'short',
+	timeZone: Liferay.ThemeDisplay.getTimeZone(),
+	year: 'numeric',
+};
+
+const CALENDAR_DAY_OPTIONS: Intl.DateTimeFormatOptions = {
+	day: '2-digit',
+	month: '2-digit',
+	timeZone: Liferay.ThemeDisplay.getTimeZone(),
+	year: 'numeric',
+};
+
+const CALENDAR_DAY_FORMATTER = new Intl.DateTimeFormat(
+	'en-US',
+	CALENDAR_DAY_OPTIONS
+);
+
+function getCalendarDayKey(date: Date): number {
+	const parts: Record<string, string> = {};
+
+	for (const part of CALENDAR_DAY_FORMATTER.formatToParts(date)) {
+		parts[part.type] = part.value;
+	}
+
+	return (
+		Number(parts.year) * 10000 +
+		Number(parts.month) * 100 +
+		Number(parts.day)
+	);
+}
+
+const ReviewDateRenderer = ({
+	itemData,
+	value,
+}: {
+	itemData?: {dateReview?: string};
+	value?: string;
+}) => {
+	const rawValue = value || itemData?.dateReview;
+
+	const locale = Liferay.ThemeDisplay.getBCP47LanguageId();
+
+	const formatter = useMemo(
+		() => new Intl.DateTimeFormat(locale, DATE_OPTIONS),
+		[locale]
+	);
+
+	if (!rawValue) {
+		return <span className="text-secondary">--</span>;
+	}
+
+	const date = new Date(rawValue);
+	const reviewed = getCalendarDayKey(date) <= getCalendarDayKey(new Date());
+
+	return (
+		<span className={reviewed ? 'text-warning' : 'text-dark'}>
+			{formatter.format(date)}
+		</span>
+	);
+};
+
+export default ReviewDateRenderer;

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/all.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/all.spec.ts
@@ -1807,3 +1807,64 @@ test(
 		}).toPass();
 	}
 );
+
+test(
+	'Review Date column shows "--" when unset and a date when set',
+	{tag: '@LPD-79678'},
+	async ({apiHelpers, assetsPage, page}) => {
+		const applicationName = 'cms/basic-web-contents';
+		const spaceName = 'Default';
+		const noReviewDateTitle = getRandomString();
+		const reviewDateTitle = getRandomString();
+
+		const toIsoDate = (date: Date) => date.toISOString().slice(0, 10);
+		const tomorrow = new Date();
+		tomorrow.setDate(tomorrow.getDate() + 1);
+
+		let noReviewEntry;
+		let reviewEntry;
+
+		try {
+			noReviewEntry = await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: noReviewDateTitle,
+				},
+				applicationName,
+				spaceName
+			);
+
+			reviewEntry = await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					reviewDate: toIsoDate(tomorrow),
+					title: reviewDateTitle,
+				},
+				applicationName,
+				spaceName
+			);
+
+			await expect(async () => {
+				await assetsPage.gotoAll();
+
+				await expect(
+					page.getByRole('row').filter({hasText: noReviewDateTitle})
+				).toContainText('--');
+
+				await expect(
+					page.getByRole('row').filter({hasText: reviewDateTitle})
+				).not.toContainText('--');
+			}).toPass();
+		}
+		finally {
+			for (const entry of [noReviewEntry, reviewEntry]) {
+				if (entry) {
+					await apiHelpers.objectEntry.deleteObjectEntry(
+						applicationName,
+						String(entry.id)
+					);
+				}
+			}
+		}
+	}
+);

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/contents.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/contents.spec.ts
@@ -773,3 +773,64 @@ test(
 		});
 	}
 );
+
+test(
+	'Review Date column shows "--" when unset and a date when set',
+	{tag: '@LPD-79678'},
+	async ({apiHelpers, contentsPage, page}) => {
+		const applicationName = 'cms/basic-web-contents';
+		const spaceName = 'Default';
+		const noReviewDateTitle = getRandomString();
+		const reviewDateTitle = getRandomString();
+
+		const toIsoDate = (date: Date) => date.toISOString().slice(0, 10);
+		const tomorrow = new Date();
+		tomorrow.setDate(tomorrow.getDate() + 1);
+
+		let noReviewEntry;
+		let reviewEntry;
+
+		try {
+			noReviewEntry = await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: noReviewDateTitle,
+				},
+				applicationName,
+				spaceName
+			);
+
+			reviewEntry = await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					reviewDate: toIsoDate(tomorrow),
+					title: reviewDateTitle,
+				},
+				applicationName,
+				spaceName
+			);
+
+			await expect(async () => {
+				await contentsPage.goto();
+
+				await expect(
+					page.getByRole('row').filter({hasText: noReviewDateTitle})
+				).toContainText('--');
+
+				await expect(
+					page.getByRole('row').filter({hasText: reviewDateTitle})
+				).not.toContainText('--');
+			}).toPass();
+		}
+		finally {
+			for (const entry of [noReviewEntry, reviewEntry]) {
+				if (entry) {
+					await apiHelpers.objectEntry.deleteObjectEntry(
+						applicationName,
+						String(entry.id)
+					);
+				}
+			}
+		}
+	}
+);


### PR DESCRIPTION
  https://liferay.atlassian.net/browse/LPD-79678                                                                  
  Content editors managing CMS assets need to see at a glance when each                                           
  item is next due for review. The All, Contents, Files, and folder views                                         
  get a new "Review Date" column that shows the date, highlights items                                            
  already past review, and shows "--" when no review date is set.                                                 
  # How am I fixing it?                                                                                           
  The FDS table schema for the CMS asset views declares a new                                                     
  `dateReview` column backed by a custom React cell renderer. The                                                 
  renderer formats the timestamp in the user's locale and timezone,                                               
  applies `text-warning` when the review date has already passed,                                                 
  `text-dark` otherwise, and renders `text-secondary --` when empty.                                              
  Date comparison is UTC on both sides, matching how the timestamp                                                
  is stored.                                             
  # How can you verify that it works?                                                                             
  Run the included automated tests:                                                                               
  - `all.spec.ts` — `Review Date column shows "--" when unset and a date when set @LPD-79678`
  - `contents.spec.ts` — `Review Date column shows "--" when unset and a date when set @LPD-79678`                
  # Note for reviewers                                   
  Testing this PR against current `brianchandotcom/master` will surface                                           
  an unrelated NPE from `ExtensionSelectionFDSFilter` when the ObjectEntry
  index is empty (breaks CMS → All / CMS → Files with "An unexpected                                              
  error occurred"). That is tracked and being addressed on
  https://liferay.atlassian.net/browse/LPD-87421 — it is not caused by                                            
  or related to the changes in this PR.