### PR TITLE
LPD-89812 Decimal separator missing or value truncated to 0 in non-English languages

### DIFF
--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/transformer/test/JournalTransformerTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/transformer/test/JournalTransformerTest.java
@@ -870,13 +870,17 @@ public class JournalTransformerTest {
 		try {
 			LocaleThreadLocal.setThemeDisplayLocale(locale);
 
+			ThemeDisplay themeDisplay = new ThemeDisplay();
+
+			themeDisplay.setSiteDefaultLocale(locale);
+
 			TemplateNode templateNode = ReflectionTestUtil.invoke(
 				_journalTransformer, "_createTemplateNode",
 				new Class<?>[] {
 					DDMFormField.class, Element.class, Locale.class,
 					ThemeDisplay.class
 				},
-				ddmFormField, rootElement, locale, new ThemeDisplay());
+				ddmFormField, rootElement, locale, themeDisplay);
 
 			Assert.assertEquals(expectedValue, templateNode.getData());
 		}

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/transformer/test/JournalTransformerTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/transformer/test/JournalTransformerTest.java
@@ -176,6 +176,10 @@ public class JournalTransformerTest {
 	@Test
 	public void testCreateTemplateNode() {
 		_testCreateTemplateNodeDocumentLibraryDDMFormField();
+		_testCreateTemplateNodeNumericDDMFormFieldWithMismatchedLocale(
+			LocaleUtil.SPAIN, LocaleUtil.US, "20.3", "20,30");
+		_testCreateTemplateNodeNumericDDMFormFieldWithMismatchedLocale(
+			LocaleUtil.US, LocaleUtil.SPAIN, "123,45", "123.45");
 		_testCreateTemplateNodeNumericDDMFormFieldWithTrailingZero(
 			"2,3", LocaleUtil.SPAIN, "2,30");
 		_testCreateTemplateNodeNumericDDMFormFieldWithTrailingZero(
@@ -845,6 +849,47 @@ public class JournalTransformerTest {
 		Assert.assertEquals("select", templateNode.getType());
 		Assert.assertTrue(ListUtil.isEmpty(templateNode.getOptions()));
 		Assert.assertTrue(MapUtil.isEmpty(templateNode.getOptionsMap()));
+	}
+
+	private void _testCreateTemplateNodeNumericDDMFormFieldWithMismatchedLocale(
+		Locale dataLocale, Locale displayLocale, String expectedValue,
+		String text) {
+
+		DDMFormField ddmFormField = new DDMFormField(
+			"numeric", DDMFormFieldTypeConstants.NUMERIC);
+
+		ddmFormField.setDataType("double");
+
+		Document document = SAXReaderUtil.createDocument();
+
+		Element rootElement = document.addElement("root");
+
+		Element dynamicContentElement = rootElement.addElement(
+			"dynamic-content");
+
+		dynamicContentElement.addAttribute(
+			"language-id", LocaleUtil.toLanguageId(dataLocale));
+		dynamicContentElement.setText(text);
+
+		Locale originalThemeDisplayLocale =
+			LocaleThreadLocal.getThemeDisplayLocale();
+
+		try {
+			LocaleThreadLocal.setThemeDisplayLocale(displayLocale);
+
+			TemplateNode templateNode = ReflectionTestUtil.invoke(
+				_journalTransformer, "_createTemplateNode",
+				new Class<?>[] {
+					DDMFormField.class, Element.class, Locale.class,
+					ThemeDisplay.class
+				},
+				ddmFormField, rootElement, displayLocale, new ThemeDisplay());
+
+			Assert.assertEquals(expectedValue, templateNode.getData());
+		}
+		finally {
+			LocaleThreadLocal.setThemeDisplayLocale(originalThemeDisplayLocale);
+		}
 	}
 
 	private void _testCreateTemplateNodeNumericDDMFormFieldWithTrailingZero(

--- a/modules/apps/journal/journal-test/src/testIntegration/resources/com/liferay/journal/transformer/test/dependencies/data_definition.json
+++ b/modules/apps/journal/journal-test/src/testIntegration/resources/com/liferay/journal/transformer/test/dependencies/data_definition.json
@@ -1,6 +1,7 @@
 {
 	"availableLanguageIds": [
-		"en_US, pt_BR"
+		"en_US",
+		"pt_BR"
 	],
 	"contentType": "journal",
 	"dataDefinitionFields": [

--- a/portal-kernel/src/com/liferay/portal/kernel/templateparser/TemplateNode.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/templateparser/TemplateNode.java
@@ -347,6 +347,22 @@ public class TemplateNode extends LinkedHashMap<String, Object> {
 		return (String)get("data");
 	}
 
+	private Locale _getDataLocale() {
+		Map<String, String> attributes = getAttributes();
+
+		if (attributes == null) {
+			return _locale;
+		}
+
+		String dataLanguageId = attributes.get("language-id");
+
+		if (Validator.isNull(dataLanguageId)) {
+			return _locale;
+		}
+
+		return LocaleUtil.fromLanguageId(dataLanguageId);
+	}
+
 	private String _getDDMJournalArticleFriendlyURL() {
 		if (_themeDisplay == null) {
 			return StringPool.BLANK;
@@ -548,7 +564,16 @@ public class TemplateNode extends LinkedHashMap<String, Object> {
 		decimalFormat.setMaximumFractionDigits(Integer.MAX_VALUE);
 		decimalFormat.setParseBigDecimal(true);
 
-		return decimalFormat.format(GetterUtil.getDouble(data, _locale));
+		double doubleValue;
+
+		try {
+			doubleValue = Double.parseDouble(data);
+		}
+		catch (NumberFormatException numberFormatException) {
+			doubleValue = GetterUtil.getDouble(data, _getDataLocale());
+		}
+
+		return decimalFormat.format(doubleValue);
 	}
 
 	private static final String _RANDOM_ID = StringUtil.randomId();

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/templateparser/TemplateNodeTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/templateparser/TemplateNodeTest.java
@@ -1,0 +1,89 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.templateparser;
+
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.LocaleUtil;
+
+import java.util.Collections;
+import java.util.Locale;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Attila Bakay
+ */
+public class TemplateNodeTest {
+
+	@Test
+	public void testGetDataNumericFormatsAcrossLocales() {
+		_assertNumericData("123.456", LocaleUtil.US, "123.456");
+		_assertNumericData("123.456", LocaleUtil.SPAIN, "123,456");
+		_assertNumericData("123.456", LocaleUtil.GERMANY, "123,456");
+		_assertNumericData("123.456", LocaleUtil.FRANCE, "123,456");
+	}
+
+	@Test
+	public void testGetDataNumericParsesJavaCanonicalDataWithSiteLocale() {
+		_assertNumericData("20.3", LocaleUtil.SPAIN, LocaleUtil.SPAIN, "20,3");
+		_assertNumericData(
+			"20.3", LocaleUtil.SPAIN, LocaleUtil.GERMANY, "20,3");
+		_assertNumericData("20.3", LocaleUtil.SPAIN, LocaleUtil.US, "20.3");
+	}
+
+	@Test
+	public void testGetDataNumericPreservesNegativeNumbers() {
+		_assertNumericData("-123.45", LocaleUtil.US, "-123.45");
+		_assertNumericData("-123.45", LocaleUtil.SPAIN, "-123,45");
+		_assertNumericData("-123.45", LocaleUtil.GERMANY, "-123,45");
+		_assertNumericData("-123.45", LocaleUtil.FRANCE, "-123,45");
+	}
+
+	@Test
+	public void testGetDataNumericPreservesSmallFractions() {
+		_assertNumericData("0.0000012345", LocaleUtil.US, "0.0000012345");
+		_assertNumericData("0.0000012345", LocaleUtil.SPAIN, "0,0000012345");
+	}
+
+	@Test
+	public void testGetDataNumericSupportsAllNumericTypes() {
+		for (String type :
+				new String[] {"numeric", "ddm-decimal", "ddm-number"}) {
+
+			ThemeDisplay themeDisplay = new ThemeDisplay();
+
+			themeDisplay.setSiteDefaultLocale(LocaleUtil.US);
+
+			TemplateNode templateNode = new TemplateNode(
+				LocaleUtil.SPAIN, themeDisplay, "field", "123.456", type,
+				Collections.emptyMap());
+
+			Assert.assertEquals("123,456", templateNode.getData());
+		}
+	}
+
+	private void _assertNumericData(
+		String data, Locale siteDefaultLocale, Locale locale, String expected) {
+
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		themeDisplay.setSiteDefaultLocale(siteDefaultLocale);
+
+		TemplateNode templateNode = new TemplateNode(
+			locale, themeDisplay, "field", data, "numeric",
+			Collections.emptyMap());
+
+		Assert.assertEquals(expected, templateNode.getData());
+	}
+
+	private void _assertNumericData(
+		String data, Locale locale, String expected) {
+
+		_assertNumericData(data, LocaleUtil.US, locale, expected);
+	}
+
+}


### PR DESCRIPTION
### What is this trying to solve?
https://liferay.atlassian.net/browse/LPD-89812 
### How am I fixing it?
By removing the double parsing, which in some cases results in an error. 
### How can you verify that it works?
Buy running the added tests