### PR TITLE
LPD-83152 Show Space breadcrumb in the copy/move modal when the user only has access to one space

### DIFF
--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/ItemSelectorModal.tsx
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/ItemSelectorModal.tsx
@@ -52,6 +52,13 @@ export type FilesUploaderComponent = React.ComponentType<{
 }>;
 
 export interface IItemSelectorModalProps<T> {
+
+	/**
+	 * When true, the Select button remains enabled even when no items are
+	 * selected. Clicking it calls onItemsChange with an empty array.
+	 */
+	allowEmptySelection?: boolean;
+
 	allowedExtensions?: string;
 
 	/**
@@ -73,6 +80,12 @@ export interface IItemSelectorModalProps<T> {
 	 * URL for item creation used to open a new tab.
 	 */
 	createItemURL?: string;
+
+	/**
+	 * Label shown in the footer as "{label} Selected" when
+	 * 'allowEmptySelection' is true and no items are selected.
+	 */
+	emptySelectionLabel?: string;
 
 	/**
 	 * Configuration properties of the Frontend Data Set used to display data.
@@ -157,11 +170,13 @@ const EMPTY_STATE_PROPS = {
 };
 
 function ItemSelectorModal<T extends Record<string, any>>({
+	allowEmptySelection = false,
 	allowedExtensions,
 	apiURL,
 	breadcrumbs,
 	breadcrumbsLabel = true,
 	createItemURL,
+	emptySelectionLabel,
 	fdsProps,
 	filesUploaderComponent: FilesUploaderComponent,
 	groupId,
@@ -200,6 +215,8 @@ function ItemSelectorModal<T extends Record<string, any>>({
 	};
 
 	const hasSelectedItems = !!selectedItems.length;
+
+	const isSelectEnabled = hasSelectedItems || allowEmptySelection;
 
 	const fileDropSettings = useMemo<IFileDropSettings>(() => {
 		return {
@@ -329,7 +346,7 @@ function ItemSelectorModal<T extends Record<string, any>>({
 				<ClayModal.Footer
 					className={classNames({
 						'bg-primary-l3 border-primary border-top':
-							hasSelectedItems,
+							isSelectEnabled,
 					})}
 					first={
 						hasSelectedItems ? (
@@ -360,6 +377,13 @@ function ItemSelectorModal<T extends Record<string, any>>({
 									</strong>
 								</ClayButton>
 							</div>
+						) : allowEmptySelection && emptySelectionLabel ? (
+							<div className="align-items-center d-flex">
+								{sub(
+									Liferay.Language.get('x-selected'),
+									emptySelectionLabel
+								)}
+							</div>
 						) : undefined
 					}
 					last={
@@ -378,7 +402,7 @@ function ItemSelectorModal<T extends Record<string, any>>({
 
 							<ClayButton
 								className="item-preview selector-button"
-								disabled={!hasSelectedItems}
+								disabled={!isSelectEnabled}
 								onClick={() => {
 									onItemsChange(
 										multiSelect

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/css/main.scss
@@ -5,6 +5,10 @@
 		.col-md-3:has(.hidden-item-selector-item) {
 			display: none;
 		}
+
+		tr.hidden-item-selector-item {
+			display: none;
+		}
 	}
 }
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/services/ApiHelper.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/services/ApiHelper.ts
@@ -106,11 +106,12 @@ async function handleRequest<T>(
 	}
 }
 
-async function get<T>(url: string) {
+async function get<T>(url: string, signal?: AbortSignal) {
 	return handleRequest<T>(() =>
 		fetch(url, {
 			headers: HEADERS_ALL_LANGUAGES,
 			method: 'GET',
+			signal,
 		})
 	);
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/services/ApiHelper.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/services/ApiHelper.ts
@@ -98,6 +98,14 @@ async function handleRequest<T>(
 		};
 	}
 	catch (error) {
+		if ((error as Error).name === 'AbortError') {
+			return {
+				data: null,
+				error: null as any,
+				status: 'aborted',
+			};
+		}
+
 		return {
 			data: null,
 			error: (error as Error).message || UNEXPECTED_ERROR_MESSAGE,

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/modal/FolderItemSelectorModalContent.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/modal/FolderItemSelectorModalContent.tsx
@@ -316,12 +316,11 @@ function FolderItemSelectorModalContent({
 	const [schemaKey, setSchemaKey] = useState(0);
 	const [currentSpace, setCurrentSpace] = useState<Space | undefined>();
 	const [folderStructure, setFolderStructure] = useState<FolderNode[]>([]);
-	const [hasRootFolder, setHasRootFolder] = useState(false);
+	const [rootFolder, setRootFolder] = useState<Folder | null>(null);
 
 	const {observer, onOpenChange, open} = useModal();
 
 	const abortControllerRef = useRef<AbortController | null>(null);
-	const rootFolderRef = useRef<Folder | null>(null);
 
 	const excludedERCs = useMemo(() => {
 		const rootExcluded = rootObjectEntryFolderExternalReferenceCode
@@ -363,11 +362,10 @@ function FolderItemSelectorModalContent({
 			const controller = new AbortController();
 			abortControllerRef.current = controller;
 
-			rootFolderRef.current = null;
+			setRootFolder(null);
 			setCurrentSpace(space);
 			setFolderStructure([]);
 			setSelectedItemType(ITEM_SELECTOR_ITEM_TYPE.FOLDER);
-			setHasRootFolder(!!rootObjectEntryFolderExternalReferenceCode);
 			setURL(getSpaceFoldersURL(cmsSection, space.scopeId));
 			setSchemaKey((prev) => prev + 1);
 
@@ -384,14 +382,11 @@ function FolderItemSelectorModalContent({
 				if (data?.items?.length) {
 					const folder = data.items[0];
 
-					rootFolderRef.current = {
+					setRootFolder({
 						id: folder.embedded.id,
 						scopeId: String(space.scopeId),
 						title: space.name,
-					};
-				}
-				else {
-					setHasRootFolder(false);
+					});
 				}
 			}
 		},
@@ -460,14 +455,6 @@ function FolderItemSelectorModalContent({
 			const folderItem = item as ISearchAssetObjectEntry;
 			const erc = folderItem.embedded?.externalReferenceCode;
 
-			if (erc === rootObjectEntryFolderExternalReferenceCode) {
-				rootFolderRef.current = {
-					id: item.embedded.id,
-					scopeId: String(item.embedded.scopeId),
-					title: currentSpace?.name || item.title,
-				};
-			}
-
 			if (erc && excludedERCs.includes(erc)) {
 				return {
 					...props,
@@ -523,11 +510,9 @@ function FolderItemSelectorModalContent({
 		},
 		[
 			assetLibraries,
-			currentSpace,
 			excludedERCs,
 			handleChildFolderClick,
 			handleSpaceClick,
-			rootObjectEntryFolderExternalReferenceCode,
 			selectedItemType,
 		]
 	);
@@ -735,7 +720,7 @@ function FolderItemSelectorModalContent({
 				<ItemSelectorModal<Folder>
 					allowEmptySelection={
 						selectedItemType === ITEM_SELECTOR_ITEM_TYPE.FOLDER &&
-						hasRootFolder
+						!!rootFolder
 					}
 					apiURL={url}
 					breadcrumbs={[
@@ -912,11 +897,11 @@ function FolderItemSelectorModalContent({
 						else if (
 							selectedItemType ===
 								ITEM_SELECTOR_ITEM_TYPE.FOLDER &&
-							rootFolderRef.current
+							rootFolder
 						) {
 							handleOnItemsChange(
-								rootFolderRef.current,
-								rootFolderRef.current.title
+								rootFolder,
+								rootFolder.title
 							);
 						}
 					}}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/modal/FolderItemSelectorModalContent.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/modal/FolderItemSelectorModalContent.tsx
@@ -899,10 +899,7 @@ function FolderItemSelectorModalContent({
 								ITEM_SELECTOR_ITEM_TYPE.FOLDER &&
 							rootFolder
 						) {
-							handleOnItemsChange(
-								rootFolder,
-								rootFolder.title
-							);
+							handleOnItemsChange(rootFolder, rootFolder.title);
 						}
 					}}
 					onOpenChange={onOpenChange}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/modal/FolderItemSelectorModalContent.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/modal/FolderItemSelectorModalContent.tsx
@@ -10,7 +10,7 @@ import {IFrontendDataSetProps, IView} from '@liferay/frontend-data-set-web';
 import {ItemSelectorModal} from '@liferay/frontend-js-item-selector-web';
 import {openToast} from 'frontend-js-components-web';
 import {sub} from 'frontend-js-web';
-import React, {useCallback, useEffect, useMemo, useState} from 'react';
+import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 
 import ApiHelper, {RequestResult} from '../../common/services/ApiHelper';
 import FolderService from '../../common/services/FolderService';
@@ -316,38 +316,86 @@ function FolderItemSelectorModalContent({
 	const [schemaKey, setSchemaKey] = useState(0);
 	const [currentSpace, setCurrentSpace] = useState<Space | undefined>();
 	const [folderStructure, setFolderStructure] = useState<FolderNode[]>([]);
+	const [hasRootFolder, setHasRootFolder] = useState(false);
 
 	const {observer, onOpenChange, open} = useModal();
 
+	const abortControllerRef = useRef<AbortController | null>(null);
+	const rootFolderRef = useRef<Folder | null>(null);
+
 	const excludedERCs = useMemo(() => {
+		const rootExcluded = rootObjectEntryFolderExternalReferenceCode
+			? [rootObjectEntryFolderExternalReferenceCode]
+			: [];
+
 		if (isBulk && selectedData?.items) {
-			return selectedData.items
-				.filter(
-					(item: any) =>
-						item.entryClassName === OBJECT_ENTRY_FOLDER_CLASS_NAME
-				)
-				.map((item: any) => item.embedded.externalReferenceCode);
+			return [
+				...rootExcluded,
+				...selectedData.items
+					.filter(
+						(item: any) =>
+							item.entryClassName ===
+							OBJECT_ENTRY_FOLDER_CLASS_NAME
+					)
+					.map((item: any) => item.embedded.externalReferenceCode),
+			];
 		}
 
 		if (
 			itemData?.entryClassName === OBJECT_ENTRY_FOLDER_CLASS_NAME &&
 			itemData.embedded?.externalReferenceCode
 		) {
-			return [itemData.embedded.externalReferenceCode];
+			return [...rootExcluded, itemData.embedded.externalReferenceCode];
 		}
 
-		return [];
-	}, [isBulk, itemData, selectedData]);
+		return rootExcluded;
+	}, [
+		isBulk,
+		itemData,
+		rootObjectEntryFolderExternalReferenceCode,
+		selectedData,
+	]);
 
 	const handleSpaceClick = useCallback(
-		(space: Space) => {
+		async (space: Space) => {
+			abortControllerRef.current?.abort();
+
+			const controller = new AbortController();
+			abortControllerRef.current = controller;
+
+			rootFolderRef.current = null;
 			setCurrentSpace(space);
 			setFolderStructure([]);
-			setSchemaKey((prev) => prev + 1);
 			setSelectedItemType(ITEM_SELECTOR_ITEM_TYPE.FOLDER);
+			setHasRootFolder(!!rootObjectEntryFolderExternalReferenceCode);
 			setURL(getSpaceFoldersURL(cmsSection, space.scopeId));
+			setSchemaKey((prev) => prev + 1);
+
+			if (rootObjectEntryFolderExternalReferenceCode) {
+				const {data} = await ApiHelper.get<any>(
+					`/o/search/v1.0/search?emptySearch=true&entryClassNames=${OBJECT_ENTRY_FOLDER_CLASS_NAME}&filter=cmsRoot eq true and cmsSection eq '${cmsSection}' and status in (0, 2, 3)&nestedFields=embedded&scope=${space.scopeId}&pageSize=1`,
+					controller.signal
+				);
+
+				if (controller.signal.aborted) {
+					return;
+				}
+
+				if (data?.items?.length) {
+					const folder = data.items[0];
+
+					rootFolderRef.current = {
+						id: folder.embedded.id,
+						scopeId: String(space.scopeId),
+						title: space.name,
+					};
+				}
+				else {
+					setHasRootFolder(false);
+				}
+			}
 		},
-		[cmsSection]
+		[cmsSection, rootObjectEntryFolderExternalReferenceCode]
 	);
 
 	const navigateToFolders = useCallback(
@@ -412,6 +460,14 @@ function FolderItemSelectorModalContent({
 			const folderItem = item as ISearchAssetObjectEntry;
 			const erc = folderItem.embedded?.externalReferenceCode;
 
+			if (erc === rootObjectEntryFolderExternalReferenceCode) {
+				rootFolderRef.current = {
+					id: item.embedded.id,
+					scopeId: String(item.embedded.scopeId),
+					title: currentSpace?.name || item.title,
+				};
+			}
+
 			if (erc && excludedERCs.includes(erc)) {
 				return {
 					...props,
@@ -467,9 +523,11 @@ function FolderItemSelectorModalContent({
 		},
 		[
 			assetLibraries,
+			currentSpace,
 			excludedERCs,
 			handleChildFolderClick,
 			handleSpaceClick,
+			rootObjectEntryFolderExternalReferenceCode,
 			selectedItemType,
 		]
 	);
@@ -665,10 +723,20 @@ function FolderItemSelectorModalContent({
 		onOpenChange(true);
 	}, [onOpenChange]);
 
+	useEffect(() => {
+		return () => {
+			abortControllerRef.current?.abort();
+		};
+	}, []);
+
 	return (
 		<>
 			{open && (
 				<ItemSelectorModal<Folder>
+					allowEmptySelection={
+						selectedItemType === ITEM_SELECTOR_ITEM_TYPE.FOLDER &&
+						hasRootFolder
+					}
 					apiURL={url}
 					breadcrumbs={[
 						{
@@ -711,6 +779,7 @@ function FolderItemSelectorModalContent({
 						})),
 					]}
 					breadcrumbsLabel={false}
+					emptySelectionLabel={currentSpace?.name}
 					fdsProps={{
 						...FDS_DEFAULT_PROPS,
 						customRenderers,
@@ -719,6 +788,8 @@ function FolderItemSelectorModalContent({
 								? itemData.embedded.id
 								: itemData.id
 						}`,
+
+						// eslint-disable-next-line react-compiler/react-compiler
 						views: [
 							{
 								contentRenderer: 'cards',
@@ -836,6 +907,16 @@ function FolderItemSelectorModalContent({
 									title: name,
 								},
 								name
+							);
+						}
+						else if (
+							selectedItemType ===
+								ITEM_SELECTOR_ITEM_TYPE.FOLDER &&
+							rootFolderRef.current
+						) {
+							handleOnItemsChange(
+								rootFolderRef.current,
+								rootFolderRef.current.title
 							);
 						}
 					}}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/modal/FolderItemSelectorModalContent.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/modal/FolderItemSelectorModalContent.tsx
@@ -371,7 +371,7 @@ function FolderItemSelectorModalContent({
 
 			if (rootObjectEntryFolderExternalReferenceCode) {
 				const {data} = await ApiHelper.get<any>(
-					`/o/search/v1.0/search?emptySearch=true&entryClassNames=${OBJECT_ENTRY_FOLDER_CLASS_NAME}&filter=cmsRoot eq true and cmsSection eq '${cmsSection}' and status in (0, 2, 3)&nestedFields=embedded&scope=${space.scopeId}&pageSize=1`,
+					`/o/search/v1.0/search?emptySearch=true&entryClassNames=${OBJECT_ENTRY_FOLDER_CLASS_NAME}&filter=title eq '${cmsSection}' and folderId eq 0 and status in (0, 2, 3)&nestedFields=embedded&scope=${space.scopeId}&pageSize=1`,
 					controller.signal
 				);
 

--- a/modules/test/playwright/tests/site-cms-site-initializer/permissions/folder.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/permissions/folder.spec.ts
@@ -77,15 +77,11 @@ test(
 
 			await copyFolderModalPage.space(spaceName).click();
 
-			await expect(async () => {
-				await copyFolderModalPage
-					.folderRadio('Contents')
-					.click({timeout: 500});
+			await expect(
+				copyFolderModalPage.folderRadio(folder2Name)
+			).toBeVisible();
 
-				await expect(copyFolderModalPage.selectButton).toBeEnabled({
-					timeout: 500,
-				});
-			}).toPass({timeout: 5000});
+			await expect(copyFolderModalPage.selectButton).toBeEnabled();
 
 			await copyFolderModalPage.selectButton.click();
 			await copyFolderModalPage.duplicateDialog.waitFor();
@@ -104,7 +100,6 @@ test(
 			});
 
 			await copyFolderModalPage.spaceInModal(spaceName).click();
-			await copyFolderModalPage.navigableFolder('Contents').click();
 
 			await expect(async () => {
 				await copyFolderModalPage
@@ -130,7 +125,6 @@ test(
 			});
 
 			await copyFolderModalPage.spaceInModal(spaceName).click();
-			await copyFolderModalPage.navigableFolder('Contents').click();
 
 			await expect(async () => {
 				await copyFolderModalPage
@@ -220,19 +214,19 @@ test(
 
 			await copyFolderModalPage.space(spaceName).click();
 
-			await expect(async () => {
-				await copyFolderModalPage
-					.folderRadio('Contents')
-					.click({timeout: 500});
+			await expect(
+				copyFolderModalPage.folderRadio(folder2Name)
+			).toBeVisible();
 
-				await expect(copyFolderModalPage.selectButton).toBeEnabled({
-					timeout: 500,
-				});
-			}).toPass({timeout: 5000});
+			await expect(copyFolderModalPage.selectButton).toBeEnabled();
 
 			await copyFolderModalPage.selectButton.click();
 
-			await waitForAlert(page, `was successfully copied to`);
+			await waitForAlert(
+				page,
+				'Assets could not be moved. Please ensure the name is unique in the destination.',
+				{type: 'danger'}
+			);
 		});
 
 		await test.step('Bulk copy a folder inside another non-root folder', async () => {
@@ -247,7 +241,6 @@ test(
 			await assetsPage.execBulkItemAction('Copy To');
 
 			await copyFolderModalPage.spaceInModal(spaceName).click();
-			await copyFolderModalPage.navigableFolder('Contents').click();
 
 			await expect(async () => {
 				await copyFolderModalPage
@@ -272,7 +265,6 @@ test(
 			await assetsPage.execBulkItemAction('Copy To');
 
 			await copyFolderModalPage.spaceInModal(spaceName).click();
-			await copyFolderModalPage.navigableFolder('Contents').click();
 
 			await expect(async () => {
 				await copyFolderModalPage
@@ -286,7 +278,153 @@ test(
 
 			await copyFolderModalPage.selectButton.click();
 
-			await waitForAlert(page, `was successfully copied to`);
+			await waitForAlert(
+				page,
+				'Assets could not be moved. Please ensure the name is unique in the destination.',
+				{type: 'danger'}
+			);
+		});
+	}
+);
+
+test(
+	'Root Contents folder is not visible in move and copy dialogs',
+	{tag: '@LPD-83152'},
+	async ({
+		apiHelpers,
+		assetsPage,
+		copyFolderModalPage,
+		page,
+		spaceSummaryPage,
+	}) => {
+		const spaceName = `Space ${getRandomString()}`;
+		const folderName = `Folder ${getRandomString()}`;
+		const contentTitle = `Content ${getRandomString()}`;
+
+		let user;
+
+		await test.step('Create a new Space', async () => {
+			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+				name: spaceName,
+				settings: {},
+				type: 'Space',
+			});
+		});
+
+		await test.step('Create a user and add as content reviewer member to the space', async () => {
+			user = await apiHelpers.headlessAdminUser.postUserAccount();
+
+			userData[user.alternateName] = {
+				name: user.givenName,
+				password: 'test',
+				surname: user.familyName,
+			};
+
+			const cmsAdminRole =
+				await apiHelpers.headlessAdminUser.getRoleByName(
+					'CMS Administrator'
+				);
+
+			await apiHelpers.headlessAdminUser.postRoleUserAccountAssociation(
+				cmsAdminRole.id,
+				Number(user.id)
+			);
+
+			await spaceSummaryPage.goto(spaceName);
+			await spaceSummaryPage.addUserOrUserGroup(user.name, 'users');
+			await spaceSummaryPage.addRoleToSpaceMember(
+				'Content Reviewer',
+				user.name
+			);
+		});
+
+		await test.step('Create a folder and content inside the Space', async () => {
+			await spaceSummaryPage.goto(spaceName);
+			await spaceSummaryPage.createContentFolder(folderName);
+
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: contentTitle,
+				},
+				'cms/basic-web-contents',
+				spaceName
+			);
+		});
+
+		await test.step('Login as content reviewer user', async () => {
+			await performUserSwitch(page, user.alternateName);
+		});
+
+		await test.step('Verify Contents folder is not visible in Copy To dialog', async () => {
+			await assetsPage.gotoContents();
+			await assetsPage.execItemAction({
+				action: 'Copy To',
+				filter: contentTitle,
+			});
+
+			await copyFolderModalPage.space(spaceName).click();
+
+			await expect(
+				page.getByRole('radio', {name: `Select ${folderName}`})
+			).toBeVisible();
+			await expect(
+				page.getByRole('radio', {name: 'Select Contents'})
+			).not.toBeVisible();
+
+			await page.getByRole('button', {name: 'Cancel'}).click();
+		});
+
+		await test.step('Verify Contents folder is not visible in Copy To dialog table view', async () => {
+			await assetsPage.gotoContents();
+
+			await assetsPage.execItemAction({
+				action: 'Copy To',
+				filter: contentTitle,
+			});
+
+			await copyFolderModalPage.space(spaceName).click();
+
+			await expect(
+				page.getByRole('radio', {name: `Select ${folderName}`})
+			).toBeVisible();
+
+			await copyFolderModalPage.selectTableView();
+
+			await expect(
+				copyFolderModalPage.modal.getByRole('cell', {
+					exact: true,
+					name: folderName,
+				})
+			).toBeVisible();
+			await expect(
+				copyFolderModalPage.modal.getByRole('cell', {
+					exact: true,
+					name: 'Contents',
+				})
+			).not.toBeVisible();
+
+			await page.getByRole('button', {name: 'Cancel'}).click();
+		});
+
+		await test.step('Verify Contents folder is not visible in Move dialog', async () => {
+			await assetsPage.gotoContents();
+
+			await assetsPage.dataSetFragmentPage.execItemAction({
+				action: 'Move',
+				filter: contentTitle,
+			});
+
+			await copyFolderModalPage.space(spaceName).click();
+
+			await expect(
+				page.getByRole('radio', {name: `Select ${folderName}`})
+			).toBeVisible();
+			await expect(
+				page.getByRole('radio', {name: 'Select Contents'})
+			).not.toBeVisible();
+
+			await page.getByRole('button', {name: 'Cancel'}).click();
 		});
 	}
 );

--- a/modules/test/playwright/tests/site-cms-site-initializer/permissions/pages/CopyFolderModalPage.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/permissions/pages/CopyFolderModalPage.ts
@@ -16,6 +16,7 @@ export class CopyFolderModalPage {
 	readonly selectButton: Locator;
 	readonly space: (spaceName: string) => Locator;
 	readonly spaceInModal: (spaceName: string) => Locator;
+	readonly changeViewComboBox: Locator;
 
 	constructor(page: Page) {
 		this.page = page;
@@ -40,5 +41,13 @@ export class CopyFolderModalPage {
 		this.spaceInModal = (spaceName: string) => {
 			return this.modal.getByLabel(spaceName);
 		};
+		this.changeViewComboBox = this.modal.getByRole('combobox', {
+			name: /View Selected/,
+		});
+	}
+
+	async selectTableView() {
+		await this.changeViewComboBox.click();
+		await this.page.getByRole('option', {name: 'Table'}).click();
 	}
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-83152

@adolfopa I've added two commits to:

- Fix the fetch with cmsRoot eq true wasn't returning the root folder — at least with pageSize=1 it returned a child (parentERC L_CONTENTS). Replaced with title eq  '<section>' and folderId eq 0, which directly matches the root in our tests.
- Merge hasRootFolder (state) and rootFolderRef (ref) into a single state rootFolder, so the Select button enables only when the destination is really available no more silent no-op when clicking too early.
- Remove the ref mutation inside setItemComponentProps (it was a side-effect during render).
- ApiHelper now treats AbortError as a non-error, so cancelled requests don't trigger user-facing toasts.

FW of: https://github.com/liferay-commerce/liferay-portal/pull/7413

cc. @brbalazs