### PR TITLE
LPD-87532 Missing Download action from the Shared content list

### DIFF
--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/sharing/servlet/taglib/ui/test/ObjectEntrySharingEntryDropdownItemContributorTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/sharing/servlet/taglib/ui/test/ObjectEntrySharingEntryDropdownItemContributorTest.java
@@ -1,0 +1,297 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.web.internal.sharing.servlet.taglib.ui.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.document.library.kernel.model.DLFolder;
+import com.liferay.document.library.test.util.DLTestUtil;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectEntryFolder;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryFolderLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.test.context.ContextUserReplace;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.sharing.model.SharingEntry;
+import com.liferay.sharing.security.permission.SharingEntryAction;
+import com.liferay.sharing.service.SharingEntryService;
+import com.liferay.sharing.servlet.taglib.ui.SharingEntryDropdownItemContributor;
+import com.liferay.site.cms.site.initializer.test.util.CMSTestUtil;
+
+import java.io.Serializable;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceReference;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * @author Mikel Lorza
+ */
+@FeatureFlags(featureFlags = @FeatureFlag("LPD-17564"))
+@RunWith(Arquillian.class)
+public class ObjectEntrySharingEntryDropdownItemContributorTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		Bundle bundle = FrameworkUtil.getBundle(getClass());
+
+		_bundleContext = bundle.getBundleContext();
+
+		_group = CMSTestUtil.getOrAddGroup(getClass());
+
+		_serviceContext = ServiceContextTestUtil.getServiceContext(
+			_group.getGroupId());
+
+		_serviceContext.setRequest(new MockHttpServletRequest());
+
+		_depotEntry = _depotEntryLocalService.addDepotEntry(
+			Collections.singletonMap(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
+			null, DepotConstants.TYPE_SPACE, _serviceContext);
+
+		_user = UserTestUtil.addUser();
+	}
+
+	@Test
+	public void testGetSharingEntryDropdownItems() throws Exception {
+		_testGetSharingEntryDropdownItemsWithCMSBasicDocument();
+		_testGetSharingEntryDropdownItemsWithCMSBasicWebContent();
+	}
+
+	private ObjectEntry _addObjectEntry(
+			ObjectDefinition objectDefinition,
+			String objectEntryFolderExternalReferenceCode,
+			Map<String, Serializable> values)
+		throws Exception {
+
+		ObjectEntryFolder objectEntryFolder =
+			_objectEntryFolderLocalService.
+				getObjectEntryFolderByExternalReferenceCode(
+					objectEntryFolderExternalReferenceCode,
+					_depotEntry.getGroupId(), _depotEntry.getCompanyId());
+
+		return _objectEntryLocalService.addObjectEntry(
+			_depotEntry.getGroupId(), TestPropsValues.getUserId(),
+			objectDefinition.getObjectDefinitionId(),
+			objectEntryFolder.getObjectEntryFolderId(), "en_US", values,
+			_serviceContext);
+	}
+
+	private List<DropdownItem> _getSharingEntryDropdownItems(
+			ObjectDefinition objectDefinition, ObjectEntry objectEntry)
+		throws Exception {
+
+		SharingEntry sharingEntry = _sharingEntryService.addSharingEntry(
+			null, 0, 0, _user.getUserId(),
+			_portal.getClassNameId(objectDefinition.getClassName()),
+			objectEntry.getObjectEntryId(), _depotEntry.getGroupId(), true,
+			Collections.singletonList(SharingEntryAction.VIEW), null,
+			_serviceContext);
+
+		Collection<ServiceReference<SharingEntryDropdownItemContributor>>
+			serviceReferences = _bundleContext.getServiceReferences(
+				SharingEntryDropdownItemContributor.class,
+				"(model.class.name=" + objectDefinition.getClassName() + ")");
+
+		if (serviceReferences.isEmpty()) {
+			return Collections.emptyList();
+		}
+
+		ThemeDisplay themeDisplay = _getThemeDisplay();
+
+		List<DropdownItem> dropdownItems = new ArrayList<>();
+
+		for (ServiceReference<SharingEntryDropdownItemContributor>
+				serviceReference : serviceReferences) {
+
+			SharingEntryDropdownItemContributor
+				sharingEntryDropdownItemContributor = _bundleContext.getService(
+					serviceReference);
+
+			try (ContextUserReplace contextUserReplace = new ContextUserReplace(
+					_user, PermissionCheckerFactoryUtil.create(_user))) {
+
+				ServiceContextThreadLocal.pushServiceContext(_serviceContext);
+
+				dropdownItems.addAll(
+					sharingEntryDropdownItemContributor.
+						getSharingEntryDropdownItems(
+							sharingEntry, themeDisplay));
+			}
+			finally {
+				_bundleContext.ungetService(serviceReference);
+			}
+		}
+
+		return dropdownItems;
+	}
+
+	private ThemeDisplay _getThemeDisplay() throws Exception {
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, themeDisplay);
+
+		themeDisplay.setLocale(LocaleUtil.US);
+		themeDisplay.setPermissionChecker(
+			PermissionCheckerFactoryUtil.create(TestPropsValues.getUser()));
+		themeDisplay.setRequest(mockHttpServletRequest);
+		themeDisplay.setScopeGroupId(_group.getGroupId());
+		themeDisplay.setSiteGroupId(_group.getGroupId());
+		themeDisplay.setUser(TestPropsValues.getUser());
+
+		return themeDisplay;
+	}
+
+	private void _testGetSharingEntryDropdownItemsWithCMSBasicDocument()
+		throws Exception {
+
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.
+				getObjectDefinitionByExternalReferenceCode(
+					"L_CMS_BASIC_DOCUMENT", _group.getCompanyId());
+
+		List<DropdownItem> dropdownItems = _getSharingEntryDropdownItems(
+			objectDefinition,
+			_addObjectEntry(
+				objectDefinition, "L_FILES",
+				HashMapBuilder.<String, Serializable>put(
+					"file",
+					() -> {
+						DLFolder dlFolder = DLTestUtil.addDLFolder(
+							_depotEntry.getGroupId());
+
+						DLFileEntry dlFileEntry = DLTestUtil.addDLFileEntry(
+							dlFolder.getFolderId());
+
+						return dlFileEntry.getFileEntryId();
+					}
+				).put(
+					"title_i18n",
+					HashMapBuilder.put(
+						"en_US", RandomTestUtil.randomString()
+					).build()
+				).build()));
+
+		Assert.assertEquals(dropdownItems.toString(), 1, dropdownItems.size());
+
+		DropdownItem dropdownItem = dropdownItems.get(0);
+
+		Assert.assertEquals("download", dropdownItem.get("icon"));
+		Assert.assertNotNull(dropdownItem.get("href"));
+		Assert.assertNotNull(dropdownItem.get("label"));
+	}
+
+	private void _testGetSharingEntryDropdownItemsWithCMSBasicWebContent()
+		throws Exception {
+
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.
+				getObjectDefinitionByExternalReferenceCode(
+					"L_CMS_BASIC_WEB_CONTENT", _group.getCompanyId());
+
+		List<DropdownItem> dropdownItems = _getSharingEntryDropdownItems(
+			objectDefinition,
+			_addObjectEntry(
+				objectDefinition, "L_CONTENTS",
+				HashMapBuilder.<String, Serializable>put(
+					"content_i18n",
+					HashMapBuilder.put(
+						"en_US", RandomTestUtil.randomString()
+					).build()
+				).put(
+					"title_i18n",
+					HashMapBuilder.put(
+						"en_US", RandomTestUtil.randomString()
+					).build()
+				).build()));
+
+		Assert.assertTrue(dropdownItems.toString(), dropdownItems.isEmpty());
+	}
+
+	private BundleContext _bundleContext;
+
+	@DeleteAfterTestRun
+	private DepotEntry _depotEntry;
+
+	@Inject
+	private DepotEntryLocalService _depotEntryLocalService;
+
+	private Group _group;
+
+	@Inject
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Inject
+	private ObjectEntryFolderLocalService _objectEntryFolderLocalService;
+
+	@Inject
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Inject
+	private Portal _portal;
+
+	private ServiceContext _serviceContext;
+
+	@Inject
+	private SharingEntryService _sharingEntryService;
+
+	@DeleteAfterTestRun
+	private User _user;
+
+}

--- a/modules/apps/object/object-web/build.gradle
+++ b/modules/apps/object/object-web/build.gradle
@@ -55,6 +55,7 @@ dependencies {
 	compileOnly project(":apps:portal-search:portal-search-api")
 	compileOnly project(":apps:portal-security:portal-security-script-management-api")
 	compileOnly project(":apps:portal-vulcan:portal-vulcan-api")
+	compileOnly project(":apps:sharing:sharing-api")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	compileOnly project(":apps:template:template-api")
 	compileOnly project(":apps:translation:translation-api")

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -9,6 +9,7 @@ import com.liferay.application.list.PanelApp;
 import com.liferay.asset.display.page.portlet.AssetDisplayPageFriendlyURLProvider;
 import com.liferay.asset.kernel.model.AssetRendererFactory;
 import com.liferay.asset.kernel.service.AssetCategoryLocalService;
+import com.liferay.asset.kernel.service.AssetEntryLocalService;
 import com.liferay.asset.kernel.service.AssetTagLocalService;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
 import com.liferay.asset.util.AssetHelper;
@@ -122,6 +123,7 @@ import com.liferay.object.web.internal.object.entries.portlet.action.EditObjectE
 import com.liferay.object.web.internal.object.entries.portlet.action.EditObjectEntryMVCRenderCommand;
 import com.liferay.object.web.internal.object.entries.portlet.action.EditObjectEntryRelatedModelMVCActionCommand;
 import com.liferay.object.web.internal.object.entries.portlet.action.UploadAttachmentMVCActionCommand;
+import com.liferay.object.web.internal.sharing.servlet.taglib.ui.ObjectEntrySharingEntryDropdownItemContributor;
 import com.liferay.petra.io.unsync.UnsyncByteArrayInputStream;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
@@ -162,6 +164,7 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.search.searcher.SearchRequestBuilderFactory;
 import com.liferay.portal.search.searcher.Searcher;
+import com.liferay.sharing.servlet.taglib.ui.SharingEntryDropdownItemContributor;
 import com.liferay.template.info.item.capability.TemplateInfoItemCapability;
 import com.liferay.template.info.item.provider.TemplateInfoItemFieldSetProvider;
 import com.liferay.translation.info.item.provider.InfoItemLanguagesProvider;
@@ -697,6 +700,15 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 					"panel.category.key", objectDefinition.getPanelCategoryKey()
 				).build()));
 
+		serviceRegistrations.add(
+			_bundleContext.registerService(
+				SharingEntryDropdownItemContributor.class,
+				new ObjectEntrySharingEntryDropdownItemContributor(
+					_assetEntryLocalService, _language, objectDefinition),
+				HashMapDictionaryBuilder.<String, Object>put(
+					"model.class.name", objectDefinition.getClassName()
+				).build()));
+
 		return serviceRegistrations;
 	}
 
@@ -742,6 +754,9 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 	@Reference
 	private AssetDisplayPageFriendlyURLProvider
 		_assetDisplayPageFriendlyURLProvider;
+
+	@Reference
+	private AssetEntryLocalService _assetEntryLocalService;
 
 	@Reference
 	private AssetHelper _assetHelper;

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -59,6 +59,7 @@ import com.liferay.list.type.service.ListTypeEntryLocalService;
 import com.liferay.object.configuration.ObjectConfiguration;
 import com.liferay.object.constants.ObjectActionKeys;
 import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.constants.ObjectFolderConstants;
 import com.liferay.object.definition.security.permission.resource.ObjectDefinitionPortletResourcePermissionRegistryUtil;
 import com.liferay.object.definition.util.ObjectDefinitionUtil;
 import com.liferay.object.deployer.ObjectDefinitionDeployer;
@@ -700,14 +701,20 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 					"panel.category.key", objectDefinition.getPanelCategoryKey()
 				).build()));
 
-		serviceRegistrations.add(
-			_bundleContext.registerService(
-				SharingEntryDropdownItemContributor.class,
-				new ObjectEntrySharingEntryDropdownItemContributor(
-					_assetEntryLocalService, _language, objectDefinition),
-				HashMapDictionaryBuilder.<String, Object>put(
-					"model.class.name", objectDefinition.getClassName()
-				).build()));
+		if (objectDefinition.isCMS() &&
+			Objects.equals(
+				objectDefinition.getObjectFolderExternalReferenceCode(),
+				ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_FILE_TYPES)) {
+
+			serviceRegistrations.add(
+				_bundleContext.registerService(
+					SharingEntryDropdownItemContributor.class,
+					new ObjectEntrySharingEntryDropdownItemContributor(
+						_assetEntryLocalService, _language),
+					HashMapDictionaryBuilder.<String, Object>put(
+						"model.class.name", objectDefinition.getClassName()
+					).build()));
+		}
 
 		return serviceRegistrations;
 	}

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/sharing/servlet/taglib/ui/ObjectEntrySharingEntryDropdownItemContributor.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/sharing/servlet/taglib/ui/ObjectEntrySharingEntryDropdownItemContributor.java
@@ -1,0 +1,117 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.web.internal.sharing.servlet.taglib.ui;
+
+import com.liferay.asset.kernel.AssetRendererFactoryRegistryUtil;
+import com.liferay.asset.kernel.model.AssetEntry;
+import com.liferay.asset.kernel.model.AssetRenderer;
+import com.liferay.asset.kernel.model.AssetRendererFactory;
+import com.liferay.asset.kernel.service.AssetEntryLocalService;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemListBuilder;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.sharing.model.SharingEntry;
+import com.liferay.sharing.servlet.taglib.ui.SharingEntryDropdownItemContributor;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * @author Mikel Lorza
+ */
+public class ObjectEntrySharingEntryDropdownItemContributor
+	implements SharingEntryDropdownItemContributor {
+
+	public ObjectEntrySharingEntryDropdownItemContributor(
+		AssetEntryLocalService assetEntryLocalService, Language language,
+		ObjectDefinition objectDefinition) {
+
+		_assetEntryLocalService = assetEntryLocalService;
+		_language = language;
+		_objectDefinition = objectDefinition;
+	}
+
+	@Override
+	public List<DropdownItem> getSharingEntryDropdownItems(
+		SharingEntry sharingEntry, ThemeDisplay themeDisplay) {
+
+		if (!_isVisible(sharingEntry) || !_objectDefinition.isCMS()) {
+			return Collections.emptyList();
+		}
+
+		String urlDownload = _getURLDownload(sharingEntry, themeDisplay);
+
+		if (Validator.isNull(urlDownload)) {
+			return Collections.emptyList();
+		}
+
+		return DropdownItemListBuilder.add(
+			dropdownItem -> {
+				dropdownItem.setHref(urlDownload);
+				dropdownItem.setIcon("download");
+				dropdownItem.setLabel(
+					_language.get(themeDisplay.getLocale(), "download"));
+			}
+		).build();
+	}
+
+	private String _getURLDownload(
+		SharingEntry sharingEntry, ThemeDisplay themeDisplay) {
+
+		try {
+			AssetRendererFactory<?> assetRendererFactory =
+				AssetRendererFactoryRegistryUtil.
+					getAssetRendererFactoryByClassName(
+						sharingEntry.getClassName());
+
+			if (assetRendererFactory == null) {
+				return null;
+			}
+
+			AssetRenderer<?> assetRenderer =
+				assetRendererFactory.getAssetRenderer(
+					sharingEntry.getClassPK());
+
+			if (assetRenderer == null) {
+				return null;
+			}
+
+			return assetRenderer.getURLDownload(themeDisplay);
+		}
+		catch (PortalException portalException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(portalException);
+			}
+
+			return null;
+		}
+	}
+
+	private boolean _isVisible(SharingEntry sharingEntry) {
+		AssetEntry assetEntry = _assetEntryLocalService.fetchEntry(
+			sharingEntry.getClassNameId(), sharingEntry.getClassPK());
+
+		if ((assetEntry != null) && assetEntry.isVisible()) {
+			return true;
+		}
+
+		return false;
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		ObjectEntrySharingEntryDropdownItemContributor.class);
+
+	private final AssetEntryLocalService _assetEntryLocalService;
+	private final Language _language;
+	private final ObjectDefinition _objectDefinition;
+
+}

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/sharing/servlet/taglib/ui/ObjectEntrySharingEntryDropdownItemContributor.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/sharing/servlet/taglib/ui/ObjectEntrySharingEntryDropdownItemContributor.java
@@ -12,7 +12,6 @@ import com.liferay.asset.kernel.model.AssetRendererFactory;
 import com.liferay.asset.kernel.service.AssetEntryLocalService;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemListBuilder;
-import com.liferay.object.model.ObjectDefinition;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
@@ -32,19 +31,17 @@ public class ObjectEntrySharingEntryDropdownItemContributor
 	implements SharingEntryDropdownItemContributor {
 
 	public ObjectEntrySharingEntryDropdownItemContributor(
-		AssetEntryLocalService assetEntryLocalService, Language language,
-		ObjectDefinition objectDefinition) {
+		AssetEntryLocalService assetEntryLocalService, Language language) {
 
 		_assetEntryLocalService = assetEntryLocalService;
 		_language = language;
-		_objectDefinition = objectDefinition;
 	}
 
 	@Override
 	public List<DropdownItem> getSharingEntryDropdownItems(
 		SharingEntry sharingEntry, ThemeDisplay themeDisplay) {
 
-		if (!_isVisible(sharingEntry) || !_objectDefinition.isCMS()) {
+		if (!_isVisible(sharingEntry)) {
 			return Collections.emptyList();
 		}
 
@@ -112,6 +109,5 @@ public class ObjectEntrySharingEntryDropdownItemContributor
 
 	private final AssetEntryLocalService _assetEntryLocalService;
 	private final Language _language;
-	private final ObjectDefinition _objectDefinition;
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-87532

**What is being fixed:** When a CMS file Object Entry is shared with another user, the Download action was missing from the dropdown in the Shared Content list, so the recipient had no way to download the file from there.

**How it is being fixed:** Register a `SharingEntryDropdownItemContributor` for the file Object Entry definitions of the CMS (scoped via `ObjectDefinitionDeployerImpl` so it is only contributed for the relevant object definitions, not every object definition in the system). The contributor adds a Download dropdown item that points to the shared file's download URL, mirroring the action available in the regular asset list.

**Test plan:**

Integration test:

```bash
cd modules/apps/object/object-test && ../../../../gradlew testIntegration --tests ObjectEntrySharingEntryDropdownItemContributorTest
```

Manual reproduction:

1. Create a user.
2. Create a space.
3. Create a file in that space and share it with the user created in step 1.
4. Log in as that user and go to Shared Content.
5. The shared file appears in the list, and its dropdown shows a Download action that downloads the file.