### PR TITLE
LPD-89104 ,LPD-89566 Liferay CMS - GA Stabilization Test Coverage - Assets > Recycle Bin

### DIFF
--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/trash/test/ObjectEntryTrashRetentionTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/trash/test/ObjectEntryTrashRetentionTest.java
@@ -1,0 +1,194 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.internal.trash.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.field.util.ObjectFieldUtil;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.related.models.test.util.ObjectEntryTestUtil;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.test.util.ObjectDefinitionTestUtil;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.Sync;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.PrefsPropsUtil;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.Time;
+import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.trash.TrashHelper;
+import com.liferay.trash.model.TrashEntry;
+import com.liferay.trash.service.TrashEntryLocalServiceUtil;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Attila Bakay
+ */
+@FeatureFlag("LPD-17564")
+@RunWith(Arquillian.class)
+@Sync(cleanTransaction = true)
+public class ObjectEntryTrashRetentionTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_deleteAllTrashEntries();
+
+		_group = _updateTrashEntriesMaxAge(
+			GroupTestUtil.addGroup(
+				TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+				GroupConstants.DEFAULT_PARENT_GROUP_ID),
+			_MAX_AGE_DAYS);
+
+		_objectDefinition = ObjectDefinitionTestUtil.publishObjectDefinition(
+			Collections.singletonList(
+				ObjectFieldUtil.createObjectField(
+					ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+					ObjectFieldConstants.DB_TYPE_STRING,
+					RandomTestUtil.randomString(),
+					RandomTestUtil.randomString())),
+			ObjectDefinitionConstants.SCOPE_SITE);
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		_deleteAllTrashEntries();
+	}
+
+	@Test
+	public void testCheckEntriesRemovesExpiredObjectEntry() throws Exception {
+		ObjectEntry expiredObjectEntry = _addObjectEntryAndMoveToTrash(true);
+		ObjectEntry freshObjectEntry = _addObjectEntryAndMoveToTrash(false);
+
+		TrashEntryLocalServiceUtil.checkEntries();
+
+		String className = _objectDefinition.getClassName();
+
+		Assert.assertNull(
+			TrashEntryLocalServiceUtil.fetchEntry(
+				className, expiredObjectEntry.getObjectEntryId()));
+		Assert.assertNotNull(
+			TrashEntryLocalServiceUtil.fetchEntry(
+				className, freshObjectEntry.getObjectEntryId()));
+	}
+
+	private ObjectEntry _addObjectEntryAndMoveToTrash(boolean expired)
+		throws Exception {
+
+		ObjectEntry objectEntry = ObjectEntryTestUtil.addObjectEntry(
+			_group.getGroupId(), _objectDefinition.getObjectDefinitionId(),
+			Collections.emptyMap());
+
+		_objectEntryLocalService.moveObjectEntryToTrash(
+			TestPropsValues.getUserId(), objectEntry,
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		if (expired) {
+			int maxAgeMinutes = _trashHelper.getMaxAge(_group);
+
+			TrashEntry trashEntry = TrashEntryLocalServiceUtil.getEntry(
+				_objectDefinition.getClassName(),
+				objectEntry.getObjectEntryId());
+
+			Date createDate = trashEntry.getCreateDate();
+
+			trashEntry.setCreateDate(
+				new Date(
+					createDate.getTime() - (maxAgeMinutes * Time.MINUTE) -
+						Time.DAY));
+
+			TrashEntryLocalServiceUtil.updateTrashEntry(trashEntry);
+		}
+
+		return objectEntry;
+	}
+
+	private void _deleteAllTrashEntries() {
+		List<TrashEntry> trashEntries =
+			TrashEntryLocalServiceUtil.getTrashEntries(
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+
+		for (TrashEntry trashEntry : trashEntries) {
+			TrashEntryLocalServiceUtil.deleteEntry(trashEntry);
+		}
+	}
+
+	private Group _updateTrashEntriesMaxAge(Group group, int days)
+		throws Exception {
+
+		UnicodeProperties typeSettingsUnicodeProperties =
+			group.getTypeSettingsProperties();
+
+		int companyTrashEntriesMaxAge = PrefsPropsUtil.getInteger(
+			group.getCompanyId(), PropsKeys.TRASH_ENTRIES_MAX_AGE);
+
+		int minutes;
+
+		if (days > 0) {
+			minutes = days * 1440;
+		}
+		else {
+			minutes = GetterUtil.getInteger(
+				typeSettingsUnicodeProperties.getProperty("trashEntriesMaxAge"),
+				companyTrashEntriesMaxAge);
+		}
+
+		if (minutes != companyTrashEntriesMaxAge) {
+			typeSettingsUnicodeProperties.setProperty(
+				"trashEntriesMaxAge", String.valueOf(minutes));
+		}
+		else {
+			typeSettingsUnicodeProperties.remove("trashEntriesMaxAge");
+		}
+
+		group.setTypeSettingsProperties(typeSettingsUnicodeProperties);
+
+		return GroupLocalServiceUtil.updateGroup(group);
+	}
+
+	private static final int _MAX_AGE_DAYS = 5;
+
+	private Group _group;
+	private ObjectDefinition _objectDefinition;
+
+	@Inject
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Inject
+	private TrashHelper _trashHelper;
+
+}

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/fragments/group/cms/fragments/vertical-navigation/index.html
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/fragments/group/cms/fragments/vertical-navigation/index.html
@@ -45,8 +45,9 @@
 		/]
 
 		[#list navItems as navItem]
-			[#if navItem.isBrowsable() || navItem.getChildren()?has_content]
-				[#assign navLayout = navItem.getLayout()! /]
+			[#assign navLayout = navItem.getLayout()! /]
+
+			[#if (navItem.isBrowsable() && navLayout?? && !navLayout.isHidden()) || navItem.getChildren()?has_content]
 
 				[#if !firstNavItem]
 					[#assign navItemsJSONArray = navItemsJSONArray + "," /]

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/model/listener/test/GroupModelListenerTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/model/listener/test/GroupModelListenerTest.java
@@ -14,7 +14,6 @@ import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
-import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -26,9 +25,6 @@ import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.site.cms.site.initializer.test.util.CMSTestUtil;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -57,10 +53,33 @@ public class GroupModelListenerTest {
 	}
 
 	@Test
-	public void testUpdateDepotEntry() throws Exception {
-		Layout layout = _getRecycleBinLayout(_cmsGroup);
+	public void testRemoveDepotEntryHidesLayout() throws Exception {
+		Layout layout = _getRecycleBinLayout();
+
+		layout = _setLayoutHidden(layout, false);
 
 		Assert.assertFalse(layout.isHidden());
+
+		DepotEntry depotEntry = _addDepotEntry();
+
+		_setTrashEnabled(depotEntry.getGroup(), Boolean.TRUE.toString());
+
+		Assert.assertFalse(layout.isHidden());
+
+		_depotEntryLocalService.deleteDepotEntry(depotEntry);
+
+		layout = _getRecycleBinLayout();
+
+		Assert.assertTrue(layout.isHidden());
+	}
+
+	@Test
+	public void testUpdateDepotEntry() throws Exception {
+		Layout layout = _getRecycleBinLayout();
+
+		layout = _setLayoutHidden(layout, false);
+
+		Assert.assertFalse(_getRecycleBinLayout().isHidden());
 
 		DepotEntry depotEntry = _addDepotEntry();
 
@@ -72,15 +91,21 @@ public class GroupModelListenerTest {
 			GetterUtil.getBoolean(
 				depotGroup.getTypeSettingsProperty("trashEnabled")));
 
+		Assert.assertFalse(layout.isHidden());
+
 		_setTrashEnabled(depotGroup, Boolean.FALSE.toString());
+
+		layout = _getRecycleBinLayout();
 
 		Assert.assertFalse(
 			GetterUtil.getBoolean(
 				depotGroup.getTypeSettingsProperty("trashEnabled")));
+
+		Assert.assertTrue(layout.isHidden());
 	}
 
 	private DepotEntry _addDepotEntry() throws Exception {
-		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
+		return _depotEntryLocalService.addDepotEntry(
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), StringUtil.randomString()
 			).build(),
@@ -89,15 +114,19 @@ public class GroupModelListenerTest {
 			).build(),
 			DepotConstants.TYPE_SPACE,
 			ServiceContextTestUtil.getServiceContext());
-
-		_depotEntries.add(depotEntry);
-
-		return depotEntry;
 	}
 
-	private Layout _getRecycleBinLayout(Group group) throws Exception {
+	private Layout _getRecycleBinLayout() throws Exception {
 		return _layoutLocalService.getLayoutByFriendlyURL(
-			group.getGroupId(), false, "/recycle-bin");
+			_cmsGroup.getGroupId(), false, "/recycle-bin");
+	}
+
+	private Layout _setLayoutHidden(Layout layout, boolean hidden)
+		throws Exception {
+
+		layout.setHidden(hidden);
+
+		return _layoutLocalService.updateLayout(layout);
 	}
 
 	private void _setTrashEnabled(Group group, String value) throws Exception {
@@ -115,9 +144,6 @@ public class GroupModelListenerTest {
 	}
 
 	private Group _cmsGroup;
-
-	@DeleteAfterTestRun
-	private final List<DepotEntry> _depotEntries = new ArrayList<>();
 
 	@Inject
 	private DepotEntryLocalService _depotEntryLocalService;

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/model/listener/GroupModelListener.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/model/listener/GroupModelListener.java
@@ -32,6 +32,16 @@ import org.osgi.service.component.annotations.Reference;
 public class GroupModelListener extends BaseModelListener<Group> {
 
 	@Override
+	public void onAfterRemove(Group group) throws ModelListenerException {
+		try {
+			_onAfterRemove(group);
+		}
+		catch (Exception exception) {
+			throw new ModelListenerException(exception);
+		}
+	}
+
+	@Override
 	public void onAfterUpdate(Group originalGroup, Group group)
 		throws ModelListenerException {
 
@@ -60,6 +70,31 @@ public class GroupModelListener extends BaseModelListener<Group> {
 			Long.class);
 	}
 
+	private void _onAfterRemove(Group group) throws Exception {
+		if (!group.isDepot() ||
+			!FeatureFlagManagerUtil.isEnabled(
+				group.getCompanyId(), "LPD-17564")) {
+
+			return;
+		}
+
+		Group cmsGroup = _groupLocalService.fetchGroup(
+			group.getCompanyId(), GroupConstants.CMS);
+
+		if (cmsGroup == null) {
+			return;
+		}
+
+		Long[] groupIds = _getDepotGroupIds(group.getCompanyId());
+
+		if (groupIds.length > 0) {
+			_updateRecycleBinLayout(cmsGroup, false);
+		}
+		else {
+			_updateRecycleBinLayout(cmsGroup, true);
+		}
+	}
+
 	private void _onAfterUpdate(Group originalGroup, Group group)
 		throws Exception {
 
@@ -79,20 +114,20 @@ public class GroupModelListener extends BaseModelListener<Group> {
 				return;
 			}
 
-			Group siteGroup = _groupLocalService.fetchGroup(
+			Group cmsGroup = _groupLocalService.fetchGroup(
 				group.getCompanyId(), GroupConstants.CMS);
 
-			if (siteGroup == null) {
+			if (cmsGroup == null) {
 				return;
 			}
 
 			Long[] groupIds = _getDepotGroupIds(group.getCompanyId());
 
 			if (groupIds.length > 0) {
-				_updateRecycleBinLayout(siteGroup, false);
+				_updateRecycleBinLayout(cmsGroup, false);
 			}
 			else {
-				_updateRecycleBinLayout(siteGroup, true);
+				_updateRecycleBinLayout(cmsGroup, true);
 			}
 		}
 	}

--- a/modules/test/playwright/helpers/HeadlessAssetLibraryApiHelper.ts
+++ b/modules/test/playwright/helpers/HeadlessAssetLibraryApiHelper.ts
@@ -55,6 +55,29 @@ export class HeadlessAssetLibraryApiHelper {
 		return response?.items;
 	}
 
+	async updateAssetLibrary({
+		externalReferenceCode,
+		name,
+		settings = {},
+		type = 'Space',
+	}: {
+		externalReferenceCode: string;
+		name: string;
+		settings?: any;
+		type?: string;
+	}) {
+		const data = JSON.stringify({
+			name,
+			settings,
+			type,
+		});
+
+		return this.apiHelpers.put(
+			`${this.apiHelpers.baseUrl}${this.basePath}/asset-libraries/${externalReferenceCode}`,
+			{data}
+		);
+	}
+
 	async deleteAssetLibrary(externalReferenceCode: string) {
 		return this.apiHelpers.delete(
 			`${this.apiHelpers.baseUrl}${this.basePath}/asset-libraries/${externalReferenceCode}`

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/recycleBin.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/recycleBin.spec.ts
@@ -1047,3 +1047,538 @@ test(
 		});
 	}
 );
+
+test(
+	'Recycle Bin menu entry is hidden when trashEnabled is false',
+	{tag: '@LPD-89104'},
+	async ({apiHelpers, page, spaceSummaryPage}) => {
+		const spaceName = getRandomString();
+
+		const allSpaces =
+			(await apiHelpers.headlessAssetLibrary.getAssetLibrariesPage(
+				`type eq 'Space'`
+			)) ?? [];
+
+		const spacesWithTrashEnabled = allSpaces.filter(
+			(s: any) => s.settings?.trashEnabled !== false
+		);
+
+		try {
+			for (const s of spacesWithTrashEnabled) {
+				await apiHelpers.headlessAssetLibrary.updateAssetLibrary({
+					externalReferenceCode: s.externalReferenceCode,
+					name: s.name,
+					settings: {trashEnabled: false},
+					type: 'Space',
+				});
+			}
+
+			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+				name: spaceName,
+				settings: {trashEnabled: false},
+				type: 'Space',
+			});
+
+			await spaceSummaryPage.goto(spaceName);
+
+			await expect(
+				page
+					.locator('.vertical-navigation-fragment')
+					.getByRole('menuitem', {name: 'Recycle Bin'})
+			).not.toBeVisible();
+		}
+		finally {
+			for (const s of spacesWithTrashEnabled) {
+				await apiHelpers.headlessAssetLibrary.updateAssetLibrary({
+					externalReferenceCode: s.externalReferenceCode,
+					name: s.name,
+					settings: {trashEnabled: true},
+					type: 'Space',
+				});
+			}
+		}
+	}
+);
+
+test(
+	'Recycle Bin menu entry is visible when trashEnabled is true',
+	{tag: '@LPD-89104'},
+	async ({apiHelpers, page, spaceSummaryPage}) => {
+		const spaceName = getRandomString();
+
+		await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			settings: {trashEnabled: true},
+			type: 'Space',
+		});
+
+		await spaceSummaryPage.goto(spaceName);
+
+		await expect(
+			page
+				.locator('.vertical-navigation-fragment')
+				.getByRole('menuitem', {name: 'Recycle Bin'})
+		).toBeVisible();
+	}
+);
+
+test(
+	'Recycle Bin row shows Space, Content Type, Removed By, and Removed Date',
+	{tag: '@LPD-89104'},
+	async ({apiHelpers, contentsPage, page, recycleBinPage}) => {
+		const contentName = getRandomString();
+		const spaceName = getRandomString();
+
+		await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			settings: {trashEnabled: true},
+			type: 'Space',
+		});
+
+		await apiHelpers.objectEntry.postObjectEntry(
+			{
+				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				title: contentName,
+			},
+			'cms/basic-web-contents',
+			spaceName
+		);
+
+		await test.step('Trash the content', async () => {
+			await contentsPage.goto();
+
+			await contentsPage.deleteContent(contentName);
+		});
+
+		await test.step('Row exposes the four metadata columns', async () => {
+			await recycleBinPage.goto();
+
+			const row = page.getByRole('row', {name: contentName});
+
+			await expect(row).toContainText(spaceName);
+			await expect(row).toContainText('Basic Web Content');
+			await expect(row).toContainText('Test Test');
+
+			await expect(row).toContainText(String(new Date().getFullYear()));
+		});
+	}
+);
+
+test(
+	'Filtering the Recycle Bin by Space narrows results to that space',
+	{tag: '@LPD-89104'},
+	async ({apiHelpers, contentsPage, page, recycleBinPage}) => {
+		const spaceName1 = getRandomString();
+		const spaceName2 = getRandomString();
+		const contentName1 = getRandomString();
+		const contentName2 = getRandomString();
+
+		const createdSpaces: Record<string, any> = {};
+
+		for (const name of [spaceName1, spaceName2]) {
+			createdSpaces[name] =
+				await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+					name,
+					settings: {trashEnabled: true},
+					type: 'Space',
+				});
+		}
+
+		for (const [space, content] of [
+			[spaceName1, contentName1],
+			[spaceName2, contentName2],
+		]) {
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: content,
+				},
+				'cms/basic-web-contents',
+				space
+			);
+		}
+
+		await test.step('Trash one content per space', async () => {
+			for (const content of [contentName1, contentName2]) {
+				await contentsPage.goto();
+
+				await contentsPage.deleteContent(content);
+			}
+		});
+
+		await test.step('Both rows are visible with no filter applied', async () => {
+			await recycleBinPage.goto();
+
+			await expect(
+				page.getByRole('row', {name: contentName1})
+			).toBeVisible();
+			await expect(
+				page.getByRole('row', {name: contentName2})
+			).toBeVisible();
+		});
+
+		await test.step('Apply a Space filter limited to Space A', async () => {
+			await page.getByRole('button', {name: 'Filter'}).click();
+
+			await page.getByRole('menuitem', {name: 'Space'}).click();
+
+			await page
+				.getByRole('checkbox', {
+					name: createdSpaces[spaceName1].assetLibraryKey,
+				})
+				.check();
+
+			await page.getByRole('button', {name: 'Add Filter'}).click();
+		});
+
+		await test.step('Only Space A content remains visible', async () => {
+			await expect(
+				page.getByRole('row', {name: contentName1})
+			).toBeVisible();
+			await expect(
+				page.getByRole('row', {name: contentName2})
+			).toBeHidden();
+		});
+	}
+);
+
+test(
+	'Restoring content whose original folder was permanently deleted lands at the Space root',
+	{tag: '@LPD-89104'},
+	async ({apiHelpers, contentsPage, page, recycleBinPage}) => {
+		const contentName = getRandomString();
+		const folderName = getRandomString();
+		const spaceName = getRandomString();
+
+		await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			settings: {trashEnabled: true},
+			type: 'Space',
+		});
+
+		const folder = await apiHelpers.objectFolder.createObjectEntryFolder({
+			parentObjectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+			scopeKey: spaceName,
+			title: folderName,
+		});
+
+		await apiHelpers.objectEntry.postObjectEntry(
+			{
+				objectEntryFolderExternalReferenceCode:
+					folder.externalReferenceCode,
+				title: contentName,
+			},
+			'cms/basic-web-contents',
+			spaceName
+		);
+
+		await test.step('Trash the content from inside the folder', async () => {
+			await contentsPage.goto();
+
+			await contentsPage.navigateTo(folderName);
+
+			await contentsPage.deleteContent(contentName);
+		});
+
+		await test.step('Permanently remove the parent folder', async () => {
+			await apiHelpers.objectFolder.deleteObjectEntryFolder(folder.id);
+
+			await recycleBinPage.goto();
+
+			await recycleBinPage.execItemAction({
+				action: 'Delete',
+				filter: folderName,
+			});
+
+			await expect(
+				recycleBinPage.deleteItemConfirmationText
+			).toBeVisible();
+
+			await recycleBinPage.deleteButton.last().click();
+
+			await waitForAlert(
+				page,
+				`Success:${folderName} has been permanently deleted.`
+			);
+		});
+
+		await test.step('Restore the content from the Recycle Bin', async () => {
+			await recycleBinPage.execItemAction({
+				action: 'Restore',
+				filter: contentName,
+			});
+
+			await waitForAlert(
+				page,
+				`Success:${contentName} was restored to Contents.`,
+				{autoClose: false}
+			);
+		});
+
+		await test.step('Content lives at the Space root, not under the deleted folder', async () => {
+			await contentsPage.goto();
+
+			await expect(
+				page.getByRole('row', {name: contentName})
+			).toBeVisible();
+
+			await expect(
+				page.getByRole('row', {name: folderName})
+			).toBeHidden();
+		});
+
+		await test.step('Clean up', async () => {
+			await contentsPage.deleteContent(contentName);
+		});
+	}
+);
+
+test(
+	'Space General Settings Recycle Bin panel honors trashEnabled and max age validation',
+	{tag: '@LPD-89104'},
+	async ({apiHelpers, page}) => {
+		const spaceName = getRandomString();
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			settings: {},
+			type: 'Space',
+		});
+
+		const {classNameId} =
+			await apiHelpers.jsonWebServicesClassName.fetchClassName(
+				'com.liferay.depot.model.DepotEntry'
+			);
+
+		await page.goto(`/web/cms/e/space-settings/${classNameId}/${space.id}`);
+
+		const enableCheckbox = page.getByRole('checkbox', {
+			name: 'Enable Recycle Bin',
+		});
+		const maxAgeField = page.getByRole('spinbutton', {
+			name: 'Trash Entries Max Age',
+		});
+		const saveButton = page.getByRole('button', {name: 'Save'});
+
+		await test.step('Panel renders with the checkbox checked and the max age field visible by default', async () => {
+			await expect(enableCheckbox).toBeChecked();
+			await expect(maxAgeField).toBeVisible();
+		});
+
+		await test.step('Disabling the bin hides the max age field', async () => {
+			await enableCheckbox.uncheck();
+			await expect(maxAgeField).toBeHidden();
+		});
+
+		await test.step('Re-enabling the bin shows the max age field again', async () => {
+			await enableCheckbox.check();
+			await expect(maxAgeField).toBeVisible();
+		});
+
+		await test.step('Max age is required when the bin is enabled', async () => {
+			await maxAgeField.fill('');
+			await saveButton.click();
+			await expect(
+				page.getByText('This field is required.')
+			).toBeVisible();
+		});
+
+		await test.step('Save succeeds when the bin is disabled with no max age', async () => {
+			await enableCheckbox.uncheck();
+			await expect(maxAgeField).toBeHidden();
+			await saveButton.click();
+			await waitForAlert(
+				page,
+				`Success:${spaceName} was saved successfully`
+			);
+		});
+	}
+);
+
+test(
+	'Recycle Bin shows the empty state when no entries exist',
+	{tag: '@LPD-89104'},
+	async ({page, recycleBinPage}) => {
+		await recycleBinPage.goto();
+
+		await expect(page.getByText('The Recycle Bin is empty.')).toBeVisible();
+	}
+);
+
+test(
+	'Restoring content whose original folder still exists puts it back in that folder',
+	{tag: '@LPD-89104'},
+	async ({apiHelpers, contentsPage, page, recycleBinPage}) => {
+		const contentName = getRandomString();
+		const folderName = getRandomString();
+		const spaceName = getRandomString();
+
+		await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			settings: {trashEnabled: true},
+			type: 'Space',
+		});
+
+		const folder = await apiHelpers.objectFolder.createObjectEntryFolder({
+			parentObjectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+			scopeKey: spaceName,
+			title: folderName,
+		});
+
+		await apiHelpers.objectEntry.postObjectEntry(
+			{
+				objectEntryFolderExternalReferenceCode:
+					folder.externalReferenceCode,
+				title: contentName,
+			},
+			'cms/basic-web-contents',
+			spaceName
+		);
+
+		await test.step('Trash the content from inside the folder', async () => {
+			await contentsPage.goto();
+
+			await contentsPage.navigateTo(folderName);
+
+			await contentsPage.deleteContent(contentName);
+		});
+
+		await test.step('Restore the content from the Recycle Bin', async () => {
+			await recycleBinPage.goto();
+
+			await recycleBinPage.execItemAction({
+				action: 'Restore',
+				filter: contentName,
+			});
+
+			await waitForAlert(
+				page,
+				`Success:${contentName} was restored to ${folderName}.`,
+				{autoClose: false}
+			);
+		});
+
+		await test.step('Content is back in the original folder, not at the Space root', async () => {
+			await contentsPage.goto();
+
+			await expect(
+				page.getByRole('row', {name: contentName})
+			).toBeHidden();
+
+			await contentsPage.navigateTo(folderName);
+
+			await expect(
+				page.getByRole('row', {name: contentName})
+			).toBeVisible();
+		});
+	}
+);
+
+test(
+	'Empty Recycle Bin bulk action permanently removes all entries',
+	{tag: '@LPD-89104'},
+	async ({apiHelpers, contentsPage, page, recycleBinPage}) => {
+		const contentName = getRandomString();
+		const spaceName = getRandomString();
+
+		await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			settings: {trashEnabled: true},
+			type: 'Space',
+		});
+
+		await apiHelpers.objectEntry.postObjectEntry(
+			{
+				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				title: contentName,
+			},
+			'cms/basic-web-contents',
+			spaceName
+		);
+
+		await test.step('Trash the content', async () => {
+			await contentsPage.goto();
+
+			await contentsPage.deleteContent(contentName);
+		});
+
+		await test.step('Open the Empty Recycle Bin confirmation', async () => {
+			await recycleBinPage.goto();
+
+			await expect(
+				page.getByRole('row', {name: contentName})
+			).toBeVisible();
+
+			await page.getByRole('button', {name: 'More Actions'}).click();
+
+			await recycleBinPage.emptyRecycleBinButton.click();
+		});
+
+		await test.step('Confirm and verify the bin is empty', async () => {
+			await page
+				.getByRole('dialog')
+				.getByRole('button', {name: 'Empty Bin'})
+				.click();
+
+			await expect
+				.poll(
+					async () => {
+						await recycleBinPage.goto();
+
+						return await page
+							.getByText('The Recycle Bin is empty.')
+							.isVisible();
+					},
+					{intervals: [1000], timeout: 10_000}
+				)
+				.toBe(true);
+		});
+	}
+);
+
+test(
+	'Delete success toast exposes a Recycle Bin link and an Undo action that restores the asset',
+	{tag: '@LPD-89104'},
+	async ({apiHelpers, contentsPage, page}) => {
+		const contentName = getRandomString();
+		const spaceName = getRandomString();
+
+		await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			settings: {trashEnabled: true},
+			type: 'Space',
+		});
+
+		await apiHelpers.objectEntry.postObjectEntry(
+			{
+				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				title: contentName,
+			},
+			'cms/basic-web-contents',
+			spaceName
+		);
+
+		await contentsPage.goto();
+
+		await contentsPage.deleteContent(contentName);
+
+		await test.step('Toast contains a link to the Recycle Bin', async () => {
+			const recycleBinLink = page.locator('.recycle-bin-link');
+
+			await expect(recycleBinLink).toBeVisible();
+
+			await expect(recycleBinLink).toHaveAttribute(
+				'href',
+				/\/cms\/recycle-bin$/
+			);
+		});
+
+		await test.step('Clicking Undo restores the content in place', async () => {
+			await page.getByRole('button', {name: 'Undo'}).click();
+
+			await expect(
+				page.getByRole('row', {name: contentName})
+			).toBeVisible();
+		});
+	}
+);


### PR DESCRIPTION
### What is this trying to solve?
https://liferay.atlassian.net/browse/LPD-89566
### How am I fixing it?
By hiding the nav element, not only the layout
### How can you verify that it works?
Buy running the following tests from LPD-89104

 | Type | Test | Ticket | Result |
  |---|---|---|---|
  | Playwright | Recycle Bin menu entry is hidden when `trashEnabled` is false | LPD-89104 | PASS |
  | Playwright | Recycle Bin menu entry is visible when `trashEnabled` is true | LPD-89104 | PASS |
  | Playwright | Recycle Bin row shows Space, Content Type, Removed By, and Removed Date | LPD-89104 | PASS |
  | Playwright | Filtering the Recycle Bin by Space narrows results to that space | LPD-89104 | PASS |
  | Playwright | Restoring content whose original folder was permanently deleted lands at the Space root | LPD-89104 | PASS |
  | Playwright | Space General Settings Recycle Bin panel honors `trashEnabled` and max age validation | LPD-89104 | PASS |
  | Playwright | Recycle Bin shows the empty state when no entries exist | LPD-85682 | PASS |
  | Playwright | Restoring content whose original folder still exists puts it back in that folder | LPD-85682 | PASS |
  | Playwright | Empty Recycle Bin bulk action permanently removes all entries | LPD-85682 | PASS |
  | Playwright | Delete success toast exposes a Recycle Bin link and an Undo action that restores the asset | LPD-85682 | PASS |
  | Integration | `GroupModelListenerTest.testUpdateDepotEntry` | LPD-89566 | PASS |
  | Integration | `GroupModelListenerTest.testRemoveDepotEntryHidesLayout` | LPD-89566 | PASS |
  | Integration | `ObjectEntryTrashRetentionTest.testCheckEntriesRemovesExpiredObjectEntry` | LPD-89104 | PASS |