### PR TITLE
LPD-90349 Preserve instance-id during JournalArticle DDM fields upgrade

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v4_0_0/JournalArticleDDMFieldsUpgradeProcess.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v4_0_0/JournalArticleDDMFieldsUpgradeProcess.java
@@ -20,7 +20,6 @@ import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.upgrade.UpgradeProcessFactory;
 import com.liferay.portal.kernel.upgrade.UpgradeStep;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.util.StringUtil;
 
 import java.io.StringReader;
 import java.io.StringWriter;
@@ -132,12 +131,6 @@ public class JournalArticleDDMFieldsUpgradeProcess extends UpgradeProcess {
 			Node node = nodeList.item(i);
 
 			NamedNodeMap namedNodeMap = node.getAttributes();
-
-			Node instanceIdNode = namedNodeMap.getNamedItem("instance-id");
-
-			if (instanceIdNode != null) {
-				instanceIdNode.setTextContent(StringUtil.randomString());
-			}
 
 			Node nameNode = namedNodeMap.getNamedItem("name");
 

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/internal/upgrade/v4_0_0/test/JournalArticleDDMFieldsUpgradeProcessTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/internal/upgrade/v4_0_0/test/JournalArticleDDMFieldsUpgradeProcessTest.java
@@ -1,0 +1,120 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.journal.internal.upgrade.v4_0_0.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
+
+import java.io.InputStream;
+import java.io.StringReader;
+
+import java.lang.reflect.Method;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import org.xml.sax.InputSource;
+
+/**
+ * @author Chaitanya Sammetla
+ */
+@RunWith(Arquillian.class)
+public class JournalArticleDDMFieldsUpgradeProcessTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	@TestInfo("LPD-90349")
+	public void testPreservesInstanceIds() throws Exception {
+		UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
+			_upgradeStepRegistrator, _CLASS_NAME);
+
+		Class<?> upgradeProcessClass = upgradeProcess.getClass();
+
+		Method convertFieldNamesMethod = upgradeProcessClass.getDeclaredMethod(
+			"_convertFieldNames", String.class);
+
+		convertFieldNamesMethod.setAccessible(true);
+
+		ClassLoader classLoader =
+			JournalArticleDDMFieldsUpgradeProcessTest.class.getClassLoader();
+
+		try (InputStream inputStream = classLoader.getResourceAsStream(
+				_JOURNAL_ARTICLE_CONTENT_WITH_REPEATABLE_FIELDS_XML)) {
+
+			String result = (String)convertFieldNamesMethod.invoke(
+				upgradeProcess, StringUtil.read(inputStream));
+
+			DocumentBuilderFactory documentBuilderFactory =
+				DocumentBuilderFactory.newInstance();
+
+			DocumentBuilder documentBuilder =
+				documentBuilderFactory.newDocumentBuilder();
+
+			Document document = documentBuilder.parse(
+				new InputSource(new StringReader(result)));
+
+			NodeList nodeList = document.getElementsByTagName(
+				"dynamic-element");
+
+			Assert.assertEquals(2, nodeList.getLength());
+
+			_assertElement(nodeList.item(0), "TextBox", "first-instance-id");
+			_assertElement(nodeList.item(1), "TextBox", "second-instance-id");
+		}
+	}
+
+	private void _assertElement(
+		Node node, String expectedName, String expectedInstanceId) {
+
+		NamedNodeMap attributes = node.getAttributes();
+
+		Node nameNode = attributes.getNamedItem("name");
+
+		Assert.assertEquals(expectedName, nameNode.getTextContent());
+
+		Node instanceIdNode = attributes.getNamedItem("instance-id");
+
+		Assert.assertEquals(
+			expectedInstanceId, instanceIdNode.getTextContent());
+	}
+
+	private static final String _CLASS_NAME =
+		"com.liferay.journal.internal.upgrade.v4_0_0." +
+			"JournalArticleDDMFieldsUpgradeProcess";
+
+	private static final String
+		_JOURNAL_ARTICLE_CONTENT_WITH_REPEATABLE_FIELDS_XML =
+			"com/liferay/journal/internal/upgrade/v4_0_0/test/dependencies" +
+				"/journal_article_content_with_repeatable_fields.xml";
+
+	@Inject(
+		filter = "(&(component.name=com.liferay.journal.internal.upgrade.registry.JournalServiceUpgradeStepRegistrator))"
+	)
+	private static UpgradeStepRegistrator _upgradeStepRegistrator;
+
+}

--- a/modules/apps/journal/journal-test/src/testIntegration/resources/com/liferay/journal/internal/upgrade/v4_0_0/test/dependencies/journal_article_content_with_repeatable_fields.xml
+++ b/modules/apps/journal/journal-test/src/testIntegration/resources/com/liferay/journal/internal/upgrade/v4_0_0/test/dependencies/journal_article_content_with_repeatable_fields.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+
+<root available-locales="en_US" default-locale="en_US">
+	<dynamic-element index-type="text" instance-id="first-instance-id" name="Text-Box" type="text_box">
+		<dynamic-content language-id="en_US"><![CDATA[first value]]></dynamic-content>
+	</dynamic-element>
+	<dynamic-element index-type="text" instance-id="second-instance-id" name="Text-Box" type="text_box">
+		<dynamic-content language-id="en_US"><![CDATA[second value]]></dynamic-content>
+	</dynamic-element>
+</root>


### PR DESCRIPTION
# What is this trying to solve?

[{LPD-90349}](https://liferay.atlassian.net/browse/LPD-90349)

 When upgrading, JournalArticleDDMFieldsUpgradeProcess converts that XML into rows in the DDMField/DDMFieldAttribute tables. Before doing so, it calls _convertFieldNames() to pre-process the XML. Every existing instance-id was replaced with a freshly generated random string before the data was written into DDMField instead of preserving the existing instance id.

# How am I fixing it?

Removed the if block, instance-id attributes are passed through unchanged, so the values written into DDMField.instanceId match what was in the original XML.

# How can you verify that it works?

Run the included tests.