### PR TITLE
LPD-87913 fixing CKEditor 5 caused failures

### DIFF
--- a/modules/test/playwright/tests/journal-web/main/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/main/journalArticle.spec.ts
@@ -43,9 +43,7 @@ const translateNameAndMetadataFields = async (
 	);
 	await fillAndClickOutside(
 		page,
-		page
-			.frameLocator(':text("Description")+div iframe')
-			.getByRole('textbox')
+		page.getByText('Description Rich Text Editor').getByRole('textbox')
 	);
 };
 
@@ -1465,9 +1463,8 @@ baseTest(
 
 		await expect(
 			page
-				.getByLabel('Content', {exact: true})
-				.locator('iframe[title="editor"]')
-				.contentFrame()
+				.getByTestId('content')
+				.getByRole('textbox', {name: 'Rich Text Editor'})
 				.getByText(catalanContent)
 		).toBeVisible();
 	}

--- a/modules/test/playwright/tests/journal-web/main/pages/JournalPage.ts
+++ b/modules/test/playwright/tests/journal-web/main/pages/JournalPage.ts
@@ -47,10 +47,8 @@ export class JournalPage {
 			'.article-content-title .input-group-item input'
 		);
 		this.articleContentTextBox = this.page
-			.getByLabel('Content')
-			.getByRole('textbox')
-			.frameLocator('iframe')
-			.locator('.html-editor');
+			.getByTestId('content')
+			.getByRole('textbox', {name: 'Rich Text Editor'});
 	}
 
 	async goto(siteUrl?: Site['friendlyUrlPath']) {


### PR DESCRIPTION
### What is this trying to solve?
https://liferay.atlassian.net/browse/LPD-87913
### How am I fixing it?
Changing the locators to matching CKEditor 5
### How can you verify that it works?
Buy running the following tests:

[journal-web/main/journalArticle.spec.ts > Check that upload field is marked as translated](https://testray.liferay.com/web/testray#/project/35392/routines/82964/build/469572134/case-result/469583718)
[journal-web/main/journalArticle.spec.ts > This is a test for reset translations button in web content](https://testray.liferay.com/web/testray#/project/35392/routines/82964/build/469572134/case-result/469583814)
[journal-web/main/journalArticle.spec.ts > Translate several fields in a Basic Web Content and check how many fields have been translated](https://testray.liferay.com/web/testray#/project/35392/routines/82964/build/469572134/case-result/469583844)
[journal-web/main/journalArticle.spec.ts > LPD-30412: This is a test for deleting multiple translations from a web content](https://testray.liferay.com/web/testray#/project/35392/routines/82964/build/469572134/case-result/469583802)
[journal-web/main/journalArticle.spec.ts > This is a test for translations filter button in web content](https://testray.liferay.com/web/testray#/project/35392/routines/82964/build/469572134/case-result/469583826)
[journal-web/main/journalArticle.spec.ts > Translate the Rich Text field and check if the translation persists after coming back to the page](https://testray.liferay.com/web/testray#/project/35392/routines/82964/build/469572134/case-result/469583850)