### PR TITLE
LPD-90359 Hide Duplicate bulk action when Select All is active

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/utils/transformFDSBulkActions.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/utils/transformFDSBulkActions.ts
@@ -44,7 +44,7 @@ export default function transformFDSBulkActions(
 				selectedItems?: Array<any>;
 			} = {}): boolean => {
 				if (allItemsSelectedActive) {
-					return key !== 'download';
+					return key !== 'download' && key !== 'duplicate';
 				}
 
 				if (key === 'download') {

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/props_transformer/utils/transformFDSBulkActions.test.ts
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/props_transformer/utils/transformFDSBulkActions.test.ts
@@ -90,7 +90,7 @@ describe('transformFDSBulkActions', () => {
 	});
 
 	describe('isVisible (allItemsSelectedActive=true)', () => {
-		it('shows non-download actions even when no items are passed', () => {
+		it('shows actions other than download and duplicate even when no items are passed', () => {
 			expect(isVisibleFor('delete')({allItemsSelectedActive: true})).toBe(
 				true
 			);
@@ -99,6 +99,12 @@ describe('transformFDSBulkActions', () => {
 		it('hides download to prevent downloading the entire data set', () => {
 			expect(
 				isVisibleFor('download')({allItemsSelectedActive: true})
+			).toBe(false);
+		});
+
+		it('hides duplicate to prevent duplicating the entire data set', () => {
+			expect(
+				isVisibleFor('duplicate')({allItemsSelectedActive: true})
 			).toBe(false);
 		});
 	});


### PR DESCRIPTION
# What is this trying to solve?
https://liferay.atlassian.net/browse/LPD-90359

In the CMS, choosing the "Duplicate" bulk action after using "Select All" threw an unexpected error. The Duplicate action should not run against an entire data set; it should drop out of the bulk menu in that state, the same way "Download" already does.

# How am I fixing it?
The frontend already filters bulk actions when "Select All" is active by short-circuiting on the action id, but the guard only excluded "download". Extending the same guard to also exclude "duplicate" prevents the action from being offered when no concrete selection exists, which is what produced the error.

# How can you verify that it works?
Run the included automated tests.