### PR TITLE
LPD-91329 | CMS: Same structure type not available in Select Related Content field configuration

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/structure_builder/components/settings/RelatedContentSettings.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/structure_builder/components/settings/RelatedContentSettings.tsx
@@ -19,8 +19,7 @@ import {useCache} from '../../contexts/CacheContext';
 import {useSelector, useStateDispatch} from '../../contexts/StateContext';
 import selectErrors from '../../selectors/selectErrors';
 import selectPublishedChildren from '../../selectors/selectPublishedChildren';
-import selectStructureERC from '../../selectors/selectStructureERC';
-import {RelatedContent, Structure} from '../../types/Structure';
+import {RelatedContent} from '../../types/Structure';
 import Breadcrumb from '../Breadcrumb';
 import ERCInput from '../ERCInput';
 import {LocalizedInput} from '../LocalizedInput';
@@ -64,7 +63,6 @@ function GeneralTab({
 	relatedContent: RelatedContent;
 }) {
 	const errors = useSelector(selectErrors(relatedContent.uuid));
-	const mainStructureERC = useSelector(selectStructureERC);
 	const publishedChildren = useSelector(selectPublishedChildren);
 
 	const isPublished = publishedChildren.has(relatedContent.uuid);
@@ -130,7 +128,7 @@ function GeneralTab({
 					aria-describedby={feedbackId}
 					disabled={isPublished || disabled}
 					id={pickerId}
-					items={getItems(objectDefinitions, mainStructureERC)}
+					items={getItems(objectDefinitions)}
 					messages={{
 						itemDescribedby: Liferay.Language.get(
 							'you-are-currently-on-a-text-element,-inside-of-a-list-box'
@@ -192,10 +190,7 @@ function GeneralTab({
 	);
 }
 
-function getItems(
-	objectDefinitions: ObjectDefinitions,
-	mainStructureERC: Structure['erc']
-) {
+function getItems(objectDefinitions: ObjectDefinitions) {
 	if (!objectDefinitions) {
 		return [];
 	}
@@ -204,9 +199,8 @@ function getItems(
 
 	for (const objectDefinition of Object.values(objectDefinitions)) {
 		if (
-			objectDefinition.externalReferenceCode === mainStructureERC ||
 			objectDefinition.objectFolderExternalReferenceCode ===
-				'L_CMS_STRUCTURE_REPEATABLE_GROUPS'
+			'L_CMS_STRUCTURE_REPEATABLE_GROUPS'
 		) {
 			continue;
 		}

--- a/modules/apps/site/site-cms-site-initializer/test/js/structure_builder/components/RelatedContentSettings.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/structure_builder/components/RelatedContentSettings.test.tsx
@@ -157,4 +157,35 @@ describe('RelatedContentSettings', () => {
 			uuid: RELATED_CONTENT_UUID,
 		});
 	});
+
+	it('allow self-selection', async () => {
+		const objectDefinitions: ObjectDefinitions = {
+			...OBJECT_DEFINITIONS,
+			'main-erc': buildObjectDefinition({
+				children: new Map(),
+				erc: 'main-erc',
+				label: {en_US: 'MainStructure'},
+				name: 'mainStructure',
+				spaces: [],
+			}),
+		};
+
+		renderComponent({objectDefinitions});
+
+		const user = userEvent.setup();
+
+		await user.click(
+			screen.getByRole('combobox', {name: 'related-content'})
+		);
+
+		expect(
+			screen.getByRole('option', {name: 'MainStructure'})
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole('option', {name: 'Structure1'})
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole('option', {name: 'Structure2'})
+		).toBeInTheDocument();
+	});
 });


### PR DESCRIPTION
### What is this trying to solve?
https://liferay.atlassian.net/browse/LPD-91329 
### How am I fixing it?
By allowing the selection of the current structure
### How can you verify that it works?
Buy running the added tests
`yarn test RelatedContentSettings -t "allow self-selection"`