### PR TITLE
LPD-89162 Show confirm modal for Delete + Select All bulk action

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/actions/deleteAssetEntriesBulkAction.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/actions/deleteAssetEntriesBulkAction.ts
@@ -132,7 +132,7 @@ async function handleBulkDeletion({
 		allEntriesHaveTrashEnabled,
 		someEntriesHaveTrashEnabled
 	);
-	if (showConfirmationModal) {
+	if (showConfirmationModal || selectedData.selectAll) {
 		showModal(apiURL, confirmationMessage, dataSetId, title, selectedData);
 	}
 	else if (allEntriesHaveTrashEnabled) {

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/actions/deleteAssetEntriesBulkAction.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/actions/deleteAssetEntriesBulkAction.ts
@@ -132,22 +132,13 @@ async function handleBulkDeletion({
 		allEntriesHaveTrashEnabled,
 		someEntriesHaveTrashEnabled
 	);
-	if (showConfirmationModal || selectedData.selectAll) {
-		showModal(apiURL, confirmationMessage, dataSetId, title, selectedData);
-	}
-	else if (allEntriesHaveTrashEnabled) {
-		if (!isFromRecycleBin(selectedData)) {
-			executeBulkDeleteAction(apiURL, dataSetId, selectedData);
-		}
-		else {
-			showModal(
-				apiURL,
-				confirmationMessage,
-				dataSetId,
-				title,
-				selectedData
-			);
-		}
+	if (
+		!showConfirmationModal &&
+		!selectedData.selectAll &&
+		allEntriesHaveTrashEnabled &&
+		!isFromRecycleBin(selectedData)
+	) {
+		executeBulkDeleteAction(apiURL, dataSetId, selectedData);
 	}
 	else {
 		showModal(apiURL, confirmationMessage, dataSetId, title, selectedData);

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/bulkActions.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/bulkActions.spec.ts
@@ -1888,6 +1888,68 @@ test(
 );
 
 test(
+	'Bulk Delete over a Select All expanded selection forwards the section filter',
+	{tag: '@LPD-89162'},
+	async ({apiHelpers, assetsPage, page}) => {
+		const fileCount = 21;
+		const titlePrefix = `BulkDeleteSelectAll ${getRandomString()}`;
+
+		await test.step(`Create ${fileCount} files in the Default space`, async () => {
+			for (let i = 0; i < fileCount; i++) {
+				const entry = await apiHelpers.objectEntry.postObjectEntry(
+					{
+						file: {
+							fileBase64: 'R0lGODlhAQABAAAAACw=',
+							name: `${titlePrefix}_${i}.gif`,
+						},
+						objectEntryFolderExternalReferenceCode: 'L_FILES',
+						title: `${titlePrefix}_${i}`,
+					},
+					'cms/basic-documents',
+					'Default'
+				);
+
+				apiHelpers.data.push({
+					id: entry.file.id,
+					type: 'document',
+				});
+			}
+		});
+
+		await assetsPage.gotoFiles();
+		await assetsPage.changeVisualizationMode('Table');
+
+		await page.getByTitle('Select Items').click();
+
+		const selectAllLink = page.getByRole('button', {
+			exact: true,
+			name: 'Select All',
+		});
+
+		await expect(selectAllLink).toBeVisible();
+
+		await selectAllLink.click();
+
+		await expect(page.getByText('All Selected')).toBeVisible();
+
+		await assetsPage.execBulkItemAction('Delete');
+
+		await waitForModal({page});
+
+		await page
+			.locator('.modal')
+			.getByRole('button', {name: 'Delete'})
+			.click();
+
+		await waitForAlert(page, 'Info:Delete action started', {
+			type: 'info',
+		});
+
+		await expect(page.getByText('Filter is null')).toHaveCount(0);
+	}
+);
+
+test(
 	'Export for Translation CMS assets in bulk',
 	{tag: '@LPD-85361'},
 	async ({apiHelpers, assetsPage, page}) => {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89162

## What is being fixed

In CMS Files, clicking **Delete** after expanding the selection with "Select All" did nothing visible to the user. With Select All active the FDS sends an empty `selectedData.items`, so `handleBulkDeletion` saw `getEntriesSpaces([])` return `[]`, marked `allEntriesHaveTrashEnabled` vacuously true, fell through to `isFromRecycleBin`, and threw when that helper dereferenced `items[0]` on the empty array — before any bulk POST went out.

## How it is being fixed

`handleBulkDeletion` now detects `selectedData.selectAll` up front and routes that case to the existing delete-all-entries confirmation modal. The modal's Delete button calls `executeBulkDeleteAction` with the filter-bearing `apiURL` from LPD-88977, so the POST carries the section filter and the backend's "Filter is null" guard is satisfied.

This branch is stacked on top of LPD-88977 (PR #8201). The PR diff will include LPD-88977's two commits until that pull request merges.