### PR TITLE
LPD-85681 Add Playwright tests for space role coverage

### DIFF
--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/02_dashboard/page.json
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/02_dashboard/page.json
@@ -60,6 +60,12 @@
 			],
 			"roleName": "Guest",
 			"scope": 4
+		},
+		{
+			"actionIds": [
+			],
+			"roleName": "Site Member",
+			"scope": 4
 		}
 	],
 	"private": false,

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/pages/SpaceSummaryPage.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/pages/SpaceSummaryPage.ts
@@ -93,6 +93,8 @@ export class SpaceSummaryPage {
 			})
 			.check();
 
+		await expect(triggerText).toContainText(roleName);
+
 		await this.closeButton.click();
 	}
 

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/pages/SpaceSummaryPage.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/pages/SpaceSummaryPage.ts
@@ -121,7 +121,8 @@ export class SpaceSummaryPage {
 			this.page,
 			type.includes('group')
 				? `Success:Group ${name} successfully added to space.`
-				: `Success:User ${name} successfully added to space.`
+				: `Success:User ${name} successfully added to space.`,
+			{autoClose: false}
 		);
 
 		await this.closeButton.click();
@@ -147,7 +148,8 @@ export class SpaceSummaryPage {
 			this.page,
 			type.includes('group')
 				? `Success:Group ${name} successfully removed from space.`
-				: `Success:User ${name} successfully removed from space.`
+				: `Success:User ${name} successfully removed from space.`,
+			{autoClose: false}
 		);
 
 		await this.closeButton.click();

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/dxpUserMenuCMSHomepage.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/dxpUserMenuCMSHomepage.spec.ts
@@ -1,0 +1,99 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Page, expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import {DataApiHelpers} from '../../../../helpers/ApiHelpers';
+import getRandomString from '../../../../utils/getRandomString';
+import {performUserSwitchViaApi} from '../../../../utils/performLogin';
+import {cmsPagesTest} from '../fixtures/cmsPagesTest';
+import {SpaceSummaryPage} from '../pages/SpaceSummaryPage';
+import {SpaceRole, addRoleMemberAndSwitch} from './helpers/roleMembership';
+
+const test = mergeTests(
+	cmsPagesTest,
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+		'LPD-34594': {enabled: true},
+	}),
+	loginTest()
+);
+
+async function expectCMSHomeNavigationForRole({
+	apiHelpers,
+	page,
+	role,
+	spaceName,
+	spaceSummaryPage,
+}: {
+	apiHelpers: DataApiHelpers;
+	page: Page;
+	role: SpaceRole;
+	spaceName: string;
+	spaceSummaryPage: SpaceSummaryPage;
+}) {
+	await performUserSwitchViaApi(page, 'test');
+
+	const {userFullName} = await addRoleMemberAndSwitch({
+		apiHelpers,
+		page,
+		role,
+		spaceName,
+		spaceSummaryPage,
+	});
+
+	await page
+		.getByRole('button', {name: `${userFullName} User Profile`})
+		.click();
+
+	await page.getByRole('menuitem', {name: 'My CMS Homepage'}).click();
+
+	await expect(page).toHaveURL(/\/web\/cms\/home/);
+}
+
+test(
+	'A Space role lands on the CMS Home from the DXP user menu link',
+	{tag: '@LPD-85681'},
+	async ({apiHelpers, page, spaceSummaryPage}) => {
+		const spaceName = `Space ${getRandomString()}`;
+
+		await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			settings: {},
+			type: 'Space',
+		});
+
+		await test.step('A Space Admin lands on the CMS Home from the DXP user menu link', () =>
+			expectCMSHomeNavigationForRole({
+				apiHelpers,
+				page,
+				role: 'Space Administrator',
+				spaceName,
+				spaceSummaryPage,
+			}));
+
+		await test.step('A Space Member lands on the CMS Home from the DXP user menu link', () =>
+			expectCMSHomeNavigationForRole({
+				apiHelpers,
+				page,
+				role: null,
+				spaceName,
+				spaceSummaryPage,
+			}));
+
+		await test.step('A Space Content Reviewer lands on the CMS Home from the DXP user menu link', () =>
+			expectCMSHomeNavigationForRole({
+				apiHelpers,
+				page,
+				role: 'Space Content Reviewer',
+				spaceName,
+				spaceSummaryPage,
+			}));
+	}
+);

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/helpers/roleMembership.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/helpers/roleMembership.ts
@@ -1,0 +1,55 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Page} from '@playwright/test';
+
+import {DataApiHelpers} from '../../../../../helpers/ApiHelpers';
+import {
+	performUserSwitchViaApi,
+	userData,
+} from '../../../../../utils/performLogin';
+import {SpaceSummaryPage} from '../../pages/SpaceSummaryPage';
+
+export type SpaceRole = 'Space Administrator' | 'Space Content Reviewer' | null;
+
+export function registerUserCredentials(user: TUserAccount) {
+	userData[user.alternateName] = {
+		name: user.givenName,
+		password: 'test',
+		surname: user.familyName,
+	};
+}
+
+export async function addRoleMemberAndSwitch({
+	apiHelpers,
+	page,
+	role,
+	spaceName,
+	spaceSummaryPage,
+}: {
+	apiHelpers: DataApiHelpers;
+	page: Page;
+	role: SpaceRole;
+	spaceName: string;
+	spaceSummaryPage: SpaceSummaryPage;
+}) {
+	const user = await apiHelpers.headlessAdminUser.postUserAccount();
+	const userFullName = `${user.givenName} ${user.familyName}`;
+
+	registerUserCredentials(user);
+
+	await spaceSummaryPage.goto(spaceName);
+	await spaceSummaryPage.addUserOrUserGroup(userFullName, 'users');
+
+	if (role) {
+		await spaceSummaryPage.addRoleToSpaceMember(role, userFullName);
+	}
+
+	await performUserSwitchViaApi(page, user.alternateName);
+
+	await spaceSummaryPage.goto(spaceName);
+
+	return {user, userFullName};
+}

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/multiSpaceMembership.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/multiSpaceMembership.spec.ts
@@ -1,0 +1,148 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Page, expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import {DataApiHelpers} from '../../../../helpers/ApiHelpers';
+import getRandomString from '../../../../utils/getRandomString';
+import {performUserSwitchViaApi} from '../../../../utils/performLogin';
+import {PORTLET_URLS} from '../../../../utils/portletUrls';
+import {cmsPagesTest} from '../fixtures/cmsPagesTest';
+import {SpaceSummaryPage} from '../pages/SpaceSummaryPage';
+import {registerUserCredentials} from './helpers/roleMembership';
+
+const test = mergeTests(
+	cmsPagesTest,
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+		'LPD-34594': {enabled: true},
+	}),
+	loginTest()
+);
+
+function createSpace(apiHelpers: DataApiHelpers, spaceName: string) {
+	return apiHelpers.headlessAssetLibrary.createAssetLibrary({
+		name: spaceName,
+		settings: {},
+		type: 'Space',
+	});
+}
+
+async function addMemberToSpaces({
+	apiHelpers,
+	page,
+	spaceNames,
+	spaceSummaryPage,
+}: {
+	apiHelpers: DataApiHelpers;
+	page: Page;
+	spaceNames: string[];
+	spaceSummaryPage: SpaceSummaryPage;
+}) {
+	const user = await apiHelpers.headlessAdminUser.postUserAccount();
+	const userFullName = `${user.givenName} ${user.familyName}`;
+
+	registerUserCredentials(user);
+
+	for (const spaceName of spaceNames) {
+		await spaceSummaryPage.goto(spaceName);
+		await spaceSummaryPage.addUserOrUserGroup(userFullName, 'users');
+	}
+
+	await performUserSwitchViaApi(page, user.alternateName);
+
+	return {user, userFullName};
+}
+
+test(
+	'A user member of multiple spaces sees only their member spaces and content',
+	{tag: '@LPD-85681'},
+	async ({apiHelpers, page, spaceSummaryPage}) => {
+		const applicationName = 'cms/basic-web-contents';
+		const memberSpace1ContentTitle = `Title ${getRandomString()}`;
+		const memberSpace2ContentTitle = `Title ${getRandomString()}`;
+		const memberSpaceName1 = `Space ${getRandomString()}`;
+		const memberSpaceName2 = `Space ${getRandomString()}`;
+		const nonMemberSpaceContentTitle = `Title ${getRandomString()}`;
+		const nonMemberSpaceName = `Space ${getRandomString()}`;
+
+		const memberSpace1 = await createSpace(apiHelpers, memberSpaceName1);
+		const memberSpace2 = await createSpace(apiHelpers, memberSpaceName2);
+		const nonMemberSpace = await createSpace(
+			apiHelpers,
+			nonMemberSpaceName
+		);
+
+		await apiHelpers.objectEntry.postObjectEntry(
+			{
+				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				title: memberSpace1ContentTitle,
+			},
+			applicationName,
+			memberSpace1.name
+		);
+		await apiHelpers.objectEntry.postObjectEntry(
+			{
+				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				title: memberSpace2ContentTitle,
+			},
+			applicationName,
+			memberSpace2.name
+		);
+		await apiHelpers.objectEntry.postObjectEntry(
+			{
+				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				title: nonMemberSpaceContentTitle,
+			},
+			applicationName,
+			nonMemberSpace.name
+		);
+
+		await addMemberToSpaces({
+			apiHelpers,
+			page,
+			spaceNames: [memberSpaceName1, memberSpaceName2],
+			spaceSummaryPage,
+		});
+
+		await test.step('Sees both member spaces in the Spaces Widget', async () => {
+			await page.goto(PORTLET_URLS.cmsHome);
+
+			await expect(
+				page.getByRole('menuitem', {name: memberSpaceName1})
+			).toBeVisible();
+			await expect(
+				page.getByRole('menuitem', {name: memberSpaceName2})
+			).toBeVisible();
+		});
+
+		await test.step('Sees content from both member spaces and not from non-member spaces in All Content', async () => {
+			await page.goto(PORTLET_URLS.cmsContents);
+
+			await expect(
+				page.getByRole('link', {
+					exact: true,
+					name: memberSpace1ContentTitle,
+				})
+			).toBeVisible();
+			await expect(
+				page.getByRole('link', {
+					exact: true,
+					name: memberSpace2ContentTitle,
+				})
+			).toBeVisible();
+			await expect(
+				page.getByRole('link', {
+					exact: true,
+					name: nonMemberSpaceContentTitle,
+				})
+			).not.toBeVisible();
+		});
+	}
+);

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/roleBasedActions.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/roleBasedActions.spec.ts
@@ -34,99 +34,14 @@ function createSpace(apiHelpers: DataApiHelpers, spaceName: string) {
 }
 
 test(
-	'A Space Member sees a restricted set of actions in the All Spaces view',
-	{tag: '@LPD-85670'},
-	async ({apiHelpers, page, spaceSummaryPage}) => {
-		const spaceName = `Space ${getRandomString()}`;
-
-		await createSpace(apiHelpers, spaceName);
-
-		await addRoleMemberAndSwitch({
-			apiHelpers,
-			page,
-			role: null,
-			spaceName,
-			spaceSummaryPage,
-		});
-
-		await page.goto(PORTLET_URLS.cmsAllSpaces);
-
-		const spaceRow = page.getByRole('row', {name: spaceName});
-
-		await spaceRow.getByRole('button', {name: 'Actions'}).click();
-
-		await expect(
-			page.getByRole('menuitem', {name: 'View Members'})
-		).toBeVisible();
-		await expect(
-			page.getByRole('menuitem', {name: 'View Connected Sites'})
-		).toBeVisible();
-
-		await expect(
-			page.getByRole('menuitem', {name: 'Delete'})
-		).not.toBeVisible();
-		await expect(
-			page.getByRole('menuitem', {name: 'Permissions'})
-		).not.toBeVisible();
-		await expect(
-			page.getByRole('menuitem', {name: 'Settings'})
-		).not.toBeVisible();
-	}
-);
-
-test(
-	'A Space Member cannot see the Add Content button in the space summary page',
-	{tag: '@LPD-85670'},
-	async ({apiHelpers, page, spaceSummaryPage}) => {
-		const spaceName = `Space ${getRandomString()}`;
-
-		await createSpace(apiHelpers, spaceName);
-
-		await addRoleMemberAndSwitch({
-			apiHelpers,
-			page,
-			role: null,
-			spaceName,
-			spaceSummaryPage,
-		});
-
-		await expect(spaceSummaryPage.addContentButton).not.toBeVisible();
-		await expect(spaceSummaryPage.addFileButton).not.toBeVisible();
-	}
-);
-
-test(
-	'A Content Reviewer can create content in a space',
-	{tag: '@LPD-85670'},
-	async ({apiHelpers, page, spaceSummaryPage}) => {
-		const spaceName = `Space ${getRandomString()}`;
-
-		await createSpace(apiHelpers, spaceName);
-
-		await addRoleMemberAndSwitch({
-			apiHelpers,
-			page,
-			role: 'Space Content Reviewer',
-			spaceName,
-			spaceSummaryPage,
-		});
-
-		await expect(spaceSummaryPage.addContentButton).toBeVisible();
-
-		const folderName = `Folder ${getRandomString()}`;
-
-		await spaceSummaryPage.createContentFolder(folderName);
-
-		await expect(page.getByRole('link', {name: folderName})).toBeVisible();
-	}
-);
-
-test(
-	'A Content Reviewer can edit content in a space',
-	{tag: '@LPD-85670'},
+	'A Space Admin can manage space content and settings',
+	{tag: '@LPD-85681'},
 	async ({apiHelpers, assetsPage, page, spaceSummaryPage}) => {
 		const applicationName = 'cms/basic-web-contents';
+		const contentFolderName = `Folder ${getRandomString()}`;
 		const contentTitle = `Title ${getRandomString()}`;
+		const description = `Description ${getRandomString()}`;
+		const fileFolderName = `Folder ${getRandomString()}`;
 		const spaceName = `Space ${getRandomString()}`;
 
 		const space = await createSpace(apiHelpers, spaceName);
@@ -143,71 +58,162 @@ test(
 		await addRoleMemberAndSwitch({
 			apiHelpers,
 			page,
-			role: 'Space Content Reviewer',
+			role: 'Space Administrator',
 			spaceName,
 			spaceSummaryPage,
 		});
 
-		await spaceSummaryPage.viewAllContentLink.click();
+		await test.step('Manage space members', async () => {
+			await spaceSummaryPage.viewAllMembersLink.click();
 
-		await assetsPage.execItemAction({
-			action: 'Edit',
-			filter: contentTitle,
+			await page.getByRole('dialog').waitFor();
+
+			await expect(
+				page.getByLabel('Add People to Collaborate', {exact: true})
+			).toBeVisible();
+
+			await spaceSummaryPage.closeButton.click();
 		});
 
-		await expect(page.getByLabel('Title')).toBeEditable();
+		await test.step('Create a content folder', async () => {
+			await expect(spaceSummaryPage.addContentButton).toBeVisible();
+
+			await spaceSummaryPage.createContentFolder(contentFolderName);
+
+			await expect(
+				page.getByRole('link', {name: contentFolderName})
+			).toBeVisible();
+		});
+
+		await test.step('Delete a content folder', async () => {
+			await spaceSummaryPage.goto(spaceName);
+
+			await spaceSummaryPage.viewAllContentLink.click();
+
+			await assetsPage.execItemAction({
+				action: 'Delete',
+				filter: contentFolderName,
+			});
+
+			await waitForAlert(page, `${contentFolderName} was moved`);
+
+			await expect(page.getByText(contentFolderName)).not.toBeVisible();
+		});
+
+		await test.step('Create a file folder', async () => {
+			await spaceSummaryPage.goto(spaceName);
+
+			await spaceSummaryPage.createFileFolder(fileFolderName);
+
+			await expect(
+				page.getByRole('link', {name: fileFolderName})
+			).toBeVisible();
+		});
+
+		await test.step('Delete a file folder', async () => {
+			await spaceSummaryPage.goto(spaceName);
+
+			await spaceSummaryPage.viewAllFilesLink.click();
+
+			await assetsPage.changeVisualizationMode('Table');
+
+			await assetsPage.execItemAction({
+				action: 'Delete',
+				filter: fileFolderName,
+			});
+
+			await waitForAlert(page, `${fileFolderName} was moved`);
+
+			await expect(page.getByText(fileFolderName)).not.toBeVisible();
+		});
+
+		await test.step('Delete content', async () => {
+			await spaceSummaryPage.goto(spaceName);
+
+			await spaceSummaryPage.viewAllContentLink.click();
+
+			await assetsPage.execItemAction({
+				action: 'Delete',
+				filter: contentTitle,
+			});
+
+			await waitForAlert(page, `${contentTitle} was moved`);
+
+			await expect(page.getByText(contentTitle)).not.toBeVisible();
+		});
+
+		await test.step('Change general settings', async () => {
+			await spaceSummaryPage.goto(spaceName);
+
+			await page.getByRole('button', {name: 'More Actions'}).click();
+			await page.getByRole('menuitem', {name: 'Settings'}).click();
+
+			const descriptionTextbox = page.getByRole('textbox', {
+				name: 'Description',
+			});
+
+			await descriptionTextbox.fill(description);
+
+			await page.getByRole('button', {name: 'Save'}).click();
+
+			await waitForAlert(page, 'Success');
+
+			await spaceSummaryPage.goto(spaceName);
+
+			await page.getByRole('button', {name: 'More Actions'}).click();
+			await page.getByRole('menuitem', {name: 'Settings'}).click();
+
+			await expect(descriptionTextbox).toHaveValue(description);
+		});
+
+		await test.step('Open Permissions modal', async () => {
+			await page.goto(PORTLET_URLS.cmsAllSpaces);
+
+			await page
+				.getByRole('row', {name: spaceName})
+				.getByRole('button', {name: 'Actions'})
+				.click();
+
+			await page
+				.getByRole('menuitem', {exact: true, name: 'Permissions'})
+				.click();
+
+			await page
+				.getByRole('menuitem', {exact: true, name: 'Permissions'})
+				.last()
+				.click();
+
+			await expect(
+				page
+					.getByRole('dialog')
+					.getByRole('heading', {name: 'Permissions'})
+			).toBeVisible();
+		});
 	}
 );
 
 test(
-	'A Content Reviewer can delete content in a space',
+	'A Space Content Reviewer can create, edit, and delete content in a space',
 	{tag: '@LPD-85670'},
 	async ({apiHelpers, assetsPage, page, spaceSummaryPage}) => {
-		const applicationName = 'cms/basic-web-contents';
+		const contentApplicationName = 'cms/basic-web-contents';
+		const contentFolderName = `Folder ${getRandomString()}`;
 		const contentTitle = `Title ${getRandomString()}`;
-		const spaceName = `Space ${getRandomString()}`;
-
-		const space = await createSpace(apiHelpers, spaceName);
-
-		await apiHelpers.objectEntry.postObjectEntry(
-			{
-				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
-				title: contentTitle,
-			},
-			applicationName,
-			space.name
-		);
-
-		await addRoleMemberAndSwitch({
-			apiHelpers,
-			page,
-			role: 'Space Content Reviewer',
-			spaceName,
-			spaceSummaryPage,
-		});
-
-		await spaceSummaryPage.viewAllContentLink.click();
-
-		await assetsPage.execItemAction({
-			action: 'Delete',
-			filter: contentTitle,
-		});
-
-		await waitForAlert(page, `${contentTitle} was moved`);
-
-		await expect(page.getByText(contentTitle)).not.toBeVisible();
-	}
-);
-
-test(
-	'A Content Reviewer can delete a file in a space',
-	{tag: '@LPD-85670'},
-	async ({apiHelpers, assetsPage, page, spaceSummaryPage}) => {
-		const applicationName = 'cms/basic-documents';
+		const fileApplicationName = 'cms/basic-documents';
+		const fileFolderName = `Folder ${getRandomString()}`;
 		const fileTitle = `File ${getRandomString()}`;
 		const spaceName = `Space ${getRandomString()}`;
 
 		const space = await createSpace(apiHelpers, spaceName);
+
+		await apiHelpers.objectEntry.postObjectEntry(
+			{
+				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				title: contentTitle,
+			},
+			contentApplicationName,
+			space.name
+		);
 
 		await apiHelpers.objectEntry.postObjectEntry(
 			{
@@ -218,7 +224,7 @@ test(
 				objectEntryFolderExternalReferenceCode: 'L_FILES',
 				title: fileTitle,
 			},
-			applicationName,
+			fileApplicationName,
 			space.name
 		);
 
@@ -230,17 +236,245 @@ test(
 			spaceSummaryPage,
 		});
 
-		await spaceSummaryPage.viewAllFilesLink.click();
+		await test.step('Create a content folder', async () => {
+			await expect(spaceSummaryPage.addContentButton).toBeVisible();
 
-		await assetsPage.changeVisualizationMode('Table');
+			await spaceSummaryPage.createContentFolder(contentFolderName);
 
-		await assetsPage.execItemAction({
-			action: 'Delete',
-			filter: fileTitle,
+			await expect(
+				page.getByRole('link', {name: contentFolderName})
+			).toBeVisible();
 		});
 
-		await waitForAlert(page, `${fileTitle} was moved`);
+		await test.step('Delete a content folder', async () => {
+			await spaceSummaryPage.goto(spaceName);
 
-		await expect(page.getByText(fileTitle)).not.toBeVisible();
+			await spaceSummaryPage.viewAllContentLink.click();
+
+			await assetsPage.execItemAction({
+				action: 'Delete',
+				filter: contentFolderName,
+			});
+
+			await waitForAlert(page, `${contentFolderName} was moved`);
+
+			await expect(page.getByText(contentFolderName)).not.toBeVisible();
+		});
+
+		await test.step('Create a file folder', async () => {
+			await spaceSummaryPage.goto(spaceName);
+
+			await spaceSummaryPage.createFileFolder(fileFolderName);
+
+			await expect(
+				page.getByRole('link', {name: fileFolderName})
+			).toBeVisible();
+		});
+
+		await test.step('Delete a file folder', async () => {
+			await spaceSummaryPage.goto(spaceName);
+
+			await spaceSummaryPage.viewAllFilesLink.click();
+
+			await assetsPage.changeVisualizationMode('Table');
+
+			await assetsPage.execItemAction({
+				action: 'Delete',
+				filter: fileFolderName,
+			});
+
+			await waitForAlert(page, `${fileFolderName} was moved`);
+
+			await expect(page.getByText(fileFolderName)).not.toBeVisible();
+		});
+
+		await test.step('Edit content', async () => {
+			await spaceSummaryPage.goto(spaceName);
+
+			await spaceSummaryPage.viewAllContentLink.click();
+
+			await assetsPage.execItemAction({
+				action: 'Edit',
+				filter: contentTitle,
+			});
+
+			await expect(page.getByLabel('Title')).toBeEditable();
+		});
+
+		await test.step('Delete content', async () => {
+			await spaceSummaryPage.goto(spaceName);
+
+			await spaceSummaryPage.viewAllContentLink.click();
+
+			await assetsPage.execItemAction({
+				action: 'Delete',
+				filter: contentTitle,
+			});
+
+			await waitForAlert(page, `${contentTitle} was moved`);
+
+			await expect(page.getByText(contentTitle)).not.toBeVisible();
+		});
+
+		await test.step('Delete a file', async () => {
+			await spaceSummaryPage.goto(spaceName);
+
+			await spaceSummaryPage.viewAllFilesLink.click();
+
+			await assetsPage.changeVisualizationMode('Table');
+
+			await assetsPage.execItemAction({
+				action: 'Delete',
+				filter: fileTitle,
+			});
+
+			await waitForAlert(page, `${fileTitle} was moved`);
+
+			await expect(page.getByText(fileTitle)).not.toBeVisible();
+		});
+	}
+);
+
+test(
+	'A Space Content Reviewer cannot manage space members or change space general settings',
+	{tag: '@LPD-85681'},
+	async ({apiHelpers, page, spaceSummaryPage}) => {
+		const spaceName = `Space ${getRandomString()}`;
+
+		await createSpace(apiHelpers, spaceName);
+
+		await addRoleMemberAndSwitch({
+			apiHelpers,
+			page,
+			role: 'Space Content Reviewer',
+			spaceName,
+			spaceSummaryPage,
+		});
+
+		await spaceSummaryPage.viewAllMembersLink.click();
+
+		await page.getByRole('dialog').waitFor();
+
+		await expect(
+			page.getByLabel('Add People to Collaborate', {exact: true})
+		).not.toBeVisible();
+
+		await spaceSummaryPage.closeButton.click();
+
+		await page.getByRole('button', {name: 'More Actions'}).click();
+
+		await expect(
+			page.getByRole('menuitem', {name: 'Settings'})
+		).not.toBeVisible();
+	}
+);
+
+test(
+	'A Space Member has restricted permissions in a space',
+	{tag: ['@LPD-85670', '@LPD-85681']},
+	async ({apiHelpers, assetsPage, page, spaceSummaryPage}) => {
+		const contentApplicationName = 'cms/basic-web-contents';
+		const contentTitle = `Title ${getRandomString()}`;
+		const fileApplicationName = 'cms/basic-documents';
+		const fileTitle = `File ${getRandomString()}`;
+		const spaceName = `Space ${getRandomString()}`;
+
+		const space = await createSpace(apiHelpers, spaceName);
+
+		await apiHelpers.objectEntry.postObjectEntry(
+			{
+				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				title: contentTitle,
+			},
+			contentApplicationName,
+			space.name
+		);
+
+		await apiHelpers.objectEntry.postObjectEntry(
+			{
+				file: {
+					fileBase64: 'SGVsbG8sIHdvcmxkIQ==',
+					name: `file_${getRandomString()}.txt`,
+				},
+				objectEntryFolderExternalReferenceCode: 'L_FILES',
+				title: fileTitle,
+			},
+			fileApplicationName,
+			space.name
+		);
+
+		await addRoleMemberAndSwitch({
+			apiHelpers,
+			page,
+			role: null,
+			spaceName,
+			spaceSummaryPage,
+		});
+
+		await test.step('Cannot see the Add Content or Add Files buttons', async () => {
+			await expect(spaceSummaryPage.addContentButton).not.toBeVisible();
+			await expect(spaceSummaryPage.addFileButton).not.toBeVisible();
+		});
+
+		await test.step('Cannot edit content', async () => {
+			await spaceSummaryPage.viewAllContentLink.click();
+
+			await page
+				.getByRole('row', {name: contentTitle})
+				.getByRole('button', {name: `${contentTitle} Actions`})
+				.click();
+
+			await expect(
+				page.getByRole('menuitem', {name: 'Edit'})
+			).not.toBeVisible();
+		});
+
+		await test.step('Cannot delete content', async () => {
+			await expect(
+				page.getByRole('menuitem', {name: 'Delete'})
+			).not.toBeVisible();
+		});
+
+		await test.step('Cannot delete a file', async () => {
+			await spaceSummaryPage.goto(spaceName);
+
+			await spaceSummaryPage.viewAllFilesLink.click();
+
+			await assetsPage.changeVisualizationMode('Table');
+
+			await page
+				.getByRole('row', {name: fileTitle})
+				.getByRole('button', {name: `${fileTitle} Actions`})
+				.click();
+
+			await expect(
+				page.getByRole('menuitem', {name: 'Delete'})
+			).not.toBeVisible();
+		});
+
+		await test.step('Sees a restricted set of actions in the All Spaces view', async () => {
+			await page.goto(PORTLET_URLS.cmsAllSpaces);
+
+			const spaceRow = page.getByRole('row', {name: spaceName});
+
+			await spaceRow.getByRole('button', {name: 'Actions'}).click();
+
+			await expect(
+				page.getByRole('menuitem', {name: 'View Members'})
+			).toBeVisible();
+			await expect(
+				page.getByRole('menuitem', {name: 'View Connected Sites'})
+			).toBeVisible();
+
+			await expect(
+				page.getByRole('menuitem', {name: 'Delete'})
+			).not.toBeVisible();
+			await expect(
+				page.getByRole('menuitem', {name: 'Permissions'})
+			).not.toBeVisible();
+			await expect(
+				page.getByRole('menuitem', {name: 'Settings'})
+			).not.toBeVisible();
+		});
 	}
 );

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/roleBasedActions.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/roleBasedActions.spec.ts
@@ -3,21 +3,17 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {Page, expect, mergeTests} from '@playwright/test';
+import {expect, mergeTests} from '@playwright/test';
 
 import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
 import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
 import {loginTest} from '../../../../fixtures/loginTest';
 import {DataApiHelpers} from '../../../../helpers/ApiHelpers';
 import getRandomString from '../../../../utils/getRandomString';
-import {
-	performUserSwitchViaApi,
-	userData,
-} from '../../../../utils/performLogin';
 import {PORTLET_URLS} from '../../../../utils/portletUrls';
 import {waitForAlert} from '../../../../utils/waitForAlert';
 import {cmsPagesTest} from '../fixtures/cmsPagesTest';
-import {SpaceSummaryPage} from '../pages/SpaceSummaryPage';
+import {addRoleMemberAndSwitch} from './helpers/roleMembership';
 
 const test = mergeTests(
 	cmsPagesTest,
@@ -29,53 +25,12 @@ const test = mergeTests(
 	loginTest()
 );
 
-type SpaceRole = 'Space Administrator' | 'Space Content Reviewer' | null;
-
-async function addRoleMemberAndSwitch({
-	apiHelpers,
-	page,
-	role,
-	spaceName,
-	spaceSummaryPage,
-}: {
-	apiHelpers: DataApiHelpers;
-	page: Page;
-	role: SpaceRole;
-	spaceName: string;
-	spaceSummaryPage: SpaceSummaryPage;
-}) {
-	const user = await apiHelpers.headlessAdminUser.postUserAccount();
-	const userFullName = `${user.givenName} ${user.familyName}`;
-
-	registerUserCredentials(user);
-
-	await spaceSummaryPage.goto(spaceName);
-	await spaceSummaryPage.addUserOrUserGroup(userFullName, 'users');
-
-	if (role) {
-		await spaceSummaryPage.addRoleToSpaceMember(role, userFullName);
-	}
-
-	await performUserSwitchViaApi(page, user.alternateName);
-	await spaceSummaryPage.goto(spaceName);
-
-	return {user, userFullName};
-}
-
-function createSpace(apiHelpers, spaceName) {
+function createSpace(apiHelpers: DataApiHelpers, spaceName: string) {
 	return apiHelpers.headlessAssetLibrary.createAssetLibrary({
 		name: spaceName,
 		settings: {},
 		type: 'Space',
 	});
-}
-
-function registerUserCredentials(user) {
-	userData[user.alternateName] = {
-		name: user.givenName,
-		password: 'test',
-		surname: user.familyName,
-	};
 }
 
 test(

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/rolePageAccess.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/rolePageAccess.spec.ts
@@ -1,0 +1,259 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Page, expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import {DataApiHelpers} from '../../../../helpers/ApiHelpers';
+import {addCMSAdministrator} from '../../../../utils/addCMSAdministrator';
+import getRandomString from '../../../../utils/getRandomString';
+import {performUserSwitchViaApi} from '../../../../utils/performLogin';
+import {PORTLET_URLS} from '../../../../utils/portletUrls';
+import {cmsPagesTest} from '../fixtures/cmsPagesTest';
+import {SpaceSummaryPage} from '../pages/SpaceSummaryPage';
+import {SpaceRole, addRoleMemberAndSwitch} from './helpers/roleMembership';
+
+const test = mergeTests(
+	cmsPagesTest,
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+		'LPD-34594': {enabled: true},
+	}),
+	loginTest()
+);
+
+const ALWAYS_VISIBLE_SECTIONS = [
+	'Home',
+	'Contents',
+	'Files',
+	'Shared with Me',
+	'Recycle Bin',
+];
+
+const CMS_ADMIN_ONLY_SECTIONS = [
+	'Dashboard',
+	'Content Structures',
+	'Categorization',
+];
+
+function createSpace(apiHelpers: DataApiHelpers, spaceName: string) {
+	return apiHelpers.headlessAssetLibrary.createAssetLibrary({
+		name: spaceName,
+		settings: {},
+		type: 'Space',
+	});
+}
+
+async function expectSectionsVisibility(
+	page: Page,
+	{hidden, visible}: {hidden: string[]; visible: string[]}
+) {
+	for (const section of visible) {
+		await expect(page.getByRole('menuitem', {name: section})).toBeVisible();
+	}
+
+	for (const section of hidden) {
+		await expect(
+			page.getByRole('menuitem', {name: section})
+		).not.toBeVisible();
+	}
+}
+
+async function expectAllowedSectionsForRole({
+	apiHelpers,
+	hidden,
+	page,
+	role,
+	spaceName,
+	spaceSummaryPage,
+	visible,
+}: {
+	apiHelpers: DataApiHelpers;
+	hidden: string[];
+	page: Page;
+	role: SpaceRole;
+	spaceName: string;
+	spaceSummaryPage: SpaceSummaryPage;
+	visible: string[];
+}) {
+	await performUserSwitchViaApi(page, 'test');
+
+	await addRoleMemberAndSwitch({
+		apiHelpers,
+		page,
+		role,
+		spaceName,
+		spaceSummaryPage,
+	});
+
+	await page.goto(PORTLET_URLS.cmsHome);
+
+	await expectSectionsVisibility(page, {hidden, visible});
+}
+
+async function expectMemberSpacesOnlyForRole({
+	apiHelpers,
+	memberSpaceName,
+	nonMemberSpaceName,
+	page,
+	role,
+	spaceSummaryPage,
+}: {
+	apiHelpers: DataApiHelpers;
+	memberSpaceName: string;
+	nonMemberSpaceName: string;
+	page: Page;
+	role: SpaceRole;
+	spaceSummaryPage: SpaceSummaryPage;
+}) {
+	await performUserSwitchViaApi(page, 'test');
+
+	await addRoleMemberAndSwitch({
+		apiHelpers,
+		page,
+		role,
+		spaceName: memberSpaceName,
+		spaceSummaryPage,
+	});
+
+	await page.goto(PORTLET_URLS.cmsHome);
+
+	await expect(
+		page.getByRole('menuitem', {name: memberSpaceName})
+	).toBeVisible();
+	await expect(
+		page.getByRole('menuitem', {name: nonMemberSpaceName})
+	).not.toBeVisible();
+}
+
+test(
+	'A CMS Admin sees all CMS sections in the navigation',
+	{tag: '@LPD-85681'},
+	async ({apiHelpers, page}) => {
+		const cmsAdmin = await addCMSAdministrator(apiHelpers);
+
+		await performUserSwitchViaApi(page, cmsAdmin.alternateName);
+
+		await page.goto(PORTLET_URLS.cmsHome);
+
+		await expectSectionsVisibility(page, {
+			hidden: [],
+			visible: [...ALWAYS_VISIBLE_SECTIONS, ...CMS_ADMIN_ONLY_SECTIONS],
+		});
+	}
+);
+
+test(
+	'A space role sees only the allowed CMS sections',
+	{tag: '@LPD-85681'},
+	async ({apiHelpers, page, spaceSummaryPage}) => {
+		const spaceName = `Space ${getRandomString()}`;
+
+		await createSpace(apiHelpers, spaceName);
+
+		await test.step('A Space Member sees only the allowed CMS sections', () =>
+			expectAllowedSectionsForRole({
+				apiHelpers,
+				hidden: CMS_ADMIN_ONLY_SECTIONS,
+				page,
+				role: null,
+				spaceName,
+				spaceSummaryPage,
+				visible: ALWAYS_VISIBLE_SECTIONS,
+			}));
+
+		await test.step('A Content Reviewer sees only the allowed CMS sections', () =>
+			expectAllowedSectionsForRole({
+				apiHelpers,
+				hidden: CMS_ADMIN_ONLY_SECTIONS,
+				page,
+				role: 'Space Content Reviewer',
+				spaceName,
+				spaceSummaryPage,
+				visible: ALWAYS_VISIBLE_SECTIONS,
+			}));
+
+		await test.step('A Space Admin sees only the allowed CMS sections', () =>
+			expectAllowedSectionsForRole({
+				apiHelpers,
+				hidden: CMS_ADMIN_ONLY_SECTIONS,
+				page,
+				role: 'Space Administrator',
+				spaceName,
+				spaceSummaryPage,
+				visible: ALWAYS_VISIBLE_SECTIONS,
+			}));
+	}
+);
+
+test(
+	'The Spaces Widget lists every space for a CMS Admin',
+	{tag: '@LPD-85681'},
+	async ({apiHelpers, page}) => {
+		const spaceName1 = `Space ${getRandomString()}`;
+		const spaceName2 = `Space ${getRandomString()}`;
+
+		await createSpace(apiHelpers, spaceName1);
+		await createSpace(apiHelpers, spaceName2);
+
+		const cmsAdmin = await addCMSAdministrator(apiHelpers);
+
+		await performUserSwitchViaApi(page, cmsAdmin.alternateName);
+
+		await page.goto(PORTLET_URLS.cmsHome);
+
+		await expect(
+			page.getByRole('menuitem', {name: spaceName1})
+		).toBeVisible();
+		await expect(
+			page.getByRole('menuitem', {name: spaceName2})
+		).toBeVisible();
+	}
+);
+
+test(
+	'The Spaces Widget lists only member spaces for each space role',
+	{tag: '@LPD-85681'},
+	async ({apiHelpers, page, spaceSummaryPage}) => {
+		const spaceName1 = `Space ${getRandomString()}`;
+		const spaceName2 = `Space ${getRandomString()}`;
+
+		await createSpace(apiHelpers, spaceName1);
+		await createSpace(apiHelpers, spaceName2);
+
+		await test.step('The Spaces Widget lists only member spaces for a Space Member', () =>
+			expectMemberSpacesOnlyForRole({
+				apiHelpers,
+				memberSpaceName: spaceName1,
+				nonMemberSpaceName: spaceName2,
+				page,
+				role: null,
+				spaceSummaryPage,
+			}));
+
+		await test.step('The Spaces Widget lists only member spaces for a Content Reviewer', () =>
+			expectMemberSpacesOnlyForRole({
+				apiHelpers,
+				memberSpaceName: spaceName1,
+				nonMemberSpaceName: spaceName2,
+				page,
+				role: 'Space Content Reviewer',
+				spaceSummaryPage,
+			}));
+
+		await test.step('The Spaces Widget lists only member spaces for a Space Admin', () =>
+			expectMemberSpacesOnlyForRole({
+				apiHelpers,
+				memberSpaceName: spaceName1,
+				nonMemberSpaceName: spaceName2,
+				page,
+				role: 'Space Administrator',
+				spaceSummaryPage,
+			}));
+	}
+);

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/spaceInvitationNotification.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/spaceInvitationNotification.spec.ts
@@ -1,0 +1,72 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import getRandomString from '../../../../utils/getRandomString';
+import {performUserSwitchViaApi} from '../../../../utils/performLogin';
+import {cmsPagesTest} from '../fixtures/cmsPagesTest';
+import {registerUserCredentials} from './helpers/roleMembership';
+
+const test = mergeTests(
+	cmsPagesTest,
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+		'LPD-34594': {enabled: true},
+	}),
+	loginTest()
+);
+
+test(
+	'Clicking the space-invite notification opens the assigned space',
+	{tag: '@LPD-85681'},
+	async ({apiHelpers, page, spaceSummaryPage}) => {
+		const spaceName = `Space ${getRandomString()}`;
+
+		await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			settings: {},
+			type: 'Space',
+		});
+
+		const user = await apiHelpers.headlessAdminUser.postUserAccount();
+		const userFullName = `${user.givenName} ${user.familyName}`;
+
+		registerUserCredentials(user);
+
+		await test.step('Add the user to the space and switch to them', async () => {
+			await spaceSummaryPage.goto(spaceName);
+			await spaceSummaryPage.addUserOrUserGroup(userFullName, 'users');
+
+			await performUserSwitchViaApi(page, user.alternateName);
+		});
+
+		const notificationLink = page.getByRole('link', {
+			name: new RegExp(spaceName),
+		});
+
+		await test.step('Open Notifications and see the space invitation', async () => {
+			await page
+				.getByRole('button', {name: `${userFullName} User Profile`})
+				.click();
+
+			await page.getByRole('menuitem', {name: 'Notifications'}).click();
+
+			await expect(notificationLink).toBeVisible();
+		});
+
+		await test.step('Click the invitation and land on the space page', async () => {
+			await notificationLink.click();
+
+			await expect(
+				page.getByRole('heading', {exact: true, name: spaceName})
+			).toBeVisible();
+		});
+	}
+);

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/spaceSummary.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/spaceSummary.spec.ts
@@ -424,7 +424,7 @@ test(
 			.getByRole('link', {name: /^Title \d+ /})
 			.count();
 
-		expect(visibleCount).toBeLessThanOrEqual(8);
+		expect(visibleCount).toBe(8);
 
 		await spaceSummaryPage.viewAllContentLink.click();
 
@@ -586,7 +586,7 @@ test(
 			.getByRole('link', {name: /^File \d+ /})
 			.count();
 
-		expect(visibleCount).toBeLessThanOrEqual(8);
+		expect(visibleCount).toBe(8);
 
 		await spaceSummaryPage.viewAllFilesLink.click();
 
@@ -655,7 +655,7 @@ test(
 			.getByRole('link', {name: /^(Folder|Entry) \d+ /})
 			.count();
 
-		expect(visibleCount).toBeLessThanOrEqual(8);
+		expect(visibleCount).toBe(8);
 
 		await spaceSummaryPage.viewAllContentLink.click();
 

--- a/modules/test/playwright/utils/performLogin.ts
+++ b/modules/test/playwright/utils/performLogin.ts
@@ -145,10 +145,6 @@ export async function performLogout(page: Page) {
 	}).toPass();
 }
 
-export async function performLogoutViaApi(page: Page) {
-	await page.goto('/c/portal/logout');
-}
-
 export async function performUserSwitch(
 	page: Page,
 	screenName: LoginScreenName | string
@@ -162,7 +158,7 @@ export async function performUserSwitchViaApi(
 	page: Page,
 	screenName: LoginScreenName | string
 ) {
-	await performLogoutViaApi(page);
+	await page.waitForURL((url) => !url.pathname.endsWith('/c/portal/logout'));
 
 	await performLoginViaApi({page, screenName});
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-85681

as result of the testing we've discover and fix: https://liferay.atlassian.net/browse/LPD-89708

**What is being fixed:** CMS Spaces lacked automated coverage for role-based UI behaviors — sidebar section visibility per role, permitted actions per role, multi-space membership content scoping, the DXP user-menu "My CMS Homepage" link, and space invitation notifications. Without these tests, regressions in role gating or per-role UI affordances would land unnoticed.

**How it is being fixed:** Adds five Playwright spec files under modules/test/playwright/tests/site-cms-site-initializer/main/spaces/ (rolePageAccess, roleBasedActions, multiSpaceMembership, dxpUserMenuCMSHomepage, spaceInvitationNotification) plus a shared helpers/roleMembership.ts module hosting addRoleMemberAndSwitch and registerUserCredentials. Tests are grouped by scenario and use test.step blocks so shared setup runs once per scenario. Two flake fixes also land here: SpaceSummaryPage.addUserOrUserGroup and removeUserOrUserGroup now pass {autoClose: false} to waitForAlert so the success toast does not race the modal close, and SpaceSummaryPage.addRoleToSpaceMember now waits for the role-trigger text to update before closing the dialog so the role assignment API has settled before the next assertion runs.

<img width="864" height="268" alt="Captura de pantalla 2026-05-07 a las 11 18 51" src="https://github.com/user-attachments/assets/a77ad92f-4724-4e62-bb6d-d335c8798055" />
