### PR TITLE
LPD-89583 Fix patching web content with nested fields

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/StructuredContentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/StructuredContentResourceImpl.java
@@ -1308,26 +1308,36 @@ public class StructuredContentResourceImpl
 			}
 		}
 
-		for (ContentField contentField : contentFields) {
-			Field field = fields.get(contentField.getName());
+		Map<String, List<ContentField>> contentFieldsMap = new HashMap<>();
 
-			Value value = DDMValueUtil.toDDMValue(
-				contentField.toString(),
-				DDMFormFieldUtil.getDDMFormField(
-					_ddmStructureService, ddmStructure, contentField.getName()),
-				_dlAppService, journalArticle.getGroupId(),
-				_journalArticleService, _layoutLocalService,
-				contextAcceptLanguage.getPreferredLocale());
+		_populateContentFieldsMap(contentFields, contentFieldsMap);
 
-			for (Locale locale : value.getAvailableLocales()) {
-				field.setValue(locale, value.getString(locale));
+		for (Map.Entry<String, List<ContentField>> entry :
+				contentFieldsMap.entrySet()) {
+
+			Field field = fields.get(entry.getKey());
+
+			if (field == null) {
+				continue;
 			}
 
-			ContentField[] nestedContentFields =
-				contentField.getNestedContentFields();
+			DDMFormField ddmFormField = DDMFormFieldUtil.getDDMFormField(
+				_ddmStructureService, ddmStructure, entry.getKey());
 
-			if (nestedContentFields != null) {
-				_toPatchedFields(nestedContentFields, journalArticle);
+			for (ContentField contentField : entry.getValue()) {
+				Value value = DDMValueUtil.toDDMValue(
+					contentField.toString(), ddmFormField, _dlAppService,
+					journalArticle.getGroupId(), _journalArticleService,
+					_layoutLocalService,
+					contextAcceptLanguage.getPreferredLocale());
+
+				if (value == null) {
+					continue;
+				}
+
+				for (Locale locale : value.getAvailableLocales()) {
+					field.setValue(locale, value.getString(locale));
+				}
 			}
 		}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/StructuredContentResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/StructuredContentResourceTest.java
@@ -534,6 +534,7 @@ public class StructuredContentResourceTest
 
 		_testPatchStructuredContentWithDateExpired();
 		_testPatchStructuredContentWithLocalizedContentFields();
+		_testPatchStructuredContentWithNestedContentFields();
 		_testPatchStructuredContentWithNewLocale();
 		_testPatchStructuredContentWithRandomTitle();
 		_testPatchStructuredContentWithUnlocalizedContentFields();
@@ -2948,6 +2949,73 @@ public class StructuredContentResourceTest
 		_assertData(
 			patchContentFieldValue_I18n,
 			GetterUtil.getString(postFrenchData.get("data")), "fr-FR");
+	}
+
+	private void _testPatchStructuredContentWithNestedContentFields()
+		throws Exception {
+
+		StructuredContent postStructuredContent =
+			structuredContentResource.postSiteStructuredContent(
+				testGroup.getGroupId(),
+				_randomComplexStructuredContent(
+					_dlFileEntry.getFileEntryId(), false));
+
+		String randomString = RandomTestUtil.randomString(10);
+
+		structuredContentResource.patchStructuredContent(
+			postStructuredContent.getId(),
+			new StructuredContent() {
+				{
+					setContentFields(
+						new ContentField[] {
+							new ContentField() {
+								{
+									name = "Fieldset39810423";
+									nestedContentFields = new ContentField[] {
+										new ContentField() {
+											{
+												contentFieldValue =
+													new ContentFieldValue() {
+														{
+															data = randomString;
+														}
+													};
+												name = "Text97681688";
+											}
+										}
+									};
+								}
+							}
+						});
+				}
+			});
+
+		StructuredContent getStructuredContent =
+			structuredContentResource.getStructuredContent(
+				postStructuredContent.getId());
+
+		String patchedData = null;
+
+		for (ContentField contentField :
+				getStructuredContent.getContentFields()) {
+
+			if (!Objects.equals(contentField.getName(), "Fieldset39810423")) {
+				continue;
+			}
+
+			for (ContentField nestedContentField :
+					contentField.getNestedContentFields()) {
+
+				if (Objects.equals(
+						nestedContentField.getName(), "Text97681688")) {
+
+					patchedData = nestedContentField.getContentFieldValue(
+					).getData();
+				}
+			}
+		}
+
+		Assert.assertEquals(randomString, patchedData);
 	}
 
 	private void _testPatchStructuredContentWithNewLocale() throws Exception {


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-89583

PATCH on a web content article fails with a NullPointerException whenever the
payload references a content field nested inside a Fieldset, and even when the
NPE is avoided the nested-field updates are silently dropped. Any structured
content that uses a Fieldset is effectively unpatchable through the headless
API.

# How am I fixing it?

Reuse the existing _populateContentFieldsMap helper — already used by the POST
path — to flatten the nested ContentField tree into a name→values map, then
resolve each entry directly against the flat DDM Fields collection. Fieldsets
are filtered out at flatten time because they carry no ContentFieldValue, so
the dereferenced-null disappears and the PATCH path now mirrors POST.

# How can you verify that it works?

Run the included automated tests.