### PR TITLE
LPD-90003 Filter comment actions by user permission

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/util/CommentUtil.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/util/CommentUtil.java
@@ -18,6 +18,8 @@ import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactoryUtil;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -38,6 +40,10 @@ public class CommentUtil {
 	public static JSONObject getCommentJSONObject(
 			Comment comment, HttpServletRequest httpServletRequest)
 		throws PortalException {
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
 
 		Date createDate = comment.getCreateDate();
 
@@ -64,6 +70,12 @@ public class CommentUtil {
 			"dateDescription", modifiedDateDescription
 		).put(
 			"edited", !createDate.equals(modifiedDate)
+		).put(
+			"hasDeletePermission",
+			_hasPermission(comment, themeDisplay, ActionKeys.DELETE)
+		).put(
+			"hasUpdatePermission",
+			_hasPermission(comment, themeDisplay, ActionKeys.UPDATE_DISCUSSION)
 		).put(
 			"negativeVotes",
 			() -> {
@@ -172,6 +184,25 @@ public class CommentUtil {
 		).put(
 			"userId", commentUser.getUserId()
 		);
+	}
+
+	private static boolean _hasPermission(
+		Comment comment, ThemeDisplay themeDisplay, String actionId) {
+
+		if (comment == null) {
+			return false;
+		}
+
+		if (themeDisplay.getUserId() == comment.getUserId()) {
+			return true;
+		}
+
+		PermissionChecker permissionChecker =
+			themeDisplay.getPermissionChecker();
+
+		return permissionChecker.hasPermission(
+			comment.getGroupId(), comment.getClassName(), comment.getClassPK(),
+			actionId);
 	}
 
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/components/panels/CommentsPanel.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/components/panels/CommentsPanel.tsx
@@ -325,35 +325,51 @@ function CommentNode({
 							</time>
 						</header>
 
-						<ClayDropDownWithItems
-							items={[
-								{
-									label: Liferay.Language.get('edit'),
-									onClick: () => setStatus('edit'),
-									symbolLeft: 'pencil',
-								},
-								{
-									label: Liferay.Language.get('delete'),
-									onClick: () =>
-										onDeleteComment(
-											comment.commentId,
-											parentCommentId
-										),
-									symbolLeft: 'trash',
-								},
-							]}
-							menuWidth="shrink"
-							trigger={
-								<ClayButtonWithIcon
-									borderless
-									displayType="secondary"
-									monospaced
-									size="xs"
-									symbol="ellipsis-v"
-									title={Liferay.Language.get('actions')}
-								/>
-							}
-						/>
+						{(comment.hasDeletePermission ||
+							comment.hasUpdatePermission) && (
+							<ClayDropDownWithItems
+								items={[
+									...(comment.hasDeletePermission
+										? [
+												{
+													label: Liferay.Language.get(
+														'edit'
+													),
+													onClick: () =>
+														setStatus('edit'),
+													symbolLeft: 'pencil',
+												},
+											]
+										: []),
+									...(comment.hasUpdatePermission
+										? [
+												{
+													label: Liferay.Language.get(
+														'delete'
+													),
+													onClick: () =>
+														onDeleteComment(
+															comment.commentId,
+															parentCommentId
+														),
+													symbolLeft: 'trash',
+												},
+											]
+										: []),
+								]}
+								menuWidth="shrink"
+								trigger={
+									<ClayButtonWithIcon
+										borderless
+										displayType="secondary"
+										monospaced
+										size="xs"
+										symbol="ellipsis-v"
+										title={Liferay.Language.get('actions')}
+									/>
+								}
+							/>
+						)}
 					</div>
 
 					{status === 'edit' ? (

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/services/CommentService.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/services/CommentService.ts
@@ -21,6 +21,8 @@ export type Comment = {
 	commentId: string;
 	dateDescription: string;
 	edited: boolean;
+	hasDeletePermission: boolean;
+	hasUpdatePermission: boolean;
 	negativeVotes: number;
 	positiveVotes: number;
 	rootComment: boolean;

--- a/modules/apps/site/site-cms-site-initializer/test/js/content_editor/components/panels/CommentsPanel.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/content_editor/components/panels/CommentsPanel.test.tsx
@@ -52,7 +52,7 @@ jest.mock('@ckeditor/ckeditor5-react', () => ({
 	},
 }));
 
-const initialComments = [
+const initialComments: Comment[] = [
 	{
 		author: {
 			fullName: 'Test User 1',
@@ -73,6 +73,8 @@ const initialComments = [
 				commentId: '2',
 				dateDescription: '55 Seconds Ago',
 				edited: false,
+				hasDeletePermission: true,
+				hasUpdatePermission: true,
 				negativeVotes: 0,
 				positiveVotes: 0,
 				rootComment: true,
@@ -82,11 +84,13 @@ const initialComments = [
 		commentId: '1',
 		dateDescription: '18 Seconds Ago',
 		edited: false,
+		hasDeletePermission: true,
+		hasUpdatePermission: true,
 		negativeVotes: 0,
 		positiveVotes: 0,
 		rootComment: true,
 	},
-] as Comment[];
+];
 
 const renderComponent = (addCommentURL = 'addCommentURL') => {
 	return render(
@@ -245,6 +249,8 @@ describe('CommentsPanel', () => {
 					commentId: '345',
 					dateDescription: 'Just now',
 					edited: false,
+					hasDeletePermission: true,
+					hasUpdatePermission: true,
 					negativeVotes: 0,
 					positiveVotes: 0,
 					rootComment: true,

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/commentsPermissions.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/commentsPermissions.spec.ts
@@ -1,0 +1,91 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import getRandomString from '../../../../utils/getRandomString';
+import {cmsPagesTest} from '../fixtures/cmsPagesTest';
+import {addRoleMemberAndSwitch} from './helpers/roleMembership';
+
+const test = mergeTests(
+	cmsPagesTest,
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-11235': {enabled: false},
+		'LPD-17564': {enabled: true},
+	}),
+	loginTest()
+);
+
+test(
+	'A Space Administrator cannot edit or delete comments authored by a System Administrator',
+	{tag: '@LPD-90003'},
+	async ({apiHelpers, contentsPage, page, spaceSummaryPage}) => {
+		const spaceName = `Space ${getRandomString()}`;
+		const commentBody = `Admin comment ${getRandomString()}`;
+		const contentTitle = `Untitled Asset`;
+
+		await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			settings: {},
+			type: 'Space',
+		});
+
+		await contentsPage.goto();
+
+		await contentsPage.createContent('Blog', spaceName);
+
+		await contentsPage.openSidePanel('Comments');
+
+		const editor = page.getByLabel('Add Comment.');
+
+		await expect(editor).toBeVisible();
+
+		await editor.scrollIntoViewIfNeeded();
+		await editor.click();
+		await page.keyboard.type(commentBody);
+
+		await page
+			.getByRole('button', {exact: true, name: 'Save'})
+			.first()
+			.click();
+
+		const adminComment = page
+			.locator('article')
+			.filter({hasText: commentBody});
+
+		await expect(adminComment).toBeVisible();
+		await expect(adminComment.getByTitle('actions')).toBeVisible();
+
+		await addRoleMemberAndSwitch({
+			apiHelpers,
+			page,
+			role: 'Space Administrator',
+			spaceName,
+			spaceSummaryPage,
+		});
+
+		await contentsPage.goto();
+
+		const row = page.locator('.fds table tbody tr', {
+			hasText: contentTitle,
+		});
+
+		await row.getByRole('link', {name: contentTitle}).click();
+
+		await contentsPage.openSidePanel('Comments');
+
+		const reloadedAdminComment = page
+			.locator('article')
+			.filter({hasText: commentBody});
+
+		await expect(reloadedAdminComment).toBeVisible();
+
+		await expect(reloadedAdminComment.getByTitle('actions')).toBeHidden();
+	}
+);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90003

## What is being fixed

A user could see and use the Edit and Delete actions on every comment
in the side panel regardless of who authored it, so a Space member
could modify a comment written by an administrator. The strut actions
also relied on a discussion permission check that resolves to a no-op
for the CMS object entry class, so the server accepted the request as
well.

## How it is being fixed

Expose per-comment hasUpdatePermission and hasDeletePermission flags
in the JSON returned to the frontend, derived from the current user:
the author always passes, anyone else needs UPDATE_DISCUSSION or
DELETE on the comment. The dropdown trigger and each menu item in
CommentsPanel render only when the matching flag is true. The change
is covered by an updated unit test suite for CommentsPanel and by an
end-to-end Playwright test that adds a Space Administrator and
verifies the actions menu is hidden over a comment posted by another
user.

## Test results

| Test | Type | Result |
| --- | --- | --- |
| `CommentsPanel.test.tsx` | Unit | ✓ 8/8 passed |
| `A Space Administrator cannot edit or delete comments authored by a System Administrator` (`@LPD-90003`) | Playwright | ✓ passed |