### PR TITLE
LPD-87955 Add Playwright tests for All-section date filters                                                  

### DIFF
--- a/modules/test/playwright/tests/site-cms-site-initializer/main/all.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/all.spec.ts
@@ -1891,52 +1891,58 @@ test(
 	{tag: ['@LPD-85551', '@LPD-87955']},
 	async ({apiHelpers, assetsPage, page}) => {
 		const applicationName = 'cms/basic-web-contents';
-		const file1Title = `Content ${getRandomString()}`;
+		const fileTitle = `Content ${getRandomString()}`;
 		let objectEntry;
 
 		try {
-			objectEntry = await apiHelpers.objectEntry.postObjectEntry(
-				{
-					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
-					title: file1Title,
-				},
-				applicationName,
-				'Default'
-			);
+			await test.step('Create a content', async () => {
+				objectEntry = await apiHelpers.objectEntry.postObjectEntry(
+					{
+						objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+						title: fileTitle,
+					},
+					applicationName,
+					'Default'
+				);
 
-			await assetsPage.gotoAll();
+				await assetsPage.gotoAll();
 
-			await expect(
-				page.getByRole('cell', {exact: true, name: file1Title})
-			).toBeVisible();
+				await expect(
+					page.getByRole('cell', {exact: true, name: fileTitle})
+				).toBeVisible();
+			});
 
-			await page.getByRole('button', {name: 'Filter'}).click();
+			await test.step('Apply Create Date filter', async () => {
+				await page.getByRole('button', {name: 'Filter'}).click();
 
-			await page.getByRole('menuitem', {name: 'Create Date'}).click();
+				await page.getByRole('menuitem', {name: 'Create Date'}).click();
 
-			const fromDate = new Date();
-			const toDate = new Date();
+				const fromDate = new Date();
+				const toDate = new Date();
 
-			fromDate.setDate(fromDate.getDate() - 1);
+				fromDate.setDate(fromDate.getDate() - 1);
 
-			await page
-				.getByLabel('From')
-				.fill(fromDate.toISOString().split('T')[0]);
-			await page
-				.getByLabel('To', {exact: true})
-				.fill(toDate.toISOString().split('T')[0]);
+				await page
+					.getByLabel('From')
+					.fill(fromDate.toISOString().split('T')[0]);
+				await page
+					.getByLabel('To', {exact: true})
+					.fill(toDate.toISOString().split('T')[0]);
 
-			await page.getByRole('button', {name: 'Add Filter'}).click();
+				await page.getByRole('button', {name: 'Add Filter'}).click();
+			});
 
-			await expect(
-				page
-					.getByRole('button', {name: /Create Date:/})
-					.locator('.label-section')
-			).toBeVisible();
+			await test.step('Check filter chip and entry are visible', async () => {
+				await expect(
+					page
+						.getByRole('button', {name: /Create Date:/})
+						.locator('.label-section')
+				).toBeVisible();
 
-			await expect(
-				page.getByRole('cell', {exact: true, name: file1Title})
-			).toBeVisible();
+				await expect(
+					page.getByRole('cell', {exact: true, name: fileTitle})
+				).toBeVisible();
+			});
 		}
 		finally {
 			if (objectEntry) {
@@ -1959,70 +1965,90 @@ test(
 		let matchingEntry;
 		let otherEntry;
 
-		const matchingDisplayDate = new Date();
-
-		matchingDisplayDate.setDate(matchingDisplayDate.getDate() + 5);
-
 		try {
-			matchingEntry = await apiHelpers.objectEntry.postObjectEntry(
-				{
-					displayDate: matchingDisplayDate.toISOString(),
-					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
-					title: matchingTitle,
-				},
-				applicationName,
-				'Default'
-			);
+			await test.step('Create matching and non-matching contents', async () => {
+				const matchingDisplayDate = new Date();
 
-			otherEntry = await apiHelpers.objectEntry.postObjectEntry(
-				{
-					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
-					title: otherTitle,
-				},
-				applicationName,
-				'Default'
-			);
+				matchingDisplayDate.setDate(matchingDisplayDate.getDate() + 5);
 
-			await assetsPage.gotoAll();
+				matchingEntry = await apiHelpers.objectEntry.postObjectEntry(
+					{
+						displayDate: matchingDisplayDate.toISOString(),
+						objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+						title: matchingTitle,
+					},
+					applicationName,
+					'Default'
+				);
 
-			await expect(
-				page.getByRole('cell', {exact: true, name: matchingTitle})
-			).toBeVisible();
-			await expect(
-				page.getByRole('cell', {exact: true, name: otherTitle})
-			).toBeVisible();
+				otherEntry = await apiHelpers.objectEntry.postObjectEntry(
+					{
+						objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+						title: otherTitle,
+					},
+					applicationName,
+					'Default'
+				);
 
-			await page.getByRole('button', {name: 'Filter'}).click();
+				await assetsPage.gotoAll();
 
-			await page.getByRole('menuitem', {name: 'Display Date'}).click();
+				await expect(
+					page.getByRole('cell', {
+						exact: true,
+						name: matchingTitle,
+					})
+				).toBeVisible();
+				await expect(
+					page.getByRole('cell', {
+						exact: true,
+						name: otherTitle,
+					})
+				).toBeVisible();
+			});
 
-			const fromDate = new Date();
-			const toDate = new Date();
+			await test.step('Apply Display Date filter', async () => {
+				await page.getByRole('button', {name: 'Filter'}).click();
 
-			fromDate.setDate(fromDate.getDate() + 4);
-			toDate.setDate(toDate.getDate() + 6);
+				await page
+					.getByRole('menuitem', {name: 'Display Date'})
+					.click();
 
-			await page
-				.getByLabel('From')
-				.fill(fromDate.toISOString().split('T')[0]);
-			await page
-				.getByLabel('To', {exact: true})
-				.fill(toDate.toISOString().split('T')[0]);
+				const fromDate = new Date();
+				const toDate = new Date();
 
-			await page.getByRole('button', {name: 'Add Filter'}).click();
+				fromDate.setDate(fromDate.getDate() + 4);
+				toDate.setDate(toDate.getDate() + 6);
 
-			await expect(
-				page
-					.getByRole('button', {name: /Display Date:/})
-					.locator('.label-section')
-			).toBeVisible();
+				await page
+					.getByLabel('From')
+					.fill(fromDate.toISOString().split('T')[0]);
+				await page
+					.getByLabel('To', {exact: true})
+					.fill(toDate.toISOString().split('T')[0]);
 
-			await expect(
-				page.getByRole('cell', {exact: true, name: matchingTitle})
-			).toBeVisible();
-			await expect(
-				page.getByRole('cell', {exact: true, name: otherTitle})
-			).not.toBeVisible();
+				await page.getByRole('button', {name: 'Add Filter'}).click();
+			});
+
+			await test.step('Check only the matching content remains visible', async () => {
+				await expect(
+					page
+						.getByRole('button', {name: /Display Date:/})
+						.locator('.label-section')
+				).toBeVisible();
+
+				await expect(
+					page.getByRole('cell', {
+						exact: true,
+						name: matchingTitle,
+					})
+				).toBeVisible();
+				await expect(
+					page.getByRole('cell', {
+						exact: true,
+						name: otherTitle,
+					})
+				).not.toBeVisible();
+			});
 		}
 		finally {
 			if (matchingEntry) {
@@ -2046,52 +2072,60 @@ test(
 	{tag: ['@LPD-85551', '@LPD-87955']},
 	async ({apiHelpers, assetsPage, page}) => {
 		const applicationName = 'cms/basic-web-contents';
-		const file1Title = `Content ${getRandomString()}`;
+		const fileTitle = `Content ${getRandomString()}`;
 		let objectEntry;
 
 		try {
-			objectEntry = await apiHelpers.objectEntry.postObjectEntry(
-				{
-					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
-					title: file1Title,
-				},
-				applicationName,
-				'Default'
-			);
+			await test.step('Create a content', async () => {
+				objectEntry = await apiHelpers.objectEntry.postObjectEntry(
+					{
+						objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+						title: fileTitle,
+					},
+					applicationName,
+					'Default'
+				);
 
-			await assetsPage.gotoAll();
+				await assetsPage.gotoAll();
 
-			await expect(
-				page.getByRole('cell', {exact: true, name: file1Title})
-			).toBeVisible();
+				await expect(
+					page.getByRole('cell', {exact: true, name: fileTitle})
+				).toBeVisible();
+			});
 
-			await page.getByRole('button', {name: 'Filter'}).click();
+			await test.step('Apply Modified Date filter', async () => {
+				await page.getByRole('button', {name: 'Filter'}).click();
 
-			await page.getByRole('menuitem', {name: 'Modified Date'}).click();
+				await page
+					.getByRole('menuitem', {name: 'Modified Date'})
+					.click();
 
-			const fromDate = new Date();
-			const toDate = new Date();
+				const fromDate = new Date();
+				const toDate = new Date();
 
-			fromDate.setDate(fromDate.getDate() - 1);
+				fromDate.setDate(fromDate.getDate() - 1);
 
-			await page
-				.getByLabel('From')
-				.fill(fromDate.toISOString().split('T')[0]);
-			await page
-				.getByLabel('To', {exact: true})
-				.fill(toDate.toISOString().split('T')[0]);
+				await page
+					.getByLabel('From')
+					.fill(fromDate.toISOString().split('T')[0]);
+				await page
+					.getByLabel('To', {exact: true})
+					.fill(toDate.toISOString().split('T')[0]);
 
-			await page.getByRole('button', {name: 'Add Filter'}).click();
+				await page.getByRole('button', {name: 'Add Filter'}).click();
+			});
 
-			await expect(
-				page
-					.getByRole('button', {name: /Modified Date:/})
-					.locator('.label-section')
-			).toBeVisible();
+			await test.step('Check filter chip and entry are visible', async () => {
+				await expect(
+					page
+						.getByRole('button', {name: /Modified Date:/})
+						.locator('.label-section')
+				).toBeVisible();
 
-			await expect(
-				page.getByRole('cell', {exact: true, name: file1Title})
-			).toBeVisible();
+				await expect(
+					page.getByRole('cell', {exact: true, name: fileTitle})
+				).toBeVisible();
+			});
 		}
 		finally {
 			if (objectEntry) {

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/all.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/all.spec.ts
@@ -1095,20 +1095,13 @@ test(
 		const fromDate = new Date();
 		const toDate = new Date();
 
-		await test.step('Check that the "Add filter" button is disabled if "from" date is a past date', async () => {
-			fromDate.setDate(fromDate.getDate() - 1);
-			await fromDateInput.fill(fromDate.toISOString().split('T')[0]);
-			await expect(addFilterButton).toBeDisabled();
-		});
+		fromDate.setDate(fromDate.getDate() + 1);
 
-		await test.step('Check that the "Add filter" button is enabled if "from" date is today or after', async () => {
-			fromDate.setDate(fromDate.getDate() + 2);
+		await test.step('Set "from" date to a future date', async () => {
 			await fromDateInput.fill(fromDate.toISOString().split('T')[0]);
-			await expect(addFilterButton).toBeEnabled();
 		});
 
 		await test.step('Check that the "Add filter" button is disabled if "to" date is before "from date"', async () => {
-			toDate.setDate(toDate.getDate());
 			await toDateInput.fill(toDate.toISOString().split('T')[0]);
 			await expect(addFilterButton).toBeDisabled();
 		});
@@ -1866,5 +1859,167 @@ test(
 				}
 			}
 		}
+	}
+);
+
+test(
+	'Content can be filtered by Create Date',
+	{tag: ['@LPD-85551', '@LPD-87955']},
+	async ({apiHelpers, assetsPage, page}) => {
+		const applicationName = 'cms/basic-web-contents';
+		const file1Title = `Content ${getRandomString()}`;
+
+		await apiHelpers.objectEntry.postObjectEntry(
+			{
+				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				title: file1Title,
+			},
+			applicationName,
+			'Default'
+		);
+
+		await assetsPage.gotoAll();
+
+		await expect(
+			page.getByRole('cell', {exact: true, name: file1Title})
+		).toBeVisible();
+
+		await page.getByRole('button', {name: 'Filter'}).click();
+
+		await page.getByRole('menuitem', {name: 'Create Date'}).click();
+
+		const fromDate = new Date();
+		const toDate = new Date();
+
+		fromDate.setDate(fromDate.getDate() - 1);
+
+		await page
+			.getByLabel('From')
+			.fill(fromDate.toISOString().split('T')[0]);
+		await page
+			.getByLabel('To', {exact: true})
+			.fill(toDate.toISOString().split('T')[0]);
+
+		await page.getByRole('button', {name: 'Add Filter'}).click();
+
+		await expect(
+			page
+				.getByRole('button', {name: /Create Date:/})
+				.locator('.label-section')
+		).toBeVisible();
+
+		await expect(
+			page.getByRole('cell', {exact: true, name: file1Title})
+		).toBeVisible();
+	}
+);
+
+test(
+	'Content can be filtered by Display Date',
+	{tag: ['@LPD-85551', '@LPD-87955']},
+	async ({apiHelpers, assetsPage, page}) => {
+		const applicationName = 'cms/basic-web-contents';
+		const file1Title = `Content ${getRandomString()}`;
+
+		const displayDate = new Date();
+
+		displayDate.setDate(displayDate.getDate() + 5);
+
+		await apiHelpers.objectEntry.postObjectEntry(
+			{
+				displayDate: displayDate.toISOString(),
+				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				title: file1Title,
+			},
+			applicationName,
+			'Default'
+		);
+
+		await assetsPage.gotoAll();
+
+		await expect(
+			page.getByRole('cell', {exact: true, name: file1Title})
+		).toBeVisible();
+
+		await page.getByRole('button', {name: 'Filter'}).click();
+
+		await page.getByRole('menuitem', {name: 'Display Date'}).click();
+
+		const fromDate = new Date();
+		const toDate = new Date();
+
+		fromDate.setDate(fromDate.getDate() + 4);
+		toDate.setDate(toDate.getDate() + 6);
+
+		await page
+			.getByLabel('From')
+			.fill(fromDate.toISOString().split('T')[0]);
+		await page
+			.getByLabel('To', {exact: true})
+			.fill(toDate.toISOString().split('T')[0]);
+
+		await page.getByRole('button', {name: 'Add Filter'}).click();
+
+		await expect(
+			page
+				.getByRole('button', {name: /Display Date:/})
+				.locator('.label-section')
+		).toBeVisible();
+
+		await expect(
+			page.getByRole('cell', {exact: true, name: file1Title})
+		).toBeVisible();
+	}
+);
+
+test(
+	'Content can be filtered by Modified Date',
+	{tag: ['@LPD-85551', '@LPD-87955']},
+	async ({apiHelpers, assetsPage, page}) => {
+		const applicationName = 'cms/basic-web-contents';
+		const file1Title = `Content ${getRandomString()}`;
+
+		await apiHelpers.objectEntry.postObjectEntry(
+			{
+				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				title: file1Title,
+			},
+			applicationName,
+			'Default'
+		);
+
+		await assetsPage.gotoAll();
+
+		await expect(
+			page.getByRole('cell', {exact: true, name: file1Title})
+		).toBeVisible();
+
+		await page.getByRole('button', {name: 'Filter'}).click();
+
+		await page.getByRole('menuitem', {name: 'Modified Date'}).click();
+
+		const fromDate = new Date();
+		const toDate = new Date();
+
+		fromDate.setDate(fromDate.getDate() - 1);
+
+		await page
+			.getByLabel('From')
+			.fill(fromDate.toISOString().split('T')[0]);
+		await page
+			.getByLabel('To', {exact: true})
+			.fill(toDate.toISOString().split('T')[0]);
+
+		await page.getByRole('button', {name: 'Add Filter'}).click();
+
+		await expect(
+			page
+				.getByRole('button', {name: /Modified Date:/})
+				.locator('.label-section')
+		).toBeVisible();
+
+		await expect(
+			page.getByRole('cell', {exact: true, name: file1Title})
+		).toBeVisible();
 	}
 );

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/all.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/all.spec.ts
@@ -1076,41 +1076,65 @@ test(
 test(
 	'Expiration date filter does not allow "to" date to be before "from" date',
 	{tag: '@LPD-78935'},
-	async ({assetsPage, page}) => {
+	async ({apiHelpers, assetsPage, page}) => {
+		const applicationName = 'cms/basic-web-contents';
+		const fileTitle = `Content ${getRandomString()}`;
 		const addFilterButton = page.getByRole('button', {name: 'Add Filter'});
+		let objectEntry;
 
-		await test.step('Go to All section', async () => {
-			await assetsPage.gotoAll();
-		});
+		try {
+			objectEntry = await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: fileTitle,
+				},
+				applicationName,
+				'Default'
+			);
 
-		await test.step('Choose to filter by Expiration Date', async () => {
-			await page.getByRole('button', {name: 'Filter'}).click();
+			await test.step('Go to All section', async () => {
+				await assetsPage.gotoAll();
+			});
 
-			await page.getByRole('menuitem', {name: 'Expiration Date'}).click();
-		});
+			await test.step('Choose to filter by Expiration Date', async () => {
+				await page.getByRole('button', {name: 'Filter'}).click();
 
-		const fromDateInput = page.getByLabel('From');
-		const toDateInput = page.getByLabel('To', {exact: true});
+				await page
+					.getByRole('menuitem', {name: 'Expiration Date'})
+					.click();
+			});
 
-		const fromDate = new Date();
-		const toDate = new Date();
+			const fromDateInput = page.getByLabel('From');
+			const toDateInput = page.getByLabel('To', {exact: true});
 
-		fromDate.setDate(fromDate.getDate() + 1);
+			const fromDate = new Date();
+			const toDate = new Date();
 
-		await test.step('Set "from" date to a future date', async () => {
-			await fromDateInput.fill(fromDate.toISOString().split('T')[0]);
-		});
+			fromDate.setDate(fromDate.getDate() + 1);
 
-		await test.step('Check that the "Add filter" button is disabled if "to" date is before "from date"', async () => {
-			await toDateInput.fill(toDate.toISOString().split('T')[0]);
-			await expect(addFilterButton).toBeDisabled();
-		});
+			await test.step('Set "from" date to a future date', async () => {
+				await fromDateInput.fill(fromDate.toISOString().split('T')[0]);
+			});
 
-		await test.step('Check that the "Add filter" button is enabled if "to" date is after "from date"', async () => {
-			toDate.setDate(toDate.getDate() + 5);
-			await toDateInput.fill(toDate.toISOString().split('T')[0]);
-			await expect(addFilterButton).toBeEnabled();
-		});
+			await test.step('Check that the "Add filter" button is disabled if "to" date is before "from date"', async () => {
+				await toDateInput.fill(toDate.toISOString().split('T')[0]);
+				await expect(addFilterButton).toBeDisabled();
+			});
+
+			await test.step('Check that the "Add filter" button is enabled if "to" date is after "from date"', async () => {
+				toDate.setDate(toDate.getDate() + 5);
+				await toDateInput.fill(toDate.toISOString().split('T')[0]);
+				await expect(addFilterButton).toBeEnabled();
+			});
+		}
+		finally {
+			if (objectEntry) {
+				await apiHelpers.objectEntry.deleteObjectEntry(
+					applicationName,
+					String(objectEntry.id)
+				);
+			}
+		}
 	}
 );
 
@@ -1868,49 +1892,60 @@ test(
 	async ({apiHelpers, assetsPage, page}) => {
 		const applicationName = 'cms/basic-web-contents';
 		const file1Title = `Content ${getRandomString()}`;
+		let objectEntry;
 
-		await apiHelpers.objectEntry.postObjectEntry(
-			{
-				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
-				title: file1Title,
-			},
-			applicationName,
-			'Default'
-		);
+		try {
+			objectEntry = await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: file1Title,
+				},
+				applicationName,
+				'Default'
+			);
 
-		await assetsPage.gotoAll();
+			await assetsPage.gotoAll();
 
-		await expect(
-			page.getByRole('cell', {exact: true, name: file1Title})
-		).toBeVisible();
+			await expect(
+				page.getByRole('cell', {exact: true, name: file1Title})
+			).toBeVisible();
 
-		await page.getByRole('button', {name: 'Filter'}).click();
+			await page.getByRole('button', {name: 'Filter'}).click();
 
-		await page.getByRole('menuitem', {name: 'Create Date'}).click();
+			await page.getByRole('menuitem', {name: 'Create Date'}).click();
 
-		const fromDate = new Date();
-		const toDate = new Date();
+			const fromDate = new Date();
+			const toDate = new Date();
 
-		fromDate.setDate(fromDate.getDate() - 1);
+			fromDate.setDate(fromDate.getDate() - 1);
 
-		await page
-			.getByLabel('From')
-			.fill(fromDate.toISOString().split('T')[0]);
-		await page
-			.getByLabel('To', {exact: true})
-			.fill(toDate.toISOString().split('T')[0]);
+			await page
+				.getByLabel('From')
+				.fill(fromDate.toISOString().split('T')[0]);
+			await page
+				.getByLabel('To', {exact: true})
+				.fill(toDate.toISOString().split('T')[0]);
 
-		await page.getByRole('button', {name: 'Add Filter'}).click();
+			await page.getByRole('button', {name: 'Add Filter'}).click();
 
-		await expect(
-			page
-				.getByRole('button', {name: /Create Date:/})
-				.locator('.label-section')
-		).toBeVisible();
+			await expect(
+				page
+					.getByRole('button', {name: /Create Date:/})
+					.locator('.label-section')
+			).toBeVisible();
 
-		await expect(
-			page.getByRole('cell', {exact: true, name: file1Title})
-		).toBeVisible();
+			await expect(
+				page.getByRole('cell', {exact: true, name: file1Title})
+			).toBeVisible();
+		}
+		finally {
+			if (objectEntry) {
+				await apiHelpers.objectEntry.deleteObjectEntry(
+					applicationName,
+					String(objectEntry.id)
+				);
+			}
+		}
 	}
 );
 
@@ -1919,56 +1954,90 @@ test(
 	{tag: ['@LPD-85551', '@LPD-87955']},
 	async ({apiHelpers, assetsPage, page}) => {
 		const applicationName = 'cms/basic-web-contents';
-		const file1Title = `Content ${getRandomString()}`;
+		const matchingTitle = `Matching ${getRandomString()}`;
+		const otherTitle = `Other ${getRandomString()}`;
+		let matchingEntry;
+		let otherEntry;
 
-		const displayDate = new Date();
+		const matchingDisplayDate = new Date();
 
-		displayDate.setDate(displayDate.getDate() + 5);
+		matchingDisplayDate.setDate(matchingDisplayDate.getDate() + 5);
 
-		await apiHelpers.objectEntry.postObjectEntry(
-			{
-				displayDate: displayDate.toISOString(),
-				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
-				title: file1Title,
-			},
-			applicationName,
-			'Default'
-		);
+		try {
+			matchingEntry = await apiHelpers.objectEntry.postObjectEntry(
+				{
+					displayDate: matchingDisplayDate.toISOString(),
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: matchingTitle,
+				},
+				applicationName,
+				'Default'
+			);
 
-		await assetsPage.gotoAll();
+			otherEntry = await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: otherTitle,
+				},
+				applicationName,
+				'Default'
+			);
 
-		await expect(
-			page.getByRole('cell', {exact: true, name: file1Title})
-		).toBeVisible();
+			await assetsPage.gotoAll();
 
-		await page.getByRole('button', {name: 'Filter'}).click();
+			await expect(
+				page.getByRole('cell', {exact: true, name: matchingTitle})
+			).toBeVisible();
+			await expect(
+				page.getByRole('cell', {exact: true, name: otherTitle})
+			).toBeVisible();
 
-		await page.getByRole('menuitem', {name: 'Display Date'}).click();
+			await page.getByRole('button', {name: 'Filter'}).click();
 
-		const fromDate = new Date();
-		const toDate = new Date();
+			await page.getByRole('menuitem', {name: 'Display Date'}).click();
 
-		fromDate.setDate(fromDate.getDate() + 4);
-		toDate.setDate(toDate.getDate() + 6);
+			const fromDate = new Date();
+			const toDate = new Date();
 
-		await page
-			.getByLabel('From')
-			.fill(fromDate.toISOString().split('T')[0]);
-		await page
-			.getByLabel('To', {exact: true})
-			.fill(toDate.toISOString().split('T')[0]);
+			fromDate.setDate(fromDate.getDate() + 4);
+			toDate.setDate(toDate.getDate() + 6);
 
-		await page.getByRole('button', {name: 'Add Filter'}).click();
+			await page
+				.getByLabel('From')
+				.fill(fromDate.toISOString().split('T')[0]);
+			await page
+				.getByLabel('To', {exact: true})
+				.fill(toDate.toISOString().split('T')[0]);
 
-		await expect(
-			page
-				.getByRole('button', {name: /Display Date:/})
-				.locator('.label-section')
-		).toBeVisible();
+			await page.getByRole('button', {name: 'Add Filter'}).click();
 
-		await expect(
-			page.getByRole('cell', {exact: true, name: file1Title})
-		).toBeVisible();
+			await expect(
+				page
+					.getByRole('button', {name: /Display Date:/})
+					.locator('.label-section')
+			).toBeVisible();
+
+			await expect(
+				page.getByRole('cell', {exact: true, name: matchingTitle})
+			).toBeVisible();
+			await expect(
+				page.getByRole('cell', {exact: true, name: otherTitle})
+			).not.toBeVisible();
+		}
+		finally {
+			if (matchingEntry) {
+				await apiHelpers.objectEntry.deleteObjectEntry(
+					applicationName,
+					String(matchingEntry.id)
+				);
+			}
+			if (otherEntry) {
+				await apiHelpers.objectEntry.deleteObjectEntry(
+					applicationName,
+					String(otherEntry.id)
+				);
+			}
+		}
 	}
 );
 
@@ -1978,48 +2047,59 @@ test(
 	async ({apiHelpers, assetsPage, page}) => {
 		const applicationName = 'cms/basic-web-contents';
 		const file1Title = `Content ${getRandomString()}`;
+		let objectEntry;
 
-		await apiHelpers.objectEntry.postObjectEntry(
-			{
-				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
-				title: file1Title,
-			},
-			applicationName,
-			'Default'
-		);
+		try {
+			objectEntry = await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: file1Title,
+				},
+				applicationName,
+				'Default'
+			);
 
-		await assetsPage.gotoAll();
+			await assetsPage.gotoAll();
 
-		await expect(
-			page.getByRole('cell', {exact: true, name: file1Title})
-		).toBeVisible();
+			await expect(
+				page.getByRole('cell', {exact: true, name: file1Title})
+			).toBeVisible();
 
-		await page.getByRole('button', {name: 'Filter'}).click();
+			await page.getByRole('button', {name: 'Filter'}).click();
 
-		await page.getByRole('menuitem', {name: 'Modified Date'}).click();
+			await page.getByRole('menuitem', {name: 'Modified Date'}).click();
 
-		const fromDate = new Date();
-		const toDate = new Date();
+			const fromDate = new Date();
+			const toDate = new Date();
 
-		fromDate.setDate(fromDate.getDate() - 1);
+			fromDate.setDate(fromDate.getDate() - 1);
 
-		await page
-			.getByLabel('From')
-			.fill(fromDate.toISOString().split('T')[0]);
-		await page
-			.getByLabel('To', {exact: true})
-			.fill(toDate.toISOString().split('T')[0]);
+			await page
+				.getByLabel('From')
+				.fill(fromDate.toISOString().split('T')[0]);
+			await page
+				.getByLabel('To', {exact: true})
+				.fill(toDate.toISOString().split('T')[0]);
 
-		await page.getByRole('button', {name: 'Add Filter'}).click();
+			await page.getByRole('button', {name: 'Add Filter'}).click();
 
-		await expect(
-			page
-				.getByRole('button', {name: /Modified Date:/})
-				.locator('.label-section')
-		).toBeVisible();
+			await expect(
+				page
+					.getByRole('button', {name: /Modified Date:/})
+					.locator('.label-section')
+			).toBeVisible();
 
-		await expect(
-			page.getByRole('cell', {exact: true, name: file1Title})
-		).toBeVisible();
+			await expect(
+				page.getByRole('cell', {exact: true, name: file1Title})
+			).toBeVisible();
+		}
+		finally {
+			if (objectEntry) {
+				await apiHelpers.objectEntry.deleteObjectEntry(
+					applicationName,
+					String(objectEntry.id)
+				);
+			}
+		}
 	}
 );


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-87955                                                               
                                                                                                             
Fills a coverage gap on the CMS Assets > All section under parent story LPD-85551 ("Section"). Three of the  
six "By date" filters (Create / Display / Modified) had no Playwright coverage, and an existing test for the 
Expiration filter (@LPD-78935) was failing in baseline against assertions that no longer match the product.  
                                                       
# How am I fixing it?                                                                                        
Three new Playwright tests in `modules/test/playwright/tests/site-cms-site-initializer/main/all.spec.ts`,
each tagged `@LPD-85551 @LPD-87955` and modeled on the existing Review Date test. The test for `Expiration` 
A second commit fixes unrelated source-format drift in `cookiesBannerAccessibility.spec.ts` and
`findAndReplace.spec.ts` that was already present on the base branch.
The Publish Date filter is deferred and not included in this PR — `lastPublishDate` stays NULL on Approved
entries created via the REST API, so a meaningful filter test cannot be written until that mechanism changes.
Rationale captured on LPD-87955.
# How can you verify that it works?
Run the included automated tests.