### PR TITLE
LPD-89762 Add Playwright tests for Copy/Move actions

### DIFF
--- a/modules/test/playwright/tests/site-cms-site-initializer/main/copyMove.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/copyMove.spec.ts
@@ -1000,3 +1000,119 @@ test(
 		});
 	}
 );
+
+test(
+	'Can move a folder of files to a different Space',
+	{tag: '@LPD-89762'},
+	async ({apiHelpers, assetsPage, page}) => {
+		const applicationName = 'cms/basic-documents';
+		const sourceSpaceName = `Space ${getRandomString()}`;
+		const destinationSpaceName = `Space ${getRandomString()}`;
+		const destinationFolderName = `Destination ${getRandomString()}`;
+		const sourceFolderName = `Source ${getRandomString()}`;
+		const fileTitle = `File ${getRandomString()}`;
+
+		await test.step('Create source and destination Spaces', async () => {
+			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+				name: sourceSpaceName,
+				settings: {},
+				type: 'Space',
+			});
+
+			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+				name: destinationSpaceName,
+				settings: {},
+				type: 'Space',
+			});
+		});
+
+		await test.step('Create a destination Files folder in the destination Space', async () => {
+			await apiHelpers.objectFolder.createObjectEntryFolder({
+				parentObjectEntryFolderExternalReferenceCode: 'L_FILES',
+				scopeKey: destinationSpaceName,
+				title: destinationFolderName,
+			});
+		});
+
+		await test.step('Create a source Files folder with a file inside it in the source Space', async () => {
+			const sourceFolder =
+				await apiHelpers.objectFolder.createObjectEntryFolder({
+					parentObjectEntryFolderExternalReferenceCode: 'L_FILES',
+					scopeKey: sourceSpaceName,
+					title: sourceFolderName,
+				});
+
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					file: {
+						fileBase64: 'R0lGODlhAQABAAAAACw=',
+						name: `file_${getRandomString()}.png`,
+					},
+					objectEntryFolderExternalReferenceCode:
+						sourceFolder.externalReferenceCode,
+					title: fileTitle,
+				},
+				applicationName,
+				sourceSpaceName
+			);
+		});
+
+		await test.step('Move the source folder to the destination folder in the destination Space', async () => {
+			await assetsPage.gotoSpaceFiles(sourceSpaceName);
+
+			await assetsPage.changeVisualizationMode('Table');
+
+			await assetsPage.moveTo({
+				destinationFolder: destinationFolderName,
+				destinationSpace: destinationSpaceName,
+				itemTitle: sourceFolderName,
+			});
+		});
+
+		await test.step('Info alert for the folder move is displayed', async () => {
+			await waitForAlert(
+				page,
+				`Info:Moving ${sourceFolderName} to ${destinationFolderName}.`,
+				{type: 'info'}
+			);
+		});
+
+		await test.step('Success alert for the folder move is displayed', async () => {
+			await waitForAlert(
+				page,
+				`Success:${sourceFolderName} was successfully moved to ${destinationFolderName}.`,
+				{first: true}
+			);
+		});
+
+		await test.step('The file is now in the destination Space', async () => {
+			const response =
+				await apiHelpers.objectEntry.getObjectDefinitionObjectEntriesByScope(
+					applicationName,
+					encodeURIComponent(destinationSpaceName),
+					new URLSearchParams({pageSize: '100'})
+				);
+
+			const movedItems = response.items.filter(
+				(item: {title: string}) => item.title === fileTitle
+			);
+
+			expect(movedItems).toHaveLength(1);
+		});
+
+		await test.step('The file is no longer in the source Space', async () => {
+			const response =
+				await apiHelpers.objectEntry.getObjectDefinitionObjectEntriesByScope(
+					applicationName,
+					encodeURIComponent(sourceSpaceName),
+					new URLSearchParams({pageSize: '100'})
+				);
+
+			const sourceItems = response.items.filter(
+				(item: {title: string}) => item.title === fileTitle
+			);
+
+			expect(sourceItems).toHaveLength(0);
+		});
+	}
+);

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/copyMove.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/copyMove.spec.ts
@@ -129,3 +129,111 @@ test(
 		});
 	}
 );
+
+test(
+	'Can move a content to a folder in a different Space',
+	{tag: '@LPD-89762'},
+	async ({apiHelpers, assetsPage, page}) => {
+		const applicationName = 'cms/basic-web-contents';
+		const sourceSpaceName = `Space ${getRandomString()}`;
+		const destinationSpaceName = `Space ${getRandomString()}`;
+		const destinationFolderName = `Destination ${getRandomString()}`;
+		const contentTitle = `Content ${getRandomString()}`;
+
+		await test.step('Create source and destination Spaces', async () => {
+			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+				name: sourceSpaceName,
+				settings: {},
+				type: 'Space',
+			});
+
+			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+				name: destinationSpaceName,
+				settings: {},
+				type: 'Space',
+			});
+		});
+
+		let destinationFolderId: number;
+
+		await test.step('Create a destination folder in the destination Space', async () => {
+			const folder =
+				await apiHelpers.objectFolder.createObjectEntryFolder({
+					parentObjectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					scopeKey: destinationSpaceName,
+					title: destinationFolderName,
+				});
+
+			destinationFolderId = folder.id;
+		});
+
+		await test.step('Create a content in the source Space', async () => {
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: contentTitle,
+				},
+				applicationName,
+				sourceSpaceName
+			);
+		});
+
+		await test.step('Move the content to the destination folder in the destination Space', async () => {
+			await assetsPage.gotoAll();
+
+			await assetsPage.moveTo({
+				destinationFolder: destinationFolderName,
+				destinationSpace: destinationSpaceName,
+				itemTitle: contentTitle,
+			});
+		});
+
+		await test.step('Info alert for the move is displayed', async () => {
+			await waitForAlert(
+				page,
+				`Info:Moving ${contentTitle} to ${destinationFolderName}.`,
+				{type: 'info'}
+			);
+		});
+
+		await test.step('Success alert for the move is displayed', async () => {
+			await waitForAlert(
+				page,
+				`Success:${contentTitle} was successfully moved to ${destinationFolderName}.`,
+				{first: true}
+			);
+		});
+
+		await test.step('The content is in the destination folder in the destination Space', async () => {
+			const response =
+				await apiHelpers.objectEntry.getObjectDefinitionObjectEntriesByScope(
+					applicationName,
+					encodeURIComponent(destinationSpaceName),
+					new URLSearchParams({pageSize: '100'})
+				);
+
+			const movedItems = response.items.filter(
+				(item: {objectEntryFolderId: number}) =>
+					item.objectEntryFolderId === destinationFolderId
+			);
+
+			expect(movedItems).toHaveLength(1);
+			expect(movedItems[0].title).toBe(contentTitle);
+		});
+
+		await test.step('The content is no longer in the source Space', async () => {
+			const response =
+				await apiHelpers.objectEntry.getObjectDefinitionObjectEntriesByScope(
+					applicationName,
+					encodeURIComponent(sourceSpaceName),
+					new URLSearchParams({pageSize: '100'})
+				);
+
+			const sourceItems = response.items.filter(
+				(item: {title: string}) => item.title === contentTitle
+			);
+
+			expect(sourceItems).toHaveLength(0);
+		});
+	}
+);

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/copyMove.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/copyMove.spec.ts
@@ -1116,3 +1116,119 @@ test(
 		});
 	}
 );
+
+test(
+	'Can copy a folder of files to a different Space',
+	{tag: '@LPD-89762'},
+	async ({apiHelpers, assetsPage, page}) => {
+		const applicationName = 'cms/basic-documents';
+		const sourceSpaceName = `Space ${getRandomString()}`;
+		const destinationSpaceName = `Space ${getRandomString()}`;
+		const destinationFolderName = `Destination ${getRandomString()}`;
+		const sourceFolderName = `Source ${getRandomString()}`;
+		const fileTitle = `File ${getRandomString()}`;
+
+		await test.step('Create source and destination Spaces', async () => {
+			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+				name: sourceSpaceName,
+				settings: {},
+				type: 'Space',
+			});
+
+			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+				name: destinationSpaceName,
+				settings: {},
+				type: 'Space',
+			});
+		});
+
+		await test.step('Create a destination Files folder in the destination Space', async () => {
+			await apiHelpers.objectFolder.createObjectEntryFolder({
+				parentObjectEntryFolderExternalReferenceCode: 'L_FILES',
+				scopeKey: destinationSpaceName,
+				title: destinationFolderName,
+			});
+		});
+
+		await test.step('Create a source Files folder with a file inside it in the source Space', async () => {
+			const sourceFolder =
+				await apiHelpers.objectFolder.createObjectEntryFolder({
+					parentObjectEntryFolderExternalReferenceCode: 'L_FILES',
+					scopeKey: sourceSpaceName,
+					title: sourceFolderName,
+				});
+
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					file: {
+						fileBase64: 'R0lGODlhAQABAAAAACw=',
+						name: `file_${getRandomString()}.png`,
+					},
+					objectEntryFolderExternalReferenceCode:
+						sourceFolder.externalReferenceCode,
+					title: fileTitle,
+				},
+				applicationName,
+				sourceSpaceName
+			);
+		});
+
+		await test.step('Copy the source folder to the destination folder in the destination Space', async () => {
+			await assetsPage.gotoSpaceFiles(sourceSpaceName);
+
+			await assetsPage.changeVisualizationMode('Table');
+
+			await assetsPage.copyTo({
+				destinationFolder: destinationFolderName,
+				destinationSpace: destinationSpaceName,
+				itemTitle: sourceFolderName,
+			});
+		});
+
+		await test.step('Info alert for the folder copy is displayed', async () => {
+			await waitForAlert(
+				page,
+				`Info:Copying ${sourceFolderName} to ${destinationFolderName}.`,
+				{type: 'info'}
+			);
+		});
+
+		await test.step('Success alert for the folder copy is displayed', async () => {
+			await waitForAlert(
+				page,
+				`Success:${sourceFolderName} was successfully copied to ${destinationFolderName}.`,
+				{first: true}
+			);
+		});
+
+		await test.step('The file is now in the destination Space', async () => {
+			const response =
+				await apiHelpers.objectEntry.getObjectDefinitionObjectEntriesByScope(
+					applicationName,
+					encodeURIComponent(destinationSpaceName),
+					new URLSearchParams({pageSize: '100'})
+				);
+
+			const copiedItems = response.items.filter(
+				(item: {title: string}) => item.title === fileTitle
+			);
+
+			expect(copiedItems).toHaveLength(1);
+		});
+
+		await test.step('The original file is still in the source Space', async () => {
+			const response =
+				await apiHelpers.objectEntry.getObjectDefinitionObjectEntriesByScope(
+					applicationName,
+					encodeURIComponent(sourceSpaceName),
+					new URLSearchParams({pageSize: '100'})
+				);
+
+			const sourceItems = response.items.filter(
+				(item: {title: string}) => item.title === fileTitle
+			);
+
+			expect(sourceItems).toHaveLength(1);
+		});
+	}
+);

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/copyMove.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/copyMove.spec.ts
@@ -237,3 +237,115 @@ test(
 		});
 	}
 );
+
+test(
+	'Can copy a file to a folder in a different Space',
+	{tag: '@LPD-89762'},
+	async ({apiHelpers, assetsPage, page}) => {
+		const applicationName = 'cms/basic-documents';
+		const sourceSpaceName = `Space ${getRandomString()}`;
+		const destinationSpaceName = `Space ${getRandomString()}`;
+		const destinationFolderName = `Destination ${getRandomString()}`;
+		const fileTitle = `File ${getRandomString()}`;
+
+		await test.step('Create source and destination Spaces', async () => {
+			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+				name: sourceSpaceName,
+				settings: {},
+				type: 'Space',
+			});
+
+			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+				name: destinationSpaceName,
+				settings: {},
+				type: 'Space',
+			});
+		});
+
+		let destinationFolderId: number;
+
+		await test.step('Create a destination folder in the destination Space', async () => {
+			const folder =
+				await apiHelpers.objectFolder.createObjectEntryFolder({
+					parentObjectEntryFolderExternalReferenceCode: 'L_FILES',
+					scopeKey: destinationSpaceName,
+					title: destinationFolderName,
+				});
+
+			destinationFolderId = folder.id;
+		});
+
+		await test.step('Create a file in the source Space', async () => {
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					file: {
+						fileBase64: 'R0lGODlhAQABAAAAACw=',
+						name: `file_${getRandomString()}.png`,
+					},
+					objectEntryFolderExternalReferenceCode: 'L_FILES',
+					title: fileTitle,
+				},
+				applicationName,
+				sourceSpaceName
+			);
+		});
+
+		await test.step('Copy the file to the destination folder in the destination Space', async () => {
+			await assetsPage.gotoAll();
+
+			await assetsPage.copyTo({
+				destinationFolder: destinationFolderName,
+				destinationSpace: destinationSpaceName,
+				itemTitle: fileTitle,
+			});
+		});
+
+		await test.step('Info alert for the copy is displayed', async () => {
+			await waitForAlert(
+				page,
+				`Info:Copying ${fileTitle} to ${destinationFolderName}.`,
+				{type: 'info'}
+			);
+		});
+
+		await test.step('Success alert for the copy is displayed', async () => {
+			await waitForAlert(
+				page,
+				`Success:${fileTitle} was successfully copied to ${destinationFolderName}.`,
+				{first: true}
+			);
+		});
+
+		await test.step('The file is in the destination folder in the destination Space', async () => {
+			const response =
+				await apiHelpers.objectEntry.getObjectDefinitionObjectEntriesByScope(
+					applicationName,
+					encodeURIComponent(destinationSpaceName),
+					new URLSearchParams({pageSize: '100'})
+				);
+
+			const copiedItems = response.items.filter(
+				(item: {objectEntryFolderId: number}) =>
+					item.objectEntryFolderId === destinationFolderId
+			);
+
+			expect(copiedItems).toHaveLength(1);
+			expect(copiedItems[0].title).toBe(fileTitle);
+		});
+
+		await test.step('The original file is still present in the source Space', async () => {
+			const response =
+				await apiHelpers.objectEntry.getObjectDefinitionObjectEntriesByScope(
+					applicationName,
+					encodeURIComponent(sourceSpaceName),
+					new URLSearchParams({pageSize: '100'})
+				);
+
+			const sourceItems = response.items.filter(
+				(item: {title: string}) => item.title === fileTitle
+			);
+
+			expect(sourceItems).toHaveLength(1);
+		});
+	}
+);

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/copyMove.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/copyMove.spec.ts
@@ -459,3 +459,113 @@ test(
 		});
 	}
 );
+
+test(
+	'Can copy a folder with its contents to a different Space',
+	{tag: '@LPD-89762'},
+	async ({apiHelpers, assetsPage, page}) => {
+		const applicationName = 'cms/basic-web-contents';
+		const sourceSpaceName = `Space ${getRandomString()}`;
+		const destinationSpaceName = `Space ${getRandomString()}`;
+		const destinationFolderName = `Destination ${getRandomString()}`;
+		const sourceFolderName = `Source ${getRandomString()}`;
+		const contentTitle = `Content ${getRandomString()}`;
+
+		await test.step('Create source and destination Spaces', async () => {
+			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+				name: sourceSpaceName,
+				settings: {},
+				type: 'Space',
+			});
+
+			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+				name: destinationSpaceName,
+				settings: {},
+				type: 'Space',
+			});
+		});
+
+		await test.step('Create a destination folder in the destination Space', async () => {
+			await apiHelpers.objectFolder.createObjectEntryFolder({
+				parentObjectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				scopeKey: destinationSpaceName,
+				title: destinationFolderName,
+			});
+		});
+
+		await test.step('Create a source folder with a content inside it in the source Space', async () => {
+			const sourceFolder =
+				await apiHelpers.objectFolder.createObjectEntryFolder({
+					parentObjectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					scopeKey: sourceSpaceName,
+					title: sourceFolderName,
+				});
+
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode:
+						sourceFolder.externalReferenceCode,
+					title: contentTitle,
+				},
+				applicationName,
+				sourceSpaceName
+			);
+		});
+
+		await test.step('Copy the source folder to the destination folder in the destination Space', async () => {
+			await assetsPage.gotoSpaceContents(sourceSpaceName);
+
+			await assetsPage.copyTo({
+				destinationFolder: destinationFolderName,
+				destinationSpace: destinationSpaceName,
+				itemTitle: sourceFolderName,
+			});
+		});
+
+		await test.step('Info alert for the folder copy is displayed', async () => {
+			await waitForAlert(
+				page,
+				`Info:Copying ${sourceFolderName} to ${destinationFolderName}.`,
+				{type: 'info'}
+			);
+		});
+
+		await test.step('Success alert for the folder copy is displayed', async () => {
+			await waitForAlert(
+				page,
+				`Success:${sourceFolderName} was successfully copied to ${destinationFolderName}.`,
+				{first: true}
+			);
+		});
+
+		await test.step('The content is now in the destination Space', async () => {
+			const response =
+				await apiHelpers.objectEntry.getObjectDefinitionObjectEntriesByScope(
+					applicationName,
+					encodeURIComponent(destinationSpaceName),
+					new URLSearchParams({pageSize: '100'})
+				);
+
+			const copiedItems = response.items.filter(
+				(item: {title: string}) => item.title === contentTitle
+			);
+
+			expect(copiedItems).toHaveLength(1);
+		});
+
+		await test.step('The original content is still in the source Space', async () => {
+			const response =
+				await apiHelpers.objectEntry.getObjectDefinitionObjectEntriesByScope(
+					applicationName,
+					encodeURIComponent(sourceSpaceName),
+					new URLSearchParams({pageSize: '100'})
+				);
+
+			const sourceItems = response.items.filter(
+				(item: {title: string}) => item.title === contentTitle
+			);
+
+			expect(sourceItems).toHaveLength(1);
+		});
+	}
+);

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/copyMove.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/copyMove.spec.ts
@@ -749,6 +749,9 @@ test(
 			await expect(
 				dialog.getByLabel('Contents', {exact: true})
 			).toBeVisible();
+			await expect(
+				dialog.getByLabel('Files', {exact: true})
+			).not.toBeVisible();
 
 			await dialog
 				.getByRole('button', {exact: true, name: 'Cancel'})
@@ -773,6 +776,9 @@ test(
 			await expect(
 				dialog.getByLabel('Files', {exact: true})
 			).toBeVisible();
+			await expect(
+				dialog.getByLabel('Contents', {exact: true})
+			).not.toBeVisible();
 
 			await dialog
 				.getByRole('button', {exact: true, name: 'Cancel'})

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/copyMove.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/copyMove.spec.ts
@@ -688,3 +688,95 @@ test(
 		});
 	}
 );
+
+test(
+	'Destination picker filters folders by section when moving content vs file',
+	{tag: '@LPD-89762'},
+	async ({apiHelpers, assetsPage}) => {
+		const spaceName = `Space ${getRandomString()}`;
+		const contentTitle = `Content ${getRandomString()}`;
+		const fileTitle = `File ${getRandomString()}`;
+
+		await test.step('Create a new Space', async () => {
+			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+				name: spaceName,
+				settings: {},
+				type: 'Space',
+			});
+		});
+
+		await test.step('Create a content in that Space', async () => {
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: contentTitle,
+				},
+				'cms/basic-web-contents',
+				spaceName
+			);
+		});
+
+		await test.step('Create a file in that Space', async () => {
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					file: {
+						fileBase64: 'R0lGODlhAQABAAAAACw=',
+						name: `file_${getRandomString()}.png`,
+					},
+					objectEntryFolderExternalReferenceCode: 'L_FILES',
+					title: fileTitle,
+				},
+				'cms/basic-documents',
+				spaceName
+			);
+		});
+
+		await test.step('Move To picker for a content shows only the Contents folder', async () => {
+			await assetsPage.gotoAll();
+
+			await assetsPage.execItemAction({
+				action: 'Move',
+				filter: contentTitle,
+			});
+
+			const dialog = assetsPage.getCopyOrMoveDestinationDialog();
+
+			await dialog.getByLabel(spaceName).click();
+
+			await expect(
+				dialog.getByText('Showing 1 to 1 of 1 entries.')
+			).toBeVisible();
+			await expect(
+				dialog.getByLabel('Contents', {exact: true})
+			).toBeVisible();
+
+			await dialog
+				.getByRole('button', {exact: true, name: 'Cancel'})
+				.click();
+		});
+
+		await test.step('Move To picker for a file shows only the Files folder', async () => {
+			await assetsPage.gotoAll();
+
+			await assetsPage.execItemAction({
+				action: 'Move',
+				filter: fileTitle,
+			});
+
+			const dialog = assetsPage.getCopyOrMoveDestinationDialog();
+
+			await dialog.getByLabel(spaceName).click();
+
+			await expect(
+				dialog.getByText('Showing 1 to 1 of 1 entries.')
+			).toBeVisible();
+			await expect(
+				dialog.getByLabel('Files', {exact: true})
+			).toBeVisible();
+
+			await dialog
+				.getByRole('button', {exact: true, name: 'Cancel'})
+				.click();
+		});
+	}
+);

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/copyMove.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/copyMove.spec.ts
@@ -892,3 +892,111 @@ test(
 		});
 	}
 );
+
+test(
+	'Can copy a content to a folder in a different Space',
+	{tag: '@LPD-89762'},
+	async ({apiHelpers, assetsPage, page}) => {
+		const applicationName = 'cms/basic-web-contents';
+		const sourceSpaceName = `Space ${getRandomString()}`;
+		const destinationSpaceName = `Space ${getRandomString()}`;
+		const destinationFolderName = `Destination ${getRandomString()}`;
+		const contentTitle = `Content ${getRandomString()}`;
+
+		await test.step('Create source and destination Spaces', async () => {
+			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+				name: sourceSpaceName,
+				settings: {},
+				type: 'Space',
+			});
+
+			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+				name: destinationSpaceName,
+				settings: {},
+				type: 'Space',
+			});
+		});
+
+		let destinationFolderId: number;
+
+		await test.step('Create a destination folder in the destination Space', async () => {
+			const folder =
+				await apiHelpers.objectFolder.createObjectEntryFolder({
+					parentObjectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					scopeKey: destinationSpaceName,
+					title: destinationFolderName,
+				});
+
+			destinationFolderId = folder.id;
+		});
+
+		await test.step('Create a content in the source Space', async () => {
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: contentTitle,
+				},
+				applicationName,
+				sourceSpaceName
+			);
+		});
+
+		await test.step('Copy the content to the destination folder in the destination Space', async () => {
+			await assetsPage.gotoAll();
+
+			await assetsPage.copyTo({
+				destinationFolder: destinationFolderName,
+				destinationSpace: destinationSpaceName,
+				itemTitle: contentTitle,
+			});
+		});
+
+		await test.step('Info alert for the copy is displayed', async () => {
+			await waitForAlert(
+				page,
+				`Info:Copying ${contentTitle} to ${destinationFolderName}.`,
+				{type: 'info'}
+			);
+		});
+
+		await test.step('Success alert for the copy is displayed', async () => {
+			await waitForAlert(
+				page,
+				`Success:${contentTitle} was successfully copied to ${destinationFolderName}.`,
+				{first: true}
+			);
+		});
+
+		await test.step('The content is in the destination folder in the destination Space', async () => {
+			const response =
+				await apiHelpers.objectEntry.getObjectDefinitionObjectEntriesByScope(
+					applicationName,
+					encodeURIComponent(destinationSpaceName),
+					new URLSearchParams({pageSize: '100'})
+				);
+
+			const copiedItems = response.items.filter(
+				(item: {objectEntryFolderId: number}) =>
+					item.objectEntryFolderId === destinationFolderId
+			);
+
+			expect(copiedItems).toHaveLength(1);
+			expect(copiedItems[0].title).toBe(contentTitle);
+		});
+
+		await test.step('The original content is still present in the source Space', async () => {
+			const response =
+				await apiHelpers.objectEntry.getObjectDefinitionObjectEntriesByScope(
+					applicationName,
+					encodeURIComponent(sourceSpaceName),
+					new URLSearchParams({pageSize: '100'})
+				);
+
+			const sourceItems = response.items.filter(
+				(item: {title: string}) => item.title === contentTitle
+			);
+
+			expect(sourceItems).toHaveLength(1);
+		});
+	}
+);

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/copyMove.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/copyMove.spec.ts
@@ -1060,8 +1060,6 @@ test(
 		await test.step('Move the source folder to the destination folder in the destination Space', async () => {
 			await assetsPage.gotoSpaceFiles(sourceSpaceName);
 
-			await assetsPage.changeVisualizationMode('Table');
-
 			await assetsPage.moveTo({
 				destinationFolder: destinationFolderName,
 				destinationSpace: destinationSpaceName,
@@ -1175,8 +1173,6 @@ test(
 
 		await test.step('Copy the source folder to the destination folder in the destination Space', async () => {
 			await assetsPage.gotoSpaceFiles(sourceSpaceName);
-
-			await assetsPage.changeVisualizationMode('Table');
 
 			await assetsPage.copyTo({
 				destinationFolder: destinationFolderName,

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/copyMove.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/copyMove.spec.ts
@@ -349,3 +349,113 @@ test(
 		});
 	}
 );
+
+test(
+	'Can move a folder with its contents to a different Space',
+	{tag: '@LPD-89762'},
+	async ({apiHelpers, assetsPage, page}) => {
+		const applicationName = 'cms/basic-web-contents';
+		const sourceSpaceName = `Space ${getRandomString()}`;
+		const destinationSpaceName = `Space ${getRandomString()}`;
+		const destinationFolderName = `Destination ${getRandomString()}`;
+		const sourceFolderName = `Source ${getRandomString()}`;
+		const contentTitle = `Content ${getRandomString()}`;
+
+		await test.step('Create source and destination Spaces', async () => {
+			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+				name: sourceSpaceName,
+				settings: {},
+				type: 'Space',
+			});
+
+			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+				name: destinationSpaceName,
+				settings: {},
+				type: 'Space',
+			});
+		});
+
+		await test.step('Create a destination folder in the destination Space', async () => {
+			await apiHelpers.objectFolder.createObjectEntryFolder({
+				parentObjectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				scopeKey: destinationSpaceName,
+				title: destinationFolderName,
+			});
+		});
+
+		await test.step('Create a source folder with a content inside it in the source Space', async () => {
+			const sourceFolder =
+				await apiHelpers.objectFolder.createObjectEntryFolder({
+					parentObjectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					scopeKey: sourceSpaceName,
+					title: sourceFolderName,
+				});
+
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode:
+						sourceFolder.externalReferenceCode,
+					title: contentTitle,
+				},
+				applicationName,
+				sourceSpaceName
+			);
+		});
+
+		await test.step('Move the source folder to the destination folder in the destination Space', async () => {
+			await assetsPage.gotoSpaceContents(sourceSpaceName);
+
+			await assetsPage.moveTo({
+				destinationFolder: destinationFolderName,
+				destinationSpace: destinationSpaceName,
+				itemTitle: sourceFolderName,
+			});
+		});
+
+		await test.step('Info alert for the folder move is displayed', async () => {
+			await waitForAlert(
+				page,
+				`Info:Moving ${sourceFolderName} to ${destinationFolderName}.`,
+				{type: 'info'}
+			);
+		});
+
+		await test.step('Success alert for the folder move is displayed', async () => {
+			await waitForAlert(
+				page,
+				`Success:${sourceFolderName} was successfully moved to ${destinationFolderName}.`,
+				{first: true}
+			);
+		});
+
+		await test.step('The content is now in the destination Space', async () => {
+			const response =
+				await apiHelpers.objectEntry.getObjectDefinitionObjectEntriesByScope(
+					applicationName,
+					encodeURIComponent(destinationSpaceName),
+					new URLSearchParams({pageSize: '100'})
+				);
+
+			const movedItems = response.items.filter(
+				(item: {title: string}) => item.title === contentTitle
+			);
+
+			expect(movedItems).toHaveLength(1);
+		});
+
+		await test.step('The content is no longer in the source Space', async () => {
+			const response =
+				await apiHelpers.objectEntry.getObjectDefinitionObjectEntriesByScope(
+					applicationName,
+					encodeURIComponent(sourceSpaceName),
+					new URLSearchParams({pageSize: '100'})
+				);
+
+			const sourceItems = response.items.filter(
+				(item: {title: string}) => item.title === contentTitle
+			);
+
+			expect(sourceItems).toHaveLength(0);
+		});
+	}
+);

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/copyMove.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/copyMove.spec.ts
@@ -1,0 +1,131 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
+import {loginTest} from '../../../fixtures/loginTest';
+import getRandomString from '../../../utils/getRandomString';
+import {performUserSwitch, userData} from '../../../utils/performLogin';
+import {waitForAlert} from '../../../utils/waitForAlert';
+import {cmsPagesTest} from './fixtures/cmsPagesTest';
+
+const test = mergeTests(
+	cmsPagesTest,
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-11235': {enabled: false},
+		'LPD-17564': {enabled: true},
+		'LPD-34594': {enabled: true},
+	}),
+	loginTest()
+);
+
+test.beforeEach(async ({apiHelpers, page}) => {
+	const user = await apiHelpers.headlessAdminUser.postUserAccount();
+
+	userData[user.alternateName] = {
+		name: user.givenName,
+		password: 'test',
+		surname: user.familyName,
+	};
+
+	const cmsAdminRole =
+		await apiHelpers.headlessAdminUser.getRoleByName('CMS Administrator');
+
+	await apiHelpers.headlessAdminUser.postRoleUserAccountAssociation(
+		cmsAdminRole.id,
+		Number(user.id)
+	);
+
+	await performUserSwitch(page, user.alternateName);
+});
+
+test(
+	'Can move a content to a folder in the same Space',
+	{tag: '@LPD-89762'},
+	async ({apiHelpers, assetsPage, page}) => {
+		const applicationName = 'cms/basic-web-contents';
+		const spaceName = `Space ${getRandomString()}`;
+		const destinationFolderName = `Destination ${getRandomString()}`;
+		const contentTitle = `Content ${getRandomString()}`;
+
+		await test.step('Create a new Space', async () => {
+			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+				name: spaceName,
+				settings: {},
+				type: 'Space',
+			});
+		});
+
+		let destinationFolderId: number;
+
+		await test.step('Create a destination folder in the Space', async () => {
+			const folder =
+				await apiHelpers.objectFolder.createObjectEntryFolder({
+					parentObjectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					scopeKey: spaceName,
+					title: destinationFolderName,
+				});
+
+			destinationFolderId = folder.id;
+		});
+
+		await test.step('Create a content at the root of the Space', async () => {
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: contentTitle,
+				},
+				applicationName,
+				spaceName
+			);
+		});
+
+		await test.step('Move the content to the destination folder', async () => {
+			await assetsPage.gotoAll();
+
+			await assetsPage.moveTo({
+				destinationFolder: destinationFolderName,
+				destinationSpace: spaceName,
+				itemTitle: contentTitle,
+			});
+		});
+
+		await test.step('Info alert for the move is displayed', async () => {
+			await waitForAlert(
+				page,
+				`Info:Moving ${contentTitle} to ${destinationFolderName}.`,
+				{type: 'info'}
+			);
+		});
+
+		await test.step('Success alert for the move is displayed', async () => {
+			await waitForAlert(
+				page,
+				`Success:${contentTitle} was successfully moved to ${destinationFolderName}.`,
+				{first: true}
+			);
+		});
+
+		await test.step('The content is in the destination folder', async () => {
+			const response =
+				await apiHelpers.objectEntry.getObjectDefinitionObjectEntriesByScope(
+					applicationName,
+					encodeURIComponent(spaceName),
+					new URLSearchParams({pageSize: '100'})
+				);
+
+			const movedItems = response.items.filter(
+				(item: {objectEntryFolderId: number}) =>
+					item.objectEntryFolderId === destinationFolderId
+			);
+
+			expect(movedItems).toHaveLength(1);
+			expect(movedItems[0].title).toBe(contentTitle);
+		});
+	}
+);

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/copyMove.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/copyMove.spec.ts
@@ -8,6 +8,7 @@ import {expect, mergeTests} from '@playwright/test';
 import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
 import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
 import {loginTest} from '../../../fixtures/loginTest';
+import {DataApiHelpers} from '../../../helpers/ApiHelpers';
 import getRandomString from '../../../utils/getRandomString';
 import {performUserSwitch, userData} from '../../../utils/performLogin';
 import {waitForAlert} from '../../../utils/waitForAlert';
@@ -23,6 +24,84 @@ const test = mergeTests(
 	}),
 	loginTest()
 );
+
+function createSpace(apiHelpers: DataApiHelpers, name: string) {
+	return apiHelpers.headlessAssetLibrary.createAssetLibrary({
+		name,
+		settings: {},
+		type: 'Space',
+	});
+}
+
+function createSpaces(apiHelpers: DataApiHelpers, ...names: string[]) {
+	return Promise.all(names.map((name) => createSpace(apiHelpers, name)));
+}
+
+function createFolder(
+	apiHelpers: DataApiHelpers,
+	{
+		parentObjectEntryFolderExternalReferenceCode,
+		scopeKey,
+		title,
+	}: {
+		parentObjectEntryFolderExternalReferenceCode: 'L_CONTENTS' | 'L_FILES';
+		scopeKey: string;
+		title: string;
+	}
+) {
+	return apiHelpers.objectFolder.createObjectEntryFolder({
+		parentObjectEntryFolderExternalReferenceCode,
+		scopeKey,
+		title,
+	});
+}
+
+function createContent(
+	apiHelpers: DataApiHelpers,
+	{
+		applicationName = 'cms/basic-web-contents',
+		objectEntryFolderExternalReferenceCode = 'L_CONTENTS',
+		scopeKey,
+		title,
+	}: {
+		applicationName?: string;
+		objectEntryFolderExternalReferenceCode?: string;
+		scopeKey: string;
+		title: string;
+	}
+) {
+	return apiHelpers.objectEntry.postObjectEntry(
+		{objectEntryFolderExternalReferenceCode, title},
+		applicationName,
+		scopeKey
+	);
+}
+
+function createFile(
+	apiHelpers: DataApiHelpers,
+	{
+		objectEntryFolderExternalReferenceCode = 'L_FILES',
+		scopeKey,
+		title,
+	}: {
+		objectEntryFolderExternalReferenceCode?: string;
+		scopeKey: string;
+		title: string;
+	}
+) {
+	return apiHelpers.objectEntry.postObjectEntry(
+		{
+			file: {
+				fileBase64: 'R0lGODlhAQABAAAAACw=',
+				name: `file_${getRandomString()}.png`,
+			},
+			objectEntryFolderExternalReferenceCode,
+			title,
+		},
+		'cms/basic-documents',
+		scopeKey
+	);
+}
 
 test.beforeEach(async ({apiHelpers, page}) => {
 	const user = await apiHelpers.headlessAdminUser.postUserAccount();
@@ -54,35 +133,27 @@ test(
 		const contentTitle = `Content ${getRandomString()}`;
 
 		await test.step('Create a new Space', async () => {
-			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
-				name: spaceName,
-				settings: {},
-				type: 'Space',
-			});
+			await createSpace(apiHelpers, spaceName);
 		});
 
 		let destinationFolderId: number;
 
 		await test.step('Create a destination folder in the Space', async () => {
-			const folder =
-				await apiHelpers.objectFolder.createObjectEntryFolder({
-					parentObjectEntryFolderExternalReferenceCode: 'L_CONTENTS',
-					scopeKey: spaceName,
-					title: destinationFolderName,
-				});
+			const folder = await createFolder(apiHelpers, {
+				parentObjectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				scopeKey: spaceName,
+				title: destinationFolderName,
+			});
 
 			destinationFolderId = folder.id;
 		});
 
 		await test.step('Create a content at the root of the Space', async () => {
-			await apiHelpers.objectEntry.postObjectEntry(
-				{
-					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
-					title: contentTitle,
-				},
+			await createContent(apiHelpers, {
 				applicationName,
-				spaceName
-			);
+				scopeKey: spaceName,
+				title: contentTitle,
+			});
 		});
 
 		await test.step('Move the content to the destination folder', async () => {
@@ -141,41 +212,31 @@ test(
 		const contentTitle = `Content ${getRandomString()}`;
 
 		await test.step('Create source and destination Spaces', async () => {
-			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
-				name: sourceSpaceName,
-				settings: {},
-				type: 'Space',
-			});
-
-			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
-				name: destinationSpaceName,
-				settings: {},
-				type: 'Space',
-			});
+			await createSpaces(
+				apiHelpers,
+				sourceSpaceName,
+				destinationSpaceName
+			);
 		});
 
 		let destinationFolderId: number;
 
 		await test.step('Create a destination folder in the destination Space', async () => {
-			const folder =
-				await apiHelpers.objectFolder.createObjectEntryFolder({
-					parentObjectEntryFolderExternalReferenceCode: 'L_CONTENTS',
-					scopeKey: destinationSpaceName,
-					title: destinationFolderName,
-				});
+			const folder = await createFolder(apiHelpers, {
+				parentObjectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				scopeKey: destinationSpaceName,
+				title: destinationFolderName,
+			});
 
 			destinationFolderId = folder.id;
 		});
 
 		await test.step('Create a content in the source Space', async () => {
-			await apiHelpers.objectEntry.postObjectEntry(
-				{
-					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
-					title: contentTitle,
-				},
+			await createContent(apiHelpers, {
 				applicationName,
-				sourceSpaceName
-			);
+				scopeKey: sourceSpaceName,
+				title: contentTitle,
+			});
 		});
 
 		await test.step('Move the content to the destination folder in the destination Space', async () => {
@@ -249,45 +310,30 @@ test(
 		const fileTitle = `File ${getRandomString()}`;
 
 		await test.step('Create source and destination Spaces', async () => {
-			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
-				name: sourceSpaceName,
-				settings: {},
-				type: 'Space',
-			});
-
-			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
-				name: destinationSpaceName,
-				settings: {},
-				type: 'Space',
-			});
+			await createSpaces(
+				apiHelpers,
+				sourceSpaceName,
+				destinationSpaceName
+			);
 		});
 
 		let destinationFolderId: number;
 
 		await test.step('Create a destination folder in the destination Space', async () => {
-			const folder =
-				await apiHelpers.objectFolder.createObjectEntryFolder({
-					parentObjectEntryFolderExternalReferenceCode: 'L_FILES',
-					scopeKey: destinationSpaceName,
-					title: destinationFolderName,
-				});
+			const folder = await createFolder(apiHelpers, {
+				parentObjectEntryFolderExternalReferenceCode: 'L_FILES',
+				scopeKey: destinationSpaceName,
+				title: destinationFolderName,
+			});
 
 			destinationFolderId = folder.id;
 		});
 
 		await test.step('Create a file in the source Space', async () => {
-			await apiHelpers.objectEntry.postObjectEntry(
-				{
-					file: {
-						fileBase64: 'R0lGODlhAQABAAAAACw=',
-						name: `file_${getRandomString()}.png`,
-					},
-					objectEntryFolderExternalReferenceCode: 'L_FILES',
-					title: fileTitle,
-				},
-				applicationName,
-				sourceSpaceName
-			);
+			await createFile(apiHelpers, {
+				scopeKey: sourceSpaceName,
+				title: fileTitle,
+			});
 		});
 
 		await test.step('Copy the file to the destination folder in the destination Space', async () => {
@@ -362,21 +408,15 @@ test(
 		const contentTitle = `Content ${getRandomString()}`;
 
 		await test.step('Create source and destination Spaces', async () => {
-			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
-				name: sourceSpaceName,
-				settings: {},
-				type: 'Space',
-			});
-
-			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
-				name: destinationSpaceName,
-				settings: {},
-				type: 'Space',
-			});
+			await createSpaces(
+				apiHelpers,
+				sourceSpaceName,
+				destinationSpaceName
+			);
 		});
 
 		await test.step('Create a destination folder in the destination Space', async () => {
-			await apiHelpers.objectFolder.createObjectEntryFolder({
+			await createFolder(apiHelpers, {
 				parentObjectEntryFolderExternalReferenceCode: 'L_CONTENTS',
 				scopeKey: destinationSpaceName,
 				title: destinationFolderName,
@@ -384,22 +424,19 @@ test(
 		});
 
 		await test.step('Create a source folder with a content inside it in the source Space', async () => {
-			const sourceFolder =
-				await apiHelpers.objectFolder.createObjectEntryFolder({
-					parentObjectEntryFolderExternalReferenceCode: 'L_CONTENTS',
-					scopeKey: sourceSpaceName,
-					title: sourceFolderName,
-				});
+			const sourceFolder = await createFolder(apiHelpers, {
+				parentObjectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				scopeKey: sourceSpaceName,
+				title: sourceFolderName,
+			});
 
-			await apiHelpers.objectEntry.postObjectEntry(
-				{
-					objectEntryFolderExternalReferenceCode:
-						sourceFolder.externalReferenceCode,
-					title: contentTitle,
-				},
+			await createContent(apiHelpers, {
 				applicationName,
-				sourceSpaceName
-			);
+				objectEntryFolderExternalReferenceCode:
+					sourceFolder.externalReferenceCode,
+				scopeKey: sourceSpaceName,
+				title: contentTitle,
+			});
 		});
 
 		await test.step('Move the source folder to the destination folder in the destination Space', async () => {
@@ -472,21 +509,15 @@ test(
 		const contentTitle = `Content ${getRandomString()}`;
 
 		await test.step('Create source and destination Spaces', async () => {
-			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
-				name: sourceSpaceName,
-				settings: {},
-				type: 'Space',
-			});
-
-			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
-				name: destinationSpaceName,
-				settings: {},
-				type: 'Space',
-			});
+			await createSpaces(
+				apiHelpers,
+				sourceSpaceName,
+				destinationSpaceName
+			);
 		});
 
 		await test.step('Create a destination folder in the destination Space', async () => {
-			await apiHelpers.objectFolder.createObjectEntryFolder({
+			await createFolder(apiHelpers, {
 				parentObjectEntryFolderExternalReferenceCode: 'L_CONTENTS',
 				scopeKey: destinationSpaceName,
 				title: destinationFolderName,
@@ -494,22 +525,19 @@ test(
 		});
 
 		await test.step('Create a source folder with a content inside it in the source Space', async () => {
-			const sourceFolder =
-				await apiHelpers.objectFolder.createObjectEntryFolder({
-					parentObjectEntryFolderExternalReferenceCode: 'L_CONTENTS',
-					scopeKey: sourceSpaceName,
-					title: sourceFolderName,
-				});
+			const sourceFolder = await createFolder(apiHelpers, {
+				parentObjectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				scopeKey: sourceSpaceName,
+				title: sourceFolderName,
+			});
 
-			await apiHelpers.objectEntry.postObjectEntry(
-				{
-					objectEntryFolderExternalReferenceCode:
-						sourceFolder.externalReferenceCode,
-					title: contentTitle,
-				},
+			await createContent(apiHelpers, {
 				applicationName,
-				sourceSpaceName
-			);
+				objectEntryFolderExternalReferenceCode:
+					sourceFolder.externalReferenceCode,
+				scopeKey: sourceSpaceName,
+				title: contentTitle,
+			});
 		});
 
 		await test.step('Copy the source folder to the destination folder in the destination Space', async () => {
@@ -582,24 +610,17 @@ test(
 		let sourceSpaceERC: string;
 
 		await test.step('Create source and destination Spaces', async () => {
-			const sourceSpace =
-				await apiHelpers.headlessAssetLibrary.createAssetLibrary({
-					name: sourceSpaceName,
-					settings: {},
-					type: 'Space',
-				});
+			const [sourceSpace] = await createSpaces(
+				apiHelpers,
+				sourceSpaceName,
+				destinationSpaceName
+			);
 
 			sourceSpaceERC = sourceSpace.externalReferenceCode;
-
-			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
-				name: destinationSpaceName,
-				settings: {},
-				type: 'Space',
-			});
 		});
 
 		await test.step('Create a destination folder in the destination Space', async () => {
-			await apiHelpers.objectFolder.createObjectEntryFolder({
+			await createFolder(apiHelpers, {
 				parentObjectEntryFolderExternalReferenceCode: 'L_CONTENTS',
 				scopeKey: destinationSpaceName,
 				title: destinationFolderName,
@@ -659,14 +680,11 @@ test(
 		});
 
 		await test.step('Seed a content in the source Space', async () => {
-			await apiHelpers.objectEntry.postObjectEntry(
-				{
-					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
-					title: contentTitle,
-				},
+			await createContent(apiHelpers, {
 				applicationName,
-				sourceSpaceName
-			);
+				scopeKey: sourceSpaceName,
+				title: contentTitle,
+			});
 		});
 
 		await test.step('Try to move the content to the destination Space', async () => {
@@ -698,37 +716,21 @@ test(
 		const fileTitle = `File ${getRandomString()}`;
 
 		await test.step('Create a new Space', async () => {
-			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
-				name: spaceName,
-				settings: {},
-				type: 'Space',
-			});
+			await createSpace(apiHelpers, spaceName);
 		});
 
 		await test.step('Create a content in that Space', async () => {
-			await apiHelpers.objectEntry.postObjectEntry(
-				{
-					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
-					title: contentTitle,
-				},
-				'cms/basic-web-contents',
-				spaceName
-			);
+			await createContent(apiHelpers, {
+				scopeKey: spaceName,
+				title: contentTitle,
+			});
 		});
 
 		await test.step('Create a file in that Space', async () => {
-			await apiHelpers.objectEntry.postObjectEntry(
-				{
-					file: {
-						fileBase64: 'R0lGODlhAQABAAAAACw=',
-						name: `file_${getRandomString()}.png`,
-					},
-					objectEntryFolderExternalReferenceCode: 'L_FILES',
-					title: fileTitle,
-				},
-				'cms/basic-documents',
-				spaceName
-			);
+			await createFile(apiHelpers, {
+				scopeKey: spaceName,
+				title: fileTitle,
+			});
 		});
 
 		await test.step('Move To picker for a content shows only the Contents folder', async () => {
@@ -798,45 +800,30 @@ test(
 		const fileTitle = `File ${getRandomString()}`;
 
 		await test.step('Create source and destination Spaces', async () => {
-			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
-				name: sourceSpaceName,
-				settings: {},
-				type: 'Space',
-			});
-
-			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
-				name: destinationSpaceName,
-				settings: {},
-				type: 'Space',
-			});
+			await createSpaces(
+				apiHelpers,
+				sourceSpaceName,
+				destinationSpaceName
+			);
 		});
 
 		let destinationFolderId: number;
 
 		await test.step('Create a destination folder in the destination Space', async () => {
-			const folder =
-				await apiHelpers.objectFolder.createObjectEntryFolder({
-					parentObjectEntryFolderExternalReferenceCode: 'L_FILES',
-					scopeKey: destinationSpaceName,
-					title: destinationFolderName,
-				});
+			const folder = await createFolder(apiHelpers, {
+				parentObjectEntryFolderExternalReferenceCode: 'L_FILES',
+				scopeKey: destinationSpaceName,
+				title: destinationFolderName,
+			});
 
 			destinationFolderId = folder.id;
 		});
 
 		await test.step('Create a file in the source Space', async () => {
-			await apiHelpers.objectEntry.postObjectEntry(
-				{
-					file: {
-						fileBase64: 'R0lGODlhAQABAAAAACw=',
-						name: `file_${getRandomString()}.png`,
-					},
-					objectEntryFolderExternalReferenceCode: 'L_FILES',
-					title: fileTitle,
-				},
-				applicationName,
-				sourceSpaceName
-			);
+			await createFile(apiHelpers, {
+				scopeKey: sourceSpaceName,
+				title: fileTitle,
+			});
 		});
 
 		await test.step('Move the file to the destination folder in the destination Space', async () => {
@@ -910,41 +897,31 @@ test(
 		const contentTitle = `Content ${getRandomString()}`;
 
 		await test.step('Create source and destination Spaces', async () => {
-			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
-				name: sourceSpaceName,
-				settings: {},
-				type: 'Space',
-			});
-
-			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
-				name: destinationSpaceName,
-				settings: {},
-				type: 'Space',
-			});
+			await createSpaces(
+				apiHelpers,
+				sourceSpaceName,
+				destinationSpaceName
+			);
 		});
 
 		let destinationFolderId: number;
 
 		await test.step('Create a destination folder in the destination Space', async () => {
-			const folder =
-				await apiHelpers.objectFolder.createObjectEntryFolder({
-					parentObjectEntryFolderExternalReferenceCode: 'L_CONTENTS',
-					scopeKey: destinationSpaceName,
-					title: destinationFolderName,
-				});
+			const folder = await createFolder(apiHelpers, {
+				parentObjectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				scopeKey: destinationSpaceName,
+				title: destinationFolderName,
+			});
 
 			destinationFolderId = folder.id;
 		});
 
 		await test.step('Create a content in the source Space', async () => {
-			await apiHelpers.objectEntry.postObjectEntry(
-				{
-					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
-					title: contentTitle,
-				},
+			await createContent(apiHelpers, {
 				applicationName,
-				sourceSpaceName
-			);
+				scopeKey: sourceSpaceName,
+				title: contentTitle,
+			});
 		});
 
 		await test.step('Copy the content to the destination folder in the destination Space', async () => {
@@ -1019,21 +996,15 @@ test(
 		const fileTitle = `File ${getRandomString()}`;
 
 		await test.step('Create source and destination Spaces', async () => {
-			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
-				name: sourceSpaceName,
-				settings: {},
-				type: 'Space',
-			});
-
-			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
-				name: destinationSpaceName,
-				settings: {},
-				type: 'Space',
-			});
+			await createSpaces(
+				apiHelpers,
+				sourceSpaceName,
+				destinationSpaceName
+			);
 		});
 
 		await test.step('Create a destination Files folder in the destination Space', async () => {
-			await apiHelpers.objectFolder.createObjectEntryFolder({
+			await createFolder(apiHelpers, {
 				parentObjectEntryFolderExternalReferenceCode: 'L_FILES',
 				scopeKey: destinationSpaceName,
 				title: destinationFolderName,
@@ -1041,26 +1012,18 @@ test(
 		});
 
 		await test.step('Create a source Files folder with a file inside it in the source Space', async () => {
-			const sourceFolder =
-				await apiHelpers.objectFolder.createObjectEntryFolder({
-					parentObjectEntryFolderExternalReferenceCode: 'L_FILES',
-					scopeKey: sourceSpaceName,
-					title: sourceFolderName,
-				});
+			const sourceFolder = await createFolder(apiHelpers, {
+				parentObjectEntryFolderExternalReferenceCode: 'L_FILES',
+				scopeKey: sourceSpaceName,
+				title: sourceFolderName,
+			});
 
-			await apiHelpers.objectEntry.postObjectEntry(
-				{
-					file: {
-						fileBase64: 'R0lGODlhAQABAAAAACw=',
-						name: `file_${getRandomString()}.png`,
-					},
-					objectEntryFolderExternalReferenceCode:
-						sourceFolder.externalReferenceCode,
-					title: fileTitle,
-				},
-				applicationName,
-				sourceSpaceName
-			);
+			await createFile(apiHelpers, {
+				objectEntryFolderExternalReferenceCode:
+					sourceFolder.externalReferenceCode,
+				scopeKey: sourceSpaceName,
+				title: fileTitle,
+			});
 		});
 
 		await test.step('Move the source folder to the destination folder in the destination Space', async () => {
@@ -1133,21 +1096,15 @@ test(
 		const fileTitle = `File ${getRandomString()}`;
 
 		await test.step('Create source and destination Spaces', async () => {
-			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
-				name: sourceSpaceName,
-				settings: {},
-				type: 'Space',
-			});
-
-			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
-				name: destinationSpaceName,
-				settings: {},
-				type: 'Space',
-			});
+			await createSpaces(
+				apiHelpers,
+				sourceSpaceName,
+				destinationSpaceName
+			);
 		});
 
 		await test.step('Create a destination Files folder in the destination Space', async () => {
-			await apiHelpers.objectFolder.createObjectEntryFolder({
+			await createFolder(apiHelpers, {
 				parentObjectEntryFolderExternalReferenceCode: 'L_FILES',
 				scopeKey: destinationSpaceName,
 				title: destinationFolderName,
@@ -1155,26 +1112,18 @@ test(
 		});
 
 		await test.step('Create a source Files folder with a file inside it in the source Space', async () => {
-			const sourceFolder =
-				await apiHelpers.objectFolder.createObjectEntryFolder({
-					parentObjectEntryFolderExternalReferenceCode: 'L_FILES',
-					scopeKey: sourceSpaceName,
-					title: sourceFolderName,
-				});
+			const sourceFolder = await createFolder(apiHelpers, {
+				parentObjectEntryFolderExternalReferenceCode: 'L_FILES',
+				scopeKey: sourceSpaceName,
+				title: sourceFolderName,
+			});
 
-			await apiHelpers.objectEntry.postObjectEntry(
-				{
-					file: {
-						fileBase64: 'R0lGODlhAQABAAAAACw=',
-						name: `file_${getRandomString()}.png`,
-					},
-					objectEntryFolderExternalReferenceCode:
-						sourceFolder.externalReferenceCode,
-					title: fileTitle,
-				},
-				applicationName,
-				sourceSpaceName
-			);
+			await createFile(apiHelpers, {
+				objectEntryFolderExternalReferenceCode:
+					sourceFolder.externalReferenceCode,
+				scopeKey: sourceSpaceName,
+				title: fileTitle,
+			});
 		});
 
 		await test.step('Copy the source folder to the destination folder in the destination Space', async () => {

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/copyMove.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/copyMove.spec.ts
@@ -569,3 +569,122 @@ test(
 		});
 	}
 );
+
+test(
+	'Move shows an error when the destination Space lacks the content structure',
+	{tag: '@LPD-89762'},
+	async ({apiHelpers, assetsPage, page}) => {
+		const sourceSpaceName = `Space ${getRandomString()}`;
+		const destinationSpaceName = `Space ${getRandomString()}`;
+		const destinationFolderName = `Destination ${getRandomString()}`;
+		const contentTitle = `Content ${getRandomString()}`;
+
+		let sourceSpaceERC: string;
+
+		await test.step('Create source and destination Spaces', async () => {
+			const sourceSpace =
+				await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+					name: sourceSpaceName,
+					settings: {},
+					type: 'Space',
+				});
+
+			sourceSpaceERC = sourceSpace.externalReferenceCode;
+
+			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+				name: destinationSpaceName,
+				settings: {},
+				type: 'Space',
+			});
+		});
+
+		await test.step('Create a destination folder in the destination Space', async () => {
+			await apiHelpers.objectFolder.createObjectEntryFolder({
+				parentObjectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				scopeKey: destinationSpaceName,
+				title: destinationFolderName,
+			});
+		});
+
+		let applicationName: string;
+
+		await test.step('Create a content structure available only in the source Space', async () => {
+			const definition =
+				await apiHelpers.objectAdmin.postRandomObjectDefinition({
+					objectDefinitionSettings: [
+						{
+							name: 'acceptedGroupExternalReferenceCodes',
+							value: sourceSpaceERC as unknown as object,
+						},
+					],
+					objectFields: [
+						{
+							DBType: 'String',
+							businessType: 'Text',
+							externalReferenceCode: getRandomString(),
+							indexed: true,
+							indexedAsKeyword: false,
+							indexedLanguageId: 'en_US',
+							label: {en_US: 'Title'},
+							localized: true,
+							name: 'title',
+							required: true,
+						},
+					],
+					objectFolderExternalReferenceCode:
+						'L_CMS_CONTENT_STRUCTURES',
+					scope: 'depot',
+					status: {code: 0},
+					titleObjectFieldName: 'title',
+				});
+
+			expect(
+				definition.id,
+				'object definition was created'
+			).toBeDefined();
+			expect(
+				definition.restContextPath,
+				'object definition has a REST context path'
+			).toBeDefined();
+
+			apiHelpers.data.push({
+				id: definition.id as number,
+				type: 'objectDefinition',
+			});
+
+			applicationName = (definition.restContextPath as string).replace(
+				/^\/o\//,
+				''
+			);
+		});
+
+		await test.step('Seed a content in the source Space', async () => {
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: contentTitle,
+				},
+				applicationName,
+				sourceSpaceName
+			);
+		});
+
+		await test.step('Try to move the content to the destination Space', async () => {
+			await assetsPage.gotoAll();
+
+			await assetsPage.moveTo({
+				destinationFolder: destinationFolderName,
+				destinationSpace: destinationSpaceName,
+				itemTitle: contentTitle,
+			});
+		});
+
+		await test.step('Error toast informs the asset cannot be moved', async () => {
+			await waitForAlert(
+				page,
+				'Error:The asset cannot be moved because its content type is not available in the destination space.',
+				{type: 'danger'}
+			);
+		});
+	}
+);

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/copyMove.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/copyMove.spec.ts
@@ -780,3 +780,115 @@ test(
 		});
 	}
 );
+
+test(
+	'Can move a file to a folder in a different Space',
+	{tag: '@LPD-89762'},
+	async ({apiHelpers, assetsPage, page}) => {
+		const applicationName = 'cms/basic-documents';
+		const sourceSpaceName = `Space ${getRandomString()}`;
+		const destinationSpaceName = `Space ${getRandomString()}`;
+		const destinationFolderName = `Destination ${getRandomString()}`;
+		const fileTitle = `File ${getRandomString()}`;
+
+		await test.step('Create source and destination Spaces', async () => {
+			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+				name: sourceSpaceName,
+				settings: {},
+				type: 'Space',
+			});
+
+			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+				name: destinationSpaceName,
+				settings: {},
+				type: 'Space',
+			});
+		});
+
+		let destinationFolderId: number;
+
+		await test.step('Create a destination folder in the destination Space', async () => {
+			const folder =
+				await apiHelpers.objectFolder.createObjectEntryFolder({
+					parentObjectEntryFolderExternalReferenceCode: 'L_FILES',
+					scopeKey: destinationSpaceName,
+					title: destinationFolderName,
+				});
+
+			destinationFolderId = folder.id;
+		});
+
+		await test.step('Create a file in the source Space', async () => {
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					file: {
+						fileBase64: 'R0lGODlhAQABAAAAACw=',
+						name: `file_${getRandomString()}.png`,
+					},
+					objectEntryFolderExternalReferenceCode: 'L_FILES',
+					title: fileTitle,
+				},
+				applicationName,
+				sourceSpaceName
+			);
+		});
+
+		await test.step('Move the file to the destination folder in the destination Space', async () => {
+			await assetsPage.gotoAll();
+
+			await assetsPage.moveTo({
+				destinationFolder: destinationFolderName,
+				destinationSpace: destinationSpaceName,
+				itemTitle: fileTitle,
+			});
+		});
+
+		await test.step('Info alert for the move is displayed', async () => {
+			await waitForAlert(
+				page,
+				`Info:Moving ${fileTitle} to ${destinationFolderName}.`,
+				{type: 'info'}
+			);
+		});
+
+		await test.step('Success alert for the move is displayed', async () => {
+			await waitForAlert(
+				page,
+				`Success:${fileTitle} was successfully moved to ${destinationFolderName}.`,
+				{first: true}
+			);
+		});
+
+		await test.step('The file is in the destination folder in the destination Space', async () => {
+			const response =
+				await apiHelpers.objectEntry.getObjectDefinitionObjectEntriesByScope(
+					applicationName,
+					encodeURIComponent(destinationSpaceName),
+					new URLSearchParams({pageSize: '100'})
+				);
+
+			const movedItems = response.items.filter(
+				(item: {objectEntryFolderId: number}) =>
+					item.objectEntryFolderId === destinationFolderId
+			);
+
+			expect(movedItems).toHaveLength(1);
+			expect(movedItems[0].title).toBe(fileTitle);
+		});
+
+		await test.step('The file is no longer in the source Space', async () => {
+			const response =
+				await apiHelpers.objectEntry.getObjectDefinitionObjectEntriesByScope(
+					applicationName,
+					encodeURIComponent(sourceSpaceName),
+					new URLSearchParams({pageSize: '100'})
+				);
+
+			const sourceItems = response.items.filter(
+				(item: {title: string}) => item.title === fileTitle
+			);
+
+			expect(sourceItems).toHaveLength(0);
+		});
+	}
+);

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/pages/AssetsPage.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/pages/AssetsPage.ts
@@ -218,6 +218,20 @@ export class AssetsPage {
 		await this.page.getByRole('heading', {name: 'Contents'}).waitFor();
 	}
 
+	async gotoSpaceFiles(spaceName: string) {
+		await this.gotoAll();
+
+		await this.page
+			.getByRole('menuitem', {exact: true, name: spaceName})
+			.click();
+
+		await this.page
+			.getByRole('menuitem', {exact: true, name: 'Files'})
+			.click();
+
+		await this.page.getByRole('heading', {name: 'Files'}).waitFor();
+	}
+
 	async execItemAction({action, filter, parentAction}: ExecItemActionArgs) {
 		await this.dataSetFragmentPage.execItemAction({
 			action,

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/pages/AssetsPage.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/pages/AssetsPage.ts
@@ -230,6 +230,8 @@ export class AssetsPage {
 			.click();
 
 		await this.page.getByRole('heading', {name: 'Files'}).waitFor();
+
+		await this.changeVisualizationMode('Table');
 	}
 
 	async execItemAction({action, filter, parentAction}: ExecItemActionArgs) {

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/pages/AssetsPage.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/pages/AssetsPage.ts
@@ -22,6 +22,7 @@ interface ExecItemActionArgs {
 		| 'Edit'
 		| 'Expire'
 		| 'Export for Translation'
+		| 'Move'
 		| 'Move To'
 		| 'Share'
 		| 'Show Details'
@@ -31,9 +32,13 @@ interface ExecItemActionArgs {
 	parentAction?: 'Copy';
 }
 
-interface BulkCopyOrMoveArgs {
+interface CopyOrMoveDestinationArgs {
 	destinationFolder: string;
 	destinationSpace: string;
+}
+
+interface ItemCopyOrMoveArgs extends CopyOrMoveDestinationArgs {
+	itemTitle: string;
 }
 
 export class AssetsPage {
@@ -140,7 +145,7 @@ export class AssetsPage {
 		await this.dataSetFragmentPage.execBulkItemAction({action});
 	}
 
-	async bulkCopyTo(args: BulkCopyOrMoveArgs) {
+	async bulkCopyTo(args: CopyOrMoveDestinationArgs) {
 		await this.page
 			.getByRole('button', {exact: true, name: 'Copy To'})
 			.click();
@@ -148,12 +153,31 @@ export class AssetsPage {
 		await this.selectCopyOrMoveDestination(args);
 	}
 
-	async bulkMoveTo(args: BulkCopyOrMoveArgs) {
+	async bulkMoveTo(args: CopyOrMoveDestinationArgs) {
 		await this.page
 			.getByRole('button', {exact: true, name: 'Move To'})
 			.click();
 
 		await this.selectCopyOrMoveDestination(args);
+	}
+
+	async copyTo({itemTitle, ...destination}: ItemCopyOrMoveArgs) {
+		await this.execItemAction({
+			action: 'Copy To',
+			filter: itemTitle,
+			parentAction: 'Copy',
+		});
+
+		await this.selectCopyOrMoveDestination(destination);
+	}
+
+	async moveTo({itemTitle, ...destination}: ItemCopyOrMoveArgs) {
+		await this.execItemAction({
+			action: 'Move',
+			filter: itemTitle,
+		});
+
+		await this.selectCopyOrMoveDestination(destination);
 	}
 
 	getCopyOrMoveDestinationDialog() {
@@ -163,7 +187,7 @@ export class AssetsPage {
 	async selectCopyOrMoveDestination({
 		destinationFolder,
 		destinationSpace,
-	}: BulkCopyOrMoveArgs) {
+	}: CopyOrMoveDestinationArgs) {
 		const dialog = this.getCopyOrMoveDestinationDialog();
 
 		await dialog.waitFor();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89762

## What is being fixed

LPD-85554 (Actions - Copy/Move) lacks functional test coverage for the single-asset copy and move flows. Only the bulk variants are covered today, by LPD-86776 / LPD-85362.

## How it is being fixed

Added 11 Playwright tests in 
`tests/site-cms-site-initializer/main/copyMove.spec.ts` covering every use case from LPD-85554 across both asset variants (content/file) and both folder variants (Content/Files folder): move and copy across Spaces, move and copy folders with their contents, content-type mismatch error path, and the destination-picker section filter for Move
(the Copy-side filter is already covered by LPD-72879).

The destination-picker interaction was extracted into shared `copyTo`, `moveTo`, and `selectCopyOrMoveDestination` helpers on `AssetsPage` so the single-asset and bulk flows reuse the same dialog code, and a `gotoSpaceFiles` helper was added to mirror the existing `gotoSpaceContents`.