### PR TITLE
LPD-92243 Make a tag available for all spaces when created with empty asset libraries

### DIFF
--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/KeywordResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/KeywordResourceImpl.java
@@ -432,11 +432,23 @@ public class KeywordResourceImpl
 
 		if (!FeatureFlagManagerUtil.isEnabled(
 				group.getCompanyId(), "LPD-17564") ||
-			!group.isCMS() || ArrayUtil.isEmpty(keyword.getAssetLibraries())) {
+			!group.isCMS()) {
 
 			return _assetTagService.addTag(
 				externalReferenceCode, siteId, keyword.getName(),
 				new ServiceContext());
+		}
+
+		if (ArrayUtil.isEmpty(keyword.getAssetLibraries())) {
+			AssetTag assetTag = _assetTagService.addTag(
+				externalReferenceCode, siteId, keyword.getName(),
+				new ServiceContext());
+
+			_assetTagGroupRelLocalService.setAssetTagGroupRels(
+				assetTag.getTagId(),
+				new long[] {GroupConstants.ANY_PARENT_GROUP_ID});
+
+			return assetTag;
 		}
 
 		long[] assetLibraryGroupIds = TaxonomyGroupUtil.getAssetLibraryGroupIds(

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/KeywordResourceTest.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/KeywordResourceTest.java
@@ -493,6 +493,19 @@ public class KeywordResourceTest extends BaseKeywordResourceTestCase {
 		assertEquals(randomKeyword, postKeyword);
 		assertValid(postKeyword);
 
+		List<AssetTagGroupRel> assetTagGroupRels =
+			_assetTagGroupRelLocalService.getAssetTagGroupRelsByTagId(
+				postKeyword.getId());
+
+		Assert.assertEquals(
+			assetTagGroupRels.toString(), 1, assetTagGroupRels.size());
+
+		AssetTagGroupRel assetTagGroupRel = assetTagGroupRels.get(0);
+
+		Assert.assertEquals(
+			assetTagGroupRels.toString(), GroupConstants.ANY_PARENT_GROUP_ID,
+			assetTagGroupRel.getGroupId());
+
 		testGroup = originalTestGroup;
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92243

## What is being fixed

Creating a tag through the headless-admin-taxonomy keyword endpoint with
an empty asset libraries list left the tag scoped only to the site it was
created in, instead of making it available across all spaces. Editing the
same tag with an empty asset libraries list did make it available
everywhere, so creation and edition behaved inconsistently.

## How it is being fixed

In `KeywordResourceImpl._addAssetTag`, the empty asset libraries case no
longer short-circuits to a plain `addTag` that skips the asset tag group
relations. When the feature flag is enabled and the group is a CMS site,
an empty asset libraries list now sets the all-spaces relation
(`ANY_PARENT_GROUP_ID`), matching what the edition endpoint already does.
The explicit asset library path and the non-CMS path are left untouched,
so the all-spaces behavior stays scoped to the CMS site.
