### PR TITLE
LPD-89353 Fix CMS content not visible in Dynamic Collection

### DIFF
--- a/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/display/context/EditAssetListDisplayContext.java
+++ b/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/display/context/EditAssetListDisplayContext.java
@@ -836,9 +836,29 @@ public class EditAssetListDisplayContext {
 			return _referencedModelsGroupIds;
 		}
 
+		long[] groupIds = getSelectedGroupIds();
+
+		if (FeatureFlagManagerUtil.isEnabled(
+				_themeDisplay.getCompanyId(), "LPD-17564")) {
+
+			for (Group group : getSelectedGroups()) {
+				int depotEntryType = GetterUtil.getInteger(
+					group.getTypeSettingsProperty("depotEntryType"));
+
+				if (depotEntryType == DepotConstants.TYPE_SPACE) {
+					Group cmsGroup = GroupLocalServiceUtil.getGroup(
+						_themeDisplay.getCompanyId(), GroupConstants.CMS);
+
+					groupIds = ArrayUtil.append(
+						groupIds, cmsGroup.getGroupId());
+
+					break;
+				}
+			}
+		}
+
 		_referencedModelsGroupIds =
-			PortalUtil.getCurrentAndAncestorSiteGroupIds(
-				getSelectedGroupIds(), true);
+			PortalUtil.getCurrentAndAncestorSiteGroupIds(groupIds, true);
 
 		return _referencedModelsGroupIds;
 	}
@@ -917,44 +937,24 @@ public class EditAssetListDisplayContext {
 	}
 
 	public List<Group> getSelectedGroups() throws PortalException {
+		if (_selectedGroups != null) {
+			return _selectedGroups;
+		}
+
 		long[] groupIds = GetterUtil.getLongValues(
 			StringUtil.split(
 				PropertiesParamUtil.getString(
 					_unicodeProperties, _httpServletRequest, "groupIds")));
 
 		if (ArrayUtil.isEmpty(groupIds)) {
-			return Collections.singletonList(_themeDisplay.getScopeGroup());
+			_selectedGroups = Collections.singletonList(
+				_themeDisplay.getScopeGroup());
+		}
+		else {
+			_selectedGroups = GroupLocalServiceUtil.getGroups(groupIds);
 		}
 
-		List<Group> groups = GroupLocalServiceUtil.getGroups(groupIds);
-
-		if (!FeatureFlagManagerUtil.isEnabled(
-				_themeDisplay.getCompanyId(), "LPD-17564")) {
-
-			return groups;
-		}
-
-		List<Group> selectedGroups = ListUtil.filter(
-			groups,
-			group -> {
-				int depotEntryType = GetterUtil.getInteger(
-					group.getTypeSettingsProperty("depotEntryType"));
-
-				return depotEntryType != DepotConstants.TYPE_SPACE;
-			});
-
-		if (selectedGroups.size() == groups.size()) {
-			return selectedGroups;
-		}
-
-		Group cmsGroup = GroupLocalServiceUtil.getGroup(
-			_themeDisplay.getCompanyId(), GroupConstants.CMS);
-
-		if (!selectedGroups.contains(cmsGroup)) {
-			selectedGroups.add(cmsGroup);
-		}
-
-		return selectedGroups;
+		return _selectedGroups;
 	}
 
 	public long[] getSelectedSegmentsEntryIds() {
@@ -1538,6 +1538,7 @@ public class EditAssetListDisplayContext {
 	private SearchContainer<AssetListEntryAssetEntryRel> _searchContainer;
 	private final SegmentsConfigurationProvider _segmentsConfigurationProvider;
 	private Long _segmentsEntryId;
+	private List<Group> _selectedGroups;
 	private long[] _selectedSegmentsEntryIds;
 	private String _selectSegmentsEntryURL;
 	private Boolean _subtypeFieldsFilterEnabled;

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/dynamicCollectionSpaceScope.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/dynamicCollectionSpaceScope.spec.ts
@@ -1,0 +1,129 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {collectionsPagesTest} from '../../../../fixtures/collectionsPagesTest';
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
+import {isolatedSiteTest} from '../../../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import getRandomString from '../../../../utils/getRandomString';
+import {PORTLET_URLS} from '../../../../utils/portletUrls';
+import {waitForAlert} from '../../../../utils/waitForAlert';
+
+const test = mergeTests(
+	collectionsPagesTest,
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+	}),
+	isolatedSiteTest,
+	loginTest()
+);
+
+test(
+	'Dynamic Collection scoped to a Space saves and displays the Space, not the CMS group',
+	{tag: '@LPD-89353'},
+	async ({apiHelpers, collectionsPage, page, site}) => {
+		const collectionName = getRandomString();
+		const spaceName = `Space ${getRandomString()}`;
+
+		const expectScopeRowShowsSpace = async () => {
+			const scopeRow = page.getByRole('row', {name: spaceName});
+
+			await expect(scopeRow).toBeVisible();
+			await expect(scopeRow).toContainText('Asset Library or Space');
+		};
+
+		await test.step('Create a Space', async () => {
+			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+				name: spaceName,
+				settings: {},
+				type: 'Space',
+			});
+		});
+
+		await test.step('Connect the Space to the site', async () => {
+			await page.goto(PORTLET_URLS.cmsAllSpaces);
+
+			await expect(
+				page.getByRole('row', {name: spaceName})
+			).toBeVisible();
+
+			await page
+				.getByRole('row', {name: spaceName})
+				.getByRole('button', {name: 'Actions'})
+				.click();
+			await page
+				.getByRole('menuitem', {name: 'View Connected Sites'})
+				.click();
+			await page.getByPlaceholder('Select a Site').fill(site.name);
+			await page.getByRole('option', {name: site.name}).click();
+
+			await expect(
+				page.getByRole('button', {name: 'Connect'})
+			).toBeEnabled();
+
+			await page.getByRole('button', {name: 'Connect'}).click();
+
+			await waitForAlert(
+				page,
+				`Success:Site ${site.name} was successfully connected to the space.`
+			);
+		});
+
+		await test.step('Create a Dynamic Collection on the site', async () => {
+			await collectionsPage.goto(site.friendlyUrlPath);
+			await collectionsPage.addNewDynamicCollection(collectionName);
+
+			await page
+				.getByLabel('Item Type')
+				.selectOption({label: 'Basic Web Content (CMS)'});
+		});
+
+		await test.step('Add the Space to the collection scope', async () => {
+			await page.getByRole('button', {name: 'Scope'}).click();
+
+			await page.getByRole('button', {name: 'Select Site'}).click();
+
+			await page
+				.getByRole('menuitem', {name: 'Other Site, Asset Library, or'})
+				.click();
+
+			await page
+				.locator('iframe[title="Scope"]')
+				.contentFrame()
+				.getByRole('link', {name: 'Spaces'})
+				.click();
+
+			await page
+				.locator('iframe[title="Scope"]')
+				.contentFrame()
+				.getByRole('link', {exact: true, name: spaceName})
+				.click();
+		});
+
+		await test.step('Scope row shows the Space name and the "Asset Library or Space" type', async () => {
+			await expectScopeRowShowsSpace();
+		});
+
+		await test.step('Save the collection and reopen it for editing', async () => {
+			await page.getByRole('button', {name: 'Save'}).click();
+
+			await waitForAlert(page);
+
+			await collectionsPage.goto(site.friendlyUrlPath);
+
+			await page.getByRole('link', {name: collectionName}).click();
+
+			await page.getByRole('button', {name: 'Scope'}).click();
+		});
+
+		await test.step('After reload, the scope row still shows the Space, not the CMS group', async () => {
+			await expectScopeRowShowsSpace();
+		});
+	}
+);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89353

## What is being fixed

When a Dynamic Collection on a DXP site is scoped to a CMS Space, the scope row displays "CMS / Site" instead of the Space's name and "Asset Library or Space" label, and the collection returns no items even when the Space is connected to the site. This regressed in LPD-86263, which substituted the CMS group for every selected Space group inside `EditAssetListDisplayContext.getSelectedGroups()`.

## How it is being fixed

The Space-to-CMS substitution belongs at the tag/category lookup layer, not the scope-selection layer. `getSelectedGroups()` feeds both the visible scope display and the persisted `groupIds` typesetting, so substituting CMS there hid the Space from the UI and saved the wrong group ID. The fix restores `getSelectedGroups()` to return the raw selection and moves the substitution into `getReferencedModelsGroupIds()`, which feeds category, tag, and class-type lookups — the consumers LPD-86263 was actually trying to serve. `AssetTagsDisplayContext._getGroupIds` continues to handle its own substitution downstream, so the tag selector still resolves CMS tags. Collections saved between LPD-86263 and this fix still hold the CMS group ID in their `typeSettings`; users must reopen and re-save those collections.