### PR TITLE
 LPD-89500 Technical Task | Cascade-delete SharingEntry rows when a Ticket is removed

### DIFF
--- a/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryLocalService.java
+++ b/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryLocalService.java
@@ -225,6 +225,8 @@ public interface SharingEntryLocalService
 			String externalReferenceCode, long groupId)
 		throws PortalException;
 
+	public void deleteToTicketSharingEntries(long toTicketId);
+
 	public void deleteToUserGroupSharingEntries(long toUserGroupId);
 
 	/**
@@ -737,4 +739,4 @@ public interface SharingEntryLocalService
 	public SharingEntry updateSharingEntry(SharingEntry sharingEntry);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:280135344
+// LIFERAY-SERVICE-BUILDER-HASH:-720703128

--- a/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryLocalServiceUtil.java
+++ b/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryLocalServiceUtil.java
@@ -246,6 +246,10 @@ public class SharingEntryLocalServiceUtil {
 			externalReferenceCode, groupId);
 	}
 
+	public static void deleteToTicketSharingEntries(long toTicketId) {
+		getService().deleteToTicketSharingEntries(toTicketId);
+	}
+
 	public static void deleteToUserGroupSharingEntries(long toUserGroupId) {
 		getService().deleteToUserGroupSharingEntries(toUserGroupId);
 	}
@@ -887,4 +891,4 @@ public class SharingEntryLocalServiceUtil {
 			SharingEntryLocalServiceUtil.class, SharingEntryLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1338912230
+// LIFERAY-SERVICE-BUILDER-HASH:646395971

--- a/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryLocalServiceWrapper.java
+++ b/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryLocalServiceWrapper.java
@@ -262,6 +262,11 @@ public class SharingEntryLocalServiceWrapper
 	}
 
 	@Override
+	public void deleteToTicketSharingEntries(long toTicketId) {
+		_sharingEntryLocalService.deleteToTicketSharingEntries(toTicketId);
+	}
+
+	@Override
 	public void deleteToUserGroupSharingEntries(long toUserGroupId) {
 		_sharingEntryLocalService.deleteToUserGroupSharingEntries(
 			toUserGroupId);
@@ -1002,4 +1007,4 @@ public class SharingEntryLocalServiceWrapper
 	private SharingEntryLocalService _sharingEntryLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1731710970
+// LIFERAY-SERVICE-BUILDER-HASH:-612691477

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/model/listener/TicketModelListener.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/model/listener/TicketModelListener.java
@@ -1,0 +1,31 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.sharing.internal.model.listener;
+
+import com.liferay.portal.kernel.model.BaseModelListener;
+import com.liferay.portal.kernel.model.ModelListener;
+import com.liferay.portal.kernel.model.Ticket;
+import com.liferay.sharing.service.SharingEntryLocalService;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Alicia García
+ */
+@Component(service = ModelListener.class)
+public class TicketModelListener extends BaseModelListener<Ticket> {
+
+	@Override
+	public void onBeforeRemove(Ticket ticket) {
+		_sharingEntryLocalService.deleteToTicketSharingEntries(
+			ticket.getTicketId());
+	}
+
+	@Reference
+	private SharingEntryLocalService _sharingEntryLocalService;
+
+}

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/impl/SharingEntryLocalServiceImpl.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/impl/SharingEntryLocalServiceImpl.java
@@ -344,6 +344,16 @@ public class SharingEntryLocalServiceImpl
 	}
 
 	@Override
+	public void deleteToTicketSharingEntries(long toTicketId) {
+		List<SharingEntry> sharingEntries =
+			sharingEntryPersistence.findByToTicketId(toTicketId);
+
+		for (SharingEntry sharingEntry : sharingEntries) {
+			sharingEntryLocalService.deleteSharingEntry(sharingEntry);
+		}
+	}
+
+	@Override
 	public void deleteToUserGroupSharingEntries(long toUserGroupId) {
 		List<SharingEntry> sharingEntries =
 			sharingEntryPersistence.findByToUserGroupId(toUserGroupId);

--- a/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/internal/model/listener/test/TicketModelListenerTest.java
+++ b/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/internal/model/listener/test/TicketModelListenerTest.java
@@ -1,0 +1,128 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.sharing.internal.model.listener.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Ticket;
+import com.liferay.portal.kernel.model.TicketConstants;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.TicketLocalService;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.sharing.model.SharingEntry;
+import com.liferay.sharing.security.permission.SharingEntryAction;
+import com.liferay.sharing.service.SharingEntryLocalService;
+
+import java.util.Arrays;
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Alicia García
+ */
+@RunWith(Arquillian.class)
+public class TicketModelListenerTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	@TestInfo("LPD-48130")
+	public void testDeleteTicket() throws Exception {
+		Ticket ticket1 = _addTicket();
+		Ticket ticket2 = _addTicket();
+
+		_addTicketSharingEntry(ticket1.getTicketId());
+		_addTicketSharingEntry(ticket2.getTicketId());
+
+		Assert.assertNotNull(
+			_sharingEntryLocalService.fetchSharingEntry(
+				ticket1.getTicketId(), 0, 0,
+				_classNameLocalService.getClassNameId(Group.class.getName()),
+				_group.getGroupId()));
+		Assert.assertNotNull(
+			_sharingEntryLocalService.fetchSharingEntry(
+				ticket2.getTicketId(), 0, 0,
+				_classNameLocalService.getClassNameId(Group.class.getName()),
+				_group.getGroupId()));
+
+		_ticketLocalService.deleteTicket(ticket1);
+
+		Assert.assertNull(
+			_sharingEntryLocalService.fetchSharingEntry(
+				ticket1.getTicketId(), 0, 0,
+				_classNameLocalService.getClassNameId(Group.class.getName()),
+				_group.getGroupId()));
+		Assert.assertNotNull(
+			_sharingEntryLocalService.fetchSharingEntry(
+				ticket2.getTicketId(), 0, 0,
+				_classNameLocalService.getClassNameId(Group.class.getName()),
+				_group.getGroupId()));
+	}
+
+	private Ticket _addTicket() throws Exception {
+		return _ticketLocalService.addTicket(
+			TestPropsValues.getCompanyId(), Group.class.getName(),
+			_group.getGroupId(), TicketConstants.TYPE_EMAIL_ADDRESS,
+			JSONUtil.put(
+				"emailAddress", RandomTestUtil.randomString() + "@liferay.com"
+			).toString(),
+			new Date(System.currentTimeMillis() + TimeUnit.HOURS.toMillis(48)),
+			new ServiceContext());
+	}
+
+	private SharingEntry _addTicketSharingEntry(long toTicketId)
+		throws Exception {
+
+		return _sharingEntryLocalService.addSharingEntry(
+			null, TestPropsValues.getUserId(), toTicketId, 0, 0,
+			_classNameLocalService.getClassNameId(Group.class.getName()),
+			_group.getGroupId(), _group.getGroupId(), true,
+			Arrays.asList(SharingEntryAction.VIEW), null,
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId()));
+	}
+
+	@Inject
+	private ClassNameLocalService _classNameLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private SharingEntryLocalService _sharingEntryLocalService;
+
+	@Inject
+	private TicketLocalService _ticketLocalService;
+
+}


### PR DESCRIPTION
LPD-89500 Cascade-delete SharingEntry rows when a Ticket is removed

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-89500 part of : https://liferay.atlassian.net/browse/LPD-48130

Completes the cascade-delete coverage for `SharingEntry` rows: when a `Ticket` is deleted, its associated sharing entries were left as orphans. This brings `Ticket` in line with the existing cleanup already in place fo `User` and `UserGroup` deletions.

# How am I fixing it?

Added `deleteToTicketSharingEntries(long toTicketId)` to `SharingEntryLocalService` / `SharingEntryLocalServiceImpl`, following the exact same pattern as `deleteToUserGroupSharingEntries`. A new `TicketModelListener` hooks into `onBeforeRemove` to call this method, mirroring `UserGroupModelListener` and `UserModelListener`.

# How can you verify that it works?

Run the included automated tests.

# Commits

- c663d1f LPD-89500 add tests
- 5a6d8a2 LPD-89500 create TicketModelListener to delete sharing entries same as UserGroupModelListener and UserModelListener
- a82be88 LPD-89500 buildService
- 7b9586c LPD-89500 create method to delete toTicketSharingEntries
