### PR TITLE
LPD-90001 Localize folder breadcrumb in Information Side Panel

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewFolderSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewFolderSectionDisplayContext.java
@@ -124,11 +124,13 @@ public class ViewFolderSectionDisplayContext extends BaseSectionDisplayContext {
 					ActionUtil.getViewFolderURL(
 						objectEntryFolder.getObjectEntryFolderId(),
 						themeDisplay),
-					objectEntryFolder.getName());
+					objectEntryFolder.getLabel(themeDisplay.getLocale()));
 			}
 		}
 
-		addBreadcrumbItem(jsonArray, true, null, objectEntryFolder.getName());
+		addBreadcrumbItem(
+			jsonArray, true, null,
+			objectEntryFolder.getLabel(themeDisplay.getLocale()));
 
 		return HashMapBuilder.<String, Object>put(
 			"breadcrumbItems", jsonArray

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/util/ObjectEntryFolderUtil.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/util/ObjectEntryFolderUtil.java
@@ -18,18 +18,22 @@ import com.liferay.object.service.ObjectEntryFolderLocalServiceUtil;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Repository;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.service.RepositoryLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
-import com.liferay.portal.kernel.util.HashMapBuilder;
-import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.TempFileEntryUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.repository.temporaryrepository.TemporaryFileEntryRepository;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * @author Jürgen Kappler
@@ -43,10 +47,10 @@ public class ObjectEntryFolderUtil {
 
 		_addObjectEntryFolder(
 			ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS,
-			depotEntry.getGroup(), "Contents", "Contents");
+			depotEntry.getGroup(), "contents", "Contents");
 		_addObjectEntryFolder(
 			ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_FILES,
-			depotEntry.getGroup(), "Files", "Files");
+			depotEntry.getGroup(), "files", "Files");
 
 		_addObjectEntryFolderFileRepository(
 			depotEntry.getGroup(), attachmentManager);
@@ -72,7 +76,7 @@ public class ObjectEntryFolderUtil {
 	}
 
 	private static void _addObjectEntryFolder(
-			String externalReferenceCode, Group group, String label,
+			String externalReferenceCode, Group group, String labelKey,
 			String name)
 		throws PortalException {
 
@@ -86,14 +90,19 @@ public class ObjectEntryFolderUtil {
 			return;
 		}
 
+		Map<Locale, String> labels = new HashMap<>();
+
+		Set<Locale> locales = LanguageUtil.getAvailableLocales(
+			group.getGroupId());
+
+		for (Locale locale : locales) {
+			labels.put(locale, LanguageUtil.get(locale, labelKey, name));
+		}
+
 		ObjectEntryFolderLocalServiceUtil.addObjectEntryFolder(
 			externalReferenceCode, group.getGroupId(), group.getCreatorUserId(),
 			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
-			"",
-			HashMapBuilder.put(
-				LocaleUtil.ENGLISH, label
-			).build(),
-			name, ServiceContextThreadLocal.getServiceContext());
+			"", labels, name, ServiceContextThreadLocal.getServiceContext());
 	}
 
 	private static void _addObjectEntryFolderFileRepository(

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/folders.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/folders.spec.ts
@@ -173,6 +173,78 @@ test(
 );
 
 test(
+	'Info panel location shows Files for a folder in the Files section',
+	{tag: '@LPD-90001'},
+	async ({apiHelpers, assetsPage, page}) => {
+		const folderName = `Folder ${getRandomString()}`;
+
+		const folder = await apiHelpers.objectFolder.createObjectEntryFolder({
+			parentObjectEntryFolderExternalReferenceCode: 'L_FILES',
+			scopeKey: 'Default',
+			title: folderName,
+		});
+
+		try {
+			await assetsPage.gotoFiles();
+
+			await assetsPage.changeVisualizationMode('Table');
+
+			await page
+				.getByRole('row', {name: folderName})
+				.getByRole('checkbox')
+				.check();
+
+			await page.getByRole('button', {name: 'Show Info Panel'}).click();
+
+			await expect(
+				page
+					.getByRole('navigation', {name: 'Breadcrumb'})
+					.getByText('Files', {exact: true})
+			).toBeVisible();
+		}
+		finally {
+			await apiHelpers.objectFolder.deleteObjectEntryFolder(folder.id);
+		}
+	}
+);
+
+test(
+	'Info panel location shows Contents for a folder in the Contents section',
+	{tag: '@LPD-90001'},
+	async ({apiHelpers, assetsPage, page}) => {
+		const folderName = `Folder ${getRandomString()}`;
+
+		const folder = await apiHelpers.objectFolder.createObjectEntryFolder({
+			parentObjectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+			scopeKey: 'Default',
+			title: folderName,
+		});
+
+		try {
+			await assetsPage.gotoContents();
+
+			await assetsPage.changeVisualizationMode('Table');
+
+			await page
+				.getByRole('row', {name: folderName})
+				.getByRole('checkbox')
+				.check();
+
+			await page.getByRole('button', {name: 'Show Info Panel'}).click();
+
+			await expect(
+				page
+					.getByRole('navigation', {name: 'Breadcrumb'})
+					.getByText('Contents', {exact: true})
+			).toBeVisible();
+		}
+		finally {
+			await apiHelpers.objectFolder.deleteObjectEntryFolder(folder.id);
+		}
+	}
+);
+
+test(
 	'Duplicating a folder creates a copy in the same parent',
 	{tag: '@LPD-88657'},
 	async ({apiHelpers, assetsPage, page}) => {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90001

## What is being fixed

When a user opens the Information Side Panel for a folder in the Files section, the Location breadcrumb showed "Content" instead of "Files". The breadcrumb code read `objectEntryFolder.getName()`, which returns the literal English identifier of the section root and ignores the user's locale — and the prior per-asset logic that produced the right label was dropped in LPD-85726 when breadcrumb construction moved to the server.

## How it is being fixed

The fix routes the breadcrumb through the existing localization layer rather than synthesizing the label client-side. `ObjectEntryFolderUtil._addObjectEntryFolder` now seeds the root Files and Contents folders with a translated `labelMap` for every company-available locale at site-initialization time. `ViewFolderSectionDisplayContext.getBreadcrumbProps` reads `objectEntryFolder.getLabel(themeDisplay.getLocale())` for both intermediate-folder loop entries and the active item, so the section root surfaces its localized label naturally and nested folders continue to display their user-supplied names.