### PR TITLE
LPD-88211 Align FDS dropdown and bulk actions in site-cms-site-initializer

### DIFF
--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewAllSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewAllSectionDisplayContextTest.java
@@ -106,7 +106,7 @@ public class ViewAllSectionDisplayContextTest
 			getBulkActionDropdownItems();
 
 		Assert.assertEquals(
-			bulkActionDropdownItems.toString(), 13,
+			bulkActionDropdownItems.toString(), 14,
 			bulkActionDropdownItems.size());
 
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
@@ -137,16 +137,19 @@ public class ViewAllSectionDisplayContextTest
 			"password-policies", "permissions", "Permissions", null,
 			bulkActionDropdownItems.get(9));
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
+			"password-policies", "default-permissions", "Default Permissions",
+			null, bulkActionDropdownItems.get(10));
+		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
 			"password-policies", "edit-default-permissions-by-role",
 			"Edit Default Permissions by Role", null,
-			bulkActionDropdownItems.get(10));
+			bulkActionDropdownItems.get(11));
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
 			"password-policies", "edit-permissions-by-role",
-			"Edit Permissions by Role", null, bulkActionDropdownItems.get(11));
+			"Edit Permissions by Role", null, bulkActionDropdownItems.get(12));
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
 			"password-policies", "reset-to-default-permissions",
 			"Reset to Default Permissions", null,
-			bulkActionDropdownItems.get(12));
+			bulkActionDropdownItems.get(13));
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewFilesSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewFilesSectionDisplayContextTest.java
@@ -109,12 +109,12 @@ public class ViewFilesSectionDisplayContextTest
 			"password-policies", "permissions", "Permissions", null,
 			bulkActionDropdownItems.get(7));
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
+			"password-policies", "default-permissions", "Default Permissions",
+			null, bulkActionDropdownItems.get(8));
+		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
 			"password-policies", "edit-default-permissions-by-role",
 			"Edit Default Permissions by Role", null,
-			bulkActionDropdownItems.get(8));
-		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
-			"password-policies", "default-permissions", "Default Permissions",
-			null, bulkActionDropdownItems.get(9));
+			bulkActionDropdownItems.get(9));
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
 			"password-policies", "edit-permissions-by-role",
 			"Edit Permissions by Role", null, bulkActionDropdownItems.get(10));

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/service/test/ObjectEntryLocalServiceTest.java
@@ -68,7 +68,6 @@ import java.io.Serializable;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
-import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -167,7 +166,9 @@ public class ObjectEntryLocalServiceTest {
 				_objectDefinition.getObjectDefinitionId(),
 				ObjectEntryFolderConstants.
 					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
-				Map.of("reviewDate", new Date()),
+				HashMapBuilder.<String, Serializable>put(
+					"reviewDate", new Date()
+				).build(),
 				ServiceContextTestUtil.getServiceContext(
 					_depotEntry.getGroupId()));
 

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/struts/test/GetPreviewDataStrutsActionTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/struts/test/GetPreviewDataStrutsActionTest.java
@@ -204,7 +204,7 @@ public class GetPreviewDataStrutsActionTest {
 			group2.getGroupId(), groupJSONObject.getLong("groupId"));
 
 		displayPageTemplatesJSONArray = groupJSONObject.getJSONArray(
-			"displayPages");
+			"displayPageTemplates");
 
 		Assert.assertEquals(1, displayPageTemplatesJSONArray.length());
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseContentsSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseContentsSectionDisplayContext.java
@@ -7,16 +7,13 @@ package com.liferay.site.cms.site.initializer.internal.display.context;
 
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
-import com.liferay.frontend.data.set.model.FDSActionDropdownItemBuilder;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.constants.ObjectFolderConstants;
 import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectDefinitionService;
 import com.liferay.object.service.ObjectDefinitionSettingLocalService;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.Language;
-import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -57,100 +54,8 @@ public abstract class BaseContentsSectionDisplayContext
 
 	@Override
 	public List<DropdownItem> getBulkActionDropdownItems() {
-		List<DropdownItem> fdsBulkActionDropdownItems =
-			super.getBulkActionDropdownItems();
-
-		fdsBulkActionDropdownItems.add(
-			FDSActionDropdownItemBuilder.setHighlighted(
-				true
-			).setHref(
-				"#"
-			).setIcon(
-				"move-folder"
-			).setLabel(
-				LanguageUtil.get(httpServletRequest, "move-to")
-			).build(
-				"move-to"
-			));
-		fdsBulkActionDropdownItems.add(
-			FDSActionDropdownItemBuilder.setHighlighted(
-				true
-			).setHref(
-				"#"
-			).setIcon(
-				"copy"
-			).setLabel(
-				LanguageUtil.get(httpServletRequest, "copy-to")
-			).build(
-				"copy-to"
-			));
-		fdsBulkActionDropdownItems.add(
-			FDSActionDropdownItemBuilder.setHighlighted(
-				true
-			).setHref(
-				"#"
-			).setIcon(
-				"time"
-			).setLabel(
-				LanguageUtil.get(httpServletRequest, "expire")
-			).build(
-				"expire"
-			));
-		fdsBulkActionDropdownItems.add(
-			FDSActionDropdownItemBuilder.setHighlighted(
-				true
-			).setHref(
-				"#"
-			).setIcon(
-				"upload"
-			).setLabel(
-				LanguageUtil.get(httpServletRequest, "export-for-translation")
-			).build(
-				"export-for-translation"
-			));
-		fdsBulkActionDropdownItems.add(
-			new FDSActionDropdownItem(
-				null, "pencil", "edit-categories",
-				LanguageUtil.get(httpServletRequest, "edit-categories"), "post",
-				"edit-categories", null));
-		fdsBulkActionDropdownItems.add(
-			new FDSActionDropdownItem(
-				null, "pencil", "edit-tags",
-				LanguageUtil.get(httpServletRequest, "edit-tags"), "post",
-				"edit-tags", null));
-		fdsBulkActionDropdownItems.add(
-			new FDSActionDropdownItem(
-				"#", "password-policies", "permissions",
-				LanguageUtil.get(httpServletRequest, "permissions"), null, null,
-				null));
-		fdsBulkActionDropdownItems.add(
-			new FDSActionDropdownItem(
-				"#", "password-policies", "default-permissions",
-				LanguageUtil.get(httpServletRequest, "default-permissions"),
-				null, null, null));
-		fdsBulkActionDropdownItems.add(
-			new FDSActionDropdownItem(
-				StringPool.BLANK, "password-policies",
-				"edit-default-permissions-by-role",
-				LanguageUtil.get(
-					httpServletRequest, "edit-default-permissions-by-role"),
-				null, null, null));
-		fdsBulkActionDropdownItems.add(
-			new FDSActionDropdownItem(
-				StringPool.BLANK, "password-policies",
-				"edit-permissions-by-role",
-				LanguageUtil.get(
-					httpServletRequest, "edit-permissions-by-role"),
-				null, null, null));
-		fdsBulkActionDropdownItems.add(
-			new FDSActionDropdownItem(
-				StringPool.BLANK, "password-policies",
-				"reset-to-default-permissions",
-				LanguageUtil.get(
-					httpServletRequest, "reset-to-default-permissions"),
-				null, null, null));
-
-		return fdsBulkActionDropdownItems;
+		return sectionDisplayContextHelper.getContentsBulkActionDropdownItems(
+			httpServletRequest);
 	}
 
 	@Override
@@ -169,6 +74,12 @@ public abstract class BaseContentsSectionDisplayContext
 		).put(
 			"title", language.get(httpServletRequest, "no-content-yet")
 		).build();
+	}
+
+	@Override
+	public List<FDSActionDropdownItem> getFDSActionDropdownItems() {
+		return sectionDisplayContextHelper.getContentsFDSActionDropdownItems(
+			httpServletRequest);
 	}
 
 	protected abstract String getEmptyStateDescriptionKey();

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseFilesSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseFilesSectionDisplayContext.java
@@ -8,18 +8,14 @@ package com.liferay.site.cms.site.initializer.internal.display.context;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.document.library.configuration.DLConfiguration;
 import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
-import com.liferay.frontend.data.set.model.FDSActionDropdownItemBuilder;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.constants.ObjectFolderConstants;
 import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectDefinitionService;
 import com.liferay.object.service.ObjectDefinitionSettingLocalService;
-import com.liferay.petra.string.StringBundler;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.language.LanguageUtil;
-import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -60,94 +56,8 @@ public abstract class BaseFilesSectionDisplayContext
 
 	@Override
 	public List<DropdownItem> getBulkActionDropdownItems() {
-		List<DropdownItem> fdsBulkActionDropdownItems =
-			super.getBulkActionDropdownItems();
-
-		fdsBulkActionDropdownItems.add(
-			FDSActionDropdownItemBuilder.setHighlighted(
-				true
-			).setHref(
-				"#"
-			).setIcon(
-				"move-folder"
-			).setLabel(
-				LanguageUtil.get(httpServletRequest, "move-to")
-			).build(
-				"move-to"
-			));
-		fdsBulkActionDropdownItems.add(
-			FDSActionDropdownItemBuilder.setHighlighted(
-				true
-			).setHref(
-				"#"
-			).setIcon(
-				"copy"
-			).setLabel(
-				LanguageUtil.get(httpServletRequest, "copy-to")
-			).build(
-				"copy-to"
-			));
-		fdsBulkActionDropdownItems.add(
-			new FDSActionDropdownItem(
-				"#", "download", "download",
-				LanguageUtil.get(httpServletRequest, "download"), null, null,
-				null));
-		fdsBulkActionDropdownItems.add(
-			new FDSActionDropdownItem(
-				null, "pencil", "edit-categories",
-				LanguageUtil.get(httpServletRequest, "edit-categories"), "post",
-				"edit-categories", null));
-		fdsBulkActionDropdownItems.add(
-			new FDSActionDropdownItem(
-				null, "pencil", "edit-tags",
-				LanguageUtil.get(httpServletRequest, "edit-tags"), "post",
-				"edit-tags", null));
-		fdsBulkActionDropdownItems.add(
-			3,
-			FDSActionDropdownItemBuilder.setHighlighted(
-				true
-			).setHref(
-				"#"
-			).setIcon(
-				"time"
-			).setLabel(
-				LanguageUtil.get(httpServletRequest, "expire")
-			).build(
-				"expire"
-			));
-		fdsBulkActionDropdownItems.add(
-			new FDSActionDropdownItem(
-				"#", "password-policies", "permissions",
-				LanguageUtil.get(httpServletRequest, "permissions"), null, null,
-				null));
-		fdsBulkActionDropdownItems.add(
-			new FDSActionDropdownItem(
-				StringPool.BLANK, "password-policies",
-				"edit-default-permissions-by-role",
-				LanguageUtil.get(
-					httpServletRequest, "edit-default-permissions-by-role"),
-				null, null, null));
-		fdsBulkActionDropdownItems.add(
-			new FDSActionDropdownItem(
-				"#", "password-policies", "default-permissions",
-				LanguageUtil.get(httpServletRequest, "default-permissions"),
-				null, null, null));
-		fdsBulkActionDropdownItems.add(
-			new FDSActionDropdownItem(
-				StringPool.BLANK, "password-policies",
-				"edit-permissions-by-role",
-				LanguageUtil.get(
-					httpServletRequest, "edit-permissions-by-role"),
-				null, null, null));
-		fdsBulkActionDropdownItems.add(
-			new FDSActionDropdownItem(
-				StringPool.BLANK, "password-policies",
-				"reset-to-default-permissions",
-				LanguageUtil.get(
-					httpServletRequest, "reset-to-default-permissions"),
-				null, null, null));
-
-		return fdsBulkActionDropdownItems;
+		return sectionDisplayContextHelper.getFilesBulkActionDropdownItems(
+			httpServletRequest);
 	}
 
 	@Override
@@ -170,31 +80,8 @@ public abstract class BaseFilesSectionDisplayContext
 
 	@Override
 	public List<FDSActionDropdownItem> getFDSActionDropdownItems() {
-		List<FDSActionDropdownItem> fdsActionDropdownItems =
-			super.getFDSActionDropdownItems();
-
-		fdsActionDropdownItems.add(
-			6,
-			new FDSActionDropdownItem(
-				"{embedded.file.link.href}", "download", "download",
-				LanguageUtil.get(httpServletRequest, "download"), "get", null,
-				"link"));
-
-		fdsActionDropdownItems.add(
-			7,
-			new FDSActionDropdownItem(
-				StringBundler.concat(
-					"/o", GroupConstants.CMS_FRIENDLY_URL, "/download-folder/",
-					portal.getClassNameId(ObjectEntryFolder.class),
-					"/{embedded.id}"),
-				"download", "download-folder",
-				LanguageUtil.get(httpServletRequest, "download"), "get", null,
-				"link",
-				HashMapBuilder.<String, Object>put(
-					"entryClassName", ObjectEntryFolder.class.getName()
-				).build()));
-
-		return fdsActionDropdownItems;
+		return sectionDisplayContextHelper.getFilesFDSActionDropdownItems(
+			httpServletRequest);
 	}
 
 	protected abstract String getEmptyStateDescriptionKey();

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
@@ -101,14 +101,14 @@ public abstract class BaseSectionDisplayContext {
 			themeDisplay.getCompanyId(),
 			httpServletRequest.getAttribute(InfoDisplayWebKeys.INFO_ITEM));
 
-		_sectionDisplayContextHelper = new SectionDisplayContextHelper(
+		sectionDisplayContextHelper = new SectionDisplayContextHelper(
 			depotEntryLocalService, groupLocalService, language,
 			objectDefinitionSettingLocalService,
 			objectEntryFolderModelResourcePermission, portal);
 	}
 
 	public String getAdditionalAPIURLParameters() {
-		return _sectionDisplayContextHelper.getAdditionalAPIURLParameters(
+		return sectionDisplayContextHelper.getAdditionalAPIURLParameters(
 			getCMSSectionFilterString(), httpServletRequest,
 			getRootObjectEntryFolderExternalReferenceCode());
 	}
@@ -125,7 +125,7 @@ public abstract class BaseSectionDisplayContext {
 			}
 		).put(
 			"assetLibraries",
-			_sectionDisplayContextHelper.getDepotEntriesJSONArray(
+			sectionDisplayContextHelper.getDepotEntriesJSONArray(
 				httpServletRequest)
 		).put(
 			"autocompleteURL",
@@ -155,7 +155,7 @@ public abstract class BaseSectionDisplayContext {
 				PropsUtil.get(PropsKeys.CMS_BROKEN_LINKS_CHECKER_ENABLED))
 		).put(
 			"candidateAssetLibraries",
-			_sectionDisplayContextHelper.getDepotEntriesJSONArray(
+			sectionDisplayContextHelper.getDepotEntriesJSONArray(
 				httpServletRequest,
 				getRootObjectEntryFolderExternalReferenceCode())
 		).put(
@@ -299,7 +299,7 @@ public abstract class BaseSectionDisplayContext {
 	}
 
 	public CreationMenu getCreationMenu() {
-		return _sectionDisplayContextHelper.getCreationMenu(
+		return sectionDisplayContextHelper.getCreationMenu(
 			getCreationMenuDropdownItems(), httpServletRequest,
 			getRootObjectEntryFolderExternalReferenceCode());
 	}
@@ -311,7 +311,7 @@ public abstract class BaseSectionDisplayContext {
 	public abstract Map<String, Object> getEmptyState();
 
 	public List<FDSActionDropdownItem> getFDSActionDropdownItems() {
-		return _sectionDisplayContextHelper.getFDSActionDropdownItems(
+		return sectionDisplayContextHelper.getFDSActionDropdownItems(
 			httpServletRequest);
 	}
 
@@ -329,12 +329,12 @@ public abstract class BaseSectionDisplayContext {
 	}
 
 	protected String appendGroupIds(String filterString) {
-		return _sectionDisplayContextHelper.appendGroupIds(
+		return sectionDisplayContextHelper.appendGroupIds(
 			filterString, httpServletRequest);
 	}
 
 	protected String appendStatus(String filterString) {
-		return _sectionDisplayContextHelper.appendStatus(filterString);
+		return sectionDisplayContextHelper.appendStatus(filterString);
 	}
 
 	protected abstract String getCMSSectionFilterString();
@@ -360,6 +360,7 @@ public abstract class BaseSectionDisplayContext {
 	protected final Language language;
 	protected final ObjectEntryFolder objectEntryFolder;
 	protected final Portal portal;
+	protected final SectionDisplayContextHelper sectionDisplayContextHelper;
 	protected final ThemeDisplay themeDisplay;
 
 	private JSONObject _getExportFileFormatJSONObject(
@@ -548,7 +549,6 @@ public abstract class BaseSectionDisplayContext {
 
 	private final DLConfiguration _dlConfiguration;
 	private final ObjectDefinitionService _objectDefinitionService;
-	private final SectionDisplayContextHelper _sectionDisplayContextHelper;
 	private final TranslationInfoItemFieldValuesExporterRegistry
 		_translationInfoItemFieldValuesExporterRegistry;
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
@@ -9,6 +9,7 @@ import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.document.library.configuration.DLConfiguration;
 import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
+import com.liferay.frontend.data.set.model.FDSActionDropdownItemBuilder;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
 import com.liferay.info.constants.InfoDisplayWebKeys;
@@ -292,10 +293,15 @@ public abstract class BaseSectionDisplayContext {
 
 	public List<DropdownItem> getBulkActionDropdownItems() {
 		return ListUtil.fromArray(
-			new FDSActionDropdownItem(
-				"#", "trash", "delete",
-				LanguageUtil.get(httpServletRequest, "delete"), null, null,
-				null));
+			FDSActionDropdownItemBuilder.setHref(
+				"#"
+			).setIcon(
+				"trash"
+			).setLabel(
+				LanguageUtil.get(httpServletRequest, "delete")
+			).build(
+				"delete"
+			));
 	}
 
 	public CreationMenu getCreationMenu() {

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/SectionDisplayContextHelper.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/SectionDisplayContextHelper.java
@@ -188,10 +188,15 @@ public class SectionDisplayContextHelper {
 				"export-for-translation"
 			));
 		bulkActionDropdownItems.add(
-			new FDSActionDropdownItem(
-				"#", "download", "download",
-				LanguageUtil.get(httpServletRequest, "download"), null, null,
-				null));
+			FDSActionDropdownItemBuilder.setHref(
+				"#"
+			).setIcon(
+				"download"
+			).setLabel(
+				LanguageUtil.get(httpServletRequest, "download")
+			).build(
+				"download"
+			));
 
 		_addEditCategoriesAndTagsBulkActions(
 			bulkActionDropdownItems, httpServletRequest);
@@ -222,10 +227,19 @@ public class SectionDisplayContextHelper {
 
 		fdsActionDropdownItems.add(
 			6,
-			new FDSActionDropdownItem(
-				"{embedded.file.link.href}", "download", "download",
-				LanguageUtil.get(httpServletRequest, "download"), "get", null,
-				"link"));
+			FDSActionDropdownItemBuilder.setHref(
+				"{embedded.file.link.href}"
+			).setIcon(
+				"download"
+			).setLabel(
+				LanguageUtil.get(httpServletRequest, "download")
+			).setMethod(
+				"get"
+			).setTarget(
+				"link"
+			).build(
+				"download"
+			));
 
 		return fdsActionDropdownItems;
 	}
@@ -401,89 +415,181 @@ public class SectionDisplayContextHelper {
 				WebKeys.THEME_DISPLAY);
 
 		return ListUtil.fromArray(
-			new FDSActionDropdownItem(
-				ActionUtil.getBaseViewFolderURL(themeDisplay) + "{embedded.id}",
-				"view", "actionLinkFolder",
-				LanguageUtil.get(httpServletRequest, "view-folder"), "get",
-				"get", null,
+			FDSActionDropdownItemBuilder.setHref(
+				ActionUtil.getBaseViewFolderURL(themeDisplay) + "{embedded.id}"
+			).setIcon(
+				"view"
+			).setLabel(
+				LanguageUtil.get(httpServletRequest, "view-folder")
+			).setMethod(
+				"get"
+			).setPermissionKey(
+				"get"
+			).setVisibilityFilters(
 				HashMapBuilder.<String, Object>put(
 					"entryClassName", ObjectEntryFolder.class.getName()
-				).build()),
-			new FDSActionDropdownItem(
+				).build()
+			).build(
+				"actionLinkFolder"
+			),
+			FDSActionDropdownItemBuilder.setHref(
 				StringBundler.concat(
 					themeDisplay.getPathFriendlyURLPublic(),
 					GroupConstants.CMS_FRIENDLY_URL, "/e/edit-folder/",
 					_portal.getClassNameId(ObjectEntryFolder.class),
-					"/{embedded.id}?redirect=", themeDisplay.getURLCurrent()),
-				"pencil", "editFolder",
-				LanguageUtil.get(httpServletRequest, "edit"), "get", "update",
-				null,
+					"/{embedded.id}?redirect=", themeDisplay.getURLCurrent())
+			).setIcon(
+				"pencil"
+			).setLabel(
+				LanguageUtil.get(httpServletRequest, "edit")
+			).setMethod(
+				"get"
+			).setPermissionKey(
+				"update"
+			).setVisibilityFilters(
 				HashMapBuilder.<String, Object>put(
 					"entryClassName", ObjectEntryFolder.class.getName()
-				).build()),
-			new FDSActionDropdownItem(
+				).build()
+			).build(
+				"editFolder"
+			),
+			FDSActionDropdownItemBuilder.setHref(
 				StringBundler.concat(
 					themeDisplay.getPortalURL(), themeDisplay.getPathMain(),
 					GroupConstants.CMS_FRIENDLY_URL,
 					"/edit_content_item?objectEntryId={embedded.id}&",
-					"redirect=", themeDisplay.getURLCurrent()),
-				"pencil", "actionLink",
-				LanguageUtil.get(httpServletRequest, "edit"), "get", "update",
-				null),
-			new FDSActionDropdownItem(
+					"redirect=", themeDisplay.getURLCurrent())
+			).setIcon(
+				"pencil"
+			).setLabel(
+				LanguageUtil.get(httpServletRequest, "edit")
+			).setMethod(
+				"get"
+			).setPermissionKey(
+				"update"
+			).build(
+				"actionLink"
+			),
+			FDSActionDropdownItemBuilder.setHref(
 				StringBundler.concat(
 					themeDisplay.getPortalURL(), themeDisplay.getPathMain(),
 					GroupConstants.CMS_FRIENDLY_URL,
 					"/edit_content_item?p_l_mode=read&p_p_state=",
 					LiferayWindowState.POP_UP, "&redirect=",
 					themeDisplay.getURLCurrent(),
-					"&objectEntryId={embedded.id}"),
-				"view", "view-content",
-				LanguageUtil.get(httpServletRequest, "view"), null, "get",
-				null),
-			new FDSActionDropdownItem(
-				StringPool.BLANK, "view", "view-file",
-				LanguageUtil.get(httpServletRequest, "view"), null, "get",
-				null),
-			new FDSActionDropdownItem(
+					"&objectEntryId={embedded.id}")
+			).setIcon(
+				"view"
+			).setLabel(
+				LanguageUtil.get(httpServletRequest, "view")
+			).setPermissionKey(
+				"get"
+			).build(
+				"view-content"
+			),
+			FDSActionDropdownItemBuilder.setHref(
+				StringPool.BLANK
+			).setIcon(
+				"view"
+			).setLabel(
+				LanguageUtil.get(httpServletRequest, "view")
+			).setPermissionKey(
+				"get"
+			).build(
+				"view-file"
+			),
+			FDSActionDropdownItemBuilder.setHref(
 				StringBundler.concat(
 					themeDisplay.getPortalURL(), themeDisplay.getPathMain(),
 					GroupConstants.CMS_FRIENDLY_URL,
 					"/translate_content_item?objectEntryId={embedded.id}&",
-					"redirect=", themeDisplay.getURLCurrent()),
-				"automatic-translate", "translate",
-				LanguageUtil.get(httpServletRequest, "translate"), "get",
-				"update", null),
-			new FDSActionDropdownItem(
-				null, "share", "share",
-				LanguageUtil.get(httpServletRequest, "share"), "get", "share",
-				"link"),
-			new FDSActionDropdownItem(
-				StringPool.BLANK, "info-circle-open", "show-details",
-				LanguageUtil.get(httpServletRequest, "show-details"), null,
-				null, "infoPanel"),
-			new FDSActionDropdownItem(
-				"{actions.expire.href}", "time", "expire",
-				LanguageUtil.get(httpServletRequest, "expire"), "post",
-				"expire", "headless"),
-			new FDSActionDropdownItem(
+					"redirect=", themeDisplay.getURLCurrent())
+			).setIcon(
+				"automatic-translate"
+			).setLabel(
+				LanguageUtil.get(httpServletRequest, "translate")
+			).setMethod(
+				"get"
+			).setPermissionKey(
+				"update"
+			).build(
+				"translate"
+			),
+			FDSActionDropdownItemBuilder.setIcon(
+				"share"
+			).setLabel(
+				LanguageUtil.get(httpServletRequest, "share")
+			).setMethod(
+				"get"
+			).setPermissionKey(
+				"share"
+			).setTarget(
+				"link"
+			).build(
+				"share"
+			),
+			FDSActionDropdownItemBuilder.setHref(
+				StringPool.BLANK
+			).setIcon(
+				"info-circle-open"
+			).setLabel(
+				LanguageUtil.get(httpServletRequest, "show-details")
+			).setTarget(
+				"infoPanel"
+			).build(
+				"show-details"
+			),
+			FDSActionDropdownItemBuilder.setHref(
+				"{actions.expire.href}"
+			).setIcon(
+				"time"
+			).setLabel(
+				LanguageUtil.get(httpServletRequest, "expire")
+			).setMethod(
+				"post"
+			).setPermissionKey(
+				"expire"
+			).setTarget(
+				"headless"
+			).build(
+				"expire"
+			),
+			FDSActionDropdownItemBuilder.setHref(
 				StringBundler.concat(
 					themeDisplay.getPathFriendlyURLPublic(),
 					GroupConstants.CMS_FRIENDLY_URL,
 					"/version-history?objectEntryId={embedded.id}&backURL=",
-					themeDisplay.getURLCurrent()),
-				"date-time", "version-history",
-				LanguageUtil.get(httpServletRequest, "view-history"), "get",
-				"versions", null),
-			new FDSActionDropdownItem(
-				null, "move-folder", "move",
-				_language.get(httpServletRequest, "move"), null, "update",
-				null),
-			new FDSActionDropdownItem(
-				null, "copy", "copy",
-				_language.get(httpServletRequest, "copy-to"), null, "update",
-				null),
-			new FDSActionDropdownItem(
+					themeDisplay.getURLCurrent())
+			).setIcon(
+				"date-time"
+			).setLabel(
+				LanguageUtil.get(httpServletRequest, "view-history")
+			).setMethod(
+				"get"
+			).setPermissionKey(
+				"versions"
+			).build(
+				"version-history"
+			),
+			FDSActionDropdownItemBuilder.setIcon(
+				"move-folder"
+			).setLabel(
+				_language.get(httpServletRequest, "move")
+			).setPermissionKey(
+				"update"
+			).build(
+				"move"
+			),
+			FDSActionDropdownItemBuilder.setIcon(
+				"copy"
+			).setLabel(
+				_language.get(httpServletRequest, "copy-to")
+			).setPermissionKey(
+				"update"
+			).build(
+				"copy"
+			),
+			FDSActionDropdownItemBuilder.setHref(
 				PortletURLBuilder.create(
 					_portal.getControlPanelPortletURL(
 						httpServletRequest, TranslationPortletKeys.TRANSLATION,
@@ -498,25 +604,42 @@ public class SectionDisplayContextHelper {
 					"groupId", "{embedded.scopeId}"
 				).setWindowState(
 					LiferayWindowState.POP_UP
-				).buildString(),
-				"upload", "export-for-translation",
-				LanguageUtil.get(httpServletRequest, "export-for-translation"),
-				null, "get", null),
-			new FDSActionDropdownItem(
+				).buildString()
+			).setIcon(
+				"upload"
+			).setLabel(
+				LanguageUtil.get(httpServletRequest, "export-for-translation")
+			).setPermissionKey(
+				"get"
+			).build(
+				"export-for-translation"
+			),
+			FDSActionDropdownItemBuilder.setHref(
 				StringBundler.concat(
 					themeDisplay.getPortalURL(), themeDisplay.getPathMain(),
 					GroupConstants.CMS_FRIENDLY_URL,
 					"/edit_content_item?objectEntryId={embedded.id}&",
-					"redirect=", themeDisplay.getURLCurrent()),
-				"download", "import-translation",
-				LanguageUtil.get(httpServletRequest, "import-translation"),
-				null, "update", null),
+					"redirect=", themeDisplay.getURLCurrent())
+			).setIcon(
+				"download"
+			).setLabel(
+				LanguageUtil.get(httpServletRequest, "import-translation")
+			).setPermissionKey(
+				"update"
+			).build(
+				"import-translation"
+			),
 			_getPermissionsFDSActionDropdownItem(
 				httpServletRequest, themeDisplay),
-			new FDSActionDropdownItem(
-				null, "trash", "delete",
-				_language.get(httpServletRequest, "delete"), null, "delete",
-				null));
+			FDSActionDropdownItemBuilder.setIcon(
+				"trash"
+			).setLabel(
+				_language.get(httpServletRequest, "delete")
+			).setPermissionKey(
+				"delete"
+			).build(
+				"delete"
+			));
 	}
 
 	public List<DropdownItem> getFilesBulkActionDropdownItems(
@@ -526,10 +649,15 @@ public class SectionDisplayContextHelper {
 			_getBulkActionDropdownItems(httpServletRequest);
 
 		bulkActionDropdownItems.add(
-			new FDSActionDropdownItem(
-				"#", "download", "download",
-				LanguageUtil.get(httpServletRequest, "download"), null, null,
-				null));
+			FDSActionDropdownItemBuilder.setHref(
+				"#"
+			).setIcon(
+				"download"
+			).setLabel(
+				LanguageUtil.get(httpServletRequest, "download")
+			).build(
+				"download"
+			));
 
 		_addEditCategoriesAndTagsBulkActions(
 			bulkActionDropdownItems, httpServletRequest);
@@ -546,23 +674,41 @@ public class SectionDisplayContextHelper {
 
 		fdsActionDropdownItems.add(
 			6,
-			new FDSActionDropdownItem(
-				"{embedded.file.link.href}", "download", "download",
-				LanguageUtil.get(httpServletRequest, "download"), "get", null,
-				"link"));
+			FDSActionDropdownItemBuilder.setHref(
+				"{embedded.file.link.href}"
+			).setIcon(
+				"download"
+			).setLabel(
+				LanguageUtil.get(httpServletRequest, "download")
+			).setMethod(
+				"get"
+			).setTarget(
+				"link"
+			).build(
+				"download"
+			));
 		fdsActionDropdownItems.add(
 			7,
-			new FDSActionDropdownItem(
+			FDSActionDropdownItemBuilder.setHref(
 				StringBundler.concat(
 					"/o", GroupConstants.CMS_FRIENDLY_URL, "/download-folder/",
 					_portal.getClassNameId(ObjectEntryFolder.class),
-					"/{embedded.id}"),
-				"download", "download-folder",
-				LanguageUtil.get(httpServletRequest, "download"), "get", null,
-				"link",
+					"/{embedded.id}")
+			).setIcon(
+				"download"
+			).setLabel(
+				LanguageUtil.get(httpServletRequest, "download")
+			).setMethod(
+				"get"
+			).setTarget(
+				"link"
+			).setVisibilityFilters(
 				HashMapBuilder.<String, Object>put(
 					"entryClassName", ObjectEntryFolder.class.getName()
-				).build()));
+				).build()
+			).build(
+				"download-folder"
+			));
 
 		return fdsActionDropdownItems;
 	}
@@ -572,15 +718,29 @@ public class SectionDisplayContextHelper {
 		HttpServletRequest httpServletRequest) {
 
 		bulkActionDropdownItems.add(
-			new FDSActionDropdownItem(
-				null, "pencil", "edit-categories",
-				LanguageUtil.get(httpServletRequest, "edit-categories"), "post",
-				"edit-categories", null));
+			FDSActionDropdownItemBuilder.setIcon(
+				"pencil"
+			).setLabel(
+				LanguageUtil.get(httpServletRequest, "edit-categories")
+			).setMethod(
+				"post"
+			).setPermissionKey(
+				"edit-categories"
+			).build(
+				"edit-categories"
+			));
 		bulkActionDropdownItems.add(
-			new FDSActionDropdownItem(
-				null, "pencil", "edit-tags",
-				LanguageUtil.get(httpServletRequest, "edit-tags"), "post",
-				"edit-tags", null));
+			FDSActionDropdownItemBuilder.setIcon(
+				"pencil"
+			).setLabel(
+				LanguageUtil.get(httpServletRequest, "edit-tags")
+			).setMethod(
+				"post"
+			).setPermissionKey(
+				"edit-tags"
+			).build(
+				"edit-tags"
+			));
 	}
 
 	private void _addPermissionsBulkActions(
@@ -588,46 +748,72 @@ public class SectionDisplayContextHelper {
 		HttpServletRequest httpServletRequest) {
 
 		bulkActionDropdownItems.add(
-			new FDSActionDropdownItem(
-				"#", "password-policies", "permissions",
-				LanguageUtil.get(httpServletRequest, "permissions"), null, null,
-				null));
+			FDSActionDropdownItemBuilder.setHref(
+				"#"
+			).setIcon(
+				"password-policies"
+			).setLabel(
+				LanguageUtil.get(httpServletRequest, "permissions")
+			).build(
+				"permissions"
+			));
 		bulkActionDropdownItems.add(
-			new FDSActionDropdownItem(
-				"#", "password-policies", "default-permissions",
-				LanguageUtil.get(httpServletRequest, "default-permissions"),
-				null, null, null));
+			FDSActionDropdownItemBuilder.setHref(
+				"#"
+			).setIcon(
+				"password-policies"
+			).setLabel(
+				LanguageUtil.get(httpServletRequest, "default-permissions")
+			).build(
+				"default-permissions"
+			));
 		bulkActionDropdownItems.add(
-			new FDSActionDropdownItem(
-				StringPool.BLANK, "password-policies",
-				"edit-default-permissions-by-role",
+			FDSActionDropdownItemBuilder.setHref(
+				StringPool.BLANK
+			).setIcon(
+				"password-policies"
+			).setLabel(
 				LanguageUtil.get(
-					httpServletRequest, "edit-default-permissions-by-role"),
-				null, null, null));
+					httpServletRequest, "edit-default-permissions-by-role")
+			).build(
+				"edit-default-permissions-by-role"
+			));
 		bulkActionDropdownItems.add(
-			new FDSActionDropdownItem(
-				StringPool.BLANK, "password-policies",
-				"edit-permissions-by-role",
-				LanguageUtil.get(
-					httpServletRequest, "edit-permissions-by-role"),
-				null, null, null));
+			FDSActionDropdownItemBuilder.setHref(
+				StringPool.BLANK
+			).setIcon(
+				"password-policies"
+			).setLabel(
+				LanguageUtil.get(httpServletRequest, "edit-permissions-by-role")
+			).build(
+				"edit-permissions-by-role"
+			));
 		bulkActionDropdownItems.add(
-			new FDSActionDropdownItem(
-				StringPool.BLANK, "password-policies",
-				"reset-to-default-permissions",
+			FDSActionDropdownItemBuilder.setHref(
+				StringPool.BLANK
+			).setIcon(
+				"password-policies"
+			).setLabel(
 				LanguageUtil.get(
-					httpServletRequest, "reset-to-default-permissions"),
-				null, null, null));
+					httpServletRequest, "reset-to-default-permissions")
+			).build(
+				"reset-to-default-permissions"
+			));
 	}
 
 	private List<DropdownItem> _getBulkActionDropdownItems(
 		HttpServletRequest httpServletRequest) {
 
 		return ListUtil.fromArray(
-			new FDSActionDropdownItem(
-				"#", "trash", "delete",
-				LanguageUtil.get(httpServletRequest, "delete"), null, null,
-				null),
+			FDSActionDropdownItemBuilder.setHref(
+				"#"
+			).setIcon(
+				"trash"
+			).setLabel(
+				LanguageUtil.get(httpServletRequest, "delete")
+			).build(
+				"delete"
+			),
 			FDSActionDropdownItemBuilder.setHighlighted(
 				true
 			).setHref(

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/SectionDisplayContextHelper.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/SectionDisplayContextHelper.java
@@ -169,6 +169,219 @@ public class SectionDisplayContextHelper {
 		return sb.toString();
 	}
 
+	public List<DropdownItem> getAllSectionBulkActionDropdownItems(
+		HttpServletRequest httpServletRequest) {
+
+		return ListUtil.fromArray(
+			new FDSActionDropdownItem(
+				"#", "trash", "delete",
+				LanguageUtil.get(httpServletRequest, "delete"), null, null,
+				null),
+			FDSActionDropdownItemBuilder.setHighlighted(
+				true
+			).setHref(
+				"#"
+			).setIcon(
+				"move-folder"
+			).setLabel(
+				LanguageUtil.get(httpServletRequest, "move-to")
+			).build(
+				"move-to"
+			),
+			FDSActionDropdownItemBuilder.setHighlighted(
+				true
+			).setHref(
+				"#"
+			).setIcon(
+				"copy"
+			).setLabel(
+				LanguageUtil.get(httpServletRequest, "copy-to")
+			).build(
+				"copy-to"
+			),
+			FDSActionDropdownItemBuilder.setHighlighted(
+				true
+			).setHref(
+				"#"
+			).setIcon(
+				"time"
+			).setLabel(
+				LanguageUtil.get(httpServletRequest, "expire")
+			).build(
+				"expire"
+			),
+			FDSActionDropdownItemBuilder.setHighlighted(
+				true
+			).setHref(
+				"#"
+			).setIcon(
+				"upload"
+			).setLabel(
+				LanguageUtil.get(httpServletRequest, "export-for-translation")
+			).build(
+				"export-for-translation"
+			),
+			new FDSActionDropdownItem(
+				"#", "download", "download",
+				LanguageUtil.get(httpServletRequest, "download"), null, null,
+				null),
+			new FDSActionDropdownItem(
+				null, "pencil", "edit-categories",
+				LanguageUtil.get(httpServletRequest, "edit-categories"), "post",
+				"edit-categories", null),
+			new FDSActionDropdownItem(
+				null, "pencil", "edit-tags",
+				LanguageUtil.get(httpServletRequest, "edit-tags"), "post",
+				"edit-tags", null),
+			FDSActionDropdownItemBuilder.setHighlighted(
+				true
+			).setHref(
+				"#"
+			).setIcon(
+				"semantic-search"
+			).setLabel(
+				LanguageUtil.get(httpServletRequest, "find-and-replace")
+			).build(
+				"find-and-replace"
+			),
+			new FDSActionDropdownItem(
+				"#", "password-policies", "permissions",
+				LanguageUtil.get(httpServletRequest, "permissions"), null, null,
+				null),
+			new FDSActionDropdownItem(
+				"#", "password-policies", "default-permissions",
+				LanguageUtil.get(httpServletRequest, "default-permissions"),
+				null, null, null),
+			new FDSActionDropdownItem(
+				StringPool.BLANK, "password-policies",
+				"edit-default-permissions-by-role",
+				LanguageUtil.get(
+					httpServletRequest, "edit-default-permissions-by-role"),
+				null, null, null),
+			new FDSActionDropdownItem(
+				StringPool.BLANK, "password-policies",
+				"edit-permissions-by-role",
+				LanguageUtil.get(
+					httpServletRequest, "edit-permissions-by-role"),
+				null, null, null),
+			new FDSActionDropdownItem(
+				StringPool.BLANK, "password-policies",
+				"reset-to-default-permissions",
+				LanguageUtil.get(
+					httpServletRequest, "reset-to-default-permissions"),
+				null, null, null));
+	}
+
+	public List<FDSActionDropdownItem> getAllSectionFDSActionDropdownItems(
+		HttpServletRequest httpServletRequest) {
+
+		List<FDSActionDropdownItem> fdsActionDropdownItems =
+			getFDSActionDropdownItems(httpServletRequest);
+
+		fdsActionDropdownItems.add(
+			6,
+			new FDSActionDropdownItem(
+				"{embedded.file.link.href}", "download", "download",
+				LanguageUtil.get(httpServletRequest, "download"), "get", null,
+				"link"));
+
+		return fdsActionDropdownItems;
+	}
+
+	public List<DropdownItem> getContentsBulkActionDropdownItems(
+		HttpServletRequest httpServletRequest) {
+
+		return ListUtil.fromArray(
+			new FDSActionDropdownItem(
+				"#", "trash", "delete",
+				LanguageUtil.get(httpServletRequest, "delete"), null, null,
+				null),
+			FDSActionDropdownItemBuilder.setHighlighted(
+				true
+			).setHref(
+				"#"
+			).setIcon(
+				"move-folder"
+			).setLabel(
+				LanguageUtil.get(httpServletRequest, "move-to")
+			).build(
+				"move-to"
+			),
+			FDSActionDropdownItemBuilder.setHighlighted(
+				true
+			).setHref(
+				"#"
+			).setIcon(
+				"copy"
+			).setLabel(
+				LanguageUtil.get(httpServletRequest, "copy-to")
+			).build(
+				"copy-to"
+			),
+			FDSActionDropdownItemBuilder.setHighlighted(
+				true
+			).setHref(
+				"#"
+			).setIcon(
+				"time"
+			).setLabel(
+				LanguageUtil.get(httpServletRequest, "expire")
+			).build(
+				"expire"
+			),
+			FDSActionDropdownItemBuilder.setHighlighted(
+				true
+			).setHref(
+				"#"
+			).setIcon(
+				"upload"
+			).setLabel(
+				LanguageUtil.get(httpServletRequest, "export-for-translation")
+			).build(
+				"export-for-translation"
+			),
+			new FDSActionDropdownItem(
+				null, "pencil", "edit-categories",
+				LanguageUtil.get(httpServletRequest, "edit-categories"), "post",
+				"edit-categories", null),
+			new FDSActionDropdownItem(
+				null, "pencil", "edit-tags",
+				LanguageUtil.get(httpServletRequest, "edit-tags"), "post",
+				"edit-tags", null),
+			new FDSActionDropdownItem(
+				"#", "password-policies", "permissions",
+				LanguageUtil.get(httpServletRequest, "permissions"), null, null,
+				null),
+			new FDSActionDropdownItem(
+				"#", "password-policies", "default-permissions",
+				LanguageUtil.get(httpServletRequest, "default-permissions"),
+				null, null, null),
+			new FDSActionDropdownItem(
+				StringPool.BLANK, "password-policies",
+				"edit-default-permissions-by-role",
+				LanguageUtil.get(
+					httpServletRequest, "edit-default-permissions-by-role"),
+				null, null, null),
+			new FDSActionDropdownItem(
+				StringPool.BLANK, "password-policies",
+				"edit-permissions-by-role",
+				LanguageUtil.get(
+					httpServletRequest, "edit-permissions-by-role"),
+				null, null, null),
+			new FDSActionDropdownItem(
+				StringPool.BLANK, "password-policies",
+				"reset-to-default-permissions",
+				LanguageUtil.get(
+					httpServletRequest, "reset-to-default-permissions"),
+				null, null, null));
+	}
+
+	public List<FDSActionDropdownItem> getContentsFDSActionDropdownItems(
+		HttpServletRequest httpServletRequest) {
+
+		return getFDSActionDropdownItems(httpServletRequest);
+	}
+
 	public CreationMenu getCreationMenu(
 		List<DropdownItem> dropdownItems, HttpServletRequest httpServletRequest,
 		String rootObjectEntryFolderExternalReferenceCode) {
@@ -366,6 +579,10 @@ public class SectionDisplayContextHelper {
 				LanguageUtil.get(httpServletRequest, "share"), "get", "share",
 				"link"),
 			new FDSActionDropdownItem(
+				StringPool.BLANK, "info-circle-open", "show-details",
+				LanguageUtil.get(httpServletRequest, "show-details"), null,
+				null, "infoPanel"),
+			new FDSActionDropdownItem(
 				"{actions.expire.href}", "time", "expire",
 				LanguageUtil.get(httpServletRequest, "expire"), "post",
 				"expire", "headless"),
@@ -420,6 +637,116 @@ public class SectionDisplayContextHelper {
 				null, "trash", "delete",
 				_language.get(httpServletRequest, "delete"), null, "delete",
 				null));
+	}
+
+	public List<DropdownItem> getFilesBulkActionDropdownItems(
+		HttpServletRequest httpServletRequest) {
+
+		return ListUtil.fromArray(
+			new FDSActionDropdownItem(
+				"#", "trash", "delete",
+				LanguageUtil.get(httpServletRequest, "delete"), null, null,
+				null),
+			FDSActionDropdownItemBuilder.setHighlighted(
+				true
+			).setHref(
+				"#"
+			).setIcon(
+				"move-folder"
+			).setLabel(
+				LanguageUtil.get(httpServletRequest, "move-to")
+			).build(
+				"move-to"
+			),
+			FDSActionDropdownItemBuilder.setHighlighted(
+				true
+			).setHref(
+				"#"
+			).setIcon(
+				"copy"
+			).setLabel(
+				LanguageUtil.get(httpServletRequest, "copy-to")
+			).build(
+				"copy-to"
+			),
+			FDSActionDropdownItemBuilder.setHighlighted(
+				true
+			).setHref(
+				"#"
+			).setIcon(
+				"time"
+			).setLabel(
+				LanguageUtil.get(httpServletRequest, "expire")
+			).build(
+				"expire"
+			),
+			new FDSActionDropdownItem(
+				"#", "download", "download",
+				LanguageUtil.get(httpServletRequest, "download"), null, null,
+				null),
+			new FDSActionDropdownItem(
+				null, "pencil", "edit-categories",
+				LanguageUtil.get(httpServletRequest, "edit-categories"), "post",
+				"edit-categories", null),
+			new FDSActionDropdownItem(
+				null, "pencil", "edit-tags",
+				LanguageUtil.get(httpServletRequest, "edit-tags"), "post",
+				"edit-tags", null),
+			new FDSActionDropdownItem(
+				"#", "password-policies", "permissions",
+				LanguageUtil.get(httpServletRequest, "permissions"), null, null,
+				null),
+			new FDSActionDropdownItem(
+				"#", "password-policies", "default-permissions",
+				LanguageUtil.get(httpServletRequest, "default-permissions"),
+				null, null, null),
+			new FDSActionDropdownItem(
+				StringPool.BLANK, "password-policies",
+				"edit-default-permissions-by-role",
+				LanguageUtil.get(
+					httpServletRequest, "edit-default-permissions-by-role"),
+				null, null, null),
+			new FDSActionDropdownItem(
+				StringPool.BLANK, "password-policies",
+				"edit-permissions-by-role",
+				LanguageUtil.get(
+					httpServletRequest, "edit-permissions-by-role"),
+				null, null, null),
+			new FDSActionDropdownItem(
+				StringPool.BLANK, "password-policies",
+				"reset-to-default-permissions",
+				LanguageUtil.get(
+					httpServletRequest, "reset-to-default-permissions"),
+				null, null, null));
+	}
+
+	public List<FDSActionDropdownItem> getFilesFDSActionDropdownItems(
+		HttpServletRequest httpServletRequest) {
+
+		List<FDSActionDropdownItem> fdsActionDropdownItems =
+			getFDSActionDropdownItems(httpServletRequest);
+
+		fdsActionDropdownItems.add(
+			6,
+			new FDSActionDropdownItem(
+				"{embedded.file.link.href}", "download", "download",
+				LanguageUtil.get(httpServletRequest, "download"), "get", null,
+				"link"));
+		fdsActionDropdownItems.add(
+			7,
+			new FDSActionDropdownItem(
+				StringBundler.concat(
+					"/o", GroupConstants.CMS_FRIENDLY_URL, "/download-folder/",
+					_portal.getClassNameId(ObjectEntryFolder.class),
+					"/{embedded.id}"),
+				"download", "download-folder",
+				LanguageUtil.get(httpServletRequest, "download"), "get", null,
+				"link",
+				HashMapBuilder.<String, Object>put(
+					"entryClassName", ObjectEntryFolder.class.getName()
+				).build()));
+
+		return fdsActionDropdownItems;
 	}
 
 	private JSONArray _getDepotEntriesJSONArray(

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/SectionDisplayContextHelper.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/SectionDisplayContextHelper.java
@@ -172,44 +172,10 @@ public class SectionDisplayContextHelper {
 	public List<DropdownItem> getAllSectionBulkActionDropdownItems(
 		HttpServletRequest httpServletRequest) {
 
-		return ListUtil.fromArray(
-			new FDSActionDropdownItem(
-				"#", "trash", "delete",
-				LanguageUtil.get(httpServletRequest, "delete"), null, null,
-				null),
-			FDSActionDropdownItemBuilder.setHighlighted(
-				true
-			).setHref(
-				"#"
-			).setIcon(
-				"move-folder"
-			).setLabel(
-				LanguageUtil.get(httpServletRequest, "move-to")
-			).build(
-				"move-to"
-			),
-			FDSActionDropdownItemBuilder.setHighlighted(
-				true
-			).setHref(
-				"#"
-			).setIcon(
-				"copy"
-			).setLabel(
-				LanguageUtil.get(httpServletRequest, "copy-to")
-			).build(
-				"copy-to"
-			),
-			FDSActionDropdownItemBuilder.setHighlighted(
-				true
-			).setHref(
-				"#"
-			).setIcon(
-				"time"
-			).setLabel(
-				LanguageUtil.get(httpServletRequest, "expire")
-			).build(
-				"expire"
-			),
+		List<DropdownItem> bulkActionDropdownItems =
+			_getBulkActionDropdownItems(httpServletRequest);
+
+		bulkActionDropdownItems.add(
 			FDSActionDropdownItemBuilder.setHighlighted(
 				true
 			).setHref(
@@ -220,19 +186,17 @@ public class SectionDisplayContextHelper {
 				LanguageUtil.get(httpServletRequest, "export-for-translation")
 			).build(
 				"export-for-translation"
-			),
+			));
+		bulkActionDropdownItems.add(
 			new FDSActionDropdownItem(
 				"#", "download", "download",
 				LanguageUtil.get(httpServletRequest, "download"), null, null,
-				null),
-			new FDSActionDropdownItem(
-				null, "pencil", "edit-categories",
-				LanguageUtil.get(httpServletRequest, "edit-categories"), "post",
-				"edit-categories", null),
-			new FDSActionDropdownItem(
-				null, "pencil", "edit-tags",
-				LanguageUtil.get(httpServletRequest, "edit-tags"), "post",
-				"edit-tags", null),
+				null));
+
+		_addEditCategoriesAndTagsBulkActions(
+			bulkActionDropdownItems, httpServletRequest);
+
+		bulkActionDropdownItems.add(
 			FDSActionDropdownItemBuilder.setHighlighted(
 				true
 			).setHref(
@@ -243,33 +207,11 @@ public class SectionDisplayContextHelper {
 				LanguageUtil.get(httpServletRequest, "find-and-replace")
 			).build(
 				"find-and-replace"
-			),
-			new FDSActionDropdownItem(
-				"#", "password-policies", "permissions",
-				LanguageUtil.get(httpServletRequest, "permissions"), null, null,
-				null),
-			new FDSActionDropdownItem(
-				"#", "password-policies", "default-permissions",
-				LanguageUtil.get(httpServletRequest, "default-permissions"),
-				null, null, null),
-			new FDSActionDropdownItem(
-				StringPool.BLANK, "password-policies",
-				"edit-default-permissions-by-role",
-				LanguageUtil.get(
-					httpServletRequest, "edit-default-permissions-by-role"),
-				null, null, null),
-			new FDSActionDropdownItem(
-				StringPool.BLANK, "password-policies",
-				"edit-permissions-by-role",
-				LanguageUtil.get(
-					httpServletRequest, "edit-permissions-by-role"),
-				null, null, null),
-			new FDSActionDropdownItem(
-				StringPool.BLANK, "password-policies",
-				"reset-to-default-permissions",
-				LanguageUtil.get(
-					httpServletRequest, "reset-to-default-permissions"),
-				null, null, null));
+			));
+
+		_addPermissionsBulkActions(bulkActionDropdownItems, httpServletRequest);
+
+		return bulkActionDropdownItems;
 	}
 
 	public List<FDSActionDropdownItem> getAllSectionFDSActionDropdownItems(
@@ -291,44 +233,10 @@ public class SectionDisplayContextHelper {
 	public List<DropdownItem> getContentsBulkActionDropdownItems(
 		HttpServletRequest httpServletRequest) {
 
-		return ListUtil.fromArray(
-			new FDSActionDropdownItem(
-				"#", "trash", "delete",
-				LanguageUtil.get(httpServletRequest, "delete"), null, null,
-				null),
-			FDSActionDropdownItemBuilder.setHighlighted(
-				true
-			).setHref(
-				"#"
-			).setIcon(
-				"move-folder"
-			).setLabel(
-				LanguageUtil.get(httpServletRequest, "move-to")
-			).build(
-				"move-to"
-			),
-			FDSActionDropdownItemBuilder.setHighlighted(
-				true
-			).setHref(
-				"#"
-			).setIcon(
-				"copy"
-			).setLabel(
-				LanguageUtil.get(httpServletRequest, "copy-to")
-			).build(
-				"copy-to"
-			),
-			FDSActionDropdownItemBuilder.setHighlighted(
-				true
-			).setHref(
-				"#"
-			).setIcon(
-				"time"
-			).setLabel(
-				LanguageUtil.get(httpServletRequest, "expire")
-			).build(
-				"expire"
-			),
+		List<DropdownItem> bulkActionDropdownItems =
+			_getBulkActionDropdownItems(httpServletRequest);
+
+		bulkActionDropdownItems.add(
 			FDSActionDropdownItemBuilder.setHighlighted(
 				true
 			).setHref(
@@ -339,41 +247,13 @@ public class SectionDisplayContextHelper {
 				LanguageUtil.get(httpServletRequest, "export-for-translation")
 			).build(
 				"export-for-translation"
-			),
-			new FDSActionDropdownItem(
-				null, "pencil", "edit-categories",
-				LanguageUtil.get(httpServletRequest, "edit-categories"), "post",
-				"edit-categories", null),
-			new FDSActionDropdownItem(
-				null, "pencil", "edit-tags",
-				LanguageUtil.get(httpServletRequest, "edit-tags"), "post",
-				"edit-tags", null),
-			new FDSActionDropdownItem(
-				"#", "password-policies", "permissions",
-				LanguageUtil.get(httpServletRequest, "permissions"), null, null,
-				null),
-			new FDSActionDropdownItem(
-				"#", "password-policies", "default-permissions",
-				LanguageUtil.get(httpServletRequest, "default-permissions"),
-				null, null, null),
-			new FDSActionDropdownItem(
-				StringPool.BLANK, "password-policies",
-				"edit-default-permissions-by-role",
-				LanguageUtil.get(
-					httpServletRequest, "edit-default-permissions-by-role"),
-				null, null, null),
-			new FDSActionDropdownItem(
-				StringPool.BLANK, "password-policies",
-				"edit-permissions-by-role",
-				LanguageUtil.get(
-					httpServletRequest, "edit-permissions-by-role"),
-				null, null, null),
-			new FDSActionDropdownItem(
-				StringPool.BLANK, "password-policies",
-				"reset-to-default-permissions",
-				LanguageUtil.get(
-					httpServletRequest, "reset-to-default-permissions"),
-				null, null, null));
+			));
+
+		_addEditCategoriesAndTagsBulkActions(
+			bulkActionDropdownItems, httpServletRequest);
+		_addPermissionsBulkActions(bulkActionDropdownItems, httpServletRequest);
+
+		return bulkActionDropdownItems;
 	}
 
 	public List<FDSActionDropdownItem> getContentsFDSActionDropdownItems(
@@ -642,6 +522,107 @@ public class SectionDisplayContextHelper {
 	public List<DropdownItem> getFilesBulkActionDropdownItems(
 		HttpServletRequest httpServletRequest) {
 
+		List<DropdownItem> bulkActionDropdownItems =
+			_getBulkActionDropdownItems(httpServletRequest);
+
+		bulkActionDropdownItems.add(
+			new FDSActionDropdownItem(
+				"#", "download", "download",
+				LanguageUtil.get(httpServletRequest, "download"), null, null,
+				null));
+
+		_addEditCategoriesAndTagsBulkActions(
+			bulkActionDropdownItems, httpServletRequest);
+		_addPermissionsBulkActions(bulkActionDropdownItems, httpServletRequest);
+
+		return bulkActionDropdownItems;
+	}
+
+	public List<FDSActionDropdownItem> getFilesFDSActionDropdownItems(
+		HttpServletRequest httpServletRequest) {
+
+		List<FDSActionDropdownItem> fdsActionDropdownItems =
+			getFDSActionDropdownItems(httpServletRequest);
+
+		fdsActionDropdownItems.add(
+			6,
+			new FDSActionDropdownItem(
+				"{embedded.file.link.href}", "download", "download",
+				LanguageUtil.get(httpServletRequest, "download"), "get", null,
+				"link"));
+		fdsActionDropdownItems.add(
+			7,
+			new FDSActionDropdownItem(
+				StringBundler.concat(
+					"/o", GroupConstants.CMS_FRIENDLY_URL, "/download-folder/",
+					_portal.getClassNameId(ObjectEntryFolder.class),
+					"/{embedded.id}"),
+				"download", "download-folder",
+				LanguageUtil.get(httpServletRequest, "download"), "get", null,
+				"link",
+				HashMapBuilder.<String, Object>put(
+					"entryClassName", ObjectEntryFolder.class.getName()
+				).build()));
+
+		return fdsActionDropdownItems;
+	}
+
+	private void _addEditCategoriesAndTagsBulkActions(
+		List<DropdownItem> bulkActionDropdownItems,
+		HttpServletRequest httpServletRequest) {
+
+		bulkActionDropdownItems.add(
+			new FDSActionDropdownItem(
+				null, "pencil", "edit-categories",
+				LanguageUtil.get(httpServletRequest, "edit-categories"), "post",
+				"edit-categories", null));
+		bulkActionDropdownItems.add(
+			new FDSActionDropdownItem(
+				null, "pencil", "edit-tags",
+				LanguageUtil.get(httpServletRequest, "edit-tags"), "post",
+				"edit-tags", null));
+	}
+
+	private void _addPermissionsBulkActions(
+		List<DropdownItem> bulkActionDropdownItems,
+		HttpServletRequest httpServletRequest) {
+
+		bulkActionDropdownItems.add(
+			new FDSActionDropdownItem(
+				"#", "password-policies", "permissions",
+				LanguageUtil.get(httpServletRequest, "permissions"), null, null,
+				null));
+		bulkActionDropdownItems.add(
+			new FDSActionDropdownItem(
+				"#", "password-policies", "default-permissions",
+				LanguageUtil.get(httpServletRequest, "default-permissions"),
+				null, null, null));
+		bulkActionDropdownItems.add(
+			new FDSActionDropdownItem(
+				StringPool.BLANK, "password-policies",
+				"edit-default-permissions-by-role",
+				LanguageUtil.get(
+					httpServletRequest, "edit-default-permissions-by-role"),
+				null, null, null));
+		bulkActionDropdownItems.add(
+			new FDSActionDropdownItem(
+				StringPool.BLANK, "password-policies",
+				"edit-permissions-by-role",
+				LanguageUtil.get(
+					httpServletRequest, "edit-permissions-by-role"),
+				null, null, null));
+		bulkActionDropdownItems.add(
+			new FDSActionDropdownItem(
+				StringPool.BLANK, "password-policies",
+				"reset-to-default-permissions",
+				LanguageUtil.get(
+					httpServletRequest, "reset-to-default-permissions"),
+				null, null, null));
+	}
+
+	private List<DropdownItem> _getBulkActionDropdownItems(
+		HttpServletRequest httpServletRequest) {
+
 		return ListUtil.fromArray(
 			new FDSActionDropdownItem(
 				"#", "trash", "delete",
@@ -679,74 +660,7 @@ public class SectionDisplayContextHelper {
 				LanguageUtil.get(httpServletRequest, "expire")
 			).build(
 				"expire"
-			),
-			new FDSActionDropdownItem(
-				"#", "download", "download",
-				LanguageUtil.get(httpServletRequest, "download"), null, null,
-				null),
-			new FDSActionDropdownItem(
-				null, "pencil", "edit-categories",
-				LanguageUtil.get(httpServletRequest, "edit-categories"), "post",
-				"edit-categories", null),
-			new FDSActionDropdownItem(
-				null, "pencil", "edit-tags",
-				LanguageUtil.get(httpServletRequest, "edit-tags"), "post",
-				"edit-tags", null),
-			new FDSActionDropdownItem(
-				"#", "password-policies", "permissions",
-				LanguageUtil.get(httpServletRequest, "permissions"), null, null,
-				null),
-			new FDSActionDropdownItem(
-				"#", "password-policies", "default-permissions",
-				LanguageUtil.get(httpServletRequest, "default-permissions"),
-				null, null, null),
-			new FDSActionDropdownItem(
-				StringPool.BLANK, "password-policies",
-				"edit-default-permissions-by-role",
-				LanguageUtil.get(
-					httpServletRequest, "edit-default-permissions-by-role"),
-				null, null, null),
-			new FDSActionDropdownItem(
-				StringPool.BLANK, "password-policies",
-				"edit-permissions-by-role",
-				LanguageUtil.get(
-					httpServletRequest, "edit-permissions-by-role"),
-				null, null, null),
-			new FDSActionDropdownItem(
-				StringPool.BLANK, "password-policies",
-				"reset-to-default-permissions",
-				LanguageUtil.get(
-					httpServletRequest, "reset-to-default-permissions"),
-				null, null, null));
-	}
-
-	public List<FDSActionDropdownItem> getFilesFDSActionDropdownItems(
-		HttpServletRequest httpServletRequest) {
-
-		List<FDSActionDropdownItem> fdsActionDropdownItems =
-			getFDSActionDropdownItems(httpServletRequest);
-
-		fdsActionDropdownItems.add(
-			6,
-			new FDSActionDropdownItem(
-				"{embedded.file.link.href}", "download", "download",
-				LanguageUtil.get(httpServletRequest, "download"), "get", null,
-				"link"));
-		fdsActionDropdownItems.add(
-			7,
-			new FDSActionDropdownItem(
-				StringBundler.concat(
-					"/o", GroupConstants.CMS_FRIENDLY_URL, "/download-folder/",
-					_portal.getClassNameId(ObjectEntryFolder.class),
-					"/{embedded.id}"),
-				"download", "download-folder",
-				LanguageUtil.get(httpServletRequest, "download"), "get", null,
-				"link",
-				HashMapBuilder.<String, Object>put(
-					"entryClassName", ObjectEntryFolder.class.getName()
-				).build()));
-
-		return fdsActionDropdownItems;
+			));
 	}
 
 	private JSONArray _getDepotEntriesJSONArray(

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewAllSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewAllSectionDisplayContext.java
@@ -11,13 +11,11 @@ import com.liferay.frontend.data.set.SystemFDSEntry;
 import com.liferay.frontend.data.set.action.FDSCreationMenu;
 import com.liferay.frontend.data.set.action.FDSItemsActions;
 import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
-import com.liferay.frontend.data.set.model.FDSActionDropdownItemBuilder;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
 import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectDefinitionService;
 import com.liferay.object.service.ObjectDefinitionSettingLocalService;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.language.LanguageUtil;
@@ -91,112 +89,8 @@ public class ViewAllSectionDisplayContext extends BaseSectionDisplayContext {
 
 	@Override
 	public List<DropdownItem> getBulkActionDropdownItems() {
-		List<DropdownItem> fdsBulkActionDropdownItems =
-			super.getBulkActionDropdownItems();
-
-		fdsBulkActionDropdownItems.add(
-			FDSActionDropdownItemBuilder.setHighlighted(
-				true
-			).setHref(
-				"#"
-			).setIcon(
-				"move-folder"
-			).setLabel(
-				LanguageUtil.get(httpServletRequest, "move-to")
-			).build(
-				"move-to"
-			));
-		fdsBulkActionDropdownItems.add(
-			FDSActionDropdownItemBuilder.setHighlighted(
-				true
-			).setHref(
-				"#"
-			).setIcon(
-				"copy"
-			).setLabel(
-				LanguageUtil.get(httpServletRequest, "copy-to")
-			).build(
-				"copy-to"
-			));
-		fdsBulkActionDropdownItems.add(
-			FDSActionDropdownItemBuilder.setHighlighted(
-				true
-			).setHref(
-				"#"
-			).setIcon(
-				"time"
-			).setLabel(
-				LanguageUtil.get(httpServletRequest, "expire")
-			).build(
-				"expire"
-			));
-		fdsBulkActionDropdownItems.add(
-			FDSActionDropdownItemBuilder.setHighlighted(
-				true
-			).setHref(
-				"#"
-			).setIcon(
-				"upload"
-			).setLabel(
-				LanguageUtil.get(httpServletRequest, "export-for-translation")
-			).build(
-				"export-for-translation"
-			));
-		fdsBulkActionDropdownItems.add(
-			new FDSActionDropdownItem(
-				StringPool.BLANK, "download", "download",
-				LanguageUtil.get(httpServletRequest, "download"), null, null,
-				null));
-		fdsBulkActionDropdownItems.add(
-			new FDSActionDropdownItem(
-				null, "pencil", "edit-categories",
-				LanguageUtil.get(httpServletRequest, "edit-categories"), "post",
-				"edit-categories", null));
-		fdsBulkActionDropdownItems.add(
-			new FDSActionDropdownItem(
-				null, "pencil", "edit-tags",
-				LanguageUtil.get(httpServletRequest, "edit-tags"), "post",
-				"edit-tags", null));
-		fdsBulkActionDropdownItems.add(
-			FDSActionDropdownItemBuilder.setHighlighted(
-				true
-			).setHref(
-				"#"
-			).setIcon(
-				"semantic-search"
-			).setLabel(
-				LanguageUtil.get(httpServletRequest, "find-and-replace")
-			).build(
-				"find-and-replace"
-			));
-		fdsBulkActionDropdownItems.add(
-			new FDSActionDropdownItem(
-				StringPool.BLANK, "password-policies", "permissions",
-				LanguageUtil.get(httpServletRequest, "permissions"), null, null,
-				null));
-		fdsBulkActionDropdownItems.add(
-			new FDSActionDropdownItem(
-				StringPool.BLANK, "password-policies",
-				"edit-default-permissions-by-role",
-				LanguageUtil.get(
-					httpServletRequest, "edit-default-permissions-by-role"),
-				null, null, null));
-		fdsBulkActionDropdownItems.add(
-			new FDSActionDropdownItem(
-				StringPool.BLANK, "password-policies",
-				"edit-permissions-by-role",
-				LanguageUtil.get(
-					httpServletRequest, "edit-permissions-by-role"),
-				null, null, null));
-		fdsBulkActionDropdownItems.add(
-			new FDSActionDropdownItem(
-				StringPool.BLANK, "password-policies",
-				"reset-to-default-permissions",
-				LanguageUtil.get(
-					httpServletRequest, "reset-to-default-permissions"),
-				null, null, null));
-
-		return fdsBulkActionDropdownItems;
+		return sectionDisplayContextHelper.getAllSectionBulkActionDropdownItems(
+			httpServletRequest);
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewContentsSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewContentsSectionDisplayContext.java
@@ -6,14 +6,11 @@
 package com.liferay.site.cms.site.initializer.internal.display.context;
 
 import com.liferay.depot.service.DepotEntryLocalService;
-import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
 import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectDefinitionService;
 import com.liferay.object.service.ObjectDefinitionSettingLocalService;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
-import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
@@ -24,7 +21,6 @@ import com.liferay.translation.exporter.TranslationInfoItemFieldValuesExporterRe
 
 import jakarta.servlet.http.HttpServletRequest;
 
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -82,21 +78,6 @@ public class ViewContentsSectionDisplayContext
 		).put(
 			"title", language.get(httpServletRequest, "no-content-yet")
 		).build();
-	}
-
-	@Override
-	public List<FDSActionDropdownItem> getFDSActionDropdownItems() {
-		List<FDSActionDropdownItem> fdsActionDropdownItems =
-			super.getFDSActionDropdownItems();
-
-		fdsActionDropdownItems.add(
-			7,
-			new FDSActionDropdownItem(
-				StringPool.BLANK, "info-circle-open", "show-details",
-				LanguageUtil.get(httpServletRequest, "show-details"), null,
-				null, "infoPanel"));
-
-		return fdsActionDropdownItems;
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewFilesSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewFilesSectionDisplayContext.java
@@ -7,11 +7,9 @@ package com.liferay.site.cms.site.initializer.internal.display.context;
 
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.document.library.configuration.DLConfiguration;
-import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
 import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectDefinitionService;
 import com.liferay.object.service.ObjectDefinitionSettingLocalService;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.language.LanguageUtil;
@@ -25,7 +23,6 @@ import com.liferay.translation.exporter.TranslationInfoItemFieldValuesExporterRe
 
 import jakarta.servlet.http.HttpServletRequest;
 
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -85,21 +82,6 @@ public class ViewFilesSectionDisplayContext
 		).put(
 			"title", LanguageUtil.get(httpServletRequest, "no-files-yet")
 		).build();
-	}
-
-	@Override
-	public List<FDSActionDropdownItem> getFDSActionDropdownItems() {
-		List<FDSActionDropdownItem> fdsActionDropdownItems =
-			super.getFDSActionDropdownItems();
-
-		fdsActionDropdownItems.add(
-			9,
-			new FDSActionDropdownItem(
-				StringPool.BLANK, "info-circle-open", "show-details",
-				LanguageUtil.get(httpServletRequest, "show-details"), null,
-				null, "infoPanel"));
-
-		return fdsActionDropdownItems;
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewFolderSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewFolderSectionDisplayContext.java
@@ -8,7 +8,6 @@ package com.liferay.site.cms.site.initializer.internal.display.context;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.document.library.configuration.DLConfiguration;
 import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
-import com.liferay.frontend.data.set.model.FDSActionDropdownItemBuilder;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.constants.ObjectFolderConstants;
@@ -17,14 +16,11 @@ import com.liferay.object.service.ObjectDefinitionService;
 import com.liferay.object.service.ObjectDefinitionSettingLocalService;
 import com.liferay.object.service.ObjectEntryFolderLocalService;
 import com.liferay.petra.string.CharPool;
-import com.liferay.petra.string.StringBundler;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -68,7 +64,6 @@ public class ViewFolderSectionDisplayContext extends BaseSectionDisplayContext {
 			objectEntryFolderModelResourcePermission, portal,
 			translationInfoItemFieldValuesExporterRegistry);
 
-		_httpServletRequest = httpServletRequest;
 		_objectEntryFolderLocalService = objectEntryFolderLocalService;
 	}
 
@@ -153,100 +148,13 @@ public class ViewFolderSectionDisplayContext extends BaseSectionDisplayContext {
 
 	@Override
 	public List<DropdownItem> getBulkActionDropdownItems() {
-		List<DropdownItem> fdsBulkActionDropdownItems =
-			super.getBulkActionDropdownItems();
+		if (_isContentsFolder()) {
+			return sectionDisplayContextHelper.
+				getContentsBulkActionDropdownItems(httpServletRequest);
+		}
 
-		fdsBulkActionDropdownItems.add(
-			FDSActionDropdownItemBuilder.setHighlighted(
-				true
-			).setHref(
-				"#"
-			).setIcon(
-				"move-folder"
-			).setLabel(
-				LanguageUtil.get(httpServletRequest, "move-to")
-			).build(
-				"move-to"
-			));
-		fdsBulkActionDropdownItems.add(
-			FDSActionDropdownItemBuilder.setHighlighted(
-				true
-			).setHref(
-				"#"
-			).setIcon(
-				"copy"
-			).setLabel(
-				LanguageUtil.get(httpServletRequest, "copy-to")
-			).build(
-				"copy-to"
-			));
-		fdsBulkActionDropdownItems.add(
-			FDSActionDropdownItemBuilder.setHighlighted(
-				true
-			).setHref(
-				"#"
-			).setIcon(
-				"upload"
-			).setLabel(
-				LanguageUtil.get(httpServletRequest, "export-for-translation")
-			).build(
-				"export-for-translation"
-			));
-		fdsBulkActionDropdownItems.add(
-			new FDSActionDropdownItem(
-				"#", "password-policies", "permissions",
-				LanguageUtil.get(httpServletRequest, "permissions"), null, null,
-				null));
-		fdsBulkActionDropdownItems.add(
-			new FDSActionDropdownItem(
-				"#", "password-policies", "default-permissions",
-				LanguageUtil.get(httpServletRequest, "default-permissions"),
-				null, null, null));
-		fdsBulkActionDropdownItems.add(
-			new FDSActionDropdownItem(
-				null, "pencil", "edit-categories",
-				LanguageUtil.get(httpServletRequest, "edit-categories"), "post",
-				"edit-categories", null));
-		fdsBulkActionDropdownItems.add(
-			new FDSActionDropdownItem(
-				null, "pencil", "edit-tags",
-				LanguageUtil.get(httpServletRequest, "edit-tags"), "post",
-				"edit-tags", null));
-		fdsBulkActionDropdownItems.add(
-			FDSActionDropdownItemBuilder.setHighlighted(
-				true
-			).setHref(
-				"#"
-			).setIcon(
-				"time"
-			).setLabel(
-				LanguageUtil.get(_httpServletRequest, "expire")
-			).build(
-				"expire"
-			));
-		fdsBulkActionDropdownItems.add(
-			new FDSActionDropdownItem(
-				StringPool.BLANK, "password-policies",
-				"edit-default-permissions-by-role",
-				LanguageUtil.get(
-					httpServletRequest, "edit-default-permissions-by-role"),
-				null, null, null));
-		fdsBulkActionDropdownItems.add(
-			new FDSActionDropdownItem(
-				StringPool.BLANK, "password-policies",
-				"edit-permissions-by-role",
-				LanguageUtil.get(
-					httpServletRequest, "edit-permissions-by-role"),
-				null, null, null));
-		fdsBulkActionDropdownItems.add(
-			new FDSActionDropdownItem(
-				StringPool.BLANK, "password-policies",
-				"reset-to-default-permissions",
-				LanguageUtil.get(
-					httpServletRequest, "reset-to-default-permissions"),
-				null, null, null));
-
-		return fdsBulkActionDropdownItems;
+		return sectionDisplayContextHelper.getFilesBulkActionDropdownItems(
+			httpServletRequest);
 	}
 
 	public String getCMSSiteInitializerFDSName() {
@@ -311,44 +219,13 @@ public class ViewFolderSectionDisplayContext extends BaseSectionDisplayContext {
 
 	@Override
 	public List<FDSActionDropdownItem> getFDSActionDropdownItems() {
-		List<FDSActionDropdownItem> fdsActionDropdownItems =
-			super.getFDSActionDropdownItems();
-
-		fdsActionDropdownItems.add(
-			6,
-			new FDSActionDropdownItem(
-				"{embedded.file.link.href}", "download", "download",
-				LanguageUtil.get(httpServletRequest, "download"), "get", null,
-				"link"));
-
-		if (!Objects.equals(
-				getRootObjectEntryFolderExternalReferenceCode(),
-				ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS)) {
-
-			fdsActionDropdownItems.add(
-				7,
-				new FDSActionDropdownItem(
-					StringBundler.concat(
-						"/o", GroupConstants.CMS_FRIENDLY_URL,
-						"/download-folder/",
-						portal.getClassNameId(ObjectEntryFolder.class),
-						"/{embedded.id}"),
-					"download", "download-folder",
-					LanguageUtil.get(httpServletRequest, "download"), "get",
-					null, "link",
-					HashMapBuilder.<String, Object>put(
-						"entryClassName", ObjectEntryFolder.class.getName()
-					).build()));
+		if (_isContentsFolder()) {
+			return sectionDisplayContextHelper.
+				getContentsFDSActionDropdownItems(httpServletRequest);
 		}
 
-		fdsActionDropdownItems.add(
-			9,
-			new FDSActionDropdownItem(
-				StringPool.BLANK, "info-circle-open", "show-details",
-				LanguageUtil.get(httpServletRequest, "show-details"), null,
-				null, "infoPanel"));
-
-		return fdsActionDropdownItems;
+		return sectionDisplayContextHelper.getFilesFDSActionDropdownItems(
+			httpServletRequest);
 	}
 
 	@Override
@@ -440,7 +317,12 @@ public class ViewFolderSectionDisplayContext extends BaseSectionDisplayContext {
 		return true;
 	}
 
-	private final HttpServletRequest _httpServletRequest;
+	private boolean _isContentsFolder() {
+		return Objects.equals(
+			getRootObjectEntryFolderExternalReferenceCode(),
+			ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS);
+	}
+
 	private final ObjectEntryFolderLocalService _objectEntryFolderLocalService;
 	private String _objectFolderExternalReferenceCode;
 	private String _rootObjectEntryFolderExternalReferenceCode;

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewRelatedAssetsSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewRelatedAssetsSectionDisplayContext.java
@@ -66,11 +66,6 @@ public class ViewRelatedAssetsSectionDisplayContext
 		Set<String> tagNames = getTagNames(objectDefinition, objectEntry);
 
 		_keywords = tagNames.toArray(new String[0]);
-
-		_sectionDisplayContextHelper = new SectionDisplayContextHelper(
-			depotEntryLocalService, groupLocalService, language,
-			objectDefinitionSettingLocalService,
-			objectEntryFolderModelResourcePermission, portal);
 	}
 
 	@Override
@@ -107,7 +102,7 @@ public class ViewRelatedAssetsSectionDisplayContext
 				"searchAPIURL",
 				() -> {
 					String additionalAPIURLParameters =
-						_sectionDisplayContextHelper.
+						sectionDisplayContextHelper.
 							getAdditionalAPIURLParameters(
 								appendStatus(
 									StringBundler.concat(
@@ -160,6 +155,5 @@ public class ViewRelatedAssetsSectionDisplayContext
 	}
 
 	private final String[] _keywords;
-	private final SectionDisplayContextHelper _sectionDisplayContextHelper;
 
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/action/ViewAllSectionFDSItemsActions.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/action/ViewAllSectionFDSItemsActions.java
@@ -10,9 +10,7 @@ import com.liferay.frontend.data.set.action.FDSItemsActions;
 import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
 import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectDefinitionSettingLocalService;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.Language;
-import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.Portal;
@@ -41,24 +39,8 @@ public class ViewAllSectionFDSItemsActions implements FDSItemsActions {
 	public List<FDSActionDropdownItem> getFDSActionDropdownItems(
 		HttpServletRequest httpServletRequest) {
 
-		List<FDSActionDropdownItem> fdsActionDropdownItems =
-			_sectionDisplayContextHelper.getFDSActionDropdownItems(
-				httpServletRequest);
-
-		fdsActionDropdownItems.add(
-			6,
-			new FDSActionDropdownItem(
-				"{embedded.file.link.href}", "download", "download",
-				LanguageUtil.get(httpServletRequest, "download"), "get", null,
-				"link"));
-		fdsActionDropdownItems.add(
-			8,
-			new FDSActionDropdownItem(
-				StringPool.BLANK, "info-circle-open", "show-details",
-				LanguageUtil.get(httpServletRequest, "show-details"), null,
-				null, "infoPanel"));
-
-		return fdsActionDropdownItems;
+		return _sectionDisplayContextHelper.getAllSectionFDSActionDropdownItems(
+			httpServletRequest);
 	}
 
 	@Activate

--- a/modules/apps/site/site-cms-site-initializer/test/js/content_editor/components/ContentEditorToolbar.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/content_editor/components/ContentEditorToolbar.test.tsx
@@ -82,6 +82,9 @@ describe('ContentEditorToolbar', () => {
 					return key;
 				}),
 			},
+			ThemeDisplay: {
+				getDefaultLanguageId: jest.fn(() => 'en_US'),
+			},
 			Util: {
 				sub: jest.fn((key, ...args) => {
 					let result = key;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88211

# What is being fixed

The Files, Contents, All, and Folder display contexts in `site-cms-site-initializer` built their FDS dropdown and bulk action lists inline, with drift: ViewFolder always emitted the content-only `export-for-translation` and never `download`, ViewAll was missing `default-permissions`, permissions sub-actions ordered differently in every section, `show-details` inserted at a drifting index, and items created inconsistently with both the constructor and the builder.

# How it is being fixed

Per-section action lists are centralized in `SectionDisplayContextHelper`; every consumer delegates to it. `show-details` is baked into the canonical list, ViewFolder dispatches on the root folder ERC, shared head and permissions blocks are extracted into private helpers, and remaining constructor calls are converted to `FDSActionDropdownItemBuilder`.

# Why it doesn't include any tests

Only presence of actions changed. Tests for each individual action still passing.