### PR TITLE
LPD-62554 LPD-67234 Align bulkActions tests with hidden-action contract

### DIFF
--- a/modules/test/playwright/tests/site-cms-site-initializer/main/bulkActions.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/bulkActions.spec.ts
@@ -1516,25 +1516,20 @@ test(
 			'Default'
 		);
 
-		await test.step('Go to All section and try to download a content asset from the bulk action, un unexpected error occurred', async () => {
-			await assetsPage.gotoAll();
+		await assetsPage.gotoAll();
+
+		await test.step('Download bulk action is hidden when a content asset is selected', async () => {
 			await assetsPage.selectItems([content1]);
-			await assetsPage.execBulkItemAction('Download');
 
-			await waitForAlert(
-				page,
-				'Error:Unable to process the bulk download. Please check your selection and try again.',
-				{
-					type: 'danger',
-				}
-			);
-		});
+			await assetsPage.expectBulkItemActionHidden('Download');
 
-		await test.step('Download a file asset from the bulk action', async () => {
 			await assetsPage
 				.getItem(content1)
 				.locator('input[title="Select Item"]')
 				.uncheck();
+		});
+
+		await test.step('Download a file asset from the bulk action', async () => {
 			await assetsPage.selectItems([fileAssetTitle1]);
 
 			const downloadPromise = page.waitForEvent('download');
@@ -1556,12 +1551,19 @@ test(
 			expect(download.suggestedFilename()).toBeDefined();
 		});
 
-		await test.step('Download both content and files assets from the bulk action, a message will inform the user that content assets will be skipped from the download', async () => {
-			await assetsPage.selectItems([
-				content1,
-				fileAssetTitle1,
-				fileAssetTitle2,
-			]);
+		await test.step('Download bulk action is hidden when a content asset and a file are selected together', async () => {
+			await assetsPage.selectItems([content1, fileAssetTitle1]);
+
+			await assetsPage.expectBulkItemActionHidden('Download');
+
+			await assetsPage
+				.getItem(content1)
+				.locator('input[title="Select Item"]')
+				.uncheck();
+		});
+
+		await test.step('Download multiple file assets from the bulk action', async () => {
+			await assetsPage.selectItems([fileAssetTitle1, fileAssetTitle2]);
 
 			const downloadPromise = page.waitForEvent('download');
 
@@ -1569,18 +1571,12 @@ test(
 
 			await waitForAlert(
 				page,
-				'Warning:You have selected both content and file assets. Only file assets can be downloaded. Content assets will be skipped.',
-				{
-					type: 'warning',
-				}
-			);
-			await waitForAlert(
-				page,
 				'Warning:The download of 2 files is being prepared. Please do not close this window or navigate to another section.',
 				{
 					type: 'warning',
 				}
 			);
+
 			await waitForAlert(page, 'Success:The download will begin shortly');
 
 			const download = await downloadPromise;

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/bulkActions.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/bulkActions.spec.ts
@@ -1645,14 +1645,14 @@ test(
 			);
 		});
 
-		await test.step('Navigate to history page and bulk delete all versions', async () => {
-			await assetsPage.gotoAll();
+		await assetsPage.gotoAll();
 
-			await assetsPage.execItemAction({
-				action: 'View History',
-				filter: webContentNames[2],
-			});
+		await assetsPage.execItemAction({
+			action: 'View History',
+			filter: webContentNames[2],
+		});
 
+		await test.step('Bulk Delete is hidden when the current version is included in the selection', async () => {
 			for (const webContentName of webContentNames) {
 				await assetsPage
 					.getItem(webContentName)
@@ -1660,6 +1660,15 @@ test(
 					.check();
 			}
 
+			await assetsPage.expectBulkItemActionHidden('Delete');
+
+			await assetsPage
+				.getItem(webContentNames[2])
+				.locator('input[title="Select Item"]')
+				.uncheck();
+		});
+
+		await test.step('Bulk delete the non-current versions', async () => {
 			await assetsPage.execBulkItemAction('Delete');
 
 			await waitForModal({
@@ -1673,7 +1682,7 @@ test(
 
 			await waitForAlert(
 				page,
-				'Info:Delete asset versions action started for 3 versions.',
+				'Info:Delete asset versions action started for 2 versions.',
 				{
 					autoClose: true,
 					type: 'info',
@@ -1681,7 +1690,7 @@ test(
 			);
 		});
 
-		await test.step('All versions are removed excluding the current one', async () => {
+		await test.step('Deleted versions are removed and the current version remains', async () => {
 			await page.reload();
 
 			await expect(
@@ -1695,24 +1704,13 @@ test(
 			await expect(assetsPage.getItem(webContentNames[2])).toBeVisible();
 		});
 
-		await test.step('Assert that current version cannot be deleted', async () => {
+		await test.step('Bulk Delete is hidden when only the current version is selected', async () => {
 			await assetsPage
 				.getItem(webContentNames[2])
 				.locator('input[title="Select Item"]')
 				.check();
 
-			await assetsPage.execBulkItemAction('Delete');
-
-			await waitForModal({
-				page,
-			});
-
-			await page
-				.locator('.modal')
-				.getByRole('button', {name: 'Ok'})
-				.click();
-
-			await expect(assetsPage.getItem(webContentNames[2])).toBeVisible();
+			await assetsPage.expectBulkItemActionHidden('Delete');
 		});
 	}
 );

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/pages/AssetsPage.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/pages/AssetsPage.ts
@@ -140,6 +140,10 @@ export class AssetsPage {
 		await this.dataSetFragmentPage.execBulkItemAction({action});
 	}
 
+	async expectBulkItemActionHidden(action: string) {
+		await this.dataSetFragmentPage.expectBulkItemActionHidden({action});
+	}
+
 	async bulkCopyTo(args: BulkCopyOrMoveArgs) {
 		await this.page
 			.getByRole('button', {exact: true, name: 'Copy To'})

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/pages/DataSetPage.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/pages/DataSetPage.ts
@@ -64,6 +64,19 @@ export class DataSetPage {
 		await dropdownMenuItemDelete.click();
 	}
 
+	async expectBulkItemActionHidden({action}: {action: string}) {
+		await this.page
+			.getByTestId('visualization-mode-table')
+			.getByLabel('Actions')
+			.click();
+
+		await expect(
+			this.page.getByRole('menuitem', {exact: true, name: action})
+		).toBeHidden();
+
+		await this.page.keyboard.press('Escape');
+	}
+
 	async execItemAction({
 		action,
 		filter,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-62554
https://liferay.atlassian.net/browse/LPD-67234

## What is being fixed

Two Playwright tests in `bulkActions.spec.ts` were failing after LPD-86106 (Apr 27–28, 2026) tightened the visibility contract for bulk actions on the CMS Assets view. Download is now hidden when any selected item lacks `embedded.file.link.href`, and Delete on the Version History view is hidden when any selected version lacks `actions.delete` (i.e., the current version). Both tests still encoded the prior contract — they expected Download to be visible for content selections and Delete to be visible when the current version was selected, then asserted error toasts or confirmation modals the new UI never produces.

## How it is being fixed

A new `expectBulkItemActionHidden` helper on `DataSetPage` (with a passthrough on `AssetsPage`) opens the Actions dropdown, asserts the named menuitem is hidden, and closes the dropdown — symmetric to the existing `execBulkItemAction`. The Download test now asserts Download is hidden for content-only and mixed content/file selections, and exercises the success path with single-file and multi-file selections. The Delete asset versions test selects all three versions, asserts Delete is hidden when the current version is included, deselects it, deletes the two older versions, then asserts Delete is also hidden when only the current version remains.

## Test execution

`cd modules/test/playwright && yarn test tests/site-cms-site-initializer/main/bulkActions.spec.ts -g "Bulk action download assets"`

`cd modules/test/playwright && yarn test tests/site-cms-site-initializer/main/bulkActions.spec.ts -g "Delete Asset Versions in bulk"`