### PR TITLE
LPD-89744 Render back button on Notifications page from user-personal-bar

### DIFF
--- a/modules/apps/product-navigation/product-navigation-personal-menu-api/src/main/java/com/liferay/product/navigation/personal/menu/util/PersonalApplicationURLUtil.java
+++ b/modules/apps/product-navigation/product-navigation-personal-menu-api/src/main/java/com/liferay/product/navigation/personal/menu/util/PersonalApplicationURLUtil.java
@@ -135,7 +135,8 @@ public class PersonalApplicationURLUtil {
 		LiferayPortletURL liferayPortletURL = PortletURLFactoryUtil.create(
 			httpServletRequest, portletId, layout, PortletRequest.RENDER_PHASE);
 
-		String backURL = ParamUtil.getString(httpServletRequest, "currentURL");
+		String backURL = ParamUtil.getString(
+			httpServletRequest, "currentURL", themeDisplay.getURLCurrent());
 
 		liferayPortletURL.setParameter("backURL", backURL);
 

--- a/modules/test/playwright/pages/product-navigation-user-personal-bar-web/UserPersonalBarPage.ts
+++ b/modules/test/playwright/pages/product-navigation-user-personal-bar-web/UserPersonalBarPage.ts
@@ -9,9 +9,11 @@ import {waitForAlert} from '../../utils/waitForAlert';
 import {GlobalMenuPage} from '../product-navigation-applications-menu/GlobalMenuPage';
 
 export class UserPersonalBarPage {
+	readonly backArrow: Locator;
 	readonly editConfigurationSubmitButton: Locator;
 	readonly globalMenuPage: GlobalMenuPage;
 	readonly notificationBadge: Locator;
+	readonly notificationsMenuItem: Locator;
 	readonly page: Page;
 	readonly processBuilderConfigurationTab: Locator;
 	readonly productsMenuItem: Locator;
@@ -20,6 +22,7 @@ export class UserPersonalBarPage {
 	readonly searchSubmit: Locator;
 	readonly showNotificationBadgeInPersonalMenuLabel: Locator;
 	readonly submitForWorkflowButton: Locator;
+	readonly userMenuButton: Locator;
 	readonly usersSetting: Locator;
 	readonly workflowDefinitionLinkCancelButton: Locator;
 	readonly workflowDefinitionLinkEditButton: Locator;
@@ -27,11 +30,16 @@ export class UserPersonalBarPage {
 	readonly workflowDefinitionLinkSelectButton: Locator;
 
 	constructor(page: Page) {
+		this.backArrow = page.getByRole('link', {exact: true, name: 'Back'});
 		this.editConfigurationSubmitButton = page.getByTestId(
 			'submitConfiguration'
 		);
 		this.globalMenuPage = new GlobalMenuPage(page);
 		this.notificationBadge = page.getByLabel('New Notification');
+		this.notificationsMenuItem = page.getByRole('menuitem', {
+			exact: true,
+			name: 'Notifications',
+		});
 		this.page = page;
 		this.processBuilderConfigurationTab = page.getByRole('link', {
 			name: 'Configuration',
@@ -58,6 +66,7 @@ export class UserPersonalBarPage {
 		this.submitForWorkflowButton = page.getByRole('link', {
 			name: 'Submit for Workflow',
 		});
+		this.userMenuButton = page.getByTestId('userPersonalMenu');
 		this.usersSetting = page.getByRole('link', {
 			name: 'Users',
 		});

--- a/modules/test/playwright/tests/notification-web/main/config.ts
+++ b/modules/test/playwright/tests/notification-web/main/config.ts
@@ -8,5 +8,6 @@ export const config = {
 	testDir: 'tests/notification-web/main',
 	use: {
 		permissions: ['clipboard-read', 'clipboard-write'],
+		testIdAttribute: 'data-qa-id',
 	},
 };

--- a/modules/test/playwright/tests/notification-web/main/userNotification.spec.ts
+++ b/modules/test/playwright/tests/notification-web/main/userNotification.spec.ts
@@ -130,6 +130,17 @@ test('review comment is added to user notification', async ({
 
 	await page.waitForLoadState('networkidle');
 
+	const workflowTaskPortletURLPattern =
+		/com_liferay_portal_workflow_task_web_portlet_MyWorkflowTaskPortlet/;
+
+	async function clickBackArrowAndExpectWorkflowTaskURL() {
+		await expect(userPersonalBarPage.backArrow).toBeVisible();
+
+		await userPersonalBarPage.backArrow.click();
+
+		await expect(page).toHaveURL(workflowTaskPortletURLPattern);
+	}
+
 	await userPersonalBarPage.notificationBadge.click();
 
 	await expect(
@@ -137,4 +148,12 @@ test('review comment is added to user notification', async ({
 			name: `Your submission was reviewed and the reviewer applied the following ${approvalComment}.`,
 		})
 	).toBeVisible();
+
+	await clickBackArrowAndExpectWorkflowTaskURL();
+
+	await userPersonalBarPage.userMenuButton.click();
+
+	await userPersonalBarPage.notificationsMenuItem.click();
+
+	await clickBackArrowAndExpectWorkflowTaskURL();
 });


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-89744

The Notifications page is supposed to render a back arrow regardless of which entry point the user took to reach it. Today the back arrow is missing whenever the user navigates via the user-personal-bar — either the red notification-count bubble on the avatar, or the Notifications item in the user-menu dropdown — leaving the user stranded with no obvious way to return to the page they came from.

# How am I fixing it?

`PersonalApplicationURLUtil.getPersonalApplicationURL` builds the Notifications URL with a `backURL` parameter that the Notifications portlet inspects to decide whether to render the back arrow. The util read `backURL` from a `currentURL` request parameter that only exists on the personal-menu's AJAX resource request, so the synchronous bubble render in `product-navigation-user-personal-bar-web` produced an empty `backURL` and the back arrow never appeared. It now falls back to `themeDisplay.getURLCurrent()` when the parameter is missing, which covers the bubble path while preserving the existing AJAX-resource behaviour.

# How can you verify that it works?

Run the included automated tests:

```
cd modules/test/playwright
yarn test tests/notification-web/main/userNotification.spec.ts
```