### PR TITLE
LPD-90056 Route CMS translation modals via the entry's REST URL

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/modal/ExportTranslationModalContent.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/modal/ExportTranslationModalContent.tsx
@@ -141,8 +141,8 @@ export default function ExportTranslationModalContent({
 	availableTargetLocales = [],
 	closeModal,
 	defaultSourceLanguageId,
-	itemId,
 	selectedData,
+	translationsAPIURL,
 }: {
 	apiURL?: string;
 	availableExportFileFormats: FileFormat[];
@@ -150,8 +150,8 @@ export default function ExportTranslationModalContent({
 	availableTargetLocales: Locale[];
 	closeModal: () => void;
 	defaultSourceLanguageId: string;
-	itemId?: number;
 	selectedData?: IBulkActionFDSData;
+	translationsAPIURL?: string;
 }) {
 	const [exportMimeType, setExportMimeType] = useState(
 		availableExportFileFormats[0].mimeType
@@ -198,17 +198,13 @@ export default function ExportTranslationModalContent({
 			version,
 		});
 
-		return fetch(
-			`/o/cms/basic-web-contents/${itemId}/translations?${params}`,
-			{
-				headers: {
-					'Accept': 'application/zip',
-					'Accept-Language':
-						Liferay.ThemeDisplay.getBCP47LanguageId(),
-					'Content-Type': 'application/json',
-				},
-			}
-		).then(async (response) => {
+		return fetch(`${translationsAPIURL}?${params}`, {
+			headers: {
+				'Accept': 'application/zip',
+				'Accept-Language': Liferay.ThemeDisplay.getBCP47LanguageId(),
+				'Content-Type': 'application/json',
+			},
+		}).then(async (response) => {
 			if (!response.ok) {
 				displayErrorToast();
 			}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/modal/ImportTranslationModalContent.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/modal/ImportTranslationModalContent.tsx
@@ -44,16 +44,16 @@ interface ImportTranslationResultData {
 
 export default function ImportTranslationModalContent({
 	actionLink,
-	itemId,
 	itemName,
 	loadData,
 	onModalClose,
+	translationsAPIURL,
 }: {
 	actionLink: string;
-	itemId: number;
 	itemName: string;
 	loadData?: () => void;
 	onModalClose: () => void;
+	translationsAPIURL: string;
 }) {
 	const getItemLink = () => {
 		return `<a href="${actionLink}" class="alert-link lead"><strong>${itemName}</strong></a>`;
@@ -67,7 +67,7 @@ export default function ImportTranslationModalContent({
 		const response =
 			await ApiHelper.postFormData<ImportTranslationResultData>(
 				formData,
-				`/o/cms/basic-web-contents/${itemId}/translations`
+				translationsAPIURL
 			);
 
 		const failureMessagesJSON = response.data?.failureMessagesJSON ?? [];

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/AssetsFDSPropsTransformer.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/AssetsFDSPropsTransformer.tsx
@@ -567,7 +567,7 @@ export default function AssetsFDSPropsTransformer({
 							closeModal,
 							defaultSourceLanguageId:
 								itemData.embedded?.defaultLanguageId,
-							itemId: itemData.embedded.id,
+							translationsAPIURL: `${itemData.actions.get.href}/translations`,
 						}),
 				});
 			}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/HomeRecentAssetsFDSPropsTransformer.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/HomeRecentAssetsFDSPropsTransformer.tsx
@@ -230,7 +230,7 @@ export default function HomeRecentAssetsFDSPropsTransformer({
 							closeModal,
 							defaultSourceLanguageId:
 								itemData.embedded?.defaultLanguageId,
-							itemId: itemData.embedded.id,
+							translationsAPIURL: `${itemData.actions.get.href}/translations`,
 						}),
 				});
 			}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/actions/importTranslationAction.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/actions/importTranslationAction.ts
@@ -15,10 +15,10 @@ export default function importTranslationAction(
 		contentComponent: ({closeModal}: {closeModal: () => void}) =>
 			ImportTranslationModalContent({
 				actionLink,
-				itemId: data.embedded.id,
 				itemName: data.embedded.title,
 				loadData,
 				onModalClose: closeModal,
+				translationsAPIURL: `${data.actions.get.href}/translations`,
 			}),
 		size: 'md',
 	});

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/modal/ExportTranslationModalContent.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/modal/ExportTranslationModalContent.test.tsx
@@ -87,7 +87,7 @@ const DEFAULT_PROPS = {
 	],
 	closeModal: mockCloseModal,
 	defaultSourceLanguageId: 'en_US',
-	itemId: 123,
+	translationsAPIURL: '/o/cms/blogs/123/translations',
 };
 
 const renderComponent = (
@@ -183,7 +183,7 @@ describe('ExportTranslationModalContent', () => {
 
 		await waitFor(() => {
 			expect(mockedFetch).toHaveBeenCalledWith(
-				'/o/cms/basic-web-contents/123/translations?sourceLanguageId=en_US&targetLanguageIds=es_ES%2Cfr_FR&version=2.0',
+				'/o/cms/blogs/123/translations?sourceLanguageId=en_US&targetLanguageIds=es_ES%2Cfr_FR&version=2.0',
 				expect.objectContaining({
 					headers: expect.objectContaining({
 						Accept: 'application/zip',

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/modal/ImportTranslationModalContent.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/modal/ImportTranslationModalContent.test.tsx
@@ -33,9 +33,9 @@ const mockModalClose = jest.fn();
 
 const DEFAULT_PROPS = {
 	actionLink: '/edit/123',
-	itemId: 123,
 	itemName: 'My Content',
 	onModalClose: mockModalClose,
+	translationsAPIURL: '/o/cms/blogs/123/translations',
 };
 
 function renderModal() {

--- a/modules/apps/translation/translation-test/src/testIntegration/java/com/liferay/translation/manager/test/TranslationManagerTest.java
+++ b/modules/apps/translation/translation-test/src/testIntegration/java/com/liferay/translation/manager/test/TranslationManagerTest.java
@@ -46,6 +46,7 @@ import java.io.Serializable;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Enumeration;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
@@ -108,6 +109,75 @@ public class TranslationManagerTest {
 
 		_testGetXLIFFFile("test-journal-article-v12.xlf", _MIMETYPE_XLIFF_1_2);
 		_testGetXLIFFFile("test-journal-article.xlf", _MIMETYPE_XLIFF_2_0);
+	}
+
+	@Test
+	@TestInfo("LPD-90056")
+	public void testGetXLIFFZipFileForObjectEntry() throws Exception {
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition(
+				Collections.singletonList(
+					new TextObjectFieldBuilder(
+					).labelMap(
+						Collections.singletonMap(
+							LocaleUtil.getDefault(), "Title")
+					).localized(
+						true
+					).name(
+						"title"
+					).build()),
+				ObjectDefinitionConstants.SCOPE_SITE);
+
+		String englishTitle = RandomTestUtil.randomString();
+		String spanishTitle = RandomTestUtil.randomString();
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId());
+
+		ObjectEntry objectEntry = _objectEntryLocalService.addObjectEntry(
+			_group.getGroupId(), TestPropsValues.getUserId(),
+			objectDefinition.getObjectDefinitionId(),
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			"en_US",
+			HashMapBuilder.put(
+				"title_i18n",
+				(Serializable)HashMapBuilder.put(
+					"en_US", englishTitle
+				).put(
+					"es_ES", spanishTitle
+				).build()
+			).build(),
+			serviceContext);
+
+		ServiceContextThreadLocal.pushServiceContext(serviceContext);
+
+		try {
+			File xliffZipFile = _translationManager.getXLIFFZipFile(
+				objectDefinition.getClassName(),
+				new long[] {objectEntry.getObjectEntryId()},
+				_MIMETYPE_XLIFF_1_2, LocaleUtil.US, "en_US",
+				_TARGET_LANGUAGE_IDS);
+
+			try (ZipFile zipFile = new ZipFile(xliffZipFile)) {
+				Enumeration<? extends ZipEntry> zipEntriesEnumeration =
+					zipFile.entries();
+
+				ZipEntry zipEntry = zipEntriesEnumeration.nextElement();
+
+				Assert.assertNotNull(zipEntry);
+
+				String xliffContent = StringUtil.read(
+					zipFile.getInputStream(zipEntry));
+
+				Assert.assertTrue(
+					xliffContent.contains("<![CDATA[" + englishTitle + "]]>"));
+				Assert.assertTrue(
+					xliffContent.contains("<![CDATA[" + spanishTitle + "]]>"));
+			}
+		}
+		finally {
+			ServiceContextThreadLocal.popServiceContext();
+		}
 	}
 
 	@Test


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-90056

Exporting and re-importing translations for a CMS Blog item produced two visible failures: the exported XLIFF files contained empty `<source>` and `<target>` blocks even when the entry held values, and the resulting import was rejected with "The translation file does not correspond to this web content." Both symptoms also affected any CMS content type other than Basic Web Content (Blog, External Video, …).

# How am I fixing it?

The import and export modals hardcoded `/o/cms/basic-web-contents/{id}/translations` for every CMS item. The REST resource at that URL is bound to the BasicWebContent ObjectDefinition, so any other entry routed through it was serialized through the wrong InfoItemFieldValuesProvider (empty properties map → empty CDATA) and rejected on re-import (file id className mismatched the BasicWebContent class). The modals now derive the per-entry base URL from the `actions.get.href` link the REST API already returns for each FDS row, and append `/translations`, so each entry hits the REST resource bound to its own ObjectDefinition (`/o/cms/blogs/...`, `/o/cms/basic-web-contents/...`, etc.).

# How can you verify that it works?

Run the included automated tests, then follow the steps described in https://liferay.atlassian.net/browse/LPD-90056. The updated jest tests (`Export/ImportTranslationModalContent.test.tsx`) prove the modal uses the URL it's given. The new integration test (`testGetXLIFFZipFileForObjectEntry`) pins the manager-side support for Object Entry round-trips.