### PR TITLE
LPD-91462 Map ADVANCED_UPDATE permission action in CMIS connector

### DIFF
--- a/modules/apps/document-library/document-library-repository-cmis-impl/src/main/java/com/liferay/document/library/repository/cmis/internal/model/BaseCMISModel.java
+++ b/modules/apps/document-library/document-library-repository-cmis-impl/src/main/java/com/liferay/document/library/repository/cmis/internal/model/BaseCMISModel.java
@@ -146,6 +146,8 @@ public abstract class BaseCMISModel {
 		).put(
 			ActionKeys.ADD_SUBFOLDER, Action.CAN_CREATE_FOLDER
 		).put(
+			ActionKeys.ADVANCED_UPDATE, Action.CAN_UPDATE_PROPERTIES
+		).put(
 			ActionKeys.DELETE, Action.CAN_DELETE_OBJECT
 		).put(
 			ActionKeys.DELETE_DISCUSSION, Action.CAN_DELETE_OBJECT


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91462

## What is being fixed

Rendering any folder served by an external CMIS repository throws
`RepositoryException: Unexpected permission action ADVANCED_UPDATE`.
`BaseCMISModel` was never updated after the portal introduced
`ActionKeys.ADVANCED_UPDATE`, so the action has no corresponding CMIS
`Action` mapping and any UI that builds the actions menu against a CMIS
item crashes.

## How it is being fixed

Add `ActionKeys.ADVANCED_UPDATE → Action.CAN_UPDATE_PROPERTIES` to the
mapping table. Both `UPDATE` and `ADVANCED_UPDATE` are "modify the
object" permissions in Liferay, and CMIS exposes a single
`CAN_UPDATE_PROPERTIES` action for that, so both Liferay actions map to
the same CMIS action.

## Why are there no tests?

The fix is exercised by a Playwright smoke that creates a CMIS AtomPub
external repository against an Alfresco backend and opens the Actions
menu (which throws without the fix). CI has no Alfresco infrastructure,
so the spec cannot run there. The spec is attached to the Jira ticket
together with the manual-test instructions for reviewers.