### PR TITLE
LPD-89999 Restore image preview in CMS Version History

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewVersionHistoryDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewVersionHistoryDisplayContext.java
@@ -57,7 +57,8 @@ public class ViewVersionHistoryDisplayContext {
 			"/o", _objectDefinition.getRESTContextPath(), "/scopes/",
 			_objectEntry.getGroupId(), "/by-external-reference-code/",
 			_objectEntry.getExternalReferenceCode(),
-			"/versions?nestedFields=file.thumbnailURL");
+			"/versions?nestedFields=file.metadata,file.previewURL,",
+			"file.thumbnailURL");
 	}
 
 	public List<DropdownItem> getBulkActionDropdownItems() {

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/versions.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/versions.spec.ts
@@ -43,7 +43,13 @@ test(
 
 		await assetsPage.gotoContents();
 
-		await testCanViewVersion(assetsPage, page, objectEntry.title, 'Table');
+		await testCanViewVersion(
+			assetsPage,
+			false,
+			page,
+			objectEntry.title,
+			'Table'
+		);
 
 		await apiHelpers.objectEntry.deleteObjectEntry(
 			applicationName,
@@ -78,6 +84,7 @@ test(
 
 		await testCanViewVersion(
 			assetsPage,
+			true,
 			page,
 			objectEntry.title,
 			'Gallery'
@@ -185,6 +192,7 @@ test(
 
 async function testCanViewVersion(
 	assetsPage,
+	hasFilePreview: boolean,
 	page,
 	title: string,
 	view: 'Table' | 'Gallery'
@@ -207,6 +215,15 @@ async function testCanViewVersion(
 	expect(
 		page.getByRole('heading', {name: `${title} (Version 1)`})
 	).toBeVisible();
+
+	if (hasFilePreview) {
+		const previewImage = page
+			.getByRole('dialog')
+			.locator('img.preview-file-image');
+
+		await expect(previewImage).toBeVisible();
+		await expect(previewImage).toHaveAttribute('src', /\S+/);
+	}
 
 	await page.getByRole('button', {name: 'Close'}).click();
 }


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-89999

When a Liferay CMS user opens Version History on a file entry and clicks a version, the preview pane shows a broken-image icon instead of the file. The behavior reproduces for omni admins as well as space admins, so it's not a permissions issue.

# How am I fixing it?

The version-history Frontend Data Set was loading entries with `nestedFields=file.thumbnailURL` only. The shared `FilePreview` component — switched on under LPD-65962 — renders images from `file.previewURL` and documents from `file.previewURL` + `file.metadata`, so the React tree mounted `<ImagePreviewer imageURL={undefined} />` and produced the broken icon. The fix extends the nested-fields list on the version-history endpoint to include all three sub-fields, mirroring the sibling `ViewAssetDisplayContext` that already requests them for the regular asset view.

# How can you verify that it works?

Run the included automated tests.