### PR TITLE
LPD-91723 Return null aspect ratio when one image dimension is zero

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/field/business/type/AttachmentObjectFieldBusinessType.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/field/business/type/AttachmentObjectFieldBusinessType.java
@@ -411,7 +411,7 @@ public class AttachmentObjectFieldBusinessType
 	private String _getAspectRatio(
 		long imageLength, long imageWidth, Locale locale) {
 
-		if ((imageLength <= 0) && (imageWidth <= 0)) {
+		if ((imageLength <= 0) || (imageWidth <= 0)) {
 			return null;
 		}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91723

## What is being fixed

The `_getAspectRatio` method in `AttachmentObjectFieldBusinessType` only returned
`null` when *both* image dimensions were non-positive. When exactly one dimension
was zero or negative — for example, when TIFF metadata extraction surfaced only
width or only height — the method fell through and classified the image as Tall,
Wide, or Square based on a comparison against zero, producing a misleading label
for an image whose true aspect ratio could not be determined.

The twin method `_getResolution` was changed from `&&` to `||` in LPD-85195.
`_getAspectRatio` was left unchanged and carried the same flaw.

## How it is being fixed

The guard at line 414 now uses `||` instead of `&&`, so the method returns
`null` whenever either dimension is non-positive. This matches the LPD-85195
fix in `_getResolution` and ensures the info panel omits the field whenever
the aspect ratio is unknowable.

## Why are there no tests?

The defect lives in a private method that requires reflection to exercise
directly, and reproducing the partial-metadata case end-to-end requires
constructing an image whose TIFF parser yields only one dimension — which is
not straightforward. The change is a one-character mirror of the LPD-85195 fix
to `_getResolution`, which already has integration coverage for the
both-positive and both-zero cases via
`ObjectEntryResourceTest.testGetObjectEntryWithAttachmentObjectFieldImageMetadata`.
