### PR TITLE
LPD-89770 Drop disconnected depot scopes from dynamic asset list queries

### DIFF
--- a/modules/apps/asset/asset-list-service/build.gradle
+++ b/modules/apps/asset/asset-list-service/build.gradle
@@ -17,6 +17,7 @@ dependencies {
 	compileOnly project(":apps:asset:asset-entry-rel-api")
 	compileOnly project(":apps:asset:asset-list-api")
 	compileOnly project(":apps:change-tracking:change-tracking-spi")
+	compileOnly project(":apps:depot:depot-api")
 	compileOnly project(":apps:document-library:document-library-api")
 	compileOnly project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")
 	compileOnly project(":apps:export-import:export-import-api")

--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/asset/entry/provider/AssetListAssetEntryProviderImpl.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/asset/entry/provider/AssetListAssetEntryProviderImpl.java
@@ -28,6 +28,9 @@ import com.liferay.asset.list.service.AssetListEntrySegmentsEntryRelLocalService
 import com.liferay.asset.list.util.comparator.AssetListEntrySegmentsEntryRelPriorityComparator;
 import com.liferay.asset.util.AssetHelper;
 import com.liferay.asset.util.AssetRendererFactoryClassProvider;
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.document.library.kernel.model.DLFileEntryType;
 import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalService;
 import com.liferay.document.library.util.DLFileEntryTypeUtil;
@@ -43,6 +46,7 @@ import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.module.configuration.ConfigurationException;
 import com.liferay.portal.kernel.search.BooleanClause;
 import com.liferay.portal.kernel.search.BooleanClauseOccur;
@@ -52,12 +56,14 @@ import com.liferay.portal.kernel.search.Hits;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.filter.BooleanFilter;
 import com.liferay.portal.kernel.search.filter.TermsFilter;
+import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
@@ -72,6 +78,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 import org.osgi.framework.BundleContext;
 import org.osgi.service.component.annotations.Activate;
@@ -155,11 +162,8 @@ public class AssetListAssetEntryProviderImpl
 			StringUtil.split(
 				unicodeProperties.getProperty("groupIds", StringPool.BLANK)));
 
-		if (ArrayUtil.isEmpty(groupIds)) {
-			groupIds = new long[] {assetListEntry.getGroupId()};
-		}
-
-		assetEntryQuery.setGroupIds(groupIds);
+		assetEntryQuery.setGroupIds(
+			_getAssetEntryQueryGroupIds(assetListEntry.getGroupId(), groupIds));
 
 		boolean anyAssetType = GetterUtil.getBoolean(
 			unicodeProperties.getProperty("anyAssetType", null), true);
@@ -373,6 +377,37 @@ public class AssetListAssetEntryProviderImpl
 		};
 	}
 
+	private long[] _getAssetEntryQueryGroupIds(
+		long assetListEntryGroupId, long[] groupIds) {
+
+		if (ArrayUtil.isEmpty(groupIds)) {
+			return new long[] {assetListEntryGroupId};
+		}
+
+		Set<Long> connectedDepotEntryGroupIds = _getConnectedDepotEntryGroupIds(
+			assetListEntryGroupId);
+
+		return ArrayUtil.filter(
+			groupIds,
+			groupId -> {
+				if (groupId == assetListEntryGroupId) {
+					return true;
+				}
+
+				Group group = _groupLocalService.fetchGroup(groupId);
+
+				if (group == null) {
+					return false;
+				}
+
+				if (!group.isDepot()) {
+					return true;
+				}
+
+				return connectedDepotEntryGroupIds.contains(groupId);
+			});
+	}
+
 	private String[] _getAssetTagNames(UnicodeProperties unicodeProperties) {
 		List<String> allAssetTagNames = new ArrayList<>();
 
@@ -582,6 +617,22 @@ public class AssetListAssetEntryProviderImpl
 		}
 
 		return combinedSegmentsEntryIds;
+	}
+
+	private Set<Long> _getConnectedDepotEntryGroupIds(long groupId) {
+		try {
+			return SetUtil.fromList(
+				TransformUtil.transform(
+					_depotEntryLocalService.getGroupConnectedDepotEntries(
+						groupId, DepotConstants.TYPE_ANY, QueryUtil.ALL_POS,
+						QueryUtil.ALL_POS),
+					DepotEntry::getGroupId));
+		}
+		catch (PortalException portalException) {
+			_log.error(portalException);
+
+			return Collections.emptySet();
+		}
 	}
 
 	private InfoPage<AssetEntry> _getDynamicAssetEntries(
@@ -1079,7 +1130,13 @@ public class AssetListAssetEntryProviderImpl
 	private DDMStructureLocalService _ddmStructureLocalService;
 
 	@Reference
+	private DepotEntryLocalService _depotEntryLocalService;
+
+	@Reference
 	private DLFileEntryTypeLocalService _dlFileEntryTypeLocalService;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/asset/asset-list-test/build.gradle
+++ b/modules/apps/asset/asset-list-test/build.gradle
@@ -13,6 +13,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:change-tracking:change-tracking-test-util")
 	testIntegrationImplementation project(":apps:data-engine:data-engine-rest-api")
 	testIntegrationImplementation project(":apps:data-engine:data-engine-rest-test-util")
+	testIntegrationImplementation project(":apps:depot:depot-api")
 	testIntegrationImplementation project(":apps:document-library:document-library-api")
 	testIntegrationImplementation project(":apps:document-library:document-library-test-util")
 	testIntegrationImplementation project(":apps:dynamic-data-mapping:dynamic-data-mapping-test-util")

--- a/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderTest.java
+++ b/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderTest.java
@@ -27,6 +27,11 @@ import com.liferay.blogs.service.BlogsEntryLocalService;
 import com.liferay.data.engine.rest.dto.v2_0.DataDefinition;
 import com.liferay.data.engine.rest.resource.v2_0.DataDefinitionResource;
 import com.liferay.data.engine.rest.test.util.DataDefinitionTestUtil;
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.model.DepotEntryGroupRel;
+import com.liferay.depot.service.DepotEntryGroupRelLocalService;
+import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
 import com.liferay.document.library.test.util.DLAppTestUtil;
@@ -46,6 +51,7 @@ import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserGroupLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
@@ -480,6 +486,55 @@ public class AssetListAssetEntryProviderTest {
 					QueryUtil.ALL_POS, QueryUtil.ALL_POS),
 				4);
 		}
+	}
+
+	@Test
+	@TestInfo("LPD-89770")
+	public void testGetAssetEntryQuery() throws Exception {
+		_depotEntry = _depotEntryLocalService.addDepotEntry(
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()
+			).build(),
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()
+			).build(),
+			DepotConstants.TYPE_SPACE,
+			ServiceContextTestUtil.getServiceContext());
+
+		DepotEntryGroupRel depotEntryGroupRel =
+			_depotEntryGroupRelLocalService.addDepotEntryGroupRel(
+				_depotEntry.getDepotEntryId(), _group.getGroupId());
+
+		UnicodeProperties unicodeProperties = UnicodePropertiesBuilder.create(
+			true
+		).put(
+			"groupIds", String.valueOf(_depotEntry.getGroupId())
+		).build();
+
+		AssetListEntry assetListEntry =
+			_assetListEntryLocalService.addAssetListEntry(
+				RandomTestUtil.randomString(), TestPropsValues.getUserId(),
+				_group.getGroupId(), RandomTestUtil.randomString(),
+				AssetListEntryTypeConstants.TYPE_DYNAMIC,
+				unicodeProperties.toString(), _serviceContext);
+
+		AssetEntryQuery assetEntryQuery =
+			_assetListAssetEntryProvider.getAssetEntryQuery(
+				assetListEntry, new long[] {SegmentsEntryConstants.ID_DEFAULT},
+				StringUtil.toHexString(TestPropsValues.getUserId()));
+
+		Assert.assertArrayEquals(
+			new long[] {_depotEntry.getGroupId()},
+			assetEntryQuery.getGroupIds());
+
+		_depotEntryGroupRelLocalService.deleteDepotEntryGroupRel(
+			depotEntryGroupRel);
+
+		assetEntryQuery = _assetListAssetEntryProvider.getAssetEntryQuery(
+			assetListEntry, new long[] {SegmentsEntryConstants.ID_DEFAULT},
+			StringUtil.toHexString(TestPropsValues.getUserId()));
+
+		Assert.assertArrayEquals(new long[0], assetEntryQuery.getGroupIds());
 	}
 
 	@Test
@@ -2141,6 +2196,15 @@ public class AssetListAssetEntryProviderTest {
 
 	@Inject
 	private DDMStructureLocalService _ddmStructureLocalService;
+
+	@DeleteAfterTestRun
+	private DepotEntry _depotEntry;
+
+	@Inject
+	private DepotEntryGroupRelLocalService _depotEntryGroupRelLocalService;
+
+	@Inject
+	private DepotEntryLocalService _depotEntryLocalService;
 
 	@DeleteAfterTestRun
 	private Group _group;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89770

## What is being fixed

A Dynamic Collection on a DXP Site can be configured with a Space as
its scope while the Space is connected to that site. After the Space is
disconnected, the persisted scope still references the Space group, so
`AssetListAssetEntryProviderImpl._createAssetEntryQuery` runs the asset
query against that group and surfaces the Space's content to every user
who can view the page — including users who never had access to the
Space. This is a regression of LPD-89353, which moved CMS group
injection out of `getSelectedGroups` so the actual Space group id is
now persisted in `typeSettings`.

## How it is being fixed

The provider filters the persisted `groupIds` at query time. It fetches
the depot entries currently connected to the asset list's owning group
once, then drops any persisted scope that maps to a depot group not in
that set. The asset list's own group, regular sites, and non-depot
scopes pass through unchanged; only stale depot references (Spaces or
Asset Libraries the site is no longer connected to) are removed. If the
user persisted scopes and every one of them is now disconnected, the
query receives an empty array and returns no results — matching the
ticket's expected behaviour.