### PR TITLE
LPD-89680 Add Playwright coverage for All section bulk Permissions flows

### DIFF
--- a/modules/test/playwright/tests/site-cms-site-initializer/main/bulkActions.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/bulkActions.spec.ts
@@ -14,6 +14,8 @@ import {performUserSwitch, userData} from '../../../utils/performLogin';
 import {waitForModal} from '../../../utils/waitFor';
 import {waitForAlert} from '../../../utils/waitForAlert';
 import {checkInZip} from '../../../utils/zip';
+import {DefaultPermissionsPage} from '../permissions/pages/DefaultPermissionsPage';
+import {PermissionsPage} from '../permissions/pages/PermissionsPage';
 import {structureBuilderPagesTest} from '../structure-builder/fixtures/structureBuilderPagesTest';
 import {cmsPagesTest} from './fixtures/cmsPagesTest';
 
@@ -3056,6 +3058,212 @@ test(
 						name: `${title} (Copy)`,
 					})
 				).toBeVisible();
+			}
+		});
+	}
+);
+
+test(
+	'Permissions can be reset to defaults in bulk from the All section',
+	{tag: '@LPD-85553'},
+	async ({apiHelpers, assetsPage, page}) => {
+		const applicationName = 'cms/basic-web-contents';
+
+		const contentNames = [getRandomString(), getRandomString()];
+
+		const spaceName = `Space ${getRandomString()}`;
+
+		await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			settings: {},
+			type: 'Space',
+		});
+
+		for (const contentName of contentNames) {
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: contentName,
+				},
+				applicationName,
+				spaceName
+			);
+		}
+
+		const permissionsPage = new PermissionsPage(page);
+
+		const overriddenPermissions = [
+			{action: 'DELETE_DISCUSSION', checked: true, role: 'Power User'},
+			{action: 'UPDATE_DISCUSSION', checked: true, role: 'User'},
+		];
+
+		await test.step('Override permissions on each asset individually', async () => {
+			await assetsPage.gotoAll();
+
+			for (const contentName of contentNames) {
+				await page
+					.getByRole('button', {name: `${contentName} Actions`})
+					.click();
+
+				await page
+					.getByRole('menuitem', {exact: true, name: 'Permissions'})
+					.click();
+
+				await page
+					.getByRole('menuitem', {exact: true, name: 'Permissions'})
+					.last()
+					.click();
+
+				await permissionsPage.checkPermissionsAndSave(
+					overriddenPermissions
+				);
+			}
+		});
+
+		await test.step('Bulk reset permissions to parent defaults', async () => {
+			await assetsPage.selectItems(contentNames);
+
+			await page
+				.getByTestId('visualization-mode-table')
+				.getByLabel('Actions')
+				.click();
+
+			await page
+				.getByRole('menuitem', {
+					exact: true,
+					name: 'Reset to Default Permissions',
+				})
+				.click();
+
+			await page.getByRole('button', {name: 'Confirm'}).click();
+
+			await waitForAlert(
+				page,
+				`Info:Reset permissions action started for ${contentNames.length} assets.`,
+				{type: 'info'}
+			);
+		});
+
+		await test.step('Verify the overridden permissions were cleared', async () => {
+			for (const contentName of contentNames) {
+				await page
+					.getByRole('button', {name: `${contentName} Actions`})
+					.click();
+
+				await page
+					.getByRole('menuitem', {exact: true, name: 'Permissions'})
+					.click();
+
+				await page
+					.getByRole('menuitem', {exact: true, name: 'Permissions'})
+					.last()
+					.click();
+
+				await permissionsPage.verifyPermissions([
+					{
+						action: 'DELETE_DISCUSSION',
+						checked: false,
+						role: 'Power User',
+					},
+					{
+						action: 'UPDATE_DISCUSSION',
+						checked: false,
+						role: 'User',
+					},
+				]);
+			}
+		});
+	}
+);
+
+test(
+	'Permissions can be edited by role in bulk from the All section',
+	{tag: '@LPD-85553'},
+	async ({apiHelpers, assetsPage, page}) => {
+		const applicationName = 'cms/basic-web-contents';
+
+		const contentNames = [getRandomString(), getRandomString()];
+
+		const spaceName = `Space ${getRandomString()}`;
+
+		await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			settings: {},
+			type: 'Space',
+		});
+
+		for (const contentName of contentNames) {
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: contentName,
+				},
+				applicationName,
+				spaceName
+			);
+		}
+
+		const defaultPermissionsPage = new DefaultPermissionsPage(page);
+		const permissionsPage = new PermissionsPage(page);
+
+		await test.step('Bulk edit Permissions by Role for the selected assets', async () => {
+			await assetsPage.gotoAll();
+
+			await assetsPage.selectItems(contentNames);
+
+			await page
+				.getByTestId('visualization-mode-table')
+				.getByLabel('Actions')
+				.click();
+
+			await page
+				.getByRole('menuitem', {
+					exact: true,
+					name: 'Edit Permissions by Role',
+				})
+				.click();
+
+			await expect(defaultPermissionsPage.permissionsModal).toBeVisible();
+
+			await defaultPermissionsPage.permissionsModalSelectRole.selectOption(
+				'Power User'
+			);
+
+			await defaultPermissionsPage.permissionsModal
+				.getByTestId('row-checkbox-Power User_VIEW')
+				.check();
+
+			await defaultPermissionsPage.permissionsModalSaveButton.click();
+
+			await waitForAlert(
+				page,
+				`update action started for ${contentNames.length} assets`,
+				{type: 'info'}
+			);
+
+			await defaultPermissionsPage.permissionsModalCancelButton.click();
+		});
+
+		await test.step('Verify the selected assets received the new permissions', async () => {
+			const expected = [
+				{action: 'VIEW', checked: true, role: 'Power User'},
+			];
+
+			for (const contentName of contentNames) {
+				await page
+					.getByRole('button', {name: `${contentName} Actions`})
+					.click();
+
+				await page
+					.getByRole('menuitem', {exact: true, name: 'Permissions'})
+					.click();
+
+				await page
+					.getByRole('menuitem', {exact: true, name: 'Permissions'})
+					.last()
+					.click();
+
+				await permissionsPage.verifyPermissions(expected);
 			}
 		});
 	}


### PR DESCRIPTION
# What is this trying to solve?
https://liferay.atlassian.net/browse/LPD-89680

LPD-85553 ("Actions - Bulk Actions") needs end-to-end coverage for the bulk Permissions flows when the user is acting from the CMS All section. Two flows are uncovered today: bulk Reset to Default Permissions, and bulk Edit Permissions by Role.
# How am I fixing it?
Two new tests in `bulkActions.spec.ts`, both tagged `@LPD-85553`:

- **Permissions can be reset to defaults in bulk from the All section** — overrides permissions on each asset individually, then bulk-resets and asserts every override has cleared.
- **Permissions can be edited by role in bulk from the All section** — opens the role-by-role permissions modal in bulk, grants Power User → VIEW, and asserts both selected assets received the new permission.

Patterns are mirrored from the existing `defaultPermissions.spec.ts` coverage on the All Spaces dashboard, retargeted at `web/cms/all`. Both tests reuse `assetsPage.selectItems(...)` and `assetsPage.gotoAll()` to stay consistent with the rest of the file, and inherit the file's existing `beforeEach` (creates a fresh user, assigns the CMS Administrator role, switches the page session), so each test runs under an admin posture without duplicating that setup.

Three adjacent areas were intentionally left out of this PR:

- **Edit Tags in bulk.** The Edit Tags modal's autocomplete does not surface tags created via `headlessAdminTaxonomy.postSiteKeyword`; only "Create New Tag" is offered. That blocks any tag-edit assertion from the API-seeded path used everywhere else in this file. Worth tracking as a separate bug.
- **Default Permissions / Edit Default Permissions by Role on the All dashboard.** Folders aren't listed on the All dashboard (it's asset-only), and Default Permissions semantically applies to containers. The bulk menu still surfaces those items when leaf entries are selected, but the resulting modal has no role/action grid to interact with. Not exercisable from this dashboard.
- **CMS Administrator role variant.** The file's `beforeEach` already assigns the CMS Administrator role to every test in the file, so a dedicated variant would be redundant.
# How can you verify that it works?
Run the included automated tests:

```bash
cd modules/test/playwright
yarn test tests/site-cms-site-initializer/main/bulkActions.spec.ts \
    -g "from the All section"
```

Expected: 4 passed (1 setup + 2 tests + 1 teardown).
