### PR TITLE
LPD-91700 Bump Apache Neethi to 3.2.2

### DIFF
--- a/lib/versions-complete.xml
+++ b/lib/versions-complete.xml
@@ -1215,13 +1215,13 @@
 			</library>
 			<library>
 				<file-name>com.liferay.document.library.repository.cmis.impl.jar!neethi.jar</file-name>
-				<version>3.1.1</version>
+				<version>3.2.2</version>
 				<project-name>Apache Neethi</project-name>
-				<project-url>http://www.apache.org/</project-url>
+				<project-url>https://www.apache.org/</project-url>
 				<licenses>
 					<license>
-						<license-name>The Apache Software License, Version 2.0</license-name>
-						<license-url>http://www.apache.org/licenses/LICENSE-2.0.txt</license-url>
+						<license-name>Apache-2.0</license-name>
+						<license-url>https://www.apache.org/licenses/LICENSE-2.0.txt</license-url>
 					</license>
 				</licenses>
 			</library>
@@ -1437,6 +1437,18 @@
 				</licenses>
 			</library>
 			<library>
+				<file-name>com.liferay.dynamic.data.mapping.data.provider.impl.jar!HdrHistogram.jar</file-name>
+				<version>2.2.2</version>
+				<project-name>HdrHistogram</project-name>
+				<project-url>http://hdrhistogram.github.io/HdrHistogram/</project-url>
+				<licenses>
+					<license>
+						<license-name>Public Domain, per Creative Commons CC0</license-name>
+						<license-url>http://creativecommons.org/publicdomain/zero/1.0/</license-url>
+					</license>
+				</licenses>
+			</library>
+			<library>
 				<file-name>com.liferay.dynamic.data.mapping.data.provider.impl.jar!archaius-core.jar</file-name>
 				<version>0.4.1</version>
 				<project-name>com.netflix.archaius:archaius-core</project-name>
@@ -1468,17 +1480,6 @@
 					<license>
 						<license-name>The Apache Software License, Version 2.0</license-name>
 						<license-url>https://www.apache.org/licenses/LICENSE-2.0.txt</license-url>
-					</license>
-				</licenses>
-			</library>
-			<library>
-				<file-name>com.liferay.dynamic.data.mapping.data.provider.impl.jar!org.hdrhistogram.jar</file-name>
-				<version>2.1.9.JAKARTA-LIFERAY-PATCHED-1</version>
-				<project-name>HdrHistogram Jakarta</project-name>
-				<licenses>
-					<license>
-						<license-name>LGPL 2.1</license-name>
-						<license-url>http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt</license-url>
 					</license>
 				</licenses>
 			</library>
@@ -7310,13 +7311,13 @@
 			</library>
 			<library>
 				<file-name>com.liferay.sharepoint.soap.repository.jar!neethi.jar</file-name>
-				<version>3.1.1</version>
+				<version>3.2.2</version>
 				<project-name>Apache Neethi</project-name>
-				<project-url>http://www.apache.org/</project-url>
+				<project-url>https://www.apache.org/</project-url>
 				<licenses>
 					<license>
-						<license-name>The Apache Software License, Version 2.0</license-name>
-						<license-url>http://www.apache.org/licenses/LICENSE-2.0.txt</license-url>
+						<license-name>Apache-2.0</license-name>
+						<license-url>https://www.apache.org/licenses/LICENSE-2.0.txt</license-url>
 					</license>
 				</licenses>
 			</library>

--- a/lib/versions.html
+++ b/lib/versions.html
@@ -663,7 +663,7 @@
                 </tr>
                 			
                 <tr>
-                    <td nowrap="nowrap">com.liferay.document.library.repository.cmis.impl.jar!neethi.jar</td><td nowrap="nowrap">3.1.1</td><td nowrap="nowrap"><a href="http://www.apache.org/">Apache Neethi</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a>
+                    <td nowrap="nowrap">com.liferay.document.library.repository.cmis.impl.jar!neethi.jar</td><td nowrap="nowrap">3.2.2</td><td nowrap="nowrap"><a href="https://www.apache.org/">Apache Neethi</a></td><td nowrap><a href="https://www.apache.org/licenses/LICENSE-2.0.txt">Apache-2.0</a>
                         <br>
                     </td><td></td>
                 </tr>
@@ -777,6 +777,12 @@
                 </tr>
                 			
                 <tr>
+                    <td nowrap="nowrap">com.liferay.dynamic.data.mapping.data.provider.impl.jar!HdrHistogram.jar</td><td nowrap="nowrap">2.2.2</td><td nowrap="nowrap"><a href="http://hdrhistogram.github.io/HdrHistogram/">HdrHistogram</a></td><td nowrap><a href="http://creativecommons.org/publicdomain/zero/1.0/">Public Domain, per Creative Commons CC0</a>
+                        <br>
+                    </td><td></td>
+                </tr>
+                			
+                <tr>
                     <td nowrap="nowrap">com.liferay.dynamic.data.mapping.data.provider.impl.jar!archaius-core.jar</td><td nowrap="nowrap">0.4.1</td><td nowrap="nowrap">com.netflix.archaius:archaius-core</td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a>
                         <br>
                     </td><td></td>
@@ -790,12 +796,6 @@
                 			
                 <tr>
                     <td nowrap="nowrap">com.liferay.dynamic.data.mapping.data.provider.impl.jar!json-path.jar</td><td nowrap="nowrap">2.9.0</td><td nowrap="nowrap"><a href="https://github.com/jayway/JsonPath">json-path</a></td><td nowrap><a href="https://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a>
-                        <br>
-                    </td><td></td>
-                </tr>
-                			
-                <tr>
-                    <td nowrap="nowrap">com.liferay.dynamic.data.mapping.data.provider.impl.jar!org.hdrhistogram.jar</td><td nowrap="nowrap">2.1.9.JAKARTA-LIFERAY-PATCHED-1</td><td nowrap="nowrap">HdrHistogram Jakarta</td><td nowrap><a href="http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt">LGPL 2.1</a>
                         <br>
                     </td><td></td>
                 </tr>
@@ -3777,7 +3777,7 @@
                 </tr>
                 			
                 <tr>
-                    <td nowrap="nowrap">com.liferay.sharepoint.soap.repository.jar!neethi.jar</td><td nowrap="nowrap">3.1.1</td><td nowrap="nowrap"><a href="http://www.apache.org/">Apache Neethi</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a>
+                    <td nowrap="nowrap">com.liferay.sharepoint.soap.repository.jar!neethi.jar</td><td nowrap="nowrap">3.2.2</td><td nowrap="nowrap"><a href="https://www.apache.org/">Apache Neethi</a></td><td nowrap><a href="https://www.apache.org/licenses/LICENSE-2.0.txt">Apache-2.0</a>
                         <br>
                     </td><td></td>
                 </tr>

--- a/modules/apps/document-library/document-library-repository-cmis-impl/build.gradle
+++ b/modules/apps/document-library/document-library-repository-cmis-impl/build.gradle
@@ -14,7 +14,7 @@ dependencies {
 	compileInclude group: "com.liferay", name: "org.apache.cxf.rt.wsdl", version: "3.6.9.JAKARTA-LIFERAY-PATCHED-1"
 	compileInclude group: "org.apache.chemistry.opencmis", name: "chemistry-opencmis-client-api", version: "0.14.0"
 	compileInclude group: "org.apache.chemistry.opencmis", name: "chemistry-opencmis-client-impl", version: "0.14.0"
-	compileInclude group: "org.apache.neethi", name: "neethi", version: "3.1.1"
+	compileInclude group: "org.apache.neethi", name: "neethi", version: "3.2.2"
 	compileOnly group: "com.fasterxml.woodstox", name: "woodstox-core", version: "6.4.0"
 	compileOnly group: "com.liferay.jakarta.portlet", name: "com.liferay.jakarta.portlet-api", version: "4.0.0"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"

--- a/modules/apps/portal-remote/portal-remote-soap-extender-impl/build.gradle
+++ b/modules/apps/portal-remote/portal-remote-soap-extender-impl/build.gradle
@@ -8,7 +8,7 @@ dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "jakarta.xml.ws", name: "jakarta.xml.ws-api", version: "3.0.1"
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.dependencymanager", version: "4.6.0"
-	compileOnly group: "org.apache.neethi", name: "neethi", version: "3.2.0"
+	compileOnly group: "org.apache.neethi", name: "neethi", version: "3.2.2"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:portal-remote:portal-remote-soap-extender-api")

--- a/modules/dxp/apps/sharepoint-soap/sharepoint-soap-repository/build.gradle
+++ b/modules/dxp/apps/sharepoint-soap/sharepoint-soap-repository/build.gradle
@@ -25,7 +25,7 @@ dependencies {
 	compileInclude group: "org.apache.axis2", name: "axis2-xmlbeans", version: "1.8.0"
 	compileInclude group: "org.apache.httpcomponents", name: "httpclient", version: "4.5.13"
 	compileInclude group: "org.apache.httpcomponents", name: "httpcore", version: "4.4.14"
-	compileInclude group: "org.apache.neethi", name: "neethi", version: "3.1.1"
+	compileInclude group: "org.apache.neethi", name: "neethi", version: "3.2.2"
 	compileInclude group: "org.apache.woden", name: "woden-api", version: "1.0M9"
 	compileInclude group: "org.apache.ws.xmlschema", name: "xmlschema-core", version: "2.2.1"
 	compileInclude group: "org.apache.xmlbeans", name: "xmlbeans", version: "3.1.0"


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91700

## What is being fixed

Apache Neethi was pinned at inconsistent, lagging versions across the SOAP/CMIS stack: 3.1.1 in document-library-repository-cmis-impl and sharepoint-soap-repository, and 3.2.0 in portal-remote-soap-extender-impl.

## How it is being fixed

Aligned all three modules on neethi 3.2.2, the current upstream release, and regenerated lib/versions-complete.xml and lib/versions.html. The change is split into two commits: the build.gradle version bumps, and the regenerated lib version metadata.

## Why are there no tests?

This is a third-party library version bump (neethi 3.1.1/3.2.0 → 3.2.2) with no behavioral change. Coverage comes from the full ant build plus the existing CMIS and SharePoint module unit tests, which pass.