### PR TITLE
LPD-88154 Convert pending email collaborator invites on user signup

### DIFF
--- a/modules/.releng/test/jenkins-results-parser/artifact.properties
+++ b/modules/.releng/test/jenkins-results-parser/artifact.properties
@@ -1,3 +1,3 @@
-artifact.git.id=08e84b0ae81a9c4b04c53a1600098f05b2ce1833
-artifact.sources.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.jenkins.results.parser/1.0.1822/com.liferay.jenkins.results.parser-1.0.1822-sources.jar
-artifact.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.jenkins.results.parser/1.0.1822/com.liferay.jenkins.results.parser-1.0.1822.jar
+artifact.git.id=b04a83c61b40236370207e6242d4e3e508ea32e7
+artifact.sources.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.jenkins.results.parser/1.0.1823/com.liferay.jenkins.results.parser-1.0.1823-sources.jar
+artifact.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.jenkins.results.parser/1.0.1823/com.liferay.jenkins.results.parser-1.0.1823.jar

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/petra/executor/GraphWalkerPortalExecutor.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/petra/executor/GraphWalkerPortalExecutor.java
@@ -6,7 +6,6 @@
 package com.liferay.portal.workflow.kaleo.runtime.internal.petra.executor;
 
 import com.liferay.petra.concurrent.NoticeableExecutorService;
-import com.liferay.petra.concurrent.NoticeableFuture;
 import com.liferay.petra.concurrent.ThreadPoolHandlerAdapter;
 import com.liferay.petra.executor.PortalExecutorConfig;
 import com.liferay.petra.executor.PortalExecutorManager;
@@ -39,7 +38,6 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
@@ -57,7 +55,7 @@ import org.osgi.service.component.annotations.Reference;
 public class GraphWalkerPortalExecutor {
 
 	public void execute(PathElement pathElement, boolean waitForCompletion) {
-		if (PortalRunMode.isTestMode()) {
+		if (PortalRunMode.isTestMode() || waitForCompletion) {
 			_walk(pathElement);
 
 			return;
@@ -65,32 +63,19 @@ public class GraphWalkerPortalExecutor {
 
 		long ctCollectionId = CTCollectionThreadLocal.getCTCollectionId();
 
-		NoticeableFuture<?> noticeableFuture =
-			_noticeableExecutorService.submit(
-				new CompanyInheritableThreadLocalCallable<>(
-					() -> {
-						try (SafeCloseable safeCloseable =
-								CTCollectionThreadLocal.
-									setCTCollectionIdWithSafeCloseable(
-										ctCollectionId)) {
+		_noticeableExecutorService.submit(
+			new CompanyInheritableThreadLocalCallable<>(
+				() -> {
+					try (SafeCloseable safeCloseable =
+							CTCollectionThreadLocal.
+								setCTCollectionIdWithSafeCloseable(
+									ctCollectionId)) {
 
-							_walk(pathElement);
-						}
+						_walk(pathElement);
+					}
 
-						return null;
-					}));
-
-		if (waitForCompletion) {
-			try {
-				noticeableFuture.get();
-			}
-			catch (ExecutionException executionException) {
-				_log.error(executionException);
-			}
-			catch (InterruptedException interruptedException) {
-				_log.error(interruptedException);
-			}
-		}
+					return null;
+				}));
 	}
 
 	@Activate

--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
@@ -1265,8 +1265,8 @@ public class DBTest {
 			return "select sleep(2)";
 		}
 		else if (dbType == DBType.ORACLE) {
-			return "select count(*) from (select level from dual connect by " +
-				"level <= 100000000)";
+			return "select sum(dbms_random.value) from (select level from " +
+				"dual connect by level <= 200000)";
 		}
 		else if (dbType == DBType.POSTGRESQL) {
 			return "select pg_sleep(2)";

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/model/listener/UserModelListener.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/model/listener/UserModelListener.java
@@ -5,8 +5,6 @@
 
 package com.liferay.sharing.internal.model.listener;
 
-import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
-import com.liferay.petra.sql.dsl.expression.Predicate;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -14,19 +12,16 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.ModelListener;
+import com.liferay.portal.kernel.model.Ticket;
 import com.liferay.portal.kernel.model.TicketConstants;
-import com.liferay.portal.kernel.model.TicketTable;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.TicketLocalService;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.sharing.model.SharingEntry;
-import com.liferay.sharing.model.SharingEntryTable;
 import com.liferay.sharing.service.SharingEntryLocalService;
 
 import java.util.Date;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -63,69 +58,55 @@ public class UserModelListener extends BaseModelListener<User> {
 		_sharingEntryLocalService.deleteToUserSharingEntries(user.getUserId());
 	}
 
-	private Predicate _getWherePredicate(User user) {
-		return TicketTable.INSTANCE.companyId.eq(
-			user.getCompanyId()
-		).and(
-			TicketTable.INSTANCE.type.eq(
-				TicketConstants.TYPE_INVITE_COLLABORATOR)
-		).and(
-			TicketTable.INSTANCE.expirationDate.gt(new Date())
-		);
-	}
-
 	private void _updateSharingEntries(User user) {
-		List<SharingEntry> sharingEntries =
-			(List<SharingEntry>)_sharingEntryLocalService.dslQuery(
-				DSLQueryFactoryUtil.selectDistinct(
-					SharingEntryTable.INSTANCE
-				).from(
-					SharingEntryTable.INSTANCE
-				).innerJoinON(
-					TicketTable.INSTANCE,
-					SharingEntryTable.INSTANCE.toTicketId.eq(
-						TicketTable.INSTANCE.ticketId)
-				).where(
-					_getWherePredicate(user)
-				),
-				false);
+		List<Ticket> tickets = _ticketLocalService.getTickets(
+			user.getCompanyId(), TicketConstants.TYPE_INVITE_COLLABORATOR,
+			user.getEmailAddress());
 
-		Set<Long> ticketIds = new HashSet<>();
+		Date now = new Date();
 
-		for (SharingEntry pendingSharingEntry : sharingEntries) {
-			ticketIds.add(pendingSharingEntry.getToTicketId());
+		for (Ticket ticket : tickets) {
+			Date expirationDate = ticket.getExpirationDate();
 
-			SharingEntry existingSharingEntry =
-				_sharingEntryLocalService.fetchSharingEntry(
-					0, pendingSharingEntry.getToUserGroupId(), user.getUserId(),
-					pendingSharingEntry.getClassNameId(),
-					pendingSharingEntry.getClassPK());
+			if ((expirationDate != null) && !expirationDate.after(now)) {
+				continue;
+			}
 
-			if (existingSharingEntry != null) {
-				if (_log.isInfoEnabled()) {
-					_log.info(
-						StringBundler.concat(
-							"A sharing entry already exists for user ",
-							user.getUserId(), " with classNameId ",
-							pendingSharingEntry.getClassNameId(),
-							" and classPK ", pendingSharingEntry.getClassPK()));
+			List<SharingEntry> pendingSharingEntries =
+				_sharingEntryLocalService.getToTicketSharingEntries(
+					ticket.getTicketId());
+
+			for (SharingEntry pendingSharingEntry : pendingSharingEntries) {
+				SharingEntry existingSharingEntry =
+					_sharingEntryLocalService.fetchSharingEntry(
+						0, pendingSharingEntry.getToUserGroupId(),
+						user.getUserId(), pendingSharingEntry.getClassNameId(),
+						pendingSharingEntry.getClassPK());
+
+				if (existingSharingEntry != null) {
+					if (_log.isInfoEnabled()) {
+						_log.info(
+							StringBundler.concat(
+								"A sharing entry already exists for user ",
+								user.getUserId(), " with classNameId ",
+								pendingSharingEntry.getClassNameId(),
+								" and classPK ", pendingSharingEntry.getClassPK()));
+					}
+
+					_sharingEntryLocalService.deleteSharingEntry(
+						pendingSharingEntry);
 				}
+				else {
+					pendingSharingEntry.setToTicketId(0);
+					pendingSharingEntry.setToUserId(user.getUserId());
 
-				_sharingEntryLocalService.deleteSharingEntry(
-					pendingSharingEntry);
+					_sharingEntryLocalService.updateSharingEntry(
+						pendingSharingEntry);
+				}
 			}
-			else {
-				pendingSharingEntry.setToTicketId(0);
-				pendingSharingEntry.setToUserId(user.getUserId());
 
-				_sharingEntryLocalService.updateSharingEntry(
-					pendingSharingEntry);
-			}
-		}
-
-		for (Long ticketId : ticketIds) {
 			try {
-				_ticketLocalService.deleteTicket(ticketId);
+				_ticketLocalService.deleteTicket(ticket.getTicketId());
 			}
 			catch (PortalException portalException) {
 				throw new ModelListenerException(portalException);

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/model/listener/UserModelListener.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/model/listener/UserModelListener.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.model.TicketTable;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.TicketLocalService;
 import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.sharing.model.SharingEntry;
 import com.liferay.sharing.model.SharingEntryTable;
 import com.liferay.sharing.service.SharingEntryLocalService;
@@ -36,11 +37,22 @@ public class UserModelListener extends BaseModelListener<User> {
 
 	@Override
 	public void onAfterCreate(User user) {
+		if (user.getStatus() != WorkflowConstants.STATUS_APPROVED) {
+			return;
+		}
+
 		_updateSharingEntries(user);
 	}
 
 	@Override
 	public void onAfterUpdate(User originalUser, User user) {
+		if ((originalUser.getStatus() == user.getStatus()) ||
+			(originalUser.getStatus() == WorkflowConstants.STATUS_APPROVED) ||
+			(user.getStatus() != WorkflowConstants.STATUS_APPROVED)) {
+
+			return;
+		}
+
 		_updateSharingEntries(user);
 	}
 
@@ -60,6 +72,17 @@ public class UserModelListener extends BaseModelListener<User> {
 		);
 	}
 
+	private Predicate _getWherePredicate(User user) {
+		return TicketTable.INSTANCE.companyId.eq(
+			user.getCompanyId()
+		).and(
+			TicketTable.INSTANCE.type.eq(
+				TicketConstants.TYPE_INVITE_COLLABORATOR)
+		).and(
+			TicketTable.INSTANCE.expirationDate.gt(new Date())
+		);
+	}
+
 	private void _updateSharingEntries(User user) {
 		TransactionCommitCallbackUtil.registerCallback(
 			() -> {
@@ -72,7 +95,7 @@ public class UserModelListener extends BaseModelListener<User> {
 						).innerJoinON(
 							SharingEntryTable.INSTANCE, _getPredicate()
 						).where(
-							_wherePredicate(user)
+							_getWherePredicate(user)
 						));
 
 				for (Ticket ticket : tickets) {
@@ -115,17 +138,6 @@ public class UserModelListener extends BaseModelListener<User> {
 		sharingEntry.setToUserId(user.getUserId());
 
 		_sharingEntryLocalService.updateSharingEntry(sharingEntry);
-	}
-
-	private Predicate _wherePredicate(User user) {
-		return TicketTable.INSTANCE.companyId.eq(
-			user.getCompanyId()
-		).and(
-			TicketTable.INSTANCE.type.eq(
-				TicketConstants.TYPE_INVITE_COLLABORATOR)
-		).and(
-			TicketTable.INSTANCE.expirationDate.gt(new Date())
-		);
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/model/listener/UserModelListener.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/model/listener/UserModelListener.java
@@ -5,10 +5,25 @@
 
 package com.liferay.sharing.internal.model.listener;
 
+import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
+import com.liferay.petra.sql.dsl.expression.Predicate;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.ModelListener;
+import com.liferay.portal.kernel.model.Ticket;
+import com.liferay.portal.kernel.model.TicketConstants;
+import com.liferay.portal.kernel.model.TicketTable;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.TicketLocalService;
+import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.sharing.model.SharingEntry;
+import com.liferay.sharing.model.SharingEntryTable;
 import com.liferay.sharing.service.SharingEntryLocalService;
+
+import java.util.Date;
+import java.util.List;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -20,11 +35,106 @@ import org.osgi.service.component.annotations.Reference;
 public class UserModelListener extends BaseModelListener<User> {
 
 	@Override
+	public void onAfterCreate(User user) {
+		_updateSharingEntries(user);
+	}
+
+	@Override
+	public void onAfterUpdate(User originalUser, User user) {
+		_updateSharingEntries(user);
+	}
+
+	@Override
 	public void onBeforeRemove(User user) {
 		_sharingEntryLocalService.deleteToUserSharingEntries(user.getUserId());
 	}
 
+	private Predicate _getPredicate() {
+		return SharingEntryTable.INSTANCE.classNameId.eq(
+			TicketTable.INSTANCE.classNameId
+		).and(
+			SharingEntryTable.INSTANCE.classPK.eq(TicketTable.INSTANCE.classPK)
+		).and(
+			SharingEntryTable.INSTANCE.toTicketId.eq(
+				TicketTable.INSTANCE.ticketId)
+		);
+	}
+
+	private void _updateSharingEntries(User user) {
+		TransactionCommitCallbackUtil.registerCallback(
+			() -> {
+				List<Ticket> tickets =
+					(List<Ticket>)_ticketLocalService.dslQuery(
+						DSLQueryFactoryUtil.selectDistinct(
+							TicketTable.INSTANCE
+						).from(
+							TicketTable.INSTANCE
+						).innerJoinON(
+							SharingEntryTable.INSTANCE, _getPredicate()
+						).where(
+							_wherePredicate(user)
+						));
+
+				for (Ticket ticket : tickets) {
+					for (SharingEntry sharingEntry :
+							_sharingEntryLocalService.getToTicketSharingEntries(
+								ticket.getTicketId())) {
+
+						_updateSharingEntry(sharingEntry, user);
+					}
+
+					_ticketLocalService.deleteTicket(ticket);
+				}
+
+				return null;
+			});
+	}
+
+	private void _updateSharingEntry(SharingEntry sharingEntry, User user) {
+		SharingEntry existingSharingEntry =
+			_sharingEntryLocalService.fetchSharingEntry(
+				0, sharingEntry.getToUserGroupId(), user.getUserId(),
+				sharingEntry.getClassNameId(), sharingEntry.getClassPK());
+
+		if (existingSharingEntry != null) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					StringBundler.concat(
+						"A sharing entry already exists for user ",
+						user.getUserId(), " with classNameId ",
+						sharingEntry.getClassNameId(), " and classPK ",
+						sharingEntry.getClassPK()));
+			}
+
+			_sharingEntryLocalService.deleteSharingEntry(sharingEntry);
+
+			return;
+		}
+
+		sharingEntry.setToTicketId(0);
+		sharingEntry.setToUserId(user.getUserId());
+
+		_sharingEntryLocalService.updateSharingEntry(sharingEntry);
+	}
+
+	private Predicate _wherePredicate(User user) {
+		return TicketTable.INSTANCE.companyId.eq(
+			user.getCompanyId()
+		).and(
+			TicketTable.INSTANCE.type.eq(
+				TicketConstants.TYPE_INVITE_COLLABORATOR)
+		).and(
+			TicketTable.INSTANCE.expirationDate.gt(new Date())
+		);
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		UserModelListener.class);
+
 	@Reference
 	private SharingEntryLocalService _sharingEntryLocalService;
+
+	@Reference
+	private TicketLocalService _ticketLocalService;
 
 }

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/model/listener/UserModelListener.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/model/listener/UserModelListener.java
@@ -8,23 +8,25 @@ package com.liferay.sharing.internal.model.listener;
 import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
 import com.liferay.petra.sql.dsl.expression.Predicate;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.exception.ModelListenerException;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.ModelListener;
-import com.liferay.portal.kernel.model.Ticket;
 import com.liferay.portal.kernel.model.TicketConstants;
 import com.liferay.portal.kernel.model.TicketTable;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.TicketLocalService;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.sharing.model.SharingEntry;
 import com.liferay.sharing.model.SharingEntryTable;
 import com.liferay.sharing.service.SharingEntryLocalService;
 
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -61,17 +63,6 @@ public class UserModelListener extends BaseModelListener<User> {
 		_sharingEntryLocalService.deleteToUserSharingEntries(user.getUserId());
 	}
 
-	private Predicate _getPredicate() {
-		return SharingEntryTable.INSTANCE.classNameId.eq(
-			TicketTable.INSTANCE.classNameId
-		).and(
-			SharingEntryTable.INSTANCE.classPK.eq(TicketTable.INSTANCE.classPK)
-		).and(
-			SharingEntryTable.INSTANCE.toTicketId.eq(
-				TicketTable.INSTANCE.ticketId)
-		);
-	}
-
 	private Predicate _getWherePredicate(User user) {
 		return TicketTable.INSTANCE.companyId.eq(
 			user.getCompanyId()
@@ -84,60 +75,62 @@ public class UserModelListener extends BaseModelListener<User> {
 	}
 
 	private void _updateSharingEntries(User user) {
-		TransactionCommitCallbackUtil.registerCallback(
-			() -> {
-				List<Ticket> tickets =
-					(List<Ticket>)_ticketLocalService.dslQuery(
-						DSLQueryFactoryUtil.selectDistinct(
-							TicketTable.INSTANCE
-						).from(
-							TicketTable.INSTANCE
-						).innerJoinON(
-							SharingEntryTable.INSTANCE, _getPredicate()
-						).where(
-							_getWherePredicate(user)
-						));
+		List<SharingEntry> sharingEntries =
+			(List<SharingEntry>)_sharingEntryLocalService.dslQuery(
+				DSLQueryFactoryUtil.selectDistinct(
+					SharingEntryTable.INSTANCE
+				).from(
+					SharingEntryTable.INSTANCE
+				).innerJoinON(
+					TicketTable.INSTANCE,
+					SharingEntryTable.INSTANCE.toTicketId.eq(
+						TicketTable.INSTANCE.ticketId)
+				).where(
+					_getWherePredicate(user)
+				),
+				false);
 
-				for (Ticket ticket : tickets) {
-					for (SharingEntry sharingEntry :
-							_sharingEntryLocalService.getToTicketSharingEntries(
-								ticket.getTicketId())) {
+		Set<Long> ticketIds = new HashSet<>();
 
-						_updateSharingEntry(sharingEntry, user);
-					}
+		for (SharingEntry pendingSharingEntry : sharingEntries) {
+			ticketIds.add(pendingSharingEntry.getToTicketId());
 
-					_ticketLocalService.deleteTicket(ticket);
+			SharingEntry existingSharingEntry =
+				_sharingEntryLocalService.fetchSharingEntry(
+					0, pendingSharingEntry.getToUserGroupId(), user.getUserId(),
+					pendingSharingEntry.getClassNameId(),
+					pendingSharingEntry.getClassPK());
+
+			if (existingSharingEntry != null) {
+				if (_log.isInfoEnabled()) {
+					_log.info(
+						StringBundler.concat(
+							"A sharing entry already exists for user ",
+							user.getUserId(), " with classNameId ",
+							pendingSharingEntry.getClassNameId(),
+							" and classPK ", pendingSharingEntry.getClassPK()));
 				}
 
-				return null;
-			});
-	}
-
-	private void _updateSharingEntry(SharingEntry sharingEntry, User user) {
-		SharingEntry existingSharingEntry =
-			_sharingEntryLocalService.fetchSharingEntry(
-				0, sharingEntry.getToUserGroupId(), user.getUserId(),
-				sharingEntry.getClassNameId(), sharingEntry.getClassPK());
-
-		if (existingSharingEntry != null) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(
-					StringBundler.concat(
-						"A sharing entry already exists for user ",
-						user.getUserId(), " with classNameId ",
-						sharingEntry.getClassNameId(), " and classPK ",
-						sharingEntry.getClassPK()));
+				_sharingEntryLocalService.deleteSharingEntry(
+					pendingSharingEntry);
 			}
+			else {
+				pendingSharingEntry.setToTicketId(0);
+				pendingSharingEntry.setToUserId(user.getUserId());
 
-			_sharingEntryLocalService.deleteSharingEntry(sharingEntry);
-
-			return;
+				_sharingEntryLocalService.updateSharingEntry(
+					pendingSharingEntry);
+			}
 		}
 
-		sharingEntry.setToTicketId(0);
-		sharingEntry.setToUserId(user.getUserId());
-
-		_sharingEntryLocalService.updateSharingEntry(sharingEntry);
+		for (Long ticketId : ticketIds) {
+			try {
+				_ticketLocalService.deleteTicket(ticketId);
+			}
+			catch (PortalException portalException) {
+				throw new ModelListenerException(portalException);
+			}
+		}
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/model/listener/UserModelListener.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/model/listener/UserModelListener.java
@@ -88,9 +88,10 @@ public class UserModelListener extends BaseModelListener<User> {
 						_log.info(
 							StringBundler.concat(
 								"A sharing entry already exists for user ",
-								user.getUserId(), " with classNameId ",
+								user.getUserId(), " with class name ID ",
 								pendingSharingEntry.getClassNameId(),
-								" and classPK ", pendingSharingEntry.getClassPK()));
+								" and class primary key ",
+								pendingSharingEntry.getClassPK()));
 					}
 
 					_sharingEntryLocalService.deleteSharingEntry(

--- a/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/internal/model/listener/test/UserModelListenerTest.java
+++ b/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/internal/model/listener/test/UserModelListenerTest.java
@@ -6,17 +6,30 @@
 package com.liferay.sharing.internal.model.listener.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Ticket;
+import com.liferay.portal.kernel.model.TicketConstants;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.UserConstants;
+import com.liferay.portal.kernel.model.WorkflowDefinitionLink;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.TicketLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalService;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -25,8 +38,12 @@ import com.liferay.sharing.model.SharingEntry;
 import com.liferay.sharing.security.permission.SharingEntryAction;
 import com.liferay.sharing.service.SharingEntryLocalService;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Date;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -51,25 +68,288 @@ public class UserModelListenerTest {
 
 	@Before
 	public void setUp() throws Exception {
-		_group = GroupTestUtil.addGroup();
+		_group1 = GroupTestUtil.addGroup();
 
 		_groupUser1 = UserTestUtil.addGroupUser(
-			_group, RoleConstants.POWER_USER);
+			_group1, RoleConstants.POWER_USER);
 		_groupUser2 = UserTestUtil.addGroupUser(
-			_group, RoleConstants.POWER_USER);
+			_group1, RoleConstants.POWER_USER);
+	}
+
+	@Test
+	@TestInfo("LPD-48130")
+	public void testAddUser() throws Exception {
+		String emailAddress1 = RandomTestUtil.randomString() + "@liferay.com";
+		String emailAddress2 = RandomTestUtil.randomString() + "@liferay.com";
+
+		_group2 = GroupTestUtil.addGroup();
+
+		Ticket ticket1 = _addInviteCollaboratorTicket(
+			_group1.getGroupId(), emailAddress1);
+		Ticket ticket2 = _addInviteCollaboratorTicket(
+			_group2.getGroupId(), emailAddress1);
+		Ticket ticket3 = _addInviteCollaboratorTicket(
+			_group1.getGroupId(), emailAddress2);
+
+		SharingEntry sharingEntry1 = _addTicketSharingEntry(
+			_group1.getGroupId(), ticket1.getTicketId());
+		SharingEntry sharingEntry2 = _addTicketSharingEntry(
+			_group2.getGroupId(), ticket2.getTicketId());
+		SharingEntry sharingEntry3 = _addTicketSharingEntry(
+			_group1.getGroupId(), ticket3.getTicketId());
+
+		User user1 = _addUser(emailAddress1);
+
+		Assert.assertNull(
+			_ticketLocalService.fetchTicket(ticket1.getTicketId()));
+		Assert.assertNull(
+			_ticketLocalService.fetchTicket(ticket2.getTicketId()));
+
+		sharingEntry1 = _sharingEntryLocalService.getSharingEntry(
+			sharingEntry1.getSharingEntryId());
+
+		Assert.assertEquals(0, sharingEntry1.getToTicketId());
+		Assert.assertEquals(user1.getUserId(), sharingEntry1.getToUserId());
+
+		sharingEntry2 = _sharingEntryLocalService.getSharingEntry(
+			sharingEntry2.getSharingEntryId());
+
+		Assert.assertEquals(0, sharingEntry2.getToTicketId());
+		Assert.assertEquals(user1.getUserId(), sharingEntry2.getToUserId());
+
+		ticket3 = _ticketLocalService.fetchTicket(ticket3.getTicketId());
+
+		sharingEntry3 = _sharingEntryLocalService.getSharingEntry(
+			sharingEntry3.getSharingEntryId());
+
+		Assert.assertEquals(
+			ticket3.getTicketId(), sharingEntry3.getToTicketId());
+		Assert.assertEquals(0, sharingEntry3.getToUserId());
+
+		// With Duplicate Sharing Entry
+
+		emailAddress1 = RandomTestUtil.randomString() + "@liferay.com";
+
+		ticket1 = _addInviteCollaboratorTicket(
+			_group1.getGroupId(), emailAddress1);
+		ticket2 = _addInviteCollaboratorTicket(
+			_group1.getGroupId(), emailAddress1);
+
+		_addTicketSharingEntry(_group1.getGroupId(), ticket1.getTicketId());
+		_addTicketSharingEntry(_group1.getGroupId(), ticket2.getTicketId());
+
+		List<SharingEntry> toTicketSharingEntries =
+			_sharingEntryLocalService.getToTicketSharingEntries(
+				ticket1.getTicketId());
+
+		Assert.assertEquals(
+			toTicketSharingEntries.toString(), 1,
+			toTicketSharingEntries.size());
+
+		toTicketSharingEntries =
+			_sharingEntryLocalService.getToTicketSharingEntries(
+				ticket2.getTicketId());
+
+		Assert.assertEquals(
+			toTicketSharingEntries.toString(), 1,
+			toTicketSharingEntries.size());
+
+		User user2 = _addUser(emailAddress1);
+
+		Assert.assertNull(
+			_ticketLocalService.fetchTicket(ticket1.getTicketId()));
+		Assert.assertNull(
+			_ticketLocalService.fetchTicket(ticket2.getTicketId()));
+
+		List<SharingEntry> toUserSharingEntries =
+			_sharingEntryLocalService.getToUserSharingEntries(
+				user2.getUserId());
+
+		Assert.assertEquals(
+			toUserSharingEntries.toString(), 1, toUserSharingEntries.size());
+
+		SharingEntry toUserSharingEntry = toUserSharingEntries.get(0);
+
+		Assert.assertEquals(0, toUserSharingEntry.getToTicketId());
+
+		toTicketSharingEntries =
+			_sharingEntryLocalService.getToTicketSharingEntries(
+				ticket1.getTicketId());
+
+		Assert.assertEquals(
+			toTicketSharingEntries.toString(), 0,
+			toTicketSharingEntries.size());
+
+		toTicketSharingEntries =
+			_sharingEntryLocalService.getToTicketSharingEntries(
+				ticket2.getTicketId());
+
+		Assert.assertEquals(
+			toTicketSharingEntries.toString(), 0,
+			toTicketSharingEntries.size());
+
+		// With Existing User-Based Sharing Entry
+
+		emailAddress1 = RandomTestUtil.randomString() + "@liferay.com";
+
+		User user3 = _addUser(emailAddress1);
+
+		ticket1 = _addInviteCollaboratorTicket(
+			_group1.getGroupId(), emailAddress1);
+
+		sharingEntry1 = _sharingEntryLocalService.addSharingEntry(
+			null, TestPropsValues.getUserId(), 0, 0, user3.getUserId(),
+			_classNameLocalService.getClassNameId(Group.class.getName()),
+			_group1.getGroupId(), _group1.getGroupId(), true,
+			Arrays.asList(SharingEntryAction.VIEW), null,
+			ServiceContextTestUtil.getServiceContext(
+				_group1.getGroupId(), TestPropsValues.getUserId()));
+
+		_addTicketSharingEntry(_group1.getGroupId(), ticket1.getTicketId());
+
+		_userLocalService.updateStatus(
+			user3.getUserId(), WorkflowConstants.STATUS_INACTIVE,
+			ServiceContextTestUtil.getServiceContext(
+				_group1.getGroupId(), TestPropsValues.getUserId()));
+
+		_userLocalService.updateStatus(
+			user3.getUserId(), WorkflowConstants.STATUS_APPROVED,
+			ServiceContextTestUtil.getServiceContext(
+				_group1.getGroupId(), TestPropsValues.getUserId()));
+
+		Assert.assertNull(
+			_ticketLocalService.fetchTicket(ticket1.getTicketId()));
+
+		toTicketSharingEntries =
+			_sharingEntryLocalService.getToTicketSharingEntries(
+				ticket1.getTicketId());
+
+		Assert.assertEquals(
+			toTicketSharingEntries.toString(), 0,
+			toTicketSharingEntries.size());
+
+		toUserSharingEntries =
+			_sharingEntryLocalService.getToUserSharingEntries(
+				user3.getUserId());
+
+		Assert.assertEquals(
+			toUserSharingEntries.toString(), 1, toUserSharingEntries.size());
+
+		toUserSharingEntry = toUserSharingEntries.get(0);
+
+		Assert.assertEquals(
+			sharingEntry1.getSharingEntryId(),
+			toUserSharingEntry.getSharingEntryId());
+
+		// With Invalid Extra Info
+
+		emailAddress1 = RandomTestUtil.randomString() + "@liferay.com";
+
+		ticket1 = _addInviteCollaboratorTicket(_group1.getGroupId(), null);
+		ticket2 = _addInviteCollaboratorTicket(
+			_group1.getGroupId(), "not-an-email");
+		ticket3 = _addInviteCollaboratorTicket(
+			_group1.getGroupId(), emailAddress1);
+
+		sharingEntry1 = _addTicketSharingEntry(
+			_group1.getGroupId(), ticket1.getTicketId());
+		sharingEntry2 = _addTicketSharingEntry(
+			_group1.getGroupId(), ticket2.getTicketId());
+		sharingEntry3 = _addTicketSharingEntry(
+			_group1.getGroupId(), ticket3.getTicketId());
+
+		User user4 = _addUser(emailAddress1);
+
+		Assert.assertNotNull(
+			_ticketLocalService.fetchTicket(ticket1.getTicketId()));
+		Assert.assertNotNull(
+			_ticketLocalService.fetchTicket(ticket2.getTicketId()));
+		Assert.assertNull(
+			_ticketLocalService.fetchTicket(ticket3.getTicketId()));
+
+		sharingEntry1 = _sharingEntryLocalService.getSharingEntry(
+			sharingEntry1.getSharingEntryId());
+
+		Assert.assertEquals(
+			ticket1.getTicketId(), sharingEntry1.getToTicketId());
+		Assert.assertEquals(0, sharingEntry1.getToUserId());
+
+		sharingEntry2 = _sharingEntryLocalService.getSharingEntry(
+			sharingEntry2.getSharingEntryId());
+
+		Assert.assertEquals(
+			ticket2.getTicketId(), sharingEntry2.getToTicketId());
+		Assert.assertEquals(0, sharingEntry2.getToUserId());
+
+		sharingEntry3 = _sharingEntryLocalService.getSharingEntry(
+			sharingEntry3.getSharingEntryId());
+
+		Assert.assertEquals(0, sharingEntry3.getToTicketId());
+		Assert.assertEquals(user4.getUserId(), sharingEntry3.getToUserId());
+	}
+
+	@Test
+	@TestInfo("LPD-48130")
+	public void testAddUserWithWorkflow() throws Exception {
+		String emailAddress1 = RandomTestUtil.randomString() + "@liferay.com";
+		String emailAddress2 = RandomTestUtil.randomString() + "@liferay.com";
+
+		_group2 = GroupTestUtil.addGroup();
+
+		Ticket ticket1 = _addInviteCollaboratorTicket(
+			_group1.getGroupId(), emailAddress1);
+		Ticket ticket2 = _addInviteCollaboratorTicket(
+			_group2.getGroupId(), emailAddress1);
+		Ticket ticket3 = _addInviteCollaboratorTicket(
+			_group1.getGroupId(), emailAddress2);
+
+		SharingEntry sharingEntry1 = _addTicketSharingEntry(
+			_group1.getGroupId(), ticket1.getTicketId());
+		SharingEntry sharingEntry2 = _addTicketSharingEntry(
+			_group2.getGroupId(), ticket2.getTicketId());
+		SharingEntry sharingEntry3 = _addTicketSharingEntry(
+			_group1.getGroupId(), ticket3.getTicketId());
+
+		User user = _addUserWithWorkflow(emailAddress1);
+
+		Assert.assertNull(
+			_ticketLocalService.fetchTicket(ticket1.getTicketId()));
+		Assert.assertNull(
+			_ticketLocalService.fetchTicket(ticket2.getTicketId()));
+
+		sharingEntry1 = _sharingEntryLocalService.getSharingEntry(
+			sharingEntry1.getSharingEntryId());
+
+		Assert.assertEquals(0, sharingEntry1.getToTicketId());
+		Assert.assertEquals(user.getUserId(), sharingEntry1.getToUserId());
+
+		sharingEntry2 = _sharingEntryLocalService.getSharingEntry(
+			sharingEntry2.getSharingEntryId());
+
+		Assert.assertEquals(0, sharingEntry2.getToTicketId());
+		Assert.assertEquals(user.getUserId(), sharingEntry2.getToUserId());
+
+		ticket3 = _ticketLocalService.fetchTicket(ticket3.getTicketId());
+
+		sharingEntry3 = _sharingEntryLocalService.getSharingEntry(
+			sharingEntry3.getSharingEntryId());
+
+		Assert.assertEquals(
+			ticket3.getTicketId(), sharingEntry3.getToTicketId());
+		Assert.assertEquals(0, sharingEntry3.getToUserId());
 	}
 
 	@Test
 	public void testDeletingUserSharedDeletesSharingEntries() throws Exception {
-		long classPK = _group.getGroupId();
+		long classPK = _group1.getGroupId();
 
 		_sharingEntryLocalService.addSharingEntry(
 			null, TestPropsValues.getUserId(), 0, 0, _groupUser1.getUserId(),
 			_classNameLocalService.getClassNameId(Group.class.getName()),
-			classPK, _group.getGroupId(), true,
+			classPK, _group1.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.VIEW), null,
 			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), TestPropsValues.getUserId()));
+				_group1.getGroupId(), TestPropsValues.getUserId()));
 
 		List<SharingEntry> toUserSharingEntries =
 			_sharingEntryLocalService.getToUserSharingEntries(
@@ -92,15 +372,15 @@ public class UserModelListenerTest {
 	public void testDeletingUserSharingDoesNotDeleteSharingEntries()
 		throws Exception {
 
-		long classPK = _group.getGroupId();
+		long classPK = _group1.getGroupId();
 
 		_sharingEntryLocalService.addSharingEntry(
 			null, TestPropsValues.getUserId(), 0, 0, _groupUser1.getUserId(),
 			_classNameLocalService.getClassNameId(Group.class.getName()),
-			classPK, _group.getGroupId(), true,
+			classPK, _group1.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.VIEW), null,
 			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), TestPropsValues.getUserId()));
+				_group1.getGroupId(), TestPropsValues.getUserId()));
 
 		List<SharingEntry> toUserSharingEntries =
 			_sharingEntryLocalService.getToUserSharingEntries(
@@ -119,11 +399,125 @@ public class UserModelListenerTest {
 			toUserSharingEntries.toString(), 1, toUserSharingEntries.size());
 	}
 
+	@Test
+	@TestInfo("LPD-48130")
+	public void testUpdateUserStatus() throws Exception {
+		WorkflowDefinitionLink workflowDefinitionLink =
+			_workflowDefinitionLinkLocalService.addWorkflowDefinitionLink(
+				null, TestPropsValues.getUserId(),
+				TestPropsValues.getCompanyId(),
+				WorkflowConstants.DEFAULT_GROUP_ID, User.class.getName(), 0, 0,
+				"Single Approver", 1);
+
+		try {
+			String emailAddress =
+				RandomTestUtil.randomString() + "@liferay.com";
+
+			Ticket ticket = _addInviteCollaboratorTicket(
+				_group1.getGroupId(), emailAddress);
+
+			SharingEntry sharingEntry = _addTicketSharingEntry(
+				_group1.getGroupId(), ticket.getTicketId());
+
+			User user = _addUserWithWorkflow(emailAddress);
+
+			Assert.assertEquals(
+				WorkflowConstants.STATUS_PENDING, user.getStatus());
+
+			Assert.assertNotNull(
+				_ticketLocalService.fetchTicket(ticket.getTicketId()));
+
+			sharingEntry = _sharingEntryLocalService.getSharingEntry(
+				sharingEntry.getSharingEntryId());
+
+			Assert.assertEquals(
+				ticket.getTicketId(), sharingEntry.getToTicketId());
+			Assert.assertEquals(0, sharingEntry.getToUserId());
+
+			_userLocalService.updateStatus(
+				user.getUserId(), WorkflowConstants.STATUS_APPROVED,
+				ServiceContextTestUtil.getServiceContext(
+					_group1.getGroupId(), TestPropsValues.getUserId()));
+
+			Assert.assertNull(
+				_ticketLocalService.fetchTicket(ticket.getTicketId()));
+
+			sharingEntry = _sharingEntryLocalService.getSharingEntry(
+				sharingEntry.getSharingEntryId());
+
+			Assert.assertEquals(0, sharingEntry.getToTicketId());
+			Assert.assertEquals(user.getUserId(), sharingEntry.getToUserId());
+		}
+		finally {
+			_workflowDefinitionLinkLocalService.deleteWorkflowDefinitionLink(
+				workflowDefinitionLink);
+		}
+	}
+
+	private Ticket _addInviteCollaboratorTicket(
+			long classPK, String emailAddress)
+		throws Exception {
+
+		return _ticketLocalService.addTicket(
+			TestPropsValues.getCompanyId(), Group.class.getName(), classPK,
+			TicketConstants.TYPE_INVITE_COLLABORATOR,
+			_normalizeEmailAddress(emailAddress),
+			new Date(System.currentTimeMillis() + TimeUnit.HOURS.toMillis(48)),
+			new ServiceContext());
+	}
+
+	private SharingEntry _addTicketSharingEntry(long classPK, long toTicketId)
+		throws Exception {
+
+		return _sharingEntryLocalService.addSharingEntry(
+			null, TestPropsValues.getUserId(), toTicketId, 0, 0,
+			_classNameLocalService.getClassNameId(Group.class.getName()),
+			classPK, _group1.getGroupId(), true,
+			Arrays.asList(SharingEntryAction.VIEW), null,
+			ServiceContextTestUtil.getServiceContext(
+				_group1.getGroupId(), TestPropsValues.getUserId()));
+	}
+
+	private User _addUser(String emailAddress) throws Exception {
+		User user = UserTestUtil.addUser(
+			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			StringPool.BLANK, emailAddress, RandomTestUtil.randomString(),
+			LocaleUtil.getDefault(), "Test", "User", null,
+			ServiceContextTestUtil.getServiceContext(
+				_group1.getGroupId(), TestPropsValues.getUserId()));
+
+		_users.add(user);
+
+		return user;
+	}
+
+	private User _addUserWithWorkflow(String emailAddress) throws Exception {
+		User user = _userLocalService.addUserWithWorkflow(
+			TestPropsValues.getUserId(), TestPropsValues.getCompanyId(), true,
+			null, null, false, RandomTestUtil.randomString(), emailAddress,
+			LocaleUtil.getDefault(), "Test", StringPool.BLANK, "User", 0, 0,
+			true, Calendar.JANUARY, 1, 1970, StringPool.BLANK,
+			UserConstants.TYPE_REGULAR, null, null, null, null, false,
+			ServiceContextTestUtil.getServiceContext(
+				_group1.getGroupId(), TestPropsValues.getUserId()));
+
+		_users.add(user);
+
+		return user;
+	}
+
+	private String _normalizeEmailAddress(String emailAddress) {
+		return StringUtil.toLowerCase(StringUtil.trim(emailAddress));
+	}
+
 	@Inject
 	private ClassNameLocalService _classNameLocalService;
 
 	@DeleteAfterTestRun
-	private Group _group;
+	private Group _group1;
+
+	@DeleteAfterTestRun
+	private Group _group2;
 
 	private User _groupUser1;
 	private User _groupUser2;
@@ -132,6 +526,16 @@ public class UserModelListenerTest {
 	private SharingEntryLocalService _sharingEntryLocalService;
 
 	@Inject
+	private TicketLocalService _ticketLocalService;
+
+	@Inject
 	private UserLocalService _userLocalService;
+
+	@DeleteAfterTestRun
+	private final List<User> _users = new ArrayList<>();
+
+	@Inject
+	private WorkflowDefinitionLinkLocalService
+		_workflowDefinitionLinkLocalService;
 
 }

--- a/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/internal/model/listener/test/UserModelListenerTest.java
+++ b/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/internal/model/listener/test/UserModelListenerTest.java
@@ -69,20 +69,15 @@ public class UserModelListenerTest {
 	@Before
 	public void setUp() throws Exception {
 		_group1 = GroupTestUtil.addGroup();
-
-		_groupUser1 = UserTestUtil.addGroupUser(
-			_group1, RoleConstants.POWER_USER);
-		_groupUser2 = UserTestUtil.addGroupUser(
-			_group1, RoleConstants.POWER_USER);
 	}
 
 	@Test
 	@TestInfo("LPD-48130")
 	public void testAddUser() throws Exception {
-		_testAddUserWithDuplicatePendingInvitations();
-		_testAddUserWithExpiredInvitationTicket();
+		_testAddUserWithDuplicateInviteCollaboratorTickets();
+		_testAddUserWithExpiredInviteCollaboratorTicket();
 		_testAddUserWithInvalidEmailAddress();
-		_testAddUserWithPendingInvitations();
+		_testAddUserWithInviteCollaboratorTickets();
 		_testAddUserWithUpperCaseEmail();
 	}
 
@@ -121,70 +116,17 @@ public class UserModelListenerTest {
 	}
 
 	@Test
-	public void testDeletingUserSharedDeletesSharingEntries() throws Exception {
-		long classPK = _group1.getGroupId();
-
-		_sharingEntryLocalService.addSharingEntry(
-			null, TestPropsValues.getUserId(), 0, 0, _groupUser1.getUserId(),
-			_classNameLocalService.getClassNameId(Group.class.getName()),
-			classPK, _group1.getGroupId(), true,
-			Arrays.asList(SharingEntryAction.VIEW), null,
-			ServiceContextTestUtil.getServiceContext(
-				_group1.getGroupId(), TestPropsValues.getUserId()));
-
-		List<SharingEntry> toUserSharingEntries =
-			_sharingEntryLocalService.getToUserSharingEntries(
-				_groupUser1.getUserId());
-
-		Assert.assertEquals(
-			toUserSharingEntries.toString(), 1, toUserSharingEntries.size());
-
-		_userLocalService.deleteUser(_groupUser1.getUserId());
-
-		toUserSharingEntries =
-			_sharingEntryLocalService.getToUserSharingEntries(
-				_groupUser1.getUserId());
-
-		Assert.assertEquals(
-			toUserSharingEntries.toString(), 0, toUserSharingEntries.size());
-	}
-
-	@Test
-	public void testDeletingUserSharingDoesNotDeleteSharingEntries()
-		throws Exception {
-
-		long classPK = _group1.getGroupId();
-
-		_sharingEntryLocalService.addSharingEntry(
-			null, TestPropsValues.getUserId(), 0, 0, _groupUser1.getUserId(),
-			_classNameLocalService.getClassNameId(Group.class.getName()),
-			classPK, _group1.getGroupId(), true,
-			Arrays.asList(SharingEntryAction.VIEW), null,
-			ServiceContextTestUtil.getServiceContext(
-				_group1.getGroupId(), TestPropsValues.getUserId()));
-
-		List<SharingEntry> toUserSharingEntries =
-			_sharingEntryLocalService.getToUserSharingEntries(
-				_groupUser1.getUserId());
-
-		Assert.assertEquals(
-			toUserSharingEntries.toString(), 1, toUserSharingEntries.size());
-
-		_userLocalService.deleteUser(_groupUser2.getUserId());
-
-		toUserSharingEntries =
-			_sharingEntryLocalService.getToUserSharingEntries(
-				_groupUser1.getUserId());
-
-		Assert.assertEquals(
-			toUserSharingEntries.toString(), 1, toUserSharingEntries.size());
+	@TestInfo("LPD-48130")
+	public void testDeleteUser() throws Exception {
+		_testDeleteUserWithToUserSharingEntries();
+		_testDeleteUserWithoutToUserSharingEntries();
 	}
 
 	@Test
 	@TestInfo("LPD-48130")
 	public void testUpdateUserStatus() throws Exception {
-		_testUpdateUserStatusWithExistingUserSharingEntry();
-		_testUpdateUserStatusWithPendingInvitations();
+		_testUpdateUserStatusWithExistingToUserSharingEntry();
+		_testUpdateUserStatusWithInviteCollaboratorTicket();
 	}
 
 	private Ticket _addInviteCollaboratorTicket(
@@ -286,7 +228,7 @@ public class UserModelListenerTest {
 		return StringUtil.toLowerCase(StringUtil.trim(emailAddress));
 	}
 
-	private void _testAddUserWithDuplicatePendingInvitations()
+	private void _testAddUserWithDuplicateInviteCollaboratorTickets()
 		throws Exception {
 
 		String emailAddress = RandomTestUtil.randomString() + "@liferay.com";
@@ -323,7 +265,9 @@ public class UserModelListenerTest {
 		_assertToTicketSharingEntriesCount(0, ticket2);
 	}
 
-	private void _testAddUserWithExpiredInvitationTicket() throws Exception {
+	private void _testAddUserWithExpiredInviteCollaboratorTicket()
+		throws Exception {
+
 		String emailAddress = RandomTestUtil.randomString() + "@liferay.com";
 
 		Ticket ticket = _addInviteCollaboratorTicket(
@@ -372,7 +316,7 @@ public class UserModelListenerTest {
 		_assertSharingEntryToUserId(sharingEntry3, user);
 	}
 
-	private void _testAddUserWithPendingInvitations() throws Exception {
+	private void _testAddUserWithInviteCollaboratorTickets() throws Exception {
 		String emailAddress1 = RandomTestUtil.randomString() + "@liferay.com";
 		String emailAddress2 = RandomTestUtil.randomString() + "@liferay.com";
 
@@ -422,7 +366,67 @@ public class UserModelListenerTest {
 		_assertSharingEntryToUserId(sharingEntry, user);
 	}
 
-	private void _testUpdateUserStatusWithExistingUserSharingEntry()
+	private void _testDeleteUserWithoutToUserSharingEntries() throws Exception {
+		User toUser = UserTestUtil.addGroupUser(
+			_group1, RoleConstants.POWER_USER);
+		User otherUser = UserTestUtil.addGroupUser(
+			_group1, RoleConstants.POWER_USER);
+
+		_sharingEntryLocalService.addSharingEntry(
+			null, TestPropsValues.getUserId(), 0, 0, toUser.getUserId(),
+			_classNameLocalService.getClassNameId(Group.class.getName()),
+			_group1.getGroupId(), _group1.getGroupId(), true,
+			Arrays.asList(SharingEntryAction.VIEW), null,
+			ServiceContextTestUtil.getServiceContext(
+				_group1.getGroupId(), TestPropsValues.getUserId()));
+
+		List<SharingEntry> toUserSharingEntries =
+			_sharingEntryLocalService.getToUserSharingEntries(
+				toUser.getUserId());
+
+		Assert.assertEquals(
+			toUserSharingEntries.toString(), 1, toUserSharingEntries.size());
+
+		_userLocalService.deleteUser(otherUser.getUserId());
+
+		toUserSharingEntries =
+			_sharingEntryLocalService.getToUserSharingEntries(
+				toUser.getUserId());
+
+		Assert.assertEquals(
+			toUserSharingEntries.toString(), 1, toUserSharingEntries.size());
+	}
+
+	private void _testDeleteUserWithToUserSharingEntries() throws Exception {
+		User toUser = UserTestUtil.addGroupUser(
+			_group1, RoleConstants.POWER_USER);
+
+		_sharingEntryLocalService.addSharingEntry(
+			null, TestPropsValues.getUserId(), 0, 0, toUser.getUserId(),
+			_classNameLocalService.getClassNameId(Group.class.getName()),
+			_group1.getGroupId(), _group1.getGroupId(), true,
+			Arrays.asList(SharingEntryAction.VIEW), null,
+			ServiceContextTestUtil.getServiceContext(
+				_group1.getGroupId(), TestPropsValues.getUserId()));
+
+		List<SharingEntry> toUserSharingEntries =
+			_sharingEntryLocalService.getToUserSharingEntries(
+				toUser.getUserId());
+
+		Assert.assertEquals(
+			toUserSharingEntries.toString(), 1, toUserSharingEntries.size());
+
+		_userLocalService.deleteUser(toUser.getUserId());
+
+		toUserSharingEntries =
+			_sharingEntryLocalService.getToUserSharingEntries(
+				toUser.getUserId());
+
+		Assert.assertEquals(
+			toUserSharingEntries.toString(), 0, toUserSharingEntries.size());
+	}
+
+	private void _testUpdateUserStatusWithExistingToUserSharingEntry()
 		throws Exception {
 
 		String emailAddress = RandomTestUtil.randomString() + "@liferay.com";
@@ -471,7 +475,7 @@ public class UserModelListenerTest {
 			toUserSharingEntry.getSharingEntryId());
 	}
 
-	private void _testUpdateUserStatusWithPendingInvitations()
+	private void _testUpdateUserStatusWithInviteCollaboratorTicket()
 		throws Exception {
 
 		WorkflowDefinitionLink workflowDefinitionLink =
@@ -520,9 +524,6 @@ public class UserModelListenerTest {
 
 	@DeleteAfterTestRun
 	private Group _group2;
-
-	private User _groupUser1;
-	private User _groupUser2;
 
 	@Inject
 	private SharingEntryLocalService _sharingEntryLocalService;

--- a/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/internal/model/listener/test/UserModelListenerTest.java
+++ b/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/internal/model/listener/test/UserModelListenerTest.java
@@ -481,40 +481,35 @@ public class UserModelListenerTest {
 				WorkflowConstants.DEFAULT_GROUP_ID, User.class.getName(), 0, 0,
 				"Single Approver", 1);
 
-		try {
-			String emailAddress =
-				RandomTestUtil.randomString() + "@liferay.com";
+		String emailAddress = RandomTestUtil.randomString() + "@liferay.com";
 
-			Ticket ticket = _addInviteCollaboratorTicket(
-				_group1.getGroupId(), emailAddress);
+		Ticket ticket = _addInviteCollaboratorTicket(
+			_group1.getGroupId(), emailAddress);
 
-			SharingEntry sharingEntry = _addTicketSharingEntry(
-				_group1.getGroupId(), ticket.getTicketId());
+		SharingEntry sharingEntry = _addTicketSharingEntry(
+			_group1.getGroupId(), ticket.getTicketId());
 
-			User user = _addUserWithWorkflow(emailAddress);
+		User user = _addUserWithWorkflow(emailAddress);
 
-			Assert.assertEquals(
-				WorkflowConstants.STATUS_PENDING, user.getStatus());
+		Assert.assertEquals(WorkflowConstants.STATUS_PENDING, user.getStatus());
 
-			Assert.assertNotNull(
-				_ticketLocalService.fetchTicket(ticket.getTicketId()));
+		Assert.assertNotNull(
+			_ticketLocalService.fetchTicket(ticket.getTicketId()));
 
-			_assertSharingEntryToTicketId(sharingEntry, ticket);
+		_assertSharingEntryToTicketId(sharingEntry, ticket);
 
-			_userLocalService.updateStatus(
-				user.getUserId(), WorkflowConstants.STATUS_APPROVED,
-				ServiceContextTestUtil.getServiceContext(
-					_group1.getGroupId(), TestPropsValues.getUserId()));
+		_userLocalService.updateStatus(
+			user.getUserId(), WorkflowConstants.STATUS_APPROVED,
+			ServiceContextTestUtil.getServiceContext(
+				_group1.getGroupId(), TestPropsValues.getUserId()));
 
-			Assert.assertNull(
-				_ticketLocalService.fetchTicket(ticket.getTicketId()));
+		Assert.assertNull(
+			_ticketLocalService.fetchTicket(ticket.getTicketId()));
 
-			_assertSharingEntryToUserId(sharingEntry, user);
-		}
-		finally {
-			_workflowDefinitionLinkLocalService.deleteWorkflowDefinitionLink(
-				workflowDefinitionLink);
-		}
+		_assertSharingEntryToUserId(sharingEntry, user);
+
+		_workflowDefinitionLinkLocalService.deleteWorkflowDefinitionLink(
+			workflowDefinitionLink);
 	}
 
 	@Inject

--- a/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/internal/model/listener/test/UserModelListenerTest.java
+++ b/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/internal/model/listener/test/UserModelListenerTest.java
@@ -79,213 +79,11 @@ public class UserModelListenerTest {
 	@Test
 	@TestInfo("LPD-48130")
 	public void testAddUser() throws Exception {
-		String emailAddress1 = RandomTestUtil.randomString() + "@liferay.com";
-		String emailAddress2 = RandomTestUtil.randomString() + "@liferay.com";
-
-		_group2 = GroupTestUtil.addGroup();
-
-		Ticket ticket1 = _addInviteCollaboratorTicket(
-			_group1.getGroupId(), emailAddress1);
-		Ticket ticket2 = _addInviteCollaboratorTicket(
-			_group2.getGroupId(), emailAddress1);
-		Ticket ticket3 = _addInviteCollaboratorTicket(
-			_group1.getGroupId(), emailAddress2);
-
-		SharingEntry sharingEntry1 = _addTicketSharingEntry(
-			_group1.getGroupId(), ticket1.getTicketId());
-		SharingEntry sharingEntry2 = _addTicketSharingEntry(
-			_group2.getGroupId(), ticket2.getTicketId());
-		SharingEntry sharingEntry3 = _addTicketSharingEntry(
-			_group1.getGroupId(), ticket3.getTicketId());
-
-		User user1 = _addUser(emailAddress1);
-
-		Assert.assertNull(
-			_ticketLocalService.fetchTicket(ticket1.getTicketId()));
-		Assert.assertNull(
-			_ticketLocalService.fetchTicket(ticket2.getTicketId()));
-
-		sharingEntry1 = _sharingEntryLocalService.getSharingEntry(
-			sharingEntry1.getSharingEntryId());
-
-		Assert.assertEquals(0, sharingEntry1.getToTicketId());
-		Assert.assertEquals(user1.getUserId(), sharingEntry1.getToUserId());
-
-		sharingEntry2 = _sharingEntryLocalService.getSharingEntry(
-			sharingEntry2.getSharingEntryId());
-
-		Assert.assertEquals(0, sharingEntry2.getToTicketId());
-		Assert.assertEquals(user1.getUserId(), sharingEntry2.getToUserId());
-
-		ticket3 = _ticketLocalService.fetchTicket(ticket3.getTicketId());
-
-		sharingEntry3 = _sharingEntryLocalService.getSharingEntry(
-			sharingEntry3.getSharingEntryId());
-
-		Assert.assertEquals(
-			ticket3.getTicketId(), sharingEntry3.getToTicketId());
-		Assert.assertEquals(0, sharingEntry3.getToUserId());
-
-		// With Duplicate Sharing Entry
-
-		emailAddress1 = RandomTestUtil.randomString() + "@liferay.com";
-
-		ticket1 = _addInviteCollaboratorTicket(
-			_group1.getGroupId(), emailAddress1);
-		ticket2 = _addInviteCollaboratorTicket(
-			_group1.getGroupId(), emailAddress1);
-
-		_addTicketSharingEntry(_group1.getGroupId(), ticket1.getTicketId());
-		_addTicketSharingEntry(_group1.getGroupId(), ticket2.getTicketId());
-
-		List<SharingEntry> toTicketSharingEntries =
-			_sharingEntryLocalService.getToTicketSharingEntries(
-				ticket1.getTicketId());
-
-		Assert.assertEquals(
-			toTicketSharingEntries.toString(), 1,
-			toTicketSharingEntries.size());
-
-		toTicketSharingEntries =
-			_sharingEntryLocalService.getToTicketSharingEntries(
-				ticket2.getTicketId());
-
-		Assert.assertEquals(
-			toTicketSharingEntries.toString(), 1,
-			toTicketSharingEntries.size());
-
-		User user2 = _addUser(emailAddress1);
-
-		Assert.assertNull(
-			_ticketLocalService.fetchTicket(ticket1.getTicketId()));
-		Assert.assertNull(
-			_ticketLocalService.fetchTicket(ticket2.getTicketId()));
-
-		List<SharingEntry> toUserSharingEntries =
-			_sharingEntryLocalService.getToUserSharingEntries(
-				user2.getUserId());
-
-		Assert.assertEquals(
-			toUserSharingEntries.toString(), 1, toUserSharingEntries.size());
-
-		SharingEntry toUserSharingEntry = toUserSharingEntries.get(0);
-
-		Assert.assertEquals(0, toUserSharingEntry.getToTicketId());
-
-		toTicketSharingEntries =
-			_sharingEntryLocalService.getToTicketSharingEntries(
-				ticket1.getTicketId());
-
-		Assert.assertEquals(
-			toTicketSharingEntries.toString(), 0,
-			toTicketSharingEntries.size());
-
-		toTicketSharingEntries =
-			_sharingEntryLocalService.getToTicketSharingEntries(
-				ticket2.getTicketId());
-
-		Assert.assertEquals(
-			toTicketSharingEntries.toString(), 0,
-			toTicketSharingEntries.size());
-
-		// With Existing User-Based Sharing Entry
-
-		emailAddress1 = RandomTestUtil.randomString() + "@liferay.com";
-
-		User user3 = _addUser(emailAddress1);
-
-		ticket1 = _addInviteCollaboratorTicket(
-			_group1.getGroupId(), emailAddress1);
-
-		sharingEntry1 = _sharingEntryLocalService.addSharingEntry(
-			null, TestPropsValues.getUserId(), 0, 0, user3.getUserId(),
-			_classNameLocalService.getClassNameId(Group.class.getName()),
-			_group1.getGroupId(), _group1.getGroupId(), true,
-			Arrays.asList(SharingEntryAction.VIEW), null,
-			ServiceContextTestUtil.getServiceContext(
-				_group1.getGroupId(), TestPropsValues.getUserId()));
-
-		_addTicketSharingEntry(_group1.getGroupId(), ticket1.getTicketId());
-
-		_userLocalService.updateStatus(
-			user3.getUserId(), WorkflowConstants.STATUS_INACTIVE,
-			ServiceContextTestUtil.getServiceContext(
-				_group1.getGroupId(), TestPropsValues.getUserId()));
-
-		_userLocalService.updateStatus(
-			user3.getUserId(), WorkflowConstants.STATUS_APPROVED,
-			ServiceContextTestUtil.getServiceContext(
-				_group1.getGroupId(), TestPropsValues.getUserId()));
-
-		Assert.assertNull(
-			_ticketLocalService.fetchTicket(ticket1.getTicketId()));
-
-		toTicketSharingEntries =
-			_sharingEntryLocalService.getToTicketSharingEntries(
-				ticket1.getTicketId());
-
-		Assert.assertEquals(
-			toTicketSharingEntries.toString(), 0,
-			toTicketSharingEntries.size());
-
-		toUserSharingEntries =
-			_sharingEntryLocalService.getToUserSharingEntries(
-				user3.getUserId());
-
-		Assert.assertEquals(
-			toUserSharingEntries.toString(), 1, toUserSharingEntries.size());
-
-		toUserSharingEntry = toUserSharingEntries.get(0);
-
-		Assert.assertEquals(
-			sharingEntry1.getSharingEntryId(),
-			toUserSharingEntry.getSharingEntryId());
-
-		// With Invalid Extra Info
-
-		emailAddress1 = RandomTestUtil.randomString() + "@liferay.com";
-
-		ticket1 = _addInviteCollaboratorTicket(_group1.getGroupId(), null);
-		ticket2 = _addInviteCollaboratorTicket(
-			_group1.getGroupId(), "not-an-email");
-		ticket3 = _addInviteCollaboratorTicket(
-			_group1.getGroupId(), emailAddress1);
-
-		sharingEntry1 = _addTicketSharingEntry(
-			_group1.getGroupId(), ticket1.getTicketId());
-		sharingEntry2 = _addTicketSharingEntry(
-			_group1.getGroupId(), ticket2.getTicketId());
-		sharingEntry3 = _addTicketSharingEntry(
-			_group1.getGroupId(), ticket3.getTicketId());
-
-		User user4 = _addUser(emailAddress1);
-
-		Assert.assertNotNull(
-			_ticketLocalService.fetchTicket(ticket1.getTicketId()));
-		Assert.assertNotNull(
-			_ticketLocalService.fetchTicket(ticket2.getTicketId()));
-		Assert.assertNull(
-			_ticketLocalService.fetchTicket(ticket3.getTicketId()));
-
-		sharingEntry1 = _sharingEntryLocalService.getSharingEntry(
-			sharingEntry1.getSharingEntryId());
-
-		Assert.assertEquals(
-			ticket1.getTicketId(), sharingEntry1.getToTicketId());
-		Assert.assertEquals(0, sharingEntry1.getToUserId());
-
-		sharingEntry2 = _sharingEntryLocalService.getSharingEntry(
-			sharingEntry2.getSharingEntryId());
-
-		Assert.assertEquals(
-			ticket2.getTicketId(), sharingEntry2.getToTicketId());
-		Assert.assertEquals(0, sharingEntry2.getToUserId());
-
-		sharingEntry3 = _sharingEntryLocalService.getSharingEntry(
-			sharingEntry3.getSharingEntryId());
-
-		Assert.assertEquals(0, sharingEntry3.getToTicketId());
-		Assert.assertEquals(user4.getUserId(), sharingEntry3.getToUserId());
+		_testAddUserWithDuplicatePendingInvitations();
+		_testAddUserWithExpiredInvitationTicket();
+		_testAddUserWithInvalidExtraInfo();
+		_testAddUserWithMixedCaseExtraInfo();
+		_testAddUserWithPendingInvitations();
 	}
 
 	@Test
@@ -317,26 +115,9 @@ public class UserModelListenerTest {
 		Assert.assertNull(
 			_ticketLocalService.fetchTicket(ticket2.getTicketId()));
 
-		sharingEntry1 = _sharingEntryLocalService.getSharingEntry(
-			sharingEntry1.getSharingEntryId());
-
-		Assert.assertEquals(0, sharingEntry1.getToTicketId());
-		Assert.assertEquals(user.getUserId(), sharingEntry1.getToUserId());
-
-		sharingEntry2 = _sharingEntryLocalService.getSharingEntry(
-			sharingEntry2.getSharingEntryId());
-
-		Assert.assertEquals(0, sharingEntry2.getToTicketId());
-		Assert.assertEquals(user.getUserId(), sharingEntry2.getToUserId());
-
-		ticket3 = _ticketLocalService.fetchTicket(ticket3.getTicketId());
-
-		sharingEntry3 = _sharingEntryLocalService.getSharingEntry(
-			sharingEntry3.getSharingEntryId());
-
-		Assert.assertEquals(
-			ticket3.getTicketId(), sharingEntry3.getToTicketId());
-		Assert.assertEquals(0, sharingEntry3.getToUserId());
+		_assertSharingEntryToUserId(sharingEntry1, user);
+		_assertSharingEntryToUserId(sharingEntry2, user);
+		_assertSharingEntryToTicketId(sharingEntry3, ticket3);
 	}
 
 	@Test
@@ -402,68 +183,28 @@ public class UserModelListenerTest {
 	@Test
 	@TestInfo("LPD-48130")
 	public void testUpdateUserStatus() throws Exception {
-		WorkflowDefinitionLink workflowDefinitionLink =
-			_workflowDefinitionLinkLocalService.addWorkflowDefinitionLink(
-				null, TestPropsValues.getUserId(),
-				TestPropsValues.getCompanyId(),
-				WorkflowConstants.DEFAULT_GROUP_ID, User.class.getName(), 0, 0,
-				"Single Approver", 1);
+		_testUpdateUserStatusWithExistingUserSharingEntry();
+		_testUpdateUserStatusWithPendingInvitations();
+	}
 
-		try {
-			String emailAddress =
-				RandomTestUtil.randomString() + "@liferay.com";
+	private Ticket _addInviteCollaboratorTicket(
+			long classPK, Date expirationDate, String extraInfo)
+		throws Exception {
 
-			Ticket ticket = _addInviteCollaboratorTicket(
-				_group1.getGroupId(), emailAddress);
-
-			SharingEntry sharingEntry = _addTicketSharingEntry(
-				_group1.getGroupId(), ticket.getTicketId());
-
-			User user = _addUserWithWorkflow(emailAddress);
-
-			Assert.assertEquals(
-				WorkflowConstants.STATUS_PENDING, user.getStatus());
-
-			Assert.assertNotNull(
-				_ticketLocalService.fetchTicket(ticket.getTicketId()));
-
-			sharingEntry = _sharingEntryLocalService.getSharingEntry(
-				sharingEntry.getSharingEntryId());
-
-			Assert.assertEquals(
-				ticket.getTicketId(), sharingEntry.getToTicketId());
-			Assert.assertEquals(0, sharingEntry.getToUserId());
-
-			_userLocalService.updateStatus(
-				user.getUserId(), WorkflowConstants.STATUS_APPROVED,
-				ServiceContextTestUtil.getServiceContext(
-					_group1.getGroupId(), TestPropsValues.getUserId()));
-
-			Assert.assertNull(
-				_ticketLocalService.fetchTicket(ticket.getTicketId()));
-
-			sharingEntry = _sharingEntryLocalService.getSharingEntry(
-				sharingEntry.getSharingEntryId());
-
-			Assert.assertEquals(0, sharingEntry.getToTicketId());
-			Assert.assertEquals(user.getUserId(), sharingEntry.getToUserId());
-		}
-		finally {
-			_workflowDefinitionLinkLocalService.deleteWorkflowDefinitionLink(
-				workflowDefinitionLink);
-		}
+		return _ticketLocalService.addTicket(
+			TestPropsValues.getCompanyId(), Group.class.getName(), classPK,
+			TicketConstants.TYPE_INVITE_COLLABORATOR, extraInfo, expirationDate,
+			new ServiceContext());
 	}
 
 	private Ticket _addInviteCollaboratorTicket(
 			long classPK, String emailAddress)
 		throws Exception {
 
-		return _ticketLocalService.addTicket(
-			TestPropsValues.getCompanyId(), Group.class.getName(), classPK,
-			TicketConstants.TYPE_INVITE_COLLABORATOR,
-			_normalizeEmailAddress(emailAddress),
+		return _addInviteCollaboratorTicket(
+			classPK,
 			new Date(System.currentTimeMillis() + TimeUnit.HOURS.toMillis(48)),
-			new ServiceContext());
+			_normalizeEmailAddress(emailAddress));
 	}
 
 	private SharingEntry _addTicketSharingEntry(long classPK, long toTicketId)
@@ -506,8 +247,277 @@ public class UserModelListenerTest {
 		return user;
 	}
 
+	private void _assertSharingEntryToTicketId(
+			SharingEntry sharingEntry, Ticket ticket)
+		throws Exception {
+
+		SharingEntry persistedSharingEntry =
+			_sharingEntryLocalService.getSharingEntry(
+				sharingEntry.getSharingEntryId());
+
+		Assert.assertEquals(
+			ticket.getTicketId(), persistedSharingEntry.getToTicketId());
+		Assert.assertEquals(0, persistedSharingEntry.getToUserId());
+	}
+
+	private void _assertSharingEntryToUserId(
+			SharingEntry sharingEntry, User user)
+		throws Exception {
+
+		SharingEntry persistedSharingEntry =
+			_sharingEntryLocalService.getSharingEntry(
+				sharingEntry.getSharingEntryId());
+
+		Assert.assertEquals(0, persistedSharingEntry.getToTicketId());
+		Assert.assertEquals(
+			user.getUserId(), persistedSharingEntry.getToUserId());
+	}
+
+	private void _assertToTicketSharingEntriesCount(int count, Ticket ticket) {
+		List<SharingEntry> toTicketSharingEntries =
+			_sharingEntryLocalService.getToTicketSharingEntries(
+				ticket.getTicketId());
+
+		Assert.assertEquals(
+			toTicketSharingEntries.toString(), count,
+			toTicketSharingEntries.size());
+	}
+
 	private String _normalizeEmailAddress(String emailAddress) {
 		return StringUtil.toLowerCase(StringUtil.trim(emailAddress));
+	}
+
+	private void _testAddUserWithDuplicatePendingInvitations()
+		throws Exception {
+
+		String emailAddress = RandomTestUtil.randomString() + "@liferay.com";
+
+		Ticket ticket1 = _addInviteCollaboratorTicket(
+			_group1.getGroupId(), emailAddress);
+		Ticket ticket2 = _addInviteCollaboratorTicket(
+			_group1.getGroupId(), emailAddress);
+
+		_addTicketSharingEntry(_group1.getGroupId(), ticket1.getTicketId());
+		_addTicketSharingEntry(_group1.getGroupId(), ticket2.getTicketId());
+
+		_assertToTicketSharingEntriesCount(1, ticket1);
+		_assertToTicketSharingEntriesCount(1, ticket2);
+
+		User user = _addUser(emailAddress);
+
+		Assert.assertNull(
+			_ticketLocalService.fetchTicket(ticket1.getTicketId()));
+		Assert.assertNull(
+			_ticketLocalService.fetchTicket(ticket2.getTicketId()));
+
+		List<SharingEntry> toUserSharingEntries =
+			_sharingEntryLocalService.getToUserSharingEntries(user.getUserId());
+
+		Assert.assertEquals(
+			toUserSharingEntries.toString(), 1, toUserSharingEntries.size());
+
+		SharingEntry toUserSharingEntry = toUserSharingEntries.get(0);
+
+		Assert.assertEquals(0, toUserSharingEntry.getToTicketId());
+
+		_assertToTicketSharingEntriesCount(0, ticket1);
+		_assertToTicketSharingEntriesCount(0, ticket2);
+	}
+
+	private void _testAddUserWithExpiredInvitationTicket() throws Exception {
+		String emailAddress = RandomTestUtil.randomString() + "@liferay.com";
+
+		Ticket ticket = _addInviteCollaboratorTicket(
+			_group1.getGroupId(),
+			new Date(System.currentTimeMillis() - TimeUnit.HOURS.toMillis(1)),
+			_normalizeEmailAddress(emailAddress));
+
+		SharingEntry sharingEntry = _addTicketSharingEntry(
+			_group1.getGroupId(), ticket.getTicketId());
+
+		_addUser(emailAddress);
+
+		Assert.assertNotNull(
+			_ticketLocalService.fetchTicket(ticket.getTicketId()));
+
+		_assertSharingEntryToTicketId(sharingEntry, ticket);
+	}
+
+	private void _testAddUserWithInvalidExtraInfo() throws Exception {
+		String emailAddress = RandomTestUtil.randomString() + "@liferay.com";
+
+		Ticket ticket1 = _addInviteCollaboratorTicket(
+			_group1.getGroupId(), null);
+		Ticket ticket2 = _addInviteCollaboratorTicket(
+			_group1.getGroupId(), "not-an-email");
+		Ticket ticket3 = _addInviteCollaboratorTicket(
+			_group1.getGroupId(), emailAddress);
+
+		SharingEntry sharingEntry1 = _addTicketSharingEntry(
+			_group1.getGroupId(), ticket1.getTicketId());
+		SharingEntry sharingEntry2 = _addTicketSharingEntry(
+			_group1.getGroupId(), ticket2.getTicketId());
+		SharingEntry sharingEntry3 = _addTicketSharingEntry(
+			_group1.getGroupId(), ticket3.getTicketId());
+
+		User user = _addUser(emailAddress);
+
+		Assert.assertNotNull(
+			_ticketLocalService.fetchTicket(ticket1.getTicketId()));
+		Assert.assertNotNull(
+			_ticketLocalService.fetchTicket(ticket2.getTicketId()));
+		Assert.assertNull(
+			_ticketLocalService.fetchTicket(ticket3.getTicketId()));
+
+		_assertSharingEntryToTicketId(sharingEntry1, ticket1);
+		_assertSharingEntryToTicketId(sharingEntry2, ticket2);
+		_assertSharingEntryToUserId(sharingEntry3, user);
+	}
+
+	private void _testAddUserWithMixedCaseExtraInfo() throws Exception {
+		String emailAddress = RandomTestUtil.randomString() + "@liferay.com";
+
+		Ticket ticket = _addInviteCollaboratorTicket(
+			_group1.getGroupId(),
+			new Date(System.currentTimeMillis() + TimeUnit.HOURS.toMillis(48)),
+			StringUtil.toUpperCase(emailAddress));
+
+		SharingEntry sharingEntry = _addTicketSharingEntry(
+			_group1.getGroupId(), ticket.getTicketId());
+
+		User user = _addUser(emailAddress);
+
+		Assert.assertNull(
+			_ticketLocalService.fetchTicket(ticket.getTicketId()));
+
+		_assertSharingEntryToUserId(sharingEntry, user);
+	}
+
+	private void _testAddUserWithPendingInvitations() throws Exception {
+		String emailAddress1 = RandomTestUtil.randomString() + "@liferay.com";
+		String emailAddress2 = RandomTestUtil.randomString() + "@liferay.com";
+
+		_group2 = GroupTestUtil.addGroup();
+
+		Ticket ticket1 = _addInviteCollaboratorTicket(
+			_group1.getGroupId(), emailAddress1);
+		Ticket ticket2 = _addInviteCollaboratorTicket(
+			_group2.getGroupId(), emailAddress1);
+		Ticket ticket3 = _addInviteCollaboratorTicket(
+			_group1.getGroupId(), emailAddress2);
+
+		SharingEntry sharingEntry1 = _addTicketSharingEntry(
+			_group1.getGroupId(), ticket1.getTicketId());
+		SharingEntry sharingEntry2 = _addTicketSharingEntry(
+			_group2.getGroupId(), ticket2.getTicketId());
+		SharingEntry sharingEntry3 = _addTicketSharingEntry(
+			_group1.getGroupId(), ticket3.getTicketId());
+
+		User user = _addUser(emailAddress1);
+
+		Assert.assertNull(
+			_ticketLocalService.fetchTicket(ticket1.getTicketId()));
+		Assert.assertNull(
+			_ticketLocalService.fetchTicket(ticket2.getTicketId()));
+
+		_assertSharingEntryToUserId(sharingEntry1, user);
+		_assertSharingEntryToUserId(sharingEntry2, user);
+		_assertSharingEntryToTicketId(sharingEntry3, ticket3);
+	}
+
+	private void _testUpdateUserStatusWithExistingUserSharingEntry()
+		throws Exception {
+
+		String emailAddress = RandomTestUtil.randomString() + "@liferay.com";
+
+		User user = _addUser(emailAddress);
+
+		Ticket ticket = _addInviteCollaboratorTicket(
+			_group1.getGroupId(), emailAddress);
+
+		SharingEntry existingSharingEntry =
+			_sharingEntryLocalService.addSharingEntry(
+				null, TestPropsValues.getUserId(), 0, 0, user.getUserId(),
+				_classNameLocalService.getClassNameId(Group.class.getName()),
+				_group1.getGroupId(), _group1.getGroupId(), true,
+				Arrays.asList(SharingEntryAction.VIEW), null,
+				ServiceContextTestUtil.getServiceContext(
+					_group1.getGroupId(), TestPropsValues.getUserId()));
+
+		_addTicketSharingEntry(_group1.getGroupId(), ticket.getTicketId());
+
+		_userLocalService.updateStatus(
+			user.getUserId(), WorkflowConstants.STATUS_INACTIVE,
+			ServiceContextTestUtil.getServiceContext(
+				_group1.getGroupId(), TestPropsValues.getUserId()));
+
+		_userLocalService.updateStatus(
+			user.getUserId(), WorkflowConstants.STATUS_APPROVED,
+			ServiceContextTestUtil.getServiceContext(
+				_group1.getGroupId(), TestPropsValues.getUserId()));
+
+		Assert.assertNull(
+			_ticketLocalService.fetchTicket(ticket.getTicketId()));
+
+		_assertToTicketSharingEntriesCount(0, ticket);
+
+		List<SharingEntry> toUserSharingEntries =
+			_sharingEntryLocalService.getToUserSharingEntries(user.getUserId());
+
+		Assert.assertEquals(
+			toUserSharingEntries.toString(), 1, toUserSharingEntries.size());
+
+		SharingEntry toUserSharingEntry = toUserSharingEntries.get(0);
+
+		Assert.assertEquals(
+			existingSharingEntry.getSharingEntryId(),
+			toUserSharingEntry.getSharingEntryId());
+	}
+
+	private void _testUpdateUserStatusWithPendingInvitations()
+		throws Exception {
+
+		WorkflowDefinitionLink workflowDefinitionLink =
+			_workflowDefinitionLinkLocalService.addWorkflowDefinitionLink(
+				null, TestPropsValues.getUserId(),
+				TestPropsValues.getCompanyId(),
+				WorkflowConstants.DEFAULT_GROUP_ID, User.class.getName(), 0, 0,
+				"Single Approver", 1);
+
+		try {
+			String emailAddress =
+				RandomTestUtil.randomString() + "@liferay.com";
+
+			Ticket ticket = _addInviteCollaboratorTicket(
+				_group1.getGroupId(), emailAddress);
+
+			SharingEntry sharingEntry = _addTicketSharingEntry(
+				_group1.getGroupId(), ticket.getTicketId());
+
+			User user = _addUserWithWorkflow(emailAddress);
+
+			Assert.assertEquals(
+				WorkflowConstants.STATUS_PENDING, user.getStatus());
+
+			Assert.assertNotNull(
+				_ticketLocalService.fetchTicket(ticket.getTicketId()));
+
+			_assertSharingEntryToTicketId(sharingEntry, ticket);
+
+			_userLocalService.updateStatus(
+				user.getUserId(), WorkflowConstants.STATUS_APPROVED,
+				ServiceContextTestUtil.getServiceContext(
+					_group1.getGroupId(), TestPropsValues.getUserId()));
+
+			Assert.assertNull(
+				_ticketLocalService.fetchTicket(ticket.getTicketId()));
+
+			_assertSharingEntryToUserId(sharingEntry, user);
+		}
+		finally {
+			_workflowDefinitionLinkLocalService.deleteWorkflowDefinitionLink(
+				workflowDefinitionLink);
+		}
 	}
 
 	@Inject

--- a/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/internal/model/listener/test/UserModelListenerTest.java
+++ b/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/internal/model/listener/test/UserModelListenerTest.java
@@ -78,7 +78,7 @@ public class UserModelListenerTest {
 		_testAddUserWithExpiredInviteCollaboratorTicket();
 		_testAddUserWithInvalidEmailAddress();
 		_testAddUserWithInviteCollaboratorTickets();
-		_testAddUserWithUpperCaseEmail();
+		_testAddUserWithUpperCaseEmailAddress();
 	}
 
 	@Test
@@ -348,7 +348,7 @@ public class UserModelListenerTest {
 		_assertSharingEntryToTicketId(sharingEntry3, ticket3);
 	}
 
-	private void _testAddUserWithUpperCaseEmail() throws Exception {
+	private void _testAddUserWithUpperCaseEmailAddress() throws Exception {
 		String emailAddress = RandomTestUtil.randomString() + "@liferay.com";
 
 		Ticket ticket = _addInviteCollaboratorTicket(
@@ -369,7 +369,10 @@ public class UserModelListenerTest {
 	private void _testDeleteUserWithoutToUserSharingEntries() throws Exception {
 		User toUser = UserTestUtil.addGroupUser(
 			_group1, RoleConstants.POWER_USER);
-		User otherUser = UserTestUtil.addGroupUser(
+
+		_users.add(toUser);
+
+		User unrelatedUser = UserTestUtil.addGroupUser(
 			_group1, RoleConstants.POWER_USER);
 
 		_sharingEntryLocalService.addSharingEntry(
@@ -387,7 +390,7 @@ public class UserModelListenerTest {
 		Assert.assertEquals(
 			toUserSharingEntries.toString(), 1, toUserSharingEntries.size());
 
-		_userLocalService.deleteUser(otherUser.getUserId());
+		_userLocalService.deleteUser(unrelatedUser.getUserId());
 
 		toUserSharingEntries =
 			_sharingEntryLocalService.getToUserSharingEntries(

--- a/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/internal/model/listener/test/UserModelListenerTest.java
+++ b/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/internal/model/listener/test/UserModelListenerTest.java
@@ -82,8 +82,8 @@ public class UserModelListenerTest {
 		_testAddUserWithDuplicatePendingInvitations();
 		_testAddUserWithExpiredInvitationTicket();
 		_testAddUserWithInvalidEmailAddress();
-		_testAddUserWithMixedCaseEmailAddress();
 		_testAddUserWithPendingInvitations();
+		_testAddUserWithUpperCaseEmail();
 	}
 
 	@Test
@@ -372,24 +372,6 @@ public class UserModelListenerTest {
 		_assertSharingEntryToUserId(sharingEntry3, user);
 	}
 
-	private void _testAddUserWithMixedCaseEmailAddress() throws Exception {
-		String emailAddress = RandomTestUtil.randomString() + "@liferay.com";
-
-		Ticket ticket = _addInviteCollaboratorTicket(
-			_group1.getGroupId(), StringUtil.toUpperCase(emailAddress),
-			new Date(System.currentTimeMillis() + TimeUnit.HOURS.toMillis(48)));
-
-		SharingEntry sharingEntry = _addTicketSharingEntry(
-			_group1.getGroupId(), ticket.getTicketId());
-
-		_addUser(emailAddress);
-
-		Assert.assertNotNull(
-			_ticketLocalService.fetchTicket(ticket.getTicketId()));
-
-		_assertSharingEntryToTicketId(sharingEntry, ticket);
-	}
-
 	private void _testAddUserWithPendingInvitations() throws Exception {
 		String emailAddress1 = RandomTestUtil.randomString() + "@liferay.com";
 		String emailAddress2 = RandomTestUtil.randomString() + "@liferay.com";
@@ -420,6 +402,24 @@ public class UserModelListenerTest {
 		_assertSharingEntryToUserId(sharingEntry1, user);
 		_assertSharingEntryToUserId(sharingEntry2, user);
 		_assertSharingEntryToTicketId(sharingEntry3, ticket3);
+	}
+
+	private void _testAddUserWithUpperCaseEmail() throws Exception {
+		String emailAddress = RandomTestUtil.randomString() + "@liferay.com";
+
+		Ticket ticket = _addInviteCollaboratorTicket(
+			_group1.getGroupId(), StringUtil.toUpperCase(emailAddress),
+			new Date(System.currentTimeMillis() + TimeUnit.HOURS.toMillis(48)));
+
+		SharingEntry sharingEntry = _addTicketSharingEntry(
+			_group1.getGroupId(), ticket.getTicketId());
+
+		User user = _addUser(emailAddress);
+
+		Assert.assertNull(
+			_ticketLocalService.fetchTicket(ticket.getTicketId()));
+
+		_assertSharingEntryToUserId(sharingEntry, user);
 	}
 
 	private void _testUpdateUserStatusWithExistingUserSharingEntry()

--- a/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/internal/model/listener/test/UserModelListenerTest.java
+++ b/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/internal/model/listener/test/UserModelListenerTest.java
@@ -81,8 +81,8 @@ public class UserModelListenerTest {
 	public void testAddUser() throws Exception {
 		_testAddUserWithDuplicatePendingInvitations();
 		_testAddUserWithExpiredInvitationTicket();
-		_testAddUserWithInvalidExtraInfo();
-		_testAddUserWithMixedCaseExtraInfo();
+		_testAddUserWithInvalidEmailAddress();
+		_testAddUserWithMixedCaseEmailAddress();
 		_testAddUserWithPendingInvitations();
 	}
 
@@ -188,23 +188,22 @@ public class UserModelListenerTest {
 	}
 
 	private Ticket _addInviteCollaboratorTicket(
-			long classPK, Date expirationDate, String extraInfo)
-		throws Exception {
-
-		return _ticketLocalService.addTicket(
-			TestPropsValues.getCompanyId(), Group.class.getName(), classPK,
-			TicketConstants.TYPE_INVITE_COLLABORATOR, extraInfo, expirationDate,
-			new ServiceContext());
-	}
-
-	private Ticket _addInviteCollaboratorTicket(
 			long classPK, String emailAddress)
 		throws Exception {
 
 		return _addInviteCollaboratorTicket(
-			classPK,
-			new Date(System.currentTimeMillis() + TimeUnit.HOURS.toMillis(48)),
-			_normalizeEmailAddress(emailAddress));
+			classPK, _normalizeEmailAddress(emailAddress),
+			new Date(System.currentTimeMillis() + TimeUnit.HOURS.toMillis(48)));
+	}
+
+	private Ticket _addInviteCollaboratorTicket(
+			long classPK, String emailAddress, Date expirationDate)
+		throws Exception {
+
+		return _ticketLocalService.addTicket(
+			TestPropsValues.getCompanyId(), Group.class.getName(), classPK,
+			TicketConstants.TYPE_INVITE_COLLABORATOR, emailAddress, null,
+			expirationDate, new ServiceContext());
 	}
 
 	private SharingEntry _addTicketSharingEntry(long classPK, long toTicketId)
@@ -328,9 +327,8 @@ public class UserModelListenerTest {
 		String emailAddress = RandomTestUtil.randomString() + "@liferay.com";
 
 		Ticket ticket = _addInviteCollaboratorTicket(
-			_group1.getGroupId(),
-			new Date(System.currentTimeMillis() - TimeUnit.HOURS.toMillis(1)),
-			_normalizeEmailAddress(emailAddress));
+			_group1.getGroupId(), _normalizeEmailAddress(emailAddress),
+			new Date(System.currentTimeMillis() - TimeUnit.HOURS.toMillis(1)));
 
 		SharingEntry sharingEntry = _addTicketSharingEntry(
 			_group1.getGroupId(), ticket.getTicketId());
@@ -343,7 +341,7 @@ public class UserModelListenerTest {
 		_assertSharingEntryToTicketId(sharingEntry, ticket);
 	}
 
-	private void _testAddUserWithInvalidExtraInfo() throws Exception {
+	private void _testAddUserWithInvalidEmailAddress() throws Exception {
 		String emailAddress = RandomTestUtil.randomString() + "@liferay.com";
 
 		Ticket ticket1 = _addInviteCollaboratorTicket(
@@ -374,23 +372,22 @@ public class UserModelListenerTest {
 		_assertSharingEntryToUserId(sharingEntry3, user);
 	}
 
-	private void _testAddUserWithMixedCaseExtraInfo() throws Exception {
+	private void _testAddUserWithMixedCaseEmailAddress() throws Exception {
 		String emailAddress = RandomTestUtil.randomString() + "@liferay.com";
 
 		Ticket ticket = _addInviteCollaboratorTicket(
-			_group1.getGroupId(),
-			new Date(System.currentTimeMillis() + TimeUnit.HOURS.toMillis(48)),
-			StringUtil.toUpperCase(emailAddress));
+			_group1.getGroupId(), StringUtil.toUpperCase(emailAddress),
+			new Date(System.currentTimeMillis() + TimeUnit.HOURS.toMillis(48)));
 
 		SharingEntry sharingEntry = _addTicketSharingEntry(
 			_group1.getGroupId(), ticket.getTicketId());
 
-		User user = _addUser(emailAddress);
+		_addUser(emailAddress);
 
-		Assert.assertNull(
+		Assert.assertNotNull(
 			_ticketLocalService.fetchTicket(ticket.getTicketId()));
 
-		_assertSharingEntryToUserId(sharingEntry, user);
+		_assertSharingEntryToTicketId(sharingEntry, ticket);
 	}
 
 	private void _testAddUserWithPendingInvitations() throws Exception {

--- a/modules/sdk/ant-build-logger/build.gradle
+++ b/modules/sdk/ant-build-logger/build.gradle
@@ -8,7 +8,7 @@ clean {
 }
 
 dependencies {
-	compileOnly group: "com.liferay", name: "com.liferay.jenkins.results.parser", version: "1.0.1821"
+	compileOnly group: "com.liferay", name: "com.liferay.jenkins.results.parser", version: "1.0.1823"
 	compileOnly group: "org.apache.ant", name: "ant", version: "1.10.14"
 }
 

--- a/modules/sdk/ant-build-logger/build.gradle
+++ b/modules/sdk/ant-build-logger/build.gradle
@@ -8,6 +8,7 @@ clean {
 }
 
 dependencies {
+	compileOnly group: "com.liferay", name: "com.liferay.jenkins.results.parser", version: "1.0.1821"
 	compileOnly group: "org.apache.ant", name: "ant", version: "1.10.14"
 }
 

--- a/modules/sdk/ant-build-logger/src/main/java/com/liferay/ant/build/logger/LiferayBuildLogger.java
+++ b/modules/sdk/ant-build-logger/src/main/java/com/liferay/ant/build/logger/LiferayBuildLogger.java
@@ -5,8 +5,15 @@
 
 package com.liferay.ant.build.logger;
 
+import com.liferay.jenkins.results.parser.SecurePrintStream;
+
+import java.io.PrintStream;
+
+import java.lang.reflect.Field;
+
 import org.apache.tools.ant.BuildEvent;
 import org.apache.tools.ant.BuildListener;
+import org.apache.tools.ant.DefaultLogger;
 import org.apache.tools.ant.Project;
 
 /**
@@ -14,10 +21,30 @@ import org.apache.tools.ant.Project;
  * @author Shuyang Zhou
  * @author Kevin Yen
  */
-public class LiferayBuildLogger implements BuildListener {
+public class LiferayBuildLogger extends DefaultLogger implements BuildListener {
 
 	public LiferayBuildLogger(BuildListener buildListener) {
 		_buildListener = buildListener;
+
+		if (!(buildListener instanceof DefaultLogger)) {
+			return;
+		}
+
+		DefaultLogger defaultLogger = (DefaultLogger)buildListener;
+
+		PrintStream errorPrintStream = _getPrintStream(defaultLogger, "err");
+
+		if (errorPrintStream != null) {
+			defaultLogger.setOutputPrintStream(
+				new SecurePrintStream(errorPrintStream));
+		}
+
+		PrintStream outputPrintStream = _getPrintStream(defaultLogger, "out");
+
+		if (outputPrintStream != null) {
+			defaultLogger.setOutputPrintStream(
+				new SecurePrintStream(outputPrintStream));
+		}
 	}
 
 	@Override
@@ -59,6 +86,27 @@ public class LiferayBuildLogger implements BuildListener {
 	@Override
 	public void taskStarted(BuildEvent buildEvent) {
 		_buildListener.taskStarted(buildEvent);
+	}
+
+	private PrintStream _getPrintStream(
+		DefaultLogger defaultLogger, String fieldName) {
+
+		try {
+			Field field = DefaultLogger.class.getDeclaredField(fieldName);
+
+			field.setAccessible(true);
+
+			Object object = field.get(defaultLogger);
+
+			if (!(object instanceof PrintStream)) {
+				return null;
+			}
+
+			return (PrintStream)object;
+		}
+		catch (IllegalAccessException | NoSuchFieldException exception) {
+			throw new RuntimeException(exception);
+		}
 	}
 
 	private final BuildListener _buildListener;

--- a/modules/sdk/ant-build-logger/src/main/java/com/liferay/ant/build/logger/LiferayBuildLogger.java
+++ b/modules/sdk/ant-build-logger/src/main/java/com/liferay/ant/build/logger/LiferayBuildLogger.java
@@ -35,7 +35,7 @@ public class LiferayBuildLogger extends DefaultLogger implements BuildListener {
 		PrintStream errorPrintStream = _getPrintStream(defaultLogger, "err");
 
 		if (errorPrintStream != null) {
-			defaultLogger.setOutputPrintStream(
+			defaultLogger.setErrorPrintStream(
 				new SecurePrintStream(errorPrintStream));
 		}
 

--- a/modules/sdk/ant-secure-property/build.gradle
+++ b/modules/sdk/ant-secure-property/build.gradle
@@ -8,7 +8,7 @@ clean {
 }
 
 dependencies {
-	compileOnly group: "com.liferay", name: "com.liferay.jenkins.results.parser", version: "1.0.1822"
+	compileOnly group: "com.liferay", name: "com.liferay.jenkins.results.parser", version: "1.0.1823"
 	compileOnly group: "org.apache.ant", name: "ant", transitive: false, version: "1.10.14"
 }
 

--- a/modules/test/jenkins-results-parser/bnd.bnd
+++ b/modules/test/jenkins-results-parser/bnd.bnd
@@ -1,3 +1,3 @@
 Bundle-Name: Liferay Jenkins Results Parser
 Bundle-SymbolicName: com.liferay.jenkins.results.parser
-Bundle-Version: 1.0.1823
+Bundle-Version: 1.0.1824

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/TicketPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/TicketPersistenceTest.java
@@ -128,6 +128,8 @@ public class TicketPersistenceTest {
 
 		newTicket.setType(RandomTestUtil.nextInt());
 
+		newTicket.setEmailAddress(RandomTestUtil.randomString());
+
 		newTicket.setExtraInfo(RandomTestUtil.randomString());
 
 		newTicket.setExpirationDate(RandomTestUtil.nextDate());
@@ -153,6 +155,8 @@ public class TicketPersistenceTest {
 		Assert.assertEquals(existingTicket.getKey(), newTicket.getKey());
 		Assert.assertEquals(existingTicket.getType(), newTicket.getType());
 		Assert.assertEquals(
+			existingTicket.getEmailAddress(), newTicket.getEmailAddress());
+		Assert.assertEquals(
 			existingTicket.getExtraInfo(), newTicket.getExtraInfo());
 		Assert.assertEquals(
 			Time.getShortTimestamp(existingTicket.getExpirationDate()),
@@ -175,6 +179,16 @@ public class TicketPersistenceTest {
 			RandomTestUtil.nextLong());
 
 		_persistence.countByC_C_C(0L, 0L, 0L);
+	}
+
+	@Test
+	public void testCountByC_T_EA() throws Exception {
+		_persistence.countByC_T_EA(
+			RandomTestUtil.nextLong(), RandomTestUtil.nextInt(), "");
+
+		_persistence.countByC_T_EA(0L, 0, "null");
+
+		_persistence.countByC_T_EA(0L, 0, (String)null);
 	}
 
 	@Test
@@ -222,7 +236,7 @@ public class TicketPersistenceTest {
 		return OrderByComparatorFactoryUtil.create(
 			"Ticket", "mvccVersion", true, "ticketId", true, "companyId", true,
 			"createDate", true, "classNameId", true, "classPK", true, "key",
-			true, "type", true, "expirationDate", true);
+			true, "type", true, "emailAddress", true, "expirationDate", true);
 	}
 
 	@Test
@@ -500,6 +514,8 @@ public class TicketPersistenceTest {
 
 		ticket.setType(RandomTestUtil.nextInt());
 
+		ticket.setEmailAddress(RandomTestUtil.randomString());
+
 		ticket.setExtraInfo(RandomTestUtil.randomString());
 
 		ticket.setExpirationDate(RandomTestUtil.nextDate());
@@ -514,4 +530,4 @@ public class TicketPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:393071913
+// LIFERAY-SERVICE-BUILDER-HASH:852277907

--- a/modules/util.gradle
+++ b/modules/util.gradle
@@ -15,7 +15,7 @@ buildscript {
 	apply from: file("build-buildscript.gradle"), to: buildscript
 
 	dependencies {
-		classpath group: "com.liferay", name: "com.liferay.jenkins.results.parser", version: "1.0.1822"
+		classpath group: "com.liferay", name: "com.liferay.jenkins.results.parser", version: "1.0.1823"
 	}
 }
 

--- a/portal-impl/src/META-INF/portal-hbm.xml
+++ b/portal-impl/src/META-INF/portal-hbm.xml
@@ -989,6 +989,7 @@
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="classPK" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" column="key_" name="key" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" column="type_" name="type" type="com.liferay.portal.dao.orm.hibernate.IntegerType" />
+		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="emailAddress" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="extraInfo" type="com.liferay.portal.dao.orm.hibernate.StringClobType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="expirationDate" type="org.hibernate.type.TimestampType" />
 	</class>

--- a/portal-impl/src/META-INF/portal-model-hints.xml
+++ b/portal-impl/src/META-INF/portal-model-hints.xml
@@ -1545,6 +1545,10 @@
 			<hint name="max-length">255</hint>
 		</field>
 		<field name="type" type="int" />
+		<field name="emailAddress" type="String">
+			<hint-collection name="EMAIL-ADDRESS" />
+			<validator name="email" />
+		</field>
 		<field name="extraInfo" type="String">
 			<hint-collection name="CLOB" />
 		</field>

--- a/portal-impl/src/com/liferay/portal/model/impl/TicketCacheModel.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/TicketCacheModel.java
@@ -67,7 +67,7 @@ public class TicketCacheModel
 
 	@Override
 	public String toString() {
-		StringBundler sb = new StringBundler(21);
+		StringBundler sb = new StringBundler(23);
 
 		sb.append("{mvccVersion=");
 		sb.append(mvccVersion);
@@ -85,6 +85,8 @@ public class TicketCacheModel
 		sb.append(key);
 		sb.append(", type=");
 		sb.append(type);
+		sb.append(", emailAddress=");
+		sb.append(emailAddress);
 		sb.append(", extraInfo=");
 		sb.append(extraInfo);
 		sb.append(", expirationDate=");
@@ -120,6 +122,13 @@ public class TicketCacheModel
 		}
 
 		ticketImpl.setType(type);
+
+		if (emailAddress == null) {
+			ticketImpl.setEmailAddress("");
+		}
+		else {
+			ticketImpl.setEmailAddress(emailAddress);
+		}
 
 		if (extraInfo == null) {
 			ticketImpl.setExtraInfo("");
@@ -157,6 +166,7 @@ public class TicketCacheModel
 		key = objectInput.readUTF();
 
 		type = objectInput.readInt();
+		emailAddress = objectInput.readUTF();
 		extraInfo = (String)objectInput.readObject();
 		expirationDate = objectInput.readLong();
 	}
@@ -183,6 +193,13 @@ public class TicketCacheModel
 
 		objectOutput.writeInt(type);
 
+		if (emailAddress == null) {
+			objectOutput.writeUTF("");
+		}
+		else {
+			objectOutput.writeUTF(emailAddress);
+		}
+
 		if (extraInfo == null) {
 			objectOutput.writeObject("");
 		}
@@ -201,8 +218,9 @@ public class TicketCacheModel
 	public long classPK;
 	public String key;
 	public int type;
+	public String emailAddress;
 	public String extraInfo;
 	public long expirationDate;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-878817001
+// LIFERAY-SERVICE-BUILDER-HASH:1332514131

--- a/portal-impl/src/com/liferay/portal/model/impl/TicketModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/TicketModelImpl.java
@@ -63,7 +63,8 @@ public class TicketModelImpl
 		{"companyId", Types.BIGINT}, {"createDate", Types.TIMESTAMP},
 		{"classNameId", Types.BIGINT}, {"classPK", Types.BIGINT},
 		{"key_", Types.VARCHAR}, {"type_", Types.INTEGER},
-		{"extraInfo", Types.CLOB}, {"expirationDate", Types.TIMESTAMP}
+		{"emailAddress", Types.VARCHAR}, {"extraInfo", Types.CLOB},
+		{"expirationDate", Types.TIMESTAMP}
 	};
 
 	public static final Map<String, Integer> TABLE_COLUMNS_MAP =
@@ -78,12 +79,13 @@ public class TicketModelImpl
 		TABLE_COLUMNS_MAP.put("classPK", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("key_", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("type_", Types.INTEGER);
+		TABLE_COLUMNS_MAP.put("emailAddress", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("extraInfo", Types.CLOB);
 		TABLE_COLUMNS_MAP.put("expirationDate", Types.TIMESTAMP);
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table Ticket (mvccVersion LONG default 0 not null,ticketId LONG not null primary key,companyId LONG,createDate DATE null,classNameId LONG,classPK LONG,key_ VARCHAR(255) null,type_ INTEGER,extraInfo TEXT null,expirationDate DATE null)";
+		"create table Ticket (mvccVersion LONG default 0 not null,ticketId LONG not null primary key,companyId LONG,createDate DATE null,classNameId LONG,classPK LONG,key_ VARCHAR(255) null,type_ INTEGER,emailAddress VARCHAR(254) null,extraInfo TEXT null,expirationDate DATE null)";
 
 	public static final String TABLE_SQL_DROP = "drop table Ticket";
 
@@ -139,20 +141,26 @@ public class TicketModelImpl
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long KEY_COLUMN_BITMASK = 8L;
+	public static final long EMAILADDRESS_COLUMN_BITMASK = 8L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long TYPE_COLUMN_BITMASK = 16L;
+	public static final long KEY_COLUMN_BITMASK = 16L;
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
+	 */
+	@Deprecated
+	public static final long TYPE_COLUMN_BITMASK = 32L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
 	 *		#getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long TICKETID_COLUMN_BITMASK = 32L;
+	public static final long TICKETID_COLUMN_BITMASK = 64L;
 
 	public static final long LOCK_EXPIRATION_TIME = GetterUtil.getLong(
 		com.liferay.portal.kernel.util.PropsUtil.get(
@@ -256,6 +264,8 @@ public class TicketModelImpl
 			attributeGetterFunctions.put("classPK", Ticket::getClassPK);
 			attributeGetterFunctions.put("key", Ticket::getKey);
 			attributeGetterFunctions.put("type", Ticket::getType);
+			attributeGetterFunctions.put(
+				"emailAddress", Ticket::getEmailAddress);
 			attributeGetterFunctions.put("extraInfo", Ticket::getExtraInfo);
 			attributeGetterFunctions.put(
 				"expirationDate", Ticket::getExpirationDate);
@@ -293,6 +303,9 @@ public class TicketModelImpl
 				"key", (BiConsumer<Ticket, String>)Ticket::setKey);
 			attributeSetterBiConsumers.put(
 				"type", (BiConsumer<Ticket, Integer>)Ticket::setType);
+			attributeSetterBiConsumers.put(
+				"emailAddress",
+				(BiConsumer<Ticket, String>)Ticket::setEmailAddress);
 			attributeSetterBiConsumers.put(
 				"extraInfo", (BiConsumer<Ticket, String>)Ticket::setExtraInfo);
 			attributeSetterBiConsumers.put(
@@ -491,6 +504,34 @@ public class TicketModelImpl
 	}
 
 	@Override
+	public String getEmailAddress() {
+		if (_emailAddress == null) {
+			return "";
+		}
+		else {
+			return _emailAddress;
+		}
+	}
+
+	@Override
+	public void setEmailAddress(String emailAddress) {
+		if (_columnOriginalValues == Collections.EMPTY_MAP) {
+			_setColumnOriginalValues();
+		}
+
+		_emailAddress = emailAddress;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #getColumnOriginalValue(String)}
+	 */
+	@Deprecated
+	public String getOriginalEmailAddress() {
+		return getColumnOriginalValue("emailAddress");
+	}
+
+	@Override
 	public String getExtraInfo() {
 		if (_extraInfo == null) {
 			return "";
@@ -587,6 +628,7 @@ public class TicketModelImpl
 		ticketImpl.setClassPK(getClassPK());
 		ticketImpl.setKey(getKey());
 		ticketImpl.setType(getType());
+		ticketImpl.setEmailAddress(getEmailAddress());
 		ticketImpl.setExtraInfo(getExtraInfo());
 		ticketImpl.setExpirationDate(getExpirationDate());
 
@@ -610,6 +652,8 @@ public class TicketModelImpl
 		ticketImpl.setClassPK(this.<Long>getColumnOriginalValue("classPK"));
 		ticketImpl.setKey(this.<String>getColumnOriginalValue("key_"));
 		ticketImpl.setType(this.<Integer>getColumnOriginalValue("type_"));
+		ticketImpl.setEmailAddress(
+			this.<String>getColumnOriginalValue("emailAddress"));
 		ticketImpl.setExtraInfo(
 			this.<String>getColumnOriginalValue("extraInfo"));
 		ticketImpl.setExpirationDate(
@@ -724,6 +768,14 @@ public class TicketModelImpl
 
 		ticketCacheModel.type = getType();
 
+		ticketCacheModel.emailAddress = getEmailAddress();
+
+		String emailAddress = ticketCacheModel.emailAddress;
+
+		if ((emailAddress != null) && (emailAddress.length() == 0)) {
+			ticketCacheModel.emailAddress = null;
+		}
+
 		ticketCacheModel.extraInfo = getExtraInfo();
 
 		String extraInfo = ticketCacheModel.extraInfo;
@@ -809,6 +861,7 @@ public class TicketModelImpl
 	private long _classPK;
 	private String _key;
 	private int _type;
+	private String _emailAddress;
 	private String _extraInfo;
 	private Date _expirationDate;
 
@@ -850,6 +903,7 @@ public class TicketModelImpl
 		_columnOriginalValues.put("classPK", _classPK);
 		_columnOriginalValues.put("key_", _key);
 		_columnOriginalValues.put("type_", _type);
+		_columnOriginalValues.put("emailAddress", _emailAddress);
 		_columnOriginalValues.put("extraInfo", _extraInfo);
 		_columnOriginalValues.put("expirationDate", _expirationDate);
 	}
@@ -892,9 +946,11 @@ public class TicketModelImpl
 
 		columnBitmasks.put("type_", 128L);
 
-		columnBitmasks.put("extraInfo", 256L);
+		columnBitmasks.put("emailAddress", 256L);
 
-		columnBitmasks.put("expirationDate", 512L);
+		columnBitmasks.put("extraInfo", 512L);
+
+		columnBitmasks.put("expirationDate", 1024L);
 
 		_columnBitmasks = Collections.unmodifiableMap(columnBitmasks);
 	}
@@ -903,4 +959,4 @@ public class TicketModelImpl
 	private Ticket _escapedModel;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2016124624
+// LIFERAY-SERVICE-BUILDER-HASH:1394219312

--- a/portal-impl/src/com/liferay/portal/service.xml
+++ b/portal-impl/src/com/liferay/portal/service.xml
@@ -2488,6 +2488,7 @@
 		<column name="classPK" type="long" />
 		<column name="key" type="String" />
 		<column name="type" type="int" />
+		<column name="emailAddress" type="String" />
 		<column name="extraInfo" type="String" />
 		<column name="expirationDate" type="Date" />
 
@@ -2506,6 +2507,11 @@
 			<finder-column name="companyId" />
 			<finder-column name="classNameId" />
 			<finder-column name="classPK" />
+		</finder>
+		<finder name="C_T_EA" return-type="Collection">
+			<finder-column name="companyId" />
+			<finder-column name="type" />
+			<finder-column name="emailAddress" />
 		</finder>
 		<finder name="C_C_T" return-type="Collection">
 			<finder-column name="classNameId" />

--- a/portal-impl/src/com/liferay/portal/service/impl/TicketLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/TicketLocalServiceImpl.java
@@ -10,6 +10,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Ticket;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
 import com.liferay.portal.service.base.TicketLocalServiceBaseImpl;
 
@@ -61,7 +62,8 @@ public class TicketLocalServiceImpl extends TicketLocalServiceBaseImpl {
 		ticket.setClassPK(classPK);
 		ticket.setKey(PortalUUIDUtil.generate());
 		ticket.setType(type);
-		ticket.setEmailAddress(emailAddress);
+		ticket.setEmailAddress(
+			StringUtil.toLowerCase(StringUtil.trim(emailAddress)));
 		ticket.setExtraInfo(extraInfo);
 		ticket.setExpirationDate(expirationDate);
 

--- a/portal-impl/src/com/liferay/portal/service/impl/TicketLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/TicketLocalServiceImpl.java
@@ -98,6 +98,15 @@ public class TicketLocalServiceImpl extends TicketLocalServiceBaseImpl {
 
 	@Override
 	public List<Ticket> getTickets(
+		long companyId, int type, String emailAddress) {
+
+		return ticketPersistence.findByC_T_EA(
+			companyId, type,
+			StringUtil.toLowerCase(StringUtil.trim(emailAddress)));
+	}
+
+	@Override
+	public List<Ticket> getTickets(
 		long companyId, String className, long classPK) {
 
 		return ticketPersistence.findByC_C_C(

--- a/portal-impl/src/com/liferay/portal/service/impl/TicketLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/TicketLocalServiceImpl.java
@@ -30,15 +30,26 @@ public class TicketLocalServiceImpl extends TicketLocalServiceBaseImpl {
 			companyId, _classNameLocalService.getClassNameId(className),
 			classPK, type);
 
-		return addTicket(
-			companyId, className, classPK, type, extraInfo, expirationDate,
-			serviceContext);
+		return ticketLocalService.addTicket(
+			companyId, className, classPK, type, null, extraInfo,
+			expirationDate, serviceContext);
 	}
 
 	@Override
 	public Ticket addTicket(
 		long companyId, String className, long classPK, int type,
 		String extraInfo, Date expirationDate, ServiceContext serviceContext) {
+
+		return ticketLocalService.addTicket(
+			companyId, className, classPK, type, null, extraInfo,
+			expirationDate, serviceContext);
+	}
+
+	@Override
+	public Ticket addTicket(
+		long companyId, String className, long classPK, int type,
+		String emailAddress, String extraInfo, Date expirationDate,
+		ServiceContext serviceContext) {
 
 		long ticketId = counterLocalService.increment();
 
@@ -50,6 +61,7 @@ public class TicketLocalServiceImpl extends TicketLocalServiceBaseImpl {
 		ticket.setClassPK(classPK);
 		ticket.setKey(PortalUUIDUtil.generate());
 		ticket.setType(type);
+		ticket.setEmailAddress(emailAddress);
 		ticket.setExtraInfo(extraInfo);
 		ticket.setExpirationDate(expirationDate);
 

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/AddressPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/AddressPersistenceImpl.java
@@ -91,6 +91,9 @@ public class AddressPersistenceImpl
 	public static final String FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION =
 		FINDER_CLASS_NAME_ENTITY + ".List2";
 
+	private FinderPath _finderPathWithPaginationFindByUuid;
+	private FinderPath _finderPathWithoutPaginationFindByUuid;
+	private FinderPath _finderPathCountByUuid;
 	private CollectionPersistenceFinder<Address>
 		_collectionPersistenceFinderByUuid;
 
@@ -230,6 +233,9 @@ public class AddressPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {uuid});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByUuid_C;
+	private FinderPath _finderPathWithoutPaginationFindByUuid_C;
+	private FinderPath _finderPathCountByUuid_C;
 	private CollectionPersistenceFinder<Address>
 		_collectionPersistenceFinderByUuid_C;
 
@@ -384,6 +390,9 @@ public class AddressPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {uuid, companyId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByCompanyId;
+	private FinderPath _finderPathWithoutPaginationFindByCompanyId;
+	private FinderPath _finderPathCountByCompanyId;
 	private CollectionPersistenceFinder<Address>
 		_collectionPersistenceFinderByCompanyId;
 
@@ -524,6 +533,9 @@ public class AddressPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {companyId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByUserId;
+	private FinderPath _finderPathWithoutPaginationFindByUserId;
+	private FinderPath _finderPathCountByUserId;
 	private CollectionPersistenceFinder<Address>
 		_collectionPersistenceFinderByUserId;
 
@@ -663,6 +675,9 @@ public class AddressPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {userId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByCountryId;
+	private FinderPath _finderPathWithoutPaginationFindByCountryId;
+	private FinderPath _finderPathCountByCountryId;
 	private CollectionPersistenceFinder<Address>
 		_collectionPersistenceFinderByCountryId;
 
@@ -803,6 +818,9 @@ public class AddressPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {countryId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByRegionId;
+	private FinderPath _finderPathWithoutPaginationFindByRegionId;
+	private FinderPath _finderPathCountByRegionId;
 	private CollectionPersistenceFinder<Address>
 		_collectionPersistenceFinderByRegionId;
 
@@ -943,6 +961,9 @@ public class AddressPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {regionId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_C;
+	private FinderPath _finderPathWithoutPaginationFindByC_C;
+	private FinderPath _finderPathCountByC_C;
 	private CollectionPersistenceFinder<Address>
 		_collectionPersistenceFinderByC_C;
 
@@ -1101,6 +1122,9 @@ public class AddressPersistenceImpl
 			new Object[] {companyId, classNameId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByCN_CPK;
+	private FinderPath _finderPathWithoutPaginationFindByCN_CPK;
+	private FinderPath _finderPathCountByCN_CPK;
 	private CollectionPersistenceFinder<Address>
 		_collectionPersistenceFinderByCN_CPK;
 
@@ -1258,6 +1282,9 @@ public class AddressPersistenceImpl
 			new Object[] {classNameId, classPK});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_C_C;
+	private FinderPath _finderPathWithoutPaginationFindByC_C_C;
+	private FinderPath _finderPathCountByC_C_C;
 	private CollectionPersistenceFinder<Address>
 		_collectionPersistenceFinderByC_C_C;
 
@@ -1428,6 +1455,9 @@ public class AddressPersistenceImpl
 			new Object[] {companyId, classNameId, classPK});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_C_C_L;
+	private FinderPath _finderPathWithoutPaginationFindByC_C_C_L;
+	private FinderPath _finderPathCountByC_C_C_L;
 	private CollectionPersistenceFinder<Address>
 		_collectionPersistenceFinderByC_C_C_L;
 
@@ -1762,6 +1792,9 @@ public class AddressPersistenceImpl
 			});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_C_C_M;
+	private FinderPath _finderPathWithoutPaginationFindByC_C_C_M;
+	private FinderPath _finderPathCountByC_C_C_M;
 	private CollectionPersistenceFinder<Address>
 		_collectionPersistenceFinderByC_C_C_M;
 
@@ -1948,6 +1981,9 @@ public class AddressPersistenceImpl
 			new Object[] {companyId, classNameId, classPK, mailing});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_C_C_P;
+	private FinderPath _finderPathWithoutPaginationFindByC_C_C_P;
+	private FinderPath _finderPathCountByC_C_C_P;
 	private CollectionPersistenceFinder<Address>
 		_collectionPersistenceFinderByC_C_C_P;
 
@@ -2134,6 +2170,7 @@ public class AddressPersistenceImpl
 			new Object[] {companyId, classNameId, classPK, primary});
 	}
 
+	private FinderPath _finderPathFetchByERC_C;
 	private UniquePersistenceFinder<Address> _uniquePersistenceFinderByERC_C;
 
 	/**
@@ -2593,50 +2630,59 @@ public class AddressPersistenceImpl
 	 * Initializes the address persistence.
 	 */
 	public void afterPropertiesSet() {
+		_finderPathWithPaginationFindByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid",
+			new String[] {
+				String.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"uuid_"}, true);
+
+		_finderPathWithoutPaginationFindByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid",
+			new String[] {String.class.getName()}, new String[] {"uuid_"}, 0, 1,
+			true, null);
+
+		_finderPathCountByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid",
+			new String[] {String.class.getName()}, new String[] {"uuid_"}, 0, 1,
+			false, null);
+
 		_collectionPersistenceFinderByUuid = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid",
-				new String[] {
-					String.class.getName(), Integer.class.getName(),
-					Integer.class.getName(), OrderByComparator.class.getName()
-				},
-				new String[] {"uuid_"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid",
-				new String[] {String.class.getName()}, new String[] {"uuid_"},
-				0, 1, true, null),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid",
-				new String[] {String.class.getName()}, new String[] {"uuid_"},
-				0, 1, false, null),
+			this, _finderPathWithPaginationFindByUuid,
+			_finderPathWithoutPaginationFindByUuid, _finderPathCountByUuid,
 			_SQL_SELECT_ADDRESS_WHERE, _SQL_COUNT_ADDRESS_WHERE,
 			AddressModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
 				"address.", "uuid", FinderColumn.Type.STRING, "=", true, true,
 				Address::getUuid));
 
+		_finderPathWithPaginationFindByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid_C",
+			new String[] {
+				String.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"uuid_", "companyId"}, true);
+
+		_finderPathWithoutPaginationFindByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"uuid_", "companyId"}, 0, 1, true, null);
+
+		_finderPathCountByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"uuid_", "companyId"}, 0, 1, false, null);
+
 		_collectionPersistenceFinderByUuid_C =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid_C",
-					new String[] {
-						String.class.getName(), Long.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"uuid_", "companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid_C",
-					new String[] {String.class.getName(), Long.class.getName()},
-					new String[] {"uuid_", "companyId"}, 0, 1, true, null),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid_C",
-					new String[] {String.class.getName(), Long.class.getName()},
-					new String[] {"uuid_", "companyId"}, 0, 1, false, null),
-				_SQL_SELECT_ADDRESS_WHERE, _SQL_COUNT_ADDRESS_WHERE,
-				AddressModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+				this, _finderPathWithPaginationFindByUuid_C,
+				_finderPathWithoutPaginationFindByUuid_C,
+				_finderPathCountByUuid_C, _SQL_SELECT_ADDRESS_WHERE,
+				_SQL_COUNT_ADDRESS_WHERE, AddressModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
 					"address.", "uuid", FinderColumn.Type.STRING, "=", true,
 					true, Address::getUuid),
@@ -2644,124 +2690,143 @@ public class AddressPersistenceImpl
 					"address.", "companyId", FinderColumn.Type.LONG, "=", true,
 					true, Address::getCompanyId));
 
+		_finderPathWithPaginationFindByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByCompanyId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"companyId"}, true);
+
+		_finderPathWithoutPaginationFindByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByCompanyId",
+			new String[] {Long.class.getName()}, new String[] {"companyId"},
+			true);
+
+		_finderPathCountByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByCompanyId",
+			new String[] {Long.class.getName()}, new String[] {"companyId"},
+			false);
+
 		_collectionPersistenceFinderByCompanyId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByCompanyId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"findByCompanyId", new String[] {Long.class.getName()},
-					new String[] {"companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByCompanyId", new String[] {Long.class.getName()},
-					new String[] {"companyId"}, false),
-				_SQL_SELECT_ADDRESS_WHERE, _SQL_COUNT_ADDRESS_WHERE,
-				AddressModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+				this, _finderPathWithPaginationFindByCompanyId,
+				_finderPathWithoutPaginationFindByCompanyId,
+				_finderPathCountByCompanyId, _SQL_SELECT_ADDRESS_WHERE,
+				_SQL_COUNT_ADDRESS_WHERE, AddressModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
 					"address.", "companyId", FinderColumn.Type.LONG, "=", true,
 					true, Address::getCompanyId));
 
+		_finderPathWithPaginationFindByUserId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUserId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"userId"}, true);
+
+		_finderPathWithoutPaginationFindByUserId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUserId",
+			new String[] {Long.class.getName()}, new String[] {"userId"}, true);
+
+		_finderPathCountByUserId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUserId",
+			new String[] {Long.class.getName()}, new String[] {"userId"},
+			false);
+
 		_collectionPersistenceFinderByUserId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUserId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"userId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUserId",
-					new String[] {Long.class.getName()},
-					new String[] {"userId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUserId",
-					new String[] {Long.class.getName()},
-					new String[] {"userId"}, false),
-				_SQL_SELECT_ADDRESS_WHERE, _SQL_COUNT_ADDRESS_WHERE,
-				AddressModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+				this, _finderPathWithPaginationFindByUserId,
+				_finderPathWithoutPaginationFindByUserId,
+				_finderPathCountByUserId, _SQL_SELECT_ADDRESS_WHERE,
+				_SQL_COUNT_ADDRESS_WHERE, AddressModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
 					"address.", "userId", FinderColumn.Type.LONG, "=", true,
 					true, Address::getUserId));
 
+		_finderPathWithPaginationFindByCountryId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByCountryId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"countryId"}, true);
+
+		_finderPathWithoutPaginationFindByCountryId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByCountryId",
+			new String[] {Long.class.getName()}, new String[] {"countryId"},
+			true);
+
+		_finderPathCountByCountryId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByCountryId",
+			new String[] {Long.class.getName()}, new String[] {"countryId"},
+			false);
+
 		_collectionPersistenceFinderByCountryId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByCountryId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"countryId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"findByCountryId", new String[] {Long.class.getName()},
-					new String[] {"countryId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByCountryId", new String[] {Long.class.getName()},
-					new String[] {"countryId"}, false),
-				_SQL_SELECT_ADDRESS_WHERE, _SQL_COUNT_ADDRESS_WHERE,
-				AddressModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+				this, _finderPathWithPaginationFindByCountryId,
+				_finderPathWithoutPaginationFindByCountryId,
+				_finderPathCountByCountryId, _SQL_SELECT_ADDRESS_WHERE,
+				_SQL_COUNT_ADDRESS_WHERE, AddressModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
 					"address.", "countryId", FinderColumn.Type.LONG, "=", true,
 					true, Address::getCountryId));
 
+		_finderPathWithPaginationFindByRegionId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByRegionId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"regionId"}, true);
+
+		_finderPathWithoutPaginationFindByRegionId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByRegionId",
+			new String[] {Long.class.getName()}, new String[] {"regionId"},
+			true);
+
+		_finderPathCountByRegionId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByRegionId",
+			new String[] {Long.class.getName()}, new String[] {"regionId"},
+			false);
+
 		_collectionPersistenceFinderByRegionId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByRegionId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"regionId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByRegionId",
-					new String[] {Long.class.getName()},
-					new String[] {"regionId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByRegionId", new String[] {Long.class.getName()},
-					new String[] {"regionId"}, false),
-				_SQL_SELECT_ADDRESS_WHERE, _SQL_COUNT_ADDRESS_WHERE,
-				AddressModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+				this, _finderPathWithPaginationFindByRegionId,
+				_finderPathWithoutPaginationFindByRegionId,
+				_finderPathCountByRegionId, _SQL_SELECT_ADDRESS_WHERE,
+				_SQL_COUNT_ADDRESS_WHERE, AddressModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
 					"address.", "regionId", FinderColumn.Type.LONG, "=", true,
 					true, Address::getRegionId));
 
+		_finderPathWithPaginationFindByC_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_C",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "classNameId"}, true);
+
+		_finderPathWithoutPaginationFindByC_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_C",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"companyId", "classNameId"}, true);
+
+		_finderPathCountByC_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_C",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"companyId", "classNameId"}, false);
+
 		_collectionPersistenceFinderByC_C = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_C",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Integer.class.getName(), Integer.class.getName(),
-					OrderByComparator.class.getName()
-				},
-				new String[] {"companyId", "classNameId"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_C",
-				new String[] {Long.class.getName(), Long.class.getName()},
-				new String[] {"companyId", "classNameId"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_C",
-				new String[] {Long.class.getName(), Long.class.getName()},
-				new String[] {"companyId", "classNameId"}, false),
+			this, _finderPathWithPaginationFindByC_C,
+			_finderPathWithoutPaginationFindByC_C, _finderPathCountByC_C,
 			_SQL_SELECT_ADDRESS_WHERE, _SQL_COUNT_ADDRESS_WHERE,
 			AddressModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
@@ -2771,27 +2836,32 @@ public class AddressPersistenceImpl
 				"address.", "classNameId", FinderColumn.Type.LONG, "=", true,
 				true, Address::getClassNameId));
 
+		_finderPathWithPaginationFindByCN_CPK = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByCN_CPK",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"classNameId", "classPK"}, true);
+
+		_finderPathWithoutPaginationFindByCN_CPK = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByCN_CPK",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"classNameId", "classPK"}, true);
+
+		_finderPathCountByCN_CPK = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByCN_CPK",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"classNameId", "classPK"}, false);
+
 		_collectionPersistenceFinderByCN_CPK =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByCN_CPK",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"classNameId", "classPK"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByCN_CPK",
-					new String[] {Long.class.getName(), Long.class.getName()},
-					new String[] {"classNameId", "classPK"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByCN_CPK",
-					new String[] {Long.class.getName(), Long.class.getName()},
-					new String[] {"classNameId", "classPK"}, false),
-				_SQL_SELECT_ADDRESS_WHERE, _SQL_COUNT_ADDRESS_WHERE,
-				AddressModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+				this, _finderPathWithPaginationFindByCN_CPK,
+				_finderPathWithoutPaginationFindByCN_CPK,
+				_finderPathCountByCN_CPK, _SQL_SELECT_ADDRESS_WHERE,
+				_SQL_COUNT_ADDRESS_WHERE, AddressModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
 					"address.", "classNameId", FinderColumn.Type.LONG, "=",
 					true, true, Address::getClassNameId),
@@ -2799,30 +2869,32 @@ public class AddressPersistenceImpl
 					"address.", "classPK", FinderColumn.Type.LONG, "=", true,
 					true, Address::getClassPK));
 
+		_finderPathWithPaginationFindByC_C_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_C_C",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "classNameId", "classPK"}, true);
+
+		_finderPathWithoutPaginationFindByC_C_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_C_C",
+			new String[] {
+				Long.class.getName(), Long.class.getName(), Long.class.getName()
+			},
+			new String[] {"companyId", "classNameId", "classPK"}, true);
+
+		_finderPathCountByC_C_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_C_C",
+			new String[] {
+				Long.class.getName(), Long.class.getName(), Long.class.getName()
+			},
+			new String[] {"companyId", "classNameId", "classPK"}, false);
+
 		_collectionPersistenceFinderByC_C_C = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_C_C",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Long.class.getName(), Integer.class.getName(),
-					Integer.class.getName(), OrderByComparator.class.getName()
-				},
-				new String[] {"companyId", "classNameId", "classPK"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_C_C",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Long.class.getName()
-				},
-				new String[] {"companyId", "classNameId", "classPK"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_C_C",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Long.class.getName()
-				},
-				new String[] {"companyId", "classNameId", "classPK"}, false),
+			this, _finderPathWithPaginationFindByC_C_C,
+			_finderPathWithoutPaginationFindByC_C_C, _finderPathCountByC_C_C,
 			_SQL_SELECT_ADDRESS_WHERE, _SQL_COUNT_ADDRESS_WHERE,
 			AddressModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
@@ -2835,43 +2907,42 @@ public class AddressPersistenceImpl
 				"address.", "classPK", FinderColumn.Type.LONG, "=", true, true,
 				Address::getClassPK));
 
+		_finderPathWithPaginationFindByC_C_C_L = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_C_C_L",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "classNameId", "classPK", "listTypeId"},
+			true);
+
+		_finderPathWithoutPaginationFindByC_C_C_L = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_C_C_L",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Long.class.getName()
+			},
+			new String[] {"companyId", "classNameId", "classPK", "listTypeId"},
+			true);
+
+		_finderPathCountByC_C_C_L = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByC_C_C_L",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Long.class.getName()
+			},
+			new String[] {"companyId", "classNameId", "classPK", "listTypeId"},
+			false);
+
 		_collectionPersistenceFinderByC_C_C_L =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_C_C_L",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						Long.class.getName(), Long.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {
-						"companyId", "classNameId", "classPK", "listTypeId"
-					},
-					true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_C_C_L",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						Long.class.getName(), Long.class.getName()
-					},
-					new String[] {
-						"companyId", "classNameId", "classPK", "listTypeId"
-					},
-					true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByC_C_C_L",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						Long.class.getName(), Long.class.getName()
-					},
-					new String[] {
-						"companyId", "classNameId", "classPK", "listTypeId"
-					},
-					false),
-				_SQL_SELECT_ADDRESS_WHERE, _SQL_COUNT_ADDRESS_WHERE,
-				AddressModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+				this, _finderPathWithPaginationFindByC_C_C_L,
+				_finderPathWithoutPaginationFindByC_C_C_L,
+				_finderPathCountByC_C_C_L, _SQL_SELECT_ADDRESS_WHERE,
+				_SQL_COUNT_ADDRESS_WHERE, AddressModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
 					"address.", "companyId", FinderColumn.Type.LONG, "=", true,
 					true, Address::getCompanyId),
@@ -2885,43 +2956,42 @@ public class AddressPersistenceImpl
 					"address.", "listTypeId", FinderColumn.Type.LONG, "=",
 					false, true, true, Address::getListTypeId));
 
+		_finderPathWithPaginationFindByC_C_C_M = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_C_C_M",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Boolean.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "classNameId", "classPK", "mailing"},
+			true);
+
+		_finderPathWithoutPaginationFindByC_C_C_M = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_C_C_M",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Boolean.class.getName()
+			},
+			new String[] {"companyId", "classNameId", "classPK", "mailing"},
+			true);
+
+		_finderPathCountByC_C_C_M = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_C_C_M",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Boolean.class.getName()
+			},
+			new String[] {"companyId", "classNameId", "classPK", "mailing"},
+			false);
+
 		_collectionPersistenceFinderByC_C_C_M =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_C_C_M",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						Long.class.getName(), Boolean.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {
-						"companyId", "classNameId", "classPK", "mailing"
-					},
-					true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_C_C_M",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						Long.class.getName(), Boolean.class.getName()
-					},
-					new String[] {
-						"companyId", "classNameId", "classPK", "mailing"
-					},
-					true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_C_C_M",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						Long.class.getName(), Boolean.class.getName()
-					},
-					new String[] {
-						"companyId", "classNameId", "classPK", "mailing"
-					},
-					false),
-				_SQL_SELECT_ADDRESS_WHERE, _SQL_COUNT_ADDRESS_WHERE,
-				AddressModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+				this, _finderPathWithPaginationFindByC_C_C_M,
+				_finderPathWithoutPaginationFindByC_C_C_M,
+				_finderPathCountByC_C_C_M, _SQL_SELECT_ADDRESS_WHERE,
+				_SQL_COUNT_ADDRESS_WHERE, AddressModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
 					"address.", "companyId", FinderColumn.Type.LONG, "=", true,
 					true, Address::getCompanyId),
@@ -2935,43 +3005,42 @@ public class AddressPersistenceImpl
 					"address.", "mailing", FinderColumn.Type.BOOLEAN, "=", true,
 					true, Address::isMailing));
 
+		_finderPathWithPaginationFindByC_C_C_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_C_C_P",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Boolean.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "classNameId", "classPK", "primary_"},
+			true);
+
+		_finderPathWithoutPaginationFindByC_C_C_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_C_C_P",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Boolean.class.getName()
+			},
+			new String[] {"companyId", "classNameId", "classPK", "primary_"},
+			true);
+
+		_finderPathCountByC_C_C_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_C_C_P",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Boolean.class.getName()
+			},
+			new String[] {"companyId", "classNameId", "classPK", "primary_"},
+			false);
+
 		_collectionPersistenceFinderByC_C_C_P =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_C_C_P",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						Long.class.getName(), Boolean.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {
-						"companyId", "classNameId", "classPK", "primary_"
-					},
-					true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_C_C_P",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						Long.class.getName(), Boolean.class.getName()
-					},
-					new String[] {
-						"companyId", "classNameId", "classPK", "primary_"
-					},
-					true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_C_C_P",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						Long.class.getName(), Boolean.class.getName()
-					},
-					new String[] {
-						"companyId", "classNameId", "classPK", "primary_"
-					},
-					false),
-				_SQL_SELECT_ADDRESS_WHERE, _SQL_COUNT_ADDRESS_WHERE,
-				AddressModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+				this, _finderPathWithPaginationFindByC_C_C_P,
+				_finderPathWithoutPaginationFindByC_C_C_P,
+				_finderPathCountByC_C_C_P, _SQL_SELECT_ADDRESS_WHERE,
+				_SQL_COUNT_ADDRESS_WHERE, AddressModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
 					"address.", "companyId", FinderColumn.Type.LONG, "=", true,
 					true, Address::getCompanyId),
@@ -2985,15 +3054,15 @@ public class AddressPersistenceImpl
 					"address.", "primary", FinderColumn.Type.BOOLEAN, "=", true,
 					true, Address::isPrimary));
 
+		_finderPathFetchByERC_C = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByERC_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "companyId"}, 0, 1, false,
+			convertNullFunction(Address::getExternalReferenceCode),
+			Address::getCompanyId);
+
 		_uniquePersistenceFinderByERC_C = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByERC_C",
-				new String[] {String.class.getName(), Long.class.getName()},
-				new String[] {"externalReferenceCode", "companyId"}, 0, 1,
-				false, convertNullFunction(Address::getExternalReferenceCode),
-				Address::getCompanyId),
-			_SQL_SELECT_ADDRESS_WHERE, "",
+			this, _finderPathFetchByERC_C, _SQL_SELECT_ADDRESS_WHERE, "",
 			new FinderColumn<>(
 				"address.", "externalReferenceCode", FinderColumn.Type.STRING,
 				"=", true, true, Address::getExternalReferenceCode),
@@ -3037,4 +3106,4 @@ public class AddressPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1720035516
+// LIFERAY-SERVICE-BUILDER-HASH:-30580340

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/BrowserTrackerPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/BrowserTrackerPersistenceImpl.java
@@ -9,6 +9,7 @@ import com.liferay.portal.kernel.dao.orm.EntityCache;
 import com.liferay.portal.kernel.dao.orm.EntityCacheUtil;
 import com.liferay.portal.kernel.dao.orm.FinderCache;
 import com.liferay.portal.kernel.dao.orm.FinderCacheUtil;
+import com.liferay.portal.kernel.dao.orm.FinderPath;
 import com.liferay.portal.kernel.dao.orm.Session;
 import com.liferay.portal.kernel.exception.NoSuchBrowserTrackerException;
 import com.liferay.portal.kernel.log.Log;
@@ -59,6 +60,7 @@ public class BrowserTrackerPersistenceImpl
 	public static final String FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION =
 		FINDER_CLASS_NAME_ENTITY + ".List2";
 
+	private FinderPath _finderPathFetchByUserId;
 	private UniquePersistenceFinder<BrowserTracker>
 		_uniquePersistenceFinderByUserId;
 
@@ -317,13 +319,14 @@ public class BrowserTrackerPersistenceImpl
 	 * Initializes the browser tracker persistence.
 	 */
 	public void afterPropertiesSet() {
+		_finderPathFetchByUserId = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByUserId",
+			new String[] {Long.class.getName()}, new String[] {"userId"}, 0, 0,
+			false, BrowserTracker::getUserId);
+
 		_uniquePersistenceFinderByUserId = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByUserId",
-				new String[] {Long.class.getName()}, new String[] {"userId"}, 0,
-				0, false, BrowserTracker::getUserId),
-			_SQL_SELECT_BROWSERTRACKER_WHERE, "",
+			this, _finderPathFetchByUserId, _SQL_SELECT_BROWSERTRACKER_WHERE,
+			"",
 			new FinderColumn<>(
 				"browserTracker.", "userId", FinderColumn.Type.LONG, "=", true,
 				true, BrowserTracker::getUserId));
@@ -355,4 +358,4 @@ public class BrowserTrackerPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1416309566
+// LIFERAY-SERVICE-BUILDER-HASH:-1854613741

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/ClassNamePersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/ClassNamePersistenceImpl.java
@@ -9,6 +9,7 @@ import com.liferay.portal.kernel.dao.orm.EntityCache;
 import com.liferay.portal.kernel.dao.orm.EntityCacheUtil;
 import com.liferay.portal.kernel.dao.orm.FinderCache;
 import com.liferay.portal.kernel.dao.orm.FinderCacheUtil;
+import com.liferay.portal.kernel.dao.orm.FinderPath;
 import com.liferay.portal.kernel.dao.orm.Session;
 import com.liferay.portal.kernel.exception.NoSuchClassNameException;
 import com.liferay.portal.kernel.log.Log;
@@ -58,6 +59,7 @@ public class ClassNamePersistenceImpl
 	public static final String FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION =
 		FINDER_CLASS_NAME_ENTITY + ".List2";
 
+	private FinderPath _finderPathFetchByValue;
 	private UniquePersistenceFinder<ClassName> _uniquePersistenceFinderByValue;
 
 	/**
@@ -306,13 +308,13 @@ public class ClassNamePersistenceImpl
 	 * Initializes the class name persistence.
 	 */
 	public void afterPropertiesSet() {
+		_finderPathFetchByValue = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByValue",
+			new String[] {String.class.getName()}, new String[] {"value"}, 0, 1,
+			false, convertNullFunction(ClassName::getValue));
+
 		_uniquePersistenceFinderByValue = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByValue",
-				new String[] {String.class.getName()}, new String[] {"value"},
-				0, 1, false, convertNullFunction(ClassName::getValue)),
-			_SQL_SELECT_CLASSNAME_WHERE, "",
+			this, _finderPathFetchByValue, _SQL_SELECT_CLASSNAME_WHERE, "",
 			new FinderColumn<>(
 				"className.", "value", FinderColumn.Type.STRING, "=", true,
 				true, ClassName::getValue));
@@ -344,4 +346,4 @@ public class ClassNamePersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1178206339
+// LIFERAY-SERVICE-BUILDER-HASH:-1421164223

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/CompanyInfoPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/CompanyInfoPersistenceImpl.java
@@ -9,6 +9,7 @@ import com.liferay.portal.kernel.dao.orm.EntityCache;
 import com.liferay.portal.kernel.dao.orm.EntityCacheUtil;
 import com.liferay.portal.kernel.dao.orm.FinderCache;
 import com.liferay.portal.kernel.dao.orm.FinderCacheUtil;
+import com.liferay.portal.kernel.dao.orm.FinderPath;
 import com.liferay.portal.kernel.dao.orm.Session;
 import com.liferay.portal.kernel.exception.NoSuchCompanyInfoException;
 import com.liferay.portal.kernel.log.Log;
@@ -62,6 +63,7 @@ public class CompanyInfoPersistenceImpl
 	public static final String FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION =
 		FINDER_CLASS_NAME_ENTITY + ".List2";
 
+	private FinderPath _finderPathFetchByCompanyId;
 	private UniquePersistenceFinder<CompanyInfo>
 		_uniquePersistenceFinderByCompanyId;
 
@@ -331,13 +333,14 @@ public class CompanyInfoPersistenceImpl
 	 * Initializes the company info persistence.
 	 */
 	public void afterPropertiesSet() {
+		_finderPathFetchByCompanyId = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByCompanyId",
+			new String[] {Long.class.getName()}, new String[] {"companyId"}, 0,
+			0, false, CompanyInfo::getCompanyId);
+
 		_uniquePersistenceFinderByCompanyId = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByCompanyId",
-				new String[] {Long.class.getName()}, new String[] {"companyId"},
-				0, 0, false, CompanyInfo::getCompanyId),
-			_SQL_SELECT_COMPANYINFO_WHERE, "",
+			this, _finderPathFetchByCompanyId, _SQL_SELECT_COMPANYINFO_WHERE,
+			"",
 			new FinderColumn<>(
 				"companyInfo.", "companyId", FinderColumn.Type.LONG, "=", true,
 				true, CompanyInfo::getCompanyId));
@@ -372,4 +375,4 @@ public class CompanyInfoPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-197627180
+// LIFERAY-SERVICE-BUILDER-HASH:191148593

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/CompanyPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/CompanyPersistenceImpl.java
@@ -69,6 +69,7 @@ public class CompanyPersistenceImpl
 	public static final String FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION =
 		FINDER_CLASS_NAME_ENTITY + ".List2";
 
+	private FinderPath _finderPathFetchByWebId;
 	private UniquePersistenceFinder<Company> _uniquePersistenceFinderByWebId;
 
 	/**
@@ -147,6 +148,9 @@ public class CompanyPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {webId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByLogoId;
+	private FinderPath _finderPathWithoutPaginationFindByLogoId;
+	private FinderPath _finderPathCountByLogoId;
 	private CollectionPersistenceFinder<Company>
 		_collectionPersistenceFinderByLogoId;
 
@@ -490,38 +494,41 @@ public class CompanyPersistenceImpl
 	 * Initializes the company persistence.
 	 */
 	public void afterPropertiesSet() {
+		_finderPathFetchByWebId = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByWebId",
+			new String[] {String.class.getName()}, new String[] {"webId"}, 0, 1,
+			false, convertNullFunction(Company::getWebId));
+
 		_uniquePersistenceFinderByWebId = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByWebId",
-				new String[] {String.class.getName()}, new String[] {"webId"},
-				0, 1, false, convertNullFunction(Company::getWebId)),
-			_SQL_SELECT_COMPANY_WHERE, "",
+			this, _finderPathFetchByWebId, _SQL_SELECT_COMPANY_WHERE, "",
 			new FinderColumn<>(
 				"company.", "webId", FinderColumn.Type.STRING, "=", true, true,
 				Company::getWebId));
 
+		_finderPathWithPaginationFindByLogoId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByLogoId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"logoId"}, true);
+
+		_finderPathWithoutPaginationFindByLogoId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByLogoId",
+			new String[] {Long.class.getName()}, new String[] {"logoId"}, true);
+
+		_finderPathCountByLogoId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByLogoId",
+			new String[] {Long.class.getName()}, new String[] {"logoId"},
+			false);
+
 		_collectionPersistenceFinderByLogoId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByLogoId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"logoId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByLogoId",
-					new String[] {Long.class.getName()},
-					new String[] {"logoId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByLogoId",
-					new String[] {Long.class.getName()},
-					new String[] {"logoId"}, false),
-				_SQL_SELECT_COMPANY_WHERE, _SQL_COUNT_COMPANY_WHERE,
-				CompanyModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+				this, _finderPathWithPaginationFindByLogoId,
+				_finderPathWithoutPaginationFindByLogoId,
+				_finderPathCountByLogoId, _SQL_SELECT_COMPANY_WHERE,
+				_SQL_COUNT_COMPANY_WHERE, CompanyModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
 					"company.", "logoId", FinderColumn.Type.LONG, "=", true,
 					true, Company::getLogoId));
@@ -562,4 +569,4 @@ public class CompanyPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:726697081
+// LIFERAY-SERVICE-BUILDER-HASH:1667084195

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/ContactPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/ContactPersistenceImpl.java
@@ -64,6 +64,9 @@ public class ContactPersistenceImpl
 	public static final String FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION =
 		FINDER_CLASS_NAME_ENTITY + ".List2";
 
+	private FinderPath _finderPathWithPaginationFindByCompanyId;
+	private FinderPath _finderPathWithoutPaginationFindByCompanyId;
+	private FinderPath _finderPathCountByCompanyId;
 	private CollectionPersistenceFinder<Contact>
 		_collectionPersistenceFinderByCompanyId;
 
@@ -204,6 +207,9 @@ public class ContactPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {companyId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByUserId;
+	private FinderPath _finderPathWithoutPaginationFindByUserId;
+	private FinderPath _finderPathCountByUserId;
 	private CollectionPersistenceFinder<Contact>
 		_collectionPersistenceFinderByUserId;
 
@@ -343,6 +349,9 @@ public class ContactPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {userId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_U;
+	private FinderPath _finderPathWithoutPaginationFindByC_U;
+	private FinderPath _finderPathCountByC_U;
 	private CollectionPersistenceFinder<Contact>
 		_collectionPersistenceFinderByC_U;
 
@@ -497,6 +506,9 @@ public class ContactPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {companyId, userId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_C;
+	private FinderPath _finderPathWithoutPaginationFindByC_C;
+	private FinderPath _finderPathCountByC_C;
 	private CollectionPersistenceFinder<Contact>
 		_collectionPersistenceFinderByC_C;
 
@@ -847,74 +859,85 @@ public class ContactPersistenceImpl
 	 * Initializes the contact persistence.
 	 */
 	public void afterPropertiesSet() {
+		_finderPathWithPaginationFindByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByCompanyId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"companyId"}, true);
+
+		_finderPathWithoutPaginationFindByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByCompanyId",
+			new String[] {Long.class.getName()}, new String[] {"companyId"},
+			true);
+
+		_finderPathCountByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByCompanyId",
+			new String[] {Long.class.getName()}, new String[] {"companyId"},
+			false);
+
 		_collectionPersistenceFinderByCompanyId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByCompanyId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"findByCompanyId", new String[] {Long.class.getName()},
-					new String[] {"companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByCompanyId", new String[] {Long.class.getName()},
-					new String[] {"companyId"}, false),
-				_SQL_SELECT_CONTACT_WHERE, _SQL_COUNT_CONTACT_WHERE,
-				ContactModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+				this, _finderPathWithPaginationFindByCompanyId,
+				_finderPathWithoutPaginationFindByCompanyId,
+				_finderPathCountByCompanyId, _SQL_SELECT_CONTACT_WHERE,
+				_SQL_COUNT_CONTACT_WHERE, ContactModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
 					"contact.", "companyId", FinderColumn.Type.LONG, "=", true,
 					true, Contact::getCompanyId));
 
+		_finderPathWithPaginationFindByUserId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUserId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"userId"}, true);
+
+		_finderPathWithoutPaginationFindByUserId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUserId",
+			new String[] {Long.class.getName()}, new String[] {"userId"}, true);
+
+		_finderPathCountByUserId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUserId",
+			new String[] {Long.class.getName()}, new String[] {"userId"},
+			false);
+
 		_collectionPersistenceFinderByUserId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUserId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"userId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUserId",
-					new String[] {Long.class.getName()},
-					new String[] {"userId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUserId",
-					new String[] {Long.class.getName()},
-					new String[] {"userId"}, false),
-				_SQL_SELECT_CONTACT_WHERE, _SQL_COUNT_CONTACT_WHERE,
-				ContactModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+				this, _finderPathWithPaginationFindByUserId,
+				_finderPathWithoutPaginationFindByUserId,
+				_finderPathCountByUserId, _SQL_SELECT_CONTACT_WHERE,
+				_SQL_COUNT_CONTACT_WHERE, ContactModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
 					"contact.", "userId", FinderColumn.Type.LONG, "=", true,
 					true, Contact::getUserId));
 
+		_finderPathWithPaginationFindByC_U = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_U",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "userId"}, true);
+
+		_finderPathWithoutPaginationFindByC_U = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_U",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"companyId", "userId"}, true);
+
+		_finderPathCountByC_U = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_U",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"companyId", "userId"}, false);
+
 		_collectionPersistenceFinderByC_U = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_U",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Integer.class.getName(), Integer.class.getName(),
-					OrderByComparator.class.getName()
-				},
-				new String[] {"companyId", "userId"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_U",
-				new String[] {Long.class.getName(), Long.class.getName()},
-				new String[] {"companyId", "userId"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_U",
-				new String[] {Long.class.getName(), Long.class.getName()},
-				new String[] {"companyId", "userId"}, false),
+			this, _finderPathWithPaginationFindByC_U,
+			_finderPathWithoutPaginationFindByC_U, _finderPathCountByC_U,
 			_SQL_SELECT_CONTACT_WHERE, _SQL_COUNT_CONTACT_WHERE,
 			ContactModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
@@ -924,24 +947,28 @@ public class ContactPersistenceImpl
 				"contact.", "userId", FinderColumn.Type.LONG, "=", true, true,
 				Contact::getUserId));
 
+		_finderPathWithPaginationFindByC_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_C",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"classNameId", "classPK"}, true);
+
+		_finderPathWithoutPaginationFindByC_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_C",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"classNameId", "classPK"}, true);
+
+		_finderPathCountByC_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_C",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"classNameId", "classPK"}, false);
+
 		_collectionPersistenceFinderByC_C = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_C",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Integer.class.getName(), Integer.class.getName(),
-					OrderByComparator.class.getName()
-				},
-				new String[] {"classNameId", "classPK"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_C",
-				new String[] {Long.class.getName(), Long.class.getName()},
-				new String[] {"classNameId", "classPK"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_C",
-				new String[] {Long.class.getName(), Long.class.getName()},
-				new String[] {"classNameId", "classPK"}, false),
+			this, _finderPathWithPaginationFindByC_C,
+			_finderPathWithoutPaginationFindByC_C, _finderPathCountByC_C,
 			_SQL_SELECT_CONTACT_WHERE, _SQL_COUNT_CONTACT_WHERE,
 			ContactModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
@@ -981,4 +1008,4 @@ public class ContactPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2064278846
+// LIFERAY-SERVICE-BUILDER-HASH:-45501526

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/CountryLocalizationPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/CountryLocalizationPersistenceImpl.java
@@ -73,6 +73,9 @@ public class CountryLocalizationPersistenceImpl
 	public static final String FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION =
 		FINDER_CLASS_NAME_ENTITY + ".List2";
 
+	private FinderPath _finderPathWithPaginationFindByCountryId;
+	private FinderPath _finderPathWithoutPaginationFindByCountryId;
+	private FinderPath _finderPathCountByCountryId;
 	private CollectionPersistenceFinder<CountryLocalization>
 		_collectionPersistenceFinderByCountryId;
 
@@ -219,6 +222,7 @@ public class CountryLocalizationPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {countryId});
 	}
 
+	private FinderPath _finderPathFetchByCountryId_LanguageId;
 	private UniquePersistenceFinder<CountryLocalization>
 		_uniquePersistenceFinderByCountryId_LanguageId;
 
@@ -566,25 +570,29 @@ public class CountryLocalizationPersistenceImpl
 	 * Initializes the country localization persistence.
 	 */
 	public void afterPropertiesSet() {
+		_finderPathWithPaginationFindByCountryId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByCountryId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"countryId"}, true);
+
+		_finderPathWithoutPaginationFindByCountryId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByCountryId",
+			new String[] {Long.class.getName()}, new String[] {"countryId"},
+			true);
+
+		_finderPathCountByCountryId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByCountryId",
+			new String[] {Long.class.getName()}, new String[] {"countryId"},
+			false);
+
 		_collectionPersistenceFinderByCountryId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByCountryId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"countryId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"findByCountryId", new String[] {Long.class.getName()},
-					new String[] {"countryId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByCountryId", new String[] {Long.class.getName()},
-					new String[] {"countryId"}, false),
+				this, _finderPathWithPaginationFindByCountryId,
+				_finderPathWithoutPaginationFindByCountryId,
+				_finderPathCountByCountryId,
 				_SQL_SELECT_COUNTRYLOCALIZATION_WHERE,
 				_SQL_COUNT_COUNTRYLOCALIZATION_WHERE,
 				CountryLocalizationModelImpl.ORDER_BY_JPQL,
@@ -593,15 +601,16 @@ public class CountryLocalizationPersistenceImpl
 					"countryLocalization.", "countryId", FinderColumn.Type.LONG,
 					"=", true, true, CountryLocalization::getCountryId));
 
+		_finderPathFetchByCountryId_LanguageId = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByCountryId_LanguageId",
+			new String[] {Long.class.getName(), String.class.getName()},
+			new String[] {"countryId", "languageId"}, 0, 2, false,
+			CountryLocalization::getCountryId,
+			convertNullFunction(CountryLocalization::getLanguageId));
+
 		_uniquePersistenceFinderByCountryId_LanguageId =
 			new UniquePersistenceFinder<>(
-				this,
-				createUniqueFinderPath(
-					FINDER_CLASS_NAME_ENTITY, "fetchByCountryId_LanguageId",
-					new String[] {Long.class.getName(), String.class.getName()},
-					new String[] {"countryId", "languageId"}, 0, 2, false,
-					CountryLocalization::getCountryId,
-					convertNullFunction(CountryLocalization::getLanguageId)),
+				this, _finderPathFetchByCountryId_LanguageId,
 				_SQL_SELECT_COUNTRYLOCALIZATION_WHERE, "",
 				new FinderColumn<>(
 					"countryLocalization.", "countryId", FinderColumn.Type.LONG,
@@ -644,4 +653,4 @@ public class CountryLocalizationPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:16331969
+// LIFERAY-SERVICE-BUILDER-HASH:-565484216

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/CountryPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/CountryPersistenceImpl.java
@@ -90,6 +90,9 @@ public class CountryPersistenceImpl
 	public static final String FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION =
 		FINDER_CLASS_NAME_ENTITY + ".List2";
 
+	private FinderPath _finderPathWithPaginationFindByUuid;
+	private FinderPath _finderPathWithoutPaginationFindByUuid;
+	private FinderPath _finderPathCountByUuid;
 	private FilterCollectionPersistenceFinder<Country>
 		_collectionPersistenceFinderByUuid;
 
@@ -293,6 +296,9 @@ public class CountryPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {uuid});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByUuid_C;
+	private FinderPath _finderPathWithoutPaginationFindByUuid_C;
+	private FinderPath _finderPathCountByUuid_C;
 	private FilterCollectionPersistenceFinder<Country>
 		_collectionPersistenceFinderByUuid_C;
 
@@ -518,6 +524,9 @@ public class CountryPersistenceImpl
 			companyId, 0);
 	}
 
+	private FinderPath _finderPathWithPaginationFindByCompanyId;
+	private FinderPath _finderPathWithoutPaginationFindByCompanyId;
+	private FinderPath _finderPathCountByCompanyId;
 	private FilterCollectionPersistenceFinder<Country>
 		_collectionPersistenceFinderByCompanyId;
 
@@ -725,6 +734,9 @@ public class CountryPersistenceImpl
 			companyId, 0);
 	}
 
+	private FinderPath _finderPathWithPaginationFindByActive;
+	private FinderPath _finderPathWithoutPaginationFindByActive;
+	private FinderPath _finderPathCountByActive;
 	private FilterCollectionPersistenceFinder<Country>
 		_collectionPersistenceFinderByActive;
 
@@ -930,6 +942,7 @@ public class CountryPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {active});
 	}
 
+	private FinderPath _finderPathFetchByC_A2;
 	private UniquePersistenceFinder<Country> _uniquePersistenceFinderByC_A2;
 
 	/**
@@ -1019,6 +1032,7 @@ public class CountryPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {companyId, a2});
 	}
 
+	private FinderPath _finderPathFetchByC_A3;
 	private UniquePersistenceFinder<Country> _uniquePersistenceFinderByC_A3;
 
 	/**
@@ -1108,6 +1122,9 @@ public class CountryPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {companyId, a3});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_Active;
+	private FinderPath _finderPathWithoutPaginationFindByC_Active;
+	private FinderPath _finderPathCountByC_Active;
 	private FilterCollectionPersistenceFinder<Country>
 		_collectionPersistenceFinderByC_Active;
 
@@ -1333,6 +1350,7 @@ public class CountryPersistenceImpl
 			companyId, 0);
 	}
 
+	private FinderPath _finderPathFetchByC_Name;
 	private UniquePersistenceFinder<Country> _uniquePersistenceFinderByC_Name;
 
 	/**
@@ -1422,6 +1440,7 @@ public class CountryPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {companyId, name});
 	}
 
+	private FinderPath _finderPathFetchByC_Number;
 	private UniquePersistenceFinder<Country> _uniquePersistenceFinderByC_Number;
 
 	/**
@@ -1511,6 +1530,9 @@ public class CountryPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {companyId, number});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_A_B;
+	private FinderPath _finderPathWithoutPaginationFindByC_A_B;
+	private FinderPath _finderPathCountByC_A_B;
 	private FilterCollectionPersistenceFinder<Country>
 		_collectionPersistenceFinderByC_A_B;
 
@@ -1771,6 +1793,9 @@ public class CountryPersistenceImpl
 			new Object[] {companyId, active, billingAllowed}, companyId, 0);
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_A_S;
+	private FinderPath _finderPathWithoutPaginationFindByC_A_S;
+	private FinderPath _finderPathCountByC_A_S;
 	private FilterCollectionPersistenceFinder<Country>
 		_collectionPersistenceFinderByC_A_S;
 
@@ -2032,6 +2057,9 @@ public class CountryPersistenceImpl
 			new Object[] {companyId, active, shippingAllowed}, companyId, 0);
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_A_B_G;
+	private FinderPath _finderPathWithoutPaginationFindByC_A_B_G;
+	private FinderPath _finderPathCountByC_A_B_G;
 	private FilterCollectionPersistenceFinder<Country>
 		_collectionPersistenceFinderByC_A_B_G;
 
@@ -2331,6 +2359,9 @@ public class CountryPersistenceImpl
 			});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_A_G_S;
+	private FinderPath _finderPathWithoutPaginationFindByC_A_G_S;
+	private FinderPath _finderPathCountByC_A_G_S;
 	private FilterCollectionPersistenceFinder<Country>
 		_collectionPersistenceFinderByC_A_G_S;
 
@@ -2629,6 +2660,9 @@ public class CountryPersistenceImpl
 			});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_A_B_G_S;
+	private FinderPath _finderPathWithoutPaginationFindByC_A_B_G_S;
+	private FinderPath _finderPathCountByC_A_B_G_S;
 	private FilterCollectionPersistenceFinder<Country>
 		_collectionPersistenceFinderByC_A_B_G_S;
 
@@ -2949,6 +2983,7 @@ public class CountryPersistenceImpl
 			});
 	}
 
+	private FinderPath _finderPathFetchByERC_C;
 	private UniquePersistenceFinder<Country> _uniquePersistenceFinderByERC_C;
 
 	/**
@@ -3416,68 +3451,76 @@ public class CountryPersistenceImpl
 	 * Initializes the country persistence.
 	 */
 	public void afterPropertiesSet() {
+		_finderPathWithPaginationFindByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid",
+			new String[] {
+				String.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"uuid_"}, true);
+
+		_finderPathWithoutPaginationFindByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid",
+			new String[] {String.class.getName()}, new String[] {"uuid_"}, 0, 1,
+			true, null);
+
+		_finderPathCountByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid",
+			new String[] {String.class.getName()}, new String[] {"uuid_"}, 0, 1,
+			false, null);
+
 		_collectionPersistenceFinderByUuid =
 			new FilterCollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid",
-					new String[] {
-						String.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"uuid_"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid",
-					new String[] {String.class.getName()},
-					new String[] {"uuid_"}, 0, 1, true, null),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid",
-					new String[] {String.class.getName()},
-					new String[] {"uuid_"}, 0, 1, false, null),
+				this, _finderPathWithPaginationFindByUuid,
+				_finderPathWithoutPaginationFindByUuid, _finderPathCountByUuid,
 				_SQL_SELECT_COUNTRY_WHERE, _SQL_COUNT_COUNTRY_WHERE,
 				CountryModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 				new FilterCollectionPersistenceFinder.FilterMetadata<>(
-					CountryImpl.class, Country.class, "country", "Country",
-					"country.countryId",
-					"SELECT DISTINCT {country.*} FROM Country country WHERE ",
-					"SELECT {Country.*} FROM (SELECT DISTINCT country.countryId FROM Country country WHERE ",
-					") TEMP_TABLE INNER JOIN Country ON TEMP_TABLE.countryId = Country.countryId",
-					"SELECT COUNT(DISTINCT country.countryId) AS COUNT_VALUE FROM Country country WHERE ",
+					CountryImpl.class, Country.class, _FILTER_ENTITY_ALIAS,
+					_FILTER_ENTITY_TABLE, _FILTER_ENTITY_TABLE_FILTER_PK_COLUMN,
+					_FILTER_SQL_SELECT_COUNTRY_WHERE,
+					_FILTER_SQL_SELECT_COUNTRY_NO_INLINE_DISTINCT_WHERE_1,
+					_FILTER_SQL_SELECT_COUNTRY_NO_INLINE_DISTINCT_WHERE_2,
+					_FILTER_SQL_COUNT_COUNTRY_WHERE,
 					CountryModelImpl.ORDER_BY_SQL,
 					CountryModelImpl.ORDER_BY_SQL_INLINE_DISTINCT),
 				new FinderColumn<>(
 					"country.", "uuid", FinderColumn.Type.STRING, "=", true,
 					true, Country::getUuid));
 
+		_finderPathWithPaginationFindByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid_C",
+			new String[] {
+				String.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"uuid_", "companyId"}, true);
+
+		_finderPathWithoutPaginationFindByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"uuid_", "companyId"}, 0, 1, true, null);
+
+		_finderPathCountByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"uuid_", "companyId"}, 0, 1, false, null);
+
 		_collectionPersistenceFinderByUuid_C =
 			new FilterCollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid_C",
-					new String[] {
-						String.class.getName(), Long.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"uuid_", "companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid_C",
-					new String[] {String.class.getName(), Long.class.getName()},
-					new String[] {"uuid_", "companyId"}, 0, 1, true, null),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid_C",
-					new String[] {String.class.getName(), Long.class.getName()},
-					new String[] {"uuid_", "companyId"}, 0, 1, false, null),
-				_SQL_SELECT_COUNTRY_WHERE, _SQL_COUNT_COUNTRY_WHERE,
-				CountryModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+				this, _finderPathWithPaginationFindByUuid_C,
+				_finderPathWithoutPaginationFindByUuid_C,
+				_finderPathCountByUuid_C, _SQL_SELECT_COUNTRY_WHERE,
+				_SQL_COUNT_COUNTRY_WHERE, CountryModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "",
 				new FilterCollectionPersistenceFinder.FilterMetadata<>(
-					CountryImpl.class, Country.class, "country", "Country",
-					"country.countryId",
-					"SELECT DISTINCT {country.*} FROM Country country WHERE ",
-					"SELECT {Country.*} FROM (SELECT DISTINCT country.countryId FROM Country country WHERE ",
-					") TEMP_TABLE INNER JOIN Country ON TEMP_TABLE.countryId = Country.countryId",
-					"SELECT COUNT(DISTINCT country.countryId) AS COUNT_VALUE FROM Country country WHERE ",
+					CountryImpl.class, Country.class, _FILTER_ENTITY_ALIAS,
+					_FILTER_ENTITY_TABLE, _FILTER_ENTITY_TABLE_FILTER_PK_COLUMN,
+					_FILTER_SQL_SELECT_COUNTRY_WHERE,
+					_FILTER_SQL_SELECT_COUNTRY_NO_INLINE_DISTINCT_WHERE_1,
+					_FILTER_SQL_SELECT_COUNTRY_NO_INLINE_DISTINCT_WHERE_2,
+					_FILTER_SQL_COUNT_COUNTRY_WHERE,
 					CountryModelImpl.ORDER_BY_SQL,
 					CountryModelImpl.ORDER_BY_SQL_INLINE_DISTINCT),
 				new FinderColumn<>(
@@ -3487,82 +3530,90 @@ public class CountryPersistenceImpl
 					"country.", "companyId", FinderColumn.Type.LONG, "=", true,
 					true, Country::getCompanyId));
 
+		_finderPathWithPaginationFindByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByCompanyId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"companyId"}, true);
+
+		_finderPathWithoutPaginationFindByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByCompanyId",
+			new String[] {Long.class.getName()}, new String[] {"companyId"},
+			true);
+
+		_finderPathCountByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByCompanyId",
+			new String[] {Long.class.getName()}, new String[] {"companyId"},
+			false);
+
 		_collectionPersistenceFinderByCompanyId =
 			new FilterCollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByCompanyId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"findByCompanyId", new String[] {Long.class.getName()},
-					new String[] {"companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByCompanyId", new String[] {Long.class.getName()},
-					new String[] {"companyId"}, false),
-				_SQL_SELECT_COUNTRY_WHERE, _SQL_COUNT_COUNTRY_WHERE,
-				CountryModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+				this, _finderPathWithPaginationFindByCompanyId,
+				_finderPathWithoutPaginationFindByCompanyId,
+				_finderPathCountByCompanyId, _SQL_SELECT_COUNTRY_WHERE,
+				_SQL_COUNT_COUNTRY_WHERE, CountryModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "",
 				new FilterCollectionPersistenceFinder.FilterMetadata<>(
-					CountryImpl.class, Country.class, "country", "Country",
-					"country.countryId",
-					"SELECT DISTINCT {country.*} FROM Country country WHERE ",
-					"SELECT {Country.*} FROM (SELECT DISTINCT country.countryId FROM Country country WHERE ",
-					") TEMP_TABLE INNER JOIN Country ON TEMP_TABLE.countryId = Country.countryId",
-					"SELECT COUNT(DISTINCT country.countryId) AS COUNT_VALUE FROM Country country WHERE ",
+					CountryImpl.class, Country.class, _FILTER_ENTITY_ALIAS,
+					_FILTER_ENTITY_TABLE, _FILTER_ENTITY_TABLE_FILTER_PK_COLUMN,
+					_FILTER_SQL_SELECT_COUNTRY_WHERE,
+					_FILTER_SQL_SELECT_COUNTRY_NO_INLINE_DISTINCT_WHERE_1,
+					_FILTER_SQL_SELECT_COUNTRY_NO_INLINE_DISTINCT_WHERE_2,
+					_FILTER_SQL_COUNT_COUNTRY_WHERE,
 					CountryModelImpl.ORDER_BY_SQL,
 					CountryModelImpl.ORDER_BY_SQL_INLINE_DISTINCT),
 				new FinderColumn<>(
 					"country.", "companyId", FinderColumn.Type.LONG, "=", true,
 					true, Country::getCompanyId));
 
+		_finderPathWithPaginationFindByActive = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByActive",
+			new String[] {
+				Boolean.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"active_"}, true);
+
+		_finderPathWithoutPaginationFindByActive = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByActive",
+			new String[] {Boolean.class.getName()}, new String[] {"active_"},
+			true);
+
+		_finderPathCountByActive = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByActive",
+			new String[] {Boolean.class.getName()}, new String[] {"active_"},
+			false);
+
 		_collectionPersistenceFinderByActive =
 			new FilterCollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByActive",
-					new String[] {
-						Boolean.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"active_"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByActive",
-					new String[] {Boolean.class.getName()},
-					new String[] {"active_"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByActive",
-					new String[] {Boolean.class.getName()},
-					new String[] {"active_"}, false),
-				_SQL_SELECT_COUNTRY_WHERE, _SQL_COUNT_COUNTRY_WHERE,
-				CountryModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+				this, _finderPathWithPaginationFindByActive,
+				_finderPathWithoutPaginationFindByActive,
+				_finderPathCountByActive, _SQL_SELECT_COUNTRY_WHERE,
+				_SQL_COUNT_COUNTRY_WHERE, CountryModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "",
 				new FilterCollectionPersistenceFinder.FilterMetadata<>(
-					CountryImpl.class, Country.class, "country", "Country",
-					"country.countryId",
-					"SELECT DISTINCT {country.*} FROM Country country WHERE ",
-					"SELECT {Country.*} FROM (SELECT DISTINCT country.countryId FROM Country country WHERE ",
-					") TEMP_TABLE INNER JOIN Country ON TEMP_TABLE.countryId = Country.countryId",
-					"SELECT COUNT(DISTINCT country.countryId) AS COUNT_VALUE FROM Country country WHERE ",
+					CountryImpl.class, Country.class, _FILTER_ENTITY_ALIAS,
+					_FILTER_ENTITY_TABLE, _FILTER_ENTITY_TABLE_FILTER_PK_COLUMN,
+					_FILTER_SQL_SELECT_COUNTRY_WHERE,
+					_FILTER_SQL_SELECT_COUNTRY_NO_INLINE_DISTINCT_WHERE_1,
+					_FILTER_SQL_SELECT_COUNTRY_NO_INLINE_DISTINCT_WHERE_2,
+					_FILTER_SQL_COUNT_COUNTRY_WHERE,
 					CountryModelImpl.ORDER_BY_SQL,
 					CountryModelImpl.ORDER_BY_SQL_INLINE_DISTINCT),
 				new FinderColumn<>(
 					"country.", "active", FinderColumn.Type.BOOLEAN, "=", true,
 					true, Country::isActive));
 
+		_finderPathFetchByC_A2 = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByC_A2",
+			new String[] {Long.class.getName(), String.class.getName()},
+			new String[] {"companyId", "a2"}, 0, 2, false,
+			Country::getCompanyId, convertNullFunction(Country::getA2));
+
 		_uniquePersistenceFinderByC_A2 = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByC_A2",
-				new String[] {Long.class.getName(), String.class.getName()},
-				new String[] {"companyId", "a2"}, 0, 2, false,
-				Country::getCompanyId, convertNullFunction(Country::getA2)),
-			_SQL_SELECT_COUNTRY_WHERE, "",
+			this, _finderPathFetchByC_A2, _SQL_SELECT_COUNTRY_WHERE, "",
 			new FinderColumn<>(
 				"country.", "companyId", FinderColumn.Type.LONG, "=", true,
 				true, Country::getCompanyId),
@@ -3570,14 +3621,14 @@ public class CountryPersistenceImpl
 				"country.", "a2", FinderColumn.Type.STRING, "=", true, true,
 				Country::getA2));
 
+		_finderPathFetchByC_A3 = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByC_A3",
+			new String[] {Long.class.getName(), String.class.getName()},
+			new String[] {"companyId", "a3"}, 0, 2, false,
+			Country::getCompanyId, convertNullFunction(Country::getA3));
+
 		_uniquePersistenceFinderByC_A3 = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByC_A3",
-				new String[] {Long.class.getName(), String.class.getName()},
-				new String[] {"companyId", "a3"}, 0, 2, false,
-				Country::getCompanyId, convertNullFunction(Country::getA3)),
-			_SQL_SELECT_COUNTRY_WHERE, "",
+			this, _finderPathFetchByC_A3, _SQL_SELECT_COUNTRY_WHERE, "",
 			new FinderColumn<>(
 				"country.", "companyId", FinderColumn.Type.LONG, "=", true,
 				true, Country::getCompanyId),
@@ -3585,39 +3636,39 @@ public class CountryPersistenceImpl
 				"country.", "a3", FinderColumn.Type.STRING, "=", true, true,
 				Country::getA3));
 
+		_finderPathWithPaginationFindByC_Active = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_Active",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "active_"}, true);
+
+		_finderPathWithoutPaginationFindByC_Active = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_Active",
+			new String[] {Long.class.getName(), Boolean.class.getName()},
+			new String[] {"companyId", "active_"}, true);
+
+		_finderPathCountByC_Active = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_Active",
+			new String[] {Long.class.getName(), Boolean.class.getName()},
+			new String[] {"companyId", "active_"}, false);
+
 		_collectionPersistenceFinderByC_Active =
 			new FilterCollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_Active",
-					new String[] {
-						Long.class.getName(), Boolean.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"companyId", "active_"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_Active",
-					new String[] {
-						Long.class.getName(), Boolean.class.getName()
-					},
-					new String[] {"companyId", "active_"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByC_Active",
-					new String[] {
-						Long.class.getName(), Boolean.class.getName()
-					},
-					new String[] {"companyId", "active_"}, false),
-				_SQL_SELECT_COUNTRY_WHERE, _SQL_COUNT_COUNTRY_WHERE,
-				CountryModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+				this, _finderPathWithPaginationFindByC_Active,
+				_finderPathWithoutPaginationFindByC_Active,
+				_finderPathCountByC_Active, _SQL_SELECT_COUNTRY_WHERE,
+				_SQL_COUNT_COUNTRY_WHERE, CountryModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "",
 				new FilterCollectionPersistenceFinder.FilterMetadata<>(
-					CountryImpl.class, Country.class, "country", "Country",
-					"country.countryId",
-					"SELECT DISTINCT {country.*} FROM Country country WHERE ",
-					"SELECT {Country.*} FROM (SELECT DISTINCT country.countryId FROM Country country WHERE ",
-					") TEMP_TABLE INNER JOIN Country ON TEMP_TABLE.countryId = Country.countryId",
-					"SELECT COUNT(DISTINCT country.countryId) AS COUNT_VALUE FROM Country country WHERE ",
+					CountryImpl.class, Country.class, _FILTER_ENTITY_ALIAS,
+					_FILTER_ENTITY_TABLE, _FILTER_ENTITY_TABLE_FILTER_PK_COLUMN,
+					_FILTER_SQL_SELECT_COUNTRY_WHERE,
+					_FILTER_SQL_SELECT_COUNTRY_NO_INLINE_DISTINCT_WHERE_1,
+					_FILTER_SQL_SELECT_COUNTRY_NO_INLINE_DISTINCT_WHERE_2,
+					_FILTER_SQL_COUNT_COUNTRY_WHERE,
 					CountryModelImpl.ORDER_BY_SQL,
 					CountryModelImpl.ORDER_BY_SQL_INLINE_DISTINCT),
 				new FinderColumn<>(
@@ -3627,14 +3678,14 @@ public class CountryPersistenceImpl
 					"country.", "active", FinderColumn.Type.BOOLEAN, "=", true,
 					true, Country::isActive));
 
+		_finderPathFetchByC_Name = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByC_Name",
+			new String[] {Long.class.getName(), String.class.getName()},
+			new String[] {"companyId", "name"}, 0, 2, false,
+			Country::getCompanyId, convertNullFunction(Country::getName));
+
 		_uniquePersistenceFinderByC_Name = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByC_Name",
-				new String[] {Long.class.getName(), String.class.getName()},
-				new String[] {"companyId", "name"}, 0, 2, false,
-				Country::getCompanyId, convertNullFunction(Country::getName)),
-			_SQL_SELECT_COUNTRY_WHERE, "",
+			this, _finderPathFetchByC_Name, _SQL_SELECT_COUNTRY_WHERE, "",
 			new FinderColumn<>(
 				"country.", "companyId", FinderColumn.Type.LONG, "=", true,
 				true, Country::getCompanyId),
@@ -3642,14 +3693,14 @@ public class CountryPersistenceImpl
 				"country.", "name", FinderColumn.Type.STRING, "=", true, true,
 				Country::getName));
 
+		_finderPathFetchByC_Number = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByC_Number",
+			new String[] {Long.class.getName(), String.class.getName()},
+			new String[] {"companyId", "number_"}, 0, 2, false,
+			Country::getCompanyId, convertNullFunction(Country::getNumber));
+
 		_uniquePersistenceFinderByC_Number = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByC_Number",
-				new String[] {Long.class.getName(), String.class.getName()},
-				new String[] {"companyId", "number_"}, 0, 2, false,
-				Country::getCompanyId, convertNullFunction(Country::getNumber)),
-			_SQL_SELECT_COUNTRY_WHERE, "",
+			this, _finderPathFetchByC_Number, _SQL_SELECT_COUNTRY_WHERE, "",
 			new FinderColumn<>(
 				"country.", "companyId", FinderColumn.Type.LONG, "=", true,
 				true, Country::getCompanyId),
@@ -3657,44 +3708,45 @@ public class CountryPersistenceImpl
 				"country.", "number", FinderColumn.Type.STRING, "=", true, true,
 				Country::getNumber));
 
+		_finderPathWithPaginationFindByC_A_B = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_A_B",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "active_", "billingAllowed"}, true);
+
+		_finderPathWithoutPaginationFindByC_A_B = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_A_B",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName()
+			},
+			new String[] {"companyId", "active_", "billingAllowed"}, true);
+
+		_finderPathCountByC_A_B = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_A_B",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName()
+			},
+			new String[] {"companyId", "active_", "billingAllowed"}, false);
+
 		_collectionPersistenceFinderByC_A_B =
 			new FilterCollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_A_B",
-					new String[] {
-						Long.class.getName(), Boolean.class.getName(),
-						Boolean.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"companyId", "active_", "billingAllowed"},
-					true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_A_B",
-					new String[] {
-						Long.class.getName(), Boolean.class.getName(),
-						Boolean.class.getName()
-					},
-					new String[] {"companyId", "active_", "billingAllowed"},
-					true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_A_B",
-					new String[] {
-						Long.class.getName(), Boolean.class.getName(),
-						Boolean.class.getName()
-					},
-					new String[] {"companyId", "active_", "billingAllowed"},
-					false),
-				_SQL_SELECT_COUNTRY_WHERE, _SQL_COUNT_COUNTRY_WHERE,
-				CountryModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+				this, _finderPathWithPaginationFindByC_A_B,
+				_finderPathWithoutPaginationFindByC_A_B,
+				_finderPathCountByC_A_B, _SQL_SELECT_COUNTRY_WHERE,
+				_SQL_COUNT_COUNTRY_WHERE, CountryModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "",
 				new FilterCollectionPersistenceFinder.FilterMetadata<>(
-					CountryImpl.class, Country.class, "country", "Country",
-					"country.countryId",
-					"SELECT DISTINCT {country.*} FROM Country country WHERE ",
-					"SELECT {Country.*} FROM (SELECT DISTINCT country.countryId FROM Country country WHERE ",
-					") TEMP_TABLE INNER JOIN Country ON TEMP_TABLE.countryId = Country.countryId",
-					"SELECT COUNT(DISTINCT country.countryId) AS COUNT_VALUE FROM Country country WHERE ",
+					CountryImpl.class, Country.class, _FILTER_ENTITY_ALIAS,
+					_FILTER_ENTITY_TABLE, _FILTER_ENTITY_TABLE_FILTER_PK_COLUMN,
+					_FILTER_SQL_SELECT_COUNTRY_WHERE,
+					_FILTER_SQL_SELECT_COUNTRY_NO_INLINE_DISTINCT_WHERE_1,
+					_FILTER_SQL_SELECT_COUNTRY_NO_INLINE_DISTINCT_WHERE_2,
+					_FILTER_SQL_COUNT_COUNTRY_WHERE,
 					CountryModelImpl.ORDER_BY_SQL,
 					CountryModelImpl.ORDER_BY_SQL_INLINE_DISTINCT),
 				new FinderColumn<>(
@@ -3707,44 +3759,45 @@ public class CountryPersistenceImpl
 					"country.", "billingAllowed", FinderColumn.Type.BOOLEAN,
 					"=", true, true, Country::isBillingAllowed));
 
+		_finderPathWithPaginationFindByC_A_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_A_S",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "active_", "shippingAllowed"}, true);
+
+		_finderPathWithoutPaginationFindByC_A_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_A_S",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName()
+			},
+			new String[] {"companyId", "active_", "shippingAllowed"}, true);
+
+		_finderPathCountByC_A_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_A_S",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName()
+			},
+			new String[] {"companyId", "active_", "shippingAllowed"}, false);
+
 		_collectionPersistenceFinderByC_A_S =
 			new FilterCollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_A_S",
-					new String[] {
-						Long.class.getName(), Boolean.class.getName(),
-						Boolean.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"companyId", "active_", "shippingAllowed"},
-					true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_A_S",
-					new String[] {
-						Long.class.getName(), Boolean.class.getName(),
-						Boolean.class.getName()
-					},
-					new String[] {"companyId", "active_", "shippingAllowed"},
-					true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_A_S",
-					new String[] {
-						Long.class.getName(), Boolean.class.getName(),
-						Boolean.class.getName()
-					},
-					new String[] {"companyId", "active_", "shippingAllowed"},
-					false),
-				_SQL_SELECT_COUNTRY_WHERE, _SQL_COUNT_COUNTRY_WHERE,
-				CountryModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+				this, _finderPathWithPaginationFindByC_A_S,
+				_finderPathWithoutPaginationFindByC_A_S,
+				_finderPathCountByC_A_S, _SQL_SELECT_COUNTRY_WHERE,
+				_SQL_COUNT_COUNTRY_WHERE, CountryModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "",
 				new FilterCollectionPersistenceFinder.FilterMetadata<>(
-					CountryImpl.class, Country.class, "country", "Country",
-					"country.countryId",
-					"SELECT DISTINCT {country.*} FROM Country country WHERE ",
-					"SELECT {Country.*} FROM (SELECT DISTINCT country.countryId FROM Country country WHERE ",
-					") TEMP_TABLE INNER JOIN Country ON TEMP_TABLE.countryId = Country.countryId",
-					"SELECT COUNT(DISTINCT country.countryId) AS COUNT_VALUE FROM Country country WHERE ",
+					CountryImpl.class, Country.class, _FILTER_ENTITY_ALIAS,
+					_FILTER_ENTITY_TABLE, _FILTER_ENTITY_TABLE_FILTER_PK_COLUMN,
+					_FILTER_SQL_SELECT_COUNTRY_WHERE,
+					_FILTER_SQL_SELECT_COUNTRY_NO_INLINE_DISTINCT_WHERE_1,
+					_FILTER_SQL_SELECT_COUNTRY_NO_INLINE_DISTINCT_WHERE_2,
+					_FILTER_SQL_COUNT_COUNTRY_WHERE,
 					CountryModelImpl.ORDER_BY_SQL,
 					CountryModelImpl.ORDER_BY_SQL_INLINE_DISTINCT),
 				new FinderColumn<>(
@@ -3757,53 +3810,55 @@ public class CountryPersistenceImpl
 					"country.", "shippingAllowed", FinderColumn.Type.BOOLEAN,
 					"=", true, true, Country::isShippingAllowed));
 
+		_finderPathWithPaginationFindByC_A_B_G = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_A_B_G",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName(), Boolean.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {
+				"countryId", "active_", "billingAllowed", "groupFilterEnabled"
+			},
+			true);
+
+		_finderPathWithoutPaginationFindByC_A_B_G = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_A_B_G",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName(), Boolean.class.getName()
+			},
+			new String[] {
+				"countryId", "active_", "billingAllowed", "groupFilterEnabled"
+			},
+			true);
+
+		_finderPathCountByC_A_B_G = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_A_B_G",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName(), Boolean.class.getName()
+			},
+			new String[] {
+				"countryId", "active_", "billingAllowed", "groupFilterEnabled"
+			},
+			false);
+
 		_collectionPersistenceFinderByC_A_B_G =
 			new FilterCollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_A_B_G",
-					new String[] {
-						Long.class.getName(), Boolean.class.getName(),
-						Boolean.class.getName(), Boolean.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {
-						"countryId", "active_", "billingAllowed",
-						"groupFilterEnabled"
-					},
-					true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_A_B_G",
-					new String[] {
-						Long.class.getName(), Boolean.class.getName(),
-						Boolean.class.getName(), Boolean.class.getName()
-					},
-					new String[] {
-						"countryId", "active_", "billingAllowed",
-						"groupFilterEnabled"
-					},
-					true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_A_B_G",
-					new String[] {
-						Long.class.getName(), Boolean.class.getName(),
-						Boolean.class.getName(), Boolean.class.getName()
-					},
-					new String[] {
-						"countryId", "active_", "billingAllowed",
-						"groupFilterEnabled"
-					},
-					false),
-				_SQL_SELECT_COUNTRY_WHERE, _SQL_COUNT_COUNTRY_WHERE,
-				CountryModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+				this, _finderPathWithPaginationFindByC_A_B_G,
+				_finderPathWithoutPaginationFindByC_A_B_G,
+				_finderPathCountByC_A_B_G, _SQL_SELECT_COUNTRY_WHERE,
+				_SQL_COUNT_COUNTRY_WHERE, CountryModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "",
 				new FilterCollectionPersistenceFinder.FilterMetadata<>(
-					CountryImpl.class, Country.class, "country", "Country",
-					"country.countryId",
-					"SELECT DISTINCT {country.*} FROM Country country WHERE ",
-					"SELECT {Country.*} FROM (SELECT DISTINCT country.countryId FROM Country country WHERE ",
-					") TEMP_TABLE INNER JOIN Country ON TEMP_TABLE.countryId = Country.countryId",
-					"SELECT COUNT(DISTINCT country.countryId) AS COUNT_VALUE FROM Country country WHERE ",
+					CountryImpl.class, Country.class, _FILTER_ENTITY_ALIAS,
+					_FILTER_ENTITY_TABLE, _FILTER_ENTITY_TABLE_FILTER_PK_COLUMN,
+					_FILTER_SQL_SELECT_COUNTRY_WHERE,
+					_FILTER_SQL_SELECT_COUNTRY_NO_INLINE_DISTINCT_WHERE_1,
+					_FILTER_SQL_SELECT_COUNTRY_NO_INLINE_DISTINCT_WHERE_2,
+					_FILTER_SQL_COUNT_COUNTRY_WHERE,
 					CountryModelImpl.ORDER_BY_SQL,
 					CountryModelImpl.ORDER_BY_SQL_INLINE_DISTINCT),
 				new FinderColumn<>(
@@ -3819,53 +3874,55 @@ public class CountryPersistenceImpl
 					"country.", "groupFilterEnabled", FinderColumn.Type.BOOLEAN,
 					"=", true, true, Country::isGroupFilterEnabled));
 
+		_finderPathWithPaginationFindByC_A_G_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_A_G_S",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName(), Boolean.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {
+				"countryId", "active_", "groupFilterEnabled", "shippingAllowed"
+			},
+			true);
+
+		_finderPathWithoutPaginationFindByC_A_G_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_A_G_S",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName(), Boolean.class.getName()
+			},
+			new String[] {
+				"countryId", "active_", "groupFilterEnabled", "shippingAllowed"
+			},
+			true);
+
+		_finderPathCountByC_A_G_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_A_G_S",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName(), Boolean.class.getName()
+			},
+			new String[] {
+				"countryId", "active_", "groupFilterEnabled", "shippingAllowed"
+			},
+			false);
+
 		_collectionPersistenceFinderByC_A_G_S =
 			new FilterCollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_A_G_S",
-					new String[] {
-						Long.class.getName(), Boolean.class.getName(),
-						Boolean.class.getName(), Boolean.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {
-						"countryId", "active_", "groupFilterEnabled",
-						"shippingAllowed"
-					},
-					true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_A_G_S",
-					new String[] {
-						Long.class.getName(), Boolean.class.getName(),
-						Boolean.class.getName(), Boolean.class.getName()
-					},
-					new String[] {
-						"countryId", "active_", "groupFilterEnabled",
-						"shippingAllowed"
-					},
-					true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_A_G_S",
-					new String[] {
-						Long.class.getName(), Boolean.class.getName(),
-						Boolean.class.getName(), Boolean.class.getName()
-					},
-					new String[] {
-						"countryId", "active_", "groupFilterEnabled",
-						"shippingAllowed"
-					},
-					false),
-				_SQL_SELECT_COUNTRY_WHERE, _SQL_COUNT_COUNTRY_WHERE,
-				CountryModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+				this, _finderPathWithPaginationFindByC_A_G_S,
+				_finderPathWithoutPaginationFindByC_A_G_S,
+				_finderPathCountByC_A_G_S, _SQL_SELECT_COUNTRY_WHERE,
+				_SQL_COUNT_COUNTRY_WHERE, CountryModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "",
 				new FilterCollectionPersistenceFinder.FilterMetadata<>(
-					CountryImpl.class, Country.class, "country", "Country",
-					"country.countryId",
-					"SELECT DISTINCT {country.*} FROM Country country WHERE ",
-					"SELECT {Country.*} FROM (SELECT DISTINCT country.countryId FROM Country country WHERE ",
-					") TEMP_TABLE INNER JOIN Country ON TEMP_TABLE.countryId = Country.countryId",
-					"SELECT COUNT(DISTINCT country.countryId) AS COUNT_VALUE FROM Country country WHERE ",
+					CountryImpl.class, Country.class, _FILTER_ENTITY_ALIAS,
+					_FILTER_ENTITY_TABLE, _FILTER_ENTITY_TABLE_FILTER_PK_COLUMN,
+					_FILTER_SQL_SELECT_COUNTRY_WHERE,
+					_FILTER_SQL_SELECT_COUNTRY_NO_INLINE_DISTINCT_WHERE_1,
+					_FILTER_SQL_SELECT_COUNTRY_NO_INLINE_DISTINCT_WHERE_2,
+					_FILTER_SQL_COUNT_COUNTRY_WHERE,
 					CountryModelImpl.ORDER_BY_SQL,
 					CountryModelImpl.ORDER_BY_SQL_INLINE_DISTINCT),
 				new FinderColumn<>(
@@ -3881,58 +3938,60 @@ public class CountryPersistenceImpl
 					"country.", "shippingAllowed", FinderColumn.Type.BOOLEAN,
 					"=", true, true, Country::isShippingAllowed));
 
+		_finderPathWithPaginationFindByC_A_B_G_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_A_B_G_S",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {
+				"countryId", "active_", "billingAllowed", "groupFilterEnabled",
+				"shippingAllowed"
+			},
+			true);
+
+		_finderPathWithoutPaginationFindByC_A_B_G_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_A_B_G_S",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName()
+			},
+			new String[] {
+				"countryId", "active_", "billingAllowed", "groupFilterEnabled",
+				"shippingAllowed"
+			},
+			true);
+
+		_finderPathCountByC_A_B_G_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_A_B_G_S",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName()
+			},
+			new String[] {
+				"countryId", "active_", "billingAllowed", "groupFilterEnabled",
+				"shippingAllowed"
+			},
+			false);
+
 		_collectionPersistenceFinderByC_A_B_G_S =
 			new FilterCollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_A_B_G_S",
-					new String[] {
-						Long.class.getName(), Boolean.class.getName(),
-						Boolean.class.getName(), Boolean.class.getName(),
-						Boolean.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {
-						"countryId", "active_", "billingAllowed",
-						"groupFilterEnabled", "shippingAllowed"
-					},
-					true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"findByC_A_B_G_S",
-					new String[] {
-						Long.class.getName(), Boolean.class.getName(),
-						Boolean.class.getName(), Boolean.class.getName(),
-						Boolean.class.getName()
-					},
-					new String[] {
-						"countryId", "active_", "billingAllowed",
-						"groupFilterEnabled", "shippingAllowed"
-					},
-					true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByC_A_B_G_S",
-					new String[] {
-						Long.class.getName(), Boolean.class.getName(),
-						Boolean.class.getName(), Boolean.class.getName(),
-						Boolean.class.getName()
-					},
-					new String[] {
-						"countryId", "active_", "billingAllowed",
-						"groupFilterEnabled", "shippingAllowed"
-					},
-					false),
-				_SQL_SELECT_COUNTRY_WHERE, _SQL_COUNT_COUNTRY_WHERE,
-				CountryModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+				this, _finderPathWithPaginationFindByC_A_B_G_S,
+				_finderPathWithoutPaginationFindByC_A_B_G_S,
+				_finderPathCountByC_A_B_G_S, _SQL_SELECT_COUNTRY_WHERE,
+				_SQL_COUNT_COUNTRY_WHERE, CountryModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "",
 				new FilterCollectionPersistenceFinder.FilterMetadata<>(
-					CountryImpl.class, Country.class, "country", "Country",
-					"country.countryId",
-					"SELECT DISTINCT {country.*} FROM Country country WHERE ",
-					"SELECT {Country.*} FROM (SELECT DISTINCT country.countryId FROM Country country WHERE ",
-					") TEMP_TABLE INNER JOIN Country ON TEMP_TABLE.countryId = Country.countryId",
-					"SELECT COUNT(DISTINCT country.countryId) AS COUNT_VALUE FROM Country country WHERE ",
+					CountryImpl.class, Country.class, _FILTER_ENTITY_ALIAS,
+					_FILTER_ENTITY_TABLE, _FILTER_ENTITY_TABLE_FILTER_PK_COLUMN,
+					_FILTER_SQL_SELECT_COUNTRY_WHERE,
+					_FILTER_SQL_SELECT_COUNTRY_NO_INLINE_DISTINCT_WHERE_1,
+					_FILTER_SQL_SELECT_COUNTRY_NO_INLINE_DISTINCT_WHERE_2,
+					_FILTER_SQL_COUNT_COUNTRY_WHERE,
 					CountryModelImpl.ORDER_BY_SQL,
 					CountryModelImpl.ORDER_BY_SQL_INLINE_DISTINCT),
 				new FinderColumn<>(
@@ -3951,15 +4010,15 @@ public class CountryPersistenceImpl
 					"country.", "shippingAllowed", FinderColumn.Type.BOOLEAN,
 					"=", true, true, Country::isShippingAllowed));
 
+		_finderPathFetchByERC_C = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByERC_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "companyId"}, 0, 1, false,
+			convertNullFunction(Country::getExternalReferenceCode),
+			Country::getCompanyId);
+
 		_uniquePersistenceFinderByERC_C = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByERC_C",
-				new String[] {String.class.getName(), Long.class.getName()},
-				new String[] {"externalReferenceCode", "companyId"}, 0, 1,
-				false, convertNullFunction(Country::getExternalReferenceCode),
-				Country::getCompanyId),
-			_SQL_SELECT_COUNTRY_WHERE, "",
+			this, _finderPathFetchByERC_C, _SQL_SELECT_COUNTRY_WHERE, "",
 			new FinderColumn<>(
 				"country.", "externalReferenceCode", FinderColumn.Type.STRING,
 				"=", true, true, Country::getExternalReferenceCode),
@@ -3991,6 +4050,27 @@ public class CountryPersistenceImpl
 	private static final String _SQL_COUNT_COUNTRY_WHERE =
 		"SELECT COUNT(country) FROM Country country WHERE ";
 
+	private static final String _FILTER_ENTITY_TABLE_FILTER_PK_COLUMN =
+		"country.countryId";
+
+	private static final String _FILTER_SQL_SELECT_COUNTRY_WHERE =
+		"SELECT DISTINCT {country.*} FROM Country country WHERE ";
+
+	private static final String
+		_FILTER_SQL_SELECT_COUNTRY_NO_INLINE_DISTINCT_WHERE_1 =
+			"SELECT {Country.*} FROM (SELECT DISTINCT country.countryId FROM Country country WHERE ";
+
+	private static final String
+		_FILTER_SQL_SELECT_COUNTRY_NO_INLINE_DISTINCT_WHERE_2 =
+			") TEMP_TABLE INNER JOIN Country ON TEMP_TABLE.countryId = Country.countryId";
+
+	private static final String _FILTER_SQL_COUNT_COUNTRY_WHERE =
+		"SELECT COUNT(DISTINCT country.countryId) AS COUNT_VALUE FROM Country country WHERE ";
+
+	private static final String _FILTER_ENTITY_ALIAS = "country";
+
+	private static final String _FILTER_ENTITY_TABLE = "Country";
+
 	private static final String _NO_SUCH_ENTITY_WITH_KEY =
 		"No Country exists with the key {";
 
@@ -4006,4 +4086,4 @@ public class CountryPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:106308678
+// LIFERAY-SERVICE-BUILDER-HASH:-719524126

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/EmailAddressPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/EmailAddressPersistenceImpl.java
@@ -88,6 +88,9 @@ public class EmailAddressPersistenceImpl
 	public static final String FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION =
 		FINDER_CLASS_NAME_ENTITY + ".List2";
 
+	private FinderPath _finderPathWithPaginationFindByUuid;
+	private FinderPath _finderPathWithoutPaginationFindByUuid;
+	private FinderPath _finderPathCountByUuid;
 	private CollectionPersistenceFinder<EmailAddress>
 		_collectionPersistenceFinderByUuid;
 
@@ -228,6 +231,9 @@ public class EmailAddressPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {uuid});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByUuid_C;
+	private FinderPath _finderPathWithoutPaginationFindByUuid_C;
+	private FinderPath _finderPathCountByUuid_C;
 	private CollectionPersistenceFinder<EmailAddress>
 		_collectionPersistenceFinderByUuid_C;
 
@@ -383,6 +389,9 @@ public class EmailAddressPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {uuid, companyId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByCompanyId;
+	private FinderPath _finderPathWithoutPaginationFindByCompanyId;
+	private FinderPath _finderPathCountByCompanyId;
 	private CollectionPersistenceFinder<EmailAddress>
 		_collectionPersistenceFinderByCompanyId;
 
@@ -527,6 +536,9 @@ public class EmailAddressPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {companyId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByUserId;
+	private FinderPath _finderPathWithoutPaginationFindByUserId;
+	private FinderPath _finderPathCountByUserId;
 	private CollectionPersistenceFinder<EmailAddress>
 		_collectionPersistenceFinderByUserId;
 
@@ -668,6 +680,9 @@ public class EmailAddressPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {userId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_C;
+	private FinderPath _finderPathWithoutPaginationFindByC_C;
+	private FinderPath _finderPathCountByC_C;
 	private CollectionPersistenceFinder<EmailAddress>
 		_collectionPersistenceFinderByC_C;
 
@@ -827,6 +842,9 @@ public class EmailAddressPersistenceImpl
 			new Object[] {companyId, classNameId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_C_C;
+	private FinderPath _finderPathWithoutPaginationFindByC_C_C;
+	private FinderPath _finderPathCountByC_C_C;
 	private CollectionPersistenceFinder<EmailAddress>
 		_collectionPersistenceFinderByC_C_C;
 
@@ -998,6 +1016,9 @@ public class EmailAddressPersistenceImpl
 			new Object[] {companyId, classNameId, classPK});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_C_C_P;
+	private FinderPath _finderPathWithoutPaginationFindByC_C_C_P;
+	private FinderPath _finderPathCountByC_C_C_P;
 	private CollectionPersistenceFinder<EmailAddress>
 		_collectionPersistenceFinderByC_C_C_P;
 
@@ -1184,6 +1205,7 @@ public class EmailAddressPersistenceImpl
 			new Object[] {companyId, classNameId, classPK, primary});
 	}
 
+	private FinderPath _finderPathFetchByERC_C;
 	private UniquePersistenceFinder<EmailAddress>
 		_uniquePersistenceFinderByERC_C;
 
@@ -1643,49 +1665,58 @@ public class EmailAddressPersistenceImpl
 	 * Initializes the email address persistence.
 	 */
 	public void afterPropertiesSet() {
+		_finderPathWithPaginationFindByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid",
+			new String[] {
+				String.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"uuid_"}, true);
+
+		_finderPathWithoutPaginationFindByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid",
+			new String[] {String.class.getName()}, new String[] {"uuid_"}, 0, 1,
+			true, null);
+
+		_finderPathCountByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid",
+			new String[] {String.class.getName()}, new String[] {"uuid_"}, 0, 1,
+			false, null);
+
 		_collectionPersistenceFinderByUuid = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid",
-				new String[] {
-					String.class.getName(), Integer.class.getName(),
-					Integer.class.getName(), OrderByComparator.class.getName()
-				},
-				new String[] {"uuid_"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid",
-				new String[] {String.class.getName()}, new String[] {"uuid_"},
-				0, 1, true, null),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid",
-				new String[] {String.class.getName()}, new String[] {"uuid_"},
-				0, 1, false, null),
+			this, _finderPathWithPaginationFindByUuid,
+			_finderPathWithoutPaginationFindByUuid, _finderPathCountByUuid,
 			_SQL_SELECT_EMAILADDRESS_WHERE, _SQL_COUNT_EMAILADDRESS_WHERE,
 			EmailAddressModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
 				"emailAddress.", "uuid", FinderColumn.Type.STRING, "=", true,
 				true, EmailAddress::getUuid));
 
+		_finderPathWithPaginationFindByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid_C",
+			new String[] {
+				String.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"uuid_", "companyId"}, true);
+
+		_finderPathWithoutPaginationFindByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"uuid_", "companyId"}, 0, 1, true, null);
+
+		_finderPathCountByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"uuid_", "companyId"}, 0, 1, false, null);
+
 		_collectionPersistenceFinderByUuid_C =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid_C",
-					new String[] {
-						String.class.getName(), Long.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"uuid_", "companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid_C",
-					new String[] {String.class.getName(), Long.class.getName()},
-					new String[] {"uuid_", "companyId"}, 0, 1, true, null),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid_C",
-					new String[] {String.class.getName(), Long.class.getName()},
-					new String[] {"uuid_", "companyId"}, 0, 1, false, null),
-				_SQL_SELECT_EMAILADDRESS_WHERE, _SQL_COUNT_EMAILADDRESS_WHERE,
+				this, _finderPathWithPaginationFindByUuid_C,
+				_finderPathWithoutPaginationFindByUuid_C,
+				_finderPathCountByUuid_C, _SQL_SELECT_EMAILADDRESS_WHERE,
+				_SQL_COUNT_EMAILADDRESS_WHERE,
 				EmailAddressModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
 					"emailAddress.", "uuid", FinderColumn.Type.STRING, "=",
@@ -1694,74 +1725,85 @@ public class EmailAddressPersistenceImpl
 					"emailAddress.", "companyId", FinderColumn.Type.LONG, "=",
 					true, true, EmailAddress::getCompanyId));
 
+		_finderPathWithPaginationFindByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByCompanyId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"companyId"}, true);
+
+		_finderPathWithoutPaginationFindByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByCompanyId",
+			new String[] {Long.class.getName()}, new String[] {"companyId"},
+			true);
+
+		_finderPathCountByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByCompanyId",
+			new String[] {Long.class.getName()}, new String[] {"companyId"},
+			false);
+
 		_collectionPersistenceFinderByCompanyId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByCompanyId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"findByCompanyId", new String[] {Long.class.getName()},
-					new String[] {"companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByCompanyId", new String[] {Long.class.getName()},
-					new String[] {"companyId"}, false),
-				_SQL_SELECT_EMAILADDRESS_WHERE, _SQL_COUNT_EMAILADDRESS_WHERE,
+				this, _finderPathWithPaginationFindByCompanyId,
+				_finderPathWithoutPaginationFindByCompanyId,
+				_finderPathCountByCompanyId, _SQL_SELECT_EMAILADDRESS_WHERE,
+				_SQL_COUNT_EMAILADDRESS_WHERE,
 				EmailAddressModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
 					"emailAddress.", "companyId", FinderColumn.Type.LONG, "=",
 					true, true, EmailAddress::getCompanyId));
 
+		_finderPathWithPaginationFindByUserId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUserId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"userId"}, true);
+
+		_finderPathWithoutPaginationFindByUserId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUserId",
+			new String[] {Long.class.getName()}, new String[] {"userId"}, true);
+
+		_finderPathCountByUserId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUserId",
+			new String[] {Long.class.getName()}, new String[] {"userId"},
+			false);
+
 		_collectionPersistenceFinderByUserId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUserId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"userId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUserId",
-					new String[] {Long.class.getName()},
-					new String[] {"userId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUserId",
-					new String[] {Long.class.getName()},
-					new String[] {"userId"}, false),
-				_SQL_SELECT_EMAILADDRESS_WHERE, _SQL_COUNT_EMAILADDRESS_WHERE,
+				this, _finderPathWithPaginationFindByUserId,
+				_finderPathWithoutPaginationFindByUserId,
+				_finderPathCountByUserId, _SQL_SELECT_EMAILADDRESS_WHERE,
+				_SQL_COUNT_EMAILADDRESS_WHERE,
 				EmailAddressModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
 					"emailAddress.", "userId", FinderColumn.Type.LONG, "=",
 					true, true, EmailAddress::getUserId));
 
+		_finderPathWithPaginationFindByC_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_C",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "classNameId"}, true);
+
+		_finderPathWithoutPaginationFindByC_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_C",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"companyId", "classNameId"}, true);
+
+		_finderPathCountByC_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_C",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"companyId", "classNameId"}, false);
+
 		_collectionPersistenceFinderByC_C = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_C",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Integer.class.getName(), Integer.class.getName(),
-					OrderByComparator.class.getName()
-				},
-				new String[] {"companyId", "classNameId"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_C",
-				new String[] {Long.class.getName(), Long.class.getName()},
-				new String[] {"companyId", "classNameId"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_C",
-				new String[] {Long.class.getName(), Long.class.getName()},
-				new String[] {"companyId", "classNameId"}, false),
+			this, _finderPathWithPaginationFindByC_C,
+			_finderPathWithoutPaginationFindByC_C, _finderPathCountByC_C,
 			_SQL_SELECT_EMAILADDRESS_WHERE, _SQL_COUNT_EMAILADDRESS_WHERE,
 			EmailAddressModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
@@ -1771,30 +1813,32 @@ public class EmailAddressPersistenceImpl
 				"emailAddress.", "classNameId", FinderColumn.Type.LONG, "=",
 				true, true, EmailAddress::getClassNameId));
 
+		_finderPathWithPaginationFindByC_C_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_C_C",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "classNameId", "classPK"}, true);
+
+		_finderPathWithoutPaginationFindByC_C_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_C_C",
+			new String[] {
+				Long.class.getName(), Long.class.getName(), Long.class.getName()
+			},
+			new String[] {"companyId", "classNameId", "classPK"}, true);
+
+		_finderPathCountByC_C_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_C_C",
+			new String[] {
+				Long.class.getName(), Long.class.getName(), Long.class.getName()
+			},
+			new String[] {"companyId", "classNameId", "classPK"}, false);
+
 		_collectionPersistenceFinderByC_C_C = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_C_C",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Long.class.getName(), Integer.class.getName(),
-					Integer.class.getName(), OrderByComparator.class.getName()
-				},
-				new String[] {"companyId", "classNameId", "classPK"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_C_C",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Long.class.getName()
-				},
-				new String[] {"companyId", "classNameId", "classPK"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_C_C",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Long.class.getName()
-				},
-				new String[] {"companyId", "classNameId", "classPK"}, false),
+			this, _finderPathWithPaginationFindByC_C_C,
+			_finderPathWithoutPaginationFindByC_C_C, _finderPathCountByC_C_C,
 			_SQL_SELECT_EMAILADDRESS_WHERE, _SQL_COUNT_EMAILADDRESS_WHERE,
 			EmailAddressModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
@@ -1807,42 +1851,41 @@ public class EmailAddressPersistenceImpl
 				"emailAddress.", "classPK", FinderColumn.Type.LONG, "=", true,
 				true, EmailAddress::getClassPK));
 
+		_finderPathWithPaginationFindByC_C_C_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_C_C_P",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Boolean.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "classNameId", "classPK", "primary_"},
+			true);
+
+		_finderPathWithoutPaginationFindByC_C_C_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_C_C_P",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Boolean.class.getName()
+			},
+			new String[] {"companyId", "classNameId", "classPK", "primary_"},
+			true);
+
+		_finderPathCountByC_C_C_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_C_C_P",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Boolean.class.getName()
+			},
+			new String[] {"companyId", "classNameId", "classPK", "primary_"},
+			false);
+
 		_collectionPersistenceFinderByC_C_C_P =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_C_C_P",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						Long.class.getName(), Boolean.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {
-						"companyId", "classNameId", "classPK", "primary_"
-					},
-					true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_C_C_P",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						Long.class.getName(), Boolean.class.getName()
-					},
-					new String[] {
-						"companyId", "classNameId", "classPK", "primary_"
-					},
-					true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_C_C_P",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						Long.class.getName(), Boolean.class.getName()
-					},
-					new String[] {
-						"companyId", "classNameId", "classPK", "primary_"
-					},
-					false),
-				_SQL_SELECT_EMAILADDRESS_WHERE, _SQL_COUNT_EMAILADDRESS_WHERE,
+				this, _finderPathWithPaginationFindByC_C_C_P,
+				_finderPathWithoutPaginationFindByC_C_C_P,
+				_finderPathCountByC_C_C_P, _SQL_SELECT_EMAILADDRESS_WHERE,
+				_SQL_COUNT_EMAILADDRESS_WHERE,
 				EmailAddressModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
 					"emailAddress.", "companyId", FinderColumn.Type.LONG, "=",
@@ -1857,16 +1900,15 @@ public class EmailAddressPersistenceImpl
 					"emailAddress.", "primary", FinderColumn.Type.BOOLEAN, "=",
 					true, true, EmailAddress::isPrimary));
 
+		_finderPathFetchByERC_C = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByERC_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "companyId"}, 0, 1, false,
+			convertNullFunction(EmailAddress::getExternalReferenceCode),
+			EmailAddress::getCompanyId);
+
 		_uniquePersistenceFinderByERC_C = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByERC_C",
-				new String[] {String.class.getName(), Long.class.getName()},
-				new String[] {"externalReferenceCode", "companyId"}, 0, 1,
-				false,
-				convertNullFunction(EmailAddress::getExternalReferenceCode),
-				EmailAddress::getCompanyId),
-			_SQL_SELECT_EMAILADDRESS_WHERE, "",
+			this, _finderPathFetchByERC_C, _SQL_SELECT_EMAILADDRESS_WHERE, "",
 			new FinderColumn<>(
 				"emailAddress.", "externalReferenceCode",
 				FinderColumn.Type.STRING, "=", true, true,
@@ -1911,4 +1953,4 @@ public class EmailAddressPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:81329556
+// LIFERAY-SERVICE-BUILDER-HASH:-14151854

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/GroupPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/GroupPersistenceImpl.java
@@ -98,6 +98,9 @@ public class GroupPersistenceImpl
 	public static final String FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION =
 		FINDER_CLASS_NAME_ENTITY + ".List2";
 
+	private FinderPath _finderPathWithPaginationFindByUuid;
+	private FinderPath _finderPathWithoutPaginationFindByUuid;
+	private FinderPath _finderPathCountByUuid;
 	private CollectionPersistenceFinder<Group>
 		_collectionPersistenceFinderByUuid;
 
@@ -237,6 +240,7 @@ public class GroupPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {uuid});
 	}
 
+	private FinderPath _finderPathFetchByUUID_G;
 	private UniquePersistenceFinder<Group> _uniquePersistenceFinderByUUID_G;
 
 	/**
@@ -326,6 +330,9 @@ public class GroupPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {uuid, groupId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByUuid_C;
+	private FinderPath _finderPathWithoutPaginationFindByUuid_C;
+	private FinderPath _finderPathCountByUuid_C;
 	private CollectionPersistenceFinder<Group>
 		_collectionPersistenceFinderByUuid_C;
 
@@ -479,6 +486,9 @@ public class GroupPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {uuid, companyId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByCompanyId;
+	private FinderPath _finderPathWithoutPaginationFindByCompanyId;
+	private FinderPath _finderPathCountByCompanyId;
 	private CollectionPersistenceFinder<Group>
 		_collectionPersistenceFinderByCompanyId;
 
@@ -619,6 +629,9 @@ public class GroupPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {companyId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByLiveGroupId;
+	private FinderPath _finderPathWithoutPaginationFindByLiveGroupId;
+	private FinderPath _finderPathCountByLiveGroupId;
 	private CollectionPersistenceFinder<Group>
 		_collectionPersistenceFinderByLiveGroupId;
 
@@ -760,6 +773,9 @@ public class GroupPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {liveGroupId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_C;
+	private FinderPath _finderPathWithoutPaginationFindByC_C;
+	private FinderPath _finderPathCountByC_C;
 	private CollectionPersistenceFinder<Group>
 		_collectionPersistenceFinderByC_C;
 
@@ -918,6 +934,9 @@ public class GroupPersistenceImpl
 			new Object[] {companyId, classNameId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_P;
+	private FinderPath _finderPathWithoutPaginationFindByC_P;
+	private FinderPath _finderPathCountByC_P;
 	private CollectionPersistenceFinder<Group>
 		_collectionPersistenceFinderByC_P;
 
@@ -1077,6 +1096,10 @@ public class GroupPersistenceImpl
 			new Object[] {companyId, parentGroupId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_GK;
+	private FinderPath _finderPathWithoutPaginationFindByC_GK;
+	private FinderPath _finderPathFetchByC_GK;
+	private FinderPath _finderPathCountByC_GK;
 	private CollectionPersistenceFinder<Group>
 		_collectionPersistenceFinderByC_GK;
 	private UniquePersistenceFinder<Group> _uniquePersistenceFinderByC_GK;
@@ -1287,6 +1310,7 @@ public class GroupPersistenceImpl
 			new Object[] {companyId, ArrayUtil.sortedUnique(groupKeys)});
 	}
 
+	private FinderPath _finderPathFetchByC_F;
 	private UniquePersistenceFinder<Group> _uniquePersistenceFinderByC_F;
 
 	/**
@@ -1378,6 +1402,9 @@ public class GroupPersistenceImpl
 			new Object[] {companyId, friendlyURL});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_S;
+	private FinderPath _finderPathWithoutPaginationFindByC_S;
+	private FinderPath _finderPathCountByC_S;
 	private CollectionPersistenceFinder<Group>
 		_collectionPersistenceFinderByC_S;
 
@@ -1530,6 +1557,9 @@ public class GroupPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {companyId, site});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_A;
+	private FinderPath _finderPathWithoutPaginationFindByC_A;
+	private FinderPath _finderPathCountByC_A;
 	private CollectionPersistenceFinder<Group>
 		_collectionPersistenceFinderByC_A;
 
@@ -1683,6 +1713,9 @@ public class GroupPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {companyId, active});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_CPK;
+	private FinderPath _finderPathWithoutPaginationFindByC_CPK;
+	private FinderPath _finderPathCountByC_CPK;
 	private CollectionPersistenceFinder<Group>
 		_collectionPersistenceFinderByC_CPK;
 
@@ -1840,6 +1873,9 @@ public class GroupPersistenceImpl
 			new Object[] {classNameId, classPK});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByT_A;
+	private FinderPath _finderPathWithoutPaginationFindByT_A;
+	private FinderPath _finderPathCountByT_A;
 	private CollectionPersistenceFinder<Group>
 		_collectionPersistenceFinderByT_A;
 
@@ -1989,6 +2025,8 @@ public class GroupPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {type, active});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByGtG_C_P;
+	private FinderPath _finderPathWithPaginationCountByGtG_C_P;
 	private CollectionPersistenceFinder<Group>
 		_collectionPersistenceFinderByGtG_C_P;
 
@@ -2165,6 +2203,7 @@ public class GroupPersistenceImpl
 			new Object[] {groupId, companyId, parentGroupId});
 	}
 
+	private FinderPath _finderPathFetchByC_C_C;
 	private UniquePersistenceFinder<Group> _uniquePersistenceFinderByC_C_C;
 
 	/**
@@ -2262,6 +2301,9 @@ public class GroupPersistenceImpl
 			new Object[] {companyId, classNameId, classPK});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_C_P;
+	private FinderPath _finderPathWithoutPaginationFindByC_C_P;
+	private FinderPath _finderPathCountByC_C_P;
 	private CollectionPersistenceFinder<Group>
 		_collectionPersistenceFinderByC_C_P;
 
@@ -2440,6 +2482,9 @@ public class GroupPersistenceImpl
 			new Object[] {companyId, classNameId, parentGroupId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_C_S;
+	private FinderPath _finderPathWithoutPaginationFindByC_C_S;
+	private FinderPath _finderPathCountByC_C_S;
 	private CollectionPersistenceFinder<Group>
 		_collectionPersistenceFinderByC_C_S;
 
@@ -2609,6 +2654,9 @@ public class GroupPersistenceImpl
 			new Object[] {companyId, classNameId, site});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_P_S;
+	private FinderPath _finderPathWithoutPaginationFindByC_P_S;
+	private FinderPath _finderPathCountByC_P_S;
 	private CollectionPersistenceFinder<Group>
 		_collectionPersistenceFinderByC_P_S;
 
@@ -2781,6 +2829,7 @@ public class GroupPersistenceImpl
 			new Object[] {companyId, parentGroupId, site});
 	}
 
+	private FinderPath _finderPathFetchByC_L_GK;
 	private UniquePersistenceFinder<Group> _uniquePersistenceFinderByC_L_GK;
 
 	/**
@@ -2883,6 +2932,8 @@ public class GroupPersistenceImpl
 			new Object[] {companyId, liveGroupId, groupKey});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_LikeT_S;
+	private FinderPath _finderPathWithPaginationCountByC_LikeT_S;
 	private CollectionPersistenceFinder<Group>
 		_collectionPersistenceFinderByC_LikeT_S;
 
@@ -3054,6 +3105,8 @@ public class GroupPersistenceImpl
 			new Object[] {companyId, treePath, site});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_LikeN_S;
+	private FinderPath _finderPathWithPaginationCountByC_LikeN_S;
 	private CollectionPersistenceFinder<Group>
 		_collectionPersistenceFinderByC_LikeN_S;
 
@@ -3222,6 +3275,9 @@ public class GroupPersistenceImpl
 			new Object[] {companyId, name, site});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_S_A;
+	private FinderPath _finderPathWithoutPaginationFindByC_S_A;
+	private FinderPath _finderPathCountByC_S_A;
 	private CollectionPersistenceFinder<Group>
 		_collectionPersistenceFinderByC_S_A;
 
@@ -3391,6 +3447,8 @@ public class GroupPersistenceImpl
 			new Object[] {companyId, site, active});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByGtG_C_C_P;
+	private FinderPath _finderPathWithPaginationCountByGtG_C_C_P;
 	private CollectionPersistenceFinder<Group>
 		_collectionPersistenceFinderByGtG_C_C_P;
 
@@ -3577,6 +3635,8 @@ public class GroupPersistenceImpl
 			new Object[] {groupId, companyId, classNameId, parentGroupId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByGtG_C_P_S;
+	private FinderPath _finderPathWithPaginationCountByGtG_C_P_S;
 	private CollectionPersistenceFinder<Group>
 		_collectionPersistenceFinderByGtG_C_P_S;
 
@@ -3763,6 +3823,7 @@ public class GroupPersistenceImpl
 			new Object[] {groupId, companyId, parentGroupId, site});
 	}
 
+	private FinderPath _finderPathFetchByC_C_L_GK;
 	private UniquePersistenceFinder<Group> _uniquePersistenceFinderByC_C_L_GK;
 
 	/**
@@ -3877,6 +3938,8 @@ public class GroupPersistenceImpl
 			new Object[] {companyId, classNameId, liveGroupId, groupKey});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_P_LikeN_S;
+	private FinderPath _finderPathWithPaginationCountByC_P_LikeN_S;
 	private CollectionPersistenceFinder<Group>
 		_collectionPersistenceFinderByC_P_LikeN_S;
 
@@ -4063,6 +4126,9 @@ public class GroupPersistenceImpl
 			new Object[] {companyId, parentGroupId, name, site});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_P_S_I;
+	private FinderPath _finderPathWithoutPaginationFindByC_P_S_I;
+	private FinderPath _finderPathCountByC_P_S_I;
 	private CollectionPersistenceFinder<Group>
 		_collectionPersistenceFinderByC_P_S_I;
 
@@ -4253,6 +4319,7 @@ public class GroupPersistenceImpl
 			new Object[] {companyId, parentGroupId, site, inheritContent});
 	}
 
+	private FinderPath _finderPathFetchByERC_C;
 	private UniquePersistenceFinder<Group> _uniquePersistenceFinderByERC_C;
 
 	/**
@@ -6048,37 +6115,41 @@ public class GroupPersistenceImpl
 			"Users_Groups", "companyId", "groupId", "userId", this,
 			userPersistence);
 
+		_finderPathWithPaginationFindByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid",
+			new String[] {
+				String.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"uuid_"}, true);
+
+		_finderPathWithoutPaginationFindByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid",
+			new String[] {String.class.getName()}, new String[] {"uuid_"}, 0, 1,
+			true, null);
+
+		_finderPathCountByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid",
+			new String[] {String.class.getName()}, new String[] {"uuid_"}, 0, 1,
+			false, null);
+
 		_collectionPersistenceFinderByUuid = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid",
-				new String[] {
-					String.class.getName(), Integer.class.getName(),
-					Integer.class.getName(), OrderByComparator.class.getName()
-				},
-				new String[] {"uuid_"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid",
-				new String[] {String.class.getName()}, new String[] {"uuid_"},
-				0, 1, true, null),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid",
-				new String[] {String.class.getName()}, new String[] {"uuid_"},
-				0, 1, false, null),
+			this, _finderPathWithPaginationFindByUuid,
+			_finderPathWithoutPaginationFindByUuid, _finderPathCountByUuid,
 			_SQL_SELECT_GROUP__WHERE, _SQL_COUNT_GROUP__WHERE,
 			GroupModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
 				"group_.", "uuid", FinderColumn.Type.STRING, "=", true, true,
 				Group::getUuid));
 
+		_finderPathFetchByUUID_G = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByUUID_G",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"uuid_", "groupId"}, 0, 1, false,
+			convertNullFunction(Group::getUuid), Group::getGroupId);
+
 		_uniquePersistenceFinderByUUID_G = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByUUID_G",
-				new String[] {String.class.getName(), Long.class.getName()},
-				new String[] {"uuid_", "groupId"}, 0, 1, false,
-				convertNullFunction(Group::getUuid), Group::getGroupId),
-			_SQL_SELECT_GROUP__WHERE, "",
+			this, _finderPathFetchByUUID_G, _SQL_SELECT_GROUP__WHERE, "",
 			new FinderColumn<>(
 				"group_.", "uuid", FinderColumn.Type.STRING, "=", true, true,
 				Group::getUuid),
@@ -6086,27 +6157,32 @@ public class GroupPersistenceImpl
 				"group_.", "groupId", FinderColumn.Type.LONG, "=", true, true,
 				Group::getGroupId));
 
+		_finderPathWithPaginationFindByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid_C",
+			new String[] {
+				String.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"uuid_", "companyId"}, true);
+
+		_finderPathWithoutPaginationFindByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"uuid_", "companyId"}, 0, 1, true, null);
+
+		_finderPathCountByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"uuid_", "companyId"}, 0, 1, false, null);
+
 		_collectionPersistenceFinderByUuid_C =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid_C",
-					new String[] {
-						String.class.getName(), Long.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"uuid_", "companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid_C",
-					new String[] {String.class.getName(), Long.class.getName()},
-					new String[] {"uuid_", "companyId"}, 0, 1, true, null),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid_C",
-					new String[] {String.class.getName(), Long.class.getName()},
-					new String[] {"uuid_", "companyId"}, 0, 1, false, null),
-				_SQL_SELECT_GROUP__WHERE, _SQL_COUNT_GROUP__WHERE,
-				GroupModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+				this, _finderPathWithPaginationFindByUuid_C,
+				_finderPathWithoutPaginationFindByUuid_C,
+				_finderPathCountByUuid_C, _SQL_SELECT_GROUP__WHERE,
+				_SQL_COUNT_GROUP__WHERE, GroupModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
 					"group_.", "uuid", FinderColumn.Type.STRING, "=", true,
 					true, Group::getUuid),
@@ -6114,74 +6190,86 @@ public class GroupPersistenceImpl
 					"group_.", "companyId", FinderColumn.Type.LONG, "=", true,
 					true, Group::getCompanyId));
 
+		_finderPathWithPaginationFindByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByCompanyId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"companyId"}, true);
+
+		_finderPathWithoutPaginationFindByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByCompanyId",
+			new String[] {Long.class.getName()}, new String[] {"companyId"},
+			true);
+
+		_finderPathCountByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByCompanyId",
+			new String[] {Long.class.getName()}, new String[] {"companyId"},
+			false);
+
 		_collectionPersistenceFinderByCompanyId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByCompanyId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"findByCompanyId", new String[] {Long.class.getName()},
-					new String[] {"companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByCompanyId", new String[] {Long.class.getName()},
-					new String[] {"companyId"}, false),
-				_SQL_SELECT_GROUP__WHERE, _SQL_COUNT_GROUP__WHERE,
-				GroupModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+				this, _finderPathWithPaginationFindByCompanyId,
+				_finderPathWithoutPaginationFindByCompanyId,
+				_finderPathCountByCompanyId, _SQL_SELECT_GROUP__WHERE,
+				_SQL_COUNT_GROUP__WHERE, GroupModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
 					"group_.", "companyId", FinderColumn.Type.LONG, "=", true,
 					true, Group::getCompanyId));
 
+		_finderPathWithPaginationFindByLiveGroupId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByLiveGroupId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"liveGroupId"}, true);
+
+		_finderPathWithoutPaginationFindByLiveGroupId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByLiveGroupId",
+			new String[] {Long.class.getName()}, new String[] {"liveGroupId"},
+			true);
+
+		_finderPathCountByLiveGroupId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByLiveGroupId",
+			new String[] {Long.class.getName()}, new String[] {"liveGroupId"},
+			false);
+
 		_collectionPersistenceFinderByLiveGroupId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByLiveGroupId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"liveGroupId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"findByLiveGroupId", new String[] {Long.class.getName()},
-					new String[] {"liveGroupId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByLiveGroupId", new String[] {Long.class.getName()},
-					new String[] {"liveGroupId"}, false),
-				_SQL_SELECT_GROUP__WHERE, _SQL_COUNT_GROUP__WHERE,
-				GroupModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+				this, _finderPathWithPaginationFindByLiveGroupId,
+				_finderPathWithoutPaginationFindByLiveGroupId,
+				_finderPathCountByLiveGroupId, _SQL_SELECT_GROUP__WHERE,
+				_SQL_COUNT_GROUP__WHERE, GroupModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
 					"group_.", "liveGroupId", FinderColumn.Type.LONG, "=", true,
 					true, Group::getLiveGroupId));
 
+		_finderPathWithPaginationFindByC_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_C",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "classNameId"}, true);
+
+		_finderPathWithoutPaginationFindByC_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_C",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"companyId", "classNameId"}, true);
+
+		_finderPathCountByC_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_C",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"companyId", "classNameId"}, false);
+
 		_collectionPersistenceFinderByC_C = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_C",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Integer.class.getName(), Integer.class.getName(),
-					OrderByComparator.class.getName()
-				},
-				new String[] {"companyId", "classNameId"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_C",
-				new String[] {Long.class.getName(), Long.class.getName()},
-				new String[] {"companyId", "classNameId"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_C",
-				new String[] {Long.class.getName(), Long.class.getName()},
-				new String[] {"companyId", "classNameId"}, false),
+			this, _finderPathWithPaginationFindByC_C,
+			_finderPathWithoutPaginationFindByC_C, _finderPathCountByC_C,
 			_SQL_SELECT_GROUP__WHERE, _SQL_COUNT_GROUP__WHERE,
 			GroupModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
@@ -6191,24 +6279,28 @@ public class GroupPersistenceImpl
 				"group_.", "classNameId", FinderColumn.Type.LONG, "=", true,
 				true, Group::getClassNameId));
 
+		_finderPathWithPaginationFindByC_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_P",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "parentGroupId"}, true);
+
+		_finderPathWithoutPaginationFindByC_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_P",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"companyId", "parentGroupId"}, true);
+
+		_finderPathCountByC_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_P",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"companyId", "parentGroupId"}, false);
+
 		_collectionPersistenceFinderByC_P = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_P",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Integer.class.getName(), Integer.class.getName(),
-					OrderByComparator.class.getName()
-				},
-				new String[] {"companyId", "parentGroupId"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_P",
-				new String[] {Long.class.getName(), Long.class.getName()},
-				new String[] {"companyId", "parentGroupId"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_P",
-				new String[] {Long.class.getName(), Long.class.getName()},
-				new String[] {"companyId", "parentGroupId"}, false),
+			this, _finderPathWithPaginationFindByC_P,
+			_finderPathWithoutPaginationFindByC_P, _finderPathCountByC_P,
 			_SQL_SELECT_GROUP__WHERE, _SQL_COUNT_GROUP__WHERE,
 			GroupModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
@@ -6218,24 +6310,34 @@ public class GroupPersistenceImpl
 				"group_.", "parentGroupId", FinderColumn.Type.LONG, "=", true,
 				true, Group::getParentGroupId));
 
+		_finderPathWithPaginationFindByC_GK = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_GK",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "groupKey"}, true);
+
+		_finderPathWithoutPaginationFindByC_GK = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_GK",
+			new String[] {Long.class.getName(), String.class.getName()},
+			new String[] {"companyId", "groupKey"}, 0, 2, true, null);
+
+		_finderPathFetchByC_GK = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByC_GK",
+			new String[] {Long.class.getName(), String.class.getName()},
+			new String[] {"companyId", "groupKey"}, 0, 2, false,
+			Group::getCompanyId, convertNullFunction(Group::getGroupKey));
+
+		_finderPathCountByC_GK = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByC_GK",
+			new String[] {Long.class.getName(), String.class.getName()},
+			new String[] {"companyId", "groupKey"}, 0, 2, false, null);
+
 		_collectionPersistenceFinderByC_GK = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_GK",
-				new String[] {
-					Long.class.getName(), String.class.getName(),
-					Integer.class.getName(), Integer.class.getName(),
-					OrderByComparator.class.getName()
-				},
-				new String[] {"companyId", "groupKey"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_GK",
-				new String[] {Long.class.getName(), String.class.getName()},
-				new String[] {"companyId", "groupKey"}, 0, 2, true, null),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByC_GK",
-				new String[] {Long.class.getName(), String.class.getName()},
-				new String[] {"companyId", "groupKey"}, 0, 2, false, null),
+			this, _finderPathWithPaginationFindByC_GK,
+			_finderPathWithoutPaginationFindByC_GK, _finderPathCountByC_GK,
 			_SQL_SELECT_GROUP__WHERE, _SQL_COUNT_GROUP__WHERE,
 			GroupModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
@@ -6246,13 +6348,7 @@ public class GroupPersistenceImpl
 				true, true, Group::getGroupKey));
 
 		_uniquePersistenceFinderByC_GK = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByC_GK",
-				new String[] {Long.class.getName(), String.class.getName()},
-				new String[] {"companyId", "groupKey"}, 0, 2, false,
-				Group::getCompanyId, convertNullFunction(Group::getGroupKey)),
-			_SQL_SELECT_GROUP__WHERE, "",
+			this, _finderPathFetchByC_GK, _SQL_SELECT_GROUP__WHERE, "",
 			new FinderColumn<>(
 				"group_.", "companyId", FinderColumn.Type.LONG, "=", true, true,
 				Group::getCompanyId),
@@ -6260,15 +6356,14 @@ public class GroupPersistenceImpl
 				"group_.", "groupKey", FinderColumn.Type.STRING, "=", true,
 				true, Group::getGroupKey));
 
+		_finderPathFetchByC_F = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByC_F",
+			new String[] {Long.class.getName(), String.class.getName()},
+			new String[] {"companyId", "friendlyURL"}, 0, 2, false,
+			Group::getCompanyId, convertNullFunction(Group::getFriendlyURL));
+
 		_uniquePersistenceFinderByC_F = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByC_F",
-				new String[] {Long.class.getName(), String.class.getName()},
-				new String[] {"companyId", "friendlyURL"}, 0, 2, false,
-				Group::getCompanyId,
-				convertNullFunction(Group::getFriendlyURL)),
-			_SQL_SELECT_GROUP__WHERE, "",
+			this, _finderPathFetchByC_F, _SQL_SELECT_GROUP__WHERE, "",
 			new FinderColumn<>(
 				"group_.", "companyId", FinderColumn.Type.LONG, "=", true, true,
 				Group::getCompanyId),
@@ -6276,24 +6371,28 @@ public class GroupPersistenceImpl
 				"group_.", "friendlyURL", FinderColumn.Type.STRING, "=", true,
 				true, Group::getFriendlyURL));
 
+		_finderPathWithPaginationFindByC_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_S",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "site"}, true);
+
+		_finderPathWithoutPaginationFindByC_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_S",
+			new String[] {Long.class.getName(), Boolean.class.getName()},
+			new String[] {"companyId", "site"}, true);
+
+		_finderPathCountByC_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_S",
+			new String[] {Long.class.getName(), Boolean.class.getName()},
+			new String[] {"companyId", "site"}, false);
+
 		_collectionPersistenceFinderByC_S = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_S",
-				new String[] {
-					Long.class.getName(), Boolean.class.getName(),
-					Integer.class.getName(), Integer.class.getName(),
-					OrderByComparator.class.getName()
-				},
-				new String[] {"companyId", "site"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_S",
-				new String[] {Long.class.getName(), Boolean.class.getName()},
-				new String[] {"companyId", "site"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_S",
-				new String[] {Long.class.getName(), Boolean.class.getName()},
-				new String[] {"companyId", "site"}, false),
+			this, _finderPathWithPaginationFindByC_S,
+			_finderPathWithoutPaginationFindByC_S, _finderPathCountByC_S,
 			_SQL_SELECT_GROUP__WHERE, _SQL_COUNT_GROUP__WHERE,
 			GroupModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
@@ -6303,24 +6402,28 @@ public class GroupPersistenceImpl
 				"group_.", "site", FinderColumn.Type.BOOLEAN, "=", true, true,
 				Group::isSite));
 
+		_finderPathWithPaginationFindByC_A = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_A",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "active_"}, true);
+
+		_finderPathWithoutPaginationFindByC_A = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_A",
+			new String[] {Long.class.getName(), Boolean.class.getName()},
+			new String[] {"companyId", "active_"}, true);
+
+		_finderPathCountByC_A = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_A",
+			new String[] {Long.class.getName(), Boolean.class.getName()},
+			new String[] {"companyId", "active_"}, false);
+
 		_collectionPersistenceFinderByC_A = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_A",
-				new String[] {
-					Long.class.getName(), Boolean.class.getName(),
-					Integer.class.getName(), Integer.class.getName(),
-					OrderByComparator.class.getName()
-				},
-				new String[] {"companyId", "active_"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_A",
-				new String[] {Long.class.getName(), Boolean.class.getName()},
-				new String[] {"companyId", "active_"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_A",
-				new String[] {Long.class.getName(), Boolean.class.getName()},
-				new String[] {"companyId", "active_"}, false),
+			this, _finderPathWithPaginationFindByC_A,
+			_finderPathWithoutPaginationFindByC_A, _finderPathCountByC_A,
 			_SQL_SELECT_GROUP__WHERE, _SQL_COUNT_GROUP__WHERE,
 			GroupModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
@@ -6330,24 +6433,28 @@ public class GroupPersistenceImpl
 				"group_.", "active", FinderColumn.Type.BOOLEAN, "=", true, true,
 				Group::isActive));
 
+		_finderPathWithPaginationFindByC_CPK = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_CPK",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"classNameId", "classPK"}, true);
+
+		_finderPathWithoutPaginationFindByC_CPK = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_CPK",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"classNameId", "classPK"}, true);
+
+		_finderPathCountByC_CPK = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_CPK",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"classNameId", "classPK"}, false);
+
 		_collectionPersistenceFinderByC_CPK = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_CPK",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Integer.class.getName(), Integer.class.getName(),
-					OrderByComparator.class.getName()
-				},
-				new String[] {"classNameId", "classPK"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_CPK",
-				new String[] {Long.class.getName(), Long.class.getName()},
-				new String[] {"classNameId", "classPK"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_CPK",
-				new String[] {Long.class.getName(), Long.class.getName()},
-				new String[] {"classNameId", "classPK"}, false),
+			this, _finderPathWithPaginationFindByC_CPK,
+			_finderPathWithoutPaginationFindByC_CPK, _finderPathCountByC_CPK,
 			_SQL_SELECT_GROUP__WHERE, _SQL_COUNT_GROUP__WHERE,
 			GroupModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
@@ -6357,24 +6464,28 @@ public class GroupPersistenceImpl
 				"group_.", "classPK", FinderColumn.Type.LONG, "=", true, true,
 				Group::getClassPK));
 
+		_finderPathWithPaginationFindByT_A = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByT_A",
+			new String[] {
+				Integer.class.getName(), Boolean.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"type_", "active_"}, true);
+
+		_finderPathWithoutPaginationFindByT_A = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByT_A",
+			new String[] {Integer.class.getName(), Boolean.class.getName()},
+			new String[] {"type_", "active_"}, true);
+
+		_finderPathCountByT_A = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByT_A",
+			new String[] {Integer.class.getName(), Boolean.class.getName()},
+			new String[] {"type_", "active_"}, false);
+
 		_collectionPersistenceFinderByT_A = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByT_A",
-				new String[] {
-					Integer.class.getName(), Boolean.class.getName(),
-					Integer.class.getName(), Integer.class.getName(),
-					OrderByComparator.class.getName()
-				},
-				new String[] {"type_", "active_"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByT_A",
-				new String[] {Integer.class.getName(), Boolean.class.getName()},
-				new String[] {"type_", "active_"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByT_A",
-				new String[] {Integer.class.getName(), Boolean.class.getName()},
-				new String[] {"type_", "active_"}, false),
+			this, _finderPathWithPaginationFindByT_A,
+			_finderPathWithoutPaginationFindByT_A, _finderPathCountByT_A,
 			_SQL_SELECT_GROUP__WHERE, _SQL_COUNT_GROUP__WHERE,
 			GroupModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
@@ -6384,28 +6495,26 @@ public class GroupPersistenceImpl
 				"group_.", "active", FinderColumn.Type.BOOLEAN, "=", true, true,
 				Group::isActive));
 
+		_finderPathWithPaginationFindByGtG_C_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByGtG_C_P",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"groupId", "companyId", "parentGroupId"}, true);
+
+		_finderPathWithPaginationCountByGtG_C_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByGtG_C_P",
+			new String[] {
+				Long.class.getName(), Long.class.getName(), Long.class.getName()
+			},
+			new String[] {"groupId", "companyId", "parentGroupId"}, false);
+
 		_collectionPersistenceFinderByGtG_C_P =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByGtG_C_P",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"groupId", "companyId", "parentGroupId"},
-					true),
-				null,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByGtG_C_P",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						Long.class.getName()
-					},
-					new String[] {"groupId", "companyId", "parentGroupId"},
-					false),
+				this, _finderPathWithPaginationFindByGtG_C_P, null,
+				_finderPathWithPaginationCountByGtG_C_P,
 				_SQL_SELECT_GROUP__WHERE, _SQL_COUNT_GROUP__WHERE,
 				GroupModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
@@ -6418,18 +6527,16 @@ public class GroupPersistenceImpl
 					"group_.", "parentGroupId", FinderColumn.Type.LONG, "=",
 					true, true, Group::getParentGroupId));
 
+		_finderPathFetchByC_C_C = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByC_C_C",
+			new String[] {
+				Long.class.getName(), Long.class.getName(), Long.class.getName()
+			},
+			new String[] {"companyId", "classNameId", "classPK"}, 0, 0, false,
+			Group::getCompanyId, Group::getClassNameId, Group::getClassPK);
+
 		_uniquePersistenceFinderByC_C_C = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByC_C_C",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Long.class.getName()
-				},
-				new String[] {"companyId", "classNameId", "classPK"}, 0, 0,
-				false, Group::getCompanyId, Group::getClassNameId,
-				Group::getClassPK),
-			_SQL_SELECT_GROUP__WHERE, "",
+			this, _finderPathFetchByC_C_C, _SQL_SELECT_GROUP__WHERE, "",
 			new FinderColumn<>(
 				"group_.", "companyId", FinderColumn.Type.LONG, "=", true, true,
 				Group::getCompanyId),
@@ -6440,33 +6547,32 @@ public class GroupPersistenceImpl
 				"group_.", "classPK", FinderColumn.Type.LONG, "=", true, true,
 				Group::getClassPK));
 
+		_finderPathWithPaginationFindByC_C_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_C_P",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "classNameId", "parentGroupId"}, true);
+
+		_finderPathWithoutPaginationFindByC_C_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_C_P",
+			new String[] {
+				Long.class.getName(), Long.class.getName(), Long.class.getName()
+			},
+			new String[] {"companyId", "classNameId", "parentGroupId"}, true);
+
+		_finderPathCountByC_C_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_C_P",
+			new String[] {
+				Long.class.getName(), Long.class.getName(), Long.class.getName()
+			},
+			new String[] {"companyId", "classNameId", "parentGroupId"}, false);
+
 		_collectionPersistenceFinderByC_C_P = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_C_P",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Long.class.getName(), Integer.class.getName(),
-					Integer.class.getName(), OrderByComparator.class.getName()
-				},
-				new String[] {"companyId", "classNameId", "parentGroupId"},
-				true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_C_P",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Long.class.getName()
-				},
-				new String[] {"companyId", "classNameId", "parentGroupId"},
-				true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_C_P",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Long.class.getName()
-				},
-				new String[] {"companyId", "classNameId", "parentGroupId"},
-				false),
+			this, _finderPathWithPaginationFindByC_C_P,
+			_finderPathWithoutPaginationFindByC_C_P, _finderPathCountByC_C_P,
 			_SQL_SELECT_GROUP__WHERE, _SQL_COUNT_GROUP__WHERE,
 			GroupModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
@@ -6479,30 +6585,34 @@ public class GroupPersistenceImpl
 				"group_.", "parentGroupId", FinderColumn.Type.LONG, "=", true,
 				true, Group::getParentGroupId));
 
+		_finderPathWithPaginationFindByC_C_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_C_S",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Boolean.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "classNameId", "site"}, true);
+
+		_finderPathWithoutPaginationFindByC_C_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_C_S",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Boolean.class.getName()
+			},
+			new String[] {"companyId", "classNameId", "site"}, true);
+
+		_finderPathCountByC_C_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_C_S",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Boolean.class.getName()
+			},
+			new String[] {"companyId", "classNameId", "site"}, false);
+
 		_collectionPersistenceFinderByC_C_S = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_C_S",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Boolean.class.getName(), Integer.class.getName(),
-					Integer.class.getName(), OrderByComparator.class.getName()
-				},
-				new String[] {"companyId", "classNameId", "site"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_C_S",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Boolean.class.getName()
-				},
-				new String[] {"companyId", "classNameId", "site"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_C_S",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Boolean.class.getName()
-				},
-				new String[] {"companyId", "classNameId", "site"}, false),
+			this, _finderPathWithPaginationFindByC_C_S,
+			_finderPathWithoutPaginationFindByC_C_S, _finderPathCountByC_C_S,
 			_SQL_SELECT_GROUP__WHERE, _SQL_COUNT_GROUP__WHERE,
 			GroupModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
@@ -6515,30 +6625,34 @@ public class GroupPersistenceImpl
 				"group_.", "site", FinderColumn.Type.BOOLEAN, "=", true, true,
 				Group::isSite));
 
+		_finderPathWithPaginationFindByC_P_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_P_S",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Boolean.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "parentGroupId", "site"}, true);
+
+		_finderPathWithoutPaginationFindByC_P_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_P_S",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Boolean.class.getName()
+			},
+			new String[] {"companyId", "parentGroupId", "site"}, true);
+
+		_finderPathCountByC_P_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_P_S",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Boolean.class.getName()
+			},
+			new String[] {"companyId", "parentGroupId", "site"}, false);
+
 		_collectionPersistenceFinderByC_P_S = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_P_S",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Boolean.class.getName(), Integer.class.getName(),
-					Integer.class.getName(), OrderByComparator.class.getName()
-				},
-				new String[] {"companyId", "parentGroupId", "site"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_P_S",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Boolean.class.getName()
-				},
-				new String[] {"companyId", "parentGroupId", "site"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_P_S",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Boolean.class.getName()
-				},
-				new String[] {"companyId", "parentGroupId", "site"}, false),
+			this, _finderPathWithPaginationFindByC_P_S,
+			_finderPathWithoutPaginationFindByC_P_S, _finderPathCountByC_P_S,
 			_SQL_SELECT_GROUP__WHERE, _SQL_COUNT_GROUP__WHERE,
 			GroupModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
@@ -6551,18 +6665,18 @@ public class GroupPersistenceImpl
 				"group_.", "site", FinderColumn.Type.BOOLEAN, "=", true, true,
 				Group::isSite));
 
+		_finderPathFetchByC_L_GK = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByC_L_GK",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				String.class.getName()
+			},
+			new String[] {"companyId", "liveGroupId", "groupKey"}, 0, 4, false,
+			Group::getCompanyId, Group::getLiveGroupId,
+			convertNullFunction(Group::getGroupKey));
+
 		_uniquePersistenceFinderByC_L_GK = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByC_L_GK",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					String.class.getName()
-				},
-				new String[] {"companyId", "liveGroupId", "groupKey"}, 0, 4,
-				false, Group::getCompanyId, Group::getLiveGroupId,
-				convertNullFunction(Group::getGroupKey)),
-			_SQL_SELECT_GROUP__WHERE, "",
+			this, _finderPathFetchByC_L_GK, _SQL_SELECT_GROUP__WHERE, "",
 			new FinderColumn<>(
 				"group_.", "companyId", FinderColumn.Type.LONG, "=", true, true,
 				Group::getCompanyId),
@@ -6573,26 +6687,27 @@ public class GroupPersistenceImpl
 				"group_.", "groupKey", FinderColumn.Type.STRING, "=", true,
 				true, Group::getGroupKey));
 
+		_finderPathWithPaginationFindByC_LikeT_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_LikeT_S",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Boolean.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "treePath", "site"}, true);
+
+		_finderPathWithPaginationCountByC_LikeT_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByC_LikeT_S",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Boolean.class.getName()
+			},
+			new String[] {"companyId", "treePath", "site"}, false);
+
 		_collectionPersistenceFinderByC_LikeT_S =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_LikeT_S",
-					new String[] {
-						Long.class.getName(), String.class.getName(),
-						Boolean.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"companyId", "treePath", "site"}, true),
-				null,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByC_LikeT_S",
-					new String[] {
-						Long.class.getName(), String.class.getName(),
-						Boolean.class.getName()
-					},
-					new String[] {"companyId", "treePath", "site"}, false),
+				this, _finderPathWithPaginationFindByC_LikeT_S, null,
+				_finderPathWithPaginationCountByC_LikeT_S,
 				_SQL_SELECT_GROUP__WHERE, _SQL_COUNT_GROUP__WHERE,
 				GroupModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
@@ -6605,26 +6720,27 @@ public class GroupPersistenceImpl
 					"group_.", "site", FinderColumn.Type.BOOLEAN, "=", true,
 					true, Group::isSite));
 
+		_finderPathWithPaginationFindByC_LikeN_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_LikeN_S",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Boolean.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "name", "site"}, true);
+
+		_finderPathWithPaginationCountByC_LikeN_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByC_LikeN_S",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Boolean.class.getName()
+			},
+			new String[] {"companyId", "name", "site"}, false);
+
 		_collectionPersistenceFinderByC_LikeN_S =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_LikeN_S",
-					new String[] {
-						Long.class.getName(), String.class.getName(),
-						Boolean.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"companyId", "name", "site"}, true),
-				null,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByC_LikeN_S",
-					new String[] {
-						Long.class.getName(), String.class.getName(),
-						Boolean.class.getName()
-					},
-					new String[] {"companyId", "name", "site"}, false),
+				this, _finderPathWithPaginationFindByC_LikeN_S, null,
+				_finderPathWithPaginationCountByC_LikeN_S,
 				_SQL_SELECT_GROUP__WHERE, _SQL_COUNT_GROUP__WHERE,
 				GroupModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
@@ -6637,30 +6753,34 @@ public class GroupPersistenceImpl
 					"group_.", "site", FinderColumn.Type.BOOLEAN, "=", true,
 					true, Group::isSite));
 
+		_finderPathWithPaginationFindByC_S_A = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_S_A",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "site", "active_"}, true);
+
+		_finderPathWithoutPaginationFindByC_S_A = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_S_A",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName()
+			},
+			new String[] {"companyId", "site", "active_"}, true);
+
+		_finderPathCountByC_S_A = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_S_A",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName()
+			},
+			new String[] {"companyId", "site", "active_"}, false);
+
 		_collectionPersistenceFinderByC_S_A = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_S_A",
-				new String[] {
-					Long.class.getName(), Boolean.class.getName(),
-					Boolean.class.getName(), Integer.class.getName(),
-					Integer.class.getName(), OrderByComparator.class.getName()
-				},
-				new String[] {"companyId", "site", "active_"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_S_A",
-				new String[] {
-					Long.class.getName(), Boolean.class.getName(),
-					Boolean.class.getName()
-				},
-				new String[] {"companyId", "site", "active_"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_S_A",
-				new String[] {
-					Long.class.getName(), Boolean.class.getName(),
-					Boolean.class.getName()
-				},
-				new String[] {"companyId", "site", "active_"}, false),
+			this, _finderPathWithPaginationFindByC_S_A,
+			_finderPathWithoutPaginationFindByC_S_A, _finderPathCountByC_S_A,
 			_SQL_SELECT_GROUP__WHERE, _SQL_COUNT_GROUP__WHERE,
 			GroupModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
@@ -6673,32 +6793,34 @@ public class GroupPersistenceImpl
 				"group_.", "active", FinderColumn.Type.BOOLEAN, "=", true, true,
 				Group::isActive));
 
+		_finderPathWithPaginationFindByGtG_C_C_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByGtG_C_C_P",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {
+				"groupId", "companyId", "classNameId", "parentGroupId"
+			},
+			true);
+
+		_finderPathWithPaginationCountByGtG_C_C_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByGtG_C_C_P",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Long.class.getName()
+			},
+			new String[] {
+				"groupId", "companyId", "classNameId", "parentGroupId"
+			},
+			false);
+
 		_collectionPersistenceFinderByGtG_C_C_P =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByGtG_C_C_P",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						Long.class.getName(), Long.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {
-						"groupId", "companyId", "classNameId", "parentGroupId"
-					},
-					true),
-				null,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByGtG_C_C_P",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						Long.class.getName(), Long.class.getName()
-					},
-					new String[] {
-						"groupId", "companyId", "classNameId", "parentGroupId"
-					},
-					false),
+				this, _finderPathWithPaginationFindByGtG_C_C_P, null,
+				_finderPathWithPaginationCountByGtG_C_C_P,
 				_SQL_SELECT_GROUP__WHERE, _SQL_COUNT_GROUP__WHERE,
 				GroupModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
@@ -6714,32 +6836,30 @@ public class GroupPersistenceImpl
 					"group_.", "parentGroupId", FinderColumn.Type.LONG, "=",
 					true, true, Group::getParentGroupId));
 
+		_finderPathWithPaginationFindByGtG_C_P_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByGtG_C_P_S",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Boolean.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"groupId", "companyId", "parentGroupId", "site"},
+			true);
+
+		_finderPathWithPaginationCountByGtG_C_P_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByGtG_C_P_S",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Boolean.class.getName()
+			},
+			new String[] {"groupId", "companyId", "parentGroupId", "site"},
+			false);
+
 		_collectionPersistenceFinderByGtG_C_P_S =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByGtG_C_P_S",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						Long.class.getName(), Boolean.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {
-						"groupId", "companyId", "parentGroupId", "site"
-					},
-					true),
-				null,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByGtG_C_P_S",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						Long.class.getName(), Boolean.class.getName()
-					},
-					new String[] {
-						"groupId", "companyId", "parentGroupId", "site"
-					},
-					false),
+				this, _finderPathWithPaginationFindByGtG_C_P_S, null,
+				_finderPathWithPaginationCountByGtG_C_P_S,
 				_SQL_SELECT_GROUP__WHERE, _SQL_COUNT_GROUP__WHERE,
 				GroupModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
@@ -6755,20 +6875,20 @@ public class GroupPersistenceImpl
 					"group_.", "site", FinderColumn.Type.BOOLEAN, "=", true,
 					true, Group::isSite));
 
+		_finderPathFetchByC_C_L_GK = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByC_C_L_GK",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), String.class.getName()
+			},
+			new String[] {
+				"companyId", "classNameId", "liveGroupId", "groupKey"
+			},
+			0, 8, false, Group::getCompanyId, Group::getClassNameId,
+			Group::getLiveGroupId, convertNullFunction(Group::getGroupKey));
+
 		_uniquePersistenceFinderByC_C_L_GK = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByC_C_L_GK",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Long.class.getName(), String.class.getName()
-				},
-				new String[] {
-					"companyId", "classNameId", "liveGroupId", "groupKey"
-				},
-				0, 8, false, Group::getCompanyId, Group::getClassNameId,
-				Group::getLiveGroupId, convertNullFunction(Group::getGroupKey)),
-			_SQL_SELECT_GROUP__WHERE, "",
+			this, _finderPathFetchByC_C_L_GK, _SQL_SELECT_GROUP__WHERE, "",
 			new FinderColumn<>(
 				"group_.", "companyId", FinderColumn.Type.LONG, "=", true, true,
 				Group::getCompanyId),
@@ -6782,29 +6902,28 @@ public class GroupPersistenceImpl
 				"group_.", "groupKey", FinderColumn.Type.STRING, "=", true,
 				true, Group::getGroupKey));
 
+		_finderPathWithPaginationFindByC_P_LikeN_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_P_LikeN_S",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				String.class.getName(), Boolean.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "parentGroupId", "name", "site"}, true);
+
+		_finderPathWithPaginationCountByC_P_LikeN_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByC_P_LikeN_S",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				String.class.getName(), Boolean.class.getName()
+			},
+			new String[] {"companyId", "parentGroupId", "name", "site"}, false);
+
 		_collectionPersistenceFinderByC_P_LikeN_S =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_P_LikeN_S",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						String.class.getName(), Boolean.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"companyId", "parentGroupId", "name", "site"},
-					true),
-				null,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION,
-					"countByC_P_LikeN_S",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						String.class.getName(), Boolean.class.getName()
-					},
-					new String[] {"companyId", "parentGroupId", "name", "site"},
-					false),
+				this, _finderPathWithPaginationFindByC_P_LikeN_S, null,
+				_finderPathWithPaginationCountByC_P_LikeN_S,
 				_SQL_SELECT_GROUP__WHERE, _SQL_COUNT_GROUP__WHERE,
 				GroupModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
@@ -6820,43 +6939,48 @@ public class GroupPersistenceImpl
 					"group_.", "site", FinderColumn.Type.BOOLEAN, "=", true,
 					true, Group::isSite));
 
+		_finderPathWithPaginationFindByC_P_S_I = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_P_S_I",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Boolean.class.getName(), Boolean.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {
+				"companyId", "parentGroupId", "site", "inheritContent"
+			},
+			true);
+
+		_finderPathWithoutPaginationFindByC_P_S_I = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_P_S_I",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Boolean.class.getName(), Boolean.class.getName()
+			},
+			new String[] {
+				"companyId", "parentGroupId", "site", "inheritContent"
+			},
+			true);
+
+		_finderPathCountByC_P_S_I = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_P_S_I",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Boolean.class.getName(), Boolean.class.getName()
+			},
+			new String[] {
+				"companyId", "parentGroupId", "site", "inheritContent"
+			},
+			false);
+
 		_collectionPersistenceFinderByC_P_S_I =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_P_S_I",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						Boolean.class.getName(), Boolean.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {
-						"companyId", "parentGroupId", "site", "inheritContent"
-					},
-					true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_P_S_I",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						Boolean.class.getName(), Boolean.class.getName()
-					},
-					new String[] {
-						"companyId", "parentGroupId", "site", "inheritContent"
-					},
-					true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_P_S_I",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						Boolean.class.getName(), Boolean.class.getName()
-					},
-					new String[] {
-						"companyId", "parentGroupId", "site", "inheritContent"
-					},
-					false),
-				_SQL_SELECT_GROUP__WHERE, _SQL_COUNT_GROUP__WHERE,
-				GroupModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+				this, _finderPathWithPaginationFindByC_P_S_I,
+				_finderPathWithoutPaginationFindByC_P_S_I,
+				_finderPathCountByC_P_S_I, _SQL_SELECT_GROUP__WHERE,
+				_SQL_COUNT_GROUP__WHERE, GroupModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
 					"group_.", "companyId", FinderColumn.Type.LONG, "=", true,
 					true, Group::getCompanyId),
@@ -6870,15 +6994,15 @@ public class GroupPersistenceImpl
 					"group_.", "inheritContent", FinderColumn.Type.BOOLEAN, "=",
 					true, true, Group::isInheritContent));
 
+		_finderPathFetchByERC_C = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByERC_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "companyId"}, 0, 1, false,
+			convertNullFunction(Group::getExternalReferenceCode),
+			Group::getCompanyId);
+
 		_uniquePersistenceFinderByERC_C = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByERC_C",
-				new String[] {String.class.getName(), Long.class.getName()},
-				new String[] {"externalReferenceCode", "companyId"}, 0, 1,
-				false, convertNullFunction(Group::getExternalReferenceCode),
-				Group::getCompanyId),
-			_SQL_SELECT_GROUP__WHERE, "",
+			this, _finderPathFetchByERC_C, _SQL_SELECT_GROUP__WHERE, "",
 			new FinderColumn<>(
 				"group_.", "externalReferenceCode", FinderColumn.Type.STRING,
 				"=", true, true, Group::getExternalReferenceCode),
@@ -6951,4 +7075,4 @@ public class GroupPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-312054716
+// LIFERAY-SERVICE-BUILDER-HASH:-2100058415

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/ImagePersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/ImagePersistenceImpl.java
@@ -74,6 +74,8 @@ public class ImagePersistenceImpl
 	public static final String FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION =
 		FINDER_CLASS_NAME_ENTITY + ".List2";
 
+	private FinderPath _finderPathWithPaginationFindByLtSize;
+	private FinderPath _finderPathWithPaginationCountByLtSize;
 	private CollectionPersistenceFinder<Image>
 		_collectionPersistenceFinderByLtSize;
 
@@ -473,24 +475,25 @@ public class ImagePersistenceImpl
 	 * Initializes the image persistence.
 	 */
 	public void afterPropertiesSet() {
+		_finderPathWithPaginationFindByLtSize = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByLtSize",
+			new String[] {
+				Integer.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"size_"}, true);
+
+		_finderPathWithPaginationCountByLtSize = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByLtSize",
+			new String[] {Integer.class.getName()}, new String[] {"size_"},
+			false);
+
 		_collectionPersistenceFinderByLtSize =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByLtSize",
-					new String[] {
-						Integer.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"size_"}, true),
-				null,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByLtSize",
-					new String[] {Integer.class.getName()},
-					new String[] {"size_"}, false),
-				_SQL_SELECT_IMAGE_WHERE, _SQL_COUNT_IMAGE_WHERE,
-				ImageModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+				this, _finderPathWithPaginationFindByLtSize, null,
+				_finderPathWithPaginationCountByLtSize, _SQL_SELECT_IMAGE_WHERE,
+				_SQL_COUNT_IMAGE_WHERE, ImageModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
 					"image.", "size", FinderColumn.Type.INTEGER, "<", true,
 					true, Image::getSize));
@@ -528,4 +531,4 @@ public class ImagePersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1576347909
+// LIFERAY-SERVICE-BUILDER-HASH:-241274120

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/LayoutBranchPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/LayoutBranchPersistenceImpl.java
@@ -64,6 +64,9 @@ public class LayoutBranchPersistenceImpl
 	public static final String FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION =
 		FINDER_CLASS_NAME_ENTITY + ".List2";
 
+	private FinderPath _finderPathWithPaginationFindByLayoutSetBranchId;
+	private FinderPath _finderPathWithoutPaginationFindByLayoutSetBranchId;
+	private FinderPath _finderPathCountByLayoutSetBranchId;
 	private CollectionPersistenceFinder<LayoutBranch>
 		_collectionPersistenceFinderByLayoutSetBranchId;
 
@@ -213,6 +216,9 @@ public class LayoutBranchPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {layoutSetBranchId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByPlid;
+	private FinderPath _finderPathWithoutPaginationFindByPlid;
+	private FinderPath _finderPathCountByPlid;
 	private CollectionPersistenceFinder<LayoutBranch>
 		_collectionPersistenceFinderByPlid;
 
@@ -353,6 +359,9 @@ public class LayoutBranchPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {plid});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByL_P;
+	private FinderPath _finderPathWithoutPaginationFindByL_P;
+	private FinderPath _finderPathCountByL_P;
 	private CollectionPersistenceFinder<LayoutBranch>
 		_collectionPersistenceFinderByL_P;
 
@@ -513,6 +522,7 @@ public class LayoutBranchPersistenceImpl
 			new Object[] {layoutSetBranchId, plid});
 	}
 
+	private FinderPath _finderPathFetchByL_P_N;
 	private UniquePersistenceFinder<LayoutBranch>
 		_uniquePersistenceFinderByL_P_N;
 
@@ -615,6 +625,9 @@ public class LayoutBranchPersistenceImpl
 			new Object[] {layoutSetBranchId, plid, name});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByL_P_M;
+	private FinderPath _finderPathWithoutPaginationFindByL_P_M;
+	private FinderPath _finderPathCountByL_P_M;
 	private CollectionPersistenceFinder<LayoutBranch>
 		_collectionPersistenceFinderByL_P_M;
 
@@ -962,28 +975,29 @@ public class LayoutBranchPersistenceImpl
 	 * Initializes the layout branch persistence.
 	 */
 	public void afterPropertiesSet() {
+		_finderPathWithPaginationFindByLayoutSetBranchId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByLayoutSetBranchId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"layoutSetBranchId"}, true);
+
+		_finderPathWithoutPaginationFindByLayoutSetBranchId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
+			"findByLayoutSetBranchId", new String[] {Long.class.getName()},
+			new String[] {"layoutSetBranchId"}, true);
+
+		_finderPathCountByLayoutSetBranchId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
+			"countByLayoutSetBranchId", new String[] {Long.class.getName()},
+			new String[] {"layoutSetBranchId"}, false);
+
 		_collectionPersistenceFinderByLayoutSetBranchId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION,
-					"findByLayoutSetBranchId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"layoutSetBranchId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"findByLayoutSetBranchId",
-					new String[] {Long.class.getName()},
-					new String[] {"layoutSetBranchId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByLayoutSetBranchId",
-					new String[] {Long.class.getName()},
-					new String[] {"layoutSetBranchId"}, false),
+				this, _finderPathWithPaginationFindByLayoutSetBranchId,
+				_finderPathWithoutPaginationFindByLayoutSetBranchId,
+				_finderPathCountByLayoutSetBranchId,
 				_SQL_SELECT_LAYOUTBRANCH_WHERE, _SQL_COUNT_LAYOUTBRANCH_WHERE,
 				LayoutBranchModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
@@ -991,47 +1005,53 @@ public class LayoutBranchPersistenceImpl
 					FinderColumn.Type.LONG, "=", true, true,
 					LayoutBranch::getLayoutSetBranchId));
 
+		_finderPathWithPaginationFindByPlid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByPlid",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"plid"}, true);
+
+		_finderPathWithoutPaginationFindByPlid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByPlid",
+			new String[] {Long.class.getName()}, new String[] {"plid"}, true);
+
+		_finderPathCountByPlid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByPlid",
+			new String[] {Long.class.getName()}, new String[] {"plid"}, false);
+
 		_collectionPersistenceFinderByPlid = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByPlid",
-				new String[] {
-					Long.class.getName(), Integer.class.getName(),
-					Integer.class.getName(), OrderByComparator.class.getName()
-				},
-				new String[] {"plid"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByPlid",
-				new String[] {Long.class.getName()}, new String[] {"plid"},
-				true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByPlid",
-				new String[] {Long.class.getName()}, new String[] {"plid"},
-				false),
+			this, _finderPathWithPaginationFindByPlid,
+			_finderPathWithoutPaginationFindByPlid, _finderPathCountByPlid,
 			_SQL_SELECT_LAYOUTBRANCH_WHERE, _SQL_COUNT_LAYOUTBRANCH_WHERE,
 			LayoutBranchModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
 				"layoutBranch.", "plid", FinderColumn.Type.LONG, "=", true,
 				true, LayoutBranch::getPlid));
 
+		_finderPathWithPaginationFindByL_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByL_P",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"layoutSetBranchId", "plid"}, true);
+
+		_finderPathWithoutPaginationFindByL_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByL_P",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"layoutSetBranchId", "plid"}, true);
+
+		_finderPathCountByL_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByL_P",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"layoutSetBranchId", "plid"}, false);
+
 		_collectionPersistenceFinderByL_P = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByL_P",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Integer.class.getName(), Integer.class.getName(),
-					OrderByComparator.class.getName()
-				},
-				new String[] {"layoutSetBranchId", "plid"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByL_P",
-				new String[] {Long.class.getName(), Long.class.getName()},
-				new String[] {"layoutSetBranchId", "plid"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByL_P",
-				new String[] {Long.class.getName(), Long.class.getName()},
-				new String[] {"layoutSetBranchId", "plid"}, false),
+			this, _finderPathWithPaginationFindByL_P,
+			_finderPathWithoutPaginationFindByL_P, _finderPathCountByL_P,
 			_SQL_SELECT_LAYOUTBRANCH_WHERE, _SQL_COUNT_LAYOUTBRANCH_WHERE,
 			LayoutBranchModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
@@ -1041,18 +1061,18 @@ public class LayoutBranchPersistenceImpl
 				"layoutBranch.", "plid", FinderColumn.Type.LONG, "=", true,
 				true, LayoutBranch::getPlid));
 
+		_finderPathFetchByL_P_N = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByL_P_N",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				String.class.getName()
+			},
+			new String[] {"layoutSetBranchId", "plid", "name"}, 0, 4, false,
+			LayoutBranch::getLayoutSetBranchId, LayoutBranch::getPlid,
+			convertNullFunction(LayoutBranch::getName));
+
 		_uniquePersistenceFinderByL_P_N = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByL_P_N",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					String.class.getName()
-				},
-				new String[] {"layoutSetBranchId", "plid", "name"}, 0, 4, false,
-				LayoutBranch::getLayoutSetBranchId, LayoutBranch::getPlid,
-				convertNullFunction(LayoutBranch::getName)),
-			_SQL_SELECT_LAYOUTBRANCH_WHERE, "",
+			this, _finderPathFetchByL_P_N, _SQL_SELECT_LAYOUTBRANCH_WHERE, "",
 			new FinderColumn<>(
 				"layoutBranch.", "layoutSetBranchId", FinderColumn.Type.LONG,
 				"=", true, true, LayoutBranch::getLayoutSetBranchId),
@@ -1063,30 +1083,34 @@ public class LayoutBranchPersistenceImpl
 				"layoutBranch.", "name", FinderColumn.Type.STRING, "=", true,
 				true, LayoutBranch::getName));
 
+		_finderPathWithPaginationFindByL_P_M = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByL_P_M",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Boolean.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"layoutSetBranchId", "plid", "master"}, true);
+
+		_finderPathWithoutPaginationFindByL_P_M = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByL_P_M",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Boolean.class.getName()
+			},
+			new String[] {"layoutSetBranchId", "plid", "master"}, true);
+
+		_finderPathCountByL_P_M = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByL_P_M",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Boolean.class.getName()
+			},
+			new String[] {"layoutSetBranchId", "plid", "master"}, false);
+
 		_collectionPersistenceFinderByL_P_M = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByL_P_M",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Boolean.class.getName(), Integer.class.getName(),
-					Integer.class.getName(), OrderByComparator.class.getName()
-				},
-				new String[] {"layoutSetBranchId", "plid", "master"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByL_P_M",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Boolean.class.getName()
-				},
-				new String[] {"layoutSetBranchId", "plid", "master"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByL_P_M",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Boolean.class.getName()
-				},
-				new String[] {"layoutSetBranchId", "plid", "master"}, false),
+			this, _finderPathWithPaginationFindByL_P_M,
+			_finderPathWithoutPaginationFindByL_P_M, _finderPathCountByL_P_M,
 			_SQL_SELECT_LAYOUTBRANCH_WHERE, _SQL_COUNT_LAYOUTBRANCH_WHERE,
 			LayoutBranchModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
@@ -1132,4 +1156,4 @@ public class LayoutBranchPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:974139768
+// LIFERAY-SERVICE-BUILDER-HASH:1246606942

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/LayoutFriendlyURLPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/LayoutFriendlyURLPersistenceImpl.java
@@ -87,6 +87,9 @@ public class LayoutFriendlyURLPersistenceImpl
 	public static final String FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION =
 		FINDER_CLASS_NAME_ENTITY + ".List2";
 
+	private FinderPath _finderPathWithPaginationFindByUuid;
+	private FinderPath _finderPathWithoutPaginationFindByUuid;
+	private FinderPath _finderPathCountByUuid;
 	private CollectionPersistenceFinder<LayoutFriendlyURL>
 		_collectionPersistenceFinderByUuid;
 
@@ -228,6 +231,7 @@ public class LayoutFriendlyURLPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {uuid});
 	}
 
+	private FinderPath _finderPathFetchByUUID_G;
 	private UniquePersistenceFinder<LayoutFriendlyURL>
 		_uniquePersistenceFinderByUUID_G;
 
@@ -318,6 +322,9 @@ public class LayoutFriendlyURLPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {uuid, groupId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByUuid_C;
+	private FinderPath _finderPathWithoutPaginationFindByUuid_C;
+	private FinderPath _finderPathCountByUuid_C;
 	private CollectionPersistenceFinder<LayoutFriendlyURL>
 		_collectionPersistenceFinderByUuid_C;
 
@@ -473,6 +480,9 @@ public class LayoutFriendlyURLPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {uuid, companyId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByGroupId;
+	private FinderPath _finderPathWithoutPaginationFindByGroupId;
+	private FinderPath _finderPathCountByGroupId;
 	private CollectionPersistenceFinder<LayoutFriendlyURL>
 		_collectionPersistenceFinderByGroupId;
 
@@ -618,6 +628,9 @@ public class LayoutFriendlyURLPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {groupId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByCompanyId;
+	private FinderPath _finderPathWithoutPaginationFindByCompanyId;
+	private FinderPath _finderPathCountByCompanyId;
 	private CollectionPersistenceFinder<LayoutFriendlyURL>
 		_collectionPersistenceFinderByCompanyId;
 
@@ -764,6 +777,9 @@ public class LayoutFriendlyURLPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {companyId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByPlid;
+	private FinderPath _finderPathWithoutPaginationFindByPlid;
+	private FinderPath _finderPathCountByPlid;
 	private CollectionPersistenceFinder<LayoutFriendlyURL>
 		_collectionPersistenceFinderByPlid;
 
@@ -905,6 +921,9 @@ public class LayoutFriendlyURLPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {plid});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_F;
+	private FinderPath _finderPathWithoutPaginationFindByC_F;
+	private FinderPath _finderPathCountByC_F;
 	private CollectionPersistenceFinder<LayoutFriendlyURL>
 		_collectionPersistenceFinderByC_F;
 
@@ -1066,6 +1085,9 @@ public class LayoutFriendlyURLPersistenceImpl
 			new Object[] {companyId, friendlyURL});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByP_F;
+	private FinderPath _finderPathWithoutPaginationFindByP_F;
+	private FinderPath _finderPathCountByP_F;
 	private CollectionPersistenceFinder<LayoutFriendlyURL>
 		_collectionPersistenceFinderByP_F;
 
@@ -1873,6 +1895,9 @@ public class LayoutFriendlyURLPersistenceImpl
 	private static final String _FINDER_COLUMN_P_L_LANGUAGEID_3 =
 		"(layoutFriendlyURL.languageId IS NULL OR layoutFriendlyURL.languageId = '')";
 
+	private FinderPath _finderPathWithPaginationFindByG_P_F;
+	private FinderPath _finderPathWithoutPaginationFindByG_P_F;
+	private FinderPath _finderPathCountByG_P_F;
 	private CollectionPersistenceFinder<LayoutFriendlyURL>
 		_collectionPersistenceFinderByG_P_F;
 
@@ -2051,6 +2076,7 @@ public class LayoutFriendlyURLPersistenceImpl
 			new Object[] {groupId, privateLayout, friendlyURL});
 	}
 
+	private FinderPath _finderPathFetchByG_P_F_L;
 	private UniquePersistenceFinder<LayoutFriendlyURL>
 		_uniquePersistenceFinderByG_P_F_L;
 
@@ -2480,23 +2506,27 @@ public class LayoutFriendlyURLPersistenceImpl
 	 * Initializes the layout friendly url persistence.
 	 */
 	public void afterPropertiesSet() {
+		_finderPathWithPaginationFindByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid",
+			new String[] {
+				String.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"uuid_"}, true);
+
+		_finderPathWithoutPaginationFindByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid",
+			new String[] {String.class.getName()}, new String[] {"uuid_"}, 0, 1,
+			true, null);
+
+		_finderPathCountByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid",
+			new String[] {String.class.getName()}, new String[] {"uuid_"}, 0, 1,
+			false, null);
+
 		_collectionPersistenceFinderByUuid = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid",
-				new String[] {
-					String.class.getName(), Integer.class.getName(),
-					Integer.class.getName(), OrderByComparator.class.getName()
-				},
-				new String[] {"uuid_"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid",
-				new String[] {String.class.getName()}, new String[] {"uuid_"},
-				0, 1, true, null),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid",
-				new String[] {String.class.getName()}, new String[] {"uuid_"},
-				0, 1, false, null),
+			this, _finderPathWithPaginationFindByUuid,
+			_finderPathWithoutPaginationFindByUuid, _finderPathCountByUuid,
 			_SQL_SELECT_LAYOUTFRIENDLYURL_WHERE,
 			_SQL_COUNT_LAYOUTFRIENDLYURL_WHERE,
 			LayoutFriendlyURLModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
@@ -2504,15 +2534,16 @@ public class LayoutFriendlyURLPersistenceImpl
 				"layoutFriendlyURL.", "uuid", FinderColumn.Type.STRING, "=",
 				true, true, LayoutFriendlyURL::getUuid));
 
+		_finderPathFetchByUUID_G = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByUUID_G",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"uuid_", "groupId"}, 0, 1, false,
+			convertNullFunction(LayoutFriendlyURL::getUuid),
+			LayoutFriendlyURL::getGroupId);
+
 		_uniquePersistenceFinderByUUID_G = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByUUID_G",
-				new String[] {String.class.getName(), Long.class.getName()},
-				new String[] {"uuid_", "groupId"}, 0, 1, false,
-				convertNullFunction(LayoutFriendlyURL::getUuid),
-				LayoutFriendlyURL::getGroupId),
-			_SQL_SELECT_LAYOUTFRIENDLYURL_WHERE, "",
+			this, _finderPathFetchByUUID_G, _SQL_SELECT_LAYOUTFRIENDLYURL_WHERE,
+			"",
 			new FinderColumn<>(
 				"layoutFriendlyURL.", "uuid", FinderColumn.Type.STRING, "=",
 				true, true, LayoutFriendlyURL::getUuid),
@@ -2520,26 +2551,30 @@ public class LayoutFriendlyURLPersistenceImpl
 				"layoutFriendlyURL.", "groupId", FinderColumn.Type.LONG, "=",
 				true, true, LayoutFriendlyURL::getGroupId));
 
+		_finderPathWithPaginationFindByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid_C",
+			new String[] {
+				String.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"uuid_", "companyId"}, true);
+
+		_finderPathWithoutPaginationFindByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"uuid_", "companyId"}, 0, 1, true, null);
+
+		_finderPathCountByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"uuid_", "companyId"}, 0, 1, false, null);
+
 		_collectionPersistenceFinderByUuid_C =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid_C",
-					new String[] {
-						String.class.getName(), Long.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"uuid_", "companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid_C",
-					new String[] {String.class.getName(), Long.class.getName()},
-					new String[] {"uuid_", "companyId"}, 0, 1, true, null),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid_C",
-					new String[] {String.class.getName(), Long.class.getName()},
-					new String[] {"uuid_", "companyId"}, 0, 1, false, null),
-				_SQL_SELECT_LAYOUTFRIENDLYURL_WHERE,
+				this, _finderPathWithPaginationFindByUuid_C,
+				_finderPathWithoutPaginationFindByUuid_C,
+				_finderPathCountByUuid_C, _SQL_SELECT_LAYOUTFRIENDLYURL_WHERE,
 				_SQL_COUNT_LAYOUTFRIENDLYURL_WHERE,
 				LayoutFriendlyURLModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
 				"",
@@ -2550,26 +2585,29 @@ public class LayoutFriendlyURLPersistenceImpl
 					"layoutFriendlyURL.", "companyId", FinderColumn.Type.LONG,
 					"=", true, true, LayoutFriendlyURL::getCompanyId));
 
+		_finderPathWithPaginationFindByGroupId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByGroupId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"groupId"}, true);
+
+		_finderPathWithoutPaginationFindByGroupId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByGroupId",
+			new String[] {Long.class.getName()}, new String[] {"groupId"},
+			true);
+
+		_finderPathCountByGroupId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByGroupId",
+			new String[] {Long.class.getName()}, new String[] {"groupId"},
+			false);
+
 		_collectionPersistenceFinderByGroupId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByGroupId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"groupId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByGroupId",
-					new String[] {Long.class.getName()},
-					new String[] {"groupId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByGroupId",
-					new String[] {Long.class.getName()},
-					new String[] {"groupId"}, false),
-				_SQL_SELECT_LAYOUTFRIENDLYURL_WHERE,
+				this, _finderPathWithPaginationFindByGroupId,
+				_finderPathWithoutPaginationFindByGroupId,
+				_finderPathCountByGroupId, _SQL_SELECT_LAYOUTFRIENDLYURL_WHERE,
 				_SQL_COUNT_LAYOUTFRIENDLYURL_WHERE,
 				LayoutFriendlyURLModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
 				"",
@@ -2577,25 +2615,29 @@ public class LayoutFriendlyURLPersistenceImpl
 					"layoutFriendlyURL.", "groupId", FinderColumn.Type.LONG,
 					"=", true, true, LayoutFriendlyURL::getGroupId));
 
+		_finderPathWithPaginationFindByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByCompanyId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"companyId"}, true);
+
+		_finderPathWithoutPaginationFindByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByCompanyId",
+			new String[] {Long.class.getName()}, new String[] {"companyId"},
+			true);
+
+		_finderPathCountByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByCompanyId",
+			new String[] {Long.class.getName()}, new String[] {"companyId"},
+			false);
+
 		_collectionPersistenceFinderByCompanyId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByCompanyId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"findByCompanyId", new String[] {Long.class.getName()},
-					new String[] {"companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByCompanyId", new String[] {Long.class.getName()},
-					new String[] {"companyId"}, false),
+				this, _finderPathWithPaginationFindByCompanyId,
+				_finderPathWithoutPaginationFindByCompanyId,
+				_finderPathCountByCompanyId,
 				_SQL_SELECT_LAYOUTFRIENDLYURL_WHERE,
 				_SQL_COUNT_LAYOUTFRIENDLYURL_WHERE,
 				LayoutFriendlyURLModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
@@ -2604,23 +2646,25 @@ public class LayoutFriendlyURLPersistenceImpl
 					"layoutFriendlyURL.", "companyId", FinderColumn.Type.LONG,
 					"=", true, true, LayoutFriendlyURL::getCompanyId));
 
+		_finderPathWithPaginationFindByPlid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByPlid",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"plid"}, true);
+
+		_finderPathWithoutPaginationFindByPlid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByPlid",
+			new String[] {Long.class.getName()}, new String[] {"plid"}, true);
+
+		_finderPathCountByPlid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByPlid",
+			new String[] {Long.class.getName()}, new String[] {"plid"}, false);
+
 		_collectionPersistenceFinderByPlid = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByPlid",
-				new String[] {
-					Long.class.getName(), Integer.class.getName(),
-					Integer.class.getName(), OrderByComparator.class.getName()
-				},
-				new String[] {"plid"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByPlid",
-				new String[] {Long.class.getName()}, new String[] {"plid"},
-				true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByPlid",
-				new String[] {Long.class.getName()}, new String[] {"plid"},
-				false),
+			this, _finderPathWithPaginationFindByPlid,
+			_finderPathWithoutPaginationFindByPlid, _finderPathCountByPlid,
 			_SQL_SELECT_LAYOUTFRIENDLYURL_WHERE,
 			_SQL_COUNT_LAYOUTFRIENDLYURL_WHERE,
 			LayoutFriendlyURLModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
@@ -2628,24 +2672,28 @@ public class LayoutFriendlyURLPersistenceImpl
 				"layoutFriendlyURL.", "plid", FinderColumn.Type.LONG, "=", true,
 				true, LayoutFriendlyURL::getPlid));
 
+		_finderPathWithPaginationFindByC_F = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_F",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "friendlyURL"}, true);
+
+		_finderPathWithoutPaginationFindByC_F = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_F",
+			new String[] {Long.class.getName(), String.class.getName()},
+			new String[] {"companyId", "friendlyURL"}, 0, 2, true, null);
+
+		_finderPathCountByC_F = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_F",
+			new String[] {Long.class.getName(), String.class.getName()},
+			new String[] {"companyId", "friendlyURL"}, 0, 2, false, null);
+
 		_collectionPersistenceFinderByC_F = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_F",
-				new String[] {
-					Long.class.getName(), String.class.getName(),
-					Integer.class.getName(), Integer.class.getName(),
-					OrderByComparator.class.getName()
-				},
-				new String[] {"companyId", "friendlyURL"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_F",
-				new String[] {Long.class.getName(), String.class.getName()},
-				new String[] {"companyId", "friendlyURL"}, 0, 2, true, null),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_F",
-				new String[] {Long.class.getName(), String.class.getName()},
-				new String[] {"companyId", "friendlyURL"}, 0, 2, false, null),
+			this, _finderPathWithPaginationFindByC_F,
+			_finderPathWithoutPaginationFindByC_F, _finderPathCountByC_F,
 			_SQL_SELECT_LAYOUTFRIENDLYURL_WHERE,
 			_SQL_COUNT_LAYOUTFRIENDLYURL_WHERE,
 			LayoutFriendlyURLModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
@@ -2656,24 +2704,28 @@ public class LayoutFriendlyURLPersistenceImpl
 				"layoutFriendlyURL.", "friendlyURL", FinderColumn.Type.STRING,
 				"=", true, true, LayoutFriendlyURL::getFriendlyURL));
 
+		_finderPathWithPaginationFindByP_F = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByP_F",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"plid", "friendlyURL"}, true);
+
+		_finderPathWithoutPaginationFindByP_F = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByP_F",
+			new String[] {Long.class.getName(), String.class.getName()},
+			new String[] {"plid", "friendlyURL"}, 0, 2, true, null);
+
+		_finderPathCountByP_F = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByP_F",
+			new String[] {Long.class.getName(), String.class.getName()},
+			new String[] {"plid", "friendlyURL"}, 0, 2, false, null);
+
 		_collectionPersistenceFinderByP_F = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByP_F",
-				new String[] {
-					Long.class.getName(), String.class.getName(),
-					Integer.class.getName(), Integer.class.getName(),
-					OrderByComparator.class.getName()
-				},
-				new String[] {"plid", "friendlyURL"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByP_F",
-				new String[] {Long.class.getName(), String.class.getName()},
-				new String[] {"plid", "friendlyURL"}, 0, 2, true, null),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByP_F",
-				new String[] {Long.class.getName(), String.class.getName()},
-				new String[] {"plid", "friendlyURL"}, 0, 2, false, null),
+			this, _finderPathWithPaginationFindByP_F,
+			_finderPathWithoutPaginationFindByP_F, _finderPathCountByP_F,
 			_SQL_SELECT_LAYOUTFRIENDLYURL_WHERE,
 			_SQL_COUNT_LAYOUTFRIENDLYURL_WHERE,
 			LayoutFriendlyURLModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
@@ -2715,32 +2767,36 @@ public class LayoutFriendlyURLPersistenceImpl
 			new String[] {Long.class.getName(), String.class.getName()},
 			new String[] {"plid", "languageId"}, false);
 
+		_finderPathWithPaginationFindByG_P_F = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_P_F",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				String.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"groupId", "privateLayout", "friendlyURL"}, true);
+
+		_finderPathWithoutPaginationFindByG_P_F = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_P_F",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				String.class.getName()
+			},
+			new String[] {"groupId", "privateLayout", "friendlyURL"}, 0, 4,
+			true, null);
+
+		_finderPathCountByG_P_F = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_P_F",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				String.class.getName()
+			},
+			new String[] {"groupId", "privateLayout", "friendlyURL"}, 0, 4,
+			false, null);
+
 		_collectionPersistenceFinderByG_P_F = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_P_F",
-				new String[] {
-					Long.class.getName(), Boolean.class.getName(),
-					String.class.getName(), Integer.class.getName(),
-					Integer.class.getName(), OrderByComparator.class.getName()
-				},
-				new String[] {"groupId", "privateLayout", "friendlyURL"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_P_F",
-				new String[] {
-					Long.class.getName(), Boolean.class.getName(),
-					String.class.getName()
-				},
-				new String[] {"groupId", "privateLayout", "friendlyURL"}, 0, 4,
-				true, null),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_P_F",
-				new String[] {
-					Long.class.getName(), Boolean.class.getName(),
-					String.class.getName()
-				},
-				new String[] {"groupId", "privateLayout", "friendlyURL"}, 0, 4,
-				false, null),
+			this, _finderPathWithPaginationFindByG_P_F,
+			_finderPathWithoutPaginationFindByG_P_F, _finderPathCountByG_P_F,
 			_SQL_SELECT_LAYOUTFRIENDLYURL_WHERE,
 			_SQL_COUNT_LAYOUTFRIENDLYURL_WHERE,
 			LayoutFriendlyURLModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
@@ -2755,21 +2811,22 @@ public class LayoutFriendlyURLPersistenceImpl
 				"layoutFriendlyURL.", "friendlyURL", FinderColumn.Type.STRING,
 				"=", true, true, LayoutFriendlyURL::getFriendlyURL));
 
+		_finderPathFetchByG_P_F_L = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByG_P_F_L",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				String.class.getName(), String.class.getName()
+			},
+			new String[] {
+				"groupId", "privateLayout", "friendlyURL", "languageId"
+			},
+			0, 12, false, LayoutFriendlyURL::getGroupId,
+			LayoutFriendlyURL::isPrivateLayout,
+			convertNullFunction(LayoutFriendlyURL::getFriendlyURL),
+			convertNullFunction(LayoutFriendlyURL::getLanguageId));
+
 		_uniquePersistenceFinderByG_P_F_L = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByG_P_F_L",
-				new String[] {
-					Long.class.getName(), Boolean.class.getName(),
-					String.class.getName(), String.class.getName()
-				},
-				new String[] {
-					"groupId", "privateLayout", "friendlyURL", "languageId"
-				},
-				0, 12, false, LayoutFriendlyURL::getGroupId,
-				LayoutFriendlyURL::isPrivateLayout,
-				convertNullFunction(LayoutFriendlyURL::getFriendlyURL),
-				convertNullFunction(LayoutFriendlyURL::getLanguageId)),
+			this, _finderPathFetchByG_P_F_L,
 			_SQL_SELECT_LAYOUTFRIENDLYURL_WHERE, "",
 			new FinderColumn<>(
 				"layoutFriendlyURL.", "groupId", FinderColumn.Type.LONG, "=",
@@ -2821,4 +2878,4 @@ public class LayoutFriendlyURLPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:122637945
+// LIFERAY-SERVICE-BUILDER-HASH:-213353994

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/LayoutPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/LayoutPersistenceImpl.java
@@ -98,6 +98,9 @@ public class LayoutPersistenceImpl
 	public static final String FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION =
 		FINDER_CLASS_NAME_ENTITY + ".List2";
 
+	private FinderPath _finderPathWithPaginationFindByUuid;
+	private FinderPath _finderPathWithoutPaginationFindByUuid;
+	private FinderPath _finderPathCountByUuid;
 	private CollectionPersistenceFinder<Layout>
 		_collectionPersistenceFinderByUuid;
 
@@ -237,6 +240,7 @@ public class LayoutPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {uuid});
 	}
 
+	private FinderPath _finderPathFetchByUUID_G_P;
 	private UniquePersistenceFinder<Layout> _uniquePersistenceFinderByUUID_G_P;
 
 	/**
@@ -340,6 +344,9 @@ public class LayoutPersistenceImpl
 			new Object[] {uuid, groupId, privateLayout});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByUuid_C;
+	private FinderPath _finderPathWithoutPaginationFindByUuid_C;
+	private FinderPath _finderPathCountByUuid_C;
 	private CollectionPersistenceFinder<Layout>
 		_collectionPersistenceFinderByUuid_C;
 
@@ -493,6 +500,9 @@ public class LayoutPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {uuid, companyId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByGroupId;
+	private FinderPath _finderPathWithoutPaginationFindByGroupId;
+	private FinderPath _finderPathCountByGroupId;
 	private FilterCollectionPersistenceFinder<Layout>
 		_collectionPersistenceFinderByGroupId;
 
@@ -697,6 +707,9 @@ public class LayoutPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {groupId}, groupId);
 	}
 
+	private FinderPath _finderPathWithPaginationFindByCompanyId;
+	private FinderPath _finderPathWithoutPaginationFindByCompanyId;
+	private FinderPath _finderPathCountByCompanyId;
 	private CollectionPersistenceFinder<Layout>
 		_collectionPersistenceFinderByCompanyId;
 
@@ -837,6 +850,9 @@ public class LayoutPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {companyId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByParentPlid;
+	private FinderPath _finderPathWithoutPaginationFindByParentPlid;
+	private FinderPath _finderPathCountByParentPlid;
 	private CollectionPersistenceFinder<Layout>
 		_collectionPersistenceFinderByParentPlid;
 
@@ -978,6 +994,9 @@ public class LayoutPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {parentPlid});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByIconImageId;
+	private FinderPath _finderPathWithoutPaginationFindByIconImageId;
+	private FinderPath _finderPathCountByIconImageId;
 	private CollectionPersistenceFinder<Layout>
 		_collectionPersistenceFinderByIconImageId;
 
@@ -1122,6 +1141,11 @@ public class LayoutPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {iconImageId});
 	}
 
+	private FinderPath
+		_finderPathWithPaginationFindByLayoutSetPrototypeLayoutERC;
+	private FinderPath
+		_finderPathWithoutPaginationFindByLayoutSetPrototypeLayoutERC;
+	private FinderPath _finderPathCountByLayoutSetPrototypeLayoutERC;
 	private CollectionPersistenceFinder<Layout>
 		_collectionPersistenceFinderByLayoutSetPrototypeLayoutERC;
 
@@ -1282,6 +1306,9 @@ public class LayoutPersistenceImpl
 			new Object[] {layoutSetPrototypeLayoutERC});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByG_P;
+	private FinderPath _finderPathWithoutPaginationFindByG_P;
+	private FinderPath _finderPathCountByG_P;
 	private FilterCollectionPersistenceFinder<Layout>
 		_collectionPersistenceFinderByG_P;
 
@@ -1512,6 +1539,9 @@ public class LayoutPersistenceImpl
 			new Object[] {groupId, privateLayout}, groupId);
 	}
 
+	private FinderPath _finderPathWithPaginationFindByG_T;
+	private FinderPath _finderPathWithoutPaginationFindByG_T;
+	private FinderPath _finderPathCountByG_T;
 	private FilterCollectionPersistenceFinder<Layout>
 		_collectionPersistenceFinderByG_T;
 
@@ -1735,6 +1765,9 @@ public class LayoutPersistenceImpl
 			groupId);
 	}
 
+	private FinderPath _finderPathWithPaginationFindByG_MLPTEERC;
+	private FinderPath _finderPathWithoutPaginationFindByG_MLPTEERC;
+	private FinderPath _finderPathCountByG_MLPTEERC;
 	private FilterCollectionPersistenceFinder<Layout>
 		_collectionPersistenceFinderByG_MLPTEERC;
 
@@ -1984,6 +2017,9 @@ public class LayoutPersistenceImpl
 			new Object[] {groupId, masterLayoutPageTemplateEntryERC}, groupId);
 	}
 
+	private FinderPath _finderPathWithPaginationFindByP_I;
+	private FinderPath _finderPathWithoutPaginationFindByP_I;
+	private FinderPath _finderPathCountByP_I;
 	private CollectionPersistenceFinder<Layout>
 		_collectionPersistenceFinderByP_I;
 
@@ -2143,6 +2179,9 @@ public class LayoutPersistenceImpl
 			new Object[] {privateLayout, iconImageId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_C;
+	private FinderPath _finderPathWithoutPaginationFindByC_C;
+	private FinderPath _finderPathCountByC_C;
 	private CollectionPersistenceFinder<Layout>
 		_collectionPersistenceFinderByC_C;
 
@@ -2411,6 +2450,9 @@ public class LayoutPersistenceImpl
 			new Object[] {classNameId, ArrayUtil.sortedUnique(classPKs)});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByPLPTEERC_PLPTESERC;
+	private FinderPath _finderPathWithoutPaginationFindByPLPTEERC_PLPTESERC;
+	private FinderPath _finderPathCountByPLPTEERC_PLPTESERC;
 	private CollectionPersistenceFinder<Layout>
 		_collectionPersistenceFinderByPLPTEERC_PLPTESERC;
 
@@ -2607,6 +2649,7 @@ public class LayoutPersistenceImpl
 			});
 	}
 
+	private FinderPath _finderPathFetchByG_P_L;
 	private UniquePersistenceFinder<Layout> _uniquePersistenceFinderByG_P_L;
 
 	/**
@@ -3966,6 +4009,9 @@ public class LayoutPersistenceImpl
 	private static final String _FINDER_COLUMN_G_P_P_PARENTLAYOUTID_7_SQL =
 		"layout.parentLayoutId IN (";
 
+	private FinderPath _finderPathWithPaginationFindByG_P_T;
+	private FinderPath _finderPathWithoutPaginationFindByG_P_T;
+	private FinderPath _finderPathCountByG_P_T;
 	private FilterCollectionPersistenceFinder<Layout>
 		_collectionPersistenceFinderByG_P_T;
 
@@ -4436,6 +4482,9 @@ public class LayoutPersistenceImpl
 			groupId);
 	}
 
+	private FinderPath _finderPathWithPaginationFindByG_P_S;
+	private FinderPath _finderPathWithoutPaginationFindByG_P_S;
+	private FinderPath _finderPathCountByG_P_S;
 	private FilterCollectionPersistenceFinder<Layout>
 		_collectionPersistenceFinderByG_P_S;
 
@@ -4694,6 +4743,7 @@ public class LayoutPersistenceImpl
 			new Object[] {groupId, privateLayout, system}, groupId);
 	}
 
+	private FinderPath _finderPathFetchByG_P_F;
 	private UniquePersistenceFinder<Layout> _uniquePersistenceFinderByG_P_F;
 
 	/**
@@ -4797,6 +4847,9 @@ public class LayoutPersistenceImpl
 			new Object[] {groupId, privateLayout, friendlyURL});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByG_P_LSPLE;
+	private FinderPath _finderPathWithoutPaginationFindByG_P_LSPLE;
+	private FinderPath _finderPathCountByG_P_LSPLE;
 	private FilterCollectionPersistenceFinder<Layout>
 		_collectionPersistenceFinderByG_P_LSPLE;
 
@@ -5070,6 +5123,9 @@ public class LayoutPersistenceImpl
 			groupId);
 	}
 
+	private FinderPath _finderPathWithPaginationFindByG_P_ST;
+	private FinderPath _finderPathWithoutPaginationFindByG_P_ST;
+	private FinderPath _finderPathCountByG_P_ST;
 	private FilterCollectionPersistenceFinder<Layout>
 		_collectionPersistenceFinderByG_P_ST;
 
@@ -8219,6 +8275,8 @@ public class LayoutPersistenceImpl
 	private static final String _FINDER_COLUMN_G_P_P_S_SYSTEM_2_SQL =
 		"layout.system_ = ?";
 
+	private FinderPath _finderPathWithPaginationFindByG_P_P_LteP;
+	private FinderPath _finderPathWithPaginationCountByG_P_P_LteP;
 	private FilterCollectionPersistenceFinder<Layout>
 		_collectionPersistenceFinderByG_P_P_LteP;
 
@@ -8501,6 +8559,7 @@ public class LayoutPersistenceImpl
 			groupId);
 	}
 
+	private FinderPath _finderPathFetchByERC_G;
 	private UniquePersistenceFinder<Layout> _uniquePersistenceFinderByERC_G;
 
 	/**
@@ -8989,41 +9048,45 @@ public class LayoutPersistenceImpl
 	 * Initializes the layout persistence.
 	 */
 	public void afterPropertiesSet() {
+		_finderPathWithPaginationFindByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid",
+			new String[] {
+				String.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"uuid_"}, true);
+
+		_finderPathWithoutPaginationFindByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid",
+			new String[] {String.class.getName()}, new String[] {"uuid_"}, 0, 1,
+			true, null);
+
+		_finderPathCountByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid",
+			new String[] {String.class.getName()}, new String[] {"uuid_"}, 0, 1,
+			false, null);
+
 		_collectionPersistenceFinderByUuid = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid",
-				new String[] {
-					String.class.getName(), Integer.class.getName(),
-					Integer.class.getName(), OrderByComparator.class.getName()
-				},
-				new String[] {"uuid_"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid",
-				new String[] {String.class.getName()}, new String[] {"uuid_"},
-				0, 1, true, null),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid",
-				new String[] {String.class.getName()}, new String[] {"uuid_"},
-				0, 1, false, null),
+			this, _finderPathWithPaginationFindByUuid,
+			_finderPathWithoutPaginationFindByUuid, _finderPathCountByUuid,
 			_SQL_SELECT_LAYOUT_WHERE, _SQL_COUNT_LAYOUT_WHERE,
 			LayoutModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
 				"layout.", "uuid", FinderColumn.Type.STRING, "=", true, true,
 				Layout::getUuid));
 
+		_finderPathFetchByUUID_G_P = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByUUID_G_P",
+			new String[] {
+				String.class.getName(), Long.class.getName(),
+				Boolean.class.getName()
+			},
+			new String[] {"uuid_", "groupId", "privateLayout"}, 0, 1, false,
+			convertNullFunction(Layout::getUuid), Layout::getGroupId,
+			Layout::isPrivateLayout);
+
 		_uniquePersistenceFinderByUUID_G_P = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByUUID_G_P",
-				new String[] {
-					String.class.getName(), Long.class.getName(),
-					Boolean.class.getName()
-				},
-				new String[] {"uuid_", "groupId", "privateLayout"}, 0, 1, false,
-				convertNullFunction(Layout::getUuid), Layout::getGroupId,
-				Layout::isPrivateLayout),
-			_SQL_SELECT_LAYOUT_WHERE, "",
+			this, _finderPathFetchByUUID_G_P, _SQL_SELECT_LAYOUT_WHERE, "",
 			new FinderColumn<>(
 				"layout.", "uuid", FinderColumn.Type.STRING, "=", true, true,
 				Layout::getUuid),
@@ -9034,27 +9097,32 @@ public class LayoutPersistenceImpl
 				"layout.", "privateLayout", FinderColumn.Type.BOOLEAN, "=",
 				true, true, Layout::isPrivateLayout));
 
+		_finderPathWithPaginationFindByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid_C",
+			new String[] {
+				String.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"uuid_", "companyId"}, true);
+
+		_finderPathWithoutPaginationFindByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"uuid_", "companyId"}, 0, 1, true, null);
+
+		_finderPathCountByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"uuid_", "companyId"}, 0, 1, false, null);
+
 		_collectionPersistenceFinderByUuid_C =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid_C",
-					new String[] {
-						String.class.getName(), Long.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"uuid_", "companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid_C",
-					new String[] {String.class.getName(), Long.class.getName()},
-					new String[] {"uuid_", "companyId"}, 0, 1, true, null),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid_C",
-					new String[] {String.class.getName(), Long.class.getName()},
-					new String[] {"uuid_", "companyId"}, 0, 1, false, null),
-				_SQL_SELECT_LAYOUT_WHERE, _SQL_COUNT_LAYOUT_WHERE,
-				LayoutModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+				this, _finderPathWithPaginationFindByUuid_C,
+				_finderPathWithoutPaginationFindByUuid_C,
+				_finderPathCountByUuid_C, _SQL_SELECT_LAYOUT_WHERE,
+				_SQL_COUNT_LAYOUT_WHERE, LayoutModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
 					"layout.", "uuid", FinderColumn.Type.STRING, "=", true,
 					true, Layout::getUuid),
@@ -9062,142 +9130,160 @@ public class LayoutPersistenceImpl
 					"layout.", "companyId", FinderColumn.Type.LONG, "=", true,
 					true, Layout::getCompanyId));
 
+		_finderPathWithPaginationFindByGroupId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByGroupId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"groupId"}, true);
+
+		_finderPathWithoutPaginationFindByGroupId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByGroupId",
+			new String[] {Long.class.getName()}, new String[] {"groupId"},
+			true);
+
+		_finderPathCountByGroupId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByGroupId",
+			new String[] {Long.class.getName()}, new String[] {"groupId"},
+			false);
+
 		_collectionPersistenceFinderByGroupId =
 			new FilterCollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByGroupId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"groupId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByGroupId",
-					new String[] {Long.class.getName()},
-					new String[] {"groupId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByGroupId",
-					new String[] {Long.class.getName()},
-					new String[] {"groupId"}, false),
-				_SQL_SELECT_LAYOUT_WHERE, _SQL_COUNT_LAYOUT_WHERE,
-				LayoutModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
-				"layout.system = [$FALSE$]",
+				this, _finderPathWithPaginationFindByGroupId,
+				_finderPathWithoutPaginationFindByGroupId,
+				_finderPathCountByGroupId, _SQL_SELECT_LAYOUT_WHERE,
+				_SQL_COUNT_LAYOUT_WHERE, LayoutModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "layout.system = [$FALSE$]",
 				new FilterCollectionPersistenceFinder.FilterMetadata<>(
-					LayoutImpl.class, Layout.class, "layout", "Layout",
-					"layout.plid",
-					"SELECT DISTINCT {layout.*} FROM Layout layout WHERE ",
-					"SELECT {Layout.*} FROM (SELECT DISTINCT layout.plid FROM Layout layout WHERE ",
-					") TEMP_TABLE INNER JOIN Layout ON TEMP_TABLE.plid = Layout.plid",
-					"SELECT COUNT(DISTINCT layout.plid) AS COUNT_VALUE FROM Layout layout WHERE ",
+					LayoutImpl.class, Layout.class, _FILTER_ENTITY_ALIAS,
+					_FILTER_ENTITY_TABLE, _FILTER_ENTITY_TABLE_FILTER_PK_COLUMN,
+					_FILTER_SQL_SELECT_LAYOUT_WHERE,
+					_FILTER_SQL_SELECT_LAYOUT_NO_INLINE_DISTINCT_WHERE_1,
+					_FILTER_SQL_SELECT_LAYOUT_NO_INLINE_DISTINCT_WHERE_2,
+					_FILTER_SQL_COUNT_LAYOUT_WHERE,
 					LayoutModelImpl.ORDER_BY_SQL,
 					LayoutModelImpl.ORDER_BY_SQL_INLINE_DISTINCT),
 				new FinderColumn<>(
 					"layout.", "groupId", FinderColumn.Type.LONG, "=", true,
 					true, Layout::getGroupId));
 
+		_finderPathWithPaginationFindByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByCompanyId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"companyId"}, true);
+
+		_finderPathWithoutPaginationFindByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByCompanyId",
+			new String[] {Long.class.getName()}, new String[] {"companyId"},
+			true);
+
+		_finderPathCountByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByCompanyId",
+			new String[] {Long.class.getName()}, new String[] {"companyId"},
+			false);
+
 		_collectionPersistenceFinderByCompanyId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByCompanyId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"findByCompanyId", new String[] {Long.class.getName()},
-					new String[] {"companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByCompanyId", new String[] {Long.class.getName()},
-					new String[] {"companyId"}, false),
-				_SQL_SELECT_LAYOUT_WHERE, _SQL_COUNT_LAYOUT_WHERE,
-				LayoutModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
-				"layout.system = [$FALSE$]",
+				this, _finderPathWithPaginationFindByCompanyId,
+				_finderPathWithoutPaginationFindByCompanyId,
+				_finderPathCountByCompanyId, _SQL_SELECT_LAYOUT_WHERE,
+				_SQL_COUNT_LAYOUT_WHERE, LayoutModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "layout.system = [$FALSE$]",
 				new FinderColumn<>(
 					"layout.", "companyId", FinderColumn.Type.LONG, "=", true,
 					true, Layout::getCompanyId));
 
+		_finderPathWithPaginationFindByParentPlid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByParentPlid",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"parentPlid"}, true);
+
+		_finderPathWithoutPaginationFindByParentPlid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByParentPlid",
+			new String[] {Long.class.getName()}, new String[] {"parentPlid"},
+			true);
+
+		_finderPathCountByParentPlid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByParentPlid",
+			new String[] {Long.class.getName()}, new String[] {"parentPlid"},
+			false);
+
 		_collectionPersistenceFinderByParentPlid =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByParentPlid",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"parentPlid"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"findByParentPlid", new String[] {Long.class.getName()},
-					new String[] {"parentPlid"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByParentPlid", new String[] {Long.class.getName()},
-					new String[] {"parentPlid"}, false),
-				_SQL_SELECT_LAYOUT_WHERE, _SQL_COUNT_LAYOUT_WHERE,
-				LayoutModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
-				"layout.system = [$FALSE$]",
+				this, _finderPathWithPaginationFindByParentPlid,
+				_finderPathWithoutPaginationFindByParentPlid,
+				_finderPathCountByParentPlid, _SQL_SELECT_LAYOUT_WHERE,
+				_SQL_COUNT_LAYOUT_WHERE, LayoutModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "layout.system = [$FALSE$]",
 				new FinderColumn<>(
 					"layout.", "parentPlid", FinderColumn.Type.LONG, "=", true,
 					true, Layout::getParentPlid));
 
+		_finderPathWithPaginationFindByIconImageId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByIconImageId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"iconImageId"}, true);
+
+		_finderPathWithoutPaginationFindByIconImageId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByIconImageId",
+			new String[] {Long.class.getName()}, new String[] {"iconImageId"},
+			true);
+
+		_finderPathCountByIconImageId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByIconImageId",
+			new String[] {Long.class.getName()}, new String[] {"iconImageId"},
+			false);
+
 		_collectionPersistenceFinderByIconImageId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByIconImageId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"iconImageId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"findByIconImageId", new String[] {Long.class.getName()},
-					new String[] {"iconImageId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByIconImageId", new String[] {Long.class.getName()},
-					new String[] {"iconImageId"}, false),
-				_SQL_SELECT_LAYOUT_WHERE, _SQL_COUNT_LAYOUT_WHERE,
-				LayoutModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+				this, _finderPathWithPaginationFindByIconImageId,
+				_finderPathWithoutPaginationFindByIconImageId,
+				_finderPathCountByIconImageId, _SQL_SELECT_LAYOUT_WHERE,
+				_SQL_COUNT_LAYOUT_WHERE, LayoutModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
 					"layout.", "iconImageId", FinderColumn.Type.LONG, "=", true,
 					true, Layout::getIconImageId));
 
+		_finderPathWithPaginationFindByLayoutSetPrototypeLayoutERC =
+			new FinderPath(
+				FINDER_CLASS_NAME_LIST_WITH_PAGINATION,
+				"findByLayoutSetPrototypeLayoutERC",
+				new String[] {
+					String.class.getName(), Integer.class.getName(),
+					Integer.class.getName(), OrderByComparator.class.getName()
+				},
+				new String[] {"layoutSetPrototypeLayoutERC"}, true);
+
+		_finderPathWithoutPaginationFindByLayoutSetPrototypeLayoutERC =
+			new FinderPath(
+				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
+				"findByLayoutSetPrototypeLayoutERC",
+				new String[] {String.class.getName()},
+				new String[] {"layoutSetPrototypeLayoutERC"}, 0, 1, true, null);
+
+		_finderPathCountByLayoutSetPrototypeLayoutERC = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
+			"countByLayoutSetPrototypeLayoutERC",
+			new String[] {String.class.getName()},
+			new String[] {"layoutSetPrototypeLayoutERC"}, 0, 1, false, null);
+
 		_collectionPersistenceFinderByLayoutSetPrototypeLayoutERC =
 			new CollectionPersistenceFinder<>(
 				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION,
-					"findByLayoutSetPrototypeLayoutERC",
-					new String[] {
-						String.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"layoutSetPrototypeLayoutERC"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"findByLayoutSetPrototypeLayoutERC",
-					new String[] {String.class.getName()},
-					new String[] {"layoutSetPrototypeLayoutERC"}, 0, 1, true,
-					null),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByLayoutSetPrototypeLayoutERC",
-					new String[] {String.class.getName()},
-					new String[] {"layoutSetPrototypeLayoutERC"}, 0, 1, false,
-					null),
+				_finderPathWithPaginationFindByLayoutSetPrototypeLayoutERC,
+				_finderPathWithoutPaginationFindByLayoutSetPrototypeLayoutERC,
+				_finderPathCountByLayoutSetPrototypeLayoutERC,
 				_SQL_SELECT_LAYOUT_WHERE, _SQL_COUNT_LAYOUT_WHERE,
 				LayoutModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
 				"layout.system = [$FALSE$]",
@@ -9206,38 +9292,38 @@ public class LayoutPersistenceImpl
 					FinderColumn.Type.STRING, "=", true, true,
 					Layout::getLayoutSetPrototypeLayoutERC));
 
+		_finderPathWithPaginationFindByG_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_P",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"groupId", "privateLayout"}, true);
+
+		_finderPathWithoutPaginationFindByG_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_P",
+			new String[] {Long.class.getName(), Boolean.class.getName()},
+			new String[] {"groupId", "privateLayout"}, true);
+
+		_finderPathCountByG_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_P",
+			new String[] {Long.class.getName(), Boolean.class.getName()},
+			new String[] {"groupId", "privateLayout"}, false);
+
 		_collectionPersistenceFinderByG_P =
 			new FilterCollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_P",
-					new String[] {
-						Long.class.getName(), Boolean.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"groupId", "privateLayout"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_P",
-					new String[] {
-						Long.class.getName(), Boolean.class.getName()
-					},
-					new String[] {"groupId", "privateLayout"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_P",
-					new String[] {
-						Long.class.getName(), Boolean.class.getName()
-					},
-					new String[] {"groupId", "privateLayout"}, false),
+				this, _finderPathWithPaginationFindByG_P,
+				_finderPathWithoutPaginationFindByG_P, _finderPathCountByG_P,
 				_SQL_SELECT_LAYOUT_WHERE, _SQL_COUNT_LAYOUT_WHERE,
 				LayoutModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 				new FilterCollectionPersistenceFinder.FilterMetadata<>(
-					LayoutImpl.class, Layout.class, "layout", "Layout",
-					"layout.plid",
-					"SELECT DISTINCT {layout.*} FROM Layout layout WHERE ",
-					"SELECT {Layout.*} FROM (SELECT DISTINCT layout.plid FROM Layout layout WHERE ",
-					") TEMP_TABLE INNER JOIN Layout ON TEMP_TABLE.plid = Layout.plid",
-					"SELECT COUNT(DISTINCT layout.plid) AS COUNT_VALUE FROM Layout layout WHERE ",
+					LayoutImpl.class, Layout.class, _FILTER_ENTITY_ALIAS,
+					_FILTER_ENTITY_TABLE, _FILTER_ENTITY_TABLE_FILTER_PK_COLUMN,
+					_FILTER_SQL_SELECT_LAYOUT_WHERE,
+					_FILTER_SQL_SELECT_LAYOUT_NO_INLINE_DISTINCT_WHERE_1,
+					_FILTER_SQL_SELECT_LAYOUT_NO_INLINE_DISTINCT_WHERE_2,
+					_FILTER_SQL_COUNT_LAYOUT_WHERE,
 					LayoutModelImpl.ORDER_BY_SQL,
 					LayoutModelImpl.ORDER_BY_SQL_INLINE_DISTINCT),
 				new FinderColumn<>(
@@ -9247,35 +9333,39 @@ public class LayoutPersistenceImpl
 					"layout.", "privateLayout", FinderColumn.Type.BOOLEAN, "=",
 					true, true, Layout::isPrivateLayout));
 
+		_finderPathWithPaginationFindByG_T = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_T",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"groupId", "type_"}, true);
+
+		_finderPathWithoutPaginationFindByG_T = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_T",
+			new String[] {Long.class.getName(), String.class.getName()},
+			new String[] {"groupId", "type_"}, 0, 2, true, null);
+
+		_finderPathCountByG_T = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_T",
+			new String[] {Long.class.getName(), String.class.getName()},
+			new String[] {"groupId", "type_"}, 0, 2, false, null);
+
 		_collectionPersistenceFinderByG_T =
 			new FilterCollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_T",
-					new String[] {
-						Long.class.getName(), String.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"groupId", "type_"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_T",
-					new String[] {Long.class.getName(), String.class.getName()},
-					new String[] {"groupId", "type_"}, 0, 2, true, null),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_T",
-					new String[] {Long.class.getName(), String.class.getName()},
-					new String[] {"groupId", "type_"}, 0, 2, false, null),
+				this, _finderPathWithPaginationFindByG_T,
+				_finderPathWithoutPaginationFindByG_T, _finderPathCountByG_T,
 				_SQL_SELECT_LAYOUT_WHERE, _SQL_COUNT_LAYOUT_WHERE,
 				LayoutModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
 				"layout.system = [$FALSE$]",
 				new FilterCollectionPersistenceFinder.FilterMetadata<>(
-					LayoutImpl.class, Layout.class, "layout", "Layout",
-					"layout.plid",
-					"SELECT DISTINCT {layout.*} FROM Layout layout WHERE ",
-					"SELECT {Layout.*} FROM (SELECT DISTINCT layout.plid FROM Layout layout WHERE ",
-					") TEMP_TABLE INNER JOIN Layout ON TEMP_TABLE.plid = Layout.plid",
-					"SELECT COUNT(DISTINCT layout.plid) AS COUNT_VALUE FROM Layout layout WHERE ",
+					LayoutImpl.class, Layout.class, _FILTER_ENTITY_ALIAS,
+					_FILTER_ENTITY_TABLE, _FILTER_ENTITY_TABLE_FILTER_PK_COLUMN,
+					_FILTER_SQL_SELECT_LAYOUT_WHERE,
+					_FILTER_SQL_SELECT_LAYOUT_NO_INLINE_DISTINCT_WHERE_1,
+					_FILTER_SQL_SELECT_LAYOUT_NO_INLINE_DISTINCT_WHERE_2,
+					_FILTER_SQL_COUNT_LAYOUT_WHERE,
 					LayoutModelImpl.ORDER_BY_SQL,
 					LayoutModelImpl.ORDER_BY_SQL_INLINE_DISTINCT),
 				new FinderColumn<>(
@@ -9285,38 +9375,39 @@ public class LayoutPersistenceImpl
 					"layout.", "type", FinderColumn.Type.STRING, "=", true,
 					true, Layout::getType));
 
+		_finderPathWithPaginationFindByG_MLPTEERC = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_MLPTEERC",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"groupId", "masterLPTEERC"}, true);
+
+		_finderPathWithoutPaginationFindByG_MLPTEERC = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_MLPTEERC",
+			new String[] {Long.class.getName(), String.class.getName()},
+			new String[] {"groupId", "masterLPTEERC"}, 0, 2, true, null);
+
+		_finderPathCountByG_MLPTEERC = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_MLPTEERC",
+			new String[] {Long.class.getName(), String.class.getName()},
+			new String[] {"groupId", "masterLPTEERC"}, 0, 2, false, null);
+
 		_collectionPersistenceFinderByG_MLPTEERC =
 			new FilterCollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_MLPTEERC",
-					new String[] {
-						Long.class.getName(), String.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"groupId", "masterLPTEERC"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"findByG_MLPTEERC",
-					new String[] {Long.class.getName(), String.class.getName()},
-					new String[] {"groupId", "masterLPTEERC"}, 0, 2, true,
-					null),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByG_MLPTEERC",
-					new String[] {Long.class.getName(), String.class.getName()},
-					new String[] {"groupId", "masterLPTEERC"}, 0, 2, false,
-					null),
-				_SQL_SELECT_LAYOUT_WHERE, _SQL_COUNT_LAYOUT_WHERE,
-				LayoutModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+				this, _finderPathWithPaginationFindByG_MLPTEERC,
+				_finderPathWithoutPaginationFindByG_MLPTEERC,
+				_finderPathCountByG_MLPTEERC, _SQL_SELECT_LAYOUT_WHERE,
+				_SQL_COUNT_LAYOUT_WHERE, LayoutModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "",
 				new FilterCollectionPersistenceFinder.FilterMetadata<>(
-					LayoutImpl.class, Layout.class, "layout", "Layout",
-					"layout.plid",
-					"SELECT DISTINCT {layout.*} FROM Layout layout WHERE ",
-					"SELECT {Layout.*} FROM (SELECT DISTINCT layout.plid FROM Layout layout WHERE ",
-					") TEMP_TABLE INNER JOIN Layout ON TEMP_TABLE.plid = Layout.plid",
-					"SELECT COUNT(DISTINCT layout.plid) AS COUNT_VALUE FROM Layout layout WHERE ",
+					LayoutImpl.class, Layout.class, _FILTER_ENTITY_ALIAS,
+					_FILTER_ENTITY_TABLE, _FILTER_ENTITY_TABLE_FILTER_PK_COLUMN,
+					_FILTER_SQL_SELECT_LAYOUT_WHERE,
+					_FILTER_SQL_SELECT_LAYOUT_NO_INLINE_DISTINCT_WHERE_1,
+					_FILTER_SQL_SELECT_LAYOUT_NO_INLINE_DISTINCT_WHERE_2,
+					_FILTER_SQL_COUNT_LAYOUT_WHERE,
 					LayoutModelImpl.ORDER_BY_SQL,
 					LayoutModelImpl.ORDER_BY_SQL_INLINE_DISTINCT),
 				new FinderColumn<>(
@@ -9327,24 +9418,28 @@ public class LayoutPersistenceImpl
 					FinderColumn.Type.STRING, "=", true, true,
 					Layout::getMasterLayoutPageTemplateEntryERC));
 
+		_finderPathWithPaginationFindByP_I = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByP_I",
+			new String[] {
+				Boolean.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"privateLayout", "iconImageId"}, true);
+
+		_finderPathWithoutPaginationFindByP_I = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByP_I",
+			new String[] {Boolean.class.getName(), Long.class.getName()},
+			new String[] {"privateLayout", "iconImageId"}, true);
+
+		_finderPathCountByP_I = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByP_I",
+			new String[] {Boolean.class.getName(), Long.class.getName()},
+			new String[] {"privateLayout", "iconImageId"}, false);
+
 		_collectionPersistenceFinderByP_I = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByP_I",
-				new String[] {
-					Boolean.class.getName(), Long.class.getName(),
-					Integer.class.getName(), Integer.class.getName(),
-					OrderByComparator.class.getName()
-				},
-				new String[] {"privateLayout", "iconImageId"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByP_I",
-				new String[] {Boolean.class.getName(), Long.class.getName()},
-				new String[] {"privateLayout", "iconImageId"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByP_I",
-				new String[] {Boolean.class.getName(), Long.class.getName()},
-				new String[] {"privateLayout", "iconImageId"}, false),
+			this, _finderPathWithPaginationFindByP_I,
+			_finderPathWithoutPaginationFindByP_I, _finderPathCountByP_I,
 			_SQL_SELECT_LAYOUT_WHERE, _SQL_COUNT_LAYOUT_WHERE,
 			LayoutModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
@@ -9354,24 +9449,28 @@ public class LayoutPersistenceImpl
 				"layout.", "iconImageId", FinderColumn.Type.LONG, "=", true,
 				true, Layout::getIconImageId));
 
+		_finderPathWithPaginationFindByC_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_C",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"classNameId", "classPK"}, true);
+
+		_finderPathWithoutPaginationFindByC_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_C",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"classNameId", "classPK"}, true);
+
+		_finderPathCountByC_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByC_C",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"classNameId", "classPK"}, false);
+
 		_collectionPersistenceFinderByC_C = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_C",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Integer.class.getName(), Integer.class.getName(),
-					OrderByComparator.class.getName()
-				},
-				new String[] {"classNameId", "classPK"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_C",
-				new String[] {Long.class.getName(), Long.class.getName()},
-				new String[] {"classNameId", "classPK"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByC_C",
-				new String[] {Long.class.getName(), Long.class.getName()},
-				new String[] {"classNameId", "classPK"}, false),
+			this, _finderPathWithPaginationFindByC_C,
+			_finderPathWithoutPaginationFindByC_C, _finderPathCountByC_C,
 			_SQL_SELECT_LAYOUT_WHERE, _SQL_COUNT_LAYOUT_WHERE,
 			LayoutModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
@@ -9381,37 +9480,36 @@ public class LayoutPersistenceImpl
 				"layout.", "classPK", FinderColumn.Type.LONG, "=", false, true,
 				true, Layout::getClassPK));
 
+		_finderPathWithPaginationFindByPLPTEERC_PLPTESERC = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByPLPTEERC_PLPTESERC",
+			new String[] {
+				String.class.getName(), String.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"portletLPTEERC", "portletLPTESERC"}, true);
+
+		_finderPathWithoutPaginationFindByPLPTEERC_PLPTESERC = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
+			"findByPLPTEERC_PLPTESERC",
+			new String[] {String.class.getName(), String.class.getName()},
+			new String[] {"portletLPTEERC", "portletLPTESERC"}, 0, 3, true,
+			null);
+
+		_finderPathCountByPLPTEERC_PLPTESERC = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
+			"countByPLPTEERC_PLPTESERC",
+			new String[] {String.class.getName(), String.class.getName()},
+			new String[] {"portletLPTEERC", "portletLPTESERC"}, 0, 3, false,
+			null);
+
 		_collectionPersistenceFinderByPLPTEERC_PLPTESERC =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION,
-					"findByPLPTEERC_PLPTESERC",
-					new String[] {
-						String.class.getName(), String.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"portletLPTEERC", "portletLPTESERC"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"findByPLPTEERC_PLPTESERC",
-					new String[] {
-						String.class.getName(), String.class.getName()
-					},
-					new String[] {"portletLPTEERC", "portletLPTESERC"}, 0, 3,
-					true, null),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByPLPTEERC_PLPTESERC",
-					new String[] {
-						String.class.getName(), String.class.getName()
-					},
-					new String[] {"portletLPTEERC", "portletLPTESERC"}, 0, 3,
-					false, null),
-				_SQL_SELECT_LAYOUT_WHERE, _SQL_COUNT_LAYOUT_WHERE,
-				LayoutModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
-				"layout.system = [$FALSE$]",
+				this, _finderPathWithPaginationFindByPLPTEERC_PLPTESERC,
+				_finderPathWithoutPaginationFindByPLPTEERC_PLPTESERC,
+				_finderPathCountByPLPTEERC_PLPTESERC, _SQL_SELECT_LAYOUT_WHERE,
+				_SQL_COUNT_LAYOUT_WHERE, LayoutModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "layout.system = [$FALSE$]",
 				new FinderColumn<>(
 					"layout.", "portletLayoutPageTemplateEntryERC",
 					FinderColumn.Type.STRING, "=", true, true,
@@ -9421,18 +9519,17 @@ public class LayoutPersistenceImpl
 					FinderColumn.Type.STRING, "=", true, true,
 					Layout::getPortletLayoutPageTemplateEntryScopeERC));
 
+		_finderPathFetchByG_P_L = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByG_P_L",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Long.class.getName()
+			},
+			new String[] {"groupId", "privateLayout", "layoutId"}, 0, 0, false,
+			Layout::getGroupId, Layout::isPrivateLayout, Layout::getLayoutId);
+
 		_uniquePersistenceFinderByG_P_L = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByG_P_L",
-				new String[] {
-					Long.class.getName(), Boolean.class.getName(),
-					Long.class.getName()
-				},
-				new String[] {"groupId", "privateLayout", "layoutId"}, 0, 0,
-				false, Layout::getGroupId, Layout::isPrivateLayout,
-				Layout::getLayoutId),
-			_SQL_SELECT_LAYOUT_WHERE, "",
+			this, _finderPathFetchByG_P_L, _SQL_SELECT_LAYOUT_WHERE, "",
 			new FinderColumn<>(
 				"layout.", "groupId", FinderColumn.Type.LONG, "=", true, true,
 				Layout::getGroupId),
@@ -9476,44 +9573,47 @@ public class LayoutPersistenceImpl
 			},
 			new String[] {"groupId", "privateLayout", "parentLayoutId"}, false);
 
+		_finderPathWithPaginationFindByG_P_T = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_P_T",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				String.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"groupId", "privateLayout", "type_"}, true);
+
+		_finderPathWithoutPaginationFindByG_P_T = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_P_T",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				String.class.getName()
+			},
+			new String[] {"groupId", "privateLayout", "type_"}, 0, 4, true,
+			null);
+
+		_finderPathCountByG_P_T = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByG_P_T",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				String.class.getName()
+			},
+			new String[] {"groupId", "privateLayout", "type_"}, 0, 4, false,
+			null);
+
 		_collectionPersistenceFinderByG_P_T =
 			new FilterCollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_P_T",
-					new String[] {
-						Long.class.getName(), Boolean.class.getName(),
-						String.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"groupId", "privateLayout", "type_"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_P_T",
-					new String[] {
-						Long.class.getName(), Boolean.class.getName(),
-						String.class.getName()
-					},
-					new String[] {"groupId", "privateLayout", "type_"}, 0, 4,
-					true, null),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByG_P_T",
-					new String[] {
-						Long.class.getName(), Boolean.class.getName(),
-						String.class.getName()
-					},
-					new String[] {"groupId", "privateLayout", "type_"}, 0, 4,
-					false, null),
-				_SQL_SELECT_LAYOUT_WHERE, _SQL_COUNT_LAYOUT_WHERE,
-				LayoutModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
-				"layout.system = [$FALSE$]",
+				this, _finderPathWithPaginationFindByG_P_T,
+				_finderPathWithoutPaginationFindByG_P_T,
+				_finderPathCountByG_P_T, _SQL_SELECT_LAYOUT_WHERE,
+				_SQL_COUNT_LAYOUT_WHERE, LayoutModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "layout.system = [$FALSE$]",
 				new FilterCollectionPersistenceFinder.FilterMetadata<>(
-					LayoutImpl.class, Layout.class, "layout", "Layout",
-					"layout.plid",
-					"SELECT DISTINCT {layout.*} FROM Layout layout WHERE ",
-					"SELECT {Layout.*} FROM (SELECT DISTINCT layout.plid FROM Layout layout WHERE ",
-					") TEMP_TABLE INNER JOIN Layout ON TEMP_TABLE.plid = Layout.plid",
-					"SELECT COUNT(DISTINCT layout.plid) AS COUNT_VALUE FROM Layout layout WHERE ",
+					LayoutImpl.class, Layout.class, _FILTER_ENTITY_ALIAS,
+					_FILTER_ENTITY_TABLE, _FILTER_ENTITY_TABLE_FILTER_PK_COLUMN,
+					_FILTER_SQL_SELECT_LAYOUT_WHERE,
+					_FILTER_SQL_SELECT_LAYOUT_NO_INLINE_DISTINCT_WHERE_1,
+					_FILTER_SQL_SELECT_LAYOUT_NO_INLINE_DISTINCT_WHERE_2,
+					_FILTER_SQL_COUNT_LAYOUT_WHERE,
 					LayoutModelImpl.ORDER_BY_SQL,
 					LayoutModelImpl.ORDER_BY_SQL_INLINE_DISTINCT),
 				new FinderColumn<>(
@@ -9526,42 +9626,45 @@ public class LayoutPersistenceImpl
 					"layout.", "type", FinderColumn.Type.STRING, "=", false,
 					true, true, Layout::getType));
 
+		_finderPathWithPaginationFindByG_P_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_P_S",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"groupId", "privateLayout", "system_"}, true);
+
+		_finderPathWithoutPaginationFindByG_P_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_P_S",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName()
+			},
+			new String[] {"groupId", "privateLayout", "system_"}, true);
+
+		_finderPathCountByG_P_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_P_S",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName()
+			},
+			new String[] {"groupId", "privateLayout", "system_"}, false);
+
 		_collectionPersistenceFinderByG_P_S =
 			new FilterCollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_P_S",
-					new String[] {
-						Long.class.getName(), Boolean.class.getName(),
-						Boolean.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"groupId", "privateLayout", "system_"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_P_S",
-					new String[] {
-						Long.class.getName(), Boolean.class.getName(),
-						Boolean.class.getName()
-					},
-					new String[] {"groupId", "privateLayout", "system_"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_P_S",
-					new String[] {
-						Long.class.getName(), Boolean.class.getName(),
-						Boolean.class.getName()
-					},
-					new String[] {"groupId", "privateLayout", "system_"},
-					false),
-				_SQL_SELECT_LAYOUT_WHERE, _SQL_COUNT_LAYOUT_WHERE,
-				LayoutModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+				this, _finderPathWithPaginationFindByG_P_S,
+				_finderPathWithoutPaginationFindByG_P_S,
+				_finderPathCountByG_P_S, _SQL_SELECT_LAYOUT_WHERE,
+				_SQL_COUNT_LAYOUT_WHERE, LayoutModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "",
 				new FilterCollectionPersistenceFinder.FilterMetadata<>(
-					LayoutImpl.class, Layout.class, "layout", "Layout",
-					"layout.plid",
-					"SELECT DISTINCT {layout.*} FROM Layout layout WHERE ",
-					"SELECT {Layout.*} FROM (SELECT DISTINCT layout.plid FROM Layout layout WHERE ",
-					") TEMP_TABLE INNER JOIN Layout ON TEMP_TABLE.plid = Layout.plid",
-					"SELECT COUNT(DISTINCT layout.plid) AS COUNT_VALUE FROM Layout layout WHERE ",
+					LayoutImpl.class, Layout.class, _FILTER_ENTITY_ALIAS,
+					_FILTER_ENTITY_TABLE, _FILTER_ENTITY_TABLE_FILTER_PK_COLUMN,
+					_FILTER_SQL_SELECT_LAYOUT_WHERE,
+					_FILTER_SQL_SELECT_LAYOUT_NO_INLINE_DISTINCT_WHERE_1,
+					_FILTER_SQL_SELECT_LAYOUT_NO_INLINE_DISTINCT_WHERE_2,
+					_FILTER_SQL_COUNT_LAYOUT_WHERE,
 					LayoutModelImpl.ORDER_BY_SQL,
 					LayoutModelImpl.ORDER_BY_SQL_INLINE_DISTINCT),
 				new FinderColumn<>(
@@ -9574,18 +9677,18 @@ public class LayoutPersistenceImpl
 					"layout.", "system", FinderColumn.Type.BOOLEAN, "=", true,
 					true, Layout::isSystem));
 
+		_finderPathFetchByG_P_F = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByG_P_F",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				String.class.getName()
+			},
+			new String[] {"groupId", "privateLayout", "friendlyURL"}, 0, 4,
+			false, Layout::getGroupId, Layout::isPrivateLayout,
+			convertNullFunction(Layout::getFriendlyURL));
+
 		_uniquePersistenceFinderByG_P_F = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByG_P_F",
-				new String[] {
-					Long.class.getName(), Boolean.class.getName(),
-					String.class.getName()
-				},
-				new String[] {"groupId", "privateLayout", "friendlyURL"}, 0, 4,
-				false, Layout::getGroupId, Layout::isPrivateLayout,
-				convertNullFunction(Layout::getFriendlyURL)),
-			_SQL_SELECT_LAYOUT_WHERE, "",
+			this, _finderPathFetchByG_P_F, _SQL_SELECT_LAYOUT_WHERE, "",
 			new FinderColumn<>(
 				"layout.", "groupId", FinderColumn.Type.LONG, "=", true, true,
 				Layout::getGroupId),
@@ -9596,55 +9699,54 @@ public class LayoutPersistenceImpl
 				"layout.", "friendlyURL", FinderColumn.Type.STRING, "=", true,
 				true, Layout::getFriendlyURL));
 
+		_finderPathWithPaginationFindByG_P_LSPLE = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_P_LSPLE",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				String.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {
+				"groupId", "privateLayout", "layoutSetPrototypeLayoutERC"
+			},
+			true);
+
+		_finderPathWithoutPaginationFindByG_P_LSPLE = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_P_LSPLE",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				String.class.getName()
+			},
+			new String[] {
+				"groupId", "privateLayout", "layoutSetPrototypeLayoutERC"
+			},
+			0, 4, true, null);
+
+		_finderPathCountByG_P_LSPLE = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_P_LSPLE",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				String.class.getName()
+			},
+			new String[] {
+				"groupId", "privateLayout", "layoutSetPrototypeLayoutERC"
+			},
+			0, 4, false, null);
+
 		_collectionPersistenceFinderByG_P_LSPLE =
 			new FilterCollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_P_LSPLE",
-					new String[] {
-						Long.class.getName(), Boolean.class.getName(),
-						String.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {
-						"groupId", "privateLayout",
-						"layoutSetPrototypeLayoutERC"
-					},
-					true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"findByG_P_LSPLE",
-					new String[] {
-						Long.class.getName(), Boolean.class.getName(),
-						String.class.getName()
-					},
-					new String[] {
-						"groupId", "privateLayout",
-						"layoutSetPrototypeLayoutERC"
-					},
-					0, 4, true, null),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByG_P_LSPLE",
-					new String[] {
-						Long.class.getName(), Boolean.class.getName(),
-						String.class.getName()
-					},
-					new String[] {
-						"groupId", "privateLayout",
-						"layoutSetPrototypeLayoutERC"
-					},
-					0, 4, false, null),
-				_SQL_SELECT_LAYOUT_WHERE, _SQL_COUNT_LAYOUT_WHERE,
-				LayoutModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+				this, _finderPathWithPaginationFindByG_P_LSPLE,
+				_finderPathWithoutPaginationFindByG_P_LSPLE,
+				_finderPathCountByG_P_LSPLE, _SQL_SELECT_LAYOUT_WHERE,
+				_SQL_COUNT_LAYOUT_WHERE, LayoutModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "",
 				new FilterCollectionPersistenceFinder.FilterMetadata<>(
-					LayoutImpl.class, Layout.class, "layout", "Layout",
-					"layout.plid",
-					"SELECT DISTINCT {layout.*} FROM Layout layout WHERE ",
-					"SELECT {Layout.*} FROM (SELECT DISTINCT layout.plid FROM Layout layout WHERE ",
-					") TEMP_TABLE INNER JOIN Layout ON TEMP_TABLE.plid = Layout.plid",
-					"SELECT COUNT(DISTINCT layout.plid) AS COUNT_VALUE FROM Layout layout WHERE ",
+					LayoutImpl.class, Layout.class, _FILTER_ENTITY_ALIAS,
+					_FILTER_ENTITY_TABLE, _FILTER_ENTITY_TABLE_FILTER_PK_COLUMN,
+					_FILTER_SQL_SELECT_LAYOUT_WHERE,
+					_FILTER_SQL_SELECT_LAYOUT_NO_INLINE_DISTINCT_WHERE_1,
+					_FILTER_SQL_SELECT_LAYOUT_NO_INLINE_DISTINCT_WHERE_2,
+					_FILTER_SQL_COUNT_LAYOUT_WHERE,
 					LayoutModelImpl.ORDER_BY_SQL,
 					LayoutModelImpl.ORDER_BY_SQL_INLINE_DISTINCT),
 				new FinderColumn<>(
@@ -9658,42 +9760,45 @@ public class LayoutPersistenceImpl
 					FinderColumn.Type.STRING, "=", true, true,
 					Layout::getLayoutSetPrototypeLayoutERC));
 
+		_finderPathWithPaginationFindByG_P_ST = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_P_ST",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"groupId", "privateLayout", "status"}, true);
+
+		_finderPathWithoutPaginationFindByG_P_ST = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_P_ST",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Integer.class.getName()
+			},
+			new String[] {"groupId", "privateLayout", "status"}, true);
+
+		_finderPathCountByG_P_ST = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByG_P_ST",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Integer.class.getName()
+			},
+			new String[] {"groupId", "privateLayout", "status"}, false);
+
 		_collectionPersistenceFinderByG_P_ST =
 			new FilterCollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_P_ST",
-					new String[] {
-						Long.class.getName(), Boolean.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"groupId", "privateLayout", "status"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_P_ST",
-					new String[] {
-						Long.class.getName(), Boolean.class.getName(),
-						Integer.class.getName()
-					},
-					new String[] {"groupId", "privateLayout", "status"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByG_P_ST",
-					new String[] {
-						Long.class.getName(), Boolean.class.getName(),
-						Integer.class.getName()
-					},
-					new String[] {"groupId", "privateLayout", "status"}, false),
-				_SQL_SELECT_LAYOUT_WHERE, _SQL_COUNT_LAYOUT_WHERE,
-				LayoutModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
-				"layout.system = [$FALSE$]",
+				this, _finderPathWithPaginationFindByG_P_ST,
+				_finderPathWithoutPaginationFindByG_P_ST,
+				_finderPathCountByG_P_ST, _SQL_SELECT_LAYOUT_WHERE,
+				_SQL_COUNT_LAYOUT_WHERE, LayoutModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "layout.system = [$FALSE$]",
 				new FilterCollectionPersistenceFinder.FilterMetadata<>(
-					LayoutImpl.class, Layout.class, "layout", "Layout",
-					"layout.plid",
-					"SELECT DISTINCT {layout.*} FROM Layout layout WHERE ",
-					"SELECT {Layout.*} FROM (SELECT DISTINCT layout.plid FROM Layout layout WHERE ",
-					") TEMP_TABLE INNER JOIN Layout ON TEMP_TABLE.plid = Layout.plid",
-					"SELECT COUNT(DISTINCT layout.plid) AS COUNT_VALUE FROM Layout layout WHERE ",
+					LayoutImpl.class, Layout.class, _FILTER_ENTITY_ALIAS,
+					_FILTER_ENTITY_TABLE, _FILTER_ENTITY_TABLE_FILTER_PK_COLUMN,
+					_FILTER_SQL_SELECT_LAYOUT_WHERE,
+					_FILTER_SQL_SELECT_LAYOUT_NO_INLINE_DISTINCT_WHERE_1,
+					_FILTER_SQL_SELECT_LAYOUT_NO_INLINE_DISTINCT_WHERE_2,
+					_FILTER_SQL_COUNT_LAYOUT_WHERE,
 					LayoutModelImpl.ORDER_BY_SQL,
 					LayoutModelImpl.ORDER_BY_SQL_INLINE_DISTINCT),
 				new FinderColumn<>(
@@ -9798,42 +9903,44 @@ public class LayoutPersistenceImpl
 			},
 			false);
 
+		_finderPathWithPaginationFindByG_P_P_LteP = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_P_P_LteP",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {
+				"groupId", "privateLayout", "parentLayoutId", "priority"
+			},
+			true);
+
+		_finderPathWithPaginationCountByG_P_P_LteP = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByG_P_P_LteP",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Long.class.getName(), Integer.class.getName()
+			},
+			new String[] {
+				"groupId", "privateLayout", "parentLayoutId", "priority"
+			},
+			false);
+
 		_collectionPersistenceFinderByG_P_P_LteP =
 			new FilterCollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_P_P_LteP",
-					new String[] {
-						Long.class.getName(), Boolean.class.getName(),
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {
-						"groupId", "privateLayout", "parentLayoutId", "priority"
-					},
-					true),
-				null,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByG_P_P_LteP",
-					new String[] {
-						Long.class.getName(), Boolean.class.getName(),
-						Long.class.getName(), Integer.class.getName()
-					},
-					new String[] {
-						"groupId", "privateLayout", "parentLayoutId", "priority"
-					},
-					false),
+				this, _finderPathWithPaginationFindByG_P_P_LteP, null,
+				_finderPathWithPaginationCountByG_P_P_LteP,
 				_SQL_SELECT_LAYOUT_WHERE, _SQL_COUNT_LAYOUT_WHERE,
 				LayoutModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
 				"layout.system = [$FALSE$]",
 				new FilterCollectionPersistenceFinder.FilterMetadata<>(
-					LayoutImpl.class, Layout.class, "layout", "Layout",
-					"layout.plid",
-					"SELECT DISTINCT {layout.*} FROM Layout layout WHERE ",
-					"SELECT {Layout.*} FROM (SELECT DISTINCT layout.plid FROM Layout layout WHERE ",
-					") TEMP_TABLE INNER JOIN Layout ON TEMP_TABLE.plid = Layout.plid",
-					"SELECT COUNT(DISTINCT layout.plid) AS COUNT_VALUE FROM Layout layout WHERE ",
+					LayoutImpl.class, Layout.class, _FILTER_ENTITY_ALIAS,
+					_FILTER_ENTITY_TABLE, _FILTER_ENTITY_TABLE_FILTER_PK_COLUMN,
+					_FILTER_SQL_SELECT_LAYOUT_WHERE,
+					_FILTER_SQL_SELECT_LAYOUT_NO_INLINE_DISTINCT_WHERE_1,
+					_FILTER_SQL_SELECT_LAYOUT_NO_INLINE_DISTINCT_WHERE_2,
+					_FILTER_SQL_COUNT_LAYOUT_WHERE,
 					LayoutModelImpl.ORDER_BY_SQL,
 					LayoutModelImpl.ORDER_BY_SQL_INLINE_DISTINCT),
 				new FinderColumn<>(
@@ -9849,15 +9956,15 @@ public class LayoutPersistenceImpl
 					"layout.", "priority", FinderColumn.Type.INTEGER, "<=",
 					true, true, Layout::getPriority));
 
+		_finderPathFetchByERC_G = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByERC_G",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "groupId"}, 0, 1, false,
+			convertNullFunction(Layout::getExternalReferenceCode),
+			Layout::getGroupId);
+
 		_uniquePersistenceFinderByERC_G = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByERC_G",
-				new String[] {String.class.getName(), Long.class.getName()},
-				new String[] {"externalReferenceCode", "groupId"}, 0, 1, false,
-				convertNullFunction(Layout::getExternalReferenceCode),
-				Layout::getGroupId),
-			_SQL_SELECT_LAYOUT_WHERE, "",
+			this, _finderPathFetchByERC_G, _SQL_SELECT_LAYOUT_WHERE, "",
 			new FinderColumn<>(
 				"layout.", "externalReferenceCode", FinderColumn.Type.STRING,
 				"=", true, true, Layout::getExternalReferenceCode),
@@ -9930,4 +10037,4 @@ public class LayoutPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:453074961
+// LIFERAY-SERVICE-BUILDER-HASH:-1008653395

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/LayoutPrototypePersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/LayoutPrototypePersistenceImpl.java
@@ -76,6 +76,9 @@ public class LayoutPrototypePersistenceImpl
 	public static final String FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION =
 		FINDER_CLASS_NAME_ENTITY + ".List2";
 
+	private FinderPath _finderPathWithPaginationFindByUuid;
+	private FinderPath _finderPathWithoutPaginationFindByUuid;
+	private FinderPath _finderPathCountByUuid;
 	private FilterCollectionPersistenceFinder<LayoutPrototype>
 		_collectionPersistenceFinderByUuid;
 
@@ -283,6 +286,9 @@ public class LayoutPrototypePersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {uuid});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByUuid_C;
+	private FinderPath _finderPathWithoutPaginationFindByUuid_C;
+	private FinderPath _finderPathCountByUuid_C;
 	private FilterCollectionPersistenceFinder<LayoutPrototype>
 		_collectionPersistenceFinderByUuid_C;
 
@@ -511,6 +517,9 @@ public class LayoutPrototypePersistenceImpl
 			companyId, 0);
 	}
 
+	private FinderPath _finderPathWithPaginationFindByCompanyId;
+	private FinderPath _finderPathWithoutPaginationFindByCompanyId;
+	private FinderPath _finderPathCountByCompanyId;
 	private FilterCollectionPersistenceFinder<LayoutPrototype>
 		_collectionPersistenceFinderByCompanyId;
 
@@ -723,6 +732,9 @@ public class LayoutPrototypePersistenceImpl
 			companyId, 0);
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_A;
+	private FinderPath _finderPathWithoutPaginationFindByC_A;
+	private FinderPath _finderPathCountByC_A;
 	private FilterCollectionPersistenceFinder<LayoutPrototype>
 		_collectionPersistenceFinderByC_A;
 
@@ -1250,74 +1262,81 @@ public class LayoutPrototypePersistenceImpl
 	 * Initializes the layout prototype persistence.
 	 */
 	public void afterPropertiesSet() {
+		_finderPathWithPaginationFindByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid",
+			new String[] {
+				String.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"uuid_"}, true);
+
+		_finderPathWithoutPaginationFindByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid",
+			new String[] {String.class.getName()}, new String[] {"uuid_"}, 0, 1,
+			true, null);
+
+		_finderPathCountByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid",
+			new String[] {String.class.getName()}, new String[] {"uuid_"}, 0, 1,
+			false, null);
+
 		_collectionPersistenceFinderByUuid =
 			new FilterCollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid",
-					new String[] {
-						String.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"uuid_"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid",
-					new String[] {String.class.getName()},
-					new String[] {"uuid_"}, 0, 1, true, null),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid",
-					new String[] {String.class.getName()},
-					new String[] {"uuid_"}, 0, 1, false, null),
+				this, _finderPathWithPaginationFindByUuid,
+				_finderPathWithoutPaginationFindByUuid, _finderPathCountByUuid,
 				_SQL_SELECT_LAYOUTPROTOTYPE_WHERE,
 				_SQL_COUNT_LAYOUTPROTOTYPE_WHERE,
 				LayoutPrototypeModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
 				"",
 				new FilterCollectionPersistenceFinder.FilterMetadata<>(
 					LayoutPrototypeImpl.class, LayoutPrototype.class,
-					"layoutPrototype", "LayoutPrototype",
-					"layoutPrototype.layoutPrototypeId",
-					"SELECT DISTINCT {layoutPrototype.*} FROM LayoutPrototype layoutPrototype WHERE ",
-					"SELECT {LayoutPrototype.*} FROM (SELECT DISTINCT layoutPrototype.layoutPrototypeId FROM LayoutPrototype layoutPrototype WHERE ",
-					") TEMP_TABLE INNER JOIN LayoutPrototype ON TEMP_TABLE.layoutPrototypeId = LayoutPrototype.layoutPrototypeId",
-					"SELECT COUNT(DISTINCT layoutPrototype.layoutPrototypeId) AS COUNT_VALUE FROM LayoutPrototype layoutPrototype WHERE ",
+					_FILTER_ENTITY_ALIAS, _FILTER_ENTITY_TABLE,
+					_FILTER_ENTITY_TABLE_FILTER_PK_COLUMN,
+					_FILTER_SQL_SELECT_LAYOUTPROTOTYPE_WHERE,
+					_FILTER_SQL_SELECT_LAYOUTPROTOTYPE_NO_INLINE_DISTINCT_WHERE_1,
+					_FILTER_SQL_SELECT_LAYOUTPROTOTYPE_NO_INLINE_DISTINCT_WHERE_2,
+					_FILTER_SQL_COUNT_LAYOUTPROTOTYPE_WHERE,
 					LayoutPrototypeModelImpl.ORDER_BY_SQL,
 					LayoutPrototypeModelImpl.ORDER_BY_SQL_INLINE_DISTINCT),
 				new FinderColumn<>(
 					"layoutPrototype.", "uuid", FinderColumn.Type.STRING, "=",
 					true, true, LayoutPrototype::getUuid));
 
+		_finderPathWithPaginationFindByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid_C",
+			new String[] {
+				String.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"uuid_", "companyId"}, true);
+
+		_finderPathWithoutPaginationFindByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"uuid_", "companyId"}, 0, 1, true, null);
+
+		_finderPathCountByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"uuid_", "companyId"}, 0, 1, false, null);
+
 		_collectionPersistenceFinderByUuid_C =
 			new FilterCollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid_C",
-					new String[] {
-						String.class.getName(), Long.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"uuid_", "companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid_C",
-					new String[] {String.class.getName(), Long.class.getName()},
-					new String[] {"uuid_", "companyId"}, 0, 1, true, null),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid_C",
-					new String[] {String.class.getName(), Long.class.getName()},
-					new String[] {"uuid_", "companyId"}, 0, 1, false, null),
-				_SQL_SELECT_LAYOUTPROTOTYPE_WHERE,
+				this, _finderPathWithPaginationFindByUuid_C,
+				_finderPathWithoutPaginationFindByUuid_C,
+				_finderPathCountByUuid_C, _SQL_SELECT_LAYOUTPROTOTYPE_WHERE,
 				_SQL_COUNT_LAYOUTPROTOTYPE_WHERE,
 				LayoutPrototypeModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
 				"",
 				new FilterCollectionPersistenceFinder.FilterMetadata<>(
 					LayoutPrototypeImpl.class, LayoutPrototype.class,
-					"layoutPrototype", "LayoutPrototype",
-					"layoutPrototype.layoutPrototypeId",
-					"SELECT DISTINCT {layoutPrototype.*} FROM LayoutPrototype layoutPrototype WHERE ",
-					"SELECT {LayoutPrototype.*} FROM (SELECT DISTINCT layoutPrototype.layoutPrototypeId FROM LayoutPrototype layoutPrototype WHERE ",
-					") TEMP_TABLE INNER JOIN LayoutPrototype ON TEMP_TABLE.layoutPrototypeId = LayoutPrototype.layoutPrototypeId",
-					"SELECT COUNT(DISTINCT layoutPrototype.layoutPrototypeId) AS COUNT_VALUE FROM LayoutPrototype layoutPrototype WHERE ",
+					_FILTER_ENTITY_ALIAS, _FILTER_ENTITY_TABLE,
+					_FILTER_ENTITY_TABLE_FILTER_PK_COLUMN,
+					_FILTER_SQL_SELECT_LAYOUTPROTOTYPE_WHERE,
+					_FILTER_SQL_SELECT_LAYOUTPROTOTYPE_NO_INLINE_DISTINCT_WHERE_1,
+					_FILTER_SQL_SELECT_LAYOUTPROTOTYPE_NO_INLINE_DISTINCT_WHERE_2,
+					_FILTER_SQL_COUNT_LAYOUTPROTOTYPE_WHERE,
 					LayoutPrototypeModelImpl.ORDER_BY_SQL,
 					LayoutPrototypeModelImpl.ORDER_BY_SQL_INLINE_DISTINCT),
 				new FinderColumn<>(
@@ -1327,78 +1346,81 @@ public class LayoutPrototypePersistenceImpl
 					"layoutPrototype.", "companyId", FinderColumn.Type.LONG,
 					"=", true, true, LayoutPrototype::getCompanyId));
 
+		_finderPathWithPaginationFindByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByCompanyId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"companyId"}, true);
+
+		_finderPathWithoutPaginationFindByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByCompanyId",
+			new String[] {Long.class.getName()}, new String[] {"companyId"},
+			true);
+
+		_finderPathCountByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByCompanyId",
+			new String[] {Long.class.getName()}, new String[] {"companyId"},
+			false);
+
 		_collectionPersistenceFinderByCompanyId =
 			new FilterCollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByCompanyId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"findByCompanyId", new String[] {Long.class.getName()},
-					new String[] {"companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByCompanyId", new String[] {Long.class.getName()},
-					new String[] {"companyId"}, false),
-				_SQL_SELECT_LAYOUTPROTOTYPE_WHERE,
+				this, _finderPathWithPaginationFindByCompanyId,
+				_finderPathWithoutPaginationFindByCompanyId,
+				_finderPathCountByCompanyId, _SQL_SELECT_LAYOUTPROTOTYPE_WHERE,
 				_SQL_COUNT_LAYOUTPROTOTYPE_WHERE,
 				LayoutPrototypeModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
 				"",
 				new FilterCollectionPersistenceFinder.FilterMetadata<>(
 					LayoutPrototypeImpl.class, LayoutPrototype.class,
-					"layoutPrototype", "LayoutPrototype",
-					"layoutPrototype.layoutPrototypeId",
-					"SELECT DISTINCT {layoutPrototype.*} FROM LayoutPrototype layoutPrototype WHERE ",
-					"SELECT {LayoutPrototype.*} FROM (SELECT DISTINCT layoutPrototype.layoutPrototypeId FROM LayoutPrototype layoutPrototype WHERE ",
-					") TEMP_TABLE INNER JOIN LayoutPrototype ON TEMP_TABLE.layoutPrototypeId = LayoutPrototype.layoutPrototypeId",
-					"SELECT COUNT(DISTINCT layoutPrototype.layoutPrototypeId) AS COUNT_VALUE FROM LayoutPrototype layoutPrototype WHERE ",
+					_FILTER_ENTITY_ALIAS, _FILTER_ENTITY_TABLE,
+					_FILTER_ENTITY_TABLE_FILTER_PK_COLUMN,
+					_FILTER_SQL_SELECT_LAYOUTPROTOTYPE_WHERE,
+					_FILTER_SQL_SELECT_LAYOUTPROTOTYPE_NO_INLINE_DISTINCT_WHERE_1,
+					_FILTER_SQL_SELECT_LAYOUTPROTOTYPE_NO_INLINE_DISTINCT_WHERE_2,
+					_FILTER_SQL_COUNT_LAYOUTPROTOTYPE_WHERE,
 					LayoutPrototypeModelImpl.ORDER_BY_SQL,
 					LayoutPrototypeModelImpl.ORDER_BY_SQL_INLINE_DISTINCT),
 				new FinderColumn<>(
 					"layoutPrototype.", "companyId", FinderColumn.Type.LONG,
 					"=", true, true, LayoutPrototype::getCompanyId));
 
+		_finderPathWithPaginationFindByC_A = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_A",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "active_"}, true);
+
+		_finderPathWithoutPaginationFindByC_A = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_A",
+			new String[] {Long.class.getName(), Boolean.class.getName()},
+			new String[] {"companyId", "active_"}, true);
+
+		_finderPathCountByC_A = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_A",
+			new String[] {Long.class.getName(), Boolean.class.getName()},
+			new String[] {"companyId", "active_"}, false);
+
 		_collectionPersistenceFinderByC_A =
 			new FilterCollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_A",
-					new String[] {
-						Long.class.getName(), Boolean.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"companyId", "active_"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_A",
-					new String[] {
-						Long.class.getName(), Boolean.class.getName()
-					},
-					new String[] {"companyId", "active_"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_A",
-					new String[] {
-						Long.class.getName(), Boolean.class.getName()
-					},
-					new String[] {"companyId", "active_"}, false),
+				this, _finderPathWithPaginationFindByC_A,
+				_finderPathWithoutPaginationFindByC_A, _finderPathCountByC_A,
 				_SQL_SELECT_LAYOUTPROTOTYPE_WHERE,
 				_SQL_COUNT_LAYOUTPROTOTYPE_WHERE,
 				LayoutPrototypeModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
 				"",
 				new FilterCollectionPersistenceFinder.FilterMetadata<>(
 					LayoutPrototypeImpl.class, LayoutPrototype.class,
-					"layoutPrototype", "LayoutPrototype",
-					"layoutPrototype.layoutPrototypeId",
-					"SELECT DISTINCT {layoutPrototype.*} FROM LayoutPrototype layoutPrototype WHERE ",
-					"SELECT {LayoutPrototype.*} FROM (SELECT DISTINCT layoutPrototype.layoutPrototypeId FROM LayoutPrototype layoutPrototype WHERE ",
-					") TEMP_TABLE INNER JOIN LayoutPrototype ON TEMP_TABLE.layoutPrototypeId = LayoutPrototype.layoutPrototypeId",
-					"SELECT COUNT(DISTINCT layoutPrototype.layoutPrototypeId) AS COUNT_VALUE FROM LayoutPrototype layoutPrototype WHERE ",
+					_FILTER_ENTITY_ALIAS, _FILTER_ENTITY_TABLE,
+					_FILTER_ENTITY_TABLE_FILTER_PK_COLUMN,
+					_FILTER_SQL_SELECT_LAYOUTPROTOTYPE_WHERE,
+					_FILTER_SQL_SELECT_LAYOUTPROTOTYPE_NO_INLINE_DISTINCT_WHERE_1,
+					_FILTER_SQL_SELECT_LAYOUTPROTOTYPE_NO_INLINE_DISTINCT_WHERE_2,
+					_FILTER_SQL_COUNT_LAYOUTPROTOTYPE_WHERE,
 					LayoutPrototypeModelImpl.ORDER_BY_SQL,
 					LayoutPrototypeModelImpl.ORDER_BY_SQL_INLINE_DISTINCT),
 				new FinderColumn<>(
@@ -1429,6 +1451,27 @@ public class LayoutPrototypePersistenceImpl
 	private static final String _SQL_COUNT_LAYOUTPROTOTYPE_WHERE =
 		"SELECT COUNT(layoutPrototype) FROM LayoutPrototype layoutPrototype WHERE ";
 
+	private static final String _FILTER_ENTITY_TABLE_FILTER_PK_COLUMN =
+		"layoutPrototype.layoutPrototypeId";
+
+	private static final String _FILTER_SQL_SELECT_LAYOUTPROTOTYPE_WHERE =
+		"SELECT DISTINCT {layoutPrototype.*} FROM LayoutPrototype layoutPrototype WHERE ";
+
+	private static final String
+		_FILTER_SQL_SELECT_LAYOUTPROTOTYPE_NO_INLINE_DISTINCT_WHERE_1 =
+			"SELECT {LayoutPrototype.*} FROM (SELECT DISTINCT layoutPrototype.layoutPrototypeId FROM LayoutPrototype layoutPrototype WHERE ";
+
+	private static final String
+		_FILTER_SQL_SELECT_LAYOUTPROTOTYPE_NO_INLINE_DISTINCT_WHERE_2 =
+			") TEMP_TABLE INNER JOIN LayoutPrototype ON TEMP_TABLE.layoutPrototypeId = LayoutPrototype.layoutPrototypeId";
+
+	private static final String _FILTER_SQL_COUNT_LAYOUTPROTOTYPE_WHERE =
+		"SELECT COUNT(DISTINCT layoutPrototype.layoutPrototypeId) AS COUNT_VALUE FROM LayoutPrototype layoutPrototype WHERE ";
+
+	private static final String _FILTER_ENTITY_ALIAS = "layoutPrototype";
+
+	private static final String _FILTER_ENTITY_TABLE = "LayoutPrototype";
+
 	private static final String _NO_SUCH_ENTITY_WITH_KEY =
 		"No LayoutPrototype exists with the key {";
 
@@ -1441,4 +1484,4 @@ public class LayoutPrototypePersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1480152103
+// LIFERAY-SERVICE-BUILDER-HASH:-730296232

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/LayoutRevisionPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/LayoutRevisionPersistenceImpl.java
@@ -64,6 +64,9 @@ public class LayoutRevisionPersistenceImpl
 	public static final String FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION =
 		FINDER_CLASS_NAME_ENTITY + ".List2";
 
+	private FinderPath _finderPathWithPaginationFindByLayoutSetBranchId;
+	private FinderPath _finderPathWithoutPaginationFindByLayoutSetBranchId;
+	private FinderPath _finderPathCountByLayoutSetBranchId;
 	private CollectionPersistenceFinder<LayoutRevision>
 		_collectionPersistenceFinderByLayoutSetBranchId;
 
@@ -215,6 +218,9 @@ public class LayoutRevisionPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {layoutSetBranchId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByPlid;
+	private FinderPath _finderPathWithoutPaginationFindByPlid;
+	private FinderPath _finderPathCountByPlid;
 	private CollectionPersistenceFinder<LayoutRevision>
 		_collectionPersistenceFinderByPlid;
 
@@ -356,6 +362,9 @@ public class LayoutRevisionPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {plid});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByStatus;
+	private FinderPath _finderPathWithoutPaginationFindByStatus;
+	private FinderPath _finderPathCountByStatus;
 	private CollectionPersistenceFinder<LayoutRevision>
 		_collectionPersistenceFinderByStatus;
 
@@ -497,6 +506,9 @@ public class LayoutRevisionPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {status});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByL_H;
+	private FinderPath _finderPathWithoutPaginationFindByL_H;
+	private FinderPath _finderPathCountByL_H;
 	private CollectionPersistenceFinder<LayoutRevision>
 		_collectionPersistenceFinderByL_H;
 
@@ -659,6 +671,9 @@ public class LayoutRevisionPersistenceImpl
 			new Object[] {layoutSetBranchId, head});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByL_P;
+	private FinderPath _finderPathWithoutPaginationFindByL_P;
+	private FinderPath _finderPathCountByL_P;
 	private CollectionPersistenceFinder<LayoutRevision>
 		_collectionPersistenceFinderByL_P;
 
@@ -819,6 +834,9 @@ public class LayoutRevisionPersistenceImpl
 			new Object[] {layoutSetBranchId, plid});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByL_S;
+	private FinderPath _finderPathWithoutPaginationFindByL_S;
+	private FinderPath _finderPathCountByL_S;
 	private CollectionPersistenceFinder<LayoutRevision>
 		_collectionPersistenceFinderByL_S;
 
@@ -979,6 +997,9 @@ public class LayoutRevisionPersistenceImpl
 			new Object[] {layoutSetBranchId, status});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByH_P;
+	private FinderPath _finderPathWithoutPaginationFindByH_P;
+	private FinderPath _finderPathCountByH_P;
 	private CollectionPersistenceFinder<LayoutRevision>
 		_collectionPersistenceFinderByH_P;
 
@@ -1133,6 +1154,8 @@ public class LayoutRevisionPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {head, plid});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByP_NotS;
+	private FinderPath _finderPathWithPaginationCountByP_NotS;
 	private CollectionPersistenceFinder<LayoutRevision>
 		_collectionPersistenceFinderByP_NotS;
 
@@ -1287,6 +1310,9 @@ public class LayoutRevisionPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {plid, status});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByL_L_P;
+	private FinderPath _finderPathWithoutPaginationFindByL_L_P;
+	private FinderPath _finderPathCountByL_L_P;
 	private CollectionPersistenceFinder<LayoutRevision>
 		_collectionPersistenceFinderByL_L_P;
 
@@ -1465,6 +1491,9 @@ public class LayoutRevisionPersistenceImpl
 			new Object[] {layoutSetBranchId, layoutBranchId, plid});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByL_P_P;
+	private FinderPath _finderPathWithoutPaginationFindByL_P_P;
+	private FinderPath _finderPathCountByL_P_P;
 	private CollectionPersistenceFinder<LayoutRevision>
 		_collectionPersistenceFinderByL_P_P;
 
@@ -1646,6 +1675,9 @@ public class LayoutRevisionPersistenceImpl
 			new Object[] {layoutSetBranchId, parentLayoutRevisionId, plid});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByL_H_P_Collection;
+	private FinderPath _finderPathWithoutPaginationFindByL_H_P_Collection;
+	private FinderPath _finderPathCountByL_H_P_Collection;
 	private CollectionPersistenceFinder<LayoutRevision>
 		_collectionPersistenceFinderByL_H_P_Collection;
 
@@ -1822,6 +1854,9 @@ public class LayoutRevisionPersistenceImpl
 			new Object[] {layoutSetBranchId, head, plid});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByL_H_S;
+	private FinderPath _finderPathWithoutPaginationFindByL_H_S;
+	private FinderPath _finderPathCountByL_H_S;
 	private CollectionPersistenceFinder<LayoutRevision>
 		_collectionPersistenceFinderByL_H_S;
 
@@ -1995,6 +2030,9 @@ public class LayoutRevisionPersistenceImpl
 			new Object[] {layoutSetBranchId, head, status});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByL_P_S;
+	private FinderPath _finderPathWithoutPaginationFindByL_P_S;
+	private FinderPath _finderPathCountByL_P_S;
 	private CollectionPersistenceFinder<LayoutRevision>
 		_collectionPersistenceFinderByL_P_S;
 
@@ -2366,28 +2404,29 @@ public class LayoutRevisionPersistenceImpl
 	 * Initializes the layout revision persistence.
 	 */
 	public void afterPropertiesSet() {
+		_finderPathWithPaginationFindByLayoutSetBranchId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByLayoutSetBranchId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"layoutSetBranchId"}, true);
+
+		_finderPathWithoutPaginationFindByLayoutSetBranchId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
+			"findByLayoutSetBranchId", new String[] {Long.class.getName()},
+			new String[] {"layoutSetBranchId"}, true);
+
+		_finderPathCountByLayoutSetBranchId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
+			"countByLayoutSetBranchId", new String[] {Long.class.getName()},
+			new String[] {"layoutSetBranchId"}, false);
+
 		_collectionPersistenceFinderByLayoutSetBranchId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION,
-					"findByLayoutSetBranchId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"layoutSetBranchId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"findByLayoutSetBranchId",
-					new String[] {Long.class.getName()},
-					new String[] {"layoutSetBranchId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByLayoutSetBranchId",
-					new String[] {Long.class.getName()},
-					new String[] {"layoutSetBranchId"}, false),
+				this, _finderPathWithPaginationFindByLayoutSetBranchId,
+				_finderPathWithoutPaginationFindByLayoutSetBranchId,
+				_finderPathCountByLayoutSetBranchId,
 				_SQL_SELECT_LAYOUTREVISION_WHERE,
 				_SQL_COUNT_LAYOUTREVISION_WHERE,
 				LayoutRevisionModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
@@ -2396,73 +2435,82 @@ public class LayoutRevisionPersistenceImpl
 					FinderColumn.Type.LONG, "=", true, true,
 					LayoutRevision::getLayoutSetBranchId));
 
+		_finderPathWithPaginationFindByPlid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByPlid",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"plid"}, true);
+
+		_finderPathWithoutPaginationFindByPlid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByPlid",
+			new String[] {Long.class.getName()}, new String[] {"plid"}, true);
+
+		_finderPathCountByPlid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByPlid",
+			new String[] {Long.class.getName()}, new String[] {"plid"}, false);
+
 		_collectionPersistenceFinderByPlid = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByPlid",
-				new String[] {
-					Long.class.getName(), Integer.class.getName(),
-					Integer.class.getName(), OrderByComparator.class.getName()
-				},
-				new String[] {"plid"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByPlid",
-				new String[] {Long.class.getName()}, new String[] {"plid"},
-				true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByPlid",
-				new String[] {Long.class.getName()}, new String[] {"plid"},
-				false),
+			this, _finderPathWithPaginationFindByPlid,
+			_finderPathWithoutPaginationFindByPlid, _finderPathCountByPlid,
 			_SQL_SELECT_LAYOUTREVISION_WHERE, _SQL_COUNT_LAYOUTREVISION_WHERE,
 			LayoutRevisionModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
 				"layoutRevision.", "plid", FinderColumn.Type.LONG, "=", true,
 				true, LayoutRevision::getPlid));
 
+		_finderPathWithPaginationFindByStatus = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByStatus",
+			new String[] {
+				Integer.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"status"}, true);
+
+		_finderPathWithoutPaginationFindByStatus = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByStatus",
+			new String[] {Integer.class.getName()}, new String[] {"status"},
+			true);
+
+		_finderPathCountByStatus = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByStatus",
+			new String[] {Integer.class.getName()}, new String[] {"status"},
+			false);
+
 		_collectionPersistenceFinderByStatus =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByStatus",
-					new String[] {
-						Integer.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"status"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByStatus",
-					new String[] {Integer.class.getName()},
-					new String[] {"status"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByStatus",
-					new String[] {Integer.class.getName()},
-					new String[] {"status"}, false),
-				_SQL_SELECT_LAYOUTREVISION_WHERE,
+				this, _finderPathWithPaginationFindByStatus,
+				_finderPathWithoutPaginationFindByStatus,
+				_finderPathCountByStatus, _SQL_SELECT_LAYOUTREVISION_WHERE,
 				_SQL_COUNT_LAYOUTREVISION_WHERE,
 				LayoutRevisionModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
 					"layoutRevision.", "status", FinderColumn.Type.INTEGER, "=",
 					true, true, LayoutRevision::getStatus));
 
+		_finderPathWithPaginationFindByL_H = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByL_H",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"layoutSetBranchId", "head"}, true);
+
+		_finderPathWithoutPaginationFindByL_H = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByL_H",
+			new String[] {Long.class.getName(), Boolean.class.getName()},
+			new String[] {"layoutSetBranchId", "head"}, true);
+
+		_finderPathCountByL_H = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByL_H",
+			new String[] {Long.class.getName(), Boolean.class.getName()},
+			new String[] {"layoutSetBranchId", "head"}, false);
+
 		_collectionPersistenceFinderByL_H = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByL_H",
-				new String[] {
-					Long.class.getName(), Boolean.class.getName(),
-					Integer.class.getName(), Integer.class.getName(),
-					OrderByComparator.class.getName()
-				},
-				new String[] {"layoutSetBranchId", "head"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByL_H",
-				new String[] {Long.class.getName(), Boolean.class.getName()},
-				new String[] {"layoutSetBranchId", "head"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByL_H",
-				new String[] {Long.class.getName(), Boolean.class.getName()},
-				new String[] {"layoutSetBranchId", "head"}, false),
+			this, _finderPathWithPaginationFindByL_H,
+			_finderPathWithoutPaginationFindByL_H, _finderPathCountByL_H,
 			_SQL_SELECT_LAYOUTREVISION_WHERE, _SQL_COUNT_LAYOUTREVISION_WHERE,
 			LayoutRevisionModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
@@ -2472,24 +2520,28 @@ public class LayoutRevisionPersistenceImpl
 				"layoutRevision.", "head", FinderColumn.Type.BOOLEAN, "=", true,
 				true, LayoutRevision::isHead));
 
+		_finderPathWithPaginationFindByL_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByL_P",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"layoutSetBranchId", "plid"}, true);
+
+		_finderPathWithoutPaginationFindByL_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByL_P",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"layoutSetBranchId", "plid"}, true);
+
+		_finderPathCountByL_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByL_P",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"layoutSetBranchId", "plid"}, false);
+
 		_collectionPersistenceFinderByL_P = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByL_P",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Integer.class.getName(), Integer.class.getName(),
-					OrderByComparator.class.getName()
-				},
-				new String[] {"layoutSetBranchId", "plid"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByL_P",
-				new String[] {Long.class.getName(), Long.class.getName()},
-				new String[] {"layoutSetBranchId", "plid"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByL_P",
-				new String[] {Long.class.getName(), Long.class.getName()},
-				new String[] {"layoutSetBranchId", "plid"}, false),
+			this, _finderPathWithPaginationFindByL_P,
+			_finderPathWithoutPaginationFindByL_P, _finderPathCountByL_P,
 			_SQL_SELECT_LAYOUTREVISION_WHERE, _SQL_COUNT_LAYOUTREVISION_WHERE,
 			LayoutRevisionModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
@@ -2499,24 +2551,28 @@ public class LayoutRevisionPersistenceImpl
 				"layoutRevision.", "plid", FinderColumn.Type.LONG, "=", true,
 				true, LayoutRevision::getPlid));
 
+		_finderPathWithPaginationFindByL_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByL_S",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"layoutSetBranchId", "status"}, true);
+
+		_finderPathWithoutPaginationFindByL_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByL_S",
+			new String[] {Long.class.getName(), Integer.class.getName()},
+			new String[] {"layoutSetBranchId", "status"}, true);
+
+		_finderPathCountByL_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByL_S",
+			new String[] {Long.class.getName(), Integer.class.getName()},
+			new String[] {"layoutSetBranchId", "status"}, false);
+
 		_collectionPersistenceFinderByL_S = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByL_S",
-				new String[] {
-					Long.class.getName(), Integer.class.getName(),
-					Integer.class.getName(), Integer.class.getName(),
-					OrderByComparator.class.getName()
-				},
-				new String[] {"layoutSetBranchId", "status"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByL_S",
-				new String[] {Long.class.getName(), Integer.class.getName()},
-				new String[] {"layoutSetBranchId", "status"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByL_S",
-				new String[] {Long.class.getName(), Integer.class.getName()},
-				new String[] {"layoutSetBranchId", "status"}, false),
+			this, _finderPathWithPaginationFindByL_S,
+			_finderPathWithoutPaginationFindByL_S, _finderPathCountByL_S,
 			_SQL_SELECT_LAYOUTREVISION_WHERE, _SQL_COUNT_LAYOUTREVISION_WHERE,
 			LayoutRevisionModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
@@ -2526,24 +2582,28 @@ public class LayoutRevisionPersistenceImpl
 				"layoutRevision.", "status", FinderColumn.Type.INTEGER, "=",
 				true, true, LayoutRevision::getStatus));
 
+		_finderPathWithPaginationFindByH_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByH_P",
+			new String[] {
+				Boolean.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"head", "plid"}, true);
+
+		_finderPathWithoutPaginationFindByH_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByH_P",
+			new String[] {Boolean.class.getName(), Long.class.getName()},
+			new String[] {"head", "plid"}, true);
+
+		_finderPathCountByH_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByH_P",
+			new String[] {Boolean.class.getName(), Long.class.getName()},
+			new String[] {"head", "plid"}, false);
+
 		_collectionPersistenceFinderByH_P = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByH_P",
-				new String[] {
-					Boolean.class.getName(), Long.class.getName(),
-					Integer.class.getName(), Integer.class.getName(),
-					OrderByComparator.class.getName()
-				},
-				new String[] {"head", "plid"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByH_P",
-				new String[] {Boolean.class.getName(), Long.class.getName()},
-				new String[] {"head", "plid"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByH_P",
-				new String[] {Boolean.class.getName(), Long.class.getName()},
-				new String[] {"head", "plid"}, false),
+			this, _finderPathWithPaginationFindByH_P,
+			_finderPathWithoutPaginationFindByH_P, _finderPathCountByH_P,
 			_SQL_SELECT_LAYOUTREVISION_WHERE, _SQL_COUNT_LAYOUTREVISION_WHERE,
 			LayoutRevisionModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
@@ -2553,24 +2613,24 @@ public class LayoutRevisionPersistenceImpl
 				"layoutRevision.", "plid", FinderColumn.Type.LONG, "=", true,
 				true, LayoutRevision::getPlid));
 
+		_finderPathWithPaginationFindByP_NotS = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByP_NotS",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"plid", "status"}, true);
+
+		_finderPathWithPaginationCountByP_NotS = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByP_NotS",
+			new String[] {Long.class.getName(), Integer.class.getName()},
+			new String[] {"plid", "status"}, false);
+
 		_collectionPersistenceFinderByP_NotS =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByP_NotS",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"plid", "status"}, true),
-				null,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByP_NotS",
-					new String[] {
-						Long.class.getName(), Integer.class.getName()
-					},
-					new String[] {"plid", "status"}, false),
+				this, _finderPathWithPaginationFindByP_NotS, null,
+				_finderPathWithPaginationCountByP_NotS,
 				_SQL_SELECT_LAYOUTREVISION_WHERE,
 				_SQL_COUNT_LAYOUTREVISION_WHERE,
 				LayoutRevisionModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
@@ -2581,33 +2641,33 @@ public class LayoutRevisionPersistenceImpl
 					"layoutRevision.", "status", FinderColumn.Type.INTEGER,
 					"!=", true, true, LayoutRevision::getStatus));
 
+		_finderPathWithPaginationFindByL_L_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByL_L_P",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"layoutSetBranchId", "layoutBranchId", "plid"}, true);
+
+		_finderPathWithoutPaginationFindByL_L_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByL_L_P",
+			new String[] {
+				Long.class.getName(), Long.class.getName(), Long.class.getName()
+			},
+			new String[] {"layoutSetBranchId", "layoutBranchId", "plid"}, true);
+
+		_finderPathCountByL_L_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByL_L_P",
+			new String[] {
+				Long.class.getName(), Long.class.getName(), Long.class.getName()
+			},
+			new String[] {"layoutSetBranchId", "layoutBranchId", "plid"},
+			false);
+
 		_collectionPersistenceFinderByL_L_P = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByL_L_P",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Long.class.getName(), Integer.class.getName(),
-					Integer.class.getName(), OrderByComparator.class.getName()
-				},
-				new String[] {"layoutSetBranchId", "layoutBranchId", "plid"},
-				true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByL_L_P",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Long.class.getName()
-				},
-				new String[] {"layoutSetBranchId", "layoutBranchId", "plid"},
-				true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByL_L_P",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Long.class.getName()
-				},
-				new String[] {"layoutSetBranchId", "layoutBranchId", "plid"},
-				false),
+			this, _finderPathWithPaginationFindByL_L_P,
+			_finderPathWithoutPaginationFindByL_L_P, _finderPathCountByL_L_P,
 			_SQL_SELECT_LAYOUTREVISION_WHERE, _SQL_COUNT_LAYOUTREVISION_WHERE,
 			LayoutRevisionModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
 			"layoutRevision.status != 5",
@@ -2621,39 +2681,41 @@ public class LayoutRevisionPersistenceImpl
 				"layoutRevision.", "plid", FinderColumn.Type.LONG, "=", true,
 				true, LayoutRevision::getPlid));
 
+		_finderPathWithPaginationFindByL_P_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByL_P_P",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {
+				"layoutSetBranchId", "parentLayoutRevisionId", "plid"
+			},
+			true);
+
+		_finderPathWithoutPaginationFindByL_P_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByL_P_P",
+			new String[] {
+				Long.class.getName(), Long.class.getName(), Long.class.getName()
+			},
+			new String[] {
+				"layoutSetBranchId", "parentLayoutRevisionId", "plid"
+			},
+			true);
+
+		_finderPathCountByL_P_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByL_P_P",
+			new String[] {
+				Long.class.getName(), Long.class.getName(), Long.class.getName()
+			},
+			new String[] {
+				"layoutSetBranchId", "parentLayoutRevisionId", "plid"
+			},
+			false);
+
 		_collectionPersistenceFinderByL_P_P = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByL_P_P",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Long.class.getName(), Integer.class.getName(),
-					Integer.class.getName(), OrderByComparator.class.getName()
-				},
-				new String[] {
-					"layoutSetBranchId", "parentLayoutRevisionId", "plid"
-				},
-				true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByL_P_P",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Long.class.getName()
-				},
-				new String[] {
-					"layoutSetBranchId", "parentLayoutRevisionId", "plid"
-				},
-				true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByL_P_P",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Long.class.getName()
-				},
-				new String[] {
-					"layoutSetBranchId", "parentLayoutRevisionId", "plid"
-				},
-				false),
+			this, _finderPathWithPaginationFindByL_P_P,
+			_finderPathWithoutPaginationFindByL_P_P, _finderPathCountByL_P_P,
 			_SQL_SELECT_LAYOUTREVISION_WHERE, _SQL_COUNT_LAYOUTREVISION_WHERE,
 			LayoutRevisionModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
@@ -2667,35 +2729,37 @@ public class LayoutRevisionPersistenceImpl
 				"layoutRevision.", "plid", FinderColumn.Type.LONG, "=", true,
 				true, LayoutRevision::getPlid));
 
+		_finderPathWithPaginationFindByL_H_P_Collection = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByL_H_P_Collection",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"layoutSetBranchId", "head", "plid"}, true);
+
+		_finderPathWithoutPaginationFindByL_H_P_Collection = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByL_H_P_Collection",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Long.class.getName()
+			},
+			new String[] {"layoutSetBranchId", "head", "plid"}, true);
+
+		_finderPathCountByL_H_P_Collection = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
+			"countByL_H_P_Collection",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Long.class.getName()
+			},
+			new String[] {"layoutSetBranchId", "head", "plid"}, false);
+
 		_collectionPersistenceFinderByL_H_P_Collection =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION,
-					"findByL_H_P_Collection",
-					new String[] {
-						Long.class.getName(), Boolean.class.getName(),
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"layoutSetBranchId", "head", "plid"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"findByL_H_P_Collection",
-					new String[] {
-						Long.class.getName(), Boolean.class.getName(),
-						Long.class.getName()
-					},
-					new String[] {"layoutSetBranchId", "head", "plid"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByL_H_P_Collection",
-					new String[] {
-						Long.class.getName(), Boolean.class.getName(),
-						Long.class.getName()
-					},
-					new String[] {"layoutSetBranchId", "head", "plid"}, false),
+				this, _finderPathWithPaginationFindByL_H_P_Collection,
+				_finderPathWithoutPaginationFindByL_H_P_Collection,
+				_finderPathCountByL_H_P_Collection,
 				_SQL_SELECT_LAYOUTREVISION_WHERE,
 				_SQL_COUNT_LAYOUTREVISION_WHERE,
 				LayoutRevisionModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
@@ -2710,30 +2774,34 @@ public class LayoutRevisionPersistenceImpl
 					"layoutRevision.", "plid", FinderColumn.Type.LONG, "=",
 					true, true, LayoutRevision::getPlid));
 
+		_finderPathWithPaginationFindByL_H_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByL_H_S",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"layoutSetBranchId", "head", "status"}, true);
+
+		_finderPathWithoutPaginationFindByL_H_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByL_H_S",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Integer.class.getName()
+			},
+			new String[] {"layoutSetBranchId", "head", "status"}, true);
+
+		_finderPathCountByL_H_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByL_H_S",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Integer.class.getName()
+			},
+			new String[] {"layoutSetBranchId", "head", "status"}, false);
+
 		_collectionPersistenceFinderByL_H_S = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByL_H_S",
-				new String[] {
-					Long.class.getName(), Boolean.class.getName(),
-					Integer.class.getName(), Integer.class.getName(),
-					Integer.class.getName(), OrderByComparator.class.getName()
-				},
-				new String[] {"layoutSetBranchId", "head", "status"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByL_H_S",
-				new String[] {
-					Long.class.getName(), Boolean.class.getName(),
-					Integer.class.getName()
-				},
-				new String[] {"layoutSetBranchId", "head", "status"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByL_H_S",
-				new String[] {
-					Long.class.getName(), Boolean.class.getName(),
-					Integer.class.getName()
-				},
-				new String[] {"layoutSetBranchId", "head", "status"}, false),
+			this, _finderPathWithPaginationFindByL_H_S,
+			_finderPathWithoutPaginationFindByL_H_S, _finderPathCountByL_H_S,
 			_SQL_SELECT_LAYOUTREVISION_WHERE, _SQL_COUNT_LAYOUTREVISION_WHERE,
 			LayoutRevisionModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
@@ -2746,30 +2814,34 @@ public class LayoutRevisionPersistenceImpl
 				"layoutRevision.", "status", FinderColumn.Type.INTEGER, "=",
 				true, true, LayoutRevision::getStatus));
 
+		_finderPathWithPaginationFindByL_P_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByL_P_S",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"layoutSetBranchId", "plid", "status"}, true);
+
+		_finderPathWithoutPaginationFindByL_P_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByL_P_S",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Integer.class.getName()
+			},
+			new String[] {"layoutSetBranchId", "plid", "status"}, true);
+
+		_finderPathCountByL_P_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByL_P_S",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Integer.class.getName()
+			},
+			new String[] {"layoutSetBranchId", "plid", "status"}, false);
+
 		_collectionPersistenceFinderByL_P_S = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByL_P_S",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Integer.class.getName(), Integer.class.getName(),
-					Integer.class.getName(), OrderByComparator.class.getName()
-				},
-				new String[] {"layoutSetBranchId", "plid", "status"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByL_P_S",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Integer.class.getName()
-				},
-				new String[] {"layoutSetBranchId", "plid", "status"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByL_P_S",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Integer.class.getName()
-				},
-				new String[] {"layoutSetBranchId", "plid", "status"}, false),
+			this, _finderPathWithPaginationFindByL_P_S,
+			_finderPathWithoutPaginationFindByL_P_S, _finderPathCountByL_P_S,
 			_SQL_SELECT_LAYOUTREVISION_WHERE, _SQL_COUNT_LAYOUTREVISION_WHERE,
 			LayoutRevisionModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
@@ -2812,4 +2884,4 @@ public class LayoutRevisionPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-726137053
+// LIFERAY-SERVICE-BUILDER-HASH:1213479984

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/LayoutSetBranchPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/LayoutSetBranchPersistenceImpl.java
@@ -70,6 +70,9 @@ public class LayoutSetBranchPersistenceImpl
 	public static final String FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION =
 		FINDER_CLASS_NAME_ENTITY + ".List2";
 
+	private FinderPath _finderPathWithPaginationFindByGroupId;
+	private FinderPath _finderPathWithoutPaginationFindByGroupId;
+	private FinderPath _finderPathCountByGroupId;
 	private FilterCollectionPersistenceFinder<LayoutSetBranch>
 		_collectionPersistenceFinderByGroupId;
 
@@ -280,6 +283,9 @@ public class LayoutSetBranchPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {groupId}, groupId);
 	}
 
+	private FinderPath _finderPathWithPaginationFindByG_P;
+	private FinderPath _finderPathWithoutPaginationFindByG_P;
+	private FinderPath _finderPathCountByG_P;
 	private FilterCollectionPersistenceFinder<LayoutSetBranch>
 		_collectionPersistenceFinderByG_P;
 
@@ -515,6 +521,7 @@ public class LayoutSetBranchPersistenceImpl
 			new Object[] {groupId, privateLayout}, groupId);
 	}
 
+	private FinderPath _finderPathFetchByG_P_N;
 	private UniquePersistenceFinder<LayoutSetBranch>
 		_uniquePersistenceFinderByG_P_N;
 
@@ -619,6 +626,9 @@ public class LayoutSetBranchPersistenceImpl
 			new Object[] {groupId, privateLayout, name});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByG_P_M;
+	private FinderPath _finderPathWithoutPaginationFindByG_P_M;
+	private FinderPath _finderPathCountByG_P_M;
 	private FilterCollectionPersistenceFinder<LayoutSetBranch>
 		_collectionPersistenceFinderByG_P_M;
 
@@ -1090,78 +1100,81 @@ public class LayoutSetBranchPersistenceImpl
 	 * Initializes the layout set branch persistence.
 	 */
 	public void afterPropertiesSet() {
+		_finderPathWithPaginationFindByGroupId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByGroupId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"groupId"}, true);
+
+		_finderPathWithoutPaginationFindByGroupId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByGroupId",
+			new String[] {Long.class.getName()}, new String[] {"groupId"},
+			true);
+
+		_finderPathCountByGroupId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByGroupId",
+			new String[] {Long.class.getName()}, new String[] {"groupId"},
+			false);
+
 		_collectionPersistenceFinderByGroupId =
 			new FilterCollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByGroupId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"groupId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByGroupId",
-					new String[] {Long.class.getName()},
-					new String[] {"groupId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByGroupId",
-					new String[] {Long.class.getName()},
-					new String[] {"groupId"}, false),
-				_SQL_SELECT_LAYOUTSETBRANCH_WHERE,
+				this, _finderPathWithPaginationFindByGroupId,
+				_finderPathWithoutPaginationFindByGroupId,
+				_finderPathCountByGroupId, _SQL_SELECT_LAYOUTSETBRANCH_WHERE,
 				_SQL_COUNT_LAYOUTSETBRANCH_WHERE,
 				LayoutSetBranchModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
 				"",
 				new FilterCollectionPersistenceFinder.FilterMetadata<>(
 					LayoutSetBranchImpl.class, LayoutSetBranch.class,
-					"layoutSetBranch", "LayoutSetBranch",
-					"layoutSetBranch.layoutSetBranchId",
-					"SELECT DISTINCT {layoutSetBranch.*} FROM LayoutSetBranch layoutSetBranch WHERE ",
-					"SELECT {LayoutSetBranch.*} FROM (SELECT DISTINCT layoutSetBranch.layoutSetBranchId FROM LayoutSetBranch layoutSetBranch WHERE ",
-					") TEMP_TABLE INNER JOIN LayoutSetBranch ON TEMP_TABLE.layoutSetBranchId = LayoutSetBranch.layoutSetBranchId",
-					"SELECT COUNT(DISTINCT layoutSetBranch.layoutSetBranchId) AS COUNT_VALUE FROM LayoutSetBranch layoutSetBranch WHERE ",
+					_FILTER_ENTITY_ALIAS, _FILTER_ENTITY_TABLE,
+					_FILTER_ENTITY_TABLE_FILTER_PK_COLUMN,
+					_FILTER_SQL_SELECT_LAYOUTSETBRANCH_WHERE,
+					_FILTER_SQL_SELECT_LAYOUTSETBRANCH_NO_INLINE_DISTINCT_WHERE_1,
+					_FILTER_SQL_SELECT_LAYOUTSETBRANCH_NO_INLINE_DISTINCT_WHERE_2,
+					_FILTER_SQL_COUNT_LAYOUTSETBRANCH_WHERE,
 					LayoutSetBranchModelImpl.ORDER_BY_SQL,
 					LayoutSetBranchModelImpl.ORDER_BY_SQL_INLINE_DISTINCT),
 				new FinderColumn<>(
 					"layoutSetBranch.", "groupId", FinderColumn.Type.LONG, "=",
 					true, true, LayoutSetBranch::getGroupId));
 
+		_finderPathWithPaginationFindByG_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_P",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"groupId", "privateLayout"}, true);
+
+		_finderPathWithoutPaginationFindByG_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_P",
+			new String[] {Long.class.getName(), Boolean.class.getName()},
+			new String[] {"groupId", "privateLayout"}, true);
+
+		_finderPathCountByG_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_P",
+			new String[] {Long.class.getName(), Boolean.class.getName()},
+			new String[] {"groupId", "privateLayout"}, false);
+
 		_collectionPersistenceFinderByG_P =
 			new FilterCollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_P",
-					new String[] {
-						Long.class.getName(), Boolean.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"groupId", "privateLayout"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_P",
-					new String[] {
-						Long.class.getName(), Boolean.class.getName()
-					},
-					new String[] {"groupId", "privateLayout"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_P",
-					new String[] {
-						Long.class.getName(), Boolean.class.getName()
-					},
-					new String[] {"groupId", "privateLayout"}, false),
+				this, _finderPathWithPaginationFindByG_P,
+				_finderPathWithoutPaginationFindByG_P, _finderPathCountByG_P,
 				_SQL_SELECT_LAYOUTSETBRANCH_WHERE,
 				_SQL_COUNT_LAYOUTSETBRANCH_WHERE,
 				LayoutSetBranchModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
 				"",
 				new FilterCollectionPersistenceFinder.FilterMetadata<>(
 					LayoutSetBranchImpl.class, LayoutSetBranch.class,
-					"layoutSetBranch", "LayoutSetBranch",
-					"layoutSetBranch.layoutSetBranchId",
-					"SELECT DISTINCT {layoutSetBranch.*} FROM LayoutSetBranch layoutSetBranch WHERE ",
-					"SELECT {LayoutSetBranch.*} FROM (SELECT DISTINCT layoutSetBranch.layoutSetBranchId FROM LayoutSetBranch layoutSetBranch WHERE ",
-					") TEMP_TABLE INNER JOIN LayoutSetBranch ON TEMP_TABLE.layoutSetBranchId = LayoutSetBranch.layoutSetBranchId",
-					"SELECT COUNT(DISTINCT layoutSetBranch.layoutSetBranchId) AS COUNT_VALUE FROM LayoutSetBranch layoutSetBranch WHERE ",
+					_FILTER_ENTITY_ALIAS, _FILTER_ENTITY_TABLE,
+					_FILTER_ENTITY_TABLE_FILTER_PK_COLUMN,
+					_FILTER_SQL_SELECT_LAYOUTSETBRANCH_WHERE,
+					_FILTER_SQL_SELECT_LAYOUTSETBRANCH_NO_INLINE_DISTINCT_WHERE_1,
+					_FILTER_SQL_SELECT_LAYOUTSETBRANCH_NO_INLINE_DISTINCT_WHERE_2,
+					_FILTER_SQL_COUNT_LAYOUTSETBRANCH_WHERE,
 					LayoutSetBranchModelImpl.ORDER_BY_SQL,
 					LayoutSetBranchModelImpl.ORDER_BY_SQL_INLINE_DISTINCT),
 				new FinderColumn<>(
@@ -1172,18 +1185,19 @@ public class LayoutSetBranchPersistenceImpl
 					FinderColumn.Type.BOOLEAN, "=", true, true,
 					LayoutSetBranch::isPrivateLayout));
 
+		_finderPathFetchByG_P_N = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByG_P_N",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				String.class.getName()
+			},
+			new String[] {"groupId", "privateLayout", "name"}, 0, 4, false,
+			LayoutSetBranch::getGroupId, LayoutSetBranch::isPrivateLayout,
+			convertNullFunction(LayoutSetBranch::getName));
+
 		_uniquePersistenceFinderByG_P_N = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByG_P_N",
-				new String[] {
-					Long.class.getName(), Boolean.class.getName(),
-					String.class.getName()
-				},
-				new String[] {"groupId", "privateLayout", "name"}, 0, 4, false,
-				LayoutSetBranch::getGroupId, LayoutSetBranch::isPrivateLayout,
-				convertNullFunction(LayoutSetBranch::getName)),
-			_SQL_SELECT_LAYOUTSETBRANCH_WHERE, "",
+			this, _finderPathFetchByG_P_N, _SQL_SELECT_LAYOUTSETBRANCH_WHERE,
+			"",
 			new FinderColumn<>(
 				"layoutSetBranch.", "groupId", FinderColumn.Type.LONG, "=",
 				true, true, LayoutSetBranch::getGroupId),
@@ -1194,44 +1208,47 @@ public class LayoutSetBranchPersistenceImpl
 				"layoutSetBranch.", "name", FinderColumn.Type.STRING, "=", true,
 				true, LayoutSetBranch::getName));
 
+		_finderPathWithPaginationFindByG_P_M = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_P_M",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"groupId", "privateLayout", "master"}, true);
+
+		_finderPathWithoutPaginationFindByG_P_M = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_P_M",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName()
+			},
+			new String[] {"groupId", "privateLayout", "master"}, true);
+
+		_finderPathCountByG_P_M = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_P_M",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName()
+			},
+			new String[] {"groupId", "privateLayout", "master"}, false);
+
 		_collectionPersistenceFinderByG_P_M =
 			new FilterCollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_P_M",
-					new String[] {
-						Long.class.getName(), Boolean.class.getName(),
-						Boolean.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"groupId", "privateLayout", "master"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_P_M",
-					new String[] {
-						Long.class.getName(), Boolean.class.getName(),
-						Boolean.class.getName()
-					},
-					new String[] {"groupId", "privateLayout", "master"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_P_M",
-					new String[] {
-						Long.class.getName(), Boolean.class.getName(),
-						Boolean.class.getName()
-					},
-					new String[] {"groupId", "privateLayout", "master"}, false),
-				_SQL_SELECT_LAYOUTSETBRANCH_WHERE,
+				this, _finderPathWithPaginationFindByG_P_M,
+				_finderPathWithoutPaginationFindByG_P_M,
+				_finderPathCountByG_P_M, _SQL_SELECT_LAYOUTSETBRANCH_WHERE,
 				_SQL_COUNT_LAYOUTSETBRANCH_WHERE,
 				LayoutSetBranchModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
 				"",
 				new FilterCollectionPersistenceFinder.FilterMetadata<>(
 					LayoutSetBranchImpl.class, LayoutSetBranch.class,
-					"layoutSetBranch", "LayoutSetBranch",
-					"layoutSetBranch.layoutSetBranchId",
-					"SELECT DISTINCT {layoutSetBranch.*} FROM LayoutSetBranch layoutSetBranch WHERE ",
-					"SELECT {LayoutSetBranch.*} FROM (SELECT DISTINCT layoutSetBranch.layoutSetBranchId FROM LayoutSetBranch layoutSetBranch WHERE ",
-					") TEMP_TABLE INNER JOIN LayoutSetBranch ON TEMP_TABLE.layoutSetBranchId = LayoutSetBranch.layoutSetBranchId",
-					"SELECT COUNT(DISTINCT layoutSetBranch.layoutSetBranchId) AS COUNT_VALUE FROM LayoutSetBranch layoutSetBranch WHERE ",
+					_FILTER_ENTITY_ALIAS, _FILTER_ENTITY_TABLE,
+					_FILTER_ENTITY_TABLE_FILTER_PK_COLUMN,
+					_FILTER_SQL_SELECT_LAYOUTSETBRANCH_WHERE,
+					_FILTER_SQL_SELECT_LAYOUTSETBRANCH_NO_INLINE_DISTINCT_WHERE_1,
+					_FILTER_SQL_SELECT_LAYOUTSETBRANCH_NO_INLINE_DISTINCT_WHERE_2,
+					_FILTER_SQL_COUNT_LAYOUTSETBRANCH_WHERE,
 					LayoutSetBranchModelImpl.ORDER_BY_SQL,
 					LayoutSetBranchModelImpl.ORDER_BY_SQL_INLINE_DISTINCT),
 				new FinderColumn<>(
@@ -1266,6 +1283,27 @@ public class LayoutSetBranchPersistenceImpl
 	private static final String _SQL_COUNT_LAYOUTSETBRANCH_WHERE =
 		"SELECT COUNT(layoutSetBranch) FROM LayoutSetBranch layoutSetBranch WHERE ";
 
+	private static final String _FILTER_ENTITY_TABLE_FILTER_PK_COLUMN =
+		"layoutSetBranch.layoutSetBranchId";
+
+	private static final String _FILTER_SQL_SELECT_LAYOUTSETBRANCH_WHERE =
+		"SELECT DISTINCT {layoutSetBranch.*} FROM LayoutSetBranch layoutSetBranch WHERE ";
+
+	private static final String
+		_FILTER_SQL_SELECT_LAYOUTSETBRANCH_NO_INLINE_DISTINCT_WHERE_1 =
+			"SELECT {LayoutSetBranch.*} FROM (SELECT DISTINCT layoutSetBranch.layoutSetBranchId FROM LayoutSetBranch layoutSetBranch WHERE ";
+
+	private static final String
+		_FILTER_SQL_SELECT_LAYOUTSETBRANCH_NO_INLINE_DISTINCT_WHERE_2 =
+			") TEMP_TABLE INNER JOIN LayoutSetBranch ON TEMP_TABLE.layoutSetBranchId = LayoutSetBranch.layoutSetBranchId";
+
+	private static final String _FILTER_SQL_COUNT_LAYOUTSETBRANCH_WHERE =
+		"SELECT COUNT(DISTINCT layoutSetBranch.layoutSetBranchId) AS COUNT_VALUE FROM LayoutSetBranch layoutSetBranch WHERE ";
+
+	private static final String _FILTER_ENTITY_ALIAS = "layoutSetBranch";
+
+	private static final String _FILTER_ENTITY_TABLE = "LayoutSetBranch";
+
 	private static final String _NO_SUCH_ENTITY_WITH_KEY =
 		"No LayoutSetBranch exists with the key {";
 
@@ -1281,4 +1319,4 @@ public class LayoutSetBranchPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:2126588874
+// LIFERAY-SERVICE-BUILDER-HASH:1576025667

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/LayoutSetPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/LayoutSetPersistenceImpl.java
@@ -77,6 +77,9 @@ public class LayoutSetPersistenceImpl
 	public static final String FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION =
 		FINDER_CLASS_NAME_ENTITY + ".List2";
 
+	private FinderPath _finderPathWithPaginationFindByGroupId;
+	private FinderPath _finderPathWithoutPaginationFindByGroupId;
+	private FinderPath _finderPathCountByGroupId;
 	private CollectionPersistenceFinder<LayoutSet>
 		_collectionPersistenceFinderByGroupId;
 
@@ -218,6 +221,9 @@ public class LayoutSetPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {groupId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByLayoutSetPrototypeUuid;
+	private FinderPath _finderPathWithoutPaginationFindByLayoutSetPrototypeUuid;
+	private FinderPath _finderPathCountByLayoutSetPrototypeUuid;
 	private CollectionPersistenceFinder<LayoutSet>
 		_collectionPersistenceFinderByLayoutSetPrototypeUuid;
 
@@ -373,6 +379,7 @@ public class LayoutSetPersistenceImpl
 			new Object[] {layoutSetPrototypeUuid});
 	}
 
+	private FinderPath _finderPathFetchByG_P;
 	private UniquePersistenceFinder<LayoutSet> _uniquePersistenceFinderByG_P;
 
 	/**
@@ -464,6 +471,9 @@ public class LayoutSetPersistenceImpl
 			new Object[] {groupId, privateLayout});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_L;
+	private FinderPath _finderPathWithoutPaginationFindByC_L;
+	private FinderPath _finderPathCountByC_L;
 	private CollectionPersistenceFinder<LayoutSet>
 		_collectionPersistenceFinderByC_L;
 
@@ -628,6 +638,9 @@ public class LayoutSetPersistenceImpl
 			new Object[] {companyId, layoutSetPrototypeUuid});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByP_L;
+	private FinderPath _finderPathWithoutPaginationFindByP_L;
+	private FinderPath _finderPathCountByP_L;
 	private CollectionPersistenceFinder<LayoutSet>
 		_collectionPersistenceFinderByP_L;
 
@@ -1069,53 +1082,62 @@ public class LayoutSetPersistenceImpl
 	 * Initializes the layout set persistence.
 	 */
 	public void afterPropertiesSet() {
+		_finderPathWithPaginationFindByGroupId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByGroupId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"groupId"}, true);
+
+		_finderPathWithoutPaginationFindByGroupId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByGroupId",
+			new String[] {Long.class.getName()}, new String[] {"groupId"},
+			true);
+
+		_finderPathCountByGroupId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByGroupId",
+			new String[] {Long.class.getName()}, new String[] {"groupId"},
+			false);
+
 		_collectionPersistenceFinderByGroupId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByGroupId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"groupId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByGroupId",
-					new String[] {Long.class.getName()},
-					new String[] {"groupId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByGroupId",
-					new String[] {Long.class.getName()},
-					new String[] {"groupId"}, false),
-				_SQL_SELECT_LAYOUTSET_WHERE, _SQL_COUNT_LAYOUTSET_WHERE,
-				LayoutSetModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+				this, _finderPathWithPaginationFindByGroupId,
+				_finderPathWithoutPaginationFindByGroupId,
+				_finderPathCountByGroupId, _SQL_SELECT_LAYOUTSET_WHERE,
+				_SQL_COUNT_LAYOUTSET_WHERE, LayoutSetModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
 					"layoutSet.", "groupId", FinderColumn.Type.LONG, "=", true,
 					true, LayoutSet::getGroupId));
 
+		_finderPathWithPaginationFindByLayoutSetPrototypeUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION,
+			"findByLayoutSetPrototypeUuid",
+			new String[] {
+				String.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"layoutSetPrototypeUuid"}, true);
+
+		_finderPathWithoutPaginationFindByLayoutSetPrototypeUuid =
+			new FinderPath(
+				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
+				"findByLayoutSetPrototypeUuid",
+				new String[] {String.class.getName()},
+				new String[] {"layoutSetPrototypeUuid"}, 0, 1, true, null);
+
+		_finderPathCountByLayoutSetPrototypeUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
+			"countByLayoutSetPrototypeUuid",
+			new String[] {String.class.getName()},
+			new String[] {"layoutSetPrototypeUuid"}, 0, 1, false, null);
+
 		_collectionPersistenceFinderByLayoutSetPrototypeUuid =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION,
-					"findByLayoutSetPrototypeUuid",
-					new String[] {
-						String.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"layoutSetPrototypeUuid"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"findByLayoutSetPrototypeUuid",
-					new String[] {String.class.getName()},
-					new String[] {"layoutSetPrototypeUuid"}, 0, 1, true, null),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByLayoutSetPrototypeUuid",
-					new String[] {String.class.getName()},
-					new String[] {"layoutSetPrototypeUuid"}, 0, 1, false, null),
+				this, _finderPathWithPaginationFindByLayoutSetPrototypeUuid,
+				_finderPathWithoutPaginationFindByLayoutSetPrototypeUuid,
+				_finderPathCountByLayoutSetPrototypeUuid,
 				_SQL_SELECT_LAYOUTSET_WHERE, _SQL_COUNT_LAYOUTSET_WHERE,
 				LayoutSetModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
@@ -1123,14 +1145,14 @@ public class LayoutSetPersistenceImpl
 					FinderColumn.Type.STRING, "=", true, true,
 					LayoutSet::getLayoutSetPrototypeUuid));
 
+		_finderPathFetchByG_P = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByG_P",
+			new String[] {Long.class.getName(), Boolean.class.getName()},
+			new String[] {"groupId", "privateLayout"}, 0, 0, false,
+			LayoutSet::getGroupId, LayoutSet::isPrivateLayout);
+
 		_uniquePersistenceFinderByG_P = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByG_P",
-				new String[] {Long.class.getName(), Boolean.class.getName()},
-				new String[] {"groupId", "privateLayout"}, 0, 0, false,
-				LayoutSet::getGroupId, LayoutSet::isPrivateLayout),
-			_SQL_SELECT_LAYOUTSET_WHERE, "",
+			this, _finderPathFetchByG_P, _SQL_SELECT_LAYOUTSET_WHERE, "",
 			new FinderColumn<>(
 				"layoutSet.", "groupId", FinderColumn.Type.LONG, "=", true,
 				true, LayoutSet::getGroupId),
@@ -1138,26 +1160,30 @@ public class LayoutSetPersistenceImpl
 				"layoutSet.", "privateLayout", FinderColumn.Type.BOOLEAN, "=",
 				true, true, LayoutSet::isPrivateLayout));
 
+		_finderPathWithPaginationFindByC_L = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_L",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "layoutSetPrototypeUuid"}, true);
+
+		_finderPathWithoutPaginationFindByC_L = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_L",
+			new String[] {Long.class.getName(), String.class.getName()},
+			new String[] {"companyId", "layoutSetPrototypeUuid"}, 0, 2, true,
+			null);
+
+		_finderPathCountByC_L = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_L",
+			new String[] {Long.class.getName(), String.class.getName()},
+			new String[] {"companyId", "layoutSetPrototypeUuid"}, 0, 2, false,
+			null);
+
 		_collectionPersistenceFinderByC_L = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_L",
-				new String[] {
-					Long.class.getName(), String.class.getName(),
-					Integer.class.getName(), Integer.class.getName(),
-					OrderByComparator.class.getName()
-				},
-				new String[] {"companyId", "layoutSetPrototypeUuid"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_L",
-				new String[] {Long.class.getName(), String.class.getName()},
-				new String[] {"companyId", "layoutSetPrototypeUuid"}, 0, 2,
-				true, null),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_L",
-				new String[] {Long.class.getName(), String.class.getName()},
-				new String[] {"companyId", "layoutSetPrototypeUuid"}, 0, 2,
-				false, null),
+			this, _finderPathWithPaginationFindByC_L,
+			_finderPathWithoutPaginationFindByC_L, _finderPathCountByC_L,
 			_SQL_SELECT_LAYOUTSET_WHERE, _SQL_COUNT_LAYOUTSET_WHERE,
 			LayoutSetModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
@@ -1168,24 +1194,28 @@ public class LayoutSetPersistenceImpl
 				FinderColumn.Type.STRING, "=", true, true,
 				LayoutSet::getLayoutSetPrototypeUuid));
 
+		_finderPathWithPaginationFindByP_L = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByP_L",
+			new String[] {
+				Boolean.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"privateLayout", "logoId"}, true);
+
+		_finderPathWithoutPaginationFindByP_L = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByP_L",
+			new String[] {Boolean.class.getName(), Long.class.getName()},
+			new String[] {"privateLayout", "logoId"}, true);
+
+		_finderPathCountByP_L = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByP_L",
+			new String[] {Boolean.class.getName(), Long.class.getName()},
+			new String[] {"privateLayout", "logoId"}, false);
+
 		_collectionPersistenceFinderByP_L = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByP_L",
-				new String[] {
-					Boolean.class.getName(), Long.class.getName(),
-					Integer.class.getName(), Integer.class.getName(),
-					OrderByComparator.class.getName()
-				},
-				new String[] {"privateLayout", "logoId"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByP_L",
-				new String[] {Boolean.class.getName(), Long.class.getName()},
-				new String[] {"privateLayout", "logoId"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByP_L",
-				new String[] {Boolean.class.getName(), Long.class.getName()},
-				new String[] {"privateLayout", "logoId"}, false),
+			this, _finderPathWithPaginationFindByP_L,
+			_finderPathWithoutPaginationFindByP_L, _finderPathCountByP_L,
 			_SQL_SELECT_LAYOUTSET_WHERE, _SQL_COUNT_LAYOUTSET_WHERE,
 			LayoutSetModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
@@ -1231,4 +1261,4 @@ public class LayoutSetPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-629017143
+// LIFERAY-SERVICE-BUILDER-HASH:-1719124840

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/LayoutSetPrototypePersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/LayoutSetPrototypePersistenceImpl.java
@@ -77,6 +77,9 @@ public class LayoutSetPrototypePersistenceImpl
 	public static final String FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION =
 		FINDER_CLASS_NAME_ENTITY + ".List2";
 
+	private FinderPath _finderPathWithPaginationFindByUuid;
+	private FinderPath _finderPathWithoutPaginationFindByUuid;
+	private FinderPath _finderPathCountByUuid;
 	private FilterCollectionPersistenceFinder<LayoutSetPrototype>
 		_collectionPersistenceFinderByUuid;
 
@@ -287,6 +290,9 @@ public class LayoutSetPrototypePersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {uuid});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByUuid_C;
+	private FinderPath _finderPathWithoutPaginationFindByUuid_C;
+	private FinderPath _finderPathCountByUuid_C;
 	private FilterCollectionPersistenceFinder<LayoutSetPrototype>
 		_collectionPersistenceFinderByUuid_C;
 
@@ -515,6 +521,9 @@ public class LayoutSetPrototypePersistenceImpl
 			companyId, 0);
 	}
 
+	private FinderPath _finderPathWithPaginationFindByCompanyId;
+	private FinderPath _finderPathWithoutPaginationFindByCompanyId;
+	private FinderPath _finderPathCountByCompanyId;
 	private FilterCollectionPersistenceFinder<LayoutSetPrototype>
 		_collectionPersistenceFinderByCompanyId;
 
@@ -728,6 +737,9 @@ public class LayoutSetPrototypePersistenceImpl
 			companyId, 0);
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_A;
+	private FinderPath _finderPathWithoutPaginationFindByC_A;
+	private FinderPath _finderPathCountByC_A;
 	private FilterCollectionPersistenceFinder<LayoutSetPrototype>
 		_collectionPersistenceFinderByC_A;
 
@@ -1259,74 +1271,81 @@ public class LayoutSetPrototypePersistenceImpl
 	 * Initializes the layout set prototype persistence.
 	 */
 	public void afterPropertiesSet() {
+		_finderPathWithPaginationFindByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid",
+			new String[] {
+				String.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"uuid_"}, true);
+
+		_finderPathWithoutPaginationFindByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid",
+			new String[] {String.class.getName()}, new String[] {"uuid_"}, 0, 1,
+			true, null);
+
+		_finderPathCountByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid",
+			new String[] {String.class.getName()}, new String[] {"uuid_"}, 0, 1,
+			false, null);
+
 		_collectionPersistenceFinderByUuid =
 			new FilterCollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid",
-					new String[] {
-						String.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"uuid_"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid",
-					new String[] {String.class.getName()},
-					new String[] {"uuid_"}, 0, 1, true, null),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid",
-					new String[] {String.class.getName()},
-					new String[] {"uuid_"}, 0, 1, false, null),
+				this, _finderPathWithPaginationFindByUuid,
+				_finderPathWithoutPaginationFindByUuid, _finderPathCountByUuid,
 				_SQL_SELECT_LAYOUTSETPROTOTYPE_WHERE,
 				_SQL_COUNT_LAYOUTSETPROTOTYPE_WHERE,
 				LayoutSetPrototypeModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
 				"",
 				new FilterCollectionPersistenceFinder.FilterMetadata<>(
 					LayoutSetPrototypeImpl.class, LayoutSetPrototype.class,
-					"layoutSetPrototype", "LayoutSetPrototype",
-					"layoutSetPrototype.layoutSetPrototypeId",
-					"SELECT DISTINCT {layoutSetPrototype.*} FROM LayoutSetPrototype layoutSetPrototype WHERE ",
-					"SELECT {LayoutSetPrototype.*} FROM (SELECT DISTINCT layoutSetPrototype.layoutSetPrototypeId FROM LayoutSetPrototype layoutSetPrototype WHERE ",
-					") TEMP_TABLE INNER JOIN LayoutSetPrototype ON TEMP_TABLE.layoutSetPrototypeId = LayoutSetPrototype.layoutSetPrototypeId",
-					"SELECT COUNT(DISTINCT layoutSetPrototype.layoutSetPrototypeId) AS COUNT_VALUE FROM LayoutSetPrototype layoutSetPrototype WHERE ",
+					_FILTER_ENTITY_ALIAS, _FILTER_ENTITY_TABLE,
+					_FILTER_ENTITY_TABLE_FILTER_PK_COLUMN,
+					_FILTER_SQL_SELECT_LAYOUTSETPROTOTYPE_WHERE,
+					_FILTER_SQL_SELECT_LAYOUTSETPROTOTYPE_NO_INLINE_DISTINCT_WHERE_1,
+					_FILTER_SQL_SELECT_LAYOUTSETPROTOTYPE_NO_INLINE_DISTINCT_WHERE_2,
+					_FILTER_SQL_COUNT_LAYOUTSETPROTOTYPE_WHERE,
 					LayoutSetPrototypeModelImpl.ORDER_BY_SQL,
 					LayoutSetPrototypeModelImpl.ORDER_BY_SQL_INLINE_DISTINCT),
 				new FinderColumn<>(
 					"layoutSetPrototype.", "uuid", FinderColumn.Type.STRING,
 					"=", true, true, LayoutSetPrototype::getUuid));
 
+		_finderPathWithPaginationFindByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid_C",
+			new String[] {
+				String.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"uuid_", "companyId"}, true);
+
+		_finderPathWithoutPaginationFindByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"uuid_", "companyId"}, 0, 1, true, null);
+
+		_finderPathCountByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"uuid_", "companyId"}, 0, 1, false, null);
+
 		_collectionPersistenceFinderByUuid_C =
 			new FilterCollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid_C",
-					new String[] {
-						String.class.getName(), Long.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"uuid_", "companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid_C",
-					new String[] {String.class.getName(), Long.class.getName()},
-					new String[] {"uuid_", "companyId"}, 0, 1, true, null),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid_C",
-					new String[] {String.class.getName(), Long.class.getName()},
-					new String[] {"uuid_", "companyId"}, 0, 1, false, null),
-				_SQL_SELECT_LAYOUTSETPROTOTYPE_WHERE,
+				this, _finderPathWithPaginationFindByUuid_C,
+				_finderPathWithoutPaginationFindByUuid_C,
+				_finderPathCountByUuid_C, _SQL_SELECT_LAYOUTSETPROTOTYPE_WHERE,
 				_SQL_COUNT_LAYOUTSETPROTOTYPE_WHERE,
 				LayoutSetPrototypeModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
 				"",
 				new FilterCollectionPersistenceFinder.FilterMetadata<>(
 					LayoutSetPrototypeImpl.class, LayoutSetPrototype.class,
-					"layoutSetPrototype", "LayoutSetPrototype",
-					"layoutSetPrototype.layoutSetPrototypeId",
-					"SELECT DISTINCT {layoutSetPrototype.*} FROM LayoutSetPrototype layoutSetPrototype WHERE ",
-					"SELECT {LayoutSetPrototype.*} FROM (SELECT DISTINCT layoutSetPrototype.layoutSetPrototypeId FROM LayoutSetPrototype layoutSetPrototype WHERE ",
-					") TEMP_TABLE INNER JOIN LayoutSetPrototype ON TEMP_TABLE.layoutSetPrototypeId = LayoutSetPrototype.layoutSetPrototypeId",
-					"SELECT COUNT(DISTINCT layoutSetPrototype.layoutSetPrototypeId) AS COUNT_VALUE FROM LayoutSetPrototype layoutSetPrototype WHERE ",
+					_FILTER_ENTITY_ALIAS, _FILTER_ENTITY_TABLE,
+					_FILTER_ENTITY_TABLE_FILTER_PK_COLUMN,
+					_FILTER_SQL_SELECT_LAYOUTSETPROTOTYPE_WHERE,
+					_FILTER_SQL_SELECT_LAYOUTSETPROTOTYPE_NO_INLINE_DISTINCT_WHERE_1,
+					_FILTER_SQL_SELECT_LAYOUTSETPROTOTYPE_NO_INLINE_DISTINCT_WHERE_2,
+					_FILTER_SQL_COUNT_LAYOUTSETPROTOTYPE_WHERE,
 					LayoutSetPrototypeModelImpl.ORDER_BY_SQL,
 					LayoutSetPrototypeModelImpl.ORDER_BY_SQL_INLINE_DISTINCT),
 				new FinderColumn<>(
@@ -1336,78 +1355,82 @@ public class LayoutSetPrototypePersistenceImpl
 					"layoutSetPrototype.", "companyId", FinderColumn.Type.LONG,
 					"=", true, true, LayoutSetPrototype::getCompanyId));
 
+		_finderPathWithPaginationFindByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByCompanyId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"companyId"}, true);
+
+		_finderPathWithoutPaginationFindByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByCompanyId",
+			new String[] {Long.class.getName()}, new String[] {"companyId"},
+			true);
+
+		_finderPathCountByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByCompanyId",
+			new String[] {Long.class.getName()}, new String[] {"companyId"},
+			false);
+
 		_collectionPersistenceFinderByCompanyId =
 			new FilterCollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByCompanyId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"findByCompanyId", new String[] {Long.class.getName()},
-					new String[] {"companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByCompanyId", new String[] {Long.class.getName()},
-					new String[] {"companyId"}, false),
+				this, _finderPathWithPaginationFindByCompanyId,
+				_finderPathWithoutPaginationFindByCompanyId,
+				_finderPathCountByCompanyId,
 				_SQL_SELECT_LAYOUTSETPROTOTYPE_WHERE,
 				_SQL_COUNT_LAYOUTSETPROTOTYPE_WHERE,
 				LayoutSetPrototypeModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
 				"",
 				new FilterCollectionPersistenceFinder.FilterMetadata<>(
 					LayoutSetPrototypeImpl.class, LayoutSetPrototype.class,
-					"layoutSetPrototype", "LayoutSetPrototype",
-					"layoutSetPrototype.layoutSetPrototypeId",
-					"SELECT DISTINCT {layoutSetPrototype.*} FROM LayoutSetPrototype layoutSetPrototype WHERE ",
-					"SELECT {LayoutSetPrototype.*} FROM (SELECT DISTINCT layoutSetPrototype.layoutSetPrototypeId FROM LayoutSetPrototype layoutSetPrototype WHERE ",
-					") TEMP_TABLE INNER JOIN LayoutSetPrototype ON TEMP_TABLE.layoutSetPrototypeId = LayoutSetPrototype.layoutSetPrototypeId",
-					"SELECT COUNT(DISTINCT layoutSetPrototype.layoutSetPrototypeId) AS COUNT_VALUE FROM LayoutSetPrototype layoutSetPrototype WHERE ",
+					_FILTER_ENTITY_ALIAS, _FILTER_ENTITY_TABLE,
+					_FILTER_ENTITY_TABLE_FILTER_PK_COLUMN,
+					_FILTER_SQL_SELECT_LAYOUTSETPROTOTYPE_WHERE,
+					_FILTER_SQL_SELECT_LAYOUTSETPROTOTYPE_NO_INLINE_DISTINCT_WHERE_1,
+					_FILTER_SQL_SELECT_LAYOUTSETPROTOTYPE_NO_INLINE_DISTINCT_WHERE_2,
+					_FILTER_SQL_COUNT_LAYOUTSETPROTOTYPE_WHERE,
 					LayoutSetPrototypeModelImpl.ORDER_BY_SQL,
 					LayoutSetPrototypeModelImpl.ORDER_BY_SQL_INLINE_DISTINCT),
 				new FinderColumn<>(
 					"layoutSetPrototype.", "companyId", FinderColumn.Type.LONG,
 					"=", true, true, LayoutSetPrototype::getCompanyId));
 
+		_finderPathWithPaginationFindByC_A = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_A",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "active_"}, true);
+
+		_finderPathWithoutPaginationFindByC_A = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_A",
+			new String[] {Long.class.getName(), Boolean.class.getName()},
+			new String[] {"companyId", "active_"}, true);
+
+		_finderPathCountByC_A = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_A",
+			new String[] {Long.class.getName(), Boolean.class.getName()},
+			new String[] {"companyId", "active_"}, false);
+
 		_collectionPersistenceFinderByC_A =
 			new FilterCollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_A",
-					new String[] {
-						Long.class.getName(), Boolean.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"companyId", "active_"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_A",
-					new String[] {
-						Long.class.getName(), Boolean.class.getName()
-					},
-					new String[] {"companyId", "active_"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_A",
-					new String[] {
-						Long.class.getName(), Boolean.class.getName()
-					},
-					new String[] {"companyId", "active_"}, false),
+				this, _finderPathWithPaginationFindByC_A,
+				_finderPathWithoutPaginationFindByC_A, _finderPathCountByC_A,
 				_SQL_SELECT_LAYOUTSETPROTOTYPE_WHERE,
 				_SQL_COUNT_LAYOUTSETPROTOTYPE_WHERE,
 				LayoutSetPrototypeModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
 				"",
 				new FilterCollectionPersistenceFinder.FilterMetadata<>(
 					LayoutSetPrototypeImpl.class, LayoutSetPrototype.class,
-					"layoutSetPrototype", "LayoutSetPrototype",
-					"layoutSetPrototype.layoutSetPrototypeId",
-					"SELECT DISTINCT {layoutSetPrototype.*} FROM LayoutSetPrototype layoutSetPrototype WHERE ",
-					"SELECT {LayoutSetPrototype.*} FROM (SELECT DISTINCT layoutSetPrototype.layoutSetPrototypeId FROM LayoutSetPrototype layoutSetPrototype WHERE ",
-					") TEMP_TABLE INNER JOIN LayoutSetPrototype ON TEMP_TABLE.layoutSetPrototypeId = LayoutSetPrototype.layoutSetPrototypeId",
-					"SELECT COUNT(DISTINCT layoutSetPrototype.layoutSetPrototypeId) AS COUNT_VALUE FROM LayoutSetPrototype layoutSetPrototype WHERE ",
+					_FILTER_ENTITY_ALIAS, _FILTER_ENTITY_TABLE,
+					_FILTER_ENTITY_TABLE_FILTER_PK_COLUMN,
+					_FILTER_SQL_SELECT_LAYOUTSETPROTOTYPE_WHERE,
+					_FILTER_SQL_SELECT_LAYOUTSETPROTOTYPE_NO_INLINE_DISTINCT_WHERE_1,
+					_FILTER_SQL_SELECT_LAYOUTSETPROTOTYPE_NO_INLINE_DISTINCT_WHERE_2,
+					_FILTER_SQL_COUNT_LAYOUTSETPROTOTYPE_WHERE,
 					LayoutSetPrototypeModelImpl.ORDER_BY_SQL,
 					LayoutSetPrototypeModelImpl.ORDER_BY_SQL_INLINE_DISTINCT),
 				new FinderColumn<>(
@@ -1438,6 +1461,27 @@ public class LayoutSetPrototypePersistenceImpl
 	private static final String _SQL_COUNT_LAYOUTSETPROTOTYPE_WHERE =
 		"SELECT COUNT(layoutSetPrototype) FROM LayoutSetPrototype layoutSetPrototype WHERE ";
 
+	private static final String _FILTER_ENTITY_TABLE_FILTER_PK_COLUMN =
+		"layoutSetPrototype.layoutSetPrototypeId";
+
+	private static final String _FILTER_SQL_SELECT_LAYOUTSETPROTOTYPE_WHERE =
+		"SELECT DISTINCT {layoutSetPrototype.*} FROM LayoutSetPrototype layoutSetPrototype WHERE ";
+
+	private static final String
+		_FILTER_SQL_SELECT_LAYOUTSETPROTOTYPE_NO_INLINE_DISTINCT_WHERE_1 =
+			"SELECT {LayoutSetPrototype.*} FROM (SELECT DISTINCT layoutSetPrototype.layoutSetPrototypeId FROM LayoutSetPrototype layoutSetPrototype WHERE ";
+
+	private static final String
+		_FILTER_SQL_SELECT_LAYOUTSETPROTOTYPE_NO_INLINE_DISTINCT_WHERE_2 =
+			") TEMP_TABLE INNER JOIN LayoutSetPrototype ON TEMP_TABLE.layoutSetPrototypeId = LayoutSetPrototype.layoutSetPrototypeId";
+
+	private static final String _FILTER_SQL_COUNT_LAYOUTSETPROTOTYPE_WHERE =
+		"SELECT COUNT(DISTINCT layoutSetPrototype.layoutSetPrototypeId) AS COUNT_VALUE FROM LayoutSetPrototype layoutSetPrototype WHERE ";
+
+	private static final String _FILTER_ENTITY_ALIAS = "layoutSetPrototype";
+
+	private static final String _FILTER_ENTITY_TABLE = "LayoutSetPrototype";
+
 	private static final String _NO_SUCH_ENTITY_WITH_KEY =
 		"No LayoutSetPrototype exists with the key {";
 
@@ -1450,4 +1494,4 @@ public class LayoutSetPrototypePersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-561153321
+// LIFERAY-SERVICE-BUILDER-HASH:-913682478

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/ListTypePersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/ListTypePersistenceImpl.java
@@ -72,6 +72,9 @@ public class ListTypePersistenceImpl
 	public static final String FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION =
 		FINDER_CLASS_NAME_ENTITY + ".List2";
 
+	private FinderPath _finderPathWithPaginationFindByUuid;
+	private FinderPath _finderPathWithoutPaginationFindByUuid;
+	private FinderPath _finderPathCountByUuid;
 	private CollectionPersistenceFinder<ListType>
 		_collectionPersistenceFinderByUuid;
 
@@ -211,6 +214,9 @@ public class ListTypePersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {uuid});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByUuid_C;
+	private FinderPath _finderPathWithoutPaginationFindByUuid_C;
+	private FinderPath _finderPathCountByUuid_C;
 	private CollectionPersistenceFinder<ListType>
 		_collectionPersistenceFinderByUuid_C;
 
@@ -365,6 +371,9 @@ public class ListTypePersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {uuid, companyId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByCompanyId;
+	private FinderPath _finderPathWithoutPaginationFindByCompanyId;
+	private FinderPath _finderPathCountByCompanyId;
 	private CollectionPersistenceFinder<ListType>
 		_collectionPersistenceFinderByCompanyId;
 
@@ -506,6 +515,9 @@ public class ListTypePersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {companyId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_T;
+	private FinderPath _finderPathWithoutPaginationFindByC_T;
+	private FinderPath _finderPathCountByC_T;
 	private CollectionPersistenceFinder<ListType>
 		_collectionPersistenceFinderByC_T;
 
@@ -659,6 +671,7 @@ public class ListTypePersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {companyId, type});
 	}
 
+	private FinderPath _finderPathFetchByC_N_T;
 	private UniquePersistenceFinder<ListType> _uniquePersistenceFinderByC_N_T;
 
 	/**
@@ -970,50 +983,59 @@ public class ListTypePersistenceImpl
 	 * Initializes the list type persistence.
 	 */
 	public void afterPropertiesSet() {
+		_finderPathWithPaginationFindByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid",
+			new String[] {
+				String.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"uuid_"}, true);
+
+		_finderPathWithoutPaginationFindByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid",
+			new String[] {String.class.getName()}, new String[] {"uuid_"}, 0, 1,
+			true, null);
+
+		_finderPathCountByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid",
+			new String[] {String.class.getName()}, new String[] {"uuid_"}, 0, 1,
+			false, null);
+
 		_collectionPersistenceFinderByUuid = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid",
-				new String[] {
-					String.class.getName(), Integer.class.getName(),
-					Integer.class.getName(), OrderByComparator.class.getName()
-				},
-				new String[] {"uuid_"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid",
-				new String[] {String.class.getName()}, new String[] {"uuid_"},
-				0, 1, true, null),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid",
-				new String[] {String.class.getName()}, new String[] {"uuid_"},
-				0, 1, false, null),
+			this, _finderPathWithPaginationFindByUuid,
+			_finderPathWithoutPaginationFindByUuid, _finderPathCountByUuid,
 			_SQL_SELECT_LISTTYPE_WHERE, _SQL_COUNT_LISTTYPE_WHERE,
 			ListTypeModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
 				"listType.", "uuid", FinderColumn.Type.STRING, "=", true, true,
 				ListType::getUuid));
 
+		_finderPathWithPaginationFindByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid_C",
+			new String[] {
+				String.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"uuid_", "companyId"}, true);
+
+		_finderPathWithoutPaginationFindByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"uuid_", "companyId"}, 0, 1, true, null);
+
+		_finderPathCountByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"uuid_", "companyId"}, 0, 1, false, null);
+
 		_collectionPersistenceFinderByUuid_C =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid_C",
-					new String[] {
-						String.class.getName(), Long.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"uuid_", "companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid_C",
-					new String[] {String.class.getName(), Long.class.getName()},
-					new String[] {"uuid_", "companyId"}, 0, 1, true, null),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid_C",
-					new String[] {String.class.getName(), Long.class.getName()},
-					new String[] {"uuid_", "companyId"}, 0, 1, false, null),
-				_SQL_SELECT_LISTTYPE_WHERE, _SQL_COUNT_LISTTYPE_WHERE,
-				ListTypeModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+				this, _finderPathWithPaginationFindByUuid_C,
+				_finderPathWithoutPaginationFindByUuid_C,
+				_finderPathCountByUuid_C, _SQL_SELECT_LISTTYPE_WHERE,
+				_SQL_COUNT_LISTTYPE_WHERE, ListTypeModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
 					"listType.", "uuid", FinderColumn.Type.STRING, "=", true,
 					true, ListType::getUuid),
@@ -1021,49 +1043,57 @@ public class ListTypePersistenceImpl
 					"listType.", "companyId", FinderColumn.Type.LONG, "=", true,
 					true, ListType::getCompanyId));
 
+		_finderPathWithPaginationFindByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByCompanyId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"companyId"}, true);
+
+		_finderPathWithoutPaginationFindByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByCompanyId",
+			new String[] {Long.class.getName()}, new String[] {"companyId"},
+			true);
+
+		_finderPathCountByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByCompanyId",
+			new String[] {Long.class.getName()}, new String[] {"companyId"},
+			false);
+
 		_collectionPersistenceFinderByCompanyId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByCompanyId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"findByCompanyId", new String[] {Long.class.getName()},
-					new String[] {"companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByCompanyId", new String[] {Long.class.getName()},
-					new String[] {"companyId"}, false),
-				_SQL_SELECT_LISTTYPE_WHERE, _SQL_COUNT_LISTTYPE_WHERE,
-				ListTypeModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+				this, _finderPathWithPaginationFindByCompanyId,
+				_finderPathWithoutPaginationFindByCompanyId,
+				_finderPathCountByCompanyId, _SQL_SELECT_LISTTYPE_WHERE,
+				_SQL_COUNT_LISTTYPE_WHERE, ListTypeModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
 					"listType.", "companyId", FinderColumn.Type.LONG, "=", true,
 					true, ListType::getCompanyId));
 
+		_finderPathWithPaginationFindByC_T = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_T",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "type_"}, true);
+
+		_finderPathWithoutPaginationFindByC_T = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_T",
+			new String[] {Long.class.getName(), String.class.getName()},
+			new String[] {"companyId", "type_"}, 0, 2, true, null);
+
+		_finderPathCountByC_T = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_T",
+			new String[] {Long.class.getName(), String.class.getName()},
+			new String[] {"companyId", "type_"}, 0, 2, false, null);
+
 		_collectionPersistenceFinderByC_T = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_T",
-				new String[] {
-					Long.class.getName(), String.class.getName(),
-					Integer.class.getName(), Integer.class.getName(),
-					OrderByComparator.class.getName()
-				},
-				new String[] {"companyId", "type_"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_T",
-				new String[] {Long.class.getName(), String.class.getName()},
-				new String[] {"companyId", "type_"}, 0, 2, true, null),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_T",
-				new String[] {Long.class.getName(), String.class.getName()},
-				new String[] {"companyId", "type_"}, 0, 2, false, null),
+			this, _finderPathWithPaginationFindByC_T,
+			_finderPathWithoutPaginationFindByC_T, _finderPathCountByC_T,
 			_SQL_SELECT_LISTTYPE_WHERE, _SQL_COUNT_LISTTYPE_WHERE,
 			ListTypeModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
@@ -1073,18 +1103,18 @@ public class ListTypePersistenceImpl
 				"listType.", "type", FinderColumn.Type.STRING, "=", true, true,
 				ListType::getType));
 
+		_finderPathFetchByC_N_T = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByC_N_T",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				String.class.getName()
+			},
+			new String[] {"companyId", "name", "type_"}, 0, 6, false,
+			ListType::getCompanyId, convertNullFunction(ListType::getName),
+			convertNullFunction(ListType::getType));
+
 		_uniquePersistenceFinderByC_N_T = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByC_N_T",
-				new String[] {
-					Long.class.getName(), String.class.getName(),
-					String.class.getName()
-				},
-				new String[] {"companyId", "name", "type_"}, 0, 6, false,
-				ListType::getCompanyId, convertNullFunction(ListType::getName),
-				convertNullFunction(ListType::getType)),
-			_SQL_SELECT_LISTTYPE_WHERE, "",
+			this, _finderPathFetchByC_N_T, _SQL_SELECT_LISTTYPE_WHERE, "",
 			new FinderColumn<>(
 				"listType.", "companyId", FinderColumn.Type.LONG, "=", true,
 				true, ListType::getCompanyId),
@@ -1131,4 +1161,4 @@ public class ListTypePersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:445381962
+// LIFERAY-SERVICE-BUILDER-HASH:1068237188

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/MembershipRequestPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/MembershipRequestPersistenceImpl.java
@@ -65,6 +65,9 @@ public class MembershipRequestPersistenceImpl
 	public static final String FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION =
 		FINDER_CLASS_NAME_ENTITY + ".List2";
 
+	private FinderPath _finderPathWithPaginationFindByGroupId;
+	private FinderPath _finderPathWithoutPaginationFindByGroupId;
+	private FinderPath _finderPathCountByGroupId;
 	private CollectionPersistenceFinder<MembershipRequest>
 		_collectionPersistenceFinderByGroupId;
 
@@ -210,6 +213,9 @@ public class MembershipRequestPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {groupId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByUserId;
+	private FinderPath _finderPathWithoutPaginationFindByUserId;
+	private FinderPath _finderPathCountByUserId;
 	private CollectionPersistenceFinder<MembershipRequest>
 		_collectionPersistenceFinderByUserId;
 
@@ -353,6 +359,9 @@ public class MembershipRequestPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {userId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByG_S;
+	private FinderPath _finderPathWithoutPaginationFindByG_S;
+	private FinderPath _finderPathCountByG_S;
 	private CollectionPersistenceFinder<MembershipRequest>
 		_collectionPersistenceFinderByG_S;
 
@@ -508,6 +517,9 @@ public class MembershipRequestPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {groupId, statusId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByG_U_S;
+	private FinderPath _finderPathWithoutPaginationFindByG_U_S;
+	private FinderPath _finderPathCountByG_U_S;
 	private CollectionPersistenceFinder<MembershipRequest>
 		_collectionPersistenceFinderByG_U_S;
 
@@ -871,26 +883,29 @@ public class MembershipRequestPersistenceImpl
 	 * Initializes the membership request persistence.
 	 */
 	public void afterPropertiesSet() {
+		_finderPathWithPaginationFindByGroupId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByGroupId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"groupId"}, true);
+
+		_finderPathWithoutPaginationFindByGroupId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByGroupId",
+			new String[] {Long.class.getName()}, new String[] {"groupId"},
+			true);
+
+		_finderPathCountByGroupId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByGroupId",
+			new String[] {Long.class.getName()}, new String[] {"groupId"},
+			false);
+
 		_collectionPersistenceFinderByGroupId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByGroupId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"groupId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByGroupId",
-					new String[] {Long.class.getName()},
-					new String[] {"groupId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByGroupId",
-					new String[] {Long.class.getName()},
-					new String[] {"groupId"}, false),
-				_SQL_SELECT_MEMBERSHIPREQUEST_WHERE,
+				this, _finderPathWithPaginationFindByGroupId,
+				_finderPathWithoutPaginationFindByGroupId,
+				_finderPathCountByGroupId, _SQL_SELECT_MEMBERSHIPREQUEST_WHERE,
 				_SQL_COUNT_MEMBERSHIPREQUEST_WHERE,
 				MembershipRequestModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
 				"",
@@ -898,26 +913,28 @@ public class MembershipRequestPersistenceImpl
 					"membershipRequest.", "groupId", FinderColumn.Type.LONG,
 					"=", true, true, MembershipRequest::getGroupId));
 
+		_finderPathWithPaginationFindByUserId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUserId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"userId"}, true);
+
+		_finderPathWithoutPaginationFindByUserId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUserId",
+			new String[] {Long.class.getName()}, new String[] {"userId"}, true);
+
+		_finderPathCountByUserId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUserId",
+			new String[] {Long.class.getName()}, new String[] {"userId"},
+			false);
+
 		_collectionPersistenceFinderByUserId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUserId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"userId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUserId",
-					new String[] {Long.class.getName()},
-					new String[] {"userId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUserId",
-					new String[] {Long.class.getName()},
-					new String[] {"userId"}, false),
-				_SQL_SELECT_MEMBERSHIPREQUEST_WHERE,
+				this, _finderPathWithPaginationFindByUserId,
+				_finderPathWithoutPaginationFindByUserId,
+				_finderPathCountByUserId, _SQL_SELECT_MEMBERSHIPREQUEST_WHERE,
 				_SQL_COUNT_MEMBERSHIPREQUEST_WHERE,
 				MembershipRequestModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
 				"",
@@ -925,24 +942,28 @@ public class MembershipRequestPersistenceImpl
 					"membershipRequest.", "userId", FinderColumn.Type.LONG, "=",
 					true, true, MembershipRequest::getUserId));
 
+		_finderPathWithPaginationFindByG_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_S",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"groupId", "statusId"}, true);
+
+		_finderPathWithoutPaginationFindByG_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_S",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"groupId", "statusId"}, true);
+
+		_finderPathCountByG_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_S",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"groupId", "statusId"}, false);
+
 		_collectionPersistenceFinderByG_S = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_S",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Integer.class.getName(), Integer.class.getName(),
-					OrderByComparator.class.getName()
-				},
-				new String[] {"groupId", "statusId"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_S",
-				new String[] {Long.class.getName(), Long.class.getName()},
-				new String[] {"groupId", "statusId"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_S",
-				new String[] {Long.class.getName(), Long.class.getName()},
-				new String[] {"groupId", "statusId"}, false),
+			this, _finderPathWithPaginationFindByG_S,
+			_finderPathWithoutPaginationFindByG_S, _finderPathCountByG_S,
 			_SQL_SELECT_MEMBERSHIPREQUEST_WHERE,
 			_SQL_COUNT_MEMBERSHIPREQUEST_WHERE,
 			MembershipRequestModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
@@ -953,30 +974,32 @@ public class MembershipRequestPersistenceImpl
 				"membershipRequest.", "statusId", FinderColumn.Type.LONG, "=",
 				true, true, MembershipRequest::getStatusId));
 
+		_finderPathWithPaginationFindByG_U_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_U_S",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"groupId", "userId", "statusId"}, true);
+
+		_finderPathWithoutPaginationFindByG_U_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_U_S",
+			new String[] {
+				Long.class.getName(), Long.class.getName(), Long.class.getName()
+			},
+			new String[] {"groupId", "userId", "statusId"}, true);
+
+		_finderPathCountByG_U_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_U_S",
+			new String[] {
+				Long.class.getName(), Long.class.getName(), Long.class.getName()
+			},
+			new String[] {"groupId", "userId", "statusId"}, false);
+
 		_collectionPersistenceFinderByG_U_S = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_U_S",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Long.class.getName(), Integer.class.getName(),
-					Integer.class.getName(), OrderByComparator.class.getName()
-				},
-				new String[] {"groupId", "userId", "statusId"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_U_S",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Long.class.getName()
-				},
-				new String[] {"groupId", "userId", "statusId"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_U_S",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Long.class.getName()
-				},
-				new String[] {"groupId", "userId", "statusId"}, false),
+			this, _finderPathWithPaginationFindByG_U_S,
+			_finderPathWithoutPaginationFindByG_U_S, _finderPathCountByG_U_S,
 			_SQL_SELECT_MEMBERSHIPREQUEST_WHERE,
 			_SQL_COUNT_MEMBERSHIPREQUEST_WHERE,
 			MembershipRequestModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
@@ -1020,4 +1043,4 @@ public class MembershipRequestPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:58792983
+// LIFERAY-SERVICE-BUILDER-HASH:799440674

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/OrgLaborPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/OrgLaborPersistenceImpl.java
@@ -61,6 +61,9 @@ public class OrgLaborPersistenceImpl
 	public static final String FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION =
 		FINDER_CLASS_NAME_ENTITY + ".List2";
 
+	private FinderPath _finderPathWithPaginationFindByOrganizationId;
+	private FinderPath _finderPathWithoutPaginationFindByOrganizationId;
+	private FinderPath _finderPathCountByOrganizationId;
 	private CollectionPersistenceFinder<OrgLabor>
 		_collectionPersistenceFinderByOrganizationId;
 
@@ -375,29 +378,31 @@ public class OrgLaborPersistenceImpl
 	 * Initializes the org labor persistence.
 	 */
 	public void afterPropertiesSet() {
+		_finderPathWithPaginationFindByOrganizationId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByOrganizationId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"organizationId"}, true);
+
+		_finderPathWithoutPaginationFindByOrganizationId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByOrganizationId",
+			new String[] {Long.class.getName()},
+			new String[] {"organizationId"}, true);
+
+		_finderPathCountByOrganizationId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByOrganizationId",
+			new String[] {Long.class.getName()},
+			new String[] {"organizationId"}, false);
+
 		_collectionPersistenceFinderByOrganizationId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION,
-					"findByOrganizationId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"organizationId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"findByOrganizationId", new String[] {Long.class.getName()},
-					new String[] {"organizationId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByOrganizationId",
-					new String[] {Long.class.getName()},
-					new String[] {"organizationId"}, false),
-				_SQL_SELECT_ORGLABOR_WHERE, _SQL_COUNT_ORGLABOR_WHERE,
-				OrgLaborModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+				this, _finderPathWithPaginationFindByOrganizationId,
+				_finderPathWithoutPaginationFindByOrganizationId,
+				_finderPathCountByOrganizationId, _SQL_SELECT_ORGLABOR_WHERE,
+				_SQL_COUNT_ORGLABOR_WHERE, OrgLaborModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
 					"orgLabor.", "organizationId", FinderColumn.Type.LONG, "=",
 					true, true, OrgLabor::getOrganizationId));
@@ -432,4 +437,4 @@ public class OrgLaborPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-525793661
+// LIFERAY-SERVICE-BUILDER-HASH:895216703

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/OrganizationPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/OrganizationPersistenceImpl.java
@@ -95,6 +95,9 @@ public class OrganizationPersistenceImpl
 	public static final String FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION =
 		FINDER_CLASS_NAME_ENTITY + ".List2";
 
+	private FinderPath _finderPathWithPaginationFindByUuid;
+	private FinderPath _finderPathWithoutPaginationFindByUuid;
+	private FinderPath _finderPathCountByUuid;
 	private FilterCollectionPersistenceFinder<Organization>
 		_collectionPersistenceFinderByUuid;
 
@@ -301,6 +304,9 @@ public class OrganizationPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {uuid});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByUuid_C;
+	private FinderPath _finderPathWithoutPaginationFindByUuid_C;
+	private FinderPath _finderPathCountByUuid_C;
 	private FilterCollectionPersistenceFinder<Organization>
 		_collectionPersistenceFinderByUuid_C;
 
@@ -527,6 +533,9 @@ public class OrganizationPersistenceImpl
 			companyId, 0);
 	}
 
+	private FinderPath _finderPathWithPaginationFindByCompanyId;
+	private FinderPath _finderPathWithoutPaginationFindByCompanyId;
+	private FinderPath _finderPathCountByCompanyId;
 	private FilterCollectionPersistenceFinder<Organization>
 		_collectionPersistenceFinderByCompanyId;
 
@@ -738,6 +747,9 @@ public class OrganizationPersistenceImpl
 			companyId, 0);
 	}
 
+	private FinderPath _finderPathWithPaginationFindByCompanyIdLocations;
+	private FinderPath _finderPathWithoutPaginationFindByCompanyIdLocations;
+	private FinderPath _finderPathCountByCompanyIdLocations;
 	private FilterCollectionPersistenceFinder<Organization>
 		_collectionPersistenceFinderByCompanyIdLocations;
 
@@ -951,6 +963,9 @@ public class OrganizationPersistenceImpl
 			companyId, 0);
 	}
 
+	private FinderPath _finderPathWithPaginationFindByLogoId;
+	private FinderPath _finderPathWithoutPaginationFindByLogoId;
+	private FinderPath _finderPathCountByLogoId;
 	private FilterCollectionPersistenceFinder<Organization>
 		_collectionPersistenceFinderByLogoId;
 
@@ -1158,6 +1173,9 @@ public class OrganizationPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {logoId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_P;
+	private FinderPath _finderPathWithoutPaginationFindByC_P;
+	private FinderPath _finderPathCountByC_P;
 	private FilterCollectionPersistenceFinder<Organization>
 		_collectionPersistenceFinderByC_P;
 
@@ -1397,6 +1415,8 @@ public class OrganizationPersistenceImpl
 			new Object[] {companyId, parentOrganizationId}, companyId, 0);
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_LikeT;
+	private FinderPath _finderPathWithPaginationCountByC_LikeT;
 	private FilterCollectionPersistenceFinder<Organization>
 		_collectionPersistenceFinderByC_LikeT;
 
@@ -1629,6 +1649,7 @@ public class OrganizationPersistenceImpl
 			new Object[] {companyId, treePath}, companyId, 0);
 	}
 
+	private FinderPath _finderPathFetchByC_N;
 	private UniquePersistenceFinder<Organization> _uniquePersistenceFinderByC_N;
 
 	/**
@@ -1718,6 +1739,8 @@ public class OrganizationPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {companyId, name});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_LikeN;
+	private FinderPath _finderPathWithPaginationCountByC_LikeN;
 	private FilterCollectionPersistenceFinder<Organization>
 		_collectionPersistenceFinderByC_LikeN;
 
@@ -1944,6 +1967,8 @@ public class OrganizationPersistenceImpl
 			companyId, 0);
 	}
 
+	private FinderPath _finderPathWithPaginationFindByGtO_C_P;
+	private FinderPath _finderPathWithPaginationCountByGtO_C_P;
 	private FilterCollectionPersistenceFinder<Organization>
 		_collectionPersistenceFinderByGtO_C_P;
 
@@ -2208,6 +2233,8 @@ public class OrganizationPersistenceImpl
 			companyId, 0);
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_P_LikeN;
+	private FinderPath _finderPathWithPaginationCountByC_P_LikeN;
 	private FilterCollectionPersistenceFinder<Organization>
 		_collectionPersistenceFinderByC_P_LikeN;
 
@@ -2469,6 +2496,7 @@ public class OrganizationPersistenceImpl
 			new Object[] {companyId, parentOrganizationId, name}, companyId, 0);
 	}
 
+	private FinderPath _finderPathFetchByERC_C;
 	private UniquePersistenceFinder<Organization>
 		_uniquePersistenceFinderByERC_C;
 
@@ -3598,68 +3626,78 @@ public class OrganizationPersistenceImpl
 			"Users_Orgs", "companyId", "organizationId", "userId", this,
 			userPersistence);
 
+		_finderPathWithPaginationFindByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid",
+			new String[] {
+				String.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"uuid_"}, true);
+
+		_finderPathWithoutPaginationFindByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid",
+			new String[] {String.class.getName()}, new String[] {"uuid_"}, 0, 1,
+			true, null);
+
+		_finderPathCountByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid",
+			new String[] {String.class.getName()}, new String[] {"uuid_"}, 0, 1,
+			false, null);
+
 		_collectionPersistenceFinderByUuid =
 			new FilterCollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid",
-					new String[] {
-						String.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"uuid_"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid",
-					new String[] {String.class.getName()},
-					new String[] {"uuid_"}, 0, 1, true, null),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid",
-					new String[] {String.class.getName()},
-					new String[] {"uuid_"}, 0, 1, false, null),
+				this, _finderPathWithPaginationFindByUuid,
+				_finderPathWithoutPaginationFindByUuid, _finderPathCountByUuid,
 				_SQL_SELECT_ORGANIZATION_WHERE, _SQL_COUNT_ORGANIZATION_WHERE,
 				OrganizationModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 				new FilterCollectionPersistenceFinder.FilterMetadata<>(
-					OrganizationImpl.class, Organization.class, "organization",
-					"Organization_", "organization.organizationId",
-					"SELECT DISTINCT {organization.*} FROM Organization_ organization WHERE ",
-					"SELECT {Organization_.*} FROM (SELECT DISTINCT organization.organizationId FROM Organization_ organization WHERE ",
-					") TEMP_TABLE INNER JOIN Organization_ ON TEMP_TABLE.organizationId = Organization_.organizationId",
-					"SELECT COUNT(DISTINCT organization.organizationId) AS COUNT_VALUE FROM Organization_ organization WHERE ",
+					OrganizationImpl.class, Organization.class,
+					_FILTER_ENTITY_ALIAS, _FILTER_ENTITY_TABLE,
+					_FILTER_ENTITY_TABLE_FILTER_PK_COLUMN,
+					_FILTER_SQL_SELECT_ORGANIZATION_WHERE,
+					_FILTER_SQL_SELECT_ORGANIZATION_NO_INLINE_DISTINCT_WHERE_1,
+					_FILTER_SQL_SELECT_ORGANIZATION_NO_INLINE_DISTINCT_WHERE_2,
+					_FILTER_SQL_COUNT_ORGANIZATION_WHERE,
 					OrganizationModelImpl.ORDER_BY_SQL,
 					OrganizationModelImpl.ORDER_BY_SQL_INLINE_DISTINCT),
 				new FinderColumn<>(
 					"organization.", "uuid", FinderColumn.Type.STRING, "=",
 					true, true, Organization::getUuid));
 
+		_finderPathWithPaginationFindByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid_C",
+			new String[] {
+				String.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"uuid_", "companyId"}, true);
+
+		_finderPathWithoutPaginationFindByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"uuid_", "companyId"}, 0, 1, true, null);
+
+		_finderPathCountByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"uuid_", "companyId"}, 0, 1, false, null);
+
 		_collectionPersistenceFinderByUuid_C =
 			new FilterCollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid_C",
-					new String[] {
-						String.class.getName(), Long.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"uuid_", "companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid_C",
-					new String[] {String.class.getName(), Long.class.getName()},
-					new String[] {"uuid_", "companyId"}, 0, 1, true, null),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid_C",
-					new String[] {String.class.getName(), Long.class.getName()},
-					new String[] {"uuid_", "companyId"}, 0, 1, false, null),
-				_SQL_SELECT_ORGANIZATION_WHERE, _SQL_COUNT_ORGANIZATION_WHERE,
+				this, _finderPathWithPaginationFindByUuid_C,
+				_finderPathWithoutPaginationFindByUuid_C,
+				_finderPathCountByUuid_C, _SQL_SELECT_ORGANIZATION_WHERE,
+				_SQL_COUNT_ORGANIZATION_WHERE,
 				OrganizationModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 				new FilterCollectionPersistenceFinder.FilterMetadata<>(
-					OrganizationImpl.class, Organization.class, "organization",
-					"Organization_", "organization.organizationId",
-					"SELECT DISTINCT {organization.*} FROM Organization_ organization WHERE ",
-					"SELECT {Organization_.*} FROM (SELECT DISTINCT organization.organizationId FROM Organization_ organization WHERE ",
-					") TEMP_TABLE INNER JOIN Organization_ ON TEMP_TABLE.organizationId = Organization_.organizationId",
-					"SELECT COUNT(DISTINCT organization.organizationId) AS COUNT_VALUE FROM Organization_ organization WHERE ",
+					OrganizationImpl.class, Organization.class,
+					_FILTER_ENTITY_ALIAS, _FILTER_ENTITY_TABLE,
+					_FILTER_ENTITY_TABLE_FILTER_PK_COLUMN,
+					_FILTER_SQL_SELECT_ORGANIZATION_WHERE,
+					_FILTER_SQL_SELECT_ORGANIZATION_NO_INLINE_DISTINCT_WHERE_1,
+					_FILTER_SQL_SELECT_ORGANIZATION_NO_INLINE_DISTINCT_WHERE_2,
+					_FILTER_SQL_COUNT_ORGANIZATION_WHERE,
 					OrganizationModelImpl.ORDER_BY_SQL,
 					OrganizationModelImpl.ORDER_BY_SQL_INLINE_DISTINCT),
 				new FinderColumn<>(
@@ -3669,140 +3707,156 @@ public class OrganizationPersistenceImpl
 					"organization.", "companyId", FinderColumn.Type.LONG, "=",
 					true, true, Organization::getCompanyId));
 
+		_finderPathWithPaginationFindByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByCompanyId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"companyId"}, true);
+
+		_finderPathWithoutPaginationFindByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByCompanyId",
+			new String[] {Long.class.getName()}, new String[] {"companyId"},
+			true);
+
+		_finderPathCountByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByCompanyId",
+			new String[] {Long.class.getName()}, new String[] {"companyId"},
+			false);
+
 		_collectionPersistenceFinderByCompanyId =
 			new FilterCollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByCompanyId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"findByCompanyId", new String[] {Long.class.getName()},
-					new String[] {"companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByCompanyId", new String[] {Long.class.getName()},
-					new String[] {"companyId"}, false),
-				_SQL_SELECT_ORGANIZATION_WHERE, _SQL_COUNT_ORGANIZATION_WHERE,
+				this, _finderPathWithPaginationFindByCompanyId,
+				_finderPathWithoutPaginationFindByCompanyId,
+				_finderPathCountByCompanyId, _SQL_SELECT_ORGANIZATION_WHERE,
+				_SQL_COUNT_ORGANIZATION_WHERE,
 				OrganizationModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 				new FilterCollectionPersistenceFinder.FilterMetadata<>(
-					OrganizationImpl.class, Organization.class, "organization",
-					"Organization_", "organization.organizationId",
-					"SELECT DISTINCT {organization.*} FROM Organization_ organization WHERE ",
-					"SELECT {Organization_.*} FROM (SELECT DISTINCT organization.organizationId FROM Organization_ organization WHERE ",
-					") TEMP_TABLE INNER JOIN Organization_ ON TEMP_TABLE.organizationId = Organization_.organizationId",
-					"SELECT COUNT(DISTINCT organization.organizationId) AS COUNT_VALUE FROM Organization_ organization WHERE ",
+					OrganizationImpl.class, Organization.class,
+					_FILTER_ENTITY_ALIAS, _FILTER_ENTITY_TABLE,
+					_FILTER_ENTITY_TABLE_FILTER_PK_COLUMN,
+					_FILTER_SQL_SELECT_ORGANIZATION_WHERE,
+					_FILTER_SQL_SELECT_ORGANIZATION_NO_INLINE_DISTINCT_WHERE_1,
+					_FILTER_SQL_SELECT_ORGANIZATION_NO_INLINE_DISTINCT_WHERE_2,
+					_FILTER_SQL_COUNT_ORGANIZATION_WHERE,
 					OrganizationModelImpl.ORDER_BY_SQL,
 					OrganizationModelImpl.ORDER_BY_SQL_INLINE_DISTINCT),
 				new FinderColumn<>(
 					"organization.", "companyId", FinderColumn.Type.LONG, "=",
 					true, true, Organization::getCompanyId));
 
+		_finderPathWithPaginationFindByCompanyIdLocations = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByCompanyIdLocations",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"companyId"}, true);
+
+		_finderPathWithoutPaginationFindByCompanyIdLocations = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
+			"findByCompanyIdLocations", new String[] {Long.class.getName()},
+			new String[] {"companyId"}, true);
+
+		_finderPathCountByCompanyIdLocations = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
+			"countByCompanyIdLocations", new String[] {Long.class.getName()},
+			new String[] {"companyId"}, false);
+
 		_collectionPersistenceFinderByCompanyIdLocations =
 			new FilterCollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION,
-					"findByCompanyIdLocations",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"findByCompanyIdLocations",
-					new String[] {Long.class.getName()},
-					new String[] {"companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByCompanyIdLocations",
-					new String[] {Long.class.getName()},
-					new String[] {"companyId"}, false),
+				this, _finderPathWithPaginationFindByCompanyIdLocations,
+				_finderPathWithoutPaginationFindByCompanyIdLocations,
+				_finderPathCountByCompanyIdLocations,
 				_SQL_SELECT_ORGANIZATION_WHERE, _SQL_COUNT_ORGANIZATION_WHERE,
 				OrganizationModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
 				"organization.parentOrganizationId != 0",
 				new FilterCollectionPersistenceFinder.FilterMetadata<>(
-					OrganizationImpl.class, Organization.class, "organization",
-					"Organization_", "organization.organizationId",
-					"SELECT DISTINCT {organization.*} FROM Organization_ organization WHERE ",
-					"SELECT {Organization_.*} FROM (SELECT DISTINCT organization.organizationId FROM Organization_ organization WHERE ",
-					") TEMP_TABLE INNER JOIN Organization_ ON TEMP_TABLE.organizationId = Organization_.organizationId",
-					"SELECT COUNT(DISTINCT organization.organizationId) AS COUNT_VALUE FROM Organization_ organization WHERE ",
+					OrganizationImpl.class, Organization.class,
+					_FILTER_ENTITY_ALIAS, _FILTER_ENTITY_TABLE,
+					_FILTER_ENTITY_TABLE_FILTER_PK_COLUMN,
+					_FILTER_SQL_SELECT_ORGANIZATION_WHERE,
+					_FILTER_SQL_SELECT_ORGANIZATION_NO_INLINE_DISTINCT_WHERE_1,
+					_FILTER_SQL_SELECT_ORGANIZATION_NO_INLINE_DISTINCT_WHERE_2,
+					_FILTER_SQL_COUNT_ORGANIZATION_WHERE,
 					OrganizationModelImpl.ORDER_BY_SQL,
 					OrganizationModelImpl.ORDER_BY_SQL_INLINE_DISTINCT),
 				new FinderColumn<>(
 					"organization.", "companyId", FinderColumn.Type.LONG, "=",
 					true, true, Organization::getCompanyId));
 
+		_finderPathWithPaginationFindByLogoId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByLogoId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"logoId"}, true);
+
+		_finderPathWithoutPaginationFindByLogoId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByLogoId",
+			new String[] {Long.class.getName()}, new String[] {"logoId"}, true);
+
+		_finderPathCountByLogoId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByLogoId",
+			new String[] {Long.class.getName()}, new String[] {"logoId"},
+			false);
+
 		_collectionPersistenceFinderByLogoId =
 			new FilterCollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByLogoId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"logoId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByLogoId",
-					new String[] {Long.class.getName()},
-					new String[] {"logoId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByLogoId",
-					new String[] {Long.class.getName()},
-					new String[] {"logoId"}, false),
-				_SQL_SELECT_ORGANIZATION_WHERE, _SQL_COUNT_ORGANIZATION_WHERE,
+				this, _finderPathWithPaginationFindByLogoId,
+				_finderPathWithoutPaginationFindByLogoId,
+				_finderPathCountByLogoId, _SQL_SELECT_ORGANIZATION_WHERE,
+				_SQL_COUNT_ORGANIZATION_WHERE,
 				OrganizationModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 				new FilterCollectionPersistenceFinder.FilterMetadata<>(
-					OrganizationImpl.class, Organization.class, "organization",
-					"Organization_", "organization.organizationId",
-					"SELECT DISTINCT {organization.*} FROM Organization_ organization WHERE ",
-					"SELECT {Organization_.*} FROM (SELECT DISTINCT organization.organizationId FROM Organization_ organization WHERE ",
-					") TEMP_TABLE INNER JOIN Organization_ ON TEMP_TABLE.organizationId = Organization_.organizationId",
-					"SELECT COUNT(DISTINCT organization.organizationId) AS COUNT_VALUE FROM Organization_ organization WHERE ",
+					OrganizationImpl.class, Organization.class,
+					_FILTER_ENTITY_ALIAS, _FILTER_ENTITY_TABLE,
+					_FILTER_ENTITY_TABLE_FILTER_PK_COLUMN,
+					_FILTER_SQL_SELECT_ORGANIZATION_WHERE,
+					_FILTER_SQL_SELECT_ORGANIZATION_NO_INLINE_DISTINCT_WHERE_1,
+					_FILTER_SQL_SELECT_ORGANIZATION_NO_INLINE_DISTINCT_WHERE_2,
+					_FILTER_SQL_COUNT_ORGANIZATION_WHERE,
 					OrganizationModelImpl.ORDER_BY_SQL,
 					OrganizationModelImpl.ORDER_BY_SQL_INLINE_DISTINCT),
 				new FinderColumn<>(
 					"organization.", "logoId", FinderColumn.Type.LONG, "=",
 					true, true, Organization::getLogoId));
 
+		_finderPathWithPaginationFindByC_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_P",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "parentOrganizationId"}, true);
+
+		_finderPathWithoutPaginationFindByC_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_P",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"companyId", "parentOrganizationId"}, true);
+
+		_finderPathCountByC_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_P",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"companyId", "parentOrganizationId"}, false);
+
 		_collectionPersistenceFinderByC_P =
 			new FilterCollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_P",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"companyId", "parentOrganizationId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_P",
-					new String[] {Long.class.getName(), Long.class.getName()},
-					new String[] {"companyId", "parentOrganizationId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_P",
-					new String[] {Long.class.getName(), Long.class.getName()},
-					new String[] {"companyId", "parentOrganizationId"}, false),
+				this, _finderPathWithPaginationFindByC_P,
+				_finderPathWithoutPaginationFindByC_P, _finderPathCountByC_P,
 				_SQL_SELECT_ORGANIZATION_WHERE, _SQL_COUNT_ORGANIZATION_WHERE,
 				OrganizationModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 				new FilterCollectionPersistenceFinder.FilterMetadata<>(
-					OrganizationImpl.class, Organization.class, "organization",
-					"Organization_", "organization.organizationId",
-					"SELECT DISTINCT {organization.*} FROM Organization_ organization WHERE ",
-					"SELECT {Organization_.*} FROM (SELECT DISTINCT organization.organizationId FROM Organization_ organization WHERE ",
-					") TEMP_TABLE INNER JOIN Organization_ ON TEMP_TABLE.organizationId = Organization_.organizationId",
-					"SELECT COUNT(DISTINCT organization.organizationId) AS COUNT_VALUE FROM Organization_ organization WHERE ",
+					OrganizationImpl.class, Organization.class,
+					_FILTER_ENTITY_ALIAS, _FILTER_ENTITY_TABLE,
+					_FILTER_ENTITY_TABLE_FILTER_PK_COLUMN,
+					_FILTER_SQL_SELECT_ORGANIZATION_WHERE,
+					_FILTER_SQL_SELECT_ORGANIZATION_NO_INLINE_DISTINCT_WHERE_1,
+					_FILTER_SQL_SELECT_ORGANIZATION_NO_INLINE_DISTINCT_WHERE_2,
+					_FILTER_SQL_COUNT_ORGANIZATION_WHERE,
 					OrganizationModelImpl.ORDER_BY_SQL,
 					OrganizationModelImpl.ORDER_BY_SQL_INLINE_DISTINCT),
 				new FinderColumn<>(
@@ -3813,31 +3867,34 @@ public class OrganizationPersistenceImpl
 					FinderColumn.Type.LONG, "=", true, true,
 					Organization::getParentOrganizationId));
 
+		_finderPathWithPaginationFindByC_LikeT = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_LikeT",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "treePath"}, true);
+
+		_finderPathWithPaginationCountByC_LikeT = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByC_LikeT",
+			new String[] {Long.class.getName(), String.class.getName()},
+			new String[] {"companyId", "treePath"}, false);
+
 		_collectionPersistenceFinderByC_LikeT =
 			new FilterCollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_LikeT",
-					new String[] {
-						Long.class.getName(), String.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"companyId", "treePath"}, true),
-				null,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByC_LikeT",
-					new String[] {Long.class.getName(), String.class.getName()},
-					new String[] {"companyId", "treePath"}, false),
+				this, _finderPathWithPaginationFindByC_LikeT, null,
+				_finderPathWithPaginationCountByC_LikeT,
 				_SQL_SELECT_ORGANIZATION_WHERE, _SQL_COUNT_ORGANIZATION_WHERE,
 				OrganizationModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 				new FilterCollectionPersistenceFinder.FilterMetadata<>(
-					OrganizationImpl.class, Organization.class, "organization",
-					"Organization_", "organization.organizationId",
-					"SELECT DISTINCT {organization.*} FROM Organization_ organization WHERE ",
-					"SELECT {Organization_.*} FROM (SELECT DISTINCT organization.organizationId FROM Organization_ organization WHERE ",
-					") TEMP_TABLE INNER JOIN Organization_ ON TEMP_TABLE.organizationId = Organization_.organizationId",
-					"SELECT COUNT(DISTINCT organization.organizationId) AS COUNT_VALUE FROM Organization_ organization WHERE ",
+					OrganizationImpl.class, Organization.class,
+					_FILTER_ENTITY_ALIAS, _FILTER_ENTITY_TABLE,
+					_FILTER_ENTITY_TABLE_FILTER_PK_COLUMN,
+					_FILTER_SQL_SELECT_ORGANIZATION_WHERE,
+					_FILTER_SQL_SELECT_ORGANIZATION_NO_INLINE_DISTINCT_WHERE_1,
+					_FILTER_SQL_SELECT_ORGANIZATION_NO_INLINE_DISTINCT_WHERE_2,
+					_FILTER_SQL_COUNT_ORGANIZATION_WHERE,
 					OrganizationModelImpl.ORDER_BY_SQL,
 					OrganizationModelImpl.ORDER_BY_SQL_INLINE_DISTINCT),
 				new FinderColumn<>(
@@ -3847,15 +3904,15 @@ public class OrganizationPersistenceImpl
 					"organization.", "treePath", FinderColumn.Type.STRING,
 					"LIKE", true, true, Organization::getTreePath));
 
+		_finderPathFetchByC_N = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByC_N",
+			new String[] {Long.class.getName(), String.class.getName()},
+			new String[] {"companyId", "name"}, 0, 2, false,
+			Organization::getCompanyId,
+			convertNullFunction(Organization::getName));
+
 		_uniquePersistenceFinderByC_N = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByC_N",
-				new String[] {Long.class.getName(), String.class.getName()},
-				new String[] {"companyId", "name"}, 0, 2, false,
-				Organization::getCompanyId,
-				convertNullFunction(Organization::getName)),
-			_SQL_SELECT_ORGANIZATION_WHERE, "",
+			this, _finderPathFetchByC_N, _SQL_SELECT_ORGANIZATION_WHERE, "",
 			new FinderColumn<>(
 				"organization.", "companyId", FinderColumn.Type.LONG, "=", true,
 				true, Organization::getCompanyId),
@@ -3863,31 +3920,34 @@ public class OrganizationPersistenceImpl
 				"organization.", "name", FinderColumn.Type.STRING, "=", true,
 				true, Organization::getName));
 
+		_finderPathWithPaginationFindByC_LikeN = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_LikeN",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "name"}, true);
+
+		_finderPathWithPaginationCountByC_LikeN = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByC_LikeN",
+			new String[] {Long.class.getName(), String.class.getName()},
+			new String[] {"companyId", "name"}, false);
+
 		_collectionPersistenceFinderByC_LikeN =
 			new FilterCollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_LikeN",
-					new String[] {
-						Long.class.getName(), String.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"companyId", "name"}, true),
-				null,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByC_LikeN",
-					new String[] {Long.class.getName(), String.class.getName()},
-					new String[] {"companyId", "name"}, false),
+				this, _finderPathWithPaginationFindByC_LikeN, null,
+				_finderPathWithPaginationCountByC_LikeN,
 				_SQL_SELECT_ORGANIZATION_WHERE, _SQL_COUNT_ORGANIZATION_WHERE,
 				OrganizationModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 				new FilterCollectionPersistenceFinder.FilterMetadata<>(
-					OrganizationImpl.class, Organization.class, "organization",
-					"Organization_", "organization.organizationId",
-					"SELECT DISTINCT {organization.*} FROM Organization_ organization WHERE ",
-					"SELECT {Organization_.*} FROM (SELECT DISTINCT organization.organizationId FROM Organization_ organization WHERE ",
-					") TEMP_TABLE INNER JOIN Organization_ ON TEMP_TABLE.organizationId = Organization_.organizationId",
-					"SELECT COUNT(DISTINCT organization.organizationId) AS COUNT_VALUE FROM Organization_ organization WHERE ",
+					OrganizationImpl.class, Organization.class,
+					_FILTER_ENTITY_ALIAS, _FILTER_ENTITY_TABLE,
+					_FILTER_ENTITY_TABLE_FILTER_PK_COLUMN,
+					_FILTER_SQL_SELECT_ORGANIZATION_WHERE,
+					_FILTER_SQL_SELECT_ORGANIZATION_NO_INLINE_DISTINCT_WHERE_1,
+					_FILTER_SQL_SELECT_ORGANIZATION_NO_INLINE_DISTINCT_WHERE_2,
+					_FILTER_SQL_COUNT_ORGANIZATION_WHERE,
 					OrganizationModelImpl.ORDER_BY_SQL,
 					OrganizationModelImpl.ORDER_BY_SQL_INLINE_DISTINCT),
 				new FinderColumn<>(
@@ -3897,41 +3957,42 @@ public class OrganizationPersistenceImpl
 					"organization.", "name", FinderColumn.Type.STRING, "LIKE",
 					false, true, Organization::getName));
 
+		_finderPathWithPaginationFindByGtO_C_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByGtO_C_P",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {
+				"organizationId", "companyId", "parentOrganizationId"
+			},
+			true);
+
+		_finderPathWithPaginationCountByGtO_C_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByGtO_C_P",
+			new String[] {
+				Long.class.getName(), Long.class.getName(), Long.class.getName()
+			},
+			new String[] {
+				"organizationId", "companyId", "parentOrganizationId"
+			},
+			false);
+
 		_collectionPersistenceFinderByGtO_C_P =
 			new FilterCollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByGtO_C_P",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {
-						"organizationId", "companyId", "parentOrganizationId"
-					},
-					true),
-				null,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByGtO_C_P",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						Long.class.getName()
-					},
-					new String[] {
-						"organizationId", "companyId", "parentOrganizationId"
-					},
-					false),
+				this, _finderPathWithPaginationFindByGtO_C_P, null,
+				_finderPathWithPaginationCountByGtO_C_P,
 				_SQL_SELECT_ORGANIZATION_WHERE, _SQL_COUNT_ORGANIZATION_WHERE,
 				OrganizationModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 				new FilterCollectionPersistenceFinder.FilterMetadata<>(
-					OrganizationImpl.class, Organization.class, "organization",
-					"Organization_", "organization.organizationId",
-					"SELECT DISTINCT {organization.*} FROM Organization_ organization WHERE ",
-					"SELECT {Organization_.*} FROM (SELECT DISTINCT organization.organizationId FROM Organization_ organization WHERE ",
-					") TEMP_TABLE INNER JOIN Organization_ ON TEMP_TABLE.organizationId = Organization_.organizationId",
-					"SELECT COUNT(DISTINCT organization.organizationId) AS COUNT_VALUE FROM Organization_ organization WHERE ",
+					OrganizationImpl.class, Organization.class,
+					_FILTER_ENTITY_ALIAS, _FILTER_ENTITY_TABLE,
+					_FILTER_ENTITY_TABLE_FILTER_PK_COLUMN,
+					_FILTER_SQL_SELECT_ORGANIZATION_WHERE,
+					_FILTER_SQL_SELECT_ORGANIZATION_NO_INLINE_DISTINCT_WHERE_1,
+					_FILTER_SQL_SELECT_ORGANIZATION_NO_INLINE_DISTINCT_WHERE_2,
+					_FILTER_SQL_COUNT_ORGANIZATION_WHERE,
 					OrganizationModelImpl.ORDER_BY_SQL,
 					OrganizationModelImpl.ORDER_BY_SQL_INLINE_DISTINCT),
 				new FinderColumn<>(
@@ -3945,37 +4006,37 @@ public class OrganizationPersistenceImpl
 					FinderColumn.Type.LONG, "=", true, true,
 					Organization::getParentOrganizationId));
 
+		_finderPathWithPaginationFindByC_P_LikeN = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_P_LikeN",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				String.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "parentOrganizationId", "name"}, true);
+
+		_finderPathWithPaginationCountByC_P_LikeN = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByC_P_LikeN",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				String.class.getName()
+			},
+			new String[] {"companyId", "parentOrganizationId", "name"}, false);
+
 		_collectionPersistenceFinderByC_P_LikeN =
 			new FilterCollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_P_LikeN",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						String.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"companyId", "parentOrganizationId", "name"},
-					true),
-				null,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByC_P_LikeN",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						String.class.getName()
-					},
-					new String[] {"companyId", "parentOrganizationId", "name"},
-					false),
+				this, _finderPathWithPaginationFindByC_P_LikeN, null,
+				_finderPathWithPaginationCountByC_P_LikeN,
 				_SQL_SELECT_ORGANIZATION_WHERE, _SQL_COUNT_ORGANIZATION_WHERE,
 				OrganizationModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 				new FilterCollectionPersistenceFinder.FilterMetadata<>(
-					OrganizationImpl.class, Organization.class, "organization",
-					"Organization_", "organization.organizationId",
-					"SELECT DISTINCT {organization.*} FROM Organization_ organization WHERE ",
-					"SELECT {Organization_.*} FROM (SELECT DISTINCT organization.organizationId FROM Organization_ organization WHERE ",
-					") TEMP_TABLE INNER JOIN Organization_ ON TEMP_TABLE.organizationId = Organization_.organizationId",
-					"SELECT COUNT(DISTINCT organization.organizationId) AS COUNT_VALUE FROM Organization_ organization WHERE ",
+					OrganizationImpl.class, Organization.class,
+					_FILTER_ENTITY_ALIAS, _FILTER_ENTITY_TABLE,
+					_FILTER_ENTITY_TABLE_FILTER_PK_COLUMN,
+					_FILTER_SQL_SELECT_ORGANIZATION_WHERE,
+					_FILTER_SQL_SELECT_ORGANIZATION_NO_INLINE_DISTINCT_WHERE_1,
+					_FILTER_SQL_SELECT_ORGANIZATION_NO_INLINE_DISTINCT_WHERE_2,
+					_FILTER_SQL_COUNT_ORGANIZATION_WHERE,
 					OrganizationModelImpl.ORDER_BY_SQL,
 					OrganizationModelImpl.ORDER_BY_SQL_INLINE_DISTINCT),
 				new FinderColumn<>(
@@ -3989,16 +4050,15 @@ public class OrganizationPersistenceImpl
 					"organization.", "name", FinderColumn.Type.STRING, "LIKE",
 					false, true, Organization::getName));
 
+		_finderPathFetchByERC_C = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByERC_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "companyId"}, 0, 1, false,
+			convertNullFunction(Organization::getExternalReferenceCode),
+			Organization::getCompanyId);
+
 		_uniquePersistenceFinderByERC_C = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByERC_C",
-				new String[] {String.class.getName(), Long.class.getName()},
-				new String[] {"externalReferenceCode", "companyId"}, 0, 1,
-				false,
-				convertNullFunction(Organization::getExternalReferenceCode),
-				Organization::getCompanyId),
-			_SQL_SELECT_ORGANIZATION_WHERE, "",
+			this, _finderPathFetchByERC_C, _SQL_SELECT_ORGANIZATION_WHERE, "",
 			new FinderColumn<>(
 				"organization.", "externalReferenceCode",
 				FinderColumn.Type.STRING, "=", true, true,
@@ -4043,6 +4103,27 @@ public class OrganizationPersistenceImpl
 	private static final String _SQL_COUNT_ORGANIZATION_WHERE =
 		"SELECT COUNT(organization) FROM Organization organization WHERE ";
 
+	private static final String _FILTER_ENTITY_TABLE_FILTER_PK_COLUMN =
+		"organization.organizationId";
+
+	private static final String _FILTER_SQL_SELECT_ORGANIZATION_WHERE =
+		"SELECT DISTINCT {organization.*} FROM Organization_ organization WHERE ";
+
+	private static final String
+		_FILTER_SQL_SELECT_ORGANIZATION_NO_INLINE_DISTINCT_WHERE_1 =
+			"SELECT {Organization_.*} FROM (SELECT DISTINCT organization.organizationId FROM Organization_ organization WHERE ";
+
+	private static final String
+		_FILTER_SQL_SELECT_ORGANIZATION_NO_INLINE_DISTINCT_WHERE_2 =
+			") TEMP_TABLE INNER JOIN Organization_ ON TEMP_TABLE.organizationId = Organization_.organizationId";
+
+	private static final String _FILTER_SQL_COUNT_ORGANIZATION_WHERE =
+		"SELECT COUNT(DISTINCT organization.organizationId) AS COUNT_VALUE FROM Organization_ organization WHERE ";
+
+	private static final String _FILTER_ENTITY_ALIAS = "organization";
+
+	private static final String _FILTER_ENTITY_TABLE = "Organization_";
+
 	private static final String _NO_SUCH_ENTITY_WITH_KEY =
 		"No Organization exists with the key {";
 
@@ -4058,4 +4139,4 @@ public class OrganizationPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:534959289
+// LIFERAY-SERVICE-BUILDER-HASH:-1850817264

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/PasswordPolicyPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/PasswordPolicyPersistenceImpl.java
@@ -72,6 +72,9 @@ public class PasswordPolicyPersistenceImpl
 	public static final String FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION =
 		FINDER_CLASS_NAME_ENTITY + ".List2";
 
+	private FinderPath _finderPathWithPaginationFindByUuid;
+	private FinderPath _finderPathWithoutPaginationFindByUuid;
+	private FinderPath _finderPathCountByUuid;
 	private FilterCollectionPersistenceFinder<PasswordPolicy>
 		_collectionPersistenceFinderByUuid;
 
@@ -279,6 +282,9 @@ public class PasswordPolicyPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {uuid});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByUuid_C;
+	private FinderPath _finderPathWithoutPaginationFindByUuid_C;
+	private FinderPath _finderPathCountByUuid_C;
 	private FilterCollectionPersistenceFinder<PasswordPolicy>
 		_collectionPersistenceFinderByUuid_C;
 
@@ -507,6 +513,9 @@ public class PasswordPolicyPersistenceImpl
 			companyId, 0);
 	}
 
+	private FinderPath _finderPathWithPaginationFindByCompanyId;
+	private FinderPath _finderPathWithoutPaginationFindByCompanyId;
+	private FinderPath _finderPathCountByCompanyId;
 	private FilterCollectionPersistenceFinder<PasswordPolicy>
 		_collectionPersistenceFinderByCompanyId;
 
@@ -718,6 +727,7 @@ public class PasswordPolicyPersistenceImpl
 			companyId, 0);
 	}
 
+	private FinderPath _finderPathFetchByC_N;
 	private UniquePersistenceFinder<PasswordPolicy>
 		_uniquePersistenceFinderByC_N;
 
@@ -1029,72 +1039,79 @@ public class PasswordPolicyPersistenceImpl
 	 * Initializes the password policy persistence.
 	 */
 	public void afterPropertiesSet() {
+		_finderPathWithPaginationFindByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid",
+			new String[] {
+				String.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"uuid_"}, true);
+
+		_finderPathWithoutPaginationFindByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid",
+			new String[] {String.class.getName()}, new String[] {"uuid_"}, 0, 1,
+			true, null);
+
+		_finderPathCountByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid",
+			new String[] {String.class.getName()}, new String[] {"uuid_"}, 0, 1,
+			false, null);
+
 		_collectionPersistenceFinderByUuid =
 			new FilterCollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid",
-					new String[] {
-						String.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"uuid_"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid",
-					new String[] {String.class.getName()},
-					new String[] {"uuid_"}, 0, 1, true, null),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid",
-					new String[] {String.class.getName()},
-					new String[] {"uuid_"}, 0, 1, false, null),
+				this, _finderPathWithPaginationFindByUuid,
+				_finderPathWithoutPaginationFindByUuid, _finderPathCountByUuid,
 				_SQL_SELECT_PASSWORDPOLICY_WHERE,
 				_SQL_COUNT_PASSWORDPOLICY_WHERE,
 				PasswordPolicyModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 				new FilterCollectionPersistenceFinder.FilterMetadata<>(
 					PasswordPolicyImpl.class, PasswordPolicy.class,
-					"passwordPolicy", "PasswordPolicy",
-					"passwordPolicy.passwordPolicyId",
-					"SELECT DISTINCT {passwordPolicy.*} FROM PasswordPolicy passwordPolicy WHERE ",
-					"SELECT {PasswordPolicy.*} FROM (SELECT DISTINCT passwordPolicy.passwordPolicyId FROM PasswordPolicy passwordPolicy WHERE ",
-					") TEMP_TABLE INNER JOIN PasswordPolicy ON TEMP_TABLE.passwordPolicyId = PasswordPolicy.passwordPolicyId",
-					"SELECT COUNT(DISTINCT passwordPolicy.passwordPolicyId) AS COUNT_VALUE FROM PasswordPolicy passwordPolicy WHERE ",
+					_FILTER_ENTITY_ALIAS, _FILTER_ENTITY_TABLE,
+					_FILTER_ENTITY_TABLE_FILTER_PK_COLUMN,
+					_FILTER_SQL_SELECT_PASSWORDPOLICY_WHERE,
+					_FILTER_SQL_SELECT_PASSWORDPOLICY_NO_INLINE_DISTINCT_WHERE_1,
+					_FILTER_SQL_SELECT_PASSWORDPOLICY_NO_INLINE_DISTINCT_WHERE_2,
+					_FILTER_SQL_COUNT_PASSWORDPOLICY_WHERE,
 					PasswordPolicyModelImpl.ORDER_BY_SQL,
 					PasswordPolicyModelImpl.ORDER_BY_SQL_INLINE_DISTINCT),
 				new FinderColumn<>(
 					"passwordPolicy.", "uuid", FinderColumn.Type.STRING, "=",
 					true, true, PasswordPolicy::getUuid));
 
+		_finderPathWithPaginationFindByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid_C",
+			new String[] {
+				String.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"uuid_", "companyId"}, true);
+
+		_finderPathWithoutPaginationFindByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"uuid_", "companyId"}, 0, 1, true, null);
+
+		_finderPathCountByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"uuid_", "companyId"}, 0, 1, false, null);
+
 		_collectionPersistenceFinderByUuid_C =
 			new FilterCollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid_C",
-					new String[] {
-						String.class.getName(), Long.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"uuid_", "companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid_C",
-					new String[] {String.class.getName(), Long.class.getName()},
-					new String[] {"uuid_", "companyId"}, 0, 1, true, null),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid_C",
-					new String[] {String.class.getName(), Long.class.getName()},
-					new String[] {"uuid_", "companyId"}, 0, 1, false, null),
-				_SQL_SELECT_PASSWORDPOLICY_WHERE,
+				this, _finderPathWithPaginationFindByUuid_C,
+				_finderPathWithoutPaginationFindByUuid_C,
+				_finderPathCountByUuid_C, _SQL_SELECT_PASSWORDPOLICY_WHERE,
 				_SQL_COUNT_PASSWORDPOLICY_WHERE,
 				PasswordPolicyModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 				new FilterCollectionPersistenceFinder.FilterMetadata<>(
 					PasswordPolicyImpl.class, PasswordPolicy.class,
-					"passwordPolicy", "PasswordPolicy",
-					"passwordPolicy.passwordPolicyId",
-					"SELECT DISTINCT {passwordPolicy.*} FROM PasswordPolicy passwordPolicy WHERE ",
-					"SELECT {PasswordPolicy.*} FROM (SELECT DISTINCT passwordPolicy.passwordPolicyId FROM PasswordPolicy passwordPolicy WHERE ",
-					") TEMP_TABLE INNER JOIN PasswordPolicy ON TEMP_TABLE.passwordPolicyId = PasswordPolicy.passwordPolicyId",
-					"SELECT COUNT(DISTINCT passwordPolicy.passwordPolicyId) AS COUNT_VALUE FROM PasswordPolicy passwordPolicy WHERE ",
+					_FILTER_ENTITY_ALIAS, _FILTER_ENTITY_TABLE,
+					_FILTER_ENTITY_TABLE_FILTER_PK_COLUMN,
+					_FILTER_SQL_SELECT_PASSWORDPOLICY_WHERE,
+					_FILTER_SQL_SELECT_PASSWORDPOLICY_NO_INLINE_DISTINCT_WHERE_1,
+					_FILTER_SQL_SELECT_PASSWORDPOLICY_NO_INLINE_DISTINCT_WHERE_2,
+					_FILTER_SQL_COUNT_PASSWORDPOLICY_WHERE,
 					PasswordPolicyModelImpl.ORDER_BY_SQL,
 					PasswordPolicyModelImpl.ORDER_BY_SQL_INLINE_DISTINCT),
 				new FinderColumn<>(
@@ -1104,51 +1121,54 @@ public class PasswordPolicyPersistenceImpl
 					"passwordPolicy.", "companyId", FinderColumn.Type.LONG, "=",
 					true, true, PasswordPolicy::getCompanyId));
 
+		_finderPathWithPaginationFindByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByCompanyId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"companyId"}, true);
+
+		_finderPathWithoutPaginationFindByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByCompanyId",
+			new String[] {Long.class.getName()}, new String[] {"companyId"},
+			true);
+
+		_finderPathCountByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByCompanyId",
+			new String[] {Long.class.getName()}, new String[] {"companyId"},
+			false);
+
 		_collectionPersistenceFinderByCompanyId =
 			new FilterCollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByCompanyId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"findByCompanyId", new String[] {Long.class.getName()},
-					new String[] {"companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByCompanyId", new String[] {Long.class.getName()},
-					new String[] {"companyId"}, false),
-				_SQL_SELECT_PASSWORDPOLICY_WHERE,
+				this, _finderPathWithPaginationFindByCompanyId,
+				_finderPathWithoutPaginationFindByCompanyId,
+				_finderPathCountByCompanyId, _SQL_SELECT_PASSWORDPOLICY_WHERE,
 				_SQL_COUNT_PASSWORDPOLICY_WHERE,
 				PasswordPolicyModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 				new FilterCollectionPersistenceFinder.FilterMetadata<>(
 					PasswordPolicyImpl.class, PasswordPolicy.class,
-					"passwordPolicy", "PasswordPolicy",
-					"passwordPolicy.passwordPolicyId",
-					"SELECT DISTINCT {passwordPolicy.*} FROM PasswordPolicy passwordPolicy WHERE ",
-					"SELECT {PasswordPolicy.*} FROM (SELECT DISTINCT passwordPolicy.passwordPolicyId FROM PasswordPolicy passwordPolicy WHERE ",
-					") TEMP_TABLE INNER JOIN PasswordPolicy ON TEMP_TABLE.passwordPolicyId = PasswordPolicy.passwordPolicyId",
-					"SELECT COUNT(DISTINCT passwordPolicy.passwordPolicyId) AS COUNT_VALUE FROM PasswordPolicy passwordPolicy WHERE ",
+					_FILTER_ENTITY_ALIAS, _FILTER_ENTITY_TABLE,
+					_FILTER_ENTITY_TABLE_FILTER_PK_COLUMN,
+					_FILTER_SQL_SELECT_PASSWORDPOLICY_WHERE,
+					_FILTER_SQL_SELECT_PASSWORDPOLICY_NO_INLINE_DISTINCT_WHERE_1,
+					_FILTER_SQL_SELECT_PASSWORDPOLICY_NO_INLINE_DISTINCT_WHERE_2,
+					_FILTER_SQL_COUNT_PASSWORDPOLICY_WHERE,
 					PasswordPolicyModelImpl.ORDER_BY_SQL,
 					PasswordPolicyModelImpl.ORDER_BY_SQL_INLINE_DISTINCT),
 				new FinderColumn<>(
 					"passwordPolicy.", "companyId", FinderColumn.Type.LONG, "=",
 					true, true, PasswordPolicy::getCompanyId));
 
+		_finderPathFetchByC_N = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByC_N",
+			new String[] {Long.class.getName(), String.class.getName()},
+			new String[] {"companyId", "name"}, 0, 2, false,
+			PasswordPolicy::getCompanyId,
+			convertNullFunction(PasswordPolicy::getName));
+
 		_uniquePersistenceFinderByC_N = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByC_N",
-				new String[] {Long.class.getName(), String.class.getName()},
-				new String[] {"companyId", "name"}, 0, 2, false,
-				PasswordPolicy::getCompanyId,
-				convertNullFunction(PasswordPolicy::getName)),
-			_SQL_SELECT_PASSWORDPOLICY_WHERE, "",
+			this, _finderPathFetchByC_N, _SQL_SELECT_PASSWORDPOLICY_WHERE, "",
 			new FinderColumn<>(
 				"passwordPolicy.", "companyId", FinderColumn.Type.LONG, "=",
 				true, true, PasswordPolicy::getCompanyId),
@@ -1177,6 +1197,27 @@ public class PasswordPolicyPersistenceImpl
 	private static final String _SQL_COUNT_PASSWORDPOLICY_WHERE =
 		"SELECT COUNT(passwordPolicy) FROM PasswordPolicy passwordPolicy WHERE ";
 
+	private static final String _FILTER_ENTITY_TABLE_FILTER_PK_COLUMN =
+		"passwordPolicy.passwordPolicyId";
+
+	private static final String _FILTER_SQL_SELECT_PASSWORDPOLICY_WHERE =
+		"SELECT DISTINCT {passwordPolicy.*} FROM PasswordPolicy passwordPolicy WHERE ";
+
+	private static final String
+		_FILTER_SQL_SELECT_PASSWORDPOLICY_NO_INLINE_DISTINCT_WHERE_1 =
+			"SELECT {PasswordPolicy.*} FROM (SELECT DISTINCT passwordPolicy.passwordPolicyId FROM PasswordPolicy passwordPolicy WHERE ";
+
+	private static final String
+		_FILTER_SQL_SELECT_PASSWORDPOLICY_NO_INLINE_DISTINCT_WHERE_2 =
+			") TEMP_TABLE INNER JOIN PasswordPolicy ON TEMP_TABLE.passwordPolicyId = PasswordPolicy.passwordPolicyId";
+
+	private static final String _FILTER_SQL_COUNT_PASSWORDPOLICY_WHERE =
+		"SELECT COUNT(DISTINCT passwordPolicy.passwordPolicyId) AS COUNT_VALUE FROM PasswordPolicy passwordPolicy WHERE ";
+
+	private static final String _FILTER_ENTITY_ALIAS = "passwordPolicy";
+
+	private static final String _FILTER_ENTITY_TABLE = "PasswordPolicy";
+
 	private static final String _NO_SUCH_ENTITY_WITH_KEY =
 		"No PasswordPolicy exists with the key {";
 
@@ -1192,4 +1233,4 @@ public class PasswordPolicyPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1179213508
+// LIFERAY-SERVICE-BUILDER-HASH:486604014

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/PasswordPolicyRelPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/PasswordPolicyRelPersistenceImpl.java
@@ -65,6 +65,9 @@ public class PasswordPolicyRelPersistenceImpl
 	public static final String FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION =
 		FINDER_CLASS_NAME_ENTITY + ".List2";
 
+	private FinderPath _finderPathWithPaginationFindByPasswordPolicyId;
+	private FinderPath _finderPathWithoutPaginationFindByPasswordPolicyId;
+	private FinderPath _finderPathCountByPasswordPolicyId;
 	private CollectionPersistenceFinder<PasswordPolicyRel>
 		_collectionPersistenceFinderByPasswordPolicyId;
 
@@ -215,6 +218,7 @@ public class PasswordPolicyRelPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {passwordPolicyId});
 	}
 
+	private FinderPath _finderPathFetchByC_C;
 	private UniquePersistenceFinder<PasswordPolicyRel>
 		_uniquePersistenceFinderByC_C;
 
@@ -485,28 +489,29 @@ public class PasswordPolicyRelPersistenceImpl
 	 * Initializes the password policy rel persistence.
 	 */
 	public void afterPropertiesSet() {
+		_finderPathWithPaginationFindByPasswordPolicyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByPasswordPolicyId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"passwordPolicyId"}, true);
+
+		_finderPathWithoutPaginationFindByPasswordPolicyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByPasswordPolicyId",
+			new String[] {Long.class.getName()},
+			new String[] {"passwordPolicyId"}, true);
+
+		_finderPathCountByPasswordPolicyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
+			"countByPasswordPolicyId", new String[] {Long.class.getName()},
+			new String[] {"passwordPolicyId"}, false);
+
 		_collectionPersistenceFinderByPasswordPolicyId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION,
-					"findByPasswordPolicyId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"passwordPolicyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"findByPasswordPolicyId",
-					new String[] {Long.class.getName()},
-					new String[] {"passwordPolicyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByPasswordPolicyId",
-					new String[] {Long.class.getName()},
-					new String[] {"passwordPolicyId"}, false),
+				this, _finderPathWithPaginationFindByPasswordPolicyId,
+				_finderPathWithoutPaginationFindByPasswordPolicyId,
+				_finderPathCountByPasswordPolicyId,
 				_SQL_SELECT_PASSWORDPOLICYREL_WHERE,
 				_SQL_COUNT_PASSWORDPOLICYREL_WHERE,
 				PasswordPolicyRelModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
@@ -516,15 +521,15 @@ public class PasswordPolicyRelPersistenceImpl
 					FinderColumn.Type.LONG, "=", true, true,
 					PasswordPolicyRel::getPasswordPolicyId));
 
+		_finderPathFetchByC_C = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByC_C",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"classNameId", "classPK"}, 0, 0, false,
+			PasswordPolicyRel::getClassNameId, PasswordPolicyRel::getClassPK);
+
 		_uniquePersistenceFinderByC_C = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByC_C",
-				new String[] {Long.class.getName(), Long.class.getName()},
-				new String[] {"classNameId", "classPK"}, 0, 0, false,
-				PasswordPolicyRel::getClassNameId,
-				PasswordPolicyRel::getClassPK),
-			_SQL_SELECT_PASSWORDPOLICYREL_WHERE, "",
+			this, _finderPathFetchByC_C, _SQL_SELECT_PASSWORDPOLICYREL_WHERE,
+			"",
 			new FinderColumn<>(
 				"passwordPolicyRel.", "classNameId", FinderColumn.Type.LONG,
 				"=", true, true, PasswordPolicyRel::getClassNameId),
@@ -565,4 +570,4 @@ public class PasswordPolicyRelPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-889227273
+// LIFERAY-SERVICE-BUILDER-HASH:1870090225

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/PasswordTrackerPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/PasswordTrackerPersistenceImpl.java
@@ -67,6 +67,9 @@ public class PasswordTrackerPersistenceImpl
 	public static final String FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION =
 		FINDER_CLASS_NAME_ENTITY + ".List2";
 
+	private FinderPath _finderPathWithPaginationFindByUserId;
+	private FinderPath _finderPathWithoutPaginationFindByUserId;
+	private FinderPath _finderPathCountByUserId;
 	private CollectionPersistenceFinder<PasswordTracker>
 		_collectionPersistenceFinderByUserId;
 
@@ -410,26 +413,28 @@ public class PasswordTrackerPersistenceImpl
 	 * Initializes the password tracker persistence.
 	 */
 	public void afterPropertiesSet() {
+		_finderPathWithPaginationFindByUserId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUserId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"userId"}, true);
+
+		_finderPathWithoutPaginationFindByUserId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUserId",
+			new String[] {Long.class.getName()}, new String[] {"userId"}, true);
+
+		_finderPathCountByUserId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUserId",
+			new String[] {Long.class.getName()}, new String[] {"userId"},
+			false);
+
 		_collectionPersistenceFinderByUserId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUserId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"userId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUserId",
-					new String[] {Long.class.getName()},
-					new String[] {"userId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUserId",
-					new String[] {Long.class.getName()},
-					new String[] {"userId"}, false),
-				_SQL_SELECT_PASSWORDTRACKER_WHERE,
+				this, _finderPathWithPaginationFindByUserId,
+				_finderPathWithoutPaginationFindByUserId,
+				_finderPathCountByUserId, _SQL_SELECT_PASSWORDTRACKER_WHERE,
 				_SQL_COUNT_PASSWORDTRACKER_WHERE,
 				PasswordTrackerModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
 				"",
@@ -470,4 +475,4 @@ public class PasswordTrackerPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:943975828
+// LIFERAY-SERVICE-BUILDER-HASH:851356046

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/PhonePersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/PhonePersistenceImpl.java
@@ -88,6 +88,9 @@ public class PhonePersistenceImpl
 	public static final String FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION =
 		FINDER_CLASS_NAME_ENTITY + ".List2";
 
+	private FinderPath _finderPathWithPaginationFindByUuid;
+	private FinderPath _finderPathWithoutPaginationFindByUuid;
+	private FinderPath _finderPathCountByUuid;
 	private CollectionPersistenceFinder<Phone>
 		_collectionPersistenceFinderByUuid;
 
@@ -227,6 +230,9 @@ public class PhonePersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {uuid});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByUuid_C;
+	private FinderPath _finderPathWithoutPaginationFindByUuid_C;
+	private FinderPath _finderPathCountByUuid_C;
 	private CollectionPersistenceFinder<Phone>
 		_collectionPersistenceFinderByUuid_C;
 
@@ -380,6 +386,9 @@ public class PhonePersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {uuid, companyId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByCompanyId;
+	private FinderPath _finderPathWithoutPaginationFindByCompanyId;
+	private FinderPath _finderPathCountByCompanyId;
 	private CollectionPersistenceFinder<Phone>
 		_collectionPersistenceFinderByCompanyId;
 
@@ -520,6 +529,9 @@ public class PhonePersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {companyId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByUserId;
+	private FinderPath _finderPathWithoutPaginationFindByUserId;
+	private FinderPath _finderPathCountByUserId;
 	private CollectionPersistenceFinder<Phone>
 		_collectionPersistenceFinderByUserId;
 
@@ -659,6 +671,9 @@ public class PhonePersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {userId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_C;
+	private FinderPath _finderPathWithoutPaginationFindByC_C;
+	private FinderPath _finderPathCountByC_C;
 	private CollectionPersistenceFinder<Phone>
 		_collectionPersistenceFinderByC_C;
 
@@ -817,6 +832,9 @@ public class PhonePersistenceImpl
 			new Object[] {companyId, classNameId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_C_C;
+	private FinderPath _finderPathWithoutPaginationFindByC_C_C;
+	private FinderPath _finderPathCountByC_C_C;
 	private CollectionPersistenceFinder<Phone>
 		_collectionPersistenceFinderByC_C_C;
 
@@ -987,6 +1005,9 @@ public class PhonePersistenceImpl
 			new Object[] {companyId, classNameId, classPK});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_C_C_P;
+	private FinderPath _finderPathWithoutPaginationFindByC_C_C_P;
+	private FinderPath _finderPathCountByC_C_C_P;
 	private CollectionPersistenceFinder<Phone>
 		_collectionPersistenceFinderByC_C_C_P;
 
@@ -1173,6 +1194,7 @@ public class PhonePersistenceImpl
 			new Object[] {companyId, classNameId, classPK, primary});
 	}
 
+	private FinderPath _finderPathFetchByERC_C;
 	private UniquePersistenceFinder<Phone> _uniquePersistenceFinderByERC_C;
 
 	/**
@@ -1614,50 +1636,59 @@ public class PhonePersistenceImpl
 	 * Initializes the phone persistence.
 	 */
 	public void afterPropertiesSet() {
+		_finderPathWithPaginationFindByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid",
+			new String[] {
+				String.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"uuid_"}, true);
+
+		_finderPathWithoutPaginationFindByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid",
+			new String[] {String.class.getName()}, new String[] {"uuid_"}, 0, 1,
+			true, null);
+
+		_finderPathCountByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid",
+			new String[] {String.class.getName()}, new String[] {"uuid_"}, 0, 1,
+			false, null);
+
 		_collectionPersistenceFinderByUuid = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid",
-				new String[] {
-					String.class.getName(), Integer.class.getName(),
-					Integer.class.getName(), OrderByComparator.class.getName()
-				},
-				new String[] {"uuid_"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid",
-				new String[] {String.class.getName()}, new String[] {"uuid_"},
-				0, 1, true, null),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid",
-				new String[] {String.class.getName()}, new String[] {"uuid_"},
-				0, 1, false, null),
+			this, _finderPathWithPaginationFindByUuid,
+			_finderPathWithoutPaginationFindByUuid, _finderPathCountByUuid,
 			_SQL_SELECT_PHONE_WHERE, _SQL_COUNT_PHONE_WHERE,
 			PhoneModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
 				"phone.", "uuid", FinderColumn.Type.STRING, "=", true, true,
 				Phone::getUuid));
 
+		_finderPathWithPaginationFindByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid_C",
+			new String[] {
+				String.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"uuid_", "companyId"}, true);
+
+		_finderPathWithoutPaginationFindByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"uuid_", "companyId"}, 0, 1, true, null);
+
+		_finderPathCountByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"uuid_", "companyId"}, 0, 1, false, null);
+
 		_collectionPersistenceFinderByUuid_C =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid_C",
-					new String[] {
-						String.class.getName(), Long.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"uuid_", "companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid_C",
-					new String[] {String.class.getName(), Long.class.getName()},
-					new String[] {"uuid_", "companyId"}, 0, 1, true, null),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid_C",
-					new String[] {String.class.getName(), Long.class.getName()},
-					new String[] {"uuid_", "companyId"}, 0, 1, false, null),
-				_SQL_SELECT_PHONE_WHERE, _SQL_COUNT_PHONE_WHERE,
-				PhoneModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+				this, _finderPathWithPaginationFindByUuid_C,
+				_finderPathWithoutPaginationFindByUuid_C,
+				_finderPathCountByUuid_C, _SQL_SELECT_PHONE_WHERE,
+				_SQL_COUNT_PHONE_WHERE, PhoneModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
 					"phone.", "uuid", FinderColumn.Type.STRING, "=", true, true,
 					Phone::getUuid),
@@ -1665,74 +1696,85 @@ public class PhonePersistenceImpl
 					"phone.", "companyId", FinderColumn.Type.LONG, "=", true,
 					true, Phone::getCompanyId));
 
+		_finderPathWithPaginationFindByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByCompanyId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"companyId"}, true);
+
+		_finderPathWithoutPaginationFindByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByCompanyId",
+			new String[] {Long.class.getName()}, new String[] {"companyId"},
+			true);
+
+		_finderPathCountByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByCompanyId",
+			new String[] {Long.class.getName()}, new String[] {"companyId"},
+			false);
+
 		_collectionPersistenceFinderByCompanyId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByCompanyId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"findByCompanyId", new String[] {Long.class.getName()},
-					new String[] {"companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByCompanyId", new String[] {Long.class.getName()},
-					new String[] {"companyId"}, false),
-				_SQL_SELECT_PHONE_WHERE, _SQL_COUNT_PHONE_WHERE,
-				PhoneModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+				this, _finderPathWithPaginationFindByCompanyId,
+				_finderPathWithoutPaginationFindByCompanyId,
+				_finderPathCountByCompanyId, _SQL_SELECT_PHONE_WHERE,
+				_SQL_COUNT_PHONE_WHERE, PhoneModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
 					"phone.", "companyId", FinderColumn.Type.LONG, "=", true,
 					true, Phone::getCompanyId));
 
+		_finderPathWithPaginationFindByUserId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUserId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"userId"}, true);
+
+		_finderPathWithoutPaginationFindByUserId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUserId",
+			new String[] {Long.class.getName()}, new String[] {"userId"}, true);
+
+		_finderPathCountByUserId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUserId",
+			new String[] {Long.class.getName()}, new String[] {"userId"},
+			false);
+
 		_collectionPersistenceFinderByUserId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUserId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"userId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUserId",
-					new String[] {Long.class.getName()},
-					new String[] {"userId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUserId",
-					new String[] {Long.class.getName()},
-					new String[] {"userId"}, false),
-				_SQL_SELECT_PHONE_WHERE, _SQL_COUNT_PHONE_WHERE,
-				PhoneModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+				this, _finderPathWithPaginationFindByUserId,
+				_finderPathWithoutPaginationFindByUserId,
+				_finderPathCountByUserId, _SQL_SELECT_PHONE_WHERE,
+				_SQL_COUNT_PHONE_WHERE, PhoneModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
 					"phone.", "userId", FinderColumn.Type.LONG, "=", true, true,
 					Phone::getUserId));
 
+		_finderPathWithPaginationFindByC_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_C",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "classNameId"}, true);
+
+		_finderPathWithoutPaginationFindByC_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_C",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"companyId", "classNameId"}, true);
+
+		_finderPathCountByC_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_C",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"companyId", "classNameId"}, false);
+
 		_collectionPersistenceFinderByC_C = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_C",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Integer.class.getName(), Integer.class.getName(),
-					OrderByComparator.class.getName()
-				},
-				new String[] {"companyId", "classNameId"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_C",
-				new String[] {Long.class.getName(), Long.class.getName()},
-				new String[] {"companyId", "classNameId"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_C",
-				new String[] {Long.class.getName(), Long.class.getName()},
-				new String[] {"companyId", "classNameId"}, false),
+			this, _finderPathWithPaginationFindByC_C,
+			_finderPathWithoutPaginationFindByC_C, _finderPathCountByC_C,
 			_SQL_SELECT_PHONE_WHERE, _SQL_COUNT_PHONE_WHERE,
 			PhoneModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
@@ -1742,30 +1784,32 @@ public class PhonePersistenceImpl
 				"phone.", "classNameId", FinderColumn.Type.LONG, "=", true,
 				true, Phone::getClassNameId));
 
+		_finderPathWithPaginationFindByC_C_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_C_C",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "classNameId", "classPK"}, true);
+
+		_finderPathWithoutPaginationFindByC_C_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_C_C",
+			new String[] {
+				Long.class.getName(), Long.class.getName(), Long.class.getName()
+			},
+			new String[] {"companyId", "classNameId", "classPK"}, true);
+
+		_finderPathCountByC_C_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_C_C",
+			new String[] {
+				Long.class.getName(), Long.class.getName(), Long.class.getName()
+			},
+			new String[] {"companyId", "classNameId", "classPK"}, false);
+
 		_collectionPersistenceFinderByC_C_C = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_C_C",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Long.class.getName(), Integer.class.getName(),
-					Integer.class.getName(), OrderByComparator.class.getName()
-				},
-				new String[] {"companyId", "classNameId", "classPK"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_C_C",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Long.class.getName()
-				},
-				new String[] {"companyId", "classNameId", "classPK"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_C_C",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Long.class.getName()
-				},
-				new String[] {"companyId", "classNameId", "classPK"}, false),
+			this, _finderPathWithPaginationFindByC_C_C,
+			_finderPathWithoutPaginationFindByC_C_C, _finderPathCountByC_C_C,
 			_SQL_SELECT_PHONE_WHERE, _SQL_COUNT_PHONE_WHERE,
 			PhoneModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
@@ -1778,43 +1822,42 @@ public class PhonePersistenceImpl
 				"phone.", "classPK", FinderColumn.Type.LONG, "=", true, true,
 				Phone::getClassPK));
 
+		_finderPathWithPaginationFindByC_C_C_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_C_C_P",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Boolean.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "classNameId", "classPK", "primary_"},
+			true);
+
+		_finderPathWithoutPaginationFindByC_C_C_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_C_C_P",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Boolean.class.getName()
+			},
+			new String[] {"companyId", "classNameId", "classPK", "primary_"},
+			true);
+
+		_finderPathCountByC_C_C_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_C_C_P",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Boolean.class.getName()
+			},
+			new String[] {"companyId", "classNameId", "classPK", "primary_"},
+			false);
+
 		_collectionPersistenceFinderByC_C_C_P =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_C_C_P",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						Long.class.getName(), Boolean.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {
-						"companyId", "classNameId", "classPK", "primary_"
-					},
-					true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_C_C_P",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						Long.class.getName(), Boolean.class.getName()
-					},
-					new String[] {
-						"companyId", "classNameId", "classPK", "primary_"
-					},
-					true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_C_C_P",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						Long.class.getName(), Boolean.class.getName()
-					},
-					new String[] {
-						"companyId", "classNameId", "classPK", "primary_"
-					},
-					false),
-				_SQL_SELECT_PHONE_WHERE, _SQL_COUNT_PHONE_WHERE,
-				PhoneModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+				this, _finderPathWithPaginationFindByC_C_C_P,
+				_finderPathWithoutPaginationFindByC_C_C_P,
+				_finderPathCountByC_C_C_P, _SQL_SELECT_PHONE_WHERE,
+				_SQL_COUNT_PHONE_WHERE, PhoneModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
 					"phone.", "companyId", FinderColumn.Type.LONG, "=", true,
 					true, Phone::getCompanyId),
@@ -1828,15 +1871,15 @@ public class PhonePersistenceImpl
 					"phone.", "primary", FinderColumn.Type.BOOLEAN, "=", true,
 					true, Phone::isPrimary));
 
+		_finderPathFetchByERC_C = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByERC_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "companyId"}, 0, 1, false,
+			convertNullFunction(Phone::getExternalReferenceCode),
+			Phone::getCompanyId);
+
 		_uniquePersistenceFinderByERC_C = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByERC_C",
-				new String[] {String.class.getName(), Long.class.getName()},
-				new String[] {"externalReferenceCode", "companyId"}, 0, 1,
-				false, convertNullFunction(Phone::getExternalReferenceCode),
-				Phone::getCompanyId),
-			_SQL_SELECT_PHONE_WHERE, "",
+			this, _finderPathFetchByERC_C, _SQL_SELECT_PHONE_WHERE, "",
 			new FinderColumn<>(
 				"phone.", "externalReferenceCode", FinderColumn.Type.STRING,
 				"=", true, true, Phone::getExternalReferenceCode),
@@ -1880,4 +1923,4 @@ public class PhonePersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-930582091
+// LIFERAY-SERVICE-BUILDER-HASH:2021975563

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/PluginSettingPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/PluginSettingPersistenceImpl.java
@@ -67,6 +67,9 @@ public class PluginSettingPersistenceImpl
 	public static final String FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION =
 		FINDER_CLASS_NAME_ENTITY + ".List2";
 
+	private FinderPath _finderPathWithPaginationFindByCompanyId;
+	private FinderPath _finderPathWithoutPaginationFindByCompanyId;
+	private FinderPath _finderPathCountByCompanyId;
 	private CollectionPersistenceFinder<PluginSetting>
 		_collectionPersistenceFinderByCompanyId;
 
@@ -211,6 +214,7 @@ public class PluginSettingPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {companyId});
 	}
 
+	private FinderPath _finderPathFetchByC_P_P;
 	private UniquePersistenceFinder<PluginSetting>
 		_uniquePersistenceFinderByC_P_P;
 
@@ -502,44 +506,48 @@ public class PluginSettingPersistenceImpl
 	 * Initializes the plugin setting persistence.
 	 */
 	public void afterPropertiesSet() {
+		_finderPathWithPaginationFindByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByCompanyId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"companyId"}, true);
+
+		_finderPathWithoutPaginationFindByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByCompanyId",
+			new String[] {Long.class.getName()}, new String[] {"companyId"},
+			true);
+
+		_finderPathCountByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByCompanyId",
+			new String[] {Long.class.getName()}, new String[] {"companyId"},
+			false);
+
 		_collectionPersistenceFinderByCompanyId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByCompanyId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"findByCompanyId", new String[] {Long.class.getName()},
-					new String[] {"companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByCompanyId", new String[] {Long.class.getName()},
-					new String[] {"companyId"}, false),
-				_SQL_SELECT_PLUGINSETTING_WHERE, _SQL_COUNT_PLUGINSETTING_WHERE,
+				this, _finderPathWithPaginationFindByCompanyId,
+				_finderPathWithoutPaginationFindByCompanyId,
+				_finderPathCountByCompanyId, _SQL_SELECT_PLUGINSETTING_WHERE,
+				_SQL_COUNT_PLUGINSETTING_WHERE,
 				PluginSettingModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
 					"pluginSetting.", "companyId", FinderColumn.Type.LONG, "=",
 					true, true, PluginSetting::getCompanyId));
 
+		_finderPathFetchByC_P_P = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByC_P_P",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				String.class.getName()
+			},
+			new String[] {"companyId", "pluginId", "pluginType"}, 0, 6, false,
+			PluginSetting::getCompanyId,
+			convertNullFunction(PluginSetting::getPluginId),
+			convertNullFunction(PluginSetting::getPluginType));
+
 		_uniquePersistenceFinderByC_P_P = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByC_P_P",
-				new String[] {
-					Long.class.getName(), String.class.getName(),
-					String.class.getName()
-				},
-				new String[] {"companyId", "pluginId", "pluginType"}, 0, 6,
-				false, PluginSetting::getCompanyId,
-				convertNullFunction(PluginSetting::getPluginId),
-				convertNullFunction(PluginSetting::getPluginType)),
-			_SQL_SELECT_PLUGINSETTING_WHERE, "",
+			this, _finderPathFetchByC_P_P, _SQL_SELECT_PLUGINSETTING_WHERE, "",
 			new FinderColumn<>(
 				"pluginSetting.", "companyId", FinderColumn.Type.LONG, "=",
 				true, true, PluginSetting::getCompanyId),
@@ -586,4 +594,4 @@ public class PluginSettingPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1943340612
+// LIFERAY-SERVICE-BUILDER-HASH:-372399732

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/PortalPreferenceValuePersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/PortalPreferenceValuePersistenceImpl.java
@@ -69,6 +69,9 @@ public class PortalPreferenceValuePersistenceImpl
 	public static final String FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION =
 		FINDER_CLASS_NAME_ENTITY + ".List2";
 
+	private FinderPath _finderPathWithPaginationFindByPortalPreferencesId;
+	private FinderPath _finderPathWithoutPaginationFindByPortalPreferencesId;
+	private FinderPath _finderPathCountByPortalPreferencesId;
 	private CollectionPersistenceFinder<PortalPreferenceValue>
 		_collectionPersistenceFinderByPortalPreferencesId;
 
@@ -325,6 +328,9 @@ public class PortalPreferenceValuePersistenceImpl
 			new Object[] {ArrayUtil.sortedUnique(portalPreferencesIds)});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByP_N;
+	private FinderPath _finderPathWithoutPaginationFindByP_N;
+	private FinderPath _finderPathCountByP_N;
 	private CollectionPersistenceFinder<PortalPreferenceValue>
 		_collectionPersistenceFinderByP_N;
 
@@ -485,6 +491,9 @@ public class PortalPreferenceValuePersistenceImpl
 			dummyFinderCache, new Object[] {portalPreferencesId, namespace});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByP_K_N;
+	private FinderPath _finderPathWithoutPaginationFindByP_K_N;
+	private FinderPath _finderPathCountByP_K_N;
 	private CollectionPersistenceFinder<PortalPreferenceValue>
 		_collectionPersistenceFinderByP_K_N;
 
@@ -663,6 +672,7 @@ public class PortalPreferenceValuePersistenceImpl
 			new Object[] {portalPreferencesId, key, namespace});
 	}
 
+	private FinderPath _finderPathFetchByP_I_K_N;
 	private UniquePersistenceFinder<PortalPreferenceValue>
 		_uniquePersistenceFinderByP_I_K_N;
 
@@ -775,6 +785,9 @@ public class PortalPreferenceValuePersistenceImpl
 			new Object[] {portalPreferencesId, index, key, namespace});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByP_K_N_SV;
+	private FinderPath _finderPathWithoutPaginationFindByP_K_N_SV;
+	private FinderPath _finderPathCountByP_K_N_SV;
 	private CollectionPersistenceFinder<PortalPreferenceValue>
 		_collectionPersistenceFinderByP_K_N_SV;
 
@@ -1167,28 +1180,29 @@ public class PortalPreferenceValuePersistenceImpl
 	 * Initializes the portal preference value persistence.
 	 */
 	public void afterPropertiesSet() {
+		_finderPathWithPaginationFindByPortalPreferencesId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByPortalPreferencesId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"portalPreferencesId"}, true);
+
+		_finderPathWithoutPaginationFindByPortalPreferencesId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
+			"findByPortalPreferencesId", new String[] {Long.class.getName()},
+			new String[] {"portalPreferencesId"}, true);
+
+		_finderPathCountByPortalPreferencesId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION,
+			"countByPortalPreferencesId", new String[] {Long.class.getName()},
+			new String[] {"portalPreferencesId"}, false);
+
 		_collectionPersistenceFinderByPortalPreferencesId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION,
-					"findByPortalPreferencesId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"portalPreferencesId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"findByPortalPreferencesId",
-					new String[] {Long.class.getName()},
-					new String[] {"portalPreferencesId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION,
-					"countByPortalPreferencesId",
-					new String[] {Long.class.getName()},
-					new String[] {"portalPreferencesId"}, false),
+				this, _finderPathWithPaginationFindByPortalPreferencesId,
+				_finderPathWithoutPaginationFindByPortalPreferencesId,
+				_finderPathCountByPortalPreferencesId,
 				_SQL_SELECT_PORTALPREFERENCEVALUE_WHERE,
 				_SQL_COUNT_PORTALPREFERENCEVALUE_WHERE,
 				PortalPreferenceValueModelImpl.ORDER_BY_JPQL,
@@ -1198,26 +1212,30 @@ public class PortalPreferenceValuePersistenceImpl
 					FinderColumn.Type.LONG, "=", false, true, true,
 					PortalPreferenceValue::getPortalPreferencesId));
 
+		_finderPathWithPaginationFindByP_N = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByP_N",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"portalPreferencesId", "namespace"}, true);
+
+		_finderPathWithoutPaginationFindByP_N = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByP_N",
+			new String[] {Long.class.getName(), String.class.getName()},
+			new String[] {"portalPreferencesId", "namespace"}, 0, 2, true,
+			null);
+
+		_finderPathCountByP_N = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByP_N",
+			new String[] {Long.class.getName(), String.class.getName()},
+			new String[] {"portalPreferencesId", "namespace"}, 0, 2, false,
+			null);
+
 		_collectionPersistenceFinderByP_N = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByP_N",
-				new String[] {
-					Long.class.getName(), String.class.getName(),
-					Integer.class.getName(), Integer.class.getName(),
-					OrderByComparator.class.getName()
-				},
-				new String[] {"portalPreferencesId", "namespace"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByP_N",
-				new String[] {Long.class.getName(), String.class.getName()},
-				new String[] {"portalPreferencesId", "namespace"}, 0, 2, true,
-				null),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByP_N",
-				new String[] {Long.class.getName(), String.class.getName()},
-				new String[] {"portalPreferencesId", "namespace"}, 0, 2, false,
-				null),
+			this, _finderPathWithPaginationFindByP_N,
+			_finderPathWithoutPaginationFindByP_N, _finderPathCountByP_N,
 			_SQL_SELECT_PORTALPREFERENCEVALUE_WHERE,
 			_SQL_COUNT_PORTALPREFERENCEVALUE_WHERE,
 			PortalPreferenceValueModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
@@ -1230,33 +1248,36 @@ public class PortalPreferenceValuePersistenceImpl
 				"portalPreferenceValue.", "namespace", FinderColumn.Type.STRING,
 				"=", true, true, PortalPreferenceValue::getNamespace));
 
+		_finderPathWithPaginationFindByP_K_N = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByP_K_N",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				String.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"portalPreferencesId", "key_", "namespace"}, true);
+
+		_finderPathWithoutPaginationFindByP_K_N = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByP_K_N",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				String.class.getName()
+			},
+			new String[] {"portalPreferencesId", "key_", "namespace"}, 0, 6,
+			true, null);
+
+		_finderPathCountByP_K_N = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByP_K_N",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				String.class.getName()
+			},
+			new String[] {"portalPreferencesId", "key_", "namespace"}, 0, 6,
+			false, null);
+
 		_collectionPersistenceFinderByP_K_N = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByP_K_N",
-				new String[] {
-					Long.class.getName(), String.class.getName(),
-					String.class.getName(), Integer.class.getName(),
-					Integer.class.getName(), OrderByComparator.class.getName()
-				},
-				new String[] {"portalPreferencesId", "key_", "namespace"},
-				true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByP_K_N",
-				new String[] {
-					Long.class.getName(), String.class.getName(),
-					String.class.getName()
-				},
-				new String[] {"portalPreferencesId", "key_", "namespace"}, 0, 6,
-				true, null),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByP_K_N",
-				new String[] {
-					Long.class.getName(), String.class.getName(),
-					String.class.getName()
-				},
-				new String[] {"portalPreferencesId", "key_", "namespace"}, 0, 6,
-				false, null),
+			this, _finderPathWithPaginationFindByP_K_N,
+			_finderPathWithoutPaginationFindByP_K_N, _finderPathCountByP_K_N,
 			_SQL_SELECT_PORTALPREFERENCEVALUE_WHERE,
 			_SQL_COUNT_PORTALPREFERENCEVALUE_WHERE,
 			PortalPreferenceValueModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
@@ -1272,21 +1293,20 @@ public class PortalPreferenceValuePersistenceImpl
 				"portalPreferenceValue.", "namespace", FinderColumn.Type.STRING,
 				"=", true, true, PortalPreferenceValue::getNamespace));
 
+		_finderPathFetchByP_I_K_N = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByP_I_K_N",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				String.class.getName(), String.class.getName()
+			},
+			new String[] {"portalPreferencesId", "index_", "key_", "namespace"},
+			0, 12, false, PortalPreferenceValue::getPortalPreferencesId,
+			PortalPreferenceValue::getIndex,
+			convertNullFunction(PortalPreferenceValue::getKey),
+			convertNullFunction(PortalPreferenceValue::getNamespace));
+
 		_uniquePersistenceFinderByP_I_K_N = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByP_I_K_N",
-				new String[] {
-					Long.class.getName(), Integer.class.getName(),
-					String.class.getName(), String.class.getName()
-				},
-				new String[] {
-					"portalPreferencesId", "index_", "key_", "namespace"
-				},
-				0, 12, false, PortalPreferenceValue::getPortalPreferencesId,
-				PortalPreferenceValue::getIndex,
-				convertNullFunction(PortalPreferenceValue::getKey),
-				convertNullFunction(PortalPreferenceValue::getNamespace)),
+			this, _finderPathFetchByP_I_K_N,
 			_SQL_SELECT_PORTALPREFERENCEVALUE_WHERE, "",
 			new FinderColumn<>(
 				"portalPreferenceValue.", "portalPreferencesId",
@@ -1302,42 +1322,46 @@ public class PortalPreferenceValuePersistenceImpl
 				"portalPreferenceValue.", "namespace", FinderColumn.Type.STRING,
 				"=", true, true, PortalPreferenceValue::getNamespace));
 
+		_finderPathWithPaginationFindByP_K_N_SV = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByP_K_N_SV",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				String.class.getName(), String.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {
+				"portalPreferencesId", "key_", "namespace", "smallValue"
+			},
+			true);
+
+		_finderPathWithoutPaginationFindByP_K_N_SV = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByP_K_N_SV",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				String.class.getName(), String.class.getName()
+			},
+			new String[] {
+				"portalPreferencesId", "key_", "namespace", "smallValue"
+			},
+			0, 14, true, null);
+
+		_finderPathCountByP_K_N_SV = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByP_K_N_SV",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				String.class.getName(), String.class.getName()
+			},
+			new String[] {
+				"portalPreferencesId", "key_", "namespace", "smallValue"
+			},
+			0, 14, false, null);
+
 		_collectionPersistenceFinderByP_K_N_SV =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByP_K_N_SV",
-					new String[] {
-						Long.class.getName(), String.class.getName(),
-						String.class.getName(), String.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {
-						"portalPreferencesId", "key_", "namespace", "smallValue"
-					},
-					true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByP_K_N_SV",
-					new String[] {
-						Long.class.getName(), String.class.getName(),
-						String.class.getName(), String.class.getName()
-					},
-					new String[] {
-						"portalPreferencesId", "key_", "namespace", "smallValue"
-					},
-					0, 14, true, null),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByP_K_N_SV",
-					new String[] {
-						Long.class.getName(), String.class.getName(),
-						String.class.getName(), String.class.getName()
-					},
-					new String[] {
-						"portalPreferencesId", "key_", "namespace", "smallValue"
-					},
-					0, 14, false, null),
+				this, _finderPathWithPaginationFindByP_K_N_SV,
+				_finderPathWithoutPaginationFindByP_K_N_SV,
+				_finderPathCountByP_K_N_SV,
 				_SQL_SELECT_PORTALPREFERENCEVALUE_WHERE,
 				_SQL_COUNT_PORTALPREFERENCEVALUE_WHERE,
 				PortalPreferenceValueModelImpl.ORDER_BY_JPQL,
@@ -1394,4 +1418,4 @@ public class PortalPreferenceValuePersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-340051936
+// LIFERAY-SERVICE-BUILDER-HASH:1771898488

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/PortalPreferencesPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/PortalPreferencesPersistenceImpl.java
@@ -64,6 +64,9 @@ public class PortalPreferencesPersistenceImpl
 	public static final String FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION =
 		FINDER_CLASS_NAME_ENTITY + ".List2";
 
+	private FinderPath _finderPathWithPaginationFindByOwnerType;
+	private FinderPath _finderPathWithoutPaginationFindByOwnerType;
+	private FinderPath _finderPathCountByOwnerType;
 	private CollectionPersistenceFinder<PortalPreferences>
 		_collectionPersistenceFinderByOwnerType;
 
@@ -209,6 +212,7 @@ public class PortalPreferencesPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {ownerType});
 	}
 
+	private FinderPath _finderPathFetchByO_O;
 	private UniquePersistenceFinder<PortalPreferences>
 		_uniquePersistenceFinderByO_O;
 
@@ -479,25 +483,29 @@ public class PortalPreferencesPersistenceImpl
 	 * Initializes the portal preferences persistence.
 	 */
 	public void afterPropertiesSet() {
+		_finderPathWithPaginationFindByOwnerType = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByOwnerType",
+			new String[] {
+				Integer.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"ownerType"}, true);
+
+		_finderPathWithoutPaginationFindByOwnerType = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByOwnerType",
+			new String[] {Integer.class.getName()}, new String[] {"ownerType"},
+			true);
+
+		_finderPathCountByOwnerType = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByOwnerType",
+			new String[] {Integer.class.getName()}, new String[] {"ownerType"},
+			false);
+
 		_collectionPersistenceFinderByOwnerType =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByOwnerType",
-					new String[] {
-						Integer.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"ownerType"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"findByOwnerType", new String[] {Integer.class.getName()},
-					new String[] {"ownerType"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByOwnerType", new String[] {Integer.class.getName()},
-					new String[] {"ownerType"}, false),
+				this, _finderPathWithPaginationFindByOwnerType,
+				_finderPathWithoutPaginationFindByOwnerType,
+				_finderPathCountByOwnerType,
 				_SQL_SELECT_PORTALPREFERENCES_WHERE,
 				_SQL_COUNT_PORTALPREFERENCES_WHERE,
 				PortalPreferencesModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
@@ -507,14 +515,15 @@ public class PortalPreferencesPersistenceImpl
 					FinderColumn.Type.INTEGER, "=", true, true,
 					PortalPreferences::getOwnerType));
 
+		_finderPathFetchByO_O = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByO_O",
+			new String[] {Long.class.getName(), Integer.class.getName()},
+			new String[] {"ownerId", "ownerType"}, 0, 0, false,
+			PortalPreferences::getOwnerId, PortalPreferences::getOwnerType);
+
 		_uniquePersistenceFinderByO_O = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByO_O",
-				new String[] {Long.class.getName(), Integer.class.getName()},
-				new String[] {"ownerId", "ownerType"}, 0, 0, false,
-				PortalPreferences::getOwnerId, PortalPreferences::getOwnerType),
-			_SQL_SELECT_PORTALPREFERENCES_WHERE, "",
+			this, _finderPathFetchByO_O, _SQL_SELECT_PORTALPREFERENCES_WHERE,
+			"",
 			new FinderColumn<>(
 				"portalPreferences.", "ownerId", FinderColumn.Type.LONG, "=",
 				true, true, PortalPreferences::getOwnerId),
@@ -555,4 +564,4 @@ public class PortalPreferencesPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1904375495
+// LIFERAY-SERVICE-BUILDER-HASH:-1166031600

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/PortletItemPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/PortletItemPersistenceImpl.java
@@ -67,6 +67,9 @@ public class PortletItemPersistenceImpl
 	public static final String FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION =
 		FINDER_CLASS_NAME_ENTITY + ".List2";
 
+	private FinderPath _finderPathWithPaginationFindByG_C;
+	private FinderPath _finderPathWithoutPaginationFindByG_C;
+	private FinderPath _finderPathCountByG_C;
 	private CollectionPersistenceFinder<PortletItem>
 		_collectionPersistenceFinderByG_C;
 
@@ -225,6 +228,9 @@ public class PortletItemPersistenceImpl
 			new Object[] {groupId, classNameId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByG_P_C;
+	private FinderPath _finderPathWithoutPaginationFindByG_P_C;
+	private FinderPath _finderPathCountByG_P_C;
 	private CollectionPersistenceFinder<PortletItem>
 		_collectionPersistenceFinderByG_P_C;
 
@@ -398,6 +404,7 @@ public class PortletItemPersistenceImpl
 			new Object[] {groupId, portletId, classNameId});
 	}
 
+	private FinderPath _finderPathFetchByG_N_P_C;
 	private UniquePersistenceFinder<PortletItem>
 		_uniquePersistenceFinderByG_N_P_C;
 
@@ -707,24 +714,28 @@ public class PortletItemPersistenceImpl
 	 * Initializes the portlet item persistence.
 	 */
 	public void afterPropertiesSet() {
+		_finderPathWithPaginationFindByG_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_C",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"groupId", "classNameId"}, true);
+
+		_finderPathWithoutPaginationFindByG_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_C",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"groupId", "classNameId"}, true);
+
+		_finderPathCountByG_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_C",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"groupId", "classNameId"}, false);
+
 		_collectionPersistenceFinderByG_C = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_C",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Integer.class.getName(), Integer.class.getName(),
-					OrderByComparator.class.getName()
-				},
-				new String[] {"groupId", "classNameId"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_C",
-				new String[] {Long.class.getName(), Long.class.getName()},
-				new String[] {"groupId", "classNameId"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_C",
-				new String[] {Long.class.getName(), Long.class.getName()},
-				new String[] {"groupId", "classNameId"}, false),
+			this, _finderPathWithPaginationFindByG_C,
+			_finderPathWithoutPaginationFindByG_C, _finderPathCountByG_C,
 			_SQL_SELECT_PORTLETITEM_WHERE, _SQL_COUNT_PORTLETITEM_WHERE,
 			PortletItemModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
@@ -734,32 +745,36 @@ public class PortletItemPersistenceImpl
 				"portletItem.", "classNameId", FinderColumn.Type.LONG, "=",
 				true, true, PortletItem::getClassNameId));
 
+		_finderPathWithPaginationFindByG_P_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_P_C",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"groupId", "portletId", "classNameId"}, true);
+
+		_finderPathWithoutPaginationFindByG_P_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_P_C",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Long.class.getName()
+			},
+			new String[] {"groupId", "portletId", "classNameId"}, 0, 2, true,
+			null);
+
+		_finderPathCountByG_P_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_P_C",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Long.class.getName()
+			},
+			new String[] {"groupId", "portletId", "classNameId"}, 0, 2, false,
+			null);
+
 		_collectionPersistenceFinderByG_P_C = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_P_C",
-				new String[] {
-					Long.class.getName(), String.class.getName(),
-					Long.class.getName(), Integer.class.getName(),
-					Integer.class.getName(), OrderByComparator.class.getName()
-				},
-				new String[] {"groupId", "portletId", "classNameId"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_P_C",
-				new String[] {
-					Long.class.getName(), String.class.getName(),
-					Long.class.getName()
-				},
-				new String[] {"groupId", "portletId", "classNameId"}, 0, 2,
-				true, null),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_P_C",
-				new String[] {
-					Long.class.getName(), String.class.getName(),
-					Long.class.getName()
-				},
-				new String[] {"groupId", "portletId", "classNameId"}, 0, 2,
-				false, null),
+			this, _finderPathWithPaginationFindByG_P_C,
+			_finderPathWithoutPaginationFindByG_P_C, _finderPathCountByG_P_C,
 			_SQL_SELECT_PORTLETITEM_WHERE, _SQL_COUNT_PORTLETITEM_WHERE,
 			PortletItemModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
@@ -772,20 +787,20 @@ public class PortletItemPersistenceImpl
 				"portletItem.", "classNameId", FinderColumn.Type.LONG, "=",
 				true, true, PortletItem::getClassNameId));
 
+		_finderPathFetchByG_N_P_C = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByG_N_P_C",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				String.class.getName(), Long.class.getName()
+			},
+			new String[] {"groupId", "name", "portletId", "classNameId"}, 2, 6,
+			false, PortletItem::getGroupId,
+			convertCaseFunction(PortletItem::getName),
+			convertNullFunction(PortletItem::getPortletId),
+			PortletItem::getClassNameId);
+
 		_uniquePersistenceFinderByG_N_P_C = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByG_N_P_C",
-				new String[] {
-					Long.class.getName(), String.class.getName(),
-					String.class.getName(), Long.class.getName()
-				},
-				new String[] {"groupId", "name", "portletId", "classNameId"}, 2,
-				6, false, PortletItem::getGroupId,
-				convertCaseFunction(PortletItem::getName),
-				convertNullFunction(PortletItem::getPortletId),
-				PortletItem::getClassNameId),
-			_SQL_SELECT_PORTLETITEM_WHERE, "",
+			this, _finderPathFetchByG_N_P_C, _SQL_SELECT_PORTLETITEM_WHERE, "",
 			new FinderColumn<>(
 				"portletItem.", "groupId", FinderColumn.Type.LONG, "=", true,
 				true, PortletItem::getGroupId),
@@ -832,4 +847,4 @@ public class PortletItemPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-840573360
+// LIFERAY-SERVICE-BUILDER-HASH:-2073724376

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/PortletPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/PortletPersistenceImpl.java
@@ -67,6 +67,9 @@ public class PortletPersistenceImpl
 	public static final String FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION =
 		FINDER_CLASS_NAME_ENTITY + ".List2";
 
+	private FinderPath _finderPathWithPaginationFindByCompanyId;
+	private FinderPath _finderPathWithoutPaginationFindByCompanyId;
+	private FinderPath _finderPathCountByCompanyId;
 	private CollectionPersistenceFinder<Portlet>
 		_collectionPersistenceFinderByCompanyId;
 
@@ -207,6 +210,7 @@ public class PortletPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {companyId});
 	}
 
+	private FinderPath _finderPathFetchByC_P;
 	private UniquePersistenceFinder<Portlet> _uniquePersistenceFinderByC_P;
 
 	/**
@@ -478,40 +482,43 @@ public class PortletPersistenceImpl
 	 * Initializes the portlet persistence.
 	 */
 	public void afterPropertiesSet() {
+		_finderPathWithPaginationFindByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByCompanyId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"companyId"}, true);
+
+		_finderPathWithoutPaginationFindByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByCompanyId",
+			new String[] {Long.class.getName()}, new String[] {"companyId"},
+			true);
+
+		_finderPathCountByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByCompanyId",
+			new String[] {Long.class.getName()}, new String[] {"companyId"},
+			false);
+
 		_collectionPersistenceFinderByCompanyId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByCompanyId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"findByCompanyId", new String[] {Long.class.getName()},
-					new String[] {"companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByCompanyId", new String[] {Long.class.getName()},
-					new String[] {"companyId"}, false),
-				_SQL_SELECT_PORTLET_WHERE, _SQL_COUNT_PORTLET_WHERE,
-				PortletModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+				this, _finderPathWithPaginationFindByCompanyId,
+				_finderPathWithoutPaginationFindByCompanyId,
+				_finderPathCountByCompanyId, _SQL_SELECT_PORTLET_WHERE,
+				_SQL_COUNT_PORTLET_WHERE, PortletModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
 					"portlet.", "companyId", FinderColumn.Type.LONG, "=", true,
 					true, Portlet::getCompanyId));
 
+		_finderPathFetchByC_P = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByC_P",
+			new String[] {Long.class.getName(), String.class.getName()},
+			new String[] {"companyId", "portletId"}, 0, 2, true,
+			Portlet::getCompanyId, convertNullFunction(Portlet::getPortletId));
+
 		_uniquePersistenceFinderByC_P = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByC_P",
-				new String[] {Long.class.getName(), String.class.getName()},
-				new String[] {"companyId", "portletId"}, 0, 2, true,
-				Portlet::getCompanyId,
-				convertNullFunction(Portlet::getPortletId)),
-			_SQL_SELECT_PORTLET_WHERE, "",
+			this, _finderPathFetchByC_P, _SQL_SELECT_PORTLET_WHERE, "",
 			new FinderColumn<>(
 				"portlet.", "companyId", FinderColumn.Type.LONG, "=", true,
 				true, Portlet::getCompanyId),
@@ -555,4 +562,4 @@ public class PortletPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1761908527
+// LIFERAY-SERVICE-BUILDER-HASH:-1303258446

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/PortletPreferenceValuePersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/PortletPreferenceValuePersistenceImpl.java
@@ -75,6 +75,9 @@ public class PortletPreferenceValuePersistenceImpl
 	public static final String FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION =
 		FINDER_CLASS_NAME_ENTITY + ".List2";
 
+	private FinderPath _finderPathWithPaginationFindByPortletPreferencesId;
+	private FinderPath _finderPathWithoutPaginationFindByPortletPreferencesId;
+	private FinderPath _finderPathCountByPortletPreferencesId;
 	private CollectionPersistenceFinder<PortletPreferenceValue>
 		_collectionPersistenceFinderByPortletPreferencesId;
 
@@ -231,6 +234,9 @@ public class PortletPreferenceValuePersistenceImpl
 			new Object[] {portletPreferencesId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByP_N;
+	private FinderPath _finderPathWithoutPaginationFindByP_N;
+	private FinderPath _finderPathCountByP_N;
 	private CollectionPersistenceFinder<PortletPreferenceValue>
 		_collectionPersistenceFinderByP_N;
 
@@ -393,6 +399,9 @@ public class PortletPreferenceValuePersistenceImpl
 			new Object[] {portletPreferencesId, name});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_N_SV;
+	private FinderPath _finderPathWithoutPaginationFindByC_N_SV;
+	private FinderPath _finderPathCountByC_N_SV;
 	private CollectionPersistenceFinder<PortletPreferenceValue>
 		_collectionPersistenceFinderByC_N_SV;
 
@@ -563,6 +572,7 @@ public class PortletPreferenceValuePersistenceImpl
 			new Object[] {companyId, name, smallValue});
 	}
 
+	private FinderPath _finderPathFetchByP_I_N;
 	private UniquePersistenceFinder<PortletPreferenceValue>
 		_uniquePersistenceFinderByP_I_N;
 
@@ -667,6 +677,9 @@ public class PortletPreferenceValuePersistenceImpl
 			new Object[] {portletPreferencesId, index, name});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByP_N_SV;
+	private FinderPath _finderPathWithoutPaginationFindByP_N_SV;
+	private FinderPath _finderPathCountByP_N_SV;
 	private CollectionPersistenceFinder<PortletPreferenceValue>
 		_collectionPersistenceFinderByP_N_SV;
 
@@ -1114,28 +1127,30 @@ public class PortletPreferenceValuePersistenceImpl
 	 * Initializes the portlet preference value persistence.
 	 */
 	public void afterPropertiesSet() {
+		_finderPathWithPaginationFindByPortletPreferencesId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION,
+			"findByPortletPreferencesId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"portletPreferencesId"}, true);
+
+		_finderPathWithoutPaginationFindByPortletPreferencesId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
+			"findByPortletPreferencesId", new String[] {Long.class.getName()},
+			new String[] {"portletPreferencesId"}, true);
+
+		_finderPathCountByPortletPreferencesId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
+			"countByPortletPreferencesId", new String[] {Long.class.getName()},
+			new String[] {"portletPreferencesId"}, false);
+
 		_collectionPersistenceFinderByPortletPreferencesId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION,
-					"findByPortletPreferencesId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"portletPreferencesId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"findByPortletPreferencesId",
-					new String[] {Long.class.getName()},
-					new String[] {"portletPreferencesId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByPortletPreferencesId",
-					new String[] {Long.class.getName()},
-					new String[] {"portletPreferencesId"}, false),
+				this, _finderPathWithPaginationFindByPortletPreferencesId,
+				_finderPathWithoutPaginationFindByPortletPreferencesId,
+				_finderPathCountByPortletPreferencesId,
 				_SQL_SELECT_PORTLETPREFERENCEVALUE_WHERE,
 				_SQL_COUNT_PORTLETPREFERENCEVALUE_WHERE,
 				PortletPreferenceValueModelImpl.ORDER_BY_JPQL,
@@ -1145,26 +1160,28 @@ public class PortletPreferenceValuePersistenceImpl
 					FinderColumn.Type.LONG, "=", true, true,
 					PortletPreferenceValue::getPortletPreferencesId));
 
+		_finderPathWithPaginationFindByP_N = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByP_N",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"portletPreferencesId", "name"}, true);
+
+		_finderPathWithoutPaginationFindByP_N = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByP_N",
+			new String[] {Long.class.getName(), String.class.getName()},
+			new String[] {"portletPreferencesId", "name"}, 0, 2, true, null);
+
+		_finderPathCountByP_N = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByP_N",
+			new String[] {Long.class.getName(), String.class.getName()},
+			new String[] {"portletPreferencesId", "name"}, 0, 2, false, null);
+
 		_collectionPersistenceFinderByP_N = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByP_N",
-				new String[] {
-					Long.class.getName(), String.class.getName(),
-					Integer.class.getName(), Integer.class.getName(),
-					OrderByComparator.class.getName()
-				},
-				new String[] {"portletPreferencesId", "name"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByP_N",
-				new String[] {Long.class.getName(), String.class.getName()},
-				new String[] {"portletPreferencesId", "name"}, 0, 2, true,
-				null),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByP_N",
-				new String[] {Long.class.getName(), String.class.getName()},
-				new String[] {"portletPreferencesId", "name"}, 0, 2, false,
-				null),
+			this, _finderPathWithPaginationFindByP_N,
+			_finderPathWithoutPaginationFindByP_N, _finderPathCountByP_N,
 			_SQL_SELECT_PORTLETPREFERENCEVALUE_WHERE,
 			_SQL_COUNT_PORTLETPREFERENCEVALUE_WHERE,
 			PortletPreferenceValueModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
@@ -1177,34 +1194,37 @@ public class PortletPreferenceValuePersistenceImpl
 				"portletPreferenceValue.", "name", FinderColumn.Type.STRING,
 				"=", true, true, PortletPreferenceValue::getName));
 
+		_finderPathWithPaginationFindByC_N_SV = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_N_SV",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				String.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "name", "smallValue"}, true);
+
+		_finderPathWithoutPaginationFindByC_N_SV = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_N_SV",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				String.class.getName()
+			},
+			new String[] {"companyId", "name", "smallValue"}, 0, 6, true, null);
+
+		_finderPathCountByC_N_SV = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_N_SV",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				String.class.getName()
+			},
+			new String[] {"companyId", "name", "smallValue"}, 0, 6, false,
+			null);
+
 		_collectionPersistenceFinderByC_N_SV =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_N_SV",
-					new String[] {
-						Long.class.getName(), String.class.getName(),
-						String.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"companyId", "name", "smallValue"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_N_SV",
-					new String[] {
-						Long.class.getName(), String.class.getName(),
-						String.class.getName()
-					},
-					new String[] {"companyId", "name", "smallValue"}, 0, 6,
-					true, null),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_N_SV",
-					new String[] {
-						Long.class.getName(), String.class.getName(),
-						String.class.getName()
-					},
-					new String[] {"companyId", "name", "smallValue"}, 0, 6,
-					false, null),
+				this, _finderPathWithPaginationFindByC_N_SV,
+				_finderPathWithoutPaginationFindByC_N_SV,
+				_finderPathCountByC_N_SV,
 				_SQL_SELECT_PORTLETPREFERENCEVALUE_WHERE,
 				_SQL_COUNT_PORTLETPREFERENCEVALUE_WHERE,
 				PortletPreferenceValueModelImpl.ORDER_BY_JPQL,
@@ -1221,18 +1241,19 @@ public class PortletPreferenceValuePersistenceImpl
 					FinderColumn.Type.STRING, "=", true, true,
 					PortletPreferenceValue::getSmallValue));
 
+		_finderPathFetchByP_I_N = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByP_I_N",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				String.class.getName()
+			},
+			new String[] {"portletPreferencesId", "index_", "name"}, 0, 4,
+			false, PortletPreferenceValue::getPortletPreferencesId,
+			PortletPreferenceValue::getIndex,
+			convertNullFunction(PortletPreferenceValue::getName));
+
 		_uniquePersistenceFinderByP_I_N = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByP_I_N",
-				new String[] {
-					Long.class.getName(), Integer.class.getName(),
-					String.class.getName()
-				},
-				new String[] {"portletPreferencesId", "index_", "name"}, 0, 4,
-				false, PortletPreferenceValue::getPortletPreferencesId,
-				PortletPreferenceValue::getIndex,
-				convertNullFunction(PortletPreferenceValue::getName)),
+			this, _finderPathFetchByP_I_N,
 			_SQL_SELECT_PORTLETPREFERENCEVALUE_WHERE, "",
 			new FinderColumn<>(
 				"portletPreferenceValue.", "portletPreferencesId",
@@ -1245,35 +1266,38 @@ public class PortletPreferenceValuePersistenceImpl
 				"portletPreferenceValue.", "name", FinderColumn.Type.STRING,
 				"=", true, true, PortletPreferenceValue::getName));
 
+		_finderPathWithPaginationFindByP_N_SV = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByP_N_SV",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				String.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"portletPreferencesId", "name", "smallValue"}, true);
+
+		_finderPathWithoutPaginationFindByP_N_SV = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByP_N_SV",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				String.class.getName()
+			},
+			new String[] {"portletPreferencesId", "name", "smallValue"}, 0, 6,
+			true, null);
+
+		_finderPathCountByP_N_SV = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByP_N_SV",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				String.class.getName()
+			},
+			new String[] {"portletPreferencesId", "name", "smallValue"}, 0, 6,
+			false, null);
+
 		_collectionPersistenceFinderByP_N_SV =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByP_N_SV",
-					new String[] {
-						Long.class.getName(), String.class.getName(),
-						String.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"portletPreferencesId", "name", "smallValue"},
-					true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByP_N_SV",
-					new String[] {
-						Long.class.getName(), String.class.getName(),
-						String.class.getName()
-					},
-					new String[] {"portletPreferencesId", "name", "smallValue"},
-					0, 6, true, null),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByP_N_SV",
-					new String[] {
-						Long.class.getName(), String.class.getName(),
-						String.class.getName()
-					},
-					new String[] {"portletPreferencesId", "name", "smallValue"},
-					0, 6, false, null),
+				this, _finderPathWithPaginationFindByP_N_SV,
+				_finderPathWithoutPaginationFindByP_N_SV,
+				_finderPathCountByP_N_SV,
 				_SQL_SELECT_PORTLETPREFERENCEVALUE_WHERE,
 				_SQL_COUNT_PORTLETPREFERENCEVALUE_WHERE,
 				PortletPreferenceValueModelImpl.ORDER_BY_JPQL,
@@ -1326,4 +1350,4 @@ public class PortletPreferenceValuePersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:415560142
+// LIFERAY-SERVICE-BUILDER-HASH:1022717792

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/PortletPreferencesPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/PortletPreferencesPersistenceImpl.java
@@ -73,6 +73,9 @@ public class PortletPreferencesPersistenceImpl
 	public static final String FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION =
 		FINDER_CLASS_NAME_ENTITY + ".List2";
 
+	private FinderPath _finderPathWithPaginationFindByOwnerId;
+	private FinderPath _finderPathWithoutPaginationFindByOwnerId;
+	private FinderPath _finderPathCountByOwnerId;
 	private CollectionPersistenceFinder<PortletPreferences>
 		_collectionPersistenceFinderByOwnerId;
 
@@ -218,6 +221,9 @@ public class PortletPreferencesPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {ownerId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByPlid;
+	private FinderPath _finderPathWithoutPaginationFindByPlid;
+	private FinderPath _finderPathCountByPlid;
 	private CollectionPersistenceFinder<PortletPreferences>
 		_collectionPersistenceFinderByPlid;
 
@@ -359,6 +365,9 @@ public class PortletPreferencesPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {plid});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByPortletId;
+	private FinderPath _finderPathWithoutPaginationFindByPortletId;
+	private FinderPath _finderPathCountByPortletId;
 	private CollectionPersistenceFinder<PortletPreferences>
 		_collectionPersistenceFinderByPortletId;
 
@@ -505,6 +514,9 @@ public class PortletPreferencesPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {portletId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByO_P;
+	private FinderPath _finderPathWithoutPaginationFindByO_P;
+	private FinderPath _finderPathCountByO_P;
 	private CollectionPersistenceFinder<PortletPreferences>
 		_collectionPersistenceFinderByO_P;
 
@@ -663,6 +675,9 @@ public class PortletPreferencesPersistenceImpl
 			new Object[] {ownerType, portletId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByP_P;
+	private FinderPath _finderPathWithoutPaginationFindByP_P;
+	private FinderPath _finderPathCountByP_P;
 	private CollectionPersistenceFinder<PortletPreferences>
 		_collectionPersistenceFinderByP_P;
 
@@ -817,6 +832,9 @@ public class PortletPreferencesPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {plid, portletId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByO_O_P;
+	private FinderPath _finderPathWithoutPaginationFindByO_O_P;
+	private FinderPath _finderPathCountByO_O_P;
 	private CollectionPersistenceFinder<PortletPreferences>
 		_collectionPersistenceFinderByO_O_P;
 
@@ -987,6 +1005,9 @@ public class PortletPreferencesPersistenceImpl
 			new Object[] {ownerId, ownerType, plid});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByO_O_PI;
+	private FinderPath _finderPathWithoutPaginationFindByO_O_PI;
+	private FinderPath _finderPathCountByO_O_PI;
 	private CollectionPersistenceFinder<PortletPreferences>
 		_collectionPersistenceFinderByO_O_PI;
 
@@ -1157,6 +1178,9 @@ public class PortletPreferencesPersistenceImpl
 			new Object[] {ownerId, ownerType, portletId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByO_P_P;
+	private FinderPath _finderPathWithoutPaginationFindByO_P_P;
+	private FinderPath _finderPathCountByO_P_P;
 	private CollectionPersistenceFinder<PortletPreferences>
 		_collectionPersistenceFinderByO_P_P;
 
@@ -1327,6 +1351,8 @@ public class PortletPreferencesPersistenceImpl
 			new Object[] {ownerType, plid, portletId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_O_O_LikeP;
+	private FinderPath _finderPathWithPaginationCountByC_O_O_LikeP;
 	private CollectionPersistenceFinder<PortletPreferences>
 		_collectionPersistenceFinderByC_O_O_LikeP;
 
@@ -1515,6 +1541,7 @@ public class PortletPreferencesPersistenceImpl
 			new Object[] {companyId, ownerId, ownerType, portletId});
 	}
 
+	private FinderPath _finderPathFetchByO_O_P_P;
 	private UniquePersistenceFinder<PortletPreferences>
 		_uniquePersistenceFinderByO_O_P_P;
 
@@ -1876,26 +1903,29 @@ public class PortletPreferencesPersistenceImpl
 	 * Initializes the portlet preferences persistence.
 	 */
 	public void afterPropertiesSet() {
+		_finderPathWithPaginationFindByOwnerId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByOwnerId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"ownerId"}, true);
+
+		_finderPathWithoutPaginationFindByOwnerId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByOwnerId",
+			new String[] {Long.class.getName()}, new String[] {"ownerId"},
+			true);
+
+		_finderPathCountByOwnerId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByOwnerId",
+			new String[] {Long.class.getName()}, new String[] {"ownerId"},
+			false);
+
 		_collectionPersistenceFinderByOwnerId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByOwnerId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"ownerId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByOwnerId",
-					new String[] {Long.class.getName()},
-					new String[] {"ownerId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByOwnerId",
-					new String[] {Long.class.getName()},
-					new String[] {"ownerId"}, false),
-				_SQL_SELECT_PORTLETPREFERENCES_WHERE,
+				this, _finderPathWithPaginationFindByOwnerId,
+				_finderPathWithoutPaginationFindByOwnerId,
+				_finderPathCountByOwnerId, _SQL_SELECT_PORTLETPREFERENCES_WHERE,
 				_SQL_COUNT_PORTLETPREFERENCES_WHERE,
 				PortletPreferencesModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
 				"",
@@ -1903,23 +1933,25 @@ public class PortletPreferencesPersistenceImpl
 					"portletPreferences.", "ownerId", FinderColumn.Type.LONG,
 					"=", true, true, PortletPreferences::getOwnerId));
 
+		_finderPathWithPaginationFindByPlid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByPlid",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"plid"}, true);
+
+		_finderPathWithoutPaginationFindByPlid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByPlid",
+			new String[] {Long.class.getName()}, new String[] {"plid"}, true);
+
+		_finderPathCountByPlid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByPlid",
+			new String[] {Long.class.getName()}, new String[] {"plid"}, false);
+
 		_collectionPersistenceFinderByPlid = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByPlid",
-				new String[] {
-					Long.class.getName(), Integer.class.getName(),
-					Integer.class.getName(), OrderByComparator.class.getName()
-				},
-				new String[] {"plid"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByPlid",
-				new String[] {Long.class.getName()}, new String[] {"plid"},
-				true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByPlid",
-				new String[] {Long.class.getName()}, new String[] {"plid"},
-				false),
+			this, _finderPathWithPaginationFindByPlid,
+			_finderPathWithoutPaginationFindByPlid, _finderPathCountByPlid,
 			_SQL_SELECT_PORTLETPREFERENCES_WHERE,
 			_SQL_COUNT_PORTLETPREFERENCES_WHERE,
 			PortletPreferencesModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
@@ -1927,25 +1959,29 @@ public class PortletPreferencesPersistenceImpl
 				"portletPreferences.", "plid", FinderColumn.Type.LONG, "=",
 				true, true, PortletPreferences::getPlid));
 
+		_finderPathWithPaginationFindByPortletId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByPortletId",
+			new String[] {
+				String.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"portletId"}, true);
+
+		_finderPathWithoutPaginationFindByPortletId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByPortletId",
+			new String[] {String.class.getName()}, new String[] {"portletId"},
+			0, 1, true, null);
+
+		_finderPathCountByPortletId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByPortletId",
+			new String[] {String.class.getName()}, new String[] {"portletId"},
+			0, 1, false, null);
+
 		_collectionPersistenceFinderByPortletId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByPortletId",
-					new String[] {
-						String.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"portletId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"findByPortletId", new String[] {String.class.getName()},
-					new String[] {"portletId"}, 0, 1, true, null),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByPortletId", new String[] {String.class.getName()},
-					new String[] {"portletId"}, 0, 1, false, null),
+				this, _finderPathWithPaginationFindByPortletId,
+				_finderPathWithoutPaginationFindByPortletId,
+				_finderPathCountByPortletId,
 				_SQL_SELECT_PORTLETPREFERENCES_WHERE,
 				_SQL_COUNT_PORTLETPREFERENCES_WHERE,
 				PortletPreferencesModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
@@ -1955,24 +1991,28 @@ public class PortletPreferencesPersistenceImpl
 					FinderColumn.Type.STRING, "=", true, true,
 					PortletPreferences::getPortletId));
 
+		_finderPathWithPaginationFindByO_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByO_P",
+			new String[] {
+				Integer.class.getName(), String.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"ownerType", "portletId"}, true);
+
+		_finderPathWithoutPaginationFindByO_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByO_P",
+			new String[] {Integer.class.getName(), String.class.getName()},
+			new String[] {"ownerType", "portletId"}, 0, 2, true, null);
+
+		_finderPathCountByO_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByO_P",
+			new String[] {Integer.class.getName(), String.class.getName()},
+			new String[] {"ownerType", "portletId"}, 0, 2, false, null);
+
 		_collectionPersistenceFinderByO_P = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByO_P",
-				new String[] {
-					Integer.class.getName(), String.class.getName(),
-					Integer.class.getName(), Integer.class.getName(),
-					OrderByComparator.class.getName()
-				},
-				new String[] {"ownerType", "portletId"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByO_P",
-				new String[] {Integer.class.getName(), String.class.getName()},
-				new String[] {"ownerType", "portletId"}, 0, 2, true, null),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByO_P",
-				new String[] {Integer.class.getName(), String.class.getName()},
-				new String[] {"ownerType", "portletId"}, 0, 2, false, null),
+			this, _finderPathWithPaginationFindByO_P,
+			_finderPathWithoutPaginationFindByO_P, _finderPathCountByO_P,
 			_SQL_SELECT_PORTLETPREFERENCES_WHERE,
 			_SQL_COUNT_PORTLETPREFERENCES_WHERE,
 			PortletPreferencesModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
@@ -1983,24 +2023,28 @@ public class PortletPreferencesPersistenceImpl
 				"portletPreferences.", "portletId", FinderColumn.Type.STRING,
 				"=", true, true, PortletPreferences::getPortletId));
 
+		_finderPathWithPaginationFindByP_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByP_P",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"plid", "portletId"}, true);
+
+		_finderPathWithoutPaginationFindByP_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByP_P",
+			new String[] {Long.class.getName(), String.class.getName()},
+			new String[] {"plid", "portletId"}, 0, 2, true, null);
+
+		_finderPathCountByP_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByP_P",
+			new String[] {Long.class.getName(), String.class.getName()},
+			new String[] {"plid", "portletId"}, 0, 2, false, null);
+
 		_collectionPersistenceFinderByP_P = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByP_P",
-				new String[] {
-					Long.class.getName(), String.class.getName(),
-					Integer.class.getName(), Integer.class.getName(),
-					OrderByComparator.class.getName()
-				},
-				new String[] {"plid", "portletId"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByP_P",
-				new String[] {Long.class.getName(), String.class.getName()},
-				new String[] {"plid", "portletId"}, 0, 2, true, null),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByP_P",
-				new String[] {Long.class.getName(), String.class.getName()},
-				new String[] {"plid", "portletId"}, 0, 2, false, null),
+			this, _finderPathWithPaginationFindByP_P,
+			_finderPathWithoutPaginationFindByP_P, _finderPathCountByP_P,
 			_SQL_SELECT_PORTLETPREFERENCES_WHERE,
 			_SQL_COUNT_PORTLETPREFERENCES_WHERE,
 			PortletPreferencesModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
@@ -2011,30 +2055,34 @@ public class PortletPreferencesPersistenceImpl
 				"portletPreferences.", "portletId", FinderColumn.Type.STRING,
 				"=", true, true, PortletPreferences::getPortletId));
 
+		_finderPathWithPaginationFindByO_O_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByO_O_P",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"ownerId", "ownerType", "plid"}, true);
+
+		_finderPathWithoutPaginationFindByO_O_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByO_O_P",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Long.class.getName()
+			},
+			new String[] {"ownerId", "ownerType", "plid"}, true);
+
+		_finderPathCountByO_O_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByO_O_P",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Long.class.getName()
+			},
+			new String[] {"ownerId", "ownerType", "plid"}, false);
+
 		_collectionPersistenceFinderByO_O_P = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByO_O_P",
-				new String[] {
-					Long.class.getName(), Integer.class.getName(),
-					Long.class.getName(), Integer.class.getName(),
-					Integer.class.getName(), OrderByComparator.class.getName()
-				},
-				new String[] {"ownerId", "ownerType", "plid"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByO_O_P",
-				new String[] {
-					Long.class.getName(), Integer.class.getName(),
-					Long.class.getName()
-				},
-				new String[] {"ownerId", "ownerType", "plid"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByO_O_P",
-				new String[] {
-					Long.class.getName(), Integer.class.getName(),
-					Long.class.getName()
-				},
-				new String[] {"ownerId", "ownerType", "plid"}, false),
+			this, _finderPathWithPaginationFindByO_O_P,
+			_finderPathWithoutPaginationFindByO_O_P, _finderPathCountByO_O_P,
 			_SQL_SELECT_PORTLETPREFERENCES_WHERE,
 			_SQL_COUNT_PORTLETPREFERENCES_WHERE,
 			PortletPreferencesModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
@@ -2048,35 +2096,38 @@ public class PortletPreferencesPersistenceImpl
 				"portletPreferences.", "plid", FinderColumn.Type.LONG, "=",
 				true, true, PortletPreferences::getPlid));
 
+		_finderPathWithPaginationFindByO_O_PI = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByO_O_PI",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				String.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"ownerId", "ownerType", "portletId"}, true);
+
+		_finderPathWithoutPaginationFindByO_O_PI = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByO_O_PI",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				String.class.getName()
+			},
+			new String[] {"ownerId", "ownerType", "portletId"}, 0, 4, true,
+			null);
+
+		_finderPathCountByO_O_PI = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByO_O_PI",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				String.class.getName()
+			},
+			new String[] {"ownerId", "ownerType", "portletId"}, 0, 4, false,
+			null);
+
 		_collectionPersistenceFinderByO_O_PI =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByO_O_PI",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						String.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"ownerId", "ownerType", "portletId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByO_O_PI",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						String.class.getName()
-					},
-					new String[] {"ownerId", "ownerType", "portletId"}, 0, 4,
-					true, null),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByO_O_PI",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						String.class.getName()
-					},
-					new String[] {"ownerId", "ownerType", "portletId"}, 0, 4,
-					false, null),
-				_SQL_SELECT_PORTLETPREFERENCES_WHERE,
+				this, _finderPathWithPaginationFindByO_O_PI,
+				_finderPathWithoutPaginationFindByO_O_PI,
+				_finderPathCountByO_O_PI, _SQL_SELECT_PORTLETPREFERENCES_WHERE,
 				_SQL_COUNT_PORTLETPREFERENCES_WHERE,
 				PortletPreferencesModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
 				"",
@@ -2092,32 +2143,34 @@ public class PortletPreferencesPersistenceImpl
 					FinderColumn.Type.STRING, "=", true, true,
 					PortletPreferences::getPortletId));
 
+		_finderPathWithPaginationFindByO_P_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByO_P_P",
+			new String[] {
+				Integer.class.getName(), Long.class.getName(),
+				String.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"ownerType", "plid", "portletId"}, true);
+
+		_finderPathWithoutPaginationFindByO_P_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByO_P_P",
+			new String[] {
+				Integer.class.getName(), Long.class.getName(),
+				String.class.getName()
+			},
+			new String[] {"ownerType", "plid", "portletId"}, 0, 4, true, null);
+
+		_finderPathCountByO_P_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByO_P_P",
+			new String[] {
+				Integer.class.getName(), Long.class.getName(),
+				String.class.getName()
+			},
+			new String[] {"ownerType", "plid", "portletId"}, 0, 4, false, null);
+
 		_collectionPersistenceFinderByO_P_P = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByO_P_P",
-				new String[] {
-					Integer.class.getName(), Long.class.getName(),
-					String.class.getName(), Integer.class.getName(),
-					Integer.class.getName(), OrderByComparator.class.getName()
-				},
-				new String[] {"ownerType", "plid", "portletId"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByO_P_P",
-				new String[] {
-					Integer.class.getName(), Long.class.getName(),
-					String.class.getName()
-				},
-				new String[] {"ownerType", "plid", "portletId"}, 0, 4, true,
-				null),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByO_P_P",
-				new String[] {
-					Integer.class.getName(), Long.class.getName(),
-					String.class.getName()
-				},
-				new String[] {"ownerType", "plid", "portletId"}, 0, 4, false,
-				null),
+			this, _finderPathWithPaginationFindByO_P_P,
+			_finderPathWithoutPaginationFindByO_P_P, _finderPathCountByO_P_P,
 			_SQL_SELECT_PORTLETPREFERENCES_WHERE,
 			_SQL_COUNT_PORTLETPREFERENCES_WHERE,
 			PortletPreferencesModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
@@ -2131,33 +2184,30 @@ public class PortletPreferencesPersistenceImpl
 				"portletPreferences.", "portletId", FinderColumn.Type.STRING,
 				"=", true, true, PortletPreferences::getPortletId));
 
+		_finderPathWithPaginationFindByC_O_O_LikeP = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_O_O_LikeP",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Integer.class.getName(), String.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "ownerId", "ownerType", "portletId"},
+			true);
+
+		_finderPathWithPaginationCountByC_O_O_LikeP = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByC_O_O_LikeP",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Integer.class.getName(), String.class.getName()
+			},
+			new String[] {"companyId", "ownerId", "ownerType", "portletId"},
+			false);
+
 		_collectionPersistenceFinderByC_O_O_LikeP =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_O_O_LikeP",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						Integer.class.getName(), String.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {
-						"companyId", "ownerId", "ownerType", "portletId"
-					},
-					true),
-				null,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION,
-					"countByC_O_O_LikeP",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						Integer.class.getName(), String.class.getName()
-					},
-					new String[] {
-						"companyId", "ownerId", "ownerType", "portletId"
-					},
-					false),
+				this, _finderPathWithPaginationFindByC_O_O_LikeP, null,
+				_finderPathWithPaginationCountByC_O_O_LikeP,
 				_SQL_SELECT_PORTLETPREFERENCES_WHERE,
 				_SQL_COUNT_PORTLETPREFERENCES_WHERE,
 				PortletPreferencesModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
@@ -2177,18 +2227,19 @@ public class PortletPreferencesPersistenceImpl
 					FinderColumn.Type.STRING, "LIKE", true, true,
 					PortletPreferences::getPortletId));
 
+		_finderPathFetchByO_O_P_P = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByO_O_P_P",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Long.class.getName(), String.class.getName()
+			},
+			new String[] {"ownerId", "ownerType", "plid", "portletId"}, 0, 8,
+			false, PortletPreferences::getOwnerId,
+			PortletPreferences::getOwnerType, PortletPreferences::getPlid,
+			convertNullFunction(PortletPreferences::getPortletId));
+
 		_uniquePersistenceFinderByO_O_P_P = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByO_O_P_P",
-				new String[] {
-					Long.class.getName(), Integer.class.getName(),
-					Long.class.getName(), String.class.getName()
-				},
-				new String[] {"ownerId", "ownerType", "plid", "portletId"}, 0,
-				8, false, PortletPreferences::getOwnerId,
-				PortletPreferences::getOwnerType, PortletPreferences::getPlid,
-				convertNullFunction(PortletPreferences::getPortletId)),
+			this, _finderPathFetchByO_O_P_P,
 			_SQL_SELECT_PORTLETPREFERENCES_WHERE, "",
 			new FinderColumn<>(
 				"portletPreferences.", "ownerId", FinderColumn.Type.LONG, "=",
@@ -2236,4 +2287,4 @@ public class PortletPreferencesPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1560673222
+// LIFERAY-SERVICE-BUILDER-HASH:-1398476014

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/RecentLayoutBranchPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/RecentLayoutBranchPersistenceImpl.java
@@ -65,6 +65,9 @@ public class RecentLayoutBranchPersistenceImpl
 	public static final String FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION =
 		FINDER_CLASS_NAME_ENTITY + ".List2";
 
+	private FinderPath _finderPathWithPaginationFindByGroupId;
+	private FinderPath _finderPathWithoutPaginationFindByGroupId;
+	private FinderPath _finderPathCountByGroupId;
 	private CollectionPersistenceFinder<RecentLayoutBranch>
 		_collectionPersistenceFinderByGroupId;
 
@@ -210,6 +213,9 @@ public class RecentLayoutBranchPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {groupId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByUserId;
+	private FinderPath _finderPathWithoutPaginationFindByUserId;
+	private FinderPath _finderPathCountByUserId;
 	private CollectionPersistenceFinder<RecentLayoutBranch>
 		_collectionPersistenceFinderByUserId;
 
@@ -354,6 +360,9 @@ public class RecentLayoutBranchPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {userId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByLayoutBranchId;
+	private FinderPath _finderPathWithoutPaginationFindByLayoutBranchId;
+	private FinderPath _finderPathCountByLayoutBranchId;
 	private CollectionPersistenceFinder<RecentLayoutBranch>
 		_collectionPersistenceFinderByLayoutBranchId;
 
@@ -501,6 +510,7 @@ public class RecentLayoutBranchPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {layoutBranchId});
 	}
 
+	private FinderPath _finderPathFetchByU_L_P;
 	private UniquePersistenceFinder<RecentLayoutBranch>
 		_uniquePersistenceFinderByU_L_P;
 
@@ -785,26 +795,29 @@ public class RecentLayoutBranchPersistenceImpl
 	 * Initializes the recent layout branch persistence.
 	 */
 	public void afterPropertiesSet() {
+		_finderPathWithPaginationFindByGroupId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByGroupId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"groupId"}, true);
+
+		_finderPathWithoutPaginationFindByGroupId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByGroupId",
+			new String[] {Long.class.getName()}, new String[] {"groupId"},
+			true);
+
+		_finderPathCountByGroupId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByGroupId",
+			new String[] {Long.class.getName()}, new String[] {"groupId"},
+			false);
+
 		_collectionPersistenceFinderByGroupId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByGroupId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"groupId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByGroupId",
-					new String[] {Long.class.getName()},
-					new String[] {"groupId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByGroupId",
-					new String[] {Long.class.getName()},
-					new String[] {"groupId"}, false),
-				_SQL_SELECT_RECENTLAYOUTBRANCH_WHERE,
+				this, _finderPathWithPaginationFindByGroupId,
+				_finderPathWithoutPaginationFindByGroupId,
+				_finderPathCountByGroupId, _SQL_SELECT_RECENTLAYOUTBRANCH_WHERE,
 				_SQL_COUNT_RECENTLAYOUTBRANCH_WHERE,
 				RecentLayoutBranchModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
 				"",
@@ -812,26 +825,28 @@ public class RecentLayoutBranchPersistenceImpl
 					"recentLayoutBranch.", "groupId", FinderColumn.Type.LONG,
 					"=", true, true, RecentLayoutBranch::getGroupId));
 
+		_finderPathWithPaginationFindByUserId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUserId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"userId"}, true);
+
+		_finderPathWithoutPaginationFindByUserId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUserId",
+			new String[] {Long.class.getName()}, new String[] {"userId"}, true);
+
+		_finderPathCountByUserId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUserId",
+			new String[] {Long.class.getName()}, new String[] {"userId"},
+			false);
+
 		_collectionPersistenceFinderByUserId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUserId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"userId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUserId",
-					new String[] {Long.class.getName()},
-					new String[] {"userId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUserId",
-					new String[] {Long.class.getName()},
-					new String[] {"userId"}, false),
-				_SQL_SELECT_RECENTLAYOUTBRANCH_WHERE,
+				this, _finderPathWithPaginationFindByUserId,
+				_finderPathWithoutPaginationFindByUserId,
+				_finderPathCountByUserId, _SQL_SELECT_RECENTLAYOUTBRANCH_WHERE,
 				_SQL_COUNT_RECENTLAYOUTBRANCH_WHERE,
 				RecentLayoutBranchModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
 				"",
@@ -839,27 +854,29 @@ public class RecentLayoutBranchPersistenceImpl
 					"recentLayoutBranch.", "userId", FinderColumn.Type.LONG,
 					"=", true, true, RecentLayoutBranch::getUserId));
 
+		_finderPathWithPaginationFindByLayoutBranchId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByLayoutBranchId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"layoutBranchId"}, true);
+
+		_finderPathWithoutPaginationFindByLayoutBranchId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByLayoutBranchId",
+			new String[] {Long.class.getName()},
+			new String[] {"layoutBranchId"}, true);
+
+		_finderPathCountByLayoutBranchId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByLayoutBranchId",
+			new String[] {Long.class.getName()},
+			new String[] {"layoutBranchId"}, false);
+
 		_collectionPersistenceFinderByLayoutBranchId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION,
-					"findByLayoutBranchId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"layoutBranchId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"findByLayoutBranchId", new String[] {Long.class.getName()},
-					new String[] {"layoutBranchId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByLayoutBranchId",
-					new String[] {Long.class.getName()},
-					new String[] {"layoutBranchId"}, false),
+				this, _finderPathWithPaginationFindByLayoutBranchId,
+				_finderPathWithoutPaginationFindByLayoutBranchId,
+				_finderPathCountByLayoutBranchId,
 				_SQL_SELECT_RECENTLAYOUTBRANCH_WHERE,
 				_SQL_COUNT_RECENTLAYOUTBRANCH_WHERE,
 				RecentLayoutBranchModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
@@ -869,19 +886,19 @@ public class RecentLayoutBranchPersistenceImpl
 					FinderColumn.Type.LONG, "=", true, true,
 					RecentLayoutBranch::getLayoutBranchId));
 
+		_finderPathFetchByU_L_P = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByU_L_P",
+			new String[] {
+				Long.class.getName(), Long.class.getName(), Long.class.getName()
+			},
+			new String[] {"userId", "layoutSetBranchId", "plid"}, 0, 0, false,
+			RecentLayoutBranch::getUserId,
+			RecentLayoutBranch::getLayoutSetBranchId,
+			RecentLayoutBranch::getPlid);
+
 		_uniquePersistenceFinderByU_L_P = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByU_L_P",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Long.class.getName()
-				},
-				new String[] {"userId", "layoutSetBranchId", "plid"}, 0, 0,
-				false, RecentLayoutBranch::getUserId,
-				RecentLayoutBranch::getLayoutSetBranchId,
-				RecentLayoutBranch::getPlid),
-			_SQL_SELECT_RECENTLAYOUTBRANCH_WHERE, "",
+			this, _finderPathFetchByU_L_P, _SQL_SELECT_RECENTLAYOUTBRANCH_WHERE,
+			"",
 			new FinderColumn<>(
 				"recentLayoutBranch.", "userId", FinderColumn.Type.LONG, "=",
 				true, true, RecentLayoutBranch::getUserId),
@@ -926,4 +943,4 @@ public class RecentLayoutBranchPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-139556447
+// LIFERAY-SERVICE-BUILDER-HASH:1050899456

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/RecentLayoutRevisionPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/RecentLayoutRevisionPersistenceImpl.java
@@ -65,6 +65,9 @@ public class RecentLayoutRevisionPersistenceImpl
 	public static final String FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION =
 		FINDER_CLASS_NAME_ENTITY + ".List2";
 
+	private FinderPath _finderPathWithPaginationFindByGroupId;
+	private FinderPath _finderPathWithoutPaginationFindByGroupId;
+	private FinderPath _finderPathCountByGroupId;
 	private CollectionPersistenceFinder<RecentLayoutRevision>
 		_collectionPersistenceFinderByGroupId;
 
@@ -211,6 +214,9 @@ public class RecentLayoutRevisionPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {groupId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByUserId;
+	private FinderPath _finderPathWithoutPaginationFindByUserId;
+	private FinderPath _finderPathCountByUserId;
 	private CollectionPersistenceFinder<RecentLayoutRevision>
 		_collectionPersistenceFinderByUserId;
 
@@ -356,6 +362,9 @@ public class RecentLayoutRevisionPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {userId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByLayoutRevisionId;
+	private FinderPath _finderPathWithoutPaginationFindByLayoutRevisionId;
+	private FinderPath _finderPathCountByLayoutRevisionId;
 	private CollectionPersistenceFinder<RecentLayoutRevision>
 		_collectionPersistenceFinderByLayoutRevisionId;
 
@@ -506,6 +515,7 @@ public class RecentLayoutRevisionPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {layoutRevisionId});
 	}
 
+	private FinderPath _finderPathFetchByU_L_P;
 	private UniquePersistenceFinder<RecentLayoutRevision>
 		_uniquePersistenceFinderByU_L_P;
 
@@ -791,25 +801,29 @@ public class RecentLayoutRevisionPersistenceImpl
 	 * Initializes the recent layout revision persistence.
 	 */
 	public void afterPropertiesSet() {
+		_finderPathWithPaginationFindByGroupId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByGroupId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"groupId"}, true);
+
+		_finderPathWithoutPaginationFindByGroupId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByGroupId",
+			new String[] {Long.class.getName()}, new String[] {"groupId"},
+			true);
+
+		_finderPathCountByGroupId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByGroupId",
+			new String[] {Long.class.getName()}, new String[] {"groupId"},
+			false);
+
 		_collectionPersistenceFinderByGroupId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByGroupId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"groupId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByGroupId",
-					new String[] {Long.class.getName()},
-					new String[] {"groupId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByGroupId",
-					new String[] {Long.class.getName()},
-					new String[] {"groupId"}, false),
+				this, _finderPathWithPaginationFindByGroupId,
+				_finderPathWithoutPaginationFindByGroupId,
+				_finderPathCountByGroupId,
 				_SQL_SELECT_RECENTLAYOUTREVISION_WHERE,
 				_SQL_COUNT_RECENTLAYOUTREVISION_WHERE,
 				RecentLayoutRevisionModelImpl.ORDER_BY_JPQL,
@@ -818,25 +832,28 @@ public class RecentLayoutRevisionPersistenceImpl
 					"recentLayoutRevision.", "groupId", FinderColumn.Type.LONG,
 					"=", true, true, RecentLayoutRevision::getGroupId));
 
+		_finderPathWithPaginationFindByUserId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUserId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"userId"}, true);
+
+		_finderPathWithoutPaginationFindByUserId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUserId",
+			new String[] {Long.class.getName()}, new String[] {"userId"}, true);
+
+		_finderPathCountByUserId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUserId",
+			new String[] {Long.class.getName()}, new String[] {"userId"},
+			false);
+
 		_collectionPersistenceFinderByUserId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUserId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"userId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUserId",
-					new String[] {Long.class.getName()},
-					new String[] {"userId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUserId",
-					new String[] {Long.class.getName()},
-					new String[] {"userId"}, false),
+				this, _finderPathWithPaginationFindByUserId,
+				_finderPathWithoutPaginationFindByUserId,
+				_finderPathCountByUserId,
 				_SQL_SELECT_RECENTLAYOUTREVISION_WHERE,
 				_SQL_COUNT_RECENTLAYOUTREVISION_WHERE,
 				RecentLayoutRevisionModelImpl.ORDER_BY_JPQL,
@@ -845,28 +862,29 @@ public class RecentLayoutRevisionPersistenceImpl
 					"recentLayoutRevision.", "userId", FinderColumn.Type.LONG,
 					"=", true, true, RecentLayoutRevision::getUserId));
 
+		_finderPathWithPaginationFindByLayoutRevisionId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByLayoutRevisionId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"layoutRevisionId"}, true);
+
+		_finderPathWithoutPaginationFindByLayoutRevisionId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByLayoutRevisionId",
+			new String[] {Long.class.getName()},
+			new String[] {"layoutRevisionId"}, true);
+
+		_finderPathCountByLayoutRevisionId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
+			"countByLayoutRevisionId", new String[] {Long.class.getName()},
+			new String[] {"layoutRevisionId"}, false);
+
 		_collectionPersistenceFinderByLayoutRevisionId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION,
-					"findByLayoutRevisionId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"layoutRevisionId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"findByLayoutRevisionId",
-					new String[] {Long.class.getName()},
-					new String[] {"layoutRevisionId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByLayoutRevisionId",
-					new String[] {Long.class.getName()},
-					new String[] {"layoutRevisionId"}, false),
+				this, _finderPathWithPaginationFindByLayoutRevisionId,
+				_finderPathWithoutPaginationFindByLayoutRevisionId,
+				_finderPathCountByLayoutRevisionId,
 				_SQL_SELECT_RECENTLAYOUTREVISION_WHERE,
 				_SQL_COUNT_RECENTLAYOUTREVISION_WHERE,
 				RecentLayoutRevisionModelImpl.ORDER_BY_JPQL,
@@ -876,18 +894,18 @@ public class RecentLayoutRevisionPersistenceImpl
 					FinderColumn.Type.LONG, "=", true, true,
 					RecentLayoutRevision::getLayoutRevisionId));
 
+		_finderPathFetchByU_L_P = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByU_L_P",
+			new String[] {
+				Long.class.getName(), Long.class.getName(), Long.class.getName()
+			},
+			new String[] {"userId", "layoutSetBranchId", "plid"}, 0, 0, false,
+			RecentLayoutRevision::getUserId,
+			RecentLayoutRevision::getLayoutSetBranchId,
+			RecentLayoutRevision::getPlid);
+
 		_uniquePersistenceFinderByU_L_P = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByU_L_P",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Long.class.getName()
-				},
-				new String[] {"userId", "layoutSetBranchId", "plid"}, 0, 0,
-				false, RecentLayoutRevision::getUserId,
-				RecentLayoutRevision::getLayoutSetBranchId,
-				RecentLayoutRevision::getPlid),
+			this, _finderPathFetchByU_L_P,
 			_SQL_SELECT_RECENTLAYOUTREVISION_WHERE, "",
 			new FinderColumn<>(
 				"recentLayoutRevision.", "userId", FinderColumn.Type.LONG, "=",
@@ -933,4 +951,4 @@ public class RecentLayoutRevisionPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1842346619
+// LIFERAY-SERVICE-BUILDER-HASH:-1172347549

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/RecentLayoutSetBranchPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/RecentLayoutSetBranchPersistenceImpl.java
@@ -65,6 +65,9 @@ public class RecentLayoutSetBranchPersistenceImpl
 	public static final String FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION =
 		FINDER_CLASS_NAME_ENTITY + ".List2";
 
+	private FinderPath _finderPathWithPaginationFindByGroupId;
+	private FinderPath _finderPathWithoutPaginationFindByGroupId;
+	private FinderPath _finderPathCountByGroupId;
 	private CollectionPersistenceFinder<RecentLayoutSetBranch>
 		_collectionPersistenceFinderByGroupId;
 
@@ -211,6 +214,9 @@ public class RecentLayoutSetBranchPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {groupId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByUserId;
+	private FinderPath _finderPathWithoutPaginationFindByUserId;
+	private FinderPath _finderPathCountByUserId;
 	private CollectionPersistenceFinder<RecentLayoutSetBranch>
 		_collectionPersistenceFinderByUserId;
 
@@ -356,6 +362,9 @@ public class RecentLayoutSetBranchPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {userId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByLayoutSetBranchId;
+	private FinderPath _finderPathWithoutPaginationFindByLayoutSetBranchId;
+	private FinderPath _finderPathCountByLayoutSetBranchId;
 	private CollectionPersistenceFinder<RecentLayoutSetBranch>
 		_collectionPersistenceFinderByLayoutSetBranchId;
 
@@ -508,6 +517,7 @@ public class RecentLayoutSetBranchPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {layoutSetBranchId});
 	}
 
+	private FinderPath _finderPathFetchByU_L;
 	private UniquePersistenceFinder<RecentLayoutSetBranch>
 		_uniquePersistenceFinderByU_L;
 
@@ -787,25 +797,29 @@ public class RecentLayoutSetBranchPersistenceImpl
 	 * Initializes the recent layout set branch persistence.
 	 */
 	public void afterPropertiesSet() {
+		_finderPathWithPaginationFindByGroupId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByGroupId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"groupId"}, true);
+
+		_finderPathWithoutPaginationFindByGroupId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByGroupId",
+			new String[] {Long.class.getName()}, new String[] {"groupId"},
+			true);
+
+		_finderPathCountByGroupId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByGroupId",
+			new String[] {Long.class.getName()}, new String[] {"groupId"},
+			false);
+
 		_collectionPersistenceFinderByGroupId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByGroupId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"groupId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByGroupId",
-					new String[] {Long.class.getName()},
-					new String[] {"groupId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByGroupId",
-					new String[] {Long.class.getName()},
-					new String[] {"groupId"}, false),
+				this, _finderPathWithPaginationFindByGroupId,
+				_finderPathWithoutPaginationFindByGroupId,
+				_finderPathCountByGroupId,
 				_SQL_SELECT_RECENTLAYOUTSETBRANCH_WHERE,
 				_SQL_COUNT_RECENTLAYOUTSETBRANCH_WHERE,
 				RecentLayoutSetBranchModelImpl.ORDER_BY_JPQL,
@@ -814,25 +828,28 @@ public class RecentLayoutSetBranchPersistenceImpl
 					"recentLayoutSetBranch.", "groupId", FinderColumn.Type.LONG,
 					"=", true, true, RecentLayoutSetBranch::getGroupId));
 
+		_finderPathWithPaginationFindByUserId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUserId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"userId"}, true);
+
+		_finderPathWithoutPaginationFindByUserId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUserId",
+			new String[] {Long.class.getName()}, new String[] {"userId"}, true);
+
+		_finderPathCountByUserId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUserId",
+			new String[] {Long.class.getName()}, new String[] {"userId"},
+			false);
+
 		_collectionPersistenceFinderByUserId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUserId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"userId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUserId",
-					new String[] {Long.class.getName()},
-					new String[] {"userId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUserId",
-					new String[] {Long.class.getName()},
-					new String[] {"userId"}, false),
+				this, _finderPathWithPaginationFindByUserId,
+				_finderPathWithoutPaginationFindByUserId,
+				_finderPathCountByUserId,
 				_SQL_SELECT_RECENTLAYOUTSETBRANCH_WHERE,
 				_SQL_COUNT_RECENTLAYOUTSETBRANCH_WHERE,
 				RecentLayoutSetBranchModelImpl.ORDER_BY_JPQL,
@@ -841,28 +858,29 @@ public class RecentLayoutSetBranchPersistenceImpl
 					"recentLayoutSetBranch.", "userId", FinderColumn.Type.LONG,
 					"=", true, true, RecentLayoutSetBranch::getUserId));
 
+		_finderPathWithPaginationFindByLayoutSetBranchId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByLayoutSetBranchId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"layoutSetBranchId"}, true);
+
+		_finderPathWithoutPaginationFindByLayoutSetBranchId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
+			"findByLayoutSetBranchId", new String[] {Long.class.getName()},
+			new String[] {"layoutSetBranchId"}, true);
+
+		_finderPathCountByLayoutSetBranchId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
+			"countByLayoutSetBranchId", new String[] {Long.class.getName()},
+			new String[] {"layoutSetBranchId"}, false);
+
 		_collectionPersistenceFinderByLayoutSetBranchId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION,
-					"findByLayoutSetBranchId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"layoutSetBranchId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"findByLayoutSetBranchId",
-					new String[] {Long.class.getName()},
-					new String[] {"layoutSetBranchId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByLayoutSetBranchId",
-					new String[] {Long.class.getName()},
-					new String[] {"layoutSetBranchId"}, false),
+				this, _finderPathWithPaginationFindByLayoutSetBranchId,
+				_finderPathWithoutPaginationFindByLayoutSetBranchId,
+				_finderPathCountByLayoutSetBranchId,
 				_SQL_SELECT_RECENTLAYOUTSETBRANCH_WHERE,
 				_SQL_COUNT_RECENTLAYOUTSETBRANCH_WHERE,
 				RecentLayoutSetBranchModelImpl.ORDER_BY_JPQL,
@@ -872,14 +890,15 @@ public class RecentLayoutSetBranchPersistenceImpl
 					FinderColumn.Type.LONG, "=", true, true,
 					RecentLayoutSetBranch::getLayoutSetBranchId));
 
+		_finderPathFetchByU_L = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByU_L",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"userId", "layoutSetId"}, 0, 0, false,
+			RecentLayoutSetBranch::getUserId,
+			RecentLayoutSetBranch::getLayoutSetId);
+
 		_uniquePersistenceFinderByU_L = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByU_L",
-				new String[] {Long.class.getName(), Long.class.getName()},
-				new String[] {"userId", "layoutSetId"}, 0, 0, false,
-				RecentLayoutSetBranch::getUserId,
-				RecentLayoutSetBranch::getLayoutSetId),
+			this, _finderPathFetchByU_L,
 			_SQL_SELECT_RECENTLAYOUTSETBRANCH_WHERE, "",
 			new FinderColumn<>(
 				"recentLayoutSetBranch.", "userId", FinderColumn.Type.LONG, "=",
@@ -921,4 +940,4 @@ public class RecentLayoutSetBranchPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-505009528
+// LIFERAY-SERVICE-BUILDER-HASH:2067927656

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/RegionLocalizationPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/RegionLocalizationPersistenceImpl.java
@@ -73,6 +73,9 @@ public class RegionLocalizationPersistenceImpl
 	public static final String FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION =
 		FINDER_CLASS_NAME_ENTITY + ".List2";
 
+	private FinderPath _finderPathWithPaginationFindByRegionId;
+	private FinderPath _finderPathWithoutPaginationFindByRegionId;
+	private FinderPath _finderPathCountByRegionId;
 	private CollectionPersistenceFinder<RegionLocalization>
 		_collectionPersistenceFinderByRegionId;
 
@@ -219,6 +222,7 @@ public class RegionLocalizationPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {regionId});
 	}
 
+	private FinderPath _finderPathFetchByRegionId_LanguageId;
 	private UniquePersistenceFinder<RegionLocalization>
 		_uniquePersistenceFinderByRegionId_LanguageId;
 
@@ -566,25 +570,29 @@ public class RegionLocalizationPersistenceImpl
 	 * Initializes the region localization persistence.
 	 */
 	public void afterPropertiesSet() {
+		_finderPathWithPaginationFindByRegionId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByRegionId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"regionId"}, true);
+
+		_finderPathWithoutPaginationFindByRegionId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByRegionId",
+			new String[] {Long.class.getName()}, new String[] {"regionId"},
+			true);
+
+		_finderPathCountByRegionId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByRegionId",
+			new String[] {Long.class.getName()}, new String[] {"regionId"},
+			false);
+
 		_collectionPersistenceFinderByRegionId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByRegionId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"regionId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByRegionId",
-					new String[] {Long.class.getName()},
-					new String[] {"regionId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByRegionId", new String[] {Long.class.getName()},
-					new String[] {"regionId"}, false),
+				this, _finderPathWithPaginationFindByRegionId,
+				_finderPathWithoutPaginationFindByRegionId,
+				_finderPathCountByRegionId,
 				_SQL_SELECT_REGIONLOCALIZATION_WHERE,
 				_SQL_COUNT_REGIONLOCALIZATION_WHERE,
 				RegionLocalizationModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
@@ -593,15 +601,16 @@ public class RegionLocalizationPersistenceImpl
 					"regionLocalization.", "regionId", FinderColumn.Type.LONG,
 					"=", true, true, RegionLocalization::getRegionId));
 
+		_finderPathFetchByRegionId_LanguageId = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByRegionId_LanguageId",
+			new String[] {Long.class.getName(), String.class.getName()},
+			new String[] {"regionId", "languageId"}, 0, 2, false,
+			RegionLocalization::getRegionId,
+			convertNullFunction(RegionLocalization::getLanguageId));
+
 		_uniquePersistenceFinderByRegionId_LanguageId =
 			new UniquePersistenceFinder<>(
-				this,
-				createUniqueFinderPath(
-					FINDER_CLASS_NAME_ENTITY, "fetchByRegionId_LanguageId",
-					new String[] {Long.class.getName(), String.class.getName()},
-					new String[] {"regionId", "languageId"}, 0, 2, false,
-					RegionLocalization::getRegionId,
-					convertNullFunction(RegionLocalization::getLanguageId)),
+				this, _finderPathFetchByRegionId_LanguageId,
 				_SQL_SELECT_REGIONLOCALIZATION_WHERE, "",
 				new FinderColumn<>(
 					"regionLocalization.", "regionId", FinderColumn.Type.LONG,
@@ -644,4 +653,4 @@ public class RegionLocalizationPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-563872121
+// LIFERAY-SERVICE-BUILDER-HASH:-1646866774

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/RegionPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/RegionPersistenceImpl.java
@@ -90,6 +90,9 @@ public class RegionPersistenceImpl
 	public static final String FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION =
 		FINDER_CLASS_NAME_ENTITY + ".List2";
 
+	private FinderPath _finderPathWithPaginationFindByUuid;
+	private FinderPath _finderPathWithoutPaginationFindByUuid;
+	private FinderPath _finderPathCountByUuid;
 	private CollectionPersistenceFinder<Region>
 		_collectionPersistenceFinderByUuid;
 
@@ -229,6 +232,9 @@ public class RegionPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {uuid});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByUuid_C;
+	private FinderPath _finderPathWithoutPaginationFindByUuid_C;
+	private FinderPath _finderPathCountByUuid_C;
 	private CollectionPersistenceFinder<Region>
 		_collectionPersistenceFinderByUuid_C;
 
@@ -382,6 +388,9 @@ public class RegionPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {uuid, companyId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByCountryId;
+	private FinderPath _finderPathWithoutPaginationFindByCountryId;
+	private FinderPath _finderPathCountByCountryId;
 	private CollectionPersistenceFinder<Region>
 		_collectionPersistenceFinderByCountryId;
 
@@ -522,6 +531,9 @@ public class RegionPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {countryId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByActive;
+	private FinderPath _finderPathWithoutPaginationFindByActive;
+	private FinderPath _finderPathCountByActive;
 	private CollectionPersistenceFinder<Region>
 		_collectionPersistenceFinderByActive;
 
@@ -661,6 +673,9 @@ public class RegionPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {active});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_A;
+	private FinderPath _finderPathWithoutPaginationFindByC_A;
+	private FinderPath _finderPathCountByC_A;
 	private CollectionPersistenceFinder<Region>
 		_collectionPersistenceFinderByC_A;
 
@@ -814,6 +829,7 @@ public class RegionPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {countryId, active});
 	}
 
+	private FinderPath _finderPathFetchByC_R;
 	private UniquePersistenceFinder<Region> _uniquePersistenceFinderByC_R;
 
 	/**
@@ -905,6 +921,7 @@ public class RegionPersistenceImpl
 			new Object[] {countryId, regionCode});
 	}
 
+	private FinderPath _finderPathFetchByERC_C;
 	private UniquePersistenceFinder<Region> _uniquePersistenceFinderByERC_C;
 
 	/**
@@ -1351,50 +1368,59 @@ public class RegionPersistenceImpl
 	 * Initializes the region persistence.
 	 */
 	public void afterPropertiesSet() {
+		_finderPathWithPaginationFindByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid",
+			new String[] {
+				String.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"uuid_"}, true);
+
+		_finderPathWithoutPaginationFindByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid",
+			new String[] {String.class.getName()}, new String[] {"uuid_"}, 0, 1,
+			true, null);
+
+		_finderPathCountByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid",
+			new String[] {String.class.getName()}, new String[] {"uuid_"}, 0, 1,
+			false, null);
+
 		_collectionPersistenceFinderByUuid = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid",
-				new String[] {
-					String.class.getName(), Integer.class.getName(),
-					Integer.class.getName(), OrderByComparator.class.getName()
-				},
-				new String[] {"uuid_"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid",
-				new String[] {String.class.getName()}, new String[] {"uuid_"},
-				0, 1, true, null),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid",
-				new String[] {String.class.getName()}, new String[] {"uuid_"},
-				0, 1, false, null),
+			this, _finderPathWithPaginationFindByUuid,
+			_finderPathWithoutPaginationFindByUuid, _finderPathCountByUuid,
 			_SQL_SELECT_REGION_WHERE, _SQL_COUNT_REGION_WHERE,
 			RegionModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
 				"region.", "uuid", FinderColumn.Type.STRING, "=", true, true,
 				Region::getUuid));
 
+		_finderPathWithPaginationFindByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid_C",
+			new String[] {
+				String.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"uuid_", "companyId"}, true);
+
+		_finderPathWithoutPaginationFindByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"uuid_", "companyId"}, 0, 1, true, null);
+
+		_finderPathCountByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"uuid_", "companyId"}, 0, 1, false, null);
+
 		_collectionPersistenceFinderByUuid_C =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid_C",
-					new String[] {
-						String.class.getName(), Long.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"uuid_", "companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid_C",
-					new String[] {String.class.getName(), Long.class.getName()},
-					new String[] {"uuid_", "companyId"}, 0, 1, true, null),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid_C",
-					new String[] {String.class.getName(), Long.class.getName()},
-					new String[] {"uuid_", "companyId"}, 0, 1, false, null),
-				_SQL_SELECT_REGION_WHERE, _SQL_COUNT_REGION_WHERE,
-				RegionModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+				this, _finderPathWithPaginationFindByUuid_C,
+				_finderPathWithoutPaginationFindByUuid_C,
+				_finderPathCountByUuid_C, _SQL_SELECT_REGION_WHERE,
+				_SQL_COUNT_REGION_WHERE, RegionModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
 					"region.", "uuid", FinderColumn.Type.STRING, "=", true,
 					true, Region::getUuid),
@@ -1402,74 +1428,86 @@ public class RegionPersistenceImpl
 					"region.", "companyId", FinderColumn.Type.LONG, "=", true,
 					true, Region::getCompanyId));
 
+		_finderPathWithPaginationFindByCountryId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByCountryId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"countryId"}, true);
+
+		_finderPathWithoutPaginationFindByCountryId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByCountryId",
+			new String[] {Long.class.getName()}, new String[] {"countryId"},
+			true);
+
+		_finderPathCountByCountryId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByCountryId",
+			new String[] {Long.class.getName()}, new String[] {"countryId"},
+			false);
+
 		_collectionPersistenceFinderByCountryId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByCountryId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"countryId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"findByCountryId", new String[] {Long.class.getName()},
-					new String[] {"countryId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByCountryId", new String[] {Long.class.getName()},
-					new String[] {"countryId"}, false),
-				_SQL_SELECT_REGION_WHERE, _SQL_COUNT_REGION_WHERE,
-				RegionModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+				this, _finderPathWithPaginationFindByCountryId,
+				_finderPathWithoutPaginationFindByCountryId,
+				_finderPathCountByCountryId, _SQL_SELECT_REGION_WHERE,
+				_SQL_COUNT_REGION_WHERE, RegionModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
 					"region.", "countryId", FinderColumn.Type.LONG, "=", true,
 					true, Region::getCountryId));
 
+		_finderPathWithPaginationFindByActive = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByActive",
+			new String[] {
+				Boolean.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"active_"}, true);
+
+		_finderPathWithoutPaginationFindByActive = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByActive",
+			new String[] {Boolean.class.getName()}, new String[] {"active_"},
+			true);
+
+		_finderPathCountByActive = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByActive",
+			new String[] {Boolean.class.getName()}, new String[] {"active_"},
+			false);
+
 		_collectionPersistenceFinderByActive =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByActive",
-					new String[] {
-						Boolean.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"active_"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByActive",
-					new String[] {Boolean.class.getName()},
-					new String[] {"active_"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByActive",
-					new String[] {Boolean.class.getName()},
-					new String[] {"active_"}, false),
-				_SQL_SELECT_REGION_WHERE, _SQL_COUNT_REGION_WHERE,
-				RegionModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+				this, _finderPathWithPaginationFindByActive,
+				_finderPathWithoutPaginationFindByActive,
+				_finderPathCountByActive, _SQL_SELECT_REGION_WHERE,
+				_SQL_COUNT_REGION_WHERE, RegionModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
 					"region.", "active", FinderColumn.Type.BOOLEAN, "=", true,
 					true, Region::isActive));
 
+		_finderPathWithPaginationFindByC_A = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_A",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"countryId", "active_"}, true);
+
+		_finderPathWithoutPaginationFindByC_A = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_A",
+			new String[] {Long.class.getName(), Boolean.class.getName()},
+			new String[] {"countryId", "active_"}, true);
+
+		_finderPathCountByC_A = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_A",
+			new String[] {Long.class.getName(), Boolean.class.getName()},
+			new String[] {"countryId", "active_"}, false);
+
 		_collectionPersistenceFinderByC_A = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_A",
-				new String[] {
-					Long.class.getName(), Boolean.class.getName(),
-					Integer.class.getName(), Integer.class.getName(),
-					OrderByComparator.class.getName()
-				},
-				new String[] {"countryId", "active_"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_A",
-				new String[] {Long.class.getName(), Boolean.class.getName()},
-				new String[] {"countryId", "active_"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_A",
-				new String[] {Long.class.getName(), Boolean.class.getName()},
-				new String[] {"countryId", "active_"}, false),
+			this, _finderPathWithPaginationFindByC_A,
+			_finderPathWithoutPaginationFindByC_A, _finderPathCountByC_A,
 			_SQL_SELECT_REGION_WHERE, _SQL_COUNT_REGION_WHERE,
 			RegionModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
@@ -1479,15 +1517,14 @@ public class RegionPersistenceImpl
 				"region.", "active", FinderColumn.Type.BOOLEAN, "=", true, true,
 				Region::isActive));
 
+		_finderPathFetchByC_R = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByC_R",
+			new String[] {Long.class.getName(), String.class.getName()},
+			new String[] {"countryId", "regionCode"}, 0, 2, false,
+			Region::getCountryId, convertNullFunction(Region::getRegionCode));
+
 		_uniquePersistenceFinderByC_R = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByC_R",
-				new String[] {Long.class.getName(), String.class.getName()},
-				new String[] {"countryId", "regionCode"}, 0, 2, false,
-				Region::getCountryId,
-				convertNullFunction(Region::getRegionCode)),
-			_SQL_SELECT_REGION_WHERE, "",
+			this, _finderPathFetchByC_R, _SQL_SELECT_REGION_WHERE, "",
 			new FinderColumn<>(
 				"region.", "countryId", FinderColumn.Type.LONG, "=", true, true,
 				Region::getCountryId),
@@ -1495,15 +1532,15 @@ public class RegionPersistenceImpl
 				"region.", "regionCode", FinderColumn.Type.STRING, "=", true,
 				true, Region::getRegionCode));
 
+		_finderPathFetchByERC_C = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByERC_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "companyId"}, 0, 1, false,
+			convertNullFunction(Region::getExternalReferenceCode),
+			Region::getCompanyId);
+
 		_uniquePersistenceFinderByERC_C = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByERC_C",
-				new String[] {String.class.getName(), Long.class.getName()},
-				new String[] {"externalReferenceCode", "companyId"}, 0, 1,
-				false, convertNullFunction(Region::getExternalReferenceCode),
-				Region::getCompanyId),
-			_SQL_SELECT_REGION_WHERE, "",
+			this, _finderPathFetchByERC_C, _SQL_SELECT_REGION_WHERE, "",
 			new FinderColumn<>(
 				"region.", "externalReferenceCode", FinderColumn.Type.STRING,
 				"=", true, true, Region::getExternalReferenceCode),
@@ -1550,4 +1587,4 @@ public class RegionPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1328168825
+// LIFERAY-SERVICE-BUILDER-HASH:1397189621

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/ReleasePersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/ReleasePersistenceImpl.java
@@ -9,6 +9,7 @@ import com.liferay.portal.kernel.dao.orm.EntityCache;
 import com.liferay.portal.kernel.dao.orm.EntityCacheUtil;
 import com.liferay.portal.kernel.dao.orm.FinderCache;
 import com.liferay.portal.kernel.dao.orm.FinderCacheUtil;
+import com.liferay.portal.kernel.dao.orm.FinderPath;
 import com.liferay.portal.kernel.dao.orm.Session;
 import com.liferay.portal.kernel.exception.NoSuchReleaseException;
 import com.liferay.portal.kernel.log.Log;
@@ -64,6 +65,7 @@ public class ReleasePersistenceImpl
 	public static final String FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION =
 		FINDER_CLASS_NAME_ENTITY + ".List2";
 
+	private FinderPath _finderPathFetchByServletContextName;
 	private UniquePersistenceFinder<Release>
 		_uniquePersistenceFinderByServletContextName;
 
@@ -354,14 +356,15 @@ public class ReleasePersistenceImpl
 	 * Initializes the release persistence.
 	 */
 	public void afterPropertiesSet() {
+		_finderPathFetchByServletContextName = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByServletContextName",
+			new String[] {String.class.getName()},
+			new String[] {"servletContextName"}, 1, 1, true,
+			convertCaseFunction(Release::getServletContextName));
+
 		_uniquePersistenceFinderByServletContextName =
 			new UniquePersistenceFinder<>(
-				this,
-				createUniqueFinderPath(
-					FINDER_CLASS_NAME_ENTITY, "fetchByServletContextName",
-					new String[] {String.class.getName()},
-					new String[] {"servletContextName"}, 1, 1, true,
-					convertCaseFunction(Release::getServletContextName)),
+				this, _finderPathFetchByServletContextName,
 				_SQL_SELECT_RELEASE__WHERE, "",
 				new FinderColumn<>(
 					"release_.", "servletContextName", FinderColumn.Type.STRING,
@@ -397,4 +400,4 @@ public class ReleasePersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1075947250
+// LIFERAY-SERVICE-BUILDER-HASH:1335640256

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/RememberMeTokenPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/RememberMeTokenPersistenceImpl.java
@@ -64,6 +64,9 @@ public class RememberMeTokenPersistenceImpl
 	public static final String FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION =
 		FINDER_CLASS_NAME_ENTITY + ".List2";
 
+	private FinderPath _finderPathWithPaginationFindByUserId;
+	private FinderPath _finderPathWithoutPaginationFindByUserId;
+	private FinderPath _finderPathCountByUserId;
 	private CollectionPersistenceFinder<RememberMeToken>
 		_collectionPersistenceFinderByUserId;
 
@@ -205,6 +208,8 @@ public class RememberMeTokenPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {userId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByLteExpirationDate;
+	private FinderPath _finderPathWithPaginationCountByLteExpirationDate;
 	private CollectionPersistenceFinder<RememberMeToken>
 		_collectionPersistenceFinderByLteExpirationDate;
 
@@ -544,26 +549,28 @@ public class RememberMeTokenPersistenceImpl
 	 * Initializes the remember me token persistence.
 	 */
 	public void afterPropertiesSet() {
+		_finderPathWithPaginationFindByUserId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUserId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"userId"}, true);
+
+		_finderPathWithoutPaginationFindByUserId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUserId",
+			new String[] {Long.class.getName()}, new String[] {"userId"}, true);
+
+		_finderPathCountByUserId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUserId",
+			new String[] {Long.class.getName()}, new String[] {"userId"},
+			false);
+
 		_collectionPersistenceFinderByUserId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUserId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"userId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUserId",
-					new String[] {Long.class.getName()},
-					new String[] {"userId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUserId",
-					new String[] {Long.class.getName()},
-					new String[] {"userId"}, false),
-				_SQL_SELECT_REMEMBERMETOKEN_WHERE,
+				this, _finderPathWithPaginationFindByUserId,
+				_finderPathWithoutPaginationFindByUserId,
+				_finderPathCountByUserId, _SQL_SELECT_REMEMBERMETOKEN_WHERE,
 				_SQL_COUNT_REMEMBERMETOKEN_WHERE,
 				RememberMeTokenModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
 				"",
@@ -571,24 +578,23 @@ public class RememberMeTokenPersistenceImpl
 					"rememberMeToken.", "userId", FinderColumn.Type.LONG, "=",
 					true, true, RememberMeToken::getUserId));
 
+		_finderPathWithPaginationFindByLteExpirationDate = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByLteExpirationDate",
+			new String[] {
+				Date.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"expirationDate"}, true);
+
+		_finderPathWithPaginationCountByLteExpirationDate = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByLteExpirationDate",
+			new String[] {Date.class.getName()},
+			new String[] {"expirationDate"}, false);
+
 		_collectionPersistenceFinderByLteExpirationDate =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION,
-					"findByLteExpirationDate",
-					new String[] {
-						Date.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"expirationDate"}, true),
-				null,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION,
-					"countByLteExpirationDate",
-					new String[] {Date.class.getName()},
-					new String[] {"expirationDate"}, false),
+				this, _finderPathWithPaginationFindByLteExpirationDate, null,
+				_finderPathWithPaginationCountByLteExpirationDate,
 				_SQL_SELECT_REMEMBERMETOKEN_WHERE,
 				_SQL_COUNT_REMEMBERMETOKEN_WHERE,
 				RememberMeTokenModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
@@ -628,4 +634,4 @@ public class RememberMeTokenPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:443431796
+// LIFERAY-SERVICE-BUILDER-HASH:-965181493

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/RepositoryEntryPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/RepositoryEntryPersistenceImpl.java
@@ -79,6 +79,9 @@ public class RepositoryEntryPersistenceImpl
 	public static final String FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION =
 		FINDER_CLASS_NAME_ENTITY + ".List2";
 
+	private FinderPath _finderPathWithPaginationFindByUuid;
+	private FinderPath _finderPathWithoutPaginationFindByUuid;
+	private FinderPath _finderPathCountByUuid;
 	private CollectionPersistenceFinder<RepositoryEntry>
 		_collectionPersistenceFinderByUuid;
 
@@ -220,6 +223,7 @@ public class RepositoryEntryPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {uuid});
 	}
 
+	private FinderPath _finderPathFetchByUUID_G;
 	private UniquePersistenceFinder<RepositoryEntry>
 		_uniquePersistenceFinderByUUID_G;
 
@@ -310,6 +314,9 @@ public class RepositoryEntryPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {uuid, groupId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByUuid_C;
+	private FinderPath _finderPathWithoutPaginationFindByUuid_C;
+	private FinderPath _finderPathCountByUuid_C;
 	private CollectionPersistenceFinder<RepositoryEntry>
 		_collectionPersistenceFinderByUuid_C;
 
@@ -465,6 +472,9 @@ public class RepositoryEntryPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {uuid, companyId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByRepositoryId;
+	private FinderPath _finderPathWithoutPaginationFindByRepositoryId;
+	private FinderPath _finderPathCountByRepositoryId;
 	private CollectionPersistenceFinder<RepositoryEntry>
 		_collectionPersistenceFinderByRepositoryId;
 
@@ -612,6 +622,7 @@ public class RepositoryEntryPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {repositoryId});
 	}
 
+	private FinderPath _finderPathFetchByR_M;
 	private UniquePersistenceFinder<RepositoryEntry>
 		_uniquePersistenceFinderByR_M;
 
@@ -1006,38 +1017,43 @@ public class RepositoryEntryPersistenceImpl
 	 * Initializes the repository entry persistence.
 	 */
 	public void afterPropertiesSet() {
+		_finderPathWithPaginationFindByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid",
+			new String[] {
+				String.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"uuid_"}, true);
+
+		_finderPathWithoutPaginationFindByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid",
+			new String[] {String.class.getName()}, new String[] {"uuid_"}, 0, 1,
+			true, null);
+
+		_finderPathCountByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid",
+			new String[] {String.class.getName()}, new String[] {"uuid_"}, 0, 1,
+			false, null);
+
 		_collectionPersistenceFinderByUuid = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid",
-				new String[] {
-					String.class.getName(), Integer.class.getName(),
-					Integer.class.getName(), OrderByComparator.class.getName()
-				},
-				new String[] {"uuid_"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid",
-				new String[] {String.class.getName()}, new String[] {"uuid_"},
-				0, 1, true, null),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid",
-				new String[] {String.class.getName()}, new String[] {"uuid_"},
-				0, 1, false, null),
+			this, _finderPathWithPaginationFindByUuid,
+			_finderPathWithoutPaginationFindByUuid, _finderPathCountByUuid,
 			_SQL_SELECT_REPOSITORYENTRY_WHERE, _SQL_COUNT_REPOSITORYENTRY_WHERE,
 			RepositoryEntryModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
 				"repositoryEntry.", "uuid", FinderColumn.Type.STRING, "=", true,
 				true, RepositoryEntry::getUuid));
 
+		_finderPathFetchByUUID_G = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByUUID_G",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"uuid_", "groupId"}, 0, 1, false,
+			convertNullFunction(RepositoryEntry::getUuid),
+			RepositoryEntry::getGroupId);
+
 		_uniquePersistenceFinderByUUID_G = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByUUID_G",
-				new String[] {String.class.getName(), Long.class.getName()},
-				new String[] {"uuid_", "groupId"}, 0, 1, false,
-				convertNullFunction(RepositoryEntry::getUuid),
-				RepositoryEntry::getGroupId),
-			_SQL_SELECT_REPOSITORYENTRY_WHERE, "",
+			this, _finderPathFetchByUUID_G, _SQL_SELECT_REPOSITORYENTRY_WHERE,
+			"",
 			new FinderColumn<>(
 				"repositoryEntry.", "uuid", FinderColumn.Type.STRING, "=", true,
 				true, RepositoryEntry::getUuid),
@@ -1045,26 +1061,30 @@ public class RepositoryEntryPersistenceImpl
 				"repositoryEntry.", "groupId", FinderColumn.Type.LONG, "=",
 				true, true, RepositoryEntry::getGroupId));
 
+		_finderPathWithPaginationFindByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid_C",
+			new String[] {
+				String.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"uuid_", "companyId"}, true);
+
+		_finderPathWithoutPaginationFindByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"uuid_", "companyId"}, 0, 1, true, null);
+
+		_finderPathCountByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"uuid_", "companyId"}, 0, 1, false, null);
+
 		_collectionPersistenceFinderByUuid_C =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid_C",
-					new String[] {
-						String.class.getName(), Long.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"uuid_", "companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid_C",
-					new String[] {String.class.getName(), Long.class.getName()},
-					new String[] {"uuid_", "companyId"}, 0, 1, true, null),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid_C",
-					new String[] {String.class.getName(), Long.class.getName()},
-					new String[] {"uuid_", "companyId"}, 0, 1, false, null),
-				_SQL_SELECT_REPOSITORYENTRY_WHERE,
+				this, _finderPathWithPaginationFindByUuid_C,
+				_finderPathWithoutPaginationFindByUuid_C,
+				_finderPathCountByUuid_C, _SQL_SELECT_REPOSITORYENTRY_WHERE,
 				_SQL_COUNT_REPOSITORYENTRY_WHERE,
 				RepositoryEntryModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
 				"",
@@ -1075,26 +1095,29 @@ public class RepositoryEntryPersistenceImpl
 					"repositoryEntry.", "companyId", FinderColumn.Type.LONG,
 					"=", true, true, RepositoryEntry::getCompanyId));
 
+		_finderPathWithPaginationFindByRepositoryId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByRepositoryId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"repositoryId"}, true);
+
+		_finderPathWithoutPaginationFindByRepositoryId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByRepositoryId",
+			new String[] {Long.class.getName()}, new String[] {"repositoryId"},
+			true);
+
+		_finderPathCountByRepositoryId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByRepositoryId",
+			new String[] {Long.class.getName()}, new String[] {"repositoryId"},
+			false);
+
 		_collectionPersistenceFinderByRepositoryId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION,
-					"findByRepositoryId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"repositoryId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"findByRepositoryId", new String[] {Long.class.getName()},
-					new String[] {"repositoryId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByRepositoryId", new String[] {Long.class.getName()},
-					new String[] {"repositoryId"}, false),
+				this, _finderPathWithPaginationFindByRepositoryId,
+				_finderPathWithoutPaginationFindByRepositoryId,
+				_finderPathCountByRepositoryId,
 				_SQL_SELECT_REPOSITORYENTRY_WHERE,
 				_SQL_COUNT_REPOSITORYENTRY_WHERE,
 				RepositoryEntryModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
@@ -1103,15 +1126,15 @@ public class RepositoryEntryPersistenceImpl
 					"repositoryEntry.", "repositoryId", FinderColumn.Type.LONG,
 					"=", true, true, RepositoryEntry::getRepositoryId));
 
+		_finderPathFetchByR_M = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByR_M",
+			new String[] {Long.class.getName(), String.class.getName()},
+			new String[] {"repositoryId", "mappedId"}, 0, 2, false,
+			RepositoryEntry::getRepositoryId,
+			convertNullFunction(RepositoryEntry::getMappedId));
+
 		_uniquePersistenceFinderByR_M = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByR_M",
-				new String[] {Long.class.getName(), String.class.getName()},
-				new String[] {"repositoryId", "mappedId"}, 0, 2, false,
-				RepositoryEntry::getRepositoryId,
-				convertNullFunction(RepositoryEntry::getMappedId)),
-			_SQL_SELECT_REPOSITORYENTRY_WHERE, "",
+			this, _finderPathFetchByR_M, _SQL_SELECT_REPOSITORYENTRY_WHERE, "",
 			new FinderColumn<>(
 				"repositoryEntry.", "repositoryId", FinderColumn.Type.LONG, "=",
 				true, true, RepositoryEntry::getRepositoryId),
@@ -1155,4 +1178,4 @@ public class RepositoryEntryPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1893838310
+// LIFERAY-SERVICE-BUILDER-HASH:-812939119

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/RepositoryPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/RepositoryPersistenceImpl.java
@@ -88,6 +88,9 @@ public class RepositoryPersistenceImpl
 	public static final String FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION =
 		FINDER_CLASS_NAME_ENTITY + ".List2";
 
+	private FinderPath _finderPathWithPaginationFindByUuid;
+	private FinderPath _finderPathWithoutPaginationFindByUuid;
+	private FinderPath _finderPathCountByUuid;
 	private CollectionPersistenceFinder<Repository>
 		_collectionPersistenceFinderByUuid;
 
@@ -228,6 +231,7 @@ public class RepositoryPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {uuid});
 	}
 
+	private FinderPath _finderPathFetchByUUID_G;
 	private UniquePersistenceFinder<Repository>
 		_uniquePersistenceFinderByUUID_G;
 
@@ -318,6 +322,9 @@ public class RepositoryPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {uuid, groupId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByUuid_C;
+	private FinderPath _finderPathWithoutPaginationFindByUuid_C;
+	private FinderPath _finderPathCountByUuid_C;
 	private CollectionPersistenceFinder<Repository>
 		_collectionPersistenceFinderByUuid_C;
 
@@ -473,6 +480,9 @@ public class RepositoryPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {uuid, companyId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByGroupId;
+	private FinderPath _finderPathWithoutPaginationFindByGroupId;
+	private FinderPath _finderPathCountByGroupId;
 	private CollectionPersistenceFinder<Repository>
 		_collectionPersistenceFinderByGroupId;
 
@@ -615,6 +625,9 @@ public class RepositoryPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {groupId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByPortletId;
+	private FinderPath _finderPathWithoutPaginationFindByPortletId;
+	private FinderPath _finderPathCountByPortletId;
 	private CollectionPersistenceFinder<Repository>
 		_collectionPersistenceFinderByPortletId;
 
@@ -759,6 +772,7 @@ public class RepositoryPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {portletId});
 	}
 
+	private FinderPath _finderPathFetchByG_N_P;
 	private UniquePersistenceFinder<Repository> _uniquePersistenceFinderByG_N_P;
 
 	/**
@@ -857,6 +871,7 @@ public class RepositoryPersistenceImpl
 			new Object[] {groupId, name, portletId});
 	}
 
+	private FinderPath _finderPathFetchByERC_G;
 	private UniquePersistenceFinder<Repository> _uniquePersistenceFinderByERC_G;
 
 	/**
@@ -1313,38 +1328,41 @@ public class RepositoryPersistenceImpl
 	 * Initializes the repository persistence.
 	 */
 	public void afterPropertiesSet() {
+		_finderPathWithPaginationFindByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid",
+			new String[] {
+				String.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"uuid_"}, true);
+
+		_finderPathWithoutPaginationFindByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid",
+			new String[] {String.class.getName()}, new String[] {"uuid_"}, 0, 1,
+			true, null);
+
+		_finderPathCountByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid",
+			new String[] {String.class.getName()}, new String[] {"uuid_"}, 0, 1,
+			false, null);
+
 		_collectionPersistenceFinderByUuid = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid",
-				new String[] {
-					String.class.getName(), Integer.class.getName(),
-					Integer.class.getName(), OrderByComparator.class.getName()
-				},
-				new String[] {"uuid_"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid",
-				new String[] {String.class.getName()}, new String[] {"uuid_"},
-				0, 1, true, null),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid",
-				new String[] {String.class.getName()}, new String[] {"uuid_"},
-				0, 1, false, null),
+			this, _finderPathWithPaginationFindByUuid,
+			_finderPathWithoutPaginationFindByUuid, _finderPathCountByUuid,
 			_SQL_SELECT_REPOSITORY_WHERE, _SQL_COUNT_REPOSITORY_WHERE,
 			RepositoryModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
 				"repository.", "uuid", FinderColumn.Type.STRING, "=", true,
 				true, Repository::getUuid));
 
+		_finderPathFetchByUUID_G = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByUUID_G",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"uuid_", "groupId"}, 0, 1, false,
+			convertNullFunction(Repository::getUuid), Repository::getGroupId);
+
 		_uniquePersistenceFinderByUUID_G = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByUUID_G",
-				new String[] {String.class.getName(), Long.class.getName()},
-				new String[] {"uuid_", "groupId"}, 0, 1, false,
-				convertNullFunction(Repository::getUuid),
-				Repository::getGroupId),
-			_SQL_SELECT_REPOSITORY_WHERE, "",
+			this, _finderPathFetchByUUID_G, _SQL_SELECT_REPOSITORY_WHERE, "",
 			new FinderColumn<>(
 				"repository.", "uuid", FinderColumn.Type.STRING, "=", true,
 				true, Repository::getUuid),
@@ -1352,27 +1370,32 @@ public class RepositoryPersistenceImpl
 				"repository.", "groupId", FinderColumn.Type.LONG, "=", true,
 				true, Repository::getGroupId));
 
+		_finderPathWithPaginationFindByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid_C",
+			new String[] {
+				String.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"uuid_", "companyId"}, true);
+
+		_finderPathWithoutPaginationFindByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"uuid_", "companyId"}, 0, 1, true, null);
+
+		_finderPathCountByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"uuid_", "companyId"}, 0, 1, false, null);
+
 		_collectionPersistenceFinderByUuid_C =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid_C",
-					new String[] {
-						String.class.getName(), Long.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"uuid_", "companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid_C",
-					new String[] {String.class.getName(), Long.class.getName()},
-					new String[] {"uuid_", "companyId"}, 0, 1, true, null),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid_C",
-					new String[] {String.class.getName(), Long.class.getName()},
-					new String[] {"uuid_", "companyId"}, 0, 1, false, null),
-				_SQL_SELECT_REPOSITORY_WHERE, _SQL_COUNT_REPOSITORY_WHERE,
-				RepositoryModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+				this, _finderPathWithPaginationFindByUuid_C,
+				_finderPathWithoutPaginationFindByUuid_C,
+				_finderPathCountByUuid_C, _SQL_SELECT_REPOSITORY_WHERE,
+				_SQL_COUNT_REPOSITORY_WHERE, RepositoryModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
 					"repository.", "uuid", FinderColumn.Type.STRING, "=", true,
 					true, Repository::getUuid),
@@ -1380,69 +1403,76 @@ public class RepositoryPersistenceImpl
 					"repository.", "companyId", FinderColumn.Type.LONG, "=",
 					true, true, Repository::getCompanyId));
 
+		_finderPathWithPaginationFindByGroupId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByGroupId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"groupId"}, true);
+
+		_finderPathWithoutPaginationFindByGroupId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByGroupId",
+			new String[] {Long.class.getName()}, new String[] {"groupId"},
+			true);
+
+		_finderPathCountByGroupId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByGroupId",
+			new String[] {Long.class.getName()}, new String[] {"groupId"},
+			false);
+
 		_collectionPersistenceFinderByGroupId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByGroupId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"groupId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByGroupId",
-					new String[] {Long.class.getName()},
-					new String[] {"groupId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByGroupId",
-					new String[] {Long.class.getName()},
-					new String[] {"groupId"}, false),
-				_SQL_SELECT_REPOSITORY_WHERE, _SQL_COUNT_REPOSITORY_WHERE,
-				RepositoryModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+				this, _finderPathWithPaginationFindByGroupId,
+				_finderPathWithoutPaginationFindByGroupId,
+				_finderPathCountByGroupId, _SQL_SELECT_REPOSITORY_WHERE,
+				_SQL_COUNT_REPOSITORY_WHERE, RepositoryModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
 					"repository.", "groupId", FinderColumn.Type.LONG, "=", true,
 					true, Repository::getGroupId));
 
+		_finderPathWithPaginationFindByPortletId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByPortletId",
+			new String[] {
+				String.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"portletId"}, true);
+
+		_finderPathWithoutPaginationFindByPortletId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByPortletId",
+			new String[] {String.class.getName()}, new String[] {"portletId"},
+			0, 1, true, null);
+
+		_finderPathCountByPortletId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByPortletId",
+			new String[] {String.class.getName()}, new String[] {"portletId"},
+			0, 1, false, null);
+
 		_collectionPersistenceFinderByPortletId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByPortletId",
-					new String[] {
-						String.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"portletId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"findByPortletId", new String[] {String.class.getName()},
-					new String[] {"portletId"}, 0, 1, true, null),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByPortletId", new String[] {String.class.getName()},
-					new String[] {"portletId"}, 0, 1, false, null),
-				_SQL_SELECT_REPOSITORY_WHERE, _SQL_COUNT_REPOSITORY_WHERE,
-				RepositoryModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+				this, _finderPathWithPaginationFindByPortletId,
+				_finderPathWithoutPaginationFindByPortletId,
+				_finderPathCountByPortletId, _SQL_SELECT_REPOSITORY_WHERE,
+				_SQL_COUNT_REPOSITORY_WHERE, RepositoryModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
 					"repository.", "portletId", FinderColumn.Type.STRING, "=",
 					true, true, Repository::getPortletId));
 
+		_finderPathFetchByG_N_P = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByG_N_P",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				String.class.getName()
+			},
+			new String[] {"groupId", "name", "portletId"}, 0, 6, false,
+			Repository::getGroupId, convertNullFunction(Repository::getName),
+			convertNullFunction(Repository::getPortletId));
+
 		_uniquePersistenceFinderByG_N_P = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByG_N_P",
-				new String[] {
-					Long.class.getName(), String.class.getName(),
-					String.class.getName()
-				},
-				new String[] {"groupId", "name", "portletId"}, 0, 6, false,
-				Repository::getGroupId,
-				convertNullFunction(Repository::getName),
-				convertNullFunction(Repository::getPortletId)),
-			_SQL_SELECT_REPOSITORY_WHERE, "",
+			this, _finderPathFetchByG_N_P, _SQL_SELECT_REPOSITORY_WHERE, "",
 			new FinderColumn<>(
 				"repository.", "groupId", FinderColumn.Type.LONG, "=", true,
 				true, Repository::getGroupId),
@@ -1453,15 +1483,15 @@ public class RepositoryPersistenceImpl
 				"repository.", "portletId", FinderColumn.Type.STRING, "=", true,
 				true, Repository::getPortletId));
 
+		_finderPathFetchByERC_G = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByERC_G",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "groupId"}, 0, 1, false,
+			convertNullFunction(Repository::getExternalReferenceCode),
+			Repository::getGroupId);
+
 		_uniquePersistenceFinderByERC_G = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByERC_G",
-				new String[] {String.class.getName(), Long.class.getName()},
-				new String[] {"externalReferenceCode", "groupId"}, 0, 1, false,
-				convertNullFunction(Repository::getExternalReferenceCode),
-				Repository::getGroupId),
-			_SQL_SELECT_REPOSITORY_WHERE, "",
+			this, _finderPathFetchByERC_G, _SQL_SELECT_REPOSITORY_WHERE, "",
 			new FinderColumn<>(
 				"repository.", "externalReferenceCode",
 				FinderColumn.Type.STRING, "=", true, true,
@@ -1506,4 +1536,4 @@ public class RepositoryPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1075284726
+// LIFERAY-SERVICE-BUILDER-HASH:2103685513

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/ResourceActionPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/ResourceActionPersistenceImpl.java
@@ -63,6 +63,9 @@ public class ResourceActionPersistenceImpl
 	public static final String FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION =
 		FINDER_CLASS_NAME_ENTITY + ".List2";
 
+	private FinderPath _finderPathWithPaginationFindByName;
+	private FinderPath _finderPathWithoutPaginationFindByName;
+	private FinderPath _finderPathCountByName;
 	private CollectionPersistenceFinder<ResourceAction>
 		_collectionPersistenceFinderByName;
 
@@ -204,6 +207,7 @@ public class ResourceActionPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {name});
 	}
 
+	private FinderPath _finderPathFetchByN_A;
 	private UniquePersistenceFinder<ResourceAction>
 		_uniquePersistenceFinderByN_A;
 
@@ -467,38 +471,42 @@ public class ResourceActionPersistenceImpl
 	 * Initializes the resource action persistence.
 	 */
 	public void afterPropertiesSet() {
+		_finderPathWithPaginationFindByName = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByName",
+			new String[] {
+				String.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"name"}, true);
+
+		_finderPathWithoutPaginationFindByName = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByName",
+			new String[] {String.class.getName()}, new String[] {"name"}, 0, 1,
+			true, null);
+
+		_finderPathCountByName = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByName",
+			new String[] {String.class.getName()}, new String[] {"name"}, 0, 1,
+			false, null);
+
 		_collectionPersistenceFinderByName = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByName",
-				new String[] {
-					String.class.getName(), Integer.class.getName(),
-					Integer.class.getName(), OrderByComparator.class.getName()
-				},
-				new String[] {"name"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByName",
-				new String[] {String.class.getName()}, new String[] {"name"}, 0,
-				1, true, null),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByName",
-				new String[] {String.class.getName()}, new String[] {"name"}, 0,
-				1, false, null),
+			this, _finderPathWithPaginationFindByName,
+			_finderPathWithoutPaginationFindByName, _finderPathCountByName,
 			_SQL_SELECT_RESOURCEACTION_WHERE, _SQL_COUNT_RESOURCEACTION_WHERE,
 			ResourceActionModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
 				"resourceAction.", "name", FinderColumn.Type.STRING, "=", true,
 				true, ResourceAction::getName));
 
+		_finderPathFetchByN_A = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByN_A",
+			new String[] {String.class.getName(), String.class.getName()},
+			new String[] {"name", "actionId"}, 0, 3, false,
+			convertNullFunction(ResourceAction::getName),
+			convertNullFunction(ResourceAction::getActionId));
+
 		_uniquePersistenceFinderByN_A = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByN_A",
-				new String[] {String.class.getName(), String.class.getName()},
-				new String[] {"name", "actionId"}, 0, 3, false,
-				convertNullFunction(ResourceAction::getName),
-				convertNullFunction(ResourceAction::getActionId)),
-			_SQL_SELECT_RESOURCEACTION_WHERE, "",
+			this, _finderPathFetchByN_A, _SQL_SELECT_RESOURCEACTION_WHERE, "",
 			new FinderColumn<>(
 				"resourceAction.", "name", FinderColumn.Type.STRING, "=", true,
 				true, ResourceAction::getName),
@@ -539,4 +547,4 @@ public class ResourceActionPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-413759394
+// LIFERAY-SERVICE-BUILDER-HASH:-1401545808

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/ResourcePermissionPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/ResourcePermissionPersistenceImpl.java
@@ -80,6 +80,9 @@ public class ResourcePermissionPersistenceImpl
 	public static final String FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION =
 		FINDER_CLASS_NAME_ENTITY + ".List2";
 
+	private FinderPath _finderPathWithPaginationFindByName;
+	private FinderPath _finderPathWithoutPaginationFindByName;
+	private FinderPath _finderPathCountByName;
 	private CollectionPersistenceFinder<ResourcePermission>
 		_collectionPersistenceFinderByName;
 
@@ -224,6 +227,9 @@ public class ResourcePermissionPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {name});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByScope;
+	private FinderPath _finderPathWithoutPaginationFindByScope;
+	private FinderPath _finderPathCountByScope;
 	private CollectionPersistenceFinder<ResourcePermission>
 		_collectionPersistenceFinderByScope;
 
@@ -466,6 +472,9 @@ public class ResourcePermissionPersistenceImpl
 			new Object[] {ArrayUtil.sortedUnique(scopes)});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByRoleId;
+	private FinderPath _finderPathWithoutPaginationFindByRoleId;
+	private FinderPath _finderPathCountByRoleId;
 	private CollectionPersistenceFinder<ResourcePermission>
 		_collectionPersistenceFinderByRoleId;
 
@@ -610,6 +619,8 @@ public class ResourcePermissionPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {roleId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_LikeP;
+	private FinderPath _finderPathWithPaginationCountByC_LikeP;
 	private CollectionPersistenceFinder<ResourcePermission>
 		_collectionPersistenceFinderByC_LikeP;
 
@@ -769,6 +780,9 @@ public class ResourcePermissionPersistenceImpl
 			new Object[] {companyId, primKey});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_N_S;
+	private FinderPath _finderPathWithoutPaginationFindByC_N_S;
+	private FinderPath _finderPathCountByC_N_S;
 	private CollectionPersistenceFinder<ResourcePermission>
 		_collectionPersistenceFinderByC_N_S;
 
@@ -938,6 +952,9 @@ public class ResourcePermissionPersistenceImpl
 			new Object[] {companyId, name, scope});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_S_P;
+	private FinderPath _finderPathWithoutPaginationFindByC_S_P;
+	private FinderPath _finderPathCountByC_S_P;
 	private CollectionPersistenceFinder<ResourcePermission>
 		_collectionPersistenceFinderByC_S_P;
 
@@ -1108,6 +1125,9 @@ public class ResourcePermissionPersistenceImpl
 			new Object[] {companyId, scope, primKey});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_N_S_P;
+	private FinderPath _finderPathWithoutPaginationFindByC_N_S_P;
+	private FinderPath _finderPathCountByC_N_S_P;
 	private CollectionPersistenceFinder<ResourcePermission>
 		_collectionPersistenceFinderByC_N_S_P;
 
@@ -1431,6 +1451,9 @@ public class ResourcePermissionPersistenceImpl
 			});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_N_S_R;
+	private FinderPath _finderPathWithoutPaginationFindByC_N_S_R;
+	private FinderPath _finderPathCountByC_N_S_R;
 	private CollectionPersistenceFinder<ResourcePermission>
 		_collectionPersistenceFinderByC_N_S_R;
 
@@ -3606,23 +3629,27 @@ public class ResourcePermissionPersistenceImpl
 	 * Initializes the resource permission persistence.
 	 */
 	public void afterPropertiesSet() {
+		_finderPathWithPaginationFindByName = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByName",
+			new String[] {
+				String.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"name"}, true);
+
+		_finderPathWithoutPaginationFindByName = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByName",
+			new String[] {String.class.getName()}, new String[] {"name"}, 0, 1,
+			true, null);
+
+		_finderPathCountByName = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByName",
+			new String[] {String.class.getName()}, new String[] {"name"}, 0, 1,
+			false, null);
+
 		_collectionPersistenceFinderByName = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByName",
-				new String[] {
-					String.class.getName(), Integer.class.getName(),
-					Integer.class.getName(), OrderByComparator.class.getName()
-				},
-				new String[] {"name"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByName",
-				new String[] {String.class.getName()}, new String[] {"name"}, 0,
-				1, true, null),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByName",
-				new String[] {String.class.getName()}, new String[] {"name"}, 0,
-				1, false, null),
+			this, _finderPathWithPaginationFindByName,
+			_finderPathWithoutPaginationFindByName, _finderPathCountByName,
 			_SQL_SELECT_RESOURCEPERMISSION_WHERE,
 			_SQL_COUNT_RESOURCEPERMISSION_WHERE,
 			ResourcePermissionModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
@@ -3630,23 +3657,27 @@ public class ResourcePermissionPersistenceImpl
 				"resourcePermission.", "name", FinderColumn.Type.STRING, "=",
 				true, true, ResourcePermission::getName));
 
+		_finderPathWithPaginationFindByScope = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByScope",
+			new String[] {
+				Integer.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"scope"}, true);
+
+		_finderPathWithoutPaginationFindByScope = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByScope",
+			new String[] {Integer.class.getName()}, new String[] {"scope"},
+			true);
+
+		_finderPathCountByScope = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByScope",
+			new String[] {Integer.class.getName()}, new String[] {"scope"},
+			false);
+
 		_collectionPersistenceFinderByScope = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByScope",
-				new String[] {
-					Integer.class.getName(), Integer.class.getName(),
-					Integer.class.getName(), OrderByComparator.class.getName()
-				},
-				new String[] {"scope"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByScope",
-				new String[] {Integer.class.getName()}, new String[] {"scope"},
-				true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByScope",
-				new String[] {Integer.class.getName()}, new String[] {"scope"},
-				false),
+			this, _finderPathWithPaginationFindByScope,
+			_finderPathWithoutPaginationFindByScope, _finderPathCountByScope,
 			_SQL_SELECT_RESOURCEPERMISSION_WHERE,
 			_SQL_COUNT_RESOURCEPERMISSION_WHERE,
 			ResourcePermissionModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
@@ -3654,26 +3685,28 @@ public class ResourcePermissionPersistenceImpl
 				"resourcePermission.", "scope", FinderColumn.Type.INTEGER, "=",
 				false, true, true, ResourcePermission::getScope));
 
+		_finderPathWithPaginationFindByRoleId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByRoleId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"roleId"}, true);
+
+		_finderPathWithoutPaginationFindByRoleId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByRoleId",
+			new String[] {Long.class.getName()}, new String[] {"roleId"}, true);
+
+		_finderPathCountByRoleId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByRoleId",
+			new String[] {Long.class.getName()}, new String[] {"roleId"},
+			false);
+
 		_collectionPersistenceFinderByRoleId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByRoleId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"roleId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByRoleId",
-					new String[] {Long.class.getName()},
-					new String[] {"roleId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByRoleId",
-					new String[] {Long.class.getName()},
-					new String[] {"roleId"}, false),
-				_SQL_SELECT_RESOURCEPERMISSION_WHERE,
+				this, _finderPathWithPaginationFindByRoleId,
+				_finderPathWithoutPaginationFindByRoleId,
+				_finderPathCountByRoleId, _SQL_SELECT_RESOURCEPERMISSION_WHERE,
 				_SQL_COUNT_RESOURCEPERMISSION_WHERE,
 				ResourcePermissionModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
 				"",
@@ -3681,22 +3714,24 @@ public class ResourcePermissionPersistenceImpl
 					"resourcePermission.", "roleId", FinderColumn.Type.LONG,
 					"=", true, true, ResourcePermission::getRoleId));
 
+		_finderPathWithPaginationFindByC_LikeP = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_LikeP",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "primKey"}, true);
+
+		_finderPathWithPaginationCountByC_LikeP = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByC_LikeP",
+			new String[] {Long.class.getName(), String.class.getName()},
+			new String[] {"companyId", "primKey"}, false);
+
 		_collectionPersistenceFinderByC_LikeP =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_LikeP",
-					new String[] {
-						Long.class.getName(), String.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"companyId", "primKey"}, true),
-				null,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByC_LikeP",
-					new String[] {Long.class.getName(), String.class.getName()},
-					new String[] {"companyId", "primKey"}, false),
+				this, _finderPathWithPaginationFindByC_LikeP, null,
+				_finderPathWithPaginationCountByC_LikeP,
 				_SQL_SELECT_RESOURCEPERMISSION_WHERE,
 				_SQL_COUNT_RESOURCEPERMISSION_WHERE,
 				ResourcePermissionModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
@@ -3708,30 +3743,34 @@ public class ResourcePermissionPersistenceImpl
 					"resourcePermission.", "primKey", FinderColumn.Type.STRING,
 					"LIKE", true, true, ResourcePermission::getPrimKey));
 
+		_finderPathWithPaginationFindByC_N_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_N_S",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "name", "scope"}, true);
+
+		_finderPathWithoutPaginationFindByC_N_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_N_S",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Integer.class.getName()
+			},
+			new String[] {"companyId", "name", "scope"}, 0, 2, true, null);
+
+		_finderPathCountByC_N_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_N_S",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Integer.class.getName()
+			},
+			new String[] {"companyId", "name", "scope"}, 0, 2, false, null);
+
 		_collectionPersistenceFinderByC_N_S = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_N_S",
-				new String[] {
-					Long.class.getName(), String.class.getName(),
-					Integer.class.getName(), Integer.class.getName(),
-					Integer.class.getName(), OrderByComparator.class.getName()
-				},
-				new String[] {"companyId", "name", "scope"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_N_S",
-				new String[] {
-					Long.class.getName(), String.class.getName(),
-					Integer.class.getName()
-				},
-				new String[] {"companyId", "name", "scope"}, 0, 2, true, null),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_N_S",
-				new String[] {
-					Long.class.getName(), String.class.getName(),
-					Integer.class.getName()
-				},
-				new String[] {"companyId", "name", "scope"}, 0, 2, false, null),
+			this, _finderPathWithPaginationFindByC_N_S,
+			_finderPathWithoutPaginationFindByC_N_S, _finderPathCountByC_N_S,
 			_SQL_SELECT_RESOURCEPERMISSION_WHERE,
 			_SQL_COUNT_RESOURCEPERMISSION_WHERE,
 			ResourcePermissionModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
@@ -3745,32 +3784,34 @@ public class ResourcePermissionPersistenceImpl
 				"resourcePermission.", "scope", FinderColumn.Type.INTEGER, "=",
 				true, true, ResourcePermission::getScope));
 
+		_finderPathWithPaginationFindByC_S_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_S_P",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				String.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "scope", "primKey"}, true);
+
+		_finderPathWithoutPaginationFindByC_S_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_S_P",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				String.class.getName()
+			},
+			new String[] {"companyId", "scope", "primKey"}, 0, 4, true, null);
+
+		_finderPathCountByC_S_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_S_P",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				String.class.getName()
+			},
+			new String[] {"companyId", "scope", "primKey"}, 0, 4, false, null);
+
 		_collectionPersistenceFinderByC_S_P = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_S_P",
-				new String[] {
-					Long.class.getName(), Integer.class.getName(),
-					String.class.getName(), Integer.class.getName(),
-					Integer.class.getName(), OrderByComparator.class.getName()
-				},
-				new String[] {"companyId", "scope", "primKey"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_S_P",
-				new String[] {
-					Long.class.getName(), Integer.class.getName(),
-					String.class.getName()
-				},
-				new String[] {"companyId", "scope", "primKey"}, 0, 4, true,
-				null),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_S_P",
-				new String[] {
-					Long.class.getName(), Integer.class.getName(),
-					String.class.getName()
-				},
-				new String[] {"companyId", "scope", "primKey"}, 0, 4, false,
-				null),
+			this, _finderPathWithPaginationFindByC_S_P,
+			_finderPathWithoutPaginationFindByC_S_P, _finderPathCountByC_S_P,
 			_SQL_SELECT_RESOURCEPERMISSION_WHERE,
 			_SQL_COUNT_RESOURCEPERMISSION_WHERE,
 			ResourcePermissionModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
@@ -3784,36 +3825,39 @@ public class ResourcePermissionPersistenceImpl
 				"resourcePermission.", "primKey", FinderColumn.Type.STRING, "=",
 				true, true, ResourcePermission::getPrimKey));
 
+		_finderPathWithPaginationFindByC_N_S_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_N_S_P",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Integer.class.getName(), String.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "name", "scope", "primKey"}, true);
+
+		_finderPathWithoutPaginationFindByC_N_S_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_N_S_P",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Integer.class.getName(), String.class.getName()
+			},
+			new String[] {"companyId", "name", "scope", "primKey"}, 0, 10, true,
+			null);
+
+		_finderPathCountByC_N_S_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByC_N_S_P",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Integer.class.getName(), String.class.getName()
+			},
+			new String[] {"companyId", "name", "scope", "primKey"}, 0, 10,
+			false, null);
+
 		_collectionPersistenceFinderByC_N_S_P =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_N_S_P",
-					new String[] {
-						Long.class.getName(), String.class.getName(),
-						Integer.class.getName(), String.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"companyId", "name", "scope", "primKey"},
-					true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_N_S_P",
-					new String[] {
-						Long.class.getName(), String.class.getName(),
-						Integer.class.getName(), String.class.getName()
-					},
-					new String[] {"companyId", "name", "scope", "primKey"}, 0,
-					10, true, null),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByC_N_S_P",
-					new String[] {
-						Long.class.getName(), String.class.getName(),
-						Integer.class.getName(), String.class.getName()
-					},
-					new String[] {"companyId", "name", "scope", "primKey"}, 0,
-					10, false, null),
-				_SQL_SELECT_RESOURCEPERMISSION_WHERE,
+				this, _finderPathWithPaginationFindByC_N_S_P,
+				_finderPathWithoutPaginationFindByC_N_S_P,
+				_finderPathCountByC_N_S_P, _SQL_SELECT_RESOURCEPERMISSION_WHERE,
 				_SQL_COUNT_RESOURCEPERMISSION_WHERE,
 				ResourcePermissionModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
 				"",
@@ -3830,36 +3874,39 @@ public class ResourcePermissionPersistenceImpl
 					"resourcePermission.", "primKey", FinderColumn.Type.STRING,
 					"=", false, true, true, ResourcePermission::getPrimKey));
 
+		_finderPathWithPaginationFindByC_N_S_R = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_N_S_R",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Integer.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "name", "scope", "roleId"}, true);
+
+		_finderPathWithoutPaginationFindByC_N_S_R = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_N_S_R",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Integer.class.getName(), Long.class.getName()
+			},
+			new String[] {"companyId", "name", "scope", "roleId"}, 0, 2, true,
+			null);
+
+		_finderPathCountByC_N_S_R = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_N_S_R",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Integer.class.getName(), Long.class.getName()
+			},
+			new String[] {"companyId", "name", "scope", "roleId"}, 0, 2, false,
+			null);
+
 		_collectionPersistenceFinderByC_N_S_R =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_N_S_R",
-					new String[] {
-						Long.class.getName(), String.class.getName(),
-						Integer.class.getName(), Long.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"companyId", "name", "scope", "roleId"},
-					true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_N_S_R",
-					new String[] {
-						Long.class.getName(), String.class.getName(),
-						Integer.class.getName(), Long.class.getName()
-					},
-					new String[] {"companyId", "name", "scope", "roleId"}, 0, 2,
-					true, null),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_N_S_R",
-					new String[] {
-						Long.class.getName(), String.class.getName(),
-						Integer.class.getName(), Long.class.getName()
-					},
-					new String[] {"companyId", "name", "scope", "roleId"}, 0, 2,
-					false, null),
-				_SQL_SELECT_RESOURCEPERMISSION_WHERE,
+				this, _finderPathWithPaginationFindByC_N_S_R,
+				_finderPathWithoutPaginationFindByC_N_S_R,
+				_finderPathCountByC_N_S_R, _SQL_SELECT_RESOURCEPERMISSION_WHERE,
 				_SQL_COUNT_RESOURCEPERMISSION_WHERE,
 				ResourcePermissionModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
 				"",
@@ -4013,4 +4060,4 @@ public class ResourcePermissionPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1044292389
+// LIFERAY-SERVICE-BUILDER-HASH:712855904

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/RolePersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/RolePersistenceImpl.java
@@ -97,6 +97,9 @@ public class RolePersistenceImpl
 	public static final String FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION =
 		FINDER_CLASS_NAME_ENTITY + ".List2";
 
+	private FinderPath _finderPathWithPaginationFindByUuid;
+	private FinderPath _finderPathWithoutPaginationFindByUuid;
+	private FinderPath _finderPathCountByUuid;
 	private FilterCollectionPersistenceFinder<Role>
 		_collectionPersistenceFinderByUuid;
 
@@ -300,6 +303,9 @@ public class RolePersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {uuid});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByUuid_C;
+	private FinderPath _finderPathWithoutPaginationFindByUuid_C;
+	private FinderPath _finderPathCountByUuid_C;
 	private FilterCollectionPersistenceFinder<Role>
 		_collectionPersistenceFinderByUuid_C;
 
@@ -524,6 +530,9 @@ public class RolePersistenceImpl
 			companyId, 0);
 	}
 
+	private FinderPath _finderPathWithPaginationFindByCompanyId;
+	private FinderPath _finderPathWithoutPaginationFindByCompanyId;
+	private FinderPath _finderPathCountByCompanyId;
 	private FilterCollectionPersistenceFinder<Role>
 		_collectionPersistenceFinderByCompanyId;
 
@@ -731,6 +740,9 @@ public class RolePersistenceImpl
 			companyId, 0);
 	}
 
+	private FinderPath _finderPathWithPaginationFindByName;
+	private FinderPath _finderPathWithoutPaginationFindByName;
+	private FinderPath _finderPathCountByName;
 	private FilterCollectionPersistenceFinder<Role>
 		_collectionPersistenceFinderByName;
 
@@ -934,6 +946,9 @@ public class RolePersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {name});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByType;
+	private FinderPath _finderPathWithoutPaginationFindByType;
+	private FinderPath _finderPathCountByType;
 	private FilterCollectionPersistenceFinder<Role>
 		_collectionPersistenceFinderByType;
 
@@ -1137,6 +1152,9 @@ public class RolePersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {type});
 	}
 
+	private FinderPath _finderPathWithPaginationFindBySubtype;
+	private FinderPath _finderPathWithoutPaginationFindBySubtype;
+	private FinderPath _finderPathCountBySubtype;
 	private FilterCollectionPersistenceFinder<Role>
 		_collectionPersistenceFinderBySubtype;
 
@@ -1341,6 +1359,7 @@ public class RolePersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {subtype});
 	}
 
+	private FinderPath _finderPathFetchByC_N;
 	private UniquePersistenceFinder<Role> _uniquePersistenceFinderByC_N;
 
 	/**
@@ -1430,6 +1449,9 @@ public class RolePersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {companyId, name});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_T;
+	private FinderPath _finderPathWithoutPaginationFindByC_T;
+	private FinderPath _finderPathCountByC_T;
 	private FilterCollectionPersistenceFinder<Role>
 		_collectionPersistenceFinderByC_T;
 
@@ -1835,6 +1857,9 @@ public class RolePersistenceImpl
 			0);
 	}
 
+	private FinderPath _finderPathWithPaginationFindByT_S;
+	private FinderPath _finderPathWithoutPaginationFindByT_S;
+	private FinderPath _finderPathCountByT_S;
 	private FilterCollectionPersistenceFinder<Role>
 		_collectionPersistenceFinderByT_S;
 
@@ -2053,6 +2078,10 @@ public class RolePersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {type, subtype});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_C_C;
+	private FinderPath _finderPathWithoutPaginationFindByC_C_C;
+	private FinderPath _finderPathFetchByC_C_C;
+	private FinderPath _finderPathCountByC_C_C;
 	private FilterCollectionPersistenceFinder<Role>
 		_collectionPersistenceFinderByC_C_C;
 	private UniquePersistenceFinder<Role> _uniquePersistenceFinderByC_C_C;
@@ -2319,6 +2348,10 @@ public class RolePersistenceImpl
 			companyId, 0);
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_C_C_T;
+	private FinderPath _finderPathWithoutPaginationFindByC_C_C_T;
+	private FinderPath _finderPathFetchByC_C_C_T;
+	private FinderPath _finderPathCountByC_C_C_T;
 	private FilterCollectionPersistenceFinder<Role>
 		_collectionPersistenceFinderByC_C_C_T;
 	private UniquePersistenceFinder<Role> _uniquePersistenceFinderByC_C_C_T;
@@ -2609,6 +2642,7 @@ public class RolePersistenceImpl
 			companyId, 0);
 	}
 
+	private FinderPath _finderPathFetchByERC_C;
 	private UniquePersistenceFinder<Role> _uniquePersistenceFinderByERC_C;
 
 	/**
@@ -3719,69 +3753,75 @@ public class RolePersistenceImpl
 			"Users_Roles", "companyId", "roleId", "userId", this,
 			userPersistence);
 
+		_finderPathWithPaginationFindByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid",
+			new String[] {
+				String.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"uuid_"}, true);
+
+		_finderPathWithoutPaginationFindByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid",
+			new String[] {String.class.getName()}, new String[] {"uuid_"}, 0, 1,
+			true, null);
+
+		_finderPathCountByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid",
+			new String[] {String.class.getName()}, new String[] {"uuid_"}, 0, 1,
+			false, null);
+
 		_collectionPersistenceFinderByUuid =
 			new FilterCollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid",
-					new String[] {
-						String.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"uuid_"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid",
-					new String[] {String.class.getName()},
-					new String[] {"uuid_"}, 0, 1, true, null),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid",
-					new String[] {String.class.getName()},
-					new String[] {"uuid_"}, 0, 1, false, null),
+				this, _finderPathWithPaginationFindByUuid,
+				_finderPathWithoutPaginationFindByUuid, _finderPathCountByUuid,
 				_SQL_SELECT_ROLE__WHERE, _SQL_COUNT_ROLE__WHERE,
 				RoleModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 				new FilterCollectionPersistenceFinder.FilterMetadata<>(
-					RoleImpl.class, Role.class, "role_", "Role_",
-					"role_.roleId",
-					"SELECT DISTINCT {role_.*} FROM Role_ role_ WHERE ",
-					"SELECT {Role_.*} FROM (SELECT DISTINCT role_.roleId FROM Role_ role_ WHERE ",
-					") TEMP_TABLE INNER JOIN Role_ ON TEMP_TABLE.roleId = Role_.roleId",
-					"SELECT COUNT(DISTINCT role_.roleId) AS COUNT_VALUE FROM Role_ role_ WHERE ",
-					RoleModelImpl.ORDER_BY_SQL,
+					RoleImpl.class, Role.class, _FILTER_ENTITY_ALIAS,
+					_FILTER_ENTITY_TABLE, _FILTER_ENTITY_TABLE_FILTER_PK_COLUMN,
+					_FILTER_SQL_SELECT_ROLE__WHERE,
+					_FILTER_SQL_SELECT_ROLE__NO_INLINE_DISTINCT_WHERE_1,
+					_FILTER_SQL_SELECT_ROLE__NO_INLINE_DISTINCT_WHERE_2,
+					_FILTER_SQL_COUNT_ROLE__WHERE, RoleModelImpl.ORDER_BY_SQL,
 					RoleModelImpl.ORDER_BY_SQL_INLINE_DISTINCT),
 				new FinderColumn<>(
 					"role_.", "uuid", FinderColumn.Type.STRING, "=", true, true,
 					Role::getUuid));
 
+		_finderPathWithPaginationFindByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid_C",
+			new String[] {
+				String.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"uuid_", "companyId"}, true);
+
+		_finderPathWithoutPaginationFindByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"uuid_", "companyId"}, 0, 1, true, null);
+
+		_finderPathCountByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"uuid_", "companyId"}, 0, 1, false, null);
+
 		_collectionPersistenceFinderByUuid_C =
 			new FilterCollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid_C",
-					new String[] {
-						String.class.getName(), Long.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"uuid_", "companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid_C",
-					new String[] {String.class.getName(), Long.class.getName()},
-					new String[] {"uuid_", "companyId"}, 0, 1, true, null),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid_C",
-					new String[] {String.class.getName(), Long.class.getName()},
-					new String[] {"uuid_", "companyId"}, 0, 1, false, null),
-				_SQL_SELECT_ROLE__WHERE, _SQL_COUNT_ROLE__WHERE,
-				RoleModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+				this, _finderPathWithPaginationFindByUuid_C,
+				_finderPathWithoutPaginationFindByUuid_C,
+				_finderPathCountByUuid_C, _SQL_SELECT_ROLE__WHERE,
+				_SQL_COUNT_ROLE__WHERE, RoleModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "",
 				new FilterCollectionPersistenceFinder.FilterMetadata<>(
-					RoleImpl.class, Role.class, "role_", "Role_",
-					"role_.roleId",
-					"SELECT DISTINCT {role_.*} FROM Role_ role_ WHERE ",
-					"SELECT {Role_.*} FROM (SELECT DISTINCT role_.roleId FROM Role_ role_ WHERE ",
-					") TEMP_TABLE INNER JOIN Role_ ON TEMP_TABLE.roleId = Role_.roleId",
-					"SELECT COUNT(DISTINCT role_.roleId) AS COUNT_VALUE FROM Role_ role_ WHERE ",
-					RoleModelImpl.ORDER_BY_SQL,
+					RoleImpl.class, Role.class, _FILTER_ENTITY_ALIAS,
+					_FILTER_ENTITY_TABLE, _FILTER_ENTITY_TABLE_FILTER_PK_COLUMN,
+					_FILTER_SQL_SELECT_ROLE__WHERE,
+					_FILTER_SQL_SELECT_ROLE__NO_INLINE_DISTINCT_WHERE_1,
+					_FILTER_SQL_SELECT_ROLE__NO_INLINE_DISTINCT_WHERE_2,
+					_FILTER_SQL_COUNT_ROLE__WHERE, RoleModelImpl.ORDER_BY_SQL,
 					RoleModelImpl.ORDER_BY_SQL_INLINE_DISTINCT),
 				new FinderColumn<>(
 					"role_.", "uuid", FinderColumn.Type.STRING, "=", true, true,
@@ -3790,150 +3830,160 @@ public class RolePersistenceImpl
 					"role_.", "companyId", FinderColumn.Type.LONG, "=", true,
 					true, Role::getCompanyId));
 
+		_finderPathWithPaginationFindByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByCompanyId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"companyId"}, true);
+
+		_finderPathWithoutPaginationFindByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByCompanyId",
+			new String[] {Long.class.getName()}, new String[] {"companyId"},
+			true);
+
+		_finderPathCountByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByCompanyId",
+			new String[] {Long.class.getName()}, new String[] {"companyId"},
+			false);
+
 		_collectionPersistenceFinderByCompanyId =
 			new FilterCollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByCompanyId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"findByCompanyId", new String[] {Long.class.getName()},
-					new String[] {"companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByCompanyId", new String[] {Long.class.getName()},
-					new String[] {"companyId"}, false),
-				_SQL_SELECT_ROLE__WHERE, _SQL_COUNT_ROLE__WHERE,
-				RoleModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+				this, _finderPathWithPaginationFindByCompanyId,
+				_finderPathWithoutPaginationFindByCompanyId,
+				_finderPathCountByCompanyId, _SQL_SELECT_ROLE__WHERE,
+				_SQL_COUNT_ROLE__WHERE, RoleModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "",
 				new FilterCollectionPersistenceFinder.FilterMetadata<>(
-					RoleImpl.class, Role.class, "role_", "Role_",
-					"role_.roleId",
-					"SELECT DISTINCT {role_.*} FROM Role_ role_ WHERE ",
-					"SELECT {Role_.*} FROM (SELECT DISTINCT role_.roleId FROM Role_ role_ WHERE ",
-					") TEMP_TABLE INNER JOIN Role_ ON TEMP_TABLE.roleId = Role_.roleId",
-					"SELECT COUNT(DISTINCT role_.roleId) AS COUNT_VALUE FROM Role_ role_ WHERE ",
-					RoleModelImpl.ORDER_BY_SQL,
+					RoleImpl.class, Role.class, _FILTER_ENTITY_ALIAS,
+					_FILTER_ENTITY_TABLE, _FILTER_ENTITY_TABLE_FILTER_PK_COLUMN,
+					_FILTER_SQL_SELECT_ROLE__WHERE,
+					_FILTER_SQL_SELECT_ROLE__NO_INLINE_DISTINCT_WHERE_1,
+					_FILTER_SQL_SELECT_ROLE__NO_INLINE_DISTINCT_WHERE_2,
+					_FILTER_SQL_COUNT_ROLE__WHERE, RoleModelImpl.ORDER_BY_SQL,
 					RoleModelImpl.ORDER_BY_SQL_INLINE_DISTINCT),
 				new FinderColumn<>(
 					"role_.", "companyId", FinderColumn.Type.LONG, "=", true,
 					true, Role::getCompanyId));
 
+		_finderPathWithPaginationFindByName = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByName",
+			new String[] {
+				String.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"name"}, true);
+
+		_finderPathWithoutPaginationFindByName = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByName",
+			new String[] {String.class.getName()}, new String[] {"name"}, 0, 1,
+			true, null);
+
+		_finderPathCountByName = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByName",
+			new String[] {String.class.getName()}, new String[] {"name"}, 0, 1,
+			false, null);
+
 		_collectionPersistenceFinderByName =
 			new FilterCollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByName",
-					new String[] {
-						String.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"name"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByName",
-					new String[] {String.class.getName()},
-					new String[] {"name"}, 0, 1, true, null),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByName",
-					new String[] {String.class.getName()},
-					new String[] {"name"}, 0, 1, false, null),
+				this, _finderPathWithPaginationFindByName,
+				_finderPathWithoutPaginationFindByName, _finderPathCountByName,
 				_SQL_SELECT_ROLE__WHERE, _SQL_COUNT_ROLE__WHERE,
 				RoleModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 				new FilterCollectionPersistenceFinder.FilterMetadata<>(
-					RoleImpl.class, Role.class, "role_", "Role_",
-					"role_.roleId",
-					"SELECT DISTINCT {role_.*} FROM Role_ role_ WHERE ",
-					"SELECT {Role_.*} FROM (SELECT DISTINCT role_.roleId FROM Role_ role_ WHERE ",
-					") TEMP_TABLE INNER JOIN Role_ ON TEMP_TABLE.roleId = Role_.roleId",
-					"SELECT COUNT(DISTINCT role_.roleId) AS COUNT_VALUE FROM Role_ role_ WHERE ",
-					RoleModelImpl.ORDER_BY_SQL,
+					RoleImpl.class, Role.class, _FILTER_ENTITY_ALIAS,
+					_FILTER_ENTITY_TABLE, _FILTER_ENTITY_TABLE_FILTER_PK_COLUMN,
+					_FILTER_SQL_SELECT_ROLE__WHERE,
+					_FILTER_SQL_SELECT_ROLE__NO_INLINE_DISTINCT_WHERE_1,
+					_FILTER_SQL_SELECT_ROLE__NO_INLINE_DISTINCT_WHERE_2,
+					_FILTER_SQL_COUNT_ROLE__WHERE, RoleModelImpl.ORDER_BY_SQL,
 					RoleModelImpl.ORDER_BY_SQL_INLINE_DISTINCT),
 				new FinderColumn<>(
 					"role_.", "name", FinderColumn.Type.STRING, "=", true, true,
 					Role::getName));
 
+		_finderPathWithPaginationFindByType = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByType",
+			new String[] {
+				Integer.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"type_"}, true);
+
+		_finderPathWithoutPaginationFindByType = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByType",
+			new String[] {Integer.class.getName()}, new String[] {"type_"},
+			true);
+
+		_finderPathCountByType = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByType",
+			new String[] {Integer.class.getName()}, new String[] {"type_"},
+			false);
+
 		_collectionPersistenceFinderByType =
 			new FilterCollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByType",
-					new String[] {
-						Integer.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"type_"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByType",
-					new String[] {Integer.class.getName()},
-					new String[] {"type_"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByType",
-					new String[] {Integer.class.getName()},
-					new String[] {"type_"}, false),
+				this, _finderPathWithPaginationFindByType,
+				_finderPathWithoutPaginationFindByType, _finderPathCountByType,
 				_SQL_SELECT_ROLE__WHERE, _SQL_COUNT_ROLE__WHERE,
 				RoleModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 				new FilterCollectionPersistenceFinder.FilterMetadata<>(
-					RoleImpl.class, Role.class, "role_", "Role_",
-					"role_.roleId",
-					"SELECT DISTINCT {role_.*} FROM Role_ role_ WHERE ",
-					"SELECT {Role_.*} FROM (SELECT DISTINCT role_.roleId FROM Role_ role_ WHERE ",
-					") TEMP_TABLE INNER JOIN Role_ ON TEMP_TABLE.roleId = Role_.roleId",
-					"SELECT COUNT(DISTINCT role_.roleId) AS COUNT_VALUE FROM Role_ role_ WHERE ",
-					RoleModelImpl.ORDER_BY_SQL,
+					RoleImpl.class, Role.class, _FILTER_ENTITY_ALIAS,
+					_FILTER_ENTITY_TABLE, _FILTER_ENTITY_TABLE_FILTER_PK_COLUMN,
+					_FILTER_SQL_SELECT_ROLE__WHERE,
+					_FILTER_SQL_SELECT_ROLE__NO_INLINE_DISTINCT_WHERE_1,
+					_FILTER_SQL_SELECT_ROLE__NO_INLINE_DISTINCT_WHERE_2,
+					_FILTER_SQL_COUNT_ROLE__WHERE, RoleModelImpl.ORDER_BY_SQL,
 					RoleModelImpl.ORDER_BY_SQL_INLINE_DISTINCT),
 				new FinderColumn<>(
 					"role_.", "type", FinderColumn.Type.INTEGER, "=", true,
 					true, Role::getType));
 
+		_finderPathWithPaginationFindBySubtype = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findBySubtype",
+			new String[] {
+				String.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"subtype"}, true);
+
+		_finderPathWithoutPaginationFindBySubtype = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findBySubtype",
+			new String[] {String.class.getName()}, new String[] {"subtype"}, 0,
+			1, true, null);
+
+		_finderPathCountBySubtype = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countBySubtype",
+			new String[] {String.class.getName()}, new String[] {"subtype"}, 0,
+			1, false, null);
+
 		_collectionPersistenceFinderBySubtype =
 			new FilterCollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findBySubtype",
-					new String[] {
-						String.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"subtype"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findBySubtype",
-					new String[] {String.class.getName()},
-					new String[] {"subtype"}, 0, 1, true, null),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countBySubtype",
-					new String[] {String.class.getName()},
-					new String[] {"subtype"}, 0, 1, false, null),
-				_SQL_SELECT_ROLE__WHERE, _SQL_COUNT_ROLE__WHERE,
-				RoleModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+				this, _finderPathWithPaginationFindBySubtype,
+				_finderPathWithoutPaginationFindBySubtype,
+				_finderPathCountBySubtype, _SQL_SELECT_ROLE__WHERE,
+				_SQL_COUNT_ROLE__WHERE, RoleModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "",
 				new FilterCollectionPersistenceFinder.FilterMetadata<>(
-					RoleImpl.class, Role.class, "role_", "Role_",
-					"role_.roleId",
-					"SELECT DISTINCT {role_.*} FROM Role_ role_ WHERE ",
-					"SELECT {Role_.*} FROM (SELECT DISTINCT role_.roleId FROM Role_ role_ WHERE ",
-					") TEMP_TABLE INNER JOIN Role_ ON TEMP_TABLE.roleId = Role_.roleId",
-					"SELECT COUNT(DISTINCT role_.roleId) AS COUNT_VALUE FROM Role_ role_ WHERE ",
-					RoleModelImpl.ORDER_BY_SQL,
+					RoleImpl.class, Role.class, _FILTER_ENTITY_ALIAS,
+					_FILTER_ENTITY_TABLE, _FILTER_ENTITY_TABLE_FILTER_PK_COLUMN,
+					_FILTER_SQL_SELECT_ROLE__WHERE,
+					_FILTER_SQL_SELECT_ROLE__NO_INLINE_DISTINCT_WHERE_1,
+					_FILTER_SQL_SELECT_ROLE__NO_INLINE_DISTINCT_WHERE_2,
+					_FILTER_SQL_COUNT_ROLE__WHERE, RoleModelImpl.ORDER_BY_SQL,
 					RoleModelImpl.ORDER_BY_SQL_INLINE_DISTINCT),
 				new FinderColumn<>(
 					"role_.", "subtype", FinderColumn.Type.STRING, "=", true,
 					true, Role::getSubtype));
 
+		_finderPathFetchByC_N = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByC_N",
+			new String[] {Long.class.getName(), String.class.getName()},
+			new String[] {"companyId", "name"}, 2, 2, true, Role::getCompanyId,
+			convertCaseFunction(Role::getName));
+
 		_uniquePersistenceFinderByC_N = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByC_N",
-				new String[] {Long.class.getName(), String.class.getName()},
-				new String[] {"companyId", "name"}, 2, 2, true,
-				Role::getCompanyId, convertCaseFunction(Role::getName)),
-			_SQL_SELECT_ROLE__WHERE, "",
+			this, _finderPathFetchByC_N, _SQL_SELECT_ROLE__WHERE, "",
 			new FinderColumn<>(
 				"role_.", "companyId", FinderColumn.Type.LONG, "=", true, true,
 				Role::getCompanyId),
@@ -3941,39 +3991,38 @@ public class RolePersistenceImpl
 				"role_.", "name", FinderColumn.Type.STRING, "=", false, true,
 				Role::getName));
 
+		_finderPathWithPaginationFindByC_T = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_T",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "type_"}, true);
+
+		_finderPathWithoutPaginationFindByC_T = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_T",
+			new String[] {Long.class.getName(), Integer.class.getName()},
+			new String[] {"companyId", "type_"}, true);
+
+		_finderPathCountByC_T = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByC_T",
+			new String[] {Long.class.getName(), Integer.class.getName()},
+			new String[] {"companyId", "type_"}, false);
+
 		_collectionPersistenceFinderByC_T =
 			new FilterCollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_T",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"companyId", "type_"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_T",
-					new String[] {
-						Long.class.getName(), Integer.class.getName()
-					},
-					new String[] {"companyId", "type_"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByC_T",
-					new String[] {
-						Long.class.getName(), Integer.class.getName()
-					},
-					new String[] {"companyId", "type_"}, false),
+				this, _finderPathWithPaginationFindByC_T,
+				_finderPathWithoutPaginationFindByC_T, _finderPathCountByC_T,
 				_SQL_SELECT_ROLE__WHERE, _SQL_COUNT_ROLE__WHERE,
 				RoleModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 				new FilterCollectionPersistenceFinder.FilterMetadata<>(
-					RoleImpl.class, Role.class, "role_", "Role_",
-					"role_.roleId",
-					"SELECT DISTINCT {role_.*} FROM Role_ role_ WHERE ",
-					"SELECT {Role_.*} FROM (SELECT DISTINCT role_.roleId FROM Role_ role_ WHERE ",
-					") TEMP_TABLE INNER JOIN Role_ ON TEMP_TABLE.roleId = Role_.roleId",
-					"SELECT COUNT(DISTINCT role_.roleId) AS COUNT_VALUE FROM Role_ role_ WHERE ",
-					RoleModelImpl.ORDER_BY_SQL,
+					RoleImpl.class, Role.class, _FILTER_ENTITY_ALIAS,
+					_FILTER_ENTITY_TABLE, _FILTER_ENTITY_TABLE_FILTER_PK_COLUMN,
+					_FILTER_SQL_SELECT_ROLE__WHERE,
+					_FILTER_SQL_SELECT_ROLE__NO_INLINE_DISTINCT_WHERE_1,
+					_FILTER_SQL_SELECT_ROLE__NO_INLINE_DISTINCT_WHERE_2,
+					_FILTER_SQL_COUNT_ROLE__WHERE, RoleModelImpl.ORDER_BY_SQL,
 					RoleModelImpl.ORDER_BY_SQL_INLINE_DISTINCT),
 				new FinderColumn<>(
 					"role_.", "companyId", FinderColumn.Type.LONG, "=", true,
@@ -3982,39 +4031,38 @@ public class RolePersistenceImpl
 					"role_.", "type", FinderColumn.Type.INTEGER, "=", false,
 					true, true, Role::getType));
 
+		_finderPathWithPaginationFindByT_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByT_S",
+			new String[] {
+				Integer.class.getName(), String.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"type_", "subtype"}, true);
+
+		_finderPathWithoutPaginationFindByT_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByT_S",
+			new String[] {Integer.class.getName(), String.class.getName()},
+			new String[] {"type_", "subtype"}, 0, 2, true, null);
+
+		_finderPathCountByT_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByT_S",
+			new String[] {Integer.class.getName(), String.class.getName()},
+			new String[] {"type_", "subtype"}, 0, 2, false, null);
+
 		_collectionPersistenceFinderByT_S =
 			new FilterCollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByT_S",
-					new String[] {
-						Integer.class.getName(), String.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"type_", "subtype"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByT_S",
-					new String[] {
-						Integer.class.getName(), String.class.getName()
-					},
-					new String[] {"type_", "subtype"}, 0, 2, true, null),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByT_S",
-					new String[] {
-						Integer.class.getName(), String.class.getName()
-					},
-					new String[] {"type_", "subtype"}, 0, 2, false, null),
+				this, _finderPathWithPaginationFindByT_S,
+				_finderPathWithoutPaginationFindByT_S, _finderPathCountByT_S,
 				_SQL_SELECT_ROLE__WHERE, _SQL_COUNT_ROLE__WHERE,
 				RoleModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 				new FilterCollectionPersistenceFinder.FilterMetadata<>(
-					RoleImpl.class, Role.class, "role_", "Role_",
-					"role_.roleId",
-					"SELECT DISTINCT {role_.*} FROM Role_ role_ WHERE ",
-					"SELECT {Role_.*} FROM (SELECT DISTINCT role_.roleId FROM Role_ role_ WHERE ",
-					") TEMP_TABLE INNER JOIN Role_ ON TEMP_TABLE.roleId = Role_.roleId",
-					"SELECT COUNT(DISTINCT role_.roleId) AS COUNT_VALUE FROM Role_ role_ WHERE ",
-					RoleModelImpl.ORDER_BY_SQL,
+					RoleImpl.class, Role.class, _FILTER_ENTITY_ALIAS,
+					_FILTER_ENTITY_TABLE, _FILTER_ENTITY_TABLE_FILTER_PK_COLUMN,
+					_FILTER_SQL_SELECT_ROLE__WHERE,
+					_FILTER_SQL_SELECT_ROLE__NO_INLINE_DISTINCT_WHERE_1,
+					_FILTER_SQL_SELECT_ROLE__NO_INLINE_DISTINCT_WHERE_2,
+					_FILTER_SQL_COUNT_ROLE__WHERE, RoleModelImpl.ORDER_BY_SQL,
 					RoleModelImpl.ORDER_BY_SQL_INLINE_DISTINCT),
 				new FinderColumn<>(
 					"role_.", "type", FinderColumn.Type.INTEGER, "=", true,
@@ -4023,43 +4071,51 @@ public class RolePersistenceImpl
 					"role_.", "subtype", FinderColumn.Type.STRING, "=", true,
 					true, Role::getSubtype));
 
+		_finderPathWithPaginationFindByC_C_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_C_C",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "classNameId", "classPK"}, true);
+
+		_finderPathWithoutPaginationFindByC_C_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_C_C",
+			new String[] {
+				Long.class.getName(), Long.class.getName(), Long.class.getName()
+			},
+			new String[] {"companyId", "classNameId", "classPK"}, true);
+
+		_finderPathFetchByC_C_C = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByC_C_C",
+			new String[] {
+				Long.class.getName(), Long.class.getName(), Long.class.getName()
+			},
+			new String[] {"companyId", "classNameId", "classPK"}, 0, 0, false,
+			Role::getCompanyId, Role::getClassNameId, Role::getClassPK);
+
+		_finderPathCountByC_C_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByC_C_C",
+			new String[] {
+				Long.class.getName(), Long.class.getName(), Long.class.getName()
+			},
+			new String[] {"companyId", "classNameId", "classPK"}, false);
+
 		_collectionPersistenceFinderByC_C_C =
 			new FilterCollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_C_C",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"companyId", "classNameId", "classPK"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_C_C",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						Long.class.getName()
-					},
-					new String[] {"companyId", "classNameId", "classPK"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByC_C_C",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						Long.class.getName()
-					},
-					new String[] {"companyId", "classNameId", "classPK"},
-					false),
-				_SQL_SELECT_ROLE__WHERE, _SQL_COUNT_ROLE__WHERE,
-				RoleModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+				this, _finderPathWithPaginationFindByC_C_C,
+				_finderPathWithoutPaginationFindByC_C_C,
+				_finderPathCountByC_C_C, _SQL_SELECT_ROLE__WHERE,
+				_SQL_COUNT_ROLE__WHERE, RoleModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "",
 				new FilterCollectionPersistenceFinder.FilterMetadata<>(
-					RoleImpl.class, Role.class, "role_", "Role_",
-					"role_.roleId",
-					"SELECT DISTINCT {role_.*} FROM Role_ role_ WHERE ",
-					"SELECT {Role_.*} FROM (SELECT DISTINCT role_.roleId FROM Role_ role_ WHERE ",
-					") TEMP_TABLE INNER JOIN Role_ ON TEMP_TABLE.roleId = Role_.roleId",
-					"SELECT COUNT(DISTINCT role_.roleId) AS COUNT_VALUE FROM Role_ role_ WHERE ",
-					RoleModelImpl.ORDER_BY_SQL,
+					RoleImpl.class, Role.class, _FILTER_ENTITY_ALIAS,
+					_FILTER_ENTITY_TABLE, _FILTER_ENTITY_TABLE_FILTER_PK_COLUMN,
+					_FILTER_SQL_SELECT_ROLE__WHERE,
+					_FILTER_SQL_SELECT_ROLE__NO_INLINE_DISTINCT_WHERE_1,
+					_FILTER_SQL_SELECT_ROLE__NO_INLINE_DISTINCT_WHERE_2,
+					_FILTER_SQL_COUNT_ROLE__WHERE, RoleModelImpl.ORDER_BY_SQL,
 					RoleModelImpl.ORDER_BY_SQL_INLINE_DISTINCT),
 				new FinderColumn<>(
 					"role_.", "companyId", FinderColumn.Type.LONG, "=", true,
@@ -4072,17 +4128,7 @@ public class RolePersistenceImpl
 					true, true, Role::getClassPK));
 
 		_uniquePersistenceFinderByC_C_C = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByC_C_C",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Long.class.getName()
-				},
-				new String[] {"companyId", "classNameId", "classPK"}, 0, 0,
-				false, Role::getCompanyId, Role::getClassNameId,
-				Role::getClassPK),
-			_SQL_SELECT_ROLE__WHERE, "",
+			this, _finderPathFetchByC_C_C, _SQL_SELECT_ROLE__WHERE, "",
 			new FinderColumn<>(
 				"role_.", "companyId", FinderColumn.Type.LONG, "=", true, true,
 				Role::getCompanyId),
@@ -4093,51 +4139,59 @@ public class RolePersistenceImpl
 				"role_.", "classPK", FinderColumn.Type.LONG, "=", true, true,
 				Role::getClassPK));
 
+		_finderPathWithPaginationFindByC_C_C_T = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_C_C_T",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "classNameId", "classPK", "type_"},
+			true);
+
+		_finderPathWithoutPaginationFindByC_C_C_T = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_C_C_T",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Integer.class.getName()
+			},
+			new String[] {"companyId", "classNameId", "classPK", "type_"},
+			true);
+
+		_finderPathFetchByC_C_C_T = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByC_C_C_T",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Integer.class.getName()
+			},
+			new String[] {"companyId", "classNameId", "classPK", "type_"}, 0, 0,
+			false, Role::getCompanyId, Role::getClassNameId, Role::getClassPK,
+			Role::getType);
+
+		_finderPathCountByC_C_C_T = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByC_C_C_T",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Integer.class.getName()
+			},
+			new String[] {"companyId", "classNameId", "classPK", "type_"},
+			false);
+
 		_collectionPersistenceFinderByC_C_C_T =
 			new FilterCollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_C_C_T",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {
-						"companyId", "classNameId", "classPK", "type_"
-					},
-					true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_C_C_T",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						Long.class.getName(), Integer.class.getName()
-					},
-					new String[] {
-						"companyId", "classNameId", "classPK", "type_"
-					},
-					true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByC_C_C_T",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						Long.class.getName(), Integer.class.getName()
-					},
-					new String[] {
-						"companyId", "classNameId", "classPK", "type_"
-					},
-					false),
-				_SQL_SELECT_ROLE__WHERE, _SQL_COUNT_ROLE__WHERE,
-				RoleModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+				this, _finderPathWithPaginationFindByC_C_C_T,
+				_finderPathWithoutPaginationFindByC_C_C_T,
+				_finderPathCountByC_C_C_T, _SQL_SELECT_ROLE__WHERE,
+				_SQL_COUNT_ROLE__WHERE, RoleModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "",
 				new FilterCollectionPersistenceFinder.FilterMetadata<>(
-					RoleImpl.class, Role.class, "role_", "Role_",
-					"role_.roleId",
-					"SELECT DISTINCT {role_.*} FROM Role_ role_ WHERE ",
-					"SELECT {Role_.*} FROM (SELECT DISTINCT role_.roleId FROM Role_ role_ WHERE ",
-					") TEMP_TABLE INNER JOIN Role_ ON TEMP_TABLE.roleId = Role_.roleId",
-					"SELECT COUNT(DISTINCT role_.roleId) AS COUNT_VALUE FROM Role_ role_ WHERE ",
-					RoleModelImpl.ORDER_BY_SQL,
+					RoleImpl.class, Role.class, _FILTER_ENTITY_ALIAS,
+					_FILTER_ENTITY_TABLE, _FILTER_ENTITY_TABLE_FILTER_PK_COLUMN,
+					_FILTER_SQL_SELECT_ROLE__WHERE,
+					_FILTER_SQL_SELECT_ROLE__NO_INLINE_DISTINCT_WHERE_1,
+					_FILTER_SQL_SELECT_ROLE__NO_INLINE_DISTINCT_WHERE_2,
+					_FILTER_SQL_COUNT_ROLE__WHERE, RoleModelImpl.ORDER_BY_SQL,
 					RoleModelImpl.ORDER_BY_SQL_INLINE_DISTINCT),
 				new FinderColumn<>(
 					"role_.", "companyId", FinderColumn.Type.LONG, "=", true,
@@ -4153,17 +4207,7 @@ public class RolePersistenceImpl
 					true, Role::getType));
 
 		_uniquePersistenceFinderByC_C_C_T = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByC_C_C_T",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Long.class.getName(), Integer.class.getName()
-				},
-				new String[] {"companyId", "classNameId", "classPK", "type_"},
-				0, 0, false, Role::getCompanyId, Role::getClassNameId,
-				Role::getClassPK, Role::getType),
-			_SQL_SELECT_ROLE__WHERE, "",
+			this, _finderPathFetchByC_C_C_T, _SQL_SELECT_ROLE__WHERE, "",
 			new FinderColumn<>(
 				"role_.", "companyId", FinderColumn.Type.LONG, "=", true, true,
 				Role::getCompanyId),
@@ -4177,15 +4221,15 @@ public class RolePersistenceImpl
 				"role_.", "type", FinderColumn.Type.INTEGER, "=", true, true,
 				Role::getType));
 
+		_finderPathFetchByERC_C = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByERC_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "companyId"}, 0, 1, false,
+			convertNullFunction(Role::getExternalReferenceCode),
+			Role::getCompanyId);
+
 		_uniquePersistenceFinderByERC_C = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByERC_C",
-				new String[] {String.class.getName(), Long.class.getName()},
-				new String[] {"externalReferenceCode", "companyId"}, 0, 1,
-				false, convertNullFunction(Role::getExternalReferenceCode),
-				Role::getCompanyId),
-			_SQL_SELECT_ROLE__WHERE, "",
+			this, _finderPathFetchByERC_C, _SQL_SELECT_ROLE__WHERE, "",
 			new FinderColumn<>(
 				"role_.", "externalReferenceCode", FinderColumn.Type.STRING,
 				"=", true, true, Role::getExternalReferenceCode),
@@ -4229,6 +4273,27 @@ public class RolePersistenceImpl
 	private static final String _SQL_COUNT_ROLE__WHERE =
 		"SELECT COUNT(role_) FROM Role role_ WHERE ";
 
+	private static final String _FILTER_ENTITY_TABLE_FILTER_PK_COLUMN =
+		"role_.roleId";
+
+	private static final String _FILTER_SQL_SELECT_ROLE__WHERE =
+		"SELECT DISTINCT {role_.*} FROM Role_ role_ WHERE ";
+
+	private static final String
+		_FILTER_SQL_SELECT_ROLE__NO_INLINE_DISTINCT_WHERE_1 =
+			"SELECT {Role_.*} FROM (SELECT DISTINCT role_.roleId FROM Role_ role_ WHERE ";
+
+	private static final String
+		_FILTER_SQL_SELECT_ROLE__NO_INLINE_DISTINCT_WHERE_2 =
+			") TEMP_TABLE INNER JOIN Role_ ON TEMP_TABLE.roleId = Role_.roleId";
+
+	private static final String _FILTER_SQL_COUNT_ROLE__WHERE =
+		"SELECT COUNT(DISTINCT role_.roleId) AS COUNT_VALUE FROM Role_ role_ WHERE ";
+
+	private static final String _FILTER_ENTITY_ALIAS = "role_";
+
+	private static final String _FILTER_ENTITY_TABLE = "Role_";
+
 	private static final String _NO_SUCH_ENTITY_WITH_KEY =
 		"No Role exists with the key {";
 
@@ -4244,4 +4309,4 @@ public class RolePersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-801049753
+// LIFERAY-SERVICE-BUILDER-HASH:-534513239

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/ServiceComponentPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/ServiceComponentPersistenceImpl.java
@@ -67,6 +67,9 @@ public class ServiceComponentPersistenceImpl
 	public static final String FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION =
 		FINDER_CLASS_NAME_ENTITY + ".List2";
 
+	private FinderPath _finderPathWithPaginationFindByBuildNamespace;
+	private FinderPath _finderPathWithoutPaginationFindByBuildNamespace;
+	private FinderPath _finderPathCountByBuildNamespace;
 	private CollectionPersistenceFinder<ServiceComponent>
 		_collectionPersistenceFinderByBuildNamespace;
 
@@ -214,6 +217,7 @@ public class ServiceComponentPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {buildNamespace});
 	}
 
+	private FinderPath _finderPathFetchByBNS_BNU;
 	private UniquePersistenceFinder<ServiceComponent>
 		_uniquePersistenceFinderByBNS_BNU;
 
@@ -497,28 +501,29 @@ public class ServiceComponentPersistenceImpl
 	 * Initializes the service component persistence.
 	 */
 	public void afterPropertiesSet() {
+		_finderPathWithPaginationFindByBuildNamespace = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByBuildNamespace",
+			new String[] {
+				String.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"buildNamespace"}, true);
+
+		_finderPathWithoutPaginationFindByBuildNamespace = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByBuildNamespace",
+			new String[] {String.class.getName()},
+			new String[] {"buildNamespace"}, 0, 1, true, null);
+
+		_finderPathCountByBuildNamespace = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByBuildNamespace",
+			new String[] {String.class.getName()},
+			new String[] {"buildNamespace"}, 0, 1, false, null);
+
 		_collectionPersistenceFinderByBuildNamespace =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION,
-					"findByBuildNamespace",
-					new String[] {
-						String.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"buildNamespace"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"findByBuildNamespace",
-					new String[] {String.class.getName()},
-					new String[] {"buildNamespace"}, 0, 1, true, null),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByBuildNamespace",
-					new String[] {String.class.getName()},
-					new String[] {"buildNamespace"}, 0, 1, false, null),
+				this, _finderPathWithPaginationFindByBuildNamespace,
+				_finderPathWithoutPaginationFindByBuildNamespace,
+				_finderPathCountByBuildNamespace,
 				_SQL_SELECT_SERVICECOMPONENT_WHERE,
 				_SQL_COUNT_SERVICECOMPONENT_WHERE,
 				ServiceComponentModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
@@ -528,15 +533,16 @@ public class ServiceComponentPersistenceImpl
 					FinderColumn.Type.STRING, "=", true, true,
 					ServiceComponent::getBuildNamespace));
 
+		_finderPathFetchByBNS_BNU = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByBNS_BNU",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"buildNamespace", "buildNumber"}, 0, 1, false,
+			convertNullFunction(ServiceComponent::getBuildNamespace),
+			ServiceComponent::getBuildNumber);
+
 		_uniquePersistenceFinderByBNS_BNU = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByBNS_BNU",
-				new String[] {String.class.getName(), Long.class.getName()},
-				new String[] {"buildNamespace", "buildNumber"}, 0, 1, false,
-				convertNullFunction(ServiceComponent::getBuildNamespace),
-				ServiceComponent::getBuildNumber),
-			_SQL_SELECT_SERVICECOMPONENT_WHERE, "",
+			this, _finderPathFetchByBNS_BNU, _SQL_SELECT_SERVICECOMPONENT_WHERE,
+			"",
 			new FinderColumn<>(
 				"serviceComponent.", "buildNamespace", FinderColumn.Type.STRING,
 				"=", true, true, ServiceComponent::getBuildNamespace),
@@ -580,4 +586,4 @@ public class ServiceComponentPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1527880538
+// LIFERAY-SERVICE-BUILDER-HASH:1596841481

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/SubscriptionPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/SubscriptionPersistenceImpl.java
@@ -73,6 +73,9 @@ public class SubscriptionPersistenceImpl
 	public static final String FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION =
 		FINDER_CLASS_NAME_ENTITY + ".List2";
 
+	private FinderPath _finderPathWithPaginationFindByUserId;
+	private FinderPath _finderPathWithoutPaginationFindByUserId;
+	private FinderPath _finderPathCountByUserId;
 	private CollectionPersistenceFinder<Subscription>
 		_collectionPersistenceFinderByUserId;
 
@@ -214,6 +217,9 @@ public class SubscriptionPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {userId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByG_U;
+	private FinderPath _finderPathWithoutPaginationFindByG_U;
+	private FinderPath _finderPathCountByG_U;
 	private CollectionPersistenceFinder<Subscription>
 		_collectionPersistenceFinderByG_U;
 
@@ -368,6 +374,9 @@ public class SubscriptionPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {groupId, userId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByU_C;
+	private FinderPath _finderPathWithoutPaginationFindByU_C;
+	private FinderPath _finderPathCountByU_C;
 	private CollectionPersistenceFinder<Subscription>
 		_collectionPersistenceFinderByU_C;
 
@@ -526,6 +535,9 @@ public class SubscriptionPersistenceImpl
 			new Object[] {userId, classNameId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_C_C;
+	private FinderPath _finderPathWithoutPaginationFindByC_C_C;
+	private FinderPath _finderPathCountByC_C_C;
 	private CollectionPersistenceFinder<Subscription>
 		_collectionPersistenceFinderByC_C_C;
 
@@ -697,6 +709,10 @@ public class SubscriptionPersistenceImpl
 			new Object[] {companyId, classNameId, classPK});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_U_C_C;
+	private FinderPath _finderPathWithoutPaginationFindByC_U_C_C;
+	private FinderPath _finderPathFetchByC_U_C_C;
+	private FinderPath _finderPathCountByC_U_C_C;
 	private CollectionPersistenceFinder<Subscription>
 		_collectionPersistenceFinderByC_U_C_C;
 	private UniquePersistenceFinder<Subscription>
@@ -1150,49 +1166,56 @@ public class SubscriptionPersistenceImpl
 	 * Initializes the subscription persistence.
 	 */
 	public void afterPropertiesSet() {
+		_finderPathWithPaginationFindByUserId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUserId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"userId"}, true);
+
+		_finderPathWithoutPaginationFindByUserId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUserId",
+			new String[] {Long.class.getName()}, new String[] {"userId"}, true);
+
+		_finderPathCountByUserId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUserId",
+			new String[] {Long.class.getName()}, new String[] {"userId"},
+			false);
+
 		_collectionPersistenceFinderByUserId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUserId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"userId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUserId",
-					new String[] {Long.class.getName()},
-					new String[] {"userId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUserId",
-					new String[] {Long.class.getName()},
-					new String[] {"userId"}, false),
-				_SQL_SELECT_SUBSCRIPTION_WHERE, _SQL_COUNT_SUBSCRIPTION_WHERE,
+				this, _finderPathWithPaginationFindByUserId,
+				_finderPathWithoutPaginationFindByUserId,
+				_finderPathCountByUserId, _SQL_SELECT_SUBSCRIPTION_WHERE,
+				_SQL_COUNT_SUBSCRIPTION_WHERE,
 				SubscriptionModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
 					"subscription.", "userId", FinderColumn.Type.LONG, "=",
 					true, true, Subscription::getUserId));
 
+		_finderPathWithPaginationFindByG_U = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_U",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"groupId", "userId"}, true);
+
+		_finderPathWithoutPaginationFindByG_U = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_U",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"groupId", "userId"}, true);
+
+		_finderPathCountByG_U = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_U",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"groupId", "userId"}, false);
+
 		_collectionPersistenceFinderByG_U = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_U",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Integer.class.getName(), Integer.class.getName(),
-					OrderByComparator.class.getName()
-				},
-				new String[] {"groupId", "userId"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_U",
-				new String[] {Long.class.getName(), Long.class.getName()},
-				new String[] {"groupId", "userId"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_U",
-				new String[] {Long.class.getName(), Long.class.getName()},
-				new String[] {"groupId", "userId"}, false),
+			this, _finderPathWithPaginationFindByG_U,
+			_finderPathWithoutPaginationFindByG_U, _finderPathCountByG_U,
 			_SQL_SELECT_SUBSCRIPTION_WHERE, _SQL_COUNT_SUBSCRIPTION_WHERE,
 			SubscriptionModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
@@ -1202,24 +1225,28 @@ public class SubscriptionPersistenceImpl
 				"subscription.", "userId", FinderColumn.Type.LONG, "=", true,
 				true, Subscription::getUserId));
 
+		_finderPathWithPaginationFindByU_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByU_C",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"userId", "classNameId"}, true);
+
+		_finderPathWithoutPaginationFindByU_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByU_C",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"userId", "classNameId"}, true);
+
+		_finderPathCountByU_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByU_C",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"userId", "classNameId"}, false);
+
 		_collectionPersistenceFinderByU_C = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByU_C",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Integer.class.getName(), Integer.class.getName(),
-					OrderByComparator.class.getName()
-				},
-				new String[] {"userId", "classNameId"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByU_C",
-				new String[] {Long.class.getName(), Long.class.getName()},
-				new String[] {"userId", "classNameId"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByU_C",
-				new String[] {Long.class.getName(), Long.class.getName()},
-				new String[] {"userId", "classNameId"}, false),
+			this, _finderPathWithPaginationFindByU_C,
+			_finderPathWithoutPaginationFindByU_C, _finderPathCountByU_C,
 			_SQL_SELECT_SUBSCRIPTION_WHERE, _SQL_COUNT_SUBSCRIPTION_WHERE,
 			SubscriptionModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
@@ -1229,30 +1256,32 @@ public class SubscriptionPersistenceImpl
 				"subscription.", "classNameId", FinderColumn.Type.LONG, "=",
 				true, true, Subscription::getClassNameId));
 
+		_finderPathWithPaginationFindByC_C_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_C_C",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "classNameId", "classPK"}, true);
+
+		_finderPathWithoutPaginationFindByC_C_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_C_C",
+			new String[] {
+				Long.class.getName(), Long.class.getName(), Long.class.getName()
+			},
+			new String[] {"companyId", "classNameId", "classPK"}, true);
+
+		_finderPathCountByC_C_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_C_C",
+			new String[] {
+				Long.class.getName(), Long.class.getName(), Long.class.getName()
+			},
+			new String[] {"companyId", "classNameId", "classPK"}, false);
+
 		_collectionPersistenceFinderByC_C_C = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_C_C",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Long.class.getName(), Integer.class.getName(),
-					Integer.class.getName(), OrderByComparator.class.getName()
-				},
-				new String[] {"companyId", "classNameId", "classPK"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_C_C",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Long.class.getName()
-				},
-				new String[] {"companyId", "classNameId", "classPK"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_C_C",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Long.class.getName()
-				},
-				new String[] {"companyId", "classNameId", "classPK"}, false),
+			this, _finderPathWithPaginationFindByC_C_C,
+			_finderPathWithoutPaginationFindByC_C_C, _finderPathCountByC_C_C,
 			_SQL_SELECT_SUBSCRIPTION_WHERE, _SQL_COUNT_SUBSCRIPTION_WHERE,
 			SubscriptionModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
@@ -1265,42 +1294,51 @@ public class SubscriptionPersistenceImpl
 				"subscription.", "classPK", FinderColumn.Type.LONG, "=", true,
 				true, Subscription::getClassPK));
 
+		_finderPathWithPaginationFindByC_U_C_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_U_C_C",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "userId", "classNameId", "classPK"},
+			true);
+
+		_finderPathWithoutPaginationFindByC_U_C_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_U_C_C",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Long.class.getName()
+			},
+			new String[] {"companyId", "userId", "classNameId", "classPK"},
+			true);
+
+		_finderPathFetchByC_U_C_C = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByC_U_C_C",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Long.class.getName()
+			},
+			new String[] {"companyId", "userId", "classNameId", "classPK"}, 0,
+			0, false, Subscription::getCompanyId, Subscription::getUserId,
+			Subscription::getClassNameId, Subscription::getClassPK);
+
+		_finderPathCountByC_U_C_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByC_U_C_C",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Long.class.getName()
+			},
+			new String[] {"companyId", "userId", "classNameId", "classPK"},
+			false);
+
 		_collectionPersistenceFinderByC_U_C_C =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_U_C_C",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						Long.class.getName(), Long.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {
-						"companyId", "userId", "classNameId", "classPK"
-					},
-					true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_U_C_C",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						Long.class.getName(), Long.class.getName()
-					},
-					new String[] {
-						"companyId", "userId", "classNameId", "classPK"
-					},
-					true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByC_U_C_C",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						Long.class.getName(), Long.class.getName()
-					},
-					new String[] {
-						"companyId", "userId", "classNameId", "classPK"
-					},
-					false),
-				_SQL_SELECT_SUBSCRIPTION_WHERE, _SQL_COUNT_SUBSCRIPTION_WHERE,
+				this, _finderPathWithPaginationFindByC_U_C_C,
+				_finderPathWithoutPaginationFindByC_U_C_C,
+				_finderPathCountByC_U_C_C, _SQL_SELECT_SUBSCRIPTION_WHERE,
+				_SQL_COUNT_SUBSCRIPTION_WHERE,
 				SubscriptionModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
 					"subscription.", "companyId", FinderColumn.Type.LONG, "=",
@@ -1316,18 +1354,7 @@ public class SubscriptionPersistenceImpl
 					false, true, true, Subscription::getClassPK));
 
 		_uniquePersistenceFinderByC_U_C_C = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByC_U_C_C",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Long.class.getName(), Long.class.getName()
-				},
-				new String[] {"companyId", "userId", "classNameId", "classPK"},
-				0, 0, false, Subscription::getCompanyId,
-				Subscription::getUserId, Subscription::getClassNameId,
-				Subscription::getClassPK),
-			_SQL_SELECT_SUBSCRIPTION_WHERE, "",
+			this, _finderPathFetchByC_U_C_C, _SQL_SELECT_SUBSCRIPTION_WHERE, "",
 			new FinderColumn<>(
 				"subscription.", "companyId", FinderColumn.Type.LONG, "=", true,
 				true, Subscription::getCompanyId),
@@ -1374,4 +1401,4 @@ public class SubscriptionPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1205296705
+// LIFERAY-SERVICE-BUILDER-HASH:-1236318560

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/SystemEventPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/SystemEventPersistenceImpl.java
@@ -74,6 +74,9 @@ public class SystemEventPersistenceImpl
 	public static final String FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION =
 		FINDER_CLASS_NAME_ENTITY + ".List2";
 
+	private FinderPath _finderPathWithPaginationFindByGroupId;
+	private FinderPath _finderPathWithoutPaginationFindByGroupId;
+	private FinderPath _finderPathCountByGroupId;
 	private CollectionPersistenceFinder<SystemEvent>
 		_collectionPersistenceFinderByGroupId;
 
@@ -216,6 +219,9 @@ public class SystemEventPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {groupId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByG_S;
+	private FinderPath _finderPathWithoutPaginationFindByG_S;
+	private FinderPath _finderPathCountByG_S;
 	private CollectionPersistenceFinder<SystemEvent>
 		_collectionPersistenceFinderByG_S;
 
@@ -376,6 +382,9 @@ public class SystemEventPersistenceImpl
 			new Object[] {groupId, systemEventSetKey});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByG_C_C;
+	private FinderPath _finderPathWithoutPaginationFindByG_C_C;
+	private FinderPath _finderPathCountByG_C_C;
 	private CollectionPersistenceFinder<SystemEvent>
 		_collectionPersistenceFinderByG_C_C;
 
@@ -546,6 +555,9 @@ public class SystemEventPersistenceImpl
 			new Object[] {groupId, classNameId, classPK});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByG_C_C_T;
+	private FinderPath _finderPathWithoutPaginationFindByG_C_C_T;
+	private FinderPath _finderPathCountByG_C_C_T;
 	private CollectionPersistenceFinder<SystemEvent>
 		_collectionPersistenceFinderByG_C_C_T;
 
@@ -1004,49 +1016,57 @@ public class SystemEventPersistenceImpl
 	 * Initializes the system event persistence.
 	 */
 	public void afterPropertiesSet() {
+		_finderPathWithPaginationFindByGroupId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByGroupId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"groupId"}, true);
+
+		_finderPathWithoutPaginationFindByGroupId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByGroupId",
+			new String[] {Long.class.getName()}, new String[] {"groupId"},
+			true);
+
+		_finderPathCountByGroupId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByGroupId",
+			new String[] {Long.class.getName()}, new String[] {"groupId"},
+			false);
+
 		_collectionPersistenceFinderByGroupId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByGroupId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"groupId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByGroupId",
-					new String[] {Long.class.getName()},
-					new String[] {"groupId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByGroupId",
-					new String[] {Long.class.getName()},
-					new String[] {"groupId"}, false),
-				_SQL_SELECT_SYSTEMEVENT_WHERE, _SQL_COUNT_SYSTEMEVENT_WHERE,
+				this, _finderPathWithPaginationFindByGroupId,
+				_finderPathWithoutPaginationFindByGroupId,
+				_finderPathCountByGroupId, _SQL_SELECT_SYSTEMEVENT_WHERE,
+				_SQL_COUNT_SYSTEMEVENT_WHERE,
 				SystemEventModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
 					"systemEvent.", "groupId", FinderColumn.Type.LONG, "=",
 					true, true, SystemEvent::getGroupId));
 
+		_finderPathWithPaginationFindByG_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_S",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"groupId", "systemEventSetKey"}, true);
+
+		_finderPathWithoutPaginationFindByG_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_S",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"groupId", "systemEventSetKey"}, true);
+
+		_finderPathCountByG_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_S",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"groupId", "systemEventSetKey"}, false);
+
 		_collectionPersistenceFinderByG_S = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_S",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Integer.class.getName(), Integer.class.getName(),
-					OrderByComparator.class.getName()
-				},
-				new String[] {"groupId", "systemEventSetKey"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_S",
-				new String[] {Long.class.getName(), Long.class.getName()},
-				new String[] {"groupId", "systemEventSetKey"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_S",
-				new String[] {Long.class.getName(), Long.class.getName()},
-				new String[] {"groupId", "systemEventSetKey"}, false),
+			this, _finderPathWithPaginationFindByG_S,
+			_finderPathWithoutPaginationFindByG_S, _finderPathCountByG_S,
 			_SQL_SELECT_SYSTEMEVENT_WHERE, _SQL_COUNT_SYSTEMEVENT_WHERE,
 			SystemEventModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
@@ -1056,30 +1076,32 @@ public class SystemEventPersistenceImpl
 				"systemEvent.", "systemEventSetKey", FinderColumn.Type.LONG,
 				"=", true, true, SystemEvent::getSystemEventSetKey));
 
+		_finderPathWithPaginationFindByG_C_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_C_C",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"groupId", "classNameId", "classPK"}, true);
+
+		_finderPathWithoutPaginationFindByG_C_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_C_C",
+			new String[] {
+				Long.class.getName(), Long.class.getName(), Long.class.getName()
+			},
+			new String[] {"groupId", "classNameId", "classPK"}, true);
+
+		_finderPathCountByG_C_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_C_C",
+			new String[] {
+				Long.class.getName(), Long.class.getName(), Long.class.getName()
+			},
+			new String[] {"groupId", "classNameId", "classPK"}, false);
+
 		_collectionPersistenceFinderByG_C_C = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_C_C",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Long.class.getName(), Integer.class.getName(),
-					Integer.class.getName(), OrderByComparator.class.getName()
-				},
-				new String[] {"groupId", "classNameId", "classPK"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_C_C",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Long.class.getName()
-				},
-				new String[] {"groupId", "classNameId", "classPK"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_C_C",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Long.class.getName()
-				},
-				new String[] {"groupId", "classNameId", "classPK"}, false),
+			this, _finderPathWithPaginationFindByG_C_C,
+			_finderPathWithoutPaginationFindByG_C_C, _finderPathCountByG_C_C,
 			_SQL_SELECT_SYSTEMEVENT_WHERE, _SQL_COUNT_SYSTEMEVENT_WHERE,
 			SystemEventModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
@@ -1092,36 +1114,38 @@ public class SystemEventPersistenceImpl
 				"systemEvent.", "classPK", FinderColumn.Type.LONG, "=", true,
 				true, SystemEvent::getClassPK));
 
+		_finderPathWithPaginationFindByG_C_C_T = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_C_C_T",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"groupId", "classNameId", "classPK", "type_"}, true);
+
+		_finderPathWithoutPaginationFindByG_C_C_T = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_C_C_T",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Integer.class.getName()
+			},
+			new String[] {"groupId", "classNameId", "classPK", "type_"}, true);
+
+		_finderPathCountByG_C_C_T = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_C_C_T",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Integer.class.getName()
+			},
+			new String[] {"groupId", "classNameId", "classPK", "type_"}, false);
+
 		_collectionPersistenceFinderByG_C_C_T =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_C_C_T",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"groupId", "classNameId", "classPK", "type_"},
-					true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_C_C_T",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						Long.class.getName(), Integer.class.getName()
-					},
-					new String[] {"groupId", "classNameId", "classPK", "type_"},
-					true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_C_C_T",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						Long.class.getName(), Integer.class.getName()
-					},
-					new String[] {"groupId", "classNameId", "classPK", "type_"},
-					false),
-				_SQL_SELECT_SYSTEMEVENT_WHERE, _SQL_COUNT_SYSTEMEVENT_WHERE,
+				this, _finderPathWithPaginationFindByG_C_C_T,
+				_finderPathWithoutPaginationFindByG_C_C_T,
+				_finderPathCountByG_C_C_T, _SQL_SELECT_SYSTEMEVENT_WHERE,
+				_SQL_COUNT_SYSTEMEVENT_WHERE,
 				SystemEventModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
 					"systemEvent.", "groupId", FinderColumn.Type.LONG, "=",
@@ -1169,4 +1193,4 @@ public class SystemEventPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1849364480
+// LIFERAY-SERVICE-BUILDER-HASH:-1458829954

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/TeamPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/TeamPersistenceImpl.java
@@ -87,6 +87,9 @@ public class TeamPersistenceImpl
 	public static final String FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION =
 		FINDER_CLASS_NAME_ENTITY + ".List2";
 
+	private FinderPath _finderPathWithPaginationFindByUuid;
+	private FinderPath _finderPathWithoutPaginationFindByUuid;
+	private FinderPath _finderPathCountByUuid;
 	private CollectionPersistenceFinder<Team>
 		_collectionPersistenceFinderByUuid;
 
@@ -226,6 +229,7 @@ public class TeamPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {uuid});
 	}
 
+	private FinderPath _finderPathFetchByUUID_G;
 	private UniquePersistenceFinder<Team> _uniquePersistenceFinderByUUID_G;
 
 	/**
@@ -315,6 +319,9 @@ public class TeamPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {uuid, groupId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByUuid_C;
+	private FinderPath _finderPathWithoutPaginationFindByUuid_C;
+	private FinderPath _finderPathCountByUuid_C;
 	private CollectionPersistenceFinder<Team>
 		_collectionPersistenceFinderByUuid_C;
 
@@ -468,6 +475,9 @@ public class TeamPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {uuid, companyId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByCompanyId;
+	private FinderPath _finderPathWithoutPaginationFindByCompanyId;
+	private FinderPath _finderPathCountByCompanyId;
 	private CollectionPersistenceFinder<Team>
 		_collectionPersistenceFinderByCompanyId;
 
@@ -608,6 +618,9 @@ public class TeamPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {companyId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByGroupId;
+	private FinderPath _finderPathWithoutPaginationFindByGroupId;
+	private FinderPath _finderPathCountByGroupId;
 	private FilterCollectionPersistenceFinder<Team>
 		_collectionPersistenceFinderByGroupId;
 
@@ -812,6 +825,7 @@ public class TeamPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {groupId}, groupId);
 	}
 
+	private FinderPath _finderPathFetchByG_N;
 	private UniquePersistenceFinder<Team> _uniquePersistenceFinderByG_N;
 
 	/**
@@ -1851,37 +1865,41 @@ public class TeamPersistenceImpl
 			"UserGroups_Teams", "companyId", "teamId", "userGroupId", this,
 			userGroupPersistence);
 
+		_finderPathWithPaginationFindByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid",
+			new String[] {
+				String.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"uuid_"}, true);
+
+		_finderPathWithoutPaginationFindByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid",
+			new String[] {String.class.getName()}, new String[] {"uuid_"}, 0, 1,
+			true, null);
+
+		_finderPathCountByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid",
+			new String[] {String.class.getName()}, new String[] {"uuid_"}, 0, 1,
+			false, null);
+
 		_collectionPersistenceFinderByUuid = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid",
-				new String[] {
-					String.class.getName(), Integer.class.getName(),
-					Integer.class.getName(), OrderByComparator.class.getName()
-				},
-				new String[] {"uuid_"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid",
-				new String[] {String.class.getName()}, new String[] {"uuid_"},
-				0, 1, true, null),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid",
-				new String[] {String.class.getName()}, new String[] {"uuid_"},
-				0, 1, false, null),
+			this, _finderPathWithPaginationFindByUuid,
+			_finderPathWithoutPaginationFindByUuid, _finderPathCountByUuid,
 			_SQL_SELECT_TEAM_WHERE, _SQL_COUNT_TEAM_WHERE,
 			TeamModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
 				"team.", "uuid", FinderColumn.Type.STRING, "=", true, true,
 				Team::getUuid));
 
+		_finderPathFetchByUUID_G = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByUUID_G",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"uuid_", "groupId"}, 0, 1, false,
+			convertNullFunction(Team::getUuid), Team::getGroupId);
+
 		_uniquePersistenceFinderByUUID_G = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByUUID_G",
-				new String[] {String.class.getName(), Long.class.getName()},
-				new String[] {"uuid_", "groupId"}, 0, 1, false,
-				convertNullFunction(Team::getUuid), Team::getGroupId),
-			_SQL_SELECT_TEAM_WHERE, "",
+			this, _finderPathFetchByUUID_G, _SQL_SELECT_TEAM_WHERE, "",
 			new FinderColumn<>(
 				"team.", "uuid", FinderColumn.Type.STRING, "=", true, true,
 				Team::getUuid),
@@ -1889,27 +1907,32 @@ public class TeamPersistenceImpl
 				"team.", "groupId", FinderColumn.Type.LONG, "=", true, true,
 				Team::getGroupId));
 
+		_finderPathWithPaginationFindByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid_C",
+			new String[] {
+				String.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"uuid_", "companyId"}, true);
+
+		_finderPathWithoutPaginationFindByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"uuid_", "companyId"}, 0, 1, true, null);
+
+		_finderPathCountByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"uuid_", "companyId"}, 0, 1, false, null);
+
 		_collectionPersistenceFinderByUuid_C =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid_C",
-					new String[] {
-						String.class.getName(), Long.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"uuid_", "companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid_C",
-					new String[] {String.class.getName(), Long.class.getName()},
-					new String[] {"uuid_", "companyId"}, 0, 1, true, null),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid_C",
-					new String[] {String.class.getName(), Long.class.getName()},
-					new String[] {"uuid_", "companyId"}, 0, 1, false, null),
-				_SQL_SELECT_TEAM_WHERE, _SQL_COUNT_TEAM_WHERE,
-				TeamModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+				this, _finderPathWithPaginationFindByUuid_C,
+				_finderPathWithoutPaginationFindByUuid_C,
+				_finderPathCountByUuid_C, _SQL_SELECT_TEAM_WHERE,
+				_SQL_COUNT_TEAM_WHERE, TeamModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
 					"team.", "uuid", FinderColumn.Type.STRING, "=", true, true,
 					Team::getUuid),
@@ -1917,72 +1940,80 @@ public class TeamPersistenceImpl
 					"team.", "companyId", FinderColumn.Type.LONG, "=", true,
 					true, Team::getCompanyId));
 
+		_finderPathWithPaginationFindByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByCompanyId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"companyId"}, true);
+
+		_finderPathWithoutPaginationFindByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByCompanyId",
+			new String[] {Long.class.getName()}, new String[] {"companyId"},
+			true);
+
+		_finderPathCountByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByCompanyId",
+			new String[] {Long.class.getName()}, new String[] {"companyId"},
+			false);
+
 		_collectionPersistenceFinderByCompanyId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByCompanyId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"findByCompanyId", new String[] {Long.class.getName()},
-					new String[] {"companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByCompanyId", new String[] {Long.class.getName()},
-					new String[] {"companyId"}, false),
-				_SQL_SELECT_TEAM_WHERE, _SQL_COUNT_TEAM_WHERE,
-				TeamModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+				this, _finderPathWithPaginationFindByCompanyId,
+				_finderPathWithoutPaginationFindByCompanyId,
+				_finderPathCountByCompanyId, _SQL_SELECT_TEAM_WHERE,
+				_SQL_COUNT_TEAM_WHERE, TeamModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
 					"team.", "companyId", FinderColumn.Type.LONG, "=", true,
 					true, Team::getCompanyId));
 
+		_finderPathWithPaginationFindByGroupId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByGroupId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"groupId"}, true);
+
+		_finderPathWithoutPaginationFindByGroupId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByGroupId",
+			new String[] {Long.class.getName()}, new String[] {"groupId"},
+			true);
+
+		_finderPathCountByGroupId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByGroupId",
+			new String[] {Long.class.getName()}, new String[] {"groupId"},
+			false);
+
 		_collectionPersistenceFinderByGroupId =
 			new FilterCollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByGroupId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"groupId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByGroupId",
-					new String[] {Long.class.getName()},
-					new String[] {"groupId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByGroupId",
-					new String[] {Long.class.getName()},
-					new String[] {"groupId"}, false),
-				_SQL_SELECT_TEAM_WHERE, _SQL_COUNT_TEAM_WHERE,
-				TeamModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+				this, _finderPathWithPaginationFindByGroupId,
+				_finderPathWithoutPaginationFindByGroupId,
+				_finderPathCountByGroupId, _SQL_SELECT_TEAM_WHERE,
+				_SQL_COUNT_TEAM_WHERE, TeamModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "",
 				new FilterCollectionPersistenceFinder.FilterMetadata<>(
-					TeamImpl.class, Team.class, "team", "Team", "team.teamId",
-					"SELECT DISTINCT {team.*} FROM Team team WHERE ",
-					"SELECT {Team.*} FROM (SELECT DISTINCT team.teamId FROM Team team WHERE ",
-					") TEMP_TABLE INNER JOIN Team ON TEMP_TABLE.teamId = Team.teamId",
-					"SELECT COUNT(DISTINCT team.teamId) AS COUNT_VALUE FROM Team team WHERE ",
-					TeamModelImpl.ORDER_BY_SQL,
+					TeamImpl.class, Team.class, _FILTER_ENTITY_ALIAS,
+					_FILTER_ENTITY_TABLE, _FILTER_ENTITY_TABLE_FILTER_PK_COLUMN,
+					_FILTER_SQL_SELECT_TEAM_WHERE,
+					_FILTER_SQL_SELECT_TEAM_NO_INLINE_DISTINCT_WHERE_1,
+					_FILTER_SQL_SELECT_TEAM_NO_INLINE_DISTINCT_WHERE_2,
+					_FILTER_SQL_COUNT_TEAM_WHERE, TeamModelImpl.ORDER_BY_SQL,
 					TeamModelImpl.ORDER_BY_SQL_INLINE_DISTINCT),
 				new FinderColumn<>(
 					"team.", "groupId", FinderColumn.Type.LONG, "=", true, true,
 					Team::getGroupId));
 
+		_finderPathFetchByG_N = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByG_N",
+			new String[] {Long.class.getName(), String.class.getName()},
+			new String[] {"groupId", "name"}, 0, 2, false, Team::getGroupId,
+			convertNullFunction(Team::getName));
+
 		_uniquePersistenceFinderByG_N = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByG_N",
-				new String[] {Long.class.getName(), String.class.getName()},
-				new String[] {"groupId", "name"}, 0, 2, false, Team::getGroupId,
-				convertNullFunction(Team::getName)),
-			_SQL_SELECT_TEAM_WHERE, "",
+			this, _finderPathFetchByG_N, _SQL_SELECT_TEAM_WHERE, "",
 			new FinderColumn<>(
 				"team.", "groupId", FinderColumn.Type.LONG, "=", true, true,
 				Team::getGroupId),
@@ -2025,6 +2056,27 @@ public class TeamPersistenceImpl
 	private static final String _SQL_COUNT_TEAM_WHERE =
 		"SELECT COUNT(team) FROM Team team WHERE ";
 
+	private static final String _FILTER_ENTITY_TABLE_FILTER_PK_COLUMN =
+		"team.teamId";
+
+	private static final String _FILTER_SQL_SELECT_TEAM_WHERE =
+		"SELECT DISTINCT {team.*} FROM Team team WHERE ";
+
+	private static final String
+		_FILTER_SQL_SELECT_TEAM_NO_INLINE_DISTINCT_WHERE_1 =
+			"SELECT {Team.*} FROM (SELECT DISTINCT team.teamId FROM Team team WHERE ";
+
+	private static final String
+		_FILTER_SQL_SELECT_TEAM_NO_INLINE_DISTINCT_WHERE_2 =
+			") TEMP_TABLE INNER JOIN Team ON TEMP_TABLE.teamId = Team.teamId";
+
+	private static final String _FILTER_SQL_COUNT_TEAM_WHERE =
+		"SELECT COUNT(DISTINCT team.teamId) AS COUNT_VALUE FROM Team team WHERE ";
+
+	private static final String _FILTER_ENTITY_ALIAS = "team";
+
+	private static final String _FILTER_ENTITY_TABLE = "Team";
+
 	private static final String _NO_SUCH_ENTITY_WITH_KEY =
 		"No Team exists with the key {";
 
@@ -2040,4 +2092,4 @@ public class TeamPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:275507117
+// LIFERAY-SERVICE-BUILDER-HASH:176426449

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/TicketPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/TicketPersistenceImpl.java
@@ -70,6 +70,7 @@ public class TicketPersistenceImpl
 	public static final String FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION =
 		FINDER_CLASS_NAME_ENTITY + ".List2";
 
+	private FinderPath _finderPathFetchByKey;
 	private UniquePersistenceFinder<Ticket> _uniquePersistenceFinderByKey;
 
 	/**
@@ -148,6 +149,9 @@ public class TicketPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {key});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_C_C;
+	private FinderPath _finderPathWithoutPaginationFindByC_C_C;
+	private FinderPath _finderPathCountByC_C_C;
 	private CollectionPersistenceFinder<Ticket>
 		_collectionPersistenceFinderByC_C_C;
 
@@ -318,6 +322,181 @@ public class TicketPersistenceImpl
 			new Object[] {companyId, classNameId, classPK});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_T_EA;
+	private FinderPath _finderPathWithoutPaginationFindByC_T_EA;
+	private FinderPath _finderPathCountByC_T_EA;
+	private CollectionPersistenceFinder<Ticket>
+		_collectionPersistenceFinderByC_T_EA;
+
+	/**
+	 * Returns all the tickets where companyId = &#63; and type = &#63; and emailAddress = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param type the type
+	 * @param emailAddress the email address
+	 * @return the matching tickets
+	 */
+	@Override
+	public List<Ticket> findByC_T_EA(
+		long companyId, int type, String emailAddress) {
+
+		return findByC_T_EA(
+			companyId, type, emailAddress, QueryUtil.ALL_POS, QueryUtil.ALL_POS,
+			null);
+	}
+
+	/**
+	 * Returns a range of all the tickets where companyId = &#63; and type = &#63; and emailAddress = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>TicketModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param type the type
+	 * @param emailAddress the email address
+	 * @param start the lower bound of the range of tickets
+	 * @param end the upper bound of the range of tickets (not inclusive)
+	 * @return the range of matching tickets
+	 */
+	@Override
+	public List<Ticket> findByC_T_EA(
+		long companyId, int type, String emailAddress, int start, int end) {
+
+		return findByC_T_EA(companyId, type, emailAddress, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the tickets where companyId = &#63; and type = &#63; and emailAddress = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>TicketModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param type the type
+	 * @param emailAddress the email address
+	 * @param start the lower bound of the range of tickets
+	 * @param end the upper bound of the range of tickets (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching tickets
+	 */
+	@Override
+	public List<Ticket> findByC_T_EA(
+		long companyId, int type, String emailAddress, int start, int end,
+		OrderByComparator<Ticket> orderByComparator) {
+
+		return findByC_T_EA(
+			companyId, type, emailAddress, start, end, orderByComparator, true);
+	}
+
+	/**
+	 * Returns an ordered range of all the tickets where companyId = &#63; and type = &#63; and emailAddress = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>TicketModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param type the type
+	 * @param emailAddress the email address
+	 * @param start the lower bound of the range of tickets
+	 * @param end the upper bound of the range of tickets (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching tickets
+	 */
+	@Override
+	public List<Ticket> findByC_T_EA(
+		long companyId, int type, String emailAddress, int start, int end,
+		OrderByComparator<Ticket> orderByComparator, boolean useFinderCache) {
+
+		return _collectionPersistenceFinderByC_T_EA.find(
+			FinderCacheUtil.getFinderCache(),
+			new Object[] {companyId, type, emailAddress}, start, end,
+			orderByComparator, useFinderCache);
+	}
+
+	/**
+	 * Returns the first ticket in the ordered set where companyId = &#63; and type = &#63; and emailAddress = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param type the type
+	 * @param emailAddress the email address
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching ticket
+	 * @throws NoSuchTicketException if a matching ticket could not be found
+	 */
+	@Override
+	public Ticket findByC_T_EA_First(
+			long companyId, int type, String emailAddress,
+			OrderByComparator<Ticket> orderByComparator)
+		throws NoSuchTicketException {
+
+		Ticket ticket = fetchByC_T_EA_First(
+			companyId, type, emailAddress, orderByComparator);
+
+		if (ticket != null) {
+			return ticket;
+		}
+
+		throw new NoSuchTicketException(
+			_collectionPersistenceFinderByC_T_EA.buildNoSuchKeyMessage(
+				_NO_SUCH_ENTITY_WITH_KEY,
+				new Object[] {companyId, type, emailAddress}));
+	}
+
+	/**
+	 * Returns the first ticket in the ordered set where companyId = &#63; and type = &#63; and emailAddress = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param type the type
+	 * @param emailAddress the email address
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching ticket, or <code>null</code> if a matching ticket could not be found
+	 */
+	@Override
+	public Ticket fetchByC_T_EA_First(
+		long companyId, int type, String emailAddress,
+		OrderByComparator<Ticket> orderByComparator) {
+
+		return _collectionPersistenceFinderByC_T_EA.fetchFirst(
+			FinderCacheUtil.getFinderCache(),
+			new Object[] {companyId, type, emailAddress}, orderByComparator);
+	}
+
+	/**
+	 * Removes all the tickets where companyId = &#63; and type = &#63; and emailAddress = &#63; from the database.
+	 *
+	 * @param companyId the company ID
+	 * @param type the type
+	 * @param emailAddress the email address
+	 */
+	@Override
+	public void removeByC_T_EA(long companyId, int type, String emailAddress) {
+		_collectionPersistenceFinderByC_T_EA.remove(
+			FinderCacheUtil.getFinderCache(),
+			new Object[] {companyId, type, emailAddress});
+	}
+
+	/**
+	 * Returns the number of tickets where companyId = &#63; and type = &#63; and emailAddress = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param type the type
+	 * @param emailAddress the email address
+	 * @return the number of matching tickets
+	 */
+	@Override
+	public int countByC_T_EA(long companyId, int type, String emailAddress) {
+		return _collectionPersistenceFinderByC_T_EA.count(
+			FinderCacheUtil.getFinderCache(),
+			new Object[] {companyId, type, emailAddress});
+	}
+
+	private FinderPath _finderPathWithPaginationFindByC_C_T;
+	private FinderPath _finderPathWithoutPaginationFindByC_C_T;
+	private FinderPath _finderPathCountByC_C_T;
 	private CollectionPersistenceFinder<Ticket>
 		_collectionPersistenceFinderByC_C_T;
 
@@ -485,6 +664,9 @@ public class TicketPersistenceImpl
 			new Object[] {classNameId, classPK, type});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_C_C_T;
+	private FinderPath _finderPathWithoutPaginationFindByC_C_C_T;
+	private FinderPath _finderPathCountByC_C_C_T;
 	private CollectionPersistenceFinder<Ticket>
 		_collectionPersistenceFinderByC_C_C_T;
 
@@ -865,41 +1047,43 @@ public class TicketPersistenceImpl
 	 * Initializes the ticket persistence.
 	 */
 	public void afterPropertiesSet() {
+		_finderPathFetchByKey = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByKey",
+			new String[] {String.class.getName()}, new String[] {"key_"}, 0, 1,
+			false, convertNullFunction(Ticket::getKey));
+
 		_uniquePersistenceFinderByKey = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByKey",
-				new String[] {String.class.getName()}, new String[] {"key_"}, 0,
-				1, false, convertNullFunction(Ticket::getKey)),
-			_SQL_SELECT_TICKET_WHERE, "",
+			this, _finderPathFetchByKey, _SQL_SELECT_TICKET_WHERE, "",
 			new FinderColumn<>(
 				"ticket.", "key", FinderColumn.Type.STRING, "=", true, true,
 				Ticket::getKey));
 
+		_finderPathWithPaginationFindByC_C_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_C_C",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "classNameId", "classPK"}, true);
+
+		_finderPathWithoutPaginationFindByC_C_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_C_C",
+			new String[] {
+				Long.class.getName(), Long.class.getName(), Long.class.getName()
+			},
+			new String[] {"companyId", "classNameId", "classPK"}, true);
+
+		_finderPathCountByC_C_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_C_C",
+			new String[] {
+				Long.class.getName(), Long.class.getName(), Long.class.getName()
+			},
+			new String[] {"companyId", "classNameId", "classPK"}, false);
+
 		_collectionPersistenceFinderByC_C_C = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_C_C",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Long.class.getName(), Integer.class.getName(),
-					Integer.class.getName(), OrderByComparator.class.getName()
-				},
-				new String[] {"companyId", "classNameId", "classPK"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_C_C",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Long.class.getName()
-				},
-				new String[] {"companyId", "classNameId", "classPK"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_C_C",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Long.class.getName()
-				},
-				new String[] {"companyId", "classNameId", "classPK"}, false),
+			this, _finderPathWithPaginationFindByC_C_C,
+			_finderPathWithoutPaginationFindByC_C_C, _finderPathCountByC_C_C,
 			_SQL_SELECT_TICKET_WHERE, _SQL_COUNT_TICKET_WHERE,
 			TicketModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
@@ -912,30 +1096,78 @@ public class TicketPersistenceImpl
 				"ticket.", "classPK", FinderColumn.Type.LONG, "=", true, true,
 				Ticket::getClassPK));
 
+		_finderPathWithPaginationFindByC_T_EA = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_T_EA",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				String.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "type_", "emailAddress"}, true);
+
+		_finderPathWithoutPaginationFindByC_T_EA = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_T_EA",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				String.class.getName()
+			},
+			new String[] {"companyId", "type_", "emailAddress"}, 0, 4, true,
+			null);
+
+		_finderPathCountByC_T_EA = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_T_EA",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				String.class.getName()
+			},
+			new String[] {"companyId", "type_", "emailAddress"}, 0, 4, false,
+			null);
+
+		_collectionPersistenceFinderByC_T_EA =
+			new CollectionPersistenceFinder<>(
+				this, _finderPathWithPaginationFindByC_T_EA,
+				_finderPathWithoutPaginationFindByC_T_EA,
+				_finderPathCountByC_T_EA, _SQL_SELECT_TICKET_WHERE,
+				_SQL_COUNT_TICKET_WHERE, TicketModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "",
+				new FinderColumn<>(
+					"ticket.", "companyId", FinderColumn.Type.LONG, "=", true,
+					true, Ticket::getCompanyId),
+				new FinderColumn<>(
+					"ticket.", "type", FinderColumn.Type.INTEGER, "=", true,
+					true, Ticket::getType),
+				new FinderColumn<>(
+					"ticket.", "emailAddress", FinderColumn.Type.STRING, "=",
+					true, true, Ticket::getEmailAddress));
+
+		_finderPathWithPaginationFindByC_C_T = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_C_T",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"classNameId", "classPK", "type_"}, true);
+
+		_finderPathWithoutPaginationFindByC_C_T = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_C_T",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Integer.class.getName()
+			},
+			new String[] {"classNameId", "classPK", "type_"}, true);
+
+		_finderPathCountByC_C_T = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_C_T",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Integer.class.getName()
+			},
+			new String[] {"classNameId", "classPK", "type_"}, false);
+
 		_collectionPersistenceFinderByC_C_T = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_C_T",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Integer.class.getName(), Integer.class.getName(),
-					Integer.class.getName(), OrderByComparator.class.getName()
-				},
-				new String[] {"classNameId", "classPK", "type_"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_C_T",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Integer.class.getName()
-				},
-				new String[] {"classNameId", "classPK", "type_"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_C_T",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Integer.class.getName()
-				},
-				new String[] {"classNameId", "classPK", "type_"}, false),
+			this, _finderPathWithPaginationFindByC_C_T,
+			_finderPathWithoutPaginationFindByC_C_T, _finderPathCountByC_C_T,
 			_SQL_SELECT_TICKET_WHERE, _SQL_COUNT_TICKET_WHERE,
 			TicketModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
@@ -948,43 +1180,42 @@ public class TicketPersistenceImpl
 				"ticket.", "type", FinderColumn.Type.INTEGER, "=", true, true,
 				Ticket::getType));
 
+		_finderPathWithPaginationFindByC_C_C_T = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_C_C_T",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "classNameId", "classPK", "type_"},
+			true);
+
+		_finderPathWithoutPaginationFindByC_C_C_T = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_C_C_T",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Integer.class.getName()
+			},
+			new String[] {"companyId", "classNameId", "classPK", "type_"},
+			true);
+
+		_finderPathCountByC_C_C_T = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_C_C_T",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Integer.class.getName()
+			},
+			new String[] {"companyId", "classNameId", "classPK", "type_"},
+			false);
+
 		_collectionPersistenceFinderByC_C_C_T =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_C_C_T",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {
-						"companyId", "classNameId", "classPK", "type_"
-					},
-					true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_C_C_T",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						Long.class.getName(), Integer.class.getName()
-					},
-					new String[] {
-						"companyId", "classNameId", "classPK", "type_"
-					},
-					true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_C_C_T",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						Long.class.getName(), Integer.class.getName()
-					},
-					new String[] {
-						"companyId", "classNameId", "classPK", "type_"
-					},
-					false),
-				_SQL_SELECT_TICKET_WHERE, _SQL_COUNT_TICKET_WHERE,
-				TicketModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+				this, _finderPathWithPaginationFindByC_C_C_T,
+				_finderPathWithoutPaginationFindByC_C_C_T,
+				_finderPathCountByC_C_C_T, _SQL_SELECT_TICKET_WHERE,
+				_SQL_COUNT_TICKET_WHERE, TicketModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
 					"ticket.", "companyId", FinderColumn.Type.LONG, "=", true,
 					true, Ticket::getCompanyId),
@@ -1034,4 +1265,4 @@ public class TicketPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:401458067
+// LIFERAY-SERVICE-BUILDER-HASH:533833473

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/UserGroupGroupRolePersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/UserGroupGroupRolePersistenceImpl.java
@@ -73,6 +73,9 @@ public class UserGroupGroupRolePersistenceImpl
 	public static final String FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION =
 		FINDER_CLASS_NAME_ENTITY + ".List2";
 
+	private FinderPath _finderPathWithPaginationFindByUserGroupId;
+	private FinderPath _finderPathWithoutPaginationFindByUserGroupId;
+	private FinderPath _finderPathCountByUserGroupId;
 	private CollectionPersistenceFinder<UserGroupGroupRole>
 		_collectionPersistenceFinderByUserGroupId;
 
@@ -220,6 +223,9 @@ public class UserGroupGroupRolePersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {userGroupId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByGroupId;
+	private FinderPath _finderPathWithoutPaginationFindByGroupId;
+	private FinderPath _finderPathCountByGroupId;
 	private CollectionPersistenceFinder<UserGroupGroupRole>
 		_collectionPersistenceFinderByGroupId;
 
@@ -365,6 +371,9 @@ public class UserGroupGroupRolePersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {groupId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByRoleId;
+	private FinderPath _finderPathWithoutPaginationFindByRoleId;
+	private FinderPath _finderPathCountByRoleId;
 	private CollectionPersistenceFinder<UserGroupGroupRole>
 		_collectionPersistenceFinderByRoleId;
 
@@ -509,6 +518,9 @@ public class UserGroupGroupRolePersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {roleId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByU_G;
+	private FinderPath _finderPathWithoutPaginationFindByU_G;
+	private FinderPath _finderPathCountByU_G;
 	private CollectionPersistenceFinder<UserGroupGroupRole>
 		_collectionPersistenceFinderByU_G;
 
@@ -667,6 +679,9 @@ public class UserGroupGroupRolePersistenceImpl
 			new Object[] {userGroupId, groupId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByG_R;
+	private FinderPath _finderPathWithoutPaginationFindByG_R;
+	private FinderPath _finderPathCountByG_R;
 	private CollectionPersistenceFinder<UserGroupGroupRole>
 		_collectionPersistenceFinderByG_R;
 
@@ -821,6 +836,7 @@ public class UserGroupGroupRolePersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {groupId, roleId});
 	}
 
+	private FinderPath _finderPathFetchByU_G_R;
 	private UniquePersistenceFinder<UserGroupGroupRole>
 		_uniquePersistenceFinderByU_G_R;
 
@@ -1173,25 +1189,29 @@ public class UserGroupGroupRolePersistenceImpl
 	 * Initializes the user group group role persistence.
 	 */
 	public void afterPropertiesSet() {
+		_finderPathWithPaginationFindByUserGroupId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUserGroupId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"userGroupId"}, true);
+
+		_finderPathWithoutPaginationFindByUserGroupId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUserGroupId",
+			new String[] {Long.class.getName()}, new String[] {"userGroupId"},
+			true);
+
+		_finderPathCountByUserGroupId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUserGroupId",
+			new String[] {Long.class.getName()}, new String[] {"userGroupId"},
+			false);
+
 		_collectionPersistenceFinderByUserGroupId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUserGroupId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"userGroupId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"findByUserGroupId", new String[] {Long.class.getName()},
-					new String[] {"userGroupId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByUserGroupId", new String[] {Long.class.getName()},
-					new String[] {"userGroupId"}, false),
+				this, _finderPathWithPaginationFindByUserGroupId,
+				_finderPathWithoutPaginationFindByUserGroupId,
+				_finderPathCountByUserGroupId,
 				_SQL_SELECT_USERGROUPGROUPROLE_WHERE,
 				_SQL_COUNT_USERGROUPGROUPROLE_WHERE,
 				UserGroupGroupRoleModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
@@ -1201,26 +1221,29 @@ public class UserGroupGroupRolePersistenceImpl
 					FinderColumn.Type.LONG, "=", true, true,
 					UserGroupGroupRole::getUserGroupId));
 
+		_finderPathWithPaginationFindByGroupId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByGroupId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"groupId"}, true);
+
+		_finderPathWithoutPaginationFindByGroupId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByGroupId",
+			new String[] {Long.class.getName()}, new String[] {"groupId"},
+			true);
+
+		_finderPathCountByGroupId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByGroupId",
+			new String[] {Long.class.getName()}, new String[] {"groupId"},
+			false);
+
 		_collectionPersistenceFinderByGroupId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByGroupId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"groupId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByGroupId",
-					new String[] {Long.class.getName()},
-					new String[] {"groupId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByGroupId",
-					new String[] {Long.class.getName()},
-					new String[] {"groupId"}, false),
-				_SQL_SELECT_USERGROUPGROUPROLE_WHERE,
+				this, _finderPathWithPaginationFindByGroupId,
+				_finderPathWithoutPaginationFindByGroupId,
+				_finderPathCountByGroupId, _SQL_SELECT_USERGROUPGROUPROLE_WHERE,
 				_SQL_COUNT_USERGROUPGROUPROLE_WHERE,
 				UserGroupGroupRoleModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
 				"",
@@ -1228,26 +1251,28 @@ public class UserGroupGroupRolePersistenceImpl
 					"userGroupGroupRole.", "groupId", FinderColumn.Type.LONG,
 					"=", true, true, UserGroupGroupRole::getGroupId));
 
+		_finderPathWithPaginationFindByRoleId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByRoleId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"roleId"}, true);
+
+		_finderPathWithoutPaginationFindByRoleId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByRoleId",
+			new String[] {Long.class.getName()}, new String[] {"roleId"}, true);
+
+		_finderPathCountByRoleId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByRoleId",
+			new String[] {Long.class.getName()}, new String[] {"roleId"},
+			false);
+
 		_collectionPersistenceFinderByRoleId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByRoleId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"roleId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByRoleId",
-					new String[] {Long.class.getName()},
-					new String[] {"roleId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByRoleId",
-					new String[] {Long.class.getName()},
-					new String[] {"roleId"}, false),
-				_SQL_SELECT_USERGROUPGROUPROLE_WHERE,
+				this, _finderPathWithPaginationFindByRoleId,
+				_finderPathWithoutPaginationFindByRoleId,
+				_finderPathCountByRoleId, _SQL_SELECT_USERGROUPGROUPROLE_WHERE,
 				_SQL_COUNT_USERGROUPGROUPROLE_WHERE,
 				UserGroupGroupRoleModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
 				"",
@@ -1255,24 +1280,28 @@ public class UserGroupGroupRolePersistenceImpl
 					"userGroupGroupRole.", "roleId", FinderColumn.Type.LONG,
 					"=", true, true, UserGroupGroupRole::getRoleId));
 
+		_finderPathWithPaginationFindByU_G = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByU_G",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"userGroupId", "groupId"}, true);
+
+		_finderPathWithoutPaginationFindByU_G = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByU_G",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"userGroupId", "groupId"}, true);
+
+		_finderPathCountByU_G = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByU_G",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"userGroupId", "groupId"}, false);
+
 		_collectionPersistenceFinderByU_G = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByU_G",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Integer.class.getName(), Integer.class.getName(),
-					OrderByComparator.class.getName()
-				},
-				new String[] {"userGroupId", "groupId"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByU_G",
-				new String[] {Long.class.getName(), Long.class.getName()},
-				new String[] {"userGroupId", "groupId"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByU_G",
-				new String[] {Long.class.getName(), Long.class.getName()},
-				new String[] {"userGroupId", "groupId"}, false),
+			this, _finderPathWithPaginationFindByU_G,
+			_finderPathWithoutPaginationFindByU_G, _finderPathCountByU_G,
 			_SQL_SELECT_USERGROUPGROUPROLE_WHERE,
 			_SQL_COUNT_USERGROUPGROUPROLE_WHERE,
 			UserGroupGroupRoleModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
@@ -1283,24 +1312,28 @@ public class UserGroupGroupRolePersistenceImpl
 				"userGroupGroupRole.", "groupId", FinderColumn.Type.LONG, "=",
 				true, true, UserGroupGroupRole::getGroupId));
 
+		_finderPathWithPaginationFindByG_R = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_R",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"groupId", "roleId"}, true);
+
+		_finderPathWithoutPaginationFindByG_R = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_R",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"groupId", "roleId"}, true);
+
+		_finderPathCountByG_R = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_R",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"groupId", "roleId"}, false);
+
 		_collectionPersistenceFinderByG_R = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_R",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Integer.class.getName(), Integer.class.getName(),
-					OrderByComparator.class.getName()
-				},
-				new String[] {"groupId", "roleId"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_R",
-				new String[] {Long.class.getName(), Long.class.getName()},
-				new String[] {"groupId", "roleId"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_R",
-				new String[] {Long.class.getName(), Long.class.getName()},
-				new String[] {"groupId", "roleId"}, false),
+			this, _finderPathWithPaginationFindByG_R,
+			_finderPathWithoutPaginationFindByG_R, _finderPathCountByG_R,
 			_SQL_SELECT_USERGROUPGROUPROLE_WHERE,
 			_SQL_COUNT_USERGROUPGROUPROLE_WHERE,
 			UserGroupGroupRoleModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
@@ -1311,18 +1344,18 @@ public class UserGroupGroupRolePersistenceImpl
 				"userGroupGroupRole.", "roleId", FinderColumn.Type.LONG, "=",
 				true, true, UserGroupGroupRole::getRoleId));
 
+		_finderPathFetchByU_G_R = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByU_G_R",
+			new String[] {
+				Long.class.getName(), Long.class.getName(), Long.class.getName()
+			},
+			new String[] {"userGroupId", "groupId", "roleId"}, 0, 0, false,
+			UserGroupGroupRole::getUserGroupId, UserGroupGroupRole::getGroupId,
+			UserGroupGroupRole::getRoleId);
+
 		_uniquePersistenceFinderByU_G_R = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByU_G_R",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Long.class.getName()
-				},
-				new String[] {"userGroupId", "groupId", "roleId"}, 0, 0, false,
-				UserGroupGroupRole::getUserGroupId,
-				UserGroupGroupRole::getGroupId, UserGroupGroupRole::getRoleId),
-			_SQL_SELECT_USERGROUPGROUPROLE_WHERE, "",
+			this, _finderPathFetchByU_G_R, _SQL_SELECT_USERGROUPGROUPROLE_WHERE,
+			"",
 			new FinderColumn<>(
 				"userGroupGroupRole.", "userGroupId", FinderColumn.Type.LONG,
 				"=", true, true, UserGroupGroupRole::getUserGroupId),
@@ -1366,4 +1399,4 @@ public class UserGroupGroupRolePersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1608523746
+// LIFERAY-SERVICE-BUILDER-HASH:1886414092

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/UserGroupPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/UserGroupPersistenceImpl.java
@@ -96,6 +96,9 @@ public class UserGroupPersistenceImpl
 	public static final String FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION =
 		FINDER_CLASS_NAME_ENTITY + ".List2";
 
+	private FinderPath _finderPathWithPaginationFindByUuid;
+	private FinderPath _finderPathWithoutPaginationFindByUuid;
+	private FinderPath _finderPathCountByUuid;
 	private FilterCollectionPersistenceFinder<UserGroup>
 		_collectionPersistenceFinderByUuid;
 
@@ -300,6 +303,9 @@ public class UserGroupPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {uuid});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByUuid_C;
+	private FinderPath _finderPathWithoutPaginationFindByUuid_C;
+	private FinderPath _finderPathCountByUuid_C;
 	private FilterCollectionPersistenceFinder<UserGroup>
 		_collectionPersistenceFinderByUuid_C;
 
@@ -526,6 +532,9 @@ public class UserGroupPersistenceImpl
 			companyId, 0);
 	}
 
+	private FinderPath _finderPathWithPaginationFindByCompanyId;
+	private FinderPath _finderPathWithoutPaginationFindByCompanyId;
+	private FinderPath _finderPathCountByCompanyId;
 	private FilterCollectionPersistenceFinder<UserGroup>
 		_collectionPersistenceFinderByCompanyId;
 
@@ -735,6 +744,9 @@ public class UserGroupPersistenceImpl
 			companyId, 0);
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_P;
+	private FinderPath _finderPathWithoutPaginationFindByC_P;
+	private FinderPath _finderPathCountByC_P;
 	private FilterCollectionPersistenceFinder<UserGroup>
 		_collectionPersistenceFinderByC_P;
 
@@ -970,6 +982,7 @@ public class UserGroupPersistenceImpl
 			new Object[] {companyId, parentUserGroupId}, companyId, 0);
 	}
 
+	private FinderPath _finderPathFetchByC_N;
 	private UniquePersistenceFinder<UserGroup> _uniquePersistenceFinderByC_N;
 
 	/**
@@ -1059,6 +1072,8 @@ public class UserGroupPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {companyId, name});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_LikeN;
+	private FinderPath _finderPathWithPaginationCountByC_LikeN;
 	private FilterCollectionPersistenceFinder<UserGroup>
 		_collectionPersistenceFinderByC_LikeN;
 
@@ -1285,6 +1300,8 @@ public class UserGroupPersistenceImpl
 			companyId, 0);
 	}
 
+	private FinderPath _finderPathWithPaginationFindByGtU_C_P;
+	private FinderPath _finderPathWithPaginationCountByGtU_C_P;
 	private FilterCollectionPersistenceFinder<UserGroup>
 		_collectionPersistenceFinderByGtU_C_P;
 
@@ -1547,6 +1564,7 @@ public class UserGroupPersistenceImpl
 			0);
 	}
 
+	private FinderPath _finderPathFetchByERC_C;
 	private UniquePersistenceFinder<UserGroup> _uniquePersistenceFinderByERC_C;
 
 	/**
@@ -2982,68 +3000,76 @@ public class UserGroupPersistenceImpl
 			"Users_UserGroups", "companyId", "userGroupId", "userId", this,
 			userPersistence);
 
+		_finderPathWithPaginationFindByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid",
+			new String[] {
+				String.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"uuid_"}, true);
+
+		_finderPathWithoutPaginationFindByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid",
+			new String[] {String.class.getName()}, new String[] {"uuid_"}, 0, 1,
+			true, null);
+
+		_finderPathCountByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid",
+			new String[] {String.class.getName()}, new String[] {"uuid_"}, 0, 1,
+			false, null);
+
 		_collectionPersistenceFinderByUuid =
 			new FilterCollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid",
-					new String[] {
-						String.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"uuid_"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid",
-					new String[] {String.class.getName()},
-					new String[] {"uuid_"}, 0, 1, true, null),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid",
-					new String[] {String.class.getName()},
-					new String[] {"uuid_"}, 0, 1, false, null),
+				this, _finderPathWithPaginationFindByUuid,
+				_finderPathWithoutPaginationFindByUuid, _finderPathCountByUuid,
 				_SQL_SELECT_USERGROUP_WHERE, _SQL_COUNT_USERGROUP_WHERE,
 				UserGroupModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 				new FilterCollectionPersistenceFinder.FilterMetadata<>(
-					UserGroupImpl.class, UserGroup.class, "userGroup",
-					"UserGroup", "userGroup.userGroupId",
-					"SELECT DISTINCT {userGroup.*} FROM UserGroup userGroup WHERE ",
-					"SELECT {UserGroup.*} FROM (SELECT DISTINCT userGroup.userGroupId FROM UserGroup userGroup WHERE ",
-					") TEMP_TABLE INNER JOIN UserGroup ON TEMP_TABLE.userGroupId = UserGroup.userGroupId",
-					"SELECT COUNT(DISTINCT userGroup.userGroupId) AS COUNT_VALUE FROM UserGroup userGroup WHERE ",
+					UserGroupImpl.class, UserGroup.class, _FILTER_ENTITY_ALIAS,
+					_FILTER_ENTITY_TABLE, _FILTER_ENTITY_TABLE_FILTER_PK_COLUMN,
+					_FILTER_SQL_SELECT_USERGROUP_WHERE,
+					_FILTER_SQL_SELECT_USERGROUP_NO_INLINE_DISTINCT_WHERE_1,
+					_FILTER_SQL_SELECT_USERGROUP_NO_INLINE_DISTINCT_WHERE_2,
+					_FILTER_SQL_COUNT_USERGROUP_WHERE,
 					UserGroupModelImpl.ORDER_BY_SQL,
 					UserGroupModelImpl.ORDER_BY_SQL_INLINE_DISTINCT),
 				new FinderColumn<>(
 					"userGroup.", "uuid", FinderColumn.Type.STRING, "=", true,
 					true, UserGroup::getUuid));
 
+		_finderPathWithPaginationFindByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid_C",
+			new String[] {
+				String.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"uuid_", "companyId"}, true);
+
+		_finderPathWithoutPaginationFindByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"uuid_", "companyId"}, 0, 1, true, null);
+
+		_finderPathCountByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"uuid_", "companyId"}, 0, 1, false, null);
+
 		_collectionPersistenceFinderByUuid_C =
 			new FilterCollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid_C",
-					new String[] {
-						String.class.getName(), Long.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"uuid_", "companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid_C",
-					new String[] {String.class.getName(), Long.class.getName()},
-					new String[] {"uuid_", "companyId"}, 0, 1, true, null),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid_C",
-					new String[] {String.class.getName(), Long.class.getName()},
-					new String[] {"uuid_", "companyId"}, 0, 1, false, null),
-				_SQL_SELECT_USERGROUP_WHERE, _SQL_COUNT_USERGROUP_WHERE,
-				UserGroupModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+				this, _finderPathWithPaginationFindByUuid_C,
+				_finderPathWithoutPaginationFindByUuid_C,
+				_finderPathCountByUuid_C, _SQL_SELECT_USERGROUP_WHERE,
+				_SQL_COUNT_USERGROUP_WHERE, UserGroupModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "",
 				new FilterCollectionPersistenceFinder.FilterMetadata<>(
-					UserGroupImpl.class, UserGroup.class, "userGroup",
-					"UserGroup", "userGroup.userGroupId",
-					"SELECT DISTINCT {userGroup.*} FROM UserGroup userGroup WHERE ",
-					"SELECT {UserGroup.*} FROM (SELECT DISTINCT userGroup.userGroupId FROM UserGroup userGroup WHERE ",
-					") TEMP_TABLE INNER JOIN UserGroup ON TEMP_TABLE.userGroupId = UserGroup.userGroupId",
-					"SELECT COUNT(DISTINCT userGroup.userGroupId) AS COUNT_VALUE FROM UserGroup userGroup WHERE ",
+					UserGroupImpl.class, UserGroup.class, _FILTER_ENTITY_ALIAS,
+					_FILTER_ENTITY_TABLE, _FILTER_ENTITY_TABLE_FILTER_PK_COLUMN,
+					_FILTER_SQL_SELECT_USERGROUP_WHERE,
+					_FILTER_SQL_SELECT_USERGROUP_NO_INLINE_DISTINCT_WHERE_1,
+					_FILTER_SQL_SELECT_USERGROUP_NO_INLINE_DISTINCT_WHERE_2,
+					_FILTER_SQL_COUNT_USERGROUP_WHERE,
 					UserGroupModelImpl.ORDER_BY_SQL,
 					UserGroupModelImpl.ORDER_BY_SQL_INLINE_DISTINCT),
 				new FinderColumn<>(
@@ -3053,68 +3079,76 @@ public class UserGroupPersistenceImpl
 					"userGroup.", "companyId", FinderColumn.Type.LONG, "=",
 					true, true, UserGroup::getCompanyId));
 
+		_finderPathWithPaginationFindByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByCompanyId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"companyId"}, true);
+
+		_finderPathWithoutPaginationFindByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByCompanyId",
+			new String[] {Long.class.getName()}, new String[] {"companyId"},
+			true);
+
+		_finderPathCountByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByCompanyId",
+			new String[] {Long.class.getName()}, new String[] {"companyId"},
+			false);
+
 		_collectionPersistenceFinderByCompanyId =
 			new FilterCollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByCompanyId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"findByCompanyId", new String[] {Long.class.getName()},
-					new String[] {"companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByCompanyId", new String[] {Long.class.getName()},
-					new String[] {"companyId"}, false),
-				_SQL_SELECT_USERGROUP_WHERE, _SQL_COUNT_USERGROUP_WHERE,
-				UserGroupModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+				this, _finderPathWithPaginationFindByCompanyId,
+				_finderPathWithoutPaginationFindByCompanyId,
+				_finderPathCountByCompanyId, _SQL_SELECT_USERGROUP_WHERE,
+				_SQL_COUNT_USERGROUP_WHERE, UserGroupModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "",
 				new FilterCollectionPersistenceFinder.FilterMetadata<>(
-					UserGroupImpl.class, UserGroup.class, "userGroup",
-					"UserGroup", "userGroup.userGroupId",
-					"SELECT DISTINCT {userGroup.*} FROM UserGroup userGroup WHERE ",
-					"SELECT {UserGroup.*} FROM (SELECT DISTINCT userGroup.userGroupId FROM UserGroup userGroup WHERE ",
-					") TEMP_TABLE INNER JOIN UserGroup ON TEMP_TABLE.userGroupId = UserGroup.userGroupId",
-					"SELECT COUNT(DISTINCT userGroup.userGroupId) AS COUNT_VALUE FROM UserGroup userGroup WHERE ",
+					UserGroupImpl.class, UserGroup.class, _FILTER_ENTITY_ALIAS,
+					_FILTER_ENTITY_TABLE, _FILTER_ENTITY_TABLE_FILTER_PK_COLUMN,
+					_FILTER_SQL_SELECT_USERGROUP_WHERE,
+					_FILTER_SQL_SELECT_USERGROUP_NO_INLINE_DISTINCT_WHERE_1,
+					_FILTER_SQL_SELECT_USERGROUP_NO_INLINE_DISTINCT_WHERE_2,
+					_FILTER_SQL_COUNT_USERGROUP_WHERE,
 					UserGroupModelImpl.ORDER_BY_SQL,
 					UserGroupModelImpl.ORDER_BY_SQL_INLINE_DISTINCT),
 				new FinderColumn<>(
 					"userGroup.", "companyId", FinderColumn.Type.LONG, "=",
 					true, true, UserGroup::getCompanyId));
 
+		_finderPathWithPaginationFindByC_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_P",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "parentUserGroupId"}, true);
+
+		_finderPathWithoutPaginationFindByC_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_P",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"companyId", "parentUserGroupId"}, true);
+
+		_finderPathCountByC_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_P",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"companyId", "parentUserGroupId"}, false);
+
 		_collectionPersistenceFinderByC_P =
 			new FilterCollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_P",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"companyId", "parentUserGroupId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_P",
-					new String[] {Long.class.getName(), Long.class.getName()},
-					new String[] {"companyId", "parentUserGroupId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_P",
-					new String[] {Long.class.getName(), Long.class.getName()},
-					new String[] {"companyId", "parentUserGroupId"}, false),
+				this, _finderPathWithPaginationFindByC_P,
+				_finderPathWithoutPaginationFindByC_P, _finderPathCountByC_P,
 				_SQL_SELECT_USERGROUP_WHERE, _SQL_COUNT_USERGROUP_WHERE,
 				UserGroupModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 				new FilterCollectionPersistenceFinder.FilterMetadata<>(
-					UserGroupImpl.class, UserGroup.class, "userGroup",
-					"UserGroup", "userGroup.userGroupId",
-					"SELECT DISTINCT {userGroup.*} FROM UserGroup userGroup WHERE ",
-					"SELECT {UserGroup.*} FROM (SELECT DISTINCT userGroup.userGroupId FROM UserGroup userGroup WHERE ",
-					") TEMP_TABLE INNER JOIN UserGroup ON TEMP_TABLE.userGroupId = UserGroup.userGroupId",
-					"SELECT COUNT(DISTINCT userGroup.userGroupId) AS COUNT_VALUE FROM UserGroup userGroup WHERE ",
+					UserGroupImpl.class, UserGroup.class, _FILTER_ENTITY_ALIAS,
+					_FILTER_ENTITY_TABLE, _FILTER_ENTITY_TABLE_FILTER_PK_COLUMN,
+					_FILTER_SQL_SELECT_USERGROUP_WHERE,
+					_FILTER_SQL_SELECT_USERGROUP_NO_INLINE_DISTINCT_WHERE_1,
+					_FILTER_SQL_SELECT_USERGROUP_NO_INLINE_DISTINCT_WHERE_2,
+					_FILTER_SQL_COUNT_USERGROUP_WHERE,
 					UserGroupModelImpl.ORDER_BY_SQL,
 					UserGroupModelImpl.ORDER_BY_SQL_INLINE_DISTINCT),
 				new FinderColumn<>(
@@ -3124,15 +3158,14 @@ public class UserGroupPersistenceImpl
 					"userGroup.", "parentUserGroupId", FinderColumn.Type.LONG,
 					"=", true, true, UserGroup::getParentUserGroupId));
 
+		_finderPathFetchByC_N = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByC_N",
+			new String[] {Long.class.getName(), String.class.getName()},
+			new String[] {"companyId", "name"}, 2, 2, false,
+			UserGroup::getCompanyId, convertCaseFunction(UserGroup::getName));
+
 		_uniquePersistenceFinderByC_N = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByC_N",
-				new String[] {Long.class.getName(), String.class.getName()},
-				new String[] {"companyId", "name"}, 2, 2, false,
-				UserGroup::getCompanyId,
-				convertCaseFunction(UserGroup::getName)),
-			_SQL_SELECT_USERGROUP_WHERE, "",
+			this, _finderPathFetchByC_N, _SQL_SELECT_USERGROUP_WHERE, "",
 			new FinderColumn<>(
 				"userGroup.", "companyId", FinderColumn.Type.LONG, "=", true,
 				true, UserGroup::getCompanyId),
@@ -3140,31 +3173,33 @@ public class UserGroupPersistenceImpl
 				"userGroup.", "name", FinderColumn.Type.STRING, "=", false,
 				true, UserGroup::getName));
 
+		_finderPathWithPaginationFindByC_LikeN = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_LikeN",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "name"}, true);
+
+		_finderPathWithPaginationCountByC_LikeN = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByC_LikeN",
+			new String[] {Long.class.getName(), String.class.getName()},
+			new String[] {"companyId", "name"}, false);
+
 		_collectionPersistenceFinderByC_LikeN =
 			new FilterCollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_LikeN",
-					new String[] {
-						Long.class.getName(), String.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"companyId", "name"}, true),
-				null,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByC_LikeN",
-					new String[] {Long.class.getName(), String.class.getName()},
-					new String[] {"companyId", "name"}, false),
+				this, _finderPathWithPaginationFindByC_LikeN, null,
+				_finderPathWithPaginationCountByC_LikeN,
 				_SQL_SELECT_USERGROUP_WHERE, _SQL_COUNT_USERGROUP_WHERE,
 				UserGroupModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 				new FilterCollectionPersistenceFinder.FilterMetadata<>(
-					UserGroupImpl.class, UserGroup.class, "userGroup",
-					"UserGroup", "userGroup.userGroupId",
-					"SELECT DISTINCT {userGroup.*} FROM UserGroup userGroup WHERE ",
-					"SELECT {UserGroup.*} FROM (SELECT DISTINCT userGroup.userGroupId FROM UserGroup userGroup WHERE ",
-					") TEMP_TABLE INNER JOIN UserGroup ON TEMP_TABLE.userGroupId = UserGroup.userGroupId",
-					"SELECT COUNT(DISTINCT userGroup.userGroupId) AS COUNT_VALUE FROM UserGroup userGroup WHERE ",
+					UserGroupImpl.class, UserGroup.class, _FILTER_ENTITY_ALIAS,
+					_FILTER_ENTITY_TABLE, _FILTER_ENTITY_TABLE_FILTER_PK_COLUMN,
+					_FILTER_SQL_SELECT_USERGROUP_WHERE,
+					_FILTER_SQL_SELECT_USERGROUP_NO_INLINE_DISTINCT_WHERE_1,
+					_FILTER_SQL_SELECT_USERGROUP_NO_INLINE_DISTINCT_WHERE_2,
+					_FILTER_SQL_COUNT_USERGROUP_WHERE,
 					UserGroupModelImpl.ORDER_BY_SQL,
 					UserGroupModelImpl.ORDER_BY_SQL_INLINE_DISTINCT),
 				new FinderColumn<>(
@@ -3174,41 +3209,37 @@ public class UserGroupPersistenceImpl
 					"userGroup.", "name", FinderColumn.Type.STRING, "LIKE",
 					false, true, UserGroup::getName));
 
+		_finderPathWithPaginationFindByGtU_C_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByGtU_C_P",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"userGroupId", "companyId", "parentUserGroupId"},
+			true);
+
+		_finderPathWithPaginationCountByGtU_C_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByGtU_C_P",
+			new String[] {
+				Long.class.getName(), Long.class.getName(), Long.class.getName()
+			},
+			new String[] {"userGroupId", "companyId", "parentUserGroupId"},
+			false);
+
 		_collectionPersistenceFinderByGtU_C_P =
 			new FilterCollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByGtU_C_P",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {
-						"userGroupId", "companyId", "parentUserGroupId"
-					},
-					true),
-				null,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByGtU_C_P",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						Long.class.getName()
-					},
-					new String[] {
-						"userGroupId", "companyId", "parentUserGroupId"
-					},
-					false),
+				this, _finderPathWithPaginationFindByGtU_C_P, null,
+				_finderPathWithPaginationCountByGtU_C_P,
 				_SQL_SELECT_USERGROUP_WHERE, _SQL_COUNT_USERGROUP_WHERE,
 				UserGroupModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 				new FilterCollectionPersistenceFinder.FilterMetadata<>(
-					UserGroupImpl.class, UserGroup.class, "userGroup",
-					"UserGroup", "userGroup.userGroupId",
-					"SELECT DISTINCT {userGroup.*} FROM UserGroup userGroup WHERE ",
-					"SELECT {UserGroup.*} FROM (SELECT DISTINCT userGroup.userGroupId FROM UserGroup userGroup WHERE ",
-					") TEMP_TABLE INNER JOIN UserGroup ON TEMP_TABLE.userGroupId = UserGroup.userGroupId",
-					"SELECT COUNT(DISTINCT userGroup.userGroupId) AS COUNT_VALUE FROM UserGroup userGroup WHERE ",
+					UserGroupImpl.class, UserGroup.class, _FILTER_ENTITY_ALIAS,
+					_FILTER_ENTITY_TABLE, _FILTER_ENTITY_TABLE_FILTER_PK_COLUMN,
+					_FILTER_SQL_SELECT_USERGROUP_WHERE,
+					_FILTER_SQL_SELECT_USERGROUP_NO_INLINE_DISTINCT_WHERE_1,
+					_FILTER_SQL_SELECT_USERGROUP_NO_INLINE_DISTINCT_WHERE_2,
+					_FILTER_SQL_COUNT_USERGROUP_WHERE,
 					UserGroupModelImpl.ORDER_BY_SQL,
 					UserGroupModelImpl.ORDER_BY_SQL_INLINE_DISTINCT),
 				new FinderColumn<>(
@@ -3221,15 +3252,15 @@ public class UserGroupPersistenceImpl
 					"userGroup.", "parentUserGroupId", FinderColumn.Type.LONG,
 					"=", true, true, UserGroup::getParentUserGroupId));
 
+		_finderPathFetchByERC_C = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByERC_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "companyId"}, 0, 1, false,
+			convertNullFunction(UserGroup::getExternalReferenceCode),
+			UserGroup::getCompanyId);
+
 		_uniquePersistenceFinderByERC_C = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByERC_C",
-				new String[] {String.class.getName(), Long.class.getName()},
-				new String[] {"externalReferenceCode", "companyId"}, 0, 1,
-				false, convertNullFunction(UserGroup::getExternalReferenceCode),
-				UserGroup::getCompanyId),
-			_SQL_SELECT_USERGROUP_WHERE, "",
+			this, _finderPathFetchByERC_C, _SQL_SELECT_USERGROUP_WHERE, "",
 			new FinderColumn<>(
 				"userGroup.", "externalReferenceCode", FinderColumn.Type.STRING,
 				"=", true, true, UserGroup::getExternalReferenceCode),
@@ -3280,6 +3311,27 @@ public class UserGroupPersistenceImpl
 	private static final String _SQL_COUNT_USERGROUP_WHERE =
 		"SELECT COUNT(userGroup) FROM UserGroup userGroup WHERE ";
 
+	private static final String _FILTER_ENTITY_TABLE_FILTER_PK_COLUMN =
+		"userGroup.userGroupId";
+
+	private static final String _FILTER_SQL_SELECT_USERGROUP_WHERE =
+		"SELECT DISTINCT {userGroup.*} FROM UserGroup userGroup WHERE ";
+
+	private static final String
+		_FILTER_SQL_SELECT_USERGROUP_NO_INLINE_DISTINCT_WHERE_1 =
+			"SELECT {UserGroup.*} FROM (SELECT DISTINCT userGroup.userGroupId FROM UserGroup userGroup WHERE ";
+
+	private static final String
+		_FILTER_SQL_SELECT_USERGROUP_NO_INLINE_DISTINCT_WHERE_2 =
+			") TEMP_TABLE INNER JOIN UserGroup ON TEMP_TABLE.userGroupId = UserGroup.userGroupId";
+
+	private static final String _FILTER_SQL_COUNT_USERGROUP_WHERE =
+		"SELECT COUNT(DISTINCT userGroup.userGroupId) AS COUNT_VALUE FROM UserGroup userGroup WHERE ";
+
+	private static final String _FILTER_ENTITY_ALIAS = "userGroup";
+
+	private static final String _FILTER_ENTITY_TABLE = "UserGroup";
+
 	private static final String _NO_SUCH_ENTITY_WITH_KEY =
 		"No UserGroup exists with the key {";
 
@@ -3295,4 +3347,4 @@ public class UserGroupPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1233600938
+// LIFERAY-SERVICE-BUILDER-HASH:22926584

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/UserGroupRolePersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/UserGroupRolePersistenceImpl.java
@@ -72,6 +72,9 @@ public class UserGroupRolePersistenceImpl
 	public static final String FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION =
 		FINDER_CLASS_NAME_ENTITY + ".List2";
 
+	private FinderPath _finderPathWithPaginationFindByUserId;
+	private FinderPath _finderPathWithoutPaginationFindByUserId;
+	private FinderPath _finderPathCountByUserId;
 	private CollectionPersistenceFinder<UserGroupRole>
 		_collectionPersistenceFinderByUserId;
 
@@ -213,6 +216,9 @@ public class UserGroupRolePersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {userId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByGroupId;
+	private FinderPath _finderPathWithoutPaginationFindByGroupId;
+	private FinderPath _finderPathCountByGroupId;
 	private CollectionPersistenceFinder<UserGroupRole>
 		_collectionPersistenceFinderByGroupId;
 
@@ -355,6 +361,9 @@ public class UserGroupRolePersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {groupId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByRoleId;
+	private FinderPath _finderPathWithoutPaginationFindByRoleId;
+	private FinderPath _finderPathCountByRoleId;
 	private CollectionPersistenceFinder<UserGroupRole>
 		_collectionPersistenceFinderByRoleId;
 
@@ -496,6 +505,9 @@ public class UserGroupRolePersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {roleId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByU_G;
+	private FinderPath _finderPathWithoutPaginationFindByU_G;
+	private FinderPath _finderPathCountByU_G;
 	private CollectionPersistenceFinder<UserGroupRole>
 		_collectionPersistenceFinderByU_G;
 
@@ -650,6 +662,9 @@ public class UserGroupRolePersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {userId, groupId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByG_R;
+	private FinderPath _finderPathWithoutPaginationFindByG_R;
+	private FinderPath _finderPathCountByG_R;
 	private CollectionPersistenceFinder<UserGroupRole>
 		_collectionPersistenceFinderByG_R;
 
@@ -804,6 +819,7 @@ public class UserGroupRolePersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {groupId, roleId});
 	}
 
+	private FinderPath _finderPathFetchByU_G_R;
 	private UniquePersistenceFinder<UserGroupRole>
 		_uniquePersistenceFinderByU_G_R;
 
@@ -1144,99 +1160,113 @@ public class UserGroupRolePersistenceImpl
 	 * Initializes the user group role persistence.
 	 */
 	public void afterPropertiesSet() {
+		_finderPathWithPaginationFindByUserId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUserId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"userId"}, true);
+
+		_finderPathWithoutPaginationFindByUserId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUserId",
+			new String[] {Long.class.getName()}, new String[] {"userId"}, true);
+
+		_finderPathCountByUserId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUserId",
+			new String[] {Long.class.getName()}, new String[] {"userId"},
+			false);
+
 		_collectionPersistenceFinderByUserId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUserId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"userId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUserId",
-					new String[] {Long.class.getName()},
-					new String[] {"userId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUserId",
-					new String[] {Long.class.getName()},
-					new String[] {"userId"}, false),
-				_SQL_SELECT_USERGROUPROLE_WHERE, _SQL_COUNT_USERGROUPROLE_WHERE,
+				this, _finderPathWithPaginationFindByUserId,
+				_finderPathWithoutPaginationFindByUserId,
+				_finderPathCountByUserId, _SQL_SELECT_USERGROUPROLE_WHERE,
+				_SQL_COUNT_USERGROUPROLE_WHERE,
 				UserGroupRoleModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
 					"userGroupRole.", "userId", FinderColumn.Type.LONG, "=",
 					true, true, UserGroupRole::getUserId));
 
+		_finderPathWithPaginationFindByGroupId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByGroupId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"groupId"}, true);
+
+		_finderPathWithoutPaginationFindByGroupId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByGroupId",
+			new String[] {Long.class.getName()}, new String[] {"groupId"},
+			true);
+
+		_finderPathCountByGroupId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByGroupId",
+			new String[] {Long.class.getName()}, new String[] {"groupId"},
+			false);
+
 		_collectionPersistenceFinderByGroupId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByGroupId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"groupId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByGroupId",
-					new String[] {Long.class.getName()},
-					new String[] {"groupId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByGroupId",
-					new String[] {Long.class.getName()},
-					new String[] {"groupId"}, false),
-				_SQL_SELECT_USERGROUPROLE_WHERE, _SQL_COUNT_USERGROUPROLE_WHERE,
+				this, _finderPathWithPaginationFindByGroupId,
+				_finderPathWithoutPaginationFindByGroupId,
+				_finderPathCountByGroupId, _SQL_SELECT_USERGROUPROLE_WHERE,
+				_SQL_COUNT_USERGROUPROLE_WHERE,
 				UserGroupRoleModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
 					"userGroupRole.", "groupId", FinderColumn.Type.LONG, "=",
 					true, true, UserGroupRole::getGroupId));
 
+		_finderPathWithPaginationFindByRoleId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByRoleId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"roleId"}, true);
+
+		_finderPathWithoutPaginationFindByRoleId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByRoleId",
+			new String[] {Long.class.getName()}, new String[] {"roleId"}, true);
+
+		_finderPathCountByRoleId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByRoleId",
+			new String[] {Long.class.getName()}, new String[] {"roleId"},
+			false);
+
 		_collectionPersistenceFinderByRoleId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByRoleId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"roleId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByRoleId",
-					new String[] {Long.class.getName()},
-					new String[] {"roleId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByRoleId",
-					new String[] {Long.class.getName()},
-					new String[] {"roleId"}, false),
-				_SQL_SELECT_USERGROUPROLE_WHERE, _SQL_COUNT_USERGROUPROLE_WHERE,
+				this, _finderPathWithPaginationFindByRoleId,
+				_finderPathWithoutPaginationFindByRoleId,
+				_finderPathCountByRoleId, _SQL_SELECT_USERGROUPROLE_WHERE,
+				_SQL_COUNT_USERGROUPROLE_WHERE,
 				UserGroupRoleModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
 					"userGroupRole.", "roleId", FinderColumn.Type.LONG, "=",
 					true, true, UserGroupRole::getRoleId));
 
+		_finderPathWithPaginationFindByU_G = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByU_G",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"userId", "groupId"}, true);
+
+		_finderPathWithoutPaginationFindByU_G = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByU_G",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"userId", "groupId"}, true);
+
+		_finderPathCountByU_G = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByU_G",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"userId", "groupId"}, false);
+
 		_collectionPersistenceFinderByU_G = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByU_G",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Integer.class.getName(), Integer.class.getName(),
-					OrderByComparator.class.getName()
-				},
-				new String[] {"userId", "groupId"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByU_G",
-				new String[] {Long.class.getName(), Long.class.getName()},
-				new String[] {"userId", "groupId"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByU_G",
-				new String[] {Long.class.getName(), Long.class.getName()},
-				new String[] {"userId", "groupId"}, false),
+			this, _finderPathWithPaginationFindByU_G,
+			_finderPathWithoutPaginationFindByU_G, _finderPathCountByU_G,
 			_SQL_SELECT_USERGROUPROLE_WHERE, _SQL_COUNT_USERGROUPROLE_WHERE,
 			UserGroupRoleModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
@@ -1246,24 +1276,28 @@ public class UserGroupRolePersistenceImpl
 				"userGroupRole.", "groupId", FinderColumn.Type.LONG, "=", true,
 				true, UserGroupRole::getGroupId));
 
+		_finderPathWithPaginationFindByG_R = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_R",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"groupId", "roleId"}, true);
+
+		_finderPathWithoutPaginationFindByG_R = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_R",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"groupId", "roleId"}, true);
+
+		_finderPathCountByG_R = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_R",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"groupId", "roleId"}, false);
+
 		_collectionPersistenceFinderByG_R = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_R",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Integer.class.getName(), Integer.class.getName(),
-					OrderByComparator.class.getName()
-				},
-				new String[] {"groupId", "roleId"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_R",
-				new String[] {Long.class.getName(), Long.class.getName()},
-				new String[] {"groupId", "roleId"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_R",
-				new String[] {Long.class.getName(), Long.class.getName()},
-				new String[] {"groupId", "roleId"}, false),
+			this, _finderPathWithPaginationFindByG_R,
+			_finderPathWithoutPaginationFindByG_R, _finderPathCountByG_R,
 			_SQL_SELECT_USERGROUPROLE_WHERE, _SQL_COUNT_USERGROUPROLE_WHERE,
 			UserGroupRoleModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
@@ -1273,18 +1307,17 @@ public class UserGroupRolePersistenceImpl
 				"userGroupRole.", "roleId", FinderColumn.Type.LONG, "=", true,
 				true, UserGroupRole::getRoleId));
 
+		_finderPathFetchByU_G_R = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByU_G_R",
+			new String[] {
+				Long.class.getName(), Long.class.getName(), Long.class.getName()
+			},
+			new String[] {"userId", "groupId", "roleId"}, 0, 0, false,
+			UserGroupRole::getUserId, UserGroupRole::getGroupId,
+			UserGroupRole::getRoleId);
+
 		_uniquePersistenceFinderByU_G_R = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByU_G_R",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Long.class.getName()
-				},
-				new String[] {"userId", "groupId", "roleId"}, 0, 0, false,
-				UserGroupRole::getUserId, UserGroupRole::getGroupId,
-				UserGroupRole::getRoleId),
-			_SQL_SELECT_USERGROUPROLE_WHERE, "",
+			this, _finderPathFetchByU_G_R, _SQL_SELECT_USERGROUPROLE_WHERE, "",
 			new FinderColumn<>(
 				"userGroupRole.", "userId", FinderColumn.Type.LONG, "=", true,
 				true, UserGroupRole::getUserId),
@@ -1328,4 +1361,4 @@ public class UserGroupRolePersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:395673706
+// LIFERAY-SERVICE-BUILDER-HASH:-382899469

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/UserIdMapperPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/UserIdMapperPersistenceImpl.java
@@ -67,6 +67,9 @@ public class UserIdMapperPersistenceImpl
 	public static final String FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION =
 		FINDER_CLASS_NAME_ENTITY + ".List2";
 
+	private FinderPath _finderPathWithPaginationFindByUserId;
+	private FinderPath _finderPathWithoutPaginationFindByUserId;
+	private FinderPath _finderPathCountByUserId;
 	private CollectionPersistenceFinder<UserIdMapper>
 		_collectionPersistenceFinderByUserId;
 
@@ -208,6 +211,7 @@ public class UserIdMapperPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {userId});
 	}
 
+	private FinderPath _finderPathFetchByU_T;
 	private UniquePersistenceFinder<UserIdMapper> _uniquePersistenceFinderByU_T;
 
 	/**
@@ -297,6 +301,7 @@ public class UserIdMapperPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {userId, type});
 	}
 
+	private FinderPath _finderPathFetchByT_E;
 	private UniquePersistenceFinder<UserIdMapper> _uniquePersistenceFinderByT_E;
 
 	/**
@@ -573,40 +578,43 @@ public class UserIdMapperPersistenceImpl
 	 * Initializes the user ID mapper persistence.
 	 */
 	public void afterPropertiesSet() {
+		_finderPathWithPaginationFindByUserId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUserId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"userId"}, true);
+
+		_finderPathWithoutPaginationFindByUserId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUserId",
+			new String[] {Long.class.getName()}, new String[] {"userId"}, true);
+
+		_finderPathCountByUserId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUserId",
+			new String[] {Long.class.getName()}, new String[] {"userId"},
+			false);
+
 		_collectionPersistenceFinderByUserId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUserId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"userId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUserId",
-					new String[] {Long.class.getName()},
-					new String[] {"userId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUserId",
-					new String[] {Long.class.getName()},
-					new String[] {"userId"}, false),
-				_SQL_SELECT_USERIDMAPPER_WHERE, _SQL_COUNT_USERIDMAPPER_WHERE,
+				this, _finderPathWithPaginationFindByUserId,
+				_finderPathWithoutPaginationFindByUserId,
+				_finderPathCountByUserId, _SQL_SELECT_USERIDMAPPER_WHERE,
+				_SQL_COUNT_USERIDMAPPER_WHERE,
 				UserIdMapperModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
 					"userIdMapper.", "userId", FinderColumn.Type.LONG, "=",
 					true, true, UserIdMapper::getUserId));
 
+		_finderPathFetchByU_T = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByU_T",
+			new String[] {Long.class.getName(), String.class.getName()},
+			new String[] {"userId", "type_"}, 0, 2, false,
+			UserIdMapper::getUserId,
+			convertNullFunction(UserIdMapper::getType));
+
 		_uniquePersistenceFinderByU_T = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByU_T",
-				new String[] {Long.class.getName(), String.class.getName()},
-				new String[] {"userId", "type_"}, 0, 2, false,
-				UserIdMapper::getUserId,
-				convertNullFunction(UserIdMapper::getType)),
-			_SQL_SELECT_USERIDMAPPER_WHERE, "",
+			this, _finderPathFetchByU_T, _SQL_SELECT_USERIDMAPPER_WHERE, "",
 			new FinderColumn<>(
 				"userIdMapper.", "userId", FinderColumn.Type.LONG, "=", true,
 				true, UserIdMapper::getUserId),
@@ -614,15 +622,15 @@ public class UserIdMapperPersistenceImpl
 				"userIdMapper.", "type", FinderColumn.Type.STRING, "=", true,
 				true, UserIdMapper::getType));
 
+		_finderPathFetchByT_E = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByT_E",
+			new String[] {String.class.getName(), String.class.getName()},
+			new String[] {"type_", "externalUserId"}, 0, 3, false,
+			convertNullFunction(UserIdMapper::getType),
+			convertNullFunction(UserIdMapper::getExternalUserId));
+
 		_uniquePersistenceFinderByT_E = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByT_E",
-				new String[] {String.class.getName(), String.class.getName()},
-				new String[] {"type_", "externalUserId"}, 0, 3, false,
-				convertNullFunction(UserIdMapper::getType),
-				convertNullFunction(UserIdMapper::getExternalUserId)),
-			_SQL_SELECT_USERIDMAPPER_WHERE, "",
+			this, _finderPathFetchByT_E, _SQL_SELECT_USERIDMAPPER_WHERE, "",
 			new FinderColumn<>(
 				"userIdMapper.", "type", FinderColumn.Type.STRING, "=", true,
 				true, UserIdMapper::getType),
@@ -666,4 +674,4 @@ public class UserIdMapperPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1200939995
+// LIFERAY-SERVICE-BUILDER-HASH:-499589595

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/UserNotificationDeliveryPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/UserNotificationDeliveryPersistenceImpl.java
@@ -65,6 +65,9 @@ public class UserNotificationDeliveryPersistenceImpl
 	public static final String FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION =
 		FINDER_CLASS_NAME_ENTITY + ".List2";
 
+	private FinderPath _finderPathWithPaginationFindByUserId;
+	private FinderPath _finderPathWithoutPaginationFindByUserId;
+	private FinderPath _finderPathCountByUserId;
 	private CollectionPersistenceFinder<UserNotificationDelivery>
 		_collectionPersistenceFinderByUserId;
 
@@ -210,6 +213,7 @@ public class UserNotificationDeliveryPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {userId});
 	}
 
+	private FinderPath _finderPathFetchByU_P_C_N_D;
 	private UniquePersistenceFinder<UserNotificationDelivery>
 		_uniquePersistenceFinderByU_P_C_N_D;
 
@@ -529,25 +533,28 @@ public class UserNotificationDeliveryPersistenceImpl
 	 * Initializes the user notification delivery persistence.
 	 */
 	public void afterPropertiesSet() {
+		_finderPathWithPaginationFindByUserId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUserId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"userId"}, true);
+
+		_finderPathWithoutPaginationFindByUserId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUserId",
+			new String[] {Long.class.getName()}, new String[] {"userId"}, true);
+
+		_finderPathCountByUserId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUserId",
+			new String[] {Long.class.getName()}, new String[] {"userId"},
+			false);
+
 		_collectionPersistenceFinderByUserId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUserId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"userId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUserId",
-					new String[] {Long.class.getName()},
-					new String[] {"userId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUserId",
-					new String[] {Long.class.getName()},
-					new String[] {"userId"}, false),
+				this, _finderPathWithPaginationFindByUserId,
+				_finderPathWithoutPaginationFindByUserId,
+				_finderPathCountByUserId,
 				_SQL_SELECT_USERNOTIFICATIONDELIVERY_WHERE,
 				_SQL_COUNT_USERNOTIFICATIONDELIVERY_WHERE,
 				UserNotificationDeliveryModelImpl.ORDER_BY_JPQL,
@@ -557,24 +564,25 @@ public class UserNotificationDeliveryPersistenceImpl
 					FinderColumn.Type.LONG, "=", true, true,
 					UserNotificationDelivery::getUserId));
 
+		_finderPathFetchByU_P_C_N_D = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByU_P_C_N_D",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName()
+			},
+			new String[] {
+				"userId", "portletId", "classNameId", "notificationType",
+				"deliveryType"
+			},
+			0, 2, false, UserNotificationDelivery::getUserId,
+			convertNullFunction(UserNotificationDelivery::getPortletId),
+			UserNotificationDelivery::getClassNameId,
+			UserNotificationDelivery::getNotificationType,
+			UserNotificationDelivery::getDeliveryType);
+
 		_uniquePersistenceFinderByU_P_C_N_D = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByU_P_C_N_D",
-				new String[] {
-					Long.class.getName(), String.class.getName(),
-					Long.class.getName(), Integer.class.getName(),
-					Integer.class.getName()
-				},
-				new String[] {
-					"userId", "portletId", "classNameId", "notificationType",
-					"deliveryType"
-				},
-				0, 2, false, UserNotificationDelivery::getUserId,
-				convertNullFunction(UserNotificationDelivery::getPortletId),
-				UserNotificationDelivery::getClassNameId,
-				UserNotificationDelivery::getNotificationType,
-				UserNotificationDelivery::getDeliveryType),
+			this, _finderPathFetchByU_P_C_N_D,
 			_SQL_SELECT_USERNOTIFICATIONDELIVERY_WHERE, "",
 			new FinderColumn<>(
 				"userNotificationDelivery.", "userId", FinderColumn.Type.LONG,
@@ -630,4 +638,4 @@ public class UserNotificationDeliveryPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1068841722
+// LIFERAY-SERVICE-BUILDER-HASH:-858695043

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/UserNotificationEventPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/UserNotificationEventPersistenceImpl.java
@@ -67,6 +67,9 @@ public class UserNotificationEventPersistenceImpl
 	public static final String FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION =
 		FINDER_CLASS_NAME_ENTITY + ".List2";
 
+	private FinderPath _finderPathWithPaginationFindByUuid;
+	private FinderPath _finderPathWithoutPaginationFindByUuid;
+	private FinderPath _finderPathCountByUuid;
 	private CollectionPersistenceFinder<UserNotificationEvent>
 		_collectionPersistenceFinderByUuid;
 
@@ -212,6 +215,9 @@ public class UserNotificationEventPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {uuid});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByUuid_C;
+	private FinderPath _finderPathWithoutPaginationFindByUuid_C;
+	private FinderPath _finderPathCountByUuid_C;
 	private CollectionPersistenceFinder<UserNotificationEvent>
 		_collectionPersistenceFinderByUuid_C;
 
@@ -369,6 +375,9 @@ public class UserNotificationEventPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {uuid, companyId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByUserId;
+	private FinderPath _finderPathWithoutPaginationFindByUserId;
+	private FinderPath _finderPathCountByUserId;
 	private CollectionPersistenceFinder<UserNotificationEvent>
 		_collectionPersistenceFinderByUserId;
 
@@ -514,6 +523,9 @@ public class UserNotificationEventPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {userId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByType;
+	private FinderPath _finderPathWithoutPaginationFindByType;
+	private FinderPath _finderPathCountByType;
 	private CollectionPersistenceFinder<UserNotificationEvent>
 		_collectionPersistenceFinderByType;
 
@@ -659,6 +671,9 @@ public class UserNotificationEventPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {type});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByU_DT;
+	private FinderPath _finderPathWithoutPaginationFindByU_DT;
+	private FinderPath _finderPathCountByU_DT;
 	private CollectionPersistenceFinder<UserNotificationEvent>
 		_collectionPersistenceFinderByU_DT;
 
@@ -819,6 +834,9 @@ public class UserNotificationEventPersistenceImpl
 			new Object[] {userId, deliveryType});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByU_D;
+	private FinderPath _finderPathWithoutPaginationFindByU_D;
+	private FinderPath _finderPathCountByU_D;
 	private CollectionPersistenceFinder<UserNotificationEvent>
 		_collectionPersistenceFinderByU_D;
 
@@ -976,6 +994,9 @@ public class UserNotificationEventPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {userId, delivered});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByU_A;
+	private FinderPath _finderPathWithoutPaginationFindByU_A;
+	private FinderPath _finderPathCountByU_A;
 	private CollectionPersistenceFinder<UserNotificationEvent>
 		_collectionPersistenceFinderByU_A;
 
@@ -1132,6 +1153,9 @@ public class UserNotificationEventPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {userId, archived});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByU_DT_D;
+	private FinderPath _finderPathWithoutPaginationFindByU_DT_D;
+	private FinderPath _finderPathCountByU_DT_D;
 	private CollectionPersistenceFinder<UserNotificationEvent>
 		_collectionPersistenceFinderByU_DT_D;
 
@@ -1305,6 +1329,9 @@ public class UserNotificationEventPersistenceImpl
 			new Object[] {userId, deliveryType, delivered});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByU_DT_A;
+	private FinderPath _finderPathWithoutPaginationFindByU_DT_A;
+	private FinderPath _finderPathCountByU_DT_A;
 	private CollectionPersistenceFinder<UserNotificationEvent>
 		_collectionPersistenceFinderByU_DT_A;
 
@@ -1478,6 +1505,9 @@ public class UserNotificationEventPersistenceImpl
 			new Object[] {userId, deliveryType, archived});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByU_D_AR;
+	private FinderPath _finderPathWithoutPaginationFindByU_D_AR;
+	private FinderPath _finderPathCountByU_D_AR;
 	private CollectionPersistenceFinder<UserNotificationEvent>
 		_collectionPersistenceFinderByU_D_AR;
 
@@ -1656,6 +1686,9 @@ public class UserNotificationEventPersistenceImpl
 			new Object[] {userId, delivered, actionRequired});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByU_D_A;
+	private FinderPath _finderPathWithoutPaginationFindByU_D_A;
+	private FinderPath _finderPathCountByU_D_A;
 	private CollectionPersistenceFinder<UserNotificationEvent>
 		_collectionPersistenceFinderByU_D_A;
 
@@ -1828,6 +1861,9 @@ public class UserNotificationEventPersistenceImpl
 			new Object[] {userId, delivered, archived});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByU_AR_A;
+	private FinderPath _finderPathWithoutPaginationFindByU_AR_A;
+	private FinderPath _finderPathCountByU_AR_A;
 	private CollectionPersistenceFinder<UserNotificationEvent>
 		_collectionPersistenceFinderByU_AR_A;
 
@@ -2004,6 +2040,8 @@ public class UserNotificationEventPersistenceImpl
 			new Object[] {userId, actionRequired, archived});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByU_T_GteT_D;
+	private FinderPath _finderPathWithPaginationCountByU_T_GteT_D;
 	private CollectionPersistenceFinder<UserNotificationEvent>
 		_collectionPersistenceFinderByU_T_GteT_D;
 
@@ -2190,6 +2228,9 @@ public class UserNotificationEventPersistenceImpl
 			new Object[] {userId, type, timestamp, delivered});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByU_T_DT_D;
+	private FinderPath _finderPathWithoutPaginationFindByU_T_DT_D;
+	private FinderPath _finderPathCountByU_T_DT_D;
 	private CollectionPersistenceFinder<UserNotificationEvent>
 		_collectionPersistenceFinderByU_T_DT_D;
 
@@ -2378,6 +2419,9 @@ public class UserNotificationEventPersistenceImpl
 			new Object[] {userId, type, deliveryType, delivered});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByU_DT_D_AR;
+	private FinderPath _finderPathWithoutPaginationFindByU_DT_D_AR;
+	private FinderPath _finderPathCountByU_DT_D_AR;
 	private CollectionPersistenceFinder<UserNotificationEvent>
 		_collectionPersistenceFinderByU_DT_D_AR;
 
@@ -2573,6 +2617,9 @@ public class UserNotificationEventPersistenceImpl
 			new Object[] {userId, deliveryType, delivered, actionRequired});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByU_DT_D_A;
+	private FinderPath _finderPathWithoutPaginationFindByU_DT_D_A;
+	private FinderPath _finderPathCountByU_DT_D_A;
 	private CollectionPersistenceFinder<UserNotificationEvent>
 		_collectionPersistenceFinderByU_DT_D_A;
 
@@ -2761,6 +2808,9 @@ public class UserNotificationEventPersistenceImpl
 			new Object[] {userId, deliveryType, delivered, archived});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByU_DT_AR_A;
+	private FinderPath _finderPathWithoutPaginationFindByU_DT_AR_A;
+	private FinderPath _finderPathCountByU_DT_AR_A;
 	private CollectionPersistenceFinder<UserNotificationEvent>
 		_collectionPersistenceFinderByU_DT_AR_A;
 
@@ -2953,6 +3003,9 @@ public class UserNotificationEventPersistenceImpl
 			new Object[] {userId, deliveryType, actionRequired, archived});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByU_D_AR_A;
+	private FinderPath _finderPathWithoutPaginationFindByU_D_AR_A;
+	private FinderPath _finderPathCountByU_D_AR_A;
 	private CollectionPersistenceFinder<UserNotificationEvent>
 		_collectionPersistenceFinderByU_D_AR_A;
 
@@ -3146,6 +3199,9 @@ public class UserNotificationEventPersistenceImpl
 			new Object[] {userId, delivered, actionRequired, archived});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByU_T_DT_D_A;
+	private FinderPath _finderPathWithoutPaginationFindByU_T_DT_D_A;
+	private FinderPath _finderPathCountByU_T_DT_D_A;
 	private CollectionPersistenceFinder<UserNotificationEvent>
 		_collectionPersistenceFinderByU_T_DT_D_A;
 
@@ -3349,6 +3405,9 @@ public class UserNotificationEventPersistenceImpl
 			new Object[] {userId, type, deliveryType, delivered, archived});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByU_DT_D_AR_A;
+	private FinderPath _finderPathWithoutPaginationFindByU_DT_D_AR_A;
+	private FinderPath _finderPathCountByU_DT_D_AR_A;
 	private CollectionPersistenceFinder<UserNotificationEvent>
 		_collectionPersistenceFinderByU_DT_D_AR_A;
 
@@ -3769,23 +3828,27 @@ public class UserNotificationEventPersistenceImpl
 	 * Initializes the user notification event persistence.
 	 */
 	public void afterPropertiesSet() {
+		_finderPathWithPaginationFindByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid",
+			new String[] {
+				String.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"uuid_"}, true);
+
+		_finderPathWithoutPaginationFindByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid",
+			new String[] {String.class.getName()}, new String[] {"uuid_"}, 0, 1,
+			true, null);
+
+		_finderPathCountByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid",
+			new String[] {String.class.getName()}, new String[] {"uuid_"}, 0, 1,
+			false, null);
+
 		_collectionPersistenceFinderByUuid = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid",
-				new String[] {
-					String.class.getName(), Integer.class.getName(),
-					Integer.class.getName(), OrderByComparator.class.getName()
-				},
-				new String[] {"uuid_"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid",
-				new String[] {String.class.getName()}, new String[] {"uuid_"},
-				0, 1, true, null),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid",
-				new String[] {String.class.getName()}, new String[] {"uuid_"},
-				0, 1, false, null),
+			this, _finderPathWithPaginationFindByUuid,
+			_finderPathWithoutPaginationFindByUuid, _finderPathCountByUuid,
 			_SQL_SELECT_USERNOTIFICATIONEVENT_WHERE,
 			_SQL_COUNT_USERNOTIFICATIONEVENT_WHERE,
 			UserNotificationEventModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
@@ -3794,25 +3857,30 @@ public class UserNotificationEventPersistenceImpl
 				"userNotificationEvent.", "uuid", FinderColumn.Type.STRING, "=",
 				true, true, UserNotificationEvent::getUuid));
 
+		_finderPathWithPaginationFindByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid_C",
+			new String[] {
+				String.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"uuid_", "companyId"}, true);
+
+		_finderPathWithoutPaginationFindByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"uuid_", "companyId"}, 0, 1, true, null);
+
+		_finderPathCountByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"uuid_", "companyId"}, 0, 1, false, null);
+
 		_collectionPersistenceFinderByUuid_C =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid_C",
-					new String[] {
-						String.class.getName(), Long.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"uuid_", "companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid_C",
-					new String[] {String.class.getName(), Long.class.getName()},
-					new String[] {"uuid_", "companyId"}, 0, 1, true, null),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid_C",
-					new String[] {String.class.getName(), Long.class.getName()},
-					new String[] {"uuid_", "companyId"}, 0, 1, false, null),
+				this, _finderPathWithPaginationFindByUuid_C,
+				_finderPathWithoutPaginationFindByUuid_C,
+				_finderPathCountByUuid_C,
 				_SQL_SELECT_USERNOTIFICATIONEVENT_WHERE,
 				_SQL_COUNT_USERNOTIFICATIONEVENT_WHERE,
 				UserNotificationEventModelImpl.ORDER_BY_JPQL,
@@ -3825,25 +3893,28 @@ public class UserNotificationEventPersistenceImpl
 					FinderColumn.Type.LONG, "=", true, true,
 					UserNotificationEvent::getCompanyId));
 
+		_finderPathWithPaginationFindByUserId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUserId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"userId"}, true);
+
+		_finderPathWithoutPaginationFindByUserId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUserId",
+			new String[] {Long.class.getName()}, new String[] {"userId"}, true);
+
+		_finderPathCountByUserId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUserId",
+			new String[] {Long.class.getName()}, new String[] {"userId"},
+			false);
+
 		_collectionPersistenceFinderByUserId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUserId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"userId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUserId",
-					new String[] {Long.class.getName()},
-					new String[] {"userId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUserId",
-					new String[] {Long.class.getName()},
-					new String[] {"userId"}, false),
+				this, _finderPathWithPaginationFindByUserId,
+				_finderPathWithoutPaginationFindByUserId,
+				_finderPathCountByUserId,
 				_SQL_SELECT_USERNOTIFICATIONEVENT_WHERE,
 				_SQL_COUNT_USERNOTIFICATIONEVENT_WHERE,
 				UserNotificationEventModelImpl.ORDER_BY_JPQL,
@@ -3852,23 +3923,27 @@ public class UserNotificationEventPersistenceImpl
 					"userNotificationEvent.", "userId", FinderColumn.Type.LONG,
 					"=", true, true, UserNotificationEvent::getUserId));
 
+		_finderPathWithPaginationFindByType = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByType",
+			new String[] {
+				String.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"type_"}, true);
+
+		_finderPathWithoutPaginationFindByType = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByType",
+			new String[] {String.class.getName()}, new String[] {"type_"}, 0, 1,
+			true, null);
+
+		_finderPathCountByType = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByType",
+			new String[] {String.class.getName()}, new String[] {"type_"}, 0, 1,
+			false, null);
+
 		_collectionPersistenceFinderByType = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByType",
-				new String[] {
-					String.class.getName(), Integer.class.getName(),
-					Integer.class.getName(), OrderByComparator.class.getName()
-				},
-				new String[] {"type_"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByType",
-				new String[] {String.class.getName()}, new String[] {"type_"},
-				0, 1, true, null),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByType",
-				new String[] {String.class.getName()}, new String[] {"type_"},
-				0, 1, false, null),
+			this, _finderPathWithPaginationFindByType,
+			_finderPathWithoutPaginationFindByType, _finderPathCountByType,
 			_SQL_SELECT_USERNOTIFICATIONEVENT_WHERE,
 			_SQL_COUNT_USERNOTIFICATIONEVENT_WHERE,
 			UserNotificationEventModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
@@ -3877,24 +3952,28 @@ public class UserNotificationEventPersistenceImpl
 				"userNotificationEvent.", "type", FinderColumn.Type.STRING, "=",
 				true, true, UserNotificationEvent::getType));
 
+		_finderPathWithPaginationFindByU_DT = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByU_DT",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"userId", "deliveryType"}, true);
+
+		_finderPathWithoutPaginationFindByU_DT = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByU_DT",
+			new String[] {Long.class.getName(), Integer.class.getName()},
+			new String[] {"userId", "deliveryType"}, true);
+
+		_finderPathCountByU_DT = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByU_DT",
+			new String[] {Long.class.getName(), Integer.class.getName()},
+			new String[] {"userId", "deliveryType"}, false);
+
 		_collectionPersistenceFinderByU_DT = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByU_DT",
-				new String[] {
-					Long.class.getName(), Integer.class.getName(),
-					Integer.class.getName(), Integer.class.getName(),
-					OrderByComparator.class.getName()
-				},
-				new String[] {"userId", "deliveryType"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByU_DT",
-				new String[] {Long.class.getName(), Integer.class.getName()},
-				new String[] {"userId", "deliveryType"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByU_DT",
-				new String[] {Long.class.getName(), Integer.class.getName()},
-				new String[] {"userId", "deliveryType"}, false),
+			this, _finderPathWithPaginationFindByU_DT,
+			_finderPathWithoutPaginationFindByU_DT, _finderPathCountByU_DT,
 			_SQL_SELECT_USERNOTIFICATIONEVENT_WHERE,
 			_SQL_COUNT_USERNOTIFICATIONEVENT_WHERE,
 			UserNotificationEventModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
@@ -3907,24 +3986,28 @@ public class UserNotificationEventPersistenceImpl
 				FinderColumn.Type.INTEGER, "=", true, true,
 				UserNotificationEvent::getDeliveryType));
 
+		_finderPathWithPaginationFindByU_D = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByU_D",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"userId", "delivered"}, true);
+
+		_finderPathWithoutPaginationFindByU_D = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByU_D",
+			new String[] {Long.class.getName(), Boolean.class.getName()},
+			new String[] {"userId", "delivered"}, true);
+
+		_finderPathCountByU_D = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByU_D",
+			new String[] {Long.class.getName(), Boolean.class.getName()},
+			new String[] {"userId", "delivered"}, false);
+
 		_collectionPersistenceFinderByU_D = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByU_D",
-				new String[] {
-					Long.class.getName(), Boolean.class.getName(),
-					Integer.class.getName(), Integer.class.getName(),
-					OrderByComparator.class.getName()
-				},
-				new String[] {"userId", "delivered"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByU_D",
-				new String[] {Long.class.getName(), Boolean.class.getName()},
-				new String[] {"userId", "delivered"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByU_D",
-				new String[] {Long.class.getName(), Boolean.class.getName()},
-				new String[] {"userId", "delivered"}, false),
+			this, _finderPathWithPaginationFindByU_D,
+			_finderPathWithoutPaginationFindByU_D, _finderPathCountByU_D,
 			_SQL_SELECT_USERNOTIFICATIONEVENT_WHERE,
 			_SQL_COUNT_USERNOTIFICATIONEVENT_WHERE,
 			UserNotificationEventModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
@@ -3937,24 +4020,28 @@ public class UserNotificationEventPersistenceImpl
 				FinderColumn.Type.BOOLEAN, "=", true, true,
 				UserNotificationEvent::isDelivered));
 
+		_finderPathWithPaginationFindByU_A = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByU_A",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"userId", "archived"}, true);
+
+		_finderPathWithoutPaginationFindByU_A = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByU_A",
+			new String[] {Long.class.getName(), Boolean.class.getName()},
+			new String[] {"userId", "archived"}, true);
+
+		_finderPathCountByU_A = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByU_A",
+			new String[] {Long.class.getName(), Boolean.class.getName()},
+			new String[] {"userId", "archived"}, false);
+
 		_collectionPersistenceFinderByU_A = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByU_A",
-				new String[] {
-					Long.class.getName(), Boolean.class.getName(),
-					Integer.class.getName(), Integer.class.getName(),
-					OrderByComparator.class.getName()
-				},
-				new String[] {"userId", "archived"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByU_A",
-				new String[] {Long.class.getName(), Boolean.class.getName()},
-				new String[] {"userId", "archived"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByU_A",
-				new String[] {Long.class.getName(), Boolean.class.getName()},
-				new String[] {"userId", "archived"}, false),
+			this, _finderPathWithPaginationFindByU_A,
+			_finderPathWithoutPaginationFindByU_A, _finderPathCountByU_A,
 			_SQL_SELECT_USERNOTIFICATIONEVENT_WHERE,
 			_SQL_COUNT_USERNOTIFICATIONEVENT_WHERE,
 			UserNotificationEventModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
@@ -3966,33 +4053,36 @@ public class UserNotificationEventPersistenceImpl
 				"userNotificationEvent.", "archived", FinderColumn.Type.BOOLEAN,
 				"=", true, true, UserNotificationEvent::isArchived));
 
+		_finderPathWithPaginationFindByU_DT_D = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByU_DT_D",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Boolean.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"userId", "deliveryType", "delivered"}, true);
+
+		_finderPathWithoutPaginationFindByU_DT_D = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByU_DT_D",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Boolean.class.getName()
+			},
+			new String[] {"userId", "deliveryType", "delivered"}, true);
+
+		_finderPathCountByU_DT_D = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByU_DT_D",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Boolean.class.getName()
+			},
+			new String[] {"userId", "deliveryType", "delivered"}, false);
+
 		_collectionPersistenceFinderByU_DT_D =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByU_DT_D",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Boolean.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"userId", "deliveryType", "delivered"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByU_DT_D",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Boolean.class.getName()
-					},
-					new String[] {"userId", "deliveryType", "delivered"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByU_DT_D",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Boolean.class.getName()
-					},
-					new String[] {"userId", "deliveryType", "delivered"},
-					false),
+				this, _finderPathWithPaginationFindByU_DT_D,
+				_finderPathWithoutPaginationFindByU_DT_D,
+				_finderPathCountByU_DT_D,
 				_SQL_SELECT_USERNOTIFICATIONEVENT_WHERE,
 				_SQL_COUNT_USERNOTIFICATIONEVENT_WHERE,
 				UserNotificationEventModelImpl.ORDER_BY_JPQL,
@@ -4009,32 +4099,36 @@ public class UserNotificationEventPersistenceImpl
 					FinderColumn.Type.BOOLEAN, "=", true, true,
 					UserNotificationEvent::isDelivered));
 
+		_finderPathWithPaginationFindByU_DT_A = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByU_DT_A",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Boolean.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"userId", "deliveryType", "archived"}, true);
+
+		_finderPathWithoutPaginationFindByU_DT_A = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByU_DT_A",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Boolean.class.getName()
+			},
+			new String[] {"userId", "deliveryType", "archived"}, true);
+
+		_finderPathCountByU_DT_A = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByU_DT_A",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Boolean.class.getName()
+			},
+			new String[] {"userId", "deliveryType", "archived"}, false);
+
 		_collectionPersistenceFinderByU_DT_A =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByU_DT_A",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Boolean.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"userId", "deliveryType", "archived"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByU_DT_A",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Boolean.class.getName()
-					},
-					new String[] {"userId", "deliveryType", "archived"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByU_DT_A",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Boolean.class.getName()
-					},
-					new String[] {"userId", "deliveryType", "archived"}, false),
+				this, _finderPathWithPaginationFindByU_DT_A,
+				_finderPathWithoutPaginationFindByU_DT_A,
+				_finderPathCountByU_DT_A,
 				_SQL_SELECT_USERNOTIFICATIONEVENT_WHERE,
 				_SQL_COUNT_USERNOTIFICATIONEVENT_WHERE,
 				UserNotificationEventModelImpl.ORDER_BY_JPQL,
@@ -4051,35 +4145,36 @@ public class UserNotificationEventPersistenceImpl
 					FinderColumn.Type.BOOLEAN, "=", true, true,
 					UserNotificationEvent::isArchived));
 
+		_finderPathWithPaginationFindByU_D_AR = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByU_D_AR",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"userId", "delivered", "actionRequired"}, true);
+
+		_finderPathWithoutPaginationFindByU_D_AR = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByU_D_AR",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName()
+			},
+			new String[] {"userId", "delivered", "actionRequired"}, true);
+
+		_finderPathCountByU_D_AR = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByU_D_AR",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName()
+			},
+			new String[] {"userId", "delivered", "actionRequired"}, false);
+
 		_collectionPersistenceFinderByU_D_AR =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByU_D_AR",
-					new String[] {
-						Long.class.getName(), Boolean.class.getName(),
-						Boolean.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"userId", "delivered", "actionRequired"},
-					true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByU_D_AR",
-					new String[] {
-						Long.class.getName(), Boolean.class.getName(),
-						Boolean.class.getName()
-					},
-					new String[] {"userId", "delivered", "actionRequired"},
-					true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByU_D_AR",
-					new String[] {
-						Long.class.getName(), Boolean.class.getName(),
-						Boolean.class.getName()
-					},
-					new String[] {"userId", "delivered", "actionRequired"},
-					false),
+				this, _finderPathWithPaginationFindByU_D_AR,
+				_finderPathWithoutPaginationFindByU_D_AR,
+				_finderPathCountByU_D_AR,
 				_SQL_SELECT_USERNOTIFICATIONEVENT_WHERE,
 				_SQL_COUNT_USERNOTIFICATIONEVENT_WHERE,
 				UserNotificationEventModelImpl.ORDER_BY_JPQL,
@@ -4096,30 +4191,34 @@ public class UserNotificationEventPersistenceImpl
 					FinderColumn.Type.BOOLEAN, "=", true, true,
 					UserNotificationEvent::isActionRequired));
 
+		_finderPathWithPaginationFindByU_D_A = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByU_D_A",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"userId", "delivered", "archived"}, true);
+
+		_finderPathWithoutPaginationFindByU_D_A = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByU_D_A",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName()
+			},
+			new String[] {"userId", "delivered", "archived"}, true);
+
+		_finderPathCountByU_D_A = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByU_D_A",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName()
+			},
+			new String[] {"userId", "delivered", "archived"}, false);
+
 		_collectionPersistenceFinderByU_D_A = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByU_D_A",
-				new String[] {
-					Long.class.getName(), Boolean.class.getName(),
-					Boolean.class.getName(), Integer.class.getName(),
-					Integer.class.getName(), OrderByComparator.class.getName()
-				},
-				new String[] {"userId", "delivered", "archived"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByU_D_A",
-				new String[] {
-					Long.class.getName(), Boolean.class.getName(),
-					Boolean.class.getName()
-				},
-				new String[] {"userId", "delivered", "archived"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByU_D_A",
-				new String[] {
-					Long.class.getName(), Boolean.class.getName(),
-					Boolean.class.getName()
-				},
-				new String[] {"userId", "delivered", "archived"}, false),
+			this, _finderPathWithPaginationFindByU_D_A,
+			_finderPathWithoutPaginationFindByU_D_A, _finderPathCountByU_D_A,
 			_SQL_SELECT_USERNOTIFICATIONEVENT_WHERE,
 			_SQL_COUNT_USERNOTIFICATIONEVENT_WHERE,
 			UserNotificationEventModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
@@ -4135,35 +4234,36 @@ public class UserNotificationEventPersistenceImpl
 				"userNotificationEvent.", "archived", FinderColumn.Type.BOOLEAN,
 				"=", true, true, UserNotificationEvent::isArchived));
 
+		_finderPathWithPaginationFindByU_AR_A = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByU_AR_A",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"userId", "actionRequired", "archived"}, true);
+
+		_finderPathWithoutPaginationFindByU_AR_A = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByU_AR_A",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName()
+			},
+			new String[] {"userId", "actionRequired", "archived"}, true);
+
+		_finderPathCountByU_AR_A = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByU_AR_A",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName()
+			},
+			new String[] {"userId", "actionRequired", "archived"}, false);
+
 		_collectionPersistenceFinderByU_AR_A =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByU_AR_A",
-					new String[] {
-						Long.class.getName(), Boolean.class.getName(),
-						Boolean.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"userId", "actionRequired", "archived"},
-					true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByU_AR_A",
-					new String[] {
-						Long.class.getName(), Boolean.class.getName(),
-						Boolean.class.getName()
-					},
-					new String[] {"userId", "actionRequired", "archived"},
-					true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByU_AR_A",
-					new String[] {
-						Long.class.getName(), Boolean.class.getName(),
-						Boolean.class.getName()
-					},
-					new String[] {"userId", "actionRequired", "archived"},
-					false),
+				this, _finderPathWithPaginationFindByU_AR_A,
+				_finderPathWithoutPaginationFindByU_AR_A,
+				_finderPathCountByU_AR_A,
 				_SQL_SELECT_USERNOTIFICATIONEVENT_WHERE,
 				_SQL_COUNT_USERNOTIFICATIONEVENT_WHERE,
 				UserNotificationEventModelImpl.ORDER_BY_JPQL,
@@ -4180,28 +4280,28 @@ public class UserNotificationEventPersistenceImpl
 					FinderColumn.Type.BOOLEAN, "=", true, true,
 					UserNotificationEvent::isArchived));
 
+		_finderPathWithPaginationFindByU_T_GteT_D = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByU_T_GteT_D",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Long.class.getName(), Boolean.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"userId", "type_", "timestamp", "delivered"}, true);
+
+		_finderPathWithPaginationCountByU_T_GteT_D = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByU_T_GteT_D",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Long.class.getName(), Boolean.class.getName()
+			},
+			new String[] {"userId", "type_", "timestamp", "delivered"}, false);
+
 		_collectionPersistenceFinderByU_T_GteT_D =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByU_T_GteT_D",
-					new String[] {
-						Long.class.getName(), String.class.getName(),
-						Long.class.getName(), Boolean.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"userId", "type_", "timestamp", "delivered"},
-					true),
-				null,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByU_T_GteT_D",
-					new String[] {
-						Long.class.getName(), String.class.getName(),
-						Long.class.getName(), Boolean.class.getName()
-					},
-					new String[] {"userId", "type_", "timestamp", "delivered"},
-					false),
+				this, _finderPathWithPaginationFindByU_T_GteT_D, null,
+				_finderPathWithPaginationCountByU_T_GteT_D,
 				_SQL_SELECT_USERNOTIFICATIONEVENT_WHERE,
 				_SQL_COUNT_USERNOTIFICATIONEVENT_WHERE,
 				UserNotificationEventModelImpl.ORDER_BY_JPQL,
@@ -4221,42 +4321,40 @@ public class UserNotificationEventPersistenceImpl
 					FinderColumn.Type.BOOLEAN, "=", true, true,
 					UserNotificationEvent::isDelivered));
 
+		_finderPathWithPaginationFindByU_T_DT_D = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByU_T_DT_D",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Integer.class.getName(), Boolean.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"userId", "type_", "deliveryType", "delivered"},
+			true);
+
+		_finderPathWithoutPaginationFindByU_T_DT_D = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByU_T_DT_D",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Integer.class.getName(), Boolean.class.getName()
+			},
+			new String[] {"userId", "type_", "deliveryType", "delivered"}, 0, 2,
+			true, null);
+
+		_finderPathCountByU_T_DT_D = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByU_T_DT_D",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Integer.class.getName(), Boolean.class.getName()
+			},
+			new String[] {"userId", "type_", "deliveryType", "delivered"}, 0, 2,
+			false, null);
+
 		_collectionPersistenceFinderByU_T_DT_D =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByU_T_DT_D",
-					new String[] {
-						Long.class.getName(), String.class.getName(),
-						Integer.class.getName(), Boolean.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {
-						"userId", "type_", "deliveryType", "delivered"
-					},
-					true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByU_T_DT_D",
-					new String[] {
-						Long.class.getName(), String.class.getName(),
-						Integer.class.getName(), Boolean.class.getName()
-					},
-					new String[] {
-						"userId", "type_", "deliveryType", "delivered"
-					},
-					0, 2, true, null),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByU_T_DT_D",
-					new String[] {
-						Long.class.getName(), String.class.getName(),
-						Integer.class.getName(), Boolean.class.getName()
-					},
-					new String[] {
-						"userId", "type_", "deliveryType", "delivered"
-					},
-					0, 2, false, null),
+				this, _finderPathWithPaginationFindByU_T_DT_D,
+				_finderPathWithoutPaginationFindByU_T_DT_D,
+				_finderPathCountByU_T_DT_D,
 				_SQL_SELECT_USERNOTIFICATIONEVENT_WHERE,
 				_SQL_COUNT_USERNOTIFICATIONEVENT_WHERE,
 				UserNotificationEventModelImpl.ORDER_BY_JPQL,
@@ -4276,43 +4374,46 @@ public class UserNotificationEventPersistenceImpl
 					FinderColumn.Type.BOOLEAN, "=", true, true,
 					UserNotificationEvent::isDelivered));
 
+		_finderPathWithPaginationFindByU_DT_D_AR = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByU_DT_D_AR",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Boolean.class.getName(), Boolean.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {
+				"userId", "deliveryType", "delivered", "actionRequired"
+			},
+			true);
+
+		_finderPathWithoutPaginationFindByU_DT_D_AR = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByU_DT_D_AR",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Boolean.class.getName(), Boolean.class.getName()
+			},
+			new String[] {
+				"userId", "deliveryType", "delivered", "actionRequired"
+			},
+			true);
+
+		_finderPathCountByU_DT_D_AR = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByU_DT_D_AR",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Boolean.class.getName(), Boolean.class.getName()
+			},
+			new String[] {
+				"userId", "deliveryType", "delivered", "actionRequired"
+			},
+			false);
+
 		_collectionPersistenceFinderByU_DT_D_AR =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByU_DT_D_AR",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Boolean.class.getName(), Boolean.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {
-						"userId", "deliveryType", "delivered", "actionRequired"
-					},
-					true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"findByU_DT_D_AR",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Boolean.class.getName(), Boolean.class.getName()
-					},
-					new String[] {
-						"userId", "deliveryType", "delivered", "actionRequired"
-					},
-					true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByU_DT_D_AR",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Boolean.class.getName(), Boolean.class.getName()
-					},
-					new String[] {
-						"userId", "deliveryType", "delivered", "actionRequired"
-					},
-					false),
+				this, _finderPathWithPaginationFindByU_DT_D_AR,
+				_finderPathWithoutPaginationFindByU_DT_D_AR,
+				_finderPathCountByU_DT_D_AR,
 				_SQL_SELECT_USERNOTIFICATIONEVENT_WHERE,
 				_SQL_COUNT_USERNOTIFICATIONEVENT_WHERE,
 				UserNotificationEventModelImpl.ORDER_BY_JPQL,
@@ -4333,42 +4434,40 @@ public class UserNotificationEventPersistenceImpl
 					FinderColumn.Type.BOOLEAN, "=", true, true,
 					UserNotificationEvent::isActionRequired));
 
+		_finderPathWithPaginationFindByU_DT_D_A = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByU_DT_D_A",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Boolean.class.getName(), Boolean.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"userId", "deliveryType", "delivered", "archived"},
+			true);
+
+		_finderPathWithoutPaginationFindByU_DT_D_A = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByU_DT_D_A",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Boolean.class.getName(), Boolean.class.getName()
+			},
+			new String[] {"userId", "deliveryType", "delivered", "archived"},
+			true);
+
+		_finderPathCountByU_DT_D_A = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByU_DT_D_A",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Boolean.class.getName(), Boolean.class.getName()
+			},
+			new String[] {"userId", "deliveryType", "delivered", "archived"},
+			false);
+
 		_collectionPersistenceFinderByU_DT_D_A =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByU_DT_D_A",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Boolean.class.getName(), Boolean.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {
-						"userId", "deliveryType", "delivered", "archived"
-					},
-					true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByU_DT_D_A",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Boolean.class.getName(), Boolean.class.getName()
-					},
-					new String[] {
-						"userId", "deliveryType", "delivered", "archived"
-					},
-					true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByU_DT_D_A",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Boolean.class.getName(), Boolean.class.getName()
-					},
-					new String[] {
-						"userId", "deliveryType", "delivered", "archived"
-					},
-					false),
+				this, _finderPathWithPaginationFindByU_DT_D_A,
+				_finderPathWithoutPaginationFindByU_DT_D_A,
+				_finderPathCountByU_DT_D_A,
 				_SQL_SELECT_USERNOTIFICATIONEVENT_WHERE,
 				_SQL_COUNT_USERNOTIFICATIONEVENT_WHERE,
 				UserNotificationEventModelImpl.ORDER_BY_JPQL,
@@ -4388,44 +4487,47 @@ public class UserNotificationEventPersistenceImpl
 					"userNotificationEvent.", "archived",
 					FinderColumn.Type.BOOLEAN, "=", true, true,
 					UserNotificationEvent::isArchived));
+
+		_finderPathWithPaginationFindByU_DT_AR_A = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByU_DT_AR_A",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Boolean.class.getName(), Boolean.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {
+				"userId", "deliveryType", "actionRequired", "archived"
+			},
+			true);
+
+		_finderPathWithoutPaginationFindByU_DT_AR_A = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByU_DT_AR_A",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Boolean.class.getName(), Boolean.class.getName()
+			},
+			new String[] {
+				"userId", "deliveryType", "actionRequired", "archived"
+			},
+			true);
+
+		_finderPathCountByU_DT_AR_A = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByU_DT_AR_A",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Boolean.class.getName(), Boolean.class.getName()
+			},
+			new String[] {
+				"userId", "deliveryType", "actionRequired", "archived"
+			},
+			false);
 
 		_collectionPersistenceFinderByU_DT_AR_A =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByU_DT_AR_A",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Boolean.class.getName(), Boolean.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {
-						"userId", "deliveryType", "actionRequired", "archived"
-					},
-					true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"findByU_DT_AR_A",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Boolean.class.getName(), Boolean.class.getName()
-					},
-					new String[] {
-						"userId", "deliveryType", "actionRequired", "archived"
-					},
-					true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByU_DT_AR_A",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Boolean.class.getName(), Boolean.class.getName()
-					},
-					new String[] {
-						"userId", "deliveryType", "actionRequired", "archived"
-					},
-					false),
+				this, _finderPathWithPaginationFindByU_DT_AR_A,
+				_finderPathWithoutPaginationFindByU_DT_AR_A,
+				_finderPathCountByU_DT_AR_A,
 				_SQL_SELECT_USERNOTIFICATIONEVENT_WHERE,
 				_SQL_COUNT_USERNOTIFICATIONEVENT_WHERE,
 				UserNotificationEventModelImpl.ORDER_BY_JPQL,
@@ -4446,42 +4548,40 @@ public class UserNotificationEventPersistenceImpl
 					FinderColumn.Type.BOOLEAN, "=", true, true,
 					UserNotificationEvent::isArchived));
 
+		_finderPathWithPaginationFindByU_D_AR_A = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByU_D_AR_A",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName(), Boolean.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"userId", "delivered", "actionRequired", "archived"},
+			true);
+
+		_finderPathWithoutPaginationFindByU_D_AR_A = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByU_D_AR_A",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName(), Boolean.class.getName()
+			},
+			new String[] {"userId", "delivered", "actionRequired", "archived"},
+			true);
+
+		_finderPathCountByU_D_AR_A = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByU_D_AR_A",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName(), Boolean.class.getName()
+			},
+			new String[] {"userId", "delivered", "actionRequired", "archived"},
+			false);
+
 		_collectionPersistenceFinderByU_D_AR_A =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByU_D_AR_A",
-					new String[] {
-						Long.class.getName(), Boolean.class.getName(),
-						Boolean.class.getName(), Boolean.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {
-						"userId", "delivered", "actionRequired", "archived"
-					},
-					true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByU_D_AR_A",
-					new String[] {
-						Long.class.getName(), Boolean.class.getName(),
-						Boolean.class.getName(), Boolean.class.getName()
-					},
-					new String[] {
-						"userId", "delivered", "actionRequired", "archived"
-					},
-					true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByU_D_AR_A",
-					new String[] {
-						Long.class.getName(), Boolean.class.getName(),
-						Boolean.class.getName(), Boolean.class.getName()
-					},
-					new String[] {
-						"userId", "delivered", "actionRequired", "archived"
-					},
-					false),
+				this, _finderPathWithPaginationFindByU_D_AR_A,
+				_finderPathWithoutPaginationFindByU_D_AR_A,
+				_finderPathCountByU_D_AR_A,
 				_SQL_SELECT_USERNOTIFICATIONEVENT_WHERE,
 				_SQL_COUNT_USERNOTIFICATIONEVENT_WHERE,
 				UserNotificationEventModelImpl.ORDER_BY_JPQL,
@@ -4502,49 +4602,48 @@ public class UserNotificationEventPersistenceImpl
 					FinderColumn.Type.BOOLEAN, "=", true, true,
 					UserNotificationEvent::isArchived));
 
+		_finderPathWithPaginationFindByU_T_DT_D_A = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByU_T_DT_D_A",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Integer.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {
+				"userId", "type_", "deliveryType", "delivered", "archived"
+			},
+			true);
+
+		_finderPathWithoutPaginationFindByU_T_DT_D_A = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByU_T_DT_D_A",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Integer.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName()
+			},
+			new String[] {
+				"userId", "type_", "deliveryType", "delivered", "archived"
+			},
+			0, 2, true, null);
+
+		_finderPathCountByU_T_DT_D_A = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByU_T_DT_D_A",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Integer.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName()
+			},
+			new String[] {
+				"userId", "type_", "deliveryType", "delivered", "archived"
+			},
+			0, 2, false, null);
+
 		_collectionPersistenceFinderByU_T_DT_D_A =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByU_T_DT_D_A",
-					new String[] {
-						Long.class.getName(), String.class.getName(),
-						Integer.class.getName(), Boolean.class.getName(),
-						Boolean.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {
-						"userId", "type_", "deliveryType", "delivered",
-						"archived"
-					},
-					true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"findByU_T_DT_D_A",
-					new String[] {
-						Long.class.getName(), String.class.getName(),
-						Integer.class.getName(), Boolean.class.getName(),
-						Boolean.class.getName()
-					},
-					new String[] {
-						"userId", "type_", "deliveryType", "delivered",
-						"archived"
-					},
-					0, 2, true, null),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByU_T_DT_D_A",
-					new String[] {
-						Long.class.getName(), String.class.getName(),
-						Integer.class.getName(), Boolean.class.getName(),
-						Boolean.class.getName()
-					},
-					new String[] {
-						"userId", "type_", "deliveryType", "delivered",
-						"archived"
-					},
-					0, 2, false, null),
+				this, _finderPathWithPaginationFindByU_T_DT_D_A,
+				_finderPathWithoutPaginationFindByU_T_DT_D_A,
+				_finderPathCountByU_T_DT_D_A,
 				_SQL_SELECT_USERNOTIFICATIONEVENT_WHERE,
 				_SQL_COUNT_USERNOTIFICATIONEVENT_WHERE,
 				UserNotificationEventModelImpl.ORDER_BY_JPQL,
@@ -4568,49 +4667,51 @@ public class UserNotificationEventPersistenceImpl
 					FinderColumn.Type.BOOLEAN, "=", true, true,
 					UserNotificationEvent::isArchived));
 
+		_finderPathWithPaginationFindByU_DT_D_AR_A = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByU_DT_D_AR_A",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Boolean.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {
+				"userId", "deliveryType", "delivered", "actionRequired",
+				"archived"
+			},
+			true);
+
+		_finderPathWithoutPaginationFindByU_DT_D_AR_A = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByU_DT_D_AR_A",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Boolean.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName()
+			},
+			new String[] {
+				"userId", "deliveryType", "delivered", "actionRequired",
+				"archived"
+			},
+			true);
+
+		_finderPathCountByU_DT_D_AR_A = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByU_DT_D_AR_A",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Boolean.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName()
+			},
+			new String[] {
+				"userId", "deliveryType", "delivered", "actionRequired",
+				"archived"
+			},
+			false);
+
 		_collectionPersistenceFinderByU_DT_D_AR_A =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByU_DT_D_AR_A",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Boolean.class.getName(), Boolean.class.getName(),
-						Boolean.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {
-						"userId", "deliveryType", "delivered", "actionRequired",
-						"archived"
-					},
-					true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"findByU_DT_D_AR_A",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Boolean.class.getName(), Boolean.class.getName(),
-						Boolean.class.getName()
-					},
-					new String[] {
-						"userId", "deliveryType", "delivered", "actionRequired",
-						"archived"
-					},
-					true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByU_DT_D_AR_A",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Boolean.class.getName(), Boolean.class.getName(),
-						Boolean.class.getName()
-					},
-					new String[] {
-						"userId", "deliveryType", "delivered", "actionRequired",
-						"archived"
-					},
-					false),
+				this, _finderPathWithPaginationFindByU_DT_D_AR_A,
+				_finderPathWithoutPaginationFindByU_DT_D_AR_A,
+				_finderPathCountByU_DT_D_AR_A,
 				_SQL_SELECT_USERNOTIFICATIONEVENT_WHERE,
 				_SQL_COUNT_USERNOTIFICATIONEVENT_WHERE,
 				UserNotificationEventModelImpl.ORDER_BY_JPQL,
@@ -4668,4 +4769,4 @@ public class UserNotificationEventPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1763991294
+// LIFERAY-SERVICE-BUILDER-HASH:1499586170

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/UserPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/UserPersistenceImpl.java
@@ -98,6 +98,9 @@ public class UserPersistenceImpl
 	public static final String FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION =
 		FINDER_CLASS_NAME_ENTITY + ".List2";
 
+	private FinderPath _finderPathWithPaginationFindByUuid;
+	private FinderPath _finderPathWithoutPaginationFindByUuid;
+	private FinderPath _finderPathCountByUuid;
 	private CollectionPersistenceFinder<User>
 		_collectionPersistenceFinderByUuid;
 
@@ -237,6 +240,9 @@ public class UserPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {uuid});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByUuid_C;
+	private FinderPath _finderPathWithoutPaginationFindByUuid_C;
+	private FinderPath _finderPathCountByUuid_C;
 	private CollectionPersistenceFinder<User>
 		_collectionPersistenceFinderByUuid_C;
 
@@ -390,6 +396,9 @@ public class UserPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {uuid, companyId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByCompanyId;
+	private FinderPath _finderPathWithoutPaginationFindByCompanyId;
+	private FinderPath _finderPathCountByCompanyId;
 	private CollectionPersistenceFinder<User>
 		_collectionPersistenceFinderByCompanyId;
 
@@ -530,6 +539,7 @@ public class UserPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {companyId});
 	}
 
+	private FinderPath _finderPathFetchByContactId;
 	private UniquePersistenceFinder<User> _uniquePersistenceFinderByContactId;
 
 	/**
@@ -608,6 +618,9 @@ public class UserPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {contactId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByEmailAddress;
+	private FinderPath _finderPathWithoutPaginationFindByEmailAddress;
+	private FinderPath _finderPathCountByEmailAddress;
 	private CollectionPersistenceFinder<User>
 		_collectionPersistenceFinderByEmailAddress;
 
@@ -751,6 +764,9 @@ public class UserPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {emailAddress});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByPortraitId;
+	private FinderPath _finderPathWithoutPaginationFindByPortraitId;
+	private FinderPath _finderPathCountByPortraitId;
 	private CollectionPersistenceFinder<User>
 		_collectionPersistenceFinderByPortraitId;
 
@@ -892,6 +908,8 @@ public class UserPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {portraitId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByGtU_C;
+	private FinderPath _finderPathWithPaginationCountByGtU_C;
 	private CollectionPersistenceFinder<User>
 		_collectionPersistenceFinderByGtU_C;
 
@@ -1045,6 +1063,7 @@ public class UserPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {userId, companyId});
 	}
 
+	private FinderPath _finderPathFetchByC_U;
 	private UniquePersistenceFinder<User> _uniquePersistenceFinderByC_U;
 
 	/**
@@ -1134,6 +1153,9 @@ public class UserPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {companyId, userId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_CD;
+	private FinderPath _finderPathWithoutPaginationFindByC_CD;
+	private FinderPath _finderPathCountByC_CD;
 	private CollectionPersistenceFinder<User>
 		_collectionPersistenceFinderByC_CD;
 
@@ -1291,6 +1313,9 @@ public class UserPersistenceImpl
 			new Object[] {companyId, createDate});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_MD;
+	private FinderPath _finderPathWithoutPaginationFindByC_MD;
+	private FinderPath _finderPathCountByC_MD;
 	private CollectionPersistenceFinder<User>
 		_collectionPersistenceFinderByC_MD;
 
@@ -1450,6 +1475,7 @@ public class UserPersistenceImpl
 			new Object[] {companyId, modifiedDate});
 	}
 
+	private FinderPath _finderPathFetchByC_SN;
 	private UniquePersistenceFinder<User> _uniquePersistenceFinderByC_SN;
 
 	/**
@@ -1541,6 +1567,7 @@ public class UserPersistenceImpl
 			new Object[] {companyId, screenName});
 	}
 
+	private FinderPath _finderPathFetchByC_EA;
 	private UniquePersistenceFinder<User> _uniquePersistenceFinderByC_EA;
 
 	/**
@@ -1632,6 +1659,9 @@ public class UserPersistenceImpl
 			new Object[] {companyId, emailAddress});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_FID;
+	private FinderPath _finderPathWithoutPaginationFindByC_FID;
+	private FinderPath _finderPathCountByC_FID;
 	private CollectionPersistenceFinder<User>
 		_collectionPersistenceFinderByC_FID;
 
@@ -1790,6 +1820,9 @@ public class UserPersistenceImpl
 			new Object[] {companyId, facebookId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_T;
+	private FinderPath _finderPathWithoutPaginationFindByC_T;
+	private FinderPath _finderPathCountByC_T;
 	private CollectionPersistenceFinder<User> _collectionPersistenceFinderByC_T;
 
 	/**
@@ -1937,6 +1970,9 @@ public class UserPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {companyId, type});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_S;
+	private FinderPath _finderPathWithoutPaginationFindByC_S;
+	private FinderPath _finderPathCountByC_S;
 	private CollectionPersistenceFinder<User> _collectionPersistenceFinderByC_S;
 
 	/**
@@ -2088,6 +2124,9 @@ public class UserPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {companyId, status});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_CD_MD;
+	private FinderPath _finderPathWithoutPaginationFindByC_CD_MD;
+	private FinderPath _finderPathCountByC_CD_MD;
 	private CollectionPersistenceFinder<User>
 		_collectionPersistenceFinderByC_CD_MD;
 
@@ -2265,6 +2304,9 @@ public class UserPersistenceImpl
 			new Object[] {companyId, createDate, modifiedDate});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_T_S;
+	private FinderPath _finderPathWithoutPaginationFindByC_T_S;
+	private FinderPath _finderPathCountByC_T_S;
 	private CollectionPersistenceFinder<User>
 		_collectionPersistenceFinderByC_T_S;
 
@@ -2432,6 +2474,7 @@ public class UserPersistenceImpl
 			new Object[] {companyId, type, status});
 	}
 
+	private FinderPath _finderPathFetchByERC_C;
 	private UniquePersistenceFinder<User> _uniquePersistenceFinderByERC_C;
 
 	/**
@@ -4578,50 +4621,59 @@ public class UserPersistenceImpl
 			"Users_UserGroups", "companyId", "userId", "userGroupId", this,
 			userGroupPersistence);
 
+		_finderPathWithPaginationFindByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid",
+			new String[] {
+				String.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"uuid_"}, true);
+
+		_finderPathWithoutPaginationFindByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid",
+			new String[] {String.class.getName()}, new String[] {"uuid_"}, 0, 1,
+			true, null);
+
+		_finderPathCountByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid",
+			new String[] {String.class.getName()}, new String[] {"uuid_"}, 0, 1,
+			false, null);
+
 		_collectionPersistenceFinderByUuid = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid",
-				new String[] {
-					String.class.getName(), Integer.class.getName(),
-					Integer.class.getName(), OrderByComparator.class.getName()
-				},
-				new String[] {"uuid_"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid",
-				new String[] {String.class.getName()}, new String[] {"uuid_"},
-				0, 1, true, null),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid",
-				new String[] {String.class.getName()}, new String[] {"uuid_"},
-				0, 1, false, null),
+			this, _finderPathWithPaginationFindByUuid,
+			_finderPathWithoutPaginationFindByUuid, _finderPathCountByUuid,
 			_SQL_SELECT_USER_WHERE, _SQL_COUNT_USER_WHERE,
 			UserModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
 				"user.", "uuid", FinderColumn.Type.STRING, "=", true, true,
 				User::getUuid));
 
+		_finderPathWithPaginationFindByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid_C",
+			new String[] {
+				String.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"uuid_", "companyId"}, true);
+
+		_finderPathWithoutPaginationFindByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"uuid_", "companyId"}, 0, 1, true, null);
+
+		_finderPathCountByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"uuid_", "companyId"}, 0, 1, false, null);
+
 		_collectionPersistenceFinderByUuid_C =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid_C",
-					new String[] {
-						String.class.getName(), Long.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"uuid_", "companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid_C",
-					new String[] {String.class.getName(), Long.class.getName()},
-					new String[] {"uuid_", "companyId"}, 0, 1, true, null),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid_C",
-					new String[] {String.class.getName(), Long.class.getName()},
-					new String[] {"uuid_", "companyId"}, 0, 1, false, null),
-				_SQL_SELECT_USER_WHERE, _SQL_COUNT_USER_WHERE,
-				UserModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+				this, _finderPathWithPaginationFindByUuid_C,
+				_finderPathWithoutPaginationFindByUuid_C,
+				_finderPathCountByUuid_C, _SQL_SELECT_USER_WHERE,
+				_SQL_COUNT_USER_WHERE, UserModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
 					"user.", "uuid", FinderColumn.Type.STRING, "=", true, true,
 					User::getUuid),
@@ -4629,111 +4681,123 @@ public class UserPersistenceImpl
 					"user.", "companyId", FinderColumn.Type.LONG, "=", true,
 					true, User::getCompanyId));
 
+		_finderPathWithPaginationFindByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByCompanyId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"companyId"}, true);
+
+		_finderPathWithoutPaginationFindByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByCompanyId",
+			new String[] {Long.class.getName()}, new String[] {"companyId"},
+			true);
+
+		_finderPathCountByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByCompanyId",
+			new String[] {Long.class.getName()}, new String[] {"companyId"},
+			false);
+
 		_collectionPersistenceFinderByCompanyId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByCompanyId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"findByCompanyId", new String[] {Long.class.getName()},
-					new String[] {"companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByCompanyId", new String[] {Long.class.getName()},
-					new String[] {"companyId"}, false),
-				_SQL_SELECT_USER_WHERE, _SQL_COUNT_USER_WHERE,
-				UserModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "type_ = 1",
+				this, _finderPathWithPaginationFindByCompanyId,
+				_finderPathWithoutPaginationFindByCompanyId,
+				_finderPathCountByCompanyId, _SQL_SELECT_USER_WHERE,
+				_SQL_COUNT_USER_WHERE, UserModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "type_ = 1",
 				new FinderColumn<>(
 					"user.", "companyId", FinderColumn.Type.LONG, "=", true,
 					true, User::getCompanyId));
 
+		_finderPathFetchByContactId = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByContactId",
+			new String[] {Long.class.getName()}, new String[] {"contactId"}, 0,
+			0, false, User::getContactId);
+
 		_uniquePersistenceFinderByContactId = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByContactId",
-				new String[] {Long.class.getName()}, new String[] {"contactId"},
-				0, 0, false, User::getContactId),
-			_SQL_SELECT_USER_WHERE, "",
+			this, _finderPathFetchByContactId, _SQL_SELECT_USER_WHERE, "",
 			new FinderColumn<>(
 				"user.", "contactId", FinderColumn.Type.LONG, "=", true, true,
 				User::getContactId));
 
+		_finderPathWithPaginationFindByEmailAddress = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByEmailAddress",
+			new String[] {
+				String.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"emailAddress"}, true);
+
+		_finderPathWithoutPaginationFindByEmailAddress = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByEmailAddress",
+			new String[] {String.class.getName()},
+			new String[] {"emailAddress"}, 0, 1, true, null);
+
+		_finderPathCountByEmailAddress = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByEmailAddress",
+			new String[] {String.class.getName()},
+			new String[] {"emailAddress"}, 0, 1, false, null);
+
 		_collectionPersistenceFinderByEmailAddress =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION,
-					"findByEmailAddress",
-					new String[] {
-						String.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"emailAddress"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"findByEmailAddress", new String[] {String.class.getName()},
-					new String[] {"emailAddress"}, 0, 1, true, null),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByEmailAddress",
-					new String[] {String.class.getName()},
-					new String[] {"emailAddress"}, 0, 1, false, null),
-				_SQL_SELECT_USER_WHERE, _SQL_COUNT_USER_WHERE,
-				UserModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+				this, _finderPathWithPaginationFindByEmailAddress,
+				_finderPathWithoutPaginationFindByEmailAddress,
+				_finderPathCountByEmailAddress, _SQL_SELECT_USER_WHERE,
+				_SQL_COUNT_USER_WHERE, UserModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
 					"user.", "emailAddress", FinderColumn.Type.STRING, "=",
 					true, true, User::getEmailAddress));
 
+		_finderPathWithPaginationFindByPortraitId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByPortraitId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"portraitId"}, true);
+
+		_finderPathWithoutPaginationFindByPortraitId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByPortraitId",
+			new String[] {Long.class.getName()}, new String[] {"portraitId"},
+			true);
+
+		_finderPathCountByPortraitId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByPortraitId",
+			new String[] {Long.class.getName()}, new String[] {"portraitId"},
+			false);
+
 		_collectionPersistenceFinderByPortraitId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByPortraitId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"portraitId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"findByPortraitId", new String[] {Long.class.getName()},
-					new String[] {"portraitId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByPortraitId", new String[] {Long.class.getName()},
-					new String[] {"portraitId"}, false),
-				_SQL_SELECT_USER_WHERE, _SQL_COUNT_USER_WHERE,
-				UserModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+				this, _finderPathWithPaginationFindByPortraitId,
+				_finderPathWithoutPaginationFindByPortraitId,
+				_finderPathCountByPortraitId, _SQL_SELECT_USER_WHERE,
+				_SQL_COUNT_USER_WHERE, UserModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
 					"user.", "portraitId", FinderColumn.Type.LONG, "=", true,
 					true, User::getPortraitId));
 
+		_finderPathWithPaginationFindByGtU_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByGtU_C",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"userId", "companyId"}, true);
+
+		_finderPathWithPaginationCountByGtU_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByGtU_C",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"userId", "companyId"}, false);
+
 		_collectionPersistenceFinderByGtU_C = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByGtU_C",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Integer.class.getName(), Integer.class.getName(),
-					OrderByComparator.class.getName()
-				},
-				new String[] {"userId", "companyId"}, true),
-			null,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByGtU_C",
-				new String[] {Long.class.getName(), Long.class.getName()},
-				new String[] {"userId", "companyId"}, false),
-			_SQL_SELECT_USER_WHERE, _SQL_COUNT_USER_WHERE,
-			UserModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "type_ = 1",
+			this, _finderPathWithPaginationFindByGtU_C, null,
+			_finderPathWithPaginationCountByGtU_C, _SQL_SELECT_USER_WHERE,
+			_SQL_COUNT_USER_WHERE, UserModelImpl.ORDER_BY_JPQL,
+			_ENTITY_ALIAS_PREFIX, "type_ = 1",
 			new FinderColumn<>(
 				"user.", "userId", FinderColumn.Type.LONG, ">", true, true,
 				User::getUserId),
@@ -4741,14 +4805,14 @@ public class UserPersistenceImpl
 				"user.", "companyId", FinderColumn.Type.LONG, "=", true, true,
 				User::getCompanyId));
 
+		_finderPathFetchByC_U = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByC_U",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"companyId", "userId"}, 0, 0, false,
+			User::getCompanyId, User::getUserId);
+
 		_uniquePersistenceFinderByC_U = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByC_U",
-				new String[] {Long.class.getName(), Long.class.getName()},
-				new String[] {"companyId", "userId"}, 0, 0, false,
-				User::getCompanyId, User::getUserId),
-			_SQL_SELECT_USER_WHERE, "",
+			this, _finderPathFetchByC_U, _SQL_SELECT_USER_WHERE, "",
 			new FinderColumn<>(
 				"user.", "companyId", FinderColumn.Type.LONG, "=", true, true,
 				User::getCompanyId),
@@ -4756,24 +4820,28 @@ public class UserPersistenceImpl
 				"user.", "userId", FinderColumn.Type.LONG, "=", true, true,
 				User::getUserId));
 
+		_finderPathWithPaginationFindByC_CD = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_CD",
+			new String[] {
+				Long.class.getName(), Date.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "createDate"}, true);
+
+		_finderPathWithoutPaginationFindByC_CD = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_CD",
+			new String[] {Long.class.getName(), Date.class.getName()},
+			new String[] {"companyId", "createDate"}, true);
+
+		_finderPathCountByC_CD = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_CD",
+			new String[] {Long.class.getName(), Date.class.getName()},
+			new String[] {"companyId", "createDate"}, false);
+
 		_collectionPersistenceFinderByC_CD = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_CD",
-				new String[] {
-					Long.class.getName(), Date.class.getName(),
-					Integer.class.getName(), Integer.class.getName(),
-					OrderByComparator.class.getName()
-				},
-				new String[] {"companyId", "createDate"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_CD",
-				new String[] {Long.class.getName(), Date.class.getName()},
-				new String[] {"companyId", "createDate"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_CD",
-				new String[] {Long.class.getName(), Date.class.getName()},
-				new String[] {"companyId", "createDate"}, false),
+			this, _finderPathWithPaginationFindByC_CD,
+			_finderPathWithoutPaginationFindByC_CD, _finderPathCountByC_CD,
 			_SQL_SELECT_USER_WHERE, _SQL_COUNT_USER_WHERE,
 			UserModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "type_ = 1",
 			new FinderColumn<>(
@@ -4783,24 +4851,28 @@ public class UserPersistenceImpl
 				"user.", "createDate", FinderColumn.Type.DATE, "=", true, true,
 				User::getCreateDate));
 
+		_finderPathWithPaginationFindByC_MD = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_MD",
+			new String[] {
+				Long.class.getName(), Date.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "modifiedDate"}, true);
+
+		_finderPathWithoutPaginationFindByC_MD = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_MD",
+			new String[] {Long.class.getName(), Date.class.getName()},
+			new String[] {"companyId", "modifiedDate"}, true);
+
+		_finderPathCountByC_MD = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_MD",
+			new String[] {Long.class.getName(), Date.class.getName()},
+			new String[] {"companyId", "modifiedDate"}, false);
+
 		_collectionPersistenceFinderByC_MD = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_MD",
-				new String[] {
-					Long.class.getName(), Date.class.getName(),
-					Integer.class.getName(), Integer.class.getName(),
-					OrderByComparator.class.getName()
-				},
-				new String[] {"companyId", "modifiedDate"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_MD",
-				new String[] {Long.class.getName(), Date.class.getName()},
-				new String[] {"companyId", "modifiedDate"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_MD",
-				new String[] {Long.class.getName(), Date.class.getName()},
-				new String[] {"companyId", "modifiedDate"}, false),
+			this, _finderPathWithPaginationFindByC_MD,
+			_finderPathWithoutPaginationFindByC_MD, _finderPathCountByC_MD,
 			_SQL_SELECT_USER_WHERE, _SQL_COUNT_USER_WHERE,
 			UserModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "type_ = 1",
 			new FinderColumn<>(
@@ -4810,14 +4882,14 @@ public class UserPersistenceImpl
 				"user.", "modifiedDate", FinderColumn.Type.DATE, "=", true,
 				true, User::getModifiedDate));
 
+		_finderPathFetchByC_SN = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByC_SN",
+			new String[] {Long.class.getName(), String.class.getName()},
+			new String[] {"companyId", "screenName"}, 0, 2, false,
+			User::getCompanyId, convertNullFunction(User::getScreenName));
+
 		_uniquePersistenceFinderByC_SN = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByC_SN",
-				new String[] {Long.class.getName(), String.class.getName()},
-				new String[] {"companyId", "screenName"}, 0, 2, false,
-				User::getCompanyId, convertNullFunction(User::getScreenName)),
-			_SQL_SELECT_USER_WHERE, "",
+			this, _finderPathFetchByC_SN, _SQL_SELECT_USER_WHERE, "",
 			new FinderColumn<>(
 				"user.", "companyId", FinderColumn.Type.LONG, "=", true, true,
 				User::getCompanyId),
@@ -4825,14 +4897,14 @@ public class UserPersistenceImpl
 				"user.", "screenName", FinderColumn.Type.STRING, "=", true,
 				true, User::getScreenName));
 
+		_finderPathFetchByC_EA = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByC_EA",
+			new String[] {Long.class.getName(), String.class.getName()},
+			new String[] {"companyId", "emailAddress"}, 0, 2, false,
+			User::getCompanyId, convertNullFunction(User::getEmailAddress));
+
 		_uniquePersistenceFinderByC_EA = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByC_EA",
-				new String[] {Long.class.getName(), String.class.getName()},
-				new String[] {"companyId", "emailAddress"}, 0, 2, false,
-				User::getCompanyId, convertNullFunction(User::getEmailAddress)),
-			_SQL_SELECT_USER_WHERE, "",
+			this, _finderPathFetchByC_EA, _SQL_SELECT_USER_WHERE, "",
 			new FinderColumn<>(
 				"user.", "companyId", FinderColumn.Type.LONG, "=", true, true,
 				User::getCompanyId),
@@ -4840,24 +4912,28 @@ public class UserPersistenceImpl
 				"user.", "emailAddress", FinderColumn.Type.STRING, "=", true,
 				true, User::getEmailAddress));
 
+		_finderPathWithPaginationFindByC_FID = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_FID",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "facebookId"}, true);
+
+		_finderPathWithoutPaginationFindByC_FID = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_FID",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"companyId", "facebookId"}, true);
+
+		_finderPathCountByC_FID = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_FID",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"companyId", "facebookId"}, false);
+
 		_collectionPersistenceFinderByC_FID = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_FID",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Integer.class.getName(), Integer.class.getName(),
-					OrderByComparator.class.getName()
-				},
-				new String[] {"companyId", "facebookId"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_FID",
-				new String[] {Long.class.getName(), Long.class.getName()},
-				new String[] {"companyId", "facebookId"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_FID",
-				new String[] {Long.class.getName(), Long.class.getName()},
-				new String[] {"companyId", "facebookId"}, false),
+			this, _finderPathWithPaginationFindByC_FID,
+			_finderPathWithoutPaginationFindByC_FID, _finderPathCountByC_FID,
 			_SQL_SELECT_USER_WHERE, _SQL_COUNT_USER_WHERE,
 			UserModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
@@ -4867,24 +4943,28 @@ public class UserPersistenceImpl
 				"user.", "facebookId", FinderColumn.Type.LONG, "=", true, true,
 				User::getFacebookId));
 
+		_finderPathWithPaginationFindByC_T = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_T",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "type_"}, true);
+
+		_finderPathWithoutPaginationFindByC_T = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_T",
+			new String[] {Long.class.getName(), Integer.class.getName()},
+			new String[] {"companyId", "type_"}, true);
+
+		_finderPathCountByC_T = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_T",
+			new String[] {Long.class.getName(), Integer.class.getName()},
+			new String[] {"companyId", "type_"}, false);
+
 		_collectionPersistenceFinderByC_T = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_T",
-				new String[] {
-					Long.class.getName(), Integer.class.getName(),
-					Integer.class.getName(), Integer.class.getName(),
-					OrderByComparator.class.getName()
-				},
-				new String[] {"companyId", "type_"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_T",
-				new String[] {Long.class.getName(), Integer.class.getName()},
-				new String[] {"companyId", "type_"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_T",
-				new String[] {Long.class.getName(), Integer.class.getName()},
-				new String[] {"companyId", "type_"}, false),
+			this, _finderPathWithPaginationFindByC_T,
+			_finderPathWithoutPaginationFindByC_T, _finderPathCountByC_T,
 			_SQL_SELECT_USER_WHERE, _SQL_COUNT_USER_WHERE,
 			UserModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
@@ -4894,24 +4974,28 @@ public class UserPersistenceImpl
 				"user.", "type", FinderColumn.Type.INTEGER, "=", true, true,
 				User::getType));
 
+		_finderPathWithPaginationFindByC_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_S",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "status"}, true);
+
+		_finderPathWithoutPaginationFindByC_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_S",
+			new String[] {Long.class.getName(), Integer.class.getName()},
+			new String[] {"companyId", "status"}, true);
+
+		_finderPathCountByC_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_S",
+			new String[] {Long.class.getName(), Integer.class.getName()},
+			new String[] {"companyId", "status"}, false);
+
 		_collectionPersistenceFinderByC_S = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_S",
-				new String[] {
-					Long.class.getName(), Integer.class.getName(),
-					Integer.class.getName(), Integer.class.getName(),
-					OrderByComparator.class.getName()
-				},
-				new String[] {"companyId", "status"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_S",
-				new String[] {Long.class.getName(), Integer.class.getName()},
-				new String[] {"companyId", "status"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_S",
-				new String[] {Long.class.getName(), Integer.class.getName()},
-				new String[] {"companyId", "status"}, false),
+			this, _finderPathWithPaginationFindByC_S,
+			_finderPathWithoutPaginationFindByC_S, _finderPathCountByC_S,
 			_SQL_SELECT_USER_WHERE, _SQL_COUNT_USER_WHERE,
 			UserModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "type_ = 1",
 			new FinderColumn<>(
@@ -4921,37 +5005,36 @@ public class UserPersistenceImpl
 				"user.", "status", FinderColumn.Type.INTEGER, "=", true, true,
 				User::getStatus));
 
+		_finderPathWithPaginationFindByC_CD_MD = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_CD_MD",
+			new String[] {
+				Long.class.getName(), Date.class.getName(),
+				Date.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "createDate", "modifiedDate"}, true);
+
+		_finderPathWithoutPaginationFindByC_CD_MD = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_CD_MD",
+			new String[] {
+				Long.class.getName(), Date.class.getName(), Date.class.getName()
+			},
+			new String[] {"companyId", "createDate", "modifiedDate"}, true);
+
+		_finderPathCountByC_CD_MD = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_CD_MD",
+			new String[] {
+				Long.class.getName(), Date.class.getName(), Date.class.getName()
+			},
+			new String[] {"companyId", "createDate", "modifiedDate"}, false);
+
 		_collectionPersistenceFinderByC_CD_MD =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_CD_MD",
-					new String[] {
-						Long.class.getName(), Date.class.getName(),
-						Date.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"companyId", "createDate", "modifiedDate"},
-					true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_CD_MD",
-					new String[] {
-						Long.class.getName(), Date.class.getName(),
-						Date.class.getName()
-					},
-					new String[] {"companyId", "createDate", "modifiedDate"},
-					true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_CD_MD",
-					new String[] {
-						Long.class.getName(), Date.class.getName(),
-						Date.class.getName()
-					},
-					new String[] {"companyId", "createDate", "modifiedDate"},
-					false),
-				_SQL_SELECT_USER_WHERE, _SQL_COUNT_USER_WHERE,
-				UserModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "type_ = 1",
+				this, _finderPathWithPaginationFindByC_CD_MD,
+				_finderPathWithoutPaginationFindByC_CD_MD,
+				_finderPathCountByC_CD_MD, _SQL_SELECT_USER_WHERE,
+				_SQL_COUNT_USER_WHERE, UserModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "type_ = 1",
 				new FinderColumn<>(
 					"user.", "companyId", FinderColumn.Type.LONG, "=", true,
 					true, User::getCompanyId),
@@ -4962,30 +5045,34 @@ public class UserPersistenceImpl
 					"user.", "modifiedDate", FinderColumn.Type.DATE, "=", true,
 					true, User::getModifiedDate));
 
+		_finderPathWithPaginationFindByC_T_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_T_S",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "type_", "status"}, true);
+
+		_finderPathWithoutPaginationFindByC_T_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_T_S",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName()
+			},
+			new String[] {"companyId", "type_", "status"}, true);
+
+		_finderPathCountByC_T_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_T_S",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName()
+			},
+			new String[] {"companyId", "type_", "status"}, false);
+
 		_collectionPersistenceFinderByC_T_S = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_T_S",
-				new String[] {
-					Long.class.getName(), Integer.class.getName(),
-					Integer.class.getName(), Integer.class.getName(),
-					Integer.class.getName(), OrderByComparator.class.getName()
-				},
-				new String[] {"companyId", "type_", "status"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_T_S",
-				new String[] {
-					Long.class.getName(), Integer.class.getName(),
-					Integer.class.getName()
-				},
-				new String[] {"companyId", "type_", "status"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_T_S",
-				new String[] {
-					Long.class.getName(), Integer.class.getName(),
-					Integer.class.getName()
-				},
-				new String[] {"companyId", "type_", "status"}, false),
+			this, _finderPathWithPaginationFindByC_T_S,
+			_finderPathWithoutPaginationFindByC_T_S, _finderPathCountByC_T_S,
 			_SQL_SELECT_USER_WHERE, _SQL_COUNT_USER_WHERE,
 			UserModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
@@ -4998,15 +5085,15 @@ public class UserPersistenceImpl
 				"user.", "status", FinderColumn.Type.INTEGER, "=", true, true,
 				User::getStatus));
 
+		_finderPathFetchByERC_C = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByERC_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "companyId"}, 0, 1, false,
+			convertNullFunction(User::getExternalReferenceCode),
+			User::getCompanyId);
+
 		_uniquePersistenceFinderByERC_C = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByERC_C",
-				new String[] {String.class.getName(), Long.class.getName()},
-				new String[] {"externalReferenceCode", "companyId"}, 0, 1,
-				false, convertNullFunction(User::getExternalReferenceCode),
-				User::getCompanyId),
-			_SQL_SELECT_USER_WHERE, "",
+			this, _finderPathFetchByERC_C, _SQL_SELECT_USER_WHERE, "",
 			new FinderColumn<>(
 				"user.", "externalReferenceCode", FinderColumn.Type.STRING, "=",
 				true, true, User::getExternalReferenceCode),
@@ -5085,4 +5172,4 @@ public class UserPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:909745314
+// LIFERAY-SERVICE-BUILDER-HASH:1628730402

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/UserTrackerPathPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/UserTrackerPathPersistenceImpl.java
@@ -64,6 +64,9 @@ public class UserTrackerPathPersistenceImpl
 	public static final String FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION =
 		FINDER_CLASS_NAME_ENTITY + ".List2";
 
+	private FinderPath _finderPathWithPaginationFindByUserTrackerId;
+	private FinderPath _finderPathWithoutPaginationFindByUserTrackerId;
+	private FinderPath _finderPathCountByUserTrackerId;
 	private CollectionPersistenceFinder<UserTrackerPath>
 		_collectionPersistenceFinderByUserTrackerId;
 
@@ -398,26 +401,29 @@ public class UserTrackerPathPersistenceImpl
 	 * Initializes the user tracker path persistence.
 	 */
 	public void afterPropertiesSet() {
+		_finderPathWithPaginationFindByUserTrackerId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUserTrackerId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"userTrackerId"}, true);
+
+		_finderPathWithoutPaginationFindByUserTrackerId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUserTrackerId",
+			new String[] {Long.class.getName()}, new String[] {"userTrackerId"},
+			true);
+
+		_finderPathCountByUserTrackerId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUserTrackerId",
+			new String[] {Long.class.getName()}, new String[] {"userTrackerId"},
+			false);
+
 		_collectionPersistenceFinderByUserTrackerId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION,
-					"findByUserTrackerId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"userTrackerId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"findByUserTrackerId", new String[] {Long.class.getName()},
-					new String[] {"userTrackerId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByUserTrackerId", new String[] {Long.class.getName()},
-					new String[] {"userTrackerId"}, false),
+				this, _finderPathWithPaginationFindByUserTrackerId,
+				_finderPathWithoutPaginationFindByUserTrackerId,
+				_finderPathCountByUserTrackerId,
 				_SQL_SELECT_USERTRACKERPATH_WHERE,
 				_SQL_COUNT_USERTRACKERPATH_WHERE,
 				UserTrackerPathModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
@@ -459,4 +465,4 @@ public class UserTrackerPathPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:672951602
+// LIFERAY-SERVICE-BUILDER-HASH:-385870074

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/UserTrackerPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/UserTrackerPersistenceImpl.java
@@ -64,6 +64,9 @@ public class UserTrackerPersistenceImpl
 	public static final String FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION =
 		FINDER_CLASS_NAME_ENTITY + ".List2";
 
+	private FinderPath _finderPathWithPaginationFindByCompanyId;
+	private FinderPath _finderPathWithoutPaginationFindByCompanyId;
+	private FinderPath _finderPathCountByCompanyId;
 	private CollectionPersistenceFinder<UserTracker>
 		_collectionPersistenceFinderByCompanyId;
 
@@ -208,6 +211,9 @@ public class UserTrackerPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {companyId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByUserId;
+	private FinderPath _finderPathWithoutPaginationFindByUserId;
+	private FinderPath _finderPathCountByUserId;
 	private CollectionPersistenceFinder<UserTracker>
 		_collectionPersistenceFinderByUserId;
 
@@ -349,6 +355,9 @@ public class UserTrackerPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {userId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindBySessionId;
+	private FinderPath _finderPathWithoutPaginationFindBySessionId;
+	private FinderPath _finderPathCountBySessionId;
 	private CollectionPersistenceFinder<UserTracker>
 		_collectionPersistenceFinderBySessionId;
 
@@ -681,76 +690,87 @@ public class UserTrackerPersistenceImpl
 	 * Initializes the user tracker persistence.
 	 */
 	public void afterPropertiesSet() {
+		_finderPathWithPaginationFindByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByCompanyId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"companyId"}, true);
+
+		_finderPathWithoutPaginationFindByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByCompanyId",
+			new String[] {Long.class.getName()}, new String[] {"companyId"},
+			true);
+
+		_finderPathCountByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByCompanyId",
+			new String[] {Long.class.getName()}, new String[] {"companyId"},
+			false);
+
 		_collectionPersistenceFinderByCompanyId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByCompanyId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"findByCompanyId", new String[] {Long.class.getName()},
-					new String[] {"companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByCompanyId", new String[] {Long.class.getName()},
-					new String[] {"companyId"}, false),
-				_SQL_SELECT_USERTRACKER_WHERE, _SQL_COUNT_USERTRACKER_WHERE,
+				this, _finderPathWithPaginationFindByCompanyId,
+				_finderPathWithoutPaginationFindByCompanyId,
+				_finderPathCountByCompanyId, _SQL_SELECT_USERTRACKER_WHERE,
+				_SQL_COUNT_USERTRACKER_WHERE,
 				UserTrackerModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
 					"userTracker.", "companyId", FinderColumn.Type.LONG, "=",
 					true, true, UserTracker::getCompanyId));
 
+		_finderPathWithPaginationFindByUserId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUserId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"userId"}, true);
+
+		_finderPathWithoutPaginationFindByUserId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUserId",
+			new String[] {Long.class.getName()}, new String[] {"userId"}, true);
+
+		_finderPathCountByUserId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUserId",
+			new String[] {Long.class.getName()}, new String[] {"userId"},
+			false);
+
 		_collectionPersistenceFinderByUserId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUserId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"userId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUserId",
-					new String[] {Long.class.getName()},
-					new String[] {"userId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUserId",
-					new String[] {Long.class.getName()},
-					new String[] {"userId"}, false),
-				_SQL_SELECT_USERTRACKER_WHERE, _SQL_COUNT_USERTRACKER_WHERE,
+				this, _finderPathWithPaginationFindByUserId,
+				_finderPathWithoutPaginationFindByUserId,
+				_finderPathCountByUserId, _SQL_SELECT_USERTRACKER_WHERE,
+				_SQL_COUNT_USERTRACKER_WHERE,
 				UserTrackerModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
 					"userTracker.", "userId", FinderColumn.Type.LONG, "=", true,
 					true, UserTracker::getUserId));
 
+		_finderPathWithPaginationFindBySessionId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findBySessionId",
+			new String[] {
+				String.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"sessionId"}, true);
+
+		_finderPathWithoutPaginationFindBySessionId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findBySessionId",
+			new String[] {String.class.getName()}, new String[] {"sessionId"},
+			0, 1, true, null);
+
+		_finderPathCountBySessionId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countBySessionId",
+			new String[] {String.class.getName()}, new String[] {"sessionId"},
+			0, 1, false, null);
+
 		_collectionPersistenceFinderBySessionId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findBySessionId",
-					new String[] {
-						String.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"sessionId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"findBySessionId", new String[] {String.class.getName()},
-					new String[] {"sessionId"}, 0, 1, true, null),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countBySessionId", new String[] {String.class.getName()},
-					new String[] {"sessionId"}, 0, 1, false, null),
-				_SQL_SELECT_USERTRACKER_WHERE, _SQL_COUNT_USERTRACKER_WHERE,
+				this, _finderPathWithPaginationFindBySessionId,
+				_finderPathWithoutPaginationFindBySessionId,
+				_finderPathCountBySessionId, _SQL_SELECT_USERTRACKER_WHERE,
+				_SQL_COUNT_USERTRACKER_WHERE,
 				UserTrackerModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
 					"userTracker.", "sessionId", FinderColumn.Type.STRING, "=",
@@ -786,4 +806,4 @@ public class UserTrackerPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1826481049
+// LIFERAY-SERVICE-BUILDER-HASH:-2124494040

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/VirtualHostPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/VirtualHostPersistenceImpl.java
@@ -74,6 +74,9 @@ public class VirtualHostPersistenceImpl
 	public static final String FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION =
 		FINDER_CLASS_NAME_ENTITY + ".List2";
 
+	private FinderPath _finderPathWithPaginationFindByCompanyId;
+	private FinderPath _finderPathWithoutPaginationFindByCompanyId;
+	private FinderPath _finderPathCountByCompanyId;
 	private CollectionPersistenceFinder<VirtualHost>
 		_collectionPersistenceFinderByCompanyId;
 
@@ -218,6 +221,7 @@ public class VirtualHostPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {companyId});
 	}
 
+	private FinderPath _finderPathFetchByHostname;
 	private UniquePersistenceFinder<VirtualHost>
 		_uniquePersistenceFinderByHostname;
 
@@ -303,6 +307,9 @@ public class VirtualHostPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {hostname});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_L;
+	private FinderPath _finderPathWithoutPaginationFindByC_L;
+	private FinderPath _finderPathCountByC_L;
 	private CollectionPersistenceFinder<VirtualHost>
 		_collectionPersistenceFinderByC_L;
 
@@ -462,6 +469,8 @@ public class VirtualHostPersistenceImpl
 			new Object[] {companyId, layoutSetId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByNotL_H;
+	private FinderPath _finderPathWithPaginationCountByNotL_H;
 	private CollectionPersistenceFinder<VirtualHost>
 		_collectionPersistenceFinderByNotL_H;
 
@@ -972,61 +981,68 @@ public class VirtualHostPersistenceImpl
 	 * Initializes the virtual host persistence.
 	 */
 	public void afterPropertiesSet() {
+		_finderPathWithPaginationFindByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByCompanyId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"companyId"}, true);
+
+		_finderPathWithoutPaginationFindByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByCompanyId",
+			new String[] {Long.class.getName()}, new String[] {"companyId"},
+			true);
+
+		_finderPathCountByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByCompanyId",
+			new String[] {Long.class.getName()}, new String[] {"companyId"},
+			false);
+
 		_collectionPersistenceFinderByCompanyId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByCompanyId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"findByCompanyId", new String[] {Long.class.getName()},
-					new String[] {"companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByCompanyId", new String[] {Long.class.getName()},
-					new String[] {"companyId"}, false),
-				_SQL_SELECT_VIRTUALHOST_WHERE, _SQL_COUNT_VIRTUALHOST_WHERE,
+				this, _finderPathWithPaginationFindByCompanyId,
+				_finderPathWithoutPaginationFindByCompanyId,
+				_finderPathCountByCompanyId, _SQL_SELECT_VIRTUALHOST_WHERE,
+				_SQL_COUNT_VIRTUALHOST_WHERE,
 				VirtualHostModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
 					"virtualHost.", "companyId", FinderColumn.Type.LONG, "=",
 					true, true, VirtualHost::getCompanyId));
 
+		_finderPathFetchByHostname = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByHostname",
+			new String[] {String.class.getName()}, new String[] {"hostname"}, 0,
+			1, false, convertNullFunction(VirtualHost::getHostname));
+
 		_uniquePersistenceFinderByHostname = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByHostname",
-				new String[] {String.class.getName()},
-				new String[] {"hostname"}, 0, 1, false,
-				convertNullFunction(VirtualHost::getHostname)),
-			_SQL_SELECT_VIRTUALHOST_WHERE, "",
+			this, _finderPathFetchByHostname, _SQL_SELECT_VIRTUALHOST_WHERE, "",
 			new FinderColumn<>(
 				"virtualHost.", "hostname", FinderColumn.Type.STRING, "=", true,
 				true, VirtualHost::getHostname));
 
+		_finderPathWithPaginationFindByC_L = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_L",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "layoutSetId"}, true);
+
+		_finderPathWithoutPaginationFindByC_L = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_L",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"companyId", "layoutSetId"}, true);
+
+		_finderPathCountByC_L = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_L",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"companyId", "layoutSetId"}, false);
+
 		_collectionPersistenceFinderByC_L = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_L",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Integer.class.getName(), Integer.class.getName(),
-					OrderByComparator.class.getName()
-				},
-				new String[] {"companyId", "layoutSetId"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_L",
-				new String[] {Long.class.getName(), Long.class.getName()},
-				new String[] {"companyId", "layoutSetId"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_L",
-				new String[] {Long.class.getName(), Long.class.getName()},
-				new String[] {"companyId", "layoutSetId"}, false),
+			this, _finderPathWithPaginationFindByC_L,
+			_finderPathWithoutPaginationFindByC_L, _finderPathCountByC_L,
 			_SQL_SELECT_VIRTUALHOST_WHERE, _SQL_COUNT_VIRTUALHOST_WHERE,
 			VirtualHostModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
@@ -1036,22 +1052,24 @@ public class VirtualHostPersistenceImpl
 				"virtualHost.", "layoutSetId", FinderColumn.Type.LONG, "=",
 				true, true, VirtualHost::getLayoutSetId));
 
+		_finderPathWithPaginationFindByNotL_H = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByNotL_H",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"layoutSetId", "hostname"}, true);
+
+		_finderPathWithPaginationCountByNotL_H = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByNotL_H",
+			new String[] {Long.class.getName(), String.class.getName()},
+			new String[] {"layoutSetId", "hostname"}, false);
+
 		_collectionPersistenceFinderByNotL_H =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByNotL_H",
-					new String[] {
-						Long.class.getName(), String.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"layoutSetId", "hostname"}, true),
-				null,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByNotL_H",
-					new String[] {Long.class.getName(), String.class.getName()},
-					new String[] {"layoutSetId", "hostname"}, false),
+				this, _finderPathWithPaginationFindByNotL_H, null,
+				_finderPathWithPaginationCountByNotL_H,
 				_SQL_SELECT_VIRTUALHOST_WHERE, _SQL_COUNT_VIRTUALHOST_WHERE,
 				VirtualHostModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
@@ -1094,4 +1112,4 @@ public class VirtualHostPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:941034150
+// LIFERAY-SERVICE-BUILDER-HASH:611993920

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/WebDAVPropsPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/WebDAVPropsPersistenceImpl.java
@@ -9,6 +9,7 @@ import com.liferay.portal.kernel.dao.orm.EntityCache;
 import com.liferay.portal.kernel.dao.orm.EntityCacheUtil;
 import com.liferay.portal.kernel.dao.orm.FinderCache;
 import com.liferay.portal.kernel.dao.orm.FinderCacheUtil;
+import com.liferay.portal.kernel.dao.orm.FinderPath;
 import com.liferay.portal.kernel.dao.orm.Session;
 import com.liferay.portal.kernel.exception.NoSuchWebDAVPropsException;
 import com.liferay.portal.kernel.log.Log;
@@ -62,6 +63,7 @@ public class WebDAVPropsPersistenceImpl
 	public static final String FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION =
 		FINDER_CLASS_NAME_ENTITY + ".List2";
 
+	private FinderPath _finderPathFetchByC_C;
 	private UniquePersistenceFinder<WebDAVProps> _uniquePersistenceFinderByC_C;
 
 	/**
@@ -350,14 +352,14 @@ public class WebDAVPropsPersistenceImpl
 	 * Initializes the web dav props persistence.
 	 */
 	public void afterPropertiesSet() {
+		_finderPathFetchByC_C = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByC_C",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"classNameId", "classPK"}, 0, 0, false,
+			WebDAVProps::getClassNameId, WebDAVProps::getClassPK);
+
 		_uniquePersistenceFinderByC_C = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByC_C",
-				new String[] {Long.class.getName(), Long.class.getName()},
-				new String[] {"classNameId", "classPK"}, 0, 0, false,
-				WebDAVProps::getClassNameId, WebDAVProps::getClassPK),
-			_SQL_SELECT_WEBDAVPROPS_WHERE, "",
+			this, _finderPathFetchByC_C, _SQL_SELECT_WEBDAVPROPS_WHERE, "",
 			new FinderColumn<>(
 				"webDAVProps.", "classNameId", FinderColumn.Type.LONG, "=",
 				true, true, WebDAVProps::getClassNameId),
@@ -392,4 +394,4 @@ public class WebDAVPropsPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-848193617
+// LIFERAY-SERVICE-BUILDER-HASH:-961733933

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/WebsitePersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/WebsitePersistenceImpl.java
@@ -81,6 +81,9 @@ public class WebsitePersistenceImpl
 	public static final String FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION =
 		FINDER_CLASS_NAME_ENTITY + ".List2";
 
+	private FinderPath _finderPathWithPaginationFindByUuid;
+	private FinderPath _finderPathWithoutPaginationFindByUuid;
+	private FinderPath _finderPathCountByUuid;
 	private CollectionPersistenceFinder<Website>
 		_collectionPersistenceFinderByUuid;
 
@@ -220,6 +223,9 @@ public class WebsitePersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {uuid});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByUuid_C;
+	private FinderPath _finderPathWithoutPaginationFindByUuid_C;
+	private FinderPath _finderPathCountByUuid_C;
 	private CollectionPersistenceFinder<Website>
 		_collectionPersistenceFinderByUuid_C;
 
@@ -374,6 +380,9 @@ public class WebsitePersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {uuid, companyId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByCompanyId;
+	private FinderPath _finderPathWithoutPaginationFindByCompanyId;
+	private FinderPath _finderPathCountByCompanyId;
 	private CollectionPersistenceFinder<Website>
 		_collectionPersistenceFinderByCompanyId;
 
@@ -514,6 +523,9 @@ public class WebsitePersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {companyId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByUserId;
+	private FinderPath _finderPathWithoutPaginationFindByUserId;
+	private FinderPath _finderPathCountByUserId;
 	private CollectionPersistenceFinder<Website>
 		_collectionPersistenceFinderByUserId;
 
@@ -653,6 +665,9 @@ public class WebsitePersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {userId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_C;
+	private FinderPath _finderPathWithoutPaginationFindByC_C;
+	private FinderPath _finderPathCountByC_C;
 	private CollectionPersistenceFinder<Website>
 		_collectionPersistenceFinderByC_C;
 
@@ -811,6 +826,9 @@ public class WebsitePersistenceImpl
 			new Object[] {companyId, classNameId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_C_C;
+	private FinderPath _finderPathWithoutPaginationFindByC_C_C;
+	private FinderPath _finderPathCountByC_C_C;
 	private CollectionPersistenceFinder<Website>
 		_collectionPersistenceFinderByC_C_C;
 
@@ -981,6 +999,9 @@ public class WebsitePersistenceImpl
 			new Object[] {companyId, classNameId, classPK});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_C_C_P;
+	private FinderPath _finderPathWithoutPaginationFindByC_C_C_P;
+	private FinderPath _finderPathCountByC_C_C_P;
 	private CollectionPersistenceFinder<Website>
 		_collectionPersistenceFinderByC_C_C_P;
 
@@ -1167,6 +1188,7 @@ public class WebsitePersistenceImpl
 			new Object[] {companyId, classNameId, classPK, primary});
 	}
 
+	private FinderPath _finderPathFetchByERC_C;
 	private UniquePersistenceFinder<Website> _uniquePersistenceFinderByERC_C;
 
 	/**
@@ -1533,50 +1555,59 @@ public class WebsitePersistenceImpl
 	 * Initializes the website persistence.
 	 */
 	public void afterPropertiesSet() {
+		_finderPathWithPaginationFindByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid",
+			new String[] {
+				String.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"uuid_"}, true);
+
+		_finderPathWithoutPaginationFindByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid",
+			new String[] {String.class.getName()}, new String[] {"uuid_"}, 0, 1,
+			true, null);
+
+		_finderPathCountByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid",
+			new String[] {String.class.getName()}, new String[] {"uuid_"}, 0, 1,
+			false, null);
+
 		_collectionPersistenceFinderByUuid = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid",
-				new String[] {
-					String.class.getName(), Integer.class.getName(),
-					Integer.class.getName(), OrderByComparator.class.getName()
-				},
-				new String[] {"uuid_"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid",
-				new String[] {String.class.getName()}, new String[] {"uuid_"},
-				0, 1, true, null),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid",
-				new String[] {String.class.getName()}, new String[] {"uuid_"},
-				0, 1, false, null),
+			this, _finderPathWithPaginationFindByUuid,
+			_finderPathWithoutPaginationFindByUuid, _finderPathCountByUuid,
 			_SQL_SELECT_WEBSITE_WHERE, _SQL_COUNT_WEBSITE_WHERE,
 			WebsiteModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
 				"website.", "uuid", FinderColumn.Type.STRING, "=", true, true,
 				Website::getUuid));
 
+		_finderPathWithPaginationFindByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid_C",
+			new String[] {
+				String.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"uuid_", "companyId"}, true);
+
+		_finderPathWithoutPaginationFindByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"uuid_", "companyId"}, 0, 1, true, null);
+
+		_finderPathCountByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"uuid_", "companyId"}, 0, 1, false, null);
+
 		_collectionPersistenceFinderByUuid_C =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid_C",
-					new String[] {
-						String.class.getName(), Long.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"uuid_", "companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid_C",
-					new String[] {String.class.getName(), Long.class.getName()},
-					new String[] {"uuid_", "companyId"}, 0, 1, true, null),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid_C",
-					new String[] {String.class.getName(), Long.class.getName()},
-					new String[] {"uuid_", "companyId"}, 0, 1, false, null),
-				_SQL_SELECT_WEBSITE_WHERE, _SQL_COUNT_WEBSITE_WHERE,
-				WebsiteModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+				this, _finderPathWithPaginationFindByUuid_C,
+				_finderPathWithoutPaginationFindByUuid_C,
+				_finderPathCountByUuid_C, _SQL_SELECT_WEBSITE_WHERE,
+				_SQL_COUNT_WEBSITE_WHERE, WebsiteModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
 					"website.", "uuid", FinderColumn.Type.STRING, "=", true,
 					true, Website::getUuid),
@@ -1584,74 +1615,85 @@ public class WebsitePersistenceImpl
 					"website.", "companyId", FinderColumn.Type.LONG, "=", true,
 					true, Website::getCompanyId));
 
+		_finderPathWithPaginationFindByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByCompanyId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"companyId"}, true);
+
+		_finderPathWithoutPaginationFindByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByCompanyId",
+			new String[] {Long.class.getName()}, new String[] {"companyId"},
+			true);
+
+		_finderPathCountByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByCompanyId",
+			new String[] {Long.class.getName()}, new String[] {"companyId"},
+			false);
+
 		_collectionPersistenceFinderByCompanyId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByCompanyId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"findByCompanyId", new String[] {Long.class.getName()},
-					new String[] {"companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByCompanyId", new String[] {Long.class.getName()},
-					new String[] {"companyId"}, false),
-				_SQL_SELECT_WEBSITE_WHERE, _SQL_COUNT_WEBSITE_WHERE,
-				WebsiteModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+				this, _finderPathWithPaginationFindByCompanyId,
+				_finderPathWithoutPaginationFindByCompanyId,
+				_finderPathCountByCompanyId, _SQL_SELECT_WEBSITE_WHERE,
+				_SQL_COUNT_WEBSITE_WHERE, WebsiteModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
 					"website.", "companyId", FinderColumn.Type.LONG, "=", true,
 					true, Website::getCompanyId));
 
+		_finderPathWithPaginationFindByUserId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUserId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"userId"}, true);
+
+		_finderPathWithoutPaginationFindByUserId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUserId",
+			new String[] {Long.class.getName()}, new String[] {"userId"}, true);
+
+		_finderPathCountByUserId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUserId",
+			new String[] {Long.class.getName()}, new String[] {"userId"},
+			false);
+
 		_collectionPersistenceFinderByUserId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUserId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"userId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUserId",
-					new String[] {Long.class.getName()},
-					new String[] {"userId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUserId",
-					new String[] {Long.class.getName()},
-					new String[] {"userId"}, false),
-				_SQL_SELECT_WEBSITE_WHERE, _SQL_COUNT_WEBSITE_WHERE,
-				WebsiteModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+				this, _finderPathWithPaginationFindByUserId,
+				_finderPathWithoutPaginationFindByUserId,
+				_finderPathCountByUserId, _SQL_SELECT_WEBSITE_WHERE,
+				_SQL_COUNT_WEBSITE_WHERE, WebsiteModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
 					"website.", "userId", FinderColumn.Type.LONG, "=", true,
 					true, Website::getUserId));
 
+		_finderPathWithPaginationFindByC_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_C",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "classNameId"}, true);
+
+		_finderPathWithoutPaginationFindByC_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_C",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"companyId", "classNameId"}, true);
+
+		_finderPathCountByC_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_C",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"companyId", "classNameId"}, false);
+
 		_collectionPersistenceFinderByC_C = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_C",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Integer.class.getName(), Integer.class.getName(),
-					OrderByComparator.class.getName()
-				},
-				new String[] {"companyId", "classNameId"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_C",
-				new String[] {Long.class.getName(), Long.class.getName()},
-				new String[] {"companyId", "classNameId"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_C",
-				new String[] {Long.class.getName(), Long.class.getName()},
-				new String[] {"companyId", "classNameId"}, false),
+			this, _finderPathWithPaginationFindByC_C,
+			_finderPathWithoutPaginationFindByC_C, _finderPathCountByC_C,
 			_SQL_SELECT_WEBSITE_WHERE, _SQL_COUNT_WEBSITE_WHERE,
 			WebsiteModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
@@ -1661,30 +1703,32 @@ public class WebsitePersistenceImpl
 				"website.", "classNameId", FinderColumn.Type.LONG, "=", true,
 				true, Website::getClassNameId));
 
+		_finderPathWithPaginationFindByC_C_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_C_C",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "classNameId", "classPK"}, true);
+
+		_finderPathWithoutPaginationFindByC_C_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_C_C",
+			new String[] {
+				Long.class.getName(), Long.class.getName(), Long.class.getName()
+			},
+			new String[] {"companyId", "classNameId", "classPK"}, true);
+
+		_finderPathCountByC_C_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_C_C",
+			new String[] {
+				Long.class.getName(), Long.class.getName(), Long.class.getName()
+			},
+			new String[] {"companyId", "classNameId", "classPK"}, false);
+
 		_collectionPersistenceFinderByC_C_C = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_C_C",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Long.class.getName(), Integer.class.getName(),
-					Integer.class.getName(), OrderByComparator.class.getName()
-				},
-				new String[] {"companyId", "classNameId", "classPK"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_C_C",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Long.class.getName()
-				},
-				new String[] {"companyId", "classNameId", "classPK"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_C_C",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Long.class.getName()
-				},
-				new String[] {"companyId", "classNameId", "classPK"}, false),
+			this, _finderPathWithPaginationFindByC_C_C,
+			_finderPathWithoutPaginationFindByC_C_C, _finderPathCountByC_C_C,
 			_SQL_SELECT_WEBSITE_WHERE, _SQL_COUNT_WEBSITE_WHERE,
 			WebsiteModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
@@ -1697,43 +1741,42 @@ public class WebsitePersistenceImpl
 				"website.", "classPK", FinderColumn.Type.LONG, "=", true, true,
 				Website::getClassPK));
 
+		_finderPathWithPaginationFindByC_C_C_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_C_C_P",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Boolean.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "classNameId", "classPK", "primary_"},
+			true);
+
+		_finderPathWithoutPaginationFindByC_C_C_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_C_C_P",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Boolean.class.getName()
+			},
+			new String[] {"companyId", "classNameId", "classPK", "primary_"},
+			true);
+
+		_finderPathCountByC_C_C_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_C_C_P",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Boolean.class.getName()
+			},
+			new String[] {"companyId", "classNameId", "classPK", "primary_"},
+			false);
+
 		_collectionPersistenceFinderByC_C_C_P =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_C_C_P",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						Long.class.getName(), Boolean.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {
-						"companyId", "classNameId", "classPK", "primary_"
-					},
-					true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_C_C_P",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						Long.class.getName(), Boolean.class.getName()
-					},
-					new String[] {
-						"companyId", "classNameId", "classPK", "primary_"
-					},
-					true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_C_C_P",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						Long.class.getName(), Boolean.class.getName()
-					},
-					new String[] {
-						"companyId", "classNameId", "classPK", "primary_"
-					},
-					false),
-				_SQL_SELECT_WEBSITE_WHERE, _SQL_COUNT_WEBSITE_WHERE,
-				WebsiteModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+				this, _finderPathWithPaginationFindByC_C_C_P,
+				_finderPathWithoutPaginationFindByC_C_C_P,
+				_finderPathCountByC_C_C_P, _SQL_SELECT_WEBSITE_WHERE,
+				_SQL_COUNT_WEBSITE_WHERE, WebsiteModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
 					"website.", "companyId", FinderColumn.Type.LONG, "=", true,
 					true, Website::getCompanyId),
@@ -1747,15 +1790,15 @@ public class WebsitePersistenceImpl
 					"website.", "primary", FinderColumn.Type.BOOLEAN, "=", true,
 					true, Website::isPrimary));
 
+		_finderPathFetchByERC_C = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByERC_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "companyId"}, 0, 1, false,
+			convertNullFunction(Website::getExternalReferenceCode),
+			Website::getCompanyId);
+
 		_uniquePersistenceFinderByERC_C = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByERC_C",
-				new String[] {String.class.getName(), Long.class.getName()},
-				new String[] {"externalReferenceCode", "companyId"}, 0, 1,
-				false, convertNullFunction(Website::getExternalReferenceCode),
-				Website::getCompanyId),
-			_SQL_SELECT_WEBSITE_WHERE, "",
+			this, _finderPathFetchByERC_C, _SQL_SELECT_WEBSITE_WHERE, "",
 			new FinderColumn<>(
 				"website.", "externalReferenceCode", FinderColumn.Type.STRING,
 				"=", true, true, Website::getExternalReferenceCode),
@@ -1799,4 +1842,4 @@ public class WebsitePersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:28767446
+// LIFERAY-SERVICE-BUILDER-HASH:568935202

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/WorkflowDefinitionLinkPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/WorkflowDefinitionLinkPersistenceImpl.java
@@ -89,6 +89,9 @@ public class WorkflowDefinitionLinkPersistenceImpl
 	public static final String FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION =
 		FINDER_CLASS_NAME_ENTITY + ".List2";
 
+	private FinderPath _finderPathWithPaginationFindByUuid;
+	private FinderPath _finderPathWithoutPaginationFindByUuid;
+	private FinderPath _finderPathCountByUuid;
 	private CollectionPersistenceFinder<WorkflowDefinitionLink>
 		_collectionPersistenceFinderByUuid;
 
@@ -234,6 +237,7 @@ public class WorkflowDefinitionLinkPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {uuid});
 	}
 
+	private FinderPath _finderPathFetchByUUID_G;
 	private UniquePersistenceFinder<WorkflowDefinitionLink>
 		_uniquePersistenceFinderByUUID_G;
 
@@ -326,6 +330,9 @@ public class WorkflowDefinitionLinkPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {uuid, groupId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByUuid_C;
+	private FinderPath _finderPathWithoutPaginationFindByUuid_C;
+	private FinderPath _finderPathCountByUuid_C;
 	private CollectionPersistenceFinder<WorkflowDefinitionLink>
 		_collectionPersistenceFinderByUuid_C;
 
@@ -483,6 +490,9 @@ public class WorkflowDefinitionLinkPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {uuid, companyId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByCompanyId;
+	private FinderPath _finderPathWithoutPaginationFindByCompanyId;
+	private FinderPath _finderPathCountByCompanyId;
 	private CollectionPersistenceFinder<WorkflowDefinitionLink>
 		_collectionPersistenceFinderByCompanyId;
 
@@ -629,6 +639,9 @@ public class WorkflowDefinitionLinkPersistenceImpl
 			FinderCacheUtil.getFinderCache(), new Object[] {companyId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_C;
+	private FinderPath _finderPathWithoutPaginationFindByC_C;
+	private FinderPath _finderPathCountByC_C;
 	private CollectionPersistenceFinder<WorkflowDefinitionLink>
 		_collectionPersistenceFinderByC_C;
 
@@ -790,6 +803,9 @@ public class WorkflowDefinitionLinkPersistenceImpl
 			new Object[] {companyId, classNameId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByG_C_C;
+	private FinderPath _finderPathWithoutPaginationFindByG_C_C;
+	private FinderPath _finderPathCountByG_C_C;
 	private CollectionPersistenceFinder<WorkflowDefinitionLink>
 		_collectionPersistenceFinderByG_C_C;
 
@@ -961,6 +977,9 @@ public class WorkflowDefinitionLinkPersistenceImpl
 			new Object[] {groupId, companyId, classNameId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByG_C_CPK;
+	private FinderPath _finderPathWithoutPaginationFindByG_C_CPK;
+	private FinderPath _finderPathCountByG_C_CPK;
 	private CollectionPersistenceFinder<WorkflowDefinitionLink>
 		_collectionPersistenceFinderByG_C_CPK;
 
@@ -1131,6 +1150,9 @@ public class WorkflowDefinitionLinkPersistenceImpl
 			new Object[] {groupId, companyId, classPK});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_W_W;
+	private FinderPath _finderPathWithoutPaginationFindByC_W_W;
+	private FinderPath _finderPathCountByC_W_W;
 	private CollectionPersistenceFinder<WorkflowDefinitionLink>
 		_collectionPersistenceFinderByC_W_W;
 
@@ -1328,6 +1350,9 @@ public class WorkflowDefinitionLinkPersistenceImpl
 			});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByG_C_C_C;
+	private FinderPath _finderPathWithoutPaginationFindByG_C_C_C;
+	private FinderPath _finderPathCountByG_C_C_C;
 	private CollectionPersistenceFinder<WorkflowDefinitionLink>
 		_collectionPersistenceFinderByG_C_C_C;
 
@@ -1514,6 +1539,9 @@ public class WorkflowDefinitionLinkPersistenceImpl
 			new Object[] {groupId, companyId, classNameId, classPK});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByG_C_C_C_T;
+	private FinderPath _finderPathWithoutPaginationFindByG_C_C_C_T;
+	private FinderPath _finderPathCountByG_C_C_C_T;
 	private CollectionPersistenceFinder<WorkflowDefinitionLink>
 		_collectionPersistenceFinderByG_C_C_C_T;
 
@@ -1718,6 +1746,7 @@ public class WorkflowDefinitionLinkPersistenceImpl
 			new Object[] {groupId, companyId, classNameId, classPK, typePK});
 	}
 
+	private FinderPath _finderPathFetchByERC_G;
 	private UniquePersistenceFinder<WorkflowDefinitionLink>
 		_uniquePersistenceFinderByERC_G;
 
@@ -2201,23 +2230,27 @@ public class WorkflowDefinitionLinkPersistenceImpl
 	 * Initializes the workflow definition link persistence.
 	 */
 	public void afterPropertiesSet() {
+		_finderPathWithPaginationFindByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid",
+			new String[] {
+				String.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"uuid_"}, true);
+
+		_finderPathWithoutPaginationFindByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid",
+			new String[] {String.class.getName()}, new String[] {"uuid_"}, 0, 1,
+			true, null);
+
+		_finderPathCountByUuid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid",
+			new String[] {String.class.getName()}, new String[] {"uuid_"}, 0, 1,
+			false, null);
+
 		_collectionPersistenceFinderByUuid = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid",
-				new String[] {
-					String.class.getName(), Integer.class.getName(),
-					Integer.class.getName(), OrderByComparator.class.getName()
-				},
-				new String[] {"uuid_"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid",
-				new String[] {String.class.getName()}, new String[] {"uuid_"},
-				0, 1, true, null),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid",
-				new String[] {String.class.getName()}, new String[] {"uuid_"},
-				0, 1, false, null),
+			this, _finderPathWithPaginationFindByUuid,
+			_finderPathWithoutPaginationFindByUuid, _finderPathCountByUuid,
 			_SQL_SELECT_WORKFLOWDEFINITIONLINK_WHERE,
 			_SQL_COUNT_WORKFLOWDEFINITIONLINK_WHERE,
 			WorkflowDefinitionLinkModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
@@ -2226,14 +2259,15 @@ public class WorkflowDefinitionLinkPersistenceImpl
 				"workflowDefinitionLink.", "uuid", FinderColumn.Type.STRING,
 				"=", true, true, WorkflowDefinitionLink::getUuid));
 
+		_finderPathFetchByUUID_G = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByUUID_G",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"uuid_", "groupId"}, 0, 1, false,
+			convertNullFunction(WorkflowDefinitionLink::getUuid),
+			WorkflowDefinitionLink::getGroupId);
+
 		_uniquePersistenceFinderByUUID_G = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByUUID_G",
-				new String[] {String.class.getName(), Long.class.getName()},
-				new String[] {"uuid_", "groupId"}, 0, 1, false,
-				convertNullFunction(WorkflowDefinitionLink::getUuid),
-				WorkflowDefinitionLink::getGroupId),
+			this, _finderPathFetchByUUID_G,
 			_SQL_SELECT_WORKFLOWDEFINITIONLINK_WHERE, "",
 			new FinderColumn<>(
 				"workflowDefinitionLink.", "uuid", FinderColumn.Type.STRING,
@@ -2242,25 +2276,30 @@ public class WorkflowDefinitionLinkPersistenceImpl
 				"workflowDefinitionLink.", "groupId", FinderColumn.Type.LONG,
 				"=", true, true, WorkflowDefinitionLink::getGroupId));
 
+		_finderPathWithPaginationFindByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid_C",
+			new String[] {
+				String.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"uuid_", "companyId"}, true);
+
+		_finderPathWithoutPaginationFindByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"uuid_", "companyId"}, 0, 1, true, null);
+
+		_finderPathCountByUuid_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"uuid_", "companyId"}, 0, 1, false, null);
+
 		_collectionPersistenceFinderByUuid_C =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByUuid_C",
-					new String[] {
-						String.class.getName(), Long.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"uuid_", "companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByUuid_C",
-					new String[] {String.class.getName(), Long.class.getName()},
-					new String[] {"uuid_", "companyId"}, 0, 1, true, null),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid_C",
-					new String[] {String.class.getName(), Long.class.getName()},
-					new String[] {"uuid_", "companyId"}, 0, 1, false, null),
+				this, _finderPathWithPaginationFindByUuid_C,
+				_finderPathWithoutPaginationFindByUuid_C,
+				_finderPathCountByUuid_C,
 				_SQL_SELECT_WORKFLOWDEFINITIONLINK_WHERE,
 				_SQL_COUNT_WORKFLOWDEFINITIONLINK_WHERE,
 				WorkflowDefinitionLinkModelImpl.ORDER_BY_JPQL,
@@ -2273,25 +2312,29 @@ public class WorkflowDefinitionLinkPersistenceImpl
 					FinderColumn.Type.LONG, "=", true, true,
 					WorkflowDefinitionLink::getCompanyId));
 
+		_finderPathWithPaginationFindByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByCompanyId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"companyId"}, true);
+
+		_finderPathWithoutPaginationFindByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByCompanyId",
+			new String[] {Long.class.getName()}, new String[] {"companyId"},
+			true);
+
+		_finderPathCountByCompanyId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByCompanyId",
+			new String[] {Long.class.getName()}, new String[] {"companyId"},
+			false);
+
 		_collectionPersistenceFinderByCompanyId =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByCompanyId",
-					new String[] {
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"findByCompanyId", new String[] {Long.class.getName()},
-					new String[] {"companyId"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByCompanyId", new String[] {Long.class.getName()},
-					new String[] {"companyId"}, false),
+				this, _finderPathWithPaginationFindByCompanyId,
+				_finderPathWithoutPaginationFindByCompanyId,
+				_finderPathCountByCompanyId,
 				_SQL_SELECT_WORKFLOWDEFINITIONLINK_WHERE,
 				_SQL_COUNT_WORKFLOWDEFINITIONLINK_WHERE,
 				WorkflowDefinitionLinkModelImpl.ORDER_BY_JPQL,
@@ -2301,24 +2344,28 @@ public class WorkflowDefinitionLinkPersistenceImpl
 					FinderColumn.Type.LONG, "=", true, true,
 					WorkflowDefinitionLink::getCompanyId));
 
+		_finderPathWithPaginationFindByC_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_C",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "classNameId"}, true);
+
+		_finderPathWithoutPaginationFindByC_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_C",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"companyId", "classNameId"}, true);
+
+		_finderPathCountByC_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_C",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"companyId", "classNameId"}, false);
+
 		_collectionPersistenceFinderByC_C = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_C",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Integer.class.getName(), Integer.class.getName(),
-					OrderByComparator.class.getName()
-				},
-				new String[] {"companyId", "classNameId"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_C",
-				new String[] {Long.class.getName(), Long.class.getName()},
-				new String[] {"companyId", "classNameId"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_C",
-				new String[] {Long.class.getName(), Long.class.getName()},
-				new String[] {"companyId", "classNameId"}, false),
+			this, _finderPathWithPaginationFindByC_C,
+			_finderPathWithoutPaginationFindByC_C, _finderPathCountByC_C,
 			_SQL_SELECT_WORKFLOWDEFINITIONLINK_WHERE,
 			_SQL_COUNT_WORKFLOWDEFINITIONLINK_WHERE,
 			WorkflowDefinitionLinkModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
@@ -2331,30 +2378,32 @@ public class WorkflowDefinitionLinkPersistenceImpl
 				FinderColumn.Type.LONG, "=", true, true,
 				WorkflowDefinitionLink::getClassNameId));
 
+		_finderPathWithPaginationFindByG_C_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_C_C",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"groupId", "companyId", "classNameId"}, true);
+
+		_finderPathWithoutPaginationFindByG_C_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_C_C",
+			new String[] {
+				Long.class.getName(), Long.class.getName(), Long.class.getName()
+			},
+			new String[] {"groupId", "companyId", "classNameId"}, true);
+
+		_finderPathCountByG_C_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_C_C",
+			new String[] {
+				Long.class.getName(), Long.class.getName(), Long.class.getName()
+			},
+			new String[] {"groupId", "companyId", "classNameId"}, false);
+
 		_collectionPersistenceFinderByG_C_C = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_C_C",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Long.class.getName(), Integer.class.getName(),
-					Integer.class.getName(), OrderByComparator.class.getName()
-				},
-				new String[] {"groupId", "companyId", "classNameId"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_C_C",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Long.class.getName()
-				},
-				new String[] {"groupId", "companyId", "classNameId"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_C_C",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Long.class.getName()
-				},
-				new String[] {"groupId", "companyId", "classNameId"}, false),
+			this, _finderPathWithPaginationFindByG_C_C,
+			_finderPathWithoutPaginationFindByG_C_C, _finderPathCountByG_C_C,
 			_SQL_SELECT_WORKFLOWDEFINITIONLINK_WHERE,
 			_SQL_COUNT_WORKFLOWDEFINITIONLINK_WHERE,
 			WorkflowDefinitionLinkModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
@@ -2370,32 +2419,34 @@ public class WorkflowDefinitionLinkPersistenceImpl
 				FinderColumn.Type.LONG, "=", true, true,
 				WorkflowDefinitionLink::getClassNameId));
 
+		_finderPathWithPaginationFindByG_C_CPK = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_C_CPK",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"groupId", "companyId", "classPK"}, true);
+
+		_finderPathWithoutPaginationFindByG_C_CPK = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_C_CPK",
+			new String[] {
+				Long.class.getName(), Long.class.getName(), Long.class.getName()
+			},
+			new String[] {"groupId", "companyId", "classPK"}, true);
+
+		_finderPathCountByG_C_CPK = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_C_CPK",
+			new String[] {
+				Long.class.getName(), Long.class.getName(), Long.class.getName()
+			},
+			new String[] {"groupId", "companyId", "classPK"}, false);
+
 		_collectionPersistenceFinderByG_C_CPK =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_C_CPK",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {"groupId", "companyId", "classPK"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_C_CPK",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						Long.class.getName()
-					},
-					new String[] {"groupId", "companyId", "classPK"}, true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_C_CPK",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						Long.class.getName()
-					},
-					new String[] {"groupId", "companyId", "classPK"}, false),
+				this, _finderPathWithPaginationFindByG_C_CPK,
+				_finderPathWithoutPaginationFindByG_C_CPK,
+				_finderPathCountByG_C_CPK,
 				_SQL_SELECT_WORKFLOWDEFINITIONLINK_WHERE,
 				_SQL_COUNT_WORKFLOWDEFINITIONLINK_WHERE,
 				WorkflowDefinitionLinkModelImpl.ORDER_BY_JPQL,
@@ -2413,42 +2464,46 @@ public class WorkflowDefinitionLinkPersistenceImpl
 					FinderColumn.Type.LONG, "=", true, true,
 					WorkflowDefinitionLink::getClassPK));
 
+		_finderPathWithPaginationFindByC_W_W = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_W_W",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {
+				"companyId", "workflowDefinitionName",
+				"workflowDefinitionVersion"
+			},
+			true);
+
+		_finderPathWithoutPaginationFindByC_W_W = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_W_W",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Integer.class.getName()
+			},
+			new String[] {
+				"companyId", "workflowDefinitionName",
+				"workflowDefinitionVersion"
+			},
+			0, 2, true, null);
+
+		_finderPathCountByC_W_W = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_W_W",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Integer.class.getName()
+			},
+			new String[] {
+				"companyId", "workflowDefinitionName",
+				"workflowDefinitionVersion"
+			},
+			0, 2, false, null);
+
 		_collectionPersistenceFinderByC_W_W = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_W_W",
-				new String[] {
-					Long.class.getName(), String.class.getName(),
-					Integer.class.getName(), Integer.class.getName(),
-					Integer.class.getName(), OrderByComparator.class.getName()
-				},
-				new String[] {
-					"companyId", "workflowDefinitionName",
-					"workflowDefinitionVersion"
-				},
-				true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_W_W",
-				new String[] {
-					Long.class.getName(), String.class.getName(),
-					Integer.class.getName()
-				},
-				new String[] {
-					"companyId", "workflowDefinitionName",
-					"workflowDefinitionVersion"
-				},
-				0, 2, true, null),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_W_W",
-				new String[] {
-					Long.class.getName(), String.class.getName(),
-					Integer.class.getName()
-				},
-				new String[] {
-					"companyId", "workflowDefinitionName",
-					"workflowDefinitionVersion"
-				},
-				0, 2, false, null),
+			this, _finderPathWithPaginationFindByC_W_W,
+			_finderPathWithoutPaginationFindByC_W_W, _finderPathCountByC_W_W,
 			_SQL_SELECT_WORKFLOWDEFINITIONLINK_WHERE,
 			_SQL_COUNT_WORKFLOWDEFINITIONLINK_WHERE,
 			WorkflowDefinitionLinkModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
@@ -2465,41 +2520,40 @@ public class WorkflowDefinitionLinkPersistenceImpl
 				FinderColumn.Type.INTEGER, "=", true, true,
 				WorkflowDefinitionLink::getWorkflowDefinitionVersion));
 
+		_finderPathWithPaginationFindByG_C_C_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_C_C_C",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"groupId", "companyId", "classNameId", "classPK"},
+			true);
+
+		_finderPathWithoutPaginationFindByG_C_C_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_C_C_C",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Long.class.getName()
+			},
+			new String[] {"groupId", "companyId", "classNameId", "classPK"},
+			true);
+
+		_finderPathCountByG_C_C_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_C_C_C",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Long.class.getName()
+			},
+			new String[] {"groupId", "companyId", "classNameId", "classPK"},
+			false);
+
 		_collectionPersistenceFinderByG_C_C_C =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_C_C_C",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						Long.class.getName(), Long.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {
-						"groupId", "companyId", "classNameId", "classPK"
-					},
-					true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_C_C_C",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						Long.class.getName(), Long.class.getName()
-					},
-					new String[] {
-						"groupId", "companyId", "classNameId", "classPK"
-					},
-					true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_C_C_C",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						Long.class.getName(), Long.class.getName()
-					},
-					new String[] {
-						"groupId", "companyId", "classNameId", "classPK"
-					},
-					false),
+				this, _finderPathWithPaginationFindByG_C_C_C,
+				_finderPathWithoutPaginationFindByG_C_C_C,
+				_finderPathCountByG_C_C_C,
 				_SQL_SELECT_WORKFLOWDEFINITIONLINK_WHERE,
 				_SQL_COUNT_WORKFLOWDEFINITIONLINK_WHERE,
 				WorkflowDefinitionLinkModelImpl.ORDER_BY_JPQL,
@@ -2521,49 +2575,46 @@ public class WorkflowDefinitionLinkPersistenceImpl
 					FinderColumn.Type.LONG, "=", true, true,
 					WorkflowDefinitionLink::getClassPK));
 
+		_finderPathWithPaginationFindByG_C_C_C_T = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_C_C_C_T",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {
+				"groupId", "companyId", "classNameId", "classPK", "typePK"
+			},
+			true);
+
+		_finderPathWithoutPaginationFindByG_C_C_C_T = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_C_C_C_T",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Long.class.getName(), Long.class.getName()
+			},
+			new String[] {
+				"groupId", "companyId", "classNameId", "classPK", "typePK"
+			},
+			true);
+
+		_finderPathCountByG_C_C_C_T = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_C_C_C_T",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Long.class.getName(), Long.class.getName()
+			},
+			new String[] {
+				"groupId", "companyId", "classNameId", "classPK", "typePK"
+			},
+			false);
+
 		_collectionPersistenceFinderByG_C_C_C_T =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_C_C_C_T",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						Long.class.getName(), Long.class.getName(),
-						Long.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {
-						"groupId", "companyId", "classNameId", "classPK",
-						"typePK"
-					},
-					true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"findByG_C_C_C_T",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						Long.class.getName(), Long.class.getName(),
-						Long.class.getName()
-					},
-					new String[] {
-						"groupId", "companyId", "classNameId", "classPK",
-						"typePK"
-					},
-					true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByG_C_C_C_T",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						Long.class.getName(), Long.class.getName(),
-						Long.class.getName()
-					},
-					new String[] {
-						"groupId", "companyId", "classNameId", "classPK",
-						"typePK"
-					},
-					false),
+				this, _finderPathWithPaginationFindByG_C_C_C_T,
+				_finderPathWithoutPaginationFindByG_C_C_C_T,
+				_finderPathCountByG_C_C_C_T,
 				_SQL_SELECT_WORKFLOWDEFINITIONLINK_WHERE,
 				_SQL_COUNT_WORKFLOWDEFINITIONLINK_WHERE,
 				WorkflowDefinitionLinkModelImpl.ORDER_BY_JPQL,
@@ -2588,15 +2639,16 @@ public class WorkflowDefinitionLinkPersistenceImpl
 					"workflowDefinitionLink.", "typePK", FinderColumn.Type.LONG,
 					"=", true, true, WorkflowDefinitionLink::getTypePK));
 
+		_finderPathFetchByERC_G = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByERC_G",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "groupId"}, 0, 1, false,
+			convertNullFunction(
+				WorkflowDefinitionLink::getExternalReferenceCode),
+			WorkflowDefinitionLink::getGroupId);
+
 		_uniquePersistenceFinderByERC_G = new UniquePersistenceFinder<>(
-			this,
-			createUniqueFinderPath(
-				FINDER_CLASS_NAME_ENTITY, "fetchByERC_G",
-				new String[] {String.class.getName(), Long.class.getName()},
-				new String[] {"externalReferenceCode", "groupId"}, 0, 1, false,
-				convertNullFunction(
-					WorkflowDefinitionLink::getExternalReferenceCode),
-				WorkflowDefinitionLink::getGroupId),
+			this, _finderPathFetchByERC_G,
 			_SQL_SELECT_WORKFLOWDEFINITIONLINK_WHERE, "",
 			new FinderColumn<>(
 				"workflowDefinitionLink.", "externalReferenceCode",
@@ -2642,4 +2694,4 @@ public class WorkflowDefinitionLinkPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1528003068
+// LIFERAY-SERVICE-BUILDER-HASH:1337393864

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/WorkflowInstanceLinkPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/WorkflowInstanceLinkPersistenceImpl.java
@@ -76,6 +76,7 @@ public class WorkflowInstanceLinkPersistenceImpl
 	public static final String FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION =
 		FINDER_CLASS_NAME_ENTITY + ".List2";
 
+	private FinderPath _finderPathFetchByWorkflowInstanceId;
 	private UniquePersistenceFinder<WorkflowInstanceLink>
 		_uniquePersistenceFinderByWorkflowInstanceId;
 
@@ -170,6 +171,9 @@ public class WorkflowInstanceLinkPersistenceImpl
 			new Object[] {workflowInstanceId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_C;
+	private FinderPath _finderPathWithoutPaginationFindByC_C;
+	private FinderPath _finderPathCountByC_C;
 	private CollectionPersistenceFinder<WorkflowInstanceLink>
 		_collectionPersistenceFinderByC_C;
 
@@ -331,6 +335,9 @@ public class WorkflowInstanceLinkPersistenceImpl
 			new Object[] {companyId, classNameId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByG_C_C;
+	private FinderPath _finderPathWithoutPaginationFindByG_C_C;
+	private FinderPath _finderPathCountByG_C_C;
 	private CollectionPersistenceFinder<WorkflowInstanceLink>
 		_collectionPersistenceFinderByG_C_C;
 
@@ -502,6 +509,9 @@ public class WorkflowInstanceLinkPersistenceImpl
 			new Object[] {groupId, companyId, classNameId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByG_C_C_C;
+	private FinderPath _finderPathWithoutPaginationFindByG_C_C_C;
+	private FinderPath _finderPathCountByG_C_C_C;
 	private CollectionPersistenceFinder<WorkflowInstanceLink>
 		_collectionPersistenceFinderByG_C_C_C;
 
@@ -970,38 +980,43 @@ public class WorkflowInstanceLinkPersistenceImpl
 	 * Initializes the workflow instance link persistence.
 	 */
 	public void afterPropertiesSet() {
+		_finderPathFetchByWorkflowInstanceId = createUniqueFinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByWorkflowInstanceId",
+			new String[] {Long.class.getName()},
+			new String[] {"workflowInstanceId"}, 0, 0, false,
+			WorkflowInstanceLink::getWorkflowInstanceId);
+
 		_uniquePersistenceFinderByWorkflowInstanceId =
 			new UniquePersistenceFinder<>(
-				this,
-				createUniqueFinderPath(
-					FINDER_CLASS_NAME_ENTITY, "fetchByWorkflowInstanceId",
-					new String[] {Long.class.getName()},
-					new String[] {"workflowInstanceId"}, 0, 0, false,
-					WorkflowInstanceLink::getWorkflowInstanceId),
+				this, _finderPathFetchByWorkflowInstanceId,
 				_SQL_SELECT_WORKFLOWINSTANCELINK_WHERE, "",
 				new FinderColumn<>(
 					"workflowInstanceLink.", "workflowInstanceId",
 					FinderColumn.Type.LONG, "=", true, true,
 					WorkflowInstanceLink::getWorkflowInstanceId));
 
+		_finderPathWithPaginationFindByC_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_C",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "classNameId"}, true);
+
+		_finderPathWithoutPaginationFindByC_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_C",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"companyId", "classNameId"}, true);
+
+		_finderPathCountByC_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_C",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"companyId", "classNameId"}, false);
+
 		_collectionPersistenceFinderByC_C = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_C",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Integer.class.getName(), Integer.class.getName(),
-					OrderByComparator.class.getName()
-				},
-				new String[] {"companyId", "classNameId"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_C",
-				new String[] {Long.class.getName(), Long.class.getName()},
-				new String[] {"companyId", "classNameId"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_C",
-				new String[] {Long.class.getName(), Long.class.getName()},
-				new String[] {"companyId", "classNameId"}, false),
+			this, _finderPathWithPaginationFindByC_C,
+			_finderPathWithoutPaginationFindByC_C, _finderPathCountByC_C,
 			_SQL_SELECT_WORKFLOWINSTANCELINK_WHERE,
 			_SQL_COUNT_WORKFLOWINSTANCELINK_WHERE,
 			WorkflowInstanceLinkModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
@@ -1013,30 +1028,32 @@ public class WorkflowInstanceLinkPersistenceImpl
 				"workflowInstanceLink.", "classNameId", FinderColumn.Type.LONG,
 				"=", true, true, WorkflowInstanceLink::getClassNameId));
 
+		_finderPathWithPaginationFindByG_C_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_C_C",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"groupId", "companyId", "classNameId"}, true);
+
+		_finderPathWithoutPaginationFindByG_C_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_C_C",
+			new String[] {
+				Long.class.getName(), Long.class.getName(), Long.class.getName()
+			},
+			new String[] {"groupId", "companyId", "classNameId"}, true);
+
+		_finderPathCountByG_C_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_C_C",
+			new String[] {
+				Long.class.getName(), Long.class.getName(), Long.class.getName()
+			},
+			new String[] {"groupId", "companyId", "classNameId"}, false);
+
 		_collectionPersistenceFinderByG_C_C = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_C_C",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Long.class.getName(), Integer.class.getName(),
-					Integer.class.getName(), OrderByComparator.class.getName()
-				},
-				new String[] {"groupId", "companyId", "classNameId"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_C_C",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Long.class.getName()
-				},
-				new String[] {"groupId", "companyId", "classNameId"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_C_C",
-				new String[] {
-					Long.class.getName(), Long.class.getName(),
-					Long.class.getName()
-				},
-				new String[] {"groupId", "companyId", "classNameId"}, false),
+			this, _finderPathWithPaginationFindByG_C_C,
+			_finderPathWithoutPaginationFindByG_C_C, _finderPathCountByG_C_C,
 			_SQL_SELECT_WORKFLOWINSTANCELINK_WHERE,
 			_SQL_COUNT_WORKFLOWINSTANCELINK_WHERE,
 			WorkflowInstanceLinkModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
@@ -1051,41 +1068,40 @@ public class WorkflowInstanceLinkPersistenceImpl
 				"workflowInstanceLink.", "classNameId", FinderColumn.Type.LONG,
 				"=", true, true, WorkflowInstanceLink::getClassNameId));
 
+		_finderPathWithPaginationFindByG_C_C_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_C_C_C",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"groupId", "companyId", "classNameId", "classPK"},
+			true);
+
+		_finderPathWithoutPaginationFindByG_C_C_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_C_C_C",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Long.class.getName()
+			},
+			new String[] {"groupId", "companyId", "classNameId", "classPK"},
+			true);
+
+		_finderPathCountByG_C_C_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_C_C_C",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Long.class.getName()
+			},
+			new String[] {"groupId", "companyId", "classNameId", "classPK"},
+			false);
+
 		_collectionPersistenceFinderByG_C_C_C =
 			new CollectionPersistenceFinder<>(
-				this,
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_C_C_C",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						Long.class.getName(), Long.class.getName(),
-						Integer.class.getName(), Integer.class.getName(),
-						OrderByComparator.class.getName()
-					},
-					new String[] {
-						"groupId", "companyId", "classNameId", "classPK"
-					},
-					true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_C_C_C",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						Long.class.getName(), Long.class.getName()
-					},
-					new String[] {
-						"groupId", "companyId", "classNameId", "classPK"
-					},
-					true),
-				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_C_C_C",
-					new String[] {
-						Long.class.getName(), Long.class.getName(),
-						Long.class.getName(), Long.class.getName()
-					},
-					new String[] {
-						"groupId", "companyId", "classNameId", "classPK"
-					},
-					false),
+				this, _finderPathWithPaginationFindByG_C_C_C,
+				_finderPathWithoutPaginationFindByG_C_C_C,
+				_finderPathCountByG_C_C_C,
 				_SQL_SELECT_WORKFLOWINSTANCELINK_WHERE,
 				_SQL_COUNT_WORKFLOWINSTANCELINK_WHERE,
 				WorkflowInstanceLinkModelImpl.ORDER_BY_JPQL,
@@ -1138,4 +1154,4 @@ public class WorkflowInstanceLinkPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-505098483
+// LIFERAY-SERVICE-BUILDER-HASH:-1173154472

--- a/portal-kernel/src/com/liferay/portal/kernel/model/TicketModel.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/TicketModel.java
@@ -178,6 +178,21 @@ public interface TicketModel
 	public void setType(int type);
 
 	/**
+	 * Returns the email address of this ticket.
+	 *
+	 * @return the email address of this ticket
+	 */
+	@AutoEscape
+	public String getEmailAddress();
+
+	/**
+	 * Sets the email address of this ticket.
+	 *
+	 * @param emailAddress the email address of this ticket
+	 */
+	public void setEmailAddress(String emailAddress);
+
+	/**
 	 * Returns the extra info of this ticket.
 	 *
 	 * @return the extra info of this ticket
@@ -214,4 +229,4 @@ public interface TicketModel
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1000540596
+// LIFERAY-SERVICE-BUILDER-HASH:1971965592

--- a/portal-kernel/src/com/liferay/portal/kernel/model/TicketTable.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/TicketTable.java
@@ -40,6 +40,8 @@ public class TicketTable extends BaseTable<TicketTable> {
 		"key_", String.class, Types.VARCHAR, Column.FLAG_DEFAULT);
 	public final Column<TicketTable, Integer> type = createColumn(
 		"type_", Integer.class, Types.INTEGER, Column.FLAG_DEFAULT);
+	public final Column<TicketTable, String> emailAddress = createColumn(
+		"emailAddress", String.class, Types.VARCHAR, Column.FLAG_DEFAULT);
 	public final Column<TicketTable, Clob> extraInfo = createColumn(
 		"extraInfo", Clob.class, Types.CLOB, Column.FLAG_DEFAULT);
 	public final Column<TicketTable, Date> expirationDate = createColumn(
@@ -50,4 +52,4 @@ public class TicketTable extends BaseTable<TicketTable> {
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1325508359
+// LIFERAY-SERVICE-BUILDER-HASH:-1420567643

--- a/portal-kernel/src/com/liferay/portal/kernel/model/TicketWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/TicketWrapper.java
@@ -39,6 +39,7 @@ public class TicketWrapper
 		attributes.put("classPK", getClassPK());
 		attributes.put("key", getKey());
 		attributes.put("type", getType());
+		attributes.put("emailAddress", getEmailAddress());
 		attributes.put("extraInfo", getExtraInfo());
 		attributes.put("expirationDate", getExpirationDate());
 
@@ -93,6 +94,12 @@ public class TicketWrapper
 
 		if (type != null) {
 			setType(type);
+		}
+
+		String emailAddress = (String)attributes.get("emailAddress");
+
+		if (emailAddress != null) {
+			setEmailAddress(emailAddress);
 		}
 
 		String extraInfo = (String)attributes.get("extraInfo");
@@ -161,6 +168,16 @@ public class TicketWrapper
 	@Override
 	public Date getCreateDate() {
 		return model.getCreateDate();
+	}
+
+	/**
+	 * Returns the email address of this ticket.
+	 *
+	 * @return the email address of this ticket
+	 */
+	@Override
+	public String getEmailAddress() {
+		return model.getEmailAddress();
 	}
 
 	/**
@@ -289,6 +306,16 @@ public class TicketWrapper
 	}
 
 	/**
+	 * Sets the email address of this ticket.
+	 *
+	 * @param emailAddress the email address of this ticket
+	 */
+	@Override
+	public void setEmailAddress(String emailAddress) {
+		model.setEmailAddress(emailAddress);
+	}
+
+	/**
 	 * Sets the expiration date of this ticket.
 	 *
 	 * @param expirationDate the expiration date of this ticket
@@ -369,4 +396,4 @@ public class TicketWrapper
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1378583455
+// LIFERAY-SERVICE-BUILDER-HASH:777544895

--- a/portal-kernel/src/com/liferay/portal/kernel/service/TicketLocalService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/TicketLocalService.java
@@ -63,6 +63,11 @@ public interface TicketLocalService
 		long companyId, String className, long classPK, int type,
 		String extraInfo, Date expirationDate, ServiceContext serviceContext);
 
+	public Ticket addTicket(
+		long companyId, String className, long classPK, int type,
+		String emailAddress, String extraInfo, Date expirationDate,
+		ServiceContext serviceContext);
+
 	/**
 	 * Adds the ticket to the database. Also notifies the appropriate model listeners.
 	 *
@@ -258,6 +263,10 @@ public interface TicketLocalService
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<Ticket> getTickets(
+		long companyId, int type, String emailAddress);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<Ticket> getTickets(
 		long companyId, String className, long classPK);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
@@ -294,4 +303,4 @@ public interface TicketLocalService
 	public Ticket updateTicket(Ticket ticket);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:351293955
+// LIFERAY-SERVICE-BUILDER-HASH:-519894446

--- a/portal-kernel/src/com/liferay/portal/kernel/service/TicketLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/TicketLocalServiceUtil.java
@@ -55,6 +55,16 @@ public class TicketLocalServiceUtil {
 			serviceContext);
 	}
 
+	public static Ticket addTicket(
+		long companyId, String className, long classPK, int type,
+		String emailAddress, String extraInfo, java.util.Date expirationDate,
+		ServiceContext serviceContext) {
+
+		return getService().addTicket(
+			companyId, className, classPK, type, emailAddress, extraInfo,
+			expirationDate, serviceContext);
+	}
+
 	/**
 	 * Adds the ticket to the database. Also notifies the appropriate model listeners.
 	 *
@@ -295,6 +305,12 @@ public class TicketLocalServiceUtil {
 	}
 
 	public static List<Ticket> getTickets(
+		long companyId, int type, String emailAddress) {
+
+		return getService().getTickets(companyId, type, emailAddress);
+	}
+
+	public static List<Ticket> getTickets(
 		long companyId, String className, long classPK) {
 
 		return getService().getTickets(companyId, className, classPK);
@@ -355,4 +371,4 @@ public class TicketLocalServiceUtil {
 	private static volatile TicketLocalService _service;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2021983297
+// LIFERAY-SERVICE-BUILDER-HASH:815814338

--- a/portal-kernel/src/com/liferay/portal/kernel/service/TicketLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/TicketLocalServiceWrapper.java
@@ -47,6 +47,17 @@ public class TicketLocalServiceWrapper
 			serviceContext);
 	}
 
+	@Override
+	public com.liferay.portal.kernel.model.Ticket addTicket(
+		long companyId, String className, long classPK, int type,
+		String emailAddress, String extraInfo, java.util.Date expirationDate,
+		ServiceContext serviceContext) {
+
+		return _ticketLocalService.addTicket(
+			companyId, className, classPK, type, emailAddress, extraInfo,
+			expirationDate, serviceContext);
+	}
+
 	/**
 	 * Adds the ticket to the database. Also notifies the appropriate model listeners.
 	 *
@@ -331,6 +342,13 @@ public class TicketLocalServiceWrapper
 
 	@Override
 	public java.util.List<com.liferay.portal.kernel.model.Ticket> getTickets(
+		long companyId, int type, String emailAddress) {
+
+		return _ticketLocalService.getTickets(companyId, type, emailAddress);
+	}
+
+	@Override
+	public java.util.List<com.liferay.portal.kernel.model.Ticket> getTickets(
 		long companyId, String className, long classPK) {
 
 		return _ticketLocalService.getTickets(companyId, className, classPK);
@@ -406,4 +424,4 @@ public class TicketLocalServiceWrapper
 	private TicketLocalService _ticketLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-338077197
+// LIFERAY-SERVICE-BUILDER-HASH:-2109147802

--- a/portal-kernel/src/com/liferay/portal/kernel/service/persistence/TicketPersistence.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/persistence/TicketPersistence.java
@@ -192,6 +192,125 @@ public interface TicketPersistence extends BasePersistence<Ticket> {
 	public int countByC_C_C(long companyId, long classNameId, long classPK);
 
 	/**
+	 * Returns all the tickets where companyId = &#63; and type = &#63; and emailAddress = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param type the type
+	 * @param emailAddress the email address
+	 * @return the matching tickets
+	 */
+	public java.util.List<Ticket> findByC_T_EA(
+		long companyId, int type, String emailAddress);
+
+	/**
+	 * Returns a range of all the tickets where companyId = &#63; and type = &#63; and emailAddress = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.portal.model.impl.TicketModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param type the type
+	 * @param emailAddress the email address
+	 * @param start the lower bound of the range of tickets
+	 * @param end the upper bound of the range of tickets (not inclusive)
+	 * @return the range of matching tickets
+	 */
+	public java.util.List<Ticket> findByC_T_EA(
+		long companyId, int type, String emailAddress, int start, int end);
+
+	/**
+	 * Returns an ordered range of all the tickets where companyId = &#63; and type = &#63; and emailAddress = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.portal.model.impl.TicketModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param type the type
+	 * @param emailAddress the email address
+	 * @param start the lower bound of the range of tickets
+	 * @param end the upper bound of the range of tickets (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching tickets
+	 */
+	public java.util.List<Ticket> findByC_T_EA(
+		long companyId, int type, String emailAddress, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<Ticket>
+			orderByComparator);
+
+	/**
+	 * Returns an ordered range of all the tickets where companyId = &#63; and type = &#63; and emailAddress = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.portal.model.impl.TicketModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param type the type
+	 * @param emailAddress the email address
+	 * @param start the lower bound of the range of tickets
+	 * @param end the upper bound of the range of tickets (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching tickets
+	 */
+	public java.util.List<Ticket> findByC_T_EA(
+		long companyId, int type, String emailAddress, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<Ticket>
+			orderByComparator,
+		boolean useFinderCache);
+
+	/**
+	 * Returns the first ticket in the ordered set where companyId = &#63; and type = &#63; and emailAddress = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param type the type
+	 * @param emailAddress the email address
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching ticket
+	 * @throws NoSuchTicketException if a matching ticket could not be found
+	 */
+	public Ticket findByC_T_EA_First(
+			long companyId, int type, String emailAddress,
+			com.liferay.portal.kernel.util.OrderByComparator<Ticket>
+				orderByComparator)
+		throws NoSuchTicketException;
+
+	/**
+	 * Returns the first ticket in the ordered set where companyId = &#63; and type = &#63; and emailAddress = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param type the type
+	 * @param emailAddress the email address
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching ticket, or <code>null</code> if a matching ticket could not be found
+	 */
+	public Ticket fetchByC_T_EA_First(
+		long companyId, int type, String emailAddress,
+		com.liferay.portal.kernel.util.OrderByComparator<Ticket>
+			orderByComparator);
+
+	/**
+	 * Removes all the tickets where companyId = &#63; and type = &#63; and emailAddress = &#63; from the database.
+	 *
+	 * @param companyId the company ID
+	 * @param type the type
+	 * @param emailAddress the email address
+	 */
+	public void removeByC_T_EA(long companyId, int type, String emailAddress);
+
+	/**
+	 * Returns the number of tickets where companyId = &#63; and type = &#63; and emailAddress = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param type the type
+	 * @param emailAddress the email address
+	 * @return the number of matching tickets
+	 */
+	public int countByC_T_EA(long companyId, int type, String emailAddress);
+
+	/**
 	 * Returns all the tickets where classNameId = &#63; and classPK = &#63; and type = &#63;.
 	 *
 	 * @param classNameId the class name ID
@@ -479,4 +598,4 @@ public interface TicketPersistence extends BasePersistence<Ticket> {
 	public Ticket fetchByPrimaryKey(long ticketId);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-369207423
+// LIFERAY-SERVICE-BUILDER-HASH:-1478384294

--- a/portal-kernel/src/com/liferay/portal/kernel/service/persistence/TicketUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/persistence/TicketUtil.java
@@ -323,6 +323,152 @@ public class TicketUtil {
 	}
 
 	/**
+	 * Returns all the tickets where companyId = &#63; and type = &#63; and emailAddress = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param type the type
+	 * @param emailAddress the email address
+	 * @return the matching tickets
+	 */
+	public static List<Ticket> findByC_T_EA(
+		long companyId, int type, String emailAddress) {
+
+		return getPersistence().findByC_T_EA(companyId, type, emailAddress);
+	}
+
+	/**
+	 * Returns a range of all the tickets where companyId = &#63; and type = &#63; and emailAddress = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.portal.model.impl.TicketModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param type the type
+	 * @param emailAddress the email address
+	 * @param start the lower bound of the range of tickets
+	 * @param end the upper bound of the range of tickets (not inclusive)
+	 * @return the range of matching tickets
+	 */
+	public static List<Ticket> findByC_T_EA(
+		long companyId, int type, String emailAddress, int start, int end) {
+
+		return getPersistence().findByC_T_EA(
+			companyId, type, emailAddress, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the tickets where companyId = &#63; and type = &#63; and emailAddress = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.portal.model.impl.TicketModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param type the type
+	 * @param emailAddress the email address
+	 * @param start the lower bound of the range of tickets
+	 * @param end the upper bound of the range of tickets (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching tickets
+	 */
+	public static List<Ticket> findByC_T_EA(
+		long companyId, int type, String emailAddress, int start, int end,
+		OrderByComparator<Ticket> orderByComparator) {
+
+		return getPersistence().findByC_T_EA(
+			companyId, type, emailAddress, start, end, orderByComparator);
+	}
+
+	/**
+	 * Returns an ordered range of all the tickets where companyId = &#63; and type = &#63; and emailAddress = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.portal.model.impl.TicketModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param type the type
+	 * @param emailAddress the email address
+	 * @param start the lower bound of the range of tickets
+	 * @param end the upper bound of the range of tickets (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching tickets
+	 */
+	public static List<Ticket> findByC_T_EA(
+		long companyId, int type, String emailAddress, int start, int end,
+		OrderByComparator<Ticket> orderByComparator, boolean useFinderCache) {
+
+		return getPersistence().findByC_T_EA(
+			companyId, type, emailAddress, start, end, orderByComparator,
+			useFinderCache);
+	}
+
+	/**
+	 * Returns the first ticket in the ordered set where companyId = &#63; and type = &#63; and emailAddress = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param type the type
+	 * @param emailAddress the email address
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching ticket
+	 * @throws NoSuchTicketException if a matching ticket could not be found
+	 */
+	public static Ticket findByC_T_EA_First(
+			long companyId, int type, String emailAddress,
+			OrderByComparator<Ticket> orderByComparator)
+		throws com.liferay.portal.kernel.exception.NoSuchTicketException {
+
+		return getPersistence().findByC_T_EA_First(
+			companyId, type, emailAddress, orderByComparator);
+	}
+
+	/**
+	 * Returns the first ticket in the ordered set where companyId = &#63; and type = &#63; and emailAddress = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param type the type
+	 * @param emailAddress the email address
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching ticket, or <code>null</code> if a matching ticket could not be found
+	 */
+	public static Ticket fetchByC_T_EA_First(
+		long companyId, int type, String emailAddress,
+		OrderByComparator<Ticket> orderByComparator) {
+
+		return getPersistence().fetchByC_T_EA_First(
+			companyId, type, emailAddress, orderByComparator);
+	}
+
+	/**
+	 * Removes all the tickets where companyId = &#63; and type = &#63; and emailAddress = &#63; from the database.
+	 *
+	 * @param companyId the company ID
+	 * @param type the type
+	 * @param emailAddress the email address
+	 */
+	public static void removeByC_T_EA(
+		long companyId, int type, String emailAddress) {
+
+		getPersistence().removeByC_T_EA(companyId, type, emailAddress);
+	}
+
+	/**
+	 * Returns the number of tickets where companyId = &#63; and type = &#63; and emailAddress = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param type the type
+	 * @param emailAddress the email address
+	 * @return the number of matching tickets
+	 */
+	public static int countByC_T_EA(
+		long companyId, int type, String emailAddress) {
+
+		return getPersistence().countByC_T_EA(companyId, type, emailAddress);
+	}
+
+	/**
 	 * Returns all the tickets where classNameId = &#63; and classPK = &#63; and type = &#63;.
 	 *
 	 * @param classNameId the class name ID
@@ -684,4 +830,4 @@ public class TicketUtil {
 	private static volatile TicketPersistence _persistence;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:709452262
+// LIFERAY-SERVICE-BUILDER-HASH:-2075755297

--- a/sql/indexes.sql
+++ b/sql/indexes.sql
@@ -432,8 +432,9 @@ create index IX_93AB8545 on Team (companyId);
 create unique index IX_D424D1E4 on Team (groupId, name[$COLUMN_LENGTH:75$], ctCollectionId);
 create unique index IX_1AAF62D7 on Team (uuid_[$COLUMN_LENGTH:75$], groupId, ctCollectionId);
 
-create index IX_DAD135B4 on Ticket (classNameId, classPK, companyId, type_);
 create index IX_1E8DFB2E on Ticket (classNameId, classPK, type_);
+create index IX_8BACD0AA on Ticket (companyId, classNameId, classPK, type_);
+create index IX_3AFCAA8B on Ticket (companyId, type_, emailAddress[$COLUMN_LENGTH:254$]);
 create unique index IX_B2468446 on Ticket (key_[$COLUMN_LENGTH:255$]);
 
 create unique index IX_544FAE0D on UserGroup (companyId, externalReferenceCode[$COLUMN_LENGTH:75$], ctCollectionId);

--- a/sql/portal-tables.sql
+++ b/sql/portal-tables.sql
@@ -1473,6 +1473,7 @@ create table Ticket (
 	classPK LONG,
 	key_ VARCHAR(255) null,
 	type_ INTEGER,
+	emailAddress VARCHAR(254) null,
 	extraInfo TEXT null,
 	expirationDate DATE null
 );


### PR DESCRIPTION
Follow-up to https://github.com/brianchandotcom/liferay-portal/pull/174661.

Switches the pending-invitation conversion in `UserModelListener` from a DSL `JOIN` to the existing `C_T_EA` finder, now that the new `Ticket.emailAddress` column from LPD-90195 makes the email lookup trivial.

### Why finders instead of DSL

- `TicketLocalService.findByC_T_EA` (added in this branch as a wrapper) is backed by the Service Builder–generated `IX_3AFCAA8B (companyId, type_, emailAddress[254])` index. The index is guaranteed by construction.
- Both `Ticket.findByC_T_EA` and `SharingEntry.findByToTicketId` hit the entity cache. The prior DSL `JOIN` bypassed it entirely.
- The code reads as plain Liferay idiom.

### Trade-off

1 + N round trips instead of a single `JOIN`. N is the number of `(companyId, type, email)` matches, which should be at most a handful in practice, and this runs only on user approval (cold path). 

https://liferay.atlassian.net/browse/LPD-88154

cc @AliciaGarciaGarcia

_AI-assisted with Claude Code._
