### PR TITLE
LPD-89731 add playwright tests for category search

### DIFF
--- a/modules/test/playwright/tests/site-cms-site-initializer/main/categorization/categories.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/categorization/categories.spec.ts
@@ -601,6 +601,61 @@ test.describe('Subcategory tests', () => {
 	);
 });
 
+test.describe('Search category tests', () => {
+	let categoryName1: string;
+	let categoryName2: string;
+	let prefix: string;
+
+	test.beforeEach('Create Categories via API', async ({apiHelpers}) => {
+		prefix = `category_name_${getRandomString().replace(/-/g, '')}`;
+		categoryName1 = `${prefix}_one`;
+		categoryName2 = `${prefix}_two`;
+
+		await apiHelpers.headlessAdminTaxonomy.postTaxonomyVocabularyTaxonomyCategory(
+			{name: categoryName1, vocabularyId}
+		);
+		await apiHelpers.headlessAdminTaxonomy.postTaxonomyVocabularyTaxonomyCategory(
+			{name: categoryName2, vocabularyId}
+		);
+	});
+
+	test(
+		"Search a Vocabulary's Categories by name and prefix",
+		{tag: '@LPD-89731'},
+		async ({categoriesPage}) => {
+			await categoriesPage.goto(vocabularyId, vocabularyName);
+
+			await categoriesPage.search(categoryName1);
+
+			await expect(categoriesPage.getItem(categoryName1)).toBeVisible();
+			await expect(categoriesPage.getItem(categoryName2)).toBeHidden();
+
+			await categoriesPage.search(prefix);
+
+			await expect(categoriesPage.getItem(categoryName1)).toBeVisible();
+			await expect(categoriesPage.getItem(categoryName2)).toBeVisible();
+		}
+	);
+
+	test(
+		"Clear search restores all of a Vocabulary's Categories",
+		{tag: '@LPD-89731'},
+		async ({categoriesPage}) => {
+			await categoriesPage.goto(vocabularyId, vocabularyName);
+
+			await categoriesPage.search(categoryName1);
+
+			await expect(categoriesPage.getItem(categoryName1)).toBeVisible();
+			await expect(categoriesPage.getItem(categoryName2)).toBeHidden();
+
+			await categoriesPage.clearSearch();
+
+			await expect(categoriesPage.getItem(categoryName1)).toBeVisible();
+			await expect(categoriesPage.getItem(categoryName2)).toBeVisible();
+		}
+	);
+});
+
 test(
 	'Content can be saved when all asset subtypes are required in a vocabulary',
 	{tag: '@LPD-83651'},

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/pages/CategoriesPage.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/pages/CategoriesPage.ts
@@ -70,6 +70,13 @@ export class CategoriesPage {
 		await this.closePermissionsModalButton.click();
 	}
 
+	async clearSearch() {
+		await this.page
+			.locator('.search-resume')
+			.getByRole('button', {name: 'Clear Search'})
+			.click();
+	}
+
 	async clickCreateNewCategoryButton() {
 		await this.createNewCategoryButton.click();
 
@@ -131,5 +138,9 @@ export class CategoriesPage {
 			: await this.deleteConfirmationModal
 					.getByRole('button', {name: 'Cancel'})
 					.click();
+	}
+
+	async search(value: string) {
+		await this.dataSetFragmentPage.search(value);
 	}
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89731

## What is being fixed

LPD-85666's acceptance criteria for Categorization > Categories list "filter and search categories" as a user-facing capability. The site-cms-site-initializer Playwright suite covered creation, edit, delete, move to vocabulary, permissions, and view-usages, but had no coverage for the search input on the categories dataset.

## How it is being fixed

Two Playwright tests were added to `categories.spec.ts` inside a new `Search category tests` describe block. The first asserts that searching by a category's full name filters out the other category and that searching by the shared prefix returns both. The second asserts that clicking the Clear Search button restores all categories after a filtered search. Two helpers, `search` and `clearSearch`, were added to `CategoriesPage` to delegate to the existing FDS dataset wrapper.

## Test execution

```
cd modules/test/playwright && yarn test main/categorization/categories.spec.ts -g "Search category tests"
```

_AI-assisted with Claude Code._