### PR TITLE
LPD-89122 Highlight overdue review dates in the info panel

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/utils/reviewDateStatus.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/utils/reviewDateStatus.ts
@@ -1,0 +1,31 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export function isReviewDateOverdue(reviewDate?: string | Date): boolean {
+	if (!reviewDate) {
+		return false;
+	}
+
+	const review = new Date(reviewDate);
+
+	if (Number.isNaN(review.getTime())) {
+		return false;
+	}
+
+	const now = new Date();
+
+	const reviewDay = Date.UTC(
+		review.getUTCFullYear(),
+		review.getUTCMonth(),
+		review.getUTCDate()
+	);
+	const todayDay = Date.UTC(
+		now.getUTCFullYear(),
+		now.getUTCMonth(),
+		now.getUTCDate()
+	);
+
+	return reviewDay <= todayDay;
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/components/AssetMetadata.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/components/AssetMetadata.tsx
@@ -20,6 +20,7 @@ import React, {
 import SpaceService from '../../../common/services/SpaceService';
 import {Space} from '../../../common/types/Space';
 import dateFormat from '../../../common/utils/dateFormat';
+import {isReviewDateOverdue} from '../../../common/utils/reviewDateStatus';
 import {displayErrorToast} from '../../../common/utils/toastUtil';
 import {SpaceSticker} from '../../../index';
 import {
@@ -111,6 +112,8 @@ const AssetMetadata = () => {
 			displayErrorToast();
 		}
 	}, [actions, asset, type]);
+
+	const reviewOverdue = isReviewDateOverdue(asset?.reviewDate as string);
 
 	return (
 		<ClayPanel
@@ -319,7 +322,13 @@ const AssetMetadata = () => {
 								{Liferay.Language.get('review-date')}
 							</p>
 
-							<p className="d-block">
+							<p
+								className={
+									reviewOverdue
+										? 'd-block text-warning'
+										: 'd-block'
+								}
+							>
 								{asset?.reviewDate
 									? dateFormat(
 											DATE_PATTERN,

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/cell_renderers/ReviewDateRenderer.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/cell_renderers/ReviewDateRenderer.tsx
@@ -5,6 +5,8 @@
 
 import React, {useMemo} from 'react';
 
+import {isReviewDateOverdue} from '../../../common/utils/reviewDateStatus';
+
 function getDateOptions(): Intl.DateTimeFormatOptions {
 	return {
 		day: 'numeric',
@@ -12,42 +14,6 @@ function getDateOptions(): Intl.DateTimeFormatOptions {
 		timeZone: Liferay.ThemeDisplay.getTimeZone(),
 		year: 'numeric',
 	};
-}
-
-function getCalendarDayOptions(): Intl.DateTimeFormatOptions {
-	return {
-		day: '2-digit',
-		month: '2-digit',
-		timeZone: Liferay.ThemeDisplay.getTimeZone(),
-		year: 'numeric',
-	};
-}
-
-let _calendarDayFormatter: Intl.DateTimeFormat | null = null;
-
-function getCalendarDayFormatter(): Intl.DateTimeFormat {
-	if (!_calendarDayFormatter) {
-		_calendarDayFormatter = new Intl.DateTimeFormat(
-			'en-US',
-			getCalendarDayOptions()
-		);
-	}
-
-	return _calendarDayFormatter;
-}
-
-function getCalendarDayKey(date: Date): number {
-	const parts: Record<string, string> = {};
-
-	for (const part of getCalendarDayFormatter().formatToParts(date)) {
-		parts[part.type] = part.value;
-	}
-
-	return (
-		Number(parts.year) * 10000 +
-		Number(parts.month) * 100 +
-		Number(parts.day)
-	);
 }
 
 const ReviewDateRenderer = ({
@@ -71,10 +37,11 @@ const ReviewDateRenderer = ({
 	}
 
 	const date = new Date(rawValue);
-	const reviewed = getCalendarDayKey(date) <= getCalendarDayKey(new Date());
 
 	return (
-		<span className={reviewed ? 'text-warning' : 'text-dark'}>
+		<span
+			className={isReviewDateOverdue(date) ? 'text-warning' : 'text-dark'}
+		>
 			{formatter.format(date)}
 		</span>
 	);

--- a/modules/apps/site/site-cms-site-initializer/test/js/common/utils/reviewDateStatus.test.ts
+++ b/modules/apps/site/site-cms-site-initializer/test/js/common/utils/reviewDateStatus.test.ts
@@ -1,0 +1,59 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {isReviewDateOverdue} from '../../../../src/main/resources/META-INF/resources/js/common/utils/reviewDateStatus';
+
+const NOW = new Date('2026-04-21T10:00:00Z');
+
+describe('reviewDateStatus', () => {
+	describe('isReviewDateOverdue', () => {
+		beforeAll(() => {
+			jest.useFakeTimers();
+			jest.setSystemTime(NOW);
+		});
+
+		afterAll(() => {
+			jest.useRealTimers();
+		});
+
+		it('returns false when the review date is missing', () => {
+			expect(isReviewDateOverdue(undefined)).toBe(false);
+			expect(isReviewDateOverdue('')).toBe(false);
+		});
+
+		it('returns false when the review date is not parseable', () => {
+			expect(isReviewDateOverdue('not-a-date')).toBe(false);
+		});
+
+		it('returns true when the review date is in the past', () => {
+			expect(isReviewDateOverdue('2026-04-20T10:00:00Z')).toBe(true);
+		});
+
+		it('returns true at the start of today in UTC', () => {
+			expect(isReviewDateOverdue('2026-04-21T00:00:00Z')).toBe(true);
+		});
+
+		it('returns true at the end of today in UTC', () => {
+			expect(isReviewDateOverdue('2026-04-21T23:59:59Z')).toBe(true);
+		});
+
+		it('returns false at the start of tomorrow in UTC', () => {
+			expect(isReviewDateOverdue('2026-04-22T00:00:00Z')).toBe(false);
+		});
+
+		it('returns false when the review date is further in the future', () => {
+			expect(isReviewDateOverdue('2026-05-01T10:00:00Z')).toBe(false);
+		});
+
+		it('accepts a Date object', () => {
+			expect(isReviewDateOverdue(new Date('2026-04-20T10:00:00Z'))).toBe(
+				true
+			);
+			expect(isReviewDateOverdue(new Date('2026-04-22T00:00:00Z'))).toBe(
+				false
+			);
+		});
+	});
+});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89122
The Info Panel's Details section is missing the warning color the FDS column applies to overdue review dates. The threshold also bucketed in the viewer's timezone, so users in different zones could see different colors for the same date.

# How am I fixing it?
- Extracted an `isReviewDateOverdue` helper in `js/common/utils/`, modeled on the sibling `expirationStatus.ts`, that buckets the comparison by UTC calendar day. Every user gets the same answer for a given stored timestamp.
- Both the FDS cell renderer and the info panel paragraph drive their warning class off the helper, so the two surfaces stay in sync.
- Display formatting still uses `Liferay.ThemeDisplay.getTimeZone()`, so the visible date string remains in each viewer's local zone — only the threshold logic changes.

# How can you verify that it works?
Run the included automated tests. To verify visually, follow the steps
described in https://liferay.atlassian.net/browse/LPD-89122.