### PR TITLE
LPD-88154 Technical Task | Update Sharing entry on user creation

### DIFF
--- a/modules/apps/headless/headless-object/headless-object-api/src/main/java/com/liferay/headless/object/util/v1_0/CollaboratorUtil.java
+++ b/modules/apps/headless/headless-object/headless-object-api/src/main/java/com/liferay/headless/object/util/v1_0/CollaboratorUtil.java
@@ -72,8 +72,7 @@ public class CollaboratorUtil {
 
 			User existingUser = userLocalService.fetchUserByEmailAddress(
 				companyId,
-				StringUtil.toLowerCase(
-					StringUtil.trim(collaborator.getEmailAddress())));
+				_normalizeEmailAddress(collaborator.getEmailAddress()));
 
 			if (existingUser != null) {
 				return toCollaborator(
@@ -138,8 +137,7 @@ public class CollaboratorUtil {
 
 				User existingUser = userLocalService.fetchUserByEmailAddress(
 					companyId,
-					StringUtil.toLowerCase(
-						StringUtil.trim(collaborator.getEmailAddress())));
+					_normalizeEmailAddress(collaborator.getEmailAddress()));
 
 				if (existingUser == null) {
 					Ticket ticket = _addOrUpdateTicket(
@@ -394,13 +392,13 @@ public class CollaboratorUtil {
 			throw new NoSuchModelException();
 		}
 
-		String extraInfo = StringUtil.toLowerCase(
-			StringUtil.trim(collaborator.getEmailAddress()));
+		String emailAddress = _normalizeEmailAddress(
+			collaborator.getEmailAddress());
 
 		if (ticket == null) {
 			return ticketLocalService.addTicket(
 				companyId, className, classPK,
-				TicketConstants.TYPE_INVITE_COLLABORATOR, extraInfo,
+				TicketConstants.TYPE_INVITE_COLLABORATOR, emailAddress,
 				GetterUtil.getObject(
 					collaborator.getDateExpired(),
 					() -> new Date(
@@ -414,7 +412,7 @@ public class CollaboratorUtil {
 			ticket.setExpirationDate(collaborator.getDateExpired());
 		}
 
-		ticket.setExtraInfo(extraInfo);
+		ticket.setExtraInfo(emailAddress);
 
 		return ticketLocalService.updateTicket(ticket);
 	}
@@ -446,6 +444,10 @@ public class CollaboratorUtil {
 		}
 
 		ticketLocalService.deleteTicket(ticket.getTicketId());
+	}
+
+	private static String _normalizeEmailAddress(String emailAddress) {
+		return StringUtil.toLowerCase(StringUtil.trim(emailAddress));
 	}
 
 	private static void _validateEmailAddress(String emailAddress) {

--- a/modules/apps/headless/headless-object/headless-object-api/src/main/java/com/liferay/headless/object/util/v1_0/CollaboratorUtil.java
+++ b/modules/apps/headless/headless-object/headless-object-api/src/main/java/com/liferay/headless/object/util/v1_0/CollaboratorUtil.java
@@ -11,7 +11,6 @@ import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.NoSuchGroupException;
 import com.liferay.portal.kernel.exception.NoSuchModelException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
-import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.Ticket;
 import com.liferay.portal.kernel.model.TicketConstants;
 import com.liferay.portal.kernel.model.User;
@@ -72,7 +71,9 @@ public class CollaboratorUtil {
 			_validateEmailAddress(collaborator.getEmailAddress());
 
 			User existingUser = userLocalService.fetchUserByEmailAddress(
-				companyId, collaborator.getEmailAddress());
+				companyId,
+				StringUtil.toLowerCase(
+					StringUtil.trim(collaborator.getEmailAddress())));
 
 			if (existingUser != null) {
 				return toCollaborator(
@@ -87,7 +88,7 @@ public class CollaboratorUtil {
 
 			Ticket ticket = _addOrUpdateTicket(
 				className, classPK, collaborator, collaboratorId, companyId,
-				ticketLocalService, type);
+				ticketLocalService);
 
 			return toCollaborator(
 				acceptLanguage, dtoConverter, dtoConverterRegistry,
@@ -136,12 +137,14 @@ public class CollaboratorUtil {
 				_validateEmailAddress(collaborator.getEmailAddress());
 
 				User existingUser = userLocalService.fetchUserByEmailAddress(
-					companyId, collaborator.getEmailAddress());
+					companyId,
+					StringUtil.toLowerCase(
+						StringUtil.trim(collaborator.getEmailAddress())));
 
 				if (existingUser == null) {
 					Ticket ticket = _addOrUpdateTicket(
 						className, classPK, collaborator, collaborator.getId(),
-						companyId, ticketLocalService, collaborator.getType());
+						companyId, ticketLocalService);
 
 					sharingEntry = _addOrUpdateSharingEntry(
 						classNameId, classPK, collaborator,
@@ -378,7 +381,7 @@ public class CollaboratorUtil {
 	private static Ticket _addOrUpdateTicket(
 			String className, long classPK, Collaborator collaborator,
 			long collaboratorId, long companyId,
-			TicketLocalService ticketLocalService, String type)
+			TicketLocalService ticketLocalService)
 		throws Exception {
 
 		Ticket ticket = ticketLocalService.fetchTicket(collaboratorId);
@@ -391,15 +394,8 @@ public class CollaboratorUtil {
 			throw new NoSuchModelException();
 		}
 
-		String extraInfo = JSONUtil.put(
-			"actionIds", collaborator.getActionIds()
-		).put(
-			"emailAddress", collaborator.getEmailAddress()
-		).put(
-			"share", collaborator.getShare()
-		).put(
-			"type", type
-		).toString();
+		String extraInfo = StringUtil.toLowerCase(
+			StringUtil.trim(collaborator.getEmailAddress()));
 
 		if (ticket == null) {
 			return ticketLocalService.addTicket(

--- a/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/dto/v1_0/converter/CollaboratorDTOConverter.java
+++ b/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/dto/v1_0/converter/CollaboratorDTOConverter.java
@@ -8,8 +8,6 @@ package com.liferay.headless.object.internal.dto.v1_0.converter;
 import com.liferay.headless.delivery.dto.v1_0.util.CreatorUtil;
 import com.liferay.headless.object.dto.v1_0.Collaborator;
 import com.liferay.petra.function.transform.TransformUtil;
-import com.liferay.portal.kernel.json.JSONFactory;
-import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.model.Ticket;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.UserGroup;
@@ -159,15 +157,12 @@ public class CollaboratorDTOConverter
 		};
 	}
 
-	private String _fetchEmailAddress(Ticket ticket) throws Exception {
+	private String _fetchEmailAddress(Ticket ticket) {
 		if (ticket == null) {
 			return null;
 		}
 
-		JSONObject jsonObject = _jsonFactory.createJSONObject(
-			ticket.getExtraInfo());
-
-		return jsonObject.getString("emailAddress");
+		return ticket.getExtraInfo();
 	}
 
 	private Ticket _fetchTicket(SharingEntry sharingEntry) {
@@ -205,9 +200,6 @@ public class CollaboratorDTOConverter
 			GuestOrUserUtil.getPermissionChecker(), user.getUserId(),
 			ActionKeys.VIEW);
 	}
-
-	@Reference
-	private JSONFactory _jsonFactory;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/headless/headless-object/headless-object-test/src/testIntegration/java/com/liferay/headless/object/internal/dto/v1_0/converter/test/CollaboratorDTOConverterTest.java
+++ b/modules/apps/headless/headless-object/headless-object-test/src/testIntegration/java/com/liferay/headless/object/internal/dto/v1_0/converter/test/CollaboratorDTOConverterTest.java
@@ -13,7 +13,6 @@ import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
-import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Ticket;
@@ -102,16 +101,7 @@ public class CollaboratorDTOConverterTest {
 		Ticket ticket = _ticketLocalService.addTicket(
 			TestPropsValues.getCompanyId(), _objectEntry.getModelClassName(),
 			_objectEntry.getObjectEntryId(),
-			TicketConstants.TYPE_INVITE_COLLABORATOR,
-			JSONUtil.put(
-				"actionIds", JSONUtil.put(SharingEntryAction.VIEW.getActionId())
-			).put(
-				"emailAddress", emailAddress
-			).put(
-				"share", true
-			).put(
-				"type", "Email"
-			).toString(),
+			TicketConstants.TYPE_INVITE_COLLABORATOR, emailAddress,
 			expirationDate, null);
 
 		SharingEntry sharingEntry = _sharingEntryLocalService.addSharingEntry(

--- a/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryLocalService.java
+++ b/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryLocalService.java
@@ -556,6 +556,9 @@ public interface SharingEntryLocalService
 			String uuid, long groupId)
 		throws PortalException;
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<SharingEntry> getToTicketSharingEntries(long toTicketId);
+
 	/**
 	 * Returns the list of sharing entries for resources shared with the user.
 	 *
@@ -729,4 +732,4 @@ public interface SharingEntryLocalService
 	public SharingEntry updateSharingEntry(SharingEntry sharingEntry);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-916700364
+// LIFERAY-SERVICE-BUILDER-HASH:1624958331

--- a/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryLocalServiceUtil.java
+++ b/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryLocalServiceUtil.java
@@ -656,6 +656,12 @@ public class SharingEntryLocalServiceUtil {
 		return getService().getSharingEntryByUuidAndGroupId(uuid, groupId);
 	}
 
+	public static List<SharingEntry> getToTicketSharingEntries(
+		long toTicketId) {
+
+		return getService().getToTicketSharingEntries(toTicketId);
+	}
+
 	/**
 	 * Returns the list of sharing entries for resources shared with the user.
 	 *
@@ -871,4 +877,4 @@ public class SharingEntryLocalServiceUtil {
 			SharingEntryLocalServiceUtil.class, SharingEntryLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1355305151
+// LIFERAY-SERVICE-BUILDER-HASH:-1187951439

--- a/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryLocalServiceWrapper.java
+++ b/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryLocalServiceWrapper.java
@@ -737,6 +737,13 @@ public class SharingEntryLocalServiceWrapper
 			uuid, groupId);
 	}
 
+	@Override
+	public java.util.List<com.liferay.sharing.model.SharingEntry>
+		getToTicketSharingEntries(long toTicketId) {
+
+		return _sharingEntryLocalService.getToTicketSharingEntries(toTicketId);
+	}
+
 	/**
 	 * Returns the list of sharing entries for resources shared with the user.
 	 *
@@ -981,4 +988,4 @@ public class SharingEntryLocalServiceWrapper
 	private SharingEntryLocalService _sharingEntryLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1457849249
+// LIFERAY-SERVICE-BUILDER-HASH:1156547837

--- a/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/persistence/SharingEntryPersistence.java
+++ b/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/persistence/SharingEntryPersistence.java
@@ -501,6 +501,108 @@ public interface SharingEntryPersistence extends BasePersistence<SharingEntry> {
 	public int countByUserId(long userId);
 
 	/**
+	 * Returns all the sharing entries where toTicketId = &#63;.
+	 *
+	 * @param toTicketId the to ticket ID
+	 * @return the matching sharing entries
+	 */
+	public java.util.List<SharingEntry> findByToTicketId(long toTicketId);
+
+	/**
+	 * Returns a range of all the sharing entries where toTicketId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.sharing.model.impl.SharingEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param toTicketId the to ticket ID
+	 * @param start the lower bound of the range of sharing entries
+	 * @param end the upper bound of the range of sharing entries (not inclusive)
+	 * @return the range of matching sharing entries
+	 */
+	public java.util.List<SharingEntry> findByToTicketId(
+		long toTicketId, int start, int end);
+
+	/**
+	 * Returns an ordered range of all the sharing entries where toTicketId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.sharing.model.impl.SharingEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param toTicketId the to ticket ID
+	 * @param start the lower bound of the range of sharing entries
+	 * @param end the upper bound of the range of sharing entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching sharing entries
+	 */
+	public java.util.List<SharingEntry> findByToTicketId(
+		long toTicketId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<SharingEntry>
+			orderByComparator);
+
+	/**
+	 * Returns an ordered range of all the sharing entries where toTicketId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.sharing.model.impl.SharingEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param toTicketId the to ticket ID
+	 * @param start the lower bound of the range of sharing entries
+	 * @param end the upper bound of the range of sharing entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching sharing entries
+	 */
+	public java.util.List<SharingEntry> findByToTicketId(
+		long toTicketId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<SharingEntry>
+			orderByComparator,
+		boolean useFinderCache);
+
+	/**
+	 * Returns the first sharing entry in the ordered set where toTicketId = &#63;.
+	 *
+	 * @param toTicketId the to ticket ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching sharing entry
+	 * @throws NoSuchEntryException if a matching sharing entry could not be found
+	 */
+	public SharingEntry findByToTicketId_First(
+			long toTicketId,
+			com.liferay.portal.kernel.util.OrderByComparator<SharingEntry>
+				orderByComparator)
+		throws NoSuchEntryException;
+
+	/**
+	 * Returns the first sharing entry in the ordered set where toTicketId = &#63;.
+	 *
+	 * @param toTicketId the to ticket ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching sharing entry, or <code>null</code> if a matching sharing entry could not be found
+	 */
+	public SharingEntry fetchByToTicketId_First(
+		long toTicketId,
+		com.liferay.portal.kernel.util.OrderByComparator<SharingEntry>
+			orderByComparator);
+
+	/**
+	 * Removes all the sharing entries where toTicketId = &#63; from the database.
+	 *
+	 * @param toTicketId the to ticket ID
+	 */
+	public void removeByToTicketId(long toTicketId);
+
+	/**
+	 * Returns the number of sharing entries where toTicketId = &#63;.
+	 *
+	 * @param toTicketId the to ticket ID
+	 * @return the number of matching sharing entries
+	 */
+	public int countByToTicketId(long toTicketId);
+
+	/**
 	 * Returns all the sharing entries where toUserId = &#63;.
 	 *
 	 * @param toUserId the to user ID
@@ -1313,4 +1415,4 @@ public interface SharingEntryPersistence extends BasePersistence<SharingEntry> {
 	public SharingEntry fetchByPrimaryKey(long sharingEntryId);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1036639967
+// LIFERAY-SERVICE-BUILDER-HASH:763617028

--- a/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/persistence/SharingEntryUtil.java
+++ b/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/persistence/SharingEntryUtil.java
@@ -677,6 +677,127 @@ public class SharingEntryUtil {
 	}
 
 	/**
+	 * Returns all the sharing entries where toTicketId = &#63;.
+	 *
+	 * @param toTicketId the to ticket ID
+	 * @return the matching sharing entries
+	 */
+	public static List<SharingEntry> findByToTicketId(long toTicketId) {
+		return getPersistence().findByToTicketId(toTicketId);
+	}
+
+	/**
+	 * Returns a range of all the sharing entries where toTicketId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.sharing.model.impl.SharingEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param toTicketId the to ticket ID
+	 * @param start the lower bound of the range of sharing entries
+	 * @param end the upper bound of the range of sharing entries (not inclusive)
+	 * @return the range of matching sharing entries
+	 */
+	public static List<SharingEntry> findByToTicketId(
+		long toTicketId, int start, int end) {
+
+		return getPersistence().findByToTicketId(toTicketId, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the sharing entries where toTicketId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.sharing.model.impl.SharingEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param toTicketId the to ticket ID
+	 * @param start the lower bound of the range of sharing entries
+	 * @param end the upper bound of the range of sharing entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching sharing entries
+	 */
+	public static List<SharingEntry> findByToTicketId(
+		long toTicketId, int start, int end,
+		OrderByComparator<SharingEntry> orderByComparator) {
+
+		return getPersistence().findByToTicketId(
+			toTicketId, start, end, orderByComparator);
+	}
+
+	/**
+	 * Returns an ordered range of all the sharing entries where toTicketId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.sharing.model.impl.SharingEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param toTicketId the to ticket ID
+	 * @param start the lower bound of the range of sharing entries
+	 * @param end the upper bound of the range of sharing entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching sharing entries
+	 */
+	public static List<SharingEntry> findByToTicketId(
+		long toTicketId, int start, int end,
+		OrderByComparator<SharingEntry> orderByComparator,
+		boolean useFinderCache) {
+
+		return getPersistence().findByToTicketId(
+			toTicketId, start, end, orderByComparator, useFinderCache);
+	}
+
+	/**
+	 * Returns the first sharing entry in the ordered set where toTicketId = &#63;.
+	 *
+	 * @param toTicketId the to ticket ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching sharing entry
+	 * @throws NoSuchEntryException if a matching sharing entry could not be found
+	 */
+	public static SharingEntry findByToTicketId_First(
+			long toTicketId, OrderByComparator<SharingEntry> orderByComparator)
+		throws com.liferay.sharing.exception.NoSuchEntryException {
+
+		return getPersistence().findByToTicketId_First(
+			toTicketId, orderByComparator);
+	}
+
+	/**
+	 * Returns the first sharing entry in the ordered set where toTicketId = &#63;.
+	 *
+	 * @param toTicketId the to ticket ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching sharing entry, or <code>null</code> if a matching sharing entry could not be found
+	 */
+	public static SharingEntry fetchByToTicketId_First(
+		long toTicketId, OrderByComparator<SharingEntry> orderByComparator) {
+
+		return getPersistence().fetchByToTicketId_First(
+			toTicketId, orderByComparator);
+	}
+
+	/**
+	 * Removes all the sharing entries where toTicketId = &#63; from the database.
+	 *
+	 * @param toTicketId the to ticket ID
+	 */
+	public static void removeByToTicketId(long toTicketId) {
+		getPersistence().removeByToTicketId(toTicketId);
+	}
+
+	/**
+	 * Returns the number of sharing entries where toTicketId = &#63;.
+	 *
+	 * @param toTicketId the to ticket ID
+	 * @return the number of matching sharing entries
+	 */
+	public static int countByToTicketId(long toTicketId) {
+		return getPersistence().countByToTicketId(toTicketId);
+	}
+
+	/**
 	 * Returns all the sharing entries where toUserId = &#63;.
 	 *
 	 * @param toUserId the to user ID
@@ -1678,4 +1799,4 @@ public class SharingEntryUtil {
 	private static volatile SharingEntryPersistence _persistence;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:2110834281
+// LIFERAY-SERVICE-BUILDER-HASH:739234814

--- a/modules/apps/sharing/sharing-service/service.xml
+++ b/modules/apps/sharing/sharing-service/service.xml
@@ -40,6 +40,9 @@
 		<finder name="UserId" return-type="Collection">
 			<finder-column name="userId" />
 		</finder>
+		<finder name="ToTicketId" return-type="Collection">
+			<finder-column name="toTicketId" />
+		</finder>
 		<finder name="ToUserId" return-type="Collection">
 			<finder-column name="toUserId" />
 		</finder>

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/model/listener/UserModelListener.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/model/listener/UserModelListener.java
@@ -9,7 +9,6 @@ import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
 import com.liferay.petra.sql.dsl.expression.Predicate;
 import com.liferay.petra.sql.dsl.query.DSLQuery;
 import com.liferay.petra.string.StringBundler;
-import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.interval.IntervalActionProcessor;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -40,7 +39,7 @@ import org.osgi.service.component.annotations.Reference;
 public class UserModelListener extends BaseModelListener<User> {
 
 	@Override
-	public void onAfterCreate(User user) throws ModelListenerException {
+	public void onAfterCreate(User user) {
 		if (user.getStatus() != WorkflowConstants.STATUS_APPROVED) {
 			return;
 		}
@@ -49,9 +48,7 @@ public class UserModelListener extends BaseModelListener<User> {
 	}
 
 	@Override
-	public void onAfterUpdate(User originalUser, User user)
-		throws ModelListenerException {
-
+	public void onAfterUpdate(User originalUser, User user) {
 		if ((originalUser.getStatus() == user.getStatus()) ||
 			(originalUser.getStatus() == WorkflowConstants.STATUS_APPROVED) ||
 			(user.getStatus() != WorkflowConstants.STATUS_APPROVED)) {
@@ -68,7 +65,8 @@ public class UserModelListener extends BaseModelListener<User> {
 	}
 
 	private DSLQuery _createCountDSLQuery(Date date, User user) {
-		return DSLQueryFactoryUtil.count(
+		return DSLQueryFactoryUtil.countDistinct(
+			TicketTable.INSTANCE.ticketId
 		).from(
 			TicketTable.INSTANCE
 		).innerJoinON(
@@ -79,7 +77,7 @@ public class UserModelListener extends BaseModelListener<User> {
 	}
 
 	private DSLQuery _createDSLQuery(Date date, int end, int start, User user) {
-		return DSLQueryFactoryUtil.select(
+		return DSLQueryFactoryUtil.selectDistinct(
 			TicketTable.INSTANCE.ticketId
 		).from(
 			TicketTable.INSTANCE

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/model/listener/UserModelListener.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/model/listener/UserModelListener.java
@@ -5,10 +5,30 @@
 
 package com.liferay.sharing.internal.model.listener;
 
+import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
+import com.liferay.petra.sql.dsl.expression.Predicate;
+import com.liferay.petra.sql.dsl.query.DSLQuery;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.exception.ModelListenerException;
+import com.liferay.portal.kernel.interval.IntervalActionProcessor;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.ModelListener;
+import com.liferay.portal.kernel.model.Ticket;
+import com.liferay.portal.kernel.model.TicketConstants;
+import com.liferay.portal.kernel.model.TicketTable;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.TicketLocalService;
+import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.sharing.model.SharingEntry;
+import com.liferay.sharing.model.SharingEntryTable;
 import com.liferay.sharing.service.SharingEntryLocalService;
+
+import java.util.Date;
+import java.util.List;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -20,11 +40,172 @@ import org.osgi.service.component.annotations.Reference;
 public class UserModelListener extends BaseModelListener<User> {
 
 	@Override
+	public void onAfterCreate(User user) throws ModelListenerException {
+		if (user.getStatus() != WorkflowConstants.STATUS_APPROVED) {
+			return;
+		}
+
+		_updateSharingEntries(user);
+	}
+
+	@Override
+	public void onAfterUpdate(User originalUser, User user)
+		throws ModelListenerException {
+
+		if ((originalUser.getStatus() == user.getStatus()) ||
+			(originalUser.getStatus() == WorkflowConstants.STATUS_APPROVED) ||
+			(user.getStatus() != WorkflowConstants.STATUS_APPROVED)) {
+
+			return;
+		}
+
+		_updateSharingEntries(user);
+	}
+
+	@Override
 	public void onBeforeRemove(User user) {
 		_sharingEntryLocalService.deleteToUserSharingEntries(user.getUserId());
 	}
 
+	private DSLQuery _createCountDSLQuery(Date date, User user) {
+		return DSLQueryFactoryUtil.count(
+		).from(
+			TicketTable.INSTANCE
+		).innerJoinON(
+			SharingEntryTable.INSTANCE, _innerJoinPredicate()
+		).where(
+			_wherePredicate(date, user)
+		);
+	}
+
+	private DSLQuery _createDSLQuery(Date date, int end, int start, User user) {
+		return DSLQueryFactoryUtil.select(
+			TicketTable.INSTANCE.ticketId
+		).from(
+			TicketTable.INSTANCE
+		).innerJoinON(
+			SharingEntryTable.INSTANCE, _innerJoinPredicate()
+		).where(
+			_wherePredicate(date, user)
+		).orderBy(
+			TicketTable.INSTANCE.ticketId.ascending()
+		).limit(
+			start, end
+		);
+	}
+
+	private Predicate _innerJoinPredicate() {
+		return SharingEntryTable.INSTANCE.classNameId.eq(
+			TicketTable.INSTANCE.classNameId
+		).and(
+			SharingEntryTable.INSTANCE.classPK.eq(TicketTable.INSTANCE.classPK)
+		).and(
+			SharingEntryTable.INSTANCE.toTicketId.eq(
+				TicketTable.INSTANCE.ticketId)
+		);
+	}
+
+	private boolean _isTicketForUser(Ticket ticket, User user) {
+		if ((ticket == null) ||
+			!StringUtil.equalsIgnoreCase(
+				ticket.getExtraInfo(), user.getEmailAddress())) {
+
+			return false;
+		}
+
+		return true;
+	}
+
+	private void _updateSharingEntries(User user) {
+		Date date = new Date();
+
+		TransactionCommitCallbackUtil.registerCallback(
+			() -> {
+				IntervalActionProcessor<Void> intervalActionProcessor =
+					new IntervalActionProcessor<>(
+						_ticketLocalService.dslQueryCount(
+							_createCountDSLQuery(date, user)));
+
+				intervalActionProcessor.setPerformIntervalActionMethod(
+					(start, end) -> {
+						List<Long> ticketIds =
+							(List<Long>)_ticketLocalService.dslQuery(
+								_createDSLQuery(date, end, start, user));
+
+						for (Long ticketId : ticketIds) {
+							Ticket ticket = _ticketLocalService.fetchTicket(
+								ticketId);
+
+							if (!_isTicketForUser(ticket, user)) {
+								intervalActionProcessor.incrementStart();
+
+								continue;
+							}
+
+							for (SharingEntry sharingEntry :
+									_sharingEntryLocalService.
+										getToTicketSharingEntries(ticketId)) {
+
+								_updateSharingEntry(sharingEntry, user);
+							}
+
+							_ticketLocalService.deleteTicket(ticket);
+						}
+
+						return null;
+					});
+
+				intervalActionProcessor.performIntervalActions();
+
+				return null;
+			});
+	}
+
+	private void _updateSharingEntry(SharingEntry sharingEntry, User user) {
+		SharingEntry existingSharingEntry =
+			_sharingEntryLocalService.fetchSharingEntry(
+				0, sharingEntry.getToUserGroupId(), user.getUserId(),
+				sharingEntry.getClassNameId(), sharingEntry.getClassPK());
+
+		if (existingSharingEntry != null) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					StringBundler.concat(
+						"A sharing entry already exists for user ",
+						user.getUserId(), " with classNameId ",
+						sharingEntry.getClassNameId(), " and classPK ",
+						sharingEntry.getClassPK()));
+			}
+
+			_sharingEntryLocalService.deleteSharingEntry(sharingEntry);
+
+			return;
+		}
+
+		sharingEntry.setToTicketId(0);
+		sharingEntry.setToUserId(user.getUserId());
+
+		_sharingEntryLocalService.updateSharingEntry(sharingEntry);
+	}
+
+	private Predicate _wherePredicate(Date date, User user) {
+		return TicketTable.INSTANCE.companyId.eq(
+			user.getCompanyId()
+		).and(
+			TicketTable.INSTANCE.type.eq(
+				TicketConstants.TYPE_INVITE_COLLABORATOR)
+		).and(
+			TicketTable.INSTANCE.expirationDate.gt(date)
+		);
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		UserModelListener.class);
+
 	@Reference
 	private SharingEntryLocalService _sharingEntryLocalService;
+
+	@Reference
+	private TicketLocalService _ticketLocalService;
 
 }

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/model/listener/UserModelListener.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/model/listener/UserModelListener.java
@@ -78,7 +78,7 @@ public class UserModelListener extends BaseModelListener<User> {
 
 	private DSLQuery _createDSLQuery(Date date, int end, int start, User user) {
 		return DSLQueryFactoryUtil.selectDistinct(
-			TicketTable.INSTANCE.ticketId
+			TicketTable.INSTANCE
 		).from(
 			TicketTable.INSTANCE
 		).innerJoinON(
@@ -103,17 +103,6 @@ public class UserModelListener extends BaseModelListener<User> {
 		);
 	}
 
-	private boolean _isTicketForUser(Ticket ticket, User user) {
-		if ((ticket == null) ||
-			!StringUtil.equalsIgnoreCase(
-				ticket.getExtraInfo(), user.getEmailAddress())) {
-
-			return false;
-		}
-
-		return true;
-	}
-
 	private void _updateSharingEntries(User user) {
 		Date date = new Date();
 
@@ -126,15 +115,16 @@ public class UserModelListener extends BaseModelListener<User> {
 
 				intervalActionProcessor.setPerformIntervalActionMethod(
 					(start, end) -> {
-						List<Long> ticketIds =
-							(List<Long>)_ticketLocalService.dslQuery(
+						List<Ticket> tickets =
+							(List<Ticket>)_ticketLocalService.dslQuery(
 								_createDSLQuery(date, end, start, user));
 
-						for (Long ticketId : ticketIds) {
-							Ticket ticket = _ticketLocalService.fetchTicket(
-								ticketId);
+						for (Ticket ticket : tickets) {
+							if ((ticket == null) ||
+								!StringUtil.equalsIgnoreCase(
+									ticket.getExtraInfo(),
+									user.getEmailAddress())) {
 
-							if (!_isTicketForUser(ticket, user)) {
 								intervalActionProcessor.incrementStart();
 
 								continue;
@@ -142,7 +132,8 @@ public class UserModelListener extends BaseModelListener<User> {
 
 							for (SharingEntry sharingEntry :
 									_sharingEntryLocalService.
-										getToTicketSharingEntries(ticketId)) {
+										getToTicketSharingEntries(
+											ticket.getTicketId())) {
 
 								_updateSharingEntry(sharingEntry, user);
 							}

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/impl/SharingEntryLocalServiceImpl.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/impl/SharingEntryLocalServiceImpl.java
@@ -529,6 +529,11 @@ public class SharingEntryLocalServiceImpl
 			toTicketId, toUserGroupId, toUserId, classNameId, classPK);
 	}
 
+	@Override
+	public List<SharingEntry> getToTicketSharingEntries(long toTicketId) {
+		return sharingEntryPersistence.findByToTicketId(toTicketId);
+	}
+
 	/**
 	 * Returns the list of sharing entries for resources shared with the user.
 	 *

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/persistence/impl/SharingEntryPersistenceImpl.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/persistence/impl/SharingEntryPersistenceImpl.java
@@ -766,6 +766,153 @@ public class SharingEntryPersistenceImpl
 			finderCache, new Object[] {userId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByToTicketId;
+	private FinderPath _finderPathWithoutPaginationFindByToTicketId;
+	private FinderPath _finderPathCountByToTicketId;
+	private CollectionPersistenceFinder<SharingEntry>
+		_collectionPersistenceFinderByToTicketId;
+
+	/**
+	 * Returns all the sharing entries where toTicketId = &#63;.
+	 *
+	 * @param toTicketId the to ticket ID
+	 * @return the matching sharing entries
+	 */
+	@Override
+	public List<SharingEntry> findByToTicketId(long toTicketId) {
+		return findByToTicketId(
+			toTicketId, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the sharing entries where toTicketId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>SharingEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param toTicketId the to ticket ID
+	 * @param start the lower bound of the range of sharing entries
+	 * @param end the upper bound of the range of sharing entries (not inclusive)
+	 * @return the range of matching sharing entries
+	 */
+	@Override
+	public List<SharingEntry> findByToTicketId(
+		long toTicketId, int start, int end) {
+
+		return findByToTicketId(toTicketId, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the sharing entries where toTicketId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>SharingEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param toTicketId the to ticket ID
+	 * @param start the lower bound of the range of sharing entries
+	 * @param end the upper bound of the range of sharing entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching sharing entries
+	 */
+	@Override
+	public List<SharingEntry> findByToTicketId(
+		long toTicketId, int start, int end,
+		OrderByComparator<SharingEntry> orderByComparator) {
+
+		return findByToTicketId(
+			toTicketId, start, end, orderByComparator, true);
+	}
+
+	/**
+	 * Returns an ordered range of all the sharing entries where toTicketId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>SharingEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param toTicketId the to ticket ID
+	 * @param start the lower bound of the range of sharing entries
+	 * @param end the upper bound of the range of sharing entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching sharing entries
+	 */
+	@Override
+	public List<SharingEntry> findByToTicketId(
+		long toTicketId, int start, int end,
+		OrderByComparator<SharingEntry> orderByComparator,
+		boolean useFinderCache) {
+
+		return _collectionPersistenceFinderByToTicketId.find(
+			finderCache, new Object[] {toTicketId}, start, end,
+			orderByComparator, useFinderCache);
+	}
+
+	/**
+	 * Returns the first sharing entry in the ordered set where toTicketId = &#63;.
+	 *
+	 * @param toTicketId the to ticket ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching sharing entry
+	 * @throws NoSuchEntryException if a matching sharing entry could not be found
+	 */
+	@Override
+	public SharingEntry findByToTicketId_First(
+			long toTicketId, OrderByComparator<SharingEntry> orderByComparator)
+		throws NoSuchEntryException {
+
+		SharingEntry sharingEntry = fetchByToTicketId_First(
+			toTicketId, orderByComparator);
+
+		if (sharingEntry != null) {
+			return sharingEntry;
+		}
+
+		throw new NoSuchEntryException(
+			_collectionPersistenceFinderByToTicketId.buildNoSuchKeyMessage(
+				_NO_SUCH_ENTITY_WITH_KEY, new Object[] {toTicketId}));
+	}
+
+	/**
+	 * Returns the first sharing entry in the ordered set where toTicketId = &#63;.
+	 *
+	 * @param toTicketId the to ticket ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching sharing entry, or <code>null</code> if a matching sharing entry could not be found
+	 */
+	@Override
+	public SharingEntry fetchByToTicketId_First(
+		long toTicketId, OrderByComparator<SharingEntry> orderByComparator) {
+
+		return _collectionPersistenceFinderByToTicketId.fetchFirst(
+			finderCache, new Object[] {toTicketId}, orderByComparator);
+	}
+
+	/**
+	 * Removes all the sharing entries where toTicketId = &#63; from the database.
+	 *
+	 * @param toTicketId the to ticket ID
+	 */
+	@Override
+	public void removeByToTicketId(long toTicketId) {
+		_collectionPersistenceFinderByToTicketId.remove(
+			finderCache, new Object[] {toTicketId});
+	}
+
+	/**
+	 * Returns the number of sharing entries where toTicketId = &#63;.
+	 *
+	 * @param toTicketId the to ticket ID
+	 * @return the number of matching sharing entries
+	 */
+	@Override
+	public int countByToTicketId(long toTicketId) {
+		return _collectionPersistenceFinderByToTicketId.count(
+			finderCache, new Object[] {toTicketId});
+	}
+
 	private FinderPath _finderPathWithPaginationFindByToUserId;
 	private FinderPath _finderPathWithoutPaginationFindByToUserId;
 	private FinderPath _finderPathCountByToUserId;
@@ -2334,6 +2481,35 @@ public class SharingEntryPersistenceImpl
 					"sharingEntry.", "userId", FinderColumn.Type.LONG, "=",
 					true, true, SharingEntry::getUserId));
 
+		_finderPathWithPaginationFindByToTicketId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByToTicketId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"toTicketId"}, true);
+
+		_finderPathWithoutPaginationFindByToTicketId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByToTicketId",
+			new String[] {Long.class.getName()}, new String[] {"toTicketId"},
+			true);
+
+		_finderPathCountByToTicketId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByToTicketId",
+			new String[] {Long.class.getName()}, new String[] {"toTicketId"},
+			false);
+
+		_collectionPersistenceFinderByToTicketId =
+			new CollectionPersistenceFinder<>(
+				this, _finderPathWithPaginationFindByToTicketId,
+				_finderPathWithoutPaginationFindByToTicketId,
+				_finderPathCountByToTicketId, _SQL_SELECT_SHARINGENTRY_WHERE,
+				_SQL_COUNT_SHARINGENTRY_WHERE,
+				SharingEntryModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
+				new FinderColumn<>(
+					"sharingEntry.", "toTicketId", FinderColumn.Type.LONG, "=",
+					true, true, SharingEntry::getToTicketId));
+
 		_finderPathWithPaginationFindByToUserId = new FinderPath(
 			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByToUserId",
 			new String[] {
@@ -2628,4 +2804,4 @@ public class SharingEntryPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1035219468
+// LIFERAY-SERVICE-BUILDER-HASH:966843877

--- a/modules/apps/sharing/sharing-service/src/main/resources/META-INF/sql/indexes.sql
+++ b/modules/apps/sharing/sharing-service/src/main/resources/META-INF/sql/indexes.sql
@@ -1,9 +1,10 @@
 create index IX_1ED300B1 on SharingEntry (classNameId, classPK);
 create index IX_CC1C3576 on SharingEntry (classNameId, companyId);
-create unique index IX_9E8B9952 on SharingEntry (classNameId, toUserId, classPK, toTicketId, toUserGroupId);
+create unique index IX_3722C73E on SharingEntry (classNameId, toUserId, toTicketId, classPK, toUserGroupId);
 create index IX_8E0359AC on SharingEntry (classNameId, userId);
 create index IX_1E35B88D on SharingEntry (expirationDate);
 create unique index IX_FA5E24AF on SharingEntry (groupId, externalReferenceCode[$COLUMN_LENGTH:75$]);
+create index IX_79E43C32 on SharingEntry (toTicketId);
 create index IX_C024CFB1 on SharingEntry (toUserId);
 create index IX_EA2FF796 on SharingEntry (userId);
 create unique index IX_5EDE78D2 on SharingEntry (uuid_[$COLUMN_LENGTH:75$], groupId);

--- a/modules/apps/sharing/sharing-service/src/main/resources/service.properties
+++ b/modules/apps/sharing/sharing-service/src/main/resources/service.properties
@@ -13,5 +13,5 @@
 ##
 
     build.namespace=com.liferay.sharing.service
-    build.number=2
-    build.date=1776902861039
+    build.number=3
+    build.date=1778079136180

--- a/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/internal/model/listener/test/UserModelListenerTest.java
+++ b/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/internal/model/listener/test/UserModelListenerTest.java
@@ -6,17 +6,30 @@
 package com.liferay.sharing.internal.model.listener.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Ticket;
+import com.liferay.portal.kernel.model.TicketConstants;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.UserConstants;
+import com.liferay.portal.kernel.model.WorkflowDefinitionLink;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.TicketLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalService;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -25,8 +38,12 @@ import com.liferay.sharing.model.SharingEntry;
 import com.liferay.sharing.security.permission.SharingEntryAction;
 import com.liferay.sharing.service.SharingEntryLocalService;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Date;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -51,25 +68,310 @@ public class UserModelListenerTest {
 
 	@Before
 	public void setUp() throws Exception {
-		_group = GroupTestUtil.addGroup();
+		_group1 = GroupTestUtil.addGroup();
 
 		_groupUser1 = UserTestUtil.addGroupUser(
-			_group, RoleConstants.POWER_USER);
+			_group1, RoleConstants.POWER_USER);
 		_groupUser2 = UserTestUtil.addGroupUser(
-			_group, RoleConstants.POWER_USER);
+			_group1, RoleConstants.POWER_USER);
+	}
+
+	@Test
+	@TestInfo("LPD-48130")
+	public void testAddUser() throws Exception {
+		String emailAddress1 = RandomTestUtil.randomString() + "@liferay.com";
+		String emailAddress2 = RandomTestUtil.randomString() + "@liferay.com";
+
+		_group2 = GroupTestUtil.addGroup();
+
+		Ticket ticket1 = _addInviteCollaboratorTicket(
+			_group1.getGroupId(), emailAddress1);
+		Ticket ticket2 = _addInviteCollaboratorTicket(
+			_group2.getGroupId(), emailAddress1);
+		Ticket ticket3 = _addInviteCollaboratorTicket(
+			_group1.getGroupId(), emailAddress2);
+
+		SharingEntry sharingEntry1 = _addTicketSharingEntry(
+			_group1.getGroupId(), ticket1.getTicketId());
+		SharingEntry sharingEntry2 = _addTicketSharingEntry(
+			_group2.getGroupId(), ticket2.getTicketId());
+		SharingEntry sharingEntry3 = _addTicketSharingEntry(
+			_group1.getGroupId(), ticket3.getTicketId());
+
+		User user1 = _addUser(emailAddress1);
+
+		Assert.assertNull(
+			_ticketLocalService.fetchTicket(ticket1.getTicketId()));
+		Assert.assertNull(
+			_ticketLocalService.fetchTicket(ticket2.getTicketId()));
+
+		sharingEntry1 = _sharingEntryLocalService.getSharingEntry(
+			sharingEntry1.getSharingEntryId());
+
+		Assert.assertEquals(0, sharingEntry1.getToTicketId());
+		Assert.assertEquals(user1.getUserId(), sharingEntry1.getToUserId());
+
+		sharingEntry2 = _sharingEntryLocalService.getSharingEntry(
+			sharingEntry2.getSharingEntryId());
+
+		Assert.assertEquals(0, sharingEntry2.getToTicketId());
+		Assert.assertEquals(user1.getUserId(), sharingEntry2.getToUserId());
+
+		ticket3 = _ticketLocalService.fetchTicket(ticket3.getTicketId());
+
+		sharingEntry3 = _sharingEntryLocalService.getSharingEntry(
+			sharingEntry3.getSharingEntryId());
+
+		Assert.assertEquals(
+			ticket3.getTicketId(), sharingEntry3.getToTicketId());
+		Assert.assertEquals(0, sharingEntry3.getToUserId());
+
+		// With Case Insensitive Email Address
+
+		emailAddress1 = RandomTestUtil.randomString() + "@liferay.com";
+
+		ticket1 = _addInviteCollaboratorTicket(
+			_group1.getGroupId(), StringUtil.toUpperCase(emailAddress1));
+
+		sharingEntry1 = _addTicketSharingEntry(
+			_group1.getGroupId(), ticket1.getTicketId());
+
+		User user2 = _addUser(emailAddress1);
+
+		Assert.assertNull(
+			_ticketLocalService.fetchTicket(ticket1.getTicketId()));
+
+		sharingEntry1 = _sharingEntryLocalService.getSharingEntry(
+			sharingEntry1.getSharingEntryId());
+
+		Assert.assertEquals(0, sharingEntry1.getToTicketId());
+		Assert.assertEquals(user2.getUserId(), sharingEntry1.getToUserId());
+
+		// With Duplicate Sharing Entry
+
+		emailAddress1 = RandomTestUtil.randomString() + "@liferay.com";
+
+		ticket1 = _addInviteCollaboratorTicket(
+			_group1.getGroupId(), emailAddress1);
+		ticket2 = _addInviteCollaboratorTicket(
+			_group1.getGroupId(), emailAddress1);
+
+		_addTicketSharingEntry(_group1.getGroupId(), ticket1.getTicketId());
+		_addTicketSharingEntry(_group1.getGroupId(), ticket2.getTicketId());
+
+		List<SharingEntry> toTicketSharingEntries =
+			_sharingEntryLocalService.getToTicketSharingEntries(
+				ticket1.getTicketId());
+
+		Assert.assertEquals(
+			toTicketSharingEntries.toString(), 1,
+			toTicketSharingEntries.size());
+
+		toTicketSharingEntries =
+			_sharingEntryLocalService.getToTicketSharingEntries(
+				ticket2.getTicketId());
+
+		Assert.assertEquals(
+			toTicketSharingEntries.toString(), 1,
+			toTicketSharingEntries.size());
+
+		User user3 = _addUser(emailAddress1);
+
+		Assert.assertNull(
+			_ticketLocalService.fetchTicket(ticket1.getTicketId()));
+		Assert.assertNull(
+			_ticketLocalService.fetchTicket(ticket2.getTicketId()));
+
+		List<SharingEntry> toUserSharingEntries =
+			_sharingEntryLocalService.getToUserSharingEntries(
+				user3.getUserId());
+
+		Assert.assertEquals(
+			toUserSharingEntries.toString(), 1, toUserSharingEntries.size());
+
+		SharingEntry toUserSharingEntry = toUserSharingEntries.get(0);
+
+		Assert.assertEquals(0, toUserSharingEntry.getToTicketId());
+
+		toTicketSharingEntries =
+			_sharingEntryLocalService.getToTicketSharingEntries(
+				ticket1.getTicketId());
+
+		Assert.assertEquals(
+			toTicketSharingEntries.toString(), 0,
+			toTicketSharingEntries.size());
+
+		toTicketSharingEntries =
+			_sharingEntryLocalService.getToTicketSharingEntries(
+				ticket2.getTicketId());
+
+		Assert.assertEquals(
+			toTicketSharingEntries.toString(), 0,
+			toTicketSharingEntries.size());
+
+		// With Invalid Extra Info
+
+		emailAddress1 = RandomTestUtil.randomString() + "@liferay.com";
+
+		ticket1 = _addInviteCollaboratorTicketWithExtraInfo(
+			_group1.getGroupId(), null);
+		ticket2 = _addInviteCollaboratorTicketWithExtraInfo(
+			_group1.getGroupId(), "not-an-email");
+		ticket3 = _addInviteCollaboratorTicket(
+			_group1.getGroupId(), emailAddress1);
+
+		sharingEntry1 = _addTicketSharingEntry(
+			_group1.getGroupId(), ticket1.getTicketId());
+		sharingEntry2 = _addTicketSharingEntry(
+			_group1.getGroupId(), ticket2.getTicketId());
+		sharingEntry3 = _addTicketSharingEntry(
+			_group1.getGroupId(), ticket3.getTicketId());
+
+		User user4 = _addUser(emailAddress1);
+
+		Assert.assertNotNull(
+			_ticketLocalService.fetchTicket(ticket1.getTicketId()));
+		Assert.assertNotNull(
+			_ticketLocalService.fetchTicket(ticket2.getTicketId()));
+		Assert.assertNull(
+			_ticketLocalService.fetchTicket(ticket3.getTicketId()));
+
+		sharingEntry1 = _sharingEntryLocalService.getSharingEntry(
+			sharingEntry1.getSharingEntryId());
+
+		Assert.assertEquals(
+			ticket1.getTicketId(), sharingEntry1.getToTicketId());
+		Assert.assertEquals(0, sharingEntry1.getToUserId());
+
+		sharingEntry2 = _sharingEntryLocalService.getSharingEntry(
+			sharingEntry2.getSharingEntryId());
+
+		Assert.assertEquals(
+			ticket2.getTicketId(), sharingEntry2.getToTicketId());
+		Assert.assertEquals(0, sharingEntry2.getToUserId());
+
+		sharingEntry3 = _sharingEntryLocalService.getSharingEntry(
+			sharingEntry3.getSharingEntryId());
+
+		Assert.assertEquals(0, sharingEntry3.getToTicketId());
+		Assert.assertEquals(user4.getUserId(), sharingEntry3.getToUserId());
+
+		// With Existing User-Based Sharing Entry
+
+		emailAddress1 = RandomTestUtil.randomString() + "@liferay.com";
+
+		User user5 = _addUser(emailAddress1);
+
+		ticket1 = _addInviteCollaboratorTicket(
+			_group1.getGroupId(), emailAddress1);
+
+		sharingEntry1 = _sharingEntryLocalService.addSharingEntry(
+			null, TestPropsValues.getUserId(), 0, 0, user5.getUserId(),
+			_classNameLocalService.getClassNameId(Group.class.getName()),
+			_group1.getGroupId(), _group1.getGroupId(), true,
+			Arrays.asList(SharingEntryAction.VIEW), null,
+			ServiceContextTestUtil.getServiceContext(
+				_group1.getGroupId(), TestPropsValues.getUserId()));
+
+		_addTicketSharingEntry(_group1.getGroupId(), ticket1.getTicketId());
+
+		_userLocalService.updateStatus(
+			user5.getUserId(), WorkflowConstants.STATUS_INACTIVE,
+			ServiceContextTestUtil.getServiceContext(
+				_group1.getGroupId(), TestPropsValues.getUserId()));
+
+		_userLocalService.updateStatus(
+			user5.getUserId(), WorkflowConstants.STATUS_APPROVED,
+			ServiceContextTestUtil.getServiceContext(
+				_group1.getGroupId(), TestPropsValues.getUserId()));
+
+		Assert.assertNull(
+			_ticketLocalService.fetchTicket(ticket1.getTicketId()));
+
+		toTicketSharingEntries =
+			_sharingEntryLocalService.getToTicketSharingEntries(
+				ticket1.getTicketId());
+
+		Assert.assertEquals(
+			toTicketSharingEntries.toString(), 0,
+			toTicketSharingEntries.size());
+
+		toUserSharingEntries =
+			_sharingEntryLocalService.getToUserSharingEntries(
+				user5.getUserId());
+
+		Assert.assertEquals(
+			toUserSharingEntries.toString(), 1, toUserSharingEntries.size());
+
+		toUserSharingEntry = toUserSharingEntries.get(0);
+
+		Assert.assertEquals(
+			sharingEntry1.getSharingEntryId(),
+			toUserSharingEntry.getSharingEntryId());
+	}
+
+	@Test
+	@TestInfo("LPD-48130")
+	public void testAddUserWithWorkflow() throws Exception {
+		String emailAddress1 = RandomTestUtil.randomString() + "@liferay.com";
+		String emailAddress2 = RandomTestUtil.randomString() + "@liferay.com";
+
+		_group2 = GroupTestUtil.addGroup();
+
+		Ticket ticket1 = _addInviteCollaboratorTicket(
+			_group1.getGroupId(), emailAddress1);
+		Ticket ticket2 = _addInviteCollaboratorTicket(
+			_group2.getGroupId(), emailAddress1);
+		Ticket ticket3 = _addInviteCollaboratorTicket(
+			_group1.getGroupId(), emailAddress2);
+
+		SharingEntry sharingEntry1 = _addTicketSharingEntry(
+			_group1.getGroupId(), ticket1.getTicketId());
+		SharingEntry sharingEntry2 = _addTicketSharingEntry(
+			_group2.getGroupId(), ticket2.getTicketId());
+		SharingEntry sharingEntry3 = _addTicketSharingEntry(
+			_group1.getGroupId(), ticket3.getTicketId());
+
+		User user = _addUserWithWorkflow(emailAddress1);
+
+		Assert.assertNull(
+			_ticketLocalService.fetchTicket(ticket1.getTicketId()));
+		Assert.assertNull(
+			_ticketLocalService.fetchTicket(ticket2.getTicketId()));
+
+		sharingEntry1 = _sharingEntryLocalService.getSharingEntry(
+			sharingEntry1.getSharingEntryId());
+
+		Assert.assertEquals(0, sharingEntry1.getToTicketId());
+		Assert.assertEquals(user.getUserId(), sharingEntry1.getToUserId());
+
+		sharingEntry2 = _sharingEntryLocalService.getSharingEntry(
+			sharingEntry2.getSharingEntryId());
+
+		Assert.assertEquals(0, sharingEntry2.getToTicketId());
+		Assert.assertEquals(user.getUserId(), sharingEntry2.getToUserId());
+
+		ticket3 = _ticketLocalService.fetchTicket(ticket3.getTicketId());
+
+		sharingEntry3 = _sharingEntryLocalService.getSharingEntry(
+			sharingEntry3.getSharingEntryId());
+
+		Assert.assertEquals(
+			ticket3.getTicketId(), sharingEntry3.getToTicketId());
+		Assert.assertEquals(0, sharingEntry3.getToUserId());
 	}
 
 	@Test
 	public void testDeletingUserSharedDeletesSharingEntries() throws Exception {
-		long classPK = _group.getGroupId();
+		long classPK = _group1.getGroupId();
 
 		_sharingEntryLocalService.addSharingEntry(
 			null, TestPropsValues.getUserId(), 0, 0, _groupUser1.getUserId(),
 			_classNameLocalService.getClassNameId(Group.class.getName()),
-			classPK, _group.getGroupId(), true,
+			classPK, _group1.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.VIEW), null,
 			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), TestPropsValues.getUserId()));
+				_group1.getGroupId(), TestPropsValues.getUserId()));
 
 		List<SharingEntry> toUserSharingEntries =
 			_sharingEntryLocalService.getToUserSharingEntries(
@@ -92,15 +394,15 @@ public class UserModelListenerTest {
 	public void testDeletingUserSharingDoesNotDeleteSharingEntries()
 		throws Exception {
 
-		long classPK = _group.getGroupId();
+		long classPK = _group1.getGroupId();
 
 		_sharingEntryLocalService.addSharingEntry(
 			null, TestPropsValues.getUserId(), 0, 0, _groupUser1.getUserId(),
 			_classNameLocalService.getClassNameId(Group.class.getName()),
-			classPK, _group.getGroupId(), true,
+			classPK, _group1.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.VIEW), null,
 			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), TestPropsValues.getUserId()));
+				_group1.getGroupId(), TestPropsValues.getUserId()));
 
 		List<SharingEntry> toUserSharingEntries =
 			_sharingEntryLocalService.getToUserSharingEntries(
@@ -119,11 +421,127 @@ public class UserModelListenerTest {
 			toUserSharingEntries.toString(), 1, toUserSharingEntries.size());
 	}
 
+	@Test
+	@TestInfo("LPD-48130")
+	public void testUpdateUserStatus() throws Exception {
+		WorkflowDefinitionLink workflowDefinitionLink =
+			_workflowDefinitionLinkLocalService.addWorkflowDefinitionLink(
+				null, TestPropsValues.getUserId(),
+				TestPropsValues.getCompanyId(),
+				WorkflowConstants.DEFAULT_GROUP_ID, User.class.getName(), 0, 0,
+				"Single Approver", 1);
+
+		try {
+			String emailAddress =
+				RandomTestUtil.randomString() + "@liferay.com";
+
+			Ticket ticket = _addInviteCollaboratorTicket(
+				_group1.getGroupId(), emailAddress);
+
+			SharingEntry sharingEntry = _addTicketSharingEntry(
+				_group1.getGroupId(), ticket.getTicketId());
+
+			User user = _addUserWithWorkflow(emailAddress);
+
+			Assert.assertEquals(
+				WorkflowConstants.STATUS_PENDING, user.getStatus());
+
+			Assert.assertNotNull(
+				_ticketLocalService.fetchTicket(ticket.getTicketId()));
+
+			sharingEntry = _sharingEntryLocalService.getSharingEntry(
+				sharingEntry.getSharingEntryId());
+
+			Assert.assertEquals(
+				ticket.getTicketId(), sharingEntry.getToTicketId());
+			Assert.assertEquals(0, sharingEntry.getToUserId());
+
+			_userLocalService.updateStatus(
+				user.getUserId(), WorkflowConstants.STATUS_APPROVED,
+				ServiceContextTestUtil.getServiceContext(
+					_group1.getGroupId(), TestPropsValues.getUserId()));
+
+			Assert.assertNull(
+				_ticketLocalService.fetchTicket(ticket.getTicketId()));
+
+			sharingEntry = _sharingEntryLocalService.getSharingEntry(
+				sharingEntry.getSharingEntryId());
+
+			Assert.assertEquals(0, sharingEntry.getToTicketId());
+			Assert.assertEquals(user.getUserId(), sharingEntry.getToUserId());
+		}
+		finally {
+			_workflowDefinitionLinkLocalService.deleteWorkflowDefinitionLink(
+				workflowDefinitionLink);
+		}
+	}
+
+	private Ticket _addInviteCollaboratorTicket(
+			long classPK, String emailAddress)
+		throws Exception {
+
+		return _addInviteCollaboratorTicketWithExtraInfo(classPK, emailAddress);
+	}
+
+	private Ticket _addInviteCollaboratorTicketWithExtraInfo(
+			long classPK, String extraInfo)
+		throws Exception {
+
+		return _ticketLocalService.addTicket(
+			TestPropsValues.getCompanyId(), Group.class.getName(), classPK,
+			TicketConstants.TYPE_INVITE_COLLABORATOR, extraInfo,
+			new Date(System.currentTimeMillis() + TimeUnit.HOURS.toMillis(48)),
+			new ServiceContext());
+	}
+
+	private SharingEntry _addTicketSharingEntry(long classPK, long toTicketId)
+		throws Exception {
+
+		return _sharingEntryLocalService.addSharingEntry(
+			null, TestPropsValues.getUserId(), toTicketId, 0, 0,
+			_classNameLocalService.getClassNameId(Group.class.getName()),
+			classPK, _group1.getGroupId(), true,
+			Arrays.asList(SharingEntryAction.VIEW), null,
+			ServiceContextTestUtil.getServiceContext(
+				_group1.getGroupId(), TestPropsValues.getUserId()));
+	}
+
+	private User _addUser(String emailAddress) throws Exception {
+		User user = UserTestUtil.addUser(
+			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			StringPool.BLANK, emailAddress, RandomTestUtil.randomString(),
+			LocaleUtil.getDefault(), "Test", "User", null,
+			ServiceContextTestUtil.getServiceContext(
+				_group1.getGroupId(), TestPropsValues.getUserId()));
+
+		_users.add(user);
+
+		return user;
+	}
+
+	private User _addUserWithWorkflow(String emailAddress) throws Exception {
+		User user = _userLocalService.addUserWithWorkflow(
+			TestPropsValues.getUserId(), TestPropsValues.getCompanyId(), true,
+			null, null, false, RandomTestUtil.randomString(), emailAddress,
+			LocaleUtil.getDefault(), "Test", StringPool.BLANK, "User", 0, 0,
+			true, Calendar.JANUARY, 1, 1970, StringPool.BLANK,
+			UserConstants.TYPE_REGULAR, null, null, null, null, false,
+			ServiceContextTestUtil.getServiceContext(
+				_group1.getGroupId(), TestPropsValues.getUserId()));
+
+		_users.add(user);
+
+		return user;
+	}
+
 	@Inject
 	private ClassNameLocalService _classNameLocalService;
 
 	@DeleteAfterTestRun
-	private Group _group;
+	private Group _group1;
+
+	@DeleteAfterTestRun
+	private Group _group2;
 
 	private User _groupUser1;
 	private User _groupUser2;
@@ -132,6 +550,16 @@ public class UserModelListenerTest {
 	private SharingEntryLocalService _sharingEntryLocalService;
 
 	@Inject
+	private TicketLocalService _ticketLocalService;
+
+	@Inject
 	private UserLocalService _userLocalService;
+
+	@DeleteAfterTestRun
+	private final List<User> _users = new ArrayList<>();
+
+	@Inject
+	private WorkflowDefinitionLinkLocalService
+		_workflowDefinitionLinkLocalService;
 
 }

--- a/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/internal/model/listener/test/UserModelListenerTest.java
+++ b/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/internal/model/listener/test/UserModelListenerTest.java
@@ -209,6 +209,59 @@ public class UserModelListenerTest {
 			toTicketSharingEntries.toString(), 0,
 			toTicketSharingEntries.size());
 
+		// With Existing User-Based Sharing Entry
+
+		emailAddress1 = RandomTestUtil.randomString() + "@liferay.com";
+
+		User user4 = _addUser(emailAddress1);
+
+		ticket1 = _addInviteCollaboratorTicket(
+			_group1.getGroupId(), emailAddress1);
+
+		sharingEntry1 = _sharingEntryLocalService.addSharingEntry(
+			null, TestPropsValues.getUserId(), 0, 0, user4.getUserId(),
+			_classNameLocalService.getClassNameId(Group.class.getName()),
+			_group1.getGroupId(), _group1.getGroupId(), true,
+			Arrays.asList(SharingEntryAction.VIEW), null,
+			ServiceContextTestUtil.getServiceContext(
+				_group1.getGroupId(), TestPropsValues.getUserId()));
+
+		_addTicketSharingEntry(_group1.getGroupId(), ticket1.getTicketId());
+
+		_userLocalService.updateStatus(
+			user4.getUserId(), WorkflowConstants.STATUS_INACTIVE,
+			ServiceContextTestUtil.getServiceContext(
+				_group1.getGroupId(), TestPropsValues.getUserId()));
+
+		_userLocalService.updateStatus(
+			user4.getUserId(), WorkflowConstants.STATUS_APPROVED,
+			ServiceContextTestUtil.getServiceContext(
+				_group1.getGroupId(), TestPropsValues.getUserId()));
+
+		Assert.assertNull(
+			_ticketLocalService.fetchTicket(ticket1.getTicketId()));
+
+		toTicketSharingEntries =
+			_sharingEntryLocalService.getToTicketSharingEntries(
+				ticket1.getTicketId());
+
+		Assert.assertEquals(
+			toTicketSharingEntries.toString(), 0,
+			toTicketSharingEntries.size());
+
+		toUserSharingEntries =
+			_sharingEntryLocalService.getToUserSharingEntries(
+				user4.getUserId());
+
+		Assert.assertEquals(
+			toUserSharingEntries.toString(), 1, toUserSharingEntries.size());
+
+		toUserSharingEntry = toUserSharingEntries.get(0);
+
+		Assert.assertEquals(
+			sharingEntry1.getSharingEntryId(),
+			toUserSharingEntry.getSharingEntryId());
+
 		// With Invalid Extra Info
 
 		emailAddress1 = RandomTestUtil.randomString() + "@liferay.com";
@@ -227,7 +280,7 @@ public class UserModelListenerTest {
 		sharingEntry3 = _addTicketSharingEntry(
 			_group1.getGroupId(), ticket3.getTicketId());
 
-		User user4 = _addUser(emailAddress1);
+		User user5 = _addUser(emailAddress1);
 
 		Assert.assertNotNull(
 			_ticketLocalService.fetchTicket(ticket1.getTicketId()));
@@ -254,60 +307,7 @@ public class UserModelListenerTest {
 			sharingEntry3.getSharingEntryId());
 
 		Assert.assertEquals(0, sharingEntry3.getToTicketId());
-		Assert.assertEquals(user4.getUserId(), sharingEntry3.getToUserId());
-
-		// With Existing User-Based Sharing Entry
-
-		emailAddress1 = RandomTestUtil.randomString() + "@liferay.com";
-
-		User user5 = _addUser(emailAddress1);
-
-		ticket1 = _addInviteCollaboratorTicket(
-			_group1.getGroupId(), emailAddress1);
-
-		sharingEntry1 = _sharingEntryLocalService.addSharingEntry(
-			null, TestPropsValues.getUserId(), 0, 0, user5.getUserId(),
-			_classNameLocalService.getClassNameId(Group.class.getName()),
-			_group1.getGroupId(), _group1.getGroupId(), true,
-			Arrays.asList(SharingEntryAction.VIEW), null,
-			ServiceContextTestUtil.getServiceContext(
-				_group1.getGroupId(), TestPropsValues.getUserId()));
-
-		_addTicketSharingEntry(_group1.getGroupId(), ticket1.getTicketId());
-
-		_userLocalService.updateStatus(
-			user5.getUserId(), WorkflowConstants.STATUS_INACTIVE,
-			ServiceContextTestUtil.getServiceContext(
-				_group1.getGroupId(), TestPropsValues.getUserId()));
-
-		_userLocalService.updateStatus(
-			user5.getUserId(), WorkflowConstants.STATUS_APPROVED,
-			ServiceContextTestUtil.getServiceContext(
-				_group1.getGroupId(), TestPropsValues.getUserId()));
-
-		Assert.assertNull(
-			_ticketLocalService.fetchTicket(ticket1.getTicketId()));
-
-		toTicketSharingEntries =
-			_sharingEntryLocalService.getToTicketSharingEntries(
-				ticket1.getTicketId());
-
-		Assert.assertEquals(
-			toTicketSharingEntries.toString(), 0,
-			toTicketSharingEntries.size());
-
-		toUserSharingEntries =
-			_sharingEntryLocalService.getToUserSharingEntries(
-				user5.getUserId());
-
-		Assert.assertEquals(
-			toUserSharingEntries.toString(), 1, toUserSharingEntries.size());
-
-		toUserSharingEntry = toUserSharingEntries.get(0);
-
-		Assert.assertEquals(
-			sharingEntry1.getSharingEntryId(),
-			toUserSharingEntry.getSharingEntryId());
+		Assert.assertEquals(user5.getUserId(), sharingEntry3.getToUserId());
 	}
 
 	@Test

--- a/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/service/persistence/test/SharingEntryPersistenceTest.java
+++ b/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/service/persistence/test/SharingEntryPersistenceTest.java
@@ -261,6 +261,13 @@ public class SharingEntryPersistenceTest {
 	}
 
 	@Test
+	public void testCountByToTicketId() throws Exception {
+		_persistence.countByToTicketId(RandomTestUtil.nextLong());
+
+		_persistence.countByToTicketId(0L);
+	}
+
+	@Test
 	public void testCountByToUserId() throws Exception {
 		_persistence.countByToUserId(RandomTestUtil.nextLong());
 
@@ -718,4 +725,4 @@ public class SharingEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1193723092
+// LIFERAY-SERVICE-BUILDER-HASH:-1957922974


### PR DESCRIPTION
LPD-88154 Convert ticket-based sharing entries to user-based on user creation

Resent after https://github.com/brianchandotcom/liferay-portal/pull/174087#issuecomment-4380777955 and https://github.com/brianchandotcom/liferay-portal/pull/173983#issuecomment-4372625330.

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-88154

When a resource is shared with someone who does not yet have an account, the invitation is stored as a `SharingEntry` linked to a `Ticket` (via `toTicketId`) rather than to a user. Once the invited person registers, those pending sharing permissions are never activated — there is no mechanism to migrate them from ticket-based to user-based.

# How am I fixing it?

## Ticket storage

`CollaboratorUtil._addOrUpdateTicket` now stores the invitee's email address as plain text in `Ticket.extraInfo` (lower-cased and trimmed), replacing the previous JSON blob. CollaboratorUtil` also normalises the email (`toLowerCase + trim`) before calling `userLocalService.fetchUserByEmailAddress`, so lookup and storage are consistent. This is consistant with other storages of tickets as on the one to create the user.

## Migration on user creation

`UserModelListener` gains two new hooks:

- **`onAfterCreate`** — fires when a new user is created with status  `APPROVED` (direct registration, LDAP sync, admin creation, etc.).
- **`onAfterUpdate`** — fires when a user transitions from any non-approved status to `APPROVED` (workflow approval).

Both delegate to `_updateSharingEntries(user)`, which runs inside `TransactionCommitCallbackUtil` so it only executes after the user's creation transaction has committed.

## Query design

The migration query uses a **DSL INNER JOIN** between `TicketTable` and `SharingEntryTable` on `(classNameId, classPK, toTicketId = ticketId)`,
filtered to non-expired `TYPE_INVITE_COLLABORATOR` tickets for the user's company. This ensures only tickets that have at least one pending `SharingEntry` linked to them are returned — rather than scanning the entire ticket table.

**Why isn't the email address filtered in the SQL WHERE clause?**

`Ticket.extraInfo` is mapped as `Types.CLOB` (Java `Clob`). Oracle — one of Liferay's supported databases — does not allow CLOB columns in `=` equality predicates. Attempting to do so raises `ORA-00932: inconsistent datatypes`.
The email comparison is therefore performed in Java via `StringUtil.equalsIgnoreCase`, which also handles the upper/lower-case divergence that can exist between what was stored in the ticket and what Liferay records as `user.getEmailAddress()`. The INNER JOIN already narrows the result set to tickets with active pending sharing entries, so the Java-side filter runs over a small population in practice.

Results are processed in batches using `IntervalActionProcessor` to avoid loading the full set into memory.


# How can you verify that it works?

Run the included integration tests


# Commits

- `611a50b75acee` LPD-88154 add finder to SharingEntry
- `5bbca2559d5b4` LPD-88154 add method to get the sharing entries by toTicketId
- `550f40517519b` LPD-88154 buildService
- `d3bda289283e1` LPD-88154 store the collaborator email address as plain text in the ticket extra info
- `a0ad9f6c13583` LPD-88154 convert pending email collaborator invite when the user signs up