### PR TITLE
LPD-91460 Technical Task | Fix DisplayContext CMS test

### DIFF
--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/BaseSectionDisplayContextTestCase.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/BaseSectionDisplayContextTestCase.java
@@ -722,6 +722,7 @@ public abstract class BaseSectionDisplayContextTestCase
 			"&nestedFields=embedded,embeddedTaxonomyCategory,",
 			"file.metadata,file.previewURL,file.thumbnailURL,",
 			"numberOfObjectEntries,numberOfObjectEntryFolders,",
+			"systemProperties.collaboratorBrief,",
 			"systemProperties.objectDefinitionBrief&sort=dateModified:desc");
 	}
 

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewAllSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewAllSectionDisplayContextTest.java
@@ -106,7 +106,7 @@ public class ViewAllSectionDisplayContextTest
 			getBulkActionDropdownItems();
 
 		Assert.assertEquals(
-			bulkActionDropdownItems.toString(), 14,
+			bulkActionDropdownItems.toString(), 15,
 			bulkActionDropdownItems.size());
 
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
@@ -117,39 +117,42 @@ public class ViewAllSectionDisplayContextTest
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
 			"copy", "copy-to", "Copy To", null, bulkActionDropdownItems.get(2));
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
-			"time", "expire", "Expire", null, bulkActionDropdownItems.get(3));
+			"copy", "duplicate", "Duplicate", null,
+			bulkActionDropdownItems.get(3));
+		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
+			"time", "expire", "Expire", null, bulkActionDropdownItems.get(4));
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
 			"upload", "export-for-translation", "Export for Translation", null,
-			bulkActionDropdownItems.get(4));
-		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
-			"download", "download", "Download", null,
 			bulkActionDropdownItems.get(5));
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
-			"pencil", "edit-categories", "Edit Categories", "post",
+			"download", "download", "Download", null,
 			bulkActionDropdownItems.get(6));
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
-			"pencil", "edit-tags", "Edit Tags", "post",
+			"pencil", "edit-categories", "Edit Categories", "post",
 			bulkActionDropdownItems.get(7));
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
-			"semantic-search", "find-and-replace", "Find and Replace", null,
+			"pencil", "edit-tags", "Edit Tags", "post",
 			bulkActionDropdownItems.get(8));
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
-			"password-policies", "permissions", "Permissions", null,
+			"semantic-search", "find-and-replace", "Find and Replace", null,
 			bulkActionDropdownItems.get(9));
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
+			"password-policies", "permissions", "Permissions", null,
+			bulkActionDropdownItems.get(10));
+		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
 			"password-policies", "default-permissions", "Default Permissions",
-			null, bulkActionDropdownItems.get(10));
+			null, bulkActionDropdownItems.get(11));
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
 			"password-policies", "edit-default-permissions-by-role",
 			"Edit Default Permissions by Role", null,
-			bulkActionDropdownItems.get(11));
+			bulkActionDropdownItems.get(12));
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
 			"password-policies", "edit-permissions-by-role",
-			"Edit Permissions by Role", null, bulkActionDropdownItems.get(12));
+			"Edit Permissions by Role", null, bulkActionDropdownItems.get(13));
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
 			"password-policies", "reset-to-default-permissions",
 			"Reset to Default Permissions", null,
-			bulkActionDropdownItems.get(13));
+			bulkActionDropdownItems.get(14));
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewContentsSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewContentsSectionDisplayContextTest.java
@@ -95,6 +95,9 @@ public class ViewContentsSectionDisplayContextTest
 			"copy", "copy-to", "Copy To", null, bulkActionDropdownItems.get(2));
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
 			"time", "expire", "Expire", null, bulkActionDropdownItems.get(3));
+			"copy", "duplicate", "Duplicate", null,
+			bulkActionDropdownItems.get(3));
+		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
 			"upload", "export-for-translation", "Export for Translation", null,
 			bulkActionDropdownItems.get(4));
@@ -168,8 +171,27 @@ public class ViewContentsSectionDisplayContextTest
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
 			"move-folder", "move", "Move", null,
 			fdsActionDropdownItems.get(10));
+
+		FDSActionDropdownItem copyFDSActionDropdownItem =
+			fdsActionDropdownItems.get(11);
+
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
-			"copy", "copy", "Copy To", null, fdsActionDropdownItems.get(11));
+			"copy", "copy-menu", "Copy", null, "contextual", null,
+			copyFDSActionDropdownItem);
+
+		List<FDSActionDropdownItem> copyFDSActionDropdownItems =
+			(List<FDSActionDropdownItem>)copyFDSActionDropdownItem.get("items");
+
+		Assert.assertEquals(
+			copyFDSActionDropdownItems.toString(), 2,
+			copyFDSActionDropdownItems.size());
+
+		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
+			"copy", "copy", "Copy To", null, copyFDSActionDropdownItems.get(0));
+		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
+			"copy", "duplicate", "Duplicate", null,
+			copyFDSActionDropdownItems.get(1));
+
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
 			"upload", "export-for-translation", "Export for Translation", null,
 			fdsActionDropdownItems.get(12));

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewContentsSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewContentsSectionDisplayContextTest.java
@@ -83,7 +83,7 @@ public class ViewContentsSectionDisplayContextTest
 			getBulkActionDropdownItems();
 
 		Assert.assertEquals(
-			bulkActionDropdownItems.toString(), 12,
+			bulkActionDropdownItems.toString(), 13,
 			bulkActionDropdownItems.size());
 
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
@@ -94,36 +94,36 @@ public class ViewContentsSectionDisplayContextTest
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
 			"copy", "copy-to", "Copy To", null, bulkActionDropdownItems.get(2));
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
-			"time", "expire", "Expire", null, bulkActionDropdownItems.get(3));
 			"copy", "duplicate", "Duplicate", null,
 			bulkActionDropdownItems.get(3));
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
+			"time", "expire", "Expire", null, bulkActionDropdownItems.get(4));
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
 			"upload", "export-for-translation", "Export for Translation", null,
-			bulkActionDropdownItems.get(4));
-		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
-			"pencil", "edit-categories", "Edit Categories", "post",
 			bulkActionDropdownItems.get(5));
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
-			"pencil", "edit-tags", "Edit Tags", "post",
+			"pencil", "edit-categories", "Edit Categories", "post",
 			bulkActionDropdownItems.get(6));
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
-			"password-policies", "permissions", "Permissions", null,
+			"pencil", "edit-tags", "Edit Tags", "post",
 			bulkActionDropdownItems.get(7));
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
+			"password-policies", "permissions", "Permissions", null,
+			bulkActionDropdownItems.get(8));
+		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
 			"password-policies", "default-permissions", "Default Permissions",
-			null, bulkActionDropdownItems.get(8));
+			null, bulkActionDropdownItems.get(9));
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
 			"password-policies", "edit-default-permissions-by-role",
 			"Edit Default Permissions by Role", null,
-			bulkActionDropdownItems.get(9));
+			bulkActionDropdownItems.get(10));
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
 			"password-policies", "edit-permissions-by-role",
-			"Edit Permissions by Role", null, bulkActionDropdownItems.get(10));
+			"Edit Permissions by Role", null, bulkActionDropdownItems.get(11));
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
 			"password-policies", "reset-to-default-permissions",
 			"Reset to Default Permissions", null,
-			bulkActionDropdownItems.get(11));
+			bulkActionDropdownItems.get(12));
 	}
 
 	@Test

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewFilesSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewFilesSectionDisplayContextTest.java
@@ -84,7 +84,7 @@ public class ViewFilesSectionDisplayContextTest
 			getBulkActionDropdownItems();
 
 		Assert.assertEquals(
-			bulkActionDropdownItems.toString(), 12,
+			bulkActionDropdownItems.toString(), 13,
 			bulkActionDropdownItems.size());
 
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
@@ -95,33 +95,36 @@ public class ViewFilesSectionDisplayContextTest
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
 			"copy", "copy-to", "Copy To", null, bulkActionDropdownItems.get(2));
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
-			"time", "expire", "Expire", null, bulkActionDropdownItems.get(3));
+			"copy", "duplicate", "Duplicate", null,
+			bulkActionDropdownItems.get(3));
+		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
+			"time", "expire", "Expire", null, bulkActionDropdownItems.get(4));
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
 			"download", "download", "Download", null,
-			bulkActionDropdownItems.get(4));
-		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
-			"pencil", "edit-categories", "Edit Categories", "post",
 			bulkActionDropdownItems.get(5));
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
-			"pencil", "edit-tags", "Edit Tags", "post",
+			"pencil", "edit-categories", "Edit Categories", "post",
 			bulkActionDropdownItems.get(6));
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
-			"password-policies", "permissions", "Permissions", null,
+			"pencil", "edit-tags", "Edit Tags", "post",
 			bulkActionDropdownItems.get(7));
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
+			"password-policies", "permissions", "Permissions", null,
+			bulkActionDropdownItems.get(8));
+		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
 			"password-policies", "default-permissions", "Default Permissions",
-			null, bulkActionDropdownItems.get(8));
+			null, bulkActionDropdownItems.get(9));
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
 			"password-policies", "edit-default-permissions-by-role",
 			"Edit Default Permissions by Role", null,
-			bulkActionDropdownItems.get(9));
+			bulkActionDropdownItems.get(10));
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
 			"password-policies", "edit-permissions-by-role",
-			"Edit Permissions by Role", null, bulkActionDropdownItems.get(10));
+			"Edit Permissions by Role", null, bulkActionDropdownItems.get(11));
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
 			"password-policies", "reset-to-default-permissions",
 			"Reset to Default Permissions", null,
-			bulkActionDropdownItems.get(11));
+			bulkActionDropdownItems.get(12));
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewHomeRecentAssetsFilesSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewHomeRecentAssetsFilesSectionDisplayContextTest.java
@@ -73,7 +73,7 @@ public class ViewHomeRecentAssetsFilesSectionDisplayContextTest
 			getFDSActionDropdownItems();
 
 		Assert.assertEquals(
-			fdsActionDropdownItems.toString(), 16,
+			fdsActionDropdownItems.toString(), 17,
 			fdsActionDropdownItems.size());
 
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
@@ -105,24 +105,28 @@ public class ViewHomeRecentAssetsFilesSectionDisplayContextTest
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
 			"share", "share", "Share", "get", fdsActionDropdownItems.get(7));
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
-			"time", "expire", "Expire", "post", fdsActionDropdownItems.get(8));
+			"info-circle-open", "show-details", "Show Details", null,
+			fdsActionDropdownItems.get(8));
+		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
+			"time", "expire", "Expire", "post", fdsActionDropdownItems.get(9));
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
 			"date-time", "version-history", "View History", "get",
-			fdsActionDropdownItems.get(9));
+			fdsActionDropdownItems.get(10));
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
 			"move-folder", "move", "Move", null,
 			fdsActionDropdownItems.get(10));
+
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
 			"copy", "copy", "Copy To", null, fdsActionDropdownItems.get(11));
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
 			"upload", "export-for-translation", "Export for Translation", null,
-			fdsActionDropdownItems.get(12));
+			fdsActionDropdownItems.get(13));
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
 			"download", "import-translation", "Import Translation", null,
-			fdsActionDropdownItems.get(13));
+			fdsActionDropdownItems.get(14));
 
 		FDSActionDropdownItem permissionsFDSActionDropdownItem =
-			fdsActionDropdownItems.get(14);
+			fdsActionDropdownItems.get(15);
 
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
 			"password-policies", "permissions-menu", "Permissions", null,
@@ -159,7 +163,7 @@ public class ViewHomeRecentAssetsFilesSectionDisplayContextTest
 			permissionsFDSActionDropdownItems.get(3));
 
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
-			"trash", "delete", "Delete", null, fdsActionDropdownItems.get(15));
+			"trash", "delete", "Delete", null, fdsActionDropdownItems.get(16));
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewHomeRecentAssetsFilesSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewHomeRecentAssetsFilesSectionDisplayContextTest.java
@@ -114,10 +114,28 @@ public class ViewHomeRecentAssetsFilesSectionDisplayContextTest
 			fdsActionDropdownItems.get(10));
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
 			"move-folder", "move", "Move", null,
-			fdsActionDropdownItems.get(10));
+			fdsActionDropdownItems.get(11));
+
+		FDSActionDropdownItem copyFDSActionDropdownItem =
+			fdsActionDropdownItems.get(12);
 
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
-			"copy", "copy", "Copy To", null, fdsActionDropdownItems.get(11));
+			"copy", "copy-menu", "Copy", null, "contextual", null,
+			copyFDSActionDropdownItem);
+
+		List<FDSActionDropdownItem> copyFDSActionDropdownItems =
+			(List<FDSActionDropdownItem>)copyFDSActionDropdownItem.get("items");
+
+		Assert.assertEquals(
+			copyFDSActionDropdownItems.toString(), 2,
+			copyFDSActionDropdownItems.size());
+
+		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
+			"copy", "copy", "Copy To", null, copyFDSActionDropdownItems.get(0));
+		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
+			"copy", "duplicate", "Duplicate", null,
+			copyFDSActionDropdownItems.get(1));
+
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
 			"upload", "export-for-translation", "Export for Translation", null,
 			fdsActionDropdownItems.get(13));

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewRecycleBinSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewRecycleBinSectionDisplayContextTest.java
@@ -101,6 +101,8 @@ public class ViewRecycleBinSectionDisplayContextTest
 					))
 			).put(
 				"hideSpace", true
+			).put(
+				"showEmptyRecycleBinAction", false
 			).build(),
 			_getBreadcrumbProps(displayContext));
 	}

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewVersionHistoryDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewVersionHistoryDisplayContextTest.java
@@ -111,7 +111,8 @@ public class ViewVersionHistoryDisplayContextTest
 				"/o", _objectDefinition.getRESTContextPath(), "/scopes/",
 				_objectEntry.getGroupId(), "/by-external-reference-code/",
 				_objectEntry.getExternalReferenceCode(),
-				"/versions?nestedFields=file.thumbnailURL"),
+				"/versions?nestedFields=file.metadata,file.previewURL,",
+				"file.thumbnailURL"),
 			ReflectionTestUtil.invoke(
 				_getViewVersionHistoryDisplayContext(
 					_getMockHttpServletRequest(_objectEntry)),

--- a/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewSpaceMembersSummarySectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewSpaceMembersSummarySectionDisplayContextTest.java
@@ -45,7 +45,7 @@ public class ViewSpaceMembersSummarySectionDisplayContextTest {
 
 		Assert.assertTrue(creationMenu.isEmpty());
 
-		CreationMenu creationMenu = _getCreationMenu(true);
+		creationMenu = _getCreationMenu(true);
 
 		Assert.assertFalse(creationMenu.isEmpty());
 	}


### PR DESCRIPTION
LPD-91460 Realign DisplayContext CMS tests with production drift

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-91460 part of : https://liferay.atlassian.net/browse/LPD-91459

Eleven DisplayContext tests in `site-cms-site-initializer` and `site-cms-site-initializer-test` were failing on master: three `testGetAdditionalProps`, three `testGetBulkActionDropdownItems`, two `testGetFDSActionDropdownItems`, plus `testGetBreadcrumbProps`, `testGetAPIURL`, and the unit `testGetCreationMenu`. This Technical Task completes the testing slice of the parent task LPD-91459.

The production `SectionDisplayContextHelper`, `ViewRecycleBinSectionDisplayContext`, and `ViewVersionHistoryDisplayContext` evolved over the past several weeks 
— LPD-66045 added `systemProperties.collaboratorBrief` to the nestedFields, LPD-88656 added a `duplicate` entry to the bulk action toolbar, LPD-88346 turned the row-level `copy` action into a `copy-menu` contextual submenu with `copy` + `duplicate` sub-items, LPD-88211 added `show-details` to the FDS action list, LPD-83226 added `showEmptyRecycleBinAction` to the recycle-bin breadcrumb props, LPD-89999 expanded the version-history nestedFields to include `file.metadata` + `file.previewURL`, and LPD-89584 introduced a duplicate local declaration in the unit test. 
None of those changes updated the corresponding test assertions, so every test that hard-codes the expected list sizes, indices, or strings began to fail.

# How am I fixing it?

Per-ticket commits, each scoped to the production change that broke it: update the expected sizes, insert the missing assertions at the right index, extract `copy-menu` and assert its sub-items the same way the file already extracts `permissions-menu`, add `systemProperties.collaboratorBrief` in alphabetical position to the shared `BaseSectionDisplayContextTestCase.getAdditionalAPIURLParameters`, add `showEmptyRecycleBinAction` to the recycle-bin breadcrumb expectation, expand the version-history `nestedFields` string, and drop the redundant `CreationMenu` redeclaration in the unit test so the outer local is reassigned. No production code is modified — the  tests are realigned to what production already does.

# How can you verify that it works?

Run the included automated tests.
