### PR TITLE
LPD-90751 Editor side panel does not suggest existing "all spaces" tags 

### DIFF
--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/KeywordResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/KeywordResourceImpl.java
@@ -30,9 +30,13 @@ import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.UserConstants;
+import com.liferay.portal.kernel.search.BooleanClauseOccur;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Sort;
+import com.liferay.portal.kernel.search.filter.BooleanFilter;
+import com.liferay.portal.kernel.search.filter.ExistsFilter;
 import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.search.filter.TermsFilter;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
@@ -464,9 +468,20 @@ public class KeywordResourceImpl
 			Pagination pagination, Sort[] sorts)
 		throws Exception {
 
+		boolean spaceDepotEntry = _isSpaceDepotEntry(groupId);
+
 		return SearchUtil.search(
 			actions,
 			booleanQuery -> {
+				if (!spaceDepotEntry) {
+					return;
+				}
+
+				BooleanFilter booleanFilter =
+					booleanQuery.getPreBooleanFilter();
+
+				booleanFilter.add(
+					_getSpaceBooleanFilter(groupId), BooleanClauseOccur.MUST);
 			},
 			filter, AssetTag.class.getName(), search, pagination,
 			queryConfig -> queryConfig.setSelectedFieldNames(
@@ -483,19 +498,7 @@ public class KeywordResourceImpl
 				searchContext.setUserId(UserConstants.USER_ID_DEFAULT);
 				searchContext.setVulcanCheckPermissions(false);
 
-				DepotEntry depotEntry = _depotEntryService.fetchGroupDepotEntry(
-					groupId);
-
-				if ((depotEntry != null) &&
-					(depotEntry.getType() == DepotConstants.TYPE_SPACE)) {
-
-					searchContext.setAttribute(
-						"groupIds",
-						new long[] {
-							groupId, GroupConstants.ANY_PARENT_GROUP_ID
-						});
-				}
-				else {
+				if (!spaceDepotEntry) {
 					searchContext.setGroupIds(
 						new long[] {
 							groupId, GroupConstants.ANY_PARENT_GROUP_ID
@@ -530,6 +533,33 @@ public class KeywordResourceImpl
 		return projectionList;
 	}
 
+	private BooleanFilter _getSpaceBooleanFilter(long groupId)
+		throws Exception {
+
+		BooleanFilter spaceBooleanFilter = new BooleanFilter();
+
+		TermsFilter groupIdsTermsFilter = new TermsFilter("groupIds");
+
+		groupIdsTermsFilter.addValues(
+			String.valueOf(groupId),
+			String.valueOf(GroupConstants.ANY_PARENT_GROUP_ID));
+
+		spaceBooleanFilter.add(groupIdsTermsFilter, BooleanClauseOccur.SHOULD);
+
+		BooleanFilter cmsGroupBooleanFilter = new BooleanFilter();
+
+		cmsGroupBooleanFilter.add(
+			new ExistsFilter("groupIds"), BooleanClauseOccur.MUST_NOT);
+		cmsGroupBooleanFilter.addRequiredTerm(
+			Field.GROUP_ID,
+			TaxonomyGroupUtil.getCMSGroupId(contextCompany.getCompanyId()));
+
+		spaceBooleanFilter.add(
+			cmsGroupBooleanFilter, BooleanClauseOccur.SHOULD);
+
+		return spaceBooleanFilter;
+	}
+
 	private long _getTotalCount(String search, Long siteId) {
 		DynamicQuery dynamicQuery = _assetTagLocalService.dynamicQuery();
 
@@ -548,6 +578,19 @@ public class KeywordResourceImpl
 		}
 
 		return _assetTagLocalService.dynamicQueryCount(dynamicQuery);
+	}
+
+	private boolean _isSpaceDepotEntry(long groupId) throws Exception {
+		DepotEntry depotEntry = _depotEntryService.fetchGroupDepotEntry(
+			groupId);
+
+		if ((depotEntry != null) &&
+			(depotEntry.getType() == DepotConstants.TYPE_SPACE)) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 	private Keyword _patchSiteKeyword(

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/KeywordResourceTest.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/KeywordResourceTest.java
@@ -409,6 +409,8 @@ public class KeywordResourceTest extends BaseKeywordResourceTestCase {
 		irrelevantGroup = originalIrrelevantGroup;
 		testGroup = originalTestGroup;
 
+		_testGetSiteKeywordsPageWithSpaceDepotEntry();
+
 		_cmsAdministratorUser = UserTestUtil.addCompanyUser(
 			testCompany, RoleConstants.CMS_ADMINISTRATOR);
 
@@ -422,7 +424,6 @@ public class KeywordResourceTest extends BaseKeywordResourceTestCase {
 
 		_testGetSiteKeywordsPageWithUser(_cmsAdministratorUser);
 		_testGetSiteKeywordsPageWithUser(_regularUser);
-		_testGetSiteKeywordsPageWithSpaceDepotEntry();
 	}
 
 	@Ignore

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/KeywordResourceTest.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/KeywordResourceTest.java
@@ -32,6 +32,7 @@ import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.UserGroupRoleLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.DataGuard;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
@@ -49,8 +50,10 @@ import com.liferay.portal.test.rule.Inject;
 import com.liferay.site.cms.site.initializer.test.util.CMSTestUtil;
 
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.junit.Assert;
 import org.junit.Ignore;
@@ -388,6 +391,7 @@ public class KeywordResourceTest extends BaseKeywordResourceTestCase {
 	@FeatureFlag("LPD-17564")
 	@Override
 	@Test
+	@TestInfo("LPD-90751")
 	public void testGetSiteKeywordsPage() throws Exception {
 		super.testGetSiteKeywordsPage();
 
@@ -418,6 +422,7 @@ public class KeywordResourceTest extends BaseKeywordResourceTestCase {
 
 		_testGetSiteKeywordsPageWithUser(_cmsAdministratorUser);
 		_testGetSiteKeywordsPageWithUser(_regularUser);
+		_testGetSiteKeywordsPageWithSpaceDepotEntry();
 	}
 
 	@Ignore
@@ -794,6 +799,47 @@ public class KeywordResourceTest extends BaseKeywordResourceTestCase {
 				scopeKey = depotEntryGroup.getGroupKey();
 			}
 		};
+	}
+
+	private void _testGetSiteKeywordsPageWithSpaceDepotEntry()
+		throws Exception {
+
+		Group originalTestGroup = testGroup;
+
+		testGroup = CMSTestUtil.getOrAddGroup(KeywordResourceTest.class);
+
+		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
+			RandomTestUtil.randomLocaleStringMap(), null,
+			DepotConstants.TYPE_SPACE,
+			ServiceContextTestUtil.getServiceContext(testGroup.getGroupId()));
+
+		Group depotEntryGroup = depotEntry.getGroup();
+
+		Keyword keyword1 = _postKeywordWithAssetLibraries();
+		Keyword keyword2 = _postKeywordWithAssetLibraries(
+			new AssetLibrary() {
+				{
+					id = depotEntryGroup.getGroupId();
+					scopeKey = depotEntryGroup.getGroupKey();
+				}
+			});
+
+		Page<Keyword> page = keywordResource.getSiteKeywordsPage(
+			depotEntryGroup.getGroupId(), null, null, null,
+			Pagination.of(1, 100), null);
+
+		Set<String> keywordNames = new HashSet<>();
+
+		for (Keyword keyword : page.getItems()) {
+			keywordNames.add(keyword.getName());
+		}
+
+		Assert.assertTrue(
+			keywordNames.toString(), keywordNames.contains(keyword1.getName()));
+		Assert.assertTrue(
+			keywordNames.toString(), keywordNames.contains(keyword2.getName()));
+
+		testGroup = originalTestGroup;
 	}
 
 	private void _testGetSiteKeywordsPageWithUser(User user) throws Exception {


### PR DESCRIPTION
LPD-90751 Surface "all spaces" tags in space editor autocomplete

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-90751

When a user creates a tag from the CMS Categorization admin with **"Make this tag available in all spaces"** ticked and then opens a content inside a Space, the editor side panel does not suggest that tag. The autocomplete dropdown only offers space-scoped tags and the "create new tag" action; typing the exact name still resolves to the existing tag (no duplicate is created), confirming the tag is in the database but invisible to the suggester.

The autocomplete calls `GET /o/headless-admin-taxonomy/v1.0/sites/{spaceGroupId}/keywords`, which for a `TYPE_SPACE` depot filters tags through the multi-valued `groupIds` index field. That field is populated exclusively from `AssetTagGroupRel` rows. Tags persisted with "all spaces" carry `AssetTag.groupId = cmsGroupId` and **zero** `AssetTagGroupRel` rows — the implicit signal the UI uses for "no scope, visible everywhere" — so the indexed `groupIds` is empty and the space-scoped `TermsFilter` never matches them.

# How am I fixing it?

In `KeywordResourceImpl._getKeywordsPage`, drop the `searchContext.setAttribute("groupIds", …)` path for SPACE depots and build a custom pre-boolean filter via the `booleanQuery` lambda. The filter is a `MUST` over two `SHOULD` branches: (1) the existing `groupIds IN [spaceGroupId, ANY_PARENT_GROUP_ID]` rel-based match, and (2) a new branch matching `Field.GROUP_ID == cmsGroupId AND NOT EXISTS "groupIds"` — the implicit "all spaces" semantics the UI persists. The CMS group is resolved via the existing `TaxonomyGroupUtil.getCMSGroupId(...)` utility. Two private helpers are extracted: `_isSpaceDepotEntry(long)` so the depot lookup happens once, and `_getSpaceBooleanFilter(long)` so the filter construction lives next to its peers (`_getProjectionList`, `_getTotalCount`). No create-path change, no `AssetTagGroupRel` backfill, no reindex.

# How can you verify that it works?

Run the included automated tests.

# Commits

- LPD-90751 we should filter by the asset tags that are created to the cms groups and there are NOT linked on any space because they are the ones that are for "all the spaces"
- LPD-90751 add test to check new tags