### PR TITLE
LPD-92150 Close the Publish modal on form submission error so the error toast becomes visible

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/modals/PublishModal.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/modals/PublishModal.js
@@ -6,7 +6,7 @@
 import ClayAlert from '@clayui/alert';
 import ClayButton from '@clayui/button';
 import ClayModal, {useModal} from '@clayui/modal';
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 
 import PermissionsOptions from '../PermissionsOptions';
 import ScheduleOptions from '../ScheduleOptions';
@@ -42,6 +42,16 @@ export default function PublishModal({
 	const [dateError, setDateError] = useState('');
 	const [showErrorAlert, setShowErrorAlert] = useState(false);
 	const [isSubmitting, setIsSubmitting] = useState(false);
+
+	useEffect(() => {
+		const handler = Liferay.on('ddmFormError', (event) => {
+			if (event.error?.statusCode) {
+				onClose();
+			}
+		});
+
+		return () => handler.detach();
+	}, [onClose]);
 
 	const handleButtonClick = () => {
 		if (isSubmitting) {

--- a/modules/apps/journal/journal-web/test/js/modals/PublishModal.test.js
+++ b/modules/apps/journal/journal-web/test/js/modals/PublishModal.test.js
@@ -1,0 +1,73 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import '@testing-library/jest-dom';
+import {act, render, waitFor} from '@testing-library/react';
+import React from 'react';
+
+import PublishModal from '../../../src/main/resources/META-INF/resources/js/modals/PublishModal';
+
+const DEFAULT_PROPS = {
+	actionButton: 'publish',
+	articleId: '123',
+	buttonDisabled: false,
+	displayDate: null,
+	onCloseModal: jest.fn(),
+	onPublishButtonClick: jest.fn(),
+	permissionsURL: null,
+	portletNamespace: 'portletNamespace',
+	showPermissionsOptions: false,
+	timeZone: 'UTC',
+	workflowEnabled: false,
+};
+
+describe('PublishModal', () => {
+	let ddmFormErrorHandler;
+
+	beforeEach(() => {
+		ddmFormErrorHandler = null;
+
+		global.Liferay.on = jest.fn((event, handler) => {
+			if (event === 'ddmFormError') {
+				ddmFormErrorHandler = handler;
+			}
+
+			return {detach: jest.fn()};
+		});
+	});
+
+	it('closes when a ddmFormError event with statusCode is fired', async () => {
+		const onCloseModal = jest.fn();
+
+		render(<PublishModal {...DEFAULT_PROPS} onCloseModal={onCloseModal} />);
+
+		expect(ddmFormErrorHandler).not.toBeNull();
+
+		act(() => {
+			ddmFormErrorHandler({
+				error: {
+					message: 'upload-size-limit-has-been-exceeded',
+					statusCode: 413,
+				},
+			});
+		});
+
+		await waitFor(() => {
+			expect(onCloseModal).toHaveBeenCalled();
+		});
+	});
+
+	it('does not close when a ddmFormError event without statusCode is fired', () => {
+		const onCloseModal = jest.fn();
+
+		render(<PublishModal {...DEFAULT_PROPS} onCloseModal={onCloseModal} />);
+
+		act(() => {
+			ddmFormErrorHandler({});
+		});
+
+		expect(onCloseModal).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-92150

When the Upload Servlet Request size limit is exceeded while publishing a Web Content from the **Publish with permissions** modal, the DDM form context provider returns 413 and `FormView` fires `ddmFormError`. `JournalPortlet.handleDDMFormError` already creates the corresponding error toast inside `.article-content-content` (the fix from LPS-198515), but the toast is rendered behind the modal backdrop introduced later by LPS-205104. The Publish button stays stuck in submitting state and the user receives no visible feedback — exactly what LPS-198515 originally fixed.

# How am I fixing it?

`PublishModal` now subscribes to `ddmFormError` and, when the event carries a `statusCode` (i.e. a server-side submission failure as opposed to a client-side validation event), invokes `onClose`. The modal goes away, the existing toast emitted by `JournalPortlet.handleDDMFormError` becomes visible, and the original behavior of LPS-198515 is restored without touching the journal-side handler or duplicating the error rendering inside the modal.

The check is filtered on `statusCode` so that non-server `ddmFormError` events (e.g. plain client-side validation failures fired by `FormView.es.js:82` / `:114`) do not dismiss the modal.

# How can you verify that it works?

Run the included automated tests (`PublishModal.test.js`):

Manually:

1. Open the **Publish with permissions** modal on a Web Content.
2. In the browser console, run \`Liferay.fire('ddmFormError', {error: {statusCode: 413, message: 'upload-size-limit-has-been-exceeded'}})\`.
3. The modal closes and the toast becomes visible.