### PR TITLE
LPD-92150 Close the Publish modal on form submission error so the error toast becomes visible

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/modals/PublishModal.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/modals/PublishModal.js
@@ -6,7 +6,7 @@
 import ClayAlert from '@clayui/alert';
 import ClayButton from '@clayui/button';
 import ClayModal, {useModal} from '@clayui/modal';
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 
 import PermissionsOptions from '../PermissionsOptions';
 import ScheduleOptions from '../ScheduleOptions';
@@ -42,6 +42,16 @@ export default function PublishModal({
 	const [dateError, setDateError] = useState('');
 	const [showErrorAlert, setShowErrorAlert] = useState(false);
 	const [isSubmitting, setIsSubmitting] = useState(false);
+
+	useEffect(() => {
+		const handler = Liferay.on('ddmFormError', (event) => {
+			if (event.error?.statusCode) {
+				onClose();
+			}
+		});
+
+		return () => handler.detach();
+	}, [onClose]);
 
 	const handleButtonClick = () => {
 		if (isSubmitting) {

--- a/modules/apps/journal/journal-web/test/js/modals/PublishModal.test.js
+++ b/modules/apps/journal/journal-web/test/js/modals/PublishModal.test.js
@@ -1,0 +1,73 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import '@testing-library/jest-dom';
+import {act, render, waitFor} from '@testing-library/react';
+import React from 'react';
+
+import PublishModal from '../../../src/main/resources/META-INF/resources/js/modals/PublishModal';
+
+const DEFAULT_PROPS = {
+	actionButton: 'publish',
+	articleId: '123',
+	buttonDisabled: false,
+	displayDate: null,
+	onCloseModal: jest.fn(),
+	onPublishButtonClick: jest.fn(),
+	permissionsURL: null,
+	portletNamespace: 'portletNamespace',
+	showPermissionsOptions: false,
+	timeZone: 'UTC',
+	workflowEnabled: false,
+};
+
+describe('PublishModal', () => {
+	let ddmFormErrorHandler;
+
+	beforeEach(() => {
+		ddmFormErrorHandler = null;
+
+		global.Liferay.on = jest.fn((event, handler) => {
+			if (event === 'ddmFormError') {
+				ddmFormErrorHandler = handler;
+			}
+
+			return {detach: jest.fn()};
+		});
+	});
+
+	it('closes when a ddmFormError event with statusCode is fired', async () => {
+		const onCloseModal = jest.fn();
+
+		render(<PublishModal {...DEFAULT_PROPS} onCloseModal={onCloseModal} />);
+
+		expect(ddmFormErrorHandler).not.toBeNull();
+
+		act(() => {
+			ddmFormErrorHandler({
+				error: {
+					message: 'upload-size-limit-has-been-exceeded',
+					statusCode: 413,
+				},
+			});
+		});
+
+		await waitFor(() => {
+			expect(onCloseModal).toHaveBeenCalled();
+		});
+	});
+
+	it('does not close when a ddmFormError event without statusCode is fired', () => {
+		const onCloseModal = jest.fn();
+
+		render(<PublishModal {...DEFAULT_PROPS} onCloseModal={onCloseModal} />);
+
+		act(() => {
+			ddmFormErrorHandler({});
+		});
+
+		expect(onCloseModal).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Summary

When the Upload Servlet Request size limit is exceeded while publishing a Web Content from the **Publish with permissions** modal, the error toast emitted by `JournalPortlet.handleDDMFormError` was rendered inside `.article-content-content` but stayed hidden behind the modal backdrop. The Publish button remained stuck in submitting state and the user had no visible feedback.

LPS-198515 introduced the toast; LPS-205104 later added `PublishModal`, which covers the toast and caused this regression.

`PublishModal` now listens for `ddmFormError` events that carry a `statusCode` (server-side submission errors) and closes itself, allowing the toast generated by `JournalPortlet.handleDDMFormError` to become visible.

## Test plan

- [x] Unit test added: `PublishModal.test.js` covers the modal closing on `ddmFormError` with `statusCode`, and not closing on `ddmFormError` without `statusCode`. Verified test fails without the fix.
- [ ] Manual: open the Publish modal on a Web Content, run \`Liferay.fire('ddmFormError', {error: {statusCode: 413, message: 'upload-size-limit-has-been-exceeded'}})\` in the browser console; the modal closes and the error toast becomes visible.
- [ ] Manual (real scenario): lower **Control Panel → System Settings → Infrastructure → Upload Servlet Request** to a few KB, create a Web Content that exceeds the limit, and publish via the modal; the 413 from the DDM form context provider triggers `ddmFormError`, the modal closes, and the toast is shown.

## Related issues

- LPP-63989 (customer issue)
- LPS-198515 (original fix)
- LPS-205104 (introduced the regression)