### PR TITLE
LPD-89497 Add Playwright tests for vocabularies

### DIFF
--- a/modules/test/playwright/tests/site-cms-site-initializer/main/categorization/vocabularies.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/categorization/vocabularies.spec.ts
@@ -463,6 +463,55 @@ test(
 );
 
 test(
+	'Open categories from the Categories column link',
+	{tag: '@LPD-89497'},
+	async ({apiHelpers, categoriesPage, vocabulariesPage}) => {
+		const siteId = await apiHelpers.headlessAdminUser
+			.getSiteByFriendlyUrlPath('cms')
+			.then((response) => response.id);
+
+		const vocabularyName = getRandomString();
+
+		const vocabularyId = await apiHelpers.headlessAdminTaxonomy
+			.postSiteTaxonomyVocabulary({
+				assetLibraries: [{id: -1}],
+				assetTypes: [
+					{
+						required: true,
+						subtype: 'AllAssetSubtypes',
+						type: 'AllAssetTypes',
+					},
+				],
+				name: vocabularyName,
+				siteId,
+				visibilityType: 'PUBLIC',
+			})
+			.then((response) => response.id);
+
+		const categoryName1 = getRandomString();
+		const categoryName2 = getRandomString();
+
+		for (const name of [categoryName1, categoryName2]) {
+			await apiHelpers.headlessAdminTaxonomy.postTaxonomyVocabularyTaxonomyCategory(
+				{
+					name,
+					vocabularyId,
+				}
+			);
+		}
+
+		await vocabulariesPage.goto();
+
+		await vocabulariesPage.clickCategoriesLink(vocabularyName);
+
+		await categoriesPage.assertBreadcrumbItemText(1, vocabularyName);
+
+		await expect(categoriesPage.getItem(categoryName1)).toBeVisible();
+		await expect(categoriesPage.getItem(categoryName2)).toBeVisible();
+	}
+);
+
+test(
 	'Search vocabularies by name',
 	{tag: '@LPD-89497'},
 	async ({apiHelpers, vocabulariesPage}) => {

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/categorization/vocabularies.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/categorization/vocabularies.spec.ts
@@ -64,10 +64,7 @@ const createScopedVocabularyAndContent = async ({
 
 	await contentsPage.publishButton.click();
 
-	const content = page.locator('.table-list-title a', {hasText: title});
-
-	await content.waitFor();
-	await content.click();
+	await page.locator('.table-list-title a', {hasText: title}).click();
 };
 
 test(

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/categorization/vocabularies.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/categorization/vocabularies.spec.ts
@@ -8,6 +8,7 @@ import {expect, mergeTests} from '@playwright/test';
 import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
 import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
 import {loginTest} from '../../../../fixtures/loginTest';
+import {createCategories} from '../../../../helpers/CreateCategories';
 import {checkAccessibility} from '../../../../utils/checkAccessibility';
 import {clickAndExpectToBeVisible} from '../../../../utils/clickAndExpectToBeVisible';
 import {getRandomInt} from '../../../../utils/getRandomInt';
@@ -459,6 +460,60 @@ test(
 		await expect(page.getByLabel('External Reference Code')).toHaveValue(
 			'x'.repeat(80)
 		);
+	}
+);
+
+test(
+	'Hide a Space-restricted vocabulary from content in another Space',
+	{tag: '@LPD-89497'},
+	async ({apiHelpers, contentsPage, page}) => {
+		const site = await apiHelpers.headlessAdminSite.getSite('L_CMS');
+
+		const spaceName = `Space ${getRandomString()}`;
+
+		const {id: spaceId} =
+			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+				name: spaceName,
+				settings: {},
+				type: 'Space',
+			});
+
+		const categoryName = getRandomString();
+		const vocabularyName = getRandomString();
+
+		await createCategories({
+			apiHelpers,
+			assetLibraries: [{id: spaceId, name: spaceName}],
+			assetTypes: [{required: false, type: 'AllAssetTypes'}],
+			categoryNames: [{name: categoryName}],
+			siteId: site.id,
+			vocabularyName,
+		});
+
+		await contentsPage.goto();
+
+		await contentsPage.createContent('Basic Web Content');
+
+		const title = getRandomString();
+
+		await page.getByPlaceholder('New Basic Web Content').fill(title);
+
+		await contentsPage.publishButton.click();
+
+		const content = page.locator('.table-list-title a', {hasText: title});
+
+		await content.waitFor();
+		await content.click();
+
+		await contentsPage.openSidePanel('Categorization');
+
+		await page.getByPlaceholder('Add category').fill(categoryName);
+
+		await page.waitForTimeout(500);
+
+		await expect(
+			page.getByRole('option', {name: categoryName})
+		).toBeHidden();
 	}
 );
 

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/categorization/vocabularies.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/categorization/vocabularies.spec.ts
@@ -32,6 +32,7 @@ const createScopedVocabularyAndContent = async ({
 	apiHelpers,
 	assetLibraries,
 	assetTypes,
+	categoryName,
 	contentsPage,
 	page,
 	siteId,
@@ -39,20 +40,18 @@ const createScopedVocabularyAndContent = async ({
 	apiHelpers: ApiHelpers;
 	assetLibraries: AssetLibrary[];
 	assetTypes: AssetType[];
+	categoryName: string;
 	contentsPage: ContentsPage;
 	page: Page;
 	siteId: string;
 }) => {
-	const categoryName = getRandomString();
-	const vocabularyName = getRandomString();
-
 	await createCategories({
 		apiHelpers,
 		assetLibraries,
 		assetTypes,
 		categoryNames: [{name: categoryName}],
 		siteId,
-		vocabularyName,
+		vocabularyName: getRandomString(),
 	});
 
 	await contentsPage.goto();
@@ -69,8 +68,6 @@ const createScopedVocabularyAndContent = async ({
 
 	await content.waitFor();
 	await content.click();
-
-	return {categoryName};
 };
 
 test(
@@ -525,10 +522,13 @@ test(
 				type: 'Space',
 			});
 
-		const {categoryName} = await createScopedVocabularyAndContent({
+		const categoryName = getRandomString();
+
+		await createScopedVocabularyAndContent({
 			apiHelpers,
 			assetLibraries: [{id: spaceId, name: spaceName}],
 			assetTypes: [{required: false, type: 'AllAssetTypes'}],
+			categoryName,
 			contentsPage,
 			page,
 			siteId: site.id,
@@ -552,10 +552,13 @@ test(
 	async ({apiHelpers, contentsPage, page}) => {
 		const site = await apiHelpers.headlessAdminSite.getSite('L_CMS');
 
-		const {categoryName} = await createScopedVocabularyAndContent({
+		const categoryName = getRandomString();
+
+		await createScopedVocabularyAndContent({
 			apiHelpers,
 			assetLibraries: [{id: -1, name: 'All Spaces'}],
 			assetTypes: [{required: false, type: 'BlogPosting'}],
+			categoryName,
 			contentsPage,
 			page,
 			siteId: site.id,

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/categorization/vocabularies.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/categorization/vocabularies.spec.ts
@@ -3,11 +3,12 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {expect, mergeTests} from '@playwright/test';
+import {Page, expect, mergeTests} from '@playwright/test';
 
 import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
 import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
 import {loginTest} from '../../../../fixtures/loginTest';
+import {ApiHelpers} from '../../../../helpers/ApiHelpers';
 import {createCategories} from '../../../../helpers/CreateCategories';
 import {checkAccessibility} from '../../../../utils/checkAccessibility';
 import {clickAndExpectToBeVisible} from '../../../../utils/clickAndExpectToBeVisible';
@@ -15,6 +16,7 @@ import {getRandomInt} from '../../../../utils/getRandomInt';
 import getRandomString from '../../../../utils/getRandomString';
 import {categorizationPagesTest} from '../fixtures/categorizationPagesTest';
 import {cmsPagesTest} from '../fixtures/cmsPagesTest';
+import {ContentsPage} from '../pages/ContentsPage';
 
 const test = mergeTests(
 	categorizationPagesTest,
@@ -25,6 +27,51 @@ const test = mergeTests(
 	}),
 	loginTest()
 );
+
+const createScopedVocabularyAndContent = async ({
+	apiHelpers,
+	assetLibraries,
+	assetTypes,
+	contentsPage,
+	page,
+	siteId,
+}: {
+	apiHelpers: ApiHelpers;
+	assetLibraries: AssetLibrary[];
+	assetTypes: AssetType[];
+	contentsPage: ContentsPage;
+	page: Page;
+	siteId: string;
+}) => {
+	const categoryName = getRandomString();
+	const vocabularyName = getRandomString();
+
+	await createCategories({
+		apiHelpers,
+		assetLibraries,
+		assetTypes,
+		categoryNames: [{name: categoryName}],
+		siteId,
+		vocabularyName,
+	});
+
+	await contentsPage.goto();
+
+	await contentsPage.createContent('Basic Web Content');
+
+	const title = getRandomString();
+
+	await page.getByPlaceholder('New Basic Web Content').fill(title);
+
+	await contentsPage.publishButton.click();
+
+	const content = page.locator('.table-list-title a', {hasText: title});
+
+	await content.waitFor();
+	await content.click();
+
+	return {categoryName};
+};
 
 test(
 	'Assert can delete vocabulary from dropdown actions',
@@ -478,32 +525,14 @@ test(
 				type: 'Space',
 			});
 
-		const categoryName = getRandomString();
-		const vocabularyName = getRandomString();
-
-		await createCategories({
+		const {categoryName} = await createScopedVocabularyAndContent({
 			apiHelpers,
 			assetLibraries: [{id: spaceId, name: spaceName}],
 			assetTypes: [{required: false, type: 'AllAssetTypes'}],
-			categoryNames: [{name: categoryName}],
+			contentsPage,
+			page,
 			siteId: site.id,
-			vocabularyName,
 		});
-
-		await contentsPage.goto();
-
-		await contentsPage.createContent('Basic Web Content');
-
-		const title = getRandomString();
-
-		await page.getByPlaceholder('New Basic Web Content').fill(title);
-
-		await contentsPage.publishButton.click();
-
-		const content = page.locator('.table-list-title a', {hasText: title});
-
-		await content.waitFor();
-		await content.click();
 
 		await contentsPage.openSidePanel('Categorization');
 

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/categorization/vocabularies.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/categorization/vocabularies.spec.ts
@@ -547,6 +547,33 @@ test(
 );
 
 test(
+	'Hide an asset-type-restricted vocabulary from content of another asset type',
+	{tag: '@LPD-89497'},
+	async ({apiHelpers, contentsPage, page}) => {
+		const site = await apiHelpers.headlessAdminSite.getSite('L_CMS');
+
+		const {categoryName} = await createScopedVocabularyAndContent({
+			apiHelpers,
+			assetLibraries: [{id: -1, name: 'All Spaces'}],
+			assetTypes: [{required: false, type: 'BlogPosting'}],
+			contentsPage,
+			page,
+			siteId: site.id,
+		});
+
+		await contentsPage.openSidePanel('Categorization');
+
+		await page.getByPlaceholder('Add category').fill(categoryName);
+
+		await page.waitForTimeout(500);
+
+		await expect(
+			page.getByRole('option', {name: categoryName})
+		).toBeHidden();
+	}
+);
+
+test(
 	'Open categories from the Categories column link',
 	{tag: '@LPD-89497'},
 	async ({apiHelpers, categoriesPage, vocabulariesPage}) => {

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/categorization/vocabularies.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/categorization/vocabularies.spec.ts
@@ -463,6 +463,42 @@ test(
 );
 
 test(
+	'Search vocabularies by name',
+	{tag: '@LPD-89497'},
+	async ({apiHelpers, vocabulariesPage}) => {
+		const siteId = await apiHelpers.headlessAdminUser
+			.getSiteByFriendlyUrlPath('cms')
+			.then((response) => response.id);
+
+		const name1 = getRandomString();
+		const name2 = getRandomString();
+
+		for (const name of [name1, name2]) {
+			await apiHelpers.headlessAdminTaxonomy.postSiteTaxonomyVocabulary({
+				assetLibraries: [{id: -1}],
+				assetTypes: [
+					{
+						required: true,
+						subtype: 'AllAssetSubtypes',
+						type: 'AllAssetTypes',
+					},
+				],
+				name,
+				siteId,
+				visibilityType: 'PUBLIC',
+			});
+		}
+
+		await vocabulariesPage.goto();
+
+		await vocabulariesPage.search(name1);
+
+		await expect(vocabulariesPage.getItem(name1)).toBeVisible();
+		await expect(vocabulariesPage.getItem(name2)).toBeHidden();
+	}
+);
+
+test(
 	'Validate that a UI error appears when attempting to create a vocabulary with a duplicate name or external reference code',
 	{tag: ['@LPD-57497', '@LPD-88752']},
 	async ({editVocabularyPage, page}) => {

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/categorization/vocabularies.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/categorization/vocabularies.spec.ts
@@ -512,7 +512,7 @@ test(
 			.getSiteByFriendlyUrlPath('cms')
 			.then((response) => response.id);
 
-		const spaceName = `Space ${getRandomString()}`;
+		const spaceName = getRandomString();
 
 		const {id: spaceId} =
 			await apiHelpers.headlessAssetLibrary.createAssetLibrary({

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/categorization/vocabularies.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/categorization/vocabularies.spec.ts
@@ -508,7 +508,9 @@ test(
 	'Hide a Space-restricted vocabulary from content in another Space',
 	{tag: '@LPD-89497'},
 	async ({apiHelpers, contentsPage, page}) => {
-		const site = await apiHelpers.headlessAdminSite.getSite('L_CMS');
+		const siteId = await apiHelpers.headlessAdminUser
+			.getSiteByFriendlyUrlPath('cms')
+			.then((response) => response.id);
 
 		const spaceName = `Space ${getRandomString()}`;
 
@@ -528,7 +530,7 @@ test(
 			categoryName,
 			contentsPage,
 			page,
-			siteId: site.id,
+			siteId,
 		});
 
 		await contentsPage.openSidePanel('Categorization');
@@ -547,7 +549,9 @@ test(
 	'Hide an asset-type-restricted vocabulary from content of another asset type',
 	{tag: '@LPD-89497'},
 	async ({apiHelpers, contentsPage, page}) => {
-		const site = await apiHelpers.headlessAdminSite.getSite('L_CMS');
+		const siteId = await apiHelpers.headlessAdminUser
+			.getSiteByFriendlyUrlPath('cms')
+			.then((response) => response.id);
 
 		const categoryName = getRandomString();
 
@@ -558,7 +562,7 @@ test(
 			categoryName,
 			contentsPage,
 			page,
-			siteId: site.id,
+			siteId,
 		});
 
 		await contentsPage.openSidePanel('Categorization');

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/pages/VocabulariesPage.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/pages/VocabulariesPage.ts
@@ -53,4 +53,8 @@ export class VocabulariesPage {
 			filter,
 		});
 	}
+
+	async search(value: string) {
+		await this.dataSetFragmentPage.search(value);
+	}
 }

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/pages/VocabulariesPage.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/pages/VocabulariesPage.ts
@@ -29,6 +29,10 @@ export class VocabulariesPage {
 		return this.dataSetFragmentPage.getRow(filter);
 	}
 
+	async clickCategoriesLink(name: string) {
+		await this.getItem(name).locator('a[href*="view-categories"]').click();
+	}
+
 	async deleteVocabulary(name: string) {
 		await this.execItemAction({
 			action: 'Delete',

--- a/modules/test/playwright/tests/site-cms-site-initializer/permissions/vocabularies.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/permissions/vocabularies.spec.ts
@@ -27,7 +27,7 @@ test(
 	'A Space Content Reviewer cannot access the Vocabularies admin page',
 	{tag: '@LPD-89497'},
 	async ({apiHelpers, page, spaceSummaryPage}) => {
-		const spaceName = `Space ${getRandomString()}`;
+		const spaceName = getRandomString();
 
 		await apiHelpers.headlessAssetLibrary.createAssetLibrary({
 			name: spaceName,

--- a/modules/test/playwright/tests/site-cms-site-initializer/permissions/vocabularies.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/permissions/vocabularies.spec.ts
@@ -1,0 +1,52 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
+import {loginTest} from '../../../fixtures/loginTest';
+import getRandomString from '../../../utils/getRandomString';
+import {PORTLET_URLS} from '../../../utils/portletUrls';
+import {addRoleMemberAndSwitch} from '../main/spaces/helpers/roleMembership';
+import {cmsPagesTest} from './fixtures/cmsPagesTest';
+
+const test = mergeTests(
+	cmsPagesTest,
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-11235': {enabled: false},
+		'LPD-17564': {enabled: true},
+	}),
+	loginTest()
+);
+
+test(
+	'A Space Content Reviewer cannot access the Vocabularies admin page',
+	{tag: '@LPD-89497'},
+	async ({apiHelpers, page, spaceSummaryPage}) => {
+		const spaceName = `Space ${getRandomString()}`;
+
+		await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			settings: {},
+			type: 'Space',
+		});
+
+		await addRoleMemberAndSwitch({
+			apiHelpers,
+			page,
+			role: 'Space Content Reviewer',
+			spaceName,
+			spaceSummaryPage,
+		});
+
+		await page.goto(PORTLET_URLS.cmsVocabularies);
+
+		await expect(
+			page.getByRole('heading', {name: 'Categorization'})
+		).toBeHidden();
+	}
+);


### PR DESCRIPTION
[LPD-89497](https://liferay.atlassian.net/browse/LPD-89497)

## Summary

- Adds 5 Playwright tests covering acceptance criteria from LPD-85664 (Categorization > Vocabularies):
  - Search vocabularies by name
  - Open categories from the Categories column link
  - Hide a Space-restricted vocabulary from content in another Space
  - Hide an asset-type-restricted vocabulary from content of another asset type
  - Non-admin (Space Content Reviewer) cannot access the Vocabularies admin page
- Extracts two reusable helpers: `createScopedVocabularyAndContent` (module-level) and `addRoleMember` (global util)
- Filter-by-asset-type AC intentionally not covered — surfaced a real product bug filed separately

## Test execution

```bash
cd modules/test/playwright

yarn test \
  tests/site-cms-site-initializer/main/categorization/vocabularies.spec.ts \
  tests/site-cms-site-initializer/permissions/vocabularies.spec.ts \
  tests/site-cms-site-initializer/main/spaces/roleBasedActions.spec.ts \
  -g "@LPD-89497|@LPD-85670"
```

Last local run: 13/13 passed in 2.3m.

---
_AI-assisted with Claude Code._