### PR TITLE
LPD-87476 Preserve display date when update passes none

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -4714,19 +4714,6 @@ public class JournalArticleLocalServiceImpl
 
 		if (displayDate == null) {
 			displayDate = article.getDisplayDate();
-
-			if ((displayDate != null) && displayDate.before(new Date())) {
-				displayDate = article.getDisplayDate();
-			}
-			else {
-				Calendar calendar = CalendarFactoryUtil.getCalendar(
-					user.getTimeZone());
-
-				calendar.set(Calendar.SECOND, 0);
-				calendar.set(Calendar.MILLISECOND, 0);
-
-				displayDate = calendar.getTime();
-			}
 		}
 
 		Date expirationDate = null;

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleLocalServiceTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleLocalServiceTest.java
@@ -2553,6 +2553,33 @@ public class JournalArticleLocalServiceTest {
 			false, true, ServiceContextTestUtil.getServiceContext());
 
 		Assert.assertEquals(date, journalArticle2.getDisplayDate());
+
+		calendar.add(Calendar.YEAR, 1);
+
+		Date futureDate = calendar.getTime();
+
+		journalArticle2 = JournalTestUtil.updateArticle(
+			journalArticle2.getUserId(), journalArticle2,
+			journalArticle2.getTitleMap(), journalArticle2.getContent(),
+			futureDate, false, true,
+			ServiceContextTestUtil.getServiceContext());
+
+		Assert.assertEquals(futureDate, journalArticle2.getDisplayDate());
+
+		journalArticle2 = _journalArticleLocalService.updateArticle(
+			journalArticle2.getUserId(), journalArticle2.getGroupId(),
+			journalArticle2.getFolderId(), journalArticle2.getArticleId(),
+			journalArticle2.getVersion(), journalArticle2.getTitleMap(),
+			journalArticle2.getDescriptionMap(), null,
+			journalArticle2.getContent(), journalArticle2.getDDMTemplateKey(),
+			journalArticle2.getLayoutUuid(), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, true,
+			0, 0, 0, 0, 0, true, journalArticle2.isIndexable(),
+			journalArticle2.isSmallImage(), 0,
+			journalArticle2.getSmallImageSource(),
+			journalArticle2.getSmallImageURL(), null, null, null,
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		Assert.assertEquals(futureDate, journalArticle2.getDisplayDate());
 	}
 
 	@Test


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-87476

**What is being fixed:** When `JournalArticleLocalService.updateArticle` is called without a display date, the service's null-fallback overwrites a future-dated article's display date with "now (truncated to the minute)". This widens an older web-form bug (LPD-52680) into a service-layer regression: it was moved into the service in LPD-57453 (June 2025), so it now affects every caller — REST, imports, and version-forks — not just the original web publish flow.

**How it is being fixed:** When the caller passes no display date, preserve the article's existing display date. The original inverted-branch shape (preserve past, overwrite future with now) made sense only for the web "publish now" form workflow and does not translate to other callers — editing the title of an old approved article should not stamp it with today's date, and a scheduled article should not have its schedule silently dropped on edit. The fix collapses to a simple null-fallback: if no display date is supplied, use the article's existing one.

## Tests

`JournalArticleLocalServiceTest.testUpdateArticleWithoutDisplayDate` was extended with a future-display-date scenario.

```bash
gradlew -p modules/apps/journal/journal-test testIntegration --tests "JournalArticleLocalServiceTest.testUpdateArticleWithoutDisplayDate"
```

_AI-assisted with Claude Code._