### PR TITLE
LPD-90768 Style the asset title as a link in review-date notifications

### DIFF
--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/notifications/ObjectUserNotificationsHandler.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/notifications/ObjectUserNotificationsHandler.java
@@ -159,10 +159,16 @@ public class ObjectUserNotificationsHandler
 			"notificationMessageKey");
 
 		if (Validator.isNotNull(notificationMessageKey)) {
-			return HtmlUtil.escape(
-				serviceContext.translate(
-					notificationMessageKey,
-					jsonObject.getString("notificationMessageArg")));
+			String notificationMessageArg = HtmlUtil.escape(
+				jsonObject.getString("notificationMessageArg"));
+
+			if (Validator.isNotNull(jsonObject.getString("notificationLink"))) {
+				notificationMessageArg =
+					"<strong><u>" + notificationMessageArg + "</u></strong>";
+			}
+
+			return serviceContext.translate(
+				notificationMessageKey, notificationMessageArg);
 		}
 
 		return HtmlUtil.escape(jsonObject.getString("notificationMessage"));


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-90768

In CMS review-date notifications, the asset title rendered as plain text inside the notification message. The design calls for the title to read like a clickable name (bold and underlined) so the eye lands on it first.

# How am I fixing it?

`ObjectUserNotificationsHandler._getMessage` now wraps the substituted title in `<strong><u>...</u></strong>` whenever the payload includes a `notificationLink` (the CMS contributor's signal), and escapes the substitution arg inside the `translate(...)` call rather than escaping the whole translated output so the wrapped markup survives. The language key itself stays plain text, which keeps source-format happy and leaves non-CMS uses of the same key untouched.

# Why doesn't this include any test?

This is a stylistic change. The handler tweak only exists so the title arg renders bold and underlined for one notification flow; the resulting visual treatment is best verified by viewing a CMS review-date notification in the running portal.

This PR covers only the message-text portion of the styling delta. The remaining items — full-row blue background on unread, corner-radius orientation, and the body text inheriting the outer anchor's underline — belong to the notifications panel and theme. See https://liferay.atlassian.net/browse/LPD-79668?focusedCommentId=5084844 for the breakdown.