### PR TITLE
LPD-90046 Empty permission dropdown displayed for current user in Members list

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/spaces/MemberListItem.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/spaces/MemberListItem.tsx
@@ -42,6 +42,8 @@ export function MembersListItem({
 		<>
 			{items.map((item) => {
 				const isUser = itemType === 'user';
+				const isCurrentUser =
+					isUser && currentUserId === String(item.id);
 				const isOwner =
 					isUser &&
 					String(assetLibraryCreatorUserId) === String(item.id);
@@ -101,7 +103,7 @@ export function MembersListItem({
 								{item.name}
 							</span>
 
-							{isUser && currentUserId === String(item.id) && (
+							{isCurrentUser && (
 								<span className="ml-1 text-lowercase text-secondary">
 									({Liferay.Language.get('you')})
 								</span>
@@ -117,6 +119,7 @@ export function MembersListItem({
 						) : hasAssignMembersPermission ? (
 							<div className="align-items-center c-gap-2 d-flex">
 								<SpaceMembersPermissionSelect
+									disabled={isCurrentUser}
 									onChange={(newRoles) =>
 										onUpdateItemRoles(item, newRoles)
 									}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/spaces/SpaceMembersPermissionSelect.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/spaces/SpaceMembersPermissionSelect.tsx
@@ -15,12 +15,14 @@ export const SPACE_MEMBER_ROLE_NAME = 'Asset Library Member';
 export const HIDDEN_MEMBER_ROLES = ['Asset Library Owner', 'CMS Consumer'];
 
 interface SpaceMembersPermissionSelectProps {
+	disabled?: boolean;
 	onChange: (selectedRoles: string[]) => void;
 	roles: Role[];
 	selectedRoles: string[];
 }
 
 export function SpaceMembersPermissionSelect({
+	disabled = false,
 	onChange,
 	roles: rawRoles = [],
 	selectedRoles,
@@ -83,6 +85,7 @@ export function SpaceMembersPermissionSelect({
 				<ClayButton
 					borderless
 					className="align-items-center d-flex"
+					disabled={disabled}
 					displayType="secondary"
 					size="xs"
 				>

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/spaces/MembersListItem.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/spaces/MembersListItem.test.tsx
@@ -100,6 +100,56 @@ describe('MemberListItem', () => {
 		expect(SpaceMembersPermissionSelect).toHaveBeenCalled();
 	});
 
+	it('passes disabled to SpaceMembersPermissionSelect when the user is the current user', () => {
+		render(
+			<MembersListItem
+				{...props}
+				itemType="user"
+				items={[testUserAccount]}
+			/>
+		);
+
+		expect(SpaceMembersPermissionSelect).toHaveBeenCalledWith(
+			expect.objectContaining({disabled: true}),
+			{}
+		);
+	});
+
+	it('passes disabled=false to SpaceMembersPermissionSelect when the user is not the current user', () => {
+		const anotherUser = {
+			emailAddress: 'another.user@example.com',
+			externalReferenceCode: 'ANOTHER_USER_ERC',
+			id: 'another-user-id',
+			name: 'Another User',
+			roles: [],
+		};
+
+		render(
+			<MembersListItem {...props} itemType="user" items={[anotherUser]} />
+		);
+
+		expect(SpaceMembersPermissionSelect).toHaveBeenCalledWith(
+			expect.objectContaining({disabled: false}),
+			{}
+		);
+	});
+
+	it('passes disabled=false to SpaceMembersPermissionSelect when the item is a group', () => {
+		render(
+			<MembersListItem
+				{...props}
+				currentUserId={testUserGroup.id}
+				itemType="group"
+				items={[testUserGroup]}
+			/>
+		);
+
+		expect(SpaceMembersPermissionSelect).toHaveBeenCalledWith(
+			expect.objectContaining({disabled: false}),
+			{}
+		);
+	});
+
 	it('renders a user with fallback image and without the (you) tag', () => {
 		const anotherUser = {
 			emailAddress: 'another.user@example.com',

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/spaces/SpaceMembersPermissionSelect.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/spaces/SpaceMembersPermissionSelect.test.tsx
@@ -116,6 +116,20 @@ describe('SpaceMembersPermissionSelect', () => {
 		expect(spaceMemberCheckbox).toBeDisabled();
 	});
 
+	it('disables the trigger button but still shows the selected roles when disabled', () => {
+		render(
+			<SpaceMembersPermissionSelect
+				{...props}
+				disabled
+				selectedRoles={[SPACE_MEMBER_ROLE_NAME, 'Role 1']}
+			/>
+		);
+
+		const button = screen.getByRole('button');
+		expect(button).toBeDisabled();
+		expect(button).toHaveTextContent('Space Member US, Role 1 US');
+	});
+
 	it('calls onChange with the new role when a checkbox is checked', async () => {
 		render(<SpaceMembersPermissionSelect {...props} />);
 

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/members.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/members.spec.ts
@@ -181,6 +181,49 @@ test(
 );
 
 test(
+	'A Space Administrator sees their own role list disabled in the View All Members list',
+	{tag: '@LPD-89984'},
+	async ({apiHelpers, page, spaceSummaryPage}) => {
+		const spaceAdmin = await apiHelpers.headlessAdminUser.postUserAccount();
+		const spaceAdminFullName = `${spaceAdmin.givenName} ${spaceAdmin.familyName}`;
+
+		userData[spaceAdmin.alternateName] = {
+			name: spaceAdmin.givenName,
+			password: 'test',
+			surname: spaceAdmin.familyName,
+		};
+
+		await apiHelpers.headlessAssetLibrary.putAssetLibraryUserAccount(
+			SITE_CMS_SPACE_EXTERNAL_REFERENCE_CODE,
+			spaceAdmin.externalReferenceCode
+		);
+
+		await apiHelpers.headlessAssetLibrary.putAssetLibraryUserAccountRoles(
+			SITE_CMS_SPACE_EXTERNAL_REFERENCE_CODE,
+			spaceAdmin.externalReferenceCode,
+			['Asset Library Administrator']
+		);
+
+		await performUserSwitchViaApi(page, spaceAdmin.alternateName);
+
+		await spaceSummaryPage.goto(SITE_CMS_SPACE_NAME);
+		await spaceSummaryPage.viewAllMembersLink.click();
+
+		const currentUserRow = page
+			.getByRole('listitem')
+			.filter({hasText: spaceAdminFullName});
+
+		await expect(
+			currentUserRow.locator('.permission-select-trigger-text')
+		).toHaveText('Space Administrator');
+
+		await expect(
+			currentUserRow.getByRole('button', {name: 'Space Administrator'})
+		).toBeDisabled();
+	}
+);
+
+test(
 	'A non-admin space member can search members in the space',
 	{tag: '@LPD-58201'},
 	async ({apiHelpers, page, spaceSummaryPage}) => {


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-90046

If we add to a Space a member with Space Admin role, then this user when logged in will see an empty dropdown for the roles in her/his entry of the Space list of members.

# How am I fixing it?

Disable the dropdown when the user is the one logged in.

# How can you verify that it works?

See unit and functional tests added.
