### PR TITLE
LPD-83058 Avoid change the CMS role key 

### DIFF
--- a/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/edit_role.jsp
+++ b/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/edit_role.jsp
@@ -138,7 +138,7 @@ renderResponse.setTitle((role == null) ? LanguageUtil.get(request, "new-role") :
 				</liferay-ui:error>
 
 				<c:choose>
-					<c:when test="<%= (role != null) && role.isSystem() %>">
+					<c:when test="<%= (role != null) && (role.isProtected() || role.isSystem()) %>">
 						<aui:input disabled="<%= true %>" helpMessage="key-field-help" label="key" name="viewNameField" type="text" value="<%= roleName %>" />
 						<aui:input name="name" type="hidden" value="<%= roleName %>" />
 					</c:when>

--- a/modules/apps/roles/roles-test/src/testIntegration/java/com/liferay/roles/service/test/RoleLocalServiceTest.java
+++ b/modules/apps/roles/roles-test/src/testIntegration/java/com/liferay/roles/service/test/RoleLocalServiceTest.java
@@ -60,6 +60,7 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.comparator.RoleRoleIdComparator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
@@ -821,6 +822,23 @@ public class RoleLocalServiceTest {
 			Assert.assertEquals(
 				WorkflowConstants.STATUS_APPROVED, role.getStatus());
 		}
+	}
+
+	@FeatureFlag("LPD-17564")
+	@Test
+	@TestInfo("LPD-83058")
+	public void testUpdateRoleWithProtectedName() throws Exception {
+		Role cmsAdministratorRole = _roleLocalService.fetchRole(
+			TestPropsValues.getCompanyId(), RoleConstants.CMS_ADMINISTRATOR);
+
+		Role role = _roleLocalService.updateRole(
+			cmsAdministratorRole.getExternalReferenceCode(),
+			cmsAdministratorRole.getRoleId(), RandomTestUtil.randomString(),
+			cmsAdministratorRole.getTitleMap(),
+			cmsAdministratorRole.getDescriptionMap(),
+			cmsAdministratorRole.getSubtype(), null);
+
+		Assert.assertEquals(cmsAdministratorRole.getName(), role.getName());
 	}
 
 	protected void assertGetTeamRoleMap(

--- a/modules/test/playwright/tests/roles-admin-web/main/roles.spec.ts
+++ b/modules/test/playwright/tests/roles-admin-web/main/roles.spec.ts
@@ -2292,3 +2292,37 @@ test(
 		}).toPass();
 	}
 );
+
+test(
+	'Cannot edit the key of the CMS Administrator role',
+	{tag: ['@LPD-83058']},
+	async ({apiHelpers, rolePage, rolesPage}) => {
+		const roleName = 'CMS Administrator';
+
+		const existingRole =
+			await apiHelpers.headlessAdminUser.getRoleByName(roleName);
+
+		if (!existingRole) {
+			await apiHelpers.headlessAdminUser.postRole({
+				name: roleName,
+				roleType: 'regular',
+			});
+		}
+
+		await rolesPage.goto();
+
+		await rolesPage.rolesTable.search(roleName);
+		await (await rolesPage.rolesTable.cellLink(roleName)).click();
+
+		const disabledKeyField = rolePage.page.locator(
+			'#_com_liferay_roles_admin_web_portlet_RolesAdminPortlet_viewNameField'
+		);
+
+		await expect(disabledKeyField).toBeVisible();
+		await expect(disabledKeyField).toBeDisabled();
+		await expect(disabledKeyField).toHaveValue(roleName);
+
+		await expect(rolePage.keyInput).toBeHidden();
+		await expect(rolePage.keyInput).toHaveValue(roleName);
+	}
+);

--- a/portal-impl/bnd.bnd
+++ b/portal-impl/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 126.1.0
+Bundle-Version: 126.2.0
 CPE-Name: ${cpe.name}
 Export-Package:\
 	com.liferay.portal.bean,\

--- a/portal-impl/src/com/liferay/portal/model/impl/RoleImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/RoleImpl.java
@@ -98,6 +98,11 @@ public class RoleImpl extends RoleBaseImpl {
 	}
 
 	@Override
+	public boolean isProtected() {
+		return RoleConstants.isProtected(getName());
+	}
+
+	@Override
 	public boolean isSystem() {
 		return PortalUtil.isSystemRole(getName());
 	}

--- a/portal-impl/src/com/liferay/portal/service/impl/RoleLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/RoleLocalServiceImpl.java
@@ -1990,7 +1990,7 @@ public class RoleLocalServiceImpl extends RoleLocalServiceBaseImpl {
 
 		validate(roleId, role.getCompanyId(), role.getClassNameId(), name);
 
-		if (role.isSystem()) {
+		if (role.isProtected() || role.isSystem()) {
 			name = role.getName();
 			subtype = null;
 		}

--- a/portal-kernel/src/com/liferay/portal/kernel/model/Role.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/Role.java
@@ -92,9 +92,11 @@ public interface Role extends PersistedModel, RoleModel {
 
 	public String getTypeLabel();
 
+	public boolean isProtected();
+
 	public boolean isSystem();
 
 	public boolean isTeam();
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1539703615
+// LIFERAY-SERVICE-BUILDER-HASH:-421240556

--- a/portal-kernel/src/com/liferay/portal/kernel/model/RoleWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/RoleWrapper.java
@@ -543,6 +543,11 @@ public class RoleWrapper
 	}
 
 	@Override
+	public boolean isProtected() {
+		return model.isProtected();
+	}
+
+	@Override
 	public boolean isSystem() {
 		return model.isSystem();
 	}
@@ -916,4 +921,4 @@ public class RoleWrapper
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1371612081
+// LIFERAY-SERVICE-BUILDER-HASH:2010397374

--- a/portal-kernel/src/com/liferay/portal/kernel/model/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/packageinfo
@@ -1,1 +1,1 @@
-version 49.0.0
+version 49.1.0

--- a/portal-kernel/src/com/liferay/portal/kernel/model/role/RoleConstants.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/role/RoleConstants.java
@@ -8,7 +8,9 @@ package com.liferay.portal.kernel.model.role;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
 
 import java.util.Locale;
 
@@ -60,6 +62,8 @@ public class RoleConstants {
 		"Portal Content Reviewer";
 
 	public static final String POWER_USER = "Power User";
+
+	public static final String[] PROTECTED_ROLES = {CMS_ADMINISTRATOR};
 
 	public static final String PUBLICATIONS_ADMIN = "Publications Admin";
 
@@ -181,6 +185,14 @@ public class RoleConstants {
 		}
 
 		return TYPE_REGULAR_LABEL;
+	}
+
+	public static boolean isProtected(String roleName) {
+		if (Validator.isNull(roleName)) {
+			return false;
+		}
+
+		return ArrayUtil.contains(PROTECTED_ROLES, roleName);
 	}
 
 	public static String toSystemRoleExternalReferenceCode(String roleName) {

--- a/portal-kernel/src/com/liferay/portal/kernel/model/role/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/role/packageinfo
@@ -1,1 +1,1 @@
-version 1.8.0
+version 1.9.0

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/model/role/RoleConstantsTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/model/role/RoleConstantsTest.java
@@ -5,6 +5,8 @@
 
 package com.liferay.portal.kernel.model.role;
 
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -12,6 +14,18 @@ import org.junit.Test;
  * @author Stefano Motta
  */
 public class RoleConstantsTest {
+
+	@Test
+	public void testIsProtected() {
+		Assert.assertFalse(RoleConstants.isProtected(null));
+		Assert.assertFalse(RoleConstants.isProtected(""));
+		Assert.assertFalse(
+			RoleConstants.isProtected(RandomTestUtil.randomString()));
+		Assert.assertFalse(
+			RoleConstants.isProtected(RoleConstants.ADMINISTRATOR));
+		Assert.assertTrue(
+			RoleConstants.isProtected(RoleConstants.CMS_ADMINISTRATOR));
+	}
 
 	@Test
 	public void testToSystemRoleExternalReferenceCode() {


### PR DESCRIPTION
### What is this trying to solve?
https://liferay.atlassian.net/browse/LPD-83058

### How am I fixing it?
Identifying CMS ADMIN as name protected role and avoiding it's key change

### How can you verify that it works?

Run the included tests:

```
com.liferay.roles.service.test.RoleLocalServiceProtectedRolesTest STANDARD_OUT
    Loading jar:file:/Users/robertodiaz/work/CE/bundles/tomcat-10.1.54/webapps/ROOT/WEB-INF/shielded-container-lib/portal-impl.jar!/system.properties

com.liferay.roles.service.test.RoleLocalServiceProtectedRolesTest > testUpdateRole STARTED

com.liferay.roles.service.test.RoleLocalServiceProtectedRolesTest > testUpdateRole PASSED

> Task :apps:roles:roles-test:stopTestableTomcat
```

and :

```
➜  playwright git:(LPD-83058) ✗ npm run playwright -- test -g 'LPD-83058' --headed

> @liferay/playwright@1.0.0 playwright
> playwright test -g LPD-83058 --headed


Running 1 test using 1 worker
  1 passed (23.8s)

To open last HTML report run:

  npx playwright show-report
```