### PR TITLE
LPD-87568 Adds Playwright and integration tests for Recent Assets

### DIFF
--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewHomeRecentAssetsFilesSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewHomeRecentAssetsFilesSectionDisplayContextTest.java
@@ -42,7 +42,7 @@ import org.springframework.mock.web.MockHttpServletResponse;
 @FeatureFlag("LPD-17564")
 @RunWith(Arquillian.class)
 @Sync
-public class ViewHomeRecentAssetsSectionDisplayContextTest
+public class ViewHomeRecentAssetsFilesSectionDisplayContextTest
 	extends BaseFilesSectionDisplayContextTestCase {
 
 	@ClassRule

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewHomeRecentAssetsSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewHomeRecentAssetsSectionDisplayContextTest.java
@@ -1,0 +1,226 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.display.context.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.fragment.renderer.FragmentRenderer;
+import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
+import com.liferay.frontend.data.set.test.util.FrontendDataSetTestUtil;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu;
+import com.liferay.object.constants.ObjectFolderConstants;
+import com.liferay.object.model.ObjectEntryFolder;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.Sync;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/**
+ * @author Jürgen Kappler
+ */
+@FeatureFlag("LPD-17564")
+@RunWith(Arquillian.class)
+@Sync
+public class ViewHomeRecentAssetsSectionDisplayContextTest
+	extends BaseFilesSectionDisplayContextTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Override
+	public Map<String, Object> getBaseAdditionalProps() throws Exception {
+		Map<String, Object> baseAdditionalProps =
+			super.getBaseAdditionalProps();
+
+		baseAdditionalProps.remove("additionalAPIURLParameters");
+
+		return baseAdditionalProps;
+	}
+
+	@Override
+	@Test
+	public void testGetCreationMenu() throws Exception {
+	}
+
+	@Test
+	public void testGetFDSActionDropdownItems() throws Exception {
+		List<FDSActionDropdownItem> fdsActionDropdownItems =
+			getFDSActionDropdownItems();
+
+		Assert.assertEquals(
+			fdsActionDropdownItems.toString(), 16,
+			fdsActionDropdownItems.size());
+
+		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
+			"view", "actionLinkFolder", "View Folder", "get",
+			HashMapBuilder.<String, Object>put(
+				"entryClassName", ObjectEntryFolder.class.getName()
+			).build(),
+			fdsActionDropdownItems.get(0));
+		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
+			"download", "download", "Download", "get",
+			fdsActionDropdownItems.get(1));
+		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
+			"pencil", "editFolder", "Edit", "get",
+			HashMapBuilder.<String, Object>put(
+				"entryClassName", ObjectEntryFolder.class.getName()
+			).build(),
+			fdsActionDropdownItems.get(2));
+		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
+			"pencil", "actionLink", "Edit", "get",
+			fdsActionDropdownItems.get(3));
+		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
+			"view", "view-content", "View", null,
+			fdsActionDropdownItems.get(4));
+		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
+			"view", "view-file", "View", null, fdsActionDropdownItems.get(5));
+		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
+			"automatic-translate", "translate", "Translate", "get",
+			fdsActionDropdownItems.get(6));
+		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
+			"share", "share", "Share", "get", fdsActionDropdownItems.get(7));
+		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
+			"time", "expire", "Expire", "post", fdsActionDropdownItems.get(8));
+		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
+			"date-time", "version-history", "View History", "get",
+			fdsActionDropdownItems.get(9));
+		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
+			"move-folder", "move", "Move", null,
+			fdsActionDropdownItems.get(10));
+		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
+			"copy", "copy", "Copy To", null, fdsActionDropdownItems.get(11));
+		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
+			"upload", "export-for-translation", "Export for Translation", null,
+			fdsActionDropdownItems.get(12));
+		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
+			"download", "import-translation", "Import Translation", null,
+			fdsActionDropdownItems.get(13));
+
+		FDSActionDropdownItem permissionsFDSActionDropdownItem =
+			fdsActionDropdownItems.get(14);
+
+		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
+			"password-policies", "permissions-menu", "Permissions", null,
+			"contextual", null, permissionsFDSActionDropdownItem);
+
+		List<FDSActionDropdownItem> permissionsFDSActionDropdownItems =
+			(List<FDSActionDropdownItem>)permissionsFDSActionDropdownItem.get(
+				"items");
+
+		Assert.assertEquals(
+			permissionsFDSActionDropdownItems.toString(), 4,
+			permissionsFDSActionDropdownItems.size());
+
+		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
+			"password-policies", "permissions", "Permissions", "get",
+			permissionsFDSActionDropdownItems.get(0));
+		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
+			"password-policies", "default-permissions", "Default Permissions",
+			null,
+			HashMapBuilder.<String, Object>put(
+				"entryClassName", ObjectEntryFolder.class.getName()
+			).build(),
+			permissionsFDSActionDropdownItems.get(1));
+		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
+			"password-policies", "edit-and-propagate-default-permissions",
+			"Edit and Propagate Default Permissions", null,
+			HashMapBuilder.<String, Object>put(
+				"entryClassName", ObjectEntryFolder.class.getName()
+			).build(),
+			permissionsFDSActionDropdownItems.get(2));
+		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
+			"password-policies", "reset-to-default-permissions",
+			"Reset to Default Permissions", null,
+			permissionsFDSActionDropdownItems.get(3));
+
+		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
+			"trash", "delete", "Delete", null, fdsActionDropdownItems.get(15));
+	}
+
+	@Override
+	protected CreationMenu getCreationMenu(ObjectEntryFolder objectEntryFolder)
+		throws Exception {
+
+		return null;
+	}
+
+	@Override
+	protected Map<String, String> getExpectedCreationMenuItems()
+		throws PortalException {
+
+		return Collections.emptyMap();
+	}
+
+	@Override
+	protected String getFilterString() {
+		return "cmsKind eq 'object' and (cmsSection eq 'contents' or " +
+			"cmsSection eq 'files')";
+	}
+
+	@Override
+	protected String getObjectFolderExternalReferenceCode() {
+		if (RandomTestUtil.randomBoolean()) {
+			return ObjectFolderConstants.
+				EXTERNAL_REFERENCE_CODE_CONTENT_STRUCTURES;
+		}
+
+		return ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_FILE_TYPES;
+	}
+
+	@Override
+	protected String[] getObjectFolderExternalReferenceCodes() {
+		return new String[] {
+			ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENT_STRUCTURES,
+			ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_FILE_TYPES
+		};
+	}
+
+	@Override
+	protected Object getSectionDisplayContext(
+			HttpServletRequest httpServletRequest)
+		throws Exception {
+
+		_fragmentRenderer.render(
+			null, httpServletRequest, new MockHttpServletResponse());
+
+		Object viewHomeRecentAssetsSectionDisplayContext =
+			httpServletRequest.getAttribute(
+				"com.liferay.site.cms.site.initializer.internal.display." +
+					"context.ViewHomeRecentAssetsSectionDisplayContext");
+
+		Assert.assertNotNull(viewHomeRecentAssetsSectionDisplayContext);
+
+		return viewHomeRecentAssetsSectionDisplayContext;
+	}
+
+	@Inject(
+		filter = "component.name=com.liferay.site.cms.site.initializer.internal.fragment.renderer.ViewHomeRecentAssetsJSPSectionFragmentRenderer"
+	)
+	private FragmentRenderer _fragmentRenderer;
+
+}

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/findAndReplace.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/findAndReplace.spec.ts
@@ -296,13 +296,7 @@ test(
 test(
 	'Find and Replace bulk action is hidden when user cannot update selected items',
 	{tag: '@LPD-78865'},
-	async ({
-		apiHelpers,
-		assetsPage,
-		dataSetPage,
-		findAndReplacePage,
-		page,
-	}) => {
+	async ({apiHelpers, assetsPage, dataSetPage, findAndReplacePage, page}) => {
 
 		// Create content
 
@@ -319,9 +313,10 @@ test(
 
 		// Add user without update permission
 
-		const [space] = await apiHelpers.headlessAssetLibrary.getAssetLibrariesPage(
-			`name eq '${SITE_CMS_SPACE_NAME}'`
-		);
+		const [space] =
+			await apiHelpers.headlessAssetLibrary.getAssetLibrariesPage(
+				`name eq '${SITE_CMS_SPACE_NAME}'`
+			);
 
 		const user = await apiHelpers.headlessAdminUser.postUserAccount();
 

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/home.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/home.spec.ts
@@ -546,6 +546,102 @@ test(
 );
 
 test(
+	'Can only see Recent Assets the user has VIEW permission on',
+	{tag: '@LPD-87568'},
+	async ({apiHelpers, homePage, page}) => {
+		const applicationName = 'cms/basic-web-contents';
+		const restrictedTitle = `restricted ${getRandomString()}`;
+		const visibleTitle = `visible ${getRandomString()}`;
+
+		const restrictedSpace =
+			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+				name: `Space ${getRandomString()}`,
+				settings: {
+					logoColor: 'outline-3',
+					sharingEnabled: true,
+				},
+				type: 'Space',
+			});
+
+		let restrictedEntry;
+		let visibleEntry;
+
+		try {
+			restrictedEntry = await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: restrictedTitle,
+				},
+				applicationName,
+				restrictedSpace.name
+			);
+
+			visibleEntry = await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: visibleTitle,
+				},
+				applicationName,
+				'Default'
+			);
+
+			const dataSetFragmentPage: DataSetPage = new DataSetPage(page);
+
+			await test.step('Default admin can see both assets in Recent Assets', async () => {
+				await homePage.goto();
+
+				await expect(
+					dataSetFragmentPage.table.bodyRows
+						.getByLabel(visibleTitle)
+						.getByText(visibleTitle)
+				).toBeVisible();
+
+				await expect(
+					dataSetFragmentPage.table.bodyRows
+						.getByLabel(restrictedTitle)
+						.getByText(restrictedTitle)
+				).toBeVisible();
+			});
+
+			await test.step('Space User cannot see the restricted asset in Recent Assets', async () => {
+				await performUserSwitch(page, spaceUser.alternateName);
+
+				await homePage.goto();
+
+				await expect(
+					dataSetFragmentPage.table.bodyRows
+						.getByLabel(visibleTitle)
+						.getByText(visibleTitle)
+				).toBeVisible();
+
+				await expect(
+					dataSetFragmentPage.table.bodyRows.getByLabel(
+						restrictedTitle
+					)
+				).toBeHidden();
+			});
+		}
+		finally {
+			await performUserSwitch(page, 'test');
+
+			if (restrictedEntry) {
+				await apiHelpers.objectEntry.deleteObjectEntry(
+					applicationName,
+					String(restrictedEntry.id)
+				);
+			}
+
+			if (visibleEntry) {
+				await apiHelpers.objectEntry.deleteObjectEntry(
+					applicationName,
+					String(visibleEntry.id)
+				);
+			}
+		}
+	}
+);
+
+test(
 	'Can use Quick Actions to create new content',
 	{tag: '@LPD-58793'},
 	async ({apiHelpers, homePage, page}) => {

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/home.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/home.spec.ts
@@ -591,15 +591,11 @@ test(
 				await homePage.goto();
 
 				await expect(
-					dataSetFragmentPage.table.bodyRows
-						.getByLabel(visibleTitle)
-						.getByText(visibleTitle)
+					dataSetFragmentPage.getRow(visibleTitle)
 				).toBeVisible();
 
 				await expect(
-					dataSetFragmentPage.table.bodyRows
-						.getByLabel(restrictedTitle)
-						.getByText(restrictedTitle)
+					dataSetFragmentPage.getRow(restrictedTitle)
 				).toBeVisible();
 			});
 
@@ -609,15 +605,11 @@ test(
 				await homePage.goto();
 
 				await expect(
-					dataSetFragmentPage.table.bodyRows
-						.getByLabel(visibleTitle)
-						.getByText(visibleTitle)
+					dataSetFragmentPage.getRow(visibleTitle)
 				).toBeVisible();
 
 				await expect(
-					dataSetFragmentPage.table.bodyRows.getByLabel(
-						restrictedTitle
-					)
+					dataSetFragmentPage.getRow(restrictedTitle)
 				).toBeHidden();
 			});
 		}
@@ -688,15 +680,11 @@ test(
 
 			await test.step('Recent Assets shows the content and file rows', async () => {
 				await expect(
-					dataSetFragmentPage.table.bodyRows
-						.getByLabel(contentTitle)
-						.getByText(contentTitle)
+					dataSetFragmentPage.getRow(contentTitle)
 				).toBeVisible();
 
 				await expect(
-					dataSetFragmentPage.table.bodyRows
-						.getByLabel(fileTitle)
-						.getByText(fileTitle)
+					dataSetFragmentPage.getRow(fileTitle)
 				).toBeVisible();
 			});
 
@@ -749,7 +737,7 @@ test(
 				}
 
 				await expect(
-					page.getByRole('menuitem', {
+					page.getByRole('menu').getByRole('menuitem', {
 						exact: true,
 						name: 'Download',
 					})

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/home.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/home.spec.ts
@@ -642,6 +642,154 @@ test(
 );
 
 test(
+	'Can perform asset actions on Recent Assets rows',
+	{tag: '@LPD-87568'},
+	async ({apiHelpers, homePage, page}) => {
+		const contentApplicationName = 'cms/basic-web-contents';
+		const contentTitle = `content ${getRandomString()}`;
+		const fileApplicationName = 'cms/basic-documents';
+		const fileName = `file_${getRandomString()}.png`;
+		const fileTitle = `file ${getRandomString()}`;
+
+		let contentEntry;
+		let fileEntry;
+
+		try {
+			contentEntry = await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: contentTitle,
+				},
+				contentApplicationName,
+				'Default'
+			);
+
+			fileEntry = await apiHelpers.objectEntry.postObjectEntry(
+				{
+					file: {
+						fileBase64: 'R0lGODlhAQABAAAAACw=',
+						name: fileName,
+					},
+					objectEntryFolderExternalReferenceCode: 'L_FILES',
+					title: fileTitle,
+				},
+				fileApplicationName,
+				'Default'
+			);
+
+			apiHelpers.data.push({
+				id: fileEntry.file.id,
+				type: 'document',
+			});
+
+			const dataSetFragmentPage: DataSetPage = new DataSetPage(page);
+
+			await homePage.goto();
+
+			await test.step('Recent Assets shows the content and file rows', async () => {
+				await expect(
+					dataSetFragmentPage.table.bodyRows
+						.getByLabel(contentTitle)
+						.getByText(contentTitle)
+				).toBeVisible();
+
+				await expect(
+					dataSetFragmentPage.table.bodyRows
+						.getByLabel(fileTitle)
+						.getByText(fileTitle)
+				).toBeVisible();
+			});
+
+			await test.step('File row action menu shows Download and inherited actions', async () => {
+				await dataSetFragmentPage
+					.getRow(fileTitle)
+					.getByRole('button', {name: `${fileTitle} Actions`})
+					.click();
+
+				for (const action of [
+					'Delete',
+					'Download',
+					'Edit',
+					'Permissions',
+					'Share',
+					'View History',
+				]) {
+					await expect(
+						page.getByRole('menuitem', {
+							exact: true,
+							name: action,
+						})
+					).toBeVisible();
+				}
+
+				await page.keyboard.press('Escape');
+			});
+
+			await test.step('Content row action menu shows inherited actions but no Download', async () => {
+				await dataSetFragmentPage
+					.getRow(contentTitle)
+					.getByRole('button', {
+						name: `${contentTitle} Actions`,
+					})
+					.click();
+
+				for (const action of [
+					'Delete',
+					'Edit',
+					'Permissions',
+					'Share',
+					'View History',
+				]) {
+					await expect(
+						page.getByRole('menuitem', {
+							exact: true,
+							name: action,
+						})
+					).toBeVisible();
+				}
+
+				await expect(
+					page.getByRole('menuitem', {
+						exact: true,
+						name: 'Download',
+					})
+				).toBeHidden();
+
+				await page.keyboard.press('Escape');
+			});
+
+			await test.step('Can download a file asset from Recent Assets', async () => {
+				const downloadPromise = page.waitForEvent('download');
+
+				await dataSetFragmentPage.execItemAction({
+					action: 'Download',
+					filter: fileTitle,
+				});
+
+				const download = await downloadPromise;
+
+				expect(download.suggestedFilename()).toBe(fileName);
+			});
+		}
+		finally {
+			if (contentEntry) {
+				await apiHelpers.objectEntry.deleteObjectEntry(
+					contentApplicationName,
+					String(contentEntry.id)
+				);
+			}
+
+			if (fileEntry) {
+				await apiHelpers.objectEntry.deleteObjectEntry(
+					fileApplicationName,
+					String(fileEntry.id)
+				);
+			}
+		}
+	}
+);
+
+test(
 	'Can use Quick Actions to create new content',
 	{tag: '@LPD-58793'},
 	async ({apiHelpers, homePage, page}) => {


### PR DESCRIPTION
Follow up to: https://github.com/brianchandotcom/liferay-portal/pull/174041#issuecomment-4378404737 

https://liferay.atlassian.net/browse/LPD-87568

Note: This branch is based on top of LPD-87559, which has been merged but not yet synced with master.

**What is being fixed:** The Recent Assets section on the CMS home page (introduced by the LPD-85506 Quick Actions story) lacked test coverage. The display context's filter string, the Recent-Assets-specific Download FDS action override, the Playwright-level permission filtering behavior, and the per-row action menu were all uncovered.

**How it is being fixed:** Three layers of coverage are added.

A Playwright permission-filtering test in `home.spec.ts` creates a Basic Web Content in the Default space and another in a restricted space the Space User is not a member of, then asserts the Space User cannot see the restricted asset in Recent Assets while the admin can see both.

A Playwright row-actions test in `home.spec.ts` posts a Basic Web Content and a Basic Document, asserts the per-row action menu shows the expected items (Download present only on the file row), and exercises the Download action via Playwright's download event.

A Java integration test `ViewHomeRecentAssetsSectionDisplayContextTest` covers the FDS dropdown items (asserting Download is added at index 1), the section filter string, the additional props, and the inherited test grid. It extends `BaseFilesSectionDisplayContextTestCase` and mirrors the override patterns from `ViewSharedWithMeSectionDisplayContextTest` and `ViewAllSectionDisplayContextTest`.

A separate `LPD-87568 Auto SF` commit holds incidental formatter touch-ups in `cookiesBannerAccessibility.spec.ts` and `findAndReplace.spec.ts`.

## How to run the tests

Playwright (from `modules/test/playwright/`):

```
yarn test tests/site-cms-site-initializer/main/home.spec.ts -g "Can only see Recent Assets the user has VIEW permission on"
yarn test tests/site-cms-site-initializer/main/home.spec.ts -g "Can perform asset actions on Recent Assets rows"
```

Integration:

```
gradlew -p modules/apps/site/site-cms-site-initializer-test testIntegration --tests ViewHomeRecentAssetsSectionDisplayContextTest
```

---

_AI-assisted with Claude Code._