### PR TITLE
LPD-91409 Include scope ERC in Asset Vocabulary item selector payload

### DIFF
--- a/modules/apps/asset/asset-vocabulary-item-selector-web/src/main/java/com/liferay/asset/vocabulary/item/selector/web/internal/AssetVocabularyItemDescriptor.java
+++ b/modules/apps/asset/asset-vocabulary-item-selector-web/src/main/java/com/liferay/asset/vocabulary/item/selector/web/internal/AssetVocabularyItemDescriptor.java
@@ -67,6 +67,24 @@ public class AssetVocabularyItemDescriptor
 		).put(
 			"groupId", String.valueOf(_assetVocabulary.getGroupId())
 		).put(
+			"scopeExternalReferenceCode",
+			() -> {
+				long scopeGroupId = themeDisplay.getRefererGroupId();
+
+				if (scopeGroupId <= 0) {
+					scopeGroupId = themeDisplay.getScopeGroupId();
+				}
+
+				if (_assetVocabulary.getGroupId() == scopeGroupId) {
+					return null;
+				}
+
+				Group group = GroupLocalServiceUtil.getGroup(
+					_assetVocabulary.getGroupId());
+
+				return group.getExternalReferenceCode();
+			}
+		).put(
 			"title", _assetVocabulary.getTitle(themeDisplay.getLocale())
 		).put(
 			"uuid", _assetVocabulary.getUuid()

--- a/modules/apps/asset/asset-vocabulary-item-selector-web/src/test/java/com/liferay/asset/vocabulary/item/selector/web/internal/AssetVocabularyItemDescriptorTest.java
+++ b/modules/apps/asset/asset-vocabulary-item-selector-web/src/test/java/com/liferay/asset/vocabulary/item/selector/web/internal/AssetVocabularyItemDescriptorTest.java
@@ -1,0 +1,189 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.asset.vocabulary.item.selector.web.internal;
+
+import com.liferay.asset.kernel.model.AssetVocabulary;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * @author Jonathan McCann
+ */
+public class AssetVocabularyItemDescriptorTest {
+
+	@ClassRule
+	public static LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	@TestInfo("LPD-91409")
+	public void testGetPayload() throws Exception {
+		long groupId = RandomTestUtil.randomLong();
+		String externalReferenceCode = RandomTestUtil.randomString();
+		String scopeExternalReferenceCode = RandomTestUtil.randomString();
+		String title = RandomTestUtil.randomString();
+		String uuid = RandomTestUtil.randomString();
+		long vocabularyId = RandomTestUtil.randomLong();
+
+		_setUpAssetVocabulary(
+			externalReferenceCode, groupId, title, uuid, vocabularyId);
+
+		AssetVocabularyItemDescriptor assetVocabularyItemDescriptor =
+			new AssetVocabularyItemDescriptor(
+				_assetVocabulary, _httpServletRequest);
+
+		_setUpThemeDisplay(0, groupId);
+
+		Assert.assertEquals(
+			JSONUtil.put(
+				"assetVocabularyId", String.valueOf(vocabularyId)
+			).put(
+				"externalReferenceCode", externalReferenceCode
+			).put(
+				"groupId", String.valueOf(groupId)
+			).put(
+				"title", title
+			).put(
+				"uuid", uuid
+			).toString(),
+			assetVocabularyItemDescriptor.getPayload());
+
+		_setUpThemeDisplay(groupId, RandomTestUtil.randomLong());
+
+		Assert.assertEquals(
+			JSONUtil.put(
+				"assetVocabularyId", String.valueOf(vocabularyId)
+			).put(
+				"externalReferenceCode", externalReferenceCode
+			).put(
+				"groupId", String.valueOf(groupId)
+			).put(
+				"title", title
+			).put(
+				"uuid", uuid
+			).toString(),
+			assetVocabularyItemDescriptor.getPayload());
+
+		_setUpThemeDisplay(0, RandomTestUtil.randomLong());
+
+		try (MockedStatic<GroupLocalServiceUtil>
+				groupLocalServiceUtilMockedStatic = Mockito.mockStatic(
+					GroupLocalServiceUtil.class)) {
+
+			Group group = Mockito.mock(Group.class);
+
+			Mockito.when(
+				group.getExternalReferenceCode()
+			).thenReturn(
+				scopeExternalReferenceCode
+			);
+
+			groupLocalServiceUtilMockedStatic.when(
+				() -> GroupLocalServiceUtil.getGroup(groupId)
+			).thenReturn(
+				group
+			);
+
+			Assert.assertEquals(
+				JSONUtil.put(
+					"assetVocabularyId", String.valueOf(vocabularyId)
+				).put(
+					"externalReferenceCode", externalReferenceCode
+				).put(
+					"groupId", String.valueOf(groupId)
+				).put(
+					"scopeExternalReferenceCode", scopeExternalReferenceCode
+				).put(
+					"title", title
+				).put(
+					"uuid", uuid
+				).toString(),
+				assetVocabularyItemDescriptor.getPayload());
+		}
+	}
+
+	private void _setUpAssetVocabulary(
+		String externalReferenceCode, long groupId, String title, String uuid,
+		long vocabularyId) {
+
+		Mockito.when(
+			_assetVocabulary.getExternalReferenceCode()
+		).thenReturn(
+			externalReferenceCode
+		);
+
+		Mockito.when(
+			_assetVocabulary.getGroupId()
+		).thenReturn(
+			groupId
+		);
+
+		Mockito.when(
+			_assetVocabulary.getTitle(LocaleUtil.US)
+		).thenReturn(
+			title
+		);
+
+		Mockito.when(
+			_assetVocabulary.getUuid()
+		).thenReturn(
+			uuid
+		);
+
+		Mockito.when(
+			_assetVocabulary.getVocabularyId()
+		).thenReturn(
+			vocabularyId
+		);
+	}
+
+	private void _setUpThemeDisplay(long refererGroupId, long scopeGroupId) {
+		Mockito.when(
+			_themeDisplay.getLocale()
+		).thenReturn(
+			LocaleUtil.US
+		);
+
+		Mockito.when(
+			_themeDisplay.getRefererGroupId()
+		).thenReturn(
+			refererGroupId
+		);
+
+		Mockito.when(
+			_themeDisplay.getScopeGroupId()
+		).thenReturn(
+			scopeGroupId
+		);
+
+		_httpServletRequest.setAttribute(WebKeys.THEME_DISPLAY, _themeDisplay);
+	}
+
+	private final AssetVocabulary _assetVocabulary = Mockito.mock(
+		AssetVocabulary.class);
+	private final HttpServletRequest _httpServletRequest =
+		new MockHttpServletRequest();
+	private final ThemeDisplay _themeDisplay = Mockito.mock(ThemeDisplay.class);
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91409

## What is being fixed

The Asset Vocabulary item-selector picker emits a payload that omits `scopeExternalReferenceCode`. When a user picks a vocabulary from a group other than the current scope (for example, the Global `Topic` vocabulary while editing a navigation menu in a site), the AJAX call to refresh the sidebar fails with `NoSuchVocabularyException` because the resource command falls back to the current scope group. Saving the menu item also persists an empty scope ERC, causing later renders to resolve against the wrong group.

## How it is being fixed

`AssetVocabularyItemDescriptor.getPayload()` now emits `scopeExternalReferenceCode` when the picked vocabulary's group differs from the current scope, mirroring the established pattern in `BlogsEntryItemSelectorView`, `JournalArticleItemSelectorViewDisplayContext`, `ObjectEntryItemDescriptor`, and `CPDefinitionItemSelectorView`. The emitter resolves the current scope from `themeDisplay.getRefererGroupId()` (falling back to `getScopeGroupId()`), returns `null` when the vocabulary is in the current scope (preserving the relative-reference semantic the other descriptors use), and otherwise looks up the vocabulary's group via `GroupLocalServiceUtil.fetchGroup()` and returns its ERC.