### PR TITLE
LPD-88360 ThemeDisplay could be null, fall back to JournalArticle for…

### DIFF
--- a/modules/apps/glowroot/glowroot-plugin-freemarker/build.gradle
+++ b/modules/apps/glowroot/glowroot-plugin-freemarker/build.gradle
@@ -3,6 +3,7 @@ task deployGlowroot
 dependencies {
 	compileInclude group: "jakarta.servlet", name: "jakarta.servlet-api", version: "6.0.0"
 	compileInclude group: "org.glowroot", name: "glowroot-agent-plugin-api", version: "0.13.6"
+	testCompileOnly project(":core:petra:petra-string")
 }
 
 deployGlowroot {

--- a/modules/apps/glowroot/glowroot-plugin-freemarker/src/main/java/com/liferay/glowroot/plugin/freemarker/TemplatesAspect.java
+++ b/modules/apps/glowroot/glowroot-plugin-freemarker/src/main/java/com/liferay/glowroot/plugin/freemarker/TemplatesAspect.java
@@ -130,6 +130,7 @@ public class TemplatesAspect {
 
 			String message = _buildMessage(
 				(DDMTemplateShim)parameters[1],
+				(JournalArticleShim)parameters[0],
 				(ThemeDisplayShim)parameters[9]);
 
 			if (_INSTRUMENTATION_LEVEL_TRACE.equals(
@@ -285,6 +286,11 @@ public class TemplatesAspect {
 
 	@Shim("com.liferay.journal.model.JournalArticle")
 	public interface JournalArticleShim {
+
+		public long getCompanyId();
+
+		public long getGroupId();
+
 	}
 
 	@Shim("com.liferay.portal.kernel.theme.ThemeDisplay")
@@ -301,14 +307,28 @@ public class TemplatesAspect {
 	}
 
 	private static String _buildMessage(
-		DDMTemplateShim dDMTemplateShim, ThemeDisplayShim themeDisplayShim) {
+		DDMTemplateShim dDMTemplateShim, JournalArticleShim journalArticleShim,
+		ThemeDisplayShim themeDisplayShim) {
 
 		StringBuilder sb = new StringBuilder();
 
 		sb.append("Journal Article FreeMarker Template (Company ID ");
-		sb.append(themeDisplayShim.getCompanyId());
-		sb.append(", Site Group ID ");
-		sb.append(themeDisplayShim.getSiteGroupId());
+
+		if (themeDisplayShim != null) {
+			sb.append(themeDisplayShim.getCompanyId());
+			sb.append(", Site Group ID ");
+			sb.append(themeDisplayShim.getSiteGroupId());
+		}
+		else if (journalArticleShim != null) {
+			sb.append(journalArticleShim.getCompanyId());
+			sb.append(", Site Group ID ");
+			sb.append(journalArticleShim.getGroupId());
+		}
+		else {
+			sb.append("?");
+			sb.append(", Site Group ID ");
+			sb.append("?");
+		}
 
 		if (dDMTemplateShim != null) {
 			sb.append(", and Dynamic Data Mapping Template ID ");

--- a/modules/apps/glowroot/glowroot-plugin-freemarker/src/main/java/com/liferay/glowroot/plugin/freemarker/TemplatesAspect.java
+++ b/modules/apps/glowroot/glowroot-plugin-freemarker/src/main/java/com/liferay/glowroot/plugin/freemarker/TemplatesAspect.java
@@ -128,32 +128,16 @@ public class TemplatesAspect {
 
 			TraceEntry traceEntry = null;
 
-			StringBuilder sb = new StringBuilder();
-
-			sb.append("Journal Article FreeMarker Template (Company ID ");
-
-			ThemeDisplayShim themeDisplayShim = (ThemeDisplayShim)parameters[9];
-
-			sb.append(themeDisplayShim.getCompanyId());
-
-			sb.append(", Site Group ID ");
-			sb.append(themeDisplayShim.getSiteGroupId());
-
-			DDMTemplateShim dDMTemplateShim = (DDMTemplateShim)parameters[1];
-
-			if (dDMTemplateShim != null) {
-				sb.append(", and Dynamic Data Mapping Template ID ");
-				sb.append(dDMTemplateShim.getTemplateId());
-			}
-
-			sb.append(")");
+			String message = _buildMessage(
+				(DDMTemplateShim)parameters[1],
+				(ThemeDisplayShim)parameters[9]);
 
 			if (_INSTRUMENTATION_LEVEL_TRACE.equals(
 					TemplatesPluginProperties.instrumentationLevel())) {
 
 				traceEntry = optionalThreadContext.startTransaction(
-					"FreeMarker Templates", sb.toString(),
-					MessageSupplier.create(sb.toString()), _timerName);
+					"FreeMarker Templates", message,
+					MessageSupplier.create(message), _timerName);
 
 				optionalThreadContext.setTransactionOuter();
 
@@ -164,14 +148,14 @@ public class TemplatesAspect {
 						TemplatesPluginProperties.instrumentationLevel())) {
 
 				traceEntry = optionalThreadContext.startTransaction(
-					"FreeMarker Templates", sb.toString(),
-					MessageSupplier.create(sb.toString()), _timerName);
+					"FreeMarker Templates", message,
+					MessageSupplier.create(message), _timerName);
 
 				optionalThreadContext.setTransactionOuter();
 			}
 			else {
 				traceEntry = optionalThreadContext.startTraceEntry(
-					MessageSupplier.create(sb.toString()), _timerName);
+					MessageSupplier.create(message), _timerName);
 			}
 
 			return traceEntry;
@@ -314,6 +298,26 @@ public class TemplatesAspect {
 
 		public long getSiteGroupId();
 
+	}
+
+	private static String _buildMessage(
+		DDMTemplateShim dDMTemplateShim, ThemeDisplayShim themeDisplayShim) {
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("Journal Article FreeMarker Template (Company ID ");
+		sb.append(themeDisplayShim.getCompanyId());
+		sb.append(", Site Group ID ");
+		sb.append(themeDisplayShim.getSiteGroupId());
+
+		if (dDMTemplateShim != null) {
+			sb.append(", and Dynamic Data Mapping Template ID ");
+			sb.append(dDMTemplateShim.getTemplateId());
+		}
+
+		sb.append(")");
+
+		return sb.toString();
 	}
 
 	private static final String _INSTRUMENTATION_LEVEL_DEBUG = "DEBUG";

--- a/modules/apps/glowroot/glowroot-plugin-freemarker/src/test/java/com/liferay/glowroot/plugin/freemarker/TemplatesAspectTest.java
+++ b/modules/apps/glowroot/glowroot-plugin-freemarker/src/test/java/com/liferay/glowroot/plugin/freemarker/TemplatesAspectTest.java
@@ -1,0 +1,149 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.glowroot.plugin.freemarker;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Gergely Szalay
+ */
+public class TemplatesAspectTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testBuildMessage() {
+		_testBuildMessageWithAllNull();
+		_testBuildMessageWithNullThemeDisplay();
+		_testBuildMessageWithThemeDisplay();
+		_testBuildMessageWithThemeDisplayAndTemplate();
+	}
+
+	private String _invokeBuildMessage(
+		TemplatesAspect.DDMTemplateShim dDMTemplateShim,
+		TemplatesAspect.JournalArticleShim journalArticleShim,
+		TemplatesAspect.ThemeDisplayShim themeDisplayShim) {
+
+		return ReflectionTestUtil.invoke(
+			TemplatesAspect.class, "_buildMessage",
+			new Class<?>[] {
+				TemplatesAspect.DDMTemplateShim.class,
+				TemplatesAspect.JournalArticleShim.class,
+				TemplatesAspect.ThemeDisplayShim.class
+			},
+			dDMTemplateShim, journalArticleShim, themeDisplayShim);
+	}
+
+	private void _testBuildMessageWithAllNull() {
+		Assert.assertEquals(
+			"Journal Article FreeMarker Template (Company ID ?, Site Group " +
+				"ID ?)",
+			_invokeBuildMessage(null, null, null));
+	}
+
+	private void _testBuildMessageWithNullThemeDisplay() {
+		long companyId = RandomTestUtil.randomLong();
+		long groupId = RandomTestUtil.randomLong();
+
+		TemplatesAspect.JournalArticleShim journalArticleShim = Mockito.mock(
+			TemplatesAspect.JournalArticleShim.class);
+
+		Mockito.when(
+			journalArticleShim.getCompanyId()
+		).thenReturn(
+			companyId
+		);
+
+		Mockito.when(
+			journalArticleShim.getGroupId()
+		).thenReturn(
+			groupId
+		);
+
+		Assert.assertEquals(
+			StringBundler.concat(
+				"Journal Article FreeMarker Template (Company ID ", companyId,
+				", Site Group ID ", groupId, ")"),
+			_invokeBuildMessage(null, journalArticleShim, null));
+	}
+
+	private void _testBuildMessageWithThemeDisplay() {
+		long companyId = RandomTestUtil.randomLong();
+		long siteGroupId = RandomTestUtil.randomLong();
+
+		TemplatesAspect.ThemeDisplayShim themeDisplayShim = Mockito.mock(
+			TemplatesAspect.ThemeDisplayShim.class);
+
+		Mockito.when(
+			themeDisplayShim.getCompanyId()
+		).thenReturn(
+			companyId
+		);
+
+		Mockito.when(
+			themeDisplayShim.getSiteGroupId()
+		).thenReturn(
+			siteGroupId
+		);
+
+		Assert.assertEquals(
+			StringBundler.concat(
+				"Journal Article FreeMarker Template (Company ID ", companyId,
+				", Site Group ID ", siteGroupId, ")"),
+			_invokeBuildMessage(null, null, themeDisplayShim));
+	}
+
+	private void _testBuildMessageWithThemeDisplayAndTemplate() {
+		long companyId = RandomTestUtil.randomLong();
+		long siteGroupId = RandomTestUtil.randomLong();
+		long templateId = RandomTestUtil.randomLong();
+
+		TemplatesAspect.DDMTemplateShim dDMTemplateShim = Mockito.mock(
+			TemplatesAspect.DDMTemplateShim.class);
+
+		Mockito.when(
+			dDMTemplateShim.getTemplateId()
+		).thenReturn(
+			templateId
+		);
+
+		TemplatesAspect.ThemeDisplayShim themeDisplayShim = Mockito.mock(
+			TemplatesAspect.ThemeDisplayShim.class);
+
+		Mockito.when(
+			themeDisplayShim.getCompanyId()
+		).thenReturn(
+			companyId
+		);
+
+		Mockito.when(
+			themeDisplayShim.getSiteGroupId()
+		).thenReturn(
+			siteGroupId
+		);
+
+		Assert.assertEquals(
+			StringBundler.concat(
+				"Journal Article FreeMarker Template (Company ID ", companyId,
+				", Site Group ID ", siteGroupId,
+				", and Dynamic Data Mapping Template ID ", templateId, ")"),
+			_invokeBuildMessage(dDMTemplateShim, null, themeDisplayShim));
+	}
+
+}


### PR DESCRIPTION
What is this trying to solve?
https://liferay.atlassian.net/browse/LPD-88360

When Glowroot is enabled, a Kaleo workflow Groovy action that renders a JournalArticle (no request
context, so no ThemeDisplay) hits NullPointerException: Cannot invoke "ThemeDisplayShim.getCompanyId()" because "themeDisplayShim" is null at TemplatesAspect.java:137,
blocking workflow execution. JournalTransformer.transform itself accepts a null ThemeDisplay
throughout — only the aspect's trace-message build dereferenced it without checking.

How am I fixing it?
In JournalTransformerAdvice.onBefore, null-guard themeDisplayShim. When null, fall back to the
article (parameters[0]) for companyId — matching what JournalTransformer._transform:929 already
does internally. JournalArticleShim gains getCompanyId().