### PR TITLE
LPD-91271 Render the Save Custom Friendly URL warning as a Clay modal

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/spaces/SpaceGeneralSettings.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/spaces/SpaceGeneralSettings.tsx
@@ -267,7 +267,18 @@ export default function SpaceGeneralSettings({
 								}
 								id={`${id}friendlyURL`}
 								name="friendlyURL"
-								onBlur={handleBlur}
+								onBlur={(event) => {
+									const value = event.target.value.trim();
+
+									if (value && !value.startsWith('/')) {
+										setFieldValue(
+											'friendlyURL',
+											'/' + value
+										);
+									}
+
+									handleBlur(event);
+								}}
 								onChange={handleChange}
 								required
 								value={values.friendlyURL}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/spaces/SpaceGeneralSettings.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/spaces/SpaceGeneralSettings.tsx
@@ -6,7 +6,7 @@
 import ClayButton from '@clayui/button';
 import ClayForm, {ClayCheckbox, ClayInput} from '@clayui/form';
 import {useFormik} from 'formik';
-import {openConfirmModal, openToast, useId} from 'frontend-js-components-web';
+import {openModal, openToast, useId} from 'frontend-js-components-web';
 import {navigate} from 'frontend-js-web';
 import React, {useState} from 'react';
 
@@ -171,15 +171,29 @@ export default function SpaceGeneralSettings({
 		}
 
 		if (values.friendlyURL !== initialFriendlyURL) {
-			openConfirmModal({
-				message: Liferay.Language.get(
+			openModal({
+				bodyHTML: Liferay.Language.get(
 					'changing-the-friendly-url-will-break-existing-inbound-links-bookmarks-and-redirects-pointing-to-this-space.-make-sure-to-set-up-redirects-and-update-any-references-before-saving'
 				),
-				onConfirm: (isConfirm: boolean) => {
-					if (isConfirm) {
-						submitForm();
-					}
-				},
+				buttons: [
+					{
+						displayType: 'secondary',
+						label: Liferay.Language.get('cancel'),
+						onClick: ({processClose}) => {
+							processClose();
+						},
+						type: 'cancel',
+					},
+					{
+						displayType: 'warning',
+						label: Liferay.Language.get('save'),
+						onClick: ({processClose}) => {
+							processClose();
+							submitForm();
+						},
+					},
+				],
+				role: 'alertdialog',
 				status: 'warning',
 				title: Liferay.Language.get('save-custom-friendly-url'),
 			});

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/spaceFriendlyURL.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/spaceFriendlyURL.spec.ts
@@ -151,9 +151,15 @@ test(
 
 		await friendlyURL.fill('cms-should-not-save');
 
-		page.once('dialog', (dialog) => dialog.dismiss());
-
 		await page.getByRole('button', {name: 'Save'}).click();
+
+		const dialog = page.getByRole('alertdialog', {
+			name: 'Save Custom Friendly URL',
+		});
+
+		await dialog.waitFor();
+
+		await dialog.getByRole('button', {name: 'Cancel'}).click();
 
 		const fetchedAssetLibrary =
 			await apiHelpers.headlessAssetLibrary.getAssetLibrary(


### PR DESCRIPTION
# What is this trying to solve?
https://liferay.atlassian.net/browse/LPD-91271
The confirmation prompt when changing a Space's friendly URL renders as the browser's native dialog instead of the styled Clay modal, breaking visual consistency with the rest of the CMS.

# How am I fixing it?
- Swapped `openConfirmModal` for a direct `openModal` call with explicit cancel/save buttons. `openConfirmModal` falls back to `window.confirm` when the per-instance Custom Dialogs setting is off; `openModal` always renders Clay and matches what other confirmation flows in this module use.
- Updated the cancel-confirmation Playwright test to interact with the Clay `alertdialog` instead of dismissing a native dialog.

# How can you verify that it works?
Run the included automated tests.