### PR TITLE
LPD-92446 Make the home Search Bar filter apply on the All page

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/index.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/index.ts
@@ -42,7 +42,11 @@ export {default as findAction} from './utils/actionItems/findAction';
 export {replaceTokens} from './utils/actionItems/formatActionURL';
 export {readConfigFromURL} from './utils/configInURL';
 
-export {getConfigParamName, serializeFDSConfig} from './utils/configInURL';
+export {
+	decodeFdsConfigParam,
+	getConfigParamName,
+	serializeFDSConfig,
+} from './utils/configInURL';
 export {default as FDS_EVENT} from './utils/eventsDefinitions';
 
 export {getFDSAtom} from './utils/getFDSAtom';

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/configInURL.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/configInURL.ts
@@ -134,7 +134,7 @@ export function contains(
 	return deepContains(a, b);
 }
 
-function decodeFdsConfigParam(
+export function decodeFdsConfigParam(
 	fdsConfigParamName: string,
 	params: URLSearchParams
 ): string {

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/home/SearchBar.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/home/SearchBar.tsx
@@ -7,6 +7,7 @@ import {ClayButtonWithIcon} from '@clayui/button';
 import {ClayInput} from '@clayui/form';
 import {
 	decodeFdsConfigParam,
+	getConfigParamName,
 	serializeFDSConfig,
 } from '@liferay/frontend-data-set-web';
 import React, {ChangeEvent, useState} from 'react';
@@ -29,8 +30,9 @@ export default function SearchBar({
 	const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
 		event.preventDefault();
 
-		const fdsConfigParamName =
-			'com.liferay.site.cms.site.initializer-allSection_fdsConfig';
+		const fdsConfigParamName = getConfigParamName(
+			'com.liferay.site.cms.site.initializer-allSection'
+		);
 
 		const params = new URLSearchParams({
 			[fdsConfigParamName]: serializeFDSConfig({q: term}),

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/home/SearchBar.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/home/SearchBar.tsx
@@ -5,7 +5,10 @@
 
 import {ClayButtonWithIcon} from '@clayui/button';
 import {ClayInput} from '@clayui/form';
-import {serializeFDSConfig} from '@liferay/frontend-data-set-web';
+import {
+	decodeFdsConfigParam,
+	serializeFDSConfig,
+} from '@liferay/frontend-data-set-web';
 import React, {ChangeEvent, useState} from 'react';
 
 import '../../../css/home/SearchBar.scss';
@@ -26,16 +29,17 @@ export default function SearchBar({
 	const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
 		event.preventDefault();
 
-		const encodedState = encodeURIComponent(serializeFDSConfig({q: term}))
-			.replace(/%28/g, '(')
-			.replace(/%29/g, ')')
-			.replace(/%2C/g, ',')
-			.replace(/%3A/g, ':');
+		const fdsConfigParamName =
+			'com.liferay.site.cms.site.initializer-allSection_fdsConfig';
 
-		window.location.href =
-			searchResultsURL +
-			'?com.liferay.site.cms.site.initializer-allSection_fdsConfig=' +
-			encodedState;
+		const params = new URLSearchParams({
+			[fdsConfigParamName]: serializeFDSConfig({q: term}),
+		});
+
+		window.location.href = `${searchResultsURL}?${decodeFdsConfigParam(
+			fdsConfigParamName,
+			params
+		)}`;
 	};
 
 	return (

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/home/SearchBar.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/home/SearchBar.tsx
@@ -5,6 +5,7 @@
 
 import {ClayButtonWithIcon} from '@clayui/button';
 import {ClayInput} from '@clayui/form';
+import {serializeFDSConfig} from '@liferay/frontend-data-set-web';
 import React, {ChangeEvent, useState} from 'react';
 
 import '../../../css/home/SearchBar.scss';
@@ -25,7 +26,11 @@ export default function SearchBar({
 	const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
 		event.preventDefault();
 
-		const encodedState = encodeURIComponent(JSON.stringify({q: term}));
+		const encodedState = encodeURIComponent(serializeFDSConfig({q: term}))
+			.replace(/%28/g, '(')
+			.replace(/%29/g, ')')
+			.replace(/%2C/g, ',')
+			.replace(/%3A/g, ':');
 
 		window.location.href =
 			searchResultsURL +

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/home/SearchBar.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/home/SearchBar.test.tsx
@@ -27,6 +27,7 @@ jest.mock('@liferay/frontend-data-set-web', () => ({
 						.replace(/%2C/g, ',')
 						.replace(/%3A/g, ':')
 			),
+	getConfigParamName: (id: string) => `${id}_fdsConfig`,
 	serializeFDSConfig: jest.fn(({q}) => `(q:${q})`),
 }));
 

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/home/SearchBar.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/home/SearchBar.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import '@testing-library/jest-dom';
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+import SearchBar from '../../../../src/main/resources/META-INF/resources/js/main_view/home/SearchBar';
+
+jest.mock('@liferay/frontend-data-set-web', () => ({
+	serializeFDSConfig: jest.fn(({q}) => `(q:${q})`),
+}));
+
+describe('SearchBar', () => {
+	const searchResultsURL = 'http://localhost:8080/web/cms/all';
+	const fdsConfigParam =
+		'com.liferay.site.cms.site.initializer-allSection_fdsConfig';
+
+	const originalLocation = window.location;
+
+	let hrefSetter: jest.Mock;
+
+	beforeEach(() => {
+		hrefSetter = jest.fn();
+
+		Object.defineProperty(window, 'location', {
+			configurable: true,
+			value: {
+				set href(value: string) {
+					hrefSetter(value);
+				},
+			},
+		});
+	});
+
+	afterEach(() => {
+		Object.defineProperty(window, 'location', {
+			configurable: true,
+			value: originalLocation,
+		});
+	});
+
+	it('submits the search query as Rison so FDS applies the filter', async () => {
+		render(
+			<SearchBar
+				searchResultsURL={searchResultsURL}
+				userFirstName="Test"
+			/>
+		);
+
+		await userEvent.type(screen.getByPlaceholderText('search'), 'mikel');
+
+		await userEvent.keyboard('{Enter}');
+
+		expect(hrefSetter).toHaveBeenCalledWith(
+			`${searchResultsURL}?${fdsConfigParam}=(q:mikel)`
+		);
+	});
+
+	it('keeps Rison structural characters decoded in the URL', async () => {
+		render(
+			<SearchBar
+				searchResultsURL={searchResultsURL}
+				userFirstName="Test"
+			/>
+		);
+
+		await userEvent.type(screen.getByPlaceholderText('search'), 'foo');
+
+		await userEvent.keyboard('{Enter}');
+
+		const url = hrefSetter.mock.calls[0][0];
+
+		expect(url).toContain('(q:foo)');
+		expect(url).not.toContain('%28');
+		expect(url).not.toContain('%29');
+		expect(url).not.toContain('%3A');
+	});
+
+	it('URL-encodes special characters within the search term', async () => {
+		render(
+			<SearchBar
+				searchResultsURL={searchResultsURL}
+				userFirstName="Test"
+			/>
+		);
+
+		await userEvent.type(screen.getByPlaceholderText('search'), 'a&b');
+
+		await userEvent.keyboard('{Enter}');
+
+		const url = hrefSetter.mock.calls[0][0];
+
+		expect(url).toContain('%26');
+	});
+});

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/home/SearchBar.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/home/SearchBar.test.tsx
@@ -11,6 +11,22 @@ import React from 'react';
 import SearchBar from '../../../../src/main/resources/META-INF/resources/js/main_view/home/SearchBar';
 
 jest.mock('@liferay/frontend-data-set-web', () => ({
+	decodeFdsConfigParam: (
+		fdsConfigParamName: string,
+		params: URLSearchParams
+	) =>
+		params
+			.toString()
+			.replace(
+				new RegExp(`(${fdsConfigParamName}=)([^&]+)`),
+				(_, key, value) =>
+					key +
+					value
+						.replace(/%28/g, '(')
+						.replace(/%29/g, ')')
+						.replace(/%2C/g, ',')
+						.replace(/%3A/g, ':')
+			),
 	serializeFDSConfig: jest.fn(({q}) => `(q:${q})`),
 }));
 

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/home.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/home.spec.ts
@@ -893,7 +893,7 @@ test(
 
 test(
 	'Can use Search Bar to search for content',
-	{tag: '@LPD-61220'},
+	{tag: ['@LPD-61220', '@LPD-92446']},
 	async ({apiHelpers, assetsPage, homePage, page}) => {
 		const applicationName = 'cms/basic-web-contents';
 		const spaceName = 'Default';

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/home.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/home.spec.ts
@@ -931,7 +931,7 @@ test(
 
 			const row = assetsPage.table.bodyRows.filter({hasText: file1Title});
 
-			await expect(row.getByText(file1Title)).toBeVisible();
+			await expect(row).toBeVisible();
 
 			await test.step('Verify search input contains the search value', async () => {
 				const searchInput = page.getByPlaceholder('Search');


### PR DESCRIPTION
## Summary

- The home Search Bar serialized the query as JSON (`{"q":"loco"}`), but FDS parses the `fdsConfig` URL parameter with JsonURL in AQF mode, which expects Rison-like syntax (`(q:loco)`). The JSON payload was silently ignored, so the home search never applied the filter on the All page.
- Switches to `serializeFDSConfig` from `@liferay/frontend-data-set-web`, then mirrors FDS's own `configInURL.ts` URL handling by decoding back the structural characters (`(`, `)`, `,`, `:`) so the generated URL shape matches the one produced when searching from `/all`.
- Adds Jest coverage on the URL construction, tightens the Playwright row assertion to avoid matching the Actions sr-only text, and tags the search bar test with the bug ticket.

## Test plan

- [x] `yarn test test/js/main_view/home/SearchBar.test.tsx` from `site-cms-site-initializer` — 3 passed.
- [x] `yarn test tests/site-cms-site-initializer/main/home.spec.ts -g "Can use Search Bar to search for content"` from `modules/test/playwright` — green.
- [x] Manual: search from the home page, confirm the All page receives `?...fdsConfig=(q:term)` and the result row is shown filtered.