### PR TITLE
LPD-89713 Adds Playwright test for viewing tag usages

### DIFF
--- a/modules/test/playwright/tests/site-cms-site-initializer/main/categorization/tags.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/categorization/tags.spec.ts
@@ -5,16 +5,19 @@
 
 import {expect, mergeTests} from '@playwright/test';
 
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
 import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
 import {loginTest} from '../../../../fixtures/loginTest';
 import {checkAccessibility} from '../../../../utils/checkAccessibility';
 import {clickAndExpectToBeHidden} from '../../../../utils/clickAndExpectToBeHidden';
 import {clickAndExpectToBeVisible} from '../../../../utils/clickAndExpectToBeVisible';
 import {getRandomInt} from '../../../../utils/getRandomInt';
+import getRandomString from '../../../../utils/getRandomString';
 import {cmsPagesTest} from '../fixtures/cmsPagesTest';
 
 const test = mergeTests(
 	cmsPagesTest,
+	dataApiHelpersTest,
 	featureFlagsTest({
 		'LPD-17564': {enabled: true},
 	}),
@@ -428,6 +431,61 @@ test(
 		});
 
 		await expect(tagsPage.getItem('<Tag>')).not.toBeVisible();
+	}
+);
+
+test(
+	"View a Tag's usages",
+	{tag: '@LPD-89713'},
+	async ({apiHelpers, dataSetPage, page, tagsPage}) => {
+		const {id: siteId} =
+			await apiHelpers.headlessAdminUser.getSiteByFriendlyUrlPath('cms');
+
+		const tagName = getRandomString();
+
+		await apiHelpers.headlessAdminTaxonomy.postSiteKeyword({
+			name: tagName,
+			siteId,
+		});
+
+		await tagsPage.goto();
+
+		await tagsPage.execItemAction({
+			action: 'View Usages',
+			filter: tagName,
+		});
+
+		await expect(page.getByText('No Results Found')).toBeVisible();
+
+		const basicWebContentTitle = getRandomString();
+
+		await apiHelpers.objectEntry.postObjectEntry(
+			{
+				keywords: [tagName],
+				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				title: basicWebContentTitle,
+			},
+			'cms/basic-web-contents/scopes/Default'
+		);
+
+		await tagsPage.goto();
+
+		await tagsPage.execItemAction({
+			action: 'View Usages',
+			filter: tagName,
+		});
+
+		await checkAccessibility({
+			page,
+			selectors: ['.content'],
+			selectorsToExclude: [
+				'.control-menu-container',
+				'.sidebar-container',
+				'.top-bar',
+			],
+		});
+
+		await expect(dataSetPage.getRow(basicWebContentTitle)).toBeVisible();
 	}
 );
 


### PR DESCRIPTION
# What is this trying to solve?

[Link to ticket](https://liferay.atlassian.net/browse/LPD-89713)

LPD-85667 (Categorization > Tags) requires users to be able to view the assets where a tag is applied. The "View Usages" row action is wired in the UI, but there was no automated coverage for it on the Tags page.

# How am I fixing it?

Adds a Playwright test that mirrors the existing "View a Category's usages" sibling. The test creates a site keyword via the headless taxonomy API, opens the CMS Tags page, runs "View Usages" and asserts the empty state, posts a Basic Web Content with that keyword attached, then re-runs "View Usages" and asserts the new content row appears. Accessibility is checked on the populated usages view.

# How can you verify it manually?

**Preconditions:** Liferay CMS feature flag `LPD-17564` enabled.

1. Navigate to Liferay CMS > Categorization > Tags.
2. Create a new tag.
3. Open the kebab on the tag row and click "View Usages". Confirm "No Results Found" appears.
4. Create a Basic Web Content and attach the tag.
5. Return to Categorization > Tags and run "View Usages" on the same tag. Confirm the Basic Web Content row appears.

# Tests

New tests added in this PR:

- `tags.spec.ts` > `View a Tag's usages` (`@LPD-89713`)

# Test execution

```
cd modules/test/playwright && yarn test tests/site-cms-site-initializer/main/categorization/tags.spec.ts --grep "View a Tag's usages"
```

---

_AI-assisted with Claude Code._