### PR TITLE
LPD-89886 Surface failure when a discussion comment submit is rejected

### DIFF
--- a/modules/apps/comment/comment-taglib/src/main/java/com/liferay/comment/taglib/internal/struts/EditDiscussionStrutsAction.java
+++ b/modules/apps/comment/comment-taglib/src/main/java/com/liferay/comment/taglib/internal/struts/EditDiscussionStrutsAction.java
@@ -64,9 +64,6 @@ public class EditDiscussionStrutsAction implements StrutsAction {
 			HttpServletResponse httpServletResponse)
 		throws Exception {
 
-		AuthTokenUtil.checkCSRFToken(
-			httpServletRequest, EditDiscussionStrutsAction.class.getName());
-
 		String namespace = ParamUtil.getString(httpServletRequest, "namespace");
 
 		HttpServletRequest namespacedHttpServletRequest =
@@ -77,6 +74,9 @@ public class EditDiscussionStrutsAction implements StrutsAction {
 			namespacedHttpServletRequest, Constants.CMD);
 
 		try {
+			AuthTokenUtil.checkCSRFToken(
+				httpServletRequest, EditDiscussionStrutsAction.class.getName());
+
 			if (cmd.equals(Constants.ADD) || cmd.equals(Constants.UPDATE)) {
 				long commentId = _updateComment(namespacedHttpServletRequest);
 

--- a/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/js/Comments.js
+++ b/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/js/Comments.js
@@ -184,21 +184,21 @@ export default function Comments({
 			method: 'POST',
 		})
 			.then((response) => {
-				let promise;
-
 				const contentType = response.headers.get('content-type');
 
 				if (
-					contentType &&
-					contentType.indexOf('application/json') !== -1
+					!response.ok ||
+					!contentType ||
+					contentType.indexOf('application/json') === -1
 				) {
-					promise = response.json();
-				}
-				else {
-					promise = response.text();
+					return Promise.reject(
+						new Error(
+							`Unexpected response (status ${response.status})`
+						)
+					);
 				}
 
-				return promise;
+				return response.json();
 			})
 			.then((response) => {
 				const exception = response.exception;

--- a/modules/apps/comment/comment-test/src/testIntegration/java/com/liferay/comment/struts/test/EditDiscussionStrutsActionTest.java
+++ b/modules/apps/comment/comment-test/src/testIntegration/java/com/liferay/comment/struts/test/EditDiscussionStrutsActionTest.java
@@ -1,0 +1,60 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.comment.struts.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.struts.StrutsAction;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/**
+ * @author Manuel Rives
+ */
+@RunWith(Arquillian.class)
+public class EditDiscussionStrutsActionTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	@TestInfo("LPD-89886")
+	public void testExecuteCheckCSRFToken() throws Exception {
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		MockHttpServletResponse mockHttpServletResponse =
+			new MockHttpServletResponse();
+
+		_editDiscussionStrutsAction.execute(
+			mockHttpServletRequest, mockHttpServletResponse);
+
+		Assert.assertEquals(
+			ContentTypes.APPLICATION_JSON,
+			mockHttpServletResponse.getContentType());
+
+		String content = mockHttpServletResponse.getContentAsString();
+
+		Assert.assertTrue(content.contains("\"exception\""));
+		Assert.assertTrue(content.contains("MustHaveSessionCSRFToken"));
+	}
+
+	@Inject(filter = "path=/portal/comment/discussion/edit")
+	private StrutsAction _editDiscussionStrutsAction;
+
+}


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-89886

Comments in Message Boards / Discussions are silently lost when the client-side session auto-extend timer renews the container session. The cached page-level CSRF token (`p_auth`) goes stale, the POST to `/c/portal/comment/discussion/edit` is rejected with `PrincipalException$MustHaveSessionCSRFToken`, and the server returns HTTP 500 with the `protected.jsp` HTML body. The frontend does not detect the failure and shows the "your-request-completed-successfully" toast, so the user is told the comment was saved when it was not.

# How am I fixing it?

Two coordinated changes, both inside `modules/apps/comment/comment-taglib`. On the server, `AuthTokenUtil.checkCSRFToken` is moved into the existing `try` block in `EditDiscussionStrutsAction.execute`, so the existing `PrincipalException` catch converts the CSRF rejection into the same `{ "exception": ... }` JSON envelope that the JS already understands. On the client, `Comments.js` now rejects any response whose status is not OK or whose `Content-Type` is not JSON, so older servers and upstream filters still surface a failure toast instead of a silent success.

The root cause (whether `/portal/extend_session` should rotate `p_auth`) is out of scope and is being clarified with AppSec in [PTR-8741](https://liferay.atlassian.net/browse/PTR-8741).

# How can you verify that it works?

Run the included automated tests.