### PR TITLE
LPD-88077 Propagate the active CTCollection in ExportTranslationServlet

### DIFF
--- a/modules/apps/translation/translation-test/build.gradle
+++ b/modules/apps/translation/translation-test/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
 	testIntegrationImplementation group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
+	testIntegrationImplementation project(":apps:change-tracking:change-tracking-api")
 	testIntegrationImplementation project(":apps:change-tracking:change-tracking-test-util")
 	testIntegrationImplementation project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")
 	testIntegrationImplementation project(":apps:dynamic-data-mapping:dynamic-data-mapping-form-field-type-api")

--- a/modules/apps/translation/translation-test/src/testIntegration/java/com/liferay/translation/web/internal/servlet/test/ExportTranslationServletTest.java
+++ b/modules/apps/translation/translation-test/src/testIntegration/java/com/liferay/translation/web/internal/servlet/test/ExportTranslationServletTest.java
@@ -1,0 +1,168 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.translation.web.internal.servlet.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.change.tracking.constants.CTConstants;
+import com.liferay.change.tracking.model.CTCollection;
+import com.liferay.change.tracking.service.CTCollectionLocalService;
+import com.liferay.change.tracking.service.CTPreferencesService;
+import com.liferay.dynamic.data.mapping.io.DDMFormDeserializer;
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.translation.test.util.TranslationTestUtil;
+
+import jakarta.servlet.Servlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/**
+ * @author Manuel Rives
+ */
+@RunWith(Arquillian.class)
+public class ExportTranslationServletTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		if (_ctCollection != null) {
+			_ctPreferencesService.checkoutCTCollection(
+				TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+				CTConstants.CT_COLLECTION_ID_PRODUCTION);
+
+			_ctCollectionLocalService.deleteCTCollection(_ctCollection);
+		}
+	}
+
+	@Test
+	@TestInfo("LPD-88077")
+	public void testDoGetExportsArticleCreatedInsidePublication()
+		throws Exception {
+
+		_ctCollection = _ctCollectionLocalService.addCTCollection(
+			null, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			0, RandomTestUtil.randomString(), null);
+
+		JournalArticle journalArticle;
+
+		try (SafeCloseable safeCloseable =
+				CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
+					_ctCollection.getCtCollectionId())) {
+
+			journalArticle = TranslationTestUtil.getJournalArticle(
+				_group, _ddmFormDeserializer);
+		}
+
+		_ctPreferencesService.checkoutCTCollection(
+			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			_ctCollection.getCtCollectionId());
+
+		User user = _userLocalService.getUser(TestPropsValues.getUserId());
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setAttribute(WebKeys.USER, user);
+		mockHttpServletRequest.setMethod("GET");
+		mockHttpServletRequest.setParameter(
+			"classNameId",
+			String.valueOf(_portal.getClassNameId(JournalArticle.class)));
+		mockHttpServletRequest.setParameter(
+			"classPK", String.valueOf(journalArticle.getResourcePrimKey()));
+		mockHttpServletRequest.setParameter(
+			"groupId", String.valueOf(_group.getGroupId()));
+		mockHttpServletRequest.setParameter(
+			"sourceLanguageId", LocaleUtil.toLanguageId(LocaleUtil.US));
+		mockHttpServletRequest.setParameter(
+			"targetLanguageIds", LocaleUtil.toLanguageId(LocaleUtil.SPAIN));
+		mockHttpServletRequest.setParameter(
+			"xliffMimeType", _MIMETYPE_XLIFF_1_2);
+
+		MockHttpServletResponse mockHttpServletResponse =
+			new MockHttpServletResponse();
+
+		ReflectionTestUtil.invoke(
+			_servlet, "doGet",
+			new Class<?>[] {
+				HttpServletRequest.class, HttpServletResponse.class
+			},
+			mockHttpServletRequest, mockHttpServletResponse);
+
+		Assert.assertEquals(
+			HttpServletResponse.SC_OK, mockHttpServletResponse.getStatus());
+
+		byte[] contentBytes = mockHttpServletResponse.getContentAsByteArray();
+
+		Assert.assertTrue(contentBytes.length > 0);
+	}
+
+	private static final String _MIMETYPE_XLIFF_1_2 = "application/x-xliff+xml";
+
+	private CTCollection _ctCollection;
+
+	@Inject
+	private CTCollectionLocalService _ctCollectionLocalService;
+
+	@Inject
+	private CTPreferencesService _ctPreferencesService;
+
+	@Inject(filter = "ddm.form.deserializer.type=json")
+	private DDMFormDeserializer _ddmFormDeserializer;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private Portal _portal;
+
+	@Inject(
+		filter = "osgi.http.whiteboard.servlet.pattern=/translation/export_translation"
+	)
+	private Servlet _servlet;
+
+	@Inject
+	private UserLocalService _userLocalService;
+
+}

--- a/modules/apps/translation/translation-web/build.gradle
+++ b/modules/apps/translation/translation-web/build.gradle
@@ -11,6 +11,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:application-list:application-list-api")
+	compileOnly project(":apps:change-tracking:change-tracking-api")
 	compileOnly project(":apps:depot:depot-api")
 	compileOnly project(":apps:frontend-editor:frontend-editor-taglib")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")

--- a/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/servlet/ExportTranslationServlet.java
+++ b/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/servlet/ExportTranslationServlet.java
@@ -5,10 +5,15 @@
 
 package com.liferay.translation.web.internal.servlet;
 
+import com.liferay.change.tracking.constants.CTConstants;
+import com.liferay.change.tracking.model.CTPreferences;
+import com.liferay.change.tracking.service.CTPreferencesLocalService;
 import com.liferay.info.item.InfoItemReference;
 import com.liferay.info.item.InfoItemServiceRegistry;
 import com.liferay.info.item.provider.InfoItemPermissionProvider;
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.User;
@@ -70,66 +75,83 @@ public class ExportTranslationServlet extends HttpServlet {
 					StringPool.BLANK);
 			}
 
-			long[] segmentsExperienceIds = ParamUtil.getLongValues(
-				httpServletRequest, "segmentsExperienceIds");
+			try (SafeCloseable safeCloseable =
+					CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
+						_getActiveCTCollectionId(user))) {
 
-			TranslationRequestHelper translationRequestHelper =
-				new TranslationRequestHelper(
-					httpServletRequest, _infoItemServiceRegistry,
-					_segmentsExperienceLocalService);
+				long[] segmentsExperienceIds = ParamUtil.getLongValues(
+					httpServletRequest, "segmentsExperienceIds");
 
-			String className = translationRequestHelper.getClassName(
-				segmentsExperienceIds);
+				TranslationRequestHelper translationRequestHelper =
+					new TranslationRequestHelper(
+						httpServletRequest, _infoItemServiceRegistry,
+						_segmentsExperienceLocalService);
 
-			Set<Long> classPKs = SetUtil.fromArray(
-				_getClassPKs(
-					className, segmentsExperienceIds,
-					translationRequestHelper));
+				String className = translationRequestHelper.getClassName(
+					segmentsExperienceIds);
 
-			InfoItemPermissionProvider infoItemPermissionProvider =
-				_infoItemServiceRegistry.getFirstInfoItemService(
-					InfoItemPermissionProvider.class, className);
+				Set<Long> classPKs = SetUtil.fromArray(
+					_getClassPKs(
+						className, segmentsExperienceIds,
+						translationRequestHelper));
 
-			PermissionChecker permissionChecker =
-				_permissionCheckerFactory.create(user);
+				InfoItemPermissionProvider infoItemPermissionProvider =
+					_infoItemServiceRegistry.getFirstInfoItemService(
+						InfoItemPermissionProvider.class, className);
 
-			PermissionThreadLocal.setPermissionChecker(permissionChecker);
+				PermissionChecker permissionChecker =
+					_permissionCheckerFactory.create(user);
 
-			if (infoItemPermissionProvider != null) {
-				for (long classPK : classPKs) {
-					if (!infoItemPermissionProvider.hasPermission(
-							permissionChecker,
-							new InfoItemReference(className, classPK),
-							ActionKeys.VIEW)) {
+				PermissionThreadLocal.setPermissionChecker(permissionChecker);
 
-						throw new PrincipalException.MustHavePermission(
-							permissionChecker, className, classPK,
-							ActionKeys.VIEW);
+				if (infoItemPermissionProvider != null) {
+					for (long classPK : classPKs) {
+						if (!infoItemPermissionProvider.hasPermission(
+								permissionChecker,
+								new InfoItemReference(className, classPK),
+								ActionKeys.VIEW)) {
+
+							throw new PrincipalException.MustHavePermission(
+								permissionChecker, className, classPK,
+								ActionKeys.VIEW);
+						}
 					}
 				}
-			}
 
-			String sourceLanguageId = ParamUtil.getString(
-				httpServletRequest, "sourceLanguageId");
-			String[] targetLanguageIds = ParamUtil.getStringValues(
-				httpServletRequest, "targetLanguageIds");
-			String xliffMimeType = ParamUtil.getString(
-				httpServletRequest, "xliffMimeType");
+				String sourceLanguageId = ParamUtil.getString(
+					httpServletRequest, "sourceLanguageId");
+				String[] targetLanguageIds = ParamUtil.getStringValues(
+					httpServletRequest, "targetLanguageIds");
+				String xliffMimeType = ParamUtil.getString(
+					httpServletRequest, "xliffMimeType");
 
-			File file = _translationManager.getXLIFFZipFile(
-				className, ArrayUtil.toLongArray(classPKs), xliffMimeType,
-				_portal.getLocale(httpServletRequest), sourceLanguageId,
-				targetLanguageIds);
+				File file = _translationManager.getXLIFFZipFile(
+					className, ArrayUtil.toLongArray(classPKs), xliffMimeType,
+					_portal.getLocale(httpServletRequest), sourceLanguageId,
+					targetLanguageIds);
 
-			try (InputStream inputStream = new FileInputStream(file)) {
-				ServletResponseUtil.sendFile(
-					httpServletRequest, httpServletResponse, file.getName(),
-					inputStream, ContentTypes.APPLICATION_ZIP);
+				try (InputStream inputStream = new FileInputStream(file)) {
+					ServletResponseUtil.sendFile(
+						httpServletRequest, httpServletResponse, file.getName(),
+						inputStream, ContentTypes.APPLICATION_ZIP);
+				}
 			}
 		}
 		catch (PortalException portalException) {
 			throw new IOException(portalException);
 		}
+	}
+
+	private long _getActiveCTCollectionId(User user) {
+		CTPreferences ctPreferences =
+			_ctPreferencesLocalService.fetchCTPreferences(
+				user.getCompanyId(), user.getUserId());
+
+		if (ctPreferences == null) {
+			return CTConstants.CT_COLLECTION_ID_PRODUCTION;
+		}
+
+		return ctPreferences.getCtCollectionId();
 	}
 
 	private long[] _getClassPKs(
@@ -168,6 +190,9 @@ public class ExportTranslationServlet extends HttpServlet {
 
 		return draftLayout.getPlid();
 	}
+
+	@Reference
+	private CTPreferencesLocalService _ctPreferencesLocalService;
 
 	@Reference
 	private InfoItemServiceRegistry _infoItemServiceRegistry;


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-88077

Inside an active Publication, "Export for Translation" on a Web Content
article (and on a Content Page) returns a 500 with NoSuchArticleException
or NoSuchLayoutException, which the browser renders as a blank page.
Outside of Publications the export works correctly.

# How am I fixing it?

The export form is rendered through the portlet pipeline, which propagates
the user's active CTCollection from session, but the form submit goes to
ExportTranslationServlet — an OSGi HTTP whiteboard servlet that bypasses
that pipeline and runs every model lookup in production scope.
ExportTranslationServlet.doGet now resolves the user's checked-out
CTCollection via CTPreferencesLocalService and wraps the model-touching
work in CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable, the
same pattern already used by CTDocumentServlet.

# How can you verify that it works?

Run the included automated tests.