### PR TITLE
LPD-89584 Hide Add Members button when user lacks ASSIGN_MEMBERS permission

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewSpaceMembersSummarySectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewSpaceMembersSummarySectionDisplayContext.java
@@ -89,7 +89,11 @@ public class ViewSpaceMembersSummarySectionDisplayContext {
 		return sb.toString();
 	}
 
-	public CreationMenu getCreationMenu() {
+	public CreationMenu getCreationMenu() throws Exception {
+		if (!_hasAssignMembersPermission()) {
+			return new CreationMenu();
+		}
+
 		return CreationMenuBuilder.addPrimaryDropdownItem(
 			dropdownItem -> {
 				dropdownItem.putData("action", "addMembers");

--- a/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewSpaceMembersSummarySectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewSpaceMembersSummarySectionDisplayContextTest.java
@@ -59,7 +59,6 @@ public class ViewSpaceMembersSummarySectionDisplayContextTest {
 			Mockito.mock(Group.class)
 		);
 
-		@SuppressWarnings("unchecked")
 		ModelResourcePermission<Group> groupModelResourcePermission =
 			Mockito.mock(ModelResourcePermission.class);
 

--- a/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewSpaceMembersSummarySectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewSpaceMembersSummarySectionDisplayContextTest.java
@@ -14,6 +14,7 @@ import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.UserGroupLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
@@ -76,9 +77,10 @@ public class ViewSpaceMembersSummarySectionDisplayContextTest {
 			WebKeys.THEME_DISPLAY, new ThemeDisplay());
 
 		return new ViewSpaceMembersSummarySectionDisplayContext(
-			Mockito.mock(DepotEntryLocalService.class), _GROUP_ID,
-			groupLocalService, groupModelResourcePermission,
-			mockHttpServletRequest, Mockito.mock(Language.class),
+			Mockito.mock(DepotEntryLocalService.class),
+			RandomTestUtil.randomLong(), groupLocalService,
+			groupModelResourcePermission, mockHttpServletRequest,
+			Mockito.mock(Language.class),
 			Mockito.mock(UserGroupLocalService.class),
 			Mockito.mock(UserLocalService.class));
 	}
@@ -108,7 +110,5 @@ public class ViewSpaceMembersSummarySectionDisplayContextTest {
 
 		Assert.assertTrue(creationMenu.isEmpty());
 	}
-
-	private static final long _GROUP_ID = 1L;
 
 }

--- a/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewSpaceMembersSummarySectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewSpaceMembersSummarySectionDisplayContextTest.java
@@ -15,11 +15,8 @@ import com.liferay.portal.kernel.service.UserGroupLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
-
-import jakarta.servlet.http.HttpServletRequest;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -52,24 +49,13 @@ public class ViewSpaceMembersSummarySectionDisplayContextTest {
 				boolean hasAssignMembersPermission)
 		throws Exception {
 
-		DepotEntryLocalService depotEntryLocalService = Mockito.mock(
-			DepotEntryLocalService.class);
-
-		Group group = Mockito.mock(Group.class);
-
-		Mockito.when(
-			group.getExternalReferenceCode()
-		).thenReturn(
-			StringUtil.randomString()
-		);
-
 		GroupLocalService groupLocalService = Mockito.mock(
 			GroupLocalService.class);
 
 		Mockito.when(
 			groupLocalService.getGroup(Mockito.anyLong())
 		).thenReturn(
-			group
+			Mockito.mock(Group.class)
 		);
 
 		@SuppressWarnings("unchecked")
@@ -89,18 +75,10 @@ public class ViewSpaceMembersSummarySectionDisplayContextTest {
 		mockHttpServletRequest.setAttribute(
 			WebKeys.THEME_DISPLAY, new ThemeDisplay());
 
-		Language language = Mockito.mock(Language.class);
-
-		Mockito.when(
-			language.get(
-				Mockito.any(HttpServletRequest.class), Mockito.anyString())
-		).thenReturn(
-			StringUtil.randomString()
-		);
-
 		return new ViewSpaceMembersSummarySectionDisplayContext(
-			depotEntryLocalService, _GROUP_ID, groupLocalService,
-			groupModelResourcePermission, mockHttpServletRequest, language,
+			Mockito.mock(DepotEntryLocalService.class), _GROUP_ID,
+			groupLocalService, groupModelResourcePermission,
+			mockHttpServletRequest, Mockito.mock(Language.class),
 			Mockito.mock(UserGroupLocalService.class),
 			Mockito.mock(UserLocalService.class));
 	}

--- a/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewSpaceMembersSummarySectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewSpaceMembersSummarySectionDisplayContextTest.java
@@ -1,0 +1,136 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.display.context;
+
+import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu;
+import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.UserGroupLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * @author Roberto Díaz
+ */
+public class ViewSpaceMembersSummarySectionDisplayContextTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	@TestInfo("LPD-89584")
+	public void testGetCreationMenu() throws Exception {
+		_testGetCreationMenuWithAssignMembersPermission();
+		_testGetCreationMenuWithoutAssignMembersPermission();
+	}
+
+	private ViewSpaceMembersSummarySectionDisplayContext
+			_getViewSpaceMembersSummarySectionDisplayContext(
+				boolean hasAssignMembersPermission)
+		throws Exception {
+
+		DepotEntryLocalService depotEntryLocalService = Mockito.mock(
+			DepotEntryLocalService.class);
+
+		Group group = Mockito.mock(Group.class);
+
+		Mockito.when(
+			group.getExternalReferenceCode()
+		).thenReturn(
+			StringUtil.randomString()
+		);
+
+		GroupLocalService groupLocalService = Mockito.mock(
+			GroupLocalService.class);
+
+		Mockito.when(
+			groupLocalService.getGroup(Mockito.anyLong())
+		).thenReturn(
+			group
+		);
+
+		@SuppressWarnings("unchecked")
+		ModelResourcePermission<Group> groupModelResourcePermission =
+			Mockito.mock(ModelResourcePermission.class);
+
+		Mockito.when(
+			groupModelResourcePermission.contains(
+				Mockito.any(), Mockito.anyLong(), Mockito.anyString())
+		).thenReturn(
+			hasAssignMembersPermission
+		);
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, new ThemeDisplay());
+
+		Language language = Mockito.mock(Language.class);
+
+		Mockito.when(
+			language.get(
+				Mockito.any(HttpServletRequest.class), Mockito.anyString())
+		).thenReturn(
+			StringUtil.randomString()
+		);
+
+		return new ViewSpaceMembersSummarySectionDisplayContext(
+			depotEntryLocalService, _GROUP_ID, groupLocalService,
+			groupModelResourcePermission, mockHttpServletRequest, language,
+			Mockito.mock(UserGroupLocalService.class),
+			Mockito.mock(UserLocalService.class));
+	}
+
+	private void _testGetCreationMenuWithAssignMembersPermission()
+		throws Exception {
+
+		ViewSpaceMembersSummarySectionDisplayContext
+			viewSpaceMembersSummarySectionDisplayContext =
+				_getViewSpaceMembersSummarySectionDisplayContext(true);
+
+		CreationMenu creationMenu =
+			viewSpaceMembersSummarySectionDisplayContext.getCreationMenu();
+
+		Assert.assertFalse(creationMenu.isEmpty());
+	}
+
+	private void _testGetCreationMenuWithoutAssignMembersPermission()
+		throws Exception {
+
+		ViewSpaceMembersSummarySectionDisplayContext
+			viewSpaceMembersSummarySectionDisplayContext =
+				_getViewSpaceMembersSummarySectionDisplayContext(false);
+
+		CreationMenu creationMenu =
+			viewSpaceMembersSummarySectionDisplayContext.getCreationMenu();
+
+		Assert.assertTrue(creationMenu.isEmpty());
+	}
+
+	private static final long _GROUP_ID = 1L;
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewSpaceMembersSummarySectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewSpaceMembersSummarySectionDisplayContextTest.java
@@ -45,9 +45,7 @@ public class ViewSpaceMembersSummarySectionDisplayContextTest {
 		_testGetCreationMenuWithoutAssignMembersPermission();
 	}
 
-	private ViewSpaceMembersSummarySectionDisplayContext
-			_getViewSpaceMembersSummarySectionDisplayContext(
-				boolean hasAssignMembersPermission)
+	private CreationMenu _getCreationMenu(boolean hasAssignMembersPermission)
 		throws Exception {
 
 		GroupLocalService groupLocalService = Mockito.mock(
@@ -75,24 +73,23 @@ public class ViewSpaceMembersSummarySectionDisplayContextTest {
 		mockHttpServletRequest.setAttribute(
 			WebKeys.THEME_DISPLAY, new ThemeDisplay());
 
-		return new ViewSpaceMembersSummarySectionDisplayContext(
-			Mockito.mock(DepotEntryLocalService.class),
-			RandomTestUtil.randomLong(), groupLocalService,
-			groupModelResourcePermission, mockHttpServletRequest,
-			Mockito.mock(Language.class),
-			Mockito.mock(UserGroupLocalService.class),
-			Mockito.mock(UserLocalService.class));
+		ViewSpaceMembersSummarySectionDisplayContext
+			viewSpaceMembersSummarySectionDisplayContext =
+				new ViewSpaceMembersSummarySectionDisplayContext(
+					Mockito.mock(DepotEntryLocalService.class),
+					RandomTestUtil.randomLong(), groupLocalService,
+					groupModelResourcePermission, mockHttpServletRequest,
+					Mockito.mock(Language.class),
+					Mockito.mock(UserGroupLocalService.class),
+					Mockito.mock(UserLocalService.class));
+
+		return viewSpaceMembersSummarySectionDisplayContext.getCreationMenu();
 	}
 
 	private void _testGetCreationMenuWithAssignMembersPermission()
 		throws Exception {
 
-		ViewSpaceMembersSummarySectionDisplayContext
-			viewSpaceMembersSummarySectionDisplayContext =
-				_getViewSpaceMembersSummarySectionDisplayContext(true);
-
-		CreationMenu creationMenu =
-			viewSpaceMembersSummarySectionDisplayContext.getCreationMenu();
+		CreationMenu creationMenu = _getCreationMenu(true);
 
 		Assert.assertFalse(creationMenu.isEmpty());
 	}
@@ -100,12 +97,7 @@ public class ViewSpaceMembersSummarySectionDisplayContextTest {
 	private void _testGetCreationMenuWithoutAssignMembersPermission()
 		throws Exception {
 
-		ViewSpaceMembersSummarySectionDisplayContext
-			viewSpaceMembersSummarySectionDisplayContext =
-				_getViewSpaceMembersSummarySectionDisplayContext(false);
-
-		CreationMenu creationMenu =
-			viewSpaceMembersSummarySectionDisplayContext.getCreationMenu();
+		CreationMenu creationMenu = _getCreationMenu(false);
 
 		Assert.assertTrue(creationMenu.isEmpty());
 	}

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/pages/SpaceSummaryPage.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/pages/SpaceSummaryPage.ts
@@ -16,6 +16,7 @@ export class SpaceSummaryPage {
 
 	readonly addContentButton: Locator;
 	readonly addFileButton: Locator;
+	readonly addMembersButton: Locator;
 	readonly closeButton: Locator;
 	readonly galleryPreview: Locator;
 	readonly userGroupsTab: Locator;
@@ -31,6 +32,11 @@ export class SpaceSummaryPage {
 		this.addContentButton = page.getByRole('button', {name: `Add Content`});
 
 		this.addFileButton = page.getByRole('button', {name: `Add Files`});
+
+		this.addMembersButton = page.getByRole('button', {
+			exact: true,
+			name: 'Add Members',
+		});
 
 		this.closeButton = this.page
 			.locator('.modal-header')

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/spaceSummary.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/spaceSummary.spec.ts
@@ -10,6 +10,10 @@ import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
 import {loginTest} from '../../../../fixtures/loginTest';
 import {getRandomInt} from '../../../../utils/getRandomInt';
 import getRandomString from '../../../../utils/getRandomString';
+import {
+	performUserSwitchViaApi,
+	userData,
+} from '../../../../utils/performLogin';
 import {cmsPagesTest} from '../fixtures/cmsPagesTest';
 
 const test = mergeTests(
@@ -323,6 +327,48 @@ test(
 		await page.getByRole('menuitem', {name: 'Disconnect'}).click();
 
 		await expect(globalSiteLocator).not.toBeVisible();
+	}
+);
+
+test(
+	'Space member without assign-members permission cannot see the Add Members button',
+	{tag: '@LPD-89584'},
+	async ({apiHelpers, spaceSummaryPage}) => {
+		const spaceName = `Space ${getRandomString()}`;
+
+		await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			settings: {},
+			type: 'Space',
+		});
+
+		const user = await apiHelpers.headlessAdminUser.postUserAccount();
+		const userFullName = `${user.givenName} ${user.familyName}`;
+
+		userData[user.alternateName] = {
+			name: user.givenName,
+			password: 'test',
+			surname: user.familyName,
+		};
+
+		await spaceSummaryPage.goto(spaceName);
+
+		await spaceSummaryPage.addUserOrUserGroup(userFullName, 'users');
+
+		await performUserSwitchViaApi(
+			spaceSummaryPage.page,
+			user.alternateName
+		);
+
+		await spaceSummaryPage.goto(spaceName);
+
+		await spaceSummaryPage.usersTab.click();
+
+		await expect(spaceSummaryPage.addMembersButton).toBeHidden();
+
+		await spaceSummaryPage.userGroupsTab.click();
+
+		await expect(spaceSummaryPage.addMembersButton).toBeHidden();
 	}
 );
 

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/spaceSummary.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/spaceSummary.spec.ts
@@ -10,11 +10,9 @@ import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
 import {loginTest} from '../../../../fixtures/loginTest';
 import {getRandomInt} from '../../../../utils/getRandomInt';
 import getRandomString from '../../../../utils/getRandomString';
-import {
-	performUserSwitchViaApi,
-	userData,
-} from '../../../../utils/performLogin';
+import {performUserSwitchViaApi} from '../../../../utils/performLogin';
 import {cmsPagesTest} from '../fixtures/cmsPagesTest';
+import {registerUserCredentials} from './helpers/roleMembership';
 
 const test = mergeTests(
 	cmsPagesTest,
@@ -334,7 +332,7 @@ test(
 	'Space member without assign-members permission cannot see the Add Members button',
 	{tag: '@LPD-89584'},
 	async ({apiHelpers, spaceSummaryPage}) => {
-		const spaceName = `Space ${getRandomString()}`;
+		const spaceName = getRandomString();
 
 		await apiHelpers.headlessAssetLibrary.createAssetLibrary({
 			name: spaceName,
@@ -345,11 +343,7 @@ test(
 		const user = await apiHelpers.headlessAdminUser.postUserAccount();
 		const userFullName = `${user.givenName} ${user.familyName}`;
 
-		userData[user.alternateName] = {
-			name: user.givenName,
-			password: 'test',
-			surname: user.familyName,
-		};
+		registerUserCredentials(user);
 
 		await spaceSummaryPage.goto(spaceName);
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89584

This PR is a follow-up of https://github.com/brianchandotcom/liferay-portal/pull/174550, addressing the review feedback from the codeowner.

## What is being fixed

The "Add Members" creation menu was rendered to every Space member, including users without the ASSIGN_MEMBERS permission. Those users could trigger the action and reach a downstream error instead of the action being hidden up front.

## How it is being fixed

`ViewSpaceMembersSummarySectionDisplayContext.getCreationMenu()` now returns `new CreationMenu()` when the current user does not have ASSIGN_MEMBERS on the Space group, so the host taglib never renders the button.

A unit test covers the permission gate at the display-context level, and a Playwright test verifies that a Space member without the permission sees no "Add Members" button under either the Users or User Groups tab.

## Review feedback addressed since #174550

- Dropped the `Space ` prefix on the random string for the test Space name and reused the shared `registerUserCredentials` helper.
- Tightened mock extraction in the unit test: dropped two stubs whose return values were never asserted, inlined the mocks that had no further usage, and aligned the extraction rule consistently.
- Replaced the `_GROUP_ID` constant with `RandomTestUtil.randomLong()` since the mock matchers don't care about the value.
- Dropped `@SuppressWarnings("unchecked")` on the `ModelResourcePermission` mock to match sibling tests (`BookmarksEntryAssetRendererTest`, `CalendarBookingAssetRendererFactoryTest`, `ObjectDefinitionsActionsDisplayContextTest`).
- Decoupled the test helper to return `CreationMenu` directly, removing the redundant display-context local in each scenario helper.

## Test execution

Unit test:

```
gradlew -p modules/apps/site/site-cms-site-initializer test --tests ViewSpaceMembersSummarySectionDisplayContextTest
```

Playwright test:

```
cd modules/test/playwright && yarn test tests/site-cms-site-initializer/main/spaces/spaceSummary.spec.ts -g "Space member without assign-members"
```

@robertoDiaz 

_AI-assisted with Claude Code._