### PR TITLE
Revert "LPD-86104 Move logic to the beginning of the method to avoid …

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/security/permission/resource/ObjectEntryModelResourcePermission.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/security/permission/resource/ObjectEntryModelResourcePermission.java
@@ -129,18 +129,6 @@ public class ObjectEntryModelResourcePermission
 			String actionId)
 		throws PortalException {
 
-		ObjectDefinition objectDefinition =
-			_objectDefinitionLocalService.getObjectDefinition(
-				objectEntry.getObjectDefinitionId());
-
-		if (Objects.equals(actionId, ActionKeys.DOWNLOAD) &&
-			Objects.equals(
-				objectDefinition.getObjectFolderExternalReferenceCode(),
-				ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_FILE_TYPES)) {
-
-			return contains(permissionChecker, objectEntry, "DOWNLOAD_FILE");
-		}
-
 		if ((objectEntry.getRootObjectEntryId() != 0) &&
 			!_isObjectActionName(
 				actionId, objectEntry.getObjectDefinitionId()) &&
@@ -160,6 +148,18 @@ public class ObjectEntryModelResourcePermission
 		}
 
 		User user = permissionChecker.getUser();
+
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.getObjectDefinition(
+				objectEntry.getObjectDefinitionId());
+
+		if (Objects.equals(actionId, ActionKeys.DOWNLOAD) &&
+			Objects.equals(
+				objectDefinition.getObjectFolderExternalReferenceCode(),
+				ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_FILE_TYPES)) {
+
+			return contains(permissionChecker, objectEntry, "DOWNLOAD_FILE");
+		}
 
 		if (_hasAssigneeUpdatePermission(
 				actionId, objectDefinition, objectEntry, user)) {


### PR DESCRIPTION
Hi,

This commit is breaking some FDS functionalities and tests. Moving the logic to the beginning of the method is altering the flow because `objectDefinition` is got based on `objectEntry` which might vary depending on the condition inside `if` block.

Thanks.

Regards.

cc @jkappler 