### PR TITLE
LPD-88769 Fix KBArticle Blueprint highlighting in headless search

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/search/KBArticleIndexer.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/search/KBArticleIndexer.java
@@ -25,6 +25,7 @@ import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Hits;
 import com.liferay.portal.kernel.search.IndexWriterHelper;
 import com.liferay.portal.kernel.search.Indexer;
+import com.liferay.portal.kernel.search.IndexerPostProcessor;
 import com.liferay.portal.kernel.search.IndexerRegistryUtil;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.SearchException;
@@ -74,6 +75,32 @@ public class KBArticleIndexer extends BaseIndexer<KBArticle> {
 	@Override
 	public String getClassName() {
 		return CLASS_NAME;
+	}
+
+	@Override
+	public Summary getSummary(Document document, Locale locale, String snippet)
+		throws SearchException {
+
+		try {
+			Summary summary = doGetSummary(
+				document, locale, snippet, null, null);
+
+			if (summary == null) {
+				return null;
+			}
+
+			for (IndexerPostProcessor indexerPostProcessor :
+					IndexerRegistryUtil.getIndexerPostProcessors(this)) {
+
+				indexerPostProcessor.postProcessSummary(
+					summary, document, locale, snippet);
+			}
+
+			return summary;
+		}
+		catch (Exception exception) {
+			throw new SearchException(exception);
+		}
 	}
 
 	@Override

--- a/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/internal/search/test/KBArticleIndexerTest.java
+++ b/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/internal/search/test/KBArticleIndexerTest.java
@@ -1,0 +1,82 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.knowledge.base.internal.search.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.knowledge.base.model.KBArticle;
+import com.liferay.knowledge.base.test.util.KBTestUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.Indexer;
+import com.liferay.portal.kernel.search.IndexerRegistryUtil;
+import com.liferay.portal.kernel.search.Summary;
+import com.liferay.portal.kernel.search.highlight.HighlightUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Akhash Ramprakash
+ */
+@RunWith(Arquillian.class)
+public class KBArticleIndexerTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+		_indexer = IndexerRegistryUtil.getIndexer(KBArticle.class);
+	}
+
+	@Test
+	public void testGetSummary() throws Exception {
+		KBArticle kbArticle = KBTestUtil.addKBArticle(_group.getGroupId());
+
+		Document document = _indexer.getDocument(kbArticle);
+
+		String title = StringBundler.concat(
+			HighlightUtil.HIGHLIGHT_TAG_OPEN, kbArticle.getTitle(),
+			HighlightUtil.HIGHLIGHT_TAG_CLOSE);
+
+		document.addText(
+			Field.SNIPPET + StringPool.UNDERLINE + Field.TITLE, title);
+
+		String content = StringBundler.concat(
+			HighlightUtil.HIGHLIGHT_TAG_OPEN, "match",
+			HighlightUtil.HIGHLIGHT_TAG_CLOSE);
+
+		document.addText(Field.SNIPPET, content);
+
+		Summary summary = _indexer.getSummary(
+			document, LocaleUtil.US, document.get(Field.SNIPPET));
+
+		Assert.assertNotNull(summary);
+		Assert.assertEquals(title, summary.getTitle());
+		Assert.assertEquals(content, summary.getContent());
+	}
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	private Indexer<KBArticle> _indexer;
+
+}


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-88769

Knowledge Base Articles returned by the headless search API
(`/o/search/v1.0/search`) come back without highlighting when a Search
Blueprint configures a `highlight` clause, even though other entry types
like Web Content do get highlighted from the same configuration.

# How am I fixing it?

`KBArticleIndexer` now provides its own implementation of the locale-only
`Indexer.getSummary` overload. The headless endpoint calls that overload,
but the inherited default returns `null`, so callers got no `Summary` to
render highlights from. The override builds the summary the same way
`BaseIndexer` does for the portlet-flavored overload, including running
registered `IndexerPostProcessor` instances against the result.

# How can you verify that it works?

Run the included automated tests.