### PR TITLE
LPD-88977 Forward section filter in CMS bulk-action POSTs

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/AssetsFDSPropsTransformer.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/AssetsFDSPropsTransformer.tsx
@@ -205,6 +205,13 @@ export default function AssetsFDSPropsTransformer({
 		...remainingAdditionalProps
 	} = additionalProps || {};
 
+	const bulkActionAPIURL =
+		additionalAPIURLParameters && otherProps.apiURL
+			? `${otherProps.apiURL}${
+					otherProps.apiURL.includes('?') ? '&' : '?'
+				}${additionalAPIURLParameters}`
+			: otherProps.apiURL;
+
 	return {
 		...otherProps,
 		additionalAPIURLParameters,
@@ -434,7 +441,7 @@ export default function AssetsFDSPropsTransformer({
 							allowPropagate:
 								action.data.id ===
 								'edit-and-propagate-default-permissions',
-							apiURL: otherProps.apiURL,
+							apiURL: bulkActionAPIURL,
 							classExternalReferenceCode:
 								itemData.embedded.externalReferenceCode,
 							className: itemData.entryClassName,
@@ -591,7 +598,7 @@ export default function AssetsFDSPropsTransformer({
 						closeModal: () => void;
 					}) =>
 						EditAssetCategoriesModalContent({
-							apiURL: otherProps.apiURL,
+							apiURL: bulkActionAPIURL,
 							assetLibraries:
 								additionalProps.candidateAssetLibraries,
 							closeModal,
@@ -613,7 +620,7 @@ export default function AssetsFDSPropsTransformer({
 						closeModal: () => void;
 					}) =>
 						EditAssetTagsModalContent({
-							apiURL: otherProps?.apiURL,
+							apiURL: bulkActionAPIURL,
 							assetLibraries:
 								additionalProps.candidateAssetLibraries,
 							closeModal,
@@ -625,7 +632,7 @@ export default function AssetsFDSPropsTransformer({
 			}
 			else if (action?.data?.id === 'default-permissions') {
 				defaultPermissionsBulkAction({
-					apiURL: otherProps.apiURL,
+					apiURL: bulkActionAPIURL,
 					className: OBJECT_ENTRY_FOLDER_CLASS_NAME,
 					defaultPermissionAdditionalProps:
 						additionalProps.defaultPermissionAdditionalProps || {},
@@ -638,11 +645,11 @@ export default function AssetsFDSPropsTransformer({
 			else if (action?.data?.id === 'delete') {
 				if (additionalProps.brokenLinksCheckerEnabled) {
 					openAssetUsageListModal({
-						apiURL: otherProps.apiURL,
+						apiURL: bulkActionAPIURL,
 						itemsData: selectedData.items,
 						onDelete: async () => {
 							executeBulkDeleteAction(
-								otherProps.apiURL as string,
+								bulkActionAPIURL as string,
 								otherProps.id || '',
 								selectedData
 							);
@@ -655,7 +662,7 @@ export default function AssetsFDSPropsTransformer({
 
 						onSkip: async () => {
 							deleteAssetEntriesBulkAction({
-								apiURL: otherProps.apiURL,
+								apiURL: bulkActionAPIURL,
 								dataSetId: otherProps.id,
 								selectedData,
 							});
@@ -665,14 +672,14 @@ export default function AssetsFDSPropsTransformer({
 				}
 				else {
 					deleteAssetEntriesBulkAction({
-						apiURL: otherProps.apiURL,
+						apiURL: bulkActionAPIURL,
 						selectedData,
 					});
 				}
 			}
 			else if (action?.data?.id === 'download') {
 				triggerAssetDownloadBulkAction({
-					apiURL: otherProps.apiURL,
+					apiURL: bulkActionAPIURL,
 					selectedData,
 					type: 'DownloadBulkAction',
 				});
@@ -680,7 +687,7 @@ export default function AssetsFDSPropsTransformer({
 			else if (action?.data?.id === 'export-for-translation') {
 				exportTranslationBulkAction({
 					additionalProps,
-					apiURL: otherProps.apiURL,
+					apiURL: bulkActionAPIURL,
 					selectedData,
 				});
 			}
@@ -688,7 +695,7 @@ export default function AssetsFDSPropsTransformer({
 				action?.data?.id === 'edit-default-permissions-by-role'
 			) {
 				defaultPermissionsBulkAction({
-					apiURL: otherProps.apiURL,
+					apiURL: bulkActionAPIURL,
 					className: OBJECT_ENTRY_FOLDER_CLASS_NAME,
 					defaultPermissionAdditionalProps:
 						additionalProps.defaultPermissionAdditionalProps || {},
@@ -701,7 +708,7 @@ export default function AssetsFDSPropsTransformer({
 			}
 			else if (action?.data?.id === 'edit-permissions-by-role') {
 				permissionsBulkAction({
-					apiURL: otherProps.apiURL,
+					apiURL: bulkActionAPIURL,
 					className: OBJECT_ENTRY_FOLDER_CLASS_NAME,
 					defaultPermissionAdditionalProps:
 						additionalProps.defaultPermissionAdditionalProps || {},
@@ -714,7 +721,7 @@ export default function AssetsFDSPropsTransformer({
 			}
 			else if (action?.data.id === 'expire') {
 				expireEntriesBulkAction({
-					apiURL: otherProps.apiURL,
+					apiURL: bulkActionAPIURL,
 					dataSetId: otherProps.id,
 					selectedData,
 				});
@@ -737,7 +744,7 @@ export default function AssetsFDSPropsTransformer({
 			}
 			else if (action?.data?.id === 'permissions') {
 				permissionsBulkAction({
-					apiURL: otherProps.apiURL,
+					apiURL: bulkActionAPIURL,
 					className: OBJECT_ENTRY_FOLDER_CLASS_NAME,
 					defaultPermissionAdditionalProps:
 						additionalProps.defaultPermissionAdditionalProps || {},
@@ -751,7 +758,7 @@ export default function AssetsFDSPropsTransformer({
 				openResetAssetPermissionModal({
 					loadData: () => {
 						executeResetPermissionObjectBulkSelectionAction({
-							apiURL: otherProps.apiURL,
+							apiURL: bulkActionAPIURL,
 							selectedData,
 						});
 					},
@@ -764,7 +771,7 @@ export default function AssetsFDSPropsTransformer({
 				copyOrMoveBulkAction({
 					action: action.data.id === 'copy-to' ? 'copy' : 'move',
 					additionalProps,
-					apiURL: otherProps.apiURL,
+					apiURL: bulkActionAPIURL,
 					dataSetId: otherProps.id,
 					selectedData,
 				});

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/bulkActions.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/bulkActions.spec.ts
@@ -1833,6 +1833,61 @@ test(
 );
 
 test(
+	'Bulk Expire over a Select All expanded selection forwards the section filter',
+	{tag: '@LPD-88977'},
+	async ({apiHelpers, assetsPage, page}) => {
+		const fileCount = 21;
+		const titlePrefix = `BulkSelectAll ${getRandomString()}`;
+
+		await test.step(`Create ${fileCount} files in the Default space`, async () => {
+			for (let i = 0; i < fileCount; i++) {
+				const entry = await apiHelpers.objectEntry.postObjectEntry(
+					{
+						file: {
+							fileBase64: 'R0lGODlhAQABAAAAACw=',
+							name: `${titlePrefix}_${i}.gif`,
+						},
+						objectEntryFolderExternalReferenceCode: 'L_FILES',
+						title: `${titlePrefix}_${i}`,
+					},
+					'cms/basic-documents',
+					'Default'
+				);
+
+				apiHelpers.data.push({
+					id: entry.file.id,
+					type: 'document',
+				});
+			}
+		});
+
+		await assetsPage.gotoFiles();
+		await assetsPage.changeVisualizationMode('Table');
+
+		await page.getByTitle('Select Items').click();
+
+		const selectAllLink = page.getByRole('button', {
+			exact: true,
+			name: 'Select All',
+		});
+
+		await expect(selectAllLink).toBeVisible();
+
+		await selectAllLink.click();
+
+		await expect(page.getByText('All Selected')).toBeVisible();
+
+		await assetsPage.execBulkItemAction('Expire');
+
+		await waitForAlert(page, 'Info:Expire action started', {
+			type: 'info',
+		});
+
+		await expect(page.getByText('Filter is null')).toHaveCount(0);
+	}
+);
+
+test(
 	'Export for Translation CMS assets in bulk',
 	{tag: '@LPD-85361'},
 	async ({apiHelpers, assetsPage, page}) => {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88977

## What is being fixed

Bulk actions in CMS Files (e.g. Expire) failed with a "Filter is null" toast after clicking "Select All". The backend rejects an unbounded `selectAll` POST that has no `filter` query param, since otherwise it would expand to every searchable entity in the index. After LPD-85986 moved the Files section filter out of the FDS api URL into `additionalAPIURLParameters` (so the search transformer could drop `cmsRoot eq true` / `folderId eq …` when searching subfolders), the bulk-action POST stopped including that filter.

## How it is being fixed

In `AssetsFDSPropsTransformer`, build a single `bulkActionAPIURL` that concatenates the api URL with `additionalAPIURLParameters` and route every bulk-action call site through it. The api URL the FDS uses for data loading is unchanged, so search-in-subfolders keeps working. The downstream `composeCreateTaskURL` already extracts `filter` from the api URL it receives, so no further plumbing is needed.