### PR TITLE
LPD-92451 Escape redirect

### DIFF
--- a/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/category/details.jsp
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/category/details.jsp
@@ -8,7 +8,7 @@
 <%@ include file="/init.jsp" %>
 
 <%
-String redirect = ParamUtil.getString(request, "redirect", assetCategoriesDisplayContext.getEditCategoryRedirect());
+String redirect = PortalUtil.escapeRedirect(ParamUtil.getString(request, "redirect", assetCategoriesDisplayContext.getEditCategoryRedirect()));
 
 long categoryId = ParamUtil.getLong(request, "categoryId");
 

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_data_definition.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_data_definition.jsp
@@ -8,7 +8,7 @@
 <%@ include file="/init.jsp" %>
 
 <%
-String redirect = ParamUtil.getString(request, "redirect");
+String redirect = PortalUtil.escapeRedirect(ParamUtil.getString(request, "redirect"));
 
 JournalEditDDMStructuresDisplayContext journalEditDDMStructuresDisplayContext = (JournalEditDDMStructuresDisplayContext)request.getAttribute(JournalEditDDMStructuresDisplayContext.class.getName());
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92451

# What is this trying to solve?

Two JSPs read the `redirect` query parameter via `ParamUtil.getString()` and inject it directly into a `<clay:link href="...">`, which renders as an `<a href="...">`. An attacker can deliver a `javascript:` URI through that parameter; when an authenticated user clicks the Cancel button on a crafted URL, arbitrary JavaScript runs in the portal origin.

Affected JSPs:

- `asset-categories-admin-web` — `category/details.jsp`
- `journal-web` — `edit_data_definition.jsp`

# How am I fixing it?

Wrap the `redirect` value with `PortalUtil.escapeRedirect()` at the point where it is read, so every downstream use (the `<clay:link>` href, the hidden `<aui:input>` that re-emits the value to the next render, and `portletDisplay.setURLBack()`) operates on an already-sanitized value. This is the same pattern already used in `journal-web`'s `edit_article.jsp` and `edit_ddm_template.jsp`.

# How can you verify that it works?

For each affected JSP, append a `javascript:` payload to the portlet's `redirect` parameter and click Cancel:

- [x] Categories — open *Categorization → Categories*, pick a vocabulary, hit *New*, append `?_com_liferay_asset_categories_admin_web_portlet_AssetCategoriesAdminPortlet_redirect=javascript:alert(document.domain)`, click *Cancel*. No alert fires; the `href` attribute is stripped.
- [x] Journal — open `/group/guest/~/control_panel/manage?p_p_id=com_liferay_journal_web_portlet_JournalPortlet&p_p_lifecycle=0&p_p_state=maximized&_com_liferay_journal_web_portlet_JournalPortlet_mvcPath=%2Fedit_data_definition.jsp&_com_liferay_journal_web_portlet_JournalPortlet_redirect=javascript:alert()`, click *Cancel*. No alert fires; the `href` attribute is stripped.

Both checkboxes were exercised locally with headless Chromium against a fresh Tomcat: the rendered Cancel anchor had `href=null` for the `javascript:` payload and `href="http://localhost:8080/web/guest/home"` for a benign redirect, confirming the sanitizer strips only the dangerous scheme.

# Why doesn't this include any test?

The change wraps the parameter with `PortalUtil.escapeRedirect()`, which already has its own coverage in `portal-impl`.