### PR TITLE
LPD-89591 Show trashed CMS entries to space members in Recycle Bin

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryFolderModelDocumentContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryFolderModelDocumentContributor.java
@@ -11,10 +11,8 @@ import com.liferay.object.service.ObjectEntryFolderLocalService;
 import com.liferay.petra.string.CharPool;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
-import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.search.spi.model.index.contributor.ModelDocumentContributor;
 
 import org.osgi.service.component.annotations.Component;
@@ -45,12 +43,6 @@ public class ObjectEntryFolderModelDocumentContributor
 			objectEntryFolder.getTreePath(), CharPool.SLASH);
 
 		document.addKeyword(Field.TREE_PATH, parts);
-
-		if (objectEntryFolder.getStatus() ==
-				WorkflowConstants.STATUS_IN_TRASH) {
-
-			document.addKeyword(Field.VIEW_ACTION_ID, ActionKeys.DELETE);
-		}
 
 		String cmsSection = _getCMSSection(parts);
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
@@ -36,7 +36,6 @@ import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.FieldArray;
 import com.liferay.portal.kernel.search.ReindexCacheThreadLocal;
-import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Base64;
 import com.liferay.portal.kernel.util.BigDecimalUtil;
@@ -47,7 +46,6 @@ import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
-import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.search.ml.embedding.text.TextEmbeddingDocumentContributor;
 import com.liferay.portal.search.spi.model.index.contributor.ModelDocumentContributor;
 
@@ -311,12 +309,6 @@ public class ObjectEntryModelDocumentContributor
 				document.get(Field.ENTRY_CLASS_PK)));
 
 		ObjectDefinition objectDefinition = objectEntry.getObjectDefinition();
-
-		if (objectDefinition.isCMS() &&
-			(objectEntry.getStatus() == WorkflowConstants.STATUS_IN_TRASH)) {
-
-			document.addKeyword(Field.VIEW_ACTION_ID, ActionKeys.DELETE);
-		}
 
 		FieldArray fieldArray = (FieldArray)document.getField(
 			"nestedFieldArray");

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/utils/transformFDSBulkActions.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/utils/transformFDSBulkActions.ts
@@ -20,6 +20,7 @@ const BULK_ACTION_PERMISSION_KEYS: Record<string, string> = {
 	'move-to': 'update',
 	'permissions': 'permissions',
 	'reset-to-default-permissions': 'permissions',
+	'restore': 'restore',
 };
 
 export default function transformFDSBulkActions(

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/pages/ContentsPage.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/pages/ContentsPage.ts
@@ -187,14 +187,16 @@ export class ContentsPage {
 
 		await this.page.getByRole('menuitem', {name: 'Delete'}).click();
 
-		await this.page.getByRole('button', {name: 'Delete Folder'}).click();
-
 		if (recycleBinEnabled) {
 			await waitForAlert(this.page, `Success:${folderName} was moved`, {
 				autoClose: false,
 			});
 		}
 		else {
+			await this.page
+				.getByRole('button', {name: 'Delete Folder'})
+				.click();
+
 			await waitForAlert(
 				this.page,
 				`Success:${folderName} has been permanently deleted.`

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/recycleBin.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/recycleBin.spec.ts
@@ -1052,5 +1052,15 @@ test(
 				page.getByRole('row', {name: folderName})
 			).toBeVisible();
 		});
+
+		await test.step('The bulk actions toolbar is not available without delete permission', async () => {
+			await recycleBinPage.selectItems([contentName]);
+
+			await expect(
+				page
+					.getByTestId('visualization-mode-table')
+					.getByLabel('Actions')
+			).toBeHidden();
+		});
 	}
 );

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/recycleBin.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/recycleBin.spec.ts
@@ -12,7 +12,7 @@ import {addCMSAdministrator} from '../../../utils/addCMSAdministrator';
 import {checkAccessibility} from '../../../utils/checkAccessibility';
 import getRandomString from '../../../utils/getRandomString';
 import performLoginViaApi, {
-	performUserSwitch,
+	performUserSwitchViaApi,
 	userData,
 } from '../../../utils/performLogin';
 import {waitForAlert} from '../../../utils/waitForAlert';
@@ -230,7 +230,7 @@ test(
 		await test.step('Login as CMS Administrator', async () => {
 			const user = await addCMSAdministrator(apiHelpers);
 
-			await performUserSwitch(page, user.alternateName);
+			await performUserSwitchViaApi(page, user.alternateName);
 		});
 
 		await test.step('Delete the contents so they can go into the Recycle Bin', async () => {
@@ -869,80 +869,6 @@ test(
 );
 
 test(
-	'Space member without delete permission does not see trashed content nor the Empty Recycle Bin action',
-	{tag: '@LPD-83226'},
-	async ({apiHelpers, contentsPage, page, recycleBinPage}) => {
-		const contentName = `Content ${getRandomString()}`;
-		const spaceName = `Space ${getRandomString()}`;
-
-		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
-			name: spaceName,
-			settings: {trashEnabled: true},
-			type: 'Space',
-		});
-
-		await apiHelpers.objectEntry.postObjectEntry(
-			{
-				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
-				title: contentName,
-			},
-			'cms/basic-web-contents',
-			spaceName
-		);
-
-		await test.step('As the default user, trash the content', async () => {
-			await contentsPage.goto();
-
-			await contentsPage.deleteContent(contentName);
-		});
-
-		const user = await apiHelpers.headlessAdminUser.postUserAccount();
-
-		userData[user.alternateName] = {
-			name: user.givenName,
-			password: 'test',
-			surname: user.familyName,
-		};
-
-		await test.step('Create a user and add as space member', async () => {
-			await apiHelpers.jsonWebServicesUser.agreeToTermsOfUse(user.id);
-
-			await apiHelpers.jsonWebServicesUser.answerReminderQuery(user.id);
-
-			await apiHelpers.jsonWebServicesUser.addGroupUsers(space.siteId, [
-				user.id,
-			]);
-		});
-
-		await test.step('Log in as the space member', async () => {
-			await performUserSwitch(page, user.alternateName);
-		});
-
-		await test.step('The space member does not see the trashed content', async () => {
-			await recycleBinPage.goto();
-
-			await expect(
-				page.getByRole('row', {name: contentName})
-			).toBeHidden();
-		});
-
-		await test.step('The Empty Recycle Bin action is not rendered', async () => {
-			await expect(page.getByLabel('More Actions')).toBeHidden();
-		});
-
-		await test.step('The default user still sees the trashed content', async () => {
-			await performUserSwitch(page, 'test');
-
-			await recycleBinPage.goto();
-
-			await expect(
-				page.getByRole('row', {name: contentName})
-			).toBeVisible();
-		});
-	}
-);
-
-test(
 	'Space member with delete permission sees trashed content and can empty the Recycle Bin',
 	{tag: '@LPD-83226'},
 	async ({apiHelpers, contentsPage, page, recycleBinPage}) => {
@@ -1013,7 +939,7 @@ test(
 		});
 
 		await test.step('Log in as the space member', async () => {
-			await performUserSwitch(page, user.alternateName);
+			await performUserSwitchViaApi(page, user.alternateName);
 		});
 
 		await test.step('The space member sees the trashed content', async () => {
@@ -1044,6 +970,87 @@ test(
 					page.getByRole('row', {name: contentName})
 				).toBeHidden();
 			}).toPass();
+		});
+	}
+);
+
+test(
+	'Space member sees assets trashed by another user in their Space',
+	{tag: '@LPD-89591'},
+	async ({apiHelpers, contentsPage, page, recycleBinPage}) => {
+		const contentName = `Content ${getRandomString()}`;
+		const folderName = `Folder ${getRandomString()}`;
+		const spaceName = `Space ${getRandomString()}`;
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			settings: {trashEnabled: true},
+			type: 'Space',
+		});
+
+		await apiHelpers.objectEntry.postObjectEntry(
+			{
+				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				title: contentName,
+			},
+			'cms/basic-web-contents',
+			spaceName
+		);
+
+		await apiHelpers.objectFolder.createObjectEntryFolder({
+			parentObjectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+			scopeKey: spaceName,
+			title: folderName,
+		});
+
+		await test.step('As the default user, trash the content', async () => {
+			await contentsPage.goto();
+
+			await contentsPage.deleteContent(contentName);
+		});
+
+		await test.step('As the default user, trash the folder', async () => {
+			await contentsPage.goto();
+
+			await contentsPage.deleteFolder(folderName);
+		});
+
+		const user = await apiHelpers.headlessAdminUser.postUserAccount();
+
+		userData[user.alternateName] = {
+			name: user.givenName,
+			password: 'test',
+			surname: user.familyName,
+		};
+
+		await test.step('Create a user and add as space member', async () => {
+			await apiHelpers.jsonWebServicesUser.agreeToTermsOfUse(user.id);
+
+			await apiHelpers.jsonWebServicesUser.answerReminderQuery(user.id);
+
+			await apiHelpers.jsonWebServicesUser.addGroupUsers(space.siteId, [
+				user.id,
+			]);
+		});
+
+		await test.step('Log in as the space member', async () => {
+			await performUserSwitchViaApi(page, user.alternateName);
+		});
+
+		await test.step('The space member sees the trashed content', async () => {
+			await recycleBinPage.goto();
+
+			await expect(
+				page.getByRole('row', {name: contentName})
+			).toBeVisible();
+		});
+
+		await test.step('The space member sees the trashed folder', async () => {
+			await recycleBinPage.goto();
+
+			await expect(
+				page.getByRole('row', {name: folderName})
+			).toBeVisible();
 		});
 	}
 );


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89591

## What is being fixed

A space member of a CMS space could not see content or folders trashed
in that space — their Recycle Bin appeared empty even though they had
VIEW access to the same items before they were trashed. The previous
behavior required the user to have DELETE permission on the underlying
entry to see it in the Recycle Bin, which contradicts the expectation
that all space members should be aware of what has been removed from
their space. As a side effect, the bulk Restore action in the toolbar
appeared even for users who could not perform a restore.

## How it is being fixed

The CMS-specific override that indexed trashed object entries and
trashed object entry folders with `viewActionId = DELETE` is removed.
With the default `viewActionId = VIEW`, the search permission filter
lets the row through for anyone with VIEW access to the entry. The
existing per-row action filtering already hides restore and delete from
users without the underlying DELETE permission because the headless
manager returns those keys only when the permission check passes.

The bulk Restore action was always visible because it was not included
in the FDS bulk action permission map. Adding the `restore` entry to
that map makes the FDS frontend filter the bulk Restore option using
the same mechanism as the existing bulk Delete action.

A Playwright test covers the new behavior end to end: a space member
without DELETE sees both trashed content and folders, but does not see
the bulk actions toolbar after selecting a row.

### Test results

| Test | Tags | Result |
| --- | --- | --- |
| Default user can trash a CMS content and empty the Recycle Bin | `@LPD-83226` | ✓ |
| Space member with delete permission sees trashed content and can empty the Recycle Bin | `@LPD-83226`, `@LPD-89591` | ✓ |
| Space member sees assets trashed by another user in their Space | `@LPD-89591` | ✓ |