### PR TITLE
LPD-89584 Hide Add Members button when user lacks ASSIGN_MEMBERS permission

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewSpaceMembersSummarySectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewSpaceMembersSummarySectionDisplayContext.java
@@ -89,7 +89,11 @@ public class ViewSpaceMembersSummarySectionDisplayContext {
 		return sb.toString();
 	}
 
-	public CreationMenu getCreationMenu() {
+	public CreationMenu getCreationMenu() throws Exception {
+		if (!_hasAssignMembersPermission()) {
+			return new CreationMenu();
+		}
+
 		return CreationMenuBuilder.addPrimaryDropdownItem(
 			dropdownItem -> {
 				dropdownItem.putData("action", "addMembers");

--- a/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewSpaceMembersSummarySectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewSpaceMembersSummarySectionDisplayContextTest.java
@@ -1,0 +1,133 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.display.context;
+
+import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu;
+import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.UserGroupLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * @author Roberto Díaz
+ */
+public class ViewSpaceMembersSummarySectionDisplayContextTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	@TestInfo("LPD-89584")
+	public void testGetCreationMenu() throws Exception {
+		_testGetCreationMenuReturnsMenuWhenUserHasAssignMembersPermission();
+		_testGetCreationMenuReturnsEmptyMenuWhenUserLacksAssignMembersPermission();
+	}
+
+	private ViewSpaceMembersSummarySectionDisplayContext _getDisplayContext(
+			boolean hasAssignMembersPermission)
+		throws Exception {
+
+		DepotEntryLocalService depotEntryLocalService = Mockito.mock(
+			DepotEntryLocalService.class);
+
+		Group group = Mockito.mock(Group.class);
+
+		Mockito.when(
+			group.getExternalReferenceCode()
+		).thenReturn(
+			StringUtil.randomString()
+		);
+
+		GroupLocalService groupLocalService = Mockito.mock(
+			GroupLocalService.class);
+
+		Mockito.when(
+			groupLocalService.getGroup(Mockito.anyLong())
+		).thenReturn(
+			group
+		);
+
+		@SuppressWarnings("unchecked")
+		ModelResourcePermission<Group> groupModelResourcePermission =
+			Mockito.mock(ModelResourcePermission.class);
+
+		Mockito.when(
+			groupModelResourcePermission.contains(
+				Mockito.any(), Mockito.anyLong(), Mockito.anyString())
+		).thenReturn(
+			hasAssignMembersPermission
+		);
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, new ThemeDisplay());
+
+		Language language = Mockito.mock(Language.class);
+
+		Mockito.when(
+			language.get(
+				Mockito.any(HttpServletRequest.class), Mockito.anyString())
+		).thenReturn(
+			StringUtil.randomString()
+		);
+
+		return new ViewSpaceMembersSummarySectionDisplayContext(
+			depotEntryLocalService, _GROUP_ID, groupLocalService,
+			groupModelResourcePermission, mockHttpServletRequest, language,
+			Mockito.mock(UserGroupLocalService.class),
+			Mockito.mock(UserLocalService.class));
+	}
+
+	private void _testGetCreationMenuReturnsEmptyMenuWhenUserLacksAssignMembersPermission()
+		throws Exception {
+
+		ViewSpaceMembersSummarySectionDisplayContext displayContext =
+			_getDisplayContext(false);
+
+		CreationMenu creationMenu = displayContext.getCreationMenu();
+
+		Assert.assertNotNull(creationMenu);
+		Assert.assertTrue(creationMenu.isEmpty());
+	}
+
+	private void _testGetCreationMenuReturnsMenuWhenUserHasAssignMembersPermission()
+		throws Exception {
+
+		ViewSpaceMembersSummarySectionDisplayContext displayContext =
+			_getDisplayContext(true);
+
+		CreationMenu creationMenu = displayContext.getCreationMenu();
+
+		Assert.assertNotNull(creationMenu);
+		Assert.assertFalse(creationMenu.isEmpty());
+	}
+
+	private static final long _GROUP_ID = 1L;
+
+}

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/pages/SpaceSummaryPage.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/pages/SpaceSummaryPage.ts
@@ -16,6 +16,7 @@ export class SpaceSummaryPage {
 
 	readonly addContentButton: Locator;
 	readonly addFileButton: Locator;
+	readonly addMembersButton: Locator;
 	readonly closeButton: Locator;
 	readonly galleryPreview: Locator;
 	readonly userGroupsTab: Locator;
@@ -31,6 +32,11 @@ export class SpaceSummaryPage {
 		this.addContentButton = page.getByRole('button', {name: `Add Content`});
 
 		this.addFileButton = page.getByRole('button', {name: `Add Files`});
+
+		this.addMembersButton = page.getByRole('button', {
+			exact: true,
+			name: 'Add Members',
+		});
 
 		this.closeButton = this.page
 			.locator('.modal-header')

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/spaceSummary.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/spaceSummary.spec.ts
@@ -10,6 +10,10 @@ import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
 import {loginTest} from '../../../../fixtures/loginTest';
 import {getRandomInt} from '../../../../utils/getRandomInt';
 import getRandomString from '../../../../utils/getRandomString';
+import {
+	performUserSwitchViaApi,
+	userData,
+} from '../../../../utils/performLogin';
 import {cmsPagesTest} from '../fixtures/cmsPagesTest';
 
 const test = mergeTests(
@@ -323,6 +327,48 @@ test(
 		await page.getByRole('menuitem', {name: 'Disconnect'}).click();
 
 		await expect(globalSiteLocator).not.toBeVisible();
+	}
+);
+
+test(
+	'Space member without assign-members permission cannot see the Add Members button',
+	{tag: '@LPD-89584'},
+	async ({apiHelpers, spaceSummaryPage}) => {
+		const spaceName = `Space ${getRandomString()}`;
+
+		await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			settings: {},
+			type: 'Space',
+		});
+
+		const user = await apiHelpers.headlessAdminUser.postUserAccount();
+		const userFullName = `${user.givenName} ${user.familyName}`;
+
+		userData[user.alternateName] = {
+			name: user.givenName,
+			password: 'test',
+			surname: user.familyName,
+		};
+
+		await spaceSummaryPage.goto(spaceName);
+
+		await spaceSummaryPage.addUserOrUserGroup(userFullName, 'users');
+
+		await performUserSwitchViaApi(
+			spaceSummaryPage.page,
+			user.alternateName
+		);
+
+		await spaceSummaryPage.goto(spaceName);
+
+		await spaceSummaryPage.usersTab.click();
+
+		await expect(spaceSummaryPage.addMembersButton).toBeHidden();
+
+		await spaceSummaryPage.userGroupsTab.click();
+
+		await expect(spaceSummaryPage.addMembersButton).toBeHidden();
 	}
 );
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89584

## What is being fixed

The "Add Members" creation menu was rendered to every Space member,
including users without the ASSIGN_MEMBERS permission. Those users could
trigger the action and reach a downstream error instead of the action
being hidden up front.

## How it is being fixed

`ViewSpaceMembersSummarySectionDisplayContext.getCreationMenu()` now
returns `new CreationMenu()` when the current user does not have ASSIGN_MEMBERS on the
Space group, so the host taglib never renders the button. 

A unit testcovers the permission gate at the display-context level, and a Playwright test verifies that a Space member without the permission sees no "Add Members" button under either the Users or User Groups tab.

The test results:
<img width="862" height="330" alt="Captura de pantalla 2026-05-12 a las 11 20 43" src="https://github.com/user-attachments/assets/c06b7bc3-443a-4897-91ab-36d76293a5d1" />


