### PR TITLE
LPD-89364 Surface upload size errors in form submit and autosave

### DIFF
--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/custom/form/FormView.es.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/custom/form/FormView.es.js
@@ -5,7 +5,7 @@
 
 import '../../../css/main.scss';
 
-import {openModal} from 'frontend-js-components-web';
+import {openModal, openToast} from 'frontend-js-components-web';
 import {fetch} from 'frontend-js-web';
 import React, {
 	useCallback,
@@ -22,6 +22,7 @@ import {INITIAL_CONFIG_STATE} from '../../core/config/initialConfigState.es';
 import {INITIAL_STATE} from '../../core/config/initialState.es';
 import {ConfigProvider, useConfig} from '../../core/hooks/useConfig.es';
 import {FormProvider, useForm, useFormState} from '../../core/hooks/useForm.es';
+import {enableSubmitButton} from '../../core/utils/submitButtonController.es';
 import {
 	activePageReducer,
 	fieldReducer,
@@ -117,7 +118,16 @@ const useFormSubmit = ({apiRef, containerRef}) => {
 					}
 				})
 				.catch((error) => {
-					console.error(error);
+					enableSubmitButton('ddm-form-submit');
+
+					openToast({
+						message:
+							error?.message ||
+							Liferay.Language.get(
+								'an-unexpected-error-occurred'
+							),
+						type: 'danger',
+					});
 
 					Liferay.fire('ddmFormError', {
 						error,

--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/utils/evaluation.es.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/utils/evaluation.es.js
@@ -181,8 +181,12 @@ const doEvaluate = debounce((fieldName, evaluatorContext, callback) => {
 		url: EVALUATOR_URL,
 	})
 		.then((newPages) => {
+			if (newPages.error) {
+				return callback(new Error(newPages.error));
+			}
+
 			if (newPages.statusCode) {
-				callback(newPages);
+				return callback(newPages);
 			}
 
 			const mergedPages = mergePages(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/java/com/liferay/dynamic/data/mapping/form/renderer/internal/servlet/DDMFormContextProviderServlet.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/java/com/liferay/dynamic/data/mapping/form/renderer/internal/servlet/DDMFormContextProviderServlet.java
@@ -74,9 +74,18 @@ public class DDMFormContextProviderServlet extends HttpServlet {
 			 uploadException.isExceededLiferayFileItemSizeLimit() ||
 			 uploadException.isExceededUploadRequestSizeLimit())) {
 
-			httpServletResponse.sendError(
-				HttpServletResponse.SC_REQUEST_ENTITY_TOO_LARGE,
-				_language.get(httpServletRequest, "upload-size-is-too-large"));
+			httpServletResponse.setContentType(ContentTypes.APPLICATION_JSON);
+			httpServletResponse.setStatus(
+				HttpServletResponse.SC_REQUEST_ENTITY_TOO_LARGE);
+
+			ServletResponseUtil.write(
+				httpServletResponse,
+				_jsonFactory.createJSONObject(
+				).put(
+					"error",
+					_language.get(
+						httpServletRequest, "upload-size-is-too-large")
+				).toString());
 
 			return;
 		}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/AddFormInstanceRecordMVCResourceCommand.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/AddFormInstanceRecordMVCResourceCommand.java
@@ -102,6 +102,10 @@ public class AddFormInstanceRecordMVCResourceCommand
 		long formInstanceId = ParamUtil.getLong(
 			resourceRequest, "formInstanceId");
 
+		if (formInstanceId == 0) {
+			return;
+		}
+
 		DDMFormInstance ddmFormInstance =
 			_ddmFormInstanceLocalService.getFormInstance(formInstanceId);
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/display/init.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/display/init.jsp
@@ -41,6 +41,7 @@ page import="com.liferay.portal.kernel.captcha.CaptchaException" %><%@
 page import="com.liferay.portal.kernel.captcha.CaptchaTextException" %><%@
 page import="com.liferay.portal.kernel.dao.search.SearchContainer" %><%@
 page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
+page import="com.liferay.portal.kernel.language.UnicodeLanguageUtil" %><%@
 page import="com.liferay.portal.kernel.model.Group" %><%@
 page import="com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil" %><%@
 page import="com.liferay.portal.kernel.util.Constants" %><%@

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/display/view.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/display/view.jsp
@@ -371,6 +371,14 @@ boolean limitToOneSubmissionPerUser = DDMFormInstanceSubmissionLimitStatusUtil.i
 							Liferay.Util.fetch('<%= autoSaveFormInstanceRecordURL.toString() %>', {
 								body: data,
 								method: 'POST',
+							}).catch(function () {
+								clearInterval(window.<portlet:namespace />intervalId);
+
+								Liferay.Util.openToast({
+									message:
+										'<%= UnicodeLanguageUtil.get(request, "autosave-error") %>',
+									type: 'warning',
+								});
 							});
 						}
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/internal/form/renderer/servlet/test/DDMFormContextProviderServletTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/internal/form/renderer/servlet/test/DDMFormContextProviderServletTest.java
@@ -6,12 +6,19 @@
 package com.liferay.dynamic.data.mapping.internal.form.renderer.servlet.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.upload.UploadException;
+import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import jakarta.servlet.Servlet;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
 
@@ -56,9 +63,51 @@ public class DDMFormContextProviderServletTest {
 			mockHttpServletRequest.getAttribute(WebKeys.THEME_DISPLAY));
 	}
 
+	@Test
+	public void testUploadExceptionReturnsJSONErrorResponse() throws Exception {
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.addPreferredLocale(LocaleUtil.US);
+
+		UploadException uploadException = new UploadException(
+			"Upload size exceeded");
+
+		uploadException.setExceededLiferayFileItemSizeLimit(true);
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.UPLOAD_EXCEPTION, uploadException);
+
+		MockHttpServletResponse mockHttpServletResponse =
+			new MockHttpServletResponse();
+
+		_ddmFormContextProviderServlet.service(
+			mockHttpServletRequest, mockHttpServletResponse);
+
+		Assert.assertEquals(
+			HttpServletResponse.SC_REQUEST_ENTITY_TOO_LARGE,
+			mockHttpServletResponse.getStatus());
+		Assert.assertEquals(
+			ContentTypes.APPLICATION_JSON,
+			mockHttpServletResponse.getContentType());
+
+		JSONObject jsonObject = _jsonFactory.createJSONObject(
+			mockHttpServletResponse.getContentAsString());
+
+		Assert.assertEquals(
+			_language.get(LocaleUtil.US, "upload-size-is-too-large"),
+			jsonObject.getString("error"));
+	}
+
 	@Inject(
 		filter = "osgi.http.whiteboard.servlet.name=com.liferay.dynamic.data.mapping.form.renderer.internal.servlet.DDMFormContextProviderServlet"
 	)
 	private Servlet _ddmFormContextProviderServlet;
+
+	@Inject
+	private JSONFactory _jsonFactory;
+
+	@Inject
+	private Language _language;
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89364

## What is being fixed

When a Dynamic Data Mapping form contains a field whose content exceeds
the configured `FileItem.threshold.size` (e.g. a rich-text field with a
very large pasted value), the form fails silently when the user clicks
Submit: the button greys out, no UI message appears, and the only
signal is a `code=413` WARN in `liferay.log` pointing at
`/o/dynamic-data-mapping-form-context-provider/`.

The same oversize body also causes the form-display autosave timer to
fail repeatedly with no user feedback, and produces a misleading
`NoSuchFormInstanceException` stack trace in `liferay.log` because the
partially-parsed request reaches the resource command without a form
instance id.

## How it is being fixed

`DDMFormContextProviderServlet` now responds to upload exceptions with
a JSON body and a 413 status via `setStatus` plus
`ServletResponseUtil.write`, rather than `sendError`, so the client can
read a structured error instead of the container's HTML error page.
The form evaluator (`evaluation.es.js`) detects the new `error` field
on the response and rejects the evaluation promise; the form's submit
handler in `FormView.es.js` then re-enables the submit button via the
existing `enableSubmitButton` helper and surfaces the localized
message through a Clay danger toast.

For the autosave timer on the user-facing form page, the
`Liferay.Util.fetch` call now has a `.catch` that clears the polling
interval and shows a warning toast so the user is told that autosave
has stopped. `AddFormInstanceRecordMVCResourceCommand` short-circuits
early when `formInstanceId` arrives as zero — which happens when the
autosave body is too big to be fully parsed — so the spurious
`NoSuchFormInstanceException` is no longer logged on every interval
tick.

A new integration test in `DDMFormContextProviderServletTest` locks
in the upload-exceeded contract: status 413, content type
`application/json`, and the localized error message in the `error`
field of the response body.
