### PR TITLE
[release-blocker] LPD-87861 fix importation process for Tags, categories and Vocabularies

### DIFF
--- a/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/exportimport/data/handler/AssetCategoryStagedModelDataHandler.java
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/exportimport/data/handler/AssetCategoryStagedModelDataHandler.java
@@ -283,6 +283,7 @@ public class AssetCategoryStagedModelDataHandler
 		}
 
 		importedCategory.setUuid(category.getUuid());
+		importedCategory.setModifiedDate(category.getModifiedDate());
 
 		importedCategory = _assetCategoryLocalService.updateAssetCategory(
 			importedCategory);

--- a/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/exportimport/data/handler/AssetVocabularyStagedModelDataHandler.java
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/exportimport/data/handler/AssetVocabularyStagedModelDataHandler.java
@@ -261,6 +261,7 @@ public class AssetVocabularyStagedModelDataHandler
 		}
 
 		importedVocabulary.setUuid(vocabulary.getUuid());
+		importedVocabulary.setModifiedDate(vocabulary.getModifiedDate());
 
 		importedVocabulary = _assetVocabularyLocalService.updateAssetVocabulary(
 			importedVocabulary);

--- a/modules/apps/asset/asset-tags-service/src/main/java/com/liferay/asset/tags/internal/exportimport/data/handler/AssetTagStagedModelDataHandler.java
+++ b/modules/apps/asset/asset-tags-service/src/main/java/com/liferay/asset/tags/internal/exportimport/data/handler/AssetTagStagedModelDataHandler.java
@@ -203,6 +203,7 @@ public class AssetTagStagedModelDataHandler
 		}
 
 		importedAssetTag.setUuid(assetTag.getUuid());
+		importedAssetTag.setModifiedDate(assetTag.getModifiedDate());
 
 		importedAssetTag = _assetTagLocalService.updateAssetTag(
 			importedAssetTag);


### PR DESCRIPTION
LPD-87861 Preserve source modifiedDate when importing asset tags, categories, and vocabularies 
 
# What is this trying to solve? 
 
https://liferay.atlassian.net/browse/LPD-87861 
 
The asset tag, category, and vocabulary staged-model data handlers leave the imported entity with a `modifiedDate` a few milliseconds after the source's, breaking export/import ound-trip equality and causing intermittent failures in the three corresponding `*StagedModelDataHandlerTest` integration tests.
 
# How am I fixing it? 

In each of the three handlers, the source `modifiedDate` is now copied onto the imported entity right before the final `updateAssetX(...)` call — alongside the existing `setUuid(...)`
This matches the precedent already used by `JournalArticleStagedModelDataHandler`, `CalendarStagedModelDataHandler`, `AssetListEntryStagedModelDataHandler`, and `MBMessageStagedModelDataHandler`. The model's `etModifiedDate` flips its `_setModifiedDate` flag, preventing the persistence layer from re-stamping the field with the current time on the second save.  
  
# How can you verify that it works?
Run the included automated tests.

# Why doesn't this include any test?
There are already tests that cover this — `AssetTagStagedModelDataHandlerTest`, `AssetCategoryStagedModelDataHandlerTest`, and `AssetVocabularyStagedModelDataHandlerTest` (both `estStagedModelDataHandler` and `testCleanStagedModelDataHandler`). They were precisely the ones failing intermittently, and they assert millisecond-level equality of `modifiedDate` after the export/import ound-trip.
 

# Commits
- 3f8973408aa63 — LPD-87861 update the modified date on importation 