### PR TITLE
LPD-89886 Show session-expired message for MustHaveSessionCSRFToken

### DIFF
--- a/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/js/Comments.js
+++ b/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/js/Comments.js
@@ -231,6 +231,13 @@ export default function Comments({
 						);
 					}
 					else if (
+						exception.indexOf('MustHaveSessionCSRFToken') > -1
+					) {
+						errorKey = Liferay.Language.get(
+							'your-session-has-expired'
+						);
+					}
+					else if (
 						exception.indexOf('NoSuchMessageException') > -1
 					) {
 						errorKey = Liferay.Language.get(


### PR DESCRIPTION
Changes requested by Brian on https://github.com/brianchandotcom/liferay-portal/pull/174944

https://liferay.atlassian.net/browse/LPD-89886

## What is being fixed

When a discussion comment submit fails because the user's session has expired, the JSON envelope sent to the JS client carries `PrincipalException.MustHaveSessionCSRFToken`. The mapping in `Comments.js` only matched `PrincipalException` generically and surfaced "you do not have the required permissions", which is misleading — the user did have permissions; the session had expired.

## How it is being fixed

A specific branch is added in `Comments.js` for `MustHaveSessionCSRFToken` that selects the existing `your-session-has-expired` language key. It is slotted alphabetically with the other exception checks, and crucially still sits ahead of the generic `PrincipalException` branch — detection works because `JSONObject.putException` serializes the class name as `class com.liferay...PrincipalException$MustHaveSessionCSRFToken:<message>`, which the new `indexOf` matches before the generic one.

## Why are there no tests?

The change is three lines of exception-to-language-key mapping. The module has no JS test infrastructure (Jest), and setting it up is out of scope. End-to-end coverage would require a new Playwright test for discussions, which is disproportionate for a string mapping. The integration test landed in the previous PR already asserts the server-side JSON envelope contains the `MustHaveSessionCSRFToken` substring this new branch matches.