### PR TITLE
LPD-87149 Fix ViewRecycleBinSectionDisplayContextTest.testGetAdditionalProps

### DIFF
--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/BaseFilesSectionDisplayContextTestCase.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/BaseFilesSectionDisplayContextTestCase.java
@@ -17,7 +17,7 @@ public abstract class BaseFilesSectionDisplayContextTestCase
 	extends BaseSectionDisplayContextTestCase {
 
 	@Override
-	public HashMap<String, Object> getBaseAdditionalProps() throws Exception {
+	public Map<String, Object> getBaseAdditionalProps() throws Exception {
 		return new HashMapBuilder<>().putAll(
 			super.getBaseAdditionalProps()
 		).put(

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/BaseSectionDisplayContextTestCase.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/BaseSectionDisplayContextTestCase.java
@@ -113,13 +113,13 @@ import org.springframework.mock.web.MockHttpServletRequest;
 public abstract class BaseSectionDisplayContextTestCase
 	extends BaseDisplayContextTestCase {
 
-	public HashMap<String, Object> getAdditionalProps() throws Exception {
+	public Map<String, Object> getAdditionalProps() throws Exception {
 		return ReflectionTestUtil.invoke(
 			getSectionDisplayContext(mockHttpServletRequest),
 			"getAdditionalProps", new Class<?>[0]);
 	}
 
-	public HashMap<String, Object> getBaseAdditionalProps() throws Exception {
+	public Map<String, Object> getBaseAdditionalProps() throws Exception {
 		ThemeDisplay themeDisplay =
 			(ThemeDisplay)mockHttpServletRequest.getAttribute(
 				WebKeys.THEME_DISPLAY);
@@ -919,7 +919,7 @@ public abstract class BaseSectionDisplayContextTestCase
 
 		for (DropdownItem dropdownItem : dropdownItems) {
 			if (Objects.equals(dropdownItem.get("label"), expectedLabel)) {
-				dropdownItemData = (HashMap<String, Object>)dropdownItem.get(
+				dropdownItemData = (Map<String, Object>)dropdownItem.get(
 					"data");
 
 				break;
@@ -954,7 +954,7 @@ public abstract class BaseSectionDisplayContextTestCase
 
 		for (DropdownItem dropdownItem : dropdownItems) {
 			if (Objects.equals(dropdownItem.get("label"), unexpectedLabel)) {
-				dropdownItemData = (HashMap<String, Object>)dropdownItem.get(
+				dropdownItemData = (Map<String, Object>)dropdownItem.get(
 					"data");
 
 				break;
@@ -980,7 +980,7 @@ public abstract class BaseSectionDisplayContextTestCase
 			JSONCompareMode.STRICT);
 	}
 
-	private HashMap<String, Object> _getBreadcrumbProps(
+	private Map<String, Object> _getBreadcrumbProps(
 			HttpServletRequest httpServletRequest)
 		throws Exception {
 
@@ -1222,8 +1222,7 @@ public abstract class BaseSectionDisplayContextTestCase
 	}
 
 	private String _getRedirect(DropdownItem dropdownItem) {
-		Map<String, Object> map = (HashMap<String, Object>)dropdownItem.get(
-			"data");
+		Map<String, Object> map = (Map<String, Object>)dropdownItem.get("data");
 
 		if (map == null) {
 			return null;

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewAllSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewAllSectionDisplayContextTest.java
@@ -25,7 +25,6 @@ import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
 import jakarta.servlet.http.HttpServletRequest;
 
-import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.Assert;
@@ -54,7 +53,7 @@ public class ViewAllSectionDisplayContextTest
 			PermissionCheckerMethodTestRule.INSTANCE);
 
 	@Override
-	public HashMap<String, Object> getBaseAdditionalProps() throws Exception {
+	public Map<String, Object> getBaseAdditionalProps() throws Exception {
 		return new HashMapBuilder<>().putAll(
 			super.getBaseAdditionalProps()
 		).put(

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewAllSpacesDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewAllSpacesDisplayContextTest.java
@@ -22,7 +22,7 @@ import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
 import jakarta.servlet.http.HttpServletRequest;
 
-import java.util.HashMap;
+import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -75,7 +75,7 @@ public class ViewAllSpacesDisplayContextTest
 			_getBreadcrumbProps(httpServletRequest));
 	}
 
-	private HashMap<String, Object> _getBreadcrumbProps(
+	private Map<String, Object> _getBreadcrumbProps(
 			HttpServletRequest httpServletRequest)
 		throws Exception {
 

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewContentsSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewContentsSectionDisplayContextTest.java
@@ -26,7 +26,6 @@ import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
 import jakarta.servlet.http.HttpServletRequest;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -55,7 +54,7 @@ public class ViewContentsSectionDisplayContextTest
 			PermissionCheckerMethodTestRule.INSTANCE);
 
 	@Override
-	public HashMap<String, Object> getBaseAdditionalProps() throws Exception {
+	public Map<String, Object> getBaseAdditionalProps() throws Exception {
 		return new HashMapBuilder<>().putAll(
 			super.getBaseAdditionalProps()
 		).put(

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewFilesSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewFilesSectionDisplayContextTest.java
@@ -23,7 +23,6 @@ import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
 import jakarta.servlet.http.HttpServletRequest;
 
-import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.Assert;
@@ -50,7 +49,7 @@ public class ViewFilesSectionDisplayContextTest
 			PermissionCheckerMethodTestRule.INSTANCE);
 
 	@Override
-	public HashMap<String, Object> getBaseAdditionalProps() throws Exception {
+	public Map<String, Object> getBaseAdditionalProps() throws Exception {
 		return new HashMapBuilder<>().putAll(
 			super.getBaseAdditionalProps()
 		).put(

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewRecycleBinSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewRecycleBinSectionDisplayContextTest.java
@@ -43,7 +43,6 @@ import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import jakarta.servlet.http.HttpServletRequest;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -70,6 +69,16 @@ public class ViewRecycleBinSectionDisplayContextTest
 		new AggregateTestRule(
 			new LiferayIntegrationTestRule(),
 			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Override
+	public Map<String, Object> getBaseAdditionalProps() throws Exception {
+		Map<String, Object> baseAdditionalProps =
+			super.getBaseAdditionalProps();
+
+		baseAdditionalProps.remove("additionalAPIURLParameters");
+
+		return baseAdditionalProps;
+	}
 
 	@Test
 	public void testGetBreadcrumbProps() throws Exception {
@@ -282,7 +291,7 @@ public class ViewRecycleBinSectionDisplayContextTest
 				depotGroup.getTypeSettingsProperty("trashEnabled")));
 	}
 
-	private HashMap<String, Object> _getBreadcrumbProps(Object displayContext) {
+	private Map<String, Object> _getBreadcrumbProps(Object displayContext) {
 		return ReflectionTestUtil.invoke(
 			displayContext, "getBreadcrumbProps", new Class<?>[0]);
 	}

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewRelatedAssetsSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewRelatedAssetsSectionDisplayContextTest.java
@@ -39,7 +39,6 @@ import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import jakarta.servlet.http.HttpServletRequest;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -128,7 +127,7 @@ public class ViewRelatedAssetsSectionDisplayContextTest
 
 	@Test
 	public void testGetAdditionalProps() throws Exception {
-		HashMap<String, Object> additionalProps = ReflectionTestUtil.invoke(
+		Map<String, Object> additionalProps = ReflectionTestUtil.invoke(
 			_getViewRelatedAssetsSectionDisplayContext(mockHttpServletRequest),
 			"getAdditionalProps", new Class<?>[0]);
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-87149

**What is being fixed:** `ViewRecycleBinSectionDisplayContextTest.testGetAdditionalProps` was failing with `expected:<18> but was:<17>`. The test base class `BaseSectionDisplayContextTestCase.getBaseAdditionalProps` unconditionally expects an `additionalAPIURLParameters` entry, but the production `BaseSectionDisplayContext.getAdditionalProps` returns `null` for that key when `isFolderSearchEnabled()` is `false` — and `HashMapBuilder` skips null supplier values, so the actual map omits the entry. `ViewRecycleBinSectionDisplayContext` does not enable folder search, so the expected and actual maps diverge by one key.

**How it is being fixed:** Override `getBaseAdditionalProps()` in `ViewRecycleBinSectionDisplayContextTest` to remove `additionalAPIURLParameters` from the inherited expected map, matching the production behavior for sections where folder search is disabled.

**How to execute the tests:**

```
gradlew -p modules/apps/site/site-cms-site-initializer-test testIntegration --tests "com.liferay.site.cms.site.initializer.internal.display.context.test.ViewRecycleBinSectionDisplayContextTest"
```

_AI-assisted with Claude Code._