### PR TITLE
LPD-91281 Show a specific error for a Space ERC over 75 characters

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/utils/constants.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/utils/constants.ts
@@ -10,6 +10,8 @@ export const OBJECT_ENTRY_FOLDER_CLASS_NAME =
 
 export const ENTERPRISE_URL = 'https://www.liferay.com/web/lr/cms-upgrade';
 
+export const ERC_MAX_LENGTH = 75;
+
 export const EXPIRING_SOON_THRESHOLD_DAYS = 7;
 
 export const FDS_EVENT_DISPLAY_UPDATED = 'fds-display-updated';

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/spaces/SpaceGeneralSettings.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/spaces/SpaceGeneralSettings.tsx
@@ -24,6 +24,7 @@ import {
 } from '../../common/components/forms/validations';
 import SpaceService from '../../common/services/SpaceService';
 import {LogoColor, Space} from '../../common/types/Space';
+import {ERC_MAX_LENGTH} from '../../common/utils/constants';
 import focusInvalidElement from '../../common/utils/focusInvalidElement';
 import SpaceBaseFields from './SpaceBaseFields';
 import SpacePanel from './SpacePanel';
@@ -138,7 +139,7 @@ export default function SpaceGeneralSettings({
 		validate: (values): Errors =>
 			validate(
 				{
-					erc: [required],
+					erc: [maxLength(ERC_MAX_LENGTH), required],
 					friendlyURL: [
 						(value) =>
 							!value

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/spaces/SpaceGeneralSettings.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/spaces/SpaceGeneralSettings.test.tsx
@@ -14,6 +14,7 @@ import React from 'react';
 
 import SpaceService from '../../../../src/main/resources/META-INF/resources/js/common/services/SpaceService';
 import {Space} from '../../../../src/main/resources/META-INF/resources/js/common/types/Space';
+import {ERC_MAX_LENGTH} from '../../../../src/main/resources/META-INF/resources/js/common/utils/constants';
 import SpaceGeneralSettings from '../../../../src/main/resources/META-INF/resources/js/main_view/spaces/SpaceGeneralSettings';
 
 jest.mock(
@@ -229,6 +230,22 @@ describe('SpaceGeneralSettings', () => {
 			).toBeInTheDocument();
 
 			expect(nameInput).toHaveFocus();
+		});
+
+		it('rejects an ERC longer than the column length', async () => {
+			renderComponent();
+
+			const ercInput = screen.getByRole('textbox', {name: /erc/});
+
+			await userEvent.clear(ercInput);
+			await userEvent.type(ercInput, 'a'.repeat(ERC_MAX_LENGTH + 1));
+
+			await userEvent.click(screen.getByRole('button', {name: 'save'}));
+
+			expect(
+				screen.getByText(/please-enter-no-more-than/)
+			).toBeInTheDocument();
+			expect(SpaceService.updateSpace).not.toBeCalled();
 		});
 	});
 });


### PR DESCRIPTION
# What is this trying to solve?
https://liferay.atlassian.net/browse/LPD-91281

When saving an ERC in a space's settings that is more than 75 characters, an unspecific internal server error occurs.

# How am I fixing it?
The Space Settings form already has validator for every other field. The ERC field only checked for presence, now it will also check for length, matching the 75 character limit in the ERC field.

# How can you verify that it works?
Run the included automated tests.