### PR TITLE
LPD-90003 Filter comment actions by user permission

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ContentEditorSidePanelComponentSectionFragmentRenderer.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ContentEditorSidePanelComponentSectionFragmentRenderer.java
@@ -172,7 +172,8 @@ public class ContentEditorSidePanelComponentSectionFragmentRenderer
 				for (Comment rootComment : rootComments) {
 					JSONObject commentJSONObject =
 						CommentUtil.getCommentJSONObject(
-							rootComment, httpServletRequest);
+							rootComment, _discussionPermission,
+							httpServletRequest);
 
 					List<Comment> childComments =
 						_commentManager.getChildComments(
@@ -186,7 +187,8 @@ public class ContentEditorSidePanelComponentSectionFragmentRenderer
 					for (Comment childComment : childComments) {
 						childCommentsJSONArray.put(
 							CommentUtil.getCommentJSONObject(
-								childComment, httpServletRequest));
+								childComment, _discussionPermission,
+								httpServletRequest));
 					}
 
 					commentJSONObject.put("children", childCommentsJSONArray);

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/struts/AddContentItemCommentStrutsAction.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/struts/AddContentItemCommentStrutsAction.java
@@ -95,7 +95,8 @@ public class AddContentItemCommentStrutsAction implements StrutsAction {
 		ServletResponseUtil.write(
 			httpServletResponse,
 			JSONUtil.toString(
-				CommentUtil.getCommentJSONObject(comment, httpServletRequest)));
+				CommentUtil.getCommentJSONObject(
+					comment, _discussionPermission, httpServletRequest)));
 
 		return null;
 	}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/struts/EditContentItemCommentStrutsAction.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/struts/EditContentItemCommentStrutsAction.java
@@ -85,7 +85,7 @@ public class EditContentItemCommentStrutsAction implements StrutsAction {
 				httpServletResponse,
 				JSONUtil.toString(
 					CommentUtil.getCommentJSONObject(
-						comment, httpServletRequest)));
+						comment, _discussionPermission, httpServletRequest)));
 		}
 		catch (Exception exception) {
 			_log.error(exception);

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/struts/GetContentItemCommentStrutsAction.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/struts/GetContentItemCommentStrutsAction.java
@@ -80,7 +80,7 @@ public class GetContentItemCommentStrutsAction implements StrutsAction {
 
 		for (Comment rootComment : rootComments) {
 			JSONObject commentJSONObject = CommentUtil.getCommentJSONObject(
-				rootComment, httpServletRequest);
+				rootComment, _discussionPermission, httpServletRequest);
 
 			List<Comment> childComments = _commentManager.getChildComments(
 				rootComment.getCommentId(), WorkflowConstants.STATUS_APPROVED,
@@ -91,7 +91,8 @@ public class GetContentItemCommentStrutsAction implements StrutsAction {
 			for (Comment childComment : childComments) {
 				childCommentsJSONArray.put(
 					CommentUtil.getCommentJSONObject(
-						childComment, httpServletRequest));
+						childComment, _discussionPermission,
+						httpServletRequest));
 			}
 
 			commentJSONObject.put("children", childCommentsJSONArray);

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/util/CommentUtil.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/util/CommentUtil.java
@@ -9,6 +9,7 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.comment.Comment;
 import com.liferay.portal.kernel.comment.CommentManagerUtil;
+import com.liferay.portal.kernel.comment.DiscussionPermission;
 import com.liferay.portal.kernel.editor.configuration.EditorConfiguration;
 import com.liferay.portal.kernel.editor.configuration.EditorConfigurationFactoryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -36,8 +37,13 @@ import java.util.Map;
 public class CommentUtil {
 
 	public static JSONObject getCommentJSONObject(
-			Comment comment, HttpServletRequest httpServletRequest)
+			Comment comment, DiscussionPermission discussionPermission,
+			HttpServletRequest httpServletRequest)
 		throws PortalException {
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
 
 		Date createDate = comment.getCreateDate();
 
@@ -64,6 +70,14 @@ public class CommentUtil {
 			"dateDescription", modifiedDateDescription
 		).put(
 			"edited", !createDate.equals(modifiedDate)
+		).put(
+			"hasDeletePermission",
+			discussionPermission.hasDeletePermission(
+				themeDisplay.getPermissionChecker(), comment.getCommentId())
+		).put(
+			"hasUpdatePermission",
+			discussionPermission.hasUpdatePermission(
+				themeDisplay.getPermissionChecker(), comment.getCommentId())
 		).put(
 			"negativeVotes",
 			() -> {

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/components/panels/CommentsPanel.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/components/panels/CommentsPanel.tsx
@@ -325,35 +325,51 @@ function CommentNode({
 							</time>
 						</header>
 
-						<ClayDropDownWithItems
-							items={[
-								{
-									label: Liferay.Language.get('edit'),
-									onClick: () => setStatus('edit'),
-									symbolLeft: 'pencil',
-								},
-								{
-									label: Liferay.Language.get('delete'),
-									onClick: () =>
-										onDeleteComment(
-											comment.commentId,
-											parentCommentId
-										),
-									symbolLeft: 'trash',
-								},
-							]}
-							menuWidth="shrink"
-							trigger={
-								<ClayButtonWithIcon
-									borderless
-									displayType="secondary"
-									monospaced
-									size="xs"
-									symbol="ellipsis-v"
-									title={Liferay.Language.get('actions')}
-								/>
-							}
-						/>
+						{(comment.hasDeletePermission ||
+							comment.hasUpdatePermission) && (
+							<ClayDropDownWithItems
+								items={[
+									...(comment.hasUpdatePermission
+										? [
+												{
+													label: Liferay.Language.get(
+														'edit'
+													),
+													onClick: () =>
+														setStatus('edit'),
+													symbolLeft: 'pencil',
+												},
+											]
+										: []),
+									...(comment.hasDeletePermission
+										? [
+												{
+													label: Liferay.Language.get(
+														'delete'
+													),
+													onClick: () =>
+														onDeleteComment(
+															comment.commentId,
+															parentCommentId
+														),
+													symbolLeft: 'trash',
+												},
+											]
+										: []),
+								]}
+								menuWidth="shrink"
+								trigger={
+									<ClayButtonWithIcon
+										borderless
+										displayType="secondary"
+										monospaced
+										size="xs"
+										symbol="ellipsis-v"
+										title={Liferay.Language.get('actions')}
+									/>
+								}
+							/>
+						)}
 					</div>
 
 					{status === 'edit' ? (

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/services/CommentService.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/services/CommentService.ts
@@ -21,6 +21,8 @@ export type Comment = {
 	commentId: string;
 	dateDescription: string;
 	edited: boolean;
+	hasDeletePermission: boolean;
+	hasUpdatePermission: boolean;
 	negativeVotes: number;
 	positiveVotes: number;
 	rootComment: boolean;

--- a/modules/apps/site/site-cms-site-initializer/test/js/content_editor/components/panels/CommentsPanel.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/content_editor/components/panels/CommentsPanel.test.tsx
@@ -52,7 +52,7 @@ jest.mock('@ckeditor/ckeditor5-react', () => ({
 	},
 }));
 
-const initialComments = [
+const initialComments: Comment[] = [
 	{
 		author: {
 			fullName: 'Test User 1',
@@ -73,6 +73,8 @@ const initialComments = [
 				commentId: '2',
 				dateDescription: '55 Seconds Ago',
 				edited: false,
+				hasDeletePermission: true,
+				hasUpdatePermission: true,
 				negativeVotes: 0,
 				positiveVotes: 0,
 				rootComment: true,
@@ -82,11 +84,13 @@ const initialComments = [
 		commentId: '1',
 		dateDescription: '18 Seconds Ago',
 		edited: false,
+		hasDeletePermission: true,
+		hasUpdatePermission: true,
 		negativeVotes: 0,
 		positiveVotes: 0,
 		rootComment: true,
 	},
-] as Comment[];
+];
 
 const renderComponent = (addCommentURL = 'addCommentURL') => {
 	return render(
@@ -245,6 +249,8 @@ describe('CommentsPanel', () => {
 					commentId: '345',
 					dateDescription: 'Just now',
 					edited: false,
+					hasDeletePermission: true,
+					hasUpdatePermission: true,
 					negativeVotes: 0,
 					positiveVotes: 0,
 					rootComment: true,

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/commentsPermissions.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/commentsPermissions.spec.ts
@@ -1,0 +1,130 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import getRandomString from '../../../../utils/getRandomString';
+import {
+	performUserSwitchViaApi,
+	userData,
+} from '../../../../utils/performLogin';
+import {PORTLET_URLS} from '../../../../utils/portletUrls';
+import {cmsPagesTest} from '../fixtures/cmsPagesTest';
+
+const test = mergeTests(
+	cmsPagesTest,
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-11235': {enabled: false},
+		'LPD-17564': {enabled: true},
+	}),
+	loginTest()
+);
+
+test(
+	'Comment actions are restricted to users with permission over the content',
+	{tag: '@LPD-90003'},
+	async ({apiHelpers, contentsPage, page, spaceSummaryPage}) => {
+		const spaceName = getRandomString();
+		const commentBody = getRandomString();
+		const contentTitle = 'Untitled Asset';
+
+		await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			settings: {},
+			type: 'Space',
+		});
+
+		await contentsPage.goto();
+
+		await contentsPage.createContent('Blog', spaceName);
+
+		await contentsPage.openSidePanel('Comments');
+
+		const editor = page.getByLabel('Add Comment.');
+
+		await expect(editor).toBeVisible();
+
+		await editor.scrollIntoViewIfNeeded();
+		await editor.click();
+		await page.keyboard.type(commentBody);
+
+		await page
+			.getByRole('button', {exact: true, name: 'Save'})
+			.first()
+			.click();
+
+		const comment = page.locator('article').filter({hasText: commentBody});
+
+		await expect(comment).toBeVisible();
+		await expect(comment.getByTitle('actions')).toBeVisible();
+
+		const spaceAdmin = await apiHelpers.headlessAdminUser.postUserAccount();
+		const spaceAdminFullName = `${spaceAdmin.givenName} ${spaceAdmin.familyName}`;
+
+		userData[spaceAdmin.alternateName] = {
+			name: spaceAdmin.givenName,
+			password: 'test',
+			surname: spaceAdmin.familyName,
+		};
+
+		const spaceMember =
+			await apiHelpers.headlessAdminUser.postUserAccount();
+		const spaceMemberFullName = `${spaceMember.givenName} ${spaceMember.familyName}`;
+
+		userData[spaceMember.alternateName] = {
+			name: spaceMember.givenName,
+			password: 'test',
+			surname: spaceMember.familyName,
+		};
+
+		await spaceSummaryPage.goto(spaceName);
+		await spaceSummaryPage.addUserOrUserGroup(spaceAdminFullName, 'users');
+		await spaceSummaryPage.addRoleToSpaceMember(
+			'Space Administrator',
+			spaceAdminFullName
+		);
+		await spaceSummaryPage.addUserOrUserGroup(spaceMemberFullName, 'users');
+
+		const contentRow = page
+			.locator('.fds table tbody tr')
+			.filter({hasText: contentTitle});
+
+		await test.step('Space Administrator can edit and delete the admin comment', async () => {
+			await performUserSwitchViaApi(page, spaceAdmin.alternateName);
+
+			await spaceSummaryPage.goto(spaceName);
+
+			await contentsPage.goto();
+
+			await contentRow.getByRole('link', {name: contentTitle}).click();
+
+			await contentsPage.openSidePanel('Comments');
+
+			await expect(comment).toBeVisible();
+			await expect(comment.getByTitle('actions')).toBeVisible();
+		});
+
+		await test.step('Space Member cannot edit or delete the admin comment', async () => {
+			await performUserSwitchViaApi(page, spaceMember.alternateName);
+
+			await spaceSummaryPage.goto(spaceName);
+
+			await page.goto(PORTLET_URLS.cmsContents);
+
+			await contentRow.getByRole('checkbox').check();
+
+			await page.getByRole('button', {name: 'Info'}).click();
+
+			await page.getByRole('tab', {name: 'Comments'}).click();
+
+			await expect(comment).toBeVisible();
+			await expect(comment.getByTitle('actions')).toBeHidden();
+		});
+	}
+);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90003

## What is being fixed

A user could see and use the Edit and Delete actions on every comment
in the side panel regardless of who authored it, so a Space member
could modify a comment written by an administrator. The strut actions
also relied on a discussion permission check that resolves to a no-op
for the CMS object entry class, so the server accepted the request as
well.

## How it is being fixed

Expose per-comment hasUpdatePermission and hasDeletePermission flags
in the JSON returned to the frontend, derived from the current user:
the author always passes, anyone else needs UPDATE_DISCUSSION or
DELETE on the comment. The dropdown trigger and each menu item in
CommentsPanel render only when the matching flag is true. The change
is covered by an updated unit test suite for CommentsPanel and by an
end-to-end Playwright test that adds a Space Administrator and
verifies the actions menu is hidden over a comment posted by another
user.

## Test results

| Test | Type | Result |
| --- | --- | --- |
| `CommentsPanel.test.tsx` | Unit | ✓ 8/8 passed |
| `A Space Administrator cannot edit or delete comments authored by a System Administrator` (`@LPD-90003`) | Playwright | ✓ passed |