### PR TITLE
LPD-27458 Fix duplicated toast when copying document URL

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/js/document_library/InfoPanel.es.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/js/document_library/InfoPanel.es.js
@@ -17,7 +17,15 @@ class InfoPanel extends PortletBase {
 	 * @review
 	 */
 	attached() {
-		this._clipboard = new ClipboardJS('.dm-infopanel-copy-clipboard');
+		this._destroyClipboard();
+
+		const selector = '.dm-infopanel-copy-clipboard';
+
+		const container = this.rootNode;
+
+		if (!container) {return;}
+
+		this._clipboard = new ClipboardJS(container.querySelectorAll(selector));
 
 		this._clipboard.on('success', this._handleClipboardSuccess.bind(this));
 	}
@@ -28,8 +36,14 @@ class InfoPanel extends PortletBase {
 	 */
 	disposeInternal() {
 		super.disposeInternal();
+		this._destroyClipboard();
+	}
 
-		this._clipboard.destroy();
+	_destroyClipboard() {
+		if (this._clipboard) {
+			this._clipboard.destroy();
+			this._clipboard = null;
+		}
 	}
 
 	_handleClipboardSuccess() {

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/js/document_library/InfoPanel.es.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/js/document_library/InfoPanel.es.js
@@ -19,13 +19,9 @@ class InfoPanel extends PortletBase {
 	attached() {
 		this._destroyClipboard();
 
-		const selector = '.dm-infopanel-copy-clipboard';
-
-		const container = this.rootNode;
-
-		if (!container) {return;}
-
-		this._clipboard = new ClipboardJS(container.querySelectorAll(selector));
+		this._clipboard = new ClipboardJS(
+			this.all('.dm-infopanel-copy-clipboard')
+		);
 
 		this._clipboard.on('success', this._handleClipboardSuccess.bind(this));
 	}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-27458

**What is being fixed:** When a user opens the document info panel for one file, switches to another file (or re-selects repeatedly), then clicks "Copy URL" or "Copy WebDAV URL", the success toast fires once *per* panel attach instead of once *per click*. The cause is that `new ClipboardJS('.dm-infopanel-copy-clipboard')` registers a delegated click listener on `document.body`; the listener persists even after the info panel re-renders, so each new `InfoPanel` instance stacks another listener.

**How it is being fixed:**

1. `LPD-27458 Avoid duplicated toast messages` — destroys the previous `ClipboardJS` instance at the top of `attached()` (and again in `disposeInternal()`), and switches the constructor argument from a CSS-selector string to a NodeList so listeners bind directly to the buttons rather than via `document.body` delegation.

2. `LPD-27458 Use PortletBase.all helper for ClipboardJS selector` — replaces the manual `this.rootNode.querySelectorAll(...)` lookup with `this.all(...)`, the in-house helper that other `PortletBase` subclasses already use. Why: `this.all()` already handles a missing `rootNode` (falls back to `document`) and namespace-prefixes ID selectors, so the explicit `if (!container) return;` guard and the temporary locals become redundant. Behaviour is unchanged — same scoping to the portlet root, same NodeList — but the code matches the in-house pattern.

**How to verify:**

1. Documents and Media admin → toggle the info panel.
2. Select a file → switch to a different file → switch again.
3. Click "Copy URL" once.
4. Exactly one "Copied link to the clipboard" toast should appear.

_AI-assisted with Claude Code._

@dmcisneroslf 