### PR TITLE
LPD-87858 Default publishDate to createDate when displayDate is null

### DIFF
--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppHelperLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppHelperLocalServiceImpl.java
@@ -137,15 +137,21 @@ public class DLAppHelperLocalServiceImpl
 		long fileEntryTypeId = getFileEntryTypeId(fileEntry);
 
 		if (fileEntryAssetEntry == null) {
+			Date publishDate = fileEntry.getDisplayDate();
+
+			if (publishDate == null) {
+				publishDate = fileEntry.getCreateDate();
+			}
+
 			fileEntryAssetEntry = _assetEntryLocalService.updateEntry(
 				userId, fileEntry.getGroupId(), fileEntry.getCreateDate(),
 				fileEntry.getModifiedDate(),
 				DLFileEntryConstants.getClassName(), fileEntry.getFileEntryId(),
 				fileEntry.getUuid(), fileEntryTypeId, assetCategoryIds,
-				assetTagNames, true, false, null, null,
-				fileEntry.getDisplayDate(), fileEntry.getExpirationDate(),
-				fileEntry.getMimeType(), fileEntry.getTitle(),
-				fileEntry.getDescription(), null, null, null, 0, 0, null);
+				assetTagNames, true, false, null, null, publishDate,
+				fileEntry.getExpirationDate(), fileEntry.getMimeType(),
+				fileEntry.getTitle(), fileEntry.getDescription(), null, null,
+				null, 0, 0, null);
 		}
 
 		AssetEntry fileVersionAssetEntry = _assetEntryLocalService.fetchEntry(
@@ -167,12 +173,18 @@ public class DLAppHelperLocalServiceImpl
 		assetTagNames = _assetTagLocalService.getTagNames(
 			DLFileEntryConstants.getClassName(), fileEntry.getFileEntryId());
 
+		Date publishDate = fileEntry.getDisplayDate();
+
+		if (publishDate == null) {
+			publishDate = fileEntry.getCreateDate();
+		}
+
 		fileVersionAssetEntry = _assetEntryLocalService.updateEntry(
 			userId, fileEntry.getGroupId(), fileEntry.getCreateDate(),
 			fileEntry.getModifiedDate(), DLFileEntryConstants.getClassName(),
 			fileVersion.getFileVersionId(), fileEntry.getUuid(),
 			fileEntryTypeId, assetCategoryIds, assetTagNames, true, false, null,
-			null, fileEntry.getDisplayDate(), fileEntry.getExpirationDate(),
+			null, publishDate, fileEntry.getExpirationDate(),
 			fileEntry.getMimeType(), fileEntry.getTitle(),
 			fileEntry.getDescription(), null, null, null, 0, 0, null);
 
@@ -528,6 +540,10 @@ public class DLAppHelperLocalServiceImpl
 
 			if (visible) {
 				publishDate = fileEntry.getDisplayDate();
+
+				if (publishDate == null) {
+					publishDate = fileEntry.getCreateDate();
+				}
 			}
 
 			assetEntry = _assetEntryLocalService.updateEntry(
@@ -708,6 +724,12 @@ public class DLAppHelperLocalServiceImpl
 							draftAssetEntry.getCategoryIds();
 						String[] assetTagNames = draftAssetEntry.getTagNames();
 
+						Date publishDate = fileEntry.getDisplayDate();
+
+						if (publishDate == null) {
+							publishDate = fileEntry.getCreateDate();
+						}
+
 						AssetEntry assetEntry =
 							_assetEntryLocalService.updateEntry(
 								userId, fileEntry.getGroupId(),
@@ -717,8 +739,7 @@ public class DLAppHelperLocalServiceImpl
 								fileEntry.getFileEntryId(), fileEntry.getUuid(),
 								fileEntryTypeId, assetCategoryIds,
 								assetTagNames, true, true, null, null,
-								fileEntry.getDisplayDate(),
-								fileEntry.getExpirationDate(),
+								publishDate, fileEntry.getExpirationDate(),
 								draftAssetEntry.getMimeType(),
 								fileEntry.getTitle(),
 								fileEntry.getDescription(), null, null, null, 0,
@@ -738,11 +759,16 @@ public class DLAppHelperLocalServiceImpl
 					fileEntry.getFileEntryId());
 
 				if (assetEntry != null) {
+					Date publishDate = fileEntry.getDisplayDate();
+
+					if (publishDate == null) {
+						publishDate = assetEntry.getCreateDate();
+					}
+
 					_assetEntryLocalService.updateEntry(
 						assetEntry.getClassName(), assetEntry.getClassPK(),
-						fileEntry.getDisplayDate(),
-						assetEntry.getExpirationDate(), assetEntry.isListable(),
-						true);
+						publishDate, assetEntry.getExpirationDate(),
+						assetEntry.isListable(), true);
 				}
 			}
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppHelperLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppHelperLocalServiceImpl.java
@@ -137,21 +137,15 @@ public class DLAppHelperLocalServiceImpl
 		long fileEntryTypeId = getFileEntryTypeId(fileEntry);
 
 		if (fileEntryAssetEntry == null) {
-			Date publishDate = fileEntry.getDisplayDate();
-
-			if (publishDate == null) {
-				publishDate = fileEntry.getCreateDate();
-			}
-
 			fileEntryAssetEntry = _assetEntryLocalService.updateEntry(
 				userId, fileEntry.getGroupId(), fileEntry.getCreateDate(),
 				fileEntry.getModifiedDate(),
 				DLFileEntryConstants.getClassName(), fileEntry.getFileEntryId(),
 				fileEntry.getUuid(), fileEntryTypeId, assetCategoryIds,
-				assetTagNames, true, false, null, null, publishDate,
-				fileEntry.getExpirationDate(), fileEntry.getMimeType(),
-				fileEntry.getTitle(), fileEntry.getDescription(), null, null,
-				null, 0, 0, null);
+				assetTagNames, true, false, null, null,
+				_getPublishDate(fileEntry), fileEntry.getExpirationDate(),
+				fileEntry.getMimeType(), fileEntry.getTitle(),
+				fileEntry.getDescription(), null, null, null, 0, 0, null);
 		}
 
 		AssetEntry fileVersionAssetEntry = _assetEntryLocalService.fetchEntry(
@@ -173,18 +167,12 @@ public class DLAppHelperLocalServiceImpl
 		assetTagNames = _assetTagLocalService.getTagNames(
 			DLFileEntryConstants.getClassName(), fileEntry.getFileEntryId());
 
-		Date publishDate = fileEntry.getDisplayDate();
-
-		if (publishDate == null) {
-			publishDate = fileEntry.getCreateDate();
-		}
-
 		fileVersionAssetEntry = _assetEntryLocalService.updateEntry(
 			userId, fileEntry.getGroupId(), fileEntry.getCreateDate(),
 			fileEntry.getModifiedDate(), DLFileEntryConstants.getClassName(),
 			fileVersion.getFileVersionId(), fileEntry.getUuid(),
 			fileEntryTypeId, assetCategoryIds, assetTagNames, true, false, null,
-			null, publishDate, fileEntry.getExpirationDate(),
+			null, _getPublishDate(fileEntry), fileEntry.getExpirationDate(),
 			fileEntry.getMimeType(), fileEntry.getTitle(),
 			fileEntry.getDescription(), null, null, null, 0, 0, null);
 
@@ -539,11 +527,7 @@ public class DLAppHelperLocalServiceImpl
 			Date publishDate = null;
 
 			if (visible) {
-				publishDate = fileEntry.getDisplayDate();
-
-				if (publishDate == null) {
-					publishDate = fileEntry.getCreateDate();
-				}
+				publishDate = _getPublishDate(fileEntry);
 			}
 
 			assetEntry = _assetEntryLocalService.updateEntry(
@@ -724,12 +708,6 @@ public class DLAppHelperLocalServiceImpl
 							draftAssetEntry.getCategoryIds();
 						String[] assetTagNames = draftAssetEntry.getTagNames();
 
-						Date publishDate = fileEntry.getDisplayDate();
-
-						if (publishDate == null) {
-							publishDate = fileEntry.getCreateDate();
-						}
-
 						AssetEntry assetEntry =
 							_assetEntryLocalService.updateEntry(
 								userId, fileEntry.getGroupId(),
@@ -739,7 +717,8 @@ public class DLAppHelperLocalServiceImpl
 								fileEntry.getFileEntryId(), fileEntry.getUuid(),
 								fileEntryTypeId, assetCategoryIds,
 								assetTagNames, true, true, null, null,
-								publishDate, fileEntry.getExpirationDate(),
+								_getPublishDate(fileEntry),
+								fileEntry.getExpirationDate(),
 								draftAssetEntry.getMimeType(),
 								fileEntry.getTitle(),
 								fileEntry.getDescription(), null, null, null, 0,
@@ -759,16 +738,11 @@ public class DLAppHelperLocalServiceImpl
 					fileEntry.getFileEntryId());
 
 				if (assetEntry != null) {
-					Date publishDate = fileEntry.getDisplayDate();
-
-					if (publishDate == null) {
-						publishDate = assetEntry.getCreateDate();
-					}
-
 					_assetEntryLocalService.updateEntry(
 						assetEntry.getClassName(), assetEntry.getClassPK(),
-						publishDate, assetEntry.getExpirationDate(),
-						assetEntry.isListable(), true);
+						_getPublishDate(fileEntry),
+						assetEntry.getExpirationDate(), assetEntry.isListable(),
+						true);
 				}
 			}
 
@@ -929,6 +903,16 @@ public class DLAppHelperLocalServiceImpl
 
 		_ratingsStatsLocalService.deleteStats(
 			DLFileEntryConstants.getClassName(), fileEntryId);
+	}
+
+	private Date _getPublishDate(FileEntry fileEntry) {
+		Date displayDate = fileEntry.getDisplayDate();
+
+		if (displayDate == null) {
+			return fileEntry.getCreateDate();
+		}
+
+		return displayDate;
 	}
 
 	@BeanReference(type = AssetCategoryLocalService.class)


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-87858

**What is being fixed:** LPD-85646 changed `DLAppHelperLocalServiceImpl` so the asset entry's `publishDate` strictly tracks the file entry's `displayDate`. When a file is added without an explicit Display Date — the default for `DLAppService.addFileEntry(...)` — `publishDate` is now persisted as `null`, which regresses several integration tests:

- `DLAppServiceWhenAddingAFileEntryTest.testAssetEntryShouldHavePublishDate` (this ticket)
- `DLFileEntryIndexerIndexedFieldsTest.testIndexedFields` ([LPD-87819](https://liferay.atlassian.net/browse/LPD-87819) — the indexer renders the null publishDate as `19700101000000`)
- `FileEntryOpenNLPDocumentAssetAutoTaggerTest.testAutoTagsAnAsset` ([LPD-87828](https://liferay.atlassian.net/browse/LPD-87828) — `AssetEntryModelListener` gates auto-tagging on `publishDate != null`, so the OpenNLP provider was never invoked)

**How it is being fixed:** Restore a fallback to the file entry's `createDate` whenever `displayDate` is null, applied at all five sites that LPD-85646 modified (`checkAssetEntry`, `updateAsset`, and both branches of `updateStatus`). The fallback is extracted into a private `_getPublishDate(FileEntry)` helper so each call site reads cleanly. LPD-85646's intent — honoring a user-set Display Date — is preserved; the helper only kicks in when no Display Date is set.

_AI-assisted with Claude Code._