### PR TITLE
LPD-91603 Add UTM parameters to the Enterprise upgrade link

### DIFF
--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/feature_indicator/FeatureIndicator.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/feature_indicator/FeatureIndicator.tsx
@@ -50,7 +50,8 @@ type featureIndicatorProps = (
 	tooltipAlign?: (typeof ALIGN_POSITIONS)[number];
 };
 
-const ENTERPRISE_URL = 'https://www.liferay.com/web/lr/cms-upgrade';
+const ENTERPRISE_URL =
+	'https://www.liferay.com/web/lr/cms-upgrade?utm_medium=referral&utm_source=cms-ft&utm_content=cms-ft-upgrade&utm_cid=701VO00000wwP6IYAU';
 
 export default function FeatureIndicator({
 	className,

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/cms/EditorCustomizerModal.tsx
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/cms/EditorCustomizerModal.tsx
@@ -92,7 +92,7 @@ function EnterpriseModal() {
 				},
 				{
 					displayType: 'primary',
-					href: 'https://www.liferay.com/web/lr/cms-upgrade',
+					href: 'https://www.liferay.com/web/lr/cms-upgrade?utm_medium=referral&utm_source=cms-ft&utm_content=cms-ft-upgrade&utm_cid=701VO00000wwP6IYAU',
 					icon: 'shortcut',
 					label: Liferay.Language.get('contact-sales'),
 				},

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/utils/constants.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/utils/constants.ts
@@ -8,7 +8,8 @@ export const OBJECT_DEFINITION_CLASS_NAME =
 export const OBJECT_ENTRY_FOLDER_CLASS_NAME =
 	'com.liferay.object.model.ObjectEntryFolder';
 
-export const ENTERPRISE_URL = 'https://www.liferay.com/web/lr/cms-upgrade';
+export const ENTERPRISE_URL =
+	'https://www.liferay.com/web/lr/cms-upgrade?utm_medium=referral&utm_source=cms-ft&utm_content=cms-ft-upgrade&utm_cid=701VO00000wwP6IYAU';
 
 export const EXPIRING_SOON_THRESHOLD_DAYS = 7;
 

--- a/modules/apps/site/site-cms-site-initializer/test/js/common/components/EnterpriseOnlyPlaceholder.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/common/components/EnterpriseOnlyPlaceholder.test.tsx
@@ -69,7 +69,7 @@ describe('EnterpriseOnlyPlaceholder', () => {
 		expect(detailsLink).toBeInTheDocument();
 		expect(detailsLink).toHaveAttribute(
 			'href',
-			'https://www.liferay.com/web/lr/cms-upgrade'
+			'https://www.liferay.com/web/lr/cms-upgrade?utm_medium=referral&utm_source=cms-ft&utm_content=cms-ft-upgrade&utm_cid=701VO00000wwP6IYAU'
 		);
 	});
 });

--- a/modules/apps/site/site-cms-site-initializer/test/js/common/components/EnterpriseProductMenuBanner.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/common/components/EnterpriseProductMenuBanner.test.tsx
@@ -32,7 +32,7 @@ describe('EnterpriseProductMenuBanner', () => {
 		expect(detailsLink).toBeInTheDocument();
 		expect(detailsLink).toHaveAttribute(
 			'href',
-			'https://www.liferay.com/web/lr/cms-upgrade'
+			'https://www.liferay.com/web/lr/cms-upgrade?utm_medium=referral&utm_source=cms-ft&utm_content=cms-ft-upgrade&utm_cid=701VO00000wwP6IYAU'
 		);
 	});
 });


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91603

## What is being fixed

The "Get Enterprise Details" and "Contact Sales" links shown to Free Tier administrators point to the bare Enterprise upgrade page, so traffic landing on the marketing page cannot be attributed to the CMS Free Tier funnel.

## How it is being fixed

The Enterprise upgrade URL referenced by the feature indicator, the editor customizer modal, and the CMS site-initializer constants is updated to include the UTM parameters requested by the marketing team (`utm_medium=referral`, `utm_source=cms-ft`, `utm_content=cms-ft-upgrade`, `utm_cid=701VO00000wwP6IYAU`). The unit tests that assert the rendered `href` are updated to match.