### PR TITLE
LPD-91323  Include past-due approved items in expiring soon count

### DIFF
--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/AssetStatisticsResourceImpl.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/AssetStatisticsResourceImpl.java
@@ -88,8 +88,6 @@ public class AssetStatisticsResourceImpl
 						ObjectEntryTable.INSTANCE.status.eq(
 							WorkflowConstants.STATUS_APPROVED
 						).and(
-							ObjectEntryTable.INSTANCE.expirationDate.gt(date)
-						).and(
 							ObjectEntryTable.INSTANCE.expirationDate.lte(
 								new Date(
 									date.getTime() +

--- a/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/AssetStatisticsResourceTest.java
+++ b/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/AssetStatisticsResourceTest.java
@@ -176,49 +176,61 @@ public class AssetStatisticsResourceTest
 
 		_assertAssetStatistics(0, 1, 0, 0, 3);
 
-		// Add object entry with overdue review date
+		// Add object entry with already-passed expiration date
 
 		ObjectEntry objectEntry4 = _addObjectEntry(
 			depotEntry, objectDefinition);
 
-		objectEntry4.setReviewDate(new Date(date.getTime() - (2 * Time.DAY)));
+		objectEntry4.setExpirationDate(
+			new Date(date.getTime() - (2 * Time.DAY)));
 
 		_objectEntryLocalService.updateObjectEntry(objectEntry4);
 
-		_assertAssetStatistics(0, 1, 0, 1, 4);
+		_assertAssetStatistics(0, 2, 0, 0, 4);
 
-		// Add object entry with status draft
+		// Add object entry with overdue review date
 
 		ObjectEntry objectEntry5 = _addObjectEntry(
 			depotEntry, objectDefinition);
 
-		_objectEntryLocalService.updateStatus(
-			TestPropsValues.getUserId(), objectEntry5.getObjectEntryId(),
-			WorkflowConstants.STATUS_DRAFT, serviceContext);
+		objectEntry5.setReviewDate(new Date(date.getTime() - (2 * Time.DAY)));
 
-		_assertAssetStatistics(0, 1, 1, 1, 5);
+		_objectEntryLocalService.updateObjectEntry(objectEntry5);
 
-		// Add object entry with status expired
+		_assertAssetStatistics(0, 2, 0, 1, 5);
+
+		// Add object entry with status draft
 
 		ObjectEntry objectEntry6 = _addObjectEntry(
 			depotEntry, objectDefinition);
 
 		_objectEntryLocalService.updateStatus(
 			TestPropsValues.getUserId(), objectEntry6.getObjectEntryId(),
-			WorkflowConstants.STATUS_EXPIRED, serviceContext);
+			WorkflowConstants.STATUS_DRAFT, serviceContext);
 
-		_assertAssetStatistics(1, 1, 1, 1, 6);
+		_assertAssetStatistics(0, 2, 1, 1, 6);
 
-		// Add object entry in a status that is not visible in the All view
+		// Add object entry with status expired
 
 		ObjectEntry objectEntry7 = _addObjectEntry(
 			depotEntry, objectDefinition);
 
 		_objectEntryLocalService.updateStatus(
 			TestPropsValues.getUserId(), objectEntry7.getObjectEntryId(),
+			WorkflowConstants.STATUS_EXPIRED, serviceContext);
+
+		_assertAssetStatistics(1, 2, 1, 1, 7);
+
+		// Add object entry in a status that is not visible in the All view
+
+		ObjectEntry objectEntry8 = _addObjectEntry(
+			depotEntry, objectDefinition);
+
+		_objectEntryLocalService.updateStatus(
+			TestPropsValues.getUserId(), objectEntry8.getObjectEntryId(),
 			WorkflowConstants.STATUS_DENIED, serviceContext);
 
-		_assertAssetStatistics(1, 1, 1, 1, 6);
+		_assertAssetStatistics(1, 2, 1, 1, 7);
 
 		_objectDefinitionLocalService.deleteObjectDefinition(
 			irrelevantObjectDefinition);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91323

## What is being fixed

The "Expiring Soon" chip count drifted from the badge it is meant to summarise. The badge stays visible for any APPROVED item whose expiration date falls before `now + 7d`, including dates already in the past — APPROVED entries linger past their expiration until the object entry expiration scheduler flips them to EXPIRED, a configurable interval that defaults to fifteen minutes. The chip count, however, excluded entries whose expiration date was already in the past, so during that window the user saw a badge on rows that the count was not acknowledging.

## How it is being fixed

`AssetStatisticsResourceImpl` no longer applies the `expirationDate > now` lower bound when computing the expiring-soon count, so the query now matches the same window the badge uses: APPROVED with `expirationDate <= now + 7d`. Backend and frontend stay consistent across the expiration-to-scheduler gap.

The integration test gains a case that adds an APPROVED entry with an already-passed expiration date and asserts it counts toward expiring-soon.