### PR TITLE
LPD-89764 We can list spaces in the collection display configuration even if the space is not connected 

### DIFF
--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/web/internal/util/test/DepotEntryAdminSearchProviderTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/web/internal/util/test/DepotEntryAdminSearchProviderTest.java
@@ -17,6 +17,7 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionRequest;
 import com.liferay.portal.kernel.test.portlet.MockLiferayPortletRenderRequest;
 import com.liferay.portal.kernel.test.portlet.MockLiferayPortletRenderResponse;
@@ -33,6 +34,7 @@ import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.site.search.GroupSearch;
 
 import jakarta.portlet.PortletRequest;
 import jakarta.portlet.PortletResponse;
@@ -130,30 +132,210 @@ public class DepotEntryAdminSearchProviderTest {
 				new MockLiferayPortletURL()));
 	}
 
-	private void _addDepotEntries() throws Exception {
-		_keywords = RandomTestUtil.randomString();
+	@Test
+	@TestInfo("LPD-89764")
+	public void testGetGroupSearchWithKeywordsAndUnconnectedDepotEntry()
+		throws Exception {
 
-		for (int i = 0; i < 3; i++) {
-			_addDepotEntry(_keywords + i);
-		}
-
-		_addDepotEntry(RandomTestUtil.randomString());
-
-		DepotEntry stagedDepotEntry = _addDepotEntry(
-			RandomTestUtil.randomString());
-
-		GroupTestUtil.enableLocalStaging(stagedDepotEntry.getGroup());
-	}
-
-	private DepotEntry _addDepotEntry(String depotEntryName) throws Exception {
 		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
-			Collections.singletonMap(LocaleUtil.getDefault(), depotEntryName),
+			Collections.singletonMap(LocaleUtil.getDefault(), _keywords),
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
 			DepotConstants.TYPE_ASSET_LIBRARY,
 			ServiceContextTestUtil.getServiceContext());
 
-		_initialDepotEntries.add(depotEntry);
+		_depotEntries.add(depotEntry);
+
+		GroupItemSelectorCriterion groupItemSelectorCriterion =
+			new GroupItemSelectorCriterion();
+
+		groupItemSelectorCriterion.setIncludeAllVisibleGroups(false);
+
+		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
+			new MockLiferayPortletActionRequest();
+
+		mockLiferayPortletActionRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, _getThemeDisplay());
+
+		mockLiferayPortletActionRequest.setParameter("keywords", _keywords);
+
+		_assertDepotEntries(
+			3,
+			ReflectionTestUtil.invoke(
+				_depotEntryAdminSearchProvider, "getDepotEntrySearch",
+				new Class<?>[] {
+					GroupItemSelectorCriterion.class, PortletRequest.class,
+					PortletResponse.class, PortletURL.class
+				},
+				groupItemSelectorCriterion, mockLiferayPortletActionRequest,
+				new MockLiferayPortletRenderResponse(),
+				new MockLiferayPortletURL()));
+	}
+
+	@Test
+	@TestInfo("LPD-89764")
+	public void testGetGroupSearchWithKeywordsAndUnconnectedSpaceDepotEntry()
+		throws Exception {
+
+		DepotEntry depotEntry1 = _addDepotEntry(
+			_keywords, DepotConstants.TYPE_SPACE);
+
+		DepotEntry depotEntry2 = _depotEntryLocalService.addDepotEntry(
+			Collections.singletonMap(
+				LocaleUtil.getDefault(),
+				_keywords + RandomTestUtil.randomString()),
+			Collections.singletonMap(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
+			DepotConstants.TYPE_SPACE,
+			ServiceContextTestUtil.getServiceContext());
+
+		_depotEntries.add(depotEntry2);
+
+		GroupItemSelectorCriterion groupItemSelectorCriterion =
+			new GroupItemSelectorCriterion();
+
+		groupItemSelectorCriterion.setDepotEntryType(DepotConstants.TYPE_SPACE);
+		groupItemSelectorCriterion.setIncludeAllVisibleGroups(false);
+
+		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
+			new MockLiferayPortletActionRequest();
+
+		mockLiferayPortletActionRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, _getThemeDisplay());
+
+		mockLiferayPortletActionRequest.setParameter("keywords", _keywords);
+
+		GroupSearch groupSearch = ReflectionTestUtil.invoke(
+			_depotEntryAdminSearchProvider, "getGroupSearch",
+			new Class<?>[] {
+				GroupItemSelectorCriterion.class, PortletRequest.class,
+				PortletResponse.class, PortletURL.class
+			},
+			groupItemSelectorCriterion, mockLiferayPortletActionRequest,
+			new MockLiferayPortletRenderResponse(),
+			new MockLiferayPortletURL());
+
+		Assert.assertEquals(1, groupSearch.getTotal());
+
+		List<Group> groups = groupSearch.getResults();
+
+		Assert.assertTrue(groups.contains(depotEntry1.getGroup()));
+		Assert.assertFalse(groups.contains(depotEntry2.getGroup()));
+	}
+
+	@Test
+	@TestInfo("LPD-89764")
+	public void testGetGroupSearchWithUnconnectedDepotEntries()
+		throws Exception {
+
+		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
+			Collections.singletonMap(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
+			Collections.singletonMap(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
+			DepotConstants.TYPE_ASSET_LIBRARY,
+			ServiceContextTestUtil.getServiceContext());
+
+		_depotEntries.add(depotEntry);
+
+		GroupItemSelectorCriterion groupItemSelectorCriterion =
+			new GroupItemSelectorCriterion();
+
+		groupItemSelectorCriterion.setIncludeAllVisibleGroups(false);
+
+		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
+			new MockLiferayPortletActionRequest();
+
+		mockLiferayPortletActionRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, _getThemeDisplay());
+
+		_assertDepotEntries(
+			5,
+			ReflectionTestUtil.invoke(
+				_depotEntryAdminSearchProvider, "getDepotEntrySearch",
+				new Class<?>[] {
+					GroupItemSelectorCriterion.class, PortletRequest.class,
+					PortletResponse.class, PortletURL.class
+				},
+				groupItemSelectorCriterion, mockLiferayPortletActionRequest,
+				new MockLiferayPortletRenderResponse(),
+				new MockLiferayPortletURL()));
+	}
+
+	@Test
+	@TestInfo("LPD-89764")
+	public void testGetGroupSearchWithUnconnectedSpaceDepotEntries()
+		throws Exception {
+
+		DepotEntry depotEntry1 = _addDepotEntry(
+			RandomTestUtil.randomString(), DepotConstants.TYPE_SPACE);
+
+		DepotEntry depotEntry2 = _depotEntryLocalService.addDepotEntry(
+			Collections.singletonMap(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
+			Collections.singletonMap(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
+			DepotConstants.TYPE_SPACE,
+			ServiceContextTestUtil.getServiceContext());
+
+		_depotEntries.add(depotEntry2);
+
+		GroupItemSelectorCriterion groupItemSelectorCriterion =
+			new GroupItemSelectorCriterion();
+
+		groupItemSelectorCriterion.setDepotEntryType(DepotConstants.TYPE_SPACE);
+		groupItemSelectorCriterion.setIncludeAllVisibleGroups(false);
+
+		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
+			new MockLiferayPortletActionRequest();
+
+		mockLiferayPortletActionRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, _getThemeDisplay());
+
+		GroupSearch groupSearch = ReflectionTestUtil.invoke(
+			_depotEntryAdminSearchProvider, "getGroupSearch",
+			new Class<?>[] {
+				GroupItemSelectorCriterion.class, PortletRequest.class,
+				PortletResponse.class, PortletURL.class
+			},
+			groupItemSelectorCriterion, mockLiferayPortletActionRequest,
+			new MockLiferayPortletRenderResponse(),
+			new MockLiferayPortletURL());
+
+		Assert.assertEquals(1, groupSearch.getTotal());
+
+		List<Group> groups = groupSearch.getResults();
+
+		Assert.assertTrue(groups.contains(depotEntry1.getGroup()));
+		Assert.assertFalse(groups.contains(depotEntry2.getGroup()));
+	}
+
+	private void _addDepotEntries() throws Exception {
+		_keywords = RandomTestUtil.randomString();
+
+		for (int i = 0; i < 3; i++) {
+			_addDepotEntry(_keywords + i, DepotConstants.TYPE_ASSET_LIBRARY);
+		}
+
+		_addDepotEntry(
+			RandomTestUtil.randomString(), DepotConstants.TYPE_ASSET_LIBRARY);
+
+		DepotEntry stagedDepotEntry = _addDepotEntry(
+			RandomTestUtil.randomString(), DepotConstants.TYPE_ASSET_LIBRARY);
+
+		GroupTestUtil.enableLocalStaging(stagedDepotEntry.getGroup());
+	}
+
+	private DepotEntry _addDepotEntry(String depotEntryName, int type)
+		throws Exception {
+
+		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
+			Collections.singletonMap(LocaleUtil.getDefault(), depotEntryName),
+			Collections.singletonMap(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
+			type, ServiceContextTestUtil.getServiceContext());
+
+		_depotEntries.add(depotEntry);
 
 		_depotEntryGroupRelLocalService.addDepotEntryGroupRel(
 			depotEntry.getDepotEntryId(), _group.getGroupId());
@@ -169,7 +351,7 @@ public class DepotEntryAdminSearchProviderTest {
 		List<DepotEntry> curDepotEntries = depotEntrySearch.getResults();
 
 		for (int i = 0; i < total; i++) {
-			DepotEntry depotEntry1 = _initialDepotEntries.get(i);
+			DepotEntry depotEntry1 = _depotEntries.get(i);
 
 			DepotEntry depotEntry2 = curDepotEntries.get(i);
 
@@ -220,6 +402,9 @@ public class DepotEntryAdminSearchProviderTest {
 	@Inject
 	private CompanyLocalService _companyLocalService;
 
+	@DeleteAfterTestRun
+	private final List<DepotEntry> _depotEntries = new ArrayList<>();
+
 	private Object _depotEntryAdminSearchProvider;
 
 	@Inject
@@ -229,10 +414,6 @@ public class DepotEntryAdminSearchProviderTest {
 	private DepotEntryLocalService _depotEntryLocalService;
 
 	private Group _group;
-
-	@DeleteAfterTestRun
-	private final List<DepotEntry> _initialDepotEntries = new ArrayList<>();
-
 	private String _keywords;
 
 	@Inject(

--- a/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/util/DepotEntryAdminSearchProvider.java
+++ b/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/util/DepotEntryAdminSearchProvider.java
@@ -7,14 +7,15 @@ package com.liferay.depot.web.internal.util;
 
 import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.model.DepotEntryGroupRel;
 import com.liferay.depot.search.DepotEntrySearch;
+import com.liferay.depot.service.DepotEntryGroupRelLocalService;
 import com.liferay.depot.service.DepotEntryService;
 import com.liferay.item.selector.criteria.group.criterion.GroupItemSelectorCriterion;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
-import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
 import com.liferay.portal.kernel.search.BooleanClause;
 import com.liferay.portal.kernel.search.BooleanClauseOccur;
@@ -29,10 +30,9 @@ import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.BooleanFilter;
 import com.liferay.portal.kernel.search.filter.TermsFilter;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
-import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.site.search.GroupSearch;
@@ -41,9 +41,8 @@ import jakarta.portlet.PortletRequest;
 import jakarta.portlet.PortletResponse;
 import jakarta.portlet.PortletURL;
 
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
-import java.util.Locale;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -103,38 +102,27 @@ public class DepotEntryAdminSearchProvider {
 		return groupSearch;
 	}
 
-	private List<DepotEntry> _filterDepotEntries(
-			List<DepotEntry> depotEntries, String keywords, Locale locale)
-		throws PortalException {
-
-		List<DepotEntry> filteredDepotEntries = new ArrayList<>();
-
-		keywords = StringUtil.toLowerCase(keywords);
-
-		for (DepotEntry depotEntry : depotEntries) {
-			Group group = depotEntry.getGroup();
-
-			String descriptiveName = StringUtil.toLowerCase(
-				group.getDescriptiveName(locale));
-
-			if (descriptiveName.contains(keywords)) {
-				filteredDepotEntries.add(depotEntry);
-			}
-		}
-
-		return filteredDepotEntries;
-	}
-
-	private BooleanClause[] _getBooleanClauses() {
+	private BooleanClause[] _getBooleanClauses(long[] depotEntryIds) {
 		BooleanQuery booleanQuery = new BooleanQuery();
 
 		BooleanFilter booleanFilter = new BooleanFilter();
 
-		TermsFilter termsFilter = new TermsFilter(Field.STAGING_GROUP);
+		if (ArrayUtil.isNotEmpty(depotEntryIds)) {
+			TermsFilter entryClassPKTermsFilter = new TermsFilter(
+				Field.ENTRY_CLASS_PK);
 
-		termsFilter.addValue("false");
+			entryClassPKTermsFilter.addValues(
+				ArrayUtil.toStringArray(depotEntryIds));
 
-		booleanFilter.add(termsFilter, BooleanClauseOccur.MUST);
+			booleanFilter.add(entryClassPKTermsFilter, BooleanClauseOccur.MUST);
+		}
+
+		TermsFilter stagingGroupTermsFilter = new TermsFilter(
+			Field.STAGING_GROUP);
+
+		stagingGroupTermsFilter.addValue("false");
+
+		booleanFilter.add(stagingGroupTermsFilter, BooleanClauseOccur.MUST);
 
 		booleanQuery.setPreBooleanFilter(booleanFilter);
 
@@ -157,8 +145,9 @@ public class DepotEntryAdminSearchProvider {
 				(depotEntryType == DepotConstants.TYPE_SPACE) ?
 					"no-spaces-were-found" : "no-asset-libraries-were-found"));
 		depotEntrySearch.setResultsAndTotal(
-			() -> _getResults(depotEntryType, depotEntrySearch, portletRequest),
-			_getTotal(depotEntryType, portletRequest));
+			() -> _getResults(
+				null, depotEntrySearch, depotEntryType, portletRequest),
+			_getTotal(null, depotEntryType, portletRequest));
 
 		return depotEntrySearch;
 	}
@@ -193,31 +182,37 @@ public class DepotEntryAdminSearchProvider {
 			return depotEntrySearch;
 		}
 
-		List<DepotEntry> depotEntries = _filterDepotEntries(
-			_depotEntryService.getGroupConnectedDepotEntries(
+		long[] depotEntryIds = TransformUtil.transformToLongArray(
+			_depotEntryGroupRelLocalService.getDepotEntryGroupRels(
 				themeDisplay.getScopeGroupId(), depotEntryType,
 				QueryUtil.ALL_POS, QueryUtil.ALL_POS),
-			keywords, themeDisplay.getLocale());
+			DepotEntryGroupRel::getDepotEntryId);
+
+		if (ArrayUtil.isEmpty(depotEntryIds)) {
+			depotEntrySearch.setResultsAndTotal(Collections::emptyList, 0);
+
+			return depotEntrySearch;
+		}
 
 		depotEntrySearch.setResultsAndTotal(
-			() -> ListUtil.subList(
-				depotEntries, depotEntrySearch.getStart(),
-				depotEntrySearch.getEnd()),
-			depotEntries.size());
+			() -> _getResults(
+				depotEntryIds, depotEntrySearch, depotEntryType,
+				portletRequest),
+			_getTotal(depotEntryIds, depotEntryType, portletRequest));
 
 		return depotEntrySearch;
 	}
 
 	private List<DepotEntry> _getResults(
-			int depotEntryType, DepotEntrySearch depotEntrySearch,
-			PortletRequest portletRequest)
+			long[] depotEntryIds, DepotEntrySearch depotEntrySearch,
+			int depotEntryType, PortletRequest portletRequest)
 		throws PortalException {
 
 		Indexer<Object> indexer = IndexerRegistryUtil.getIndexer(
 			DepotEntry.class.getName());
 
 		SearchContext searchContext = _getSearchContext(
-			depotEntryType, portletRequest);
+			depotEntryIds, depotEntryType, portletRequest);
 
 		searchContext.setEnd(depotEntrySearch.getEnd());
 		searchContext.setSorts(new Sort(Field.NAME, false));
@@ -232,17 +227,21 @@ public class DepotEntryAdminSearchProvider {
 	}
 
 	private SearchContext _getSearchContext(
-		int depotEntryType, PortletRequest portletRequest) {
+		long[] depotEntryIds, int depotEntryType,
+		PortletRequest portletRequest) {
 
 		SearchContext searchContext = new SearchContext();
 
 		searchContext.setAttribute(Field.TYPE, depotEntryType);
-		searchContext.setBooleanClauses(_getBooleanClauses());
+
+		searchContext.setBooleanClauses(_getBooleanClauses(depotEntryIds));
 
 		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
 		searchContext.setCompanyId(themeDisplay.getCompanyId());
+
+		searchContext.setIncludeStagingGroups(false);
 
 		String keywords = ParamUtil.getString(portletRequest, "keywords");
 
@@ -253,15 +252,20 @@ public class DepotEntryAdminSearchProvider {
 		return searchContext;
 	}
 
-	private int _getTotal(int depotEntryType, PortletRequest portletRequest)
+	private int _getTotal(
+			long[] depotEntryIds, int depotEntryType,
+			PortletRequest portletRequest)
 		throws SearchException {
 
 		Indexer<Object> indexer = IndexerRegistryUtil.getIndexer(
 			DepotEntry.class.getName());
 
 		return (int)indexer.searchCount(
-			_getSearchContext(depotEntryType, portletRequest));
+			_getSearchContext(depotEntryIds, depotEntryType, portletRequest));
 	}
+
+	@Reference
+	private DepotEntryGroupRelLocalService _depotEntryGroupRelLocalService;
 
 	@Reference
 	private DepotEntryService _depotEntryService;

--- a/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/util/DepotEntryAdminSearchProvider.java
+++ b/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/util/DepotEntryAdminSearchProvider.java
@@ -82,9 +82,9 @@ public class DepotEntryAdminSearchProvider {
 			PortletURL portletURL)
 		throws PortalException {
 
-		DepotEntrySearch depotEntrySearch = _getDepotEntrySearch(
-			groupItemSelectorCriterion.getDepotEntryType(), portletRequest,
-			portletResponse, portletURL);
+		DepotEntrySearch depotEntrySearch = getDepotEntrySearch(
+			groupItemSelectorCriterion, portletRequest, portletResponse,
+			portletURL);
 
 		GroupSearch groupSearch = new GroupSearch(portletRequest, portletURL);
 

--- a/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/util/DepotEntryAdminSearchProvider.java
+++ b/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/util/DepotEntryAdminSearchProvider.java
@@ -153,7 +153,9 @@ public class DepotEntryAdminSearchProvider {
 
 		depotEntrySearch.setEmptyResultsMessage(
 			_language.get(
-				portletRequest.getLocale(), "no-asset-libraries-were-found"));
+				portletRequest.getLocale(),
+				(depotEntryType == DepotConstants.TYPE_SPACE) ?
+					"no-spaces-were-found" : "no-asset-libraries-were-found"));
 		depotEntrySearch.setResultsAndTotal(
 			() -> _getResults(depotEntryType, depotEntrySearch, portletRequest),
 			_getTotal(depotEntryType, portletRequest));

--- a/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/util/DepotEntryAdminSearchProvider.java
+++ b/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/util/DepotEntryAdminSearchProvider.java
@@ -11,8 +11,10 @@ import com.liferay.depot.search.DepotEntrySearch;
 import com.liferay.depot.service.DepotEntryService;
 import com.liferay.item.selector.criteria.group.criterion.GroupItemSelectorCriterion;
 import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
 import com.liferay.portal.kernel.search.BooleanClause;
 import com.liferay.portal.kernel.search.BooleanClauseOccur;
@@ -28,7 +30,9 @@ import com.liferay.portal.kernel.search.filter.BooleanFilter;
 import com.liferay.portal.kernel.search.filter.TermsFilter;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.site.search.GroupSearch;
@@ -37,7 +41,9 @@ import jakarta.portlet.PortletRequest;
 import jakarta.portlet.PortletResponse;
 import jakarta.portlet.PortletURL;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -54,9 +60,7 @@ public class DepotEntryAdminSearchProvider {
 			PortletURL portletURL)
 		throws PortalException {
 
-		if (Validator.isNull(ParamUtil.getString(portletRequest, "keywords")) &&
-			!groupItemSelectorCriterion.isIncludeAllVisibleGroups()) {
-
+		if (!groupItemSelectorCriterion.isIncludeAllVisibleGroups()) {
 			return _getGroupConnectedDepotEntrySearch(
 				groupItemSelectorCriterion.getDepotEntryType(), portletRequest,
 				portletResponse, portletURL);
@@ -97,6 +101,28 @@ public class DepotEntryAdminSearchProvider {
 			depotEntrySearch.getTotal());
 
 		return groupSearch;
+	}
+
+	private List<DepotEntry> _filterDepotEntries(
+			List<DepotEntry> depotEntries, String keywords, Locale locale)
+		throws PortalException {
+
+		List<DepotEntry> filteredDepotEntries = new ArrayList<>();
+
+		keywords = StringUtil.toLowerCase(keywords);
+
+		for (DepotEntry depotEntry : depotEntries) {
+			Group group = depotEntry.getGroup();
+
+			String descriptiveName = StringUtil.toLowerCase(
+				group.getDescriptiveName(locale));
+
+			if (descriptiveName.contains(keywords)) {
+				filteredDepotEntries.add(depotEntry);
+			}
+		}
+
+		return filteredDepotEntries;
 	}
 
 	private BooleanClause[] _getBooleanClauses() {
@@ -151,12 +177,31 @@ public class DepotEntryAdminSearchProvider {
 				portletRequest.getLocale(),
 				(depotEntryType == DepotConstants.TYPE_SPACE) ?
 					"no-spaces-were-found" : "no-asset-libraries-were-found"));
-		depotEntrySearch.setResultsAndTotal(
-			() -> _depotEntryService.getGroupConnectedDepotEntries(
+
+		String keywords = ParamUtil.getString(portletRequest, "keywords");
+
+		if (Validator.isNull(keywords)) {
+			depotEntrySearch.setResultsAndTotal(
+				() -> _depotEntryService.getGroupConnectedDepotEntries(
+					themeDisplay.getScopeGroupId(), depotEntryType,
+					depotEntrySearch.getStart(), depotEntrySearch.getEnd()),
+				_depotEntryService.getGroupConnectedDepotEntriesCount(
+					themeDisplay.getScopeGroupId(), depotEntryType));
+
+			return depotEntrySearch;
+		}
+
+		List<DepotEntry> depotEntries = _filterDepotEntries(
+			_depotEntryService.getGroupConnectedDepotEntries(
 				themeDisplay.getScopeGroupId(), depotEntryType,
-				depotEntrySearch.getStart(), depotEntrySearch.getEnd()),
-			_depotEntryService.getGroupConnectedDepotEntriesCount(
-				themeDisplay.getScopeGroupId(), depotEntryType));
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS),
+			keywords, themeDisplay.getLocale());
+
+		depotEntrySearch.setResultsAndTotal(
+			() -> ListUtil.subList(
+				depotEntries, depotEntrySearch.getStart(),
+				depotEntrySearch.getEnd()),
+			depotEntries.size());
 
 		return depotEntrySearch;
 	}


### PR DESCRIPTION
LPD-89764 Filter disconnected depots out of the group item selector

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-89764

In a Site's *Collection Display* configuration, opening *Configure Scope* → *Browse* listed every Space in the company, including those not connected to the Site. Both the default browse and the keyword-search box exposed unconnected depots.

`DepotEntryAdminSearchProvider#getGroupSearch` always delegated to the indexer-backed `_getDepotEntrySearch`, which queries every `DepotEntry` in the company. The sibling overload `getDepotEntrySearch(criterion, ...)` already routed through the connection-aware lookup, but only when no keyword was typed — as soon as the user searched, it fell back to the same unfiltered indexer query. The connection contract (a Site sees a Space's content only through `DepotEntryGroupRel`) was never enforced in the picker.

# How am I fixing it?

`getDepotEntrySearch(criterion, ...)` now always routes to `_getGroupConnectedDepotEntrySearch` whenever `isIncludeAllVisibleGroups()` is `false`, regardless of keywords. `_getGroupConnectedDepotEntrySearch` loads the connected depots via `DepotEntryService#getGroupConnectedDepotEntries` and applies the keyword filter in memory against `Group#getDescriptiveName(locale)`. `getGroupSearch` collapses into a thin wrapper that delegates to the criterion-aware overload, so the picker and any caller using `GroupItemSelectorCriterion` share the same connection-respecting behavior.

# How can you verify that it works?

Run the included automated tests.

# Commits

- 2ac89a0f7ca68 LPD-89764 add tests
- 60ac1b74cea3c LPD-89764 change message depending on depotEntryType
- 237d54b4936eb LPD-89764 Filter disconnected depots out of the group item selector
- d5ed2c98dcc9e LPD-89764 use the main method to show only the conected