### PR TITLE
LPD-89977 Content Modified By metadata incorrectly attributed after Space move

### DIFF
--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryVersionLocalService.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryVersionLocalService.java
@@ -57,7 +57,8 @@ public interface ObjectEntryVersionLocalService
 	 *
 	 * Never modify this interface directly. Add custom service methods to <code>com.liferay.object.service.impl.ObjectEntryVersionLocalServiceImpl</code> and rerun ServiceBuilder to automatically copy the method declarations to this interface. Consume the object entry version local service via injection or a <code>org.osgi.util.tracker.ServiceTracker</code>. Use {@link ObjectEntryVersionLocalServiceUtil} if injection and service tracking are not available.
 	 */
-	public ObjectEntryVersion addObjectEntryVersion(ObjectEntry objectEntry)
+	public ObjectEntryVersion addObjectEntryVersion(
+			ObjectEntry objectEntry, long userId)
 		throws PortalException;
 
 	/**
@@ -229,6 +230,9 @@ public interface ObjectEntryVersionLocalService
 		OrderByComparator<ObjectEntryVersion> orderByComparator);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public ObjectEntryVersion fetchLatestObjectEntryVersion(long objectEntryId);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public ObjectEntryVersion fetchObjectEntryVersion(
 		long objectEntryVersionId);
 
@@ -343,7 +347,7 @@ public interface ObjectEntryVersionLocalService
 		throws PortalException;
 
 	public ObjectEntryVersion updateLatestObjectEntryVersion(
-			ObjectEntry objectEntry)
+			ObjectEntry objectEntry, long userId)
 		throws PortalException;
 
 	public ObjectEntryVersion updateLatestObjectEntryVersionModifiedDate(
@@ -365,4 +369,4 @@ public interface ObjectEntryVersionLocalService
 		ObjectEntryVersion objectEntryVersion);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1964991365
+// LIFERAY-SERVICE-BUILDER-HASH:1386928055

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryVersionLocalServiceUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryVersionLocalServiceUtil.java
@@ -37,10 +37,10 @@ public class ObjectEntryVersionLocalServiceUtil {
 	 * Never modify this class directly. Add custom service methods to <code>com.liferay.object.service.impl.ObjectEntryVersionLocalServiceImpl</code> and rerun ServiceBuilder to regenerate this class.
 	 */
 	public static ObjectEntryVersion addObjectEntryVersion(
-			com.liferay.object.model.ObjectEntry objectEntry)
+			com.liferay.object.model.ObjectEntry objectEntry, long userId)
 		throws PortalException {
 
-		return getService().addObjectEntryVersion(objectEntry);
+		return getService().addObjectEntryVersion(objectEntry, userId);
 	}
 
 	/**
@@ -269,6 +269,12 @@ public class ObjectEntryVersionLocalServiceUtil {
 			objectEntryId, orderByComparator);
 	}
 
+	public static ObjectEntryVersion fetchLatestObjectEntryVersion(
+		long objectEntryId) {
+
+		return getService().fetchLatestObjectEntryVersion(objectEntryId);
+	}
+
 	public static ObjectEntryVersion fetchObjectEntryVersion(
 		long objectEntryVersionId) {
 
@@ -429,10 +435,10 @@ public class ObjectEntryVersionLocalServiceUtil {
 	}
 
 	public static ObjectEntryVersion updateLatestObjectEntryVersion(
-			com.liferay.object.model.ObjectEntry objectEntry)
+			com.liferay.object.model.ObjectEntry objectEntry, long userId)
 		throws PortalException {
 
-		return getService().updateLatestObjectEntryVersion(objectEntry);
+		return getService().updateLatestObjectEntryVersion(objectEntry, userId);
 	}
 
 	public static ObjectEntryVersion updateLatestObjectEntryVersionModifiedDate(
@@ -469,4 +475,4 @@ public class ObjectEntryVersionLocalServiceUtil {
 			ObjectEntryVersionLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1715928762
+// LIFERAY-SERVICE-BUILDER-HASH:1371637702

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryVersionLocalServiceWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryVersionLocalServiceWrapper.java
@@ -31,11 +31,11 @@ public class ObjectEntryVersionLocalServiceWrapper
 
 	@Override
 	public com.liferay.object.model.ObjectEntryVersion addObjectEntryVersion(
-			com.liferay.object.model.ObjectEntry objectEntry)
+			com.liferay.object.model.ObjectEntry objectEntry, long userId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _objectEntryVersionLocalService.addObjectEntryVersion(
-			objectEntry);
+			objectEntry, userId);
 	}
 
 	/**
@@ -310,6 +310,14 @@ public class ObjectEntryVersionLocalServiceWrapper
 	}
 
 	@Override
+	public com.liferay.object.model.ObjectEntryVersion
+		fetchLatestObjectEntryVersion(long objectEntryId) {
+
+		return _objectEntryVersionLocalService.fetchLatestObjectEntryVersion(
+			objectEntryId);
+	}
+
+	@Override
 	public com.liferay.object.model.ObjectEntryVersion fetchObjectEntryVersion(
 		long objectEntryVersionId) {
 
@@ -502,11 +510,11 @@ public class ObjectEntryVersionLocalServiceWrapper
 	@Override
 	public com.liferay.object.model.ObjectEntryVersion
 			updateLatestObjectEntryVersion(
-				com.liferay.object.model.ObjectEntry objectEntry)
+				com.liferay.object.model.ObjectEntry objectEntry, long userId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _objectEntryVersionLocalService.updateLatestObjectEntryVersion(
-			objectEntry);
+			objectEntry, userId);
 	}
 
 	@Override
@@ -558,4 +566,4 @@ public class ObjectEntryVersionLocalServiceWrapper
 	private ObjectEntryVersionLocalService _objectEntryVersionLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1136742427
+// LIFERAY-SERVICE-BUILDER-HASH:786590984

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/service/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/service/packageinfo
@@ -1,1 +1,1 @@
-version 85.1.0
+version 86.0.0

--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/ObjectEntry.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/ObjectEntry.java
@@ -659,6 +659,51 @@ public class ObjectEntry implements Serializable {
 	@JsonIgnore
 	private Supplier<String[]> _keywordsSupplier;
 
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "Optional field with the full name of the user who last modified the object entry, can be embedded with nestedFields"
+	)
+	public String getModifiedByUserName() {
+		if (_modifiedByUserNameSupplier != null) {
+			modifiedByUserName = _modifiedByUserNameSupplier.get();
+
+			_modifiedByUserNameSupplier = null;
+		}
+
+		return modifiedByUserName;
+	}
+
+	public void setModifiedByUserName(String modifiedByUserName) {
+		this.modifiedByUserName = modifiedByUserName;
+
+		_modifiedByUserNameSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setModifiedByUserName(
+		UnsafeSupplier<String, Exception> modifiedByUserNameUnsafeSupplier) {
+
+		_modifiedByUserNameSupplier = () -> {
+			try {
+				return modifiedByUserNameUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(
+		description = "Optional field with the full name of the user who last modified the object entry, can be embedded with nestedFields"
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String modifiedByUserName;
+
+	@JsonIgnore
+	private Supplier<String> _modifiedByUserNameSupplier;
+
 	@io.swagger.v3.oas.annotations.media.Schema
 	public String getObjectEntryFolderExternalReferenceCode() {
 		if (_objectEntryFolderExternalReferenceCodeSupplier != null) {
@@ -1314,6 +1359,9 @@ public class ObjectEntry implements Serializable {
 		else if (Objects.equals(propertyName, "keywords")) {
 			return getKeywords();
 		}
+		else if (Objects.equals(propertyName, "modifiedByUserName")) {
+			return getModifiedByUserName();
+		}
 		else if (Objects.equals(
 					propertyName, "objectEntryFolderExternalReferenceCode")) {
 
@@ -1417,6 +1465,9 @@ public class ObjectEntry implements Serializable {
 		}
 		else if (Objects.equals(propertyName, "keywords")) {
 			setKeywords((String[])propertyValue);
+		}
+		else if (Objects.equals(propertyName, "modifiedByUserName")) {
+			setModifiedByUserName((String)propertyValue);
 		}
 		else if (Objects.equals(
 					propertyName, "objectEntryFolderExternalReferenceCode")) {
@@ -1735,6 +1786,22 @@ public class ObjectEntry implements Serializable {
 			sb.append("]");
 		}
 
+		String modifiedByUserName = getModifiedByUserName();
+
+		if (modifiedByUserName != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"modifiedByUserName\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(modifiedByUserName));
+
+			sb.append("\"");
+		}
+
 		String objectEntryFolderExternalReferenceCode =
 			getObjectEntryFolderExternalReferenceCode();
 
@@ -2041,4 +2108,4 @@ public class ObjectEntry implements Serializable {
 	private Map<String, Serializable> _extendedProperties;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1306455185
+// LIFERAY-REST-BUILDER-HASH:1296975098

--- a/modules/apps/object/object-rest-impl/rest-openapi.yaml
+++ b/modules/apps/object/object-rest-impl/rest-openapi.yaml
@@ -237,6 +237,12 @@ components:
                     items:
                         type: string
                     type: array
+                modifiedByUserName:
+                    description:
+                        Optional field with the full name of the user who last modified the object entry, can be
+                        embedded with nestedFields
+                    readOnly: true
+                    type: string
                 objectEntryFolderExternalReferenceCode:
                     type: string
                 objectEntryFolderId:

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
@@ -48,6 +48,7 @@ import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryFolderLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectEntryService;
+import com.liferay.object.service.ObjectEntryVersionLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.object.system.SystemObjectDefinitionManager;
@@ -333,6 +334,29 @@ public class ObjectEntryDTOConverter
 						serviceBuilderObjectEntry.getObjectEntryId()),
 					AssetTag.NAME_ACCESSOR);
 			});
+		objectEntry.setModifiedByUserName(
+			() -> NestedFieldsSupplier.supply(
+				"modifiedByUserName",
+				nestedFieldNames -> {
+					ObjectEntryVersion latestObjectEntryVersion =
+						_fetchObjectEntryVersion(
+							objectDefinition,
+							serviceBuilderObjectEntry.getObjectEntryId(),
+							objectEntryVersion);
+
+					if (latestObjectEntryVersion == null) {
+						return null;
+					}
+
+					User user = _userLocalService.fetchUser(
+						latestObjectEntryVersion.getUserId());
+
+					if (user == null) {
+						return null;
+					}
+
+					return user.getFullName();
+				}));
 		objectEntry.setObjectEntryFolderExternalReferenceCode(
 			() -> {
 				ObjectEntryFolder objectEntryFolder =
@@ -649,6 +673,22 @@ public class ObjectEntryDTOConverter
 				unsafeSuppliers.put(manyToOneRelationshipName, entry::getValue);
 			}
 		}
+	}
+
+	private ObjectEntryVersion _fetchObjectEntryVersion(
+		ObjectDefinition objectDefinition, long objectEntryId,
+		ObjectEntryVersion objectEntryVersion) {
+
+		if (objectEntryVersion != null) {
+			return objectEntryVersion;
+		}
+
+		if (!objectDefinition.isEnableObjectEntryVersioning()) {
+			return null;
+		}
+
+		return _objectEntryVersionLocalService.fetchLatestObjectEntryVersion(
+			objectEntryId);
 	}
 
 	private <T> T _getAttribute(
@@ -1378,6 +1418,9 @@ public class ObjectEntryDTOConverter
 
 	@Reference
 	private ObjectEntryService _objectEntryService;
+
+	@Reference
+	private ObjectEntryVersionLocalService _objectEntryVersionLocalService;
 
 	@Reference
 	private ObjectFieldBusinessTypeRegistry _objectFieldBusinessTypeRegistry;

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
@@ -7477,6 +7477,7 @@ public class DefaultObjectEntryManagerImplTest
 
 	@FeatureFlag("LPD-17564")
 	@Test
+	@TestInfo("LPD-89977")
 	public void testMoveObjectEntry() throws Exception {
 		DepotEntry depotEntry = _addDepotEntry();
 
@@ -7527,6 +7528,7 @@ public class DefaultObjectEntryManagerImplTest
 
 		_testMoveObjectEntryGroup(
 			depotEntry.getGroupId(), objectDefinitionSetting);
+		_testMoveObjectEntryUpdatesVersionUser(depotEntry.getGroupId());
 	}
 
 	@FeatureFlag("LPD-17564")
@@ -9015,6 +9017,67 @@ public class DefaultObjectEntryManagerImplTest
 					).build();
 				}
 			});
+	}
+
+	@FeatureFlag("LPD-17564")
+	@Test
+	@TestInfo("LPD-89977")
+	public void testUpdateObjectEntryAssignsLatestVersionToEditor()
+		throws Exception {
+
+		DepotEntry depotEntry = _addDepotEntry();
+
+		_objectDefinitionSettingLocalService.addObjectDefinitionSetting(
+			TestPropsValues.getUserId(),
+			_objectDefinition7.getObjectDefinitionId(),
+			ObjectDefinitionSettingConstants.NAME_ACCEPTED_GROUP_IDS,
+			String.valueOf(depotEntry.getGroupId()));
+
+		ObjectEntry objectEntry = _addObjectEntry(
+			_objectDefinition7,
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			String.valueOf(depotEntry.getGroupId()), 1);
+
+		User user = UserTestUtil.addOmniadminUser();
+
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+		String principalName = PrincipalThreadLocal.getName();
+
+		try {
+			PermissionThreadLocal.setPermissionChecker(
+				PermissionCheckerFactoryUtil.create(user));
+			PrincipalThreadLocal.setName(user.getUserId());
+
+			objectEntry = _defaultObjectEntryManager.updateObjectEntry(
+				_createDTOConverterContext(user), _objectDefinition7,
+				objectEntry.getId(),
+				new ObjectEntry() {
+					{
+						properties = HashMapBuilder.<String, Object>put(
+							"textObjectFieldName", RandomTestUtil.randomString()
+						).build();
+					}
+				});
+		}
+		finally {
+			PermissionThreadLocal.setPermissionChecker(permissionChecker);
+			PrincipalThreadLocal.setName(principalName);
+		}
+
+		com.liferay.object.model.ObjectEntry serviceBuilderObjectEntry =
+			_objectEntryLocalService.getObjectEntry(objectEntry.getId());
+
+		Assert.assertEquals(
+			adminUser.getUserId(), serviceBuilderObjectEntry.getUserId());
+
+		ObjectEntryVersion objectEntryVersion =
+			_objectEntryVersionLocalService.getObjectEntryVersion(
+				objectEntry.getId(), serviceBuilderObjectEntry.getVersion());
+
+		Assert.assertEquals(
+			user.getFullName(), objectEntryVersion.getUserName());
+		Assert.assertEquals(user.getUserId(), objectEntryVersion.getUserId());
 	}
 
 	@Test
@@ -12689,6 +12752,90 @@ public class DefaultObjectEntryManagerImplTest
 			String.valueOf(
 				destinationObjectEntryFolder.getObjectEntryFolderId()),
 			String.valueOf(objectEntry2.getObjectEntryFolderId()));
+	}
+
+	private void _testMoveObjectEntryUpdatesVersionUser(long groupId)
+		throws Exception {
+
+		ObjectEntryFolder objectEntryFolder =
+			_objectEntryFolderLocalService.addObjectEntryFolder(
+				RandomTestUtil.randomString(), groupId, adminUser.getUserId(),
+				ObjectEntryFolderConstants.
+					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+				null, null, RandomTestUtil.randomString(),
+				ServiceContextTestUtil.getServiceContext());
+
+		ObjectEntry objectEntry = _addObjectEntry(
+			_objectDefinition7,
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			String.valueOf(groupId), 1);
+
+		User user = UserTestUtil.addOmniadminUser();
+
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+		String principalName = PrincipalThreadLocal.getName();
+
+		try {
+			PermissionThreadLocal.setPermissionChecker(
+				PermissionCheckerFactoryUtil.create(user));
+			PrincipalThreadLocal.setName(user.getUserId());
+
+			objectEntry = _defaultObjectEntryManager.moveObjectEntry(
+				_createDTOConverterContext(user), objectEntry.getId(),
+				objectEntryFolder.getObjectEntryFolderId(), false);
+		}
+		finally {
+			PermissionThreadLocal.setPermissionChecker(permissionChecker);
+			PrincipalThreadLocal.setName(principalName);
+		}
+
+		com.liferay.object.model.ObjectEntry serviceBuilderObjectEntry =
+			_objectEntryLocalService.getObjectEntry(objectEntry.getId());
+
+		Assert.assertEquals(
+			adminUser.getUserId(), serviceBuilderObjectEntry.getUserId());
+
+		ObjectEntryVersion objectEntryVersion =
+			_objectEntryVersionLocalService.getObjectEntryVersion(
+				objectEntry.getId(), serviceBuilderObjectEntry.getVersion());
+
+		Assert.assertEquals(
+			user.getFullName(), objectEntryVersion.getUserName());
+		Assert.assertEquals(user.getUserId(), objectEntryVersion.getUserId());
+
+		NestedFieldsContext originalNestedFieldsContext =
+			NestedFieldsContextThreadLocal.getNestedFieldsContext();
+
+		try {
+			NestedFieldsContextThreadLocal.setNestedFieldsContext(
+				new NestedFieldsContext(
+					1, null, Arrays.asList("modifiedByUserName"), null, null,
+					null));
+
+			ObjectEntry retrievedObjectEntry =
+				_defaultObjectEntryManager.getObjectEntry(
+					_createDTOConverterContext(adminUser), _objectDefinition7,
+					objectEntry.getId());
+
+			Assert.assertEquals(
+				user.getFullName(),
+				retrievedObjectEntry.getModifiedByUserName());
+
+			NestedFieldsContextThreadLocal.setNestedFieldsContext(null);
+
+			ObjectEntry retrievedObjectEntryWithoutNestedField =
+				_defaultObjectEntryManager.getObjectEntry(
+					_createDTOConverterContext(adminUser), _objectDefinition7,
+					objectEntry.getId());
+
+			Assert.assertNull(
+				retrievedObjectEntryWithoutNestedField.getModifiedByUserName());
+		}
+		finally {
+			NestedFieldsContextThreadLocal.setNestedFieldsContext(
+				originalNestedFieldsContext);
+		}
 	}
 
 	private void _testUpdateObjectEntryWithAccountEntryRestricted2(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -549,7 +549,8 @@ public class ObjectEntryLocalServiceImpl
 			_deleteTempFileEntries(dlFileEntriesMap);
 		}
 
-		objectEntry = _addObjectEntryVersion(objectDefinition, objectEntry);
+		objectEntry = _addObjectEntryVersion(
+			objectDefinition, objectEntry, userId);
 
 		boolean clearObjectEntryIdsMap =
 			ObjectActionThreadLocal.isClearObjectEntryIdsMap();
@@ -2443,11 +2444,13 @@ public class ObjectEntryLocalServiceImpl
 					objectEntry.getObjectEntryId());
 
 			if (count > 0) {
-				_updateLatestObjectEntryVersion(objectDefinition, objectEntry);
+				_updateLatestObjectEntryVersion(
+					objectDefinition, objectEntry, userId);
 			}
 		}
 		else if (!objectEntry.isInTrash() && !originalObjectEntry.isInTrash()) {
-			objectEntry = _addObjectEntryVersion(objectDefinition, objectEntry);
+			objectEntry = _addObjectEntryVersion(
+				objectDefinition, objectEntry, userId);
 		}
 
 		if (objectDefinition.isRootNode()) {
@@ -2902,7 +2905,8 @@ public class ObjectEntryLocalServiceImpl
 	}
 
 	private ObjectEntry _addObjectEntryVersion(
-			ObjectDefinition objectDefinition, ObjectEntry objectEntry)
+			ObjectDefinition objectDefinition, ObjectEntry objectEntry,
+			long userId)
 		throws PortalException {
 
 		if (!objectDefinition.isEnableObjectEntryVersioning()) {
@@ -2910,7 +2914,8 @@ public class ObjectEntryLocalServiceImpl
 		}
 
 		ObjectEntryVersion objectEntryVersion =
-			_objectEntryVersionLocalService.addObjectEntryVersion(objectEntry);
+			_objectEntryVersionLocalService.addObjectEntryVersion(
+				objectEntry, userId);
 
 		objectEntry.setVersion(objectEntryVersion.getVersion());
 
@@ -6952,7 +6957,8 @@ public class ObjectEntryLocalServiceImpl
 	}
 
 	private void _updateLatestObjectEntryVersion(
-			ObjectDefinition objectDefinition, ObjectEntry objectEntry)
+			ObjectDefinition objectDefinition, ObjectEntry objectEntry,
+			long userId)
 		throws PortalException {
 
 		if (!objectDefinition.isEnableObjectEntryVersioning()) {
@@ -6960,7 +6966,7 @@ public class ObjectEntryLocalServiceImpl
 		}
 
 		_objectEntryVersionLocalService.updateLatestObjectEntryVersion(
-			objectEntry);
+			objectEntry, userId);
 	}
 
 	private ObjectEntry _updateObjectEntry(
@@ -7080,6 +7086,9 @@ public class ObjectEntryLocalServiceImpl
 			serviceContext.getAssetPriority(), serviceContext);
 
 		if (move) {
+			_updateLatestObjectEntryVersion(
+				objectDefinition, objectEntry, userId);
+
 			return objectEntry;
 		}
 
@@ -7111,11 +7120,12 @@ public class ObjectEntryLocalServiceImpl
 			if (objectEntry.isPending() || originalObjectEntry.isDraft() ||
 				originalObjectEntry.isExpired()) {
 
-				_updateLatestObjectEntryVersion(objectDefinition, objectEntry);
+				_updateLatestObjectEntryVersion(
+					objectDefinition, objectEntry, userId);
 			}
 			else {
 				objectEntry = _addObjectEntryVersion(
-					objectDefinition, objectEntry);
+					objectDefinition, objectEntry, userId);
 			}
 		}
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryVersionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryVersionLocalServiceImpl.java
@@ -232,6 +232,15 @@ public class ObjectEntryVersionLocalServiceImpl
 	}
 
 	@Override
+	public ObjectEntryVersion fetchLatestObjectEntryVersion(
+		long objectEntryId) {
+
+		return objectEntryVersionPersistence.fetchByObjectEntryId_First(
+			objectEntryId,
+			ObjectEntryVersionVersionComparator.getInstance(false));
+	}
+
+	@Override
 	public ObjectEntryVersion fetchObjectEntryVersion(
 		long objectEntryId, int version) {
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryVersionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryVersionLocalServiceImpl.java
@@ -53,14 +53,15 @@ public class ObjectEntryVersionLocalServiceImpl
 	extends ObjectEntryVersionLocalServiceBaseImpl {
 
 	@Override
-	public ObjectEntryVersion addObjectEntryVersion(ObjectEntry objectEntry)
+	public ObjectEntryVersion addObjectEntryVersion(
+			ObjectEntry objectEntry, long userId)
 		throws PortalException {
 
 		ObjectEntryVersion objectEntryVersion = _updateObjectEntryVersion(
 			objectEntry,
 			objectEntryVersionPersistence.create(
 				counterLocalService.increment()),
-			objectEntry.getVersion() + 1);
+			userId, objectEntry.getVersion() + 1);
 
 		if (_exceedsMaximumVersions(objectEntry.getObjectEntryId())) {
 			ObjectEntryVersion oldestObjectEntryVersion =
@@ -291,7 +292,7 @@ public class ObjectEntryVersionLocalServiceImpl
 
 	@Override
 	public ObjectEntryVersion updateLatestObjectEntryVersion(
-			ObjectEntry objectEntry)
+			ObjectEntry objectEntry, long userId)
 		throws PortalException {
 
 		return _updateObjectEntryVersion(
@@ -299,7 +300,7 @@ public class ObjectEntryVersionLocalServiceImpl
 			objectEntryVersionPersistence.fetchByObjectEntryId_First(
 				objectEntry.getObjectEntryId(),
 				ObjectEntryVersionVersionComparator.getInstance(false)),
-			objectEntry.getVersion());
+			userId, objectEntry.getVersion());
 	}
 
 	@Override
@@ -390,10 +391,10 @@ public class ObjectEntryVersionLocalServiceImpl
 
 	private ObjectEntryVersion _updateObjectEntryVersion(
 			ObjectEntry objectEntry, ObjectEntryVersion objectEntryVersion,
-			int version)
+			long userId, int version)
 		throws PortalException {
 
-		User user = _userLocalService.getUser(objectEntry.getUserId());
+		User user = _userLocalService.getUser(userId);
 
 		objectEntryVersion.setUserId(user.getUserId());
 		objectEntryVersion.setUserName(user.getFullName());

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/SectionDisplayContextHelper.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/SectionDisplayContextHelper.java
@@ -136,7 +136,7 @@ public class SectionDisplayContextHelper {
 			httpServletRequest.getAttribute(InfoDisplayWebKeys.INFO_ITEM),
 			rootObjectEntryFolderExternalReferenceCode);
 
-		StringBundler sb = new StringBundler(12);
+		StringBundler sb = new StringBundler(13);
 
 		sb.append("emptySearch=true&filter=");
 
@@ -162,7 +162,8 @@ public class SectionDisplayContextHelper {
 
 		sb.append("&nestedFields=embedded,embeddedTaxonomyCategory,");
 		sb.append("file.metadata,file.previewURL,file.thumbnailURL,");
-		sb.append("numberOfObjectEntries,numberOfObjectEntryFolders,");
+		sb.append("modifiedByUserName,numberOfObjectEntries,");
+		sb.append("numberOfObjectEntryFolders,");
 		sb.append("systemProperties.collaboratorBrief,");
 		sb.append("systemProperties.objectDefinitionBrief");
 		sb.append("&sort=dateModified:desc");

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/cell_renderers/AssetRenderer.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/cell_renderers/AssetRenderer.tsx
@@ -114,7 +114,8 @@ export default function AssetRenderer({
 					{sub(
 						Liferay.Language.get('modified-at-x-by-x'),
 						formatDate(itemData.dateModified),
-						itemData.embedded.creator.name
+						itemData.embedded.modifiedByUserName ??
+							itemData.embedded.creator.name
 					)}
 				</div>
 			</div>

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/props_transformer/cell_renderers/AssetRenderer.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/props_transformer/cell_renderers/AssetRenderer.test.tsx
@@ -12,6 +12,23 @@ import React from 'react';
 
 import AssetRenderer from '../../../../../src/main/resources/META-INF/resources/js/main_view/props_transformer/cell_renderers/AssetRenderer';
 
+jest.mock('frontend-js-web', () => {
+	const mockedModule = jest.requireActual('frontend-js-web');
+
+	return {
+		...mockedModule,
+		sub: (str: string, ...args: string[]) => {
+			let result = str;
+
+			args.forEach((arg) => {
+				result = result.replace('x', arg);
+			});
+
+			return result;
+		},
+	};
+});
+
 const testActionBase = {
 	data: {id: 'update'},
 	href: 'http://localhost:8080/o/cms/blogs/12345',
@@ -155,5 +172,30 @@ describe('AssetRenderer. Show metadata and icons.', () => {
 		expect(screen.getByRole('presentation', {name: ''})).toHaveClass(
 			'lexicon-icon-blogs'
 		);
+	});
+});
+
+describe('AssetRenderer. Modified by user name.', () => {
+	it('falls back to the creator name when modifiedByUserName is missing', () => {
+		render(<AssetRenderer {...testBaseProps} />);
+
+		expect(screen.getByText(/by-Test Test$/)).toBeInTheDocument();
+	});
+
+	it('shows modifiedByUserName when it is provided', () => {
+		render(
+			<AssetRenderer
+				{...testBaseProps}
+				itemData={{
+					...testBaseProps.itemData,
+					embedded: {
+						...testBaseProps.itemData.embedded,
+						modifiedByUserName: 'Admin Moved',
+					},
+				}}
+			/>
+		);
+
+		expect(screen.getByText(/by-Admin Moved$/)).toBeInTheDocument();
 	});
 });

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/home.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/home.spec.ts
@@ -17,6 +17,7 @@ import performLogin, {
 	performLoginViaApi,
 	performLogout,
 	performUserSwitch,
+	performUserSwitchViaApi,
 	userData,
 } from '../../../utils/performLogin';
 import {structureBuilderPagesTest} from '../structure-builder/fixtures/structureBuilderPagesTest';
@@ -993,5 +994,152 @@ test(
 		await expect(
 			page.getByRole('heading', {name: `Welcome, ${user.givenName}!`})
 		).toBeVisible();
+	}
+);
+
+test(
+	'Recent Assets shows the editor as "Modified by" after another user moves the content',
+	{tag: '@LPD-89977'},
+	async ({apiHelpers, assetsPage, homePage, page}) => {
+		const applicationName = 'cms/basic-web-contents';
+		const contentTitle = `Content ${getRandomString()}`;
+		const destinationFolderName = `Folder ${getRandomString()}`;
+		const destinationSpaceName = `Destination ${getRandomString()}`;
+
+		const dataSetFragmentPage: DataSetPage = new DataSetPage(page);
+		const editorFullName = `${spaceAdminUser.givenName} ${spaceAdminUser.familyName}`;
+
+		let contentEntry;
+
+		try {
+			const destinationSpace =
+				await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+					name: destinationSpaceName,
+					settings: {},
+					type: 'Space',
+				});
+
+			await apiHelpers.headlessAssetLibrary.putAssetLibraryUserAccount(
+				destinationSpace.externalReferenceCode,
+				spaceAdminUser.externalReferenceCode
+			);
+
+			await apiHelpers.headlessAssetLibrary.putAssetLibraryUserAccountRoles(
+				destinationSpace.externalReferenceCode,
+				spaceAdminUser.externalReferenceCode,
+				['Asset Library Administrator']
+			);
+
+			await apiHelpers.objectFolder.createObjectEntryFolder({
+				parentObjectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				scopeKey: destinationSpaceName,
+				title: destinationFolderName,
+			});
+
+			contentEntry = await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: contentTitle,
+				},
+				applicationName,
+				'Default'
+			);
+
+			await test.step('Sign in as the Space Administrator and move the content to the destination Space', async () => {
+				await performUserSwitchViaApi(
+					page,
+					spaceAdminUser.alternateName
+				);
+
+				await assetsPage.gotoAll();
+
+				await assetsPage.selectItems([contentTitle]);
+
+				await assetsPage.bulkMoveTo({
+					destinationFolder: destinationFolderName,
+					destinationSpace: destinationSpaceName,
+				});
+			});
+
+			await test.step('Recent Assets attributes the modification to the Space Administrator', async () => {
+				await homePage.goto();
+
+				const row = dataSetFragmentPage.getRow(contentTitle);
+
+				await expect(
+					row.getByText(new RegExp(`by ${editorFullName}$`))
+				).toBeVisible();
+
+				await expect(row.getByText(/by Test Test$/)).toBeHidden();
+			});
+		}
+		finally {
+			await performUserSwitchViaApi(page, 'test');
+
+			if (contentEntry) {
+				await apiHelpers.objectEntry.deleteObjectEntry(
+					applicationName,
+					String(contentEntry.id)
+				);
+			}
+		}
+	}
+);
+
+test(
+	'Recent Assets shows the editor as "Modified by" after another user edits the content',
+	{tag: '@LPD-89977'},
+	async ({apiHelpers, homePage, page}) => {
+		const applicationName = 'cms/basic-web-contents';
+		const contentTitle = `Content ${getRandomString()}`;
+		const updatedTitle = `Updated ${getRandomString()}`;
+
+		const dataSetFragmentPage: DataSetPage = new DataSetPage(page);
+		const editorFullName = `${spaceAdminUser.givenName} ${spaceAdminUser.familyName}`;
+
+		let contentEntry;
+
+		try {
+			contentEntry = await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: contentTitle,
+				},
+				applicationName,
+				'Default'
+			);
+
+			await performUserSwitchViaApi(page, spaceAdminUser.alternateName);
+
+			await apiHelpers.objectEntry.patchObjectEntry(
+				{
+					title_i18n: {
+						en_US: updatedTitle,
+					},
+				},
+				applicationName,
+				contentEntry.id
+			);
+
+			await homePage.goto();
+
+			const row = dataSetFragmentPage.getRow(updatedTitle);
+
+			await expect(
+				row.getByText(new RegExp(`by ${editorFullName}$`))
+			).toBeVisible();
+
+			await expect(row.getByText(/by Test Test$/)).toBeHidden();
+		}
+		finally {
+			await performUserSwitchViaApi(page, 'test');
+
+			if (contentEntry) {
+				await apiHelpers.objectEntry.deleteObjectEntry(
+					applicationName,
+					String(contentEntry.id)
+				);
+			}
+		}
 	}
 );


### PR DESCRIPTION
LPD-89977 Attribute ObjectEntry version to the actual editor

Note : maybe this PR should be sent to the **Owner Team of the Object** after this revision

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-89977

Each new `ObjectEntryVersion` was attributed to the entry's creator, so the CMS Recent Assets card displayed "Modified by <creator>" even when a different user moved or edited the entry. This change makes the version row record the user who actually performed the change, and exposes that name to the frontend.
**We are not using the Creator because the objectEntryVersion is only present on the case that we are asking about a version in particular. Modifying this can break the intended behavior of this field.**

# How am I fixing it?

`ObjectEntryVersionLocalService.addObjectEntryVersion` and `updateLatestObjectEntryVersion` now take the caller's `userId` instead of reading `objectEntry.getUserId()`. `ObjectEntryLocalServiceImpl` propagates the editor's id on the add, update, and move branches of `_updateObjectEntry`, keeping `objectEntry.userId` (the creator) untouched. A new `fetchLatestObjectEntryVersion` service method lets `ObjectEntryDTOConverter` resolve the latest version when no specific one is requested, and a new opt-in `modifiedByUserName` nested field on the `ObjectEntry` REST DTO surfaces the editor's full name. The CMS site initializer requests `modifiedByUserName` in its FDS query, and `AssetRenderer.tsx` prefers it over `creator.name` when present, falling back gracefully when the field is null (versioning disabled, user deleted, or older entries).

# How can you verify that it works?

Run the included automated tests.

**Front test are IA guided so**

# Commits

- 6f1694ce1b LPD-89977 Update addObjectEntryVersion and updateLatestObjectEntryVersion with the user that are creating the version
- abbbd79e04 LPD-89977 method to fetch the last version of the objectEntry
- 0c96dbe086 LPD-89977 buildService
- 78084c6e82 LPD-89977 baseline
- f4fd77d707 LPD-89977 add modifiedByUserName nested field. We are not using the Creator because the objectEntryVersion is only present on the case that we are asking about a version in particular. Modifying this can break the intended behavior of this field.
- 824b34fd03 LPD-89977 buildRest
- 5b9641439a LPD-89977 if modifiedByUserName is present, give the nested field modifiedByUserName. We are not using the Creator because the objectEntryVersion is only present on the case that we are asking about a version in particular. Modifying this can break the intended behavior of this field.
- 59a309f234 LPD-89977 send the new nestedField modifiedByUserName on the search and show, if present, instead of the creator.
- 633027eb53 LPD-89977 add tests