### PR TITLE
LPD 78490  Fix Success toast has wrong message

### DIFF
--- a/modules/apps/site/site-cmp-site-initializer/src/main/java/com/liferay/site/cmp/site/initializer/internal/fragment/renderer/EditorToolbarComponentSectionFragmentRenderer.java
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/java/com/liferay/site/cmp/site/initializer/internal/fragment/renderer/EditorToolbarComponentSectionFragmentRenderer.java
@@ -80,8 +80,6 @@ public class EditorToolbarComponentSectionFragmentRenderer
 		return HashMapBuilder.<String, Object>put(
 			"backURL", ParamUtil.getString(httpServletRequest, "redirect")
 		).put(
-			"isNew", (objectEntry != null) && objectEntry.isDraft()
-		).put(
 			"formSubmitURL",
 			() -> {
 				String action = ParamUtil.getString(
@@ -126,6 +124,8 @@ public class EditorToolbarComponentSectionFragmentRenderer
 
 				return null;
 			}
+		).put(
+			"isNew", (objectEntry != null) && objectEntry.isDraft()
 		).put(
 			"title",
 			() -> {

--- a/modules/apps/site/site-cmp-site-initializer/src/main/java/com/liferay/site/cmp/site/initializer/internal/fragment/renderer/EditorToolbarComponentSectionFragmentRenderer.java
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/java/com/liferay/site/cmp/site/initializer/internal/fragment/renderer/EditorToolbarComponentSectionFragmentRenderer.java
@@ -80,6 +80,8 @@ public class EditorToolbarComponentSectionFragmentRenderer
 		return HashMapBuilder.<String, Object>put(
 			"backURL", ParamUtil.getString(httpServletRequest, "redirect")
 		).put(
+			"isNew", (objectEntry != null) && objectEntry.isDraft()
+		).put(
 			"formSubmitURL",
 			() -> {
 				String action = ParamUtil.getString(

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/EditorToolbar.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/EditorToolbar.tsx
@@ -14,10 +14,12 @@ import React, {useEffect, useId, useState} from 'react';
 export default function EditorToolbar({
 	backURL,
 	formSubmitURL,
+	isNew,
 	title,
 }: {
 	backURL: string;
 	formSubmitURL?: string;
+	isNew: boolean;
 	title: string;
 }) {
 	const [formId, setFormId] = useState<string | undefined>();
@@ -105,9 +107,13 @@ export default function EditorToolbar({
 							sessionStorage.setItem(
 								'com.liferay.site.cmp.site.initializer.successMessage',
 								sub(
-									Liferay.Language.get(
-										'x-was-published-successfully'
-									),
+									isNew
+										? Liferay.Language.get(
+												'x-was-created-successfully'
+											)
+										: Liferay.Language.get(
+												'x-was-updated-successfully'
+											),
 									`<strong>${value}</strong>`
 								),
 								sessionStorage.TYPES.NECESSARY

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ContentEditorToolbarComponentSectionFragmentRenderer.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ContentEditorToolbarComponentSectionFragmentRenderer.java
@@ -116,11 +116,6 @@ public class ContentEditorToolbarComponentSectionFragmentRenderer
 			layoutDisplayPageObjectProvider, objectDefinition, themeDisplay);
 
 		return hashMapWrapper.put(
-			"isNew",
-			Objects.equals(
-				Constants.ADD,
-				ParamUtil.getString(httpServletRequest, Constants.CMD))
-		).put(
 			"displayDate",
 			() -> {
 				String restoredDisplayDate =
@@ -191,6 +186,11 @@ public class ContentEditorToolbarComponentSectionFragmentRenderer
 				return language.format(
 					themeDisplay.getLocale(), "edit-x", title);
 			}
+		).put(
+			"isNew",
+			Objects.equals(
+				Constants.ADD,
+				ParamUtil.getString(httpServletRequest, Constants.CMD))
 		).put(
 			"title", title
 		).put(

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ContentEditorToolbarComponentSectionFragmentRenderer.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ContentEditorToolbarComponentSectionFragmentRenderer.java
@@ -116,6 +116,11 @@ public class ContentEditorToolbarComponentSectionFragmentRenderer
 			layoutDisplayPageObjectProvider, objectDefinition, themeDisplay);
 
 		return hashMapWrapper.put(
+			"isNew",
+			Objects.equals(
+				Constants.ADD,
+				ParamUtil.getString(httpServletRequest, Constants.CMD))
+		).put(
 			"displayDate",
 			() -> {
 				String restoredDisplayDate =

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/components/ContentEditorToolbar.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/components/ContentEditorToolbar.tsx
@@ -35,6 +35,7 @@ export default function ContentEditorToolbar({
 	getPreviewDataURL,
 	hasWorkflow,
 	headerTitle,
+	isNew,
 	title,
 	type,
 }: {
@@ -43,6 +44,7 @@ export default function ContentEditorToolbar({
 	getPreviewDataURL: string;
 	hasWorkflow: boolean;
 	headerTitle: string;
+	isNew: boolean;
 	title: string;
 	type: string;
 }) {
@@ -112,9 +114,11 @@ export default function ContentEditorToolbar({
 		setSuccessMessage(
 			hasWorkflow
 				? Liferay.Language.get('x-was-submitted-for-workflow')
-				: Liferay.Language.get('x-was-published-successfully')
+				: isNew
+					? Liferay.Language.get('x-was-created-successfully')
+					: Liferay.Language.get('x-was-updated-successfully')
 		);
-	}, [hasWorkflow, setSuccessMessage]);
+	}, [hasWorkflow, isNew, setSuccessMessage]);
 
 	useEffect(() => {
 		const form = getForm();

--- a/modules/apps/site/site-cms-site-initializer/test/js/content_editor/components/ContentEditorToolbar.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/content_editor/components/ContentEditorToolbar.test.tsx
@@ -33,7 +33,7 @@ jest.mock('frontend-js-web', () => {
 	};
 });
 
-const renderComponent = () => {
+const renderComponent = (isNew = false) => {
 	return render(
 		<>
 			<ContentEditorToolbar
@@ -42,6 +42,7 @@ const renderComponent = () => {
 				getPreviewDataURL="getPreviewDataURL"
 				hasWorkflow={false}
 				headerTitle="New Content edit"
+				isNew={isNew}
 				title="New Content"
 				type="Basic Web Content"
 			/>
@@ -75,8 +76,12 @@ describe('ContentEditorToolbar', () => {
 			},
 			Language: {
 				get: jest.fn((key) => {
-					if (key === 'x-was-published-successfully') {
-						return '{0} was published successfully';
+					if (key === 'x-was-created-successfully') {
+						return '{0} was created successfully';
+					}
+
+					if (key === 'x-was-updated-successfully') {
+						return '{0} was updated successfully';
 					}
 
 					return key;
@@ -134,7 +139,34 @@ describe('ContentEditorToolbar', () => {
 
 		expect(sessionStorage.setItem).toHaveBeenCalledWith(
 			'com.liferay.site.cms.site.initializer.successMessage',
-			expect.stringContaining('<strong>My Test Content</strong>'),
+			'<strong>My Test Content</strong> was updated successfully',
+			'NECESSARY'
+		);
+	});
+
+	it('shows created message when publishing a new entry with ctrl + alt + Enter', () => {
+		renderComponent(true);
+
+		const form = screen.getByTestId('form') as HTMLFormElement;
+
+		form.checkValidity = jest.fn(() => true);
+
+		form.addEventListener('submit', (event: Event) =>
+			event.preventDefault()
+		);
+
+		document.body.dispatchEvent(
+			new KeyboardEvent('keydown', {
+				altKey: true,
+				bubbles: true,
+				ctrlKey: true,
+				key: 'Enter',
+			})
+		);
+
+		expect(sessionStorage.setItem).toHaveBeenCalledWith(
+			'com.liferay.site.cms.site.initializer.successMessage',
+			'<strong>My Test Content</strong> was created successfully',
 			'NECESSARY'
 		);
 	});


### PR DESCRIPTION
**What is being fixed**
The success toast shown after saving a project, task, or CMS content always displayed the same message regardless of whether the user was creating a new entry or editing an existing one. Creating a new task or project showed "X was published successfully" instead of something that reflects the actual action performed.

**How it is being fixed**
An isNew boolean prop is added to both toolbar components. In EditorToolbarComponentSectionFragmentRenderer (CMP), isNew is derived from objectEntry.isDraft() — draft entries are new objects not yet published. In ContentEditorToolbarComponentSectionFragmentRenderer (CMS), isNew is derived from Constants.CMD being "add". Both renderers pass the prop down to their React components.

On the frontend, EditorToolbar and ContentEditorToolbar use isNew to select the appropriate language key: x-was-created-successfully for new entries and x-was-updated-successfully for existing ones. The workflow path (x-was-submitted-for-workflow) is unchanged. The ContentEditorToolbar test is updated to reflect the new message and pass isNew explicitly.

<img width="2100" height="1364" alt="image" src="https://github.com/user-attachments/assets/3347ff11-67c1-4f53-9830-f5d55d80cf7c" />
<img width="1320" height="1422" alt="image" src="https://github.com/user-attachments/assets/e3ae7840-f510-42d8-a3ce-4688f767527b" />
