### PR TITLE
LPD-87401 | LPD-87401 ensure that we store the email in plain data on the extraInfo of the ticket

### DIFF
--- a/modules/apps/headless/headless-object/headless-object-api/src/main/java/com/liferay/headless/object/util/v1_0/CollaboratorUtil.java
+++ b/modules/apps/headless/headless-object/headless-object-api/src/main/java/com/liferay/headless/object/util/v1_0/CollaboratorUtil.java
@@ -11,7 +11,6 @@ import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.NoSuchGroupException;
 import com.liferay.portal.kernel.exception.NoSuchModelException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
-import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.Ticket;
 import com.liferay.portal.kernel.model.TicketConstants;
 import com.liferay.portal.kernel.model.User;
@@ -72,7 +71,9 @@ public class CollaboratorUtil {
 			_validateEmailAddress(collaborator.getEmailAddress());
 
 			User existingUser = userLocalService.fetchUserByEmailAddress(
-				companyId, collaborator.getEmailAddress());
+				companyId,
+				StringUtil.toLowerCase(
+					StringUtil.trim(collaborator.getEmailAddress())));
 
 			if (existingUser != null) {
 				return toCollaborator(
@@ -87,7 +88,7 @@ public class CollaboratorUtil {
 
 			Ticket ticket = _addOrUpdateTicket(
 				className, classPK, collaborator, collaboratorId, companyId,
-				ticketLocalService, type);
+				ticketLocalService);
 
 			return toCollaborator(
 				acceptLanguage, dtoConverter, dtoConverterRegistry,
@@ -136,7 +137,9 @@ public class CollaboratorUtil {
 				_validateEmailAddress(collaborator.getEmailAddress());
 
 				User existingUser = userLocalService.fetchUserByEmailAddress(
-					companyId, collaborator.getEmailAddress());
+					companyId,
+					StringUtil.toLowerCase(
+						StringUtil.trim(collaborator.getEmailAddress())));
 
 				if (existingUser == null) {
 					Ticket ticket = _addOrUpdateTicket(
@@ -379,7 +382,7 @@ public class CollaboratorUtil {
 	private static Ticket _addOrUpdateTicket(
 			String className, long classPK, Collaborator collaborator,
 			long collaboratorId, long companyId,
-			TicketLocalService ticketLocalService, String type)
+			TicketLocalService ticketLocalService)
 		throws Exception {
 
 		Ticket ticket = ticketLocalService.fetchTicket(collaboratorId);
@@ -392,15 +395,8 @@ public class CollaboratorUtil {
 			throw new NoSuchModelException();
 		}
 
-		String extraInfo = JSONUtil.put(
-			"actionIds", collaborator.getActionIds()
-		).put(
-			"emailAddress", collaborator.getEmailAddress()
-		).put(
-			"share", collaborator.getShare()
-		).put(
-			"type", type
-		).toString();
+		String extraInfo = StringUtil.toLowerCase(
+			StringUtil.trim(collaborator.getEmailAddress()));
 
 		if (ticket == null) {
 			return ticketLocalService.addTicket(

--- a/modules/apps/headless/headless-object/headless-object-api/src/main/java/com/liferay/headless/object/util/v1_0/CollaboratorUtil.java
+++ b/modules/apps/headless/headless-object/headless-object-api/src/main/java/com/liferay/headless/object/util/v1_0/CollaboratorUtil.java
@@ -72,8 +72,7 @@ public class CollaboratorUtil {
 
 			User existingUser = userLocalService.fetchUserByEmailAddress(
 				companyId,
-				StringUtil.toLowerCase(
-					StringUtil.trim(collaborator.getEmailAddress())));
+				_normalizeEmailAddress(collaborator.getEmailAddress()));
 
 			if (existingUser != null) {
 				return toCollaborator(
@@ -138,8 +137,7 @@ public class CollaboratorUtil {
 
 				User existingUser = userLocalService.fetchUserByEmailAddress(
 					companyId,
-					StringUtil.toLowerCase(
-						StringUtil.trim(collaborator.getEmailAddress())));
+					_normalizeEmailAddress(collaborator.getEmailAddress()));
 
 				if (existingUser == null) {
 					Ticket ticket = _addOrUpdateTicket(
@@ -395,13 +393,13 @@ public class CollaboratorUtil {
 			throw new NoSuchModelException();
 		}
 
-		String extraInfo = StringUtil.toLowerCase(
-			StringUtil.trim(collaborator.getEmailAddress()));
+		String emailAddress = _normalizeEmailAddress(
+			collaborator.getEmailAddress());
 
 		if (ticket == null) {
 			return ticketLocalService.addTicket(
 				companyId, className, classPK,
-				TicketConstants.TYPE_INVITE_COLLABORATOR, extraInfo,
+				TicketConstants.TYPE_INVITE_COLLABORATOR, emailAddress,
 				GetterUtil.getObject(
 					collaborator.getDateExpired(),
 					() -> new Date(
@@ -415,7 +413,7 @@ public class CollaboratorUtil {
 			ticket.setExpirationDate(collaborator.getDateExpired());
 		}
 
-		ticket.setExtraInfo(extraInfo);
+		ticket.setExtraInfo(emailAddress);
 
 		return ticketLocalService.updateTicket(ticket);
 	}
@@ -447,6 +445,10 @@ public class CollaboratorUtil {
 		}
 
 		ticketLocalService.deleteTicket(ticket.getTicketId());
+	}
+
+	private static String _normalizeEmailAddress(String emailAddress) {
+		return StringUtil.toLowerCase(StringUtil.trim(emailAddress));
 	}
 
 	private static void _validateEmailAddress(String emailAddress) {

--- a/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/dto/v1_0/converter/CollaboratorDTOConverter.java
+++ b/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/dto/v1_0/converter/CollaboratorDTOConverter.java
@@ -8,8 +8,6 @@ package com.liferay.headless.object.internal.dto.v1_0.converter;
 import com.liferay.headless.delivery.dto.v1_0.util.CreatorUtil;
 import com.liferay.headless.object.dto.v1_0.Collaborator;
 import com.liferay.petra.function.transform.TransformUtil;
-import com.liferay.portal.kernel.json.JSONFactory;
-import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.model.Ticket;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.UserGroup;
@@ -159,15 +157,12 @@ public class CollaboratorDTOConverter
 		};
 	}
 
-	private String _fetchEmailAddress(Ticket ticket) throws Exception {
+	private String _fetchEmailAddress(Ticket ticket) {
 		if (ticket == null) {
 			return null;
 		}
 
-		JSONObject jsonObject = _jsonFactory.createJSONObject(
-			ticket.getExtraInfo());
-
-		return jsonObject.getString("emailAddress");
+		return ticket.getExtraInfo();
 	}
 
 	private Ticket _fetchTicket(SharingEntry sharingEntry) {
@@ -205,9 +200,6 @@ public class CollaboratorDTOConverter
 			GuestOrUserUtil.getPermissionChecker(), user.getUserId(),
 			ActionKeys.VIEW);
 	}
-
-	@Reference
-	private JSONFactory _jsonFactory;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/headless/headless-object/headless-object-test/src/testIntegration/java/com/liferay/headless/object/internal/dto/v1_0/converter/test/CollaboratorDTOConverterTest.java
+++ b/modules/apps/headless/headless-object/headless-object-test/src/testIntegration/java/com/liferay/headless/object/internal/dto/v1_0/converter/test/CollaboratorDTOConverterTest.java
@@ -13,7 +13,6 @@ import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
-import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Ticket;
@@ -102,16 +101,7 @@ public class CollaboratorDTOConverterTest {
 		Ticket ticket = _ticketLocalService.addTicket(
 			TestPropsValues.getCompanyId(), _objectEntry.getModelClassName(),
 			_objectEntry.getObjectEntryId(),
-			TicketConstants.TYPE_INVITE_COLLABORATOR,
-			JSONUtil.put(
-				"actionIds", JSONUtil.put(SharingEntryAction.VIEW.getActionId())
-			).put(
-				"emailAddress", emailAddress
-			).put(
-				"share", true
-			).put(
-				"type", "Email"
-			).toString(),
+			TicketConstants.TYPE_INVITE_COLLABORATOR, emailAddress,
 			expirationDate, null);
 
 		SharingEntry sharingEntry = _sharingEntryLocalService.addSharingEntry(


### PR DESCRIPTION
LPD-87401 Store the collaborator email address as plain text in the ticket extra info

This is a common part of the code that it's needed on several technical task, so I decided to extract to a sigle PR.
 
# What is this trying to solve? 
https://liferay.atlassian.net/browse/LPD-87401
 
The `Ticket.extraInfo` field was storing a JSON blob with multiple fields (`actionIds`, `emailAddress`, `share`, `type`) for email-based collaborator invitations. Only the
email address is actually needed at read time, so the JSON structure was unnecessary overhead that required parsing on every read. Additionally, the email address wasn't 
being normalized before storage, which could cause lookup mismatches when the same address was written with different casing or whitespace. 
 
# How am I fixing it? 
 
Instead of serializing a JSON object into `extraInfo`, the ticket now stores just the normalized (trimmed + lowercased) email address as plain text.
`CollaboratorDTOConverter._fetchEmailAddress` is simplified accordingly — no more JSON parsing, it just returns `ticket.getExtraInfo()`. A private `_normalizeEmailAddress` 
helper in `CollaboratorUtil` centralizes the normalization so it's applied consistently on both write and on lookup via `fetchUserByEmailAddress`.
 
# How can you verify that it works? 

Run the included automated tests.

# Commits

- `4edc27b` LPD-87401 store the collaborator email address as plain text in the ticket extra info
- `758268e` LPD-87401 extract _normalizeEmailAddress helper
