### PR TITLE
LPD-90195 Add upgrade step for Ticket.emailAddress column

### DIFF
--- a/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/PortalUpgradeProcessRegistryImpl.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/PortalUpgradeProcessRegistryImpl.java
@@ -766,6 +766,11 @@ public class PortalUpgradeProcessRegistryImpl
 		upgradeVersionTreeMap.put(
 			new Version(38, 4, 1),
 			new RegionExternalReferenceCodeUpgradeProcess());
+
+		upgradeVersionTreeMap.put(
+			new Version(38, 4, 2),
+			UpgradeProcessFactory.addColumns(
+				"Ticket", "emailAddress VARCHAR(254) null"));
 	}
 
 }


### PR DESCRIPTION
 LPD-90195 Add upgrade step for Ticket.emailAddress column

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-90195 part of : https://liferay.atlassian.net/browse/LPD-48130

As part of LPD-48130, the `Ticket` entity is gaining an indexed `emailAddress` column so that lookups of email-invitation tickets become indexable. The column is already
declared on the `Ticket` entity in `portal-impl/src/com/liferay/portal/service.xml`, so fresh installs get it through Service Builder's `CREATE TABLE`. Without an explicit
upgrade step, existing 7.4.x installations that boot against an older schema would not have the column, and any code that reads `Ticket.emailAddress`, including the
email-invitation flow built on top of this column, would fail at runtime.

The portal upgrade framework (`PortalUpgradeProcessRegistryImpl`) is the mechanism that bridges this gap: each schema-changing release version mapped in the version tree map
carries the missing structural change. Until this PR there is no entry that adds `Ticket.emailAddress`, so upgraded instances remain on the old schema.

# How am I fixing it?

Add a small `UpgradeProcess` whose `doUpgrade()` calls `alterTableAddColumn("Ticket", "emailAddress", "VARCHAR(254) null")` , same type Service Builder declares for fresh installs. Wired into `PortalUpgradeProcessRegistryImpl` at portal upgrade version `(38, 4, 2)`, the next free slot after `(38,
4, 1) RegionExternalReferenceCodeUpgradeProcess`. `BaseDBProcess.alterTableAddColumn` is idempotent — it checks `hasColumn` before issuing the `ALTER` and throws only when
the column already exists with a different type — so the call is safe on already-upgraded instances and no extra `if (!hasColumn(...))` guard is needed.


# Why doesn't this include any test?

The change is purely declarative: one `alterTableAddColumn` call with no backfill or transformation logic. In `portal-impl/test/unit/com/liferay/portal/upgrade/v7_4_x/`, only
1 of 25+ upgrade processes ships with a unit test (`UpgradeReleaseTest`, justified by non-trivial logic); column-add upgrades are intentionally untested at that layer. In
`modules/apps/portal/portal-upgrade-test/`, every per-class integration test asserts a data backfill or transformation side effect, which this upgrade does not have. The
underlying `alterTableAddColumn` primitive itself is already covered by `UpgradeProcessFactoryTest.testAddColumn` (scratch-table assertion via `DBInspector.hasColumnType`).
End-to-end coverage of the upgrade from an older schema is provided by the existing upgrade-from-7.4 CI matrix.


# Commits

- 1ee1f6857aad5 LPD-90195 Add upgrade step for Ticket.emailAddress column
