### PR TITLE
LPD-89744 Render back button on Notifications page from personal bar

### DIFF
--- a/modules/apps/product-navigation/product-navigation-personal-menu-api/src/main/java/com/liferay/product/navigation/personal/menu/util/PersonalApplicationURLUtil.java
+++ b/modules/apps/product-navigation/product-navigation-personal-menu-api/src/main/java/com/liferay/product/navigation/personal/menu/util/PersonalApplicationURLUtil.java
@@ -31,6 +31,7 @@ import com.liferay.portal.kernel.util.FriendlyURLNormalizerUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.product.navigation.personal.menu.configuration.PersonalMenuConfiguration;
 import com.liferay.product.navigation.personal.menu.configuration.PersonalMenuConfigurationRegistry;
@@ -136,6 +137,10 @@ public class PersonalApplicationURLUtil {
 			httpServletRequest, portletId, layout, PortletRequest.RENDER_PHASE);
 
 		String backURL = ParamUtil.getString(httpServletRequest, "currentURL");
+
+		if (Validator.isNull(backURL)) {
+			backURL = themeDisplay.getURLCurrent();
+		}
 
 		liferayPortletURL.setParameter("backURL", backURL);
 

--- a/modules/test/playwright/tests/notification-web/main/userNotification.spec.ts
+++ b/modules/test/playwright/tests/notification-web/main/userNotification.spec.ts
@@ -130,6 +130,8 @@ test('review comment is added to user notification', async ({
 
 	await page.waitForLoadState('networkidle');
 
+	const previousURL = page.url();
+
 	await userPersonalBarPage.notificationBadge.click();
 
 	await expect(
@@ -137,4 +139,24 @@ test('review comment is added to user notification', async ({
 			name: `Your submission was reviewed and the reviewer applied the following ${approvalComment}.`,
 		})
 	).toBeVisible();
+
+	const backLink = page.getByRole('link', {exact: true, name: 'Back'});
+
+	await expect(backLink).toBeVisible();
+
+	await backLink.click();
+
+	await expect(page).toHaveURL(previousURL);
+
+	await page.getByRole('button', {name: /User Profile$/}).click();
+
+	await page
+		.getByRole('menuitem', {exact: true, name: 'Notifications'})
+		.click();
+
+	await expect(backLink).toBeVisible();
+
+	await backLink.click();
+
+	await expect(page).toHaveURL(previousURL);
 });


### PR DESCRIPTION
## Summary

- `PersonalApplicationURLUtil.getPersonalApplicationURL` now falls back to `themeDisplay.getURLCurrent()` when no `currentURL` request parameter is supplied. The synchronous user-personal-bar bubble (`product-navigation-user-personal-bar-web/.../view.jsp`) and the `personal_menu_icon.jsp` variant build the Notifications link inside a normal page render where no `currentURL` parameter exists — without the fallback, `backURL` was empty and the Notifications portlet skipped the back-icon block.
- The user-menu dropdown path keeps working because the personal-menu portlet's AJAX `serveResource` call (`/product_navigation_personal_menu/get_personal_menu_items`) explicitly passes the page URL as a `currentURL` parameter. Inside that AJAX request `themeDisplay.getURLCurrent()` would return the AJAX endpoint URL itself, so the `ParamUtil.getString(request, "currentURL")` read is preserved and tried first.
- Playwright `userNotification.spec.ts` extended to cover both navigation paths and assert the back chevron returns to the originating URL.

## Test plan

- [x] `yarn test tests/notification-web/main/userNotification.spec.ts` — 1 passed (15.8s)
- [x] Manual: login → user menu → Notifications → click a notification → user menu → Notifications → back chevron returns to the originating Space page (no raw-JSON regression from `get_personal_menu_items`)
- [x] `ant format-source-current-branch` clean