### PR TITLE
LPD-83226 Don't display empty bin action always

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryFolderModelDocumentContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryFolderModelDocumentContributor.java
@@ -11,8 +11,10 @@ import com.liferay.object.service.ObjectEntryFolderLocalService;
 import com.liferay.petra.string.CharPool;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.search.spi.model.index.contributor.ModelDocumentContributor;
 
 import org.osgi.service.component.annotations.Component;
@@ -38,6 +40,12 @@ public class ObjectEntryFolderModelDocumentContributor
 		document.addText(Field.NAME, objectEntryFolder.getName());
 		document.addKeyword(Field.STATUS, objectEntryFolder.getStatus());
 		document.addText(Field.TITLE, objectEntryFolder.getName());
+
+		if (objectEntryFolder.getStatus() ==
+				WorkflowConstants.STATUS_IN_TRASH) {
+
+			document.addKeyword(Field.VIEW_ACTION_ID, ActionKeys.DELETE);
+		}
 
 		String[] parts = StringUtil.split(
 			objectEntryFolder.getTreePath(), CharPool.SLASH);

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
@@ -36,6 +36,7 @@ import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.FieldArray;
 import com.liferay.portal.kernel.search.ReindexCacheThreadLocal;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Base64;
 import com.liferay.portal.kernel.util.BigDecimalUtil;
@@ -46,6 +47,7 @@ import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.search.ml.embedding.text.TextEmbeddingDocumentContributor;
 import com.liferay.portal.search.spi.model.index.contributor.ModelDocumentContributor;
 
@@ -321,6 +323,12 @@ public class ObjectEntryModelDocumentContributor
 			"objectDefinitionId", objectEntry.getObjectDefinitionId());
 
 		ObjectDefinition objectDefinition = objectEntry.getObjectDefinition();
+
+		if (objectDefinition.isCMS() &&
+			(objectEntry.getStatus() == WorkflowConstants.STATUS_IN_TRASH)) {
+
+			document.addKeyword(Field.VIEW_ACTION_ID, ActionKeys.DELETE);
+		}
 
 		document.addKeyword(
 			"objectDefinitionExternalReferenceCode",

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/bulk/selection/test/DeleteObjectBulkSelectionActionTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/bulk/selection/test/DeleteObjectBulkSelectionActionTest.java
@@ -15,7 +15,6 @@ import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectEntryFolderLocalService;
 import com.liferay.object.test.util.ObjectEntryFolderTestUtil;
 import com.liferay.portal.kernel.model.User;
-import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
@@ -26,7 +25,6 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
-import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
@@ -84,28 +82,20 @@ public class DeleteObjectBulkSelectionActionTest {
 				ObjectEntryFolderConstants.
 					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT);
 
-		try {
-			try (ContextUserReplace contextUserReplace = new ContextUserReplace(
-					_user, PermissionCheckerFactoryUtil.create(_user))) {
+		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
+				_user, PermissionCheckerFactoryUtil.create(_user))) {
 
-				ReflectionTestUtil.invoke(
-					_deleteObjectBulkSelectionAction, "doExecute",
-					new Class<?>[] {User.class, Map.class, Object.class}, _user,
-					Collections.emptyMap(), objectEntryFolder);
-
-				Assert.fail();
-			}
+			ReflectionTestUtil.invoke(
+				_deleteObjectBulkSelectionAction, "doExecute",
+				new Class<?>[] {User.class, Map.class, Object.class}, _user,
+				Collections.emptyMap(), objectEntryFolder);
 		}
-		catch (Exception exception) {
-			Assert.assertTrue(
-				exception instanceof PrincipalException.MustHavePermission);
 
-			Assert.assertTrue(
-				StringUtil.startsWith(
-					exception.getMessage(),
-					"User " + _user.getUserId() +
-						" must have DELETE permission for"));
-		}
+		objectEntryFolder = _objectEntryFolderLocalService.getObjectEntryFolder(
+			objectEntryFolder.getObjectEntryFolderId());
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_APPROVED, objectEntryFolder.getStatus());
 
 		ReflectionTestUtil.invoke(
 			_deleteObjectBulkSelectionAction, "doExecute",

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/bulk/selection/DeleteObjectBulkSelectionAction.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/bulk/selection/DeleteObjectBulkSelectionAction.java
@@ -13,8 +13,12 @@ import com.liferay.object.rest.manager.v1_0.DefaultObjectEntryManager;
 import com.liferay.object.rest.manager.v1_0.DefaultObjectEntryManagerProvider;
 import com.liferay.object.rest.manager.v1_0.ObjectEntryManagerRegistry;
 import com.liferay.object.service.ObjectEntryFolderService;
+import com.liferay.object.service.ObjectEntryService;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.site.cms.site.initializer.bulk.selection.BaseObjectBulkSelectionAction;
 import com.liferay.trash.TrashHelper;
@@ -48,19 +52,34 @@ public class DeleteObjectBulkSelectionAction
 				objectDefinitionLocalService.getObjectDefinition(
 					objectObjectEntry.getObjectDefinitionId());
 
-			DefaultObjectEntryManager defaultObjectEntryManager =
-				DefaultObjectEntryManagerProvider.provide(
-					_objectEntryManagerRegistry.getObjectEntryManager(
-						objectDefinition.getCompanyId(),
-						objectDefinition.getStorageType()));
+			ModelResourcePermission<ObjectEntry> modelResourcePermission =
+				_objectEntryService.getModelResourcePermission(
+					objectDefinition.getObjectDefinitionId());
 
-			defaultObjectEntryManager.deleteObjectEntry(
-				objectDefinition, objectObjectEntry.getObjectEntryId());
+			if (modelResourcePermission.contains(
+					PermissionThreadLocal.getPermissionChecker(),
+					objectObjectEntry, ActionKeys.DELETE)) {
+
+				DefaultObjectEntryManager defaultObjectEntryManager =
+					DefaultObjectEntryManagerProvider.provide(
+						_objectEntryManagerRegistry.getObjectEntryManager(
+							objectDefinition.getCompanyId(),
+							objectDefinition.getStorageType()));
+
+				defaultObjectEntryManager.deleteObjectEntry(
+					objectDefinition, objectObjectEntry.getObjectEntryId());
+			}
 		}
 		else {
 			ObjectEntryFolder objectEntryFolder = (ObjectEntryFolder)object;
 
-			_deleteObjectEntryFolder(objectEntryFolder);
+			if (_objectEntryFolderModelResourcePermission.contains(
+					PermissionThreadLocal.getPermissionChecker(),
+					objectEntryFolder.getObjectEntryFolderId(),
+					ActionKeys.DELETE)) {
+
+				_deleteObjectEntryFolder(objectEntryFolder);
+			}
 		}
 	}
 
@@ -80,11 +99,20 @@ public class DeleteObjectBulkSelectionAction
 		}
 	}
 
+	@Reference(
+		target = "(model.class.name=com.liferay.object.model.ObjectEntryFolder)"
+	)
+	private ModelResourcePermission<ObjectEntryFolder>
+		_objectEntryFolderModelResourcePermission;
+
 	@Reference
 	private ObjectEntryFolderService _objectEntryFolderService;
 
 	@Reference
 	private ObjectEntryManagerRegistry _objectEntryManagerRegistry;
+
+	@Reference
+	private ObjectEntryService _objectEntryService;
 
 	@Reference
 	private TrashHelper _trashHelper;

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewRecycleBinSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewRecycleBinSectionDisplayContext.java
@@ -21,6 +21,8 @@ import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
@@ -32,6 +34,10 @@ import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.search.rest.dto.v1_0.SearchResult;
+import com.liferay.portal.search.rest.resource.v1_0.SearchResultResource;
+import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.site.cms.site.initializer.internal.util.ActionUtil;
 import com.liferay.translation.exporter.TranslationInfoItemFieldValuesExporterRegistry;
 import com.liferay.trash.TrashHelper;
@@ -57,7 +63,7 @@ public class ViewRecycleBinSectionDisplayContext
 		ObjectEntryFolderLocalService objectEntryFolderLocalService,
 		ModelResourcePermission<ObjectEntryFolder>
 			objectEntryFolderModelResourcePermission,
-		Portal portal,
+		Portal portal, SearchResultResource.Factory searchResultResourceFactory,
 		TranslationInfoItemFieldValuesExporterRegistry
 			translationInfoItemFieldValuesExporterRegistry,
 		TrashHelper trashHelper) {
@@ -72,6 +78,7 @@ public class ViewRecycleBinSectionDisplayContext
 		_assetLibraryResourceFactory = assetLibraryResourceFactory;
 		_groupId = groupId;
 		_objectEntryFolderLocalService = objectEntryFolderLocalService;
+		_searchResultResourceFactory = searchResultResourceFactory;
 		_trashHelper = trashHelper;
 
 		_themeDisplay = (ThemeDisplay)httpServletRequest.getAttribute(
@@ -90,6 +97,8 @@ public class ViewRecycleBinSectionDisplayContext
 				"breadcrumbItems", jsonArray
 			).put(
 				"hideSpace", true
+			).put(
+				"showEmptyRecycleBinAction", _isShowEmptyRecycleBinAction()
 			).build();
 		}
 
@@ -186,19 +195,7 @@ public class ViewRecycleBinSectionDisplayContext
 			"cmsRoot eq true and (cmsSection eq 'contents' or cmsSection eq " +
 				"'files')";
 
-		List<Long> groupIds = ListUtil.filter(
-			DepotEntryServiceUtil.getDepotEntryGroupIds(
-				themeDisplay.getCompanyId(), themeDisplay.getUserId(),
-				DepotConstants.TYPE_SPACE),
-			groupId -> {
-				Group group = groupLocalService.fetchGroup(groupId);
-
-				if ((group != null) && _trashHelper.isTrashEnabled(group)) {
-					return true;
-				}
-
-				return false;
-			});
+		List<Long> groupIds = _getTrashEnabledDepotEntryGroupIds();
 
 		if (ListUtil.isEmpty(groupIds)) {
 			return filterString + " and status eq " +
@@ -211,9 +208,63 @@ public class ViewRecycleBinSectionDisplayContext
 			WorkflowConstants.STATUS_IN_TRASH);
 	}
 
+	private List<Long> _getTrashEnabledDepotEntryGroupIds() {
+		return ListUtil.filter(
+			DepotEntryServiceUtil.getDepotEntryGroupIds(
+				themeDisplay.getCompanyId(), themeDisplay.getUserId(),
+				DepotConstants.TYPE_SPACE),
+			groupId -> {
+				Group group = groupLocalService.fetchGroup(groupId);
+
+				if ((group != null) && _trashHelper.isTrashEnabled(group)) {
+					return true;
+				}
+
+				return false;
+			});
+	}
+
+	private boolean _isShowEmptyRecycleBinAction() {
+		if (ListUtil.isEmpty(_getTrashEnabledDepotEntryGroupIds())) {
+			return false;
+		}
+
+		try {
+			SearchResultResource searchResultResource =
+				_searchResultResourceFactory.create(
+				).httpServletRequest(
+					httpServletRequest
+				).preferredLocale(
+					themeDisplay.getLocale()
+				).user(
+					themeDisplay.getUser()
+				).build();
+
+			Page<SearchResult> page = searchResultResource.getSearchPage(
+				null, true, null, null, null,
+				searchResultResource.toFilter(getCMSSectionFilterString()),
+				Pagination.of(1, 0), null);
+
+			if (page.getTotalCount() > 0) {
+				return true;
+			}
+
+			return false;
+		}
+		catch (Exception exception) {
+			_log.error(exception);
+
+			return false;
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		ViewRecycleBinSectionDisplayContext.class);
+
 	private final AssetLibraryResource.Factory _assetLibraryResourceFactory;
 	private final long _groupId;
 	private final ObjectEntryFolderLocalService _objectEntryFolderLocalService;
+	private final SearchResultResource.Factory _searchResultResourceFactory;
 	private final ThemeDisplay _themeDisplay;
 	private final TrashHelper _trashHelper;
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ViewRecycleBinJSPSectionFragmentRenderer.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ViewRecycleBinJSPSectionFragmentRenderer.java
@@ -17,6 +17,7 @@ import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermi
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.search.rest.resource.v1_0.SearchResultResource;
 import com.liferay.site.cms.site.initializer.internal.display.context.ViewRecycleBinSectionDisplayContext;
 import com.liferay.trash.TrashHelper;
 
@@ -54,6 +55,7 @@ public class ViewRecycleBinJSPSectionFragmentRenderer
 			_objectDefinitionSettingLocalService,
 			_objectEntryFolderLocalService,
 			_objectEntryFolderModelResourcePermission, _portal,
+			_searchResultResourceFactory,
 			translationInfoItemFieldValuesExporterRegistry, _trashHelper);
 	}
 
@@ -86,6 +88,9 @@ public class ViewRecycleBinJSPSectionFragmentRenderer
 
 	@Reference
 	private Portal _portal;
+
+	@Reference
+	private SearchResultResource.Factory _searchResultResourceFactory;
 
 	@Reference
 	private TrashHelper _trashHelper;

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/modal/EmptyRecycleBinModalContent.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/modal/EmptyRecycleBinModalContent.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 
 import {triggerAssetBulkAction} from '../props_transformer/actions/triggerAssetBulkAction';
 
-const CMS_EMPTY_RECYCLE_BIN_FILTER =
+const CMS_RECYCLE_BIN_FILTER =
 	"cmsRoot eq true and (cmsSection eq 'contents' or cmsSection eq 'files') and status eq 8";
 
 export default function EmptyRecycleBinModalContent({
@@ -21,7 +21,7 @@ export default function EmptyRecycleBinModalContent({
 		event.preventDefault();
 
 		triggerAssetBulkAction({
-			apiURL: `/o/bulk/v1.0/bulk-action?filter=${encodeURIComponent(CMS_EMPTY_RECYCLE_BIN_FILTER)}&nestedFields=embedded`,
+			apiURL: `/o/bulk/v1.0/bulk-action?filter=${encodeURIComponent(CMS_RECYCLE_BIN_FILTER)}&nestedFields=embedded`,
 			selectedData: {selectAll: true},
 			type: 'DeleteObjectBulkSelectionAction',
 		});

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/recycle_bin/RecycleBinToolbar.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/recycle_bin/RecycleBinToolbar.tsx
@@ -16,33 +16,37 @@ import EmptyRecycleBinModalContent from '../modal/EmptyRecycleBinModalContent';
 
 interface Props {
 	breadcrumbItems: any[];
+	showEmptyRecycleBinAction: boolean;
 }
 
-export default function RecycleBinToolbar({breadcrumbItems}: Props) {
+export default function RecycleBinToolbar({
+	breadcrumbItems,
+	showEmptyRecycleBinAction,
+}: Props) {
 	return isRecycleBinRootPage(breadcrumbItems) ? (
-		<div>
-			<ClayToolbar
-				aria-label={Liferay.Language.get('recycle-bin')}
-				className="border-0"
-				light
-				style={{height: '72px'}}
-			>
-				<div className="container-fluid px-4">
-					<ClayToolbar.Nav>
-						<ClayToolbar.Item>
-							<ClayToolbar.Section>
-								<div
-									aria-level={2}
-									className="text-dark"
-									role="heading"
-								>
-									<Text as="span" size={7} weight="semi-bold">
-										{Liferay.Language.get('recycle-bin')}
-									</Text>
-								</div>
-							</ClayToolbar.Section>
-						</ClayToolbar.Item>
+		<ClayToolbar
+			aria-label={Liferay.Language.get('recycle-bin')}
+			className="border-0"
+			light
+			style={{height: '72px'}}
+		>
+			<div className="container-fluid px-4">
+				<ClayToolbar.Nav>
+					<ClayToolbar.Item>
+						<ClayToolbar.Section>
+							<div
+								aria-level={2}
+								className="text-dark"
+								role="heading"
+							>
+								<Text as="span" size={7} weight="semi-bold">
+									{Liferay.Language.get('recycle-bin')}
+								</Text>
+							</div>
+						</ClayToolbar.Section>
+					</ClayToolbar.Item>
 
+					{showEmptyRecycleBinAction && (
 						<ClayToolbar.Item>
 							<ClayDropDownWithItems
 								items={[
@@ -82,10 +86,10 @@ export default function RecycleBinToolbar({breadcrumbItems}: Props) {
 								}
 							/>
 						</ClayToolbar.Item>
-					</ClayToolbar.Nav>
-				</div>
-			</ClayToolbar>
-		</div>
+					)}
+				</ClayToolbar.Nav>
+			</div>
+		</ClayToolbar>
 	) : (
 		<Breadcrumb breadcrumbItems={breadcrumbItems} hideSpace={true} />
 	);

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/recycle_bin/RecycleBinHeader.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/recycle_bin/RecycleBinHeader.test.tsx
@@ -56,7 +56,12 @@ describe('RecycleBinToolbar', () => {
 	it('renders header text when isRecycleBinRootPage returns true', () => {
 		(isRecycleBinRootPage as jest.Mock).mockReturnValue(true);
 
-		render(<RecycleBinToolbar breadcrumbItems={breadcrumbItems} />);
+		render(
+			<RecycleBinToolbar
+				breadcrumbItems={breadcrumbItems}
+				showEmptyRecycleBinAction={true}
+			/>
+		);
 
 		expect(screen.getAllByText('recycle-bin')).toHaveLength(1);
 
@@ -67,10 +72,30 @@ describe('RecycleBinToolbar', () => {
 		).toBeInTheDocument();
 	});
 
+	it('hides Empty Recycle Bin action when showEmptyRecycleBinAction is false', () => {
+		(isRecycleBinRootPage as jest.Mock).mockReturnValue(true);
+
+		render(
+			<RecycleBinToolbar
+				breadcrumbItems={breadcrumbItems}
+				showEmptyRecycleBinAction={false}
+			/>
+		);
+
+		expect(
+			screen.queryByRole('button', {name: 'more-actions'})
+		).not.toBeInTheDocument();
+	});
+
 	it('renders breadcrumb links when isRecycleBinRootPage returns false', () => {
 		(isRecycleBinRootPage as jest.Mock).mockReturnValue(false);
 
-		render(<RecycleBinToolbar breadcrumbItems={breadcrumbItems} />);
+		render(
+			<RecycleBinToolbar
+				breadcrumbItems={breadcrumbItems}
+				showEmptyRecycleBinAction={true}
+			/>
+		);
 
 		expect(screen.getByRole('link', {name: 'Home'})).toHaveAttribute(
 			'href',

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/recycleBin.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/recycleBin.spec.ts
@@ -13,6 +13,7 @@ import {checkAccessibility} from '../../../utils/checkAccessibility';
 import getRandomString from '../../../utils/getRandomString';
 import performLoginViaApi, {
 	performUserSwitch,
+	userData,
 } from '../../../utils/performLogin';
 import {waitForAlert} from '../../../utils/waitForAlert';
 import {cmsPagesTest} from './fixtures/cmsPagesTest';
@@ -647,6 +648,250 @@ test(
 			await expect(
 				page.getByText(`Success:${contentName} was moved to the`)
 			).toBeHidden();
+		});
+	}
+);
+
+test(
+	'Default user can trash a CMS content and empty the Recycle Bin',
+	{tag: '@LPD-83226'},
+	async ({apiHelpers, contentsPage, page, recycleBinPage}) => {
+		const contentName = `Content ${getRandomString()}`;
+		const spaceName = `Space ${getRandomString()}`;
+
+		await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			settings: {trashEnabled: true},
+			type: 'Space',
+		});
+
+		await apiHelpers.objectEntry.postObjectEntry(
+			{
+				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				title: contentName,
+			},
+			'cms/basic-web-contents',
+			spaceName
+		);
+
+		await test.step('Send the content to the Recycle Bin', async () => {
+			await contentsPage.goto();
+
+			await contentsPage.deleteContent(contentName);
+		});
+
+		await test.step('The content appears in the Recycle Bin', async () => {
+			await recycleBinPage.goto();
+
+			await expect(
+				page.getByRole('row', {name: contentName})
+			).toBeVisible();
+		});
+
+		await test.step('The Empty Recycle Bin option is available', async () => {
+			await page.getByLabel('More Actions').click();
+
+			await expect(recycleBinPage.emptyRecycleBinButton).toBeVisible();
+		});
+
+		await test.step('Empty the Recycle Bin and the content is gone', async () => {
+			await recycleBinPage.emptyRecycleBinButton.click();
+
+			await page.getByRole('button', {name: 'Empty Bin'}).click();
+
+			await waitForAlert(
+				page,
+				'Info:Delete action started for all assets.',
+				{type: 'info'}
+			);
+
+			await expect(async () => {
+				await page.reload();
+
+				await expect(
+					page.getByRole('row', {name: contentName})
+				).toBeHidden();
+			}).toPass();
+		});
+	}
+);
+
+test(
+	'Space member without delete permission does not see trashed content nor the Empty Recycle Bin action',
+	{tag: '@LPD-83226'},
+	async ({apiHelpers, contentsPage, page, recycleBinPage}) => {
+		const contentName = `Content ${getRandomString()}`;
+		const spaceName = `Space ${getRandomString()}`;
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			settings: {trashEnabled: true},
+			type: 'Space',
+		});
+
+		await apiHelpers.objectEntry.postObjectEntry(
+			{
+				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				title: contentName,
+			},
+			'cms/basic-web-contents',
+			spaceName
+		);
+
+		await test.step('As the default user, trash the content', async () => {
+			await contentsPage.goto();
+
+			await contentsPage.deleteContent(contentName);
+		});
+
+		const user = await apiHelpers.headlessAdminUser.postUserAccount();
+
+		userData[user.alternateName] = {
+			name: user.givenName,
+			password: 'test',
+			surname: user.familyName,
+		};
+
+		await test.step('Create a user and add as space member', async () => {
+			await apiHelpers.jsonWebServicesUser.agreeToTermsOfUse(user.id);
+
+			await apiHelpers.jsonWebServicesUser.answerReminderQuery(user.id);
+
+			await apiHelpers.jsonWebServicesUser.addGroupUsers(space.siteId, [
+				user.id,
+			]);
+		});
+
+		await test.step('Log in as the space member', async () => {
+			await performUserSwitch(page, user.alternateName);
+		});
+
+		await test.step('The space member does not see the trashed content', async () => {
+			await recycleBinPage.goto();
+
+			await expect(
+				page.getByRole('row', {name: contentName})
+			).toBeHidden();
+		});
+
+		await test.step('The Empty Recycle Bin action is not rendered', async () => {
+			await expect(page.getByLabel('More Actions')).toBeHidden();
+		});
+
+		await test.step('The default user still sees the trashed content', async () => {
+			await performUserSwitch(page, 'test');
+
+			await recycleBinPage.goto();
+
+			await expect(
+				page.getByRole('row', {name: contentName})
+			).toBeVisible();
+		});
+	}
+);
+
+test(
+	'Space member with delete permission sees trashed content and can empty the Recycle Bin',
+	{tag: '@LPD-83226'},
+	async ({apiHelpers, contentsPage, page, recycleBinPage}) => {
+		const contentName = `Content ${getRandomString()}`;
+		const spaceName = `Space ${getRandomString()}`;
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			settings: {trashEnabled: true},
+			type: 'Space',
+		});
+
+		const objectEntry = await apiHelpers.objectEntry.postObjectEntry(
+			{
+				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				title: contentName,
+			},
+			'cms/basic-web-contents',
+			spaceName
+		);
+
+		const objectDefinition = await apiHelpers.get(
+			`${apiHelpers.baseUrl}object-admin/v1.0/object-definitions/by-external-reference-code/L_CMS_BASIC_WEB_CONTENT`
+		);
+
+		const assetLibraryMemberRole =
+			await apiHelpers.headlessAdminUser.getRoleByName(
+				'Asset Library Member'
+			);
+
+		const companyId = await page.evaluate(() =>
+			Liferay.ThemeDisplay.getCompanyId()
+		);
+
+		await test.step('Grant delete permission to Asset Library Member on the content', async () => {
+			await apiHelpers.jsonWebServicesResourcePermissionApiHelper.setIndividualResourcePermissions(
+				['DELETE', 'VIEW'],
+				String(companyId),
+				String(space.siteId),
+				objectDefinition.className,
+				String(objectEntry.id),
+				String(assetLibraryMemberRole.id)
+			);
+		});
+
+		await test.step('As the default user, trash the content', async () => {
+			await contentsPage.goto();
+
+			await contentsPage.deleteContent(contentName);
+		});
+
+		const user = await apiHelpers.headlessAdminUser.postUserAccount();
+
+		userData[user.alternateName] = {
+			name: user.givenName,
+			password: 'test',
+			surname: user.familyName,
+		};
+
+		await test.step('Create a user and add as space member', async () => {
+			await apiHelpers.jsonWebServicesUser.agreeToTermsOfUse(user.id);
+
+			await apiHelpers.jsonWebServicesUser.answerReminderQuery(user.id);
+
+			await apiHelpers.jsonWebServicesUser.addGroupUsers(space.siteId, [
+				user.id,
+			]);
+		});
+
+		await test.step('Log in as the space member', async () => {
+			await performUserSwitch(page, user.alternateName);
+		});
+
+		await test.step('The space member sees the trashed content', async () => {
+			await recycleBinPage.goto();
+
+			await expect(
+				page.getByRole('row', {name: contentName})
+			).toBeVisible();
+		});
+
+		await test.step('Empty the Recycle Bin and the content is gone', async () => {
+			await page.getByLabel('More Actions').click();
+
+			await recycleBinPage.emptyRecycleBinButton.click();
+
+			await page.getByRole('button', {name: 'Empty Bin'}).click();
+
+			await waitForAlert(
+				page,
+				'Info:Delete action started for all assets.',
+				{type: 'info'}
+			);
+
+			await expect(async () => {
+				await page.reload();
+
+				await expect(
+					page.getByRole('row', {name: contentName})
+				).toBeHidden();
+			}).toPass();
 		});
 	}
 );


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-83226

The "Emtpy Recycle Bin" action is always displayed.  The backend correctly handles permisions, but this may confuse users.

# How am I fixing it?

I've applied multiple fixes to this issue:
1. Only trashed entries that the user could have sent to the recycle bin are listed (i.e. the user has delete permission over the entry).
2. The "Empty recycle bin" action is only displayed if there are entries to delete.
3. The backend ignores entries for which the user has no permission.  This makes it possible to use the empty recycle bin action to delete the user's own entries in a simple way.

# How can you verify that it works?

Run the included playwright tests.