### PR TITLE
LPD-90072 Hide Vocabulary quick action when user lacks ADD_VOCABULARY

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewHomeQuickActionsDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewHomeQuickActionsDisplayContext.java
@@ -33,6 +33,7 @@ import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portlet.asset.service.permission.AssetCategoriesPermission;
 import com.liferay.site.cms.site.initializer.internal.util.ActionUtil;
 
 import java.util.ArrayList;
@@ -217,24 +218,29 @@ public class ViewHomeQuickActionsDisplayContext {
 					depotEntriesJSONArray, actionIcon, objectDefinition));
 		}
 
-		quickActions.add(
-			HashMapBuilder.<String, Object>put(
-				"action", "createVocabulary"
-			).put(
-				"icon", _icons.get("L_CMS_VOCABULARY")
-			).put(
-				"redirect",
-				StringBundler.concat(
-					PortalUtil.getLayoutFullURL(
-						LayoutLocalServiceUtil.getLayoutByFriendlyURL(
-							_themeDisplay.getScopeGroupId(), false,
-							"/categorization/new-vocabulary"),
-						_themeDisplay),
-					"?backURL=", _themeDisplay.getURLCurrent())
-			).put(
-				"title",
-				LanguageUtil.get(_themeDisplay.getLocale(), "vocabulary")
-			).build());
+		if (AssetCategoriesPermission.contains(
+				_themeDisplay.getPermissionChecker(),
+				_themeDisplay.getScopeGroupId(), ActionKeys.ADD_VOCABULARY)) {
+
+			quickActions.add(
+				HashMapBuilder.<String, Object>put(
+					"action", "createVocabulary"
+				).put(
+					"icon", _icons.get("L_CMS_VOCABULARY")
+				).put(
+					"redirect",
+					StringBundler.concat(
+						PortalUtil.getLayoutFullURL(
+							LayoutLocalServiceUtil.getLayoutByFriendlyURL(
+								_themeDisplay.getScopeGroupId(), false,
+								"/categorization/new-vocabulary"),
+							_themeDisplay),
+						"?backURL=", _themeDisplay.getURLCurrent())
+				).put(
+					"title",
+					LanguageUtil.get(_themeDisplay.getLocale(), "vocabulary")
+				).build());
+		}
 
 		return quickActions;
 	}

--- a/modules/test/playwright/tests/site-cms-site-initializer/permissions/fixtures/cmsPagesTest.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/permissions/fixtures/cmsPagesTest.ts
@@ -8,6 +8,7 @@ import {test} from '@playwright/test';
 import {AssetsPage} from '../../main/pages/AssetsPage';
 import {ContentsPage} from '../../main/pages/ContentsPage';
 import {FolderPage} from '../../main/pages/FolderPage';
+import {HomePage} from '../../main/pages/HomePage';
 import {SpaceSummaryPage} from '../../main/pages/SpaceSummaryPage';
 import {CopyFolderModalPage} from '../pages/CopyFolderModalPage';
 import {DefaultPermissionsPage} from '../pages/DefaultPermissionsPage';
@@ -21,6 +22,7 @@ const cmsPagesTest = test.extend<{
 	defaultPermissionsPage: DefaultPermissionsPage;
 	filesPage: FilesPage;
 	folderPage: FolderPage;
+	homePage: HomePage;
 	permissionsPage: PermissionsPage;
 	spaceSummaryPage: SpaceSummaryPage;
 }>({
@@ -41,6 +43,9 @@ const cmsPagesTest = test.extend<{
 	},
 	folderPage: async ({page}, use) => {
 		await use(new FolderPage(page));
+	},
+	homePage: async ({page}, use) => {
+		await use(new HomePage(page));
 	},
 	permissionsPage: async ({page}, use) => {
 		await use(new PermissionsPage(page));

--- a/modules/test/playwright/tests/site-cms-site-initializer/permissions/vocabularies.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/permissions/vocabularies.spec.ts
@@ -9,6 +9,7 @@ import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
 import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
 import {loginTest} from '../../../fixtures/loginTest';
 import getRandomString from '../../../utils/getRandomString';
+import {performUserSwitch, userData} from '../../../utils/performLogin';
 import {PORTLET_URLS} from '../../../utils/portletUrls';
 import {addRoleMemberAndSwitch} from '../main/spaces/helpers/roleMembership';
 import {cmsPagesTest} from './fixtures/cmsPagesTest';
@@ -48,5 +49,81 @@ test(
 		await expect(
 			page.getByRole('heading', {name: 'Categorization'})
 		).toBeHidden();
+	}
+);
+
+test(
+	'A Space Content Reviewer does not see the Vocabulary Quick Action on the CMS Home Page',
+	{tag: '@LPD-90072'},
+	async ({apiHelpers, homePage, page, spaceSummaryPage}) => {
+		const spaceName = getRandomString();
+
+		await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			settings: {},
+			type: 'Space',
+		});
+
+		await addRoleMemberAndSwitch({
+			apiHelpers,
+			page,
+			role: 'Space Content Reviewer',
+			spaceName,
+			spaceSummaryPage,
+		});
+
+		await homePage.goto();
+
+		await expect(
+			page.getByRole('heading', {name: 'Quick Actions'})
+		).toBeVisible();
+
+		await expect(homePage.vocabularyButton).toBeHidden();
+	}
+);
+
+test(
+	'A CMS Administrator sees the Vocabulary Quick Action on the CMS Home Page',
+	{tag: '@LPD-90072'},
+	async ({apiHelpers, homePage, page, spaceSummaryPage}) => {
+		const spaceName = getRandomString();
+
+		await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			settings: {},
+			type: 'Space',
+		});
+
+		const user = await apiHelpers.headlessAdminUser.postUserAccount();
+
+		userData[user.alternateName] = {
+			name: user.givenName,
+			password: 'test',
+			surname: user.familyName,
+		};
+
+		const cmsAdministratorRole =
+			await apiHelpers.headlessAdminUser.getRoleByName(
+				'CMS Administrator'
+			);
+
+		await apiHelpers.headlessAdminUser.postRoleUserAccountAssociation(
+			cmsAdministratorRole.id,
+			Number(user.id)
+		);
+
+		await spaceSummaryPage.goto(spaceName);
+
+		await spaceSummaryPage.addUserOrUserGroup(user.name, 'users');
+
+		await performUserSwitch(page, user.alternateName);
+
+		await homePage.goto();
+
+		await expect(
+			page.getByRole('heading', {name: 'Quick Actions'})
+		).toBeVisible();
+
+		await expect(homePage.vocabularyButton).toBeVisible();
 	}
 );


### PR DESCRIPTION
# What is this trying to solve?
https://liferay.atlassian.net/browse/LPD-90072

On the CMS Home Page, the "Vocabulary" tile under Quick Actions was shown to every user who could see the panel — including roles like Space Content Reviewer that lack permission to create a vocabulary. Clicking it dropped them onto the categorization page with a red "Error: Not Found" banner. The expected behavior is that the tile should not appear at all when the current user cannot add a vocabulary at the active scope group.
# How am I fixing it?
The Vocabulary entry was being appended unconditionally inside `ViewHomeQuickActionsDisplayContext`, while the surrounding panel gate only checked the content-authoring permission. The fix guards that one entry with an `AssetCategoriesPermission.contains(..., ADD_VOCABULARY)` check against the scope group, mirroring the existing pattern in `AssetCategoriesDisplayContext.hasAddVocabularyPermission()`. The destination page itself is left untouched — this is a visibility fix, not a routing one.
# How can you verify that it works?
Run the included automated tests.