### PR TITLE
LPD-85356 Add functional tests for CMS User Flows Improvements

### DIFF
--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/util/test/CMSUserUtilTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/util/test/CMSUserUtilTest.java
@@ -21,7 +21,6 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
-import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
@@ -29,6 +28,8 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.site.cms.site.initializer.test.util.CMSTestUtil;
 import com.liferay.site.cms.site.initializer.util.CMSUserUtil;
+
+import java.util.Arrays;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -117,11 +118,14 @@ public class CMSUserUtilTest {
 	}
 
 	private void _assertUserIds(long... expectedUserIds) {
-		Assert.assertTrue(
-			ArrayUtil.containsAll(
-				TransformUtil.transformToLongArray(
-					CMSUserUtil.getUsers(), User::getUserId),
-				expectedUserIds));
+		long[] actualUserIds = TransformUtil.transformToLongArray(
+			CMSUserUtil.getUsers(), User::getUserId);
+
+		Arrays.sort(actualUserIds);
+
+		Arrays.sort(expectedUserIds);
+
+		Assert.assertArrayEquals(expectedUserIds, actualUserIds);
 	}
 
 	private void _setUser(User user) {

--- a/modules/test/playwright/helpers/HeadlessAssetLibraryApiHelper.ts
+++ b/modules/test/playwright/helpers/HeadlessAssetLibraryApiHelper.ts
@@ -60,4 +60,24 @@ export class HeadlessAssetLibraryApiHelper {
 			`${this.apiHelpers.baseUrl}${this.basePath}/asset-libraries/${externalReferenceCode}`
 		);
 	}
+
+	async putAssetLibraryUserAccount(
+		assetLibraryExternalReferenceCode: string,
+		userAccountExternalReferenceCode: string
+	) {
+		return this.apiHelpers.put(
+			`${this.apiHelpers.baseUrl}${this.basePath}/asset-libraries/${assetLibraryExternalReferenceCode}/user-accounts/${userAccountExternalReferenceCode}`
+		);
+	}
+
+	async putAssetLibraryUserAccountRoles(
+		assetLibraryExternalReferenceCode: string,
+		userAccountExternalReferenceCode: string,
+		roleNames: string[]
+	) {
+		return this.apiHelpers.put(
+			`${this.apiHelpers.baseUrl}${this.basePath}/asset-libraries/${assetLibraryExternalReferenceCode}/user-accounts/${userAccountExternalReferenceCode}/roles`,
+			{data: roleNames.map((name) => ({name}))}
+		);
+	}
 }

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/all.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/all.spec.ts
@@ -17,6 +17,7 @@ import getRandomString from '../../../utils/getRandomString';
 import performLogin, {
 	performLoginViaApi,
 	performLogout,
+	performUserSwitchViaApi,
 	userData,
 } from '../../../utils/performLogin';
 import {waitForAlert} from '../../../utils/waitForAlert';
@@ -2200,5 +2201,70 @@ test(
 				);
 			}
 		}
+	}
+);
+
+test(
+	"Author filter lists only members of the current user's Spaces",
+	{tag: '@LPD-70773'},
+	async ({apiHelpers, assetsPage, page}) => {
+		const space1 = await apiHelpers.headlessAssetLibrary.createAssetLibrary(
+			{
+				name: `Space ${getRandomString()}`,
+				settings: {},
+				type: 'Space',
+			}
+		);
+
+		const space2 = await apiHelpers.headlessAssetLibrary.createAssetLibrary(
+			{
+				name: `Space ${getRandomString()}`,
+				settings: {},
+				type: 'Space',
+			}
+		);
+
+		const viewer = await apiHelpers.headlessAdminUser.postUserAccount();
+
+		userData[viewer.alternateName] = {
+			name: viewer.givenName,
+			password: 'test',
+			surname: viewer.familyName,
+		};
+
+		await apiHelpers.headlessAssetLibrary.putAssetLibraryUserAccount(
+			space1.externalReferenceCode,
+			viewer.externalReferenceCode
+		);
+
+		const insider = await apiHelpers.headlessAdminUser.postUserAccount();
+		const insiderFullName = `${insider.givenName} ${insider.familyName}`;
+
+		await apiHelpers.headlessAssetLibrary.putAssetLibraryUserAccount(
+			space1.externalReferenceCode,
+			insider.externalReferenceCode
+		);
+
+		const outsider = await apiHelpers.headlessAdminUser.postUserAccount();
+		const outsiderFullName = `${outsider.givenName} ${outsider.familyName}`;
+
+		await apiHelpers.headlessAssetLibrary.putAssetLibraryUserAccount(
+			space2.externalReferenceCode,
+			outsider.externalReferenceCode
+		);
+
+		await performUserSwitchViaApi(page, viewer.alternateName);
+
+		await assetsPage.gotoAll();
+
+		await page.getByRole('button', {name: 'Filter'}).click();
+		await page.getByRole('menuitem', {name: 'Author'}).click();
+
+		await expect(
+			page.getByRole('checkbox', {name: insiderFullName})
+		).toBeVisible();
+		await expect(
+			page.getByRole('checkbox', {name: outsiderFullName})
+		).toBeHidden();
 	}
 );

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/all.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/all.spec.ts
@@ -2268,3 +2268,72 @@ test(
 		).toBeHidden();
 	}
 );
+
+test(
+	"All section lists only content from the current user's Spaces",
+	{tag: '@LPD-76453'},
+	async ({apiHelpers, assetsPage, page}) => {
+		const space1 = await apiHelpers.headlessAssetLibrary.createAssetLibrary(
+			{
+				name: `Space ${getRandomString()}`,
+				settings: {},
+				type: 'Space',
+			}
+		);
+
+		const space2 = await apiHelpers.headlessAssetLibrary.createAssetLibrary(
+			{
+				name: `Space ${getRandomString()}`,
+				settings: {},
+				type: 'Space',
+			}
+		);
+
+		const insideTitle = `Content ${getRandomString()}`;
+		const outsideTitle = `Content ${getRandomString()}`;
+
+		await apiHelpers.objectEntry.postObjectEntry(
+			{
+				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				title: insideTitle,
+			},
+			'cms/basic-web-contents',
+			space1.name
+		);
+
+		await apiHelpers.objectEntry.postObjectEntry(
+			{
+				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				title: outsideTitle,
+			},
+			'cms/basic-web-contents',
+			space2.name
+		);
+
+		const viewer = await apiHelpers.headlessAdminUser.postUserAccount();
+
+		userData[viewer.alternateName] = {
+			name: viewer.givenName,
+			password: 'test',
+			surname: viewer.familyName,
+		};
+
+		await apiHelpers.headlessAssetLibrary.putAssetLibraryUserAccount(
+			space1.externalReferenceCode,
+			viewer.externalReferenceCode
+		);
+
+		await performUserSwitchViaApi(page, viewer.alternateName);
+
+		await assetsPage.gotoAll();
+
+		await expect(assetsPage.getItem(insideTitle)).toBeVisible();
+		await expect(assetsPage.getItem(outsideTitle)).toBeHidden();
+
+		await test.step("Search results are scoped to the viewer's Spaces", async () => {
+			await page.getByPlaceholder('Search').fill(outsideTitle);
+
+			await expect(assetsPage.getItem(outsideTitle)).toBeHidden();
+		});
+	}
+);

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/categorization/vocabularies.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/categorization/vocabularies.spec.ts
@@ -5,16 +5,20 @@
 
 import {expect, mergeTests} from '@playwright/test';
 
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
 import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
 import {loginTest} from '../../../../fixtures/loginTest';
 import {checkAccessibility} from '../../../../utils/checkAccessibility';
 import {clickAndExpectToBeVisible} from '../../../../utils/clickAndExpectToBeVisible';
 import {getRandomInt} from '../../../../utils/getRandomInt';
 import getRandomString from '../../../../utils/getRandomString';
+import {categorizationPagesTest} from '../fixtures/categorizationPagesTest';
 import {cmsPagesTest} from '../fixtures/cmsPagesTest';
 
 const test = mergeTests(
+	categorizationPagesTest,
 	cmsPagesTest,
+	dataApiHelpersTest,
 	featureFlagsTest({
 		'LPD-17564': {enabled: true},
 	}),
@@ -129,6 +133,57 @@ test(
 		await expect(
 			page.getByRole('heading', {name: 'Permissions'})
 		).toBeVisible();
+	}
+);
+
+test(
+	'Add category from vocabulary dropdown actions',
+	{tag: '@LPD-69691'},
+	async ({
+		apiHelpers,
+		categoriesPage,
+		editCategoryPage,
+		page,
+		vocabulariesPage,
+	}) => {
+		const siteId = await apiHelpers.headlessAdminUser
+			.getSiteByFriendlyUrlPath('cms')
+			.then((response) => response.id);
+
+		const vocabularyName = getRandomString();
+
+		await apiHelpers.headlessAdminTaxonomy.postSiteTaxonomyVocabulary({
+			assetLibraries: [{id: -1}],
+			assetTypes: [
+				{
+					required: true,
+					subtype: 'AllAssetSubtypes',
+					type: 'AllAssetTypes',
+				},
+			],
+			name: vocabularyName,
+			siteId,
+			visibilityType: 'PUBLIC',
+		});
+
+		await vocabulariesPage.goto();
+
+		await vocabulariesPage.execItemAction({
+			action: 'Add Category',
+			filter: vocabularyName,
+		});
+
+		await expect(page.getByText('Basic Info')).toBeVisible();
+
+		const categoryName = getRandomString();
+
+		await editCategoryPage.fillName(categoryName);
+		await editCategoryPage.clickSave();
+
+		await categoriesPage.assertBreadcrumbItemText(0, 'Categorization');
+		await categoriesPage.assertBreadcrumbItemText(1, vocabularyName);
+
+		await expect(categoriesPage.getItem(categoryName)).toBeVisible();
 	}
 );
 

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/members.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/members.spec.ts
@@ -10,6 +10,10 @@ import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
 import {loginTest} from '../../../../fixtures/loginTest';
 import {DataApiHelpers} from '../../../../helpers/ApiHelpers';
 import getRandomString from '../../../../utils/getRandomString';
+import {
+	performUserSwitchViaApi,
+	userData,
+} from '../../../../utils/performLogin';
 import {cmsPagesTest} from '../fixtures/cmsPagesTest';
 import {SpaceSummaryPage} from '../pages/SpaceSummaryPage';
 
@@ -117,5 +121,69 @@ test(
 				role: 'Space Content Reviewer',
 				spaceSummaryPage,
 			}));
+	}
+);
+
+test(
+	'A non-admin space member can search members in the space',
+	{tag: '@LPD-58201'},
+	async ({apiHelpers, page, spaceSummaryPage}) => {
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: `Space ${getRandomString()}`,
+			settings: {},
+			type: 'Space',
+		});
+
+		const viewer = await apiHelpers.headlessAdminUser.postUserAccount();
+		const viewerFullName = `${viewer.givenName} ${viewer.familyName}`;
+
+		userData[viewer.alternateName] = {
+			name: viewer.givenName,
+			password: 'test',
+			surname: viewer.familyName,
+		};
+
+		await apiHelpers.headlessAssetLibrary.putAssetLibraryUserAccount(
+			space.externalReferenceCode,
+			viewer.externalReferenceCode
+		);
+
+		const reviewer = await apiHelpers.headlessAdminUser.postUserAccount();
+		const reviewerFullName = `${reviewer.givenName} ${reviewer.familyName}`;
+
+		await apiHelpers.headlessAssetLibrary.putAssetLibraryUserAccount(
+			space.externalReferenceCode,
+			reviewer.externalReferenceCode
+		);
+
+		await apiHelpers.headlessAssetLibrary.putAssetLibraryUserAccountRoles(
+			space.externalReferenceCode,
+			reviewer.externalReferenceCode,
+			['Asset Library Content Reviewer']
+		);
+
+		await performUserSwitchViaApi(page, viewer.alternateName);
+
+		await spaceSummaryPage.goto(space.name);
+		await spaceSummaryPage.viewAllMembersLink.click();
+
+		const searchInput = page.getByPlaceholder('Search for name or email');
+
+		await expect(searchInput).toBeVisible();
+
+		await searchInput.fill(reviewer.givenName);
+
+		const reviewerRow = page
+			.getByRole('listitem')
+			.filter({hasText: reviewerFullName});
+
+		await expect(reviewerRow).toBeVisible();
+		await expect(
+			page.getByRole('listitem').filter({hasText: viewerFullName})
+		).toBeHidden();
+
+		await expect(
+			reviewerRow.getByRole('button', {name: 'Space Content Reviewer'})
+		).toBeHidden();
 	}
 );

--- a/modules/test/playwright/types/account.d.ts
+++ b/modules/test/playwright/types/account.d.ts
@@ -6,6 +6,7 @@
 type TUserAccount = {
 	alternateName?: string;
 	emailAddress?: string;
+	externalReferenceCode?: string;
 	familyName?: string;
 	givenName?: string;
 	id?: string;


### PR DESCRIPTION
## Executive summary

LPD-85356 is the Functional Test sub-task under epic [LPD-70434 — CMS User Flows Improvements](https://liferay.atlassian.net/browse/LPD-70434). The epic has six closed Stories. This branch closes the functional-test gap by adding new Playwright tests, tightening one integration test, and identifying the cases already covered elsewhere.

## Coverage

| Story | Title | Coverage |
|---|---|---|
| LPD-59948 | List view for folders/content in Spaces | Already covered by `spaceSummary.spec.ts` (existing) |
| LPD-69691 | Add category from vocabulary dropdown | **New Playwright test** in `vocabularies.spec.ts` |
| LPD-69876 | Filter content structures by Space | Covered by LPD-89342's `Content Structures list can be filtered by space with include and exclude` test |
| LPD-58201 | Non-admin Space member search | **New Playwright test** in `members.spec.ts` + new headless asset-library membership helpers (`putAssetLibraryUserAccount`, `putAssetLibraryUserAccountRoles`) |
| LPD-70773 | Author filter scoped to current user's Spaces | **Tightened** `CMSUserUtilTest.testGetUsers` (was one-way \`containsAll\`; now exact-set with sorted \`assertArrayEquals\`) + **new Playwright test** in \`all.spec.ts\` |
| LPD-76453 | Members only see content from their Spaces | Existing tight integration test (\`testGetCMSSectionFilterString\`) + **new Playwright test** in \`all.spec.ts\` for end-to-end FDS wiring |

## Test execution

**Playwright** (run from \`modules/test/playwright\`):

\`\`\`bash
yarn test \\
  tests/site-cms-site-initializer/main/categorization/vocabularies.spec.ts \\
  tests/site-cms-site-initializer/main/spaces/members.spec.ts \\
  tests/site-cms-site-initializer/main/all.spec.ts \\
  --grep "Add category from vocabulary dropdown actions|non-admin space member can search|Author filter lists only members|All section lists only content"
\`\`\`

**Integration** (CMSUserUtilTest tightening):

\`\`\`bash
gradlew -p modules/apps/site/site-cms-site-initializer-test testIntegration --tests CMSUserUtilTest
\`\`\`

## Test plan

- [x] All 4 new Playwright tests pass locally (49.9s total)
- [x] \`CMSUserUtilTest.testGetUsers\` passes after tightening

## Jira

https://liferay.atlassian.net/browse/LPD-85356

---

_AI-assisted with Claude Code._