### PR TITLE
LPD-88003 Technical Task | Cascade-delete SharingEntry rows when a User, UserGroup or Ticket is removed

### DIFF
--- a/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryLocalService.java
+++ b/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryLocalService.java
@@ -556,6 +556,9 @@ public interface SharingEntryLocalService
 			String uuid, long groupId)
 		throws PortalException;
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<SharingEntry> getToTicketSharingEntries(long toTicketId);
+
 	/**
 	 * Returns the list of sharing entries for resources shared with the user.
 	 *
@@ -729,4 +732,4 @@ public interface SharingEntryLocalService
 	public SharingEntry updateSharingEntry(SharingEntry sharingEntry);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-916700364
+// LIFERAY-SERVICE-BUILDER-HASH:1624958331

--- a/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryLocalService.java
+++ b/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryLocalService.java
@@ -225,6 +225,10 @@ public interface SharingEntryLocalService
 			String externalReferenceCode, long groupId)
 		throws PortalException;
 
+	public void deleteToTicketSharingEntries(long toTicketId);
+
+	public void deleteToUserGroupSharingEntries(long toUserGroupId);
+
 	/**
 	 * Deletes the sharing entries for resources shared with the user.
 	 *
@@ -559,6 +563,9 @@ public interface SharingEntryLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<SharingEntry> getToTicketSharingEntries(long toTicketId);
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<SharingEntry> getToUserGroupSharingEntries(long toUserGroupId);
+
 	/**
 	 * Returns the list of sharing entries for resources shared with the user.
 	 *
@@ -732,4 +739,4 @@ public interface SharingEntryLocalService
 	public SharingEntry updateSharingEntry(SharingEntry sharingEntry);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1624958331
+// LIFERAY-SERVICE-BUILDER-HASH:-720703128

--- a/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryLocalServiceUtil.java
+++ b/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryLocalServiceUtil.java
@@ -656,6 +656,12 @@ public class SharingEntryLocalServiceUtil {
 		return getService().getSharingEntryByUuidAndGroupId(uuid, groupId);
 	}
 
+	public static List<SharingEntry> getToTicketSharingEntries(
+		long toTicketId) {
+
+		return getService().getToTicketSharingEntries(toTicketId);
+	}
+
 	/**
 	 * Returns the list of sharing entries for resources shared with the user.
 	 *
@@ -871,4 +877,4 @@ public class SharingEntryLocalServiceUtil {
 			SharingEntryLocalServiceUtil.class, SharingEntryLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1355305151
+// LIFERAY-SERVICE-BUILDER-HASH:-1187951439

--- a/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryLocalServiceUtil.java
+++ b/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryLocalServiceUtil.java
@@ -246,6 +246,14 @@ public class SharingEntryLocalServiceUtil {
 			externalReferenceCode, groupId);
 	}
 
+	public static void deleteToTicketSharingEntries(long toTicketId) {
+		getService().deleteToTicketSharingEntries(toTicketId);
+	}
+
+	public static void deleteToUserGroupSharingEntries(long toUserGroupId) {
+		getService().deleteToUserGroupSharingEntries(toUserGroupId);
+	}
+
 	/**
 	 * Deletes the sharing entries for resources shared with the user.
 	 *
@@ -662,6 +670,12 @@ public class SharingEntryLocalServiceUtil {
 		return getService().getToTicketSharingEntries(toTicketId);
 	}
 
+	public static List<SharingEntry> getToUserGroupSharingEntries(
+		long toUserGroupId) {
+
+		return getService().getToUserGroupSharingEntries(toUserGroupId);
+	}
+
 	/**
 	 * Returns the list of sharing entries for resources shared with the user.
 	 *
@@ -877,4 +891,4 @@ public class SharingEntryLocalServiceUtil {
 			SharingEntryLocalServiceUtil.class, SharingEntryLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1187951439
+// LIFERAY-SERVICE-BUILDER-HASH:646395971

--- a/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryLocalServiceWrapper.java
+++ b/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryLocalServiceWrapper.java
@@ -737,6 +737,13 @@ public class SharingEntryLocalServiceWrapper
 			uuid, groupId);
 	}
 
+	@Override
+	public java.util.List<com.liferay.sharing.model.SharingEntry>
+		getToTicketSharingEntries(long toTicketId) {
+
+		return _sharingEntryLocalService.getToTicketSharingEntries(toTicketId);
+	}
+
 	/**
 	 * Returns the list of sharing entries for resources shared with the user.
 	 *
@@ -981,4 +988,4 @@ public class SharingEntryLocalServiceWrapper
 	private SharingEntryLocalService _sharingEntryLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1457849249
+// LIFERAY-SERVICE-BUILDER-HASH:1156547837

--- a/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryLocalServiceWrapper.java
+++ b/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryLocalServiceWrapper.java
@@ -261,6 +261,17 @@ public class SharingEntryLocalServiceWrapper
 				externalReferenceCode, groupId);
 	}
 
+	@Override
+	public void deleteToTicketSharingEntries(long toTicketId) {
+		_sharingEntryLocalService.deleteToTicketSharingEntries(toTicketId);
+	}
+
+	@Override
+	public void deleteToUserGroupSharingEntries(long toUserGroupId) {
+		_sharingEntryLocalService.deleteToUserGroupSharingEntries(
+			toUserGroupId);
+	}
+
 	/**
 	 * Deletes the sharing entries for resources shared with the user.
 	 *
@@ -744,6 +755,14 @@ public class SharingEntryLocalServiceWrapper
 		return _sharingEntryLocalService.getToTicketSharingEntries(toTicketId);
 	}
 
+	@Override
+	public java.util.List<com.liferay.sharing.model.SharingEntry>
+		getToUserGroupSharingEntries(long toUserGroupId) {
+
+		return _sharingEntryLocalService.getToUserGroupSharingEntries(
+			toUserGroupId);
+	}
+
 	/**
 	 * Returns the list of sharing entries for resources shared with the user.
 	 *
@@ -988,4 +1007,4 @@ public class SharingEntryLocalServiceWrapper
 	private SharingEntryLocalService _sharingEntryLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1156547837
+// LIFERAY-SERVICE-BUILDER-HASH:-612691477

--- a/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/persistence/SharingEntryPersistence.java
+++ b/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/persistence/SharingEntryPersistence.java
@@ -501,6 +501,108 @@ public interface SharingEntryPersistence extends BasePersistence<SharingEntry> {
 	public int countByUserId(long userId);
 
 	/**
+	 * Returns all the sharing entries where toTicketId = &#63;.
+	 *
+	 * @param toTicketId the to ticket ID
+	 * @return the matching sharing entries
+	 */
+	public java.util.List<SharingEntry> findByToTicketId(long toTicketId);
+
+	/**
+	 * Returns a range of all the sharing entries where toTicketId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.sharing.model.impl.SharingEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param toTicketId the to ticket ID
+	 * @param start the lower bound of the range of sharing entries
+	 * @param end the upper bound of the range of sharing entries (not inclusive)
+	 * @return the range of matching sharing entries
+	 */
+	public java.util.List<SharingEntry> findByToTicketId(
+		long toTicketId, int start, int end);
+
+	/**
+	 * Returns an ordered range of all the sharing entries where toTicketId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.sharing.model.impl.SharingEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param toTicketId the to ticket ID
+	 * @param start the lower bound of the range of sharing entries
+	 * @param end the upper bound of the range of sharing entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching sharing entries
+	 */
+	public java.util.List<SharingEntry> findByToTicketId(
+		long toTicketId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<SharingEntry>
+			orderByComparator);
+
+	/**
+	 * Returns an ordered range of all the sharing entries where toTicketId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.sharing.model.impl.SharingEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param toTicketId the to ticket ID
+	 * @param start the lower bound of the range of sharing entries
+	 * @param end the upper bound of the range of sharing entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching sharing entries
+	 */
+	public java.util.List<SharingEntry> findByToTicketId(
+		long toTicketId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<SharingEntry>
+			orderByComparator,
+		boolean useFinderCache);
+
+	/**
+	 * Returns the first sharing entry in the ordered set where toTicketId = &#63;.
+	 *
+	 * @param toTicketId the to ticket ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching sharing entry
+	 * @throws NoSuchEntryException if a matching sharing entry could not be found
+	 */
+	public SharingEntry findByToTicketId_First(
+			long toTicketId,
+			com.liferay.portal.kernel.util.OrderByComparator<SharingEntry>
+				orderByComparator)
+		throws NoSuchEntryException;
+
+	/**
+	 * Returns the first sharing entry in the ordered set where toTicketId = &#63;.
+	 *
+	 * @param toTicketId the to ticket ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching sharing entry, or <code>null</code> if a matching sharing entry could not be found
+	 */
+	public SharingEntry fetchByToTicketId_First(
+		long toTicketId,
+		com.liferay.portal.kernel.util.OrderByComparator<SharingEntry>
+			orderByComparator);
+
+	/**
+	 * Removes all the sharing entries where toTicketId = &#63; from the database.
+	 *
+	 * @param toTicketId the to ticket ID
+	 */
+	public void removeByToTicketId(long toTicketId);
+
+	/**
+	 * Returns the number of sharing entries where toTicketId = &#63;.
+	 *
+	 * @param toTicketId the to ticket ID
+	 * @return the number of matching sharing entries
+	 */
+	public int countByToTicketId(long toTicketId);
+
+	/**
 	 * Returns all the sharing entries where toUserId = &#63;.
 	 *
 	 * @param toUserId the to user ID
@@ -1327,4 +1429,4 @@ public interface SharingEntryPersistence extends BasePersistence<SharingEntry> {
 	public SharingEntry fetchByPrimaryKey(long sharingEntryId);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1661335027
+// LIFERAY-SERVICE-BUILDER-HASH:-1415111248

--- a/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/persistence/SharingEntryPersistence.java
+++ b/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/persistence/SharingEntryPersistence.java
@@ -603,6 +603,108 @@ public interface SharingEntryPersistence extends BasePersistence<SharingEntry> {
 	public int countByToTicketId(long toTicketId);
 
 	/**
+	 * Returns all the sharing entries where toUserGroupId = &#63;.
+	 *
+	 * @param toUserGroupId the to user group ID
+	 * @return the matching sharing entries
+	 */
+	public java.util.List<SharingEntry> findByToUserGroupId(long toUserGroupId);
+
+	/**
+	 * Returns a range of all the sharing entries where toUserGroupId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.sharing.model.impl.SharingEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param toUserGroupId the to user group ID
+	 * @param start the lower bound of the range of sharing entries
+	 * @param end the upper bound of the range of sharing entries (not inclusive)
+	 * @return the range of matching sharing entries
+	 */
+	public java.util.List<SharingEntry> findByToUserGroupId(
+		long toUserGroupId, int start, int end);
+
+	/**
+	 * Returns an ordered range of all the sharing entries where toUserGroupId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.sharing.model.impl.SharingEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param toUserGroupId the to user group ID
+	 * @param start the lower bound of the range of sharing entries
+	 * @param end the upper bound of the range of sharing entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching sharing entries
+	 */
+	public java.util.List<SharingEntry> findByToUserGroupId(
+		long toUserGroupId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<SharingEntry>
+			orderByComparator);
+
+	/**
+	 * Returns an ordered range of all the sharing entries where toUserGroupId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.sharing.model.impl.SharingEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param toUserGroupId the to user group ID
+	 * @param start the lower bound of the range of sharing entries
+	 * @param end the upper bound of the range of sharing entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching sharing entries
+	 */
+	public java.util.List<SharingEntry> findByToUserGroupId(
+		long toUserGroupId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<SharingEntry>
+			orderByComparator,
+		boolean useFinderCache);
+
+	/**
+	 * Returns the first sharing entry in the ordered set where toUserGroupId = &#63;.
+	 *
+	 * @param toUserGroupId the to user group ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching sharing entry
+	 * @throws NoSuchEntryException if a matching sharing entry could not be found
+	 */
+	public SharingEntry findByToUserGroupId_First(
+			long toUserGroupId,
+			com.liferay.portal.kernel.util.OrderByComparator<SharingEntry>
+				orderByComparator)
+		throws NoSuchEntryException;
+
+	/**
+	 * Returns the first sharing entry in the ordered set where toUserGroupId = &#63;.
+	 *
+	 * @param toUserGroupId the to user group ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching sharing entry, or <code>null</code> if a matching sharing entry could not be found
+	 */
+	public SharingEntry fetchByToUserGroupId_First(
+		long toUserGroupId,
+		com.liferay.portal.kernel.util.OrderByComparator<SharingEntry>
+			orderByComparator);
+
+	/**
+	 * Removes all the sharing entries where toUserGroupId = &#63; from the database.
+	 *
+	 * @param toUserGroupId the to user group ID
+	 */
+	public void removeByToUserGroupId(long toUserGroupId);
+
+	/**
+	 * Returns the number of sharing entries where toUserGroupId = &#63;.
+	 *
+	 * @param toUserGroupId the to user group ID
+	 * @return the number of matching sharing entries
+	 */
+	public int countByToUserGroupId(long toUserGroupId);
+
+	/**
 	 * Returns all the sharing entries where toUserId = &#63;.
 	 *
 	 * @param toUserId the to user ID
@@ -1429,4 +1531,4 @@ public interface SharingEntryPersistence extends BasePersistence<SharingEntry> {
 	public SharingEntry fetchByPrimaryKey(long sharingEntryId);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1415111248
+// LIFERAY-SERVICE-BUILDER-HASH:-1893669597

--- a/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/persistence/SharingEntryUtil.java
+++ b/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/persistence/SharingEntryUtil.java
@@ -663,6 +663,127 @@ public class SharingEntryUtil {
 	}
 
 	/**
+	 * Returns all the sharing entries where toTicketId = &#63;.
+	 *
+	 * @param toTicketId the to ticket ID
+	 * @return the matching sharing entries
+	 */
+	public static List<SharingEntry> findByToTicketId(long toTicketId) {
+		return getPersistence().findByToTicketId(toTicketId);
+	}
+
+	/**
+	 * Returns a range of all the sharing entries where toTicketId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.sharing.model.impl.SharingEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param toTicketId the to ticket ID
+	 * @param start the lower bound of the range of sharing entries
+	 * @param end the upper bound of the range of sharing entries (not inclusive)
+	 * @return the range of matching sharing entries
+	 */
+	public static List<SharingEntry> findByToTicketId(
+		long toTicketId, int start, int end) {
+
+		return getPersistence().findByToTicketId(toTicketId, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the sharing entries where toTicketId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.sharing.model.impl.SharingEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param toTicketId the to ticket ID
+	 * @param start the lower bound of the range of sharing entries
+	 * @param end the upper bound of the range of sharing entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching sharing entries
+	 */
+	public static List<SharingEntry> findByToTicketId(
+		long toTicketId, int start, int end,
+		OrderByComparator<SharingEntry> orderByComparator) {
+
+		return getPersistence().findByToTicketId(
+			toTicketId, start, end, orderByComparator);
+	}
+
+	/**
+	 * Returns an ordered range of all the sharing entries where toTicketId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.sharing.model.impl.SharingEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param toTicketId the to ticket ID
+	 * @param start the lower bound of the range of sharing entries
+	 * @param end the upper bound of the range of sharing entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching sharing entries
+	 */
+	public static List<SharingEntry> findByToTicketId(
+		long toTicketId, int start, int end,
+		OrderByComparator<SharingEntry> orderByComparator,
+		boolean useFinderCache) {
+
+		return getPersistence().findByToTicketId(
+			toTicketId, start, end, orderByComparator, useFinderCache);
+	}
+
+	/**
+	 * Returns the first sharing entry in the ordered set where toTicketId = &#63;.
+	 *
+	 * @param toTicketId the to ticket ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching sharing entry
+	 * @throws NoSuchEntryException if a matching sharing entry could not be found
+	 */
+	public static SharingEntry findByToTicketId_First(
+			long toTicketId, OrderByComparator<SharingEntry> orderByComparator)
+		throws com.liferay.sharing.exception.NoSuchEntryException {
+
+		return getPersistence().findByToTicketId_First(
+			toTicketId, orderByComparator);
+	}
+
+	/**
+	 * Returns the first sharing entry in the ordered set where toTicketId = &#63;.
+	 *
+	 * @param toTicketId the to ticket ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching sharing entry, or <code>null</code> if a matching sharing entry could not be found
+	 */
+	public static SharingEntry fetchByToTicketId_First(
+		long toTicketId, OrderByComparator<SharingEntry> orderByComparator) {
+
+		return getPersistence().fetchByToTicketId_First(
+			toTicketId, orderByComparator);
+	}
+
+	/**
+	 * Removes all the sharing entries where toTicketId = &#63; from the database.
+	 *
+	 * @param toTicketId the to ticket ID
+	 */
+	public static void removeByToTicketId(long toTicketId) {
+		getPersistence().removeByToTicketId(toTicketId);
+	}
+
+	/**
+	 * Returns the number of sharing entries where toTicketId = &#63;.
+	 *
+	 * @param toTicketId the to ticket ID
+	 * @return the number of matching sharing entries
+	 */
+	public static int countByToTicketId(long toTicketId) {
+		return getPersistence().countByToTicketId(toTicketId);
+	}
+
+	/**
 	 * Returns all the sharing entries where toUserId = &#63;.
 	 *
 	 * @param toUserId the to user ID
@@ -1682,4 +1803,4 @@ public class SharingEntryUtil {
 	private static volatile SharingEntryPersistence _persistence;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1913374404
+// LIFERAY-SERVICE-BUILDER-HASH:-2019835357

--- a/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/persistence/SharingEntryUtil.java
+++ b/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/persistence/SharingEntryUtil.java
@@ -784,6 +784,128 @@ public class SharingEntryUtil {
 	}
 
 	/**
+	 * Returns all the sharing entries where toUserGroupId = &#63;.
+	 *
+	 * @param toUserGroupId the to user group ID
+	 * @return the matching sharing entries
+	 */
+	public static List<SharingEntry> findByToUserGroupId(long toUserGroupId) {
+		return getPersistence().findByToUserGroupId(toUserGroupId);
+	}
+
+	/**
+	 * Returns a range of all the sharing entries where toUserGroupId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.sharing.model.impl.SharingEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param toUserGroupId the to user group ID
+	 * @param start the lower bound of the range of sharing entries
+	 * @param end the upper bound of the range of sharing entries (not inclusive)
+	 * @return the range of matching sharing entries
+	 */
+	public static List<SharingEntry> findByToUserGroupId(
+		long toUserGroupId, int start, int end) {
+
+		return getPersistence().findByToUserGroupId(toUserGroupId, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the sharing entries where toUserGroupId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.sharing.model.impl.SharingEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param toUserGroupId the to user group ID
+	 * @param start the lower bound of the range of sharing entries
+	 * @param end the upper bound of the range of sharing entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching sharing entries
+	 */
+	public static List<SharingEntry> findByToUserGroupId(
+		long toUserGroupId, int start, int end,
+		OrderByComparator<SharingEntry> orderByComparator) {
+
+		return getPersistence().findByToUserGroupId(
+			toUserGroupId, start, end, orderByComparator);
+	}
+
+	/**
+	 * Returns an ordered range of all the sharing entries where toUserGroupId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.sharing.model.impl.SharingEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param toUserGroupId the to user group ID
+	 * @param start the lower bound of the range of sharing entries
+	 * @param end the upper bound of the range of sharing entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching sharing entries
+	 */
+	public static List<SharingEntry> findByToUserGroupId(
+		long toUserGroupId, int start, int end,
+		OrderByComparator<SharingEntry> orderByComparator,
+		boolean useFinderCache) {
+
+		return getPersistence().findByToUserGroupId(
+			toUserGroupId, start, end, orderByComparator, useFinderCache);
+	}
+
+	/**
+	 * Returns the first sharing entry in the ordered set where toUserGroupId = &#63;.
+	 *
+	 * @param toUserGroupId the to user group ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching sharing entry
+	 * @throws NoSuchEntryException if a matching sharing entry could not be found
+	 */
+	public static SharingEntry findByToUserGroupId_First(
+			long toUserGroupId,
+			OrderByComparator<SharingEntry> orderByComparator)
+		throws com.liferay.sharing.exception.NoSuchEntryException {
+
+		return getPersistence().findByToUserGroupId_First(
+			toUserGroupId, orderByComparator);
+	}
+
+	/**
+	 * Returns the first sharing entry in the ordered set where toUserGroupId = &#63;.
+	 *
+	 * @param toUserGroupId the to user group ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching sharing entry, or <code>null</code> if a matching sharing entry could not be found
+	 */
+	public static SharingEntry fetchByToUserGroupId_First(
+		long toUserGroupId, OrderByComparator<SharingEntry> orderByComparator) {
+
+		return getPersistence().fetchByToUserGroupId_First(
+			toUserGroupId, orderByComparator);
+	}
+
+	/**
+	 * Removes all the sharing entries where toUserGroupId = &#63; from the database.
+	 *
+	 * @param toUserGroupId the to user group ID
+	 */
+	public static void removeByToUserGroupId(long toUserGroupId) {
+		getPersistence().removeByToUserGroupId(toUserGroupId);
+	}
+
+	/**
+	 * Returns the number of sharing entries where toUserGroupId = &#63;.
+	 *
+	 * @param toUserGroupId the to user group ID
+	 * @return the number of matching sharing entries
+	 */
+	public static int countByToUserGroupId(long toUserGroupId) {
+		return getPersistence().countByToUserGroupId(toUserGroupId);
+	}
+
+	/**
 	 * Returns all the sharing entries where toUserId = &#63;.
 	 *
 	 * @param toUserId the to user ID
@@ -1803,4 +1925,4 @@ public class SharingEntryUtil {
 	private static volatile SharingEntryPersistence _persistence;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2019835357
+// LIFERAY-SERVICE-BUILDER-HASH:-2074678688

--- a/modules/apps/sharing/sharing-service/bnd.bnd
+++ b/modules/apps/sharing/sharing-service/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Sharing Service
 Bundle-SymbolicName: com.liferay.sharing.service
 Bundle-Version: 3.0.67
-Liferay-Require-SchemaVersion: 1.3.0
+Liferay-Require-SchemaVersion: 1.4.0
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/sharing/sharing-service/service.xml
+++ b/modules/apps/sharing/sharing-service/service.xml
@@ -40,6 +40,9 @@
 		<finder name="UserId" return-type="Collection">
 			<finder-column name="userId" />
 		</finder>
+		<finder name="ToTicketId" return-type="Collection">
+			<finder-column name="toTicketId" />
+		</finder>
 		<finder name="ToUserId" return-type="Collection">
 			<finder-column name="toUserId" />
 		</finder>

--- a/modules/apps/sharing/sharing-service/service.xml
+++ b/modules/apps/sharing/sharing-service/service.xml
@@ -43,6 +43,9 @@
 		<finder name="ToTicketId" return-type="Collection">
 			<finder-column name="toTicketId" />
 		</finder>
+		<finder name="ToUserGroupId" return-type="Collection">
+			<finder-column name="toUserGroupId" />
+		</finder>
 		<finder name="ToUserId" return-type="Collection">
 			<finder-column name="toUserId" />
 		</finder>

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/model/listener/TicketModelListener.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/model/listener/TicketModelListener.java
@@ -1,0 +1,31 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.sharing.internal.model.listener;
+
+import com.liferay.portal.kernel.model.BaseModelListener;
+import com.liferay.portal.kernel.model.ModelListener;
+import com.liferay.portal.kernel.model.Ticket;
+import com.liferay.sharing.service.SharingEntryLocalService;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Alicia García
+ */
+@Component(service = ModelListener.class)
+public class TicketModelListener extends BaseModelListener<Ticket> {
+
+	@Override
+	public void onBeforeRemove(Ticket ticket) {
+		_sharingEntryLocalService.deleteToTicketSharingEntries(
+			ticket.getTicketId());
+	}
+
+	@Reference
+	private SharingEntryLocalService _sharingEntryLocalService;
+
+}

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/model/listener/UserGroupModelListener.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/model/listener/UserGroupModelListener.java
@@ -1,0 +1,31 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.sharing.internal.model.listener;
+
+import com.liferay.portal.kernel.model.BaseModelListener;
+import com.liferay.portal.kernel.model.ModelListener;
+import com.liferay.portal.kernel.model.UserGroup;
+import com.liferay.sharing.service.SharingEntryLocalService;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Alicia García
+ */
+@Component(service = ModelListener.class)
+public class UserGroupModelListener extends BaseModelListener<UserGroup> {
+
+	@Override
+	public void onBeforeRemove(UserGroup userGroup) {
+		_sharingEntryLocalService.deleteToUserGroupSharingEntries(
+			userGroup.getUserGroupId());
+	}
+
+	@Reference
+	private SharingEntryLocalService _sharingEntryLocalService;
+
+}

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/model/listener/UserModelListener.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/model/listener/UserModelListener.java
@@ -99,6 +99,8 @@ public class UserModelListener extends BaseModelListener<User> {
 							sharingEntry.getClassPK()));
 				}
 
+				_sharingEntryLocalService.deleteSharingEntry(sharingEntry);
+
 				continue;
 			}
 

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/model/listener/UserModelListener.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/model/listener/UserModelListener.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.TicketLocalService;
 import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.sharing.model.SharingEntry;
 import com.liferay.sharing.service.SharingEntryLocalService;
 
@@ -37,6 +38,65 @@ public class UserModelListener extends BaseModelListener<User> {
 
 	@Override
 	public void onAfterCreate(User user) throws ModelListenerException {
+		if (user.getStatus() != WorkflowConstants.STATUS_APPROVED) {
+			return;
+		}
+
+		_updateSharingEntries(user);
+	}
+
+	@Override
+	public void onAfterUpdate(User originalUser, User user)
+		throws ModelListenerException {
+
+		if ((originalUser.getStatus() == user.getStatus()) ||
+			(originalUser.getStatus() == WorkflowConstants.STATUS_APPROVED) ||
+			(user.getStatus() != WorkflowConstants.STATUS_APPROVED)) {
+
+			return;
+		}
+
+		_updateSharingEntries(user);
+	}
+
+	@Override
+	public void onBeforeRemove(User user) {
+		_sharingEntryLocalService.deleteToUserSharingEntries(user.getUserId());
+	}
+
+	private void _updateSharingEntries(Ticket ticket, User user) {
+		for (SharingEntry sharingEntry :
+				_sharingEntryLocalService.getToTicketSharingEntries(
+					ticket.getTicketId())) {
+
+			SharingEntry existingSharingEntry =
+				_sharingEntryLocalService.fetchSharingEntry(
+					0, sharingEntry.getToUserGroupId(), user.getUserId(),
+					sharingEntry.getClassNameId(), sharingEntry.getClassPK());
+
+			if (existingSharingEntry != null) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(
+						StringBundler.concat(
+							"A sharing entry already exists for user ",
+							user.getUserId(), " with classNameId ",
+							sharingEntry.getClassNameId(), " and classPK ",
+							sharingEntry.getClassPK()));
+				}
+
+				_sharingEntryLocalService.deleteSharingEntry(sharingEntry);
+
+				continue;
+			}
+
+			sharingEntry.setToTicketId(0);
+			sharingEntry.setToUserId(user.getUserId());
+
+			_sharingEntryLocalService.updateSharingEntry(sharingEntry);
+		}
+	}
+
+	private void _updateSharingEntries(User user) {
 		TransactionCommitCallbackUtil.registerCallback(
 			() -> {
 				ActionableDynamicQuery actionableDynamicQuery =
@@ -91,43 +151,6 @@ public class UserModelListener extends BaseModelListener<User> {
 
 				return null;
 			});
-	}
-
-	@Override
-	public void onBeforeRemove(User user) {
-		_sharingEntryLocalService.deleteToUserSharingEntries(user.getUserId());
-	}
-
-	private void _updateSharingEntries(Ticket ticket, User user) {
-		for (SharingEntry sharingEntry :
-				_sharingEntryLocalService.getToTicketSharingEntries(
-					ticket.getTicketId())) {
-
-			SharingEntry existingSharingEntry =
-				_sharingEntryLocalService.fetchSharingEntry(
-					0, sharingEntry.getToUserGroupId(), user.getUserId(),
-					sharingEntry.getClassNameId(), sharingEntry.getClassPK());
-
-			if (existingSharingEntry != null) {
-				if (_log.isDebugEnabled()) {
-					_log.debug(
-						StringBundler.concat(
-							"A sharing entry already exists for user ",
-							user.getUserId(), " with classNameId ",
-							sharingEntry.getClassNameId(), " and classPK ",
-							sharingEntry.getClassPK()));
-				}
-
-				_sharingEntryLocalService.deleteSharingEntry(sharingEntry);
-
-				continue;
-			}
-
-			sharingEntry.setToTicketId(0);
-			sharingEntry.setToUserId(user.getUserId());
-
-			_sharingEntryLocalService.updateSharingEntry(sharingEntry);
-		}
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/model/listener/UserModelListener.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/model/listener/UserModelListener.java
@@ -9,6 +9,7 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.RestrictionsFactoryUtil;
 import com.liferay.portal.kernel.exception.ModelListenerException;
+import com.liferay.portal.kernel.json.JSONException;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.log.Log;
@@ -21,6 +22,7 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.TicketLocalService;
 import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.sharing.model.SharingEntry;
 import com.liferay.sharing.service.SharingEntryLocalService;
 
@@ -53,8 +55,25 @@ public class UserModelListener extends BaseModelListener<User> {
 
 				actionableDynamicQuery.setPerformActionMethod(
 					(Ticket ticket) -> {
-						JSONObject jsonObject = _jsonFactory.createJSONObject(
-							ticket.getExtraInfo());
+						String extraInfo = ticket.getExtraInfo();
+
+						if (Validator.isNull(extraInfo)) {
+							return;
+						}
+
+						JSONObject jsonObject;
+
+						try {
+							jsonObject = _jsonFactory.createJSONObject(
+								extraInfo);
+						}
+						catch (JSONException jsonException) {
+							if (_log.isWarnEnabled()) {
+								_log.warn(jsonException);
+							}
+
+							return;
+						}
 
 						if (!StringUtil.equalsIgnoreCase(
 								jsonObject.getString("emailAddress"),

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/model/listener/UserModelListener.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/model/listener/UserModelListener.java
@@ -5,9 +5,23 @@
 
 package com.liferay.sharing.internal.model.listener;
 
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
+import com.liferay.portal.kernel.dao.orm.RestrictionsFactoryUtil;
+import com.liferay.portal.kernel.exception.ModelListenerException;
+import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.ModelListener;
+import com.liferay.portal.kernel.model.Ticket;
+import com.liferay.portal.kernel.model.TicketConstants;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.TicketLocalService;
+import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.sharing.model.SharingEntry;
 import com.liferay.sharing.service.SharingEntryLocalService;
 
 import org.osgi.service.component.annotations.Component;
@@ -20,11 +34,91 @@ import org.osgi.service.component.annotations.Reference;
 public class UserModelListener extends BaseModelListener<User> {
 
 	@Override
+	public void onAfterCreate(User user) throws ModelListenerException {
+		TransactionCommitCallbackUtil.registerCallback(
+			() -> {
+				ActionableDynamicQuery actionableDynamicQuery =
+					_ticketLocalService.getActionableDynamicQuery();
+
+				actionableDynamicQuery.setAddCriteriaMethod(
+					dynamicQuery -> {
+						dynamicQuery.add(
+							RestrictionsFactoryUtil.eq(
+								"companyId", user.getCompanyId()));
+						dynamicQuery.add(
+							RestrictionsFactoryUtil.eq(
+								"type",
+								TicketConstants.TYPE_INVITE_COLLABORATOR));
+					});
+
+				actionableDynamicQuery.setPerformActionMethod(
+					(Ticket ticket) -> {
+						JSONObject jsonObject = _jsonFactory.createJSONObject(
+							ticket.getExtraInfo());
+
+						if (!StringUtil.equalsIgnoreCase(
+								jsonObject.getString("emailAddress"),
+								user.getEmailAddress())) {
+
+							return;
+						}
+
+						_updateSharingEntries(ticket, user);
+
+						_ticketLocalService.deleteTicket(ticket);
+					});
+
+				actionableDynamicQuery.performActions();
+
+				return null;
+			});
+	}
+
+	@Override
 	public void onBeforeRemove(User user) {
 		_sharingEntryLocalService.deleteToUserSharingEntries(user.getUserId());
 	}
 
+	private void _updateSharingEntries(Ticket ticket, User user) {
+		for (SharingEntry sharingEntry :
+				_sharingEntryLocalService.getToTicketSharingEntries(
+					ticket.getTicketId())) {
+
+			SharingEntry existingSharingEntry =
+				_sharingEntryLocalService.fetchSharingEntry(
+					0, sharingEntry.getToUserGroupId(), user.getUserId(),
+					sharingEntry.getClassNameId(), sharingEntry.getClassPK());
+
+			if (existingSharingEntry != null) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(
+						StringBundler.concat(
+							"A sharing entry already exists for user ",
+							user.getUserId(), " with classNameId ",
+							sharingEntry.getClassNameId(), " and classPK ",
+							sharingEntry.getClassPK()));
+				}
+
+				continue;
+			}
+
+			sharingEntry.setToTicketId(0);
+			sharingEntry.setToUserId(user.getUserId());
+
+			_sharingEntryLocalService.updateSharingEntry(sharingEntry);
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		UserModelListener.class);
+
+	@Reference
+	private JSONFactory _jsonFactory;
+
 	@Reference
 	private SharingEntryLocalService _sharingEntryLocalService;
+
+	@Reference
+	private TicketLocalService _ticketLocalService;
 
 }

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/upgrade/registry/SharingServiceUpgradeStepRegistrator.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/upgrade/registry/SharingServiceUpgradeStepRegistrator.java
@@ -6,6 +6,7 @@
 package com.liferay.sharing.internal.upgrade.registry;
 
 import com.liferay.portal.kernel.upgrade.BaseExternalReferenceCodeUpgradeProcess;
+import com.liferay.portal.kernel.upgrade.DummyUpgradeProcess;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 
 import org.osgi.service.component.annotations.Component;
@@ -39,6 +40,8 @@ public class SharingServiceUpgradeStepRegistrator
 			"1.2.0", "1.3.0",
 			new com.liferay.sharing.internal.upgrade.v1_3_0.
 				SharingEntryUpgradeProcess());
+
+		registry.register("1.3.0", "1.4.0", new DummyUpgradeProcess());
 	}
 
 }

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/impl/SharingEntryLocalServiceImpl.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/impl/SharingEntryLocalServiceImpl.java
@@ -529,6 +529,11 @@ public class SharingEntryLocalServiceImpl
 			toTicketId, toUserGroupId, toUserId, classNameId, classPK);
 	}
 
+	@Override
+	public List<SharingEntry> getToTicketSharingEntries(long toTicketId) {
+		return sharingEntryPersistence.findByToTicketId(toTicketId);
+	}
+
 	/**
 	 * Returns the list of sharing entries for resources shared with the user.
 	 *

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/impl/SharingEntryLocalServiceImpl.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/impl/SharingEntryLocalServiceImpl.java
@@ -343,6 +343,26 @@ public class SharingEntryLocalServiceImpl
 				externalReferenceCode, groupId));
 	}
 
+	@Override
+	public void deleteToTicketSharingEntries(long toTicketId) {
+		List<SharingEntry> sharingEntries =
+			sharingEntryPersistence.findByToTicketId(toTicketId);
+
+		for (SharingEntry sharingEntry : sharingEntries) {
+			sharingEntryLocalService.deleteSharingEntry(sharingEntry);
+		}
+	}
+
+	@Override
+	public void deleteToUserGroupSharingEntries(long toUserGroupId) {
+		List<SharingEntry> sharingEntries =
+			sharingEntryPersistence.findByToUserGroupId(toUserGroupId);
+
+		for (SharingEntry sharingEntry : sharingEntries) {
+			sharingEntryLocalService.deleteSharingEntry(sharingEntry);
+		}
+	}
+
 	/**
 	 * Deletes the sharing entries for resources shared with the user.
 	 *
@@ -532,6 +552,11 @@ public class SharingEntryLocalServiceImpl
 	@Override
 	public List<SharingEntry> getToTicketSharingEntries(long toTicketId) {
 		return sharingEntryPersistence.findByToTicketId(toTicketId);
+	}
+
+	@Override
+	public List<SharingEntry> getToUserGroupSharingEntries(long toUserGroupId) {
+		return sharingEntryPersistence.findByToUserGroupId(toUserGroupId);
 	}
 
 	/**

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/persistence/impl/SharingEntryPersistenceImpl.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/persistence/impl/SharingEntryPersistenceImpl.java
@@ -768,6 +768,153 @@ public class SharingEntryPersistenceImpl
 			finderCache, new Object[] {userId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByToTicketId;
+	private FinderPath _finderPathWithoutPaginationFindByToTicketId;
+	private FinderPath _finderPathCountByToTicketId;
+	private CollectionPersistenceFinder<SharingEntry>
+		_collectionPersistenceFinderByToTicketId;
+
+	/**
+	 * Returns all the sharing entries where toTicketId = &#63;.
+	 *
+	 * @param toTicketId the to ticket ID
+	 * @return the matching sharing entries
+	 */
+	@Override
+	public List<SharingEntry> findByToTicketId(long toTicketId) {
+		return findByToTicketId(
+			toTicketId, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the sharing entries where toTicketId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>SharingEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param toTicketId the to ticket ID
+	 * @param start the lower bound of the range of sharing entries
+	 * @param end the upper bound of the range of sharing entries (not inclusive)
+	 * @return the range of matching sharing entries
+	 */
+	@Override
+	public List<SharingEntry> findByToTicketId(
+		long toTicketId, int start, int end) {
+
+		return findByToTicketId(toTicketId, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the sharing entries where toTicketId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>SharingEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param toTicketId the to ticket ID
+	 * @param start the lower bound of the range of sharing entries
+	 * @param end the upper bound of the range of sharing entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching sharing entries
+	 */
+	@Override
+	public List<SharingEntry> findByToTicketId(
+		long toTicketId, int start, int end,
+		OrderByComparator<SharingEntry> orderByComparator) {
+
+		return findByToTicketId(
+			toTicketId, start, end, orderByComparator, true);
+	}
+
+	/**
+	 * Returns an ordered range of all the sharing entries where toTicketId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>SharingEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param toTicketId the to ticket ID
+	 * @param start the lower bound of the range of sharing entries
+	 * @param end the upper bound of the range of sharing entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching sharing entries
+	 */
+	@Override
+	public List<SharingEntry> findByToTicketId(
+		long toTicketId, int start, int end,
+		OrderByComparator<SharingEntry> orderByComparator,
+		boolean useFinderCache) {
+
+		return _collectionPersistenceFinderByToTicketId.find(
+			finderCache, new Object[] {toTicketId}, start, end,
+			orderByComparator, useFinderCache);
+	}
+
+	/**
+	 * Returns the first sharing entry in the ordered set where toTicketId = &#63;.
+	 *
+	 * @param toTicketId the to ticket ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching sharing entry
+	 * @throws NoSuchEntryException if a matching sharing entry could not be found
+	 */
+	@Override
+	public SharingEntry findByToTicketId_First(
+			long toTicketId, OrderByComparator<SharingEntry> orderByComparator)
+		throws NoSuchEntryException {
+
+		SharingEntry sharingEntry = fetchByToTicketId_First(
+			toTicketId, orderByComparator);
+
+		if (sharingEntry != null) {
+			return sharingEntry;
+		}
+
+		throw new NoSuchEntryException(
+			_collectionPersistenceFinderByToTicketId.buildNoSuchKeyMessage(
+				_NO_SUCH_ENTITY_WITH_KEY, new Object[] {toTicketId}));
+	}
+
+	/**
+	 * Returns the first sharing entry in the ordered set where toTicketId = &#63;.
+	 *
+	 * @param toTicketId the to ticket ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching sharing entry, or <code>null</code> if a matching sharing entry could not be found
+	 */
+	@Override
+	public SharingEntry fetchByToTicketId_First(
+		long toTicketId, OrderByComparator<SharingEntry> orderByComparator) {
+
+		return _collectionPersistenceFinderByToTicketId.fetchFirst(
+			finderCache, new Object[] {toTicketId}, orderByComparator);
+	}
+
+	/**
+	 * Removes all the sharing entries where toTicketId = &#63; from the database.
+	 *
+	 * @param toTicketId the to ticket ID
+	 */
+	@Override
+	public void removeByToTicketId(long toTicketId) {
+		_collectionPersistenceFinderByToTicketId.remove(
+			finderCache, new Object[] {toTicketId});
+	}
+
+	/**
+	 * Returns the number of sharing entries where toTicketId = &#63;.
+	 *
+	 * @param toTicketId the to ticket ID
+	 * @return the number of matching sharing entries
+	 */
+	@Override
+	public int countByToTicketId(long toTicketId) {
+		return _collectionPersistenceFinderByToTicketId.count(
+			finderCache, new Object[] {toTicketId});
+	}
+
 	private FinderPath _finderPathWithPaginationFindByToUserId;
 	private FinderPath _finderPathWithoutPaginationFindByToUserId;
 	private FinderPath _finderPathCountByToUserId;
@@ -2430,6 +2577,35 @@ public class SharingEntryPersistenceImpl
 					"sharingEntry.", "userId", FinderColumn.Type.LONG, "=",
 					true, true, SharingEntry::getUserId));
 
+		_finderPathWithPaginationFindByToTicketId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByToTicketId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"toTicketId"}, true);
+
+		_finderPathWithoutPaginationFindByToTicketId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByToTicketId",
+			new String[] {Long.class.getName()}, new String[] {"toTicketId"},
+			true);
+
+		_finderPathCountByToTicketId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByToTicketId",
+			new String[] {Long.class.getName()}, new String[] {"toTicketId"},
+			false);
+
+		_collectionPersistenceFinderByToTicketId =
+			new CollectionPersistenceFinder<>(
+				this, _finderPathWithPaginationFindByToTicketId,
+				_finderPathWithoutPaginationFindByToTicketId,
+				_finderPathCountByToTicketId, _SQL_SELECT_SHARINGENTRY_WHERE,
+				_SQL_COUNT_SHARINGENTRY_WHERE,
+				SharingEntryModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
+				new FinderColumn<>(
+					"sharingEntry.", "toTicketId", FinderColumn.Type.LONG, "=",
+					true, true, SharingEntry::getToTicketId));
+
 		_finderPathWithPaginationFindByToUserId = new FinderPath(
 			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByToUserId",
 			new String[] {
@@ -2721,4 +2897,4 @@ public class SharingEntryPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1772236288
+// LIFERAY-SERVICE-BUILDER-HASH:1094267747

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/persistence/impl/SharingEntryPersistenceImpl.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/persistence/impl/SharingEntryPersistenceImpl.java
@@ -915,6 +915,154 @@ public class SharingEntryPersistenceImpl
 			finderCache, new Object[] {toTicketId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByToUserGroupId;
+	private FinderPath _finderPathWithoutPaginationFindByToUserGroupId;
+	private FinderPath _finderPathCountByToUserGroupId;
+	private CollectionPersistenceFinder<SharingEntry>
+		_collectionPersistenceFinderByToUserGroupId;
+
+	/**
+	 * Returns all the sharing entries where toUserGroupId = &#63;.
+	 *
+	 * @param toUserGroupId the to user group ID
+	 * @return the matching sharing entries
+	 */
+	@Override
+	public List<SharingEntry> findByToUserGroupId(long toUserGroupId) {
+		return findByToUserGroupId(
+			toUserGroupId, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the sharing entries where toUserGroupId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>SharingEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param toUserGroupId the to user group ID
+	 * @param start the lower bound of the range of sharing entries
+	 * @param end the upper bound of the range of sharing entries (not inclusive)
+	 * @return the range of matching sharing entries
+	 */
+	@Override
+	public List<SharingEntry> findByToUserGroupId(
+		long toUserGroupId, int start, int end) {
+
+		return findByToUserGroupId(toUserGroupId, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the sharing entries where toUserGroupId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>SharingEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param toUserGroupId the to user group ID
+	 * @param start the lower bound of the range of sharing entries
+	 * @param end the upper bound of the range of sharing entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching sharing entries
+	 */
+	@Override
+	public List<SharingEntry> findByToUserGroupId(
+		long toUserGroupId, int start, int end,
+		OrderByComparator<SharingEntry> orderByComparator) {
+
+		return findByToUserGroupId(
+			toUserGroupId, start, end, orderByComparator, true);
+	}
+
+	/**
+	 * Returns an ordered range of all the sharing entries where toUserGroupId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>SharingEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param toUserGroupId the to user group ID
+	 * @param start the lower bound of the range of sharing entries
+	 * @param end the upper bound of the range of sharing entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching sharing entries
+	 */
+	@Override
+	public List<SharingEntry> findByToUserGroupId(
+		long toUserGroupId, int start, int end,
+		OrderByComparator<SharingEntry> orderByComparator,
+		boolean useFinderCache) {
+
+		return _collectionPersistenceFinderByToUserGroupId.find(
+			finderCache, new Object[] {toUserGroupId}, start, end,
+			orderByComparator, useFinderCache);
+	}
+
+	/**
+	 * Returns the first sharing entry in the ordered set where toUserGroupId = &#63;.
+	 *
+	 * @param toUserGroupId the to user group ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching sharing entry
+	 * @throws NoSuchEntryException if a matching sharing entry could not be found
+	 */
+	@Override
+	public SharingEntry findByToUserGroupId_First(
+			long toUserGroupId,
+			OrderByComparator<SharingEntry> orderByComparator)
+		throws NoSuchEntryException {
+
+		SharingEntry sharingEntry = fetchByToUserGroupId_First(
+			toUserGroupId, orderByComparator);
+
+		if (sharingEntry != null) {
+			return sharingEntry;
+		}
+
+		throw new NoSuchEntryException(
+			_collectionPersistenceFinderByToUserGroupId.buildNoSuchKeyMessage(
+				_NO_SUCH_ENTITY_WITH_KEY, new Object[] {toUserGroupId}));
+	}
+
+	/**
+	 * Returns the first sharing entry in the ordered set where toUserGroupId = &#63;.
+	 *
+	 * @param toUserGroupId the to user group ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching sharing entry, or <code>null</code> if a matching sharing entry could not be found
+	 */
+	@Override
+	public SharingEntry fetchByToUserGroupId_First(
+		long toUserGroupId, OrderByComparator<SharingEntry> orderByComparator) {
+
+		return _collectionPersistenceFinderByToUserGroupId.fetchFirst(
+			finderCache, new Object[] {toUserGroupId}, orderByComparator);
+	}
+
+	/**
+	 * Removes all the sharing entries where toUserGroupId = &#63; from the database.
+	 *
+	 * @param toUserGroupId the to user group ID
+	 */
+	@Override
+	public void removeByToUserGroupId(long toUserGroupId) {
+		_collectionPersistenceFinderByToUserGroupId.remove(
+			finderCache, new Object[] {toUserGroupId});
+	}
+
+	/**
+	 * Returns the number of sharing entries where toUserGroupId = &#63;.
+	 *
+	 * @param toUserGroupId the to user group ID
+	 * @return the number of matching sharing entries
+	 */
+	@Override
+	public int countByToUserGroupId(long toUserGroupId) {
+		return _collectionPersistenceFinderByToUserGroupId.count(
+			finderCache, new Object[] {toUserGroupId});
+	}
+
 	private FinderPath _finderPathWithPaginationFindByToUserId;
 	private FinderPath _finderPathWithoutPaginationFindByToUserId;
 	private FinderPath _finderPathCountByToUserId;
@@ -2606,6 +2754,35 @@ public class SharingEntryPersistenceImpl
 					"sharingEntry.", "toTicketId", FinderColumn.Type.LONG, "=",
 					true, true, SharingEntry::getToTicketId));
 
+		_finderPathWithPaginationFindByToUserGroupId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByToUserGroupId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"toUserGroupId"}, true);
+
+		_finderPathWithoutPaginationFindByToUserGroupId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByToUserGroupId",
+			new String[] {Long.class.getName()}, new String[] {"toUserGroupId"},
+			true);
+
+		_finderPathCountByToUserGroupId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByToUserGroupId",
+			new String[] {Long.class.getName()}, new String[] {"toUserGroupId"},
+			false);
+
+		_collectionPersistenceFinderByToUserGroupId =
+			new CollectionPersistenceFinder<>(
+				this, _finderPathWithPaginationFindByToUserGroupId,
+				_finderPathWithoutPaginationFindByToUserGroupId,
+				_finderPathCountByToUserGroupId, _SQL_SELECT_SHARINGENTRY_WHERE,
+				_SQL_COUNT_SHARINGENTRY_WHERE,
+				SharingEntryModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
+				new FinderColumn<>(
+					"sharingEntry.", "toUserGroupId", FinderColumn.Type.LONG,
+					"=", true, true, SharingEntry::getToUserGroupId));
+
 		_finderPathWithPaginationFindByToUserId = new FinderPath(
 			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByToUserId",
 			new String[] {
@@ -2897,4 +3074,4 @@ public class SharingEntryPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1094267747
+// LIFERAY-SERVICE-BUILDER-HASH:623170324

--- a/modules/apps/sharing/sharing-service/src/main/resources/META-INF/sql/indexes.sql
+++ b/modules/apps/sharing/sharing-service/src/main/resources/META-INF/sql/indexes.sql
@@ -1,9 +1,10 @@
 create index IX_1ED300B1 on SharingEntry (classNameId, classPK);
 create index IX_CC1C3576 on SharingEntry (classNameId, companyId);
-create unique index IX_9E8B9952 on SharingEntry (classNameId, toUserId, classPK, toTicketId, toUserGroupId);
+create unique index IX_3722C73E on SharingEntry (classNameId, toUserId, toTicketId, classPK, toUserGroupId);
 create index IX_8E0359AC on SharingEntry (classNameId, userId);
 create index IX_1E35B88D on SharingEntry (expirationDate);
 create unique index IX_FA5E24AF on SharingEntry (groupId, externalReferenceCode[$COLUMN_LENGTH:75$]);
+create index IX_79E43C32 on SharingEntry (toTicketId);
 create index IX_C024CFB1 on SharingEntry (toUserId);
 create index IX_EA2FF796 on SharingEntry (userId);
 create unique index IX_5EDE78D2 on SharingEntry (uuid_[$COLUMN_LENGTH:75$], groupId);

--- a/modules/apps/sharing/sharing-service/src/main/resources/META-INF/sql/indexes.sql
+++ b/modules/apps/sharing/sharing-service/src/main/resources/META-INF/sql/indexes.sql
@@ -1,10 +1,11 @@
 create index IX_1ED300B1 on SharingEntry (classNameId, classPK);
 create index IX_CC1C3576 on SharingEntry (classNameId, companyId);
-create unique index IX_3722C73E on SharingEntry (classNameId, toUserId, toTicketId, classPK, toUserGroupId);
+create unique index IX_D59EA21C on SharingEntry (classNameId, toUserId, toTicketId, toUserGroupId, classPK);
 create index IX_8E0359AC on SharingEntry (classNameId, userId);
 create index IX_1E35B88D on SharingEntry (expirationDate);
 create unique index IX_FA5E24AF on SharingEntry (groupId, externalReferenceCode[$COLUMN_LENGTH:75$]);
 create index IX_79E43C32 on SharingEntry (toTicketId);
+create index IX_85902908 on SharingEntry (toUserGroupId);
 create index IX_C024CFB1 on SharingEntry (toUserId);
 create index IX_EA2FF796 on SharingEntry (userId);
 create unique index IX_5EDE78D2 on SharingEntry (uuid_[$COLUMN_LENGTH:75$], groupId);

--- a/modules/apps/sharing/sharing-service/src/main/resources/service.properties
+++ b/modules/apps/sharing/sharing-service/src/main/resources/service.properties
@@ -13,5 +13,5 @@
 ##
 
     build.namespace=com.liferay.sharing.service
-    build.number=2
-    build.date=1776902861039
+    build.number=3
+    build.date=1777571248197

--- a/modules/apps/sharing/sharing-service/src/main/resources/service.properties
+++ b/modules/apps/sharing/sharing-service/src/main/resources/service.properties
@@ -13,5 +13,5 @@
 ##
 
     build.namespace=com.liferay.sharing.service
-    build.number=3
-    build.date=1777571248197
+    build.number=4
+    build.date=1777883110716

--- a/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/internal/model/listener/test/TicketModelListenerTest.java
+++ b/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/internal/model/listener/test/TicketModelListenerTest.java
@@ -1,0 +1,141 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.sharing.internal.model.listener.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Ticket;
+import com.liferay.portal.kernel.model.TicketConstants;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.TicketLocalService;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.test.rule.SynchronousMailTestRule;
+import com.liferay.sharing.model.SharingEntry;
+import com.liferay.sharing.security.permission.SharingEntryAction;
+import com.liferay.sharing.service.SharingEntryLocalService;
+
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Alicia García
+ */
+@RunWith(Arquillian.class)
+public class TicketModelListenerTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE,
+			SynchronousMailTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	@TestInfo("LPD-48130")
+	public void testDeletingTicketDeletesSharingEntries() throws Exception {
+		Ticket ticket1 = _addInviteCollaboratorTicket();
+		Ticket ticket2 = _addInviteCollaboratorTicket();
+
+		_addToTicketIdSharingEntry(_group.getGroupId(), ticket1.getTicketId());
+		_addToTicketIdSharingEntry(_group.getGroupId(), ticket2.getTicketId());
+
+		List<SharingEntry> toTicketSharingEntries =
+			_sharingEntryLocalService.getToTicketSharingEntries(
+				ticket1.getTicketId());
+
+		Assert.assertEquals(
+			toTicketSharingEntries.toString(), 1,
+			toTicketSharingEntries.size());
+
+		toTicketSharingEntries =
+			_sharingEntryLocalService.getToTicketSharingEntries(
+				ticket2.getTicketId());
+
+		Assert.assertEquals(
+			toTicketSharingEntries.toString(), 1,
+			toTicketSharingEntries.size());
+
+		_ticketLocalService.deleteTicket(ticket1);
+
+		toTicketSharingEntries =
+			_sharingEntryLocalService.getToTicketSharingEntries(
+				ticket1.getTicketId());
+
+		Assert.assertEquals(
+			toTicketSharingEntries.toString(), 0,
+			toTicketSharingEntries.size());
+
+		toTicketSharingEntries =
+			_sharingEntryLocalService.getToTicketSharingEntries(
+				ticket2.getTicketId());
+
+		Assert.assertEquals(
+			toTicketSharingEntries.toString(), 1,
+			toTicketSharingEntries.size());
+	}
+
+	private Ticket _addInviteCollaboratorTicket() throws Exception {
+		return _ticketLocalService.addTicket(
+			TestPropsValues.getCompanyId(), Group.class.getName(),
+			_group.getGroupId(), TicketConstants.TYPE_INVITE_COLLABORATOR,
+			JSONUtil.put(
+				"emailAddress", RandomTestUtil.randomString() + "@liferay.com"
+			).toString(),
+			new Date(System.currentTimeMillis() + TimeUnit.HOURS.toMillis(48)),
+			new ServiceContext());
+	}
+
+	private void _addToTicketIdSharingEntry(long classPK, long toTicketId)
+		throws Exception {
+
+		_sharingEntryLocalService.addSharingEntry(
+			null, TestPropsValues.getUserId(), toTicketId, 0, 0,
+			_classNameLocalService.getClassNameId(Group.class.getName()),
+			classPK, _group.getGroupId(), true,
+			Arrays.asList(SharingEntryAction.VIEW), null,
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId()));
+	}
+
+	@Inject
+	private ClassNameLocalService _classNameLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private SharingEntryLocalService _sharingEntryLocalService;
+
+	@Inject
+	private TicketLocalService _ticketLocalService;
+
+}

--- a/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/internal/model/listener/test/UserGroupModelListenerTest.java
+++ b/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/internal/model/listener/test/UserGroupModelListenerTest.java
@@ -1,0 +1,127 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.sharing.internal.model.listener.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.UserGroup;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.service.UserGroupLocalService;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserGroupTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.test.rule.SynchronousMailTestRule;
+import com.liferay.sharing.model.SharingEntry;
+import com.liferay.sharing.security.permission.SharingEntryAction;
+import com.liferay.sharing.service.SharingEntryLocalService;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Alicia García
+ */
+@RunWith(Arquillian.class)
+public class UserGroupModelListenerTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE,
+			SynchronousMailTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	@TestInfo("LPD-48130")
+	public void testDeletingUserGroupDeletesSharingEntries() throws Exception {
+		UserGroup userGroup1 = UserGroupTestUtil.addUserGroup();
+		UserGroup userGroup2 = UserGroupTestUtil.addUserGroup();
+
+		_addToUserGroupIdSharingEntry(
+			_group.getGroupId(), userGroup1.getUserGroupId());
+		_addToUserGroupIdSharingEntry(
+			_group.getGroupId(), userGroup2.getUserGroupId());
+
+		List<SharingEntry> toUserGroupSharingEntries =
+			_sharingEntryLocalService.getToUserGroupSharingEntries(
+				userGroup1.getUserGroupId());
+
+		Assert.assertEquals(
+			toUserGroupSharingEntries.toString(), 1,
+			toUserGroupSharingEntries.size());
+
+		toUserGroupSharingEntries =
+			_sharingEntryLocalService.getToUserGroupSharingEntries(
+				userGroup2.getUserGroupId());
+
+		Assert.assertEquals(
+			toUserGroupSharingEntries.toString(), 1,
+			toUserGroupSharingEntries.size());
+
+		_userGroupLocalService.deleteUserGroup(userGroup1);
+
+		toUserGroupSharingEntries =
+			_sharingEntryLocalService.getToUserGroupSharingEntries(
+				userGroup1.getUserGroupId());
+
+		Assert.assertEquals(
+			toUserGroupSharingEntries.toString(), 0,
+			toUserGroupSharingEntries.size());
+
+		toUserGroupSharingEntries =
+			_sharingEntryLocalService.getToUserGroupSharingEntries(
+				userGroup2.getUserGroupId());
+
+		Assert.assertEquals(
+			toUserGroupSharingEntries.toString(), 1,
+			toUserGroupSharingEntries.size());
+	}
+
+	private void _addToUserGroupIdSharingEntry(long classPK, long toUserGroupId)
+		throws Exception {
+
+		_sharingEntryLocalService.addSharingEntry(
+			null, TestPropsValues.getUserId(), 0, toUserGroupId, 0,
+			_classNameLocalService.getClassNameId(Group.class.getName()),
+			classPK, _group.getGroupId(), true,
+			Arrays.asList(SharingEntryAction.VIEW), null,
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId()));
+	}
+
+	@Inject
+	private ClassNameLocalService _classNameLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private SharingEntryLocalService _sharingEntryLocalService;
+
+	@Inject
+	private UserGroupLocalService _userGroupLocalService;
+
+}

--- a/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/internal/model/listener/test/UserModelListenerTest.java
+++ b/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/internal/model/listener/test/UserModelListenerTest.java
@@ -152,6 +152,22 @@ public class UserModelListenerTest {
 		_addToTicketIdSharingEntry(_group1.getGroupId(), ticket1.getTicketId());
 		_addToTicketIdSharingEntry(_group1.getGroupId(), ticket2.getTicketId());
 
+		List<SharingEntry> toTicketSharingEntries =
+			_sharingEntryLocalService.getToTicketSharingEntries(
+				ticket1.getTicketId());
+
+		Assert.assertEquals(
+			toTicketSharingEntries.toString(), 1,
+			toTicketSharingEntries.size());
+
+		toTicketSharingEntries =
+			_sharingEntryLocalService.getToTicketSharingEntries(
+				ticket2.getTicketId());
+
+		Assert.assertEquals(
+			toTicketSharingEntries.toString(), 1,
+			toTicketSharingEntries.size());
+
 		User user3 = _addUser(emailAddress1);
 
 		Assert.assertNull(
@@ -169,6 +185,22 @@ public class UserModelListenerTest {
 		sharingEntry1 = toUserSharingEntries.get(0);
 
 		Assert.assertEquals(0, sharingEntry1.getToTicketId());
+
+		toTicketSharingEntries =
+			_sharingEntryLocalService.getToTicketSharingEntries(
+				ticket1.getTicketId());
+
+		Assert.assertEquals(
+			toTicketSharingEntries.toString(), 0,
+			toTicketSharingEntries.size());
+
+		toTicketSharingEntries =
+			_sharingEntryLocalService.getToTicketSharingEntries(
+				ticket2.getTicketId());
+
+		Assert.assertEquals(
+			toTicketSharingEntries.toString(), 0,
+			toTicketSharingEntries.size());
 	}
 
 	@Test

--- a/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/internal/model/listener/test/UserModelListenerTest.java
+++ b/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/internal/model/listener/test/UserModelListenerTest.java
@@ -28,6 +28,7 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -201,6 +202,48 @@ public class UserModelListenerTest {
 		Assert.assertEquals(
 			toTicketSharingEntries.toString(), 0,
 			toTicketSharingEntries.size());
+
+		emailAddress1 = RandomTestUtil.randomString() + "@liferay.com";
+
+		ticket1 = _addInviteCollaboratorTicketWithExtraInfo(null);
+		ticket2 = _addInviteCollaboratorTicketWithExtraInfo("not-json");
+		ticket3 = _addInviteCollaboratorTicket(emailAddress1);
+
+		sharingEntry1 = _addToTicketIdSharingEntry(
+			_group1.getGroupId(), ticket1.getTicketId());
+		sharingEntry2 = _addToTicketIdSharingEntry(
+			_group1.getGroupId(), ticket2.getTicketId());
+		sharingEntry3 = _addToTicketIdSharingEntry(
+			_group1.getGroupId(), ticket3.getTicketId());
+
+		User user4 = _addUser(emailAddress1);
+
+		Assert.assertNotNull(
+			_ticketLocalService.fetchTicket(ticket1.getTicketId()));
+		Assert.assertNotNull(
+			_ticketLocalService.fetchTicket(ticket2.getTicketId()));
+		Assert.assertNull(
+			_ticketLocalService.fetchTicket(ticket3.getTicketId()));
+
+		sharingEntry1 = _sharingEntryLocalService.getSharingEntry(
+			sharingEntry1.getSharingEntryId());
+
+		Assert.assertEquals(
+			ticket1.getTicketId(), sharingEntry1.getToTicketId());
+		Assert.assertEquals(0, sharingEntry1.getToUserId());
+
+		sharingEntry2 = _sharingEntryLocalService.getSharingEntry(
+			sharingEntry2.getSharingEntryId());
+
+		Assert.assertEquals(
+			ticket2.getTicketId(), sharingEntry2.getToTicketId());
+		Assert.assertEquals(0, sharingEntry2.getToUserId());
+
+		sharingEntry3 = _sharingEntryLocalService.getSharingEntry(
+			sharingEntry3.getSharingEntryId());
+
+		Assert.assertEquals(0, sharingEntry3.getToTicketId());
+		Assert.assertEquals(user4.getUserId(), sharingEntry3.getToUserId());
 	}
 
 	@Test
@@ -314,12 +357,19 @@ public class UserModelListenerTest {
 	private Ticket _addInviteCollaboratorTicket(String emailAddress)
 		throws Exception {
 
+		return _addInviteCollaboratorTicketWithExtraInfo(
+			JSONUtil.put(
+				"emailAddress", emailAddress
+			).toString());
+	}
+
+	private Ticket _addInviteCollaboratorTicketWithExtraInfo(String extraInfo)
+		throws Exception {
+
 		return _ticketLocalService.addTicket(
 			TestPropsValues.getCompanyId(), Group.class.getName(),
 			_group1.getGroupId(), TicketConstants.TYPE_INVITE_COLLABORATOR,
-			JSONUtil.put(
-				"emailAddress", emailAddress
-			).toString(),
+			extraInfo,
 			new Date(System.currentTimeMillis() + TimeUnit.HOURS.toMillis(48)),
 			new ServiceContext());
 	}

--- a/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/internal/model/listener/test/UserModelListenerTest.java
+++ b/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/internal/model/listener/test/UserModelListenerTest.java
@@ -13,11 +13,13 @@ import com.liferay.portal.kernel.model.Ticket;
 import com.liferay.portal.kernel.model.TicketConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.UserConstants;
+import com.liferay.portal.kernel.model.WorkflowDefinitionLink;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.TicketLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalService;
 import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
@@ -354,6 +356,60 @@ public class UserModelListenerTest {
 			toUserSharingEntries.toString(), 1, toUserSharingEntries.size());
 	}
 
+	@Test
+	@TestInfo("LPD-48130")
+	public void testUpdateUserStatus() throws Exception {
+		WorkflowDefinitionLink workflowDefinitionLink =
+			_workflowDefinitionLinkLocalService.addWorkflowDefinitionLink(
+				null, TestPropsValues.getUserId(),
+				TestPropsValues.getCompanyId(),
+				WorkflowConstants.DEFAULT_GROUP_ID, User.class.getName(), 0, 0,
+				"Single Approver", 1);
+
+		try {
+			String emailAddress =
+				RandomTestUtil.randomString() + "@liferay.com";
+
+			Ticket ticket = _addInviteCollaboratorTicket(emailAddress);
+
+			SharingEntry sharingEntry = _addToTicketIdSharingEntry(
+				_group1.getGroupId(), ticket.getTicketId());
+
+			User user = _addUserWithWorkflow(emailAddress);
+
+			Assert.assertEquals(
+				WorkflowConstants.STATUS_PENDING, user.getStatus());
+
+			Assert.assertNotNull(
+				_ticketLocalService.fetchTicket(ticket.getTicketId()));
+
+			sharingEntry = _sharingEntryLocalService.getSharingEntry(
+				sharingEntry.getSharingEntryId());
+
+			Assert.assertEquals(
+				ticket.getTicketId(), sharingEntry.getToTicketId());
+			Assert.assertEquals(0, sharingEntry.getToUserId());
+
+			_userLocalService.updateStatus(
+				user.getUserId(), WorkflowConstants.STATUS_APPROVED,
+				ServiceContextTestUtil.getServiceContext(
+					_group1.getGroupId(), TestPropsValues.getUserId()));
+
+			Assert.assertNull(
+				_ticketLocalService.fetchTicket(ticket.getTicketId()));
+
+			sharingEntry = _sharingEntryLocalService.getSharingEntry(
+				sharingEntry.getSharingEntryId());
+
+			Assert.assertEquals(0, sharingEntry.getToTicketId());
+			Assert.assertEquals(user.getUserId(), sharingEntry.getToUserId());
+		}
+		finally {
+			_workflowDefinitionLinkLocalService.deleteWorkflowDefinitionLink(
+				workflowDefinitionLink);
+		}
+	}
+
 	private Ticket _addInviteCollaboratorTicket(String emailAddress)
 		throws Exception {
 
@@ -438,5 +494,9 @@ public class UserModelListenerTest {
 
 	@DeleteAfterTestRun
 	private final List<User> _users = new ArrayList<>();
+
+	@Inject
+	private WorkflowDefinitionLinkLocalService
+		_workflowDefinitionLinkLocalService;
 
 }

--- a/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/internal/model/listener/test/UserModelListenerTest.java
+++ b/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/internal/model/listener/test/UserModelListenerTest.java
@@ -6,17 +6,28 @@
 package com.liferay.sharing.internal.model.listener.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Ticket;
+import com.liferay.portal.kernel.model.TicketConstants;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.UserConstants;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.TicketLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -25,8 +36,12 @@ import com.liferay.sharing.model.SharingEntry;
 import com.liferay.sharing.security.permission.SharingEntryAction;
 import com.liferay.sharing.service.SharingEntryLocalService;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Date;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -51,25 +66,170 @@ public class UserModelListenerTest {
 
 	@Before
 	public void setUp() throws Exception {
-		_group = GroupTestUtil.addGroup();
+		_group1 = GroupTestUtil.addGroup();
 
 		_groupUser1 = UserTestUtil.addGroupUser(
-			_group, RoleConstants.POWER_USER);
+			_group1, RoleConstants.POWER_USER);
 		_groupUser2 = UserTestUtil.addGroupUser(
-			_group, RoleConstants.POWER_USER);
+			_group1, RoleConstants.POWER_USER);
+	}
+
+	@Test
+	@TestInfo("LPD-48130")
+	public void testAddUser() throws Exception {
+		String emailAddress1 = RandomTestUtil.randomString() + "@liferay.com";
+		String emailAddress2 = RandomTestUtil.randomString() + "@liferay.com";
+
+		Ticket ticket1 = _addInviteCollaboratorTicket(emailAddress1);
+		Ticket ticket2 = _addInviteCollaboratorTicket(emailAddress1);
+		Ticket ticket3 = _addInviteCollaboratorTicket(emailAddress2);
+
+		_group2 = GroupTestUtil.addGroup();
+
+		SharingEntry sharingEntry1 = _addToTicketIdSharingEntry(
+			_group1.getGroupId(), ticket1.getTicketId());
+		SharingEntry sharingEntry2 = _addToTicketIdSharingEntry(
+			_group2.getGroupId(), ticket2.getTicketId());
+		SharingEntry sharingEntry3 = _addToTicketIdSharingEntry(
+			_group1.getGroupId(), ticket3.getTicketId());
+
+		User user1 = _addUser(emailAddress1);
+
+		Assert.assertNull(
+			_ticketLocalService.fetchTicket(ticket1.getTicketId()));
+		Assert.assertNull(
+			_ticketLocalService.fetchTicket(ticket2.getTicketId()));
+
+		sharingEntry1 = _sharingEntryLocalService.getSharingEntry(
+			sharingEntry1.getSharingEntryId());
+
+		Assert.assertEquals(0, sharingEntry1.getToTicketId());
+		Assert.assertEquals(user1.getUserId(), sharingEntry1.getToUserId());
+
+		sharingEntry2 = _sharingEntryLocalService.getSharingEntry(
+			sharingEntry2.getSharingEntryId());
+
+		Assert.assertEquals(0, sharingEntry2.getToTicketId());
+		Assert.assertEquals(user1.getUserId(), sharingEntry2.getToUserId());
+
+		ticket3 = _ticketLocalService.fetchTicket(ticket3.getTicketId());
+
+		sharingEntry3 = _sharingEntryLocalService.getSharingEntry(
+			sharingEntry3.getSharingEntryId());
+
+		Assert.assertEquals(
+			ticket3.getTicketId(), sharingEntry3.getToTicketId());
+		Assert.assertEquals(0, sharingEntry3.getToUserId());
+
+		// With Case Insensitive Email Address
+
+		emailAddress1 = RandomTestUtil.randomString() + "@liferay.com";
+
+		ticket1 = _addInviteCollaboratorTicket(
+			StringUtil.toUpperCase(emailAddress1));
+
+		sharingEntry1 = _addToTicketIdSharingEntry(
+			_group1.getGroupId(), ticket1.getTicketId());
+
+		User user2 = _addUser(emailAddress1);
+
+		Assert.assertNull(
+			_ticketLocalService.fetchTicket(ticket1.getTicketId()));
+
+		sharingEntry1 = _sharingEntryLocalService.getSharingEntry(
+			sharingEntry1.getSharingEntryId());
+
+		Assert.assertEquals(0, sharingEntry1.getToTicketId());
+		Assert.assertEquals(user2.getUserId(), sharingEntry1.getToUserId());
+
+		// With Duplicate Sharing Entry
+
+		emailAddress1 = RandomTestUtil.randomString() + "@liferay.com";
+
+		ticket1 = _addInviteCollaboratorTicket(emailAddress1);
+		ticket2 = _addInviteCollaboratorTicket(emailAddress1);
+
+		_addToTicketIdSharingEntry(_group1.getGroupId(), ticket1.getTicketId());
+		_addToTicketIdSharingEntry(_group1.getGroupId(), ticket2.getTicketId());
+
+		User user3 = _addUser(emailAddress1);
+
+		Assert.assertNull(
+			_ticketLocalService.fetchTicket(ticket1.getTicketId()));
+		Assert.assertNull(
+			_ticketLocalService.fetchTicket(ticket2.getTicketId()));
+
+		List<SharingEntry> toUserSharingEntries =
+			_sharingEntryLocalService.getToUserSharingEntries(
+				user3.getUserId());
+
+		Assert.assertEquals(
+			toUserSharingEntries.toString(), 1, toUserSharingEntries.size());
+
+		sharingEntry1 = toUserSharingEntries.get(0);
+
+		Assert.assertEquals(0, sharingEntry1.getToTicketId());
+	}
+
+	@Test
+	@TestInfo("LPD-48130")
+	public void testAddUserWithWorkflow() throws Exception {
+		String emailAddress1 = RandomTestUtil.randomString() + "@liferay.com";
+		String emailAddress2 = RandomTestUtil.randomString() + "@liferay.com";
+
+		Ticket ticket1 = _addInviteCollaboratorTicket(emailAddress1);
+		Ticket ticket2 = _addInviteCollaboratorTicket(emailAddress1);
+		Ticket ticket3 = _addInviteCollaboratorTicket(emailAddress2);
+
+		_group2 = GroupTestUtil.addGroup();
+
+		SharingEntry sharingEntry1 = _addToTicketIdSharingEntry(
+			_group1.getGroupId(), ticket1.getTicketId());
+		SharingEntry sharingEntry2 = _addToTicketIdSharingEntry(
+			_group2.getGroupId(), ticket2.getTicketId());
+		SharingEntry sharingEntry3 = _addToTicketIdSharingEntry(
+			_group1.getGroupId(), ticket3.getTicketId());
+
+		User user = _addUserWithWorkflow(emailAddress1);
+
+		Assert.assertNull(
+			_ticketLocalService.fetchTicket(ticket1.getTicketId()));
+		Assert.assertNull(
+			_ticketLocalService.fetchTicket(ticket2.getTicketId()));
+
+		sharingEntry1 = _sharingEntryLocalService.getSharingEntry(
+			sharingEntry1.getSharingEntryId());
+
+		Assert.assertEquals(0, sharingEntry1.getToTicketId());
+		Assert.assertEquals(user.getUserId(), sharingEntry1.getToUserId());
+
+		sharingEntry2 = _sharingEntryLocalService.getSharingEntry(
+			sharingEntry2.getSharingEntryId());
+
+		Assert.assertEquals(0, sharingEntry2.getToTicketId());
+		Assert.assertEquals(user.getUserId(), sharingEntry2.getToUserId());
+
+		ticket3 = _ticketLocalService.fetchTicket(ticket3.getTicketId());
+
+		sharingEntry3 = _sharingEntryLocalService.getSharingEntry(
+			sharingEntry3.getSharingEntryId());
+
+		Assert.assertEquals(
+			ticket3.getTicketId(), sharingEntry3.getToTicketId());
+		Assert.assertEquals(0, sharingEntry3.getToUserId());
 	}
 
 	@Test
 	public void testDeletingUserSharedDeletesSharingEntries() throws Exception {
-		long classPK = _group.getGroupId();
+		long classPK = _group1.getGroupId();
 
 		_sharingEntryLocalService.addSharingEntry(
 			null, TestPropsValues.getUserId(), 0, 0, _groupUser1.getUserId(),
 			_classNameLocalService.getClassNameId(Group.class.getName()),
-			classPK, _group.getGroupId(), true,
+			classPK, _group1.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.VIEW), null,
 			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), TestPropsValues.getUserId()));
+				_group1.getGroupId(), TestPropsValues.getUserId()));
 
 		List<SharingEntry> toUserSharingEntries =
 			_sharingEntryLocalService.getToUserSharingEntries(
@@ -92,15 +252,15 @@ public class UserModelListenerTest {
 	public void testDeletingUserSharingDoesNotDeleteSharingEntries()
 		throws Exception {
 
-		long classPK = _group.getGroupId();
+		long classPK = _group1.getGroupId();
 
 		_sharingEntryLocalService.addSharingEntry(
 			null, TestPropsValues.getUserId(), 0, 0, _groupUser1.getUserId(),
 			_classNameLocalService.getClassNameId(Group.class.getName()),
-			classPK, _group.getGroupId(), true,
+			classPK, _group1.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.VIEW), null,
 			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), TestPropsValues.getUserId()));
+				_group1.getGroupId(), TestPropsValues.getUserId()));
 
 		List<SharingEntry> toUserSharingEntries =
 			_sharingEntryLocalService.getToUserSharingEntries(
@@ -119,11 +279,68 @@ public class UserModelListenerTest {
 			toUserSharingEntries.toString(), 1, toUserSharingEntries.size());
 	}
 
+	private Ticket _addInviteCollaboratorTicket(String emailAddress)
+		throws Exception {
+
+		return _ticketLocalService.addTicket(
+			TestPropsValues.getCompanyId(), Group.class.getName(),
+			_group1.getGroupId(), TicketConstants.TYPE_INVITE_COLLABORATOR,
+			JSONUtil.put(
+				"emailAddress", emailAddress
+			).toString(),
+			new Date(System.currentTimeMillis() + TimeUnit.HOURS.toMillis(48)),
+			new ServiceContext());
+	}
+
+	private SharingEntry _addToTicketIdSharingEntry(
+			long classPK, long toTicketId)
+		throws Exception {
+
+		return _sharingEntryLocalService.addSharingEntry(
+			null, TestPropsValues.getUserId(), toTicketId, 0, 0,
+			_classNameLocalService.getClassNameId(Group.class.getName()),
+			classPK, _group1.getGroupId(), true,
+			Arrays.asList(SharingEntryAction.VIEW), null,
+			ServiceContextTestUtil.getServiceContext(
+				_group1.getGroupId(), TestPropsValues.getUserId()));
+	}
+
+	private User _addUser(String emailAddress) throws Exception {
+		User user = UserTestUtil.addUser(
+			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			StringPool.BLANK, emailAddress, RandomTestUtil.randomString(),
+			LocaleUtil.getDefault(), "Test", "User", null,
+			ServiceContextTestUtil.getServiceContext(
+				_group1.getGroupId(), TestPropsValues.getUserId()));
+
+		_users.add(user);
+
+		return user;
+	}
+
+	private User _addUserWithWorkflow(String emailAddress) throws Exception {
+		User user = _userLocalService.addUserWithWorkflow(
+			TestPropsValues.getUserId(), TestPropsValues.getCompanyId(), true,
+			null, null, false, RandomTestUtil.randomString(), emailAddress,
+			LocaleUtil.getDefault(), "Test", StringPool.BLANK, "User", 0, 0,
+			true, Calendar.JANUARY, 1, 1970, StringPool.BLANK,
+			UserConstants.TYPE_REGULAR, null, null, null, null, false,
+			ServiceContextTestUtil.getServiceContext(
+				_group1.getGroupId(), TestPropsValues.getUserId()));
+
+		_users.add(user);
+
+		return user;
+	}
+
 	@Inject
 	private ClassNameLocalService _classNameLocalService;
 
 	@DeleteAfterTestRun
-	private Group _group;
+	private Group _group1;
+
+	@DeleteAfterTestRun
+	private Group _group2;
 
 	private User _groupUser1;
 	private User _groupUser2;
@@ -132,6 +349,12 @@ public class UserModelListenerTest {
 	private SharingEntryLocalService _sharingEntryLocalService;
 
 	@Inject
+	private TicketLocalService _ticketLocalService;
+
+	@Inject
 	private UserLocalService _userLocalService;
+
+	@DeleteAfterTestRun
+	private final List<User> _users = new ArrayList<>();
 
 }

--- a/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/service/persistence/test/SharingEntryPersistenceTest.java
+++ b/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/service/persistence/test/SharingEntryPersistenceTest.java
@@ -261,6 +261,13 @@ public class SharingEntryPersistenceTest {
 	}
 
 	@Test
+	public void testCountByToTicketId() throws Exception {
+		_persistence.countByToTicketId(RandomTestUtil.nextLong());
+
+		_persistence.countByToTicketId(0L);
+	}
+
+	@Test
 	public void testCountByToUserId() throws Exception {
 		_persistence.countByToUserId(RandomTestUtil.nextLong());
 
@@ -718,4 +725,4 @@ public class SharingEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1193723092
+// LIFERAY-SERVICE-BUILDER-HASH:-1957922974

--- a/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/service/persistence/test/SharingEntryPersistenceTest.java
+++ b/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/service/persistence/test/SharingEntryPersistenceTest.java
@@ -268,6 +268,13 @@ public class SharingEntryPersistenceTest {
 	}
 
 	@Test
+	public void testCountByToUserGroupId() throws Exception {
+		_persistence.countByToUserGroupId(RandomTestUtil.nextLong());
+
+		_persistence.countByToUserGroupId(0L);
+	}
+
+	@Test
 	public void testCountByToUserId() throws Exception {
 		_persistence.countByToUserId(RandomTestUtil.nextLong());
 
@@ -725,4 +732,4 @@ public class SharingEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1957922974
+// LIFERAY-SERVICE-BUILDER-HASH:-1087120718

--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -744,7 +744,7 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 			externalReferenceCode, companyId);
 
 		if (user == null) {
-			user = addUserWithWorkflow(
+			user = userLocalService.addUserWithWorkflow(
 				creatorUserId, companyId, autoPassword, password1, password2,
 				autoScreenName, screenName, emailAddress, locale, firstName,
 				middleName, lastName, prefixListTypeId, suffixListTypeId, male,
@@ -1045,7 +1045,7 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 					WorkflowConstants.ACTION_PUBLISH);
 			}
 
-			return addUserWithWorkflow(
+			return userLocalService.addUserWithWorkflow(
 				creatorUserId, companyId, autoPassword, password1, password2,
 				autoScreenName, screenName, emailAddress, locale, firstName,
 				middleName, lastName, prefixListTypeId, suffixListTypeId, male,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88003

Note: this PR is over Brian Master. And over https://github.com/liferay-content-management/liferay-portal/pull/8183 so We need that to pass to follow this PR. Only commits with LPD-88003 are in need of review.

## What is being fixed

When a `Ticket` or `UserGroup` is deleted, any `SharingEntry` rows referencing them via `toTicketId` or `toUserGroupId` were left as orphans in the database.

## How it is being fixed

Two new model listeners are added to `sharing-service`:`TicketModelListener` and `UserGroupModelListener`. Both hook`onBeforeRemove` and delegate to new service methods —`deleteToTicketSharingEntries` and `deleteToUserGroupSharingEntries` — thatfind all matching entries via the persistence layer and delete them one by
one, following the same pattern as the existing `GroupModelListener` and`UserModelListener.onBeforeRemove`.

A `ToUserGroupId` finder is added to `service.xml` (with a corresponding DB index) to support the new lookup. The unique composite index columns are reordered to match the updated finder definition.


# How can you verify that it works?

Run the included automated tests.

# Commits

- ab6d35aa74376 LPD-88003 add finder for UserGroup on sharing entry
- 8fd8e5fbd38df LPD-88003 add methods, to deletes by toTicketId and ToUserGroupId. To search by ToUserGroupId
- b25a8d528e378 LPD-88003 buildService
- 6bff3a5341b01 LPD-88003 add model listeners to delete the sharing entries when the object is deleted
- 74a4b215fb706 LPD-88003 add tests for the new modelListeners