### PR TITLE
LPD-85963 Validate sourceLanguageId and targetLanguageId

### DIFF
--- a/modules/apps/analytics/analytics-layout-page-template-web/src/main/java/com/liferay/analytics/layout/page/template/web/internal/servlet/taglib/AnalyticsRenderFragmentLayoutPreDynamicInclude.java
+++ b/modules/apps/analytics/analytics-layout-page-template-web/src/main/java/com/liferay/analytics/layout/page/template/web/internal/servlet/taglib/AnalyticsRenderFragmentLayoutPreDynamicInclude.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.servlet.taglib.DynamicInclude;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.TreeMapBuilder;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -72,7 +73,7 @@ public class AnalyticsRenderFragmentLayoutPreDynamicInclude
 		PrintWriter printWriter = httpServletResponse.getWriter();
 
 		String data = HtmlUtil.buildData(
-			HashMapBuilder.<String, Object>put(
+			TreeMapBuilder.<String, Object>put(
 				"analytics-asset-id",
 				layoutDisplayPageObjectProvider.getClassPK()
 			).put(
@@ -87,7 +88,7 @@ public class AnalyticsRenderFragmentLayoutPreDynamicInclude
 					layoutDisplayPageObjectProvider.getDisplayObject())
 			).build());
 
-		printWriter.print("<div " + data + ">");
+		printWriter.print("<div " + data.strip() + ">");
 	}
 
 	@Override

--- a/modules/apps/analytics/analytics-settings-rest-api/src/main/java/com/liferay/analytics/settings/rest/constants/FieldOrderConstants.java
+++ b/modules/apps/analytics/analytics-settings-rest-api/src/main/java/com/liferay/analytics/settings/rest/constants/FieldOrderConstants.java
@@ -11,10 +11,10 @@ package com.liferay.analytics.settings.rest.constants;
 public class FieldOrderConstants {
 
 	public static final String[] FIELD_ORDER_EXAMPLES = {
-		"30130", "30130", "2017-07-21", "USD", "key1=value1, key2=value2, ...",
-		"AB-34098-789-N", "30130", "2017-08-21", "2017-07-21",
-		"[item, item,...]", "0", "AB-34098-789-N", "30130", "paypal", "0", "0",
-		"113", "12345"
+		"AB-34098-789-N", "30130", "30130", "2017-07-21", "USD",
+		"key1=value1, key2=value2, ...", "AB-34098-789-N", "30130",
+		"2017-08-21", "2017-07-21", "[item, item,...]", "0", "AB-34098-789-N",
+		"30130", "paypal", "0", "0", "113", "12345"
 	};
 
 	public static final String[] FIELD_ORDER_ITEM_EXAMPLES = {

--- a/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/manager/TranslationManagerImpl.java
+++ b/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/manager/TranslationManagerImpl.java
@@ -79,15 +79,8 @@ public class TranslationManagerImpl implements TranslationManager {
 			String sourceLanguageId, String targetLanguageId)
 		throws IOException, PortalException {
 
-		if (!_language.isAvailableLocale(sourceLanguageId)) {
-			throw new XLIFFFileException.MustBeSupportedLanguage(
-				sourceLanguageId);
-		}
-
-		if (!_language.isAvailableLocale(targetLanguageId)) {
-			throw new XLIFFFileException.MustBeSupportedLanguage(
-				targetLanguageId);
-		}
+		_validateLanguageId(sourceLanguageId);
+		_validateLanguageId(targetLanguageId);
 
 		String fileName = _getXLIFFFileName(
 			className, classPK, locale, sourceLanguageId, targetLanguageId);
@@ -120,16 +113,10 @@ public class TranslationManagerImpl implements TranslationManager {
 				"targetLanguageIds");
 		}
 
-		if (!_language.isAvailableLocale(sourceLanguageId)) {
-			throw new XLIFFFileException.MustBeSupportedLanguage(
-				sourceLanguageId);
-		}
+		_validateLanguageId(sourceLanguageId);
 
 		for (String targetLanguageId : targetLanguageIds) {
-			if (!_language.isAvailableLocale(targetLanguageId)) {
-				throw new XLIFFFileException.MustBeSupportedLanguage(
-					targetLanguageId);
-			}
+			_validateLanguageId(targetLanguageId);
 		}
 
 		String fileName = StringBundler.concat(
@@ -364,6 +351,12 @@ public class TranslationManagerImpl implements TranslationManager {
 			if (_log.isDebugEnabled()) {
 				_log.debug(exception);
 			}
+		}
+	}
+
+	private void _validateLanguageId(String languageId) throws PortalException {
+		if (!_language.isAvailableLocale(languageId)) {
+			throw new XLIFFFileException.MustBeSupportedLanguage(languageId);
 		}
 	}
 

--- a/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/manager/TranslationManagerImpl.java
+++ b/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/manager/TranslationManagerImpl.java
@@ -111,6 +111,15 @@ public class TranslationManagerImpl implements TranslationManager {
 			Locale locale, String sourceLanguageId, String[] targetLanguageIds)
 		throws IOException, PortalException {
 
+		if (classPKs == null) {
+			throw new XLIFFFileException.MustHaveValidParameter("classPKs");
+		}
+
+		if (targetLanguageIds == null) {
+			throw new XLIFFFileException.MustHaveValidParameter(
+				"targetLanguageIds");
+		}
+
 		if (!_language.isAvailableLocale(sourceLanguageId)) {
 			throw new XLIFFFileException.MustBeSupportedLanguage(
 				sourceLanguageId);

--- a/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/manager/TranslationManagerImpl.java
+++ b/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/manager/TranslationManagerImpl.java
@@ -79,6 +79,16 @@ public class TranslationManagerImpl implements TranslationManager {
 			String sourceLanguageId, String targetLanguageId)
 		throws IOException, PortalException {
 
+		if (!_language.isAvailableLocale(sourceLanguageId)) {
+			throw new XLIFFFileException.MustBeSupportedLanguage(
+				sourceLanguageId);
+		}
+
+		if (!_language.isAvailableLocale(targetLanguageId)) {
+			throw new XLIFFFileException.MustBeSupportedLanguage(
+				targetLanguageId);
+		}
+
 		String fileName = _getXLIFFFileName(
 			className, classPK, locale, sourceLanguageId, targetLanguageId);
 
@@ -100,6 +110,18 @@ public class TranslationManagerImpl implements TranslationManager {
 			String className, long[] classPKs, String xliffMimeType,
 			Locale locale, String sourceLanguageId, String[] targetLanguageIds)
 		throws IOException, PortalException {
+
+		if (!_language.isAvailableLocale(sourceLanguageId)) {
+			throw new XLIFFFileException.MustBeSupportedLanguage(
+				sourceLanguageId);
+		}
+
+		for (String targetLanguageId : targetLanguageIds) {
+			if (!_language.isAvailableLocale(targetLanguageId)) {
+				throw new XLIFFFileException.MustBeSupportedLanguage(
+					targetLanguageId);
+			}
+		}
 
 		String fileName = StringBundler.concat(
 			StringUtil.removeSubstrings(

--- a/modules/apps/translation/translation-test/src/testIntegration/java/com/liferay/translation/manager/test/TranslationManagerTest.java
+++ b/modules/apps/translation/translation-test/src/testIntegration/java/com/liferay/translation/manager/test/TranslationManagerTest.java
@@ -159,6 +159,27 @@ public class TranslationManagerTest {
 			new String[] {_INVALID_LANGUAGE_ID});
 	}
 
+	@Test(expected = XLIFFFileException.MustHaveValidParameter.class)
+	@TestInfo("LPD-85963")
+	public void testGetXLIFFZipFileFailsWithNullClassPKs() throws Exception {
+		_translationManager.getXLIFFZipFile(
+			JournalArticle.class.getName(), null, _MIMETYPE_XLIFF_1_2,
+			LocaleUtil.US, LocaleUtil.toLanguageId(LocaleUtil.US),
+			_TARGET_LANGUAGE_IDS);
+	}
+
+	@Test(expected = XLIFFFileException.MustHaveValidParameter.class)
+	@TestInfo("LPD-85963")
+	public void testGetXLIFFZipFileFailsWithNullTargetLanguageIds()
+		throws Exception {
+
+		_translationManager.getXLIFFZipFile(
+			JournalArticle.class.getName(),
+			new long[] {_journalArticle.getResourcePrimKey()},
+			_MIMETYPE_XLIFF_1_2, LocaleUtil.US,
+			LocaleUtil.toLanguageId(LocaleUtil.US), null);
+	}
+
 	@Test
 	@TestInfo("LPD-85323")
 	public void testObjectEntryGetTitle() throws Exception {

--- a/modules/apps/translation/translation-test/src/testIntegration/java/com/liferay/translation/manager/test/TranslationManagerTest.java
+++ b/modules/apps/translation/translation-test/src/testIntegration/java/com/liferay/translation/manager/test/TranslationManagerTest.java
@@ -35,6 +35,7 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.translation.exception.XLIFFFileException;
 import com.liferay.translation.manager.Translation;
 import com.liferay.translation.manager.TranslationManager;
 import com.liferay.translation.test.util.TranslationTestUtil;
@@ -108,6 +109,54 @@ public class TranslationManagerTest {
 
 		_testGetXLIFFFile("test-journal-article-v12.xlf", _MIMETYPE_XLIFF_1_2);
 		_testGetXLIFFFile("test-journal-article.xlf", _MIMETYPE_XLIFF_2_0);
+	}
+
+	@Test(expected = XLIFFFileException.MustBeSupportedLanguage.class)
+	@TestInfo("LPD-85963")
+	public void testGetXLIFFFileFailsWithInvalidSourceLanguageId()
+		throws Exception {
+
+		_translationManager.getXLIFFFile(
+			JournalArticle.class.getName(),
+			_journalArticle.getResourcePrimKey(), _MIMETYPE_XLIFF_1_2,
+			LocaleUtil.US, _INVALID_LANGUAGE_ID, _TARGET_LANGUAGE_IDS[0]);
+	}
+
+	@Test(expected = XLIFFFileException.MustBeSupportedLanguage.class)
+	@TestInfo("LPD-85963")
+	public void testGetXLIFFFileFailsWithInvalidTargetLanguageId()
+		throws Exception {
+
+		_translationManager.getXLIFFFile(
+			JournalArticle.class.getName(),
+			_journalArticle.getResourcePrimKey(), _MIMETYPE_XLIFF_1_2,
+			LocaleUtil.US, LocaleUtil.toLanguageId(LocaleUtil.US),
+			_INVALID_LANGUAGE_ID);
+	}
+
+	@Test(expected = XLIFFFileException.MustBeSupportedLanguage.class)
+	@TestInfo("LPD-85963")
+	public void testGetXLIFFZipFileFailsWithInvalidSourceLanguageId()
+		throws Exception {
+
+		_translationManager.getXLIFFZipFile(
+			JournalArticle.class.getName(),
+			new long[] {_journalArticle.getResourcePrimKey()},
+			_MIMETYPE_XLIFF_1_2, LocaleUtil.US, _INVALID_LANGUAGE_ID,
+			_TARGET_LANGUAGE_IDS);
+	}
+
+	@Test(expected = XLIFFFileException.MustBeSupportedLanguage.class)
+	@TestInfo("LPD-85963")
+	public void testGetXLIFFZipFileFailsWithInvalidTargetLanguageId()
+		throws Exception {
+
+		_translationManager.getXLIFFZipFile(
+			JournalArticle.class.getName(),
+			new long[] {_journalArticle.getResourcePrimKey()},
+			_MIMETYPE_XLIFF_1_2, LocaleUtil.US,
+			LocaleUtil.toLanguageId(LocaleUtil.US),
+			new String[] {_INVALID_LANGUAGE_ID});
 	}
 
 	@Test
@@ -370,6 +419,8 @@ public class TranslationManagerTest {
 
 		_assertProcessXLIFFTranslationSuccess(failureMessages, successMessages);
 	}
+
+	private static final String _INVALID_LANGUAGE_ID = "xx_XX";
 
 	private static final String _MIMETYPE_XLIFF_1_2 = "application/x-xliff+xml";
 

--- a/portal-impl/bnd.bnd
+++ b/portal-impl/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 126.1.0
+Bundle-Version: 127.0.0
 CPE-Name: ${cpe.name}
 Export-Package:\
 	com.liferay.portal.bean,\

--- a/portal-impl/src/com/liferay/portal/dao/orm/hibernate/packageinfo
+++ b/portal-impl/src/com/liferay/portal/dao/orm/hibernate/packageinfo
@@ -1,1 +1,1 @@
-version 8.0.0
+version 9.0.0

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/packageinfo
@@ -1,1 +1,1 @@
-version 22.2.0
+version 22.1.0

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/orm/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/orm/packageinfo
@@ -1,1 +1,1 @@
-version 15.2.0
+version 16.0.0


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-85963

Previous PR: https://github.com/liferay-content-management/liferay-portal/pull/8039

`TranslationManagerImpl.getXLIFFFile` and `getXLIFFZipFile` accepted any language ID string and only failed deep inside the XLIFF generation. Calls with unsupported language IDs should fail fast with a clear, typed error.

# How am I fixing it?

The language IDs are now validated.

# How can you verify that it works?

Run the included automated tests.