### PR TITLE
LPD-78457 Allow sharing ObjectEntry collaborators by email address

### DIFF
--- a/modules/apps/headless/headless-object/headless-object-api/bnd.bnd
+++ b/modules/apps/headless/headless-object/headless-object-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless Object API
 Bundle-SymbolicName: com.liferay.headless.object.api
-Bundle-Version: 4.0.3
+Bundle-Version: 5.0.0
 Export-Package:\
 	com.liferay.headless.object.dto.v1_0,\
 	com.liferay.headless.object.resource.v1_0,\

--- a/modules/apps/headless/headless-object/headless-object-api/src/main/java/com/liferay/headless/object/dto/v1_0/Collaborator.java
+++ b/modules/apps/headless/headless-object/headless-object-api/src/main/java/com/liferay/headless/object/dto/v1_0/Collaborator.java
@@ -243,6 +243,47 @@ public class Collaborator implements Serializable {
 	@JsonIgnore
 	private Supplier<Date> _dateExpiredSupplier;
 
+	@io.swagger.v3.oas.annotations.media.Schema
+	public String getEmailAddress() {
+		if (_emailAddressSupplier != null) {
+			emailAddress = _emailAddressSupplier.get();
+
+			_emailAddressSupplier = null;
+		}
+
+		return emailAddress;
+	}
+
+	public void setEmailAddress(String emailAddress) {
+		this.emailAddress = emailAddress;
+
+		_emailAddressSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setEmailAddress(
+		UnsafeSupplier<String, Exception> emailAddressUnsafeSupplier) {
+
+		_emailAddressSupplier = () -> {
+			try {
+				return emailAddressUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String emailAddress;
+
+	@JsonIgnore
+	private Supplier<String> _emailAddressSupplier;
+
 	@io.swagger.v3.oas.annotations.media.Schema(
 		description = "The collaborator external reference code."
 	)
@@ -594,6 +635,22 @@ public class Collaborator implements Serializable {
 			sb.append("\"");
 		}
 
+		String emailAddress = getEmailAddress();
+
+		if (emailAddress != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"emailAddress\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(emailAddress));
+
+			sb.append("\"");
+		}
+
 		String externalReferenceCode = getExternalReferenceCode();
 
 		if (externalReferenceCode != null) {
@@ -783,4 +840,4 @@ public class Collaborator implements Serializable {
 	private Map<String, Serializable> _extendedProperties;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-969258372
+// LIFERAY-REST-BUILDER-HASH:1784333370

--- a/modules/apps/headless/headless-object/headless-object-api/src/main/java/com/liferay/headless/object/util/v1_0/CollaboratorUtil.java
+++ b/modules/apps/headless/headless-object/headless-object-api/src/main/java/com/liferay/headless/object/util/v1_0/CollaboratorUtil.java
@@ -280,19 +280,19 @@ public class CollaboratorUtil {
 	}
 
 	public static void deleteCollaborator(
-			String className, long classNameId, long classPK,
-			Long collaboratorId, SharingEntryService sharingEntryService,
-			TicketLocalService ticketLocalService, String type)
+			long classNameId, long classPK, Long collaboratorId,
+			SharingEntryService sharingEntryService, String type)
 		throws Exception {
 
 		_validateType(type);
 
 		if (StringUtil.equals("Email", type)) {
-			_deleteCollaboratorTicket(
-				className, classNameId, classPK, collaboratorId,
-				sharingEntryService, ticketLocalService);
+			throw new IllegalArgumentException(
+				"Use deleteCollaboratorByEmailAddress to delete a " +
+					"collaborator of type \"Email\"");
 		}
-		else if (StringUtil.equals("User", type)) {
+
+		if (StringUtil.equals("User", type)) {
 			sharingEntryService.deleteSharingEntry(
 				0, 0, collaboratorId, classNameId, classPK);
 		}
@@ -349,39 +349,20 @@ public class CollaboratorUtil {
 	}
 
 	public static Collaborator getCollaborator(
-			AcceptLanguage acceptLanguage, String className, long classNameId,
-			long classPK, Long collaboratorId,
+			AcceptLanguage acceptLanguage, long classNameId, long classPK,
+			Long collaboratorId,
 			DTOConverter<SharingEntry, Collaborator> dtoConverter,
 			DTOConverterRegistry dtoConverterRegistry,
-			SharingEntryService sharingEntryService,
-			TicketLocalService ticketLocalService, String type, UriInfo uriInfo,
-			User user)
+			SharingEntryService sharingEntryService, String type,
+			UriInfo uriInfo, User user)
 		throws Exception {
 
 		_validateType(type);
 
 		if (StringUtil.equals("Email", type)) {
-			Ticket ticket = ticketLocalService.fetchTicket(collaboratorId);
-
-			if ((ticket == null) ||
-				!Objects.equals(className, ticket.getClassName()) ||
-				(classPK != ticket.getClassPK()) ||
-				(ticket.getType() !=
-					SharingTicketConstants.TYPE_INVITE_COLLABORATOR)) {
-
-				throw new NoSuchModelException();
-			}
-
-			SharingEntry sharingEntry = sharingEntryService.fetchSharingEntry(
-				collaboratorId, 0, 0, classNameId, classPK);
-
-			if (sharingEntry == null) {
-				throw new NoSuchModelException();
-			}
-
-			return toCollaborator(
-				acceptLanguage, dtoConverter, dtoConverterRegistry,
-				sharingEntry, uriInfo, user);
+			throw new IllegalArgumentException(
+				"Use getCollaboratorByEmailAddress to retrieve a " +
+					"collaborator of type \"Email\"");
 		}
 
 		if (StringUtil.equals("User", type)) {
@@ -599,33 +580,6 @@ public class CollaboratorUtil {
 		ticket.setExtraInfo(extraInfo);
 
 		return ticketLocalService.updateTicket(ticket);
-	}
-
-	private static void _deleteCollaboratorTicket(
-			String className, long classNameId, long classPK,
-			Long collaboratorId, SharingEntryService sharingEntryService,
-			TicketLocalService ticketLocalService)
-		throws Exception {
-
-		Ticket ticket = ticketLocalService.fetchTicket(collaboratorId);
-
-		if ((ticket == null) ||
-			!Objects.equals(className, ticket.getClassName()) ||
-			(classPK != ticket.getClassPK()) ||
-			(ticket.getType() !=
-				SharingTicketConstants.TYPE_INVITE_COLLABORATOR)) {
-
-			throw new NoSuchModelException();
-		}
-
-		SharingEntry sharingEntry = sharingEntryService.fetchSharingEntry(
-			collaboratorId, 0, 0, classNameId, classPK);
-
-		if (sharingEntry != null) {
-			sharingEntryService.deleteSharingEntry(sharingEntry);
-		}
-
-		ticketLocalService.deleteTicket(ticket.getTicketId());
 	}
 
 	private static Ticket _fetchTicketByEmailAddress(

--- a/modules/apps/headless/headless-object/headless-object-api/src/main/java/com/liferay/headless/object/util/v1_0/CollaboratorUtil.java
+++ b/modules/apps/headless/headless-object/headless-object-api/src/main/java/com/liferay/headless/object/util/v1_0/CollaboratorUtil.java
@@ -7,6 +7,7 @@ package com.liferay.headless.object.util.v1_0;
 
 import com.liferay.headless.object.dto.v1_0.Collaborator;
 import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.NoSuchGroupException;
 import com.liferay.portal.kernel.exception.NoSuchModelException;
@@ -36,6 +37,7 @@ import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.util.GroupUtil;
 import com.liferay.sharing.constants.SharingTicketConstants;
+import com.liferay.sharing.exception.DuplicateSharingEntryException;
 import com.liferay.sharing.model.SharingEntry;
 import com.liferay.sharing.security.permission.SharingEntryAction;
 import com.liferay.sharing.service.SharingEntryLocalService;
@@ -110,7 +112,20 @@ public class CollaboratorUtil {
 			companyId, emailAddress, userLocalService);
 
 		if (userId > 0) {
-			SharingEntry sharingEntry = _addOrUpdateSharingEntry(
+			SharingEntry sharingEntry = sharingEntryService.fetchSharingEntry(
+				0, 0, userId, classNameId, classPK);
+
+			if ((sharingEntry != null) &&
+				(sharingEntry.getUserId() != user.getUserId())) {
+
+				throw new DuplicateSharingEntryException(
+					StringBundler.concat(
+						"A sharing entry already exists for user ", userId,
+						" with classNameId ", classNameId, " and classPK ",
+						classPK));
+			}
+
+			sharingEntry = _addOrUpdateSharingEntry(
 				classNameId, classPK, collaborator, userId, groupId,
 				sharingEntryService, "User", userGroupLocalService,
 				userLocalService);
@@ -178,6 +193,19 @@ public class CollaboratorUtil {
 					userLocalService);
 
 				if (userId > 0) {
+					sharingEntry = sharingEntryService.fetchSharingEntry(
+						0, 0, userId, classNameId, classPK);
+
+					if ((sharingEntry != null) &&
+						(sharingEntry.getUserId() != user.getUserId())) {
+
+						throw new DuplicateSharingEntryException(
+							StringBundler.concat(
+								"A sharing entry already exists for user ",
+								userId, " with classNameId ", classNameId,
+								" and classPK ", classPK));
+					}
+
 					sharingEntry = _addOrUpdateSharingEntry(
 						classNameId, classPK, collaborator, userId, groupId,
 						sharingEntryService, "User", userGroupLocalService,

--- a/modules/apps/headless/headless-object/headless-object-api/src/main/java/com/liferay/headless/object/util/v1_0/CollaboratorUtil.java
+++ b/modules/apps/headless/headless-object/headless-object-api/src/main/java/com/liferay/headless/object/util/v1_0/CollaboratorUtil.java
@@ -74,13 +74,23 @@ public class CollaboratorUtil {
 				companyId, collaborator.getEmailAddress());
 
 			if (existingUser != null) {
+				SharingEntry sharingEntry = _addOrUpdateSharingEntry(
+					classNameId, classPK, collaborator,
+					existingUser.getUserId(), groupId, sharingEntryService,
+					"User", userGroupLocalService, userLocalService);
+
+				Ticket ticket = _fetchTicketByEmailAddress(
+					companyId, className, classPK,
+					collaborator.getEmailAddress(), jsonFactory,
+					ticketLocalService);
+
+				if (ticket != null) {
+					ticketLocalService.deleteTicket(ticket.getTicketId());
+				}
+
 				return toCollaborator(
 					acceptLanguage, dtoConverter, dtoConverterRegistry,
-					_addOrUpdateSharingEntry(
-						classNameId, classPK, collaborator,
-						existingUser.getUserId(), groupId, sharingEntryService,
-						"User", userGroupLocalService, userLocalService),
-					uriInfo, user);
+					sharingEntry, uriInfo, user);
 			}
 
 			Ticket ticket = _addOrUpdateTicket(

--- a/modules/apps/headless/headless-object/headless-object-api/src/main/java/com/liferay/headless/object/util/v1_0/CollaboratorUtil.java
+++ b/modules/apps/headless/headless-object/headless-object-api/src/main/java/com/liferay/headless/object/util/v1_0/CollaboratorUtil.java
@@ -186,10 +186,10 @@ public class CollaboratorUtil {
 				else {
 					Ticket ticket = _addOrUpdateTicket(
 						className, classPK, collaborator, companyId,
-						_fetchTicket(
-							className, classPK, collaborator,
-							GetterUtil.getLong(collaborator.getId()), companyId,
-							jsonFactory, ticketLocalService),
+						_fetchTicketByEmailAddress(
+							className, classPK, companyId,
+							collaborator.getEmailAddress(), jsonFactory,
+							ticketLocalService),
 						ticketLocalService, collaborator.getType());
 
 					sharingEntry = _addOrUpdateSharingEntry(
@@ -598,23 +598,6 @@ public class CollaboratorUtil {
 		}
 
 		ticketLocalService.deleteTicket(ticket.getTicketId());
-	}
-
-	private static Ticket _fetchTicket(
-			String className, long classPK, Collaborator collaborator,
-			long collaboratorId, long companyId, JSONFactory jsonFactory,
-			TicketLocalService ticketLocalService)
-		throws Exception {
-
-		Ticket ticket = ticketLocalService.fetchTicket(collaboratorId);
-
-		if (ticket != null) {
-			return ticket;
-		}
-
-		return _fetchTicketByEmailAddress(
-			className, classPK, companyId, collaborator.getEmailAddress(),
-			jsonFactory, ticketLocalService);
 	}
 
 	private static Ticket _fetchTicketByEmailAddress(

--- a/modules/apps/headless/headless-object/headless-object-api/src/main/java/com/liferay/headless/object/util/v1_0/CollaboratorUtil.java
+++ b/modules/apps/headless/headless-object/headless-object-api/src/main/java/com/liferay/headless/object/util/v1_0/CollaboratorUtil.java
@@ -9,14 +9,21 @@ import com.liferay.headless.object.dto.v1_0.Collaborator;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.NoSuchGroupException;
+import com.liferay.portal.kernel.exception.NoSuchModelException;
+import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.model.Ticket;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.UserGroup;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.TicketLocalService;
 import com.liferay.portal.kernel.service.UserGroupLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.OrderByComparatorFactoryUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
@@ -24,6 +31,7 @@ import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.util.GroupUtil;
+import com.liferay.sharing.constants.SharingTicketConstants;
 import com.liferay.sharing.model.SharingEntry;
 import com.liferay.sharing.security.permission.SharingEntryAction;
 import com.liferay.sharing.service.SharingEntryLocalService;
@@ -34,9 +42,11 @@ import jakarta.ws.rs.core.UriInfo;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 
 /**
  * @author Mikel Lorza
@@ -44,16 +54,54 @@ import java.util.Objects;
 public class CollaboratorUtil {
 
 	public static Collaborator addOrUpdateCollaborator(
-			AcceptLanguage acceptLanguage, long classNameId, long classPK,
-			Collaborator collaborator, long collaboratorId,
+			AcceptLanguage acceptLanguage, String className, long classNameId,
+			long classPK, Collaborator collaborator, long collaboratorId,
 			DTOConverter<SharingEntry, Collaborator> dtoConverter,
-			DTOConverterRegistry dtoConverterRegistry, long groupId,
-			SharingEntryService sharingEntryService, String type,
+			long companyId, DTOConverterRegistry dtoConverterRegistry,
+			long groupId, JSONFactory jsonFactory,
+			SharingEntryService sharingEntryService,
+			TicketLocalService ticketLocalService, String type,
 			UserGroupLocalService userGroupLocalService, UriInfo uriInfo,
 			User user, UserLocalService userLocalService)
 		throws Exception {
 
 		_validateType(type);
+
+		if (Objects.equals(type, "Email")) {
+			_validateEmailAddress(collaborator.getEmailAddress());
+
+			User existingUser = userLocalService.fetchUserByEmailAddress(
+				companyId, collaborator.getEmailAddress());
+
+			if (existingUser != null) {
+				_addOrUpdateSharingEntry(
+					classNameId, classPK, collaborator,
+					existingUser.getUserId(), groupId, sharingEntryService,
+					"User", userGroupLocalService, userLocalService);
+
+				return new Collaborator() {
+					{
+						setActionIds(collaborator::getActionIds);
+						setEmailAddress(collaborator::getEmailAddress);
+						setId(existingUser::getUserId);
+						setShare(collaborator::getShare);
+						setType(() -> "Email");
+					}
+				};
+			}
+
+			Ticket ticket = _addOrUpdateTicket(
+				className, classPK, collaborator, collaboratorId, companyId,
+				ticketLocalService, type);
+
+			return toCollaborator(
+				acceptLanguage, dtoConverter, dtoConverterRegistry,
+				_addOrUpdateSharingEntry(
+					classNameId, classPK, collaborator, ticket.getTicketId(),
+					groupId, sharingEntryService, type, userGroupLocalService,
+					userLocalService),
+				uriInfo, user);
+		}
 
 		return toCollaborator(
 			acceptLanguage, dtoConverter, dtoConverterRegistry,
@@ -65,11 +113,12 @@ public class CollaboratorUtil {
 	}
 
 	public static Page<Collaborator> addOrUpdateCollaborators(
-			AcceptLanguage acceptLanguage, long classNameId, long classPK,
-			Collaborator[] collaborators,
+			AcceptLanguage acceptLanguage, String className, long classNameId,
+			long classPK, Collaborator[] collaborators, long companyId,
 			DTOConverter<SharingEntry, Collaborator> dtoConverter,
 			DTOConverterRegistry dtoConverterRegistry, long groupId,
-			SharingEntryService sharingEntryService, UriInfo uriInfo, User user,
+			JSONFactory jsonFactory, SharingEntryService sharingEntryService,
+			TicketLocalService ticketLocalService, UriInfo uriInfo, User user,
 			UserGroupLocalService userGroupLocalService,
 			UserLocalService userLocalService)
 		throws Exception {
@@ -79,18 +128,64 @@ public class CollaboratorUtil {
 				classNameId, classPK, groupId, QueryUtil.ALL_POS,
 				QueryUtil.ALL_POS, null);
 
+		List<String> collaboratorEmailAddresses = new ArrayList<>();
 		List<SharingEntry> newSharingEntries = new ArrayList<>();
-
 		List<Long> sharingEntriesIds = new ArrayList<>();
 
 		for (Collaborator collaborator : collaborators) {
-			SharingEntry sharingEntry = _addOrUpdateSharingEntry(
-				classNameId, classPK, collaborator, collaborator.getId(),
-				groupId, sharingEntryService, collaborator.getType(),
-				userGroupLocalService, userLocalService);
+			SharingEntry sharingEntry = null;
+
+			if (Objects.equals(collaborator.getType(), "Email")) {
+				_validateEmailAddress(collaborator.getEmailAddress());
+
+				User existingUser = userLocalService.fetchUserByEmailAddress(
+					companyId, collaborator.getEmailAddress());
+
+				if (existingUser == null) {
+					Ticket ticket = _addOrUpdateTicket(
+						className, classPK, collaborator, collaborator.getId(),
+						companyId, ticketLocalService, collaborator.getType());
+
+					sharingEntry = _addOrUpdateSharingEntry(
+						classNameId, classPK, collaborator,
+						ticket.getTicketId(), groupId, sharingEntryService,
+						collaborator.getType(), userGroupLocalService,
+						userLocalService);
+
+					collaboratorEmailAddresses.add(
+						collaborator.getEmailAddress());
+				}
+				else {
+					sharingEntry = _addOrUpdateSharingEntry(
+						classNameId, classPK, collaborator,
+						existingUser.getUserId(), groupId, sharingEntryService,
+						"User", userGroupLocalService, userLocalService);
+				}
+			}
+			else {
+				sharingEntry = _addOrUpdateSharingEntry(
+					classNameId, classPK, collaborator, collaborator.getId(),
+					groupId, sharingEntryService, collaborator.getType(),
+					userGroupLocalService, userLocalService);
+			}
 
 			newSharingEntries.add(sharingEntry);
 			sharingEntriesIds.add(sharingEntry.getSharingEntryId());
+		}
+
+		List<Ticket> tickets = ticketLocalService.getTickets(
+			className, classPK,
+			SharingTicketConstants.TYPE_INVITE_COLLABORATOR);
+
+		for (Ticket ticket : tickets) {
+			JSONObject jsonObject = jsonFactory.createJSONObject(
+				ticket.getExtraInfo());
+
+			if (!collaboratorEmailAddresses.contains(
+					jsonObject.getString("emailAddress"))) {
+
+				ticketLocalService.deleteTicket(ticket.getTicketId());
+			}
 		}
 
 		for (SharingEntry sharingEntry : oldSharingEntries) {
@@ -116,32 +211,57 @@ public class CollaboratorUtil {
 	}
 
 	public static void deleteCollaborator(
-			long classNameId, long classPK, Long collaboratorId,
-			SharingEntryService sharingEntryService, String type)
+			String className, long classNameId, long classPK,
+			Long collaboratorId, SharingEntryService sharingEntryService,
+			TicketLocalService ticketLocalService, String type)
 		throws Exception {
 
 		_validateType(type);
 
-		if (StringUtil.equals("User", type)) {
+		if (StringUtil.equals("Email", type)) {
+			_deleteInvitedCollaborator(
+				collaboratorId, className, classNameId, classPK,
+				sharingEntryService, ticketLocalService);
+		}
+		else if (StringUtil.equals("User", type)) {
 			sharingEntryService.deleteSharingEntry(
 				0, 0, collaboratorId, classNameId, classPK);
 		}
-		else {
+		else if (StringUtil.equals("UserGroup", type)) {
 			sharingEntryService.deleteSharingEntry(
 				0, collaboratorId, 0, classNameId, classPK);
 		}
 	}
 
 	public static Collaborator getCollaborator(
-			AcceptLanguage acceptLanguage, long classNameId, long classPK,
-			Long collaboratorId,
+			AcceptLanguage acceptLanguage, String className, long classNameId,
+			long classPK, Long collaboratorId,
 			DTOConverter<SharingEntry, Collaborator> dtoConverter,
-			DTOConverterRegistry dtoConverterRegistry,
-			SharingEntryService sharingEntryService, String type,
-			UriInfo uriInfo, User user)
+			DTOConverterRegistry dtoConverterRegistry, JSONFactory jsonFactory,
+			SharingEntryService sharingEntryService,
+			TicketLocalService ticketLocalService, String type, UriInfo uriInfo,
+			User user)
 		throws Exception {
 
 		_validateType(type);
+
+		if (StringUtil.equals("Email", type)) {
+			Ticket ticket = ticketLocalService.getTicket(collaboratorId);
+
+			if (!Objects.equals(className, ticket.getClassName()) ||
+				(classPK != ticket.getClassPK()) ||
+				(ticket.getType() !=
+					SharingTicketConstants.TYPE_INVITE_COLLABORATOR)) {
+
+				throw new NoSuchModelException();
+			}
+
+			return toCollaborator(
+				acceptLanguage, dtoConverter, dtoConverterRegistry,
+				sharingEntryService.getSharingEntry(
+					collaboratorId, 0, 0, classNameId, classPK),
+				uriInfo, user);
+		}
 
 		if (StringUtil.equals("User", type)) {
 			return toCollaborator(
@@ -167,20 +287,22 @@ public class CollaboratorUtil {
 			SharingEntryService sharingEntryService, UriInfo uriInfo, User user)
 		throws Exception {
 
-		return Page.of(
-			TransformUtil.transform(
-				sharingEntryService.getSharingEntries(
-					classNameId, classPK, groupId,
-					pagination.getStartPosition(), pagination.getEndPosition(),
-					OrderByComparatorFactoryUtil.create(
-						"SharingEntry", "createDate", false, "sharingEntryId",
-						false)),
-				sharingEntry -> toCollaborator(
-					acceptLanguage, dtoConverter, dtoConverterRegistry,
-					sharingEntry, uriInfo, user)),
-			pagination,
+		int sharingEntriesCount =
 			sharingEntryLocalService.getSharingEntriesCount(
-				classNameId, classPK));
+				classNameId, classPK);
+
+		List<Collaborator> collaborators = TransformUtil.transform(
+			sharingEntryService.getSharingEntries(
+				classNameId, classPK, groupId, pagination.getStartPosition(),
+				pagination.getEndPosition(),
+				OrderByComparatorFactoryUtil.create(
+					"SharingEntry", "createDate", false, "sharingEntryId",
+					false)),
+			sharingEntry -> toCollaborator(
+				acceptLanguage, dtoConverter, dtoConverterRegistry,
+				sharingEntry, uriInfo, user));
+
+		return Page.of(collaborators, pagination, sharingEntriesCount);
 	}
 
 	public static long getGroupId(
@@ -227,16 +349,20 @@ public class CollaboratorUtil {
 
 		_validateType(type);
 
+		long toTicketId = 0;
 		long toUserGroupId = 0;
 		long toUserId = 0;
 
-		if (StringUtil.equals("UserGroup", type)) {
+		if (StringUtil.equals("Email", type)) {
+			toTicketId = collaboratorId;
+		}
+		else if (StringUtil.equals("UserGroup", type)) {
 			UserGroup userGroup = userGroupLocalService.getUserGroup(
 				collaboratorId);
 
 			toUserGroupId = userGroup.getUserGroupId();
 		}
-		else {
+		else if (StringUtil.equals("User", type)) {
 			User user = userLocalService.getUser(collaboratorId);
 
 			toUserId = user.getUserId();
@@ -249,20 +375,117 @@ public class CollaboratorUtil {
 		}
 
 		return sharingEntryService.addOrUpdateSharingEntry(
-			null, 0, toUserGroupId, toUserId, classNameId, classPK, groupId,
-			shareable,
+			null, toTicketId, toUserGroupId, toUserId, classNameId, classPK,
+			groupId, shareable,
 			TransformUtil.transformToList(
 				collaborator.getActionIds(),
 				SharingEntryAction::parseFromActionId),
 			collaborator.getDateExpired(), new ServiceContext());
 	}
 
+	private static Ticket _addOrUpdateTicket(
+			String className, long classPK, Collaborator collaborator,
+			long collaboratorId, long companyId,
+			TicketLocalService ticketLocalService, String type)
+		throws Exception {
+
+		Ticket ticket = ticketLocalService.fetchTicket(collaboratorId);
+
+		if ((ticket != null) &&
+			(!Objects.equals(className, ticket.getClassName()) ||
+			 (classPK != ticket.getClassPK()) ||
+			 (ticket.getType() !=
+				 SharingTicketConstants.TYPE_INVITE_COLLABORATOR))) {
+
+			throw new NoSuchModelException();
+		}
+
+		String extraInfo = JSONUtil.put(
+			"actionIds", collaborator.getActionIds()
+		).put(
+			"emailAddress", collaborator.getEmailAddress()
+		).put(
+			"share", collaborator.getShare()
+		).put(
+			"type", type
+		).toString();
+
+		if (ticket == null) {
+			Date expirationDate = collaborator.getDateExpired();
+
+			if (expirationDate == null) {
+				expirationDate = new Date(
+					System.currentTimeMillis() +
+						TimeUnit.HOURS.toMillis(
+							SharingTicketConstants.
+								DEFAULT_INVITATION_EXPIRATION_HOURS));
+			}
+
+			return ticketLocalService.addTicket(
+				companyId, className, classPK,
+				SharingTicketConstants.TYPE_INVITE_COLLABORATOR, extraInfo,
+				expirationDate, null);
+		}
+
+		if (collaborator.getDateExpired() != null) {
+			ticket.setExpirationDate(collaborator.getDateExpired());
+		}
+
+		ticket.setExtraInfo(extraInfo);
+
+		return ticketLocalService.updateTicket(ticket);
+	}
+
+	private static void _deleteInvitedCollaborator(
+			Long invitedCollaboratorId, String className, long classNameId,
+			long classPK, SharingEntryService sharingEntryService,
+			TicketLocalService ticketLocalService)
+		throws Exception {
+
+		Ticket ticket = ticketLocalService.fetchTicket(invitedCollaboratorId);
+
+		if (ticket == null) {
+			return;
+		}
+
+		if (!Objects.equals(className, ticket.getClassName()) ||
+			(classPK != ticket.getClassPK()) ||
+			(ticket.getType() !=
+				SharingTicketConstants.TYPE_INVITE_COLLABORATOR)) {
+
+			throw new NoSuchModelException();
+		}
+
+		ticketLocalService.deleteTicket(ticket.getTicketId());
+
+		SharingEntry sharingEntry = sharingEntryService.fetchSharingEntry(
+			invitedCollaboratorId, 0, 0, classNameId, classPK);
+
+		if (sharingEntry != null) {
+			sharingEntryService.deleteSharingEntry(sharingEntry);
+		}
+	}
+
+	private static void _validateEmailAddress(String emailAddress) {
+		if (Validator.isNull(emailAddress)) {
+			throw new IllegalArgumentException(
+				"Collaborator type \"Email\" must have an email address");
+		}
+
+		if (!Validator.isEmailAddress(emailAddress)) {
+			throw new IllegalArgumentException(
+				"Invalid email address: " + emailAddress);
+		}
+	}
+
 	private static void _validateType(String type) {
-		if (!StringUtil.equals("User", type) &&
+		if (!StringUtil.equals("Email", type) &&
+			!StringUtil.equals("User", type) &&
 			!StringUtil.equals("UserGroup", type)) {
 
 			throw new IllegalArgumentException(
-				"Collaborator type must be \"User\" or \"UserGroup\"");
+				"Collaborator type must be \"Email\", \"User\" or " +
+					"\"UserGroup\"");
 		}
 	}
 

--- a/modules/apps/headless/headless-object/headless-object-api/src/main/java/com/liferay/headless/object/util/v1_0/CollaboratorUtil.java
+++ b/modules/apps/headless/headless-object/headless-object-api/src/main/java/com/liferay/headless/object/util/v1_0/CollaboratorUtil.java
@@ -91,7 +91,10 @@ public class CollaboratorUtil {
 			}
 
 			Ticket ticket = _addOrUpdateTicket(
-				className, classPK, collaborator, collaboratorId, companyId,
+				className, classPK, collaborator, companyId,
+				_fetchTicket(
+					companyId, className, classPK, collaborator, collaboratorId,
+					jsonFactory, ticketLocalService),
 				ticketLocalService, type);
 
 			return toCollaborator(
@@ -143,8 +146,12 @@ public class CollaboratorUtil {
 
 				if (existingUser == null) {
 					Ticket ticket = _addOrUpdateTicket(
-						className, classPK, collaborator, collaborator.getId(),
-						companyId, ticketLocalService, collaborator.getType());
+						className, classPK, collaborator, companyId,
+						_fetchTicket(
+							companyId, className, classPK, collaborator,
+							collaborator.getId(), jsonFactory,
+							ticketLocalService),
+						ticketLocalService, collaborator.getType());
 
 					sharingEntry = _addOrUpdateSharingEntry(
 						classNameId, classPK, collaborator,
@@ -385,11 +392,9 @@ public class CollaboratorUtil {
 
 	private static Ticket _addOrUpdateTicket(
 			String className, long classPK, Collaborator collaborator,
-			long collaboratorId, long companyId,
+			long companyId, Ticket ticket,
 			TicketLocalService ticketLocalService, String type)
 		throws Exception {
-
-		Ticket ticket = ticketLocalService.fetchTicket(collaboratorId);
 
 		if ((ticket != null) &&
 			(!Objects.equals(className, ticket.getClassName()) ||
@@ -456,14 +461,54 @@ public class CollaboratorUtil {
 			throw new NoSuchModelException();
 		}
 
-		ticketLocalService.deleteTicket(ticket.getTicketId());
-
 		SharingEntry sharingEntry = sharingEntryService.fetchSharingEntry(
 			invitedCollaboratorId, 0, 0, classNameId, classPK);
 
 		if (sharingEntry != null) {
 			sharingEntryService.deleteSharingEntry(sharingEntry);
 		}
+
+		ticketLocalService.deleteTicket(ticket.getTicketId());
+	}
+
+	private static Ticket _fetchTicket(
+			long companyId, String className, long classPK,
+			Collaborator collaborator, long collaboratorId,
+			JSONFactory jsonFactory, TicketLocalService ticketLocalService)
+		throws Exception {
+
+		Ticket ticket = ticketLocalService.fetchTicket(collaboratorId);
+
+		if (ticket != null) {
+			return ticket;
+		}
+
+		return _fetchTicketByEmailAddress(
+			companyId, className, classPK, collaborator.getEmailAddress(),
+			jsonFactory, ticketLocalService);
+	}
+
+	private static Ticket _fetchTicketByEmailAddress(
+			long companyId, String className, long classPK, String emailAddress,
+			JSONFactory jsonFactory, TicketLocalService ticketLocalService)
+		throws Exception {
+
+		List<Ticket> tickets = ticketLocalService.getTickets(
+			companyId, className, classPK,
+			SharingTicketConstants.TYPE_INVITE_COLLABORATOR);
+
+		for (Ticket ticket : tickets) {
+			JSONObject jsonObject = jsonFactory.createJSONObject(
+				ticket.getExtraInfo());
+
+			if (Objects.equals(
+					emailAddress, jsonObject.getString("emailAddress"))) {
+
+				return ticket;
+			}
+		}
+
+		return null;
 	}
 
 	private static void _validateEmailAddress(String emailAddress) {

--- a/modules/apps/headless/headless-object/headless-object-api/src/main/java/com/liferay/headless/object/util/v1_0/CollaboratorUtil.java
+++ b/modules/apps/headless/headless-object/headless-object-api/src/main/java/com/liferay/headless/object/util/v1_0/CollaboratorUtil.java
@@ -16,11 +16,14 @@ import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.Ticket;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.UserGroup;
+import com.liferay.portal.kernel.security.auth.GuestOrUserUtil;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.TicketLocalService;
 import com.liferay.portal.kernel.service.UserGroupLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.service.permission.UserPermissionUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.OrderByComparatorFactoryUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -275,7 +278,7 @@ public class CollaboratorUtil {
 			String className, long classNameId, long classPK, long companyId,
 			String emailAddress, JSONFactory jsonFactory,
 			SharingEntryService sharingEntryService,
-			TicketLocalService ticketLocalService,
+			TicketLocalService ticketLocalService, long userId,
 			UserLocalService userLocalService)
 		throws Exception {
 
@@ -289,6 +292,12 @@ public class CollaboratorUtil {
 				0, 0, user.getUserId(), classNameId, classPK);
 
 			if (sharingEntry != null) {
+				if ((sharingEntry.getUserId() != userId) &&
+					!_hasViewPermission(user)) {
+
+					throw new NoSuchModelException();
+				}
+
 				sharingEntryService.deleteSharingEntry(sharingEntry);
 			}
 		}
@@ -643,6 +652,12 @@ public class CollaboratorUtil {
 		}
 
 		return user.getUserId();
+	}
+
+	private static boolean _hasViewPermission(User user) throws Exception {
+		return UserPermissionUtil.contains(
+			GuestOrUserUtil.getPermissionChecker(), user.getUserId(),
+			ActionKeys.VIEW);
 	}
 
 	private static void _validateEmailActionIds(String[] actionIds) {

--- a/modules/apps/headless/headless-object/headless-object-api/src/main/java/com/liferay/headless/object/util/v1_0/CollaboratorUtil.java
+++ b/modules/apps/headless/headless-object/headless-object-api/src/main/java/com/liferay/headless/object/util/v1_0/CollaboratorUtil.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.TicketLocalService;
 import com.liferay.portal.kernel.service.UserGroupLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.OrderByComparatorFactoryUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -56,57 +57,24 @@ public class CollaboratorUtil {
 	public static Collaborator addOrUpdateCollaborator(
 			AcceptLanguage acceptLanguage, String className, long classNameId,
 			long classPK, Collaborator collaborator, long collaboratorId,
+			long companyId,
 			DTOConverter<SharingEntry, Collaborator> dtoConverter,
-			long companyId, DTOConverterRegistry dtoConverterRegistry,
-			long groupId, JSONFactory jsonFactory,
-			SharingEntryService sharingEntryService,
-			TicketLocalService ticketLocalService, String type,
-			UserGroupLocalService userGroupLocalService, UriInfo uriInfo,
-			User user, UserLocalService userLocalService)
+			DTOConverterRegistry dtoConverterRegistry, long groupId,
+			JSONFactory jsonFactory, SharingEntryService sharingEntryService,
+			TicketLocalService ticketLocalService, String type, UriInfo uriInfo,
+			User user, UserGroupLocalService userGroupLocalService,
+			UserLocalService userLocalService)
 		throws Exception {
 
 		_validateType(type);
 
-		if (Objects.equals(type, "Email")) {
-			_validateEmailAddress(collaborator.getEmailAddress());
-
-			User existingUser = userLocalService.fetchUserByEmailAddress(
-				companyId, collaborator.getEmailAddress());
-
-			if (existingUser != null) {
-				SharingEntry sharingEntry = _addOrUpdateSharingEntry(
-					classNameId, classPK, collaborator,
-					existingUser.getUserId(), groupId, sharingEntryService,
-					"User", userGroupLocalService, userLocalService);
-
-				Ticket ticket = _fetchTicketByEmailAddress(
-					companyId, className, classPK,
-					collaborator.getEmailAddress(), jsonFactory,
-					ticketLocalService);
-
-				if (ticket != null) {
-					ticketLocalService.deleteTicket(ticket.getTicketId());
-				}
-
-				return toCollaborator(
-					acceptLanguage, dtoConverter, dtoConverterRegistry,
-					sharingEntry, uriInfo, user);
-			}
-
-			Ticket ticket = _addOrUpdateTicket(
-				className, classPK, collaborator, companyId,
-				_fetchTicket(
-					companyId, className, classPK, collaborator, collaboratorId,
-					jsonFactory, ticketLocalService),
-				ticketLocalService, type);
-
-			return toCollaborator(
-				acceptLanguage, dtoConverter, dtoConverterRegistry,
-				_addOrUpdateSharingEntry(
-					classNameId, classPK, collaborator, ticket.getTicketId(),
-					groupId, sharingEntryService, type, userGroupLocalService,
-					userLocalService),
-				uriInfo, user);
+		if (StringUtil.equals("Email", type)) {
+			return addOrUpdateCollaboratorByEmailAddress(
+				acceptLanguage, className, classNameId, classPK, collaborator,
+				companyId, dtoConverter, dtoConverterRegistry,
+				collaborator.getEmailAddress(), groupId, jsonFactory,
+				sharingEntryService, ticketLocalService, uriInfo, user,
+				userGroupLocalService, userLocalService);
 		}
 
 		return toCollaborator(
@@ -114,6 +82,61 @@ public class CollaboratorUtil {
 			_addOrUpdateSharingEntry(
 				classNameId, classPK, collaborator, collaboratorId, groupId,
 				sharingEntryService, type, userGroupLocalService,
+				userLocalService),
+			uriInfo, user);
+	}
+
+	public static Collaborator addOrUpdateCollaboratorByEmailAddress(
+			AcceptLanguage acceptLanguage, String className, long classNameId,
+			long classPK, Collaborator collaborator, long companyId,
+			DTOConverter<SharingEntry, Collaborator> dtoConverter,
+			DTOConverterRegistry dtoConverterRegistry, String emailAddress,
+			long groupId, JSONFactory jsonFactory,
+			SharingEntryService sharingEntryService,
+			TicketLocalService ticketLocalService, UriInfo uriInfo, User user,
+			UserGroupLocalService userGroupLocalService,
+			UserLocalService userLocalService)
+		throws Exception {
+
+		_validateEmailAddress(emailAddress);
+		_validateEmailActionIds(collaborator.getActionIds());
+
+		collaborator.setEmailAddress(() -> emailAddress);
+
+		long userId = _fetchUserIdByEmailAddress(
+			companyId, emailAddress, userLocalService);
+
+		if (userId > 0) {
+			SharingEntry sharingEntry = _addOrUpdateSharingEntry(
+				classNameId, classPK, collaborator, userId, groupId,
+				sharingEntryService, "User", userGroupLocalService,
+				userLocalService);
+
+			Ticket ticket = _fetchTicketByEmailAddress(
+				className, classPK, companyId, emailAddress, jsonFactory,
+				ticketLocalService);
+
+			if (ticket != null) {
+				ticketLocalService.deleteTicket(ticket.getTicketId());
+			}
+
+			return toCollaborator(
+				acceptLanguage, dtoConverter, dtoConverterRegistry,
+				sharingEntry, uriInfo, user);
+		}
+
+		Ticket ticket = _addOrUpdateTicket(
+			className, classPK, collaborator, companyId,
+			_fetchTicketByEmailAddress(
+				className, classPK, companyId, emailAddress, jsonFactory,
+				ticketLocalService),
+			ticketLocalService, "Email");
+
+		return toCollaborator(
+			acceptLanguage, dtoConverter, dtoConverterRegistry,
+			_addOrUpdateSharingEntry(
+				classNameId, classPK, collaborator, ticket.getTicketId(),
+				groupId, sharingEntryService, "Email", userGroupLocalService,
 				userLocalService),
 			uriInfo, user);
 	}
@@ -139,21 +162,31 @@ public class CollaboratorUtil {
 		List<Long> sharingEntriesIds = new ArrayList<>();
 
 		for (Collaborator collaborator : collaborators) {
+			_validateType(collaborator.getType());
+
 			SharingEntry sharingEntry = null;
 
-			if (Objects.equals(collaborator.getType(), "Email")) {
+			if (StringUtil.equals("Email", collaborator.getType())) {
 				_validateEmailAddress(collaborator.getEmailAddress());
+				_validateEmailActionIds(collaborator.getActionIds());
 
-				User existingUser = userLocalService.fetchUserByEmailAddress(
-					companyId, collaborator.getEmailAddress());
+				long userId = _fetchUserIdByEmailAddress(
+					companyId, collaborator.getEmailAddress(),
+					userLocalService);
 
-				if (existingUser == null) {
+				if (userId > 0) {
+					sharingEntry = _addOrUpdateSharingEntry(
+						classNameId, classPK, collaborator, userId, groupId,
+						sharingEntryService, "User", userGroupLocalService,
+						userLocalService);
+				}
+				else {
 					Ticket ticket = _addOrUpdateTicket(
 						className, classPK, collaborator, companyId,
 						_fetchTicket(
-							companyId, className, classPK, collaborator,
-							collaborator.getId(), jsonFactory,
-							ticketLocalService),
+							className, classPK, collaborator,
+							GetterUtil.getLong(collaborator.getId()), companyId,
+							jsonFactory, ticketLocalService),
 						ticketLocalService, collaborator.getType());
 
 					sharingEntry = _addOrUpdateSharingEntry(
@@ -165,17 +198,12 @@ public class CollaboratorUtil {
 					collaboratorEmailAddresses.add(
 						collaborator.getEmailAddress());
 				}
-				else {
-					sharingEntry = _addOrUpdateSharingEntry(
-						classNameId, classPK, collaborator,
-						existingUser.getUserId(), groupId, sharingEntryService,
-						"User", userGroupLocalService, userLocalService);
-				}
 			}
 			else {
 				sharingEntry = _addOrUpdateSharingEntry(
-					classNameId, classPK, collaborator, collaborator.getId(),
-					groupId, sharingEntryService, collaborator.getType(),
+					classNameId, classPK, collaborator,
+					GetterUtil.getLong(collaborator.getId()), groupId,
+					sharingEntryService, collaborator.getType(),
 					userGroupLocalService, userLocalService);
 			}
 
@@ -184,7 +212,7 @@ public class CollaboratorUtil {
 		}
 
 		List<Ticket> tickets = ticketLocalService.getTickets(
-			className, classPK,
+			companyId, className, classPK,
 			SharingTicketConstants.TYPE_INVITE_COLLABORATOR);
 
 		for (Ticket ticket : tickets) {
@@ -229,8 +257,8 @@ public class CollaboratorUtil {
 		_validateType(type);
 
 		if (StringUtil.equals("Email", type)) {
-			_deleteInvitedCollaborator(
-				collaboratorId, className, classNameId, classPK,
+			_deleteCollaboratorTicket(
+				className, classNameId, classPK, collaboratorId,
 				sharingEntryService, ticketLocalService);
 		}
 		else if (StringUtil.equals("User", type)) {
@@ -243,11 +271,51 @@ public class CollaboratorUtil {
 		}
 	}
 
+	public static void deleteCollaboratorByEmailAddress(
+			String className, long classNameId, long classPK, long companyId,
+			String emailAddress, JSONFactory jsonFactory,
+			SharingEntryService sharingEntryService,
+			TicketLocalService ticketLocalService,
+			UserLocalService userLocalService)
+		throws Exception {
+
+		_validateEmailAddress(emailAddress);
+
+		User user = userLocalService.fetchUserByEmailAddress(
+			companyId, emailAddress);
+
+		if (user != null) {
+			SharingEntry sharingEntry = sharingEntryService.fetchSharingEntry(
+				0, 0, user.getUserId(), classNameId, classPK);
+
+			if (sharingEntry != null) {
+				sharingEntryService.deleteSharingEntry(sharingEntry);
+			}
+		}
+
+		Ticket ticket = _fetchTicketByEmailAddress(
+			className, classPK, companyId, emailAddress, jsonFactory,
+			ticketLocalService);
+
+		if (ticket == null) {
+			return;
+		}
+
+		SharingEntry sharingEntry = sharingEntryService.fetchSharingEntry(
+			ticket.getTicketId(), 0, 0, classNameId, classPK);
+
+		if (sharingEntry != null) {
+			sharingEntryService.deleteSharingEntry(sharingEntry);
+		}
+
+		ticketLocalService.deleteTicket(ticket.getTicketId());
+	}
+
 	public static Collaborator getCollaborator(
 			AcceptLanguage acceptLanguage, String className, long classNameId,
 			long classPK, Long collaboratorId,
 			DTOConverter<SharingEntry, Collaborator> dtoConverter,
-			DTOConverterRegistry dtoConverterRegistry, JSONFactory jsonFactory,
+			DTOConverterRegistry dtoConverterRegistry,
 			SharingEntryService sharingEntryService,
 			TicketLocalService ticketLocalService, String type, UriInfo uriInfo,
 			User user)
@@ -256,9 +324,10 @@ public class CollaboratorUtil {
 		_validateType(type);
 
 		if (StringUtil.equals("Email", type)) {
-			Ticket ticket = ticketLocalService.getTicket(collaboratorId);
+			Ticket ticket = ticketLocalService.fetchTicket(collaboratorId);
 
-			if (!Objects.equals(className, ticket.getClassName()) ||
+			if ((ticket == null) ||
+				!Objects.equals(className, ticket.getClassName()) ||
 				(classPK != ticket.getClassPK()) ||
 				(ticket.getType() !=
 					SharingTicketConstants.TYPE_INVITE_COLLABORATOR)) {
@@ -266,11 +335,16 @@ public class CollaboratorUtil {
 				throw new NoSuchModelException();
 			}
 
+			SharingEntry sharingEntry = sharingEntryService.fetchSharingEntry(
+				collaboratorId, 0, 0, classNameId, classPK);
+
+			if (sharingEntry == null) {
+				throw new NoSuchModelException();
+			}
+
 			return toCollaborator(
 				acceptLanguage, dtoConverter, dtoConverterRegistry,
-				sharingEntryService.getSharingEntry(
-					collaboratorId, 0, 0, classNameId, classPK),
-				uriInfo, user);
+				sharingEntry, uriInfo, user);
 		}
 
 		if (StringUtil.equals("User", type)) {
@@ -285,6 +359,54 @@ public class CollaboratorUtil {
 			acceptLanguage, dtoConverter, dtoConverterRegistry,
 			sharingEntryService.getSharingEntry(
 				0, collaboratorId, 0, classNameId, classPK),
+			uriInfo, user);
+	}
+
+	public static Collaborator getCollaboratorByEmailAddress(
+			AcceptLanguage acceptLanguage, String className, long classNameId,
+			long classPK, long companyId,
+			DTOConverter<SharingEntry, Collaborator> dtoConverter,
+			DTOConverterRegistry dtoConverterRegistry, String emailAddress,
+			JSONFactory jsonFactory, SharingEntryService sharingEntryService,
+			TicketLocalService ticketLocalService, UriInfo uriInfo, User user,
+			UserLocalService userLocalService)
+		throws Exception {
+
+		_validateEmailAddress(emailAddress);
+
+		long userId = _fetchUserIdByEmailAddress(
+			companyId, emailAddress, userLocalService);
+
+		if (userId > 0) {
+			SharingEntry sharingEntry = sharingEntryService.fetchSharingEntry(
+				0, 0, userId, classNameId, classPK);
+
+			if (sharingEntry != null) {
+				return toCollaborator(
+					acceptLanguage, dtoConverter, dtoConverterRegistry,
+					sharingEntry, uriInfo, user);
+			}
+
+			throw new NoSuchModelException();
+		}
+
+		Ticket ticket = _fetchTicketByEmailAddress(
+			className, classPK, companyId, emailAddress, jsonFactory,
+			ticketLocalService);
+
+		if (ticket == null) {
+			throw new NoSuchModelException();
+		}
+
+		SharingEntry sharingEntry = sharingEntryService.fetchSharingEntry(
+			ticket.getTicketId(), 0, 0, classNameId, classPK);
+
+		if (sharingEntry == null) {
+			throw new NoSuchModelException();
+		}
+
+		return toCollaborator(
+			acceptLanguage, dtoConverter, dtoConverterRegistry, sharingEntry,
 			uriInfo, user);
 	}
 
@@ -356,8 +478,6 @@ public class CollaboratorUtil {
 			UserGroupLocalService userGroupLocalService,
 			UserLocalService userLocalService)
 		throws Exception {
-
-		_validateType(type);
 
 		long toTicketId = 0;
 		long toUserGroupId = 0;
@@ -444,19 +564,16 @@ public class CollaboratorUtil {
 		return ticketLocalService.updateTicket(ticket);
 	}
 
-	private static void _deleteInvitedCollaborator(
-			Long invitedCollaboratorId, String className, long classNameId,
-			long classPK, SharingEntryService sharingEntryService,
+	private static void _deleteCollaboratorTicket(
+			String className, long classNameId, long classPK,
+			Long collaboratorId, SharingEntryService sharingEntryService,
 			TicketLocalService ticketLocalService)
 		throws Exception {
 
-		Ticket ticket = ticketLocalService.fetchTicket(invitedCollaboratorId);
+		Ticket ticket = ticketLocalService.fetchTicket(collaboratorId);
 
-		if (ticket == null) {
-			return;
-		}
-
-		if (!Objects.equals(className, ticket.getClassName()) ||
+		if ((ticket == null) ||
+			!Objects.equals(className, ticket.getClassName()) ||
 			(classPK != ticket.getClassPK()) ||
 			(ticket.getType() !=
 				SharingTicketConstants.TYPE_INVITE_COLLABORATOR)) {
@@ -465,7 +582,7 @@ public class CollaboratorUtil {
 		}
 
 		SharingEntry sharingEntry = sharingEntryService.fetchSharingEntry(
-			invitedCollaboratorId, 0, 0, classNameId, classPK);
+			collaboratorId, 0, 0, classNameId, classPK);
 
 		if (sharingEntry != null) {
 			sharingEntryService.deleteSharingEntry(sharingEntry);
@@ -475,9 +592,9 @@ public class CollaboratorUtil {
 	}
 
 	private static Ticket _fetchTicket(
-			long companyId, String className, long classPK,
-			Collaborator collaborator, long collaboratorId,
-			JSONFactory jsonFactory, TicketLocalService ticketLocalService)
+			String className, long classPK, Collaborator collaborator,
+			long collaboratorId, long companyId, JSONFactory jsonFactory,
+			TicketLocalService ticketLocalService)
 		throws Exception {
 
 		Ticket ticket = ticketLocalService.fetchTicket(collaboratorId);
@@ -487,12 +604,12 @@ public class CollaboratorUtil {
 		}
 
 		return _fetchTicketByEmailAddress(
-			companyId, className, classPK, collaborator.getEmailAddress(),
+			className, classPK, companyId, collaborator.getEmailAddress(),
 			jsonFactory, ticketLocalService);
 	}
 
 	private static Ticket _fetchTicketByEmailAddress(
-			long companyId, String className, long classPK, String emailAddress,
+			String className, long classPK, long companyId, String emailAddress,
 			JSONFactory jsonFactory, TicketLocalService ticketLocalService)
 		throws Exception {
 
@@ -512,6 +629,36 @@ public class CollaboratorUtil {
 		}
 
 		return null;
+	}
+
+	private static long _fetchUserIdByEmailAddress(
+		long companyId, String emailAddress,
+		UserLocalService userLocalService) {
+
+		User user = userLocalService.fetchUserByEmailAddress(
+			companyId, emailAddress);
+
+		if (user == null) {
+			return 0;
+		}
+
+		return user.getUserId();
+	}
+
+	private static void _validateEmailActionIds(String[] actionIds) {
+		if (actionIds == null) {
+			return;
+		}
+
+		for (String actionId : actionIds) {
+			if (!Objects.equals(
+					SharingEntryAction.VIEW.getActionId(), actionId)) {
+
+				throw new IllegalArgumentException(
+					"Collaborators of type \"Email\" can only be granted the " +
+						"VIEW action");
+			}
+		}
 	}
 
 	private static void _validateEmailAddress(String emailAddress) {

--- a/modules/apps/headless/headless-object/headless-object-api/src/main/java/com/liferay/headless/object/util/v1_0/CollaboratorUtil.java
+++ b/modules/apps/headless/headless-object/headless-object-api/src/main/java/com/liferay/headless/object/util/v1_0/CollaboratorUtil.java
@@ -74,20 +74,13 @@ public class CollaboratorUtil {
 				companyId, collaborator.getEmailAddress());
 
 			if (existingUser != null) {
-				_addOrUpdateSharingEntry(
-					classNameId, classPK, collaborator,
-					existingUser.getUserId(), groupId, sharingEntryService,
-					"User", userGroupLocalService, userLocalService);
-
-				return new Collaborator() {
-					{
-						setActionIds(collaborator::getActionIds);
-						setEmailAddress(collaborator::getEmailAddress);
-						setId(existingUser::getUserId);
-						setShare(collaborator::getShare);
-						setType(() -> "Email");
-					}
-				};
+				return toCollaborator(
+					acceptLanguage, dtoConverter, dtoConverterRegistry,
+					_addOrUpdateSharingEntry(
+						classNameId, classPK, collaborator,
+						existingUser.getUserId(), groupId, sharingEntryService,
+						"User", userGroupLocalService, userLocalService),
+					uriInfo, user);
 			}
 
 			Ticket ticket = _addOrUpdateTicket(

--- a/modules/apps/headless/headless-object/headless-object-api/src/main/resources/com/liferay/headless/object/dto/v1_0/packageinfo
+++ b/modules/apps/headless/headless-object/headless-object-api/src/main/resources/com/liferay/headless/object/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 4.0.0
+version 4.1.0

--- a/modules/apps/headless/headless-object/headless-object-api/src/main/resources/com/liferay/headless/object/util/v1_0/packageinfo
+++ b/modules/apps/headless/headless-object/headless-object-api/src/main/resources/com/liferay/headless/object/util/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 3.0.0

--- a/modules/apps/headless/headless-object/headless-object-client/src/main/java/com/liferay/headless/object/client/dto/v1_0/Collaborator.java
+++ b/modules/apps/headless/headless-object/headless-object-client/src/main/java/com/liferay/headless/object/client/dto/v1_0/Collaborator.java
@@ -111,6 +111,27 @@ public class Collaborator implements Cloneable, Serializable {
 
 	protected Date dateExpired;
 
+	public String getEmailAddress() {
+		return emailAddress;
+	}
+
+	public void setEmailAddress(String emailAddress) {
+		this.emailAddress = emailAddress;
+	}
+
+	public void setEmailAddress(
+		UnsafeSupplier<String, Exception> emailAddressUnsafeSupplier) {
+
+		try {
+			emailAddress = emailAddressUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String emailAddress;
+
 	public String getExternalReferenceCode() {
 		return externalReferenceCode;
 	}
@@ -263,4 +284,4 @@ public class Collaborator implements Cloneable, Serializable {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1761515157
+// LIFERAY-REST-BUILDER-HASH:911244300

--- a/modules/apps/headless/headless-object/headless-object-client/src/main/java/com/liferay/headless/object/client/serdes/v1_0/CollaboratorSerDes.java
+++ b/modules/apps/headless/headless-object/headless-object-client/src/main/java/com/liferay/headless/object/client/serdes/v1_0/CollaboratorSerDes.java
@@ -107,6 +107,20 @@ public class CollaboratorSerDes {
 			sb.append("\"");
 		}
 
+		if (collaborator.getEmailAddress() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"emailAddress\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(collaborator.getEmailAddress()));
+
+			sb.append("\"");
+		}
+
 		if (collaborator.getExternalReferenceCode() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -235,6 +249,14 @@ public class CollaboratorSerDes {
 				liferayToJSONDateFormat.format(collaborator.getDateExpired()));
 		}
 
+		if (collaborator.getEmailAddress() == null) {
+			map.put("emailAddress", null);
+		}
+		else {
+			map.put(
+				"emailAddress", String.valueOf(collaborator.getEmailAddress()));
+		}
+
 		if (collaborator.getExternalReferenceCode() == null) {
 			map.put("externalReferenceCode", null);
 		}
@@ -309,6 +331,9 @@ public class CollaboratorSerDes {
 			else if (Objects.equals(jsonParserFieldName, "dateExpired")) {
 				return false;
 			}
+			else if (Objects.equals(jsonParserFieldName, "emailAddress")) {
+				return false;
+			}
 			else if (Objects.equals(
 						jsonParserFieldName, "externalReferenceCode")) {
 
@@ -360,6 +385,11 @@ public class CollaboratorSerDes {
 				if (jsonParserFieldValue != null) {
 					collaborator.setDateExpired(
 						toDate((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "emailAddress")) {
+				if (jsonParserFieldValue != null) {
+					collaborator.setEmailAddress((String)jsonParserFieldValue);
 				}
 			}
 			else if (Objects.equals(
@@ -477,4 +507,4 @@ public class CollaboratorSerDes {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1312907804
+// LIFERAY-REST-BUILDER-HASH:-1693806390

--- a/modules/apps/headless/headless-object/headless-object-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-object/headless-object-impl/rest-openapi.yaml
@@ -28,6 +28,8 @@ components:
                         The expiration date to be a collaborator of the asset.
                     format: date-time
                     type: string
+                emailAddress:
+                    type: string
                 externalReferenceCode:
                     # @review
                     description:

--- a/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/dto/v1_0/converter/CollaboratorDTOConverter.java
+++ b/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/dto/v1_0/converter/CollaboratorDTOConverter.java
@@ -8,8 +8,12 @@ package com.liferay.headless.object.internal.dto.v1_0.converter;
 import com.liferay.headless.delivery.dto.v1_0.util.CreatorUtil;
 import com.liferay.headless.object.dto.v1_0.Collaborator;
 import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.model.Ticket;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.UserGroup;
+import com.liferay.portal.kernel.service.TicketLocalService;
 import com.liferay.portal.kernel.service.UserGroupLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -44,6 +48,7 @@ public class CollaboratorDTOConverter
 
 		User user = _getUser(sharingEntry);
 		UserGroup userGroup = _getUserGroup(sharingEntry);
+		Ticket ticket = _getTicket(sharingEntry);
 
 		return new Collaborator() {
 			{
@@ -57,13 +62,29 @@ public class CollaboratorDTOConverter
 						dtoConverterContext, _portal,
 						_userLocalService.getUser(sharingEntry.getUserId())));
 				setDateExpired(sharingEntry::getExpirationDate);
+				setEmailAddress(
+					() -> {
+						if (ticket != null) {
+							JSONObject jsonObject =
+								_jsonFactory.createJSONObject(
+									ticket.getExtraInfo());
+
+							return jsonObject.getString("emailAddress");
+						}
+
+						return null;
+					});
 				setExternalReferenceCode(
 					() -> {
 						if (user != null) {
 							return user.getExternalReferenceCode();
 						}
 
-						return userGroup.getExternalReferenceCode();
+						if (userGroup != null) {
+							return userGroup.getExternalReferenceCode();
+						}
+
+						return null;
 					});
 				setId(
 					() -> {
@@ -71,7 +92,15 @@ public class CollaboratorDTOConverter
 							return user.getUserId();
 						}
 
-						return userGroup.getUserGroupId();
+						if (userGroup != null) {
+							return userGroup.getUserGroupId();
+						}
+
+						if (ticket != null) {
+							return ticket.getTicketId();
+						}
+
+						return null;
 					});
 				setName(
 					() -> {
@@ -79,7 +108,19 @@ public class CollaboratorDTOConverter
 							return user.getFullName();
 						}
 
-						return userGroup.getName();
+						if (userGroup != null) {
+							return userGroup.getName();
+						}
+
+						if (ticket != null) {
+							JSONObject jsonObject =
+								_jsonFactory.createJSONObject(
+									ticket.getExtraInfo());
+
+							return jsonObject.getString("emailAddress");
+						}
+
+						return null;
 					});
 				setPortrait(
 					() -> {
@@ -106,10 +147,22 @@ public class CollaboratorDTOConverter
 							return "User";
 						}
 
-						return "UserGroup";
+						if (userGroup != null) {
+							return "UserGroup";
+						}
+
+						return "Email";
 					});
 			}
 		};
+	}
+
+	private Ticket _getTicket(SharingEntry sharingEntry) throws Exception {
+		if (sharingEntry.getToTicketId() > 0) {
+			return _ticketLocalService.getTicket(sharingEntry.getToTicketId());
+		}
+
+		return null;
 	}
 
 	private User _getUser(SharingEntry sharingEntry) throws Exception {
@@ -132,7 +185,13 @@ public class CollaboratorDTOConverter
 	}
 
 	@Reference
+	private JSONFactory _jsonFactory;
+
+	@Reference
 	private Portal _portal;
+
+	@Reference
+	private TicketLocalService _ticketLocalService;
 
 	@Reference
 	private UserGroupLocalService _userGroupLocalService;

--- a/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/dto/v1_0/converter/CollaboratorDTOConverter.java
+++ b/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/dto/v1_0/converter/CollaboratorDTOConverter.java
@@ -13,9 +13,12 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.model.Ticket;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.UserGroup;
+import com.liferay.portal.kernel.security.auth.GuestOrUserUtil;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.TicketLocalService;
 import com.liferay.portal.kernel.service.UserGroupLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.service.permission.UserPermissionUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
@@ -48,7 +51,12 @@ public class CollaboratorDTOConverter
 
 		User user = _getUser(sharingEntry);
 		UserGroup userGroup = _getUserGroup(sharingEntry);
+
 		Ticket ticket = _getTicket(sharingEntry);
+
+		String ticketEmailAddress = _getEmailAddress(ticket);
+
+		boolean hasViewPermission = _hasViewPermission(user);
 
 		return new Collaborator() {
 			{
@@ -60,16 +68,16 @@ public class CollaboratorDTOConverter
 				setCreator(
 					() -> CreatorUtil.toCreator(
 						dtoConverterContext, _portal,
-						_userLocalService.getUser(sharingEntry.getUserId())));
+						_userLocalService.fetchUser(sharingEntry.getUserId())));
 				setDateExpired(sharingEntry::getExpirationDate);
 				setEmailAddress(
 					() -> {
-						if (ticket != null) {
-							JSONObject jsonObject =
-								_jsonFactory.createJSONObject(
-									ticket.getExtraInfo());
+						if (ticketEmailAddress != null) {
+							return ticketEmailAddress;
+						}
 
-							return jsonObject.getString("emailAddress");
+						if ((user != null) && !hasViewPermission) {
+							return user.getEmailAddress();
 						}
 
 						return null;
@@ -77,6 +85,10 @@ public class CollaboratorDTOConverter
 				setExternalReferenceCode(
 					() -> {
 						if (user != null) {
+							if (!hasViewPermission) {
+								return null;
+							}
+
 							return user.getExternalReferenceCode();
 						}
 
@@ -88,6 +100,10 @@ public class CollaboratorDTOConverter
 					});
 				setId(
 					() -> {
+						if (ticket != null) {
+							return ticket.getTicketId();
+						}
+
 						if (user != null) {
 							return user.getUserId();
 						}
@@ -96,15 +112,15 @@ public class CollaboratorDTOConverter
 							return userGroup.getUserGroupId();
 						}
 
-						if (ticket != null) {
-							return ticket.getTicketId();
-						}
-
 						return null;
 					});
 				setName(
 					() -> {
 						if (user != null) {
+							if (!hasViewPermission) {
+								return user.getEmailAddress();
+							}
+
 							return user.getFullName();
 						}
 
@@ -112,38 +128,28 @@ public class CollaboratorDTOConverter
 							return userGroup.getName();
 						}
 
-						if (ticket != null) {
-							JSONObject jsonObject =
-								_jsonFactory.createJSONObject(
-									ticket.getExtraInfo());
-
-							return jsonObject.getString("emailAddress");
-						}
-
-						return null;
+						return ticketEmailAddress;
 					});
 				setPortrait(
 					() -> {
-						if (user != null) {
-							if (user.getPortraitId() == 0) {
-								return null;
-							}
+						if ((user == null) || !hasViewPermission ||
+							(user.getPortraitId() == 0)) {
 
-							ThemeDisplay themeDisplay = new ThemeDisplay() {
-								{
-									setPathImage(_portal.getPathImage());
-								}
-							};
-
-							return user.getPortraitURL(themeDisplay);
+							return null;
 						}
 
-						return null;
+						ThemeDisplay themeDisplay = new ThemeDisplay() {
+							{
+								setPathImage(_portal.getPathImage());
+							}
+						};
+
+						return user.getPortraitURL(themeDisplay);
 					});
 				setShare(sharingEntry::isShareable);
 				setType(
 					() -> {
-						if (user != null) {
+						if ((user != null) && hasViewPermission) {
 							return "User";
 						}
 
@@ -157,31 +163,51 @@ public class CollaboratorDTOConverter
 		};
 	}
 
-	private Ticket _getTicket(SharingEntry sharingEntry) throws Exception {
+	private String _getEmailAddress(Ticket ticket) throws Exception {
+		if (ticket == null) {
+			return null;
+		}
+
+		JSONObject jsonObject = _jsonFactory.createJSONObject(
+			ticket.getExtraInfo());
+
+		return jsonObject.getString("emailAddress");
+	}
+
+	private Ticket _getTicket(SharingEntry sharingEntry) {
 		if (sharingEntry.getToTicketId() > 0) {
-			return _ticketLocalService.getTicket(sharingEntry.getToTicketId());
+			return _ticketLocalService.fetchTicket(
+				sharingEntry.getToTicketId());
 		}
 
 		return null;
 	}
 
-	private User _getUser(SharingEntry sharingEntry) throws Exception {
+	private User _getUser(SharingEntry sharingEntry) {
 		if (sharingEntry.getToUserId() > 0) {
-			return _userLocalService.getUser(sharingEntry.getToUserId());
+			return _userLocalService.fetchUser(sharingEntry.getToUserId());
 		}
 
 		return null;
 	}
 
-	private UserGroup _getUserGroup(SharingEntry sharingEntry)
-		throws Exception {
-
+	private UserGroup _getUserGroup(SharingEntry sharingEntry) {
 		if (sharingEntry.getToUserGroupId() > 0) {
-			return _userGroupLocalService.getUserGroup(
+			return _userGroupLocalService.fetchUserGroup(
 				sharingEntry.getToUserGroupId());
 		}
 
 		return null;
+	}
+
+	private boolean _hasViewPermission(User user) throws Exception {
+		if (user == null) {
+			return false;
+		}
+
+		return UserPermissionUtil.contains(
+			GuestOrUserUtil.getPermissionChecker(), user.getUserId(),
+			ActionKeys.VIEW);
 	}
 
 	@Reference

--- a/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/dto/v1_0/converter/CollaboratorDTOConverter.java
+++ b/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/dto/v1_0/converter/CollaboratorDTOConverter.java
@@ -52,9 +52,7 @@ public class CollaboratorDTOConverter
 		User user = _getUser(sharingEntry);
 		UserGroup userGroup = _getUserGroup(sharingEntry);
 
-		Ticket ticket = _getTicket(sharingEntry);
-
-		String ticketEmailAddress = _getEmailAddress(ticket);
+		String ticketEmailAddress = _getEmailAddress(_getTicket(sharingEntry));
 
 		boolean hasViewPermission = _hasViewPermission(user);
 
@@ -100,11 +98,7 @@ public class CollaboratorDTOConverter
 					});
 				setId(
 					() -> {
-						if (ticket != null) {
-							return ticket.getTicketId();
-						}
-
-						if (user != null) {
+						if ((user != null) && hasViewPermission) {
 							return user.getUserId();
 						}
 

--- a/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/graphql/query/v1_0/Query.java
@@ -63,7 +63,7 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {objectEntryFolderCollaboratorByTypeCollaborator(collaboratorId: ___, objectEntryFolderId: ___, type: ___){actionIds, actions, creator, dateExpired, externalReferenceCode, id, name, portrait, share, type}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {objectEntryFolderCollaboratorByTypeCollaborator(collaboratorId: ___, objectEntryFolderId: ___, type: ___){actionIds, actions, creator, dateExpired, emailAddress, externalReferenceCode, id, name, portrait, share, type}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField(
 		description = "Retrieves the collaborator of an object entry."
@@ -108,7 +108,7 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {scopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator(collaboratorId: ___, externalReferenceCode: ___, scopeKey: ___, type: ___){actionIds, actions, creator, dateExpired, externalReferenceCode, id, name, portrait, share, type}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {scopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator(collaboratorId: ___, externalReferenceCode: ___, scopeKey: ___, type: ___){actionIds, actions, creator, dateExpired, emailAddress, externalReferenceCode, id, name, portrait, share, type}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField(
 		description = "Retrieves the collaborator for an object entry folder."
@@ -496,4 +496,4 @@ public class Query {
 	private com.liferay.portal.kernel.model.User _user;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-5503561
+// LIFERAY-REST-BUILDER-HASH:-953754825

--- a/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/resource/v1_0/BaseCollaboratorResourceImpl.java
+++ b/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/resource/v1_0/BaseCollaboratorResourceImpl.java
@@ -582,7 +582,7 @@ public abstract class BaseCollaboratorResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/headless-object/v1.0/object-entry-folders/{objectEntryFolderId}/collaborators/by-type/{type}/{collaboratorId}' -d $'{"actionIds": ___, "dateExpired": ___, "id": ___, "share": ___, "type": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/headless-object/v1.0/object-entry-folders/{objectEntryFolderId}/collaborators/by-type/{type}/{collaboratorId}' -d $'{"actionIds": ___, "dateExpired": ___, "emailAddress": ___, "id": ___, "share": ___, "type": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Add or update a collaborator received in the request."
@@ -635,7 +635,7 @@ public abstract class BaseCollaboratorResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/headless-object/v1.0/scopes/{scopeKey}/object-entry-folders/by-external-reference-code/{externalReferenceCode}/collaborators/by-type/{type}/{collaboratorId}' -d $'{"actionIds": ___, "dateExpired": ___, "id": ___, "share": ___, "type": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/headless-object/v1.0/scopes/{scopeKey}/object-entry-folders/by-external-reference-code/{externalReferenceCode}/collaborators/by-type/{type}/{collaboratorId}' -d $'{"actionIds": ___, "dateExpired": ___, "emailAddress": ___, "id": ___, "share": ___, "type": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Add or update a collaborator received in the request."
@@ -1368,4 +1368,4 @@ public abstract class BaseCollaboratorResourceImpl
 		LogFactoryUtil.getLog(BaseCollaboratorResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:147681478
+// LIFERAY-REST-BUILDER-HASH:230273300

--- a/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/resource/v1_0/CollaboratorResourceImpl.java
+++ b/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/resource/v1_0/CollaboratorResourceImpl.java
@@ -57,11 +57,10 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 				objectEntryFolderId);
 
 		CollaboratorUtil.deleteCollaborator(
-			ObjectEntryFolder.class.getName(),
 			_classNameLocalService.getClassNameId(
 				ObjectEntryFolder.class.getName()),
 			objectEntryFolder.getObjectEntryFolderId(), collaboratorId,
-			_sharingEntryService, _ticketLocalService, type);
+			_sharingEntryService, type);
 	}
 
 	@Override
@@ -88,11 +87,10 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 					contextCompany.getCompanyId());
 
 		CollaboratorUtil.deleteCollaborator(
-			ObjectEntryFolder.class.getName(),
 			_classNameLocalService.getClassNameId(
 				ObjectEntryFolder.class.getName()),
 			objectEntryFolder.getObjectEntryFolderId(), collaboratorId,
-			_sharingEntryService, _ticketLocalService, type);
+			_sharingEntryService, type);
 	}
 
 	@Override
@@ -112,13 +110,12 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 				objectEntryFolderId);
 
 		return CollaboratorUtil.getCollaborator(
-			contextAcceptLanguage, ObjectEntryFolder.class.getName(),
+			contextAcceptLanguage,
 			_classNameLocalService.getClassNameId(
 				ObjectEntryFolder.class.getName()),
 			objectEntryFolder.getObjectEntryFolderId(), collaboratorId,
 			_collaboratorDTOConverter, _dtoConverterRegistry,
-			_sharingEntryService, _ticketLocalService, type, contextUriInfo,
-			contextUser);
+			_sharingEntryService, type, contextUriInfo, contextUser);
 	}
 
 	@Override
@@ -171,13 +168,12 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 					contextCompany.getCompanyId());
 
 		return CollaboratorUtil.getCollaborator(
-			contextAcceptLanguage, ObjectEntryFolder.class.getName(),
+			contextAcceptLanguage,
 			_classNameLocalService.getClassNameId(
 				ObjectEntryFolder.class.getName()),
 			objectEntryFolder.getObjectEntryFolderId(), collaboratorId,
 			_collaboratorDTOConverter, _dtoConverterRegistry,
-			_sharingEntryService, _ticketLocalService, type, contextUriInfo,
-			contextUser);
+			_sharingEntryService, type, contextUriInfo, contextUser);
 	}
 
 	@Override

--- a/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/resource/v1_0/CollaboratorResourceImpl.java
+++ b/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/resource/v1_0/CollaboratorResourceImpl.java
@@ -25,6 +25,8 @@ import com.liferay.sharing.model.SharingEntry;
 import com.liferay.sharing.service.SharingEntryLocalService;
 import com.liferay.sharing.service.SharingEntryService;
 
+import java.util.Objects;
+
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ServiceScope;
@@ -43,7 +45,10 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 			Long objectEntryFolderId, String type, Long collaboratorId)
 		throws Exception {
 
-		if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
+		if (!FeatureFlagManagerUtil.isEnabled(
+				contextCompany.getCompanyId(), "LPD-17564") ||
+			Objects.equals(type, "Email")) {
+
 			throw new UnsupportedOperationException();
 		}
 
@@ -66,7 +71,10 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 				Long collaboratorId)
 		throws Exception {
 
-		if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
+		if (!FeatureFlagManagerUtil.isEnabled(
+				contextCompany.getCompanyId(), "LPD-17564") ||
+			Objects.equals(type, "Email")) {
+
 			throw new UnsupportedOperationException();
 		}
 
@@ -92,7 +100,10 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 			Long objectEntryFolderId, String type, Long collaboratorId)
 		throws Exception {
 
-		if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
+		if (!FeatureFlagManagerUtil.isEnabled(
+				contextCompany.getCompanyId(), "LPD-17564") ||
+			Objects.equals(type, "Email")) {
+
 			throw new UnsupportedOperationException();
 		}
 
@@ -115,7 +126,9 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 			Long objectEntryFolderId, Pagination pagination)
 		throws Exception {
 
-		if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
+		if (!FeatureFlagManagerUtil.isEnabled(
+				contextCompany.getCompanyId(), "LPD-17564")) {
+
 			throw new UnsupportedOperationException();
 		}
 
@@ -141,7 +154,10 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 				Long collaboratorId)
 		throws Exception {
 
-		if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
+		if (!FeatureFlagManagerUtil.isEnabled(
+				contextCompany.getCompanyId(), "LPD-17564") ||
+			Objects.equals(type, "Email")) {
+
 			throw new UnsupportedOperationException();
 		}
 
@@ -171,7 +187,9 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 				Pagination pagination)
 		throws Exception {
 
-		if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
+		if (!FeatureFlagManagerUtil.isEnabled(
+				contextCompany.getCompanyId(), "LPD-17564")) {
+
 			throw new UnsupportedOperationException();
 		}
 
@@ -200,8 +218,16 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 			Long objectEntryFolderId, Collaborator[] collaborators)
 		throws Exception {
 
-		if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
+		if (!FeatureFlagManagerUtil.isEnabled(
+				contextCompany.getCompanyId(), "LPD-17564")) {
+
 			throw new UnsupportedOperationException();
+		}
+
+		for (Collaborator collaborator : collaborators) {
+			if (Objects.equals(collaborator.getType(), "Email")) {
+				throw new UnsupportedOperationException();
+			}
 		}
 
 		ObjectEntryFolder objectEntryFolder =
@@ -226,8 +252,16 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 				Collaborator[] collaborators)
 		throws Exception {
 
-		if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
+		if (!FeatureFlagManagerUtil.isEnabled(
+				contextCompany.getCompanyId(), "LPD-17564")) {
+
 			throw new UnsupportedOperationException();
+		}
+
+		for (Collaborator collaborator : collaborators) {
+			if (Objects.equals(collaborator.getType(), "Email")) {
+				throw new UnsupportedOperationException();
+			}
 		}
 
 		ObjectEntryFolder objectEntryFolder =
@@ -256,7 +290,10 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 			Collaborator collaborator)
 		throws Exception {
 
-		if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
+		if (!FeatureFlagManagerUtil.isEnabled(
+				contextCompany.getCompanyId(), "LPD-17564") ||
+			Objects.equals(type, "Email")) {
+
 			throw new UnsupportedOperationException();
 		}
 
@@ -283,7 +320,10 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 				Long collaboratorId, Collaborator collaborator)
 		throws Exception {
 
-		if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
+		if (!FeatureFlagManagerUtil.isEnabled(
+				contextCompany.getCompanyId(), "LPD-17564") ||
+			Objects.equals(type, "Email")) {
+
 			throw new UnsupportedOperationException();
 		}
 

--- a/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/resource/v1_0/CollaboratorResourceImpl.java
+++ b/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/resource/v1_0/CollaboratorResourceImpl.java
@@ -11,8 +11,10 @@ import com.liferay.headless.object.util.v1_0.CollaboratorUtil;
 import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectEntryFolderLocalService;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.TicketLocalService;
 import com.liferay.portal.kernel.service.UserGroupLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
@@ -50,10 +52,11 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 				objectEntryFolderId);
 
 		CollaboratorUtil.deleteCollaborator(
+			ObjectEntryFolder.class.getName(),
 			_classNameLocalService.getClassNameId(
 				ObjectEntryFolder.class.getName()),
 			objectEntryFolder.getObjectEntryFolderId(), collaboratorId,
-			_sharingEntryService, type);
+			_sharingEntryService, _ticketLocalService, type);
 	}
 
 	@Override
@@ -77,10 +80,11 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 					contextCompany.getCompanyId());
 
 		CollaboratorUtil.deleteCollaborator(
+			ObjectEntryFolder.class.getName(),
 			_classNameLocalService.getClassNameId(
 				ObjectEntryFolder.class.getName()),
 			objectEntryFolder.getObjectEntryFolderId(), collaboratorId,
-			_sharingEntryService, type);
+			_sharingEntryService, _ticketLocalService, type);
 	}
 
 	@Override
@@ -97,12 +101,13 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 				objectEntryFolderId);
 
 		return CollaboratorUtil.getCollaborator(
-			contextAcceptLanguage,
+			contextAcceptLanguage, ObjectEntryFolder.class.getName(),
 			_classNameLocalService.getClassNameId(
 				ObjectEntryFolder.class.getName()),
 			objectEntryFolder.getObjectEntryFolderId(), collaboratorId,
-			_collaboratorDTOConverter, _dtoConverterRegistry,
-			_sharingEntryService, type, contextUriInfo, contextUser);
+			_collaboratorDTOConverter, _dtoConverterRegistry, _jsonFactory,
+			_sharingEntryService, _ticketLocalService, type, contextUriInfo,
+			contextUser);
 	}
 
 	@Override
@@ -150,12 +155,13 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 					contextCompany.getCompanyId());
 
 		return CollaboratorUtil.getCollaborator(
-			contextAcceptLanguage,
+			contextAcceptLanguage, ObjectEntryFolder.class.getName(),
 			_classNameLocalService.getClassNameId(
 				ObjectEntryFolder.class.getName()),
 			objectEntryFolder.getObjectEntryFolderId(), collaboratorId,
-			_collaboratorDTOConverter, _dtoConverterRegistry,
-			_sharingEntryService, type, contextUriInfo, contextUser);
+			_collaboratorDTOConverter, _dtoConverterRegistry, _jsonFactory,
+			_sharingEntryService, _ticketLocalService, type, contextUriInfo,
+			contextUser);
 	}
 
 	@Override
@@ -203,14 +209,14 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 				objectEntryFolderId);
 
 		return CollaboratorUtil.addOrUpdateCollaborators(
-			contextAcceptLanguage,
+			contextAcceptLanguage, ObjectEntryFolder.class.getName(),
 			_classNameLocalService.getClassNameId(
 				ObjectEntryFolder.class.getName()),
 			objectEntryFolder.getObjectEntryFolderId(), collaborators,
-			_collaboratorDTOConverter, _dtoConverterRegistry,
-			objectEntryFolder.getGroupId(), _sharingEntryService,
-			contextUriInfo, contextUser, _userGroupLocalService,
-			_userLocalService);
+			contextCompany.getCompanyId(), _collaboratorDTOConverter,
+			_dtoConverterRegistry, objectEntryFolder.getGroupId(), _jsonFactory,
+			_sharingEntryService, _ticketLocalService, contextUriInfo,
+			contextUser, _userGroupLocalService, _userLocalService);
 	}
 
 	@Override
@@ -234,14 +240,14 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 					contextCompany.getCompanyId());
 
 		return CollaboratorUtil.addOrUpdateCollaborators(
-			contextAcceptLanguage,
+			contextAcceptLanguage, ObjectEntryFolder.class.getName(),
 			_classNameLocalService.getClassNameId(
 				ObjectEntryFolder.class.getName()),
 			objectEntryFolder.getObjectEntryFolderId(), collaborators,
-			_collaboratorDTOConverter, _dtoConverterRegistry,
-			objectEntryFolder.getGroupId(), _sharingEntryService,
-			contextUriInfo, contextUser, _userGroupLocalService,
-			_userLocalService);
+			contextCompany.getCompanyId(), _collaboratorDTOConverter,
+			_dtoConverterRegistry, objectEntryFolder.getGroupId(), _jsonFactory,
+			_sharingEntryService, _ticketLocalService, contextUriInfo,
+			contextUser, _userGroupLocalService, _userLocalService);
 	}
 
 	@Override
@@ -259,14 +265,15 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 				objectEntryFolderId);
 
 		return CollaboratorUtil.addOrUpdateCollaborator(
-			contextAcceptLanguage,
+			contextAcceptLanguage, ObjectEntryFolder.class.getName(),
 			_classNameLocalService.getClassNameId(
 				ObjectEntryFolder.class.getName()),
 			objectEntryFolder.getObjectEntryFolderId(), collaborator,
-			collaboratorId, _collaboratorDTOConverter, _dtoConverterRegistry,
-			objectEntryFolder.getGroupId(), _sharingEntryService, type,
-			_userGroupLocalService, contextUriInfo, contextUser,
-			_userLocalService);
+			collaboratorId, _collaboratorDTOConverter,
+			contextCompany.getCompanyId(), _dtoConverterRegistry,
+			objectEntryFolder.getGroupId(), _jsonFactory, _sharingEntryService,
+			_ticketLocalService, type, _userGroupLocalService, contextUriInfo,
+			contextUser, _userLocalService);
 	}
 
 	@Override
@@ -290,14 +297,15 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 					contextCompany.getCompanyId());
 
 		return CollaboratorUtil.addOrUpdateCollaborator(
-			contextAcceptLanguage,
+			contextAcceptLanguage, ObjectEntryFolder.class.getName(),
 			_classNameLocalService.getClassNameId(
 				ObjectEntryFolder.class.getName()),
 			objectEntryFolder.getObjectEntryFolderId(), collaborator,
-			collaboratorId, _collaboratorDTOConverter, _dtoConverterRegistry,
-			objectEntryFolder.getGroupId(), _sharingEntryService, type,
-			_userGroupLocalService, contextUriInfo, contextUser,
-			_userLocalService);
+			collaboratorId, _collaboratorDTOConverter,
+			contextCompany.getCompanyId(), _dtoConverterRegistry,
+			objectEntryFolder.getGroupId(), _jsonFactory, _sharingEntryService,
+			_ticketLocalService, type, _userGroupLocalService, contextUriInfo,
+			contextUser, _userLocalService);
 	}
 
 	@Reference
@@ -315,6 +323,9 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 	private GroupLocalService _groupLocalService;
 
 	@Reference
+	private JSONFactory _jsonFactory;
+
+	@Reference
 	private ObjectEntryFolderLocalService _objectEntryFolderLocalService;
 
 	@Reference
@@ -322,6 +333,9 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 
 	@Reference
 	private SharingEntryService _sharingEntryService;
+
+	@Reference
+	private TicketLocalService _ticketLocalService;
 
 	@Reference
 	private UserGroupLocalService _userGroupLocalService;

--- a/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/resource/v1_0/CollaboratorResourceImpl.java
+++ b/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/resource/v1_0/CollaboratorResourceImpl.java
@@ -116,7 +116,7 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 			_classNameLocalService.getClassNameId(
 				ObjectEntryFolder.class.getName()),
 			objectEntryFolder.getObjectEntryFolderId(), collaboratorId,
-			_collaboratorDTOConverter, _dtoConverterRegistry, _jsonFactory,
+			_collaboratorDTOConverter, _dtoConverterRegistry,
 			_sharingEntryService, _ticketLocalService, type, contextUriInfo,
 			contextUser);
 	}
@@ -175,7 +175,7 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 			_classNameLocalService.getClassNameId(
 				ObjectEntryFolder.class.getName()),
 			objectEntryFolder.getObjectEntryFolderId(), collaboratorId,
-			_collaboratorDTOConverter, _dtoConverterRegistry, _jsonFactory,
+			_collaboratorDTOConverter, _dtoConverterRegistry,
 			_sharingEntryService, _ticketLocalService, type, contextUriInfo,
 			contextUser);
 	}
@@ -306,11 +306,11 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 			_classNameLocalService.getClassNameId(
 				ObjectEntryFolder.class.getName()),
 			objectEntryFolder.getObjectEntryFolderId(), collaborator,
-			collaboratorId, _collaboratorDTOConverter,
-			contextCompany.getCompanyId(), _dtoConverterRegistry,
+			collaboratorId, contextCompany.getCompanyId(),
+			_collaboratorDTOConverter, _dtoConverterRegistry,
 			objectEntryFolder.getGroupId(), _jsonFactory, _sharingEntryService,
-			_ticketLocalService, type, _userGroupLocalService, contextUriInfo,
-			contextUser, _userLocalService);
+			_ticketLocalService, type, contextUriInfo, contextUser,
+			_userGroupLocalService, _userLocalService);
 	}
 
 	@Override
@@ -341,11 +341,11 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 			_classNameLocalService.getClassNameId(
 				ObjectEntryFolder.class.getName()),
 			objectEntryFolder.getObjectEntryFolderId(), collaborator,
-			collaboratorId, _collaboratorDTOConverter,
-			contextCompany.getCompanyId(), _dtoConverterRegistry,
+			collaboratorId, contextCompany.getCompanyId(),
+			_collaboratorDTOConverter, _dtoConverterRegistry,
 			objectEntryFolder.getGroupId(), _jsonFactory, _sharingEntryService,
-			_ticketLocalService, type, _userGroupLocalService, contextUriInfo,
-			contextUser, _userLocalService);
+			_ticketLocalService, type, contextUriInfo, contextUser,
+			_userGroupLocalService, _userLocalService);
 	}
 
 	@Reference

--- a/modules/apps/headless/headless-object/headless-object-test/src/testIntegration/java/com/liferay/headless/object/internal/dto/v1_0/converter/test/CollaboratorDTOConverterTest.java
+++ b/modules/apps/headless/headless-object/headless-object-test/src/testIntegration/java/com/liferay/headless/object/internal/dto/v1_0/converter/test/CollaboratorDTOConverterTest.java
@@ -8,21 +8,26 @@ package com.liferay.headless.object.internal.dto.v1_0.converter.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.headless.object.dto.v1_0.Collaborator;
 import com.liferay.object.constants.ObjectDefinitionConstants;
-import com.liferay.object.constants.ObjectEntryFolderConstants;
-import com.liferay.object.constants.ObjectFieldConstants;
-import com.liferay.object.field.util.ObjectFieldUtil;
+import com.liferay.object.field.builder.TextObjectFieldBuilder;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
 import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Ticket;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.UserGroup;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
-import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.TicketLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
@@ -31,8 +36,10 @@ import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserGroupTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -40,10 +47,13 @@ import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
 import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
+import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 import com.liferay.sharing.constants.SharingTicketConstants;
 import com.liferay.sharing.model.SharingEntry;
 import com.liferay.sharing.security.permission.SharingEntryAction;
 import com.liferay.sharing.service.SharingEntryLocalService;
+
+import java.io.Serializable;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -78,17 +88,17 @@ public class CollaboratorDTOConverterTest {
 
 		_objectDefinition = _addObjectDefinition();
 
-		_objectEntry = _addObjectEntry(
-			_objectDefinition.getObjectDefinitionId());
+		_objectEntry = _addObjectEntry();
 	}
 
 	@Test
+	@TestInfo("LPD-48130")
 	public void testToDTOEmail() throws Exception {
 		String emailAddress =
 			StringUtil.toLowerCase(RandomTestUtil.randomString()) +
 				"@liferay.com";
 
-		Date expirationDate = RandomTestUtil.nextDate();
+		Date expirationDate = new Date(System.currentTimeMillis() + Time.DAY);
 
 		Ticket ticket = _ticketLocalService.addTicket(
 			TestPropsValues.getCompanyId(), _objectEntry.getModelClassName(),
@@ -135,13 +145,14 @@ public class CollaboratorDTOConverterTest {
 	}
 
 	@Test
+	@TestInfo("LPD-48130")
 	public void testToDTOUser() throws Exception {
-		User user = UserTestUtil.addUser();
+		User user1 = UserTestUtil.addUser();
 
-		Date expirationDate = RandomTestUtil.nextDate();
+		Date expirationDate = new Date(System.currentTimeMillis() + Time.DAY);
 
 		SharingEntry sharingEntry = _sharingEntryLocalService.addSharingEntry(
-			null, TestPropsValues.getUserId(), 0, 0, user.getUserId(),
+			null, TestPropsValues.getUserId(), 0, 0, user1.getUserId(),
 			_classNameLocalService.getClassNameId(
 				_objectEntry.getModelClassName()),
 			_objectEntry.getObjectEntryId(), _group.getGroupId(), true,
@@ -155,11 +166,11 @@ public class CollaboratorDTOConverterTest {
 
 		Assert.assertEquals("User", collaborator.getType());
 		Assert.assertNull(collaborator.getEmailAddress());
-		Assert.assertEquals(user.getFullName(), collaborator.getName());
+		Assert.assertEquals(user1.getFullName(), collaborator.getName());
 		Assert.assertEquals(
-			Long.valueOf(user.getUserId()), collaborator.getId());
+			Long.valueOf(user1.getUserId()), collaborator.getId());
 		Assert.assertEquals(
-			user.getExternalReferenceCode(),
+			user1.getExternalReferenceCode(),
 			collaborator.getExternalReferenceCode());
 		Assert.assertNull(collaborator.getPortrait());
 		Assert.assertTrue(collaborator.getShare());
@@ -167,13 +178,59 @@ public class CollaboratorDTOConverterTest {
 		Assert.assertArrayEquals(
 			new String[] {SharingEntryAction.VIEW.getActionId()},
 			collaborator.getActionIds());
+
+		Company company = _companyLocalService.getCompany(
+			TestPropsValues.getCompanyId());
+
+		User user2 = company.getGuestUser();
+
+		String name = PrincipalThreadLocal.getName();
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		try {
+			PrincipalThreadLocal.setName(user2.getUserId());
+
+			PermissionThreadLocal.setPermissionChecker(
+				PermissionCheckerFactoryUtil.create(user2));
+
+			collaborator = _toDTO(sharingEntry);
+
+			Assert.assertEquals("Email", collaborator.getType());
+			Assert.assertEquals(
+				user1.getEmailAddress(), collaborator.getEmailAddress());
+			Assert.assertEquals(
+				user1.getEmailAddress(), collaborator.getName());
+			Assert.assertEquals(
+				Long.valueOf(user1.getUserId()), collaborator.getId());
+			Assert.assertNull(collaborator.getExternalReferenceCode());
+			Assert.assertNull(collaborator.getPortrait());
+			Assert.assertTrue(collaborator.getShare());
+			Assert.assertEquals(expirationDate, collaborator.getDateExpired());
+			Assert.assertArrayEquals(
+				new String[] {SharingEntryAction.VIEW.getActionId()},
+				collaborator.getActionIds());
+		}
+		finally {
+			PermissionThreadLocal.setPermissionChecker(permissionChecker);
+			PrincipalThreadLocal.setName(name);
+		}
+
+		user1.setPortraitId(RandomTestUtil.nextLong());
+
+		_userLocalService.updateUser(user1);
+
+		collaborator = _toDTO(sharingEntry);
+
+		Assert.assertNotNull(collaborator.getPortrait());
 	}
 
 	@Test
+	@TestInfo("LPD-48130")
 	public void testToDTOUserGroup() throws Exception {
 		UserGroup userGroup = UserGroupTestUtil.addUserGroup();
 
-		Date expirationDate = RandomTestUtil.nextDate();
+		Date expirationDate = new Date(System.currentTimeMillis() + Time.DAY);
 
 		SharingEntry sharingEntry = _sharingEntryLocalService.addSharingEntry(
 			null, TestPropsValues.getUserId(), 0, userGroup.getUserGroupId(), 0,
@@ -206,26 +263,33 @@ public class CollaboratorDTOConverterTest {
 
 	private ObjectDefinition _addObjectDefinition() throws Exception {
 		return ObjectDefinitionTestUtil.publishObjectDefinition(
+			"A" + RandomTestUtil.randomString(),
 			Collections.singletonList(
-				ObjectFieldUtil.createObjectField(
-					ObjectFieldConstants.BUSINESS_TYPE_TEXT,
-					ObjectFieldConstants.DB_TYPE_STRING,
-					RandomTestUtil.randomString(), "fieldName")),
-			ObjectDefinitionConstants.SCOPE_SITE);
+				new TextObjectFieldBuilder(
+				).labelMap(
+					LocalizedMapUtil.getLocalizedMap(
+						RandomTestUtil.randomString())
+				).indexed(
+					true
+				).indexedAsKeyword(
+					true
+				).name(
+					"title"
+				).localized(
+					false
+				).build()),
+			ObjectDefinitionConstants.SCOPE_SITE, TestPropsValues.getUserId());
 	}
 
-	private ObjectEntry _addObjectEntry(long objectDefinitionId)
-		throws Exception {
-
-		ServiceContext serviceContext =
-			ServiceContextTestUtil.getServiceContext(
-				_group, TestPropsValues.getUserId());
-
+	private ObjectEntry _addObjectEntry() throws Exception {
 		return _objectEntryLocalService.addObjectEntry(
-			TestPropsValues.getUserId(), _group.getGroupId(),
-			objectDefinitionId,
-			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
-			null, Collections.emptyMap(), serviceContext);
+			_group.getGroupId(), TestPropsValues.getUserId(),
+			_objectDefinition.getObjectDefinitionId(), 0, null,
+			HashMapBuilder.<String, Serializable>put(
+				"title", RandomTestUtil.randomString()
+			).build(),
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId()));
 	}
 
 	private Collaborator _toDTO(SharingEntry sharingEntry) throws Exception {
@@ -243,6 +307,9 @@ public class CollaboratorDTOConverterTest {
 
 	@Inject
 	private ClassNameLocalService _classNameLocalService;
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
 
 	@Inject
 	private DTOConverterRegistry _dtoConverterRegistry;
@@ -268,5 +335,8 @@ public class CollaboratorDTOConverterTest {
 
 	@DeleteAfterTestRun
 	private final List<Ticket> _tickets = new ArrayList<>();
+
+	@Inject
+	private UserLocalService _userLocalService;
 
 }

--- a/modules/apps/headless/headless-object/headless-object-test/src/testIntegration/java/com/liferay/headless/object/internal/dto/v1_0/converter/test/CollaboratorDTOConverterTest.java
+++ b/modules/apps/headless/headless-object/headless-object-test/src/testIntegration/java/com/liferay/headless/object/internal/dto/v1_0/converter/test/CollaboratorDTOConverterTest.java
@@ -1,0 +1,272 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.object.internal.dto.v1_0.converter.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.headless.object.dto.v1_0.Collaborator;
+import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.field.util.ObjectFieldUtil;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.test.util.ObjectDefinitionTestUtil;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Ticket;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.UserGroup;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.TicketLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserGroupTestUtil;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.vulcan.dto.converter.DTOConverter;
+import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
+import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
+import com.liferay.sharing.constants.SharingTicketConstants;
+import com.liferay.sharing.model.SharingEntry;
+import com.liferay.sharing.security.permission.SharingEntryAction;
+import com.liferay.sharing.service.SharingEntryLocalService;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Alicia García
+ */
+@FeatureFlag("LPD-17564")
+@RunWith(Arquillian.class)
+public class CollaboratorDTOConverterTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_objectDefinition = _addObjectDefinition();
+
+		_objectEntry = _addObjectEntry(
+			_objectDefinition.getObjectDefinitionId());
+	}
+
+	@Test
+	public void testToDTOEmail() throws Exception {
+		String emailAddress =
+			StringUtil.toLowerCase(RandomTestUtil.randomString()) +
+				"@liferay.com";
+
+		Date expirationDate = RandomTestUtil.nextDate();
+
+		Ticket ticket = _ticketLocalService.addTicket(
+			TestPropsValues.getCompanyId(), _objectEntry.getModelClassName(),
+			_objectEntry.getObjectEntryId(),
+			SharingTicketConstants.TYPE_INVITE_COLLABORATOR,
+			JSONUtil.put(
+				"actionIds", JSONUtil.put(SharingEntryAction.VIEW.getActionId())
+			).put(
+				"emailAddress", emailAddress
+			).put(
+				"share", true
+			).put(
+				"type", "Email"
+			).toString(),
+			expirationDate, null);
+
+		SharingEntry sharingEntry = _sharingEntryLocalService.addSharingEntry(
+			null, TestPropsValues.getUserId(), ticket.getTicketId(), 0, 0,
+			_classNameLocalService.getClassNameId(
+				_objectEntry.getModelClassName()),
+			_objectEntry.getObjectEntryId(), _group.getGroupId(), true,
+			Arrays.asList(SharingEntryAction.VIEW), expirationDate,
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId()));
+
+		_tickets.add(ticket);
+
+		_sharingEntries.add(sharingEntry);
+
+		Collaborator collaborator = _toDTO(sharingEntry);
+
+		Assert.assertEquals("Email", collaborator.getType());
+		Assert.assertEquals(emailAddress, collaborator.getEmailAddress());
+		Assert.assertEquals(emailAddress, collaborator.getName());
+		Assert.assertEquals(
+			Long.valueOf(ticket.getTicketId()), collaborator.getId());
+		Assert.assertNull(collaborator.getExternalReferenceCode());
+		Assert.assertNull(collaborator.getPortrait());
+		Assert.assertTrue(collaborator.getShare());
+		Assert.assertEquals(expirationDate, collaborator.getDateExpired());
+		Assert.assertArrayEquals(
+			new String[] {SharingEntryAction.VIEW.getActionId()},
+			collaborator.getActionIds());
+	}
+
+	@Test
+	public void testToDTOUser() throws Exception {
+		User user = UserTestUtil.addUser();
+
+		Date expirationDate = RandomTestUtil.nextDate();
+
+		SharingEntry sharingEntry = _sharingEntryLocalService.addSharingEntry(
+			null, TestPropsValues.getUserId(), 0, 0, user.getUserId(),
+			_classNameLocalService.getClassNameId(
+				_objectEntry.getModelClassName()),
+			_objectEntry.getObjectEntryId(), _group.getGroupId(), true,
+			Arrays.asList(SharingEntryAction.VIEW), expirationDate,
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId()));
+
+		_sharingEntries.add(sharingEntry);
+
+		Collaborator collaborator = _toDTO(sharingEntry);
+
+		Assert.assertEquals("User", collaborator.getType());
+		Assert.assertNull(collaborator.getEmailAddress());
+		Assert.assertEquals(user.getFullName(), collaborator.getName());
+		Assert.assertEquals(
+			Long.valueOf(user.getUserId()), collaborator.getId());
+		Assert.assertEquals(
+			user.getExternalReferenceCode(),
+			collaborator.getExternalReferenceCode());
+		Assert.assertNull(collaborator.getPortrait());
+		Assert.assertTrue(collaborator.getShare());
+		Assert.assertEquals(expirationDate, collaborator.getDateExpired());
+		Assert.assertArrayEquals(
+			new String[] {SharingEntryAction.VIEW.getActionId()},
+			collaborator.getActionIds());
+	}
+
+	@Test
+	public void testToDTOUserGroup() throws Exception {
+		UserGroup userGroup = UserGroupTestUtil.addUserGroup();
+
+		Date expirationDate = RandomTestUtil.nextDate();
+
+		SharingEntry sharingEntry = _sharingEntryLocalService.addSharingEntry(
+			null, TestPropsValues.getUserId(), 0, userGroup.getUserGroupId(), 0,
+			_classNameLocalService.getClassNameId(
+				_objectEntry.getModelClassName()),
+			_objectEntry.getObjectEntryId(), _group.getGroupId(), true,
+			Arrays.asList(SharingEntryAction.VIEW), expirationDate,
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId()));
+
+		_sharingEntries.add(sharingEntry);
+
+		Collaborator collaborator = _toDTO(sharingEntry);
+
+		Assert.assertEquals("UserGroup", collaborator.getType());
+		Assert.assertNull(collaborator.getEmailAddress());
+		Assert.assertEquals(userGroup.getName(), collaborator.getName());
+		Assert.assertEquals(
+			Long.valueOf(userGroup.getUserGroupId()), collaborator.getId());
+		Assert.assertEquals(
+			userGroup.getExternalReferenceCode(),
+			collaborator.getExternalReferenceCode());
+		Assert.assertNull(collaborator.getPortrait());
+		Assert.assertTrue(collaborator.getShare());
+		Assert.assertEquals(expirationDate, collaborator.getDateExpired());
+		Assert.assertArrayEquals(
+			new String[] {SharingEntryAction.VIEW.getActionId()},
+			collaborator.getActionIds());
+	}
+
+	private ObjectDefinition _addObjectDefinition() throws Exception {
+		return ObjectDefinitionTestUtil.publishObjectDefinition(
+			Collections.singletonList(
+				ObjectFieldUtil.createObjectField(
+					ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+					ObjectFieldConstants.DB_TYPE_STRING,
+					RandomTestUtil.randomString(), "fieldName")),
+			ObjectDefinitionConstants.SCOPE_SITE);
+	}
+
+	private ObjectEntry _addObjectEntry(long objectDefinitionId)
+		throws Exception {
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				_group, TestPropsValues.getUserId());
+
+		return _objectEntryLocalService.addObjectEntry(
+			TestPropsValues.getUserId(), _group.getGroupId(),
+			objectDefinitionId,
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			null, Collections.emptyMap(), serviceContext);
+	}
+
+	private Collaborator _toDTO(SharingEntry sharingEntry) throws Exception {
+		DTOConverter<SharingEntry, Collaborator> dtoConverter =
+			(DTOConverter<SharingEntry, Collaborator>)
+				_dtoConverterRegistry.getDTOConverter(
+					Collaborator.class.getName());
+
+		return dtoConverter.toDTO(
+			new DefaultDTOConverterContext(
+				_dtoConverterRegistry, sharingEntry.getSharingEntryId(),
+				LocaleUtil.getDefault(), null, null),
+			sharingEntry);
+	}
+
+	@Inject
+	private ClassNameLocalService _classNameLocalService;
+
+	@Inject
+	private DTOConverterRegistry _dtoConverterRegistry;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@DeleteAfterTestRun
+	private ObjectDefinition _objectDefinition;
+
+	private ObjectEntry _objectEntry;
+
+	@Inject
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	private final List<SharingEntry> _sharingEntries = new ArrayList<>();
+
+	@Inject
+	private SharingEntryLocalService _sharingEntryLocalService;
+
+	@Inject
+	private TicketLocalService _ticketLocalService;
+
+	@DeleteAfterTestRun
+	private final List<Ticket> _tickets = new ArrayList<>();
+
+}

--- a/modules/apps/headless/headless-object/headless-object-test/src/testIntegration/java/com/liferay/headless/object/internal/dto/v1_0/converter/test/CollaboratorDTOConverterTest.java
+++ b/modules/apps/headless/headless-object/headless-object-test/src/testIntegration/java/com/liferay/headless/object/internal/dto/v1_0/converter/test/CollaboratorDTOConverterTest.java
@@ -133,8 +133,7 @@ public class CollaboratorDTOConverterTest {
 		Assert.assertEquals("Email", collaborator.getType());
 		Assert.assertEquals(emailAddress, collaborator.getEmailAddress());
 		Assert.assertEquals(emailAddress, collaborator.getName());
-		Assert.assertEquals(
-			Long.valueOf(ticket.getTicketId()), collaborator.getId());
+		Assert.assertNull(collaborator.getId());
 		Assert.assertNull(collaborator.getExternalReferenceCode());
 		Assert.assertNull(collaborator.getPortrait());
 		Assert.assertTrue(collaborator.getShare());
@@ -201,8 +200,7 @@ public class CollaboratorDTOConverterTest {
 				user1.getEmailAddress(), collaborator.getEmailAddress());
 			Assert.assertEquals(
 				user1.getEmailAddress(), collaborator.getName());
-			Assert.assertEquals(
-				Long.valueOf(user1.getUserId()), collaborator.getId());
+			Assert.assertNull(collaborator.getId());
 			Assert.assertNull(collaborator.getExternalReferenceCode());
 			Assert.assertNull(collaborator.getPortrait());
 			Assert.assertTrue(collaborator.getShare());

--- a/modules/apps/headless/headless-object/headless-object-test/src/testIntegration/java/com/liferay/headless/object/resource/v1_0/test/BaseCollaboratorResourceTestCase.java
+++ b/modules/apps/headless/headless-object/headless-object-test/src/testIntegration/java/com/liferay/headless/object/resource/v1_0/test/BaseCollaboratorResourceTestCase.java
@@ -169,6 +169,7 @@ public abstract class BaseCollaboratorResourceTestCase {
 
 		Collaborator collaborator = randomCollaborator();
 
+		collaborator.setEmailAddress(regex);
 		collaborator.setExternalReferenceCode(regex);
 		collaborator.setName(regex);
 		collaborator.setPortrait(regex);
@@ -180,6 +181,7 @@ public abstract class BaseCollaboratorResourceTestCase {
 
 		collaborator = CollaboratorSerDes.toDTO(json);
 
+		Assert.assertEquals(regex, collaborator.getEmailAddress());
 		Assert.assertEquals(regex, collaborator.getExternalReferenceCode());
 		Assert.assertEquals(regex, collaborator.getName());
 		Assert.assertEquals(regex, collaborator.getPortrait());
@@ -1576,6 +1578,14 @@ public abstract class BaseCollaboratorResourceTestCase {
 				continue;
 			}
 
+			if (Objects.equals("emailAddress", additionalAssertFieldName)) {
+				if (collaborator.getEmailAddress() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals(
 					"externalReferenceCode", additionalAssertFieldName)) {
 
@@ -1777,6 +1787,17 @@ public abstract class BaseCollaboratorResourceTestCase {
 				if (!Objects.deepEquals(
 						collaborator1.getDateExpired(),
 						collaborator2.getDateExpired())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("emailAddress", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						collaborator1.getEmailAddress(),
+						collaborator2.getEmailAddress())) {
 
 					return false;
 				}
@@ -1994,6 +2015,52 @@ public abstract class BaseCollaboratorResourceTestCase {
 				sb.append(" ");
 
 				sb.append(_format.format(collaborator.getDateExpired()));
+			}
+
+			return sb.toString();
+		}
+
+		if (entityFieldName.equals("emailAddress")) {
+			Object object = collaborator.getEmailAddress();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
 			}
 
 			return sb.toString();
@@ -2239,6 +2306,9 @@ public abstract class BaseCollaboratorResourceTestCase {
 		return new Collaborator() {
 			{
 				dateExpired = RandomTestUtil.nextDate();
+				emailAddress =
+					StringUtil.toLowerCase(RandomTestUtil.randomString()) +
+						"@liferay.com";
 				externalReferenceCode = StringUtil.toLowerCase(
 					RandomTestUtil.randomString());
 				id = RandomTestUtil.randomLong();
@@ -2471,4 +2541,4 @@ public abstract class BaseCollaboratorResourceTestCase {
 		_collaboratorResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1008502985
+// LIFERAY-REST-BUILDER-HASH:-777099857

--- a/modules/apps/headless/headless-object/headless-object-test/src/testIntegration/java/com/liferay/headless/object/resource/v1_0/test/CollaboratorResourceTest.java
+++ b/modules/apps/headless/headless-object/headless-object-test/src/testIntegration/java/com/liferay/headless/object/resource/v1_0/test/CollaboratorResourceTest.java
@@ -8,9 +8,11 @@ package com.liferay.headless.object.resource.v1_0.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.headless.object.client.dto.v1_0.Collaborator;
 import com.liferay.headless.object.client.pagination.Page;
+import com.liferay.headless.object.client.problem.Problem;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectEntryFolderLocalService;
+import com.liferay.petra.function.UnsafeRunnable;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.UserGroup;
@@ -19,6 +21,7 @@ import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserGroupLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -70,6 +73,70 @@ public class CollaboratorResourceTest extends BaseCollaboratorResourceTestCase {
 		super.setUp();
 
 		_objectEntryFolder = _addObjectEntryFolder();
+	}
+
+	@Test
+	@TestInfo("LPD-48130")
+	public void testObjectEntryFolderCollaboratorWithEmailTypeUnsupported()
+		throws Exception {
+
+		_assertRejectsEmailType(
+			() ->
+				collaboratorResource.
+					deleteObjectEntryFolderCollaboratorByTypeCollaborator(
+						_objectEntryFolder.getObjectEntryFolderId(), "Email",
+						0L));
+
+		_assertRejectsEmailType(
+			() ->
+				collaboratorResource.
+					deleteScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator(
+						testGroup.getGroupKey(),
+						_objectEntryFolder.getExternalReferenceCode(), "Email",
+						0L));
+
+		_assertRejectsEmailType(
+			() ->
+				collaboratorResource.
+					getObjectEntryFolderCollaboratorByTypeCollaborator(
+						_objectEntryFolder.getObjectEntryFolderId(), "Email",
+						0L));
+
+		_assertRejectsEmailType(
+			() ->
+				collaboratorResource.
+					getScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator(
+						testGroup.getGroupKey(),
+						_objectEntryFolder.getExternalReferenceCode(), "Email",
+						0L));
+
+		_assertRejectsEmailType(
+			() -> collaboratorResource.postObjectEntryFolderCollaboratorsPage(
+				_objectEntryFolder.getObjectEntryFolderId(),
+				new Collaborator[] {_getEmailCollaborator()}));
+
+		_assertRejectsEmailType(
+			() ->
+				collaboratorResource.
+					postScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPage(
+						testGroup.getGroupKey(),
+						_objectEntryFolder.getExternalReferenceCode(),
+						new Collaborator[] {_getEmailCollaborator()}));
+
+		_assertRejectsEmailType(
+			() ->
+				collaboratorResource.
+					putObjectEntryFolderCollaboratorByTypeCollaborator(
+						_objectEntryFolder.getObjectEntryFolderId(), "Email",
+						0L, _getEmailCollaborator()));
+
+		_assertRejectsEmailType(
+			() ->
+				collaboratorResource.
+					putScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator(
+						testGroup.getGroupKey(),
+						_objectEntryFolder.getExternalReferenceCode(), "Email",
+						0L, _getEmailCollaborator()));
 	}
 
 	@Override
@@ -413,11 +480,19 @@ public class CollaboratorResourceTest extends BaseCollaboratorResourceTestCase {
 			RandomTestUtil.randomString(), new ServiceContext());
 	}
 
+	private User _addUser() throws Exception {
+		User user = UserTestUtil.addUser();
+
+		_users.add(user);
+
+		return user;
+	}
+
 	private Collaborator _addUserCollaborator(
 			ObjectEntryFolder objectEntryFolder)
 		throws Exception {
 
-		User user = _getUser();
+		User user = _addUser();
 
 		return _toCollaborator(
 			_sharingEntryLocalService.addSharingEntry(
@@ -431,11 +506,19 @@ public class CollaboratorResourceTest extends BaseCollaboratorResourceTestCase {
 					testGroup.getGroupId(), TestPropsValues.getUserId())));
 	}
 
+	private UserGroup _addUserGroup() throws Exception {
+		UserGroup userGroup = UserGroupTestUtil.addUserGroup();
+
+		_userGroups.add(userGroup);
+
+		return userGroup;
+	}
+
 	private Collaborator _addUserGroupCollaborator(
 			ObjectEntryFolder objectEntryFolder)
 		throws Exception {
 
-		UserGroup userGroup = _getUserGroup();
+		UserGroup userGroup = _addUserGroup();
 
 		return _toCollaborator(
 			_sharingEntryLocalService.addSharingEntry(
@@ -463,16 +546,39 @@ public class CollaboratorResourceTest extends BaseCollaboratorResourceTestCase {
 		}
 	}
 
-	private User _getUser() throws Exception {
-		User user = UserTestUtil.addUser();
+	private void _assertRejectsEmailType(
+			UnsafeRunnable<Exception> unsafeRunnable)
+		throws Exception {
 
-		_users.add(user);
+		try {
+			unsafeRunnable.run();
 
-		return user;
+			Assert.fail();
+		}
+		catch (Problem.ProblemException problemException) {
+			Problem problem = problemException.getProblem();
+
+			Assert.assertEquals("BAD_REQUEST", problem.getStatus());
+		}
+	}
+
+	private Collaborator _getEmailCollaborator() {
+		return new Collaborator() {
+			{
+				actionIds = new String[] {
+					SharingEntryAction.VIEW.getActionId()
+				};
+				emailAddress =
+					StringUtil.toLowerCase(RandomTestUtil.randomString()) +
+						"@liferay.com";
+				share = true;
+				type = "Email";
+			}
+		};
 	}
 
 	private Collaborator _getUserCollaborator() throws Exception {
-		User user = _getUser();
+		User user = _addUser();
 
 		return new Collaborator() {
 			{
@@ -489,16 +595,8 @@ public class CollaboratorResourceTest extends BaseCollaboratorResourceTestCase {
 		};
 	}
 
-	private UserGroup _getUserGroup() throws Exception {
-		UserGroup userGroup = UserGroupTestUtil.addUserGroup();
-
-		_userGroups.add(userGroup);
-
-		return userGroup;
-	}
-
 	private Collaborator _getUserGroupCollaborator() throws Exception {
-		UserGroup userGroup = _getUserGroup();
+		UserGroup userGroup = _addUserGroup();
 
 		return new Collaborator() {
 			{

--- a/modules/apps/object/object-rest-api/bnd.bnd
+++ b/modules/apps/object/object-rest-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Object REST API
 Bundle-SymbolicName: com.liferay.object.rest.api
-Bundle-Version: 34.3.1
+Bundle-Version: 34.4.0
 Export-Package:\
 	com.liferay.object.rest.dto.v1_0,\
 	com.liferay.object.rest.dto.v1_0.util,\

--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/resource/v1_0/CollaboratorResource.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/resource/v1_0/CollaboratorResource.java
@@ -41,14 +41,29 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface CollaboratorResource {
 
+	public void deleteObjectEntryCollaboratorByEmailAddress(
+			Long objectEntryId, String emailAddress)
+		throws Exception;
+
 	public void deleteObjectEntryCollaboratorByTypeCollaborator(
 			Long objectEntryId, String type, Long collaboratorId)
+		throws Exception;
+
+	public void
+			deleteScopeScopeKeyByExternalReferenceCodeCollaboratorByEmailAddress(
+				String scopeKey, String externalReferenceCode,
+				String emailAddress)
 		throws Exception;
 
 	public void
 			deleteScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaborator(
 				String scopeKey, String externalReferenceCode, String type,
 				Long collaboratorId)
+		throws Exception;
+
+	public com.liferay.headless.object.dto.v1_0.Collaborator
+			getObjectEntryCollaboratorByEmailAddress(
+				Long objectEntryId, String emailAddress)
 		throws Exception;
 
 	public com.liferay.headless.object.dto.v1_0.Collaborator
@@ -59,6 +74,12 @@ public interface CollaboratorResource {
 	public Page<com.liferay.headless.object.dto.v1_0.Collaborator>
 			getObjectEntryCollaboratorsPage(
 				Long objectEntryId, Pagination pagination)
+		throws Exception;
+
+	public com.liferay.headless.object.dto.v1_0.Collaborator
+			getScopeScopeKeyByExternalReferenceCodeCollaboratorByEmailAddress(
+				String scopeKey, String externalReferenceCode,
+				String emailAddress)
 		throws Exception;
 
 	public com.liferay.headless.object.dto.v1_0.Collaborator
@@ -93,8 +114,21 @@ public interface CollaboratorResource {
 		throws Exception;
 
 	public com.liferay.headless.object.dto.v1_0.Collaborator
+			putObjectEntryCollaboratorByEmailAddress(
+				Long objectEntryId, String emailAddress,
+				com.liferay.headless.object.dto.v1_0.Collaborator collaborator)
+		throws Exception;
+
+	public com.liferay.headless.object.dto.v1_0.Collaborator
 			putObjectEntryCollaboratorByTypeCollaborator(
 				Long objectEntryId, String type, Long collaboratorId,
+				com.liferay.headless.object.dto.v1_0.Collaborator collaborator)
+		throws Exception;
+
+	public com.liferay.headless.object.dto.v1_0.Collaborator
+			putScopeScopeKeyByExternalReferenceCodeCollaboratorByEmailAddress(
+				String scopeKey, String externalReferenceCode,
+				String emailAddress,
 				com.liferay.headless.object.dto.v1_0.Collaborator collaborator)
 		throws Exception;
 
@@ -201,4 +235,4 @@ public interface CollaboratorResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:625659714
+// LIFERAY-REST-BUILDER-HASH:373799310

--- a/modules/apps/object/object-rest-api/src/main/resources/com/liferay/object/rest/resource/v1_0/packageinfo
+++ b/modules/apps/object/object-rest-api/src/main/resources/com/liferay/object/rest/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 10.1.0
+version 10.2.0

--- a/modules/apps/object/object-rest-impl/rest-openapi.yaml
+++ b/modules/apps/object/object-rest-impl/rest-openapi.yaml
@@ -1551,6 +1551,7 @@ paths:
         delete:
             description:
                 Deletes the collaborator for an object entry and returns a 204 if the operation succeeds.
+            operationId: deleteScopeScopeKeyByExternalReferenceCodeCollaboratorByEmailAddress
             parameters:
                 -   in: path
                     name: scopeKey
@@ -1576,6 +1577,7 @@ paths:
         get:
             description:
                 Retrieves the collaborator for an object entry.
+            operationId: getScopeScopeKeyByExternalReferenceCodeCollaboratorByEmailAddress
             parameters:
                 -   in: path
                     name: scopeKey
@@ -1617,6 +1619,7 @@ paths:
         put:
             description:
                 Add or update a collaborator received in the request.
+            operationId: putScopeScopeKeyByExternalReferenceCodeCollaboratorByEmailAddress
             parameters:
                 -   in: path
                     name: scopeKey
@@ -2677,6 +2680,7 @@ paths:
         delete:
             description:
                 Deletes the collaborator for an object entry and returns a 204 if the operation succeeds.
+            operationId: deleteObjectEntryCollaboratorByEmailAddress
             parameters:
                 -   in: path
                     name: objectEntryId
@@ -2698,6 +2702,7 @@ paths:
         get:
             description:
                 Retrieves the collaborator for an object entry.
+            operationId: getObjectEntryCollaboratorByEmailAddress
             parameters:
                 -   in: path
                     name: objectEntryId
@@ -2735,6 +2740,7 @@ paths:
         put:
             description:
                 Add or update a collaborator received in the request.
+            operationId: putObjectEntryCollaboratorByEmailAddress
             parameters:
                 -   in: path
                     name: objectEntryId

--- a/modules/apps/object/object-rest-impl/rest-openapi.yaml
+++ b/modules/apps/object/object-rest-impl/rest-openapi.yaml
@@ -1547,6 +1547,110 @@ paths:
                                     $ref: ../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator
                                 type: array
             tags: ["Collaborator"]
+    "/scopes/{scopeKey}/by-external-reference-code/{externalReferenceCode}/collaborators/by-email-address/{emailAddress}":
+        delete:
+            description:
+                Deletes the collaborator for an object entry and returns a 204 if the operation succeeds.
+            parameters:
+                -   in: path
+                    name: scopeKey
+                    required: true
+                    schema:
+                        type: string
+                -   in: path
+                    name: externalReferenceCode
+                    required: true
+                    schema:
+                        type: string
+                -   in: path
+                    name: emailAddress
+                    required: true
+                    schema:
+                        type: string
+            responses:
+                204:
+                    content:
+                        application/json: {}
+                        application/xml: {}
+            tags: ["Collaborator"]
+        get:
+            description:
+                Retrieves the collaborator for an object entry.
+            parameters:
+                -   in: path
+                    name: scopeKey
+                    required: true
+                    schema:
+                        type: string
+                -   in: path
+                    name: externalReferenceCode
+                    required: true
+                    schema:
+                        type: string
+                -   in: path
+                    name: emailAddress
+                    required: true
+                    schema:
+                        type: string
+                -   in: query
+                    name: fields
+                    schema:
+                        type: string
+                -   in: query
+                    name: nestedFields
+                    schema:
+                        type: string
+                -   in: query
+                    name: restrictFields
+                    schema:
+                        type: string
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: ../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator
+                        application/xml:
+                            schema:
+                                $ref: ../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator
+            tags: ["Collaborator"]
+        put:
+            description:
+                Add or update a collaborator received in the request.
+            parameters:
+                -   in: path
+                    name: scopeKey
+                    required: true
+                    schema:
+                        type: string
+                -   in: path
+                    name: externalReferenceCode
+                    required: true
+                    schema:
+                        type: string
+                -   in: path
+                    name: emailAddress
+                    required: true
+                    schema:
+                        type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: ../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator
+                    application/xml:
+                        schema:
+                            $ref: ../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: ../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator
+                        application/xml:
+                            schema:
+                                $ref: ../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator
+            tags: ["Collaborator"]
     "/scopes/{scopeKey}/by-external-reference-code/{externalReferenceCode}/collaborators/by-type/{type}/{collaboratorId}":
         delete:
             description:
@@ -2568,6 +2672,98 @@ paths:
                                 items:
                                     $ref: ../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator
                                 type: array
+            tags: ["Collaborator"]
+    "/{objectEntryId}/collaborators/by-email-address/{emailAddress}":
+        delete:
+            description:
+                Deletes the collaborator for an object entry and returns a 204 if the operation succeeds.
+            parameters:
+                -   in: path
+                    name: objectEntryId
+                    required: true
+                    schema:
+                        format: int64
+                        type: integer
+                -   in: path
+                    name: emailAddress
+                    required: true
+                    schema:
+                        type: string
+            responses:
+                204:
+                    content:
+                        application/json: {}
+                        application/xml: {}
+            tags: ["Collaborator"]
+        get:
+            description:
+                Retrieves the collaborator for an object entry.
+            parameters:
+                -   in: path
+                    name: objectEntryId
+                    required: true
+                    schema:
+                        format: int64
+                        type: integer
+                -   in: path
+                    name: emailAddress
+                    required: true
+                    schema:
+                        type: string
+                -   in: query
+                    name: fields
+                    schema:
+                        type: string
+                -   in: query
+                    name: nestedFields
+                    schema:
+                        type: string
+                -   in: query
+                    name: restrictFields
+                    schema:
+                        type: string
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: ../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator
+                        application/xml:
+                            schema:
+                                $ref: ../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator
+            tags: ["Collaborator"]
+        put:
+            description:
+                Add or update a collaborator received in the request.
+            parameters:
+                -   in: path
+                    name: objectEntryId
+                    required: true
+                    schema:
+                        format: int64
+                        type: integer
+                -   in: path
+                    name: emailAddress
+                    required: true
+                    schema:
+                        type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: ../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator
+                    application/xml:
+                        schema:
+                            $ref: ../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: ../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator
+                        application/xml:
+                            schema:
+                                $ref: ../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator
             tags: ["Collaborator"]
     "/{objectEntryId}/collaborators/by-type/{type}/{collaboratorId}":
         delete:

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -87,6 +87,7 @@ import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.TicketLocalService;
 import com.liferay.portal.kernel.service.UserGroupLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
@@ -219,8 +220,9 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 	private CollaboratorResourceImpl _createCollaboratorResourceImpl() {
 		return new CollaboratorResourceImpl(
 			_classNameLocalService, _collaboratorDTOConverter,
-			_dtoConverterRegistry, _groupLocalService, _objectEntryLocalService,
-			_sharingEntryService, _sharingEntryLocalService,
+			_dtoConverterRegistry, _groupLocalService, _jsonFactory,
+			_objectEntryLocalService, _sharingEntryService,
+			_sharingEntryLocalService, _ticketLocalService,
 			_userGroupLocalService, _userLocalService);
 	}
 
@@ -1298,6 +1300,9 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 	@Reference
 	private SystemObjectDefinitionManagerRegistry
 		_systemObjectDefinitionManagerRegistry;
+
+	@Reference
+	private TicketLocalService _ticketLocalService;
 
 	@Reference
 	private TranslationManager _translationManager;

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -221,9 +221,9 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 		return new CollaboratorResourceImpl(
 			_classNameLocalService, _collaboratorDTOConverter,
 			_dtoConverterRegistry, _groupLocalService, _jsonFactory,
-			_objectEntryLocalService, _sharingEntryService,
-			_sharingEntryLocalService, _ticketLocalService,
-			_userGroupLocalService, _userLocalService);
+			_objectEntryLocalService, _sharingEntryLocalService,
+			_sharingEntryService, _ticketLocalService, _userGroupLocalService,
+			_userLocalService);
 	}
 
 	private CommentResourceImpl _createCommentResourceImpl(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/BaseCollaboratorResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/BaseCollaboratorResourceImpl.java
@@ -78,6 +78,42 @@ public abstract class BaseCollaboratorResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "emailAddress"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Collaborator")}
+	)
+	@jakarta.ws.rs.DELETE
+	@jakarta.ws.rs.Path(
+		"/{objectEntryId}/collaborators/by-email-address/{emailAddress}"
+	)
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public void deleteObjectEntryCollaboratorByEmailAddress(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.validation.constraints.NotNull
+			@jakarta.ws.rs.PathParam("objectEntryId")
+			Long objectEntryId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.validation.constraints.NotNull
+			@jakarta.ws.rs.PathParam("emailAddress")
+			String emailAddress)
+		throws Exception {
+	}
+
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Deletes the collaborator for an object entry and returns a 204 if the operation succeeds."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "objectEntryId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
 				name = "type"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
@@ -108,6 +144,51 @@ public abstract class BaseCollaboratorResourceImpl
 			@jakarta.validation.constraints.NotNull
 			@jakarta.ws.rs.PathParam("collaboratorId")
 			Long collaboratorId)
+		throws Exception {
+	}
+
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Deletes the collaborator for an object entry and returns a 204 if the operation succeeds."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "scopeKey"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "externalReferenceCode"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "emailAddress"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Collaborator")}
+	)
+	@jakarta.ws.rs.DELETE
+	@jakarta.ws.rs.Path(
+		"/scopes/{scopeKey}/by-external-reference-code/{externalReferenceCode}/collaborators/by-email-address/{emailAddress}"
+	)
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public void
+			deleteScopeScopeKeyByExternalReferenceCodeCollaboratorByEmailAddress(
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@jakarta.validation.constraints.NotNull
+				@jakarta.ws.rs.PathParam("scopeKey")
+				String scopeKey,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@jakarta.validation.constraints.NotNull
+				@jakarta.ws.rs.PathParam("externalReferenceCode")
+				String externalReferenceCode,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@jakarta.validation.constraints.NotNull
+				@jakarta.ws.rs.PathParam("emailAddress")
+				String emailAddress)
 		throws Exception {
 	}
 
@@ -162,6 +243,57 @@ public abstract class BaseCollaboratorResourceImpl
 				@jakarta.ws.rs.PathParam("collaboratorId")
 				Long collaboratorId)
 		throws Exception {
+	}
+
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Retrieves the collaborator for an object entry."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "objectEntryId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "emailAddress"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "fields"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "nestedFields"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "restrictFields"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Collaborator")}
+	)
+	@jakarta.ws.rs.GET
+	@jakarta.ws.rs.Path(
+		"/{objectEntryId}/collaborators/by-email-address/{emailAddress}"
+	)
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public com.liferay.headless.object.dto.v1_0.Collaborator
+			getObjectEntryCollaboratorByEmailAddress(
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@jakarta.validation.constraints.NotNull
+				@jakarta.ws.rs.PathParam("objectEntryId")
+				Long objectEntryId,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@jakarta.validation.constraints.NotNull
+				@jakarta.ws.rs.PathParam("emailAddress")
+				String emailAddress)
+		throws Exception {
+
+		return new com.liferay.headless.object.dto.v1_0.Collaborator();
 	}
 
 	@io.swagger.v3.oas.annotations.Operation(
@@ -271,6 +403,65 @@ public abstract class BaseCollaboratorResourceImpl
 		throws Exception {
 
 		return Page.of(Collections.emptyList());
+	}
+
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Retrieves the collaborator for an object entry."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "scopeKey"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "externalReferenceCode"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "emailAddress"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "fields"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "nestedFields"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "restrictFields"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Collaborator")}
+	)
+	@jakarta.ws.rs.GET
+	@jakarta.ws.rs.Path(
+		"/scopes/{scopeKey}/by-external-reference-code/{externalReferenceCode}/collaborators/by-email-address/{emailAddress}"
+	)
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public com.liferay.headless.object.dto.v1_0.Collaborator
+			getScopeScopeKeyByExternalReferenceCodeCollaboratorByEmailAddress(
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@jakarta.validation.constraints.NotNull
+				@jakarta.ws.rs.PathParam("scopeKey")
+				String scopeKey,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@jakarta.validation.constraints.NotNull
+				@jakarta.ws.rs.PathParam("externalReferenceCode")
+				String externalReferenceCode,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@jakarta.validation.constraints.NotNull
+				@jakarta.ws.rs.PathParam("emailAddress")
+				String emailAddress)
+		throws Exception {
+
+		return new com.liferay.headless.object.dto.v1_0.Collaborator();
 	}
 
 	@io.swagger.v3.oas.annotations.Operation(
@@ -550,6 +741,47 @@ public abstract class BaseCollaboratorResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "emailAddress"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Collaborator")}
+	)
+	@jakarta.ws.rs.Consumes({"application/json", "application/xml"})
+	@jakarta.ws.rs.Path(
+		"/{objectEntryId}/collaborators/by-email-address/{emailAddress}"
+	)
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@jakarta.ws.rs.PUT
+	@Override
+	public com.liferay.headless.object.dto.v1_0.Collaborator
+			putObjectEntryCollaboratorByEmailAddress(
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@jakarta.validation.constraints.NotNull
+				@jakarta.ws.rs.PathParam("objectEntryId")
+				Long objectEntryId,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@jakarta.validation.constraints.NotNull
+				@jakarta.ws.rs.PathParam("emailAddress")
+				String emailAddress,
+				com.liferay.headless.object.dto.v1_0.Collaborator collaborator)
+		throws Exception {
+
+		return new com.liferay.headless.object.dto.v1_0.Collaborator();
+	}
+
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Add or update a collaborator received in the request."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "objectEntryId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
 				name = "type"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
@@ -582,6 +814,55 @@ public abstract class BaseCollaboratorResourceImpl
 				@jakarta.validation.constraints.NotNull
 				@jakarta.ws.rs.PathParam("collaboratorId")
 				Long collaboratorId,
+				com.liferay.headless.object.dto.v1_0.Collaborator collaborator)
+		throws Exception {
+
+		return new com.liferay.headless.object.dto.v1_0.Collaborator();
+	}
+
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Add or update a collaborator received in the request."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "scopeKey"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "externalReferenceCode"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "emailAddress"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Collaborator")}
+	)
+	@jakarta.ws.rs.Consumes({"application/json", "application/xml"})
+	@jakarta.ws.rs.Path(
+		"/scopes/{scopeKey}/by-external-reference-code/{externalReferenceCode}/collaborators/by-email-address/{emailAddress}"
+	)
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@jakarta.ws.rs.PUT
+	@Override
+	public com.liferay.headless.object.dto.v1_0.Collaborator
+			putScopeScopeKeyByExternalReferenceCodeCollaboratorByEmailAddress(
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@jakarta.validation.constraints.NotNull
+				@jakarta.ws.rs.PathParam("scopeKey")
+				String scopeKey,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@jakarta.validation.constraints.NotNull
+				@jakarta.ws.rs.PathParam("externalReferenceCode")
+				String externalReferenceCode,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@jakarta.validation.constraints.NotNull
+				@jakarta.ws.rs.PathParam("emailAddress")
+				String emailAddress,
 				com.liferay.headless.object.dto.v1_0.Collaborator collaborator)
 		throws Exception {
 
@@ -1330,4 +1611,4 @@ public abstract class BaseCollaboratorResourceImpl
 		LogFactoryUtil.getLog(BaseCollaboratorResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:-2090014147
+// LIFERAY-REST-BUILDER-HASH:1204458739

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/CollaboratorResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/CollaboratorResourceImpl.java
@@ -77,7 +77,7 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 				objectEntry.getModelClassName()),
 			objectEntry.getObjectEntryId(), contextCompany.getCompanyId(),
 			emailAddress, _jsonFactory, _sharingEntryService,
-			_ticketLocalService, _userLocalService);
+			_ticketLocalService, contextUser.getUserId(), _userLocalService);
 	}
 
 	@Override
@@ -127,7 +127,7 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 				objectEntry.getModelClassName()),
 			objectEntry.getObjectEntryId(), contextCompany.getCompanyId(),
 			emailAddress, _jsonFactory, _sharingEntryService,
-			_ticketLocalService, _userLocalService);
+			_ticketLocalService, contextUser.getUserId(), _userLocalService);
 	}
 
 	@Override

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/CollaboratorResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/CollaboratorResourceImpl.java
@@ -58,6 +58,29 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 	}
 
 	@Override
+	public void deleteObjectEntryCollaboratorByEmailAddress(
+			Long objectEntryId, String emailAddress)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled(
+				contextCompany.getCompanyId(), "LPD-17564")) {
+
+			throw new UnsupportedOperationException();
+		}
+
+		ObjectEntry objectEntry = _objectEntryLocalService.getObjectEntry(
+			objectEntryId);
+
+		CollaboratorUtil.deleteCollaboratorByEmailAddress(
+			objectEntry.getModelClassName(),
+			_classNameLocalService.getClassNameId(
+				objectEntry.getModelClassName()),
+			objectEntry.getObjectEntryId(), contextCompany.getCompanyId(),
+			emailAddress, _jsonFactory, _sharingEntryService,
+			_ticketLocalService, _userLocalService);
+	}
+
+	@Override
 	public void deleteObjectEntryCollaboratorByTypeCollaborator(
 			Long objectEntryId, String type, Long collaboratorId)
 		throws Exception {
@@ -77,6 +100,34 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 				objectEntry.getModelClassName()),
 			objectEntry.getObjectEntryId(), collaboratorId,
 			_sharingEntryService, _ticketLocalService, type);
+	}
+
+	@Override
+	public void
+			deleteScopeScopeKeyByExternalReferenceCodeCollaboratorByEmailAddress(
+				String scopeKey, String externalReferenceCode,
+				String emailAddress)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled(
+				contextCompany.getCompanyId(), "LPD-17564")) {
+
+			throw new UnsupportedOperationException();
+		}
+
+		ObjectEntry objectEntry = _objectEntryLocalService.getObjectEntry(
+			externalReferenceCode,
+			CollaboratorUtil.getGroupId(
+				contextCompany.getCompanyId(), _groupLocalService, scopeKey),
+			_objectDefinition.getObjectDefinitionId());
+
+		CollaboratorUtil.deleteCollaboratorByEmailAddress(
+			objectEntry.getModelClassName(),
+			_classNameLocalService.getClassNameId(
+				objectEntry.getModelClassName()),
+			objectEntry.getObjectEntryId(), contextCompany.getCompanyId(),
+			emailAddress, _jsonFactory, _sharingEntryService,
+			_ticketLocalService, _userLocalService);
 	}
 
 	@Override
@@ -107,6 +158,30 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 	}
 
 	@Override
+	public Collaborator getObjectEntryCollaboratorByEmailAddress(
+			Long objectEntryId, String emailAddress)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled(
+				contextCompany.getCompanyId(), "LPD-17564")) {
+
+			throw new UnsupportedOperationException();
+		}
+
+		ObjectEntry objectEntry = _objectEntryLocalService.getObjectEntry(
+			objectEntryId);
+
+		return CollaboratorUtil.getCollaboratorByEmailAddress(
+			contextAcceptLanguage, objectEntry.getModelClassName(),
+			_classNameLocalService.getClassNameId(
+				objectEntry.getModelClassName()),
+			objectEntry.getObjectEntryId(), contextCompany.getCompanyId(),
+			_collaboratorDTOConverter, _dtoConverterRegistry, emailAddress,
+			_jsonFactory, _sharingEntryService, _ticketLocalService,
+			contextUriInfo, contextUser, _userLocalService);
+	}
+
+	@Override
 	public Collaborator getObjectEntryCollaboratorByTypeCollaborator(
 			Long objectEntryId, String type, Long collaboratorId)
 		throws Exception {
@@ -125,7 +200,7 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 			_classNameLocalService.getClassNameId(
 				objectEntry.getModelClassName()),
 			objectEntry.getObjectEntryId(), collaboratorId,
-			_collaboratorDTOConverter, _dtoConverterRegistry, _jsonFactory,
+			_collaboratorDTOConverter, _dtoConverterRegistry,
 			_sharingEntryService, _ticketLocalService, type, contextUriInfo,
 			contextUser);
 	}
@@ -156,6 +231,35 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 
 	@Override
 	public Collaborator
+			getScopeScopeKeyByExternalReferenceCodeCollaboratorByEmailAddress(
+				String scopeKey, String externalReferenceCode,
+				String emailAddress)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled(
+				contextCompany.getCompanyId(), "LPD-17564")) {
+
+			throw new UnsupportedOperationException();
+		}
+
+		ObjectEntry objectEntry = _objectEntryLocalService.getObjectEntry(
+			externalReferenceCode,
+			CollaboratorUtil.getGroupId(
+				contextCompany.getCompanyId(), _groupLocalService, scopeKey),
+			_objectDefinition.getObjectDefinitionId());
+
+		return CollaboratorUtil.getCollaboratorByEmailAddress(
+			contextAcceptLanguage, objectEntry.getModelClassName(),
+			_classNameLocalService.getClassNameId(
+				objectEntry.getModelClassName()),
+			objectEntry.getObjectEntryId(), contextCompany.getCompanyId(),
+			_collaboratorDTOConverter, _dtoConverterRegistry, emailAddress,
+			_jsonFactory, _sharingEntryService, _ticketLocalService,
+			contextUriInfo, contextUser, _userLocalService);
+	}
+
+	@Override
+	public Collaborator
 			getScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaborator(
 				String scopeKey, String externalReferenceCode, String type,
 				Long collaboratorId)
@@ -178,7 +282,7 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 			_classNameLocalService.getClassNameId(
 				objectEntry.getModelClassName()),
 			objectEntry.getObjectEntryId(), collaboratorId,
-			_collaboratorDTOConverter, _dtoConverterRegistry, _jsonFactory,
+			_collaboratorDTOConverter, _dtoConverterRegistry,
 			_sharingEntryService, _ticketLocalService, type, contextUriInfo,
 			contextUser);
 	}
@@ -268,6 +372,32 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 	}
 
 	@Override
+	public Collaborator putObjectEntryCollaboratorByEmailAddress(
+			Long objectEntryId, String emailAddress, Collaborator collaborator)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled(
+				contextCompany.getCompanyId(), "LPD-17564")) {
+
+			throw new UnsupportedOperationException();
+		}
+
+		ObjectEntry objectEntry = _objectEntryLocalService.getObjectEntry(
+			objectEntryId);
+
+		return CollaboratorUtil.addOrUpdateCollaboratorByEmailAddress(
+			contextAcceptLanguage, objectEntry.getModelClassName(),
+			_classNameLocalService.getClassNameId(
+				objectEntry.getModelClassName()),
+			objectEntry.getObjectEntryId(), collaborator,
+			contextCompany.getCompanyId(), _collaboratorDTOConverter,
+			_dtoConverterRegistry, emailAddress, objectEntry.getGroupId(),
+			_jsonFactory, _sharingEntryService, _ticketLocalService,
+			contextUriInfo, contextUser, _userGroupLocalService,
+			_userLocalService);
+	}
+
+	@Override
 	public Collaborator putObjectEntryCollaboratorByTypeCollaborator(
 			Long objectEntryId, String type, Long collaboratorId,
 			Collaborator collaborator)
@@ -287,10 +417,40 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 			_classNameLocalService.getClassNameId(
 				objectEntry.getModelClassName()),
 			objectEntry.getObjectEntryId(), collaborator, collaboratorId,
-			_collaboratorDTOConverter, contextCompany.getCompanyId(),
+			contextCompany.getCompanyId(), _collaboratorDTOConverter,
 			_dtoConverterRegistry, objectEntry.getGroupId(), _jsonFactory,
-			_sharingEntryService, _ticketLocalService, type,
-			_userGroupLocalService, contextUriInfo, contextUser,
+			_sharingEntryService, _ticketLocalService, type, contextUriInfo,
+			contextUser, _userGroupLocalService, _userLocalService);
+	}
+
+	@Override
+	public Collaborator
+			putScopeScopeKeyByExternalReferenceCodeCollaboratorByEmailAddress(
+				String scopeKey, String externalReferenceCode,
+				String emailAddress, Collaborator collaborator)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled(
+				contextCompany.getCompanyId(), "LPD-17564")) {
+
+			throw new UnsupportedOperationException();
+		}
+
+		ObjectEntry objectEntry = _objectEntryLocalService.getObjectEntry(
+			externalReferenceCode,
+			CollaboratorUtil.getGroupId(
+				contextCompany.getCompanyId(), _groupLocalService, scopeKey),
+			_objectDefinition.getObjectDefinitionId());
+
+		return CollaboratorUtil.addOrUpdateCollaboratorByEmailAddress(
+			contextAcceptLanguage, objectEntry.getModelClassName(),
+			_classNameLocalService.getClassNameId(
+				objectEntry.getModelClassName()),
+			objectEntry.getObjectEntryId(), collaborator,
+			contextCompany.getCompanyId(), _collaboratorDTOConverter,
+			_dtoConverterRegistry, emailAddress, objectEntry.getGroupId(),
+			_jsonFactory, _sharingEntryService, _ticketLocalService,
+			contextUriInfo, contextUser, _userGroupLocalService,
 			_userLocalService);
 	}
 
@@ -318,11 +478,10 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 			_classNameLocalService.getClassNameId(
 				objectEntry.getModelClassName()),
 			objectEntry.getObjectEntryId(), collaborator, collaboratorId,
-			_collaboratorDTOConverter, contextCompany.getCompanyId(),
+			contextCompany.getCompanyId(), _collaboratorDTOConverter,
 			_dtoConverterRegistry, objectEntry.getGroupId(), _jsonFactory,
-			_sharingEntryService, _ticketLocalService, type,
-			_userGroupLocalService, contextUriInfo, contextUser,
-			_userLocalService);
+			_sharingEntryService, _ticketLocalService, type, contextUriInfo,
+			contextUser, _userGroupLocalService, _userLocalService);
 	}
 
 	public void setObjectDefinition(ObjectDefinition objectDefinition) {

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/CollaboratorResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/CollaboratorResourceImpl.java
@@ -11,8 +11,10 @@ import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.TicketLocalService;
 import com.liferay.portal.kernel.service.UserGroupLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
@@ -34,10 +36,11 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 		ClassNameLocalService classNameLocalService,
 		DTOConverter<SharingEntry, Collaborator> collaboratorDTOConverter,
 		DTOConverterRegistry dtoConverterRegistry,
-		GroupLocalService groupLocalService,
+		GroupLocalService groupLocalService, JSONFactory jsonFactory,
 		ObjectEntryLocalService objectEntryLocalService,
-		SharingEntryService sharingEntryService,
 		SharingEntryLocalService sharingEntryLocalService,
+		SharingEntryService sharingEntryService,
+		TicketLocalService ticketLocalService,
 		UserGroupLocalService userGroupLocalService,
 		UserLocalService userLocalService) {
 
@@ -45,9 +48,11 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 		_collaboratorDTOConverter = collaboratorDTOConverter;
 		_dtoConverterRegistry = dtoConverterRegistry;
 		_groupLocalService = groupLocalService;
+		_jsonFactory = jsonFactory;
 		_objectEntryLocalService = objectEntryLocalService;
-		_sharingEntryService = sharingEntryService;
 		_sharingEntryLocalService = sharingEntryLocalService;
+		_sharingEntryService = sharingEntryService;
+		_ticketLocalService = ticketLocalService;
 		_userGroupLocalService = userGroupLocalService;
 		_userLocalService = userLocalService;
 	}
@@ -57,7 +62,9 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 			Long objectEntryId, String type, Long collaboratorId)
 		throws Exception {
 
-		if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
+		if (!FeatureFlagManagerUtil.isEnabled(
+				contextCompany.getCompanyId(), "LPD-17564")) {
+
 			throw new UnsupportedOperationException();
 		}
 
@@ -65,10 +72,11 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 			objectEntryId);
 
 		CollaboratorUtil.deleteCollaborator(
+			objectEntry.getModelClassName(),
 			_classNameLocalService.getClassNameId(
 				objectEntry.getModelClassName()),
 			objectEntry.getObjectEntryId(), collaboratorId,
-			_sharingEntryService, type);
+			_sharingEntryService, _ticketLocalService, type);
 	}
 
 	@Override
@@ -78,7 +86,9 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 				Long collaboratorId)
 		throws Exception {
 
-		if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
+		if (!FeatureFlagManagerUtil.isEnabled(
+				contextCompany.getCompanyId(), "LPD-17564")) {
+
 			throw new UnsupportedOperationException();
 		}
 
@@ -89,10 +99,11 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 			_objectDefinition.getObjectDefinitionId());
 
 		CollaboratorUtil.deleteCollaborator(
+			objectEntry.getModelClassName(),
 			_classNameLocalService.getClassNameId(
 				objectEntry.getModelClassName()),
 			objectEntry.getObjectEntryId(), collaboratorId,
-			_sharingEntryService, type);
+			_sharingEntryService, _ticketLocalService, type);
 	}
 
 	@Override
@@ -100,7 +111,9 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 			Long objectEntryId, String type, Long collaboratorId)
 		throws Exception {
 
-		if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
+		if (!FeatureFlagManagerUtil.isEnabled(
+				contextCompany.getCompanyId(), "LPD-17564")) {
+
 			throw new UnsupportedOperationException();
 		}
 
@@ -108,12 +121,13 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 			objectEntryId);
 
 		return CollaboratorUtil.getCollaborator(
-			contextAcceptLanguage,
+			contextAcceptLanguage, objectEntry.getModelClassName(),
 			_classNameLocalService.getClassNameId(
 				objectEntry.getModelClassName()),
 			objectEntry.getObjectEntryId(), collaboratorId,
-			_collaboratorDTOConverter, _dtoConverterRegistry,
-			_sharingEntryService, type, contextUriInfo, contextUser);
+			_collaboratorDTOConverter, _dtoConverterRegistry, _jsonFactory,
+			_sharingEntryService, _ticketLocalService, type, contextUriInfo,
+			contextUser);
 	}
 
 	@Override
@@ -121,7 +135,9 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 			Long objectEntryId, Pagination pagination)
 		throws Exception {
 
-		if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
+		if (!FeatureFlagManagerUtil.isEnabled(
+				contextCompany.getCompanyId(), "LPD-17564")) {
+
 			throw new UnsupportedOperationException();
 		}
 
@@ -145,7 +161,9 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 				Long collaboratorId)
 		throws Exception {
 
-		if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
+		if (!FeatureFlagManagerUtil.isEnabled(
+				contextCompany.getCompanyId(), "LPD-17564")) {
+
 			throw new UnsupportedOperationException();
 		}
 
@@ -156,12 +174,13 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 			_objectDefinition.getObjectDefinitionId());
 
 		return CollaboratorUtil.getCollaborator(
-			contextAcceptLanguage,
+			contextAcceptLanguage, objectEntry.getModelClassName(),
 			_classNameLocalService.getClassNameId(
 				objectEntry.getModelClassName()),
 			objectEntry.getObjectEntryId(), collaboratorId,
-			_collaboratorDTOConverter, _dtoConverterRegistry,
-			_sharingEntryService, type, contextUriInfo, contextUser);
+			_collaboratorDTOConverter, _dtoConverterRegistry, _jsonFactory,
+			_sharingEntryService, _ticketLocalService, type, contextUriInfo,
+			contextUser);
 	}
 
 	@Override
@@ -171,7 +190,9 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 				Pagination pagination)
 		throws Exception {
 
-		if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
+		if (!FeatureFlagManagerUtil.isEnabled(
+				contextCompany.getCompanyId(), "LPD-17564")) {
+
 			throw new UnsupportedOperationException();
 		}
 
@@ -196,7 +217,9 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 			Long objectEntryId, Collaborator[] collaborators)
 		throws Exception {
 
-		if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
+		if (!FeatureFlagManagerUtil.isEnabled(
+				contextCompany.getCompanyId(), "LPD-17564")) {
+
 			throw new UnsupportedOperationException();
 		}
 
@@ -204,12 +227,13 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 			objectEntryId);
 
 		return CollaboratorUtil.addOrUpdateCollaborators(
-			contextAcceptLanguage,
+			contextAcceptLanguage, objectEntry.getModelClassName(),
 			_classNameLocalService.getClassNameId(
 				objectEntry.getModelClassName()),
 			objectEntry.getObjectEntryId(), collaborators,
-			_collaboratorDTOConverter, _dtoConverterRegistry,
-			objectEntry.getGroupId(), _sharingEntryService, contextUriInfo,
+			contextCompany.getCompanyId(), _collaboratorDTOConverter,
+			_dtoConverterRegistry, objectEntry.getGroupId(), _jsonFactory,
+			_sharingEntryService, _ticketLocalService, contextUriInfo,
 			contextUser, _userGroupLocalService, _userLocalService);
 	}
 
@@ -220,7 +244,9 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 				Collaborator[] collaborators)
 		throws Exception {
 
-		if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
+		if (!FeatureFlagManagerUtil.isEnabled(
+				contextCompany.getCompanyId(), "LPD-17564")) {
+
 			throw new UnsupportedOperationException();
 		}
 
@@ -231,12 +257,13 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 			_objectDefinition.getObjectDefinitionId());
 
 		return CollaboratorUtil.addOrUpdateCollaborators(
-			contextAcceptLanguage,
+			contextAcceptLanguage, objectEntry.getModelClassName(),
 			_classNameLocalService.getClassNameId(
 				objectEntry.getModelClassName()),
 			objectEntry.getObjectEntryId(), collaborators,
-			_collaboratorDTOConverter, _dtoConverterRegistry,
-			objectEntry.getGroupId(), _sharingEntryService, contextUriInfo,
+			contextCompany.getCompanyId(), _collaboratorDTOConverter,
+			_dtoConverterRegistry, objectEntry.getGroupId(), _jsonFactory,
+			_sharingEntryService, _ticketLocalService, contextUriInfo,
 			contextUser, _userGroupLocalService, _userLocalService);
 	}
 
@@ -246,7 +273,9 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 			Collaborator collaborator)
 		throws Exception {
 
-		if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
+		if (!FeatureFlagManagerUtil.isEnabled(
+				contextCompany.getCompanyId(), "LPD-17564")) {
+
 			throw new UnsupportedOperationException();
 		}
 
@@ -254,12 +283,13 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 			objectEntryId);
 
 		return CollaboratorUtil.addOrUpdateCollaborator(
-			contextAcceptLanguage,
+			contextAcceptLanguage, objectEntry.getModelClassName(),
 			_classNameLocalService.getClassNameId(
 				objectEntry.getModelClassName()),
 			objectEntry.getObjectEntryId(), collaborator, collaboratorId,
-			_collaboratorDTOConverter, _dtoConverterRegistry,
-			objectEntry.getGroupId(), _sharingEntryService, type,
+			_collaboratorDTOConverter, contextCompany.getCompanyId(),
+			_dtoConverterRegistry, objectEntry.getGroupId(), _jsonFactory,
+			_sharingEntryService, _ticketLocalService, type,
 			_userGroupLocalService, contextUriInfo, contextUser,
 			_userLocalService);
 	}
@@ -271,7 +301,9 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 				Long collaboratorId, Collaborator collaborator)
 		throws Exception {
 
-		if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
+		if (!FeatureFlagManagerUtil.isEnabled(
+				contextCompany.getCompanyId(), "LPD-17564")) {
+
 			throw new UnsupportedOperationException();
 		}
 
@@ -282,12 +314,13 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 			_objectDefinition.getObjectDefinitionId());
 
 		return CollaboratorUtil.addOrUpdateCollaborator(
-			contextAcceptLanguage,
+			contextAcceptLanguage, objectEntry.getModelClassName(),
 			_classNameLocalService.getClassNameId(
 				objectEntry.getModelClassName()),
 			objectEntry.getObjectEntryId(), collaborator, collaboratorId,
-			_collaboratorDTOConverter, _dtoConverterRegistry,
-			objectEntry.getGroupId(), _sharingEntryService, type,
+			_collaboratorDTOConverter, contextCompany.getCompanyId(),
+			_dtoConverterRegistry, objectEntry.getGroupId(), _jsonFactory,
+			_sharingEntryService, _ticketLocalService, type,
 			_userGroupLocalService, contextUriInfo, contextUser,
 			_userLocalService);
 	}
@@ -301,6 +334,7 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 		_collaboratorDTOConverter;
 	private final DTOConverterRegistry _dtoConverterRegistry;
 	private final GroupLocalService _groupLocalService;
+	private final JSONFactory _jsonFactory;
 
 	@Context
 	private ObjectDefinition _objectDefinition;
@@ -308,6 +342,7 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 	private final ObjectEntryLocalService _objectEntryLocalService;
 	private final SharingEntryLocalService _sharingEntryLocalService;
 	private final SharingEntryService _sharingEntryService;
+	private final TicketLocalService _ticketLocalService;
 	private final UserGroupLocalService _userGroupLocalService;
 	private final UserLocalService _userLocalService;
 

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/CollaboratorResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/CollaboratorResourceImpl.java
@@ -95,11 +95,10 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 			objectEntryId);
 
 		CollaboratorUtil.deleteCollaborator(
-			objectEntry.getModelClassName(),
 			_classNameLocalService.getClassNameId(
 				objectEntry.getModelClassName()),
 			objectEntry.getObjectEntryId(), collaboratorId,
-			_sharingEntryService, _ticketLocalService, type);
+			_sharingEntryService, type);
 	}
 
 	@Override
@@ -150,11 +149,10 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 			_objectDefinition.getObjectDefinitionId());
 
 		CollaboratorUtil.deleteCollaborator(
-			objectEntry.getModelClassName(),
 			_classNameLocalService.getClassNameId(
 				objectEntry.getModelClassName()),
 			objectEntry.getObjectEntryId(), collaboratorId,
-			_sharingEntryService, _ticketLocalService, type);
+			_sharingEntryService, type);
 	}
 
 	@Override
@@ -196,13 +194,12 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 			objectEntryId);
 
 		return CollaboratorUtil.getCollaborator(
-			contextAcceptLanguage, objectEntry.getModelClassName(),
+			contextAcceptLanguage,
 			_classNameLocalService.getClassNameId(
 				objectEntry.getModelClassName()),
 			objectEntry.getObjectEntryId(), collaboratorId,
 			_collaboratorDTOConverter, _dtoConverterRegistry,
-			_sharingEntryService, _ticketLocalService, type, contextUriInfo,
-			contextUser);
+			_sharingEntryService, type, contextUriInfo, contextUser);
 	}
 
 	@Override
@@ -278,13 +275,12 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 			_objectDefinition.getObjectDefinitionId());
 
 		return CollaboratorUtil.getCollaborator(
-			contextAcceptLanguage, objectEntry.getModelClassName(),
+			contextAcceptLanguage,
 			_classNameLocalService.getClassNameId(
 				objectEntry.getModelClassName()),
 			objectEntry.getObjectEntryId(), collaboratorId,
 			_collaboratorDTOConverter, _dtoConverterRegistry,
-			_sharingEntryService, _ticketLocalService, type, contextUriInfo,
-			contextUser);
+			_sharingEntryService, type, contextUriInfo, contextUser);
 	}
 
 	@Override

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/CollaboratorResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/CollaboratorResourceTest.java
@@ -16,29 +16,45 @@ import com.liferay.object.test.util.ObjectDefinitionTestUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.Ticket;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.UserGroup;
+import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.TicketLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.HTTPTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.RoleTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserGroupTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
+import com.liferay.sharing.constants.SharingTicketConstants;
+import com.liferay.sharing.model.SharingEntry;
 import com.liferay.sharing.security.permission.SharingEntryAction;
+import com.liferay.sharing.service.SharingEntryLocalService;
 
 import java.io.Serializable;
 
@@ -86,19 +102,331 @@ public class CollaboratorResourceTest {
 	}
 
 	@Test
-	public void testDeleteObjectEntryCollaboratorByTypeCollaborator()
+	@TestInfo("LPD-48130")
+	public void testDeleteObjectEntryCollaboratorByEmailAddress()
 		throws Exception {
+
+		String emailAddress =
+			StringUtil.toLowerCase(RandomTestUtil.randomString()) +
+				"@liferay.com";
 
 		ObjectEntry objectEntry = _addObjectEntry();
 
-		User user = _getUser();
+		HTTPTestUtil.invokeToJSONObject(
+			null,
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
+				objectEntry.getObjectEntryId(),
+				"/collaborators/by-email-address/", emailAddress),
+			Http.Method.DELETE);
+
+		HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				_getEmailCollaboratorJSONObject(emailAddress)
+			).toString(),
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
+				objectEntry.getObjectEntryId(), "/collaborators"),
+			Http.Method.POST);
+
+		Ticket ticket = _fetchTicketByEmailAddress(
+			objectEntry.getModelClassName(), objectEntry.getObjectEntryId(),
+			emailAddress);
+
+		HTTPTestUtil.invokeToJSONObject(
+			null,
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
+				objectEntry.getObjectEntryId(),
+				"/collaborators/by-email-address/", emailAddress),
+			Http.Method.DELETE);
+
+		Assert.assertNull(
+			_ticketLocalService.fetchTicket(ticket.getTicketId()));
+
+		Assert.assertNull(
+			_sharingEntryLocalService.fetchSharingEntry(
+				ticket.getTicketId(), 0, 0,
+				_classNameLocalService.getClassNameId(
+					objectEntry.getModelClassName()),
+				objectEntry.getObjectEntryId()));
+
+		User user1 = _addUser();
+
+		emailAddress = user1.getEmailAddress();
+
+		HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				_getEmailCollaboratorJSONObject(emailAddress)
+			).toString(),
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
+				objectEntry.getObjectEntryId(), "/collaborators"),
+			Http.Method.POST);
+
+		Assert.assertNotNull(
+			_sharingEntryLocalService.fetchSharingEntry(
+				0, 0, user1.getUserId(),
+				_classNameLocalService.getClassNameId(
+					objectEntry.getModelClassName()),
+				objectEntry.getObjectEntryId()));
+
+		HTTPTestUtil.invokeToJSONObject(
+			null,
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
+				objectEntry.getObjectEntryId(),
+				"/collaborators/by-email-address/", emailAddress),
+			Http.Method.DELETE);
+
+		Assert.assertNull(
+			_sharingEntryLocalService.fetchSharingEntry(
+				0, 0, user1.getUserId(),
+				_classNameLocalService.getClassNameId(
+					objectEntry.getModelClassName()),
+				objectEntry.getObjectEntryId()));
+
+		emailAddress =
+			StringUtil.toLowerCase(RandomTestUtil.randomString()) +
+				"@liferay.com";
+
+		HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				_getEmailCollaboratorJSONObject(emailAddress)
+			).toString(),
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
+				objectEntry.getObjectEntryId(), "/collaborators"),
+			Http.Method.POST);
+
+		ticket = _fetchTicketByEmailAddress(
+			objectEntry.getModelClassName(), objectEntry.getObjectEntryId(),
+			emailAddress);
+
+		_addUser(emailAddress);
+
+		HTTPTestUtil.invokeToJSONObject(
+			null,
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
+				objectEntry.getObjectEntryId(),
+				"/collaborators/by-email-address/", emailAddress),
+			Http.Method.DELETE);
+
+		Assert.assertNull(
+			_ticketLocalService.fetchTicket(ticket.getTicketId()));
+
+		Assert.assertNull(
+			_sharingEntryLocalService.fetchSharingEntry(
+				ticket.getTicketId(), 0, 0,
+				_classNameLocalService.getClassNameId(
+					objectEntry.getModelClassName()),
+				objectEntry.getObjectEntryId()));
+
+		long classNameId = _classNameLocalService.getClassNameId(
+			objectEntry.getModelClassName());
+
+		_role = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
+
+		RoleTestUtil.addResourcePermission(
+			_role, _objectDefinition.getClassName(),
+			ResourceConstants.SCOPE_COMPANY,
+			String.valueOf(TestPropsValues.getCompanyId()), ActionKeys.UPDATE);
+		RoleTestUtil.addResourcePermission(
+			_role, _objectDefinition.getClassName(),
+			ResourceConstants.SCOPE_COMPANY,
+			String.valueOf(TestPropsValues.getCompanyId()), ActionKeys.VIEW);
+
+		String password = RandomTestUtil.randomString();
+
+		user1 = _addUser();
+
+		User user2 = UserTestUtil.addUser(
+			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			password, RandomTestUtil.randomString() + "@liferay.com",
+			RandomTestUtil.randomString(), LocaleUtil.getDefault(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(), null,
+			ServiceContextTestUtil.getServiceContext());
+
+		user2.setEmailAddressVerified(true);
+
+		user2 = _userLocalService.updateUser(user2);
+
+		_users.add(user2);
+
+		_userLocalService.addRoleUser(_role.getRoleId(), user2.getUserId());
+
+		SharingEntry sharingEntry = _sharingEntryLocalService.addSharingEntry(
+			null, TestPropsValues.getUserId(), 0, 0, user1.getUserId(),
+			classNameId, objectEntry.getObjectEntryId(),
+			objectEntry.getGroupId(), false,
+			Collections.singletonList(SharingEntryAction.VIEW), null,
+			new ServiceContext());
+
+		String endpoint = StringBundler.concat(
+			_objectDefinition.getRESTContextPath(), StringPool.SLASH,
+			objectEntry.getObjectEntryId(), "/collaborators/by-email-address/",
+			user1.getEmailAddress());
+
+		HTTPTestUtil.customize(
+		).withCredentials(
+			user2.getEmailAddress(), password
+		).apply(
+			() -> {
+				JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
+					null, endpoint, Http.Method.DELETE);
+
+				Assert.assertEquals(
+					"NOT_FOUND", jsonObject.getString("status"));
+			}
+		);
+
+		Assert.assertNotNull(
+			_sharingEntryLocalService.fetchSharingEntry(
+				0, 0, user1.getUserId(), classNameId,
+				objectEntry.getObjectEntryId()));
+
+		_sharingEntryLocalService.deleteSharingEntry(sharingEntry);
+
+		_sharingEntryLocalService.addSharingEntry(
+			null, user2.getUserId(), 0, 0, user1.getUserId(), classNameId,
+			objectEntry.getObjectEntryId(), objectEntry.getGroupId(), false,
+			Collections.singletonList(SharingEntryAction.VIEW), null,
+			new ServiceContext());
+
+		HTTPTestUtil.customize(
+		).withCredentials(
+			user2.getEmailAddress(), password
+		).apply(
+			() -> HTTPTestUtil.invokeToJSONObject(
+				null, endpoint, Http.Method.DELETE)
+		);
+
+		Assert.assertNull(
+			_sharingEntryLocalService.fetchSharingEntry(
+				0, 0, user1.getUserId(), classNameId,
+				objectEntry.getObjectEntryId()));
+	}
+
+	@Test
+	@TestInfo("LPD-48130")
+	public void testDeleteObjectEntryCollaboratorByTypeCollaborator()
+		throws Exception {
+
+		ObjectEntry objectEntry1 = _addObjectEntry();
+
+		User user = _addUser();
 
 		_assertDeleteObjectEntryCollaborator(
 			StringBundler.concat(
 				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
-				objectEntry.getObjectEntryId(), "/collaborators/by-type/User/",
+				objectEntry1.getObjectEntryId(), "/collaborators/by-type/User/",
 				user.getUserId()),
 			user);
+
+		String emailAddress1 =
+			StringUtil.toLowerCase(RandomTestUtil.randomString()) +
+				"@liferay.com";
+
+		HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				_getEmailCollaboratorJSONObject(emailAddress1)
+			).toString(),
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
+				objectEntry1.getObjectEntryId(), "/collaborators"),
+			Http.Method.POST);
+
+		Ticket ticket1 = _fetchTicketByEmailAddress(
+			objectEntry1.getModelClassName(), objectEntry1.getObjectEntryId(),
+			emailAddress1);
+
+		HTTPTestUtil.invokeToJSONObject(
+			null,
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
+				objectEntry1.getObjectEntryId(),
+				"/collaborators/by-type/Email/", ticket1.getTicketId()),
+			Http.Method.DELETE);
+
+		Assert.assertNull(
+			_ticketLocalService.fetchTicket(ticket1.getTicketId()));
+
+		Assert.assertNull(
+			_sharingEntryLocalService.fetchSharingEntry(
+				ticket1.getTicketId(), 0, 0,
+				_classNameLocalService.getClassNameId(
+					objectEntry1.getModelClassName()),
+				objectEntry1.getObjectEntryId()));
+
+		String emailAddress2 =
+			StringUtil.toLowerCase(RandomTestUtil.randomString()) +
+				"@liferay.com";
+
+		ObjectEntry objectEntry2 = _addObjectEntry();
+
+		HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				_getEmailCollaboratorJSONObject(emailAddress2)
+			).toString(),
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
+				objectEntry2.getObjectEntryId(), "/collaborators"),
+			Http.Method.POST);
+
+		Ticket ticket2 = _fetchTicketByEmailAddress(
+			objectEntry2.getModelClassName(), objectEntry2.getObjectEntryId(),
+			emailAddress2);
+
+		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
+			null,
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
+				objectEntry1.getObjectEntryId(),
+				"/collaborators/by-type/Email/", ticket2.getTicketId()),
+			Http.Method.DELETE);
+
+		Assert.assertEquals("NOT_FOUND", jsonObject.getString("status"));
+
+		Assert.assertNotNull(
+			_ticketLocalService.fetchTicket(ticket2.getTicketId()));
+	}
+
+	@Test
+	@TestInfo("LPD-48130")
+	public void testDeleteScopeScopeKeyByExternalReferenceCodeCollaboratorByEmailAddress()
+		throws Exception {
+
+		String emailAddress =
+			StringUtil.toLowerCase(RandomTestUtil.randomString()) +
+				"@liferay.com";
+
+		ObjectEntry objectEntry = _addObjectEntry();
+
+		HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				_getEmailCollaboratorJSONObject(emailAddress)
+			).toString(),
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
+				objectEntry.getObjectEntryId(), "/collaborators"),
+			Http.Method.POST);
+
+		Ticket ticket = _fetchTicketByEmailAddress(
+			objectEntry.getModelClassName(), objectEntry.getObjectEntryId(),
+			emailAddress);
+
+		HTTPTestUtil.invokeToJSONObject(
+			null,
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), "/scopes/",
+				_group.getGroupId(), "/by-external-reference-code/",
+				objectEntry.getExternalReferenceCode(),
+				"/collaborators/by-email-address/", emailAddress),
+			Http.Method.DELETE);
+
+		Assert.assertNull(
+			_ticketLocalService.fetchTicket(ticket.getTicketId()));
 	}
 
 	@Test
@@ -107,7 +435,7 @@ public class CollaboratorResourceTest {
 
 		ObjectEntry objectEntry = _addObjectEntry();
 
-		User user = _getUser();
+		User user = _addUser();
 
 		_assertDeleteObjectEntryCollaborator(
 			StringBundler.concat(
@@ -119,22 +447,183 @@ public class CollaboratorResourceTest {
 	}
 
 	@Test
+	@TestInfo("LPD-48130")
+	public void testGetObjectEntryCollaboratorByEmailAddress()
+		throws Exception {
+
+		String emailAddress =
+			StringUtil.toLowerCase(RandomTestUtil.randomString()) +
+				"@liferay.com";
+
+		ObjectEntry objectEntry1 = _addObjectEntry();
+
+		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
+			null,
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
+				objectEntry1.getObjectEntryId(),
+				"/collaborators/by-email-address/", emailAddress),
+			Http.Method.GET);
+
+		Assert.assertEquals("NOT_FOUND", jsonObject.getString("status"));
+
+		HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				_getEmailCollaboratorJSONObject(emailAddress)
+			).toString(),
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
+				objectEntry1.getObjectEntryId(), "/collaborators"),
+			Http.Method.POST);
+
+		jsonObject = HTTPTestUtil.invokeToJSONObject(
+			null,
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
+				objectEntry1.getObjectEntryId(),
+				"/collaborators/by-email-address/", emailAddress),
+			Http.Method.GET);
+
+		Assert.assertEquals("Email", jsonObject.getString("type"));
+		Assert.assertEquals(emailAddress, jsonObject.getString("emailAddress"));
+
+		Ticket ticket = _fetchTicketByEmailAddress(
+			objectEntry1.getModelClassName(), objectEntry1.getObjectEntryId(),
+			emailAddress);
+
+		_sharingEntryLocalService.deleteSharingEntry(
+			_sharingEntryLocalService.fetchSharingEntry(
+				ticket.getTicketId(), 0, 0,
+				_classNameLocalService.getClassNameId(
+					objectEntry1.getModelClassName()),
+				objectEntry1.getObjectEntryId()));
+
+		jsonObject = HTTPTestUtil.invokeToJSONObject(
+			null,
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
+				objectEntry1.getObjectEntryId(),
+				"/collaborators/by-email-address/", emailAddress),
+			Http.Method.GET);
+
+		Assert.assertEquals("NOT_FOUND", jsonObject.getString("status"));
+
+		_ticketLocalService.deleteTicket(ticket.getTicketId());
+
+		User user = _addUser();
+
+		ObjectEntry objectEntry2 = _addObjectEntry();
+
+		jsonObject = HTTPTestUtil.invokeToJSONObject(
+			null,
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
+				objectEntry2.getObjectEntryId(),
+				"/collaborators/by-email-address/", user.getEmailAddress()),
+			Http.Method.GET);
+
+		Assert.assertEquals("NOT_FOUND", jsonObject.getString("status"));
+
+		HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				_getEmailCollaboratorJSONObject(user.getEmailAddress())
+			).toString(),
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
+				objectEntry2.getObjectEntryId(), "/collaborators"),
+			Http.Method.POST);
+
+		jsonObject = HTTPTestUtil.invokeToJSONObject(
+			null,
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
+				objectEntry2.getObjectEntryId(),
+				"/collaborators/by-email-address/", user.getEmailAddress()),
+			Http.Method.GET);
+
+		Assert.assertEquals("User", jsonObject.getString("type"));
+		Assert.assertEquals(
+			String.valueOf(user.getUserId()), jsonObject.getString("id"));
+	}
+
+	@Test
+	@TestInfo("LPD-48130")
 	public void testGetObjectEntryCollaboratorByTypeCollaborator()
 		throws Exception {
 
-		ObjectEntry objectEntry = _addObjectEntry();
+		ObjectEntry objectEntry1 = _addObjectEntry();
 
-		User user = _getUser();
+		User user = _addUser();
 
 		_assertGetObjectEntryCollaborator(
 			StringBundler.concat(
 				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
-				objectEntry.getObjectEntryId(), "/collaborators/by-type/User/",
+				objectEntry1.getObjectEntryId(), "/collaborators/by-type/User/",
 				user.getUserId()),
 			user);
+
+		String emailAddress =
+			StringUtil.toLowerCase(RandomTestUtil.randomString()) +
+				"@liferay.com";
+
+		HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				_getEmailCollaboratorJSONObject(emailAddress)
+			).toString(),
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
+				objectEntry1.getObjectEntryId(), "/collaborators"),
+			Http.Method.POST);
+
+		Ticket ticket = _fetchTicketByEmailAddress(
+			objectEntry1.getModelClassName(), objectEntry1.getObjectEntryId(),
+			emailAddress);
+
+		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
+			null,
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
+				objectEntry1.getObjectEntryId(),
+				"/collaborators/by-type/Email/", ticket.getTicketId()),
+			Http.Method.GET);
+
+		Assert.assertEquals("Email", jsonObject.getString("type"));
+		Assert.assertEquals(emailAddress, jsonObject.getString("emailAddress"));
+		Assert.assertEquals(
+			String.valueOf(ticket.getTicketId()), jsonObject.getString("id"));
+
+		ObjectEntry objectEntry2 = _addObjectEntry();
+
+		jsonObject = HTTPTestUtil.invokeToJSONObject(
+			null,
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
+				objectEntry2.getObjectEntryId(),
+				"/collaborators/by-type/Email/", ticket.getTicketId()),
+			Http.Method.GET);
+
+		Assert.assertEquals("NOT_FOUND", jsonObject.getString("status"));
+
+		_sharingEntryLocalService.deleteSharingEntry(
+			_sharingEntryLocalService.fetchSharingEntry(
+				ticket.getTicketId(), 0, 0,
+				_classNameLocalService.getClassNameId(
+					objectEntry1.getModelClassName()),
+				objectEntry1.getObjectEntryId()));
+
+		jsonObject = HTTPTestUtil.invokeToJSONObject(
+			null,
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
+				objectEntry1.getObjectEntryId(),
+				"/collaborators/by-type/Email/", ticket.getTicketId()),
+			Http.Method.GET);
+
+		Assert.assertEquals("NOT_FOUND", jsonObject.getString("status"));
 	}
 
 	@Test
+	@TestInfo("LPD-48130")
 	public void testGetObjectEntryCollaboratorsPage() throws Exception {
 		JSONObject collaboratorJSONObject1 = _getUserCollaboratorJSONObject();
 		JSONObject collaboratorJSONObject2 = _getUserCollaboratorJSONObject();
@@ -163,6 +652,68 @@ public class CollaboratorResourceTest {
 				collaboratorJSONObject3, collaboratorJSONObject2,
 				collaboratorJSONObject1),
 			jsonObject.getJSONArray("items"));
+
+		String emailAddress =
+			StringUtil.toLowerCase(RandomTestUtil.randomString()) +
+				"@liferay.com";
+
+		HTTPTestUtil.invokeToJSONObject(
+			_getEmailCollaboratorJSONObject(
+				emailAddress
+			).toString(),
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
+				objectEntry.getObjectEntryId(),
+				"/collaborators/by-email-address/", emailAddress),
+			Http.Method.PUT);
+
+		Ticket ticket = _fetchTicketByEmailAddress(
+			objectEntry.getModelClassName(), objectEntry.getObjectEntryId(),
+			emailAddress);
+
+		_ticketLocalService.deleteTicket(ticket.getTicketId());
+
+		jsonObject = HTTPTestUtil.invokeToJSONObject(
+			null,
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
+				objectEntry.getObjectEntryId(), "/collaborators"),
+			Http.Method.GET);
+
+		Assert.assertEquals(4, jsonObject.getInt("totalCount"));
+	}
+
+	@Test
+	@TestInfo("LPD-48130")
+	public void testGetScopeScopeKeyByExternalReferenceCodeCollaboratorByEmailAddress()
+		throws Exception {
+
+		String emailAddress =
+			StringUtil.toLowerCase(RandomTestUtil.randomString()) +
+				"@liferay.com";
+
+		ObjectEntry objectEntry = _addObjectEntry();
+
+		HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				_getEmailCollaboratorJSONObject(emailAddress)
+			).toString(),
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
+				objectEntry.getObjectEntryId(), "/collaborators"),
+			Http.Method.POST);
+
+		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
+			null,
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), "/scopes/",
+				_group.getGroupId(), "/by-external-reference-code/",
+				objectEntry.getExternalReferenceCode(),
+				"/collaborators/by-email-address/", emailAddress),
+			Http.Method.GET);
+
+		Assert.assertEquals("Email", jsonObject.getString("type"));
+		Assert.assertEquals(emailAddress, jsonObject.getString("emailAddress"));
 	}
 
 	@Test
@@ -171,7 +722,7 @@ public class CollaboratorResourceTest {
 
 		ObjectEntry objectEntry = _addObjectEntry();
 
-		User user = _getUser();
+		User user = _addUser();
 
 		_assertGetObjectEntryCollaborator(
 			StringBundler.concat(
@@ -214,28 +765,287 @@ public class CollaboratorResourceTest {
 	}
 
 	@Test
+	@TestInfo("LPD-48130")
 	public void testPostObjectEntryCollaboratorsPage() throws Exception {
 		JSONObject collaboratorJSONObject1 = _getUserCollaboratorJSONObject();
 		JSONObject collaboratorJSONObject2 =
 			_getUserGroupCollaboratorJSONObject();
 		JSONObject collaboratorJSONObject3 = _getUserCollaboratorJSONObject();
-		ObjectEntry objectEntry = _addObjectEntry();
+		ObjectEntry objectEntry1 = _addObjectEntry();
 
-		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
+		JSONObject jsonObject1 = HTTPTestUtil.invokeToJSONObject(
 			JSONUtil.putAll(
 				collaboratorJSONObject1, collaboratorJSONObject2,
 				collaboratorJSONObject3
 			).toString(),
 			StringBundler.concat(
 				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
-				objectEntry.getObjectEntryId(), "/collaborators"),
+				objectEntry1.getObjectEntryId(), "/collaborators"),
 			Http.Method.POST);
 
 		_assertEquals(
 			JSONUtil.putAll(
 				collaboratorJSONObject3, collaboratorJSONObject2,
 				collaboratorJSONObject1),
-			jsonObject.getJSONArray("items"));
+			jsonObject1.getJSONArray("items"));
+
+		ObjectEntry objectEntry2 = _addObjectEntry();
+
+		jsonObject1 = HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				_getEmailCollaboratorJSONObject("not-an-email")
+			).toString(),
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
+				objectEntry2.getObjectEntryId(), "/collaborators"),
+			Http.Method.POST);
+
+		Assert.assertEquals("BAD_REQUEST", jsonObject1.getString("status"));
+
+		jsonObject1 = HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				JSONUtil.put(
+					"actionIds",
+					JSONUtil.put(SharingEntryAction.VIEW.getActionId())
+				).put(
+					"share", true
+				).put(
+					"type", "Email"
+				)
+			).toString(),
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
+				objectEntry2.getObjectEntryId(), "/collaborators"),
+			Http.Method.POST);
+
+		Assert.assertEquals("BAD_REQUEST", jsonObject1.getString("status"));
+
+		String emailAddress1 =
+			StringUtil.toLowerCase(RandomTestUtil.randomString()) +
+				"@liferay.com";
+
+		HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				JSONUtil.put(
+					"actionIds", JSONUtil.put("INVALID_ACTION")
+				).put(
+					"emailAddress", emailAddress1
+				).put(
+					"share", true
+				).put(
+					"type", "Email"
+				)
+			).toString(),
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
+				objectEntry2.getObjectEntryId(), "/collaborators"),
+			Http.Method.POST);
+
+		Assert.assertNull(
+			_fetchTicketByEmailAddress(
+				objectEntry2.getModelClassName(),
+				objectEntry2.getObjectEntryId(), emailAddress1));
+
+		jsonObject1 = HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				_getEmailCollaboratorJSONObject(
+					emailAddress1, SharingEntryAction.UPDATE,
+					SharingEntryAction.VIEW)
+			).toString(),
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
+				objectEntry2.getObjectEntryId(), "/collaborators"),
+			Http.Method.POST);
+
+		Assert.assertEquals("BAD_REQUEST", jsonObject1.getString("status"));
+
+		Assert.assertNull(
+			_fetchTicketByEmailAddress(
+				objectEntry2.getModelClassName(),
+				objectEntry2.getObjectEntryId(), emailAddress1));
+
+		HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				_getEmailCollaboratorJSONObject(emailAddress1)
+			).toString(),
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
+				objectEntry2.getObjectEntryId(), "/collaborators"),
+			Http.Method.POST);
+
+		Ticket ticket1 = _fetchTicketByEmailAddress(
+			objectEntry2.getModelClassName(), objectEntry2.getObjectEntryId(),
+			emailAddress1);
+
+		Assert.assertNotNull(ticket1);
+
+		Assert.assertNotNull(
+			_sharingEntryLocalService.fetchSharingEntry(
+				ticket1.getTicketId(), 0, 0,
+				_classNameLocalService.getClassNameId(
+					objectEntry2.getModelClassName()),
+				objectEntry2.getObjectEntryId()));
+
+		HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				_getEmailCollaboratorJSONObject(emailAddress1)
+			).toString(),
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
+				objectEntry2.getObjectEntryId(), "/collaborators"),
+			Http.Method.POST);
+
+		List<Ticket> tickets = _ticketLocalService.getTickets(
+			TestPropsValues.getCompanyId(), objectEntry2.getModelClassName(),
+			objectEntry2.getObjectEntryId(),
+			SharingTicketConstants.TYPE_INVITE_COLLABORATOR);
+
+		Assert.assertEquals(tickets.toString(), 1, tickets.size());
+
+		Ticket ticket2 = tickets.get(0);
+
+		Assert.assertEquals(ticket1.getTicketId(), ticket2.getTicketId());
+
+		User user1 = _addUser(emailAddress1);
+
+		HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				_getEmailCollaboratorJSONObject(emailAddress1)
+			).toString(),
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
+				objectEntry2.getObjectEntryId(), "/collaborators"),
+			Http.Method.POST);
+
+		Assert.assertNull(
+			_fetchTicketByEmailAddress(
+				objectEntry2.getModelClassName(),
+				objectEntry2.getObjectEntryId(), emailAddress1));
+		Assert.assertNotNull(
+			_sharingEntryLocalService.fetchSharingEntry(
+				0, 0, user1.getUserId(),
+				_classNameLocalService.getClassNameId(
+					objectEntry2.getModelClassName()),
+				objectEntry2.getObjectEntryId()));
+
+		User user2 = _addUser();
+
+		ObjectEntry objectEntry3 = _addObjectEntry();
+
+		HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				_getEmailCollaboratorJSONObject(user2.getEmailAddress())
+			).toString(),
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
+				objectEntry3.getObjectEntryId(), "/collaborators"),
+			Http.Method.POST);
+
+		Assert.assertNull(
+			"No ticket should be created when the email resolves to an " +
+				"existing user",
+			_fetchTicketByEmailAddress(
+				objectEntry3.getModelClassName(),
+				objectEntry3.getObjectEntryId(), user2.getEmailAddress()));
+
+		Assert.assertNotNull(
+			"A User-type sharing entry must exist for the resolved user",
+			_sharingEntryLocalService.fetchSharingEntry(
+				0, 0, user2.getUserId(),
+				_classNameLocalService.getClassNameId(
+					objectEntry3.getModelClassName()),
+				objectEntry3.getObjectEntryId()));
+
+		String emailAddress2 =
+			StringUtil.toLowerCase(RandomTestUtil.randomString()) +
+				"@liferay.com";
+
+		JSONObject jsonObject2 = _getEmailCollaboratorJSONObject(emailAddress2);
+
+		JSONObject jsonObject3 = _getUserCollaboratorJSONObject();
+		JSONObject jsonObject4 = _getUserGroupCollaboratorJSONObject();
+
+		ObjectEntry objectEntry4 = _addObjectEntry();
+
+		JSONObject jsonObject5 = HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.putAll(
+				jsonObject2, jsonObject3, jsonObject4
+			).toString(),
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
+				objectEntry4.getObjectEntryId(), "/collaborators"),
+			Http.Method.POST);
+
+		JSONArray itemsJSONArray = jsonObject5.getJSONArray("items");
+
+		Assert.assertEquals(
+			itemsJSONArray.toString(), 3, itemsJSONArray.length());
+
+		Assert.assertNotNull(
+			_fetchTicketByEmailAddress(
+				objectEntry4.getModelClassName(),
+				objectEntry4.getObjectEntryId(), emailAddress2));
+
+		String emailAddress3 =
+			StringUtil.toLowerCase(RandomTestUtil.randomString()) +
+				"@liferay.com";
+		String emailAddress4 =
+			StringUtil.toLowerCase(RandomTestUtil.randomString()) +
+				"@liferay.com";
+
+		User user3 = _addUser();
+
+		ObjectEntry objectEntry5 = _addObjectEntry();
+
+		HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.putAll(
+				_getEmailCollaboratorJSONObject(emailAddress3),
+				_getEmailCollaboratorJSONObject(emailAddress4),
+				_getEmailCollaboratorJSONObject(user3.getEmailAddress())
+			).toString(),
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
+				objectEntry5.getObjectEntryId(), "/collaborators"),
+			Http.Method.POST);
+
+		Assert.assertNotNull(
+			_fetchTicketByEmailAddress(
+				objectEntry5.getModelClassName(),
+				objectEntry5.getObjectEntryId(), emailAddress3));
+		Assert.assertNotNull(
+			_fetchTicketByEmailAddress(
+				objectEntry5.getModelClassName(),
+				objectEntry5.getObjectEntryId(), emailAddress4));
+		Assert.assertNotNull(
+			_sharingEntryLocalService.fetchSharingEntry(
+				0, 0, user3.getUserId(),
+				_classNameLocalService.getClassNameId(
+					objectEntry5.getModelClassName()),
+				objectEntry5.getObjectEntryId()));
+
+		HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				_getEmailCollaboratorJSONObject(user3.getEmailAddress())
+			).toString(),
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
+				objectEntry5.getObjectEntryId(), "/collaborators"),
+			Http.Method.POST);
+
+		Assert.assertNull(
+			_fetchTicketByEmailAddress(
+				objectEntry5.getModelClassName(),
+				objectEntry5.getObjectEntryId(), emailAddress3));
+		Assert.assertNull(
+			_fetchTicketByEmailAddress(
+				objectEntry5.getModelClassName(),
+				objectEntry5.getObjectEntryId(), emailAddress4));
+		Assert.assertNotNull(
+			_sharingEntryLocalService.fetchSharingEntry(
+				0, 0, user3.getUserId(),
+				_classNameLocalService.getClassNameId(
+					objectEntry5.getModelClassName()),
+				objectEntry5.getObjectEntryId()));
 	}
 
 	@Test
@@ -269,20 +1079,245 @@ public class CollaboratorResourceTest {
 	}
 
 	@Test
+	@TestInfo("LPD-48130")
+	public void testPutObjectEntryCollaboratorByEmailAddress()
+		throws Exception {
+
+		User user = _addUser();
+
+		ObjectEntry objectEntry1 = _addObjectEntry();
+
+		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
+			_getEmailCollaboratorJSONObject(
+				user.getEmailAddress(), SharingEntryAction.UPDATE,
+				SharingEntryAction.VIEW
+			).toString(),
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
+				objectEntry1.getObjectEntryId(),
+				"/collaborators/by-email-address/", user.getEmailAddress()),
+			Http.Method.PUT);
+
+		Assert.assertEquals("BAD_REQUEST", jsonObject.getString("status"));
+
+		jsonObject = HTTPTestUtil.invokeToJSONObject(
+			_getEmailCollaboratorJSONObject(
+				user.getEmailAddress()
+			).toString(),
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
+				objectEntry1.getObjectEntryId(),
+				"/collaborators/by-email-address/", user.getEmailAddress()),
+			Http.Method.PUT);
+
+		Assert.assertEquals("User", jsonObject.getString("type"));
+		Assert.assertEquals(
+			String.valueOf(user.getUserId()), jsonObject.getString("id"));
+
+		Assert.assertNotNull(
+			_sharingEntryLocalService.fetchSharingEntry(
+				0, 0, user.getUserId(),
+				_classNameLocalService.getClassNameId(
+					objectEntry1.getModelClassName()),
+				objectEntry1.getObjectEntryId()));
+
+		Assert.assertNull(
+			_fetchTicketByEmailAddress(
+				objectEntry1.getModelClassName(),
+				objectEntry1.getObjectEntryId(), user.getEmailAddress()));
+
+		String emailAddress =
+			StringUtil.toLowerCase(RandomTestUtil.randomString()) +
+				"@liferay.com";
+
+		ObjectEntry objectEntry2 = _addObjectEntry();
+
+		jsonObject = HTTPTestUtil.invokeToJSONObject(
+			_getEmailCollaboratorJSONObject(
+				emailAddress, SharingEntryAction.UPDATE, SharingEntryAction.VIEW
+			).toString(),
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
+				objectEntry2.getObjectEntryId(),
+				"/collaborators/by-email-address/", emailAddress),
+			Http.Method.PUT);
+
+		Assert.assertEquals("BAD_REQUEST", jsonObject.getString("status"));
+
+		Assert.assertNull(
+			_fetchTicketByEmailAddress(
+				objectEntry2.getModelClassName(),
+				objectEntry2.getObjectEntryId(), emailAddress));
+
+		jsonObject = HTTPTestUtil.invokeToJSONObject(
+			_getEmailCollaboratorJSONObject(
+				emailAddress
+			).toString(),
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
+				objectEntry2.getObjectEntryId(),
+				"/collaborators/by-email-address/", emailAddress),
+			Http.Method.PUT);
+
+		Assert.assertEquals("Email", jsonObject.getString("type"));
+		Assert.assertEquals(emailAddress, jsonObject.getString("emailAddress"));
+
+		Ticket ticket = _fetchTicketByEmailAddress(
+			objectEntry2.getModelClassName(), objectEntry2.getObjectEntryId(),
+			emailAddress);
+
+		Assert.assertNotNull(ticket);
+
+		Assert.assertNotNull(
+			_sharingEntryLocalService.fetchSharingEntry(
+				ticket.getTicketId(), 0, 0,
+				_classNameLocalService.getClassNameId(
+					objectEntry2.getModelClassName()),
+				objectEntry2.getObjectEntryId()));
+	}
+
+	@Test
+	@TestInfo("LPD-48130")
 	public void testPutObjectEntryCollaboratorByTypeCollaborator()
 		throws Exception {
 
-		ObjectEntry objectEntry = _addObjectEntry();
+		ObjectEntry objectEntry1 = _addObjectEntry();
 
-		UserGroup userGroup = _getUserGroup();
+		UserGroup userGroup = _addUserGroup();
 
 		_assertPutObjectEntryCollaborator(
 			StringBundler.concat(
 				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
-				objectEntry.getObjectEntryId(),
+				objectEntry1.getObjectEntryId(),
 				"/collaborators/by-type/UserGroup/",
 				userGroup.getUserGroupId()),
 			userGroup);
+
+		String emailAddress1 =
+			StringUtil.toLowerCase(RandomTestUtil.randomString()) +
+				"@liferay.com";
+
+		HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				"actionIds", JSONUtil.put("INVALID_ACTION")
+			).put(
+				"emailAddress", emailAddress1
+			).put(
+				"share", true
+			).put(
+				"type", "Email"
+			).toString(),
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
+				objectEntry1.getObjectEntryId(),
+				"/collaborators/by-type/Email/0"),
+			Http.Method.PUT);
+
+		Assert.assertNull(
+			_fetchTicketByEmailAddress(
+				objectEntry1.getModelClassName(),
+				objectEntry1.getObjectEntryId(), emailAddress1));
+
+		HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				_getEmailCollaboratorJSONObject(emailAddress1)
+			).toString(),
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
+				objectEntry1.getObjectEntryId(), "/collaborators"),
+			Http.Method.POST);
+
+		Ticket ticket1 = _fetchTicketByEmailAddress(
+			objectEntry1.getModelClassName(), objectEntry1.getObjectEntryId(),
+			emailAddress1);
+
+		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
+			_getEmailCollaboratorJSONObject(
+				emailAddress1
+			).toString(),
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
+				objectEntry1.getObjectEntryId(),
+				"/collaborators/by-type/Email/", ticket1.getTicketId()),
+			Http.Method.PUT);
+
+		Assert.assertEquals("Email", jsonObject.getString("type"));
+		Assert.assertEquals(
+			String.valueOf(ticket1.getTicketId()), jsonObject.getString("id"));
+
+		List<Ticket> tickets = _ticketLocalService.getTickets(
+			TestPropsValues.getCompanyId(), objectEntry1.getModelClassName(),
+			objectEntry1.getObjectEntryId(),
+			SharingTicketConstants.TYPE_INVITE_COLLABORATOR);
+
+		Assert.assertEquals(tickets.toString(), 1, tickets.size());
+
+		String emailAddress2 =
+			StringUtil.toLowerCase(RandomTestUtil.randomString()) +
+				"@liferay.com";
+
+		ObjectEntry objectEntry2 = _addObjectEntry();
+
+		HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				_getEmailCollaboratorJSONObject(emailAddress2)
+			).toString(),
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
+				objectEntry2.getObjectEntryId(), "/collaborators"),
+			Http.Method.POST);
+
+		Ticket ticket2 = _fetchTicketByEmailAddress(
+			objectEntry2.getModelClassName(), objectEntry2.getObjectEntryId(),
+			emailAddress2);
+
+		_addUser(emailAddress2);
+
+		HTTPTestUtil.invokeToJSONObject(
+			_getEmailCollaboratorJSONObject(
+				emailAddress2
+			).toString(),
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
+				objectEntry2.getObjectEntryId(),
+				"/collaborators/by-type/Email/", ticket2.getTicketId()),
+			Http.Method.PUT);
+
+		Assert.assertNull(
+			_fetchTicketByEmailAddress(
+				objectEntry2.getModelClassName(),
+				objectEntry2.getObjectEntryId(), emailAddress2));
+	}
+
+	@Test
+	@TestInfo("LPD-48130")
+	public void testPutScopeScopeKeyByExternalReferenceCodeCollaboratorByEmailAddress()
+		throws Exception {
+
+		String emailAddress =
+			StringUtil.toLowerCase(RandomTestUtil.randomString()) +
+				"@liferay.com";
+
+		ObjectEntry objectEntry = _addObjectEntry();
+
+		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
+			_getEmailCollaboratorJSONObject(
+				emailAddress
+			).toString(),
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), "/scopes/",
+				_group.getGroupId(), "/by-external-reference-code/",
+				objectEntry.getExternalReferenceCode(),
+				"/collaborators/by-email-address/", emailAddress),
+			Http.Method.PUT);
+
+		Assert.assertEquals("Email", jsonObject.getString("type"));
+		Assert.assertEquals(emailAddress, jsonObject.getString("emailAddress"));
+
+		Assert.assertNotNull(
+			_fetchTicketByEmailAddress(
+				objectEntry.getModelClassName(), objectEntry.getObjectEntryId(),
+				emailAddress));
 	}
 
 	@Test
@@ -291,7 +1326,7 @@ public class CollaboratorResourceTest {
 
 		ObjectEntry objectEntry = _addObjectEntry();
 
-		UserGroup userGroup = _getUserGroup();
+		UserGroup userGroup = _addUserGroup();
 
 		_assertPutObjectEntryCollaborator(
 			StringBundler.concat(
@@ -332,6 +1367,35 @@ public class CollaboratorResourceTest {
 			).build(),
 			ServiceContextTestUtil.getServiceContext(
 				_group.getGroupId(), TestPropsValues.getUserId()));
+	}
+
+	private User _addUser() throws Exception {
+		User user = UserTestUtil.addUser();
+
+		_users.add(user);
+
+		return user;
+	}
+
+	private User _addUser(String emailAddress) throws Exception {
+		User user = UserTestUtil.addUser(
+			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			StringPool.BLANK, emailAddress, RandomTestUtil.randomString(),
+			LocaleUtil.getDefault(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), null,
+			ServiceContextTestUtil.getServiceContext());
+
+		_users.add(user);
+
+		return user;
+	}
+
+	private UserGroup _addUserGroup() throws Exception {
+		UserGroup userGroup = UserGroupTestUtil.addUserGroup();
+
+		_userGroups.add(userGroup);
+
+		return userGroup;
 	}
 
 	private void _assertDeleteObjectEntryCollaborator(
@@ -421,17 +1485,6 @@ public class CollaboratorResourceTest {
 				continue;
 			}
 
-			if (Objects.equals(assertFieldName, "id")) {
-				if (!StringUtil.equals(
-						jsonObject1.getString("id"),
-						jsonObject2.getString("id"))) {
-
-					return false;
-				}
-
-				continue;
-			}
-
 			if (Objects.equals(assertFieldName, "name")) {
 				if (!StringUtil.equals(
 						jsonObject1.getString("name"),
@@ -444,7 +1497,7 @@ public class CollaboratorResourceTest {
 			}
 
 			if (Objects.equals(assertFieldName, "share")) {
-				if (!jsonObject1.getBoolean("share") == jsonObject2.getBoolean(
+				if (jsonObject1.getBoolean("share") != jsonObject2.getBoolean(
 						"share")) {
 
 					return false;
@@ -465,16 +1518,55 @@ public class CollaboratorResourceTest {
 		return true;
 	}
 
-	private User _getUser() throws Exception {
-		User user = UserTestUtil.addUser();
+	private Ticket _fetchTicketByEmailAddress(
+			String className, long classPK, String emailAddress)
+		throws Exception {
 
-		_users.add(user);
+		List<Ticket> tickets = _ticketLocalService.getTickets(
+			TestPropsValues.getCompanyId(), className, classPK,
+			SharingTicketConstants.TYPE_INVITE_COLLABORATOR);
 
-		return user;
+		for (Ticket ticket : tickets) {
+			JSONObject jsonObject = _jsonFactory.createJSONObject(
+				ticket.getExtraInfo());
+
+			if (Objects.equals(
+					emailAddress, jsonObject.getString("emailAddress"))) {
+
+				return ticket;
+			}
+		}
+
+		return null;
+	}
+
+	private JSONObject _getEmailCollaboratorJSONObject(String emailAddress) {
+		return _getEmailCollaboratorJSONObject(
+			emailAddress, SharingEntryAction.VIEW);
+	}
+
+	private JSONObject _getEmailCollaboratorJSONObject(
+		String emailAddress, SharingEntryAction... sharingEntryActions) {
+
+		JSONArray jsonArray = _jsonFactory.createJSONArray();
+
+		for (SharingEntryAction sharingEntryAction : sharingEntryActions) {
+			jsonArray.put(sharingEntryAction.getActionId());
+		}
+
+		return JSONUtil.put(
+			"actionIds", jsonArray
+		).put(
+			"emailAddress", emailAddress
+		).put(
+			"share", true
+		).put(
+			"type", "Email"
+		);
 	}
 
 	private JSONObject _getUserCollaboratorJSONObject() throws Exception {
-		return _getUserCollaboratorJSONObject(_getUser());
+		return _getUserCollaboratorJSONObject(_addUser());
 	}
 
 	private JSONObject _getUserCollaboratorJSONObject(User user)
@@ -495,16 +1587,8 @@ public class CollaboratorResourceTest {
 		);
 	}
 
-	private UserGroup _getUserGroup() throws Exception {
-		UserGroup userGroup = UserGroupTestUtil.addUserGroup();
-
-		_userGroups.add(userGroup);
-
-		return userGroup;
-	}
-
 	private JSONObject _getUserGroupCollaboratorJSONObject() throws Exception {
-		return _getUserGroupCollaboratorJSONObject(_getUserGroup());
+		return _getUserGroupCollaboratorJSONObject(_addUserGroup());
 	}
 
 	private JSONObject _getUserGroupCollaboratorJSONObject(UserGroup userGroup)
@@ -534,14 +1618,32 @@ public class CollaboratorResourceTest {
 	@Inject
 	private static ObjectDefinitionLocalService _objectDefinitionLocalService;
 
+	@Inject
+	private ClassNameLocalService _classNameLocalService;
+
 	@DeleteAfterTestRun
 	private Group _group;
+
+	@Inject
+	private JSONFactory _jsonFactory;
 
 	@Inject
 	private ObjectEntryLocalService _objectEntryLocalService;
 
 	@DeleteAfterTestRun
+	private Role _role;
+
+	@Inject
+	private SharingEntryLocalService _sharingEntryLocalService;
+
+	@Inject
+	private TicketLocalService _ticketLocalService;
+
+	@DeleteAfterTestRun
 	private List<UserGroup> _userGroups = new ArrayList<>();
+
+	@Inject
+	private UserLocalService _userLocalService;
 
 	@DeleteAfterTestRun
 	private List<User> _users = new ArrayList<>();

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/CollaboratorResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/CollaboratorResourceTest.java
@@ -263,7 +263,7 @@ public class CollaboratorResourceTest {
 			Collections.singletonList(SharingEntryAction.VIEW), null,
 			new ServiceContext());
 
-		String endpoint = StringBundler.concat(
+		String endpoint1 = StringBundler.concat(
 			_objectDefinition.getRESTContextPath(), StringPool.SLASH,
 			objectEntry.getObjectEntryId(), "/collaborators/by-email-address/",
 			user1.getEmailAddress());
@@ -274,7 +274,7 @@ public class CollaboratorResourceTest {
 		).apply(
 			() -> {
 				JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
-					null, endpoint, Http.Method.DELETE);
+					null, endpoint1, Http.Method.DELETE);
 
 				Assert.assertEquals(
 					"NOT_FOUND", jsonObject.getString("status"));
@@ -299,13 +299,53 @@ public class CollaboratorResourceTest {
 			user2.getEmailAddress(), password
 		).apply(
 			() -> HTTPTestUtil.invokeToJSONObject(
-				null, endpoint, Http.Method.DELETE)
+				null, endpoint1, Http.Method.DELETE)
+		);
+
+		Assert.assertNotNull(
+			_sharingEntryLocalService.fetchSharingEntry(
+				0, 0, user1.getUserId(), classNameId,
+				objectEntry.getObjectEntryId()));
+
+		_sharingEntryLocalService.deleteSharingEntry(
+			_sharingEntryLocalService.fetchSharingEntry(
+				0, 0, user1.getUserId(), classNameId,
+				objectEntry.getObjectEntryId()));
+
+		objectEntry = _objectEntryLocalService.addObjectEntry(
+			_group.getGroupId(), user2.getUserId(),
+			_objectDefinition.getObjectDefinitionId(), 0, null,
+			HashMapBuilder.<String, Serializable>put(
+				"title", RandomTestUtil.randomString()
+			).build(),
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), user2.getUserId()));
+
+		_sharingEntryLocalService.addSharingEntry(
+			null, user2.getUserId(), 0, 0, user1.getUserId(), classNameId,
+			objectEntry.getObjectEntryId(), objectEntry.getGroupId(), false,
+			Collections.singletonList(SharingEntryAction.VIEW), null,
+			new ServiceContext());
+
+		String endpoint2 = StringBundler.concat(
+			_objectDefinition.getRESTContextPath(), StringPool.SLASH,
+			objectEntry.getObjectEntryId(), "/collaborators/by-email-address/",
+			user1.getEmailAddress());
+
+		HTTPTestUtil.customize(
+		).withCredentials(
+			user2.getEmailAddress(), password
+		).apply(
+			() -> HTTPTestUtil.invokeToJSONObject(
+				null, endpoint2, Http.Method.DELETE)
 		);
 
 		Assert.assertNull(
 			_sharingEntryLocalService.fetchSharingEntry(
 				0, 0, user1.getUserId(), classNameId,
 				objectEntry.getObjectEntryId()));
+
+		_objectEntryLocalService.deleteObjectEntry(objectEntry);
 	}
 
 	@Test

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/CollaboratorResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/CollaboratorResourceTest.java
@@ -313,83 +313,26 @@ public class CollaboratorResourceTest {
 	public void testDeleteObjectEntryCollaboratorByTypeCollaborator()
 		throws Exception {
 
-		ObjectEntry objectEntry1 = _addObjectEntry();
+		ObjectEntry objectEntry = _addObjectEntry();
 
 		User user = _addUser();
 
 		_assertDeleteObjectEntryCollaborator(
 			StringBundler.concat(
 				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
-				objectEntry1.getObjectEntryId(), "/collaborators/by-type/User/",
+				objectEntry.getObjectEntryId(), "/collaborators/by-type/User/",
 				user.getUserId()),
 			user);
-
-		String emailAddress1 =
-			StringUtil.toLowerCase(RandomTestUtil.randomString()) +
-				"@liferay.com";
-
-		HTTPTestUtil.invokeToJSONObject(
-			JSONUtil.put(
-				_getEmailCollaboratorJSONObject(emailAddress1)
-			).toString(),
-			StringBundler.concat(
-				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
-				objectEntry1.getObjectEntryId(), "/collaborators"),
-			Http.Method.POST);
-
-		Ticket ticket1 = _fetchTicketByEmailAddress(
-			objectEntry1.getModelClassName(), objectEntry1.getObjectEntryId(),
-			emailAddress1);
-
-		HTTPTestUtil.invokeToJSONObject(
-			null,
-			StringBundler.concat(
-				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
-				objectEntry1.getObjectEntryId(),
-				"/collaborators/by-type/Email/", ticket1.getTicketId()),
-			Http.Method.DELETE);
-
-		Assert.assertNull(
-			_ticketLocalService.fetchTicket(ticket1.getTicketId()));
-
-		Assert.assertNull(
-			_sharingEntryLocalService.fetchSharingEntry(
-				ticket1.getTicketId(), 0, 0,
-				_classNameLocalService.getClassNameId(
-					objectEntry1.getModelClassName()),
-				objectEntry1.getObjectEntryId()));
-
-		String emailAddress2 =
-			StringUtil.toLowerCase(RandomTestUtil.randomString()) +
-				"@liferay.com";
-
-		ObjectEntry objectEntry2 = _addObjectEntry();
-
-		HTTPTestUtil.invokeToJSONObject(
-			JSONUtil.put(
-				_getEmailCollaboratorJSONObject(emailAddress2)
-			).toString(),
-			StringBundler.concat(
-				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
-				objectEntry2.getObjectEntryId(), "/collaborators"),
-			Http.Method.POST);
-
-		Ticket ticket2 = _fetchTicketByEmailAddress(
-			objectEntry2.getModelClassName(), objectEntry2.getObjectEntryId(),
-			emailAddress2);
 
 		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
 			null,
 			StringBundler.concat(
 				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
-				objectEntry1.getObjectEntryId(),
-				"/collaborators/by-type/Email/", ticket2.getTicketId()),
+				objectEntry.getObjectEntryId(), "/collaborators/by-type/Email/",
+				user.getUserId()),
 			Http.Method.DELETE);
 
-		Assert.assertEquals("NOT_FOUND", jsonObject.getString("status"));
-
-		Assert.assertNotNull(
-			_ticketLocalService.fetchTicket(ticket2.getTicketId()));
+		Assert.assertEquals("BAD_REQUEST", jsonObject.getString("status"));
 	}
 
 	@Test
@@ -444,6 +387,17 @@ public class CollaboratorResourceTest {
 				objectEntry.getExternalReferenceCode(),
 				"/collaborators/by-type/User/", user.getUserId()),
 			user);
+
+		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
+			null,
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), "/scopes/",
+				_group.getGroupId(), "/by-external-reference-code/",
+				objectEntry.getExternalReferenceCode(),
+				"/collaborators/by-type/Email/", user.getUserId()),
+			Http.Method.DELETE);
+
+		Assert.assertEquals("BAD_REQUEST", jsonObject.getString("status"));
 	}
 
 	@Test
@@ -551,75 +505,26 @@ public class CollaboratorResourceTest {
 	public void testGetObjectEntryCollaboratorByTypeCollaborator()
 		throws Exception {
 
-		ObjectEntry objectEntry1 = _addObjectEntry();
+		ObjectEntry objectEntry = _addObjectEntry();
 
 		User user = _addUser();
 
 		_assertGetObjectEntryCollaborator(
 			StringBundler.concat(
 				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
-				objectEntry1.getObjectEntryId(), "/collaborators/by-type/User/",
+				objectEntry.getObjectEntryId(), "/collaborators/by-type/User/",
 				user.getUserId()),
 			user);
-
-		String emailAddress =
-			StringUtil.toLowerCase(RandomTestUtil.randomString()) +
-				"@liferay.com";
-
-		HTTPTestUtil.invokeToJSONObject(
-			JSONUtil.put(
-				_getEmailCollaboratorJSONObject(emailAddress)
-			).toString(),
-			StringBundler.concat(
-				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
-				objectEntry1.getObjectEntryId(), "/collaborators"),
-			Http.Method.POST);
-
-		Ticket ticket = _fetchTicketByEmailAddress(
-			objectEntry1.getModelClassName(), objectEntry1.getObjectEntryId(),
-			emailAddress);
 
 		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
 			null,
 			StringBundler.concat(
 				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
-				objectEntry1.getObjectEntryId(),
-				"/collaborators/by-type/Email/", ticket.getTicketId()),
+				objectEntry.getObjectEntryId(), "/collaborators/by-type/Email/",
+				user.getUserId()),
 			Http.Method.GET);
 
-		Assert.assertEquals("Email", jsonObject.getString("type"));
-		Assert.assertEquals(emailAddress, jsonObject.getString("emailAddress"));
-		Assert.assertEquals(
-			String.valueOf(ticket.getTicketId()), jsonObject.getString("id"));
-
-		ObjectEntry objectEntry2 = _addObjectEntry();
-
-		jsonObject = HTTPTestUtil.invokeToJSONObject(
-			null,
-			StringBundler.concat(
-				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
-				objectEntry2.getObjectEntryId(),
-				"/collaborators/by-type/Email/", ticket.getTicketId()),
-			Http.Method.GET);
-
-		Assert.assertEquals("NOT_FOUND", jsonObject.getString("status"));
-
-		_sharingEntryLocalService.deleteSharingEntry(
-			_sharingEntryLocalService.fetchSharingEntry(
-				ticket.getTicketId(), 0, 0,
-				_classNameLocalService.getClassNameId(
-					objectEntry1.getModelClassName()),
-				objectEntry1.getObjectEntryId()));
-
-		jsonObject = HTTPTestUtil.invokeToJSONObject(
-			null,
-			StringBundler.concat(
-				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
-				objectEntry1.getObjectEntryId(),
-				"/collaborators/by-type/Email/", ticket.getTicketId()),
-			Http.Method.GET);
-
-		Assert.assertEquals("NOT_FOUND", jsonObject.getString("status"));
+		Assert.assertEquals("BAD_REQUEST", jsonObject.getString("status"));
 	}
 
 	@Test
@@ -731,6 +636,17 @@ public class CollaboratorResourceTest {
 				objectEntry.getExternalReferenceCode(),
 				"/collaborators/by-type/User/", user.getUserId()),
 			user);
+
+		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
+			null,
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), "/scopes/",
+				_group.getGroupId(), "/by-external-reference-code/",
+				objectEntry.getExternalReferenceCode(),
+				"/collaborators/by-type/Email/", user.getUserId()),
+			Http.Method.GET);
+
+		Assert.assertEquals("BAD_REQUEST", jsonObject.getString("status"));
 	}
 
 	@Test
@@ -1181,112 +1097,17 @@ public class CollaboratorResourceTest {
 	public void testPutObjectEntryCollaboratorByTypeCollaborator()
 		throws Exception {
 
-		ObjectEntry objectEntry1 = _addObjectEntry();
+		ObjectEntry objectEntry = _addObjectEntry();
 
 		UserGroup userGroup = _addUserGroup();
 
 		_assertPutObjectEntryCollaborator(
 			StringBundler.concat(
 				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
-				objectEntry1.getObjectEntryId(),
+				objectEntry.getObjectEntryId(),
 				"/collaborators/by-type/UserGroup/",
 				userGroup.getUserGroupId()),
 			userGroup);
-
-		String emailAddress1 =
-			StringUtil.toLowerCase(RandomTestUtil.randomString()) +
-				"@liferay.com";
-
-		HTTPTestUtil.invokeToJSONObject(
-			JSONUtil.put(
-				"actionIds", JSONUtil.put("INVALID_ACTION")
-			).put(
-				"emailAddress", emailAddress1
-			).put(
-				"share", true
-			).put(
-				"type", "Email"
-			).toString(),
-			StringBundler.concat(
-				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
-				objectEntry1.getObjectEntryId(),
-				"/collaborators/by-type/Email/0"),
-			Http.Method.PUT);
-
-		Assert.assertNull(
-			_fetchTicketByEmailAddress(
-				objectEntry1.getModelClassName(),
-				objectEntry1.getObjectEntryId(), emailAddress1));
-
-		HTTPTestUtil.invokeToJSONObject(
-			JSONUtil.put(
-				_getEmailCollaboratorJSONObject(emailAddress1)
-			).toString(),
-			StringBundler.concat(
-				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
-				objectEntry1.getObjectEntryId(), "/collaborators"),
-			Http.Method.POST);
-
-		Ticket ticket1 = _fetchTicketByEmailAddress(
-			objectEntry1.getModelClassName(), objectEntry1.getObjectEntryId(),
-			emailAddress1);
-
-		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
-			_getEmailCollaboratorJSONObject(
-				emailAddress1
-			).toString(),
-			StringBundler.concat(
-				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
-				objectEntry1.getObjectEntryId(),
-				"/collaborators/by-type/Email/", ticket1.getTicketId()),
-			Http.Method.PUT);
-
-		Assert.assertEquals("Email", jsonObject.getString("type"));
-		Assert.assertEquals(
-			String.valueOf(ticket1.getTicketId()), jsonObject.getString("id"));
-
-		List<Ticket> tickets = _ticketLocalService.getTickets(
-			TestPropsValues.getCompanyId(), objectEntry1.getModelClassName(),
-			objectEntry1.getObjectEntryId(),
-			SharingTicketConstants.TYPE_INVITE_COLLABORATOR);
-
-		Assert.assertEquals(tickets.toString(), 1, tickets.size());
-
-		String emailAddress2 =
-			StringUtil.toLowerCase(RandomTestUtil.randomString()) +
-				"@liferay.com";
-
-		ObjectEntry objectEntry2 = _addObjectEntry();
-
-		HTTPTestUtil.invokeToJSONObject(
-			JSONUtil.put(
-				_getEmailCollaboratorJSONObject(emailAddress2)
-			).toString(),
-			StringBundler.concat(
-				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
-				objectEntry2.getObjectEntryId(), "/collaborators"),
-			Http.Method.POST);
-
-		Ticket ticket2 = _fetchTicketByEmailAddress(
-			objectEntry2.getModelClassName(), objectEntry2.getObjectEntryId(),
-			emailAddress2);
-
-		_addUser(emailAddress2);
-
-		HTTPTestUtil.invokeToJSONObject(
-			_getEmailCollaboratorJSONObject(
-				emailAddress2
-			).toString(),
-			StringBundler.concat(
-				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
-				objectEntry2.getObjectEntryId(),
-				"/collaborators/by-type/Email/", ticket2.getTicketId()),
-			Http.Method.PUT);
-
-		Assert.assertNull(
-			_fetchTicketByEmailAddress(
-				objectEntry2.getModelClassName(),
-				objectEntry2.getObjectEntryId(), emailAddress2));
 	}
 
 	@Test

--- a/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/constants/SharingTicketConstants.java
+++ b/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/constants/SharingTicketConstants.java
@@ -1,0 +1,17 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.sharing.constants;
+
+/**
+ * @author Alicia García
+ */
+public class SharingTicketConstants {
+
+	public static final int DEFAULT_INVITATION_EXPIRATION_HOURS = 48;
+
+	public static final int TYPE_INVITE_COLLABORATOR = 7;
+
+}

--- a/modules/apps/sharing/sharing-api/src/main/resources/com/liferay/sharing/constants/packageinfo
+++ b/modules/apps/sharing/sharing-api/src/main/resources/com/liferay/sharing/constants/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 1.2.0

--- a/modules/apps/sharing/sharing-notifications/src/main/java/com/liferay/sharing/notifications/internal/service/NotificationsSharingEntryLocalServiceWrapper.java
+++ b/modules/apps/sharing/sharing-notifications/src/main/java/com/liferay/sharing/notifications/internal/service/NotificationsSharingEntryLocalServiceWrapper.java
@@ -9,8 +9,11 @@ import com.liferay.petra.io.unsync.UnsyncStringWriter;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Ticket;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.notifications.UserNotificationDefinition;
 import com.liferay.portal.kernel.portlet.PortletProvider;
@@ -18,6 +21,7 @@ import com.liferay.portal.kernel.portlet.PortletProviderUtil;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceWrapper;
+import com.liferay.portal.kernel.service.TicketLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.template.Template;
 import com.liferay.portal.kernel.template.TemplateConstants;
@@ -29,7 +33,9 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PrefsPropsUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.sharing.constants.SharingPortletKeys;
+import com.liferay.sharing.constants.SharingTicketConstants;
 import com.liferay.sharing.interpreter.SharingEntryInterpreter;
 import com.liferay.sharing.interpreter.SharingEntryInterpreterProvider;
 import com.liferay.sharing.model.SharingEntry;
@@ -59,17 +65,17 @@ public class NotificationsSharingEntryLocalServiceWrapper
 
 	@Override
 	public SharingEntry addSharingEntry(
-			String externalReferenceCode, long fromUserId, long toTicketId,
-			long userGroupId, long toUserId, long classNameId, long classPK,
+			String externalReferenceCode, long userId, long toTicketId,
+			long toUserGroupId, long toUserId, long classNameId, long classPK,
 			long groupId, boolean shareable,
 			Collection<SharingEntryAction> sharingEntryActions,
 			Date expirationDate, ServiceContext serviceContext)
 		throws PortalException {
 
 		SharingEntry sharingEntry = super.addSharingEntry(
-			externalReferenceCode, fromUserId, toTicketId, userGroupId,
-			toUserId, classNameId, classPK, groupId, shareable,
-			sharingEntryActions, expirationDate, serviceContext);
+			externalReferenceCode, userId, toTicketId, toUserGroupId, toUserId,
+			classNameId, classPK, groupId, shareable, sharingEntryActions,
+			expirationDate, serviceContext);
 
 		_sendNotificationEvent(
 			sharingEntry,
@@ -299,14 +305,147 @@ public class NotificationsSharingEntryLocalServiceWrapper
 	}
 
 	private void _sendNotificationEvent(
+			long companyId, String emailAddress, String fullName, Locale locale,
+			int notificationType, ServiceContext serviceContext,
+			SharingEntry sharingEntry)
+		throws Exception {
+
+		SharingNotificationSubcriptionSender
+			sharingNotificationSubcriptionSender =
+				new SharingNotificationSubcriptionSender();
+
+		sharingNotificationSubcriptionSender.setSubject(
+			_getNotificationMessage(sharingEntry, locale, null));
+
+		String entryURL = _getNotificationURL(
+			sharingEntry, serviceContext.getLiferayPortletRequest());
+
+		sharingNotificationSubcriptionSender.setBody(
+			_getNotificationEmailBody(
+				sharingEntry, serviceContext.getLiferayPortletRequest()));
+
+		sharingNotificationSubcriptionSender.setClassName(
+			sharingEntry.getModelClassName());
+		sharingNotificationSubcriptionSender.setClassPK(
+			sharingEntry.getSharingEntryId());
+		sharingNotificationSubcriptionSender.setCurrentUserId(
+			serviceContext.getUserId());
+		sharingNotificationSubcriptionSender.setEntryURL(entryURL);
+
+		String fromName = PrefsPropsUtil.getString(
+			companyId, PropsKeys.ADMIN_EMAIL_FROM_NAME);
+		String fromAddress = PrefsPropsUtil.getString(
+			companyId, PropsKeys.ADMIN_EMAIL_FROM_ADDRESS);
+
+		sharingNotificationSubcriptionSender.setFrom(fromAddress, fromName);
+
+		sharingNotificationSubcriptionSender.setHtmlFormat(true);
+		sharingNotificationSubcriptionSender.setMailId(
+			"sharing_entry", sharingEntry.getSharingEntryId());
+		sharingNotificationSubcriptionSender.setNotificationType(
+			notificationType);
+		sharingNotificationSubcriptionSender.setPortletId(
+			SharingPortletKeys.SHARING);
+		sharingNotificationSubcriptionSender.setScopeGroupId(
+			sharingEntry.getGroupId());
+		sharingNotificationSubcriptionSender.setServiceContext(serviceContext);
+
+		sharingNotificationSubcriptionSender.addRuntimeSubscribers(
+			emailAddress, fullName);
+
+		sharingNotificationSubcriptionSender.flushNotificationsAsync();
+	}
+
+	private void _sendNotificationEvent(
 		SharingEntry sharingEntry, int notificationType,
 		ServiceContext serviceContext) {
 
 		try {
 			if (sharingEntry.getToUserId() > 0) {
+				User user = _userLocalService.fetchUser(
+					sharingEntry.getToUserId());
+
+				if (user == null) {
+					if (_log.isWarnEnabled()) {
+						_log.warn(
+							StringBundler.concat(
+								"Unable to send notification for sharing ",
+								"entry ", sharingEntry.getSharingEntryId(),
+								": user ", sharingEntry.getToUserId(),
+								" does not exist"));
+					}
+
+					return;
+				}
+
 				_sendNotificationEvent(
-					sharingEntry, notificationType, serviceContext,
-					_userLocalService.getUser(sharingEntry.getToUserId()));
+					sharingEntry, notificationType, serviceContext, user);
+
+				return;
+			}
+
+			if (sharingEntry.getToTicketId() > 0) {
+				Ticket ticket = _ticketLocalService.fetchTicket(
+					sharingEntry.getToTicketId());
+
+				if (ticket == null) {
+					if (_log.isWarnEnabled()) {
+						_log.warn(
+							StringBundler.concat(
+								"Unable to send notification for sharing ",
+								"entry ", sharingEntry.getSharingEntryId(),
+								": ticket ", sharingEntry.getToTicketId(),
+								" does not exist"));
+					}
+
+					return;
+				}
+
+				if (ticket.getType() !=
+						SharingTicketConstants.TYPE_INVITE_COLLABORATOR) {
+
+					if (_log.isWarnEnabled()) {
+						_log.warn(
+							StringBundler.concat(
+								"Unable to send notification for sharing ",
+								"entry ", sharingEntry.getSharingEntryId(),
+								": ticket ", ticket.getTicketId(),
+								" is not a sharing invitation"));
+					}
+
+					return;
+				}
+
+				JSONObject jsonObject = _jsonFactory.createJSONObject(
+					ticket.getExtraInfo());
+
+				String emailAddress = jsonObject.getString("emailAddress");
+
+				if (Validator.isNull(emailAddress)) {
+					if (_log.isWarnEnabled()) {
+						_log.warn(
+							StringBundler.concat(
+								"Unable to send notification for sharing ",
+								"entry ", sharingEntry.getSharingEntryId(),
+								": ticket ", ticket.getTicketId(),
+								" has no email address in extra info"));
+					}
+
+					return;
+				}
+
+				User user = _userLocalService.fetchUser(
+					sharingEntry.getUserId());
+
+				Locale locale = LocaleUtil.getDefault();
+
+				if (user != null) {
+					locale = user.getLocale();
+				}
+
+				_sendNotificationEvent(
+					sharingEntry.getCompanyId(), emailAddress, emailAddress,
+					locale, notificationType, serviceContext, sharingEntry);
 
 				return;
 			}
@@ -334,57 +473,22 @@ public class NotificationsSharingEntryLocalServiceWrapper
 			ServiceContext serviceContext, User user)
 		throws Exception {
 
-		SharingNotificationSubcriptionSender
-			sharingNotificationSubcriptionSender =
-				new SharingNotificationSubcriptionSender();
-
-		sharingNotificationSubcriptionSender.setSubject(
-			_getNotificationMessage(sharingEntry, user.getLocale(), null));
-
-		String entryURL = _getNotificationURL(
-			sharingEntry, serviceContext.getLiferayPortletRequest());
-
-		sharingNotificationSubcriptionSender.setBody(
-			_getNotificationEmailBody(
-				sharingEntry, serviceContext.getLiferayPortletRequest()));
-
-		sharingNotificationSubcriptionSender.setClassName(
-			sharingEntry.getModelClassName());
-		sharingNotificationSubcriptionSender.setClassPK(
-			sharingEntry.getSharingEntryId());
-		sharingNotificationSubcriptionSender.setCurrentUserId(
-			serviceContext.getUserId());
-		sharingNotificationSubcriptionSender.setEntryURL(entryURL);
-
-		String fromName = PrefsPropsUtil.getString(
-			user.getCompanyId(), PropsKeys.ADMIN_EMAIL_FROM_NAME);
-		String fromAddress = PrefsPropsUtil.getString(
-			user.getCompanyId(), PropsKeys.ADMIN_EMAIL_FROM_ADDRESS);
-
-		sharingNotificationSubcriptionSender.setFrom(fromAddress, fromName);
-
-		sharingNotificationSubcriptionSender.setHtmlFormat(true);
-		sharingNotificationSubcriptionSender.setMailId(
-			"sharing_entry", sharingEntry.getSharingEntryId());
-		sharingNotificationSubcriptionSender.setNotificationType(
-			notificationType);
-		sharingNotificationSubcriptionSender.setPortletId(
-			SharingPortletKeys.SHARING);
-		sharingNotificationSubcriptionSender.setScopeGroupId(
-			sharingEntry.getGroupId());
-		sharingNotificationSubcriptionSender.setServiceContext(serviceContext);
-
-		sharingNotificationSubcriptionSender.addRuntimeSubscribers(
-			user.getEmailAddress(), user.getFullName());
-
-		sharingNotificationSubcriptionSender.flushNotificationsAsync();
+		_sendNotificationEvent(
+			user.getCompanyId(), user.getEmailAddress(), user.getFullName(),
+			user.getLocale(), notificationType, serviceContext, sharingEntry);
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		NotificationsSharingEntryLocalServiceWrapper.class);
 
 	@Reference
+	private JSONFactory _jsonFactory;
+
+	@Reference
 	private SharingEntryInterpreterProvider _sharingEntryInterpreterProvider;
+
+	@Reference
+	private TicketLocalService _ticketLocalService;
 
 	@Reference
 	private UserLocalService _userLocalService;

--- a/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/internal/upgrade/v1_3_0/test/SharingEntryUpgradeProcessTest.java
+++ b/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/internal/upgrade/v1_3_0/test/SharingEntryUpgradeProcessTest.java
@@ -74,7 +74,7 @@ public class SharingEntryUpgradeProcessTest {
 	}
 
 	@Test
-	@TestInfo("LPD-86507")
+	@TestInfo("LPD-48130")
 	public void testUpgrade() throws Exception {
 		User toUser = UserTestUtil.addUser();
 

--- a/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/service/test/SharingEntryLocalServiceTest.java
+++ b/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/service/test/SharingEntryLocalServiceTest.java
@@ -141,7 +141,7 @@ public class SharingEntryLocalServiceTest {
 	}
 
 	@Test
-	@TestInfo("LPD-86507")
+	@TestInfo("LPD-48130")
 	public void testAddOrUpdateSharingEntryUpdatesSharingEntryByTicket()
 		throws Exception {
 
@@ -290,7 +290,7 @@ public class SharingEntryLocalServiceTest {
 	}
 
 	@Test
-	@TestInfo("LPD-86507")
+	@TestInfo("LPD-48130")
 	public void testAddSharingEntryToTicket() throws Exception {
 		String externalReferenceCode = RandomTestUtil.randomString();
 
@@ -494,7 +494,7 @@ public class SharingEntryLocalServiceTest {
 	}
 
 	@Test(expected = NoSuchTicketException.class)
-	@TestInfo("LPD-86507")
+	@TestInfo("LPD-48130")
 	public void testAddSharingEntryWithNonexistentTicket() throws Exception {
 		_sharingEntryLocalService.addSharingEntry(
 			null, _fromUser.getUserId(), RandomTestUtil.randomLong(), 0, 0,
@@ -503,7 +503,7 @@ public class SharingEntryLocalServiceTest {
 	}
 
 	@Test(expected = InvalidSharingEntryUserException.class)
-	@TestInfo("LPD-86507")
+	@TestInfo("LPD-48130")
 	public void testAddSharingEntryWithNoTarget() throws Exception {
 		_sharingEntryLocalService.addSharingEntry(
 			RandomTestUtil.randomString(), _fromUser.getUserId(), 0, 0, 0,
@@ -810,7 +810,7 @@ public class SharingEntryLocalServiceTest {
 	}
 
 	@Test
-	@TestInfo("LPD-86507")
+	@TestInfo("LPD-48130")
 	public void testFetchSharingEntryByTicket() throws Exception {
 		Ticket ticket = _addTicket();
 
@@ -828,7 +828,7 @@ public class SharingEntryLocalServiceTest {
 	}
 
 	@Test
-	@TestInfo("LPD-86507")
+	@TestInfo("LPD-48130")
 	public void testFetchSharingEntryByUser() throws Exception {
 		Assert.assertNull(
 			_sharingEntryLocalService.fetchSharingEntry(
@@ -848,7 +848,7 @@ public class SharingEntryLocalServiceTest {
 	}
 
 	@Test
-	@TestInfo("LPD-86507")
+	@TestInfo("LPD-48130")
 	public void testFetchSharingEntryByUserGroup() throws Exception {
 		UserGroup userGroup = UserGroupTestUtil.addUserGroup();
 
@@ -874,7 +874,7 @@ public class SharingEntryLocalServiceTest {
 	}
 
 	@Test
-	@TestInfo("LPD-86507")
+	@TestInfo("LPD-48130")
 	public void testGetSharingEntryByTicket() throws Exception {
 		Ticket ticket = _addTicket();
 
@@ -892,7 +892,7 @@ public class SharingEntryLocalServiceTest {
 	}
 
 	@Test(expected = NoSuchEntryException.class)
-	@TestInfo("LPD-86507")
+	@TestInfo("LPD-48130")
 	public void testGetSharingEntryThrowsWhenNotFound() throws Exception {
 		_sharingEntryLocalService.getSharingEntry(
 			0, 0, _toUser.getUserId(), _classNameId, _group.getGroupId());

--- a/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/service/test/SharingEntryServiceTest.java
+++ b/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/service/test/SharingEntryServiceTest.java
@@ -225,7 +225,7 @@ public class SharingEntryServiceTest {
 	}
 
 	@Test
-	@TestInfo("LPD-86507")
+	@TestInfo("LPD-48130")
 	public void testAddSharingEntryToTicket() throws Exception {
 		_registerSharingPermissionChecker(SharingEntryAction.VIEW);
 
@@ -577,7 +577,7 @@ public class SharingEntryServiceTest {
 	}
 
 	@Test
-	@TestInfo("LPD-86507")
+	@TestInfo("LPD-48130")
 	public void testDeleteSharingEntryByTicket() throws Exception {
 		_registerSharingPermissionChecker(SharingEntryAction.VIEW);
 
@@ -598,7 +598,7 @@ public class SharingEntryServiceTest {
 	}
 
 	@Test
-	@TestInfo("LPD-86507")
+	@TestInfo("LPD-48130")
 	public void testFetchSharingEntry() throws Exception {
 		Assert.assertNull(
 			_sharingEntryService.fetchSharingEntry(
@@ -656,7 +656,7 @@ public class SharingEntryServiceTest {
 	}
 
 	@Test
-	@TestInfo("LPD-86507")
+	@TestInfo("LPD-48130")
 	public void testGetSharingEntryByTicket() throws Exception {
 		_registerSharingPermissionChecker(SharingEntryAction.VIEW);
 


### PR DESCRIPTION
LPD-78457 Allow sharing ObjectEntry collaborators by email address
 
# What is this trying to solve? 
 
https://liferay.atlassian.net/browse/LPD-78457 
 
Today an `ObjectEntry` can only be shared with existing portal users or user groups. We need to let an inviter share an entry directly by email address so external recipients (with no portal account yet) can be granted a view-only invitation that turns into a real share once they sign up. 
 
# How am I fixing it? 

- The `Collaborator` DTO gains an `emailAddress` field and the REST contract gets dedicated email-keyed endpoints alongside the existing user / user-group ones (single GET/PUT/DELETE plus bulk POST). 
- The shared `CollaboratorUtil` resolves the email on every write: if it maps to an existing user a User-type `SharingEntry` is created and the response comes back as `type="User"`; if it doesn't, a `TYPE_INVITE_COLLABORATOR` ticket is created together with a ticket-backed `SharingEntry` and the response is `type="Email"`. Pending tickets are reused when the same email is re-invited and purged when the user finally exists or when a bulk replace 
drops them. 
- Email-typed collaborators are constrained to `ActionKeys.VIEW` only, regardless of whether the email resolves to a known user — anything else fails with `BAD_REQUEST`. `ObjectEntryFolder` rejects email collaborators entirely (product rule for this iteration). 
- The `CollaboratorDTOConverter` hides `id` / `name` / `emailAddress` of the resolved user when the inviter has no view permission over them, so the response never leaks information the inviter wouldn't otherwise see.
- `DELETE /collaborators/by-email-address/{email}` now refuses to remove a User-type `SharingEntry` when the caller is neither the original inviter nor has view permission on the resolved user — it returns `NOT_FOUND` instead of leaking the user's existence or letting an unrelated manager revoke an invite they couldn't even see. 
- Ticket-backed shares are wired into `NotificationsSharingEntryLocalServiceWrapper` so the invitation mail is sent through the existing sharing notification pipeline. 
 
# How can you verify that it works? 
 
Run the included automated tests. 

# Commits 
 
- `LPD-78457 add email address to the collaborator entity` 
- `LPD-78457 take into account that by type we can not delete the emailAddress, so we need other endpoints for this` 
- `LPD-78457 modify CollaboratorDTOConverter and add tests`
- `LPD-78457 add logic when collaborator is Email` 
- `LPD-78457 Folders can not be shared if collaborator is Email`
- `LPD-78457 notification on the case of sharing entry type ticket` 
- `LPD-78457 reuse the ticket if ticket is already created.` 
- `LPD-78457 use the same way to return the collaborator to the inviter. but we should take into account that the inviter can not have permission to see the user, if it exists, and we can not give them that information. so check the permission on the dto converter`
- `LPD-78457 if user exist, and there is a ticket for the invitation, delete it`
- `LPD-78457 implement the endpoints for the email, extracting the logic on the case that type is email. We should take into account that external users only can have view sharing permission` 
- `LPD-78457 you should not de-invite a user you can not see and you do not invited` 
- `LPD-78457 add tests`
 