### PR TITLE
LPD-89496 Add Playwright tests for Embedded Content Structures

### DIFF
--- a/modules/test/playwright/tests/site-cms-site-initializer/main/contentEditor.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/contentEditor.spec.ts
@@ -1616,6 +1616,19 @@ test(
 
 		await structureBuilderPage.publishStructure();
 
+		// Verify the embedded structure renders in the customize editor
+
+		await structureBuilderPage.customizeEditor();
+
+		await expect(
+			page.locator('.lfr-layout-structure-item-basic-component-accordion')
+		).toBeVisible();
+
+		await page
+			.locator('.management-bar')
+			.getByRole('link', {name: 'Back'})
+			.click();
+
 		// Go to CMS Contents
 
 		await contentsPage.goto();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89496

## Executive Summary

Extends the existing `Create item with referenced structure` Playwright
test to verify the customize editor renders the embedded structure when
the parent contains a Referenced Content Structure. The remaining
behavioral requirements from story LPD-85660 — embedding Content into
File Structures and vice versa, root-type stability after embedding,
and content authoring against a parent with an embedded structure —
are already covered by existing tests in `referencedStructures.spec.ts`
and `Create item with referenced structure` itself. The story's
space-availability requirement is not enforced by the platform today
and is filed separately as a platform bug (LPD-89537).

## How to launch the test

From ``modules/test/playwright``:

``` bash
PORTAL_URL=http://localhost:8080 yarn test \
    --project=site-cms-site-initializer.main \
    --grep "Create item with referenced structure"
```

_AI-assisted with Claude Code._