### PR TITLE
LPD-89780 Add Jest coverage for Info Panel Categorization tab

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/info_panel/components/AssetCategories.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/info_panel/components/AssetCategories.test.tsx
@@ -1,0 +1,190 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import '@testing-library/jest-dom';
+import {render, screen, within} from '@testing-library/react';
+import React from 'react';
+
+import AssetCategories from '../../../../../src/main/resources/META-INF/resources/js/main_view/info_panel/components/AssetCategories';
+
+function MockItemSelector({apiURL}: {apiURL?: string}) {
+	return <div data-api-url={apiURL} data-testid="item-selector" />;
+}
+
+function MockItemSelectorItem({children}: {children: React.ReactNode}) {
+	return <div>{children}</div>;
+}
+
+jest.mock('@liferay/frontend-js-item-selector-web', () => {
+	return {
+		ItemSelector: Object.assign(MockItemSelector, {
+			Item: MockItemSelectorItem,
+		}),
+	};
+});
+
+function buildCategoryBrief({
+	id,
+	name,
+	taxonomyVocabularyId,
+	vocabularyName,
+}: {
+	id: number;
+	name: string;
+	taxonomyVocabularyId: number;
+	vocabularyName: string;
+}) {
+	return {
+		embeddedTaxonomyCategory: {
+			id,
+			name,
+			parentTaxonomyVocabulary: {
+				id: taxonomyVocabularyId,
+				name: vocabularyName,
+			},
+			taxonomyVocabularyId,
+		},
+	};
+}
+
+function renderComponent({
+	classNameId = 1,
+	cmsGroupId = 456,
+	collapsable,
+	scopeId = 123,
+	taxonomyCategoryBriefs = [],
+}: {
+	classNameId?: number;
+	cmsGroupId?: number;
+	collapsable?: boolean;
+	scopeId?: number;
+	taxonomyCategoryBriefs?: ReturnType<typeof buildCategoryBrief>[];
+} = {}) {
+	return render(
+		<AssetCategories
+			cmsGroupId={cmsGroupId}
+			collapsable={collapsable}
+			hasUpdatePermission={true}
+			objectEntry={
+				{
+					scopeId,
+					systemProperties: {
+						objectDefinitionBrief: {classNameId},
+					},
+					taxonomyCategoryBriefs,
+				} as any
+			}
+			updateObjectEntry={jest.fn()}
+		/>
+	);
+}
+
+describe('AssetCategories', () => {
+	beforeEach(() => {
+		(global as any).Liferay = {
+			Language: {
+				get: jest.fn((key: string) => key),
+			},
+			ThemeDisplay: {
+				getPortalURL: () => 'https://www.liferay.com',
+			},
+		};
+	});
+
+	afterEach(() => {
+		jest.resetAllMocks();
+	});
+
+	it('renders categories grouped under their vocabulary names', () => {
+		renderComponent({
+			taxonomyCategoryBriefs: [
+				buildCategoryBrief({
+					id: 1,
+					name: 'category-1',
+					taxonomyVocabularyId: 10,
+					vocabularyName: 'vocabulary-a',
+				}),
+				buildCategoryBrief({
+					id: 2,
+					name: 'category-2',
+					taxonomyVocabularyId: 10,
+					vocabularyName: 'vocabulary-a',
+				}),
+				buildCategoryBrief({
+					id: 3,
+					name: 'category-3',
+					taxonomyVocabularyId: 20,
+					vocabularyName: 'vocabulary-b',
+				}),
+			],
+		});
+
+		const vocabularyAGroup = screen
+			.getByText('vocabulary-a')
+			.closest('div')!;
+		const vocabularyBGroup = screen
+			.getByText('vocabulary-b')
+			.closest('div')!;
+
+		expect(
+			within(vocabularyAGroup).getByText('category-1')
+		).toBeInTheDocument();
+		expect(
+			within(vocabularyAGroup).getByText('category-2')
+		).toBeInTheDocument();
+		expect(
+			within(vocabularyAGroup).queryByText('category-3')
+		).not.toBeInTheDocument();
+
+		expect(
+			within(vocabularyBGroup).getByText('category-3')
+		).toBeInTheDocument();
+	});
+
+	it('renders the panel as collapsable by default', () => {
+		renderComponent();
+
+		const toggle = screen.getByRole('button', {name: 'categories'});
+
+		expect(toggle).toHaveAttribute('aria-expanded', 'true');
+	});
+
+	it('renders the panel as non-collapsable when collapsable is false', () => {
+		renderComponent({collapsable: false});
+
+		expect(
+			screen.queryByRole('button', {name: 'categories'})
+		).not.toBeInTheDocument();
+
+		expect(screen.getByText('categories')).toBeInTheDocument();
+	});
+
+	it('builds the categories apiURL against the asset library when the scope is positive', () => {
+		renderComponent({classNameId: 1, scopeId: 123});
+
+		const apiURL = screen
+			.getByTestId('item-selector')
+			.getAttribute('data-api-url');
+
+		expect(apiURL).toContain(
+			'/o/headless-admin-taxonomy/v1.0/asset-libraries/123/taxonomy-categories'
+		);
+		expect(apiURL).toContain("assetTypes in ('0', '1')");
+		expect(apiURL).not.toContain('assetLibraries in');
+	});
+
+	it('builds the categories apiURL against the site with an asset library filter when the scope is negative', () => {
+		renderComponent({classNameId: 1, cmsGroupId: 456, scopeId: -1});
+
+		const apiURL = screen
+			.getByTestId('item-selector')
+			.getAttribute('data-api-url');
+
+		expect(apiURL).toContain(
+			'/o/headless-admin-taxonomy/v1.0/sites/456/taxonomy-categories'
+		);
+		expect(apiURL).toContain("assetLibraries in ('-1')");
+	});
+});

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/info_panel/components/AssetTags.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/info_panel/components/AssetTags.test.tsx
@@ -11,9 +11,11 @@ import ApiHelper from '../../../../../src/main/resources/META-INF/resources/js/c
 import AssetTags from '../../../../../src/main/resources/META-INF/resources/js/main_view/info_panel/components/AssetTags';
 
 function MockItemSelector({
+	apiURL,
 	onChange,
 	primaryAction,
 }: {
+	apiURL?: string;
 	onChange: (value: string) => void;
 	primaryAction?: {
 		label: string;
@@ -21,7 +23,7 @@ function MockItemSelector({
 	};
 }) {
 	return (
-		<div data-testid="item-selector">
+		<div data-api-url={apiURL} data-testid="item-selector">
 			<input
 				data-testid="item-selector-input"
 				onChange={(event) => onChange(event.target.value)}
@@ -55,25 +57,27 @@ jest.mock('@liferay/frontend-js-item-selector-web', () => {
 	};
 });
 
-(global as any).Liferay = {
-	Language: {
-		get: jest.fn((key: string) => key),
-	},
-	ThemeDisplay: {
-		getPortalURL: () => 'https://www.liferay.com',
-	},
-};
-
-function renderComponent() {
+function renderComponent({
+	cmsGroupId = 456,
+	collapsable,
+	keywords = ['tag1'],
+	scopeId = 123,
+}: {
+	cmsGroupId?: number;
+	collapsable?: boolean;
+	keywords?: string[];
+	scopeId?: number;
+} = {}) {
 	return render(
 		<AssetTags
 			assetLibraryId={123}
-			cmsGroupId={456}
+			cmsGroupId={cmsGroupId}
+			collapsable={collapsable}
 			hasUpdatePermission={true}
 			objectEntry={
 				{
-					keywords: ['tag1'],
-					scopeId: 123,
+					keywords,
+					scopeId,
 				} as any
 			}
 			updateObjectEntry={jest.fn()}
@@ -82,6 +86,22 @@ function renderComponent() {
 }
 
 describe('AssetTags', () => {
+	beforeEach(() => {
+		(global as any).Liferay = {
+			Language: {
+				get: jest.fn((key: string) => key),
+			},
+			ThemeDisplay: {
+				getPortalURL: () => 'https://www.liferay.com',
+			},
+		};
+
+		(ApiHelper.get as jest.Mock).mockResolvedValue({
+			data: {actions: {}},
+			error: null,
+		});
+	});
+
 	afterEach(() => {
 		jest.resetAllMocks();
 	});
@@ -146,5 +166,56 @@ describe('AssetTags', () => {
 		fireEvent.change(input, {target: {value: 'tag1'}});
 
 		expect(screen.queryByTestId('primary-action')).not.toBeInTheDocument();
+	});
+
+	it('renders existing keywords as labels', () => {
+		renderComponent({keywords: ['keyword-a', 'keyword-b']});
+
+		expect(screen.getByText('keyword-a')).toBeInTheDocument();
+		expect(screen.getByText('keyword-b')).toBeInTheDocument();
+	});
+
+	it('renders the panel as collapsable by default', () => {
+		renderComponent();
+
+		const toggle = screen.getByRole('button', {name: 'tags'});
+
+		expect(toggle).toHaveAttribute('aria-expanded', 'true');
+	});
+
+	it('renders the panel as non-collapsable when collapsable is false', () => {
+		renderComponent({collapsable: false});
+
+		expect(
+			screen.queryByRole('button', {name: 'tags'})
+		).not.toBeInTheDocument();
+
+		expect(screen.getByText('tags')).toBeInTheDocument();
+	});
+
+	it('builds the tags apiURL against the scope site when the scope is positive', () => {
+		renderComponent({scopeId: 123});
+
+		const apiURL = screen
+			.getByTestId('item-selector')
+			.getAttribute('data-api-url');
+
+		expect(apiURL).toContain(
+			'/o/headless-admin-taxonomy/v1.0/sites/123/keywords'
+		);
+		expect(apiURL).not.toContain('groupIds in');
+	});
+
+	it('builds the tags apiURL against the cmsGroup site with a groupIds filter when the scope is negative', () => {
+		renderComponent({cmsGroupId: 456, scopeId: -1});
+
+		const apiURL = screen
+			.getByTestId('item-selector')
+			.getAttribute('data-api-url');
+
+		expect(apiURL).toContain(
+			'/o/headless-admin-taxonomy/v1.0/sites/456/keywords'
+		);
+		expect(apiURL).toContain("groupIds in ('-1')");
 	});
 });


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89780

## What is being fixed

The Categorization tab in the Info Panel lacked unit coverage for three story acceptance criteria: that the Categories and Tags panels render as collapsable, that categories are grouped under their parent vocabulary, and that the autocomplete `apiURL` carries the right space-scoped filter for both site-scoped and asset-library-scoped entries.

## How it is being fixed

A new `AssetCategories.test.tsx` covers the categories side with five tests: vocabulary-grouped rendering (asserted via `within(...)` scoped queries so a regression that collapses all categories into one vocab is caught), collapsable default plus override, and the `apiURL` shape for both positive and negative `scopeId`. `AssetTags.test.tsx` is extended with the symmetric set on the tags side — existing keyword rendering, collapsable default plus override, and the `apiURL` keywords endpoint with the `groupIds in (...)` filter when the asset is space-scoped. The Tags render harness moves the `Liferay` global and `ApiHelper.get` defaults into `beforeEach` so `resetAllMocks` between tests can't leave them empty.

The story acceptance criterion "Listed alphabetically under their corresponding vocabulary" is excluded from this PR. Static inspection of the frontend (`AssetCategories.tsx`) and backend (`AssetEntryAssetCategoryRelAssetCategoryLocalServiceWrapper`, ordered by `AssetCategoryId`) shows neither sorts by name today, so this is a product question rather than a coverage gap.

The cross-space leakage on the Categories side is already covered by `vocabularies.spec.ts` `'Hide a Space-restricted vocabulary from content in another Space'` (LPD-89497); the Tags equivalent is left out because the Jest URL-build tests already pin the frontend and the categories Playwright proves the server honors the parallel filter pattern.

## Test execution

cd modules/apps/site/site-cms-site-initializer && yarn test test/js/main_view/info_panel/components/