### PR TITLE
LPD-87676 Consolidate portal-content-management Poshi tests (round 3)

### DIFF
--- a/modules/apps/depot/depot-test/src/testFunctional/tests/DepotDocumentSiteIntegration.testcase
+++ b/modules/apps/depot/depot-test/src/testFunctional/tests/DepotDocumentSiteIntegration.testcase
@@ -189,7 +189,7 @@ definition {
 
 	@description = "This ensures that a document in a connected site can be copied to the depot."
 	@priority = 5
-	test CanCopyDocumentFromConnectedSiteToDepot {
+	test CanCopyDocumentFromConnectedSiteToDepotAndCannotFromUnconnected {
 		JSONDepot.connectSite(
 			depotName = "Test Depot Name",
 			groupName = "Site Name");

--- a/modules/apps/depot/depot-test/src/testFunctional/tests/DepotDocumentSiteIntegration.testcase
+++ b/modules/apps/depot/depot-test/src/testFunctional/tests/DepotDocumentSiteIntegration.testcase
@@ -280,7 +280,7 @@ definition {
 
 	@description = "This ensures that a folder in a connected site can be copied to the depot."
 	@priority = 5
-	test CanCopyFolderFromConnectedSiteToDepot {
+	test CanCopyFolderFromConnectedSiteToDepotAndCannotFromUnconnected {
 		JSONDepot.connectSite(
 			depotName = "Test Depot Name",
 			groupName = "Site Name");

--- a/modules/apps/depot/depot-test/src/testFunctional/tests/DepotDocumentSiteIntegration.testcase
+++ b/modules/apps/depot/depot-test/src/testFunctional/tests/DepotDocumentSiteIntegration.testcase
@@ -211,6 +211,20 @@ definition {
 		DepotNavigator.openDepotDocumentsAndMediaAdmin(depotName = "Test Depot Name");
 
 		LexiconEntry.viewEntryName(rowEntry = "DM Document Title");
+
+		JSONDepot.disconnectSite(groupName = "Site Name");
+
+		DMNavigator.openDocumentsAndMediaAdmin(siteURLKey = "site-name");
+
+		LexiconEntry.gotoEntryMenuItem(
+			menuItem = "Copy To",
+			rowEntry = "DM Document Title");
+
+		Button.clickSelect();
+
+		ItemSelector.changeWorkspaces(workspacesType = "Asset Library");
+
+		LexiconCard.viewCardNotPresent(card = "Test Depot Name");
 	}
 
 	@description = "This ensures that a document in a depot can be copied to the connected site."
@@ -345,29 +359,6 @@ definition {
 		DMNavigator.openDocumentsAndMediaAdmin(siteURLKey = "site-name");
 
 		LexiconEntry.viewNoEntry(rowEntry = "DM Document Title");
-	}
-
-	@description = "This ensures that a document in a site can not be copied to the unconnected depot."
-	@priority = 4
-	test CannotCopyDocumentFromUnconnectedSiteToDepot {
-		JSONDocument.addFileWithUploadedFile(
-			dmDocumentDescription = "DM Document Description",
-			dmDocumentTitle = "DM Document Title",
-			groupName = "Site Name",
-			mimeType = "image/jpeg",
-			sourceFileName = "Document_2.jpeg");
-
-		DMNavigator.openDocumentsAndMediaAdmin(siteURLKey = "site-name");
-
-		LexiconEntry.gotoEntryMenuItem(
-			menuItem = "Copy To",
-			rowEntry = "DM Document Title");
-
-		Button.clickSelect();
-
-		ItemSelector.changeWorkspaces(workspacesType = "Asset Library");
-
-		LexiconCard.viewCardNotPresent(card = "Test Depot Name");
 	}
 
 	@description = "This ensures that a folder in a depot can not be copied to an unconnected site."

--- a/modules/apps/depot/depot-test/src/testFunctional/tests/DepotDocumentSiteIntegration.testcase
+++ b/modules/apps/depot/depot-test/src/testFunctional/tests/DepotDocumentSiteIntegration.testcase
@@ -189,7 +189,7 @@ definition {
 
 	@description = "This ensures that a document in a site can be copied to the depot when connected, but not when unconnected."
 	@priority = 5
-	test CanCopyDocumentFromConnectedSiteToDepotAndCannotFromUnconnected {
+	test CanCopyDocumentFromConnectedSiteToDepotAndCannotFromUnconnectedSite {
 		JSONDepot.connectSite(
 			depotName = "Test Depot Name",
 			groupName = "Site Name");
@@ -229,7 +229,7 @@ definition {
 
 	@description = "This ensures that a document in a depot can be copied to a site when connected, but not when unconnected."
 	@priority = 5
-	test CanCopyDocumentFromDepotToConnectedSiteAndCannotToUnconnected {
+	test CanCopyDocumentFromDepotToConnectedSiteAndCannotToUnconnectedSite {
 		JSONDepot.connectSite(
 			depotName = "Test Depot Name",
 			groupName = "Site Name");
@@ -280,7 +280,7 @@ definition {
 
 	@description = "This ensures that a folder in a site can be copied to the depot when connected, but not when unconnected."
 	@priority = 5
-	test CanCopyFolderFromConnectedSiteToDepotAndCannotFromUnconnected {
+	test CanCopyFolderFromConnectedSiteToDepotAndCannotFromUnconnectedSite {
 		JSONDepot.connectSite(
 			depotName = "Test Depot Name",
 			groupName = "Site Name");
@@ -332,7 +332,7 @@ definition {
 
 	@description = "This ensures that a folder in a depot can be copied to a site when connected, but not when unconnected."
 	@priority = 5
-	test CanCopyFolderFromDepotToConnectedSiteAndCannotToUnconnected {
+	test CanCopyFolderFromDepotToConnectedSiteAndCannotToUnconnectedSite {
 		JSONDepot.connectSite(
 			depotName = "Test Depot Name",
 			groupName = "Site Name");

--- a/modules/apps/depot/depot-test/src/testFunctional/tests/DepotDocumentSiteIntegration.testcase
+++ b/modules/apps/depot/depot-test/src/testFunctional/tests/DepotDocumentSiteIntegration.testcase
@@ -332,7 +332,7 @@ definition {
 
 	@description = "This ensures that a folder in a depot can be copied to the connected site."
 	@priority = 5
-	test CanCopyFolderFromDepotToConnectedSite {
+	test CanCopyFolderFromDepotToConnectedSiteAndCannotToUnconnected {
 		JSONDepot.connectSite(
 			depotName = "Test Depot Name",
 			groupName = "Site Name");

--- a/modules/apps/depot/depot-test/src/testFunctional/tests/DepotDocumentSiteIntegration.testcase
+++ b/modules/apps/depot/depot-test/src/testFunctional/tests/DepotDocumentSiteIntegration.testcase
@@ -371,27 +371,25 @@ definition {
 			siteURLKey = "site-name");
 
 		LexiconEntry.viewEntryName(rowEntry = "DM Document Title");
-	}
 
-	@description = "This ensures that a folder in a depot can not be copied to an unconnected site."
-	@priority = 4
-	test CannotCopyFolderFromDepotToUnconnectedSite {
+		JSONDepot.disconnectSite(groupName = "Site Name");
+
 		JSONFolder.addFolder(
 			dmFolderDescription = "DM Folder Description",
-			dmFolderName = "DM Folder Name",
+			dmFolderName = "DM Folder Name 2",
 			groupName = "Test Depot Name");
 
 		DepotNavigator.openDepotDocumentsAndMediaAdmin(depotName = "Test Depot Name");
 
 		DMFolder.copy(
 			copyToUnconnectedSite = "true",
-			dmFolderName = "DM Folder Name",
+			dmFolderName = "DM Folder Name 2",
 			homeFolder = "true",
 			siteName = "Site Name");
 
 		DMNavigator.openDocumentsAndMediaAdmin(siteURLKey = "site-name");
 
-		LexiconEntry.viewNoEntry(rowEntry = "DM Folder Name");
+		LexiconEntry.viewNoEntry(rowEntry = "DM Folder Name 2");
 	}
 
 	@description = "This ensures that a document using a type stored in AL can be removed on a connected site."

--- a/modules/apps/depot/depot-test/src/testFunctional/tests/DepotDocumentSiteIntegration.testcase
+++ b/modules/apps/depot/depot-test/src/testFunctional/tests/DepotDocumentSiteIntegration.testcase
@@ -187,7 +187,7 @@ definition {
 			webContentTitle = "WC WebContent Title");
 	}
 
-	@description = "This ensures that a document in a connected site can be copied to the depot."
+	@description = "This ensures that a document in a site can be copied to the depot when connected, but not when unconnected."
 	@priority = 5
 	test CanCopyDocumentFromConnectedSiteToDepotAndCannotFromUnconnected {
 		JSONDepot.connectSite(
@@ -227,7 +227,7 @@ definition {
 		LexiconCard.viewCardNotPresent(card = "Test Depot Name");
 	}
 
-	@description = "This ensures that a document in a depot can be copied to the connected site."
+	@description = "This ensures that a document in a depot can be copied to a site when connected, but not when unconnected."
 	@priority = 5
 	test CanCopyDocumentFromDepotToConnectedSiteAndCannotToUnconnected {
 		JSONDepot.connectSite(
@@ -278,7 +278,7 @@ definition {
 		LexiconEntry.viewNoEntry(rowEntry = "DM Document Title 2");
 	}
 
-	@description = "This ensures that a folder in a connected site can be copied to the depot."
+	@description = "This ensures that a folder in a site can be copied to the depot when connected, but not when unconnected."
 	@priority = 5
 	test CanCopyFolderFromConnectedSiteToDepotAndCannotFromUnconnected {
 		JSONDepot.connectSite(
@@ -330,7 +330,7 @@ definition {
 		LexiconCard.viewCardNotPresent(card = "Test Depot Name");
 	}
 
-	@description = "This ensures that a folder in a depot can be copied to the connected site."
+	@description = "This ensures that a folder in a depot can be copied to a site when connected, but not when unconnected."
 	@priority = 5
 	test CanCopyFolderFromDepotToConnectedSiteAndCannotToUnconnected {
 		JSONDepot.connectSite(

--- a/modules/apps/depot/depot-test/src/testFunctional/tests/DepotDocumentSiteIntegration.testcase
+++ b/modules/apps/depot/depot-test/src/testFunctional/tests/DepotDocumentSiteIntegration.testcase
@@ -255,6 +255,27 @@ definition {
 		DMNavigator.openDocumentsAndMediaAdmin(siteURLKey = "site-name");
 
 		LexiconEntry.viewEntryName(rowEntry = "DM Document Title");
+
+		JSONDepot.disconnectSite(groupName = "Site Name");
+
+		JSONDocument.addFileWithUploadedFile(
+			dmDocumentDescription = "DM Document Description",
+			dmDocumentTitle = "DM Document Title 2",
+			groupName = "Test Depot Name",
+			mimeType = "application/msword",
+			sourceFileName = "Document_1.doc");
+
+		DepotNavigator.openDepotDocumentsAndMediaAdmin(depotName = "Test Depot Name");
+
+		DMDocument.copy(
+			copyToUnconnectedSite = "true",
+			dmDocumentTitle = "DM Document Title 2",
+			homeFolder = "true",
+			siteName = "Site Name");
+
+		DMNavigator.openDocumentsAndMediaAdmin(siteURLKey = "site-name");
+
+		LexiconEntry.viewNoEntry(rowEntry = "DM Document Title 2");
 	}
 
 	@description = "This ensures that a folder in a connected site can be copied to the depot."
@@ -336,29 +357,6 @@ definition {
 			siteURLKey = "site-name");
 
 		LexiconEntry.viewEntryName(rowEntry = "DM Document Title");
-	}
-
-	@description = "This ensures that a document in a depot can not be copied to an unconnected site."
-	@priority = 4
-	test CannotCopyDocumentFromDepotToUnconnectedSite {
-		JSONDocument.addFileWithUploadedFile(
-			dmDocumentDescription = "DM Document Description",
-			dmDocumentTitle = "DM Document Title",
-			groupName = "Test Depot Name",
-			mimeType = "application/msword",
-			sourceFileName = "Document_1.doc");
-
-		DepotNavigator.openDepotDocumentsAndMediaAdmin(depotName = "Test Depot Name");
-
-		DMDocument.copy(
-			copyToUnconnectedSite = "true",
-			dmDocumentTitle = "DM Document Title",
-			homeFolder = "true",
-			siteName = "Site Name");
-
-		DMNavigator.openDocumentsAndMediaAdmin(siteURLKey = "site-name");
-
-		LexiconEntry.viewNoEntry(rowEntry = "DM Document Title");
 	}
 
 	@description = "This ensures that a folder in a depot can not be copied to an unconnected site."

--- a/modules/apps/depot/depot-test/src/testFunctional/tests/DepotDocumentSiteIntegration.testcase
+++ b/modules/apps/depot/depot-test/src/testFunctional/tests/DepotDocumentSiteIntegration.testcase
@@ -314,6 +314,20 @@ definition {
 			folderName = "DM Folder Name");
 
 		LexiconEntry.viewEntryName(rowEntry = "DM Document Title");
+
+		JSONDepot.disconnectSite(groupName = "Site Name");
+
+		DMNavigator.openDocumentsAndMediaAdmin(siteURLKey = "site-name");
+
+		LexiconEntry.gotoEntryMenuItem(
+			menuItem = "Copy To",
+			rowEntry = "DM Folder Name");
+
+		Button.clickSelect();
+
+		ItemSelector.changeWorkspaces(workspacesType = "Asset Library");
+
+		LexiconCard.viewCardNotPresent(card = "Test Depot Name");
 	}
 
 	@description = "This ensures that a folder in a depot can be copied to the connected site."
@@ -378,27 +392,6 @@ definition {
 		DMNavigator.openDocumentsAndMediaAdmin(siteURLKey = "site-name");
 
 		LexiconEntry.viewNoEntry(rowEntry = "DM Folder Name");
-	}
-
-	@description = "This ensures that a folder in a site can not be copied to the unconnected depot."
-	@priority = 4
-	test CannotCopyFolderFromUnconnectedSiteToDepot {
-		JSONFolder.addFolder(
-			dmFolderDescription = "DM Folder Description",
-			dmFolderName = "DM Folder Name",
-			groupName = "Site Name");
-
-		DMNavigator.openDocumentsAndMediaAdmin(siteURLKey = "site-name");
-
-		LexiconEntry.gotoEntryMenuItem(
-			menuItem = "Copy To",
-			rowEntry = "DM Folder Nam");
-
-		Button.clickSelect();
-
-		ItemSelector.changeWorkspaces(workspacesType = "Asset Library");
-
-		LexiconCard.viewCardNotPresent(card = "Test Depot Name");
 	}
 
 	@description = "This ensures that a document using a type stored in AL can be removed on a connected site."

--- a/modules/apps/depot/depot-test/src/testFunctional/tests/DepotDocumentSiteIntegration.testcase
+++ b/modules/apps/depot/depot-test/src/testFunctional/tests/DepotDocumentSiteIntegration.testcase
@@ -229,7 +229,7 @@ definition {
 
 	@description = "This ensures that a document in a depot can be copied to the connected site."
 	@priority = 5
-	test CanCopyDocumentFromDepotToConnectedSite {
+	test CanCopyDocumentFromDepotToConnectedSiteAndCannotToUnconnected {
 		JSONDepot.connectSite(
 			depotName = "Test Depot Name",
 			groupName = "Site Name");

--- a/modules/apps/depot/depot-test/src/testFunctional/tests/DepotLocalStagingDM.testcase
+++ b/modules/apps/depot/depot-test/src/testFunctional/tests/DepotLocalStagingDM.testcase
@@ -231,109 +231,6 @@ definition {
 		OpenGraph.viewNoPreviewImage(imageName = "Document_2.jpg");
 	}
 
-	@description = "This ensures that the image in depot can be removed and republished in web content when enabling local staging."
-	@priority = 5
-	@refactordone
-	test CanDeleteWCImage {
-		JSONDocument.addFileWithUploadedFile(
-			dmDocumentDescription = "DM Document Description",
-			dmDocumentTitle = "Document_1.jpg",
-			groupName = "Test Depot Name-staging",
-			mimeType = "image/jpeg",
-			sourceFileName = "Document_1.jpg");
-
-		DepotNavigator.openDepotDocumentsAndMediaAdminStaging(depotName = "Test Depot Name");
-
-		DepotNavigator.switchStagingStatus(stagingItem = "Publish to Live");
-
-		Staging.publishToLive();
-
-		WebContentNavigator.openWebContentAdmin(siteURLKey = "site-name-staging");
-
-		NavItem.gotoStructures();
-
-		WebContentStructures.addCP(structureName = "WC Structure Name");
-
-		DataEngine.addField(
-			fieldFieldLabel = "Image",
-			fieldName = "Image");
-
-		WebContentStructures.saveCP(structureName = "WC Structure Name");
-
-		WebContentNavigator.openWebContentAdmin(siteURLKey = "site-name-staging");
-
-		WebContentNavigator.gotoAddWithStructureCP(structureName = "WC Structure Name");
-
-		WebContent.addWithStructureCP(
-			depotName = "Test Depot Name",
-			imageFileName = "Document_1.jpg",
-			navTab = "Documents and Media",
-			structureName = "WC Structure Name",
-			webContentImage = "Document_1.jpg",
-			webContentTitle = "Web Content Title");
-
-		WebContent.publishWithPermissions();
-
-		JSONLayout.addWidgetToPublicLayout(
-			groupName = "Site Name (Staging)",
-			layoutName = "Test Page",
-			site = "false",
-			widgetName = "Web Content Display");
-
-		Navigator.gotoStagedSitePage(
-			pageName = "Test Page",
-			siteName = "Site Name");
-
-		WebContentDisplayPortlet.selectWebContent(webContentTitle = "Web Content Title");
-
-		IFrame.closeFrame();
-
-		Staging.gotoPublishToLive();
-
-		Staging.publishToLive();
-
-		Navigator.gotoStagedSitePage(
-			pageName = "Test Page",
-			siteName = "Site Name");
-
-		WebContentDisplayPortlet.viewContent(
-			imageFileName = "Document_1.jpg",
-			webContentTitle = "Web Content Title");
-
-		DepotNavigator.openDepotDocumentsAndMediaAdminStaging(depotName = "Test Depot Name");
-
-		DMDocument.deleteCP(dmDocumentTitle = "Document_1.jpg");
-
-		DepotNavigator.openDepotRecycleBinAdminStaging(depotName = "Test Depot Name");
-
-		RecycleBin.deleteCP(
-			assetName = "Document_1.jpg",
-			assetType = "Document");
-
-		DepotNavigator.openDepotDocumentsAndMediaAdminStaging(depotName = "Test Depot Name");
-
-		DepotNavigator.switchStagingStatus(stagingItem = "Publish to Live");
-
-		Staging.publishToLive();
-
-		Navigator.gotoStagedSitePage(
-			pageName = "Test Page",
-			siteName = "Site Name");
-
-		Staging.gotoPublishToLive();
-
-		Staging.publishToLive();
-
-		Navigator.openSitePage(
-			pageName = "Test Page",
-			siteName = "Site Name");
-
-		AssertElementNotPresent(
-			key_imageFileName = "Document_1.jpg",
-			key_webContentTitle = "Web Content Title",
-			locator1 = "WCD#WEB_CONTENT_IMAGE");
-	}
-
 	@description = "This ensures that the blog image from a depot can be edited and republished when enabling local staging. Skip the instance for performance improvement."
 	@priority = 4
 	@refactordone
@@ -540,7 +437,7 @@ definition {
 	}
 
 	@description = "This ensures that the image in depot can be replaced and republished in web content when enabling local staging. Skip the instance for performance improvement."
-	@priority = 4
+	@priority = 5
 	@refactordone
 	test CanEditAndDeleteWCImage {
 		property test.liferay.virtual.instance = "false";
@@ -643,6 +540,39 @@ definition {
 		WebContentDisplayPortlet.viewContent(
 			imageFileName = "Document_2.jpg",
 			webContentTitle = "Web Content Title");
+
+		DepotNavigator.openDepotDocumentsAndMediaAdminStaging(depotName = "Test Depot Name");
+
+		DMDocument.deleteCP(dmDocumentTitle = "Document_2.jpg");
+
+		DepotNavigator.openDepotRecycleBinAdminStaging(depotName = "Test Depot Name");
+
+		RecycleBin.deleteCP(
+			assetName = "Document_2.jpg",
+			assetType = "Document");
+
+		DepotNavigator.openDepotDocumentsAndMediaAdminStaging(depotName = "Test Depot Name");
+
+		DepotNavigator.switchStagingStatus(stagingItem = "Publish to Live");
+
+		Staging.publishToLive();
+
+		Navigator.gotoStagedSitePage(
+			pageName = "Test Page",
+			siteName = "Site Name");
+
+		Staging.gotoPublishToLive();
+
+		Staging.publishToLive();
+
+		Navigator.openSitePage(
+			pageName = "Test Page",
+			siteName = "Site Name");
+
+		AssertElementNotPresent(
+			key_imageFileName = "Document_2.jpg",
+			key_webContentTitle = "Web Content Title",
+			locator1 = "WCD#WEB_CONTENT_IMAGE");
 	}
 
 	@description = "This ensures that a document pending review cannot be searched for in a staged site when enabling local staging."

--- a/modules/apps/depot/depot-test/src/testFunctional/tests/DepotLocalStagingDM.testcase
+++ b/modules/apps/depot/depot-test/src/testFunctional/tests/DepotLocalStagingDM.testcase
@@ -511,7 +511,7 @@ definition {
 	@description = "This ensures that an image in depot can be replaced and republished in AP through widget config manual selection when enabling local staging. Skip the instance for performance improvement."
 	@priority = 4
 	@refactordone
-	test CanEditDMImage {
+	test CanEditAndDeleteDMImage {
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 

--- a/modules/apps/depot/depot-test/src/testFunctional/tests/DepotLocalStagingDM.testcase
+++ b/modules/apps/depot/depot-test/src/testFunctional/tests/DepotLocalStagingDM.testcase
@@ -231,102 +231,6 @@ definition {
 		OpenGraph.viewNoPreviewImage(imageName = "Document_2.jpg");
 	}
 
-	@description = "This ensures that the blog image from a depot can be edited and republished when enabling local staging. Skip the instance for performance improvement."
-	@priority = 4
-	@refactordone
-	test CanEditBlogCoverImage {
-		property test.liferay.virtual.instance = "false";
-		property test.run.type = "single";
-
-		for (var num : list "1,2") {
-			JSONDocument.addFileWithUploadedFile(
-				dmDocumentDescription = "DM Document Description",
-				dmDocumentTitle = "Document_${num}.jpg",
-				groupName = "Test Depot Name-staging",
-				mimeType = "image/jpeg",
-				sourceFileName = "Document_${num}.jpg");
-		}
-
-		DepotNavigator.openDepotDocumentsAndMediaAdminStaging(depotName = "Test Depot Name");
-
-		DepotNavigator.switchStagingStatus(stagingItem = "Publish to Live");
-
-		Staging.publishToLive();
-
-		Blogs.addEntryWithCoverImageFromDepot(
-			depotName = "Test Depot Name",
-			entryContent = "Blogs Entry Content",
-			entrySubtitle = "Blogs Entry Subtitle",
-			entryTitle = "Blogs Entry Title",
-			imageFileName = "Document_2.jpg",
-			siteURLKey = "site-name-staging");
-
-		JSONLayout.addWidgetToPublicLayout(
-			groupName = "Site Name (Staging)",
-			layoutName = "Test Page",
-			site = "false",
-			widgetName = "Blogs");
-
-		Navigator.gotoStagedSitePage(
-			pageName = "Test Page",
-			siteName = "Site Name");
-
-		BlogsEntry.viewCoverImage(uploadFileName = "Document_2.jpg");
-
-		Staging.gotoPublishToLive();
-
-		Staging.publishToLive();
-
-		Navigator.openSitePage(
-			pageName = "Test Page",
-			siteName = "Site Name");
-
-		BlogsEntry.viewCoverImage(uploadFileName = "Document_2.jpg");
-
-		Navigator.gotoStagedSitePage(
-			pageName = "Test Page",
-			siteName = "Site Name");
-
-		Portlet.mouseOverPortletTitle(portletTitleName = "Blogs");
-
-		Blogs.clickEllipsisItemPG(
-			entryTitle = "Blogs Entry Title",
-			item = "Edit");
-
-		MouseOver(
-			key_text = "picture",
-			locator1 = "Icon#ANY");
-
-		AssertVisible(
-			key_content = "Change Image",
-			locator1 = "Tooltip#FLOATING_TOOLTIP_CONTENT");
-
-		BlogsNavigator.gotoBrowseImage();
-
-		ItemSelector.selectRepositoryImage(
-			depotName = "Test Depot Name",
-			imageFileName = "Document_1.jpg",
-			navTab = "Documents and Media");
-
-		Button.clickPublish();
-
-		Navigator.gotoStagedSitePage(
-			pageName = "Test Page",
-			siteName = "Site Name");
-
-		BlogsEntry.viewCoverImage(uploadFileName = "Document_1.jpg");
-
-		Staging.gotoPublishToLive();
-
-		Staging.publishToLive();
-
-		Navigator.openSitePage(
-			pageName = "Test Page",
-			siteName = "Site Name");
-
-		BlogsEntry.viewCoverImage(uploadFileName = "Document_1.jpg");
-	}
-
 	@description = "This ensures that an image in depot can be replaced or removed and republished in AP through widget config manual selection when enabling local staging. Skip the instance for performance improvement."
 	@e2e
 	@priority = 5
@@ -573,6 +477,102 @@ definition {
 			key_imageFileName = "Document_2.jpg",
 			key_webContentTitle = "Web Content Title",
 			locator1 = "WCD#WEB_CONTENT_IMAGE");
+	}
+
+	@description = "This ensures that the blog image from a depot can be edited and republished when enabling local staging. Skip the instance for performance improvement."
+	@priority = 4
+	@refactordone
+	test CanEditBlogCoverImage {
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
+
+		for (var num : list "1,2") {
+			JSONDocument.addFileWithUploadedFile(
+				dmDocumentDescription = "DM Document Description",
+				dmDocumentTitle = "Document_${num}.jpg",
+				groupName = "Test Depot Name-staging",
+				mimeType = "image/jpeg",
+				sourceFileName = "Document_${num}.jpg");
+		}
+
+		DepotNavigator.openDepotDocumentsAndMediaAdminStaging(depotName = "Test Depot Name");
+
+		DepotNavigator.switchStagingStatus(stagingItem = "Publish to Live");
+
+		Staging.publishToLive();
+
+		Blogs.addEntryWithCoverImageFromDepot(
+			depotName = "Test Depot Name",
+			entryContent = "Blogs Entry Content",
+			entrySubtitle = "Blogs Entry Subtitle",
+			entryTitle = "Blogs Entry Title",
+			imageFileName = "Document_2.jpg",
+			siteURLKey = "site-name-staging");
+
+		JSONLayout.addWidgetToPublicLayout(
+			groupName = "Site Name (Staging)",
+			layoutName = "Test Page",
+			site = "false",
+			widgetName = "Blogs");
+
+		Navigator.gotoStagedSitePage(
+			pageName = "Test Page",
+			siteName = "Site Name");
+
+		BlogsEntry.viewCoverImage(uploadFileName = "Document_2.jpg");
+
+		Staging.gotoPublishToLive();
+
+		Staging.publishToLive();
+
+		Navigator.openSitePage(
+			pageName = "Test Page",
+			siteName = "Site Name");
+
+		BlogsEntry.viewCoverImage(uploadFileName = "Document_2.jpg");
+
+		Navigator.gotoStagedSitePage(
+			pageName = "Test Page",
+			siteName = "Site Name");
+
+		Portlet.mouseOverPortletTitle(portletTitleName = "Blogs");
+
+		Blogs.clickEllipsisItemPG(
+			entryTitle = "Blogs Entry Title",
+			item = "Edit");
+
+		MouseOver(
+			key_text = "picture",
+			locator1 = "Icon#ANY");
+
+		AssertVisible(
+			key_content = "Change Image",
+			locator1 = "Tooltip#FLOATING_TOOLTIP_CONTENT");
+
+		BlogsNavigator.gotoBrowseImage();
+
+		ItemSelector.selectRepositoryImage(
+			depotName = "Test Depot Name",
+			imageFileName = "Document_1.jpg",
+			navTab = "Documents and Media");
+
+		Button.clickPublish();
+
+		Navigator.gotoStagedSitePage(
+			pageName = "Test Page",
+			siteName = "Site Name");
+
+		BlogsEntry.viewCoverImage(uploadFileName = "Document_1.jpg");
+
+		Staging.gotoPublishToLive();
+
+		Staging.publishToLive();
+
+		Navigator.openSitePage(
+			pageName = "Test Page",
+			siteName = "Site Name");
+
+		BlogsEntry.viewCoverImage(uploadFileName = "Document_1.jpg");
 	}
 
 	@description = "This ensures that a document pending review cannot be searched for in a staged site when enabling local staging."

--- a/modules/apps/depot/depot-test/src/testFunctional/tests/DepotLocalStagingDM.testcase
+++ b/modules/apps/depot/depot-test/src/testFunctional/tests/DepotLocalStagingDM.testcase
@@ -55,84 +55,6 @@ definition {
 		}
 	}
 
-	@description = "This ensures that image in depot can be removed and republished in AP through widget config manual selection when enabling local staging. Skip the instance for performance improvement."
-	@e2e
-	@priority = 5
-	@refactordone
-	test CanDeleteDMImage {
-		property portal.acceptance = "true";
-		property test.liferay.virtual.instance = "false";
-		property test.run.type = "single";
-
-		JSONDocument.addFileWithUploadedFile(
-			dmDocumentDescription = "DM Document Description",
-			dmDocumentTitle = "Document_2.jpg",
-			groupName = "Test Depot Name-staging",
-			mimeType = "image/jpeg",
-			sourceFileName = "Document_2.jpg");
-
-		DepotNavigator.openDepotDocumentsAndMediaAdminStaging(depotName = "Test Depot Name");
-
-		DepotNavigator.switchStagingStatus(stagingItem = "Publish to Live");
-
-		Staging.publishToLive();
-
-		JSONLayout.addWidgetToPublicLayout(
-			groupName = "Site Name (Staging)",
-			layoutName = "Test Page",
-			site = "false",
-			widgetName = "Asset Publisher");
-
-		Navigator.gotoStagedSitePage(
-			pageName = "Test Page",
-			siteName = "Site Name");
-
-		AssetPublisherPortlet.configureManualAssetSelectionPG(
-			assetTitle = "Document_2.jpg",
-			assetType = "Basic Document",
-			depotName = "Test Depot Name");
-
-		Navigator.gotoStagedSitePage(
-			pageName = "Test Page",
-			siteName = "Site Name");
-
-		AssetPublisherPortlet.viewAssetPG(assetTitle = "Document_2.jpg");
-
-		Staging.gotoPublishToLive();
-
-		Staging.publishToLive();
-
-		Navigator.openSitePage(
-			pageName = "Test Page",
-			siteName = "Site Name");
-
-		AssetPublisherPortlet.viewAssetPG(assetTitle = "Document_2.jpg");
-
-		DepotNavigator.openDepotDocumentsAndMediaAdminStaging(depotName = "Test Depot Name");
-
-		DMDocument.deleteCP(dmDocumentTitle = "Document_2.jpg");
-
-		DepotNavigator.openDepotRecycleBinAdminStaging(depotName = "Test Depot Name");
-
-		RecycleBin.deleteCP(
-			assetName = "Document_2.jpg",
-			assetType = "Document");
-
-		DepotNavigator.switchStagingStatus(stagingItem = "Publish to Live");
-
-		Staging.publishToLive();
-
-		Navigator.gotoStagedSitePage(
-			pageName = "Test Page",
-			siteName = "Site Name");
-
-		AssetPublisherPortlet.viewAssetNotPresentPG(assetTitle = "Document_2.jpg");
-
-		Navigator.openSiteURL(siteName = "Site Name");
-
-		Navigator.gotoStagedView();
-	}
-
 	@description = "This ensures that custom field in document from depot can be deleted and republished in the site when enabling local staging. Skip the instance for performance improvement."
 	@priority = 4
 	@refactordone
@@ -509,9 +431,11 @@ definition {
 	}
 
 	@description = "This ensures that an image in depot can be replaced and republished in AP through widget config manual selection when enabling local staging. Skip the instance for performance improvement."
-	@priority = 4
+	@e2e
+	@priority = 5
 	@refactordone
 	test CanEditAndDeleteDMImage {
+		property portal.acceptance = "true";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 
@@ -589,6 +513,30 @@ definition {
 			siteName = "Site Name");
 
 		AssetPublisherPortlet.viewAssetPG(assetTitle = "Document_1.jpg");
+
+		DepotNavigator.openDepotDocumentsAndMediaAdminStaging(depotName = "Test Depot Name");
+
+		DMDocument.deleteCP(dmDocumentTitle = "Document_1.jpg");
+
+		DepotNavigator.openDepotRecycleBinAdminStaging(depotName = "Test Depot Name");
+
+		RecycleBin.deleteCP(
+			assetName = "Document_1.jpg",
+			assetType = "Document");
+
+		DepotNavigator.switchStagingStatus(stagingItem = "Publish to Live");
+
+		Staging.publishToLive();
+
+		Navigator.gotoStagedSitePage(
+			pageName = "Test Page",
+			siteName = "Site Name");
+
+		AssetPublisherPortlet.viewAssetNotPresentPG(assetTitle = "Document_1.jpg");
+
+		Navigator.openSiteURL(siteName = "Site Name");
+
+		Navigator.gotoStagedView();
 	}
 
 	@description = "This ensures that the image in depot can be replaced and republished in web content when enabling local staging. Skip the instance for performance improvement."

--- a/modules/apps/depot/depot-test/src/testFunctional/tests/DepotLocalStagingDM.testcase
+++ b/modules/apps/depot/depot-test/src/testFunctional/tests/DepotLocalStagingDM.testcase
@@ -542,7 +542,7 @@ definition {
 	@description = "This ensures that the image in depot can be replaced and republished in web content when enabling local staging. Skip the instance for performance improvement."
 	@priority = 4
 	@refactordone
-	test CanEditWCImage {
+	test CanEditAndDeleteWCImage {
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 

--- a/modules/apps/depot/depot-test/src/testFunctional/tests/DepotLocalStagingDM.testcase
+++ b/modules/apps/depot/depot-test/src/testFunctional/tests/DepotLocalStagingDM.testcase
@@ -327,7 +327,7 @@ definition {
 		BlogsEntry.viewCoverImage(uploadFileName = "Document_1.jpg");
 	}
 
-	@description = "This ensures that an image in depot can be replaced and republished in AP through widget config manual selection when enabling local staging. Skip the instance for performance improvement."
+	@description = "This ensures that an image in depot can be replaced or removed and republished in AP through widget config manual selection when enabling local staging. Skip the instance for performance improvement."
 	@e2e
 	@priority = 5
 	@refactordone
@@ -436,7 +436,7 @@ definition {
 		Navigator.gotoStagedView();
 	}
 
-	@description = "This ensures that the image in depot can be replaced and republished in web content when enabling local staging. Skip the instance for performance improvement."
+	@description = "This ensures that the image in depot can be replaced or removed and republished in web content when enabling local staging. Skip the instance for performance improvement."
 	@priority = 5
 	@refactordone
 	test CanEditAndDeleteWCImage {

--- a/modules/apps/depot/depot-test/src/testFunctional/tests/DepotRemoteStagingDM.testcase
+++ b/modules/apps/depot/depot-test/src/testFunctional/tests/DepotRemoteStagingDM.testcase
@@ -62,7 +62,7 @@ definition {
 		}
 	}
 
-	@description = "This ensures that the blog image from a depot can be edited and republished when enabling remote staging."
+	@description = "This ensures that the blog image from a depot can be edited or removed and republished when enabling remote staging."
 	@priority = 4
 	@refactordone
 	test CanEditAndDeleteBlogCoverImage {
@@ -218,7 +218,7 @@ definition {
 		BlogsEntry.viewCoverImage(uploadFileName = "Document_1.jpg");
 	}
 
-	@description = "This ensures that document in depot can be replaced and republished in AP through widget config manual selection when enabling remote staging."
+	@description = "This ensures that a document in depot can be replaced or removed and republished in AP through widget config manual selection when enabling remote staging."
 	@priority = 5
 	@refactordone
 	test CanEditAndDeleteDocument {
@@ -360,7 +360,7 @@ definition {
 		AssetPublisherPortlet.viewAssetNotPresentPG(assetTitle = "Document_3.doc");
 	}
 
-	@description = "This ensures that the open graph image from a depot can be edited and republished when enabling remote staging."
+	@description = "This ensures that the open graph image from a depot can be edited or removed and republished when enabling remote staging."
 	@priority = 5
 	@refactordone
 	test CanEditAndDeleteOpenGraphImage {
@@ -541,7 +541,7 @@ definition {
 		OpenGraph.viewNoOpenGraphProperties(ogPropertyList = '''og:image" content="http://localhost:9080/documents/${groupId}/0/Document_2.jpg"''');
 	}
 
-	@description = "This ensures that the image in depot can be replaced and republished in web content when enabling remote staging."
+	@description = "This ensures that the image in depot can be replaced or removed and republished in web content when enabling remote staging."
 	@priority = 4
 	@refactordone
 	test CanEditAndDeleteWCImage {

--- a/modules/apps/depot/depot-test/src/testFunctional/tests/DepotRemoteStagingDM.testcase
+++ b/modules/apps/depot/depot-test/src/testFunctional/tests/DepotRemoteStagingDM.testcase
@@ -62,108 +62,6 @@ definition {
 		}
 	}
 
-	@description = "This ensures that a document in depot can be removed and republished in AP through widget config manual selection when enabling remote staging."
-	@priority = 5
-	@refactordone
-	test CanDeleteDocument {
-		property test.liferay.virtual.instance = "false";
-		property test.run.type = "single";
-
-		JSONDocument.addFileWithUploadedFile(
-			dmDocumentDescription = "DM Document Description",
-			dmDocumentTitle = "Document_1.doc",
-			groupName = "Test Depot Name",
-			mimeType = "application/msword",
-			sourceFileName = "Document_1.doc");
-
-		DepotNavigator.openDepotDocumentsAndMediaAdmin(depotName = "Test Depot Name");
-
-		DepotNavigator.switchStagingStatus(stagingItem = "Publish to Live");
-
-		Staging.publishToLive(remoteStaging = "true");
-
-		JSONLayout.addWidgetToPublicLayout(
-			groupName = "Site Name",
-			layoutName = "Test Page",
-			widgetName = "Asset Publisher");
-
-		Navigator.openSitePage(
-			pageName = "Test Page",
-			siteName = "Site Name");
-
-		AssetPublisherPortlet.configureManualAssetSelectionPG(
-			assetTitle = "Document_1.doc",
-			assetType = "Basic Document",
-			depotName = "Test Depot Name");
-
-		Navigator.openSitePage(
-			pageName = "Test Page",
-			siteName = "Site Name");
-
-		AssetPublisherPortlet.viewAssetPG(assetTitle = "Document_1.doc");
-
-		Staging.gotoPublishToLive();
-
-		Staging.publishToLive(remoteStaging = "true");
-
-		User.logoutPG();
-
-		User.firstLoginUI(
-			password = PropsUtil.get("default.admin.password"),
-			specificURL = "http://localhost:9080",
-			userEmailAddress = "test@liferay.com");
-
-		Navigator.openSitePage(
-			baseURL = "http://localhost:9080",
-			pageName = "Test Page",
-			siteName = "Remote Site");
-
-		AssetPublisherPortlet.viewAssetPG(assetTitle = "Document_1.doc");
-
-		User.loginPG(
-			nodePort = 8080,
-			password = PropsUtil.get("default.admin.password"),
-			userEmailAddress = "test@liferay.com");
-
-		DepotNavigator.openDepotDocumentsAndMediaAdmin(depotName = "Test Depot Name");
-
-		DMDocument.deleteCP(dmDocumentTitle = "Document_1.doc");
-
-		DepotNavigator.openDepotRecycleBinAdmin(depotName = "Test Depot Name");
-
-		RecycleBin.deleteCP(
-			assetName = "Document_1.doc",
-			assetType = "Document");
-
-		DepotNavigator.switchStagingStatus(stagingItem = "Publish to Live");
-
-		Staging.publishToLive(remoteStaging = "true");
-
-		Navigator.openSitePage(
-			pageName = "Test Page",
-			siteName = "Site Name");
-
-		AssetPublisherPortlet.viewAssetNotPresentPG(assetTitle = "Document_1.doc");
-
-		Staging.gotoPublishToLive();
-
-		Staging.publishToLive(remoteStaging = "true");
-
-		User.logoutPG();
-
-		User.firstLoginUI(
-			password = PropsUtil.get("default.admin.password"),
-			specificURL = "http://localhost:9080",
-			userEmailAddress = "test@liferay.com");
-
-		Navigator.openSitePage(
-			baseURL = "http://localhost:9080",
-			pageName = "Test Page",
-			siteName = "Remote Site");
-
-		AssetPublisherPortlet.viewAssetNotPresentPG(assetTitle = "Document_1.doc");
-	}
-
 	@description = "This ensures that the image in depot can be removed and republished in open graph when enabling remote staging."
 	@priority = 4
 	@refactordone
@@ -672,6 +570,49 @@ definition {
 			siteName = "Remote Site");
 
 		AssetPublisherPortlet.viewAssetPG(assetTitle = "Document_3.doc");
+
+		User.loginPG(
+			nodePort = 8080,
+			password = PropsUtil.get("default.admin.password"),
+			userEmailAddress = "test@liferay.com");
+
+		DepotNavigator.openDepotDocumentsAndMediaAdmin(depotName = "Test Depot Name");
+
+		DMDocument.deleteCP(dmDocumentTitle = "Document_3.doc");
+
+		DepotNavigator.openDepotRecycleBinAdmin(depotName = "Test Depot Name");
+
+		RecycleBin.deleteCP(
+			assetName = "Document_3.doc",
+			assetType = "Document");
+
+		DepotNavigator.switchStagingStatus(stagingItem = "Publish to Live");
+
+		Staging.publishToLive(remoteStaging = "true");
+
+		Navigator.openSitePage(
+			pageName = "Test Page",
+			siteName = "Site Name");
+
+		AssetPublisherPortlet.viewAssetNotPresentPG(assetTitle = "Document_3.doc");
+
+		Staging.gotoPublishToLive();
+
+		Staging.publishToLive(remoteStaging = "true");
+
+		User.logoutPG();
+
+		User.firstLoginUI(
+			password = PropsUtil.get("default.admin.password"),
+			specificURL = "http://localhost:9080",
+			userEmailAddress = "test@liferay.com");
+
+		Navigator.openSitePage(
+			baseURL = "http://localhost:9080",
+			pageName = "Test Page",
+			siteName = "Remote Site");
+
+		AssetPublisherPortlet.viewAssetNotPresentPG(assetTitle = "Document_3.doc");
 	}
 
 	@description = "This ensures that the open graph image from a depot can be edited and republished when enabling remote staging."

--- a/modules/apps/depot/depot-test/src/testFunctional/tests/DepotRemoteStagingDM.testcase
+++ b/modules/apps/depot/depot-test/src/testFunctional/tests/DepotRemoteStagingDM.testcase
@@ -62,111 +62,6 @@ definition {
 		}
 	}
 
-	@description = "This ensures that the image in depot can be removed and republished in Blogs cover image when enabling remote staging."
-	@priority = 4
-	@refactordone
-	test CanDeleteBlogCoverImage {
-		property test.liferay.virtual.instance = "false";
-		property test.run.type = "single";
-
-		JSONDocument.addFileWithUploadedFile(
-			dmDocumentDescription = "DM Document Description",
-			dmDocumentTitle = "Document_2.jpg",
-			groupName = "Test Depot Name",
-			mimeType = "image/jpeg",
-			sourceFileName = "Document_2.jpg");
-
-		DepotNavigator.openDepotDocumentsAndMediaAdmin(depotName = "Test Depot Name");
-
-		DepotNavigator.switchStagingStatus(stagingItem = "Publish to Live");
-
-		Staging.publishToLive(remoteStaging = "true");
-
-		Blogs.addEntryWithCoverImageFromDepot(
-			depotName = "Test Depot Name",
-			entryContent = "Blogs Entry Content",
-			entrySubtitle = "Blogs Entry Subtitle",
-			entryTitle = "Blogs Entry Title",
-			imageFileName = "Document_2.jpg",
-			siteURLKey = "site-name");
-
-		JSONLayout.addWidgetToPublicLayout(
-			groupName = "Site Name",
-			layoutName = "Test Page",
-			widgetName = "Blogs");
-
-		Navigator.openSitePage(
-			pageName = "Test Page",
-			siteName = "Site Name");
-
-		Staging.gotoPublishToLive();
-
-		Staging.publishToLive(remoteStaging = "true");
-
-		User.logoutPG();
-
-		User.firstLoginUI(
-			password = PropsUtil.get("default.admin.password"),
-			specificURL = "http://localhost:9080",
-			userEmailAddress = "test@liferay.com");
-
-		Navigator.openSitePage(
-			baseURL = "http://localhost:9080",
-			pageName = "Test Page",
-			siteName = "Remote Site");
-
-		BlogsEntry.viewCoverImage(uploadFileName = "Document_2.jpg");
-
-		User.loginPG(
-			nodePort = 8080,
-			password = PropsUtil.get("default.admin.password"),
-			userEmailAddress = "test@liferay.com");
-
-		Navigator.openSitePage(
-			pageName = "Test Page",
-			siteName = "Site Name");
-
-		DepotNavigator.openDepotDocumentsAndMediaAdmin(depotName = "Test Depot Name");
-
-		DMDocument.deleteCP(dmDocumentTitle = "Document_2.jpg");
-
-		DepotNavigator.openDepotRecycleBinAdmin(depotName = "Test Depot Name");
-
-		RecycleBin.deleteCP(
-			assetName = "Document_2.jpg",
-			assetType = "Document");
-
-		DepotNavigator.openDepotDocumentsAndMediaAdmin(depotName = "Test Depot Name");
-
-		DepotNavigator.switchStagingStatus(stagingItem = "Publish to Live");
-
-		Staging.publishToLive(remoteStaging = "true");
-
-		Navigator.openSitePage(
-			pageName = "Test Page",
-			siteName = "Site Name");
-
-		BlogsEntry.viewCoverImage(uploadFileName = "Document_2.jpg");
-
-		Staging.gotoPublishToLive();
-
-		Staging.publishToLive(remoteStaging = "true");
-
-		User.logoutPG();
-
-		User.firstLoginUI(
-			password = PropsUtil.get("default.admin.password"),
-			specificURL = "http://localhost:9080",
-			userEmailAddress = "test@liferay.com");
-
-		Navigator.openSitePage(
-			baseURL = "http://localhost:9080",
-			pageName = "Test Page",
-			siteName = "Remote Site");
-
-		BlogsEntry.viewCoverImage(uploadFileName = "Document_2.jpg");
-	}
-
 	@description = "This ensures that a document in depot can be removed and republished in AP through widget config manual selection when enabling remote staging."
 	@priority = 5
 	@refactordone
@@ -609,6 +504,51 @@ definition {
 			navTab = "Documents and Media");
 
 		Button.clickPublish();
+
+		Navigator.openSitePage(
+			pageName = "Test Page",
+			siteName = "Site Name");
+
+		BlogsEntry.viewCoverImage(uploadFileName = "Document_1.jpg");
+
+		Staging.gotoPublishToLive();
+
+		Staging.publishToLive(remoteStaging = "true");
+
+		User.logoutPG();
+
+		User.firstLoginUI(
+			password = PropsUtil.get("default.admin.password"),
+			specificURL = "http://localhost:9080",
+			userEmailAddress = "test@liferay.com");
+
+		Navigator.openSitePage(
+			baseURL = "http://localhost:9080",
+			pageName = "Test Page",
+			siteName = "Remote Site");
+
+		BlogsEntry.viewCoverImage(uploadFileName = "Document_1.jpg");
+
+		User.loginPG(
+			nodePort = 8080,
+			password = PropsUtil.get("default.admin.password"),
+			userEmailAddress = "test@liferay.com");
+
+		DepotNavigator.openDepotDocumentsAndMediaAdmin(depotName = "Test Depot Name");
+
+		DMDocument.deleteCP(dmDocumentTitle = "Document_1.jpg");
+
+		DepotNavigator.openDepotRecycleBinAdmin(depotName = "Test Depot Name");
+
+		RecycleBin.deleteCP(
+			assetName = "Document_1.jpg",
+			assetType = "Document");
+
+		DepotNavigator.openDepotDocumentsAndMediaAdmin(depotName = "Test Depot Name");
+
+		DepotNavigator.switchStagingStatus(stagingItem = "Publish to Live");
+
+		Staging.publishToLive(remoteStaging = "true");
 
 		Navigator.openSitePage(
 			pageName = "Test Page",

--- a/modules/apps/depot/depot-test/src/testFunctional/tests/DepotRemoteStagingDM.testcase
+++ b/modules/apps/depot/depot-test/src/testFunctional/tests/DepotRemoteStagingDM.testcase
@@ -670,7 +670,7 @@ definition {
 	@description = "This ensures that the image in depot can be replaced and republished in web content when enabling remote staging."
 	@priority = 4
 	@refactordone
-	test CanEditWCImage {
+	test CanEditAndDeleteWCImage {
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 

--- a/modules/apps/depot/depot-test/src/testFunctional/tests/DepotRemoteStagingDM.testcase
+++ b/modules/apps/depot/depot-test/src/testFunctional/tests/DepotRemoteStagingDM.testcase
@@ -62,132 +62,6 @@ definition {
 		}
 	}
 
-	@description = "This ensures that the image in depot can be removed and republished in web content when enabling remote staging."
-	@priority = 5
-	@refactordone
-	test CanDeleteWCImage {
-		property test.liferay.virtual.instance = "false";
-		property test.run.type = "single";
-
-		JSONDocument.addFileWithUploadedFile(
-			dmDocumentDescription = "DM Document Description",
-			dmDocumentTitle = "Document_1.jpg",
-			groupName = "Test Depot Name",
-			mimeType = "image/jpeg",
-			sourceFileName = "Document_1.jpg");
-
-		DepotNavigator.openDepotDocumentsAndMediaAdmin(depotName = "Test Depot Name");
-
-		DepotNavigator.switchStagingStatus(stagingItem = "Publish to Live");
-
-		Staging.publishToLive(remoteStaging = "true");
-
-		WebContentNavigator.openWebContentAdmin(siteURLKey = "site-name");
-
-		NavItem.gotoStructures();
-
-		WebContentStructures.addCP(structureName = "WC Structure Name");
-
-		DataEngine.addField(
-			fieldFieldLabel = "Image",
-			fieldName = "Image");
-
-		WebContentStructures.saveCP(structureName = "WC Structure Name");
-
-		WebContentNavigator.openWebContentAdmin(siteURLKey = "site-name");
-
-		WebContentNavigator.gotoAddWithStructureCP(structureName = "WC Structure Name");
-
-		WebContent.addWithStructureCP(
-			depotName = "Test Depot Name",
-			imageFileName = "Document_1.jpg",
-			navTab = "Documents and Media",
-			structureName = "WC Structure Name",
-			webContentImage = "Document_1.jpg",
-			webContentTitle = "Web Content Title");
-
-		WebContent.publishWithPermissions();
-
-		JSONLayout.addWidgetToPublicLayout(
-			groupName = "Site Name",
-			layoutName = "Test Page",
-			widgetName = "Web Content Display");
-
-		Navigator.openSitePage(
-			pageName = "Test Page",
-			siteName = "Site Name");
-
-		WebContentDisplayPortlet.selectWebContent(webContentTitle = "Web Content Title");
-
-		IFrame.closeFrame();
-
-		Staging.gotoPublishToLive();
-
-		Staging.publishToLive(remoteStaging = "true");
-
-		User.logoutPG();
-
-		User.firstLoginUI(
-			password = PropsUtil.get("default.admin.password"),
-			specificURL = "http://localhost:9080",
-			userEmailAddress = "test@liferay.com");
-
-		Navigator.openSitePage(
-			baseURL = "http://localhost:9080",
-			pageName = "Test Page",
-			siteName = "Remote Site");
-
-		WebContentDisplayPortlet.viewContent(
-			imageFileName = "Document_1.jpg",
-			webContentTitle = "Web Content Title");
-
-		User.loginPG(
-			nodePort = 8080,
-			password = PropsUtil.get("default.admin.password"),
-			userEmailAddress = "test@liferay.com");
-
-		DepotNavigator.openDepotDocumentsAndMediaAdmin(depotName = "Test Depot Name");
-
-		DMDocument.deleteCP(dmDocumentTitle = "Document_1.jpg");
-
-		DepotNavigator.openDepotRecycleBinAdmin(depotName = "Test Depot Name");
-
-		RecycleBin.deleteCP(
-			assetName = "Document_1.jpg",
-			assetType = "Document");
-
-		DepotNavigator.openDepotDocumentsAndMediaAdmin(depotName = "Test Depot Name");
-
-		DepotNavigator.switchStagingStatus(stagingItem = "Publish to Live");
-
-		Staging.publishToLive(remoteStaging = "true");
-
-		Navigator.openSitePage(
-			pageName = "Test Page",
-			siteName = "Site Name");
-
-		Staging.gotoPublishToLive();
-
-		Staging.publishToLive(remoteStaging = "true");
-
-		User.logoutPG();
-
-		User.firstLoginUI(
-			password = PropsUtil.get("default.admin.password"),
-			specificURL = "http://localhost:9080",
-			userEmailAddress = "test@liferay.com");
-
-		Navigator.openSitePage(
-			baseURL = "http://localhost:9080",
-			pageName = "Test Page",
-			siteName = "Remote Site");
-
-		AssertElementNotPresent(
-			key_imageFileName = "Document_1.jpg",
-			key_webContentTitle = "Web Content Title",
-			locator1 = "WCD#WEB_CONTENT_IMAGE");
-	}
-
 	@description = "This ensures that the blog image from a depot can be edited and republished when enabling remote staging."
 	@priority = 4
 	@refactordone
@@ -793,6 +667,52 @@ definition {
 		WebContentDisplayPortlet.viewContent(
 			imageFileName = "Document_2.jpg",
 			webContentTitle = "Web Content Title");
+
+		User.loginPG(
+			nodePort = 8080,
+			password = PropsUtil.get("default.admin.password"),
+			userEmailAddress = "test@liferay.com");
+
+		DepotNavigator.openDepotDocumentsAndMediaAdmin(depotName = "Test Depot Name");
+
+		DMDocument.deleteCP(dmDocumentTitle = "Document_2.jpg");
+
+		DepotNavigator.openDepotRecycleBinAdmin(depotName = "Test Depot Name");
+
+		RecycleBin.deleteCP(
+			assetName = "Document_2.jpg",
+			assetType = "Document");
+
+		DepotNavigator.openDepotDocumentsAndMediaAdmin(depotName = "Test Depot Name");
+
+		DepotNavigator.switchStagingStatus(stagingItem = "Publish to Live");
+
+		Staging.publishToLive(remoteStaging = "true");
+
+		Navigator.openSitePage(
+			pageName = "Test Page",
+			siteName = "Site Name");
+
+		Staging.gotoPublishToLive();
+
+		Staging.publishToLive(remoteStaging = "true");
+
+		User.logoutPG();
+
+		User.firstLoginUI(
+			password = PropsUtil.get("default.admin.password"),
+			specificURL = "http://localhost:9080",
+			userEmailAddress = "test@liferay.com");
+
+		Navigator.openSitePage(
+			baseURL = "http://localhost:9080",
+			pageName = "Test Page",
+			siteName = "Remote Site");
+
+		AssertElementNotPresent(
+			key_imageFileName = "Document_2.jpg",
+			key_webContentTitle = "Web Content Title",
+			locator1 = "WCD#WEB_CONTENT_IMAGE");
 	}
 
 	@description = "This ensures that a document pending review cannot be searched for in a staged site when enabling remote staging."

--- a/modules/apps/depot/depot-test/src/testFunctional/tests/DepotRemoteStagingDM.testcase
+++ b/modules/apps/depot/depot-test/src/testFunctional/tests/DepotRemoteStagingDM.testcase
@@ -578,7 +578,7 @@ definition {
 	@description = "This ensures that document in depot can be replaced and republished in AP through widget config manual selection when enabling remote staging."
 	@priority = 5
 	@refactordone
-	test CanEditDocument {
+	test CanEditAndDeleteDocument {
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 

--- a/modules/apps/depot/depot-test/src/testFunctional/tests/DepotRemoteStagingDM.testcase
+++ b/modules/apps/depot/depot-test/src/testFunctional/tests/DepotRemoteStagingDM.testcase
@@ -527,7 +527,7 @@ definition {
 	@description = "This ensures that the blog image from a depot can be edited and republished when enabling remote staging."
 	@priority = 4
 	@refactordone
-	test CanEditBlogCoverImage {
+	test CanEditAndDeleteBlogCoverImage {
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 

--- a/modules/apps/depot/depot-test/src/testFunctional/tests/DepotRemoteStagingDM.testcase
+++ b/modules/apps/depot/depot-test/src/testFunctional/tests/DepotRemoteStagingDM.testcase
@@ -62,135 +62,6 @@ definition {
 		}
 	}
 
-	@description = "This ensures that the image in depot can be removed and republished in open graph when enabling remote staging."
-	@priority = 4
-	@refactordone
-	test CanDeleteOpenGraphImage {
-		property test.liferay.virtual.instance = "false";
-		property test.run.type = "single";
-
-		JSONDocument.addFileWithUploadedFile(
-			dmDocumentDescription = "DM Document Description",
-			dmDocumentTitle = "Document_2.jpg",
-			groupName = "Test Depot Name",
-			mimeType = "image/jpeg",
-			sourceFileName = "Document_2.jpg");
-
-		DepotNavigator.openDepotDocumentsAndMediaAdmin(depotName = "Test Depot Name");
-
-		DepotNavigator.switchStagingStatus(stagingItem = "Publish to Live");
-
-		Staging.publishToLive(remoteStaging = "true");
-
-		Navigator.openToGroupPagesPortlet(
-			groupName = "Site Name",
-			layoutName = "Test Page",
-			portlet = "Open Graph",
-			siteURLKey = "site-name");
-
-		OpenGraph.configureOpenGraph(
-			customImage = "true",
-			depotName = "Test Depot Name",
-			uploadFileName = "Document_2.jpg");
-
-		OpenGraph.viewPreviewImage(imageName = "Document_2.jpg");
-
-		Navigator.openSitePage(
-			pageName = "Test Page",
-			siteName = "Site Name");
-
-		Staging.gotoPublishToLive();
-
-		Staging.publishToLive(remoteStaging = "true");
-
-		User.logoutPG();
-
-		User.firstLoginUI(
-			password = PropsUtil.get("default.admin.password"),
-			specificURL = "http://localhost:9080",
-			userEmailAddress = "test@liferay.com");
-
-		Navigator.openToGroupPagesPortlet(
-			baseURL = "http://localhost:9080",
-			groupName = "Remote Site",
-			layoutName = "Test Page",
-			portalURL = "http://localhost:9080",
-			portlet = "Open Graph",
-			siteURLKey = "remote-site");
-
-		OpenGraph.viewPreviewImage(imageName = "Document_2.jpg");
-
-		var groupId = Depot.getGroupID(depotName = "Remote Depot");
-
-		User.logoutPG();
-
-		Navigator.openSpecificURL(url = "http://localhost:9080/web/remote-site/test-page");
-
-		OpenGraph.viewOpenGraphProperties(ogPropertyList = '''"og:image" content="http://localhost:9080/documents/${groupId}/0/Document_2.jpg''');
-
-		User.loginPG(
-			nodePort = 8080,
-			password = PropsUtil.get("default.admin.password"),
-			userEmailAddress = "test@liferay.com");
-
-		DepotNavigator.openDepotDocumentsAndMediaAdmin(depotName = "Test Depot Name");
-
-		DMDocument.deleteCP(dmDocumentTitle = "Document_2.jpg");
-
-		DepotNavigator.openDepotRecycleBinAdmin(depotName = "Test Depot Name");
-
-		RecycleBin.deleteCP(
-			assetName = "Document_2.jpg",
-			assetType = "Document");
-
-		DepotNavigator.openDepotRecycleBinAdmin(depotName = "Test Depot Name");
-
-		DepotNavigator.switchStagingStatus(stagingItem = "Publish to Live");
-
-		Staging.publishToLive(remoteStaging = "true");
-
-		Navigator.openToGroupPagesPortlet(
-			groupName = "Site Name",
-			layoutName = "Test Page",
-			portlet = "Open Graph",
-			siteURLKey = "site-name");
-
-		OpenGraph.viewNoPreviewImage(imageName = "Document_2.jpg");
-
-		Navigator.openSitePage(
-			pageName = "Test Page",
-			siteName = "Site Name");
-
-		Staging.gotoPublishToLive();
-
-		Staging.publishToLive(remoteStaging = "true");
-
-		User.logoutPG();
-
-		User.firstLoginUI(
-			password = PropsUtil.get("default.admin.password"),
-			specificURL = "http://localhost:9080",
-			userEmailAddress = "test@liferay.com");
-
-		Navigator.openToGroupPagesPortlet(
-			baseURL = "http://localhost:9080",
-			groupName = "Remote Site",
-			layoutName = "Test Page",
-			portalURL = "http://localhost:9080",
-			portlet = "Open Graph",
-			siteURLKey = "remote-site");
-
-		OpenGraph.viewNoPreviewImage(imageName = "Document_2.jpg");
-
-		var groupId = Depot.getGroupID(depotName = "Remote Depot");
-
-		User.logoutPG();
-
-		Navigator.openSpecificURL(url = "http://localhost:9080/web/remote-site/test-page");
-
-		OpenGraph.viewNoOpenGraphProperties(ogPropertyList = '''og:image" content="http://localhost:9080/documents/${groupId}/0/Document_2.jpg"''');
-	}
-
 	@description = "This ensures that the image in depot can be removed and republished in web content when enabling remote staging."
 	@priority = 5
 	@refactordone
@@ -734,6 +605,66 @@ definition {
 		Navigator.openSpecificURL(url = "http://localhost:9080/web/remote-site/test-page");
 
 		OpenGraph.viewOpenGraphProperties(ogPropertyList = '''"og:image" content="http://localhost:9080/documents/${groupId}/0/Document_2.jpg''');
+
+		User.loginPG(
+			nodePort = 8080,
+			password = PropsUtil.get("default.admin.password"),
+			userEmailAddress = "test@liferay.com");
+
+		DepotNavigator.openDepotDocumentsAndMediaAdmin(depotName = "Test Depot Name");
+
+		DMDocument.deleteCP(dmDocumentTitle = "Document_2.jpg");
+
+		DepotNavigator.openDepotRecycleBinAdmin(depotName = "Test Depot Name");
+
+		RecycleBin.deleteCP(
+			assetName = "Document_2.jpg",
+			assetType = "Document");
+
+		DepotNavigator.openDepotRecycleBinAdmin(depotName = "Test Depot Name");
+
+		DepotNavigator.switchStagingStatus(stagingItem = "Publish to Live");
+
+		Staging.publishToLive(remoteStaging = "true");
+
+		Navigator.openToGroupPagesPortlet(
+			groupName = "Site Name",
+			layoutName = "Test Page",
+			portlet = "Open Graph",
+			siteURLKey = "site-name");
+
+		OpenGraph.viewNoPreviewImage(imageName = "Document_2.jpg");
+
+		Navigator.openSitePage(
+			pageName = "Test Page",
+			siteName = "Site Name");
+
+		Staging.gotoPublishToLive();
+
+		Staging.publishToLive(remoteStaging = "true");
+
+		User.logoutPG();
+
+		User.firstLoginUI(
+			password = PropsUtil.get("default.admin.password"),
+			specificURL = "http://localhost:9080",
+			userEmailAddress = "test@liferay.com");
+
+		Navigator.openToGroupPagesPortlet(
+			baseURL = "http://localhost:9080",
+			groupName = "Remote Site",
+			layoutName = "Test Page",
+			portalURL = "http://localhost:9080",
+			portlet = "Open Graph",
+			siteURLKey = "remote-site");
+
+		OpenGraph.viewNoPreviewImage(imageName = "Document_2.jpg");
+
+		User.logoutPG();
+
+		Navigator.openSpecificURL(url = "http://localhost:9080/web/remote-site/test-page");
+
+		OpenGraph.viewNoOpenGraphProperties(ogPropertyList = '''og:image" content="http://localhost:9080/documents/${groupId}/0/Document_2.jpg"''');
 	}
 
 	@description = "This ensures that the image in depot can be replaced and republished in web content when enabling remote staging."

--- a/modules/apps/depot/depot-test/src/testFunctional/tests/DepotRemoteStagingDM.testcase
+++ b/modules/apps/depot/depot-test/src/testFunctional/tests/DepotRemoteStagingDM.testcase
@@ -618,7 +618,7 @@ definition {
 	@description = "This ensures that the open graph image from a depot can be edited and republished when enabling remote staging."
 	@priority = 5
 	@refactordone
-	test CanEditOpenGraphImage {
+	test CanEditAndDeleteOpenGraphImage {
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-87676

# What is this trying to solve? 

Several Poshi tests in `DepotDocumentSiteIntegration`, `DepotLocalStagingDM`, and `DepotRemoteStagingDM` exercise closely related happy and sad paths as separate test cases — for example a `CanEdit*` test next to a `CanDelete*` test, or a `CanCopy*ToDepot` test next to a `CannotCopy*FromUnconnectedSite` test. Each pair walks through the same fixtures and the same screens twice, which slows the suite and adds maintenance noise without exercising new behavior. Some of the negative suffixes (`CannotFromUnconnected`, `CannotToUnconnected`) also read awkwardly compared to their positive counterparts.

# How am I fixing it? 

Each pair has been merged into a single test that covers both flows back-to-back, named to reflect the combined
scope: for example `CanEditAndDeleteDocument`, `CanEditAndDeleteWCImage`, and `CanCopyFolderFromConnectedSiteToDepotAndCannotFromUnconnectedSite`. The negative-path suffixes were standardized from `Cannot...Unconnected` to `...UnconnectedSite` so the test names read naturally, and a few
overlapping descriptions were unified along the way.