### PR TITLE
LPD-89799 Use a CMS-specific breadcrumb for Spaces

### DIFF
--- a/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/servlet/taglib/DepotBreadcrumbEntryContributorImpl.java
+++ b/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/servlet/taglib/DepotBreadcrumbEntryContributorImpl.java
@@ -5,6 +5,7 @@
 
 package com.liferay.depot.web.internal.servlet.taglib;
 
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.constants.DepotPortletKeys;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryService;
@@ -76,14 +77,20 @@ public class DepotBreadcrumbEntryContributorImpl
 		List<BreadcrumbEntry> breadcrumbEntries = new ArrayList<>();
 
 		try {
+			DepotEntry depotEntry = _getDepotEntry(
+				scopeGroup.getGroupId(), depotEntryId);
+
+			if (depotEntry.getType() == DepotConstants.TYPE_SPACE) {
+				return originalBreadcrumbEntries;
+			}
+
 			breadcrumbEntries.add(
 				_getAssetLibrariesBreadcrumbEntry(
 					themeDisplay.getControlPanelGroup(), httpServletRequest));
 
 			breadcrumbEntries.add(
 				_getAssetLibraryBreadcrumbEntry(
-					_getDepotEntry(scopeGroup.getGroupId(), depotEntryId),
-					httpServletRequest));
+					depotEntry, httpServletRequest));
 
 			if (originalBreadcrumbEntries.isEmpty() &&
 				!Objects.equals(

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/servlet/taglib/test/SpaceDepotEntryBreadcrumbEntryContributorTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/servlet/taglib/test/SpaceDepotEntryBreadcrumbEntryContributorTest.java
@@ -1,0 +1,268 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.servlet.taglib.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.servlet.PortletServlet;
+import com.liferay.portal.kernel.servlet.taglib.ui.BreadcrumbEntry;
+import com.liferay.portal.kernel.servlet.taglib.ui.BreadcrumbEntryContributorUtil;
+import com.liferay.portal.kernel.test.portlet.MockLiferayResourceRequest;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.JavaConstants;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.site.cms.site.initializer.test.util.CMSTestUtil;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * @author Adolfo Pérez
+ */
+@FeatureFlag("LPD-17564")
+@RunWith(Arquillian.class)
+public class SpaceDepotEntryBreadcrumbEntryContributorTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		PermissionThreadLocal.setPermissionChecker(
+			PermissionCheckerFactoryUtil.create(TestPropsValues.getUser()));
+
+		CMSTestUtil.getOrAddGroup(
+			SpaceDepotEntryBreadcrumbEntryContributorTest.class);
+	}
+
+	@Test
+	public void testContributeBreadcrumbEntries() throws Exception {
+		_testContributeBreadcrumbEntriesWithGroupNotSpaceDepotEntry();
+		_testContributeBreadcrumbEntriesWithOriginalBreadcrumbEntries();
+		_testContributeBreadcrumbEntriesWithSpaceDepotEntry();
+	}
+
+	private DepotEntry _addDepotEntry() throws Exception {
+		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()
+			).build(),
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()
+			).build(),
+			DepotConstants.TYPE_SPACE,
+			ServiceContextTestUtil.getServiceContext());
+
+		_depotEntries.add(depotEntry);
+
+		return depotEntry;
+	}
+
+	private void _assertBreadcrumbEntryNotBrowsable(
+		BreadcrumbEntry breadcrumbEntry) {
+
+		Assert.assertFalse(
+			breadcrumbEntry.toString(), breadcrumbEntry.isBrowsable());
+		Assert.assertNull(breadcrumbEntry.toString(), breadcrumbEntry.getURL());
+	}
+
+	private void _assertSpaceDepotEntryBreadcrumbEntry(
+			BreadcrumbEntry breadcrumbEntry, DepotEntry depotEntry,
+			MockHttpServletRequest mockHttpServletRequest)
+		throws Exception {
+
+		Group group = depotEntry.getGroup();
+
+		Assert.assertEquals(
+			breadcrumbEntry.toString(),
+			group.getDescriptiveName(_portal.getLocale(mockHttpServletRequest)),
+			breadcrumbEntry.getTitle());
+
+		String url = breadcrumbEntry.getURL();
+
+		Assert.assertNotNull(breadcrumbEntry.toString(), url);
+		Assert.assertTrue(
+			breadcrumbEntry.toString(), url.contains("/cms/e/space/"));
+		Assert.assertTrue(
+			breadcrumbEntry.toString(),
+			url.endsWith("/" + depotEntry.getDepotEntryId()));
+	}
+
+	private BreadcrumbEntry _getBreadcrumbEntry() {
+		BreadcrumbEntry breadcrumbEntry = new BreadcrumbEntry();
+
+		breadcrumbEntry.setTitle(RandomTestUtil.randomString());
+		breadcrumbEntry.setURL(RandomTestUtil.randomString());
+
+		return breadcrumbEntry;
+	}
+
+	private MockHttpServletRequest _getMockHttpServletRequest(Group group)
+		throws Exception {
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		ThemeDisplay themeDisplay = _getThemeDisplay(group);
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, themeDisplay);
+
+		MockLiferayResourceRequest mockPortletRequest =
+			new MockLiferayResourceRequest();
+
+		mockPortletRequest.setAttribute(
+			PortletServlet.PORTLET_SERVLET_REQUEST, mockHttpServletRequest);
+		mockPortletRequest.setAttribute(WebKeys.THEME_DISPLAY, themeDisplay);
+
+		mockHttpServletRequest.setAttribute(
+			JavaConstants.JAKARTA_PORTLET_REQUEST, mockPortletRequest);
+
+		return mockHttpServletRequest;
+	}
+
+	private ThemeDisplay _getThemeDisplay(Group group) throws Exception {
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		themeDisplay.setCompany(
+			_companyLocalService.fetchCompany(TestPropsValues.getCompanyId()));
+		themeDisplay.setLanguageId(group.getDefaultLanguageId());
+		themeDisplay.setPathFriendlyURLPublic("/web");
+		themeDisplay.setPermissionChecker(
+			PermissionThreadLocal.getPermissionChecker());
+		themeDisplay.setScopeGroupId(group.getGroupId());
+		themeDisplay.setSiteGroupId(group.getGroupId());
+		themeDisplay.setUser(TestPropsValues.getUser());
+
+		return themeDisplay;
+	}
+
+	private void _testContributeBreadcrumbEntriesWithGroupNotSpaceDepotEntry()
+		throws Exception {
+
+		_group = GroupTestUtil.addGroup();
+
+		List<BreadcrumbEntry> breadcrumbEntries =
+			BreadcrumbEntryContributorUtil.contribute(
+				Collections.emptyList(), _getMockHttpServletRequest(_group));
+
+		Assert.assertEquals(
+			breadcrumbEntries.toString(), Collections.emptyList(),
+			breadcrumbEntries);
+	}
+
+	private void _testContributeBreadcrumbEntriesWithOriginalBreadcrumbEntries()
+		throws Exception {
+
+		DepotEntry depotEntry = _addDepotEntry();
+
+		MockHttpServletRequest mockHttpServletRequest =
+			_getMockHttpServletRequest(depotEntry.getGroup());
+
+		List<BreadcrumbEntry> originalBreadcrumbEntries = List.of(
+			_getBreadcrumbEntry(), _getBreadcrumbEntry());
+
+		List<BreadcrumbEntry> breadcrumbEntries =
+			BreadcrumbEntryContributorUtil.contribute(
+				originalBreadcrumbEntries, mockHttpServletRequest);
+
+		Assert.assertEquals(
+			breadcrumbEntries.toString(), originalBreadcrumbEntries.size() + 1,
+			breadcrumbEntries.size());
+
+		_assertSpaceDepotEntryBreadcrumbEntry(
+			breadcrumbEntries.get(0), depotEntry, mockHttpServletRequest);
+
+		Assert.assertEquals(
+			breadcrumbEntries.subList(1, breadcrumbEntries.size()),
+			originalBreadcrumbEntries);
+
+		_assertBreadcrumbEntryNotBrowsable(
+			breadcrumbEntries.get(breadcrumbEntries.size() - 1));
+	}
+
+	private void _testContributeBreadcrumbEntriesWithSpaceDepotEntry()
+		throws Exception {
+
+		DepotEntry depotEntry = _addDepotEntry();
+
+		MockHttpServletRequest mockHttpServletRequest =
+			_getMockHttpServletRequest(depotEntry.getGroup());
+
+		List<BreadcrumbEntry> breadcrumbEntries =
+			BreadcrumbEntryContributorUtil.contribute(
+				Collections.emptyList(), mockHttpServletRequest);
+
+		Assert.assertEquals(
+			breadcrumbEntries.toString(), 2, breadcrumbEntries.size());
+
+		_assertSpaceDepotEntryBreadcrumbEntry(
+			breadcrumbEntries.get(0), depotEntry, mockHttpServletRequest);
+
+		BreadcrumbEntry homeBreadcrumbEntry = breadcrumbEntries.get(1);
+
+		Assert.assertEquals(
+			homeBreadcrumbEntry.toString(),
+			_language.get(mockHttpServletRequest, "home"),
+			homeBreadcrumbEntry.getTitle());
+
+		_assertBreadcrumbEntryNotBrowsable(
+			breadcrumbEntries.get(breadcrumbEntries.size() - 1));
+	}
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
+
+	@DeleteAfterTestRun
+	private final List<DepotEntry> _depotEntries = new ArrayList<>();
+
+	@Inject
+	private DepotEntryLocalService _depotEntryLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private Language _language;
+
+	@Inject
+	private Portal _portal;
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/servlet/taglib/SpaceDepotEntryBreadcrumbEntryContributorImpl.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/servlet/taglib/SpaceDepotEntryBreadcrumbEntryContributorImpl.java
@@ -1,0 +1,179 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.servlet.taglib;
+
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryService;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.servlet.taglib.ui.BreadcrumbEntry;
+import com.liferay.portal.kernel.servlet.taglib.ui.BreadcrumbEntryContributor;
+import com.liferay.portal.kernel.theme.PortletDisplay;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.site.cms.site.initializer.internal.util.ActionUtil;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Adolfo Pérez
+ */
+@Component(service = BreadcrumbEntryContributor.class)
+public class SpaceDepotEntryBreadcrumbEntryContributorImpl
+	implements BreadcrumbEntryContributor {
+
+	@Override
+	public List<BreadcrumbEntry> getBreadcrumbEntries(
+		List<BreadcrumbEntry> originalBreadcrumbEntries,
+		HttpServletRequest httpServletRequest) {
+
+		long depotEntryId = ParamUtil.getLong(
+			httpServletRequest, "depotEntryId");
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		Group scopeGroup = themeDisplay.getScopeGroup();
+
+		if (((depotEntryId == 0) && !scopeGroup.isDepot()) ||
+			themeDisplay.isStatePopUp()) {
+
+			return originalBreadcrumbEntries;
+		}
+
+		try {
+			DepotEntry depotEntry = _getDepotEntry(
+				depotEntryId, scopeGroup.getGroupId());
+
+			if (depotEntry.getType() != DepotConstants.TYPE_SPACE) {
+				return originalBreadcrumbEntries;
+			}
+
+			List<BreadcrumbEntry> breadcrumbEntries = new ArrayList<>();
+
+			breadcrumbEntries.add(
+				_getSpaceDepotEntryBreadcrumbEntry(
+					depotEntry, httpServletRequest, themeDisplay));
+
+			PortletDisplay portletDisplay = themeDisplay.getPortletDisplay();
+
+			if (originalBreadcrumbEntries.isEmpty()) {
+				BreadcrumbEntry portletBreadcrumbEntry = new BreadcrumbEntry();
+
+				portletBreadcrumbEntry.setTitle(
+					_getTitle(
+						httpServletRequest, themeDisplay.getLanguageId(),
+						portletDisplay));
+
+				breadcrumbEntries.add(portletBreadcrumbEntry);
+			}
+			else {
+				BreadcrumbEntry firstBreadcrumbEntry =
+					originalBreadcrumbEntries.get(0);
+
+				if (Objects.equals(
+						firstBreadcrumbEntry.getTitle(),
+						_language.get(httpServletRequest, "home"))) {
+
+					firstBreadcrumbEntry.setTitle(
+						portletDisplay.getPortletDisplayName());
+				}
+			}
+
+			breadcrumbEntries.addAll(originalBreadcrumbEntries);
+
+			BreadcrumbEntry lastBreadcrumbEntry = breadcrumbEntries.get(
+				breadcrumbEntries.size() - 1);
+
+			lastBreadcrumbEntry.setBrowsable(false);
+			lastBreadcrumbEntry.setURL(null);
+
+			return breadcrumbEntries;
+		}
+		catch (PortalException portalException) {
+			_log.error(portalException);
+
+			return originalBreadcrumbEntries;
+		}
+	}
+
+	private DepotEntry _getDepotEntry(long depotEntryId, long groupId)
+		throws PortalException {
+
+		if (depotEntryId == 0) {
+			return _depotEntryService.getGroupDepotEntry(groupId);
+		}
+
+		return _depotEntryService.getDepotEntry(depotEntryId);
+	}
+
+	private BreadcrumbEntry _getSpaceDepotEntryBreadcrumbEntry(
+			DepotEntry depotEntry, HttpServletRequest httpServletRequest,
+			ThemeDisplay themeDisplay)
+		throws PortalException {
+
+		BreadcrumbEntry breadcrumbEntry = new BreadcrumbEntry();
+
+		Group group = depotEntry.getGroup();
+
+		breadcrumbEntry.setTitle(
+			group.getDescriptiveName(_portal.getLocale(httpServletRequest)));
+
+		breadcrumbEntry.setURL(
+			ActionUtil.getSpaceURL(depotEntry.getDepotEntryId(), themeDisplay));
+
+		return breadcrumbEntry;
+	}
+
+	private String _getTitle(
+		HttpServletRequest httpServletRequest, String languageId,
+		PortletDisplay portletDisplay) {
+
+		String title = portletDisplay.getPortletDisplayName();
+
+		if (Validator.isNotNull(title)) {
+			return title;
+		}
+
+		if (Validator.isNotNull(portletDisplay.getId())) {
+			title = _portal.getPortletTitle(portletDisplay.getId(), languageId);
+
+			if (Validator.isNotNull(title)) {
+				return title;
+			}
+		}
+
+		return _language.get(httpServletRequest, "home");
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		SpaceDepotEntryBreadcrumbEntryContributorImpl.class);
+
+	@Reference
+	private DepotEntryService _depotEntryService;
+
+	@Reference
+	private Language _language;
+
+	@Reference
+	private Portal _portal;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89799

## What is being fixed

The Export/Import portlet — and every other portlet that runs through the depot breadcrumb contributor — renders "Asset Libraries > <Space name> > <Page>" when scoped to a CMS Space, with both prefix entries linking back to the control-panel depot admin. The chain pulls the user out of the CMS the moment they navigate back from any depot-scoped page on a Space.

## How it is being fixed

Contributor responsibility is split along the existing module boundary. `DepotBreadcrumbEntryContributorImpl` now short-circuits on `DepotConstants.TYPE_SPACE` and stops producing asset-libraries entries for CMS Spaces. A new `SpaceDepotEntryBreadcrumbEntryContributorImpl` in `site-cms-site-initializer` fires only for `TYPE_SPACE` depots and emits a single `<Space name>` entry linked through `ActionUtil.getSpaceURL` to the CMS space page; the leaf portlet entry and the `setBrowsable(false)/setURL(null)` finalizer mirror the depot contributor so unrelated callers see the same shape as before. Plain asset libraries (`TYPE_ASSET_LIBRARY`) keep the legacy chain.

The new contributor is covered by an integration test that mirrors `DepotBreadcrumbEntryContributorTest` — verifying empty-original, non-depot, and original-entries scenarios, and asserting the `/cms/e/space/<depotEntryId>` URL.