### PR TITLE
LPD-90005 Keep multiple file upload footer visible on short viewports

### DIFF
--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/css/components/MultipleFileUploader.scss
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/css/components/MultipleFileUploader.scss
@@ -2,7 +2,7 @@
 
 .multiple-file-uploader {
 	.modal-body.inline-scroller {
-		max-height: 600px;
+		max-height: min(600px, calc(100vh - 14rem));
 	}
 
 	.dropzone {

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/all.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/all.spec.ts
@@ -328,6 +328,54 @@ test(
 );
 
 test(
+	'Upload button stays in viewport when many files are queued on a short screen',
+	{tag: '@LPD-90005'},
+	async ({assetsPage, page}) => {
+		await page.setViewportSize({height: 500, width: 1024});
+
+		await assetsPage.gotoAll();
+
+		const dataSetWrapper = page.locator('div.data-set-wrapper').first();
+		const dataTransfer = await page.evaluateHandle(
+			(data) => {
+				const dt = new DataTransfer();
+
+				for (let i = 1; i <= 10; i++) {
+					const file = new File(
+						[data.toString('hex')],
+						`file_upload_image_${i}.jpeg`,
+						{
+							type: 'image/jpg',
+						}
+					);
+					dt.items.add(file);
+				}
+
+				return dt;
+			},
+			readFileSync(
+				path.join(__dirname, '/dependencies/file_upload_image_1.jpg')
+			)
+		);
+
+		await dataSetWrapper.dispatchEvent('dragstart', {dataTransfer});
+		await dataSetWrapper.dispatchEvent('dragenter', {dataTransfer});
+		await dataSetWrapper.dispatchEvent('dragover', {dataTransfer});
+
+		await dataSetWrapper.dispatchEvent('drop', {dataTransfer});
+		await dataSetWrapper.dispatchEvent('dragend', {dataTransfer});
+
+		await expect(assetsPage.modal.container).toBeVisible();
+
+		await expect(
+			assetsPage.modal.footer.getByRole('button', {
+				name: 'Upload (10)',
+			})
+		).toBeInViewport();
+	}
+);
+
+test(
 	'Expiration date filter allows future dates',
 	{tag: '@LPD-69189'},
 	async ({apiHelpers, assetsPage, page}) => {

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/recycleBin.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/recycleBin.spec.ts
@@ -313,7 +313,7 @@ test(
 		await test.step('Login as CMS Administrator', async () => {
 			const user = await addCMSAdministrator(apiHelpers);
 
-			await performUserSwitch(page, user.alternateName);
+			await performUserSwitchViaApi(page, user.alternateName);
 		});
 
 		await test.step('Delete all the contents so they can go into the Recycle Bin', async () => {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90005

## What is being fixed

On laptops with low vertical resolution (or after resizing the browser window to a low height), the Upload button in the multiple file upload modal could be pushed below the viewport when several files were queued. The user could not reach the button to complete the action.

The root cause was in `MultipleFileUploader.scss`: the modal body had a hardcoded `max-height: 600px`. Adding the modal margins, header and footer on top, the total modal height reached ~776px, which is taller than any viewport below ~780px. The footer (with Upload and Cancel) ended up below the bottom edge of the screen.

## How it is being fixed

The body's `max-height` now adapts to the viewport: `min(600px, calc(100vh - 14rem))`. On tall viewports the existing 600px cap still wins, so the visual behavior is unchanged. On short viewports the body shrinks so that the entire modal — header, body and footer — fits within the available height, the inline scroller activates on the file list, and the Upload button stays in view.

A Playwright test has been added next to the existing drag-and-drop test in `all.spec.ts`. It sets the viewport to 1024×500, drops 10 files into the data set, and asserts that the `Upload (10)` button is in the viewport. Without the fix the assertion fails because the footer sits at ~776px, well below the 500px viewport.