### PR TITLE
LPD-90750 Move Duplicate out of the primary bulk action toolbar

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/SectionDisplayContextHelper.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/SectionDisplayContextHelper.java
@@ -829,9 +829,7 @@ public class SectionDisplayContextHelper {
 			).build(
 				"copy-to"
 			),
-			FDSActionDropdownItemBuilder.setHighlighted(
-				true
-			).setHref(
+			FDSActionDropdownItemBuilder.setHref(
 				"#"
 			).setIcon(
 				"copy"


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90750

## What is being fixed

The bulk action toolbar on the CMS Contents and Files listings surfaces "Duplicate" as a highlighted primary button alongside Move To, Copy To, Expire, and Export for Translation. Product wants Duplicate demoted out of the primary slot so it appears only inside the overflow menu, reducing visual weight in the toolbar.

## How it is being fixed

Drop the `setHighlighted(true)` chain from the duplicate entry in `_getBulkActionDropdownItems` in `SectionDisplayContextHelper.java`. Without an explicit `highlighted` flag the FDS action builder treats the entry as non-highlighted, placing it inside the overflow (kebab) dropdown instead of the primary toolbar. Move To, Copy To, Expire, and Export for Translation are intentionally left highlighted since they remain primary actions.

## Why are there no tests?

Toolbar placement is a one-line literal removal in a fluent builder chain. There is no Java unit test for `SectionDisplayContextHelper`, and the existing Playwright bulk-action specs do not assert on highlighted-vs-overflow placement (they reach Duplicate through the kebab regardless). A focused test would only assert the absence of a button in a specific slot — low signal for the maintenance cost.

_AI-assisted with Claude Code._