### PR TITLE
LPD-91035 Space setting "Trash entries max age" should handle days

### DIFF
--- a/modules/apps/depot/depot-service/bnd.bnd
+++ b/modules/apps/depot/depot-service/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Depot Service
 Bundle-SymbolicName: com.liferay.depot.service
 Bundle-Version: 3.0.85
-Liferay-Require-SchemaVersion: 2.3.0
+Liferay-Require-SchemaVersion: 2.4.0
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/upgrade/registry/DepotServiceUpgradeStepRegistrator.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/upgrade/registry/DepotServiceUpgradeStepRegistrator.java
@@ -7,11 +7,15 @@ package com.liferay.depot.internal.upgrade.registry;
 
 import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.internal.upgrade.v2_2_0.util.DepotEntryPinTable;
+import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.upgrade.CTModelUpgradeProcess;
 import com.liferay.portal.kernel.upgrade.UpgradeProcessFactory;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Alejandro Tardín
@@ -56,6 +60,22 @@ public class DepotServiceUpgradeStepRegistrator
 			UpgradeProcessFactory.runSQL(
 				"update DepotEntryGroupRel set type_ = " +
 					DepotConstants.TYPE_ASSET_LIBRARY));
+
+		registry.register(
+			"2.3.0", "2.4.0",
+			new com.liferay.depot.internal.upgrade.v2_4_0.
+				TrashEntriesMaxAgeUpgradeProcess(
+					_companyLocalService, _depotEntryLocalService,
+					_groupLocalService));
 	}
+
+	@Reference
+	private CompanyLocalService _companyLocalService;
+
+	@Reference
+	private DepotEntryLocalService _depotEntryLocalService;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
 
 }

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/upgrade/v2_4_0/TrashEntriesMaxAgeUpgradeProcess.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/upgrade/v2_4_0/TrashEntriesMaxAgeUpgradeProcess.java
@@ -1,0 +1,105 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.depot.internal.upgrade.v2_4_0;
+
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.PrefsPropsUtil;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.util.List;
+
+/**
+ * @author Alicia García
+ */
+public class TrashEntriesMaxAgeUpgradeProcess extends UpgradeProcess {
+
+	public TrashEntriesMaxAgeUpgradeProcess(
+		CompanyLocalService companyLocalService,
+		DepotEntryLocalService depotEntryLocalService,
+		GroupLocalService groupLocalService) {
+
+		_companyLocalService = companyLocalService;
+		_depotEntryLocalService = depotEntryLocalService;
+		_groupLocalService = groupLocalService;
+	}
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		_companyLocalService.forEachCompanyId(
+			companyId -> {
+				int trashEntriesMaxAgeCompany = PrefsPropsUtil.getInteger(
+					companyId, PropsKeys.TRASH_ENTRIES_MAX_AGE,
+					PropsValues.TRASH_ENTRIES_MAX_AGE);
+
+				if (trashEntriesMaxAgeCompany <= 0) {
+					return;
+				}
+
+				List<DepotEntry> depotEntries =
+					_depotEntryLocalService.getDepotEntries(
+						companyId, DepotConstants.TYPE_SPACE);
+
+				for (DepotEntry depotEntry : depotEntries) {
+					Group group = _groupLocalService.fetchGroup(
+						depotEntry.getGroupId());
+
+					if (group == null) {
+						continue;
+					}
+
+					_updateTrashEntriesMaxAge(group, trashEntriesMaxAgeCompany);
+				}
+			});
+	}
+
+	private void _updateTrashEntriesMaxAge(
+			Group group, int trashEntriesMaxAgeCompany)
+		throws Exception {
+
+		UnicodeProperties typeSettingsUnicodeProperties =
+			group.getTypeSettingsProperties();
+
+		String trashEntriesMaxAgeGroup =
+			typeSettingsUnicodeProperties.getProperty("trashEntriesMaxAge");
+
+		if (Validator.isNotNull(trashEntriesMaxAgeGroup) &&
+			(GetterUtil.getInteger(trashEntriesMaxAgeGroup) > 0)) {
+
+			return;
+		}
+
+		typeSettingsUnicodeProperties.setProperty(
+			"trashEntriesMaxAge", String.valueOf(trashEntriesMaxAgeCompany));
+
+		_groupLocalService.updateGroup(
+			group.getGroupId(), typeSettingsUnicodeProperties.toString());
+
+		if (_log.isDebugEnabled()) {
+			_log.debug(
+				"Set trash entries max age for group ID " + group.getGroupId());
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		TrashEntriesMaxAgeUpgradeProcess.class);
+
+	private final CompanyLocalService _companyLocalService;
+	private final DepotEntryLocalService _depotEntryLocalService;
+	private final GroupLocalService _groupLocalService;
+
+}

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/impl/DepotEntryLocalServiceImpl.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/impl/DepotEntryLocalServiceImpl.java
@@ -119,10 +119,12 @@ public class DepotEntryLocalServiceImpl extends DepotEntryLocalServiceBaseImpl {
 		depotEntry.setUuid(serviceContext.getUuid());
 
 		Group group = _groupLocalService.addGroup(
-			StringPool.BLANK, serviceContext.getUserId(),
-			GroupConstants.DEFAULT_PARENT_GROUP_ID, DepotEntry.class.getName(),
-			depotEntry.getDepotEntryId(), GroupConstants.DEFAULT_LIVE_GROUP_ID,
-			nameMap, descriptionMap, GroupConstants.TYPE_DEPOT, null, true,
+			GetterUtil.getString(
+				serviceContext.getAttribute("groupExternalReferenceCode")),
+			serviceContext.getUserId(), GroupConstants.DEFAULT_PARENT_GROUP_ID,
+			DepotEntry.class.getName(), depotEntry.getDepotEntryId(),
+			GroupConstants.DEFAULT_LIVE_GROUP_ID, nameMap, descriptionMap,
+			GroupConstants.TYPE_DEPOT, null, true,
 			GroupConstants.DEFAULT_MEMBERSHIP_RESTRICTION,
 			"/asset-library-" + depotEntry.getDepotEntryId(), false, false,
 			true, serviceContext);

--- a/modules/apps/depot/depot-test/build.gradle
+++ b/modules/apps/depot/depot-test/build.gradle
@@ -22,8 +22,10 @@ dependencies {
 	testIntegrationImplementation project(":apps:portal-search:portal-search-test-util")
 	testIntegrationImplementation project(":apps:portal-search:portal-search-web-api")
 	testIntegrationImplementation project(":apps:portal-vulcan:portal-vulcan-api")
+	testIntegrationImplementation project(":apps:portal:portal-upgrade-test-util")
 	testIntegrationImplementation project(":apps:site:site-api")
 	testIntegrationImplementation project(":apps:site:site-memberships-api")
 	testIntegrationImplementation project(":apps:staging:staging-api")
+	testIntegrationImplementation project(":apps:static:portal:portal-upgrade-api")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/upgrade/v2_4_0/test/TrashEntriesMaxAgeUpgradeProcessTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/upgrade/v2_4_0/test/TrashEntriesMaxAgeUpgradeProcessTest.java
@@ -1,0 +1,188 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.depot.internal.upgrade.v2_4_0.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.portal.kernel.cache.MultiVMPool;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PrefsPropsUtil;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Alicia García
+ */
+@RunWith(Arquillian.class)
+public class TrashEntriesMaxAgeUpgradeProcessTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Test
+	@TestInfo("LPD-91035")
+	public void testUpgrade() throws Exception {
+		_testUpgradeWithAssetLibraryDepotEntry();
+		_testUpgradeWithCustomMaxAge();
+		_testUpgradeWithMissingMaxAge();
+		_testUpgradeWithZeroMaxAge();
+	}
+
+	private DepotEntry _addDepotEntry(int type) throws Exception {
+		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
+			Collections.singletonMap(
+				LocaleUtil.US, RandomTestUtil.randomString()),
+			Collections.singletonMap(
+				LocaleUtil.US, RandomTestUtil.randomString()),
+			type, ServiceContextTestUtil.getServiceContext());
+
+		_depotEntries.add(depotEntry);
+
+		return depotEntry;
+	}
+
+	private int _getTrashEntriesMaxAgeCompany() throws Exception {
+		return PrefsPropsUtil.getInteger(
+			TestPropsValues.getCompanyId(), PropsKeys.TRASH_ENTRIES_MAX_AGE,
+			PropsValues.TRASH_ENTRIES_MAX_AGE);
+	}
+
+	private String _getTrashEntriesMaxAgeGroup(DepotEntry depotEntry) {
+		Group group = _groupLocalService.fetchGroup(depotEntry.getGroupId());
+
+		UnicodeProperties typeSettingsUnicodeProperties =
+			group.getTypeSettingsProperties();
+
+		return typeSettingsUnicodeProperties.getProperty("trashEntriesMaxAge");
+	}
+
+	private void _runUpgradeProcess() throws Exception {
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				_CLASS_NAME, LoggerTestUtil.OFF)) {
+
+			UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
+				_upgradeStepRegistrator, _CLASS_NAME);
+
+			upgradeProcess.upgrade();
+
+			_multiVMPool.clear();
+		}
+	}
+
+	private void _setTrashEntriesMaxAgeGroup(
+			DepotEntry depotEntry, String trashEntriesMaxAge)
+		throws Exception {
+
+		Group group = _groupLocalService.fetchGroup(depotEntry.getGroupId());
+
+		UnicodeProperties typeSettingsUnicodeProperties =
+			group.getTypeSettingsProperties();
+
+		typeSettingsUnicodeProperties.setProperty(
+			"trashEntriesMaxAge", trashEntriesMaxAge);
+
+		_groupLocalService.updateGroup(
+			group.getGroupId(), typeSettingsUnicodeProperties.toString());
+	}
+
+	private void _testUpgradeWithAssetLibraryDepotEntry() throws Exception {
+		DepotEntry depotEntry = _addDepotEntry(
+			DepotConstants.TYPE_ASSET_LIBRARY);
+
+		_setTrashEntriesMaxAgeGroup(depotEntry, "0");
+
+		_runUpgradeProcess();
+
+		Assert.assertEquals("0", _getTrashEntriesMaxAgeGroup(depotEntry));
+	}
+
+	private void _testUpgradeWithCustomMaxAge() throws Exception {
+		DepotEntry depotEntry = _addDepotEntry(DepotConstants.TYPE_SPACE);
+
+		_setTrashEntriesMaxAgeGroup(depotEntry, "1440");
+
+		_runUpgradeProcess();
+
+		Assert.assertEquals("1440", _getTrashEntriesMaxAgeGroup(depotEntry));
+	}
+
+	private void _testUpgradeWithMissingMaxAge() throws Exception {
+		DepotEntry depotEntry = _addDepotEntry(DepotConstants.TYPE_SPACE);
+
+		_runUpgradeProcess();
+
+		Assert.assertEquals(
+			String.valueOf(_getTrashEntriesMaxAgeCompany()),
+			_getTrashEntriesMaxAgeGroup(depotEntry));
+	}
+
+	private void _testUpgradeWithZeroMaxAge() throws Exception {
+		DepotEntry depotEntry = _addDepotEntry(DepotConstants.TYPE_SPACE);
+
+		_setTrashEntriesMaxAgeGroup(depotEntry, "0");
+
+		_runUpgradeProcess();
+
+		Assert.assertEquals(
+			String.valueOf(_getTrashEntriesMaxAgeCompany()),
+			_getTrashEntriesMaxAgeGroup(depotEntry));
+	}
+
+	private static final String _CLASS_NAME =
+		"com.liferay.depot.internal.upgrade.v2_4_0." +
+			"TrashEntriesMaxAgeUpgradeProcess";
+
+	@DeleteAfterTestRun
+	private final List<DepotEntry> _depotEntries = new ArrayList<>();
+
+	@Inject
+	private DepotEntryLocalService _depotEntryLocalService;
+
+	@Inject
+	private GroupLocalService _groupLocalService;
+
+	@Inject
+	private MultiVMPool _multiVMPool;
+
+	@Inject(
+		filter = "component.name=com.liferay.depot.internal.upgrade.registry.DepotServiceUpgradeStepRegistrator"
+	)
+	private UpgradeStepRegistrator _upgradeStepRegistrator;
+
+}

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/test/DepotEntryLocalServiceTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/test/DepotEntryLocalServiceTest.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserGroupLocalService;
 import com.liferay.portal.kernel.service.UserGroupRoleLocalService;
 import com.liferay.portal.kernel.test.AssertUtils;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.CompanyTestUtil;
@@ -116,6 +117,36 @@ public class DepotEntryLocalServiceTest {
 		_addDepotEntry(
 			group.getName(LocaleUtil.getDefault()),
 			RandomTestUtil.randomString());
+	}
+
+	@Test
+	@TestInfo("LPD-92654")
+	public void testAddDepotEntryWithGroupExternalReferenceCode()
+		throws Exception {
+
+		String groupExternalReferenceCode = RandomTestUtil.randomString();
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext();
+
+		serviceContext.setAttribute(
+			"groupExternalReferenceCode", groupExternalReferenceCode);
+
+		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()
+			).build(),
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()
+			).build(),
+			DepotConstants.TYPE_ASSET_LIBRARY, serviceContext);
+
+		_depotEntries.add(depotEntry);
+
+		Group group = _groupLocalService.getGroup(depotEntry.getGroupId());
+
+		Assert.assertEquals(
+			groupExternalReferenceCode, group.getExternalReferenceCode());
 	}
 
 	@Test(expected = DepotEntryNameException.class)

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/test/DepotEntryLocalServiceTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/test/DepotEntryLocalServiceTest.java
@@ -124,13 +124,13 @@ public class DepotEntryLocalServiceTest {
 	public void testAddDepotEntryWithGroupExternalReferenceCode()
 		throws Exception {
 
-		String groupExternalReferenceCode = RandomTestUtil.randomString();
+		String externalReferenceCode = RandomTestUtil.randomString();
 
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext();
 
 		serviceContext.setAttribute(
-			"groupExternalReferenceCode", groupExternalReferenceCode);
+			"groupExternalReferenceCode", externalReferenceCode);
 
 		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
 			HashMapBuilder.put(
@@ -146,7 +146,7 @@ public class DepotEntryLocalServiceTest {
 		Group group = _groupLocalService.getGroup(depotEntry.getGroupId());
 
 		Assert.assertEquals(
-			groupExternalReferenceCode, group.getExternalReferenceCode());
+			externalReferenceCode, group.getExternalReferenceCode());
 	}
 
 	@Test(expected = DepotEntryNameException.class)

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/dto/v1_0/converter/AssetLibraryDTOConverter.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/dto/v1_0/converter/AssetLibraryDTOConverter.java
@@ -26,6 +26,9 @@ import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.PrefsPropsUtil;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
@@ -224,8 +227,20 @@ public class AssetLibraryDTOConverter
 					() -> GetterUtil.getBoolean(
 						unicodeProperties.get("trashEnabled"), true));
 				setTrashEntriesMaxAge(
-					() -> GetterUtil.getInteger(
-						unicodeProperties.getProperty("trashEntriesMaxAge")));
+					() -> {
+						int trashEntriesMaxAge = GetterUtil.getInteger(
+							unicodeProperties.getProperty(
+								"trashEntriesMaxAge"));
+
+						if (trashEntriesMaxAge > 0) {
+							return trashEntriesMaxAge;
+						}
+
+						return PrefsPropsUtil.getInteger(
+							group.getCompanyId(),
+							PropsKeys.TRASH_ENTRIES_MAX_AGE,
+							PropsValues.TRASH_ENTRIES_MAX_AGE);
+					});
 				setUseCustomLanguages(
 					() -> !GetterUtil.getBoolean(
 						unicodeProperties.get("inheritLocales")));

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/AssetLibraryResourceImpl.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/AssetLibraryResourceImpl.java
@@ -436,6 +436,11 @@ public class AssetLibraryResourceImpl extends BaseAssetLibraryResourceImpl {
 			return updatedDepotEntry;
 		}
 
+		if (Validator.isNotNull(externalReferenceCode)) {
+			serviceContext.setAttribute(
+				"groupExternalReferenceCode", externalReferenceCode);
+		}
+
 		DepotEntry depotEntry = _depotEntryService.addDepotEntry(
 			nameMap, descriptionMap,
 			AssetLibraryUtil.getDepotEntryType(
@@ -446,21 +451,13 @@ public class AssetLibraryResourceImpl extends BaseAssetLibraryResourceImpl {
 
 		group = depotEntry.getGroup();
 
-		if (Validator.isNotNull(externalReferenceCode) ||
-			((unicodeProperties != null) && !unicodeProperties.isEmpty())) {
-
-			if (Validator.isNotNull(externalReferenceCode)) {
-				group.setExternalReferenceCode(externalReferenceCode);
-			}
-
-			if ((unicodeProperties != null) && !unicodeProperties.isEmpty()) {
-				group.setTypeSettingsProperties(
-					UnicodePropertiesBuilder.create(
-						group.getTypeSettingsProperties(), true
-					).putAll(
-						unicodeProperties
-					).build());
-			}
+		if ((unicodeProperties != null) && !unicodeProperties.isEmpty()) {
+			group.setTypeSettingsProperties(
+				UnicodePropertiesBuilder.create(
+					group.getTypeSettingsProperties(), true
+				).putAll(
+					unicodeProperties
+				).build());
 
 			group = _groupLocalService.updateGroup(group);
 		}

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/AssetLibraryResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/AssetLibraryResourceTest.java
@@ -36,6 +36,9 @@ import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PrefsPropsUtil;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.odata.entity.EntityField;
@@ -191,6 +194,7 @@ public class AssetLibraryResourceTest extends BaseAssetLibraryResourceTestCase {
 		_testPostAssetLibrary(new MimeTypeLimit[0]);
 		_testPostAssetLibraryWithDuplicateExternalReferenceCode();
 		_testPostAssetLibraryWithExternalReferenceCode();
+		_testPostAssetLibraryWithMissingTrashEntriesMaxAge();
 		_testPostAssetLibraryWithNoSettings();
 
 		AssetLibrary randomAssetLibrary = randomAssetLibrary();
@@ -796,6 +800,28 @@ public class AssetLibraryResourceTest extends BaseAssetLibraryResourceTestCase {
 		Assert.assertNotNull(
 			_groupLocalService.fetchGroupByExternalReferenceCode(
 				externalReferenceCode, testCompany.getCompanyId()));
+	}
+
+	private void _testPostAssetLibraryWithMissingTrashEntriesMaxAge()
+		throws Exception {
+
+		AssetLibrary randomAssetLibrary = randomAssetLibrary();
+
+		randomAssetLibrary.setSettings(new Settings());
+		randomAssetLibrary.setType(AssetLibrary.Type.SPACE);
+
+		AssetLibrary postedAssetLibrary = assetLibraryResource.postAssetLibrary(
+			randomAssetLibrary);
+
+		Settings settings = postedAssetLibrary.getSettings();
+
+		Assert.assertEquals(
+			Integer.valueOf(
+				PrefsPropsUtil.getInteger(
+					TestPropsValues.getCompanyId(),
+					PropsKeys.TRASH_ENTRIES_MAX_AGE,
+					PropsValues.TRASH_ENTRIES_MAX_AGE)),
+			settings.getTrashEntriesMaxAge());
 	}
 
 	private void _testPostAssetLibraryWithNoSettings() throws Exception {

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/AssetLibraryResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/AssetLibraryResourceTest.java
@@ -793,11 +793,9 @@ public class AssetLibraryResourceTest extends BaseAssetLibraryResourceTestCase {
 			externalReferenceCode,
 			postedAssetLibrary.getExternalReferenceCode());
 
-		Group group = _groupLocalService.getGroupByExternalReferenceCode(
-			externalReferenceCode, testCompany.getCompanyId());
-
-		Assert.assertEquals(
-			externalReferenceCode, group.getExternalReferenceCode());
+		Assert.assertNotNull(
+			_groupLocalService.fetchGroupByExternalReferenceCode(
+				externalReferenceCode, testCompany.getCompanyId()));
 	}
 
 	private void _testPostAssetLibraryWithNoSettings() throws Exception {

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/AssetLibraryResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/AssetLibraryResourceTest.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
@@ -174,6 +175,7 @@ public class AssetLibraryResourceTest extends BaseAssetLibraryResourceTestCase {
 
 	@Override
 	@Test
+	@TestInfo("LPD-92654")
 	public void testPostAssetLibrary() throws Exception {
 		super.testPostAssetLibrary();
 
@@ -188,6 +190,7 @@ public class AssetLibraryResourceTest extends BaseAssetLibraryResourceTestCase {
 			});
 		_testPostAssetLibrary(new MimeTypeLimit[0]);
 		_testPostAssetLibraryWithDuplicateExternalReferenceCode();
+		_testPostAssetLibraryWithExternalReferenceCode();
 		_testPostAssetLibraryWithNoSettings();
 
 		AssetLibrary randomAssetLibrary = randomAssetLibrary();
@@ -771,6 +774,30 @@ public class AssetLibraryResourceTest extends BaseAssetLibraryResourceTestCase {
 					"this-external-reference-code-is-already-in-use"),
 				problem.getTitle());
 		}
+	}
+
+	private void _testPostAssetLibraryWithExternalReferenceCode()
+		throws Exception {
+
+		String externalReferenceCode = RandomTestUtil.randomString();
+
+		AssetLibrary randomAssetLibrary = randomAssetLibrary();
+
+		randomAssetLibrary.setExternalReferenceCode(externalReferenceCode);
+		randomAssetLibrary.setType(AssetLibrary.Type.SPACE);
+
+		AssetLibrary postedAssetLibrary =
+			testGetAssetLibrariesPage_addAssetLibrary(randomAssetLibrary);
+
+		Assert.assertEquals(
+			externalReferenceCode,
+			postedAssetLibrary.getExternalReferenceCode());
+
+		Group group = _groupLocalService.getGroupByExternalReferenceCode(
+			externalReferenceCode, testCompany.getCompanyId());
+
+		Assert.assertEquals(
+			externalReferenceCode, group.getExternalReferenceCode());
 	}
 
 	private void _testPostAssetLibraryWithNoSettings() throws Exception {

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalConverterImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalConverterImpl.java
@@ -190,7 +190,7 @@ public class JournalConverterImpl implements JournalConverter {
 					ddmFormField.getType(),
 					DDMFormFieldTypeConstants.FIELDSET)) {
 
-				_updateFieldsDisplay(
+				_populateFieldsDisplayValue(
 					ddmFormFieldName, StringUtil.randomString(), sb);
 			}
 
@@ -237,7 +237,7 @@ public class JournalConverterImpl implements JournalConverter {
 				}
 			}
 
-			_updateFieldsDisplay(
+			_populateFieldsDisplayValue(
 				ddmFormFieldName,
 				dynamicElementElement.attributeValue("instance-id"), sb);
 
@@ -540,6 +540,22 @@ public class JournalConverterImpl implements JournalConverter {
 		return jsonArray.toString();
 	}
 
+	private void _populateFieldsDisplayValue(
+		String fieldName, String instanceId, StringBundler sb) {
+
+		if (Validator.isNull(instanceId)) {
+			instanceId = StringUtil.randomString();
+		}
+
+		if (sb.index() > 0) {
+			sb.append(StringPool.COMMA);
+		}
+
+		sb.append(fieldName);
+		sb.append(DDM.INSTANCE_SEPARATOR);
+		sb.append(instanceId);
+	}
+
 	private String[] _splitFieldsDisplayValue(Field fieldsDisplayField) {
 		String value = (String)fieldsDisplayField.getValue();
 
@@ -759,22 +775,6 @@ public class JournalConverterImpl implements JournalConverter {
 
 			ddmFieldsCounter.incrementKey(ddmFormFieldName);
 		}
-	}
-
-	private void _updateFieldsDisplay(
-		String fieldName, String instanceId, StringBundler sb) {
-
-		if (Validator.isNull(instanceId)) {
-			instanceId = StringUtil.randomString();
-		}
-
-		if (sb.index() > 0) {
-			sb.append(StringPool.COMMA);
-		}
-
-		sb.append(fieldName);
-		sb.append(DDM.INSTANCE_SEPARATOR);
-		sb.append(instanceId);
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalConverterImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalConverterImpl.java
@@ -29,7 +29,6 @@ import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -91,10 +90,11 @@ public class JournalConverterImpl implements JournalConverter {
 
 			Fields ddmFields = new Fields();
 
-			ddmFields.put(
-				new Field(
-					ddmStructure.getStructureId(), DDM.FIELDS_DISPLAY_NAME,
-					StringPool.BLANK));
+			Field fieldsDisplayField = new Field(
+				ddmStructure.getStructureId(), DDM.FIELDS_DISPLAY_NAME,
+				StringPool.BLANK);
+
+			ddmFields.put(fieldsDisplayField);
 
 			DDMForm ddmForm = ddmStructure.getDDMForm();
 
@@ -105,11 +105,15 @@ public class JournalConverterImpl implements JournalConverter {
 			String defaultLanguageId = rootElement.attributeValue(
 				"default-locale");
 
+			StringBundler sb = new StringBundler();
+
 			for (DDMFormField ddmFormField : ddmForm.getDDMFormFields()) {
 				_addDDMFields(
 					availableLanguageIds, defaultLanguageId, ddmFields,
-					ddmFormField, ddmStructure, rootElement, rootElement);
+					ddmFormField, ddmStructure, rootElement, rootElement, sb);
 			}
+
+			fieldsDisplayField.setValue(sb.toString());
 
 			return ddmFields;
 		}
@@ -156,7 +160,8 @@ public class JournalConverterImpl implements JournalConverter {
 	private void _addDDMFields(
 			String[] availableLanguageIds, String defaultLanguageId,
 			Fields ddmFields, DDMFormField ddmFormField,
-			DDMStructure ddmStructure, Element element, Element rootElement)
+			DDMStructure ddmStructure, Element element, Element rootElement,
+			StringBundler sb)
 		throws PortalException {
 
 		String ddmFormFieldName = ddmFormField.getName();
@@ -186,12 +191,12 @@ public class JournalConverterImpl implements JournalConverter {
 					DDMFormFieldTypeConstants.FIELDSET)) {
 
 				_updateFieldsDisplay(
-					ddmFields, ddmFormFieldName, StringUtil.randomString());
+					ddmFormFieldName, StringUtil.randomString(), sb);
 			}
 
 			_addNestedDDMFields(
 				availableLanguageIds, defaultLanguageId, ddmFields,
-				ddmFormField, ddmStructure, element, rootElement);
+				ddmFormField, ddmStructure, element, rootElement, sb);
 
 			return;
 		}
@@ -233,19 +238,21 @@ public class JournalConverterImpl implements JournalConverter {
 			}
 
 			_updateFieldsDisplay(
-				ddmFields, ddmFormFieldName,
-				dynamicElementElement.attributeValue("instance-id"));
+				ddmFormFieldName,
+				dynamicElementElement.attributeValue("instance-id"), sb);
 
 			_addNestedDDMFields(
 				availableLanguageIds, defaultLanguageId, ddmFields,
-				ddmFormField, ddmStructure, dynamicElementElement, rootElement);
+				ddmFormField, ddmStructure, dynamicElementElement, rootElement,
+				sb);
 		}
 	}
 
 	private void _addNestedDDMFields(
 			String[] availableLanguageIds, String defaultLanguageId,
 			Fields ddmFields, DDMFormField ddmFormField,
-			DDMStructure ddmStructure, Element element, Element rootElement)
+			DDMStructure ddmStructure, Element element, Element rootElement,
+			StringBundler sb)
 		throws PortalException {
 
 		for (DDMFormField nestedDDMFormField :
@@ -253,7 +260,7 @@ public class JournalConverterImpl implements JournalConverter {
 
 			_addDDMFields(
 				availableLanguageIds, defaultLanguageId, ddmFields,
-				nestedDDMFormField, ddmStructure, element, rootElement);
+				nestedDDMFormField, ddmStructure, element, rootElement, sb);
 		}
 	}
 
@@ -755,24 +762,19 @@ public class JournalConverterImpl implements JournalConverter {
 	}
 
 	private void _updateFieldsDisplay(
-		Fields ddmFields, String fieldName, String instanceId) {
+		String fieldName, String instanceId, StringBundler sb) {
 
 		if (Validator.isNull(instanceId)) {
 			instanceId = StringUtil.randomString();
 		}
 
-		String fieldsDisplayValue = StringBundler.concat(
-			fieldName, DDM.INSTANCE_SEPARATOR, instanceId);
+		if (sb.length() > 0) {
+			sb.append(StringPool.COMMA);
+		}
 
-		Field fieldsDisplayField = ddmFields.get(DDM.FIELDS_DISPLAY_NAME);
-
-		String[] fieldsDisplayValues = StringUtil.split(
-			(String)fieldsDisplayField.getValue());
-
-		fieldsDisplayValues = ArrayUtil.append(
-			fieldsDisplayValues, fieldsDisplayValue);
-
-		fieldsDisplayField.setValue(StringUtil.merge(fieldsDisplayValues));
+		sb.append(fieldName);
+		sb.append(DDM.INSTANCE_SEPARATOR);
+		sb.append(instanceId);
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalConverterImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalConverterImpl.java
@@ -768,7 +768,7 @@ public class JournalConverterImpl implements JournalConverter {
 			instanceId = StringUtil.randomString();
 		}
 
-		if (sb.length() > 0) {
+		if (sb.index() > 0) {
 			sb.append(StringPool.COMMA);
 		}
 

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalConverterImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalConverterImpl.java
@@ -110,7 +110,7 @@ public class JournalConverterImpl implements JournalConverter {
 			for (DDMFormField ddmFormField : ddmForm.getDDMFormFields()) {
 				_addDDMFields(
 					availableLanguageIds, defaultLanguageId, ddmFields,
-					ddmFormField, ddmStructure, rootElement, rootElement, sb);
+					ddmFormField, ddmStructure, rootElement, sb, rootElement);
 			}
 
 			fieldsDisplayField.setValue(sb.toString());
@@ -160,8 +160,8 @@ public class JournalConverterImpl implements JournalConverter {
 	private void _addDDMFields(
 			String[] availableLanguageIds, String defaultLanguageId,
 			Fields ddmFields, DDMFormField ddmFormField,
-			DDMStructure ddmStructure, Element element, Element rootElement,
-			StringBundler sb)
+			DDMStructure ddmStructure, Element element, StringBundler sb,
+			Element rootElement)
 		throws PortalException {
 
 		String ddmFormFieldName = ddmFormField.getName();
@@ -196,7 +196,7 @@ public class JournalConverterImpl implements JournalConverter {
 
 			_addNestedDDMFields(
 				availableLanguageIds, defaultLanguageId, ddmFields,
-				ddmFormField, ddmStructure, element, rootElement, sb);
+				ddmFormField, ddmStructure, element, sb, rootElement);
 
 			return;
 		}
@@ -243,16 +243,16 @@ public class JournalConverterImpl implements JournalConverter {
 
 			_addNestedDDMFields(
 				availableLanguageIds, defaultLanguageId, ddmFields,
-				ddmFormField, ddmStructure, dynamicElementElement, rootElement,
-				sb);
+				ddmFormField, ddmStructure, dynamicElementElement, sb,
+				rootElement);
 		}
 	}
 
 	private void _addNestedDDMFields(
 			String[] availableLanguageIds, String defaultLanguageId,
 			Fields ddmFields, DDMFormField ddmFormField,
-			DDMStructure ddmStructure, Element element, Element rootElement,
-			StringBundler sb)
+			DDMStructure ddmStructure, Element element, StringBundler sb,
+			Element rootElement)
 		throws PortalException {
 
 		for (DDMFormField nestedDDMFormField :
@@ -260,7 +260,7 @@ public class JournalConverterImpl implements JournalConverter {
 
 			_addDDMFields(
 				availableLanguageIds, defaultLanguageId, ddmFields,
-				nestedDDMFormField, ddmStructure, element, rootElement, sb);
+				nestedDDMFormField, ddmStructure, element, sb, rootElement);
 		}
 	}
 

--- a/modules/apps/journal/journal-service/src/test/java/com/liferay/journal/internal/util/JournalConverterImplTest.java
+++ b/modules/apps/journal/journal-service/src/test/java/com/liferay/journal/internal/util/JournalConverterImplTest.java
@@ -5,12 +5,21 @@
 
 package com.liferay.journal.internal.util;
 
+import com.liferay.dynamic.data.mapping.model.DDMForm;
 import com.liferay.dynamic.data.mapping.model.DDMFormField;
 import com.liferay.dynamic.data.mapping.model.DDMFormFieldOptions;
+import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.dynamic.data.mapping.service.DDMStructureLocalServiceUtil;
 import com.liferay.dynamic.data.mapping.storage.Field;
+import com.liferay.dynamic.data.mapping.storage.Fields;
+import com.liferay.dynamic.data.mapping.util.DDM;
+import com.liferay.journal.util.JournalConverter;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.json.JSONFactoryImpl;
 import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -18,6 +27,8 @@ import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.xml.Document;
 import com.liferay.portal.kernel.xml.Element;
+import com.liferay.portal.kernel.xml.SAXReaderUtil;
+import com.liferay.portal.kernel.xml.UnsecureSAXReaderUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 import com.liferay.portal.xml.SAXReaderImpl;
 
@@ -26,11 +37,17 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 
+import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 /**
  * @author Jürgen Kappler
@@ -41,6 +58,123 @@ public class JournalConverterImplTest {
 	@Rule
 	public static final LiferayUnitTestRule liferayUnitTestRule =
 		LiferayUnitTestRule.INSTANCE;
+
+	@BeforeClass
+	public static void setUpClass() {
+		Language language = Mockito.mock(Language.class);
+
+		Mockito.when(
+			language.isAvailableLanguageCode(Mockito.anyString())
+		).thenReturn(
+			true
+		);
+
+		Mockito.when(
+			language.isAvailableLocale(Mockito.any(Locale.class))
+		).thenReturn(
+			true
+		);
+
+		LanguageUtil languageUtil = new LanguageUtil();
+
+		languageUtil.setLanguage(language);
+
+		SAXReaderUtil saxReaderUtil = new SAXReaderUtil();
+
+		SAXReaderImpl secureSAXReaderImpl = new SAXReaderImpl();
+
+		secureSAXReaderImpl.setSecure(true);
+
+		saxReaderUtil.setSAXReader(secureSAXReaderImpl);
+
+		UnsecureSAXReaderUtil unsecureSAXReaderUtil =
+			new UnsecureSAXReaderUtil();
+
+		unsecureSAXReaderUtil.setSAXReader(new SAXReaderImpl());
+
+		_mockedStatic = Mockito.mockStatic(DDMStructureLocalServiceUtil.class);
+	}
+
+	@AfterClass
+	public static void tearDownClass() {
+		_mockedStatic.close();
+	}
+
+	@Test
+	public void testGetDDMFields() throws Exception {
+		JournalConverter journalConverter = new JournalConverterImpl();
+
+		DDMStructure ddmStructure = Mockito.mock(DDMStructure.class);
+
+		Mockito.when(
+			ddmStructure.getStructureId()
+		).thenReturn(
+			RandomTestUtil.randomLong()
+		);
+
+		Mockito.when(
+			DDMStructureLocalServiceUtil.fetchDDMStructure(Mockito.anyLong())
+		).thenReturn(
+			ddmStructure
+		);
+
+		DDMForm ddmForm = new DDMForm();
+
+		Mockito.when(
+			ddmStructure.getDDMForm()
+		).thenReturn(
+			ddmForm
+		);
+
+		int leafCount = 50;
+
+		StringBundler contentSB = new StringBundler(3 + (leafCount * 7));
+
+		contentSB.append("<?xml version=\"1.0\"?><root available-locales=");
+		contentSB.append("\"en_US\" default-locale=\"en_US\">");
+
+		StringBundler expectedSB = new StringBundler((leafCount * 4) - 1);
+
+		for (int i = 0; i < leafCount; i++) {
+			String name = "text" + i;
+			String instanceId = "instance" + i;
+
+			DDMFormField ddmFormField = _createDDMFormField(
+				"string", true, name, "text");
+
+			ddmForm.addDDMFormField(ddmFormField);
+
+			Mockito.when(
+				ddmStructure.getDDMFormField(name)
+			).thenReturn(
+				ddmFormField
+			);
+
+			contentSB.append("<dynamic-element instance-id=\"");
+			contentSB.append(instanceId);
+			contentSB.append("\" name=\"");
+			contentSB.append(name);
+			contentSB.append("\" type=\"text\"><dynamic-content language-id=");
+			contentSB.append("\"en_US\"><![CDATA[v]]></dynamic-content>");
+			contentSB.append("</dynamic-element>");
+
+			if (i > 0) {
+				expectedSB.append(StringPool.COMMA);
+			}
+
+			expectedSB.append(name);
+			expectedSB.append(DDM.INSTANCE_SEPARATOR);
+			expectedSB.append(instanceId);
+		}
+
+		contentSB.append("</root>");
+
+		Assert.assertEquals(
+			expectedSB.toString(),
+			_getFieldsDisplayValue(
+				journalConverter.getDDMFields(
+					ddmStructure, contentSB.toString())));
+	}
 
 	@Test
 	public void testUpdateContentDynamicElement() {
@@ -97,6 +231,15 @@ public class JournalConverterImplTest {
 		Document document = saxReaderImpl.createDocument();
 
 		return document.addElement("root");
+	}
+
+	private String _getFieldsDisplayValue(Fields ddmFields) {
+		Field fieldsDisplayField = ddmFields.get(DDM.FIELDS_DISPLAY_NAME);
+
+		List<Serializable> values = fieldsDisplayField.getValues(
+			LocaleUtil.getSiteDefault());
+
+		return (String)values.get(0);
 	}
 
 	private void _testUpdateContentDynamicElement(
@@ -290,5 +433,7 @@ public class JournalConverterImplTest {
 			},
 			0, ddmFormField, rootElement, field);
 	}
+
+	private static MockedStatic<DDMStructureLocalServiceUtil> _mockedStatic;
 
 }

--- a/modules/apps/journal/journal-service/src/test/java/com/liferay/journal/internal/util/JournalConverterImplTest.java
+++ b/modules/apps/journal/journal-service/src/test/java/com/liferay/journal/internal/util/JournalConverterImplTest.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.xml.Document;
 import com.liferay.portal.kernel.xml.Element;
+import com.liferay.portal.kernel.xml.SAXReader;
 import com.liferay.portal.kernel.xml.SAXReaderUtil;
 import com.liferay.portal.kernel.xml.UnsecureSAXReaderUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
@@ -61,6 +62,10 @@ public class JournalConverterImplTest {
 
 	@BeforeClass
 	public static void setUpClass() {
+		_originalLanguage = LanguageUtil.getLanguage();
+		_originalSAXReader = SAXReaderUtil.getSAXReader();
+		_originalUnsecureSAXReader = UnsecureSAXReaderUtil.getSAXReader();
+
 		Language language = Mockito.mock(Language.class);
 
 		Mockito.when(
@@ -98,6 +103,19 @@ public class JournalConverterImplTest {
 	@AfterClass
 	public static void tearDownClass() {
 		_mockedStatic.close();
+
+		LanguageUtil languageUtil = new LanguageUtil();
+
+		languageUtil.setLanguage(_originalLanguage);
+
+		SAXReaderUtil saxReaderUtil = new SAXReaderUtil();
+
+		saxReaderUtil.setSAXReader(_originalSAXReader);
+
+		UnsecureSAXReaderUtil unsecureSAXReaderUtil =
+			new UnsecureSAXReaderUtil();
+
+		unsecureSAXReaderUtil.setSAXReader(_originalUnsecureSAXReader);
 	}
 
 	@Test
@@ -113,7 +131,7 @@ public class JournalConverterImplTest {
 		);
 
 		Mockito.when(
-			DDMStructureLocalServiceUtil.fetchDDMStructure(Mockito.anyLong())
+			DDMStructureLocalServiceUtil.fetchStructure(Mockito.anyLong())
 		).thenReturn(
 			ddmStructure
 		);
@@ -180,8 +198,9 @@ public class JournalConverterImplTest {
 	public void testUpdateContentDynamicElement() {
 		_testUpdateContentDynamicElement(StringPool.BLANK, null);
 
-		_testUpdateContentDynamicElement(
-			RandomTestUtil.randomString(), RandomTestUtil.randomString());
+		String value = RandomTestUtil.randomString();
+
+		_testUpdateContentDynamicElement(value, value);
 
 		_testUpdateContentDynamicElementWithCheckBox();
 		_testUpdateContentDynamicElementWithOptions();
@@ -435,5 +454,8 @@ public class JournalConverterImplTest {
 	}
 
 	private static MockedStatic<DDMStructureLocalServiceUtil> _mockedStatic;
+	private static Language _originalLanguage;
+	private static SAXReader _originalSAXReader;
+	private static SAXReader _originalUnsecureSAXReader;
 
 }

--- a/modules/apps/journal/journal-service/src/test/java/com/liferay/journal/internal/util/JournalConverterImplTest.java
+++ b/modules/apps/journal/journal-service/src/test/java/com/liferay/journal/internal/util/JournalConverterImplTest.java
@@ -66,6 +66,8 @@ public class JournalConverterImplTest {
 		_originalSAXReader = SAXReaderUtil.getSAXReader();
 		_originalUnsecureSAXReader = UnsecureSAXReaderUtil.getSAXReader();
 
+		LanguageUtil languageUtil = new LanguageUtil();
+
 		Language language = Mockito.mock(Language.class);
 
 		Mockito.when(
@@ -80,15 +82,13 @@ public class JournalConverterImplTest {
 			true
 		);
 
-		LanguageUtil languageUtil = new LanguageUtil();
-
 		languageUtil.setLanguage(language);
+
+		SAXReaderUtil saxReaderUtil = new SAXReaderUtil();
 
 		SAXReaderImpl secureSAXReaderImpl = new SAXReaderImpl();
 
 		secureSAXReaderImpl.setSecure(true);
-
-		SAXReaderUtil saxReaderUtil = new SAXReaderUtil();
 
 		saxReaderUtil.setSAXReader(secureSAXReaderImpl);
 
@@ -215,10 +215,7 @@ public class JournalConverterImplTest {
 			"option-reference");
 
 		if (ListUtil.isEmpty(expectedReferences)) {
-			Assert.assertTrue(
-				"Expected no option references, but found: " +
-					optionReferenceElements,
-				optionReferenceElements.isEmpty());
+			Assert.assertTrue(optionReferenceElements.isEmpty());
 
 			return;
 		}

--- a/modules/apps/journal/journal-service/src/test/java/com/liferay/journal/internal/util/JournalConverterImplTest.java
+++ b/modules/apps/journal/journal-service/src/test/java/com/liferay/journal/internal/util/JournalConverterImplTest.java
@@ -84,11 +84,11 @@ public class JournalConverterImplTest {
 
 		languageUtil.setLanguage(language);
 
-		SAXReaderUtil saxReaderUtil = new SAXReaderUtil();
-
 		SAXReaderImpl secureSAXReaderImpl = new SAXReaderImpl();
 
 		secureSAXReaderImpl.setSecure(true);
+
+		SAXReaderUtil saxReaderUtil = new SAXReaderUtil();
 
 		saxReaderUtil.setSAXReader(secureSAXReaderImpl);
 
@@ -144,9 +144,9 @@ public class JournalConverterImplTest {
 			ddmForm
 		);
 
-		int leafCount = 50;
+		int leafCount = RandomTestUtil.randomInt(10, 50);
 
-		StringBundler contentSB = new StringBundler(3 + (leafCount * 7));
+		StringBundler contentSB = new StringBundler(3 + (leafCount * 9));
 
 		contentSB.append("<?xml version=\"1.0\"?><root available-locales=");
 		contentSB.append("\"en_US\" default-locale=\"en_US\">");
@@ -173,7 +173,9 @@ public class JournalConverterImplTest {
 			contentSB.append("\" name=\"");
 			contentSB.append(name);
 			contentSB.append("\" type=\"text\"><dynamic-content language-id=");
-			contentSB.append("\"en_US\"><![CDATA[v]]></dynamic-content>");
+			contentSB.append("\"en_US\"><![CDATA[");
+			contentSB.append(RandomTestUtil.randomString());
+			contentSB.append("]]></dynamic-content>");
 			contentSB.append("</dynamic-element>");
 
 			if (i > 0) {

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/helper/structure/test/LayoutStructureRulesHelperTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/helper/structure/test/LayoutStructureRulesHelperTest.java
@@ -690,7 +690,9 @@ public class LayoutStructureRulesHelperTest {
 				HashMapBuilder.put(
 					"FIELD_NAME", fieldName
 				).put(
-					"FIELD_VALUE", fieldValueJSONArray.toString()
+					"FIELD_VALUE",
+					StringUtil.merge(
+						JSONUtil.toStringArray(fieldValueJSONArray), "\",\"")
 				).put(
 					"OPERATOR", operator
 				).build()));

--- a/modules/apps/layout/layout-test/src/testIntegration/resources/com/liferay/layout/helper/structure/test/dependencies/layout_data_rules_multiselect_field.json
+++ b/modules/apps/layout/layout-test/src/testIntegration/resources/com/liferay/layout/helper/structure/test/dependencies/layout_data_rules_multiselect_field.json
@@ -61,7 +61,9 @@
 					"id": "condition1",
 					"options": {
 						"type": "${OPERATOR}",
-						"value": ${FIELD_VALUE}
+						"value": [
+							"${FIELD_VALUE}"
+						]
 					},
 					"type": "field"
 				}

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/util/test/CMSDefaultPermissionUtilTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/util/test/CMSDefaultPermissionUtilTest.java
@@ -190,13 +190,13 @@ public class CMSDefaultPermissionUtilTest {
 	public void testGetJSONObjectWhenSpaceCreatedWithGroupExternalReferenceCode()
 		throws Exception {
 
-		String groupExternalReferenceCode = RandomTestUtil.randomString();
+		String externalReferenceCode = RandomTestUtil.randomString();
 
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext();
 
 		serviceContext.setAttribute(
-			"groupExternalReferenceCode", groupExternalReferenceCode);
+			"groupExternalReferenceCode", externalReferenceCode);
 
 		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
 			HashMapBuilder.put(
@@ -212,7 +212,7 @@ public class CMSDefaultPermissionUtilTest {
 		Group group = depotEntry.getGroup();
 
 		Assert.assertEquals(
-			groupExternalReferenceCode, group.getExternalReferenceCode());
+			externalReferenceCode, group.getExternalReferenceCode());
 
 		Assert.assertFalse(
 			JSONUtil.isEmpty(

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/util/test/CMSDefaultPermissionUtilTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/util/test/CMSDefaultPermissionUtilTest.java
@@ -20,8 +20,8 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
-import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
-import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -38,6 +38,8 @@ import com.liferay.site.cms.site.initializer.util.CMSDefaultPermissionUtil;
 
 import java.io.Serializable;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.Assert;
@@ -183,6 +185,46 @@ public class CMSDefaultPermissionUtilTest {
 		Assert.assertEquals(2, jsonArray.length());
 	}
 
+	@Test
+	@TestInfo("LPD-92654")
+	public void testGetJSONObjectWhenSpaceCreatedWithGroupExternalReferenceCode()
+		throws Exception {
+
+		String groupExternalReferenceCode = RandomTestUtil.randomString();
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext();
+
+		serviceContext.setAttribute(
+			"groupExternalReferenceCode", groupExternalReferenceCode);
+
+		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()
+			).build(),
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()
+			).build(),
+			DepotConstants.TYPE_SPACE, serviceContext);
+
+		_depotEntries.add(depotEntry);
+
+		Group group = depotEntry.getGroup();
+
+		Assert.assertEquals(
+			groupExternalReferenceCode, group.getExternalReferenceCode());
+
+		Assert.assertFalse(
+			JSONUtil.isEmpty(
+				CMSDefaultPermissionUtil.getJSONObject(
+					group.getCompanyId(), group.getCreatorUserId(),
+					group.getExternalReferenceCode(),
+					depotEntry.getModelClassName(), _filterFactory)));
+	}
+
+	@DeleteAfterTestRun
+	private final List<DepotEntry> _depotEntries = new ArrayList<>();
+
 	@DeleteAfterTestRun
 	private DepotEntry _depotEntry;
 
@@ -193,11 +235,5 @@ public class CMSDefaultPermissionUtilTest {
 		filter = "filter.factory.key=" + ObjectDefinitionConstants.STORAGE_TYPE_DEFAULT
 	)
 	private FilterFactory<Predicate> _filterFactory;
-
-	@Inject
-	private ResourcePermissionLocalService _resourcePermissionLocalService;
-
-	@Inject
-	private RoleLocalService _roleLocalService;
 
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/components/forms/validations.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/components/forms/validations.ts
@@ -41,6 +41,24 @@ const maxLength =
 		}
 	};
 
+const minValue =
+	(min: number): ValidationFunction =>
+	(value) => {
+		if (
+			value !== '' &&
+			value !== undefined &&
+			value !== null &&
+			Number(value) < min
+		) {
+			return sub(
+				Liferay.Language.get(
+					'please-enter-a-value-greater-than-or-equal-to-x'
+				),
+				min
+			);
+		}
+	};
+
 const notNull: ValidationFunction = (value) => {
 	if (value === 'null') {
 		return Liferay.Language.get('name-cannot-be-null');
@@ -102,6 +120,7 @@ export {
 	alphanumeric,
 	invalidCharacters,
 	maxLength,
+	minValue,
 	notNull,
 	nonNumeric,
 	required,

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/spaces/SpaceGeneralSettings.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/spaces/SpaceGeneralSettings.tsx
@@ -16,6 +16,7 @@ import {
 	Errors,
 	invalidCharacters,
 	maxLength,
+	minValue,
 	nonNumeric,
 	notNull,
 	required,
@@ -28,6 +29,8 @@ import {ERC_MAX_LENGTH} from '../../common/utils/constants';
 import focusInvalidElement from '../../common/utils/focusInvalidElement';
 import SpaceBaseFields from './SpaceBaseFields';
 import SpacePanel from './SpacePanel';
+
+const MINUTES_PER_DAY = 1440;
 
 export default function SpaceGeneralSettings({
 	backURL,
@@ -67,7 +70,9 @@ export default function SpaceGeneralSettings({
 			sharingEnabled: space.settings?.sharingEnabled ?? false,
 			trashEnabled: space.settings?.trashEnabled ?? true,
 			trashEntriesMaxAge: String(
-				space.settings?.trashEntriesMaxAge ?? ''
+				Math.round(
+					(space.settings?.trashEntriesMaxAge ?? 0) / MINUTES_PER_DAY
+				)
 			),
 		},
 		onSubmit: async (values) => {
@@ -93,7 +98,8 @@ export default function SpaceGeneralSettings({
 						logoColor,
 						sharingEnabled,
 						trashEnabled,
-						trashEntriesMaxAge: Number(trashEntriesMaxAge),
+						trashEntriesMaxAge:
+							Number(trashEntriesMaxAge) * MINUTES_PER_DAY,
 					},
 				}
 			);
@@ -156,7 +162,7 @@ export default function SpaceGeneralSettings({
 						maxLength(150),
 					],
 					trashEntriesMaxAge: values.trashEnabled
-						? [required, validNumber]
+						? [minValue(1), required, validNumber]
 						: [],
 				},
 				values,

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/spaces/SpaceGeneralSettings.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/spaces/SpaceGeneralSettings.test.tsx
@@ -37,7 +37,7 @@ const SPACE: Partial<Space> = {
 		logoColor: 'outline-2',
 		sharingEnabled: true,
 		trashEnabled: true,
-		trashEntriesMaxAge: 0,
+		trashEntriesMaxAge: 2880,
 	},
 };
 
@@ -196,6 +196,65 @@ describe('SpaceGeneralSettings', () => {
 		});
 
 		await closeToast();
+	});
+
+	describe('Trash entries max age', () => {
+		it('displays the value in days converted from the stored minutes', () => {
+			renderComponent({
+				space: {
+					...SPACE,
+					settings: {
+						...SPACE.settings!,
+						trashEntriesMaxAge: 7200,
+					},
+				} as Partial<Space>,
+			});
+
+			expect(screen.getByLabelText('trash-entries-max-age')).toHaveValue(
+				5
+			);
+		});
+
+		it('converts the value to minutes on save', async () => {
+			renderComponent();
+
+			const trashEntriesMaxAgeField = screen.getByLabelText(
+				'trash-entries-max-age'
+			);
+
+			await userEvent.clear(trashEntriesMaxAgeField);
+			await userEvent.type(trashEntriesMaxAgeField, '5');
+
+			await userEvent.click(screen.getByRole('button', {name: 'save'}));
+
+			await waitFor(() => {
+				expect(SpaceService.updateSpace).toBeCalledWith(
+					expect.any(String),
+					expect.objectContaining({
+						settings: expect.objectContaining({
+							trashEntriesMaxAge: 7200,
+						}),
+					})
+				);
+			});
+
+			await closeToast();
+		});
+
+		it('does not save when the value is less than 1', async () => {
+			renderComponent();
+
+			const trashEntriesMaxAgeField = screen.getByLabelText(
+				'trash-entries-max-age'
+			);
+
+			await userEvent.clear(trashEntriesMaxAgeField);
+			await userEvent.type(trashEntriesMaxAgeField, '0');
+
+			await userEvent.click(screen.getByRole('button', {name: 'save'}));
+
+			expect(SpaceService.updateSpace).not.toHaveBeenCalled();
+		});
 	});
 
 	describe('Errors', () => {

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/object-definitions/crawler-job-object-definition.json
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/object-definitions/crawler-job-object-definition.json
@@ -142,6 +142,18 @@
 			"type": "String"
 		},
 		{
+			"DBType": "Long",
+			"businessType": "LongInteger",
+			"externalReferenceCode": "INDEXED_DOCUMENT_BYTES",
+			"indexed": true,
+			"label": {
+				"en_US": "Indexed Document Bytes"
+			},
+			"name": "indexedDocumentBytes",
+			"system": true,
+			"type": "Long"
+		},
+		{
 			"DBType": "DateTime",
 			"businessType": "DateTime",
 			"externalReferenceCode": "START_DATE",

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/spaceManagement.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/spaceManagement.spec.ts
@@ -99,6 +99,50 @@ test(
 );
 
 test(
+	'Trash entries max age field shows the company default in days and rejects values below 1',
+	{tag: '@LPD-91035'},
+	async ({apiHelpers, page, spaceSummaryPage}) => {
+		const spaceName = `Space ${getRandomString()}`;
+
+		await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			settings: {},
+			type: 'Space',
+		});
+
+		await spaceSummaryPage.goto(spaceName);
+
+		await page.getByRole('button', {name: 'More Actions'}).click();
+		await page.getByRole('menuitem', {name: 'Settings'}).click();
+
+		const trashEntriesMaxAgeField = page.getByRole('spinbutton', {
+			name: 'Trash Entries Max Age',
+		});
+
+		await expect(trashEntriesMaxAgeField).toHaveValue('30');
+
+		await trashEntriesMaxAgeField.fill('0');
+		await page.getByRole('button', {name: 'Save'}).click();
+
+		await expect(
+			page.getByText('Please enter a value greater than or equal to 1')
+		).toBeVisible();
+
+		await trashEntriesMaxAgeField.fill('7');
+		await page.getByRole('button', {name: 'Save'}).click();
+
+		await waitForAlert(page, 'Success');
+
+		await spaceSummaryPage.goto(spaceName);
+
+		await page.getByRole('button', {name: 'More Actions'}).click();
+		await page.getByRole('menuitem', {name: 'Settings'}).click();
+
+		await expect(trashEntriesMaxAgeField).toHaveValue('7');
+	}
+);
+
+test(
 	'The Permissions modal can be opened from the All Spaces row actions',
 	{tag: '@LPD-85670'},
 	async ({apiHelpers, page}) => {

--- a/portal-impl/src/com/liferay/portal/tools/ConfigurationEnvBuilder.java
+++ b/portal-impl/src/com/liferay/portal/tools/ConfigurationEnvBuilder.java
@@ -12,6 +12,7 @@ import com.liferay.portal.json.JSONFactoryImpl;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
@@ -504,7 +505,7 @@ public class ConfigurationEnvBuilder {
 			);
 		}
 
-		return schemaJSONObject.toString();
+		return JSONUtil.toString(schemaJSONObject);
 	}
 
 	private static String _lang(String key) {

--- a/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-etc-spring-boot/client-extension.yaml
+++ b/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-etc-spring-boot/client-extension.yaml
@@ -5,7 +5,7 @@ liferay-aihub-etc-spring-boot-oahs:
     .serviceScheme: http
     name: Liferay AI Hub Etc Spring Boot OAuth Application Headless Server
     scopes:
-        -   c_aihubcrawlerjob.everything
+        -   aihubcrawlerjob.everything
     type: oAuthApplicationHeadlessServer
 liferay-aihub-etc-spring-boot-oaua:
     .serviceAddress: localhost:58081

--- a/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-etc-spring-boot/src/main/java/com/liferay/ai/hub/AIHubSpringBootApplication.java
+++ b/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-etc-spring-boot/src/main/java/com/liferay/ai/hub/AIHubSpringBootApplication.java
@@ -10,10 +10,12 @@ import com.liferay.client.extension.util.spring.boot3.ClientExtensionUtilSpringB
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Import;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 /**
  * @author José Abelenda
  */
+@EnableScheduling
 @Import(ClientExtensionUtilSpringBootComponentScan.class)
 @SpringBootApplication
 public class AIHubSpringBootApplication {

--- a/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-etc-spring-boot/src/main/java/com/liferay/ai/hub/ObjectActionCrawlerRestController.java
+++ b/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-etc-spring-boot/src/main/java/com/liferay/ai/hub/ObjectActionCrawlerRestController.java
@@ -55,6 +55,8 @@ public class ObjectActionCrawlerRestController extends BaseRestController {
 			"values");
 
 		Job job = _kubernetesJobService.createJob(
+			valuesJSONObject.getLong(
+				"r_accountToAIHubContentRetrievers_accountEntryId"),
 			valuesJSONObject.getString("indexName"),
 			valuesJSONObject.getString("url"));
 

--- a/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-etc-spring-boot/src/main/java/com/liferay/ai/hub/service/CrawlerJobStatusService.java
+++ b/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-etc-spring-boot/src/main/java/com/liferay/ai/hub/service/CrawlerJobStatusService.java
@@ -9,6 +9,7 @@ import com.liferay.client.extension.util.spring.boot3.client.LiferayOAuth2Access
 import com.liferay.client.extension.util.spring.boot3.service.BaseService;
 import com.liferay.petra.string.StringBundler;
 
+import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.batch.v1.Job;
 import io.fabric8.kubernetes.api.model.batch.v1.JobCondition;
 import io.fabric8.kubernetes.api.model.batch.v1.JobStatus;
@@ -127,10 +128,10 @@ public class CrawlerJobStatusService extends BaseService {
 
 					patchJSONObject.put("endDate", endDate);
 
+					ObjectMeta objectMeta = job.getMetadata();
+
 					_putIndexedDocumentStats(
-						patchJSONObject,
-						job.getMetadata(
-						).getName());
+						patchJSONObject, objectMeta.getName());
 				}
 
 				long id = jsonObject.getLong("id");

--- a/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-etc-spring-boot/src/main/java/com/liferay/ai/hub/service/CrawlerJobStatusService.java
+++ b/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-etc-spring-boot/src/main/java/com/liferay/ai/hub/service/CrawlerJobStatusService.java
@@ -1,0 +1,291 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ai.hub.service;
+
+import com.liferay.client.extension.util.spring.boot3.client.LiferayOAuth2AccessTokenManager;
+import com.liferay.client.extension.util.spring.boot3.service.BaseService;
+import com.liferay.petra.string.StringBundler;
+
+import io.fabric8.kubernetes.api.model.batch.v1.Job;
+import io.fabric8.kubernetes.api.model.batch.v1.JobCondition;
+import io.fabric8.kubernetes.api.model.batch.v1.JobStatus;
+
+import java.net.URI;
+import java.net.URLEncoder;
+
+import java.nio.charset.StandardCharsets;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+/**
+ * @author José Abelenda
+ */
+@Service
+public class CrawlerJobStatusService extends BaseService {
+
+	public CrawlerJobStatusService(KubernetesJobService kubernetesJobService) {
+		_kubernetesJobService = kubernetesJobService;
+	}
+
+	@Scheduled(fixedDelay = 60000)
+	public void updateStatuses() {
+		JSONArray jsonArray = _getActiveCrawlerJobsJSONArray();
+
+		for (int i = 0; i < jsonArray.length(); i++) {
+			JSONObject jsonObject = jsonArray.getJSONObject(i);
+
+			try {
+				String executionId = jsonObject.optString("executionId");
+
+				if (executionId.isEmpty()) {
+					continue;
+				}
+
+				Job job = _kubernetesJobService.getJob(executionId);
+
+				String crawlerJobStatus = _getCrawlerJobStatus(job);
+
+				if ((crawlerJobStatus == null) ||
+					crawlerJobStatus.equals(
+						jsonObject.optString("crawlerJobStatus"))) {
+
+					continue;
+				}
+
+				JobStatus jobStatus = null;
+				String startDate = null;
+
+				if (job != null) {
+					jobStatus = job.getStatus();
+
+					startDate = jobStatus.getStartTime();
+				}
+
+				JSONObject patchJSONObject = new JSONObject(
+				).put(
+					"crawlerJobStatus", crawlerJobStatus
+				).put(
+					"startDate", startDate
+				);
+
+				if (crawlerJobStatus.equals("abandoned")) {
+					patchJSONObject.put(
+						"endDate", _getCurrentDateTime()
+					).put(
+						"errorMessage", "Kubernetes job not found"
+					);
+				}
+				else if (crawlerJobStatus.equals("failed")) {
+					JobCondition jobCondition = _getJobCondition(
+						jobStatus, "Failed");
+
+					if (jobCondition == null) {
+						continue;
+					}
+
+					String endDate = jobCondition.getLastTransitionTime();
+
+					if (endDate == null) {
+						endDate = _getCurrentDateTime();
+					}
+
+					String errorMessage = jobCondition.getMessage();
+
+					if (errorMessage == null) {
+						errorMessage = "Kubernetes job failed";
+					}
+
+					patchJSONObject.put(
+						"endDate", endDate
+					).put(
+						"errorMessage", errorMessage
+					);
+				}
+				else if (crawlerJobStatus.equals("succeeded")) {
+					String endDate = jobStatus.getCompletionTime();
+
+					if (endDate == null) {
+						endDate = _getCurrentDateTime();
+					}
+
+					patchJSONObject.put("endDate", endDate);
+
+					_putIndexedDocumentStats(
+						patchJSONObject,
+						job.getMetadata(
+						).getName());
+				}
+
+				long id = jsonObject.getLong("id");
+
+				patch(
+					_liferayOAuth2AccessTokenManager.getAuthorization(
+						"liferay-aihub-etc-spring-boot-oahs"),
+					patchJSONObject.toString(),
+					URI.create("/o/ai-hub/crawler-jobs/" + id));
+
+				if (_log.isInfoEnabled()) {
+					_log.info(
+						StringBundler.concat(
+							"Crawler job ", id, " status updated to ",
+							patchJSONObject.getString("crawlerJobStatus")));
+				}
+			}
+			catch (Exception exception) {
+				_log.error(
+					"Unable to update status of crawler job " +
+						jsonObject.optLong("id"),
+					exception);
+			}
+		}
+	}
+
+	private JSONArray _getActiveCrawlerJobsJSONArray() {
+		String response = get(
+			_liferayOAuth2AccessTokenManager.getAuthorization(
+				"liferay-aihub-etc-spring-boot-oahs"),
+			URI.create(
+				StringBundler.concat(
+					"/o/ai-hub/crawler-jobs?filter=",
+					URLEncoder.encode(
+						"crawlerJobStatus in ('dispatched','queued','running')",
+						StandardCharsets.UTF_8),
+					"&pageSize=100")));
+
+		JSONObject jsonObject = new JSONObject(response);
+
+		return jsonObject.optJSONArray("items");
+	}
+
+	private String _getCrawlerJobStatus(Job job) {
+		if (job == null) {
+			return "abandoned";
+		}
+
+		JobStatus jobStatus = job.getStatus();
+
+		if (jobStatus == null) {
+			return null;
+		}
+
+		Integer succeeded = jobStatus.getSucceeded();
+
+		if ((succeeded != null) && (succeeded > 0)) {
+			return "succeeded";
+		}
+
+		Integer failed = jobStatus.getFailed();
+
+		if ((failed != null) && (failed > 0)) {
+			return "failed";
+		}
+
+		Integer active = jobStatus.getActive();
+
+		if ((active != null) && (active > 0)) {
+			return "running";
+		}
+
+		return null;
+	}
+
+	private String _getCurrentDateTime() {
+		return Instant.now(
+		).truncatedTo(
+			ChronoUnit.SECONDS
+		).toString();
+	}
+
+	private JobCondition _getJobCondition(JobStatus jobStatus, String type) {
+		List<JobCondition> jobConditions = jobStatus.getConditions();
+
+		if (jobConditions == null) {
+			return null;
+		}
+
+		for (JobCondition jobCondition : jobConditions) {
+			if (type.equals(jobCondition.getType()) &&
+				Objects.equals(jobCondition.getStatus(), "True")) {
+
+				return jobCondition;
+			}
+		}
+
+		return null;
+	}
+
+	private void _putIndexedDocumentStats(JSONObject jsonObject, String name) {
+		try {
+			String log = _kubernetesJobService.getJobLog(name, 50);
+
+			if (log == null) {
+				return;
+			}
+
+			for (String line : log.split("\n")) {
+				if (!line.contains("crawler_final_report")) {
+					continue;
+				}
+
+				JSONObject lineJSONObject = new JSONObject(line);
+
+				JSONObject jsonPayloadJSONObject = lineJSONObject.optJSONObject(
+					"jsonPayload");
+
+				if (jsonPayloadJSONObject == null) {
+					jsonPayloadJSONObject = lineJSONObject;
+				}
+
+				JSONObject crawlerJSONObject =
+					jsonPayloadJSONObject.optJSONObject("crawler");
+
+				if (crawlerJSONObject == null) {
+					return;
+				}
+
+				jsonObject.put(
+					"indexedDocumentBytes",
+					crawlerJSONObject.getLong("docs_upserted_bytes")
+				).put(
+					"indexedDocumentCount",
+					crawlerJSONObject.getLong("docs_upserted")
+				);
+
+				return;
+			}
+		}
+		catch (Exception exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Unable to read indexed document stats for job " + name,
+					exception);
+			}
+		}
+	}
+
+	private static final Log _log = LogFactory.getLog(
+		CrawlerJobStatusService.class);
+
+	private final KubernetesJobService _kubernetesJobService;
+
+	@Autowired
+	private LiferayOAuth2AccessTokenManager _liferayOAuth2AccessTokenManager;
+
+}

--- a/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-etc-spring-boot/src/main/java/com/liferay/ai/hub/service/CrawlerJobStatusService.java
+++ b/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-etc-spring-boot/src/main/java/com/liferay/ai/hub/service/CrawlerJobStatusService.java
@@ -71,26 +71,26 @@ public class CrawlerJobStatusService extends BaseService {
 				}
 
 				JobStatus jobStatus = null;
-				String startDate = null;
+				String startDateString = null;
 
 				if (job != null) {
 					jobStatus = job.getStatus();
 
-					startDate = jobStatus.getStartTime();
+					startDateString = jobStatus.getStartTime();
 				}
 
 				JSONObject patchJSONObject = new JSONObject(
 				).put(
 					"crawlerJobStatus", crawlerJobStatus
 				).put(
-					"startDate", startDate
+					"startDate", startDateString
 				);
 
 				if (crawlerJobStatus.equals("abandoned")) {
 					patchJSONObject.put(
 						"endDate", _getCurrentDateTime()
 					).put(
-						"errorMessage", "Kubernetes job not found"
+						"errorMessage", "Kubernetes job does not exist"
 					);
 				}
 				else if (crawlerJobStatus.equals("failed")) {
@@ -101,10 +101,10 @@ public class CrawlerJobStatusService extends BaseService {
 						continue;
 					}
 
-					String endDate = jobCondition.getLastTransitionTime();
+					String endDateString = jobCondition.getLastTransitionTime();
 
-					if (endDate == null) {
-						endDate = _getCurrentDateTime();
+					if (endDateString == null) {
+						endDateString = _getCurrentDateTime();
 					}
 
 					String errorMessage = jobCondition.getMessage();
@@ -114,19 +114,19 @@ public class CrawlerJobStatusService extends BaseService {
 					}
 
 					patchJSONObject.put(
-						"endDate", endDate
+						"endDate", endDateString
 					).put(
 						"errorMessage", errorMessage
 					);
 				}
 				else if (crawlerJobStatus.equals("succeeded")) {
-					String endDate = jobStatus.getCompletionTime();
+					String endDateString = jobStatus.getCompletionTime();
 
-					if (endDate == null) {
-						endDate = _getCurrentDateTime();
+					if (endDateString == null) {
+						endDateString = _getCurrentDateTime();
 					}
 
-					patchJSONObject.put("endDate", endDate);
+					patchJSONObject.put("endDate", endDateString);
 
 					ObjectMeta objectMeta = job.getMetadata();
 
@@ -186,10 +186,10 @@ public class CrawlerJobStatusService extends BaseService {
 			return null;
 		}
 
-		Integer succeeded = jobStatus.getSucceeded();
+		Integer active = jobStatus.getActive();
 
-		if ((succeeded != null) && (succeeded > 0)) {
-			return "succeeded";
+		if ((active != null) && (active > 0)) {
+			return "running";
 		}
 
 		Integer failed = jobStatus.getFailed();
@@ -198,10 +198,10 @@ public class CrawlerJobStatusService extends BaseService {
 			return "failed";
 		}
 
-		Integer active = jobStatus.getActive();
+		Integer succeeded = jobStatus.getSucceeded();
 
-		if ((active != null) && (active > 0)) {
-			return "running";
+		if ((succeeded != null) && (succeeded > 0)) {
+			return "succeeded";
 		}
 
 		return null;

--- a/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-etc-spring-boot/src/main/java/com/liferay/ai/hub/service/CrawlerJobStatusService.java
+++ b/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-etc-spring-boot/src/main/java/com/liferay/ai/hub/service/CrawlerJobStatusService.java
@@ -234,13 +234,13 @@ public class CrawlerJobStatusService extends BaseService {
 
 	private void _putIndexedDocumentStats(JSONObject jsonObject, String name) {
 		try {
-			String log = _kubernetesJobService.getJobLog(name, 50);
+			String jobLog = _kubernetesJobService.getJobLog(name, 50);
 
-			if (log == null) {
+			if (jobLog == null) {
 				return;
 			}
 
-			for (String line : log.split("\n")) {
+			for (String line : jobLog.split("\n")) {
 				if (!line.contains("crawler_final_report")) {
 					continue;
 				}

--- a/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-etc-spring-boot/src/main/java/com/liferay/ai/hub/service/KubernetesJobService.java
+++ b/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-etc-spring-boot/src/main/java/com/liferay/ai/hub/service/KubernetesJobService.java
@@ -11,6 +11,7 @@ import io.fabric8.kubernetes.api.model.batch.v1.Job;
 import io.fabric8.kubernetes.api.model.batch.v1.JobBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+import io.fabric8.kubernetes.client.dsl.ScalableResource;
 import io.fabric8.kubernetes.client.utils.Serialization;
 
 import jakarta.annotation.PreDestroy;
@@ -53,7 +54,7 @@ public class KubernetesJobService {
 		_kubernetesClient.close();
 	}
 
-	public Job createJob(String indexName, String url) {
+	public Job createJob(long accountEntryId, String indexName, String url) {
 		URI uri;
 
 		try {
@@ -73,13 +74,23 @@ public class KubernetesJobService {
 		).resource(
 			new JobBuilder(
 				_jobTemplate
+			).editMetadata(
+			).addToLabels(
+				"account-entry-id", String.valueOf(accountEntryId)
+			).endMetadata(
 			).editSpec(
 			).editTemplate(
+			).editMetadata(
+			).addToLabels(
+				"account-entry-id", String.valueOf(accountEntryId)
+			).endMetadata(
 			).editSpec(
 			).editFirstContainer(
 			).withImage(
 				_imageName
 			).withEnv(
+				_createEnvVar(
+					"ACCOUNT_ENTRY_ID", String.valueOf(accountEntryId)),
 				_createEnvVar(
 					"CRAWLER_DOMAIN_URL",
 					uri.getScheme() + "://" + uri.getAuthority()),
@@ -105,6 +116,20 @@ public class KubernetesJobService {
 		return job;
 	}
 
+	public Job getJob(String name) {
+		return _getJobScalableResource(
+			name
+		).get();
+	}
+
+	public String getJobLog(String name, int tailLines) {
+		return _getJobScalableResource(
+			name
+		).tailingLines(
+			tailLines
+		).getLog();
+	}
+
 	private EnvVar _createEnvVar(String name, String value) {
 		return new EnvVarBuilder(
 		).withName(
@@ -112,6 +137,17 @@ public class KubernetesJobService {
 		).withValue(
 			value
 		).build();
+	}
+
+	private ScalableResource<Job> _getJobScalableResource(String name) {
+		return _kubernetesClient.batch(
+		).v1(
+		).jobs(
+		).inNamespace(
+			_namespace
+		).withName(
+			name
+		);
 	}
 
 	private Job _loadJobTemplate() {

--- a/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-etc-spring-boot/src/main/java/com/liferay/ai/hub/service/KubernetesJobService.java
+++ b/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-etc-spring-boot/src/main/java/com/liferay/ai/hub/service/KubernetesJobService.java
@@ -7,10 +7,12 @@ package com.liferay.ai.hub.service;
 
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.EnvVarBuilder;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.batch.v1.Job;
 import io.fabric8.kubernetes.api.model.batch.v1.JobBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+import io.fabric8.kubernetes.client.dsl.PrettyLoggable;
 import io.fabric8.kubernetes.client.dsl.ScalableResource;
 import io.fabric8.kubernetes.client.utils.Serialization;
 
@@ -107,27 +109,27 @@ public class KubernetesJobService {
 		).create();
 
 		if (_log.isInfoEnabled()) {
-			String jobName = job.getMetadata(
-			).getName();
+			ObjectMeta objectMeta = job.getMetadata();
 
-			_log.info("Kubernetes job dispatched: " + jobName);
+			_log.info("Kubernetes job dispatched: " + objectMeta.getName());
 		}
 
 		return job;
 	}
 
 	public Job getJob(String name) {
-		return _getJobScalableResource(
-			name
-		).get();
+		ScalableResource<Job> scalableResource = _getJobScalableResource(name);
+
+		return scalableResource.get();
 	}
 
 	public String getJobLog(String name, int tailLines) {
-		return _getJobScalableResource(
-			name
-		).tailingLines(
-			tailLines
-		).getLog();
+		ScalableResource<Job> scalableResource = _getJobScalableResource(name);
+
+		PrettyLoggable prettyLoggable = scalableResource.tailingLines(
+			tailLines);
+
+		return prettyLoggable.getLog();
 	}
 
 	private EnvVar _createEnvVar(String name, String value) {

--- a/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-etc-spring-boot/src/main/resources/application-default.properties
+++ b/workspaces/liferay-aihub-workspace/client-extensions/liferay-aihub-etc-spring-boot/src/main/resources/application-default.properties
@@ -2,10 +2,10 @@
 # Application
 #
 
-liferay.ai.hub.crawler.elasticsearch.host=
-liferay.ai.hub.crawler.elasticsearch.port=
-liferay.ai.hub.crawler.k8s.image.name=
-liferay.ai.hub.crawler.k8s.namespace=
+liferay.ai.hub.crawler.elasticsearch.host=${LIFERAY_AI_HUB_CRAWLER_ELASTICSEARCH_HOST}
+liferay.ai.hub.crawler.elasticsearch.port=${LIFERAY_AI_HUB_CRAWLER_ELASTICSEARCH_PORT}
+liferay.ai.hub.crawler.k8s.image.name=${LIFERAY_AI_HUB_CRAWLER_K8S_IMAGE_NAME}
+liferay.ai.hub.crawler.k8s.namespace=${LIFERAY_AI_HUB_CRAWLER_K8S_NAMESPACE}
 
 #
 # LXC


### PR DESCRIPTION
LPD-91035 Show Space trash entries max age in days

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-91035

The Space settings UI for "Trash Entries Max Age" shows `0` by default, accepts `0` as a valid input, and treats the entered number as minutes even though users type expecting days — so "30" stores 30 minutes, not 30 days. The setting also has no minimum, allowing values that disable the auto-deletion silently.

The wire format for `trashEntriesMaxAge` is minutes (the system property `trash.entries.max.age` is documented in minutes, and `TrashHelperImpl#getMaxAge` reads it that way). The Space settings UI never converted minutes ↔ days, it just rendered and sent the raw integer. On top of that, when the per-Space `typeSettings` value was missing, the headless converter returned `0` instead of falling back to the company-level config — so the UI displayed `0` and accepted it as a valid input.

# How am I fixing it?

Three layers, each pinning down one slice of the problem:

- `AssetLibraryDTOConverter._toSettings` now falls back to `PrefsPropsUtil.getInteger(companyId, PropsKeys.TRASH_ENTRIES_MAX_AGE, PropsValues.TRASH_ENTRIES_MAX_AGE)` when the per-Space `typeSetting` is missing or `0`. This is the same fallback chain `TrashHelperImpl#getMaxAge` already uses on the server side, so the value the UI receives matches what the scheduler reads.
- `TrashEntriesMaxAgeUpgradeProcess` (depot schema `2.3.0` → `2.4.0`) backfills the typeSettings of existing Space-type `DepotEntry` groups with the same company default in minutes, so previously-saved zeros disappear without user intervention.
- `SpaceGeneralSettings.tsx` converts minutes ↔ days on read and on submit (`1 day = 1440 minutes`). A new `minValue(1)` Formik validator rejects values below `1`, replacing the missing minimum.

The auto-deletion symptom originally described in the ticket (`PrincipalException` in the scheduler) was scoped out to https://liferay.atlassian.net/browse/LPD-91679 and shipped there.

# How can you verify that it works?

Run the included automated tests.

# Commits

- 4cd1c008433ef LPD-91035 Fill missing trashEntriesMaxAge for Space groups types
- d51c49211921a LPD-91035 add test for the upgrade process
- 25923ad6ed702 LPD-91035 if value is 0, return the TRASH_ENTRIES_MAX_AGE value by default for the company
- ccb348754535b LPD-91035 Show Space trash entries max age in days
- 39698c3596e37 LPD-91035 add test for the value on the space settings