### PR TITLE
LPD-89342 Adds Playwright tests for Custom Content Structures

### DIFF
--- a/modules/test/playwright/helpers/HeadlessAssetLibraryApiHelper.ts
+++ b/modules/test/playwright/helpers/HeadlessAssetLibraryApiHelper.ts
@@ -23,7 +23,7 @@ export class HeadlessAssetLibraryApiHelper {
 		description?: string;
 		name: string;
 		settings?: any;
-		type: string;
+		type?: string;
 	}) {
 		const data = JSON.stringify({
 			description,

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/structures.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/structures.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import {ObjectDefinition} from '@liferay/object-admin-rest-client-js';
-import {expect, mergeTests} from '@playwright/test';
+import {Page, expect, mergeTests} from '@playwright/test';
 
 import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
 import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
@@ -858,5 +858,68 @@ test(
 		await expect(
 			page.locator('.label-secondary', {hasText: spaceName2})
 		).toBeVisible();
+	}
+);
+
+async function applySpaceFilter(
+	page: Page,
+	{exclude = false, space}: {exclude?: boolean; space: string}
+) {
+	await page.getByRole('button', {exact: true, name: 'Filter'}).click();
+	await page.getByRole('menuitem', {exact: true, name: 'Space'}).click();
+	await page.getByRole('checkbox', {exact: true, name: space}).check();
+
+	if (exclude) {
+		await page.getByRole('switch', {exact: true, name: 'Exclude'}).click();
+	}
+
+	await page.getByRole('button', {exact: true, name: 'Add Filter'}).click();
+
+	const chipName = exclude ? `Space: (Exclude) ${space}` : `Space: ${space}`;
+
+	await expect(page.getByRole('button', {name: chipName})).toBeVisible();
+}
+
+test(
+	'Content Structures list can be filtered by space with include and exclude',
+	{tag: '@LPD-89342'},
+	async ({apiHelpers, page, structureBuilderPage, structuresPage}) => {
+		const spaceName1 = `Space ${getRandomString()}`;
+		const spaceName2 = `Space ${getRandomString()}`;
+		const structureLabel = `Structure${getRandomString()}`;
+
+		await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName1,
+			settings: {},
+		});
+
+		await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName2,
+			settings: {},
+		});
+
+		await structureBuilderPage.createStructureFromData({
+			label: structureLabel,
+			page: structureBuilderPage,
+			spaces: [spaceName1],
+		});
+
+		const row = structuresPage.getItem(structureLabel);
+
+		await structuresPage.goto();
+		await applySpaceFilter(page, {space: spaceName1});
+		await expect(row).toBeVisible();
+
+		await structuresPage.goto();
+		await applySpaceFilter(page, {space: spaceName2});
+		await expect(row).toBeHidden();
+
+		await structuresPage.goto();
+		await applySpaceFilter(page, {exclude: true, space: spaceName1});
+		await expect(row).toBeHidden();
+
+		await structuresPage.goto();
+		await applySpaceFilter(page, {exclude: true, space: spaceName2});
+		await expect(row).toBeVisible();
 	}
 );

--- a/modules/test/playwright/tests/site-cms-site-initializer/structure-builder/structureBuilder.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/structure-builder/structureBuilder.spec.ts
@@ -399,6 +399,30 @@ test(
 );
 
 test(
+	'Title and File fields are locked and cannot be removed on File Content Structures',
+	{tag: '@LPD-89342'},
+	async ({page, structureBuilderPage}) => {
+		await structureBuilderPage.goToCreateStructure('file');
+
+		for (const fieldName of ['Title', 'File']) {
+			const field = page.getByRole('treeitem', {
+				exact: true,
+				name: fieldName,
+			});
+
+			await expect(field).toBeVisible();
+			await expect(field.getByText('Locked Field')).toBeVisible();
+
+			await field.hover();
+
+			await expect(
+				field.getByRole('button', {name: 'Field Options'})
+			).toBeHidden();
+		}
+	}
+);
+
+test(
 	'Fields are sorted',
 	{
 		tag: '@LPD-61206',


### PR DESCRIPTION
## Summary

Adds Playwright coverage for the Custom Content Structures sub-task ([LPD-89342](https://liferay.atlassian.net/browse/LPD-89342)):

- Title and File fields are locked and cannot be removed on File Content Structures.
- The Structures list can be filtered by Space with include and exclude.

The `type` parameter on `createAssetLibrary` is made optional to match its existing default.

## Test plan

```
cd modules/test/playwright
yarn test tests/site-cms-site-initializer/main/structures.spec.ts -g @LPD-89342
yarn test tests/site-cms-site-initializer/structure-builder/structureBuilder.spec.ts -g @LPD-89342
```

_AI-assisted with Claude Code._