### PR TITLE
LPD-85590 Avoid spurious error toast on customized status page

### DIFF
--- a/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/servlet/CTReviewChangesServlet.java
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/servlet/CTReviewChangesServlet.java
@@ -14,7 +14,6 @@ import com.liferay.portal.kernel.model.Ticket;
 import com.liferay.portal.kernel.model.TicketConstants;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.TicketLocalService;
-import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -62,12 +61,9 @@ public class CTReviewChangesServlet extends HttpServlet {
 		Ticket ticket = _getTicket(httpServletRequest);
 
 		if (ticket == null) {
-			SessionErrors.add(httpServletRequest, NoSuchTicketException.class);
-
-			httpServletResponse.setStatus(HttpServletResponse.SC_NOT_FOUND);
-
-			httpServletResponse.sendRedirect(
-				Portal.PATH_MAIN + "/portal/status");
+			_portal.sendError(
+				new NoSuchTicketException(), httpServletRequest,
+				httpServletResponse);
 
 			return;
 		}

--- a/modules/apps/layout/layout-utility-page/layout-utility-page-status/src/main/java/com/liferay/layout/utility/page/status/internal/display/context/StatusDisplayContext.java
+++ b/modules/apps/layout/layout-utility-page/layout-utility-page-status/src/main/java/com/liferay/layout/utility/page/status/internal/display/context/StatusDisplayContext.java
@@ -9,7 +9,6 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.NoSuchLayoutException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HtmlUtil;
@@ -17,6 +16,7 @@ import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.util.WebKeys;
 
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -40,6 +40,11 @@ public class StatusDisplayContext {
 			HttpComponentsUtil.decodeURL(themeDisplay.getPortalURL() + url));
 	}
 
+	public Exception getException() {
+		return (Exception)_httpServletRequest.getAttribute(
+			WebKeys.STATUS_EXCEPTION);
+	}
+
 	public boolean isNoSuchResourceException() {
 		if (GetterUtil.getBoolean(
 				_httpServletRequest.getAttribute(
@@ -48,45 +53,56 @@ public class StatusDisplayContext {
 			return true;
 		}
 
-		for (String key : SessionErrors.keySet(_httpServletRequest)) {
-			key = key.substring(key.lastIndexOf(StringPool.PERIOD) + 1);
+		Exception exception = getException();
 
-			if (key.startsWith("NoSuch") && key.endsWith("Exception")) {
+		if (exception != null) {
+			Class<?> clazz = exception.getClass();
+
+			String name = clazz.getName();
+
+			name = name.substring(name.lastIndexOf(StringPool.PERIOD) + 1);
+
+			if (_isNoSuchExceptionName(name)) {
 				return true;
 			}
 		}
 
-		String exception = ParamUtil.getString(
+		String exceptionParam = ParamUtil.getString(
 			_httpServletRequest, "exception");
 
-		if (Validator.isNotNull(exception)) {
-			exception = exception.substring(
-				exception.lastIndexOf(StringPool.PERIOD) + 1);
+		if (Validator.isNotNull(exceptionParam) &&
+			_isNoSuchExceptionName(
+				exceptionParam.substring(
+					exceptionParam.lastIndexOf(StringPool.PERIOD) + 1))) {
 
-			if (exception.startsWith("NoSuch") &&
-				exception.endsWith("Exception")) {
-
-				return true;
-			}
+			return true;
 		}
 
 		return false;
 	}
 
-	public void logSessionErrors() {
-		for (String key : SessionErrors.keySet(_httpServletRequest)) {
-			Object value = SessionErrors.get(_httpServletRequest, key);
+	public void logException() {
+		Exception exception = getException();
 
-			if (value instanceof Exception) {
-				Exception exception = (Exception)value;
-
-				_log.error("Error: " + exception.getMessage());
-
-				if (_log.isDebugEnabled()) {
-					_log.debug(exception);
-				}
-			}
+		if (exception == null) {
+			return;
 		}
+
+		_log.error("Error: " + exception.getMessage());
+
+		if (_log.isDebugEnabled()) {
+			_log.debug(exception);
+		}
+	}
+
+	private boolean _isNoSuchExceptionName(String simpleName) {
+		if (simpleName.startsWith("NoSuch") &&
+			simpleName.endsWith("Exception")) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/layout/layout-utility-page/layout-utility-page-status/src/main/java/com/liferay/layout/utility/page/status/internal/struts/StatusStrutsAction.java
+++ b/modules/apps/layout/layout-utility-page/layout-utility-page-status/src/main/java/com/liferay/layout/utility/page/status/internal/struts/StatusStrutsAction.java
@@ -66,9 +66,9 @@ public class StatusStrutsAction implements StrutsAction {
 		PipingServletResponse pipingServletResponse = new PipingServletResponse(
 			httpServletResponse, unsyncStringWriter);
 
-		requestDispatcher.include(httpServletRequest, pipingServletResponse);
-
 		SessionErrors.clear(httpServletRequest);
+
+		requestDispatcher.include(httpServletRequest, pipingServletResponse);
 
 		Document document = null;
 

--- a/modules/apps/layout/layout-utility-page/layout-utility-page-status/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/layout/layout-utility-page/layout-utility-page-status/src/main/resources/META-INF/resources/init.jsp
@@ -17,7 +17,6 @@ page import="com.liferay.layout.utility.page.status.internal.display.context.Sta
 page import="com.liferay.portal.kernel.exception.PortalException" %><%@
 page import="com.liferay.portal.kernel.exception.SystemException" %><%@
 page import="com.liferay.portal.kernel.security.auth.PrincipalException" %><%@
-page import="com.liferay.portal.kernel.servlet.SessionErrors" %><%@
 page import="com.liferay.portal.kernel.templateparser.TransformException" %><%@
 page import="com.liferay.portal.kernel.util.GetterUtil" %><%@
 page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@

--- a/modules/apps/layout/layout-utility-page/layout-utility-page-status/src/main/resources/META-INF/resources/internal_server_error.jsp
+++ b/modules/apps/layout/layout-utility-page/layout-utility-page-status/src/main/resources/META-INF/resources/internal_server_error.jsp
@@ -22,7 +22,7 @@
 	<code class="lfr-url-error"><%= statusDisplayContext.getEscapedURL(themeDisplay) %></code>
 
 	<%
-	statusDisplayContext.logSessionErrors();
+	statusDisplayContext.logException();
 	%>
 
 </liferay-layout:render-layout-utility-page-entry>

--- a/modules/apps/layout/layout-utility-page/layout-utility-page-status/src/main/resources/META-INF/resources/status.jsp
+++ b/modules/apps/layout/layout-utility-page/layout-utility-page-status/src/main/resources/META-INF/resources/status.jsp
@@ -21,10 +21,14 @@
 	if (status > 0) {
 		response.setStatus(status);
 	}
+
+	Exception statusException = statusDisplayContext.getException();
+
+	Class<?> statusExceptionClass = (statusException == null) ? null : statusException.getClass();
 	%>
 
 	<c:choose>
-		<c:when test="<%= SessionErrors.contains(request, PrincipalException.getNestedClasses()) %>">
+		<c:when test="<%= statusException instanceof PrincipalException %>">
 			<clay:alert
 				displayType="danger"
 				message="forbidden"
@@ -40,7 +44,7 @@
 
 			<a href="javascript:history.go(-1);">&laquo; <liferay-ui:message key="back" /></a>
 		</c:when>
-		<c:when test="<%= SessionErrors.contains(request, PortalException.class.getName()) || SessionErrors.contains(request, SystemException.class.getName()) %>">
+		<c:when test="<%= (statusExceptionClass == PortalException.class) || (statusExceptionClass == SystemException.class) %>">
 			<clay:alert
 				displayType="danger"
 				message="internal-server-error"
@@ -56,7 +60,7 @@
 
 			<a href="javascript:history.go(-1);">&laquo; <liferay-ui:message key="back" /></a>
 		</c:when>
-		<c:when test="<%= SessionErrors.contains(request, TransformException.class.getName()) %>">
+		<c:when test="<%= statusExceptionClass == TransformException.class %>">
 			<clay:alert
 				displayType="danger"
 				message="internal-server-error"
@@ -71,7 +75,7 @@
 			<br /><br />
 
 			<%
-			TransformException te = (TransformException)SessionErrors.get(request, TransformException.class.getName());
+			TransformException te = (TransformException)statusException;
 			%>
 
 			<div>
@@ -116,7 +120,7 @@
 				<code class="lfr-url-error"><%= statusDisplayContext.getEscapedURL(themeDisplay) %></code>
 
 				<%
-				statusDisplayContext.logSessionErrors();
+				statusDisplayContext.logException();
 				%>
 
 			</liferay-layout:render-layout-utility-page-entry>
@@ -134,7 +138,7 @@
 			<code class="lfr-url-error"><%= statusDisplayContext.getEscapedURL(themeDisplay) %></code>
 
 			<%
-			statusDisplayContext.logSessionErrors();
+			statusDisplayContext.logException();
 			%>
 
 			<hr class="separator" />

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -6075,7 +6075,12 @@ public class PortalImpl implements Portal {
 
 			httpServletResponse.setStatus(status);
 
-			SessionErrors.add(httpSession, exception.getClass(), exception);
+			if (exception != null) {
+				httpServletRequest.setAttribute(
+					WebKeys.STATUS_EXCEPTION, exception);
+
+				SessionErrors.add(httpSession, exception.getClass(), exception);
+			}
 
 			ServletContext servletContext = httpSession.getServletContext();
 

--- a/portal-impl/test/unit/com/liferay/portal/util/PortalImplUnitTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/util/PortalImplUnitTest.java
@@ -5,9 +5,11 @@
 
 package com.liferay.portal.util;
 
+import com.liferay.layout.utility.page.kernel.StatusLayoutUtilityPageEntryRequestContributorRegistryUtil;
 import com.liferay.petra.io.BigEndianCodec;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.NoSuchImageException;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutConstants;
@@ -21,7 +23,10 @@ import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.servlet.DummyHttpServletResponse;
 import com.liferay.portal.kernel.servlet.DynamicServletRequest;
 import com.liferay.portal.kernel.servlet.PersistentHttpServletRequestWrapper;
+import com.liferay.portal.kernel.servlet.PortalSessionThreadLocal;
+import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.upgrade.MockPortletPreferences;
@@ -56,8 +61,12 @@ import jakarta.portlet.PortletException;
 import jakarta.portlet.PortletMode;
 import jakarta.portlet.WindowState;
 
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletContext;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletRequestWrapper;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -811,6 +820,75 @@ public class PortalImplUnitTest {
 
 			Assert.assertFalse(_portalImpl.isValidResourceId("%view.jsp"));
 		}
+	}
+
+	@Test
+	@TestInfo("LPD-85590")
+	public void testSendErrorPassesExceptionViaRequestAttributeAndSessionErrors()
+		throws Exception {
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		HttpServletResponse mockHttpServletResponse = Mockito.mock(
+			HttpServletResponse.class);
+
+		Mockito.when(
+			mockHttpServletResponse.isCommitted()
+		).thenReturn(
+			false
+		);
+
+		HttpSession mockHttpSession = Mockito.mock(HttpSession.class);
+
+		ServletContext mockServletContext = Mockito.mock(ServletContext.class);
+
+		Mockito.when(
+			mockHttpSession.getServletContext()
+		).thenReturn(
+			mockServletContext
+		);
+
+		Mockito.when(
+			mockServletContext.getRequestDispatcher(Mockito.anyString())
+		).thenReturn(
+			Mockito.mock(RequestDispatcher.class)
+		);
+
+		mockHttpServletRequest.setSession(mockHttpSession);
+
+		NoSuchImageException noSuchImageException = new NoSuchImageException();
+
+		try (MockedStatic<PortalSessionThreadLocal>
+				portalSessionThreadLocalMockedStatic = Mockito.mockStatic(
+					PortalSessionThreadLocal.class);
+			MockedStatic<SessionErrors> sessionErrorsMockedStatic =
+				Mockito.mockStatic(SessionErrors.class);
+			MockedStatic
+				<StatusLayoutUtilityPageEntryRequestContributorRegistryUtil>
+					statusLayoutUtilityPageEntryRequestContributorRegistryUtilMockedStatic =
+						Mockito.mockStatic(
+							StatusLayoutUtilityPageEntryRequestContributorRegistryUtil.class)) {
+
+			portalSessionThreadLocalMockedStatic.when(
+				PortalSessionThreadLocal::getHttpSession
+			).thenReturn(
+				mockHttpSession
+			);
+
+			_portalImpl.sendError(
+				0, noSuchImageException, mockHttpServletRequest,
+				mockHttpServletResponse);
+
+			sessionErrorsMockedStatic.verify(
+				() -> SessionErrors.add(
+					mockHttpSession, NoSuchImageException.class,
+					noSuchImageException));
+		}
+
+		Assert.assertSame(
+			noSuchImageException,
+			mockHttpServletRequest.getAttribute(WebKeys.STATUS_EXCEPTION));
 	}
 
 	@Test

--- a/portal-kernel/src/com/liferay/portal/kernel/util/WebKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/WebKeys.java
@@ -626,6 +626,8 @@ public interface WebKeys {
 
 	public static final String STARTUP_FINISHED = "STARTUP_FINISHED";
 
+	public static final String STATUS_EXCEPTION = "STATUS_EXCEPTION";
+
 	public static final String SUBJECT = "SUBJECT";
 
 	public static final String TAB_INDEX = "TAB_INDEX";


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-85590

## What is being fixed

When `LAYOUT_SHOW_HTTP_STATUS` routes an error to `/portal/status` and the customer has customized the status utility page (e.g. the default 404 page under Site Builder > Pages > Utility Pages) to include a standard portlet such as the Language Selector, the user sees a spurious "Your request failed to complete" toast on top of the intended status page.

The toast comes from `<liferay-ui:error/>` (see `ErrorTag`) which fires whenever `MultiSessionErrors` is non-empty for the rendering portlet. `PortalImpl.sendError` had previously seeded the session with the exception via `SessionErrors.add(...)`, and that entry was not cleared until *after* `requestDispatcher.include(...)` of `/status.jsp` finished — so the embedded portlets rendered with SessionErrors populated and the tag fired.

Reproduction is `/image/fff` on a 2025.q1.12 bundle with the Language Selector added to the default 404 utility page (see Jira for the exact steps).

## How it is being fixed

The fix is purely additive — it preserves the existing API of `PortalImpl.sendError` so external callers that read SessionErrors after sendError keep working.

`PortalImpl.sendError` now sets a new request attribute (`WebKeys.STATUS_EXCEPTION`) alongside the existing `SessionErrors.add(...)`, giving the status page a request-scoped channel that doesn't depend on session state. `StatusDisplayContext`, `status.jsp`, `internal_server_error.jsp`, and `init.jsp` read from that attribute instead of iterating SessionErrors. The `<c:choose>` branches in `status.jsp` that previously matched on the SessionErrors key (full class name) now match on the typed exception via `instanceof` / class-identity. For `PortalException`, `SystemException`, and `TransformException` that is exactly equivalent (master's check was an exact-name lookup keyed on the actual subclass). For `PrincipalException` it is strictly equivalent for the classes listed in `PrincipalException.getNestedClasses()`, plus `MustBeGroupAdmin` which the array accidentally omits — a small behavior fix in passing.

The toast bug-fix itself is a one-line reorder in `StatusStrutsAction`: clear SessionErrors *before* `requestDispatcher.include(...)`, not after. With the status page no longer reading from SessionErrors, this drops the entry `sendError` just seeded before the customized utility page renders, so embedded portlets see an empty `MultiSessionErrors` and `<liferay-ui:error/>` does not fire. The clear was already there in master; moving it earlier is the actual fix. Note the clear only touches the HSR/session-scoped namespace — portlet-scoped entries are namespaced per (portlet, plid) and cannot leak onto the status utility page anyway.

Finally, `CTReviewChangesServlet` was the one place still writing SessionErrors and `sendRedirect`-ing to `/portal/status` manually — it relied on the old SessionErrors-iteration in `StatusDisplayContext.isNoSuchResourceException()`. With that iteration gone, this servlet would have degraded to the generic "internal-server-error" UI for missing tickets even though the HTTP status was still 404. Switching it to `_portal.sendError(new NoSuchTicketException(), ...)` aligns it with every other servlet in `portal-impl` and restores the dedicated "not-found" UI.

A unit test covers the new contract: `sendError` sets `STATUS_EXCEPTION` on the request and still calls `SessionErrors.add` for backward compatibility.
