### PR TITLE
LPD-77709 Sanitize stored XSS in Web Content translation views

### DIFF
--- a/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/display/context/TranslateDisplayContext.java
+++ b/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/display/context/TranslateDisplayContext.java
@@ -18,6 +18,7 @@ import com.liferay.info.localized.InfoLocalizedValue;
 import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.bean.BeanParamUtil;
 import com.liferay.portal.kernel.editor.configuration.EditorConfiguration;
 import com.liferay.portal.kernel.editor.configuration.EditorConfigurationFactoryUtil;
@@ -29,9 +30,12 @@ import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactoryUtil;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
+import com.liferay.portal.kernel.sanitizer.SanitizerException;
+import com.liferay.portal.kernel.sanitizer.SanitizerUtil;
 import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalServiceUtil;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HtmlUtil;
@@ -315,6 +319,13 @@ public class TranslateDisplayContext {
 		}
 
 		return "publish";
+	}
+
+	public String getSanitizedHTML(String html) throws SanitizerException {
+		return SanitizerUtil.sanitize(
+			_themeDisplay.getCompanyId(), _themeDisplay.getScopeGroupId(),
+			_themeDisplay.getUserId(), StringPool.BLANK, 0,
+			ContentTypes.TEXT_HTML, html);
 	}
 
 	public String getSaveButtonLabel() {

--- a/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/display/context/ViewDisplayContext.java
+++ b/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/display/context/ViewDisplayContext.java
@@ -37,6 +37,7 @@ import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -228,7 +229,8 @@ public class ViewDisplayContext {
 		AssetRenderer<?> assetRenderer = assetRendererFactory.getAssetRenderer(
 			translationEntry.getTranslationEntryId());
 
-		return assetRenderer.getTitle(_themeDisplay.getLocale());
+		return HtmlUtil.escape(
+			assetRenderer.getTitle(_themeDisplay.getLocale()));
 	}
 
 	public PortletURL getTranslatePortletURL(

--- a/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/display/context/ViewTranslationDisplayContext.java
+++ b/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/display/context/ViewTranslationDisplayContext.java
@@ -16,11 +16,17 @@ import com.liferay.info.form.InfoForm;
 import com.liferay.info.item.InfoItemFieldValues;
 import com.liferay.info.localized.InfoLocalizedValue;
 import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.sanitizer.SanitizerException;
+import com.liferay.portal.kernel.sanitizer.SanitizerUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.translation.info.field.TranslationInfoFieldChecker;
 import com.liferay.translation.snapshot.TranslationSnapshot;
 
@@ -101,6 +107,17 @@ public class ViewTranslationDisplayContext {
 	public String getLanguageIdTitle(String languageId) {
 		return StringUtil.replace(
 			languageId, CharPool.UNDERLINE, CharPool.DASH);
+	}
+
+	public String getSanitizedHTML(String html) throws SanitizerException {
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)_httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		return SanitizerUtil.sanitize(
+			themeDisplay.getCompanyId(), themeDisplay.getScopeGroupId(),
+			themeDisplay.getUserId(), StringPool.BLANK, 0,
+			ContentTypes.TEXT_HTML, html);
 	}
 
 	public String getSourceLanguageId() {

--- a/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/asset/full_content.jsp
+++ b/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/asset/full_content.jsp
@@ -119,7 +119,7 @@ ViewTranslationDisplayContext viewTranslationDisplayContext = (ViewTranslationDi
 									</label>
 
 									<div class="translation-editor-preview" dir="<%= sourceContentDir %>">
-										<%= sourceContent %>
+										<%= viewTranslationDisplayContext.getSanitizedHTML(sourceContent) %>
 									</div>
 								</c:when>
 								<c:otherwise>
@@ -138,7 +138,7 @@ ViewTranslationDisplayContext viewTranslationDisplayContext = (ViewTranslationDi
 									</label>
 
 									<div class="translation-editor-preview" dir="<%= LanguageUtil.get(viewTranslationDisplayContext.getTargetLocale(), "lang.dir") %>">
-										<%= targetContent %>
+										<%= viewTranslationDisplayContext.getSanitizedHTML(targetContent) %>
 									</div>
 								</c:when>
 								<c:otherwise>

--- a/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/translate_field.jspf
+++ b/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/translate_field.jspf
@@ -16,7 +16,7 @@
 				</label>
 
 				<div class="translation-editor-preview" dir="<%= sourceContentDir %>">
-					<%= sourceContent %>
+					<%= translateDisplayContext.getSanitizedHTML(sourceContent) %>
 				</div>
 			</c:when>
 			<c:otherwise>
@@ -35,7 +35,7 @@
 				</label>
 
 				<div class="translation-editor-preview" dir="<%= LanguageUtil.get(translateDisplayContext.getTargetLocale(), "lang.dir") %>">
-					<%= targetContent %>
+					<%= translateDisplayContext.getSanitizedHTML(targetContent) %>
 				</div>
 			</c:when>
 			<c:otherwise>

--- a/modules/test/playwright/tests/journal-web/main/translation.spec.ts
+++ b/modules/test/playwright/tests/journal-web/main/translation.spec.ts
@@ -1,0 +1,81 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {mergeTests} from '@playwright/test';
+
+import {apiHelpersTest} from '../../../fixtures/apiHelpersTest';
+import {isolatedSiteTest} from '../../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../../fixtures/loginTest';
+import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisible';
+import {PORTLET_URLS} from '../../../utils/portletUrls';
+import getBasicWebContentStructureId from '../../../utils/structured-content/getBasicWebContentStructureId';
+import {waitForAlert} from '../../../utils/waitForAlert';
+import {watchForDialog} from '../../../utils/watchForDialog';
+import {journalPagesTest} from './fixtures/journalPagesTest';
+
+const test = mergeTests(
+	apiHelpersTest,
+	isolatedSiteTest,
+	journalPagesTest,
+	loginTest()
+);
+
+test(
+	'Stored XSS payload in a Web Content is sanitized in the translation editor and processes list',
+	{
+		tag: '@LPD-77709',
+	},
+	async ({
+		apiHelpers,
+		journalEditArticleTranslationsPage,
+		journalPage,
+		page,
+		site,
+	}) => {
+		const watcher = watchForDialog(page);
+
+		try {
+			const xssPayload = '<script>alert(123)</script>';
+			const contentStructureId =
+				await getBasicWebContentStructureId(apiHelpers);
+
+			await apiHelpers.jsonWebServicesJournal.addWebContent({
+				content: xssPayload,
+				ddmStructureId: contentStructureId,
+				descriptionMap: {en_US: xssPayload},
+				groupId: site.id,
+				titleMap: {en_US: xssPayload},
+			});
+
+			await journalPage.goto(site.friendlyUrlPath);
+
+			await clickAndExpectToBeVisible({
+				autoClick: true,
+				target: page.getByRole('menuitem', {
+					exact: true,
+					name: 'Translate',
+				}),
+				trigger: page.locator('[aria-label^="Actions for"]').first(),
+			});
+
+			await journalEditArticleTranslationsPage.titleInput.fill(
+				xssPayload
+			);
+
+			await journalEditArticleTranslationsPage.publishButton.click();
+
+			await waitForAlert(page);
+
+			await page.goto(
+				`/group${site.friendlyUrlPath}${PORTLET_URLS.translation}`
+			);
+
+			watcher.assertNoDialog();
+		}
+		finally {
+			watcher.dispose();
+		}
+	}
+);

--- a/modules/test/playwright/utils/portletUrls.ts
+++ b/modules/test/playwright/utils/portletUrls.ts
@@ -129,6 +129,8 @@ export const PORTLET_URLS = {
 	teams: '/~/control_panel/manage/-/site_teams/teams',
 	templates:
 		'/~/control_panel/manage?p_p_id=com_liferay_template_web_internal_portlet_TemplatePortlet&p_p_lifecycle=0&p_p_state=maximized&p_p_mode=view',
+	translation:
+		'/~/control_panel/manage?p_p_id=com_liferay_translation_web_internal_portlet_TranslationPortlet',
 	utilityPages:
 		'/~/control_panel/manage?p_p_id=com_liferay_layout_admin_web_portlet_GroupPagesPortlet&_com_liferay_layout_admin_web_portlet_GroupPagesPortlet_tabs1=utility-pages',
 	widgetPageTemplates:


### PR DESCRIPTION
What is this trying to solve?
https://liferay.atlassian.net/browse/LPD-77709

A stored `<script>` payload in a Web Content title, description, or
content executes when an admin opens the translation editor or the
Translation Processes list. The preview panes render content raw, and
the processes list renders the entry title unescaped.

How am I fixing it?
`TranslateDisplayContext` and `ViewTranslationDisplayContext` now
expose `getSanitizedHTML(String)`, which runs the value through
`SanitizerUtil.sanitize(..., TEXT_HTML, ...)`. The two preview panes
in `asset/full_content.jsp` and `translate_field.jspf` go through it
instead of emitting `sourceContent` / `targetContent` raw. In
`view.jsp`, the title cell is wrapped in `HtmlUtil.escape(...)`.

How can you verify that it works?
Run `modules/test/playwright/tests/journal-web/main/translation.spec.ts`
(tag `@LPD-77709`). It seeds a Web Content whose title, description,
and content all contain `<script>window.xssExecuted = true;</script>`,
publishes a translation, opens the Translation Processes portlet, and
asserts `window.xssExecuted` was never set.