### PR TITLE
LPD-87542 added footer padding for import dialog modal

### DIFF
--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/css/main.scss
@@ -1,3 +1,7 @@
+:root {
+	--cms-button-holder-dialog-footer-height: 61px;
+}
+
 @import 'cadmin-variables';
 
 @mixin default-label {
@@ -352,6 +356,12 @@ html#{$cadmin-selector} {
 	.cadmin {
 		.site-cms-export-import-dialog {
 			.export-dialog-tree {
+				.container-fluid {
+					padding-bottom: calc(
+						var(--cms-button-holder-dialog-footer-height) + 24px
+					);
+				}
+
 				a.configuration-link,
 				a.content-link,
 				a.options-link,
@@ -364,9 +374,9 @@ html#{$cadmin-selector} {
 				.content-options legend {
 					border-top: solid #e5e5e5;
 					border-width: 1px 0 0;
-					font-size: 16px;
+					font-size: 14px;
 					font-weight: normal;
-					line-height: 1em;
+					line-height: 14px;
 					margin-bottom: 0.5em;
 					padding-top: 0.75em;
 				}


### PR DESCRIPTION
## What is this trying to solve?
https://liferay.atlassian.net/browse/LPD-87542

## Steps to Reproduce

1. Navigate to Content Structures section
2. Open either the Import or Export modal
3. Observe the modal layout

## Expected Result

- The modal body should respect a consistent bottom padding of 24px. There should be clear separation between the content area and the footer, with no visual overlap or clipping.
- The text “For each of the selected…” should use the same typography scale as the rest of the modal, 14px font size.

## Actual Result

- The modal body shows incorrect bottom padding. The footer appears to overlap or visually “cut into” the content area, reducing the available space in the central body.
- In the Import modal, within the Content section, the text “For each of the selected…” appears too large compared to the surrounding UI typography, leading to inconsistent visual hierarchy.

## How am I fixing it?
I use a "parent" wrap variable _site-cms-export-import-dialog_ to apply these changes only at CMS's pages. 

A variable **_--cms-button-holder-dialog-footer-height_** to set the button holder footer height, then is more readable to identify what 61px means. 

## How can you verify that it works?
Follow the "steps to reproduce" and inspect the elements to check it. 