### PR TITLE
LPD-92120 Fix broken site-cms-site-initializer Playwright tests

### DIFF
--- a/modules/test/playwright/tests/site-cms-site-initializer/main/contentEditor.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/contentEditor.spec.ts
@@ -1386,7 +1386,7 @@ test.describe('Schedule Publication', () => {
 			// Check that it remains on the page and the error is shown
 
 			await expect(
-				page.getByRole('heading', {name: 'Edit Basic Web Content'})
+				page.getByRole('heading', {name: 'New Basic Web Content'})
 			).toBeAttached();
 
 			await expect(

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/info-panel/details.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/info-panel/details.spec.ts
@@ -8,9 +8,7 @@ import {expect, mergeTests} from '@playwright/test';
 import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
 import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
 import {loginTest} from '../../../../fixtures/loginTest';
-import {getRandomInt} from '../../../../utils/getRandomInt';
 import getRandomString from '../../../../utils/getRandomString';
-import {structureBuilderPagesTest} from '../../structure-builder/fixtures/structureBuilderPagesTest';
 import {cmsPagesTest} from '../fixtures/cmsPagesTest';
 
 const test = mergeTests(
@@ -21,43 +19,25 @@ const test = mergeTests(
 		'LPD-17564': {enabled: true},
 		'LPD-34594': {enabled: true},
 	}),
-	loginTest(),
-	structureBuilderPagesTest
+	loginTest()
 );
 
 test(
 	'Info panel shows title with content structure',
 	{tag: ['@LPD-69788', '@LPD-76513']},
-	async ({
-		assetsPage,
-		contentsPage,
-		infoPanelPage,
-		page,
-		structureBuilderPage,
-	}) => {
-		const structureLabel = `StructureName${getRandomInt()}`;
-		const title = getRandomString();
+	async ({apiHelpers, assetsPage, infoPanelPage, page}) => {
+		const title = `Content ${getRandomString()}`;
 
-		await test.step('Create a content structure', async () => {
-			await structureBuilderPage.createStructureFromData({
-				label: structureLabel,
-				page: structureBuilderPage,
-			});
-		});
+		await apiHelpers.objectEntry.postObjectEntry(
+			{
+				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				title,
+			},
+			'cms/basic-web-contents',
+			'Default'
+		);
 
-		await test.step('Navigate to All Assets and create a new content', async () => {
-			await assetsPage.gotoAll();
-
-			await contentsPage.createContent(structureLabel);
-
-			await expect(
-				page.getByRole('heading', {name: `New ${structureLabel}`})
-			).toBeVisible();
-
-			await page.getByPlaceholder(`New ${structureLabel}`).fill(title);
-
-			await contentsPage.saveContent();
-		});
+		await assetsPage.gotoAll();
 
 		await test.step('Open Info Panel and assert that title is not empty', async () => {
 			await assetsPage.execItemAction({

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/pages/AssetsPage.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/pages/AssetsPage.ts
@@ -132,7 +132,7 @@ export class AssetsPage {
 					{externalReferenceCode: 'L_CONTENTS', scopeKey: spaceName}
 				);
 
-			this.gotoFolder(rootFolder.id, rootFolder.title);
+			await this.gotoFolder(rootFolder.id, rootFolder.title);
 		}
 		else {
 			await this.page.goto(PORTLET_URLS.cmsContents);
@@ -152,7 +152,7 @@ export class AssetsPage {
 			);
 
 		await this.page.goto(
-			`${PORTLET_URLS.cmsViewFolder}${className.classNameId}/${folderId}`
+			`${PORTLET_URLS.cmsViewFolder}/${className.classNameId}/${folderId}`
 		);
 
 		await this.page.getByTestId(`testId${folderTitle}`).waitFor();

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/pages/ContentsPage.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/pages/ContentsPage.ts
@@ -140,8 +140,12 @@ export class ContentsPage {
 		await this.page.getByLabel('NameRequired').fill(folderName);
 
 		if (spaceName) {
-			await this.page.getByLabel('SpaceMandatory').click();
-			await this.page.getByRole('option', {name: spaceName}).click();
+			const spaceSelector = this.page.getByLabel('SpaceMandatory');
+
+			if (await spaceSelector.isVisible()) {
+				await spaceSelector.click();
+				await this.page.getByRole('option', {name: spaceName}).click();
+			}
 		}
 
 		await this.page.getByRole('button', {name: 'Save'}).click();

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/pages/HomePage.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/pages/HomePage.ts
@@ -31,21 +31,26 @@ export class HomePage {
 			name: 'Assigned to My Roles',
 		});
 		this.basicDocumentButton = page.getByRole('button', {
+			exact: true,
 			name: 'Basic Document',
 		});
 		this.basicWebContentButton = page.getByRole('button', {
+			exact: true,
 			name: 'Basic Web Content',
 		});
 		this.blogButton = page.getByRole('button', {
+			exact: true,
 			name: 'Blog',
 		});
 		this.knowledgeBaseButton = page.getByRole('button', {
+			exact: true,
 			name: 'Knowledge Base',
 		});
 		this.viewAllButton = page.getByRole('link', {
 			name: 'View All',
 		});
 		this.vocabularyButton = page.getByRole('button', {
+			exact: true,
 			name: 'Vocabulary',
 		});
 		this.workflowTaskFilterButton = page.getByRole('button', {

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/recycleBin.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/recycleBin.spec.ts
@@ -740,9 +740,9 @@ test(
 		);
 
 		await test.step('Move the folder to Recycle Bin', async () => {
-			await contentsPage.goto();
-
-			await contentsPage.deleteFolder(folderName);
+			await apiHelpers.objectFolder.deleteObjectEntryFolder(
+				folderData.id
+			);
 		});
 
 		await test.step('Assert navigation within Recycle Bin', async () => {

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/versions.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/versions.spec.ts
@@ -4,6 +4,7 @@
  */
 
 import {expect, mergeTests} from '@playwright/test';
+import fs from 'fs';
 import path from 'path';
 
 import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
@@ -65,11 +66,17 @@ test(
 		const applicationName = 'cms/basic-documents';
 		const spaceName = 'Default';
 
+		const fileBase64 = fs
+			.readFileSync(
+				path.join(__dirname, '/dependencies/file_upload_image_1.jpg')
+			)
+			.toString('base64');
+
 		const objectEntry = await apiHelpers.objectEntry.postObjectEntry(
 			{
 				file: {
-					fileBase64: 'R0lGODlhAQABAAAAACw=',
-					name: `file_${getRandomString()}.png`,
+					fileBase64,
+					name: `file_${getRandomString()}.jpg`,
 				},
 				objectEntryFolderExternalReferenceCode: 'L_FILES',
 				title: `title ${getRandomString()}`,

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/versions.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/versions.spec.ts
@@ -197,7 +197,7 @@ async function testCanViewVersion(
 	title: string,
 	view: 'Table' | 'Gallery'
 ) {
-	await expect(page.getByRole('heading', {name: title})).toBeVisible();
+	await expect(page.getByText(title, {exact: true})).toBeVisible();
 
 	if (view === 'Table') {
 		assetsPage.execItemAction({action: 'View History', filter: title});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92120
https://liferay.atlassian.net/browse/LPD-92123
https://liferay.atlassian.net/browse/LPD-92132
https://liferay.atlassian.net/browse/LPD-92140
https://liferay.atlassian.net/browse/LPD-92175
https://liferay.atlassian.net/browse/LPD-92177
https://liferay.atlassian.net/browse/LPD-92194
https://liferay.atlassian.net/browse/LPD-92197

## What is being fixed

Several Playwright tests under site-cms-site-initializer broke as the CMS UI evolved (locators, headings, navigation, and required test data), making the suite fail.

## How it is being fixed

Each commit fixes one test:

| Ticket | Fix | Test |
|---|---|---|
| LPD-92120 | Move folder to Recycle Bin via API in restore test | recycleBin.spec.ts › Can restore a folder and its contents from Recycle Bin |
| LPD-92123 | Fix gotoFolder URL slash and missing await | recycleBin.spec.ts › Can delete over a Select All expanded selection from Recycle Bin |
| LPD-92132 | Match title locator to actual rendered element | versions.spec.ts › Can view a content version |
| LPD-92140 | Upload a real image so file version preview renders | versions.spec.ts › Can view a file version |
| LPD-92175 | Create content via API in info panel test | info-panel/details.spec.ts › Info panel shows title with content structure |
| LPD-92177 | Match Quick Actions buttons by exact name | home.spec.ts › Can use Quick Actions to create new content |
| LPD-92194 | Skip space selector when not rendered in createFolder | categories.spec.ts › Folder can be saved when all asset subtypes are required in a vocabulary |
| LPD-92197 | Expect New Basic Web Content heading instead of Edit Basic Web Content | contentEditor.spec.ts › Do not allow scheduling a publication if there are errors in the fields |
