### PR TITLE
LPD-91997 Make Gallery view preview adapt to viewport height

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/css/props_transformer/GalleryView.scss
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/css/props_transformer/GalleryView.scss
@@ -1,8 +1,10 @@
 @import 'atlas-variables';
 
 .fds-gallery-view {
+	$gallery-preview-height: unquote('max(320px, calc(100dvh - 475px))');
+
 	&__preview {
-		height: 570px;
+		height: $gallery-preview-height;
 
 		&-wrapper > * {
 			margin: 0;
@@ -15,7 +17,7 @@
 	}
 
 	.preview-file .preview-file-container.preview-file-max-height {
-		height: 570px;
+		height: $gallery-preview-height;
 		max-height: 100%;
 	}
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/css/props_transformer/GalleryView.scss
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/css/props_transformer/GalleryView.scss
@@ -6,6 +6,19 @@
 	&__preview {
 		height: $gallery-preview-height;
 
+		.c-empty-state {
+			align-self: center;
+			margin: 0;
+		}
+
+		.c-empty-state-image {
+			max-width: 200px;
+		}
+
+		.c-empty-state-title {
+			margin-top: 1rem;
+		}
+
 		&-wrapper > * {
 			margin: 0;
 			width: 100%;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91997

## What is being fixed

The CMS Files Gallery view rendered its preview area at a hardcoded `570px` regardless of viewport height. On tall viewports the preview was unnecessarily small with wasted space below; on short viewports the inner "No Preview Available" empty state overflowed past the preview into the thumbnail bar.

## How it is being fixed

The preview height is now `max(320px, calc(100dvh - 460px))` — it grows with the viewport down to a 320px floor, and the same value drives the inner `.preview-file-container` so the document/image previewer chain still has a definite parent height. The empty state branch is contained inside the preview at any viewport: the image is capped at 200px wide, Clay's default outer margins are zeroed so the box sits at its natural size via `align-self: center`, and the image-to-title gap is tightened to 1rem.

Verified manually at viewport heights 700/900/1200 px in both the multi-select empty state and the single-non-previewable empty state.

[lpd-91997-2026-05-25_18.16.10.webm](https://github.com/user-attachments/assets/f943927b-d79b-4223-ab23-e490085980cc)


## Why are there no tests?

This is a pure CSS layout change — no DOM, state, or selector changes. The existing `GalleryView.test.tsx` Jest suite (9 tests, all passing) and the existing `tests/site-cms-site-initializer/main/files.spec.ts` Playwright coverage continue to exercise the gallery's behaviour (default view, navigation, empty states). Layout assertions in Jest are impractical (jsdom doesn't compute layout) and CSS-value assertions in Playwright are brittle.