### PR TITLE
LPD-87387 Anchor template item selector filter to referer site tree

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-item-selector-web/src/main/java/com/liferay/dynamic/data/mapping/item/selector/web/internal/DDMTemplateItemSelectorViewDescriptor.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-item-selector-web/src/main/java/com/liferay/dynamic/data/mapping/item/selector/web/internal/DDMTemplateItemSelectorViewDescriptor.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
@@ -34,6 +35,9 @@ import jakarta.portlet.PortletRequest;
 import jakarta.portlet.PortletURL;
 
 import jakarta.servlet.http.HttpServletRequest;
+
+import java.util.Collections;
+import java.util.Set;
 
 /**
  * @author Eudaldo Alonso
@@ -115,23 +119,13 @@ public class DDMTemplateItemSelectorViewDescriptor
 				getOrderByCol(), getOrderByType()));
 		ddmTemplateSearchContainer.setOrderByType(getOrderByType());
 
-		DDMStructure ddmStructure = _ddmStructureLocalService.fetchDDMStructure(
-			_ddmTemplateItemSelectorCriterion.getDDMStructureId());
+		long[] groupIds = _getGroupIds();
 
-		long[] currentAndAncestorSiteGroupIds =
-			PortalUtil.getCurrentAndAncestorSiteGroupIds(
-				_themeDisplay.getScopeGroupId(), false);
+		if (groupIds.length == 0) {
+			ddmTemplateSearchContainer.setResultsAndTotal(
+				Collections.emptyList());
 
-		long[] groupIds;
-
-		if ((ddmStructure != null) &&
-			_isDepotGroup(ddmStructure.getGroupId())) {
-
-			groupIds = ArrayUtil.append(
-				currentAndAncestorSiteGroupIds, ddmStructure.getGroupId());
-		}
-		else {
-			groupIds = currentAndAncestorSiteGroupIds;
+			return ddmTemplateSearchContainer;
 		}
 
 		ddmTemplateSearchContainer.setResultsAndTotal(
@@ -163,6 +157,40 @@ public class DDMTemplateItemSelectorViewDescriptor
 	@Override
 	public boolean isShowSearch() {
 		return true;
+	}
+
+	private long[] _getGroupIds() {
+		long refererGroupId = _themeDisplay.getRefererGroupId();
+
+		long scopeGroupId = _themeDisplay.getScopeGroupId();
+
+		long[] scopeAndAncestorSiteGroupIds =
+			PortalUtil.getCurrentAndAncestorSiteGroupIds(scopeGroupId, false);
+
+		long[] refererAndAncestorSiteGroupIds = scopeAndAncestorSiteGroupIds;
+
+		if ((refererGroupId != 0) && (refererGroupId != scopeGroupId)) {
+			refererAndAncestorSiteGroupIds =
+				PortalUtil.getCurrentAndAncestorSiteGroupIds(
+					refererGroupId, false);
+		}
+
+		Set<Long> validGroupIds = SetUtil.fromArray(
+			refererAndAncestorSiteGroupIds);
+
+		validGroupIds.add(_themeDisplay.getCompanyGroupId());
+
+		DDMStructure ddmStructure = _ddmStructureLocalService.fetchDDMStructure(
+			_ddmTemplateItemSelectorCriterion.getDDMStructureId());
+
+		if ((ddmStructure != null) &&
+			_isDepotGroup(ddmStructure.getGroupId())) {
+
+			validGroupIds.add(ddmStructure.getGroupId());
+		}
+
+		return ArrayUtil.filter(
+			scopeAndAncestorSiteGroupIds, validGroupIds::contains);
 	}
 
 	private String _getKeywords() {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/item/selector/web/internal/test/DDMTemplateItemSelectorViewDescriptorTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/item/selector/web/internal/test/DDMTemplateItemSelectorViewDescriptorTest.java
@@ -95,36 +95,49 @@ public class DDMTemplateItemSelectorViewDescriptorTest {
 	public void testSearchContainerExcludesCrossSiteTemplatesForAssetLibraryStructure()
 		throws Exception {
 
-		Group group1 = GroupTestUtil.addGroup();
-		Group group2 = GroupTestUtil.addGroup();
+		_setUpDepotEntry();
 
-		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
-			HashMapBuilder.put(
-				LocaleUtil.getDefault(), RandomTestUtil.randomString()
-			).build(),
-			Collections.emptyMap(), DepotConstants.TYPE_ASSET_LIBRARY,
-			ServiceContextTestUtil.getServiceContext());
+		DDMTemplate depotDDMTemplate = _addDDMTemplate(
+			_depotEntry.getGroupId());
+		DDMTemplate group1DDMTemplate = _addDDMTemplate(_group1.getGroupId());
+		DDMTemplate group2DDMTemplate = _addDDMTemplate(_group2.getGroupId());
 
-		_depotEntryGroupRelLocalService.addDepotEntryGroupRel(
-			depotEntry.getDepotEntryId(), group1.getGroupId());
-		_depotEntryGroupRelLocalService.addDepotEntryGroupRel(
-			depotEntry.getDepotEntryId(), group2.getGroupId());
+		List<DDMTemplate> ddmTemplates = _getDDMTemplates(
+			0, _group1.getGroupId());
 
-		DDMStructure ddmStructure = DDMStructureTestUtil.addStructure(
-			depotEntry.getGroupId(), JournalArticle.class.getName());
+		Assert.assertTrue(
+			ddmTemplates.toString(), ddmTemplates.contains(group1DDMTemplate));
+		Assert.assertFalse(
+			ddmTemplates.toString(), ddmTemplates.contains(depotDDMTemplate));
+		Assert.assertFalse(
+			ddmTemplates.toString(), ddmTemplates.contains(group2DDMTemplate));
+	}
 
-		DDMTemplate group1Template = DDMTemplateTestUtil.addTemplate(
-			group1.getGroupId(), ddmStructure.getStructureId(),
-			ddmStructure.getClassNameId(), TemplateConstants.LANG_TYPE_FTL,
+	@Test
+	public void testSearchContainerReturnsNoTemplatesWhenNavigatingToUnrelatedSite()
+		throws Exception {
+
+		_setUpDepotEntry();
+
+		_addDDMTemplate(_depotEntry.getGroupId());
+		_addDDMTemplate(_group2.getGroupId());
+
+		List<DDMTemplate> ddmTemplates = _getDDMTemplates(
+			_group1.getGroupId(), _group2.getGroupId());
+
+		Assert.assertTrue(ddmTemplates.toString(), ddmTemplates.isEmpty());
+	}
+
+	private DDMTemplate _addDDMTemplate(long groupId) throws Exception {
+		return DDMTemplateTestUtil.addTemplate(
+			groupId, _ddmStructure.getStructureId(),
+			_ddmStructure.getClassNameId(), TemplateConstants.LANG_TYPE_FTL,
 			_SCRIPT, LocaleUtil.getSiteDefault());
-		DDMTemplate group2Template = DDMTemplateTestUtil.addTemplate(
-			group2.getGroupId(), ddmStructure.getStructureId(),
-			ddmStructure.getClassNameId(), TemplateConstants.LANG_TYPE_FTL,
-			_SCRIPT, LocaleUtil.getSiteDefault());
-		DDMTemplate depotTemplate = DDMTemplateTestUtil.addTemplate(
-			depotEntry.getGroupId(), ddmStructure.getStructureId(),
-			ddmStructure.getClassNameId(), TemplateConstants.LANG_TYPE_FTL,
-			_SCRIPT, LocaleUtil.getSiteDefault());
+	}
+
+	private List<DDMTemplate> _getDDMTemplates(
+			long refererGroupId, long scopeGroupId)
+		throws Exception {
 
 		DDMTemplateItemSelectorCriterion ddmTemplateItemSelectorCriterion =
 			new DDMTemplateItemSelectorCriterion();
@@ -132,14 +145,15 @@ public class DDMTemplateItemSelectorViewDescriptorTest {
 		ddmTemplateItemSelectorCriterion.setClassNameId(
 			PortalUtil.getClassNameId(JournalArticle.class.getName()));
 		ddmTemplateItemSelectorCriterion.setDDMStructureId(
-			ddmStructure.getStructureId());
+			_ddmStructure.getStructureId());
 
 		ThemeDisplay themeDisplay = new ThemeDisplay();
 
 		themeDisplay.setCompany(
 			_companyLocalService.getCompany(TestPropsValues.getCompanyId()));
-		themeDisplay.setScopeGroupId(group1.getGroupId());
-		themeDisplay.setSiteGroupId(group1.getGroupId());
+		themeDisplay.setRefererGroupId(refererGroupId);
+		themeDisplay.setScopeGroupId(scopeGroupId);
+		themeDisplay.setSiteGroupId(scopeGroupId);
 		themeDisplay.setUser(TestPropsValues.getUser());
 
 		MockLiferayResourceRequest mockLiferayResourceRequest =
@@ -174,14 +188,27 @@ public class DDMTemplateItemSelectorViewDescriptorTest {
 				ddmTemplateItemSelectorViewDescriptor, "getSearchContainer",
 				new Class<?>[0]);
 
-		List<DDMTemplate> ddmTemplates = searchContainer.getResults();
+		return searchContainer.getResults();
+	}
 
-		Assert.assertTrue(
-			ddmTemplates.toString(), ddmTemplates.contains(group1Template));
-		Assert.assertTrue(
-			ddmTemplates.toString(), ddmTemplates.contains(depotTemplate));
-		Assert.assertFalse(
-			ddmTemplates.toString(), ddmTemplates.contains(group2Template));
+	private void _setUpDepotEntry() throws Exception {
+		_group1 = GroupTestUtil.addGroup();
+		_group2 = GroupTestUtil.addGroup();
+
+		_depotEntry = _depotEntryLocalService.addDepotEntry(
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()
+			).build(),
+			Collections.emptyMap(), DepotConstants.TYPE_ASSET_LIBRARY,
+			ServiceContextTestUtil.getServiceContext());
+
+		_depotEntryGroupRelLocalService.addDepotEntryGroupRel(
+			_depotEntry.getDepotEntryId(), _group1.getGroupId());
+		_depotEntryGroupRelLocalService.addDepotEntryGroupRel(
+			_depotEntry.getDepotEntryId(), _group2.getGroupId());
+
+		_ddmStructure = DDMStructureTestUtil.addStructure(
+			_depotEntry.getGroupId(), JournalArticle.class.getName());
 	}
 
 	private static final String _SCRIPT = "${variable}";
@@ -189,8 +216,12 @@ public class DDMTemplateItemSelectorViewDescriptorTest {
 	@Inject
 	private CompanyLocalService _companyLocalService;
 
+	private DDMStructure _ddmStructure;
+
 	@Inject
 	private DDMStructureLocalService _ddmStructureLocalService;
+
+	private DepotEntry _depotEntry;
 
 	@Inject
 	private DepotEntryGroupRelLocalService _depotEntryGroupRelLocalService;
@@ -198,6 +229,8 @@ public class DDMTemplateItemSelectorViewDescriptorTest {
 	@Inject
 	private DepotEntryLocalService _depotEntryLocalService;
 
+	private Group _group1;
+	private Group _group2;
 	private String _originalName;
 	private PermissionChecker _originalPermissionChecker;
 


### PR DESCRIPTION
## Summary

Follow-up to the LPD-87387 fix. The previous filter narrowed only the default picker view, so a user could still pick a cross-site template by navigating the "Sites and Libraries" breadcrumb to another connected site.

The valid template-group set is now anchored to the referer's site tree (the article editor's scope), the company group, and the structure's depot (when applicable). The current scope's site tree is intersected with that set:

| Breadcrumb navigates to | `groupIds` | Result |
|---|---|---|
| Default scope (referer) | referer site tree | site templates |
| Asset Library | `[depot]` | depot templates |
| Global / Liferay DXP | `[company]` | Global templates |
| Unrelated site | `[]` | empty list — bug repro closed |

Parent-site inheritance is preserved: ancestors of the scope are still included when the scope is in the referer's tree.

## Test plan

- [ ] `gradlew testIntegration --tests DDMTemplateItemSelectorViewDescriptorTest` passes (covers default-scope filter and the breadcrumb-hop-to-unrelated-site case)
- [ ] Manual LPD-87387 repro: in Site B, configure WCD widget with web content using an Asset Library structure, breadcrumb-hop to Site A — template list should be empty (was leaking Site A templates before)
- [ ] Manual: breadcrumb-hop to the Asset Library shows depot templates
- [ ] Manual: breadcrumb-hop to Global shows Global templates
- [ ] Manual: child site default view still shows parent site's templates
