### PR TITLE
LPD-91933 Restore integer entity field type on CMS selection filters

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/SpaceSelectionFDSFilter.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/SpaceSelectionFDSFilter.java
@@ -5,6 +5,7 @@
 
 package com.liferay.site.cms.site.initializer.internal.frontend.data.set.filter;
 
+import com.liferay.frontend.data.set.constants.FDSEntityFieldTypes;
 import com.liferay.frontend.data.set.filter.BaseSelectionFDSFilter;
 import com.liferay.frontend.data.set.filter.FDSFilter;
 import com.liferay.site.cms.site.initializer.internal.constants.CMSSiteInitializerFDSNames;
@@ -32,6 +33,11 @@ public class SpaceSelectionFDSFilter extends BaseSelectionFDSFilter {
 	public String getAPIURL() {
 		return "/o/headless-asset-library/v1.0/asset-libraries?filter=type " +
 			"eq 'Space'";
+	}
+
+	@Override
+	public String getEntityFieldType() {
+		return FDSEntityFieldTypes.INTEGER;
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/StructureSpaceSelectionFDSFilter.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/StructureSpaceSelectionFDSFilter.java
@@ -5,6 +5,7 @@
 
 package com.liferay.site.cms.site.initializer.internal.frontend.data.set.filter;
 
+import com.liferay.frontend.data.set.constants.FDSEntityFieldTypes;
 import com.liferay.frontend.data.set.filter.BaseSelectionFDSFilter;
 import com.liferay.frontend.data.set.filter.FDSFilter;
 import com.liferay.site.cms.site.initializer.internal.constants.CMSSiteInitializerFDSNames;
@@ -27,6 +28,11 @@ public class StructureSpaceSelectionFDSFilter extends BaseSelectionFDSFilter {
 	public String getAPIURL() {
 		return "/o/headless-asset-library/v1.0/asset-libraries?filter=type " +
 			"eq 'Space'";
+	}
+
+	@Override
+	public String getEntityFieldType() {
+		return FDSEntityFieldTypes.COLLECTION_INTEGER;
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/WorkflowStatusSelectionFDSFilter.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/WorkflowStatusSelectionFDSFilter.java
@@ -5,6 +5,7 @@
 
 package com.liferay.site.cms.site.initializer.internal.frontend.data.set.filter;
 
+import com.liferay.frontend.data.set.constants.FDSEntityFieldTypes;
 import com.liferay.frontend.data.set.filter.BaseSelectionFDSFilter;
 import com.liferay.frontend.data.set.filter.FDSFilter;
 import com.liferay.frontend.data.set.filter.SelectionFDSFilterItem;
@@ -34,6 +35,11 @@ import org.osgi.service.component.annotations.Component;
 	service = FDSFilter.class
 )
 public class WorkflowStatusSelectionFDSFilter extends BaseSelectionFDSFilter {
+
+	@Override
+	public String getEntityFieldType() {
+		return FDSEntityFieldTypes.INTEGER;
+	}
 
 	@Override
 	public String getId() {

--- a/modules/test/playwright/helpers/ObjectEntryApiHelper.ts
+++ b/modules/test/playwright/helpers/ObjectEntryApiHelper.ts
@@ -29,6 +29,16 @@ export class ObjectEntryApiHelper {
 		);
 	}
 
+	async expireObjectEntryByExternalReferenceCode(
+		applicationName: string,
+		scopeKey: string,
+		externalReferenceCode: string
+	) {
+		return this.apiHelpers.post(
+			`${this.apiHelpers.baseUrl}${applicationName}/scopes/${scopeKey}/by-external-reference-code/${externalReferenceCode}/expire`
+		);
+	}
+
 	async getObjectDefinitionObjectEntries(
 		applicationName: string,
 		searchParams?: URLSearchParams

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/all.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/all.spec.ts
@@ -1078,3 +1078,147 @@ test(
 		});
 	}
 );
+
+test(
+	'All section can be filtered by Space',
+	{tag: '@LPD-91933'},
+	async ({apiHelpers, assetsPage, page}) => {
+		const applicationName = 'cms/basic-web-contents';
+		const space1Name = `Space ${getRandomString()}`;
+		const space2Name = `Space ${getRandomString()}`;
+		const space1ContentTitle = `Content ${getRandomString()}`;
+		const space2ContentTitle = `Content ${getRandomString()}`;
+
+		await test.step('Create two Spaces with one content each', async () => {
+			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+				name: space1Name,
+				settings: {},
+				type: 'Space',
+			});
+
+			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+				name: space2Name,
+				settings: {},
+				type: 'Space',
+			});
+
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: space1ContentTitle,
+				},
+				applicationName,
+				space1Name
+			);
+
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: space2ContentTitle,
+				},
+				applicationName,
+				space2Name
+			);
+		});
+
+		await test.step('Both contents are visible before filtering', async () => {
+			await assetsPage.gotoAll();
+
+			await expect(assetsPage.getItem(space1ContentTitle)).toBeVisible();
+			await expect(assetsPage.getItem(space2ContentTitle)).toBeVisible();
+		});
+
+		await test.step('Filter by Space and check only the matching content is visible', async () => {
+			await page
+				.getByRole('button', {exact: true, name: 'Filter'})
+				.click();
+
+			await page
+				.getByRole('menuitem', {exact: true, name: 'Space'})
+				.click();
+
+			await page
+				.getByRole('checkbox', {exact: true, name: space1Name})
+				.check();
+
+			await page
+				.getByRole('button', {exact: true, name: 'Add Filter'})
+				.click();
+
+			await expect(
+				page.getByRole('button', {name: `Space: ${space1Name}`})
+			).toBeVisible();
+
+			await expect(assetsPage.getItem(space1ContentTitle)).toBeVisible();
+			await expect(assetsPage.getItem(space2ContentTitle)).toBeHidden();
+		});
+	}
+);
+
+test(
+	'All section can be filtered by Status',
+	{tag: '@LPD-91933'},
+	async ({apiHelpers, assetsPage, page}) => {
+		const applicationName = 'cms/basic-web-contents';
+		const approvedTitle = `Content A ${getRandomString()}`;
+		const expiredTitle = `Content B ${getRandomString()}`;
+
+		await test.step('Create one approved and one expired content in the Default Space', async () => {
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: approvedTitle,
+				},
+				applicationName,
+				'Default'
+			);
+
+			const expiredEntry = await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: expiredTitle,
+				},
+				applicationName,
+				'Default'
+			);
+
+			await apiHelpers.objectEntry.expireObjectEntryByExternalReferenceCode(
+				applicationName,
+				'Default',
+				expiredEntry.externalReferenceCode
+			);
+		});
+
+		await test.step('Both contents are visible before filtering', async () => {
+			await assetsPage.gotoAll();
+
+			await expect(assetsPage.getItem(approvedTitle)).toBeVisible();
+			await expect(assetsPage.getItem(expiredTitle)).toBeVisible();
+		});
+
+		await test.step('Filter by Status Approved and check only the approved content is visible', async () => {
+			await page
+				.getByRole('button', {exact: true, name: 'Filter'})
+				.click();
+
+			await page
+				.getByRole('menuitem', {exact: true, name: 'Status'})
+				.click();
+
+			await page
+				.getByRole('checkbox', {exact: true, name: 'Approved'})
+				.check();
+
+			await page
+				.getByRole('button', {exact: true, name: 'Add Filter'})
+				.click();
+
+			await expect(
+				page.getByRole('button', {name: 'Status: Approved'})
+			).toBeVisible();
+
+			await expect(assetsPage.getItem(approvedTitle)).toBeVisible();
+			await expect(assetsPage.getItem(expiredTitle)).toBeHidden();
+		});
+	}
+);

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/all.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/all.spec.ts
@@ -10,6 +10,7 @@ import path from 'path';
 import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
 import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
 import {loginTest} from '../../../fixtures/loginTest';
+import {applyFDSSelectionFilter} from '../../../utils/applyFDSSelectionFilter';
 import getRandomString from '../../../utils/getRandomString';
 import {performUserSwitchViaApi, userData} from '../../../utils/performLogin';
 import {waitForAlert} from '../../../utils/waitForAlert';
@@ -1129,25 +1130,10 @@ test(
 		});
 
 		await test.step('Filter by Space and check only the matching content is visible', async () => {
-			await page
-				.getByRole('button', {exact: true, name: 'Filter'})
-				.click();
-
-			await page
-				.getByRole('menuitem', {exact: true, name: 'Space'})
-				.click();
-
-			await page
-				.getByRole('checkbox', {exact: true, name: space1Name})
-				.check();
-
-			await page
-				.getByRole('button', {exact: true, name: 'Add Filter'})
-				.click();
-
-			await expect(
-				page.getByRole('button', {name: `Space: ${space1Name}`})
-			).toBeVisible();
+			await applyFDSSelectionFilter(page, {
+				filter: 'Space',
+				value: space1Name,
+			});
 
 			await expect(assetsPage.getItem(space1ContentTitle)).toBeVisible();
 			await expect(assetsPage.getItem(space2ContentTitle)).toBeHidden();
@@ -1197,25 +1183,10 @@ test(
 		});
 
 		await test.step('Filter by Status Approved and check only the approved content is visible', async () => {
-			await page
-				.getByRole('button', {exact: true, name: 'Filter'})
-				.click();
-
-			await page
-				.getByRole('menuitem', {exact: true, name: 'Status'})
-				.click();
-
-			await page
-				.getByRole('checkbox', {exact: true, name: 'Approved'})
-				.check();
-
-			await page
-				.getByRole('button', {exact: true, name: 'Add Filter'})
-				.click();
-
-			await expect(
-				page.getByRole('button', {name: 'Status: Approved'})
-			).toBeVisible();
+			await applyFDSSelectionFilter(page, {
+				filter: 'Status',
+				value: 'Approved',
+			});
 
 			await expect(assetsPage.getItem(approvedTitle)).toBeVisible();
 			await expect(assetsPage.getItem(expiredTitle)).toBeHidden();

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/recycleBin.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/recycleBin.spec.ts
@@ -12,6 +12,7 @@ import {addCMSAdministrator} from '../../../utils/addCMSAdministrator';
 import {checkAccessibility} from '../../../utils/checkAccessibility';
 import getRandomString from '../../../utils/getRandomString';
 import performLoginViaApi, {
+	performUserSwitch,
 	performUserSwitchViaApi,
 	userData,
 } from '../../../utils/performLogin';

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/structures.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/structures.spec.ts
@@ -893,7 +893,7 @@ async function applySpaceFilter(
 
 test(
 	'Content Structures list can be filtered by space with include and exclude',
-	{tag: '@LPD-89342'},
+	{tag: ['@LPD-89342', '@LPD-91933']},
 	async ({apiHelpers, page, structureBuilderPage, structuresPage}) => {
 		const spaceName1 = `Space ${getRandomString()}`;
 		const spaceName2 = `Space ${getRandomString()}`;

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/structures.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/structures.spec.ts
@@ -4,12 +4,13 @@
  */
 
 import {ObjectDefinition} from '@liferay/object-admin-rest-client-js';
-import {Page, expect, mergeTests} from '@playwright/test';
+import {expect, mergeTests} from '@playwright/test';
 
 import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
 import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
 import {loginTest} from '../../../fixtures/loginTest';
 import {addCMSAdministrator} from '../../../utils/addCMSAdministrator';
+import {applyFDSSelectionFilter} from '../../../utils/applyFDSSelectionFilter';
 import {clickAndExpectToBeHidden} from '../../../utils/clickAndExpectToBeHidden';
 import {getRandomInt} from '../../../utils/getRandomInt';
 import getRandomString from '../../../utils/getRandomString';
@@ -872,25 +873,6 @@ test(
 	}
 );
 
-async function applySpaceFilter(
-	page: Page,
-	{exclude = false, space}: {exclude?: boolean; space: string}
-) {
-	await page.getByRole('button', {exact: true, name: 'Filter'}).click();
-	await page.getByRole('menuitem', {exact: true, name: 'Space'}).click();
-	await page.getByRole('checkbox', {exact: true, name: space}).check();
-
-	if (exclude) {
-		await page.getByRole('switch', {exact: true, name: 'Exclude'}).click();
-	}
-
-	await page.getByRole('button', {exact: true, name: 'Add Filter'}).click();
-
-	const chipName = exclude ? `Space: (Exclude) ${space}` : `Space: ${space}`;
-
-	await expect(page.getByRole('button', {name: chipName})).toBeVisible();
-}
-
 test(
 	'Content Structures list can be filtered by space with include and exclude',
 	{tag: ['@LPD-89342', '@LPD-91933']},
@@ -918,19 +900,33 @@ test(
 		const row = structuresPage.getItem(structureLabel);
 
 		await structuresPage.goto();
-		await applySpaceFilter(page, {space: spaceName1});
+		await applyFDSSelectionFilter(page, {
+			filter: 'Space',
+			value: spaceName1,
+		});
 		await expect(row).toBeVisible();
 
 		await structuresPage.goto();
-		await applySpaceFilter(page, {space: spaceName2});
+		await applyFDSSelectionFilter(page, {
+			filter: 'Space',
+			value: spaceName2,
+		});
 		await expect(row).toBeHidden();
 
 		await structuresPage.goto();
-		await applySpaceFilter(page, {exclude: true, space: spaceName1});
+		await applyFDSSelectionFilter(page, {
+			exclude: true,
+			filter: 'Space',
+			value: spaceName1,
+		});
 		await expect(row).toBeHidden();
 
 		await structuresPage.goto();
-		await applySpaceFilter(page, {exclude: true, space: spaceName2});
+		await applyFDSSelectionFilter(page, {
+			exclude: true,
+			filter: 'Space',
+			value: spaceName2,
+		});
 		await expect(row).toBeVisible();
 	}
 );

--- a/modules/test/playwright/utils/applyFDSSelectionFilter.ts
+++ b/modules/test/playwright/utils/applyFDSSelectionFilter.ts
@@ -1,0 +1,33 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Page, expect} from '@playwright/test';
+
+export async function applyFDSSelectionFilter(
+	page: Page,
+	{
+		exclude = false,
+		filter,
+		value,
+	}: {exclude?: boolean; filter: string; value: string}
+) {
+	await page.getByRole('button', {exact: true, name: 'Filter'}).click();
+
+	await page.getByRole('menuitem', {exact: true, name: filter}).click();
+
+	await page.getByRole('checkbox', {exact: true, name: value}).check();
+
+	if (exclude) {
+		await page.getByRole('switch', {exact: true, name: 'Exclude'}).click();
+	}
+
+	await page.getByRole('button', {exact: true, name: 'Add Filter'}).click();
+
+	const chipName = exclude
+		? `${filter}: (Exclude) ${value}`
+		: `${filter}: ${value}`;
+
+	await expect(page.getByRole('button', {name: chipName})).toBeVisible();
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91933

## What is being fixed

LPD-79347 set the default `getEntityFieldType()` on `BaseSelectionFDSFilter` to `STRING`. Three CMS subclasses whose underlying field is numeric — `SpaceSelectionFDSFilter` (`scopeGroupId`), `StructureSpaceSelectionFDSFilter` (`acceptedGroupIds`), and `WorkflowStatusSelectionFDSFilter` (`status`) — inherited that default and stopped filtering: the FDS layer emitted OData comparing numeric fields against quoted string literals, returning empty results.

## How it is being fixed

Restore the explicit `getEntityFieldType()` override on each affected filter (`INTEGER` for Space and WorkflowStatus, `COLLECTION_INTEGER` for StructureSpace). Add Playwright coverage that creates data via API, applies the corresponding selection filter through the UI, and asserts the filtered row set. The existing structures test (LPD-89342) already covered `StructureSpace` end-to-end and now carries `@LPD-91933` as a second tag for discoverability. Extract the shared filter-apply sequence into `applyFDSSelectionFilter` under `modules/test/playwright/utils`, replacing one local helper and the inline duplication in the new tests.