### PR TITLE
LPD-86554: validates viewEntryURL and coverImageURL parameters to ens…

### DIFF
--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/entry_cover_image_caption.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/entry_cover_image_caption.jsp
@@ -13,7 +13,7 @@ String coverImageURL = ParamUtil.getString(request, "coverImageURL");
 
 String viewEntryURL = ParamUtil.getString(request, "viewEntryURL");
 
-boolean validViewEntryURL = Validator.isNotNull(viewEntryURL) && Validator.isUrl(viewEntryURL);
+boolean validViewEntryURL = Validator.isUrl(viewEntryURL);
 %>
 
 <c:if test="<%= Validator.isURL(coverImageURL) %>">

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/entry_cover_image_caption.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/entry_cover_image_caption.jsp
@@ -16,13 +16,13 @@ String viewEntryURL = ParamUtil.getString(request, "viewEntryURL");
 boolean validViewEntryURL = Validator.isNotNull(viewEntryURL) && Validator.isUrl(viewEntryURL);
 %>
 
-<c:if test="<%= Validator.isNotNull(coverImageURL) %>">
+<c:if test="<%= Validator.isURL(coverImageURL) %>">
 	<c:if test="<%= validViewEntryURL %>">
 		<a href="<%= HtmlUtil.escapeHREF(viewEntryURL) %>">
 	</c:if>
 
 	<liferay-ui:csp>
-		<div <c:if test="<%= Validator.isNotNull(coverImageCaption) %>">aria-label="<%= HtmlUtil.escapeAttribute(HtmlUtil.stripHtml(coverImageCaption)) %>" role="img"</c:if> class="aspect-ratio aspect-ratio-8-to-3 aspect-ratio-bg-cover cover-image" style="background-image: url(<%= HtmlUtil.escapeAttribute(coverImageURL) %>);"></div>
+		<div <c:if test="<%= Validator.isNotNull(coverImageCaption) %>">aria-label="<%= HtmlUtil.escapeAttribute(HtmlUtil.stripHtml(coverImageCaption)) %>" role="img"</c:if> class="aspect-ratio aspect-ratio-8-to-3 aspect-ratio-bg-cover cover-image" style="background-image: url('<%= HtmlUtil.escapeAttribute(coverImageURL) %>');"></div>
 	</liferay-ui:csp>
 
 	<c:if test="<%= validViewEntryURL %>">

--- a/modules/test/playwright/tests/blogs-web/main/blogEntry.spec.ts
+++ b/modules/test/playwright/tests/blogs-web/main/blogEntry.spec.ts
@@ -11,6 +11,7 @@ import {apiHelpersTest} from '../../../fixtures/apiHelpersTest';
 import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
 import {isolatedSiteTest} from '../../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../../fixtures/loginTest';
+import {liferayConfig} from '../../../liferay.config';
 import getRandomString from '../../../utils/getRandomString';
 import {watchForDialog} from '../../../utils/watchForDialog';
 import {blogsPagesTest} from './fixtures/blogsPagesTest';
@@ -687,5 +688,86 @@ test(
 		for (const title of titles) {
 			await blogsPage.assertEntryPresent(title, false);
 		}
+	}
+);
+
+test(
+	'Prevents attribute injection via coverImageCaption',
+	{
+		tag: '@LPD-86554',
+	},
+	async ({page}) => {
+		const payload = `" onmouseover=alert(1) x="`;
+
+		await page.goto(
+			`${liferayConfig.environment.baseUrl}/o/blogs-web/blogs/entry_cover_image_caption.jsp?coverImageCaption=${encodeURIComponent(payload)}&coverImageURL=https://example.com/image.png`
+		);
+
+		await expect(page.locator('.cover-image')).not.toHaveAttribute('onmouseover', /.+/);
+		await expect(page.locator('.cover-image')).toHaveAttribute('aria-label', /onmouseover=alert\(1\)/);
+	}
+);
+
+test(
+	'Prevents HTML injection via coverImageCaption',
+	{
+		tag: '@LPD-86554',
+	},
+	async ({page}) => {
+		const payload = `"><img src=x onerror=alert(1)>`;
+
+		await page.goto(
+			`${liferayConfig.environment.baseUrl}/o/blogs-web/blogs/entry_cover_image_caption.jsp?coverImageCaption=${encodeURIComponent(payload)}&coverImageURL=https://example.com/image.png`
+		);
+
+		await expect(page.getByRole('img')).toHaveCount(0);
+	}
+);
+
+test(
+	'Does not allow javascript URL in coverImageURL',
+	{
+		tag: '@LPD-86554',
+	},
+	async ({page}) => {
+		const payload = `javascript:alert(1)`;
+
+		await page.goto(
+			`${liferayConfig.environment.baseUrl}/o/blogs-web/blogs/entry_cover_image_caption.jsp?coverImageCaption=safe&coverImageURL=${encodeURIComponent(payload)}`
+		);
+
+		await expect(page.locator('.cover-image')).toHaveCount(0);
+	}
+);
+
+test(
+	'Only valid URLs are applied to background-image',
+	{
+		tag: '@LPD-86554',
+	},
+	async ({page}) => {
+		const validUrl = 'https://example.com/image.png';
+
+		await page.goto(
+			`${liferayConfig.environment.baseUrl}/o/blogs-web/blogs/entry_cover_image_caption.jsp?coverImageCaption=safe&coverImageURL=${encodeURIComponent(validUrl)}`
+		);
+
+		await expect(page.locator('.cover-image')).toHaveAttribute('style', new RegExp(validUrl));
+	}
+);
+
+test(
+	'Invalid URL prevents background-image rendering',
+	{
+		tag: '@LPD-86554',
+	},
+	async ({page}) => {
+		const invalidUrl = `not-a-valid-url`;
+
+		await page.goto(
+			`${liferayConfig.environment.baseUrl}/o/blogs-web/blogs/entry_cover_image_caption.jsp?coverImageCaption=safe&coverImageURL=${encodeURIComponent(invalidUrl)}`
+		);
+
+		await expect(page.locator('.cover-image')).toHaveCount(0);
 	}
 );

--- a/modules/test/playwright/tests/blogs-web/main/blogEntry.spec.ts
+++ b/modules/test/playwright/tests/blogs-web/main/blogEntry.spec.ts
@@ -703,8 +703,14 @@ test(
 			`${liferayConfig.environment.baseUrl}/o/blogs-web/blogs/entry_cover_image_caption.jsp?coverImageCaption=${encodeURIComponent(payload)}&coverImageURL=https://example.com/image.png`
 		);
 
-		await expect(page.locator('.cover-image')).not.toHaveAttribute('onmouseover', /.+/);
-		await expect(page.locator('.cover-image')).toHaveAttribute('aria-label', /onmouseover=alert\(1\)/);
+		await expect(page.locator('.cover-image')).not.toHaveAttribute(
+			'onmouseover',
+			/.+/
+		);
+		await expect(page.locator('.cover-image')).toHaveAttribute(
+			'aria-label',
+			/onmouseover=alert\(1\)/
+		);
 	}
 );
 
@@ -752,7 +758,10 @@ test(
 			`${liferayConfig.environment.baseUrl}/o/blogs-web/blogs/entry_cover_image_caption.jsp?coverImageCaption=safe&coverImageURL=${encodeURIComponent(validUrl)}`
 		);
 
-		await expect(page.locator('.cover-image')).toHaveAttribute('style', new RegExp(validUrl));
+		await expect(page.locator('.cover-image')).toHaveAttribute(
+			'style',
+			new RegExp(validUrl)
+		);
 	}
 );
 


### PR DESCRIPTION
followup of https://github.com/liferay-content-management/liferay-portal/pull/8079

What is this trying to solve?
https://liferay.atlassian.net/browse/LPD-86554

How am I fixing it?
Validate coverImageURL and viewEntryURL using Validator.isUrl

How can you verify that it works?
run the included playwright tests

cc djbrownjr40 , like this