### PR TITLE
LPD-87533 Grant CMS Administrator export/import permissions

### DIFF
--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/roles.json
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/roles.json
@@ -142,7 +142,17 @@
 				"scope": 1
 			},
 			{
+				"actionId": "EXPORT_IMPORT_LAYOUTS",
+				"resource": "com.liferay.portal.kernel.model.Group",
+				"scope": 1
+			},
+			{
 				"actionId": "EXPORT_IMPORT_PORTLET_INFO",
+				"resource": "com.liferay.portal.kernel.model.Group",
+				"scope": 1
+			},
+			{
+				"actionId": "MANAGE_STAGING",
 				"resource": "com.liferay.portal.kernel.model.Group",
 				"scope": 1
 			},
@@ -219,6 +229,11 @@
 			{
 				"actionId": "VIEW",
 				"resource": "com_liferay_asset_tags_admin_web_portlet_AssetTagsAdminPortlet",
+				"scope": 1
+			},
+			{
+				"actionId": "CONFIGURATION",
+				"resource": "com_liferay_object_web_internal_object_definitions_portlet_ObjectDefinitionsPortlet",
 				"scope": 1
 			}
 		],

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/structures.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/structures.spec.ts
@@ -9,10 +9,12 @@ import {expect, mergeTests} from '@playwright/test';
 import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
 import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
 import {loginTest} from '../../../fixtures/loginTest';
+import {addCMSAdministrator} from '../../../utils/addCMSAdministrator';
 import {clickAndExpectToBeHidden} from '../../../utils/clickAndExpectToBeHidden';
 import {getRandomInt} from '../../../utils/getRandomInt';
 import getRandomString from '../../../utils/getRandomString';
 import {performUserSwitch, userData} from '../../../utils/performLogin';
+import {getTempDir} from '../../../utils/temp';
 import {waitForAlert} from '../../../utils/waitForAlert';
 import postSingleApproverCopy from '../../portal-workflow-kaleo-designer-web/main/utils/postSingleApproverCopy';
 import {structureBuilderPagesTest} from '../structure-builder/fixtures/structureBuilderPagesTest';
@@ -464,6 +466,81 @@ test(
 		await expect(page.locator('.modal-title')).toHaveText(
 			'Import Content Structures'
 		);
+	}
+);
+
+test(
+	'CMS Administrator can export and import content structures',
+	{tag: '@LPD-87533'},
+	async ({apiHelpers, page, structuresPage}) => {
+		let larFilePath: string;
+
+		await test.step('Log in as a CMS Administrator', async () => {
+			const user = await addCMSAdministrator(apiHelpers);
+
+			await performUserSwitch(page, user.alternateName);
+		});
+
+		await test.step('Export content structures and download the LAR', async () => {
+			await structuresPage.openMenuItem('Export');
+
+			await expect(page.locator('.modal-title')).toHaveText(
+				'Export Content Structures'
+			);
+
+			const exportDialog = page
+				.getByRole('dialog', {name: 'Export Content Structures'})
+				.frameLocator('iframe');
+
+			await exportDialog
+				.getByRole('button', {exact: true, name: 'Export'})
+				.click();
+
+			await expect(
+				exportDialog.getByRole('cell', {name: 'In Progress'}).first()
+			).toBeVisible();
+
+			await expect(
+				exportDialog.getByRole('cell', {name: 'Successful'}).first()
+			).toBeVisible({timeout: 30000});
+
+			const downloadPromise = page.waitForEvent('download');
+
+			await exportDialog
+				.getByRole('link', {name: /\.lar/i})
+				.first()
+				.click();
+
+			const download = await downloadPromise;
+
+			larFilePath = `${getTempDir()}/${download.suggestedFilename()}`;
+
+			await download.saveAs(larFilePath);
+		});
+
+		await test.step('Import the downloaded LAR back', async () => {
+			await structuresPage.openMenuItem('Import');
+
+			await expect(page.locator('.modal-title')).toHaveText(
+				'Import Content Structures'
+			);
+
+			const importDialog = page
+				.getByRole('dialog', {name: 'Import Content Structures'})
+				.frameLocator('iframe');
+
+			await importDialog
+				.locator('input[type="file"]')
+				.setInputFiles(larFilePath);
+
+			await importDialog.getByRole('button', {name: 'Continue'}).click();
+
+			await importDialog.getByRole('button', {name: 'Import'}).click();
+
+			await expect(
+				importDialog.getByRole('cell', {name: 'Successful'}).first()
+			).toBeVisible({timeout: 30000});
+		});
 	}
 );
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-87533

# What is being fixed

The "CMS Administrator" role provisioned by the site-initializer-cms can see the Export and Import action items on the Content Structures page, but the flow itself fails because several downstream permission checks are not satisfied. Opening the modal hits the "you do not have permission" message gated by `MANAGE_STAGING` in `export_import.jsp`, the export/import portlet is not reachable through the control-panel access check in `ExportImportControlPanelEntry`, and submitting the form fails the `CONFIGURATION` check in `ActionUtil.getPortlet` on the Object Definitions admin portlet.

# How it is being fixed

Three missing permission entries are added to the role definition in `roles.json` so the full flow works for a user that only holds the CMS Administrator role: `EXPORT_IMPORT_LAYOUTS` and `MANAGE_STAGING` on `com.liferay.portal.kernel.model.Group`, and `CONFIGURATION` on `com_liferay_object_web_internal_object_definitions_portlet_ObjectDefinitionsPortlet`. A Playwright test in `structures.spec.ts` exercises the full chain end-to-end (open the modal, submit, wait for the background task to transition from In Progress to Successful) so the regression is covered for future runs.