### PR TITLE
LPD-90009 Inherit current Space when drag-and-dropping into a folder

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/actions/fileDropAction.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/actions/fileDropAction.ts
@@ -5,6 +5,7 @@
 
 import {navigate} from 'frontend-js-web';
 
+import {AssetLibrary} from '../../../common/types/AssetLibrary';
 import multipleFilesUploadAction, {
 	MultipleFileUploaderData,
 } from './multipleFilesUploadAction';
@@ -12,6 +13,7 @@ import multipleFilesUploadAction, {
 export default function fileDropAction(
 	additionalProps: MultipleFileUploaderData & {
 		baseFolderViewURL: string;
+		candidateAssetLibraries: AssetLibrary[];
 		loadData?: () => void;
 		redirect: string;
 	},
@@ -23,9 +25,9 @@ export default function fileDropAction(
 	}
 
 	const {
-		assetLibraries,
 		baseAssetLibraryViewURL,
 		baseFolderViewURL,
+		candidateAssetLibraries,
 		keywords,
 		loadData,
 		parentObjectEntryFolderExternalReferenceCode,
@@ -34,7 +36,7 @@ export default function fileDropAction(
 
 	multipleFilesUploadAction(
 		{
-			assetLibraries,
+			assetLibraries: candidateAssetLibraries,
 			baseAssetLibraryViewURL,
 			filesToUpload: droppedFiles.map((file: any) => ({
 				errorMessage: '',

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/props_transformer/actions/fileDropAction.test.ts
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/props_transformer/actions/fileDropAction.test.ts
@@ -1,0 +1,83 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import fileDropAction from '../../../../../src/main/resources/META-INF/resources/js/main_view/props_transformer/actions/fileDropAction';
+import multipleFilesUploadAction from '../../../../../src/main/resources/META-INF/resources/js/main_view/props_transformer/actions/multipleFilesUploadAction';
+
+jest.mock(
+	'../../../../../src/main/resources/META-INF/resources/js/main_view/props_transformer/actions/multipleFilesUploadAction',
+	() => ({
+		__esModule: true,
+		default: jest.fn(),
+	})
+);
+
+jest.mock('frontend-js-web', () => ({
+	navigate: jest.fn(),
+}));
+
+const allAssetLibraries = [
+	{externalReferenceCode: 'space-a', groupId: 1001, name: 'Space A'},
+	{externalReferenceCode: 'space-b', groupId: 1002, name: 'Space B'},
+];
+
+const currentSpaceAssetLibraries = [allAssetLibraries[0]];
+
+const baseAdditionalProps = {
+	assetLibraries: allAssetLibraries,
+	baseAssetLibraryViewURL: '/space/',
+	baseFolderViewURL: '/folder/',
+	candidateAssetLibraries: currentSpaceAssetLibraries,
+	keywords: '',
+	parentObjectEntryFolderExternalReferenceCode: 'L_FILES',
+	redirect: '/back',
+};
+
+const droppedFile = {name: 'report.pdf', size: 123};
+
+describe('fileDropAction', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('does nothing when no files are dropped', () => {
+		fileDropAction(baseAdditionalProps, null);
+
+		expect(multipleFilesUploadAction).not.toHaveBeenCalled();
+	});
+
+	it('passes candidateAssetLibraries to the upload modal so the current Space is implicit', () => {
+		fileDropAction(baseAdditionalProps, [droppedFile]);
+
+		const [data] = (multipleFilesUploadAction as jest.Mock).mock.calls[0];
+
+		expect(data.assetLibraries).toEqual(currentSpaceAssetLibraries);
+		expect(data.assetLibraries).not.toEqual(allAssetLibraries);
+	});
+
+	it('uses the parent folder ERC from additionalProps when no dropTarget is provided', () => {
+		fileDropAction(baseAdditionalProps, [droppedFile]);
+
+		const [data] = (multipleFilesUploadAction as jest.Mock).mock.calls[0];
+
+		expect(data.parentObjectEntryFolderExternalReferenceCode).toBe(
+			'L_FILES'
+		);
+	});
+
+	it('uses the dropTarget folder ERC when a dropTarget is provided', () => {
+		const dropTarget = {
+			embedded: {externalReferenceCode: 'subfolder-erc', id: 42},
+		};
+
+		fileDropAction(baseAdditionalProps, [droppedFile], dropTarget);
+
+		const [data] = (multipleFilesUploadAction as jest.Mock).mock.calls[0];
+
+		expect(data.parentObjectEntryFolderExternalReferenceCode).toBe(
+			'subfolder-erc'
+		);
+	});
+});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90009

## What is being fixed

Dragging files onto a Space's Files folder opened the upload modal with
an empty Space selector. Even though the drop happened inside a specific
Space, the modal still forced the user to search for and pick that same
Space before the Upload button activated.

## How it is being fixed

The drag-and-drop path now feeds `candidateAssetLibraries` (the
display-context value that is already scoped to the current Space when
an `ObjectEntryFolder` is in context) into the upload modal under the
`assetLibraries` key, instead of the unscoped full library list. When
the user is inside a Space, the modal sees a single-entry array,
auto-selects the Space, and hides the picker — the upload starts with
one click. The global Files view is unaffected, because outside of a
Space `candidateAssetLibraries` and `assetLibraries` are equal.

A unit test covers the new pass-through (scoped libraries forwarded,
parent-folder ERC taken from a drop target when present).