### PR TITLE
LPD-87905 Use WebContentNavigator to open Web Content admin

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/trash/RecycleBinWithWebContent.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/trash/RecycleBinWithWebContent.testcase
@@ -130,11 +130,7 @@ definition {
 		}
 
 		task ("Navigate to Web Content admin") {
-			ApplicationsMenu.gotoSite(site = "Test Site Name");
-
-			ProductMenu.gotoPortlet(
-				category = "Content & Data",
-				portlet = "Web Content");
+			WebContentNavigator.openWebContentAdmin(siteURLKey = "test-site-name");
 		}
 
 		task ("Expand the Recycle Bin category") {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-87905

**What is being fixed:** The Poshi test `RecycleBinWithWebContent#MoveWebContentToRecycleBinViaDragAndDrop` was failing on CI with `Element is not present at "//*[@data-qa-id='productMenuBody']"`. The test navigated to Web Content admin via `ApplicationsMenu.gotoSite(...)` followed by `ProductMenu.gotoPortlet(...)`, a two-step path that occasionally left the product menu in a state where the body was not yet rendered when the next assertion ran.

**How it is being fixed:** Replace the two-step navigation with a direct call to `WebContentNavigator.openWebContentAdmin(siteURLKey = "test-site-name")`, which navigates straight to the admin URL and bypasses the product-menu interaction. This matches the navigation pattern the sibling tests in the same testcase already use.