### PR TITLE
LPD-40749 Align Share Option Position for External Video Shortcuts

### DIFF
--- a/modules/apps/sharing/sharing-document-library-test/src/testIntegration/java/com/liferay/sharing/document/library/internal/display/context/test/SharingDLViewFileVersionDisplayContextTest.java
+++ b/modules/apps/sharing/sharing-document-library-test/src/testIntegration/java/com/liferay/sharing/document/library/internal/display/context/test/SharingDLViewFileVersionDisplayContextTest.java
@@ -8,6 +8,7 @@ package com.liferay.sharing.document.library.internal.display.context.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.document.library.constants.DLPortletKeys;
 import com.liferay.document.library.display.context.DLDisplayContextFactory;
+import com.liferay.document.library.display.context.DLUIItemKeys;
 import com.liferay.document.library.display.context.DLViewFileVersionDisplayContext;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
@@ -16,8 +17,11 @@ import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
 import com.liferay.friendly.url.model.FriendlyURLEntry;
 import com.liferay.friendly.url.service.FriendlyURLEntryLocalService;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownGroupItem;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownGroupItemBuilder;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemList;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemListBuilder;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -26,11 +30,14 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.portlet.constants.FriendlyURLResolverConstants;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.portlet.MockLiferayPortletRenderRequest;
 import com.liferay.portal.kernel.test.portlet.MockLiferayPortletRenderResponse;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.theme.PortletDisplay;
@@ -86,17 +93,24 @@ public class SharingDLViewFileVersionDisplayContextTest {
 
 	@FeatureFlag("LPS-197477")
 	@Test
-	public void testGetActionDropdownItems() throws PortalException {
-		FileEntry fileEntry = _dlAppLocalService.addFileEntry(
-			null, TestPropsValues.getUserId(), _group.getGroupId(),
-			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-			StringUtil.randomString(), "text/plain", StringUtil.randomString(),
-			StringUtil.randomString(), StringUtil.randomString(),
-			StringPool.BLANK, "test".getBytes(), null, null, null,
-			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+	@TestInfo("LPD-40749")
+	public void testGetActionDropdownItemsSharing() throws Exception {
+		FileEntry fileEntry = _addFileEntry();
 
+		_testGetActionDropdownItemsSharingPosition(fileEntry);
 		_testGetActionDropdownItemsWithSharingDisabled(fileEntry);
 		_testGetActionDropdownItemsWithSharingEnabled(fileEntry);
+	}
+
+	private FileEntry _addFileEntry() throws Exception {
+		return _dlAppLocalService.addFileEntry(
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			RandomTestUtil.randomString(), "text/plain",
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), StringPool.BLANK, "test".getBytes(),
+			null, null, null,
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
 	}
 
 	private void _assertCopyLinkDropdownItem(
@@ -141,7 +155,19 @@ public class SharingDLViewFileVersionDisplayContextTest {
 
 	private List<DropdownItem> _getDropdownItems(
 			FileEntry fileEntry, boolean signedIn)
-		throws PortalException {
+		throws Exception {
+
+		DLViewFileVersionDisplayContext dlViewFileVersionDisplayContext =
+			_dlDisplayContextFactory.getDLViewFileVersionDisplayContext(
+				new TestParentDLViewFileVersionDisplayContext(),
+				_getHttpServletRequest(signedIn), new MockHttpServletResponse(),
+				fileEntry.getFileVersion());
+
+		return dlViewFileVersionDisplayContext.getActionDropdownItems();
+	}
+
+	private HttpServletRequest _getHttpServletRequest(boolean signedIn)
+		throws Exception {
 
 		HttpServletRequest httpServletRequest = new MockHttpServletRequest();
 
@@ -158,6 +184,8 @@ public class SharingDLViewFileVersionDisplayContextTest {
 
 		portletDisplay.setPortletName(DLPortletKeys.DOCUMENT_LIBRARY_ADMIN);
 
+		themeDisplay.setCompany(
+			_companyLocalService.getCompany(_group.getCompanyId()));
 		themeDisplay.setLocale(LocaleUtil.getDefault());
 		themeDisplay.setPermissionChecker(
 			PermissionCheckerFactoryUtil.create(TestPropsValues.getUser()));
@@ -166,18 +194,70 @@ public class SharingDLViewFileVersionDisplayContextTest {
 
 		httpServletRequest.setAttribute(WebKeys.THEME_DISPLAY, themeDisplay);
 
+		return httpServletRequest;
+	}
+
+	private void _testGetActionDropdownItemsSharingPosition(FileEntry fileEntry)
+		throws Exception {
+
+		DropdownItem editDropdownItem = new DropdownItem();
+
+		editDropdownItem.setKey(DLUIItemKeys.EDIT);
+
+		DropdownItemList groupItems = DropdownItemListBuilder.add(
+			editDropdownItem
+		).build();
+
+		DropdownGroupItem dropdownGroupItem =
+			DropdownGroupItemBuilder.setDropdownItems(
+				groupItems
+			).build();
+
+		List<DropdownItem> parentDropdownItems = new ArrayList<>();
+
+		parentDropdownItems.add(dropdownGroupItem);
+
 		DLViewFileVersionDisplayContext dlViewFileVersionDisplayContext =
 			_dlDisplayContextFactory.getDLViewFileVersionDisplayContext(
-				new TestParentDLViewFileVersionDisplayContext(),
-				httpServletRequest, new MockHttpServletResponse(),
+				new TestParentDLViewFileVersionDisplayContext(
+					parentDropdownItems),
+				_getHttpServletRequest(true), new MockHttpServletResponse(),
 				fileEntry.getFileVersion());
 
-		return dlViewFileVersionDisplayContext.getActionDropdownItems();
+		List<DropdownItem> actionDropdownItems =
+			dlViewFileVersionDisplayContext.getActionDropdownItems();
+
+		Assert.assertEquals(
+			actionDropdownItems.toString(), 1, actionDropdownItems.size());
+
+		DropdownItem groupDropdownItem = actionDropdownItems.get(0);
+
+		DropdownItemList groupDropdownItemList =
+			(DropdownItemList)groupDropdownItem.get("items");
+
+		Assert.assertEquals(
+			groupDropdownItemList.toString(), 2, groupDropdownItemList.size());
+
+		DropdownItem sharingDropdownItem = groupDropdownItemList.get(0);
+
+		DropdownItemList sharingDropdownItemList =
+			(DropdownItemList)sharingDropdownItem.get("items");
+
+		Assert.assertEquals(
+			sharingDropdownItemList.toString(), 2,
+			sharingDropdownItemList.size());
+
+		_assertShareDropdownItem(sharingDropdownItemList.get(0), fileEntry);
+		_assertCopyLinkDropdownItem(sharingDropdownItemList.get(1), fileEntry);
+
+		editDropdownItem = groupDropdownItemList.get(1);
+
+		Assert.assertEquals(DLUIItemKeys.EDIT, editDropdownItem.get("key"));
 	}
 
 	private void _testGetActionDropdownItemsWithSharingDisabled(
 			FileEntry fileEntry)
-		throws PortalException {
+		throws Exception {
 
 		List<DropdownItem> actionDropdownItems = _getDropdownItems(
 			fileEntry, false);
@@ -190,7 +270,7 @@ public class SharingDLViewFileVersionDisplayContextTest {
 
 	private void _testGetActionDropdownItemsWithSharingEnabled(
 			FileEntry fileEntry)
-		throws PortalException {
+		throws Exception {
 
 		List<DropdownItem> actionDropdownItems = _getDropdownItems(
 			fileEntry, true);
@@ -203,11 +283,15 @@ public class SharingDLViewFileVersionDisplayContextTest {
 		DropdownItemList dropdownItemList = (DropdownItemList)dropdownItem.get(
 			"items");
 
-		Assert.assertEquals(2, dropdownItemList.size());
+		Assert.assertEquals(
+			dropdownItemList.toString(), 2, dropdownItemList.size());
 
 		_assertShareDropdownItem(dropdownItemList.get(0), fileEntry);
 		_assertCopyLinkDropdownItem(dropdownItemList.get(1), fileEntry);
 	}
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
 
 	@Inject
 	private DLAppLocalService _dlAppLocalService;
@@ -229,11 +313,21 @@ public class SharingDLViewFileVersionDisplayContextTest {
 	private class TestParentDLViewFileVersionDisplayContext
 		implements DLViewFileVersionDisplayContext {
 
+		public TestParentDLViewFileVersionDisplayContext() {
+			_dropdownItems = new ArrayList<>();
+		}
+
+		public TestParentDLViewFileVersionDisplayContext(
+			List<DropdownItem> dropdownItems) {
+
+			_dropdownItems = dropdownItems;
+		}
+
 		@Override
 		public List<DropdownItem> getActionDropdownItems()
 			throws PortalException {
 
-			return new ArrayList<>();
+			return _dropdownItems;
 		}
 
 		@Override
@@ -311,6 +405,8 @@ public class SharingDLViewFileVersionDisplayContextTest {
 				HttpServletResponse httpServletResponse)
 			throws IOException, ServletException {
 		}
+
+		private final List<DropdownItem> _dropdownItems;
 
 	}
 

--- a/modules/apps/sharing/sharing-document-library/src/main/java/com/liferay/sharing/document/library/internal/display/context/SharingDLViewFileVersionDisplayContext.java
+++ b/modules/apps/sharing/sharing-document-library/src/main/java/com/liferay/sharing/document/library/internal/display/context/SharingDLViewFileVersionDisplayContext.java
@@ -123,7 +123,7 @@ public class SharingDLViewFileVersionDisplayContext
 			List<DropdownItem> dropdownItems)
 		throws PortalException {
 
-		int i = 1;
+		int i = 0;
 
 		for (DropdownItem dropdownItem : dropdownItems) {
 			if (dropdownItem instanceof DropdownGroupItem) {
@@ -137,7 +137,7 @@ public class SharingDLViewFileVersionDisplayContext
 				}
 			}
 			else if (Objects.equals(
-						DLUIItemKeys.DOWNLOAD, dropdownItem.get("key"))) {
+						DLUIItemKeys.EDIT, dropdownItem.get("key"))) {
 
 				break;
 			}
@@ -145,7 +145,9 @@ public class SharingDLViewFileVersionDisplayContext
 			i++;
 		}
 
-		if (FeatureFlagManagerUtil.isEnabled("LPS-197477")) {
+		if (FeatureFlagManagerUtil.isEnabled(
+				_themeDisplay.getCompanyId(), "LPS-197477")) {
+
 			if (_isSharingEnabled()) {
 				dropdownItems.addAll(
 					Math.min(i, dropdownItems.size()),
@@ -183,7 +185,7 @@ public class SharingDLViewFileVersionDisplayContext
 			List<DropdownItem> dropdownItems)
 		throws PortalException {
 
-		int i = 1;
+		int i = 0;
 
 		for (DropdownItem dropdownItem : dropdownItems) {
 			if (dropdownItem instanceof DropdownGroupItem) {
@@ -197,7 +199,7 @@ public class SharingDLViewFileVersionDisplayContext
 				}
 			}
 			else if (Objects.equals(
-						DLUIItemKeys.DOWNLOAD, dropdownItem.get("key"))) {
+						DLUIItemKeys.EDIT, dropdownItem.get("key"))) {
 
 				break;
 			}
@@ -206,7 +208,9 @@ public class SharingDLViewFileVersionDisplayContext
 		}
 
 		if (i < dropdownItems.size()) {
-			if (FeatureFlagManagerUtil.isEnabled("LPS-197477")) {
+			if (FeatureFlagManagerUtil.isEnabled(
+					_themeDisplay.getCompanyId(), "LPS-197477")) {
+
 				if (_isSharingEnabled()) {
 					dropdownItems.addAll(
 						i,


### PR DESCRIPTION
### Issue
The "Share" option was misplaced for external video shortcuts.

### How I fixed it
I changed the logic to consistently anchor the Share option to the "Edit" element. Previously, the code checked for the "Download" element, which does not exist for external video shortcuts, causing the placement error.

If no edit permissions exist, the Share option is now correctly appended to the end of the dropdown menu in all cases.

**Tests**
No existing tests changes required.