### PR TITLE
LPD-92303 Create the depot entry as a space in AssetUsageResourceTest

### DIFF
--- a/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/AssetUsageResourceTest.java
+++ b/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/AssetUsageResourceTest.java
@@ -121,7 +121,7 @@ public class AssetUsageResourceTest extends BaseAssetUsageResourceTestCase {
 		_depotEntry = _depotEntryLocalService.addDepotEntry(
 			Collections.singletonMap(
 				LocaleUtil.US, RandomTestUtil.randomString()),
-			null, DepotConstants.TYPE_ASSET_LIBRARY, _serviceContext);
+			null, DepotConstants.TYPE_SPACE, _serviceContext);
 
 		_objectEntryFolder =
 			_objectEntryFolderLocalService.


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92303

## What is being fixed

`AssetUsageResourceTest#setUp` looks up the "L_FILES" object entry folder in the depot entry's group, but that folder is only provisioned for space depot entries, not asset libraries. Because setUp creates the depot entry as an asset library, the lookup fails with `NoSuchObjectEntryFolderException` and every test in the class fails before its body runs.

## How it is being fixed

Create the depot entry as a space (`DepotConstants.TYPE_SPACE`) so the "L_FILES" folder is provisioned and setUp succeeds.

## Validation

Ran `AssetUsageResourceTest` locally (9/9 passing), both in isolation and together with the other headless-cms CMS tests.