### PR TITLE
LPD-86106 Make bulk actions honor permissions

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/AllSpacesFDSPropsTransformer.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/AllSpacesFDSPropsTransformer.ts
@@ -3,7 +3,10 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {IInternalRenderer} from '@liferay/frontend-data-set-web';
+import {
+	IBulkActionItem,
+	IInternalRenderer,
+} from '@liferay/frontend-data-set-web';
 import {navigate, sessionStorage, sub} from 'frontend-js-web';
 
 import {openCMSModal} from '../../common/utils/openCMSModal';
@@ -20,23 +23,27 @@ import manageMembersAction, {
 import SpaceRenderer from './cell_renderers/SpaceRenderer';
 import addOnClickToCreationMenuItems from './utils/addOnClickToCreationMenuItems';
 import {executeAsyncItemAction} from './utils/executeAsyncItemAction';
+import transformFDSBulkActions from './utils/transformFDSBulkActions';
 
 const ACTIONS = {};
 const DEPOT_CLASS_NAME = 'com.liferay.depot.model.DepotEntry';
 
 export default function AllSpacesFDSPropsTransformer({
 	additionalProps,
+	bulkActions = [],
 	creationMenu,
 	itemsActions = [],
 	...otherProps
 }: {
 	additionalProps: any;
+	bulkActions: Array<IBulkActionItem>;
 	creationMenu: any;
 	itemsActions?: any[];
 	otherProps: any;
 }) {
 	return {
 		...otherProps,
+		bulkActions: transformFDSBulkActions(bulkActions),
 		creationMenu: {
 			...creationMenu,
 			primaryItems: addOnClickToCreationMenuItems(

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/StructuresFDSPropsTransformer.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/StructuresFDSPropsTransformer.ts
@@ -3,7 +3,10 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {IInternalRenderer} from '@liferay/frontend-data-set-web';
+import {
+	IBulkActionItem,
+	IInternalRenderer,
+} from '@liferay/frontend-data-set-web';
 
 import StatusLabel from '../../common/components/StatusLabel';
 import {IBulkActionFDSData} from '../../common/types/BulkActionTask';
@@ -18,15 +21,19 @@ import AuthorRenderer from './cell_renderers/AuthorRenderer';
 import SimpleActionLinkRenderer from './cell_renderers/SimpleActionLinkRenderer';
 import StructureScopeRenderer from './cell_renderers/StructureScopeRenderer';
 import TypeRenderer from './cell_renderers/TypeRenderer';
+import transformFDSBulkActions from './utils/transformFDSBulkActions';
 
 export default function StructuresFDSPropsTransformer({
+	bulkActions = [],
 	...otherProps
 }: {
 	apiURL: string;
+	bulkActions: Array<IBulkActionItem>;
 	otherProps: any;
 }) {
 	return {
 		...otherProps,
+		bulkActions: transformFDSBulkActions(bulkActions),
 		customRenderers: {
 			tableCell: [
 				{

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/ViewVersionHistoryFDSPropsTransformer.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/ViewVersionHistoryFDSPropsTransformer.ts
@@ -3,7 +3,11 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {IInternalRenderer, replaceTokens} from '@liferay/frontend-data-set-web';
+import {
+	IBulkActionItem,
+	IInternalRenderer,
+	replaceTokens,
+} from '@liferay/frontend-data-set-web';
 import {navigate, sessionStorage, sub} from 'frontend-js-web';
 
 import StatusLabel from '../../common/components/StatusLabel';
@@ -16,19 +20,23 @@ import AssetVersionRenderer from './cell_renderers/AssetVersionRenderer';
 import AuthorRenderer from './cell_renderers/AuthorRenderer';
 import VersionRenderer from './cell_renderers/VersionRenderer';
 import {executeAsyncItemAction} from './utils/executeAsyncItemAction';
+import transformFDSBulkActions from './utils/transformFDSBulkActions';
 
 export default function ViewVersionHistoryFDSPropsTransformer({
 	additionalProps,
+	bulkActions = [],
 	itemsActions = [],
 	...otherProps
 }: {
 	additionalProps: any;
 	apiURL?: string;
+	bulkActions: Array<IBulkActionItem>;
 	id?: string;
 	itemsActions?: any[];
 }) {
 	return {
 		...otherProps,
+		bulkActions: transformFDSBulkActions(bulkActions),
 		customRenderers: {
 			tableCell: [
 				{

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/utils/transformFDSBulkActions.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/utils/transformFDSBulkActions.ts
@@ -6,6 +6,7 @@
 import {IBulkActionItem} from '@liferay/frontend-data-set-web';
 
 const BULK_ACTION_PERMISSION_KEYS: Record<string, string> = {
+	'assign-default-workflow': 'update',
 	'copy-to': 'update',
 	'default-permissions': 'permissions',
 	'delete': 'delete',

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/utils/transformFDSBulkActions.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/utils/transformFDSBulkActions.ts
@@ -35,10 +35,16 @@ export default function transformFDSBulkActions(
 		return {
 			...action,
 			isVisible: ({
+				allItemsSelectedActive,
 				selectedItems,
 			}: {
+				allItemsSelectedActive?: boolean;
 				selectedItems?: Array<any>;
 			} = {}): boolean => {
+				if (allItemsSelectedActive && key === 'download') {
+					return false;
+				}
+
 				return (
 					selectedItems?.every(
 						(item: any) => item?.actions?.[permissionKey]

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/utils/transformFDSBulkActions.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/utils/transformFDSBulkActions.ts
@@ -42,8 +42,8 @@ export default function transformFDSBulkActions(
 				allItemsSelectedActive?: boolean;
 				selectedItems?: Array<any>;
 			} = {}): boolean => {
-				if (allItemsSelectedActive && key === 'download') {
-					return false;
+				if (allItemsSelectedActive) {
+					return key !== 'download';
 				}
 
 				return (

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/utils/transformFDSBulkActions.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/utils/transformFDSBulkActions.ts
@@ -5,13 +5,30 @@
 
 import {IBulkActionItem} from '@liferay/frontend-data-set-web';
 
+const BULK_ACTION_PERMISSION_KEYS: Record<string, string> = {
+	'copy-to': 'update',
+	'default-permissions': 'permissions',
+	'delete': 'delete',
+	'download': 'download',
+	'edit-categories': 'edit-categories',
+	'edit-default-permissions-by-role': 'permissions',
+	'edit-permissions-by-role': 'permissions',
+	'edit-tags': 'edit-tags',
+	'expire': 'expire',
+	'export-for-translation': 'get',
+	'move-to': 'update',
+	'permissions': 'permissions',
+	'reset-to-default-permissions': 'permissions',
+};
+
 export default function transformFDSBulkActions(
 	bulkActions: Array<IBulkActionItem>
 ): Array<IBulkActionItem> {
 	return bulkActions.map((action: IBulkActionItem) => {
 		const key = action?.data?.id as string;
+		const permissionKey = key && BULK_ACTION_PERMISSION_KEYS[key];
 
-		if (!key || key !== 'delete') {
+		if (!permissionKey) {
 			return action;
 		}
 
@@ -24,7 +41,7 @@ export default function transformFDSBulkActions(
 			} = {}): boolean => {
 				return (
 					selectedItems?.every(
-						(item: any) => item?.actions?.['delete']
+						(item: any) => item?.actions?.[permissionKey]
 					) ?? false
 				);
 			},

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/utils/transformFDSBulkActions.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/utils/transformFDSBulkActions.ts
@@ -10,7 +10,7 @@ const BULK_ACTION_PERMISSION_KEYS: Record<string, string> = {
 	'copy-to': 'update',
 	'default-permissions': 'permissions',
 	'delete': 'delete',
-	'download': 'download',
+	'download': 'get',
 	'edit-categories': 'edit-categories',
 	'edit-default-permissions-by-role': 'permissions',
 	'edit-permissions-by-role': 'permissions',
@@ -44,6 +44,14 @@ export default function transformFDSBulkActions(
 			} = {}): boolean => {
 				if (allItemsSelectedActive) {
 					return key !== 'download';
+				}
+
+				if (key === 'download') {
+					return (
+						selectedItems?.every((item: any) =>
+							Boolean(item?.embedded?.file?.link?.href)
+						) ?? false
+					);
 				}
 
 				return (

--- a/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/ExtensionSelectionFDSFilterTest.java
+++ b/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/ExtensionSelectionFDSFilterTest.java
@@ -173,7 +173,7 @@ public class ExtensionSelectionFDSFilterTest {
 	@Mock
 	private DepotEntryLocalService _depotEntryLocalService;
 
-	private ExtensionSelectionFDSFilter _extensionSelectionFDSFilter =
+	private final ExtensionSelectionFDSFilter _extensionSelectionFDSFilter =
 		new ExtensionSelectionFDSFilter();
 	private final Locale _locale = LocaleUtil.US;
 

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/props_transformer/utils/transformFDSBulkActions.test.ts
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/props_transformer/utils/transformFDSBulkActions.test.ts
@@ -1,0 +1,105 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import transformFDSBulkActions from '../../../../../src/main/resources/META-INF/resources/js/main_view/props_transformer/utils/transformFDSBulkActions';
+
+jest.mock('@liferay/frontend-data-set-web', () => ({}));
+
+const action = (id: string) => ({data: {id}}) as any;
+
+const isVisibleFor = (id: string) => {
+	const [{isVisible}] = transformFDSBulkActions([action(id)]);
+
+	return isVisible!;
+};
+
+const itemWith = (actions: Record<string, unknown>) => ({actions});
+
+const fileItemWithLink = () => ({
+	embedded: {file: {link: {href: 'http://example.com/file.png'}}},
+});
+
+const fileItemWithoutLink = () => ({embedded: {file: {}}});
+
+describe('transformFDSBulkActions', () => {
+	it('passes through actions whose id is not in the permission map', () => {
+		const unknown = action('unknown-action');
+
+		const [transformed] = transformFDSBulkActions([unknown]);
+
+		expect(transformed).toBe(unknown);
+		expect(transformed.isVisible).toBeUndefined();
+	});
+
+	it('attaches an isVisible callback to actions in the permission map', () => {
+		const [transformed] = transformFDSBulkActions([action('delete')]);
+
+		expect(typeof transformed.isVisible).toBe('function');
+	});
+
+	describe('isVisible (allItemsSelectedActive=false)', () => {
+		it('shows the action when every selected item has the permission', () => {
+			expect(
+				isVisibleFor('delete')({
+					selectedItems: [
+						itemWith({delete: {}}),
+						itemWith({delete: {}}),
+					],
+				})
+			).toBe(true);
+		});
+
+		it('hides the action when any selected item lacks the permission', () => {
+			expect(
+				isVisibleFor('delete')({
+					selectedItems: [itemWith({delete: {}}), itemWith({})],
+				})
+			).toBe(false);
+		});
+
+		it('hides the action when no items are selected', () => {
+			const isVisible = isVisibleFor('delete');
+
+			expect(isVisible({})).toBe(false);
+			expect(isVisible({selectedItems: undefined})).toBe(false);
+		});
+
+		it('checks the mapped permission key, not the action id', () => {
+			const isVisible = isVisibleFor('move-to');
+
+			expect(isVisible({selectedItems: [itemWith({update: {}})]})).toBe(
+				true
+			);
+			expect(
+				isVisible({selectedItems: [itemWith({['move-to']: {}})]})
+			).toBe(false);
+		});
+
+		it('checks file link presence for the download action', () => {
+			const isVisible = isVisibleFor('download');
+
+			expect(isVisible({selectedItems: [fileItemWithLink()]})).toBe(true);
+			expect(
+				isVisible({
+					selectedItems: [fileItemWithLink(), fileItemWithoutLink()],
+				})
+			).toBe(false);
+		});
+	});
+
+	describe('isVisible (allItemsSelectedActive=true)', () => {
+		it('shows non-download actions even when no items are passed', () => {
+			expect(isVisibleFor('delete')({allItemsSelectedActive: true})).toBe(
+				true
+			);
+		});
+
+		it('hides download to prevent downloading the entire data set', () => {
+			expect(
+				isVisibleFor('download')({allItemsSelectedActive: true})
+			).toBe(false);
+		});
+	});
+});

--- a/modules/test/playwright/tests/site-cms-site-initializer/permissions/transformFDSBulkActions.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/permissions/transformFDSBulkActions.spec.ts
@@ -5,9 +5,9 @@
 
 import {Page, expect, mergeTests} from '@playwright/test';
 
-import {ApiHelpers} from '../../../helpers/ApiHelpers';
 import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
 import {loginTest} from '../../../fixtures/loginTest';
+import {ApiHelpers} from '../../../helpers/ApiHelpers';
 import getRandomString from '../../../utils/getRandomString';
 import {performLoginViaApi} from '../../../utils/performLogin';
 import {DataSetPage} from '../main/pages/DataSetPage';
@@ -31,18 +31,6 @@ async function openBulkActionMenu(page: Page) {
 		.getByTestId('visualization-mode-table')
 		.getByLabel('Actions')
 		.click();
-}
-
-async function expectBulkActionAbsent(page: Page, action: string) {
-	await expect(async () => {
-		await openBulkActionMenu(page);
-
-		await expect(
-			page.getByRole('menuitem', {exact: true, name: action})
-		).toHaveCount(0, {timeout: 1000});
-
-		await page.keyboard.press('Escape');
-	}).toPass({timeout: 5000});
 }
 
 async function expectBulkActionVisible(page: Page, action: string) {
@@ -69,7 +57,7 @@ async function selectRow(page: Page, title: string, checked: boolean) {
 }
 
 test.describe(
-	'transformFDSBulkActions filters bulk actions by permission',
+	'transformFDSBulkActions wires the bulk action menu in the Files view',
 	{tag: '@LPD-86106'},
 	() => {
 		test.beforeAll(async ({browser}) => {
@@ -124,7 +112,7 @@ test.describe(
 			await page.close();
 		});
 
-		test('shows Delete on a single deletable item', async ({
+		test('shows Delete in the bulk menu when a single item is selected', async ({
 			assetsPage,
 			page,
 		}) => {
@@ -139,7 +127,7 @@ test.describe(
 			await expectBulkActionVisible(page, 'Delete');
 		});
 
-		test('shows Delete on a multi-selection of deletable items', async ({
+		test('shows Delete in the bulk menu when multiple items are selected', async ({
 			assetsPage,
 			page,
 		}) => {
@@ -153,42 +141,6 @@ test.describe(
 			await selectRow(page, `${titlePrefix}_1`, true);
 
 			await expectBulkActionVisible(page, 'Delete');
-		});
-
-		test('shows Delete when all items are selected across pages', async ({
-			assetsPage,
-			page,
-		}) => {
-			await assetsPage.gotoFiles();
-			await assetsPage.changeVisualizationMode('Table');
-
-			const dataSetPage = new DataSetPage(page);
-
-			await dataSetPage.search(titlePrefix);
-
-			await page.getByLabel('Select All Items on the Page').check();
-
-			await dataSetPage.selectAll();
-
-			await expectBulkActionVisible(page, 'Delete');
-		});
-
-		test('hides Download when all items are selected across pages', async ({
-			assetsPage,
-			page,
-		}) => {
-			await assetsPage.gotoFiles();
-			await assetsPage.changeVisualizationMode('Table');
-
-			const dataSetPage = new DataSetPage(page);
-
-			await dataSetPage.search(titlePrefix);
-
-			await page.getByLabel('Select All Items on the Page').check();
-
-			await dataSetPage.selectAll();
-
-			await expectBulkActionAbsent(page, 'Download');
 		});
 	}
 );

--- a/modules/test/playwright/tests/site-cms-site-initializer/permissions/transformFDSBulkActions.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/permissions/transformFDSBulkActions.spec.ts
@@ -1,0 +1,194 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Page, expect, mergeTests} from '@playwright/test';
+
+import {ApiHelpers} from '../../../helpers/ApiHelpers';
+import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
+import {loginTest} from '../../../fixtures/loginTest';
+import getRandomString from '../../../utils/getRandomString';
+import {performLoginViaApi} from '../../../utils/performLogin';
+import {DataSetPage} from '../main/pages/DataSetPage';
+import {cmsPagesTest} from './fixtures/cmsPagesTest';
+
+const test = mergeTests(cmsPagesTest, dataApiHelpersTest, loginTest());
+
+const APPLICATION_NAME = 'cms/basic-documents';
+const FILE_COUNT = 12;
+
+const SPACE_NAME = 'Default';
+
+const VALID_IMAGE_FILE_BASE64 =
+	'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQMAAAAl21bKAAAAA1BMVEUAAACnej3aAAAAAXRSTlMAQObYZgAAAApJREFUCNdjYAAAAAIAAeIhvDMAAAAASUVORK5CYII=';
+
+let createdEntryIds: number[];
+let titlePrefix: string;
+
+async function openBulkActionMenu(page: Page) {
+	await page
+		.getByTestId('visualization-mode-table')
+		.getByLabel('Actions')
+		.click();
+}
+
+async function expectBulkActionAbsent(page: Page, action: string) {
+	await expect(async () => {
+		await openBulkActionMenu(page);
+
+		await expect(
+			page.getByRole('menuitem', {exact: true, name: action})
+		).toHaveCount(0, {timeout: 1000});
+
+		await page.keyboard.press('Escape');
+	}).toPass({timeout: 5000});
+}
+
+async function expectBulkActionVisible(page: Page, action: string) {
+	await expect(async () => {
+		await openBulkActionMenu(page);
+
+		await expect(
+			page.getByRole('menuitem', {exact: true, name: action})
+		).toBeVisible({timeout: 1000});
+
+		await page.keyboard.press('Escape');
+	}).toPass({timeout: 5000});
+}
+
+async function selectRow(page: Page, title: string, checked: boolean) {
+	const checkbox = page.getByLabel(`Select ${title}`, {exact: true});
+
+	if (checked) {
+		await checkbox.check();
+	}
+	else {
+		await checkbox.uncheck();
+	}
+}
+
+test.describe(
+	'transformFDSBulkActions filters bulk actions by permission',
+	{tag: '@LPD-86106'},
+	() => {
+		test.beforeAll(async ({browser}) => {
+			const page = await browser.newPage();
+
+			await performLoginViaApi({page, screenName: 'test'});
+
+			const setupApiHelpers = new ApiHelpers(page);
+
+			titlePrefix = `bulkfilter_${getRandomString().replace(/-/g, '')}`;
+
+			const createdEntries: ObjectEntry[] = [];
+
+			for (let i = 0; i < FILE_COUNT; i++) {
+				const title = `${titlePrefix}_${i}`;
+				const entry = await setupApiHelpers.objectEntry.postObjectEntry(
+					{
+						file: {
+							fileBase64: VALID_IMAGE_FILE_BASE64,
+							name: `${title}.png`,
+						},
+						objectEntryFolderExternalReferenceCode: 'L_FILES',
+						title,
+					},
+					APPLICATION_NAME,
+					SPACE_NAME
+				);
+
+				createdEntries.push(entry);
+			}
+
+			createdEntryIds = createdEntries.map((entry) => entry.id);
+
+			await page.close();
+		});
+
+		test.afterAll(async ({browser}) => {
+			const page = await browser.newPage();
+
+			await performLoginViaApi({page, screenName: 'test'});
+
+			const teardownApiHelpers = new ApiHelpers(page);
+
+			if (createdEntryIds?.length) {
+				for (const entryId of createdEntryIds) {
+					await teardownApiHelpers.objectEntry
+						.deleteObjectEntry(APPLICATION_NAME, String(entryId))
+						.catch(() => {});
+				}
+			}
+
+			await page.close();
+		});
+
+		test('shows Delete on a single deletable item', async ({
+			assetsPage,
+			page,
+		}) => {
+			await assetsPage.gotoFiles();
+			await assetsPage.changeVisualizationMode('Table');
+
+			const dataSetPage = new DataSetPage(page);
+
+			await dataSetPage.search(`${titlePrefix}_0`);
+			await selectRow(page, `${titlePrefix}_0`, true);
+
+			await expectBulkActionVisible(page, 'Delete');
+		});
+
+		test('shows Delete on a multi-selection of deletable items', async ({
+			assetsPage,
+			page,
+		}) => {
+			await assetsPage.gotoFiles();
+			await assetsPage.changeVisualizationMode('Table');
+
+			const dataSetPage = new DataSetPage(page);
+
+			await dataSetPage.search(titlePrefix);
+			await selectRow(page, `${titlePrefix}_0`, true);
+			await selectRow(page, `${titlePrefix}_1`, true);
+
+			await expectBulkActionVisible(page, 'Delete');
+		});
+
+		test('shows Delete when all items are selected across pages', async ({
+			assetsPage,
+			page,
+		}) => {
+			await assetsPage.gotoFiles();
+			await assetsPage.changeVisualizationMode('Table');
+
+			const dataSetPage = new DataSetPage(page);
+
+			await dataSetPage.search(titlePrefix);
+
+			await page.getByLabel('Select All Items on the Page').check();
+
+			await dataSetPage.selectAll();
+
+			await expectBulkActionVisible(page, 'Delete');
+		});
+
+		test('hides Download when all items are selected across pages', async ({
+			assetsPage,
+			page,
+		}) => {
+			await assetsPage.gotoFiles();
+			await assetsPage.changeVisualizationMode('Table');
+
+			const dataSetPage = new DataSetPage(page);
+
+			await dataSetPage.search(titlePrefix);
+
+			await page.getByLabel('Select All Items on the Page').check();
+
+			await dataSetPage.selectAll();
+
+			await expectBulkActionAbsent(page, 'Download');
+		});
+	}
+);


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-86106

Even though bulk action backend checks permissions, the FDS was always rendering them no matter what.

# How am I fixing it?

By matching each bulk action with its corresponding permission key in the frontend.

# How can you verify that it works?

Run the included function tests.