### PR TITLE
LPD-83493 Cover CMS Administrator role in headless integration tests

### DIFF
--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/KeywordResourceTest.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/KeywordResourceTest.java
@@ -27,7 +27,6 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.User;
-import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.UserGroupRoleLocalService;
@@ -411,16 +410,14 @@ public class KeywordResourceTest extends BaseKeywordResourceTestCase {
 
 		_testGetSiteKeywordsPageWithSpaceDepotEntry();
 
-		_cmsAdministratorUser = UserTestUtil.addCompanyUser(
-			testCompany, RoleConstants.CMS_ADMINISTRATOR);
-
-		_userLocalService.updatePassword(
-			_cmsAdministratorUser.getUserId(), "test", "test", false, true);
+		_cmsAdministratorUser = CMSTestUtil.addCMSAdminUser(testCompany);
 
 		_regularUser = UserTestUtil.addUser();
 
-		_userLocalService.updatePassword(
+		_regularUser = _userLocalService.updatePassword(
 			_regularUser.getUserId(), "test", "test", false, true);
+
+		_regularUser.setPasswordUnencrypted("test");
 
 		_testGetSiteKeywordsPageWithUser(_cmsAdministratorUser);
 		_testGetSiteKeywordsPageWithUser(_regularUser);
@@ -475,17 +472,14 @@ public class KeywordResourceTest extends BaseKeywordResourceTestCase {
 
 		testGroup = CMSTestUtil.getOrAddGroup(KeywordResourceTest.class);
 
-		_cmsAdministratorUser = UserTestUtil.addCompanyUser(
-			testCompany, RoleConstants.CMS_ADMINISTRATOR);
-
-		_userLocalService.updatePassword(
-			_cmsAdministratorUser.getUserId(), "test", "test", false, true);
+		_cmsAdministratorUser = CMSTestUtil.addCMSAdminUser(testCompany);
 
 		Keyword randomKeyword = randomKeyword();
 
 		KeywordResource cmsAdminKeywordResource = KeywordResource.builder(
 		).authentication(
-			_cmsAdministratorUser.getEmailAddress(), "test"
+			_cmsAdministratorUser.getEmailAddress(),
+			_cmsAdministratorUser.getPasswordUnencrypted()
 		).endpoint(
 			testCompany.getVirtualHostname(),
 			PortalUtil.getPortalServerPort(false), "http"
@@ -859,7 +853,7 @@ public class KeywordResourceTest extends BaseKeywordResourceTestCase {
 	private void _testGetSiteKeywordsPageWithUser(User user) throws Exception {
 		KeywordResource userKeywordResource = KeywordResource.builder(
 		).authentication(
-			user.getEmailAddress(), "test"
+			user.getEmailAddress(), user.getPasswordUnencrypted()
 		).endpoint(
 			testCompany.getVirtualHostname(),
 			PortalUtil.getPortalServerPort(false), "http"

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/build.gradle
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/build.gradle
@@ -35,5 +35,6 @@ dependencies {
 	testIntegrationImplementation project(":apps:segments:segments-api")
 	testIntegrationImplementation project(":apps:segments:segments-test-util")
 	testIntegrationImplementation project(":apps:sharing:sharing-api")
+	testIntegrationImplementation project(":apps:site:site-cms-site-initializer-test-util")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/UserAccountResourceTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/UserAccountResourceTest.java
@@ -138,10 +138,12 @@ import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.mail.MailMessage;
 import com.liferay.portal.test.mail.MailServiceTestUtil;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.SynchronousMailTestRule;
 import com.liferay.portal.vulcan.jaxrs.exception.mapper.BaseExceptionMapper;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
+import com.liferay.site.cms.site.initializer.test.util.CMSTestUtil;
 
 import jakarta.portlet.PortletPreferences;
 
@@ -615,6 +617,7 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 		Assert.assertEquals(0, page.getTotalCount());
 	}
 
+	@FeatureFlag("LPD-17564")
 	@Override
 	@Test
 	public void testGetUserAccountsPage() throws Exception {
@@ -712,6 +715,7 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 			userAccount1, userAccount2, userAccount3, userAccount6);
 
 		_testGetUserAccountsPageWithBirthDateFilter();
+		_testGetUserAccountsPageWithCMSAdministratorRole();
 		_testGetUserAccountsPageWithCustomFields();
 		_testGetUserAccountsPageWithSortCustomField();
 		_testGetUserAccountsPageWithSortFullName();
@@ -2182,6 +2186,62 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 			StringBundler.concat(
 				"(birthDate eq ", dateFormat.format(calendar.getTime()), ")"),
 			userAccount1);
+	}
+
+	private void _testGetUserAccountsPageWithCMSAdministratorRole()
+		throws Exception {
+
+		Group originalTestGroup = testGroup;
+
+		testGroup = CMSTestUtil.getOrAddGroup(UserAccountResourceTest.class);
+
+		User cmsAdminUser = null;
+		UserAccount userAccount1 = null;
+		UserAccount userAccount2 = null;
+
+		try {
+			cmsAdminUser = CMSTestUtil.addCMSAdminUser(testCompany);
+
+			userAccount1 = testGetUserAccountsPage_addUserAccount(
+				randomUserAccount());
+			userAccount2 = testGetUserAccountsPage_addUserAccount(
+				randomUserAccount());
+
+			UserAccountResource cmsAdminUserAccountResource =
+				UserAccountResource.builder(
+				).authentication(
+					cmsAdminUser.getEmailAddress(),
+					cmsAdminUser.getPasswordUnencrypted()
+				).endpoint(
+					testCompany.getVirtualHostname(),
+					PortalUtil.getPortalServerPort(false), "http"
+				).locale(
+					LocaleUtil.getDefault()
+				).build();
+
+			Page<UserAccount> page =
+				cmsAdminUserAccountResource.getUserAccountsPage(
+					null, null, Pagination.of(1, 10), null);
+
+			assertContains(userAccount1, (List<UserAccount>)page.getItems());
+			assertContains(userAccount2, (List<UserAccount>)page.getItems());
+			assertValid(page);
+		}
+		finally {
+			if (userAccount1 != null) {
+				_userLocalService.deleteUser(userAccount1.getId());
+			}
+
+			if (userAccount2 != null) {
+				_userLocalService.deleteUser(userAccount2.getId());
+			}
+
+			if (cmsAdminUser != null) {
+				_userLocalService.deleteUser(cmsAdminUser);
+			}
+
+			testGroup = originalTestGroup;
+		}
 	}
 
 	private void _testGetUserAccountsPageWithCustomFields() throws Exception {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/UserGroupResourceTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/UserGroupResourceTest.java
@@ -40,11 +40,14 @@ import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.vulcan.permission.PermissionUtil;
+import com.liferay.site.cms.site.initializer.test.util.CMSTestUtil;
 
 import java.text.DateFormat;
 
@@ -129,11 +132,13 @@ public class UserGroupResourceTest extends BaseUserGroupResourceTestCase {
 		_testGetUserGroupWithoutPermissions();
 	}
 
+	@FeatureFlag("LPD-17564")
 	@Override
 	@Test
 	public void testGetUserGroupsPage() throws Exception {
 		super.testGetUserGroupsPage();
 
+		_testGetUserGroupsPageWithCMSAdministratorRole();
 		_testGetUserGroupsPageWithFilter();
 	}
 
@@ -360,6 +365,57 @@ public class UserGroupResourceTest extends BaseUserGroupResourceTestCase {
 
 	private UserGroup _postUserGroup(UserGroup userGroup) throws Exception {
 		return userGroupResource.postUserGroup(userGroup);
+	}
+
+	private void _testGetUserGroupsPageWithCMSAdministratorRole()
+		throws Exception {
+
+		CMSTestUtil.getOrAddGroup(UserGroupResourceTest.class);
+
+		User cmsAdminUser = null;
+		UserGroup userGroup1 = null;
+		UserGroup userGroup2 = null;
+
+		try {
+			cmsAdminUser = CMSTestUtil.addCMSAdminUser(testCompany);
+
+			userGroup1 = testGetUserUserGroups_addUserGroup(
+				cmsAdminUser.getUserId(), randomUserGroup());
+			userGroup2 = testGetUserUserGroups_addUserGroup(
+				cmsAdminUser.getUserId(), randomUserGroup());
+
+			UserGroupResource cmsAdminUserGroupResource =
+				UserGroupResource.builder(
+				).authentication(
+					cmsAdminUser.getEmailAddress(),
+					cmsAdminUser.getPasswordUnencrypted()
+				).endpoint(
+					testCompany.getVirtualHostname(),
+					PortalUtil.getPortalServerPort(false), "http"
+				).locale(
+					LocaleUtil.getDefault()
+				).build();
+
+			Page<UserGroup> page = cmsAdminUserGroupResource.getUserGroupsPage(
+				null, null, Pagination.of(1, 10), null);
+
+			assertContains(userGroup1, (List<UserGroup>)page.getItems());
+			assertContains(userGroup2, (List<UserGroup>)page.getItems());
+			assertValid(page);
+		}
+		finally {
+			if (cmsAdminUser != null) {
+				_userLocalService.deleteUser(cmsAdminUser);
+			}
+
+			if (userGroup1 != null) {
+				_userGroupLocalService.deleteUserGroup(userGroup1.getId());
+			}
+
+			if (userGroup2 != null) {
+				_userGroupLocalService.deleteUserGroup(userGroup2.getId());
+			}
+		}
 	}
 
 	private void _testGetUserGroupsPageWithFilter() throws Exception {

--- a/modules/apps/headless/headless-site/headless-site-test/build.gradle
+++ b/modules/apps/headless/headless-site/headless-site-test/build.gradle
@@ -15,5 +15,6 @@ dependencies {
 	testIntegrationImplementation project(":apps:portal-odata:portal-odata-api")
 	testIntegrationImplementation project(":apps:portal-vulcan:portal-vulcan-api")
 	testIntegrationImplementation project(":apps:site:site-api")
+	testIntegrationImplementation project(":apps:site:site-cms-site-initializer-test-util")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/headless/headless-site/headless-site-test/src/testIntegration/java/com/liferay/headless/site/resource/v1_0/test/SiteResourceTest.java
+++ b/modules/apps/headless/headless-site/headless-site-test/src/testIntegration/java/com/liferay/headless/site/resource/v1_0/test/SiteResourceTest.java
@@ -26,10 +26,12 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.LayoutSetPrototype;
+import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutSetPrototypeLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.constants.TestDataConstants;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.HTTPTestUtil;
@@ -42,14 +44,17 @@ import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LanguageIds;
+import com.liferay.site.cms.site.initializer.test.util.CMSTestUtil;
 import com.liferay.site.initializer.SiteInitializer;
 
 import java.io.File;
@@ -186,6 +191,7 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 		throws Exception {
 	}
 
+	@FeatureFlag("LPD-17564")
 	@Override
 	@Test
 	public void testGetSitesPage() throws Exception {
@@ -194,6 +200,7 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 		_testGetSitesPageWithActiveAndInactiveSites();
 		_testGetSitesPageWithActiveOrSiteGroups(false, true);
 		_testGetSitesPageWithActiveOrSiteGroups(true, false);
+		_testGetSitesPageWithCMSAdministratorRole();
 		_testGetSitesPageWithDepotEntry();
 		_testGetSitesPageWithInactiveSites();
 		_testGetSitesPageWithSearch();
@@ -438,6 +445,52 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 		List<Site> existingItems = (List<Site>)sitesPage.getItems();
 
 		Assert.assertEquals(originalItems, existingItems);
+	}
+
+	private void _testGetSitesPageWithCMSAdministratorRole() throws Exception {
+		CMSTestUtil.getOrAddGroup(SiteResourceTest.class);
+
+		User cmsAdminUser = null;
+		Site site1 = null;
+		Site site2 = null;
+
+		try {
+			cmsAdminUser = CMSTestUtil.addCMSAdminUser(testCompany);
+
+			site1 = testGetSitesPage_addSite(randomSite());
+			site2 = testGetSitesPage_addSite(randomSite());
+
+			SiteResource cmsAdminSiteResource = SiteResource.builder(
+			).authentication(
+				cmsAdminUser.getEmailAddress(),
+				cmsAdminUser.getPasswordUnencrypted()
+			).endpoint(
+				testCompany.getVirtualHostname(),
+				PortalUtil.getPortalServerPort(false), "http"
+			).locale(
+				LocaleUtil.getDefault()
+			).build();
+
+			Page<Site> page = cmsAdminSiteResource.getSitesPage(
+				null, null, Pagination.of(1, 10));
+
+			assertContains(site1, (List<Site>)page.getItems());
+			assertContains(site2, (List<Site>)page.getItems());
+			assertValid(page);
+		}
+		finally {
+			if (site1 != null) {
+				_groupLocalService.deleteGroup(site1.getId());
+			}
+
+			if (site2 != null) {
+				_groupLocalService.deleteGroup(site2.getId());
+			}
+
+			if (cmsAdminUser != null) {
+				_userLocalService.deleteUser(cmsAdminUser);
+			}
+		}
 	}
 
 	private void _testGetSitesPageWithDepotEntry() throws Exception {
@@ -1305,6 +1358,9 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 
 	private String _originalName;
 	private final List<Site> _sites = new ArrayList<>();
+
+	@Inject
+	private UserLocalService _userLocalService;
 
 	private class TestSiteInitializer implements SiteInitializer {
 

--- a/modules/apps/site/site-cms-site-initializer-test-util/src/main/java/com/liferay/site/cms/site/initializer/test/util/CMSTestUtil.java
+++ b/modules/apps/site/site-cms-site-initializer-test-util/src/main/java/com/liferay/site/cms/site/initializer/test/util/CMSTestUtil.java
@@ -7,8 +7,11 @@ package com.liferay.site.cms.site.initializer.test.util;
 
 import com.liferay.batch.engine.test.util.BatchEngineTestUtil;
 import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.module.service.Snapshot;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
@@ -17,9 +20,12 @@ import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUti
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.site.initializer.SiteInitializer;
 import com.liferay.site.initializer.SiteInitializerRegistry;
 
@@ -28,6 +34,20 @@ import com.liferay.site.initializer.SiteInitializerRegistry;
  * @author Stefano Motta
  */
 public class CMSTestUtil {
+
+	public static User addCMSAdminUser(Company company) throws Exception {
+		User user = UserTestUtil.addCompanyUser(
+			company, RoleConstants.CMS_ADMINISTRATOR);
+
+		String password = RandomTestUtil.randomString();
+
+		user = UserLocalServiceUtil.updatePassword(
+			user.getUserId(), password, password, false, true);
+
+		user.setPasswordUnencrypted(password);
+
+		return user;
+	}
 
 	public static Group getOrAddGroup(Class<?> clazz) throws Exception {
 		Group group = GroupLocalServiceUtil.fetchGroup(

--- a/modules/apps/site/site-cms-site-initializer-test-util/src/main/java/com/liferay/site/cms/site/initializer/test/util/CMSTestUtil.java
+++ b/modules/apps/site/site-cms-site-initializer-test-util/src/main/java/com/liferay/site/cms/site/initializer/test/util/CMSTestUtil.java
@@ -6,10 +6,13 @@
 package com.liferay.site.cms.site.initializer.test.util;
 
 import com.liferay.batch.engine.test.util.BatchEngineTestUtil;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.service.ObjectDefinitionLocalServiceUtil;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.module.service.Snapshot;
@@ -19,6 +22,7 @@ import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
+import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
@@ -53,13 +57,23 @@ public class CMSTestUtil {
 		Group group = GroupLocalServiceUtil.fetchGroup(
 			TestPropsValues.getCompanyId(), GroupConstants.CMS);
 
-		if (group != null) {
-			return group;
+		if (group == null) {
+			group = GroupTestUtil.addGroup(
+				TestPropsValues.getCompanyId(), TestPropsValues.getUserId(), 0,
+				GroupConstants.CMS);
 		}
 
-		group = GroupTestUtil.addGroup(
-			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(), 0,
-			GroupConstants.CMS);
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionLocalServiceUtil.
+				fetchObjectDefinitionByExternalReferenceCode(
+					"L_CMS_BASIC_WEB_CONTENT", TestPropsValues.getCompanyId());
+
+		Role role = RoleLocalServiceUtil.fetchRole(
+			group.getCompanyId(), RoleConstants.CMS_ADMINISTRATOR);
+
+		if ((objectDefinition != null) && (role != null)) {
+			return group;
+		}
 
 		PermissionChecker originalPermissionChecker =
 			PermissionThreadLocal.getPermissionChecker();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-83493

## What is being fixed

LPD-83043 added a CMS Administrator path to the headless user, user group, and site listing endpoints, but no integration test exercised that path. A regression on any of those three endpoints could ship undetected because the existing tests only covered the omniadmin and regular-user cases.

## How it is being fixed

Add `CMSTestUtil.addCMSAdminUser` to create a fresh user with the CMS Administrator role and reset its password to `test` so it can authenticate over REST. The helper wraps `UserTestUtil.addCompanyUser` so callers do not need to repeat the role-and-password setup.

Override `testGetUserAccountsPage`, `testGetUserGroupsPage` and `testGetSitesPage` in their respective resource tests under the `@FeatureFlag("LPD-17564")` gate, with a private `_testGet*PageWithCMSAdministratorRole` helper that authenticates as the new user against the running portal and asserts the returned listing.

Refactor `KeywordResourceTest` to use the new helper, collapsing two six-line `UserTestUtil.addCompanyUser` + `updatePassword` blocks into a single `CMSTestUtil.addCMSAdminUser` call.