### PR TITLE
LPD-92491 Match the tag name case before reusing an existing tag

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/services/TagService.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/services/TagService.ts
@@ -39,7 +39,7 @@ async function createTag({
 		throw new Error(error);
 	}
 
-	const tag = data?.items[0];
+	const tag = data?.items.find((item) => item.name === name);
 
 	if (tag) {
 		if (assetLibraryId) {

--- a/modules/apps/site/site-cms-site-initializer/test/js/common/services/TagService.test.ts
+++ b/modules/apps/site/site-cms-site-initializer/test/js/common/services/TagService.test.ts
@@ -1,0 +1,123 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ApiHelper from '../../../../src/main/resources/META-INF/resources/js/common/services/ApiHelper';
+import TagService from '../../../../src/main/resources/META-INF/resources/js/common/services/TagService';
+
+describe('TagService.createTag', () => {
+	const cmsGroupId = 20121;
+	const assetLibraryId = 37540;
+
+	afterEach(() => {
+		jest.restoreAllMocks();
+	});
+
+	it('POSTs a new tag when no case-insensitive match exists', async () => {
+		jest.spyOn(ApiHelper, 'get').mockResolvedValue({
+			data: {items: []},
+			error: null,
+		} as any);
+
+		const postSpy = jest
+			.spyOn(ApiHelper, 'post')
+			.mockResolvedValue({data: {name: 'Hola'}} as any);
+
+		await TagService.createTag({
+			assetLibraryId,
+			cmsGroupId,
+			name: 'Hola',
+		});
+
+		expect(postSpy).toHaveBeenCalledWith(
+			`/o/headless-admin-taxonomy/v1.0/sites/${cmsGroupId}/keywords`,
+			{
+				assetLibraries: [{id: assetLibraryId}],
+				name: 'Hola',
+			}
+		);
+	});
+
+	it('POSTs a new tag when only a different-case tag exists', async () => {
+
+		// The OData filter `name eq` is case-insensitive (it maps to the
+		// lowercased sortable index field), so a search for 'Hola' returns
+		// 'hola'. The service must still POST 'Hola' as a new tag, not
+		// PATCH the existing 'hola'.
+
+		jest.spyOn(ApiHelper, 'get').mockResolvedValue({
+			data: {items: [{name: 'hola'}]},
+			error: null,
+		} as any);
+
+		const patchSpy = jest.spyOn(ApiHelper, 'patch');
+		const postSpy = jest
+			.spyOn(ApiHelper, 'post')
+			.mockResolvedValue({data: {name: 'Hola'}} as any);
+
+		await TagService.createTag({
+			assetLibraryId,
+			cmsGroupId,
+			name: 'Hola',
+		});
+
+		expect(patchSpy).not.toHaveBeenCalled();
+		expect(postSpy).toHaveBeenCalledWith(
+			`/o/headless-admin-taxonomy/v1.0/sites/${cmsGroupId}/keywords`,
+			{
+				assetLibraries: [{id: assetLibraryId}],
+				name: 'Hola',
+			}
+		);
+	});
+
+	it('PATCHes the existing tag when the same-case tag already exists in an asset library', async () => {
+		jest.spyOn(ApiHelper, 'get').mockResolvedValue({
+			data: {items: [{name: 'hola'}, {name: 'Hola'}]},
+			error: null,
+		} as any);
+
+		const patchSpy = jest
+			.spyOn(ApiHelper, 'patch')
+			.mockResolvedValue({data: {name: 'Hola'}} as any);
+		const postSpy = jest.spyOn(ApiHelper, 'post');
+
+		await TagService.createTag({
+			assetLibraryId,
+			cmsGroupId,
+			name: 'Hola',
+		});
+
+		expect(postSpy).not.toHaveBeenCalled();
+		expect(patchSpy).toHaveBeenCalledWith(
+			{
+				assetLibraries: [{id: assetLibraryId}],
+				name: 'Hola',
+			},
+			`/o/headless-admin-taxonomy/v1.0/sites/${cmsGroupId}/keywords`
+		);
+	});
+
+	it('returns the existing same-case tag without writing when no asset library is given', async () => {
+		const existing = {name: 'Hola'};
+
+		jest.spyOn(ApiHelper, 'get').mockResolvedValue({
+			data: {items: [{name: 'hola'}, existing]},
+			error: null,
+		} as any);
+
+		const patchSpy = jest.spyOn(ApiHelper, 'patch');
+		const postSpy = jest.spyOn(ApiHelper, 'post');
+
+		const result = await TagService.createTag({
+			assetLibraryId: null,
+			cmsGroupId,
+			name: 'Hola',
+		});
+
+		expect(patchSpy).not.toHaveBeenCalled();
+		expect(postSpy).not.toHaveBeenCalled();
+		expect(result).toEqual({data: existing, error: null, status: null});
+	});
+});

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/categorization/tags.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/categorization/tags.spec.ts
@@ -527,7 +527,7 @@ test('Validate tag inputs', {tag: ['@LPD-69687']}, async ({page, tagsPage}) => {
 
 test(
 	'Tags with the same name can be created',
-	{tag: '@LPD-69204'},
+	{tag: ['@LPD-69204', '@LPD-92491']},
 	async ({apiHelpers, assetsPage, infoPanelPage, page}) => {
 		const applicationName = 'cms/basic-web-contents';
 		const contentTitle = `title ${getRandomString()}`;


### PR DESCRIPTION
## Summary

- `TagService.createTag` pre-checks the headless taxonomy keywords endpoint with `filter=name eq '<name>'` to avoid POSTing a duplicate, then returns or patches the first item. The OData `name` field maps to the lowercased sortable index in `KeywordEntityModel`, so the filter matches case-insensitively: a search for `Hola` returns the existing `hola`, and the service patches `hola` (or returns it as the freshly created tag). The user-facing result is that adding `Hola` from the Info Panel → Categorization tab when `hola` already exists silently does nothing.
- Filters the response with a strict equality check so only an exact-case match counts as already-existing. The OData filter still narrows the result set, but the client picks the strict match before deciding to PATCH or return. This mirrors `AssetTagLocalServiceImpl#fetchTag`, which combines a case-insensitive `findByG_N` with a `StringUtil.equals` check before treating a tag as duplicate.
- Adds Jest coverage on `TagService.createTag` for the four branches (no match, different-case match, same-case match with asset library, same-case match without asset library), and tags the existing Playwright test `Tags with the same name can be created` with `@LPD-92491`.

## Why the fix is on the client, not the API

The case-insensitive behavior of `filter=name eq` is not a bug — it falls out of `KeywordEntityModel` mapping `name` to the lowercased sortable variant of the field, which is shared with sorting and free-text search. Flipping it to a case-sensitive field would change behavior for every consumer of the headless taxonomy endpoint (ordering, search, third-party clients), so the fix stays in the service that already knows the case it asked for.

## Test plan

- [x] `yarn test test/js/common/services/TagService.test.ts` from `site-cms-site-initializer` — 4 passed.
- [x] `yarn test tests/site-cms-site-initializer/main/categorization/tags.spec.ts -g "Tags with the same name can be created"` from `modules/test/playwright` — green in 26.8s.
- [x] Manual: from Info Panel → Categorization, with an existing `hola` tag, adding `Hello` now produces a new tag instead of silently no-oping.