### PR TITLE
LPD-88036 Add type field to ConnectedSite headless API

### DIFF
--- a/modules/apps/headless/headless-asset-library/headless-asset-library-api/src/main/java/com/liferay/headless/asset/library/dto/v1_0/ConnectedSite.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-api/src/main/java/com/liferay/headless/asset/library/dto/v1_0/ConnectedSite.java
@@ -5,9 +5,12 @@
 
 package com.liferay.headless.asset.library.dto.v1_0;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.string.StringBundler;
@@ -388,6 +391,58 @@ public class ConnectedSite implements Serializable {
 	@JsonIgnore
 	private Supplier<Boolean> _searchableSupplier;
 
+	@io.swagger.v3.oas.annotations.media.Schema
+	@JsonGetter("type")
+	@Valid
+	public Type getType() {
+		if (_typeSupplier != null) {
+			type = _typeSupplier.get();
+
+			_typeSupplier = null;
+		}
+
+		return type;
+	}
+
+	@JsonIgnore
+	public String getTypeAsString() {
+		Type type = getType();
+
+		if (type == null) {
+			return null;
+		}
+
+		return type.toString();
+	}
+
+	public void setType(Type type) {
+		this.type = type;
+
+		_typeSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setType(UnsafeSupplier<Type, Exception> typeUnsafeSupplier) {
+		_typeSupplier = () -> {
+			try {
+				return typeUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Type type;
+
+	@JsonIgnore
+	private Supplier<Type> _typeSupplier;
+
 	@Override
 	public boolean equals(Object object) {
 		if (this == object) {
@@ -527,6 +582,20 @@ public class ConnectedSite implements Serializable {
 			sb.append(searchable);
 		}
 
+		Type type = getType();
+
+		if (type != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"type\": ");
+
+			sb.append("\"");
+			sb.append(type);
+			sb.append("\"");
+		}
+
 		sb.append("}");
 
 		return sb.toString();
@@ -538,6 +607,44 @@ public class ConnectedSite implements Serializable {
 		name = "x-class-name"
 	)
 	public String xClassName;
+
+	@GraphQLName("Type")
+	public static enum Type {
+
+		SITE("Site"), SITE_TEMPLATE("SiteTemplate");
+
+		@JsonCreator
+		public static Type create(String value) {
+			if ((value == null) || value.equals("")) {
+				return null;
+			}
+
+			for (Type type : values()) {
+				if (Objects.equals(type.getValue(), value)) {
+					return type;
+				}
+			}
+
+			throw new IllegalArgumentException("Invalid enum value: " + value);
+		}
+
+		@JsonValue
+		public String getValue() {
+			return _value;
+		}
+
+		@Override
+		public String toString() {
+			return _value;
+		}
+
+		private Type(String value) {
+			_value = value;
+		}
+
+		private final String _value;
+
+	}
 
 	private static String _escape(Object object) {
 		return StringUtil.replace(
@@ -628,4 +735,4 @@ public class ConnectedSite implements Serializable {
 	private Map<String, Serializable> _extendedProperties;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1457832937
+// LIFERAY-REST-BUILDER-HASH:109143184

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-client/src/main/java/com/liferay/headless/asset/library/client/dto/v1_0/ConnectedSite.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-client/src/main/java/com/liferay/headless/asset/library/client/dto/v1_0/ConnectedSite.java
@@ -192,6 +192,33 @@ public class ConnectedSite implements Cloneable, Serializable {
 
 	protected Boolean searchable;
 
+	public Type getType() {
+		return type;
+	}
+
+	public String getTypeAsString() {
+		if (type == null) {
+			return null;
+		}
+
+		return type.toString();
+	}
+
+	public void setType(Type type) {
+		this.type = type;
+	}
+
+	public void setType(UnsafeSupplier<Type, Exception> typeUnsafeSupplier) {
+		try {
+			type = typeUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Type type;
+
 	@Override
 	public ConnectedSite clone() throws CloneNotSupportedException {
 		return (ConnectedSite)super.clone();
@@ -223,5 +250,38 @@ public class ConnectedSite implements Cloneable, Serializable {
 		return ConnectedSiteSerDes.toJSON(this);
 	}
 
+	public static enum Type {
+
+		SITE("Site"), SITE_TEMPLATE("SiteTemplate");
+
+		public static Type create(String value) {
+			for (Type type : values()) {
+				if (Objects.equals(type.getValue(), value) ||
+					Objects.equals(type.name(), value)) {
+
+					return type;
+				}
+			}
+
+			return null;
+		}
+
+		public String getValue() {
+			return _value;
+		}
+
+		@Override
+		public String toString() {
+			return _value;
+		}
+
+		private Type(String value) {
+			_value = value;
+		}
+
+		private final String _value;
+
+	}
+
 }
-// LIFERAY-REST-BUILDER-HASH:1122600106
+// LIFERAY-REST-BUILDER-HASH:-1771151761

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-client/src/main/java/com/liferay/headless/asset/library/client/serdes/v1_0/ConnectedSiteSerDes.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-client/src/main/java/com/liferay/headless/asset/library/client/serdes/v1_0/ConnectedSiteSerDes.java
@@ -142,6 +142,18 @@ public class ConnectedSiteSerDes {
 			sb.append(connectedSite.getSearchable());
 		}
 
+		if (connectedSite.getType() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"type\": ");
+
+			sb.append("\"");
+			sb.append(connectedSite.getType());
+			sb.append("\"");
+		}
+
 		sb.append("}");
 
 		return sb.toString();
@@ -224,6 +236,13 @@ public class ConnectedSiteSerDes {
 				"searchable", String.valueOf(connectedSite.getSearchable()));
 		}
 
+		if (connectedSite.getType() == null) {
+			map.put("type", null);
+		}
+		else {
+			map.put("type", String.valueOf(connectedSite.getType()));
+		}
+
 		return map;
 	}
 
@@ -268,6 +287,9 @@ public class ConnectedSiteSerDes {
 				return true;
 			}
 			else if (Objects.equals(jsonParserFieldName, "searchable")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "type")) {
 				return false;
 			}
 
@@ -326,6 +348,13 @@ public class ConnectedSiteSerDes {
 			else if (Objects.equals(jsonParserFieldName, "searchable")) {
 				if (jsonParserFieldValue != null) {
 					connectedSite.setSearchable((Boolean)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "type")) {
+				if (jsonParserFieldValue != null) {
+					connectedSite.setType(
+						ConnectedSite.Type.create(
+							(String)jsonParserFieldValue));
 				}
 			}
 		}
@@ -409,4 +438,4 @@ public class ConnectedSiteSerDes {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-2070842123
+// LIFERAY-REST-BUILDER-HASH:-1796380456

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/rest-openapi.yaml
@@ -168,6 +168,10 @@ components:
                 searchable:
                     default: true
                     type: boolean
+                type:
+                    enum: [Site, SiteTemplate]
+                    readOnly: true
+                    type: string
             type: object
         Creator:
             description:

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/dto/v1_0/converter/ConnectedSiteDTOConverter.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/dto/v1_0/converter/ConnectedSiteDTOConverter.java
@@ -84,6 +84,14 @@ public class ConnectedSiteDTOConverter
 						dtoConverterContext.isAcceptAllLanguages(),
 						group.getNameMap()));
 				setSearchable(depotEntryGroupRel::isSearchable);
+				setType(
+					() -> {
+						if (group.isLayoutSetPrototype()) {
+							return ConnectedSite.Type.SITE_TEMPLATE;
+						}
+
+						return ConnectedSite.Type.SITE;
+					});
 			}
 		};
 	}

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/BaseConnectedSiteResourceTestCase.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/BaseConnectedSiteResourceTestCase.java
@@ -732,6 +732,14 @@ public abstract class BaseConnectedSiteResourceTestCase {
 				continue;
 			}
 
+			if (Objects.equals("type", additionalAssertFieldName)) {
+				if (connectedSite.getType() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
 			throw new IllegalArgumentException(
 				"Invalid additional assert field name " +
 					additionalAssertFieldName);
@@ -937,6 +945,16 @@ public abstract class BaseConnectedSiteResourceTestCase {
 				if (!Objects.deepEquals(
 						connectedSite1.getSearchable(),
 						connectedSite2.getSearchable())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("type", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						connectedSite1.getType(), connectedSite2.getType())) {
 
 					return false;
 				}
@@ -1255,6 +1273,11 @@ public abstract class BaseConnectedSiteResourceTestCase {
 				"Invalid entity field " + entityFieldName);
 		}
 
+		if (entityFieldName.equals("type")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
 		throw new IllegalArgumentException(
 			"Invalid entity field " + entityFieldName);
 	}
@@ -1562,4 +1585,4 @@ public abstract class BaseConnectedSiteResourceTestCase {
 			_connectedSiteResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1736997199
+// LIFERAY-REST-BUILDER-HASH:-1474763763

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/ConnectedSiteResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/ConnectedSiteResourceTest.java
@@ -8,14 +8,24 @@ package com.liferay.headless.asset.library.resource.v1_0.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.headless.asset.library.client.dto.v1_0.ConnectedSite;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.LayoutSetPrototype;
+import com.liferay.portal.kernel.service.LayoutSetPrototypeLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -41,6 +51,15 @@ public class ConnectedSiteResourceTest
 	@Override
 	@Test
 	public void testBatchEngineDeleteImportTask() {
+	}
+
+	@Override
+	@Test
+	public void testPutAssetLibraryConnectedSite() throws Exception {
+		super.testPutAssetLibraryConnectedSite();
+
+		_testPutAssetLibraryConnectedSiteReturnsTypeSite();
+		_testPutAssetLibraryConnectedSiteReturnsTypeSiteTemplate();
 	}
 
 	@Override
@@ -148,8 +167,47 @@ public class ConnectedSiteResourceTest
 		};
 	}
 
+	private void _testPutAssetLibraryConnectedSiteReturnsTypeSite()
+		throws Exception {
+
+		ConnectedSite connectedSite =
+			connectedSiteResource.putAssetLibraryConnectedSite(
+				testDepotEntry.getGroup(
+				).getExternalReferenceCode(),
+				_testConnectedSite.getExternalReferenceCode(),
+				new ConnectedSite());
+
+		Assert.assertEquals(ConnectedSite.Type.SITE, connectedSite.getType());
+	}
+
+	private void _testPutAssetLibraryConnectedSiteReturnsTypeSiteTemplate()
+		throws Exception {
+
+		LayoutSetPrototype layoutSetPrototype =
+			_layoutSetPrototypeLocalService.addLayoutSetPrototype(
+				TestPropsValues.getUserId(), TestPropsValues.getCompanyId(),
+				HashMapBuilder.put(
+					LocaleUtil.getDefault(), RandomTestUtil.randomString()
+				).build(),
+				new HashMap<>(), true, true, new ServiceContext());
+
+		ConnectedSite connectedSite =
+			connectedSiteResource.putAssetLibraryConnectedSite(
+				testDepotEntry.getGroup(
+				).getExternalReferenceCode(),
+				layoutSetPrototype.getGroup(
+				).getExternalReferenceCode(),
+				new ConnectedSite());
+
+		Assert.assertEquals(
+			ConnectedSite.Type.SITE_TEMPLATE, connectedSite.getType());
+	}
+
 	@DeleteAfterTestRun
 	private List<Group> _groups = new ArrayList<>();
+
+	@Inject
+	private LayoutSetPrototypeLocalService _layoutSetPrototypeLocalService;
 
 	private ConnectedSite _testConnectedSite;
 

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/ConnectedSiteResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/ConnectedSiteResourceTest.java
@@ -11,7 +11,6 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.LayoutSetPrototype;
 import com.liferay.portal.kernel.service.LayoutSetPrototypeLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
-import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -21,9 +20,7 @@ import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -153,8 +150,6 @@ public class ConnectedSiteResourceTest
 	private ConnectedSite _addConnectedSite() throws Exception {
 		Group group = GroupTestUtil.addGroup();
 
-		_groups.add(group);
-
 		return new ConnectedSite() {
 			{
 				externalReferenceCode = group.getExternalReferenceCode();
@@ -202,9 +197,6 @@ public class ConnectedSiteResourceTest
 		Assert.assertEquals(
 			ConnectedSite.Type.SITE_TEMPLATE, connectedSite.getType());
 	}
-
-	@DeleteAfterTestRun
-	private List<Group> _groups = new ArrayList<>();
 
 	@Inject
 	private LayoutSetPrototypeLocalService _layoutSetPrototypeLocalService;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88036

**What is being fixed:** The headless `/connected-sites` endpoint
did not distinguish Site connections from Site Template connections.

**How it is being fixed:** Adds a `type` enum (`Site | SiteTemplate`)
to the `ConnectedSite` schema.