### PR TITLE
LPD-87713 Enable Widget Questions deprecation flag via Instance Settings setUp task

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/questions/QuestionsAllQuestionsList.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/questions/QuestionsAllQuestionsList.testcase
@@ -1,7 +1,6 @@
 @component-name = "portal-content-management"
 definition {
 
-	property custom.properties = "feature.flag.LPD-82301=true";
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property testray.main.component.name = "Questions";
@@ -10,6 +9,20 @@ definition {
 		TestCase.setUpPortalInstance();
 
 		User.firstLoginPG();
+
+		task ("Enable Widget Questions deprecation feature flag") {
+			PortalSettings.openInstanceSettingsAdmin();
+
+			SystemSettings.gotoConfiguration(
+				configurationCategory = "Feature Flags",
+				configurationName = "Deprecation",
+				configurationScope = "Virtual Instance Scope");
+
+			FeatureFlag.enableFeatureFlag(
+				configurationScope = "Virtual Instance Scope",
+				featureFlag = "Widget Questions",
+				scope = "Deprecation");
+		}
 
 		JSONLayout.addPublicLayout(
 			groupName = "Guest",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/questions/QuestionsDetailedView.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/questions/QuestionsDetailedView.testcase
@@ -1,7 +1,6 @@
 @component-name = "portal-content-management"
 definition {
 
-	property custom.properties = "feature.flag.LPD-82301=true";
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property testray.main.component.name = "Questions";
@@ -10,6 +9,20 @@ definition {
 		TestCase.setUpPortalInstance();
 
 		User.firstLoginPG();
+
+		task ("Enable Widget Questions deprecation feature flag") {
+			PortalSettings.openInstanceSettingsAdmin();
+
+			SystemSettings.gotoConfiguration(
+				configurationCategory = "Feature Flags",
+				configurationName = "Deprecation",
+				configurationScope = "Virtual Instance Scope");
+
+			FeatureFlag.enableFeatureFlag(
+				configurationScope = "Virtual Instance Scope",
+				featureFlag = "Widget Questions",
+				scope = "Deprecation");
+		}
 
 		JSONLayout.addPublicLayout(
 			groupName = "Guest",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/questions/QuestionsEntry.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/questions/QuestionsEntry.testcase
@@ -2,7 +2,6 @@
 definition {
 
 	property browser.chrome.version = "139.0";
-	property custom.properties = "feature.flag.LPD-82301=true";
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property testray.main.component.name = "Questions";
@@ -11,6 +10,20 @@ definition {
 		TestCase.setUpPortalInstance();
 
 		User.firstLoginPG();
+
+		task ("Enable Widget Questions deprecation feature flag") {
+			PortalSettings.openInstanceSettingsAdmin();
+
+			SystemSettings.gotoConfiguration(
+				configurationCategory = "Feature Flags",
+				configurationName = "Deprecation",
+				configurationScope = "Virtual Instance Scope");
+
+			FeatureFlag.enableFeatureFlag(
+				configurationScope = "Virtual Instance Scope",
+				featureFlag = "Widget Questions",
+				scope = "Deprecation");
+		}
 
 		JSONLayout.addPublicLayout(
 			groupName = "Guest",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/questions/QuestionsEntryTag.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/questions/QuestionsEntryTag.testcase
@@ -1,7 +1,6 @@
 @component-name = "portal-content-management"
 definition {
 
-	property custom.properties = "feature.flag.LPD-82301=true";
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property testray.main.component.name = "Questions";
@@ -10,6 +9,20 @@ definition {
 		TestCase.setUpPortalInstance();
 
 		User.firstLoginPG();
+
+		task ("Enable Widget Questions deprecation feature flag") {
+			PortalSettings.openInstanceSettingsAdmin();
+
+			SystemSettings.gotoConfiguration(
+				configurationCategory = "Feature Flags",
+				configurationName = "Deprecation",
+				configurationScope = "Virtual Instance Scope");
+
+			FeatureFlag.enableFeatureFlag(
+				configurationScope = "Virtual Instance Scope",
+				featureFlag = "Widget Questions",
+				scope = "Deprecation");
+		}
 
 		JSONLayout.addPublicLayout(
 			groupName = "Guest",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/questions/QuestionsLocalization.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/questions/QuestionsLocalization.testcase
@@ -1,7 +1,6 @@
 @component-name = "portal-content-management"
 definition {
 
-	property custom.properties = "feature.flag.LPD-82301=true";
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property testray.main.component.name = "Questions";
@@ -10,6 +9,20 @@ definition {
 		TestCase.setUpPortalInstance();
 
 		User.firstLoginPG();
+
+		task ("Enable Widget Questions deprecation feature flag") {
+			PortalSettings.openInstanceSettingsAdmin();
+
+			SystemSettings.gotoConfiguration(
+				configurationCategory = "Feature Flags",
+				configurationName = "Deprecation",
+				configurationScope = "Virtual Instance Scope");
+
+			FeatureFlag.enableFeatureFlag(
+				configurationScope = "Virtual Instance Scope",
+				featureFlag = "Widget Questions",
+				scope = "Deprecation");
+		}
 
 		JSONLayout.addPublicLayout(
 			groupName = "Guest",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/questions/QuestionsPermissions.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/questions/QuestionsPermissions.testcase
@@ -1,7 +1,6 @@
 @component-name = "portal-content-management"
 definition {
 
-	property custom.properties = "feature.flag.LPD-82301=true";
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property testray.main.component.name = "Questions";
@@ -10,6 +9,20 @@ definition {
 		TestCase.setUpPortalInstance();
 
 		User.firstLoginPG();
+
+		task ("Enable Widget Questions deprecation feature flag") {
+			PortalSettings.openInstanceSettingsAdmin();
+
+			SystemSettings.gotoConfiguration(
+				configurationCategory = "Feature Flags",
+				configurationName = "Deprecation",
+				configurationScope = "Virtual Instance Scope");
+
+			FeatureFlag.enableFeatureFlag(
+				configurationScope = "Virtual Instance Scope",
+				featureFlag = "Widget Questions",
+				scope = "Deprecation");
+		}
 
 		JSONLayout.addPublicLayout(
 			groupName = "Guest",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/questions/QuestionsSubscriptionEnhanchement.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/questions/QuestionsSubscriptionEnhanchement.testcase
@@ -2,7 +2,6 @@
 definition {
 
 	property browser.chrome.version = "139.0";
-	property custom.properties = "feature.flag.LPD-82301=true";
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property testray.main.component.name = "Questions";
@@ -11,6 +10,20 @@ definition {
 		TestCase.setUpPortalInstance();
 
 		User.firstLoginPG();
+
+		task ("Enable Widget Questions deprecation feature flag") {
+			PortalSettings.openInstanceSettingsAdmin();
+
+			SystemSettings.gotoConfiguration(
+				configurationCategory = "Feature Flags",
+				configurationName = "Deprecation",
+				configurationScope = "Virtual Instance Scope");
+
+			FeatureFlag.enableFeatureFlag(
+				configurationScope = "Virtual Instance Scope",
+				featureFlag = "Widget Questions",
+				scope = "Deprecation");
+		}
 
 		JSONLayout.addPublicLayout(
 			groupName = "Guest",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/questions/QuestionsWorkflow.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/questions/QuestionsWorkflow.testcase
@@ -1,7 +1,6 @@
 @component-name = "portal-content-management"
 definition {
 
-	property custom.properties = "feature.flag.LPD-82301=true";
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property testray.main.component.name = "Questions";
@@ -10,6 +9,20 @@ definition {
 		TestCase.setUpPortalInstance();
 
 		User.firstLoginPG();
+
+		task ("Enable Widget Questions deprecation feature flag") {
+			PortalSettings.openInstanceSettingsAdmin();
+
+			SystemSettings.gotoConfiguration(
+				configurationCategory = "Feature Flags",
+				configurationName = "Deprecation",
+				configurationScope = "Virtual Instance Scope");
+
+			FeatureFlag.enableFeatureFlag(
+				configurationScope = "Virtual Instance Scope",
+				featureFlag = "Widget Questions",
+				scope = "Deprecation");
+		}
 
 		JSONLayout.addPublicLayout(
 			groupName = "Guest",


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-87713

**What is being fixed:** A CMS test run on Testray reported 78 failing test cases under the Questions component, spread across 8 testcase files (`QuestionsEntry`, `QuestionsLocalization`, `QuestionsSubscriptionEnhanchement`, `QuestionsEntryTag`, `QuestionsAllQuestionsList`, `QuestionsPermissions`, `QuestionsWorkflow`, `QuestionsDetailedView`). All failures are `ElementNotFoundPoshiRunnerException` instances — across 41 distinct selectors — for elements that only render when the Questions UI is enabled (question cards, "Add Answer" / "Add Comment" / "New Topic" buttons, the questions search input, the bell-on subscription button, the questions empty-state message, etc.). The Questions feature is gated by `feature.flag.LPD-82301` ("Widget Questions"), introduced by `LPD-82305` (Hide QuestionsPortlet, configurations, add/widget pages, and collection display behind FF LPD-82301).

**Why the existing per-file `custom.properties` line was not enough:** Each of the 8 testcase files already declared, at the `definition { … }` level:

    property custom.properties = "feature.flag.LPD-82301=true";

This works locally — the Poshi runner injects the property into the portal at boot — but the value is **ignored by CI for feature flags whose `feature.flag.LPD-XXXXX.type=deprecation`**. Deprecation-typed flags follow the deprecation lifecycle and cannot be re-enabled by a system property in the CI environment, so on every Testray run the flag is effectively off, the Questions UI never renders, and every selector lookup misses. We confirmed this empirically by running `QuestionsEntry#CanEditAnswer` locally (passes, with the property line) and observing the Testray failure for the same case (fails, despite the property line).

**How it is being fixed:** Replace the property line with an explicit `setUp` task that signs into the running portal, opens Instance Settings, navigates to **System Settings → Feature Flags → Deprecation** at **Virtual Instance Scope**, and toggles **Widget Questions** on. This is the same pattern already used elsewhere in the suite for deprecation-typed flags (see `ABTesting.testcase`, `ContentPageReview.testcase`, `SitesExportImport.testcase`, the segmentation testcases, etc.), but adapted for the Virtual Instance Scope:

    setUp {
        TestCase.setUpPortalInstance();

        User.firstLoginPG();

        task ("Enable Widget Questions deprecation feature flag") {
            PortalSettings.openInstanceSettingsAdmin();

            SystemSettings.gotoConfiguration(
                configurationCategory = "Feature Flags",
                configurationName = "Deprecation",
                configurationScope = "Virtual Instance Scope");

            FeatureFlag.enableFeatureFlag(
                configurationScope = "Virtual Instance Scope",
                featureFlag = "Widget Questions",
                scope = "Deprecation");
        }

        // existing setup steps (layout, widget, etc.)
    }

The task runs **after** `TestCase.setUpPortalInstance()` and `User.firstLoginPG()` because the portal instance must exist and an admin user must be signed in before Instance Settings can be opened — otherwise the Virtual Instance Scope navigation has nothing to render.

**Scope of changes:**

- 8 testcase files updated (every Questions testcase file under `portal-web/test/functional/.../enduser/collaboration/questions/`).
- The class-level `property custom.properties = "feature.flag.LPD-82301=true";` is removed from each file.
- A `task ("Enable Widget Questions deprecation feature flag") { … }` is added in each file's `setUp` block, right after `User.firstLoginPG();`.
- Source formatter (`ant format-source-current-branch`) was run; no formatter-driven diffs.

**How to execute the tests:** Each impacted test runs as a Poshi single-test invocation. A representative spot check that was verified locally with this branch:

    HOSTNAME=localhost ant -buildfile build-test.xml run-selenium-test -Dtest.class=QuestionsEntry#CanEditAnswer

Replace the `-Dtest.class=` value with any of the 78 affected `<TestcaseFile>#<TestName>` pairs. To run a whole testcase file, drop the `#<TestName>` suffix.

_AI-assisted with Claude Code._