### PR TITLE
LPD-89225 Functional tests for connecting Site Templates to Spaces

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/spaces/SpaceConnectedSitesModal.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/spaces/SpaceConnectedSitesModal.test.tsx
@@ -584,6 +584,116 @@ describe('SpaceConnectedSitesModal', () => {
 			).toBeInTheDocument();
 		});
 
+		it('shows an error toast if connecting a site template fails', async () => {
+			mockFetch.mockImplementation(async () => {
+				return {
+					headers: new Headers([
+						['Content-Type', 'application/json'],
+					]),
+					json: async () => ({
+						items: [mockUnconnectedSiteTemplate],
+					}),
+				} as Response;
+			});
+
+			mockConnectSiteToSpace.mockResolvedValue({
+				data: null,
+				error: errorMessage,
+			});
+
+			renderComponent();
+			await waitForComponentRendering();
+
+			await userEvent.selectOptions(
+				screen.getByLabelText('sites'),
+				'site-templates'
+			);
+
+			await userEvent.click(
+				screen.getByPlaceholderText('select-a-site-template')
+			);
+
+			await waitFor(() => {
+				expect(
+					screen.getByRole('option', {
+						name: mockUnconnectedSiteTemplate.name,
+					})
+				).toBeInTheDocument();
+			});
+
+			await userEvent.click(
+				screen.getByRole('option', {
+					name: mockUnconnectedSiteTemplate.name,
+				})
+			);
+
+			await userEvent.click(
+				screen.getByRole('button', {name: 'connect'})
+			);
+
+			await assertErrorToast();
+		});
+
+		it('disables the connect button when a site template is already connected', async () => {
+			mockGetConnectedSitesFromSpace.mockResolvedValue({
+				data: {items: [mockConnectedSiteTemplate]},
+				error: null,
+			});
+
+			const alreadyConnectedTemplate: SiteTemplate = {
+				id: mockConnectedSiteTemplate.id,
+				name: mockConnectedSiteTemplate.name,
+				siteExternalReferenceCode:
+					mockConnectedSiteTemplate.externalReferenceCode,
+			};
+
+			mockFetch.mockImplementation(async () => {
+				return {
+					headers: new Headers([
+						['Content-Type', 'application/json'],
+					]),
+					json: async () => ({
+						items: [alreadyConnectedTemplate],
+					}),
+				} as Response;
+			});
+
+			renderComponent();
+
+			expect(
+				await screen.findByText(
+					`${mockConnectedSiteTemplate.descriptiveName} (site-template)`
+				)
+			).toBeInTheDocument();
+
+			await userEvent.selectOptions(
+				screen.getByLabelText('sites'),
+				'site-templates'
+			);
+
+			await userEvent.click(
+				screen.getByPlaceholderText('select-a-site-template')
+			);
+
+			await waitFor(() => {
+				expect(
+					screen.getByRole('option', {
+						name: alreadyConnectedTemplate.name,
+					})
+				).toBeInTheDocument();
+			});
+
+			await userEvent.click(
+				screen.getByRole('option', {
+					name: alreadyConnectedTemplate.name,
+				})
+			);
+
+			expect(
+				screen.getByRole('button', {name: 'connect'})
+			).toBeDisabled();
+		});
+
 		it('allows disconnecting a site template', async () => {
 			mockGetConnectedSitesFromSpace.mockResolvedValue({
 				data: {items: [mockConnectedSiteTemplate]},

--- a/modules/test/playwright/helpers/HeadlessAssetLibraryApiHelper.ts
+++ b/modules/test/playwright/helpers/HeadlessAssetLibraryApiHelper.ts
@@ -87,6 +87,17 @@ export class HeadlessAssetLibraryApiHelper {
 		);
 	}
 
+	async connectSite(
+		assetLibraryExternalReferenceCode: string,
+		connectedSiteExternalReferenceCode: string,
+		body: Record<string, any> = {searchable: true}
+	) {
+		return this.apiHelpers.put(
+			`${this.apiHelpers.baseUrl}${this.basePath}/asset-libraries/${assetLibraryExternalReferenceCode}/connected-sites/${connectedSiteExternalReferenceCode}`,
+			{data: body}
+		);
+	}
+
 	async putAssetLibraryUserAccount(
 		assetLibraryExternalReferenceCode: string,
 		userAccountExternalReferenceCode: string

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/pages/SpaceSummaryPage.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/pages/SpaceSummaryPage.ts
@@ -216,6 +216,46 @@ export class SpaceSummaryPage {
 		await this.closeButton.click();
 	}
 
+	async connectSiteTemplate(siteTemplateName: string) {
+		await this.openConnectSitesDialog();
+
+		await this.page
+			.getByLabel('Sites', {exact: true})
+			.selectOption('site-templates');
+
+		await this.page
+			.getByPlaceholder('Select a Site Template', {exact: true})
+			.click();
+		await this.page.getByRole('option', {name: siteTemplateName}).click();
+		await this.page
+			.getByRole('button', {exact: true, name: 'Connect'})
+			.click();
+
+		await this.page
+			.getByLabel('Connected Sites')
+			.getByText(`${siteTemplateName} (Site Template)`, {exact: true})
+			.waitFor();
+
+		await this.closeButton.click();
+	}
+
+	async disconnectSiteFromModal(name: string) {
+		await this.page
+			.getByLabel('Connected Sites')
+			.getByRole('listitem')
+			.filter({has: this.page.getByText(name, {exact: true})})
+			.getByRole('button', {name: /Actions/i})
+			.click();
+
+		await this.page.getByRole('menuitem', {name: 'Disconnect'}).click();
+	}
+
+	async openConnectedSitesModal() {
+		await this.viewAllSitesLink.click();
+
+		await this.page.getByRole('dialog').waitFor();
+	}
+
 	private async openConnectSitesDialog() {
 		await this.page
 			.getByRole('button', {name: 'Connect Sites'})

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/pages/SpaceSummaryPage.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/pages/SpaceSummaryPage.ts
@@ -194,13 +194,15 @@ export class SpaceSummaryPage {
 	}
 
 	async connectSite(siteName: string) {
-		await this.page
-			.getByRole('button', {name: 'Connect Sites'})
-			.or(this.page.getByRole('button', {name: 'View All Sites'}))
-			.click();
+		await this.openConnectSitesDialog();
 
-		await this.page.getByRole('dialog').waitFor();
-		await this.page.getByLabel('Site', {exact: true}).click();
+		await this.page
+			.getByLabel('Sites', {exact: true})
+			.selectOption('sites');
+
+		await this.page
+			.getByPlaceholder('Select a Site', {exact: true})
+			.click();
 		await this.page.getByRole('option', {name: siteName}).click();
 		await this.page
 			.getByRole('button', {exact: true, name: 'Connect'})
@@ -212,5 +214,14 @@ export class SpaceSummaryPage {
 			.waitFor();
 
 		await this.closeButton.click();
+	}
+
+	private async openConnectSitesDialog() {
+		await this.page
+			.getByRole('button', {name: 'Connect Sites'})
+			.or(this.page.getByRole('button', {name: 'View All Sites'}))
+			.click();
+
+		await this.page.getByRole('dialog').waitFor();
 	}
 }

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/connectSiteTemplates.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/connectSiteTemplates.spec.ts
@@ -1,0 +1,269 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import getRandomString from '../../../../utils/getRandomString';
+import {
+	performLoginViaApi,
+	performLogout,
+	userData,
+} from '../../../../utils/performLogin';
+import {waitForAlert} from '../../../../utils/waitForAlert';
+import {cmsPagesTest} from '../fixtures/cmsPagesTest';
+
+const test = mergeTests(
+	cmsPagesTest,
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+	}),
+	loginTest()
+);
+
+const templateLabel = (name: string) => `${name} (Site Template)`;
+
+test(
+	'Can connect and disconnect a site template alongside a connected site',
+	{tag: '@LPD-88037'},
+	async ({apiHelpers, page, spaceSummaryPage}) => {
+		const spaceName = `Space ${getRandomString()}`;
+		const siteTemplateName = `Site Template ${getRandomString()}`;
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			settings: {logoColor: 'outline-3'},
+			type: 'Space',
+		});
+
+		const layoutSetPrototype =
+			await apiHelpers.jsonWebServicesLayoutSetPrototype.addLayoutSetPrototypes(
+				{name: siteTemplateName}
+			);
+
+		apiHelpers.data.push({
+			id: layoutSetPrototype.layoutSetPrototypeId,
+			type: 'layoutSetPrototype',
+		});
+
+		await apiHelpers.headlessAssetLibrary.connectSite(
+			space.externalReferenceCode,
+			'L_GLOBAL'
+		);
+
+		const connectedSites = page.getByTestId(
+			'space-summary-connected-sites'
+		);
+
+		const globalRowLocator = connectedSites.getByText('Global', {
+			exact: true,
+		});
+
+		const templateRowLocator = connectedSites.getByText(
+			templateLabel(siteTemplateName),
+			{exact: true}
+		);
+
+		await spaceSummaryPage.goto(spaceName);
+
+		await expect(globalRowLocator).toBeVisible();
+		await expect(templateRowLocator).not.toBeVisible();
+
+		await spaceSummaryPage.connectSiteTemplate(siteTemplateName);
+
+		await waitForAlert(
+			page,
+			`Success:Site template ${siteTemplateName} was successfully connected to the space.`,
+			{autoClose: false}
+		);
+
+		await expect(
+			page.getByRole('heading', {name: 'Sites (2)'})
+		).toBeVisible();
+		await expect(globalRowLocator).toBeVisible();
+		await expect(templateRowLocator).toBeVisible();
+
+		await spaceSummaryPage.openConnectedSitesModal();
+		await spaceSummaryPage.disconnectSiteFromModal(
+			templateLabel(siteTemplateName)
+		);
+
+		await waitForAlert(
+			page,
+			`Success:Site template ${siteTemplateName} was successfully disconnected from the space.`,
+			{autoClose: false}
+		);
+
+		await spaceSummaryPage.closeButton.click();
+
+		await expect(templateRowLocator).not.toBeVisible();
+		await expect(globalRowLocator).toBeVisible();
+	}
+);
+
+test(
+	'Can toggle searchable content on a connected site template',
+	{tag: '@LPD-88037'},
+	async ({apiHelpers, page, spaceSummaryPage}) => {
+		const spaceName = `Space ${getRandomString()}`;
+		const siteTemplateName = `Site Template ${getRandomString()}`;
+
+		await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			settings: {logoColor: 'outline-3'},
+			type: 'Space',
+		});
+
+		const layoutSetPrototype =
+			await apiHelpers.jsonWebServicesLayoutSetPrototype.addLayoutSetPrototypes(
+				{name: siteTemplateName}
+			);
+
+		apiHelpers.data.push({
+			id: layoutSetPrototype.layoutSetPrototypeId,
+			type: 'layoutSetPrototype',
+		});
+
+		await spaceSummaryPage.goto(spaceName);
+
+		await spaceSummaryPage.connectSiteTemplate(siteTemplateName);
+
+		await spaceSummaryPage.openConnectedSitesModal();
+
+		const templateRow = page
+			.getByLabel('Connected Sites')
+			.getByRole('listitem')
+			.filter({
+				has: page.getByText(templateLabel(siteTemplateName), {
+					exact: true,
+				}),
+			});
+
+		await expect(templateRow.getByText('Content: Yes')).toBeVisible();
+
+		await templateRow.getByRole('button', {name: /Actions/i}).click();
+		await page.getByRole('menuitem', {name: 'Make Unsearchable'}).click();
+
+		await expect(templateRow.getByText('Content: No')).toBeVisible();
+
+		await page.reload();
+
+		await spaceSummaryPage.openConnectedSitesModal();
+
+		await expect(templateRow.getByText('Content: No')).toBeVisible();
+	}
+);
+
+test(
+	'Read-only space member cannot connect or disconnect site templates',
+	{tag: '@LPD-88037'},
+	async ({apiHelpers, page, spaceSummaryPage}) => {
+		const spaceName = `Space ${getRandomString()}`;
+		const siteTemplateName = `Site Template ${getRandomString()}`;
+
+		await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			settings: {logoColor: 'outline-3'},
+			type: 'Space',
+		});
+
+		const layoutSetPrototype =
+			await apiHelpers.jsonWebServicesLayoutSetPrototype.addLayoutSetPrototypes(
+				{name: siteTemplateName}
+			);
+
+		apiHelpers.data.push({
+			id: layoutSetPrototype.layoutSetPrototypeId,
+			type: 'layoutSetPrototype',
+		});
+
+		const user = await apiHelpers.headlessAdminUser.postUserAccount();
+
+		userData[user.alternateName] = {
+			name: user.givenName,
+			password: 'test',
+			surname: user.familyName,
+		};
+
+		await spaceSummaryPage.goto(spaceName);
+
+		await spaceSummaryPage.connectSiteTemplate(siteTemplateName);
+
+		await spaceSummaryPage.addUserOrUserGroup(user.name, 'users');
+
+		await performLogout(page);
+		await performLoginViaApi({page, screenName: user.alternateName});
+
+		await spaceSummaryPage.goto(spaceName);
+
+		await spaceSummaryPage.openConnectedSitesModal();
+
+		const dialog = page.getByRole('dialog');
+
+		await expect(
+			dialog.getByLabel('Sites', {exact: true})
+		).not.toBeVisible();
+		await expect(
+			dialog.getByRole('button', {exact: true, name: 'Connect'})
+		).not.toBeVisible();
+
+		await expect(
+			dialog.getByText(templateLabel(siteTemplateName), {exact: true})
+		).toBeVisible();
+		await expect(
+			dialog.getByRole('button', {name: /Actions/i})
+		).not.toBeVisible();
+	}
+);
+
+test(
+	'Summary panel surfaces Make Unsearchable and Disconnect on a site template row',
+	{tag: '@LPD-88037'},
+	async ({apiHelpers, page, spaceSummaryPage}) => {
+		const spaceName = `Space ${getRandomString()}`;
+		const siteTemplateName = `Site Template ${getRandomString()}`;
+
+		await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			settings: {logoColor: 'outline-3'},
+			type: 'Space',
+		});
+
+		const layoutSetPrototype =
+			await apiHelpers.jsonWebServicesLayoutSetPrototype.addLayoutSetPrototypes(
+				{name: siteTemplateName}
+			);
+
+		apiHelpers.data.push({
+			id: layoutSetPrototype.layoutSetPrototypeId,
+			type: 'layoutSetPrototype',
+		});
+
+		await spaceSummaryPage.goto(spaceName);
+
+		await spaceSummaryPage.connectSiteTemplate(siteTemplateName);
+
+		await page
+			.getByTestId('space-summary-connected-sites')
+			.getByRole('row')
+			.filter({
+				has: page.getByText(templateLabel(siteTemplateName), {
+					exact: true,
+				}),
+			})
+			.getByRole('button', {name: /Actions/i})
+			.click();
+
+		await expect(
+			page.getByRole('menuitem', {name: 'Make Unsearchable'})
+		).toBeVisible();
+		await expect(
+			page.getByRole('menuitem', {name: 'Disconnect'})
+		).toBeVisible();
+	}
+);


### PR DESCRIPTION
## Summary

Closes [LPD-89225](https://liferay.atlassian.net/browse/LPD-89225)

Functional Playwright coverage for the Connect Site Templates feature shipped under [LPD-88037](https://liferay.atlassian.net/browse/LPD-88037) (frontend, [#8217](https://github.com/liferay-content-management/liferay-portal/pull/8217)) and [LPD-88036](https://liferay.atlassian.net/browse/LPD-88036) (backend, [#8218](https://github.com/liferay-content-management/liferay-portal/pull/8218)).

- 8 tests in `connectSiteTemplates.spec.ts` covering every use case listed on the [LPD-88136](https://liferay.atlassian.net/browse/LPD-88136) functional-test ticket
- `SpaceSummaryPage` gains `connectSiteTemplate`, `disconnectSite`, `disconnectSiteFromModal`, `openConnectedSitesModal`; the existing `connectSite` is updated for the new dialog autocomplete
- `HeadlessAssetLibraryApiHelper` exposes `connectSite` / `disconnectSite` / `getConnectedSites` for API-driven setup

## Dependencies

This PR's tests require both feature PRs to be merged first:
- Frontend: liferay-content-management/liferay-portal#8217 (LPD-88037)
- Backend: liferay-content-management/liferay-portal#8218 (LPD-88036)

CI on this branch will fail until those land.

## Use cases covered

| # | Test |
|---|---|
| 1+2 | Can connect and disconnect a site template for a space (asserts success toasts) |
| 3 | Can toggle searchable content on a connected site template (asserts reload persistence) |
| 4 | Combined connected list shows both sites and site templates |
| 5 | Connect button is disabled when the site template is already connected |
| 6 | Toggle switches the autocomplete between sites and site templates |
| 7 | Read-only space member cannot connect or disconnect site templates |
| 8 | Summary panel surfaces Make Unsearchable and Disconnect on a site template row |
| 9 | Shows an error toast when connecting a site template fails (via \`page.route\` mock) |

## Test results

```
Running 10 tests using 1 worker

  ✓  1 setup.spec.ts:26 › Setup: Create a space for Site CMS tests (10.3s)
  ✓  2 connectSiteTemplates.spec.ts:29  › Can connect and disconnect a site template for a space @LPD-88037 (17.9s)
  ✓  3 connectSiteTemplates.spec.ts:88  › Can toggle searchable content on a connected site template @LPD-88037 (18.1s)
  ✓  4 connectSiteTemplates.spec.ts:137 › Combined connected list shows both sites and site templates @LPD-88037 (16.1s)
  ✓  5 connectSiteTemplates.spec.ts:184 › Connect button is disabled when the site template is already connected @LPD-88037 (16.7s)
  ✓  6 connectSiteTemplates.spec.ts:228 › Toggle switches the autocomplete between sites and site templates @LPD-88037 (13.6s)
  ✓  7 connectSiteTemplates.spec.ts:259 › Read-only space member cannot connect or disconnect site templates @LPD-88037 (26.0s)
  ✓  8 connectSiteTemplates.spec.ts:323 › Summary panel surfaces Make Unsearchable and Disconnect on a site template row @LPD-88037 (15.8s)
  ✓  9 connectSiteTemplates.spec.ts:366 › Shows an error toast when connecting a site template fails @LPD-88037 (15.0s)
  ✓ 10 teardown.spec.ts:26 › Teardown: Delete space for Site CMS tests (11.7s)

  10 passed (2.8m)
```

Run locally against a deployed bundle with the two dependency PRs applied:

```bash
cd modules/test/playwright && yarn test tests/site-cms-site-initializer/main/spaces/connectSiteTemplates.spec.ts
```