### PR TITLE
LPD-92349 Fix broken site-cms-site-initializer Playwright tests

### DIFF
--- a/modules/test/playwright/tests/site-cms-site-initializer/main/categorization/tags.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/categorization/tags.spec.ts
@@ -336,7 +336,7 @@ test('Merge tags', {tag: '@LPD-43388'}, async ({page, tagsPage}) => {
 
 test(
 	'Validate that a UI error appears when attempting to create or edit a tag with an existing name',
-	{tag: '@LPD-57497'},
+	{tag: ['@LPD-57497', '@LPD-92349']},
 	async ({page, tagsPage}) => {
 		const name1 = await tagsPage.createTag();
 
@@ -349,9 +349,11 @@ test(
 		await page.getByLabel('NameRequired').fill(name1);
 
 		await clickAndExpectToBeVisible({
-			target: page.getByText(
-				'Please enter a unique name. This one is already in use.'
-			),
+			target: page
+				.locator('.modal-body')
+				.getByText(
+					'Please enter a unique name. This one is already in use.'
+				),
 			trigger: tagsPage.saveButton,
 		});
 
@@ -383,9 +385,11 @@ test(
 		await page.getByLabel('NameRequired').fill(name1);
 
 		await clickAndExpectToBeVisible({
-			target: page.getByText(
-				'Please enter a unique name. This one is already in use.'
-			),
+			target: page
+				.locator('.modal-body')
+				.getByText(
+					'Please enter a unique name. This one is already in use.'
+				),
 			trigger: tagsPage.saveButton,
 		});
 

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/contentEditor.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/contentEditor.spec.ts
@@ -360,7 +360,11 @@ test(
 
 		// Check that the content is visible that means we redirected to the folder
 
-		await expect(page.getByText(title)).toBeVisible();
+		await expect(
+			page
+				.locator('tr', {hasText: title})
+				.or(page.locator('.card-row', {hasText: title}))
+		).toBeVisible();
 
 		// Delete content and folder
 
@@ -370,7 +374,11 @@ test(
 
 		await folderPage.deleteFolder(folderName);
 
-		await expect(page.getByText(folderName)).not.toBeVisible();
+		await expect(
+			page
+				.locator('tr', {hasText: folderName})
+				.or(page.locator('.card-row', {hasText: folderName}))
+		).not.toBeVisible();
 	}
 );
 

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/contentEditor.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/contentEditor.spec.ts
@@ -1854,7 +1854,7 @@ test(
 test(
 	'Repetable text input is validated correctly',
 	{
-		tag: '@LPD-69446',
+		tag: ['@LPD-69446', '@LPD-92353'],
 	},
 	async ({contentsPage, page, structureBuilderPage}) => {
 
@@ -1908,7 +1908,9 @@ test(
 
 		const firstText = page.getByRole('textbox', {name: 'Text'}).first();
 
-		await firstText.fill('MoreThan5Characters');
+		await firstText.pressSequentially('MoreThan5Characters');
+
+		await expect(firstText).toHaveValue('MoreThan5Characters');
 
 		// Save content
 
@@ -1919,8 +1921,6 @@ test(
 		await expect(
 			page.getByText('Value exceeds maximum length of 5 for field Text.')
 		).toBeVisible();
-
-		await expect(firstText).toHaveValue('MoreThan5Characters');
 
 		// Delete content
 

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/contents.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/contents.spec.ts
@@ -467,7 +467,7 @@ test(
 
 test(
 	'Content with Upload fragment opens new Item Selector',
-	{tag: '@LPD-67215'},
+	{tag: ['@LPD-67215', '@LPD-92364']},
 	async ({apiHelpers, contentsPage, page, structureBuilderPage}) => {
 		const applicationName = 'cms/basic-documents';
 		const fileName = `file_${getRandomString()}.png`;
@@ -539,7 +539,7 @@ test(
 
 			await contentsPage.saveContent();
 
-			await page.getByLabel(contentTitle).click();
+			await page.getByRole('link', {name: contentTitle}).click();
 
 			await expect(page.getByText(`Edit ${contentTitle}`)).toBeVisible();
 
@@ -555,7 +555,9 @@ test(
 
 			await expect(page.getByText(`${fileName} Selected`)).toBeVisible();
 
-			await expect(page.getByLabel(`Select ${fileName}`)).toBeChecked();
+			await expect(
+				page.getByRole('button', {name: 'Clear'})
+			).toBeVisible();
 		});
 
 		await test.step('Delete file', async () => {

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/folders.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/folders.spec.ts
@@ -63,26 +63,23 @@ test(
 
 test(
 	'Folders should not show status',
-	{tag: '@LPD-78615'},
+	{tag: ['@LPD-78615', '@LPD-92355']},
 	async ({apiHelpers, assetsPage, page}) => {
 		const folderTitle = getRandomString();
 
 		await apiHelpers.objectFolder.createObjectEntryFolder({
+			parentObjectEntryFolderExternalReferenceCode: 'L_CONTENTS',
 			scopeKey: 'Default',
 			title: folderTitle,
 		});
 
-		await assetsPage.gotoFiles();
-
-		await assetsPage.changeVisualizationMode('Table');
+		await assetsPage.gotoContents();
 
 		const row = page
 			.getByRole('row')
 			.filter({has: page.getByRole('link', {name: folderTitle})});
 
-		await expect(
-			row.getByRole('cell', {exact: true, name: '--'})
-		).toBeVisible();
+		await expect(row.locator('.cell-embedded-status')).toHaveText('--');
 	}
 );
 

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/home.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/home.spec.ts
@@ -19,10 +19,10 @@ import performLogin, {
 	performUserSwitch,
 	userData,
 } from '../../../utils/performLogin';
+import {SITE_CMS_SPACE_EXTERNAL_REFERENCE_CODE} from '../../setup/site-cms-site/constants/space';
 import {structureBuilderPagesTest} from '../structure-builder/fixtures/structureBuilderPagesTest';
 import {cmsPagesTest} from './fixtures/cmsPagesTest';
 import {DataSetPage} from './pages/DataSetPage';
-import {SpaceSummaryPage} from './pages/SpaceSummaryPage';
 
 const test = mergeTests(
 	cmsPagesTest,
@@ -72,18 +72,21 @@ test.beforeAll(async ({browser}) => {
 		surname: spaceUser.familyName,
 	};
 
-	const spaceSummaryPage = new SpaceSummaryPage(page);
-
-	await spaceSummaryPage.goto('Default');
-
-	await spaceSummaryPage.addUserOrUserGroup(spaceAdminUser.name, 'users');
-
-	await spaceSummaryPage.addRoleToSpaceMember(
-		'Space Administrator',
-		spaceAdminUser.name
+	await apiHelpers.headlessAssetLibrary.putAssetLibraryUserAccount(
+		SITE_CMS_SPACE_EXTERNAL_REFERENCE_CODE,
+		spaceAdminUser.externalReferenceCode
 	);
 
-	await spaceSummaryPage.addUserOrUserGroup(spaceUser.name, 'users');
+	await apiHelpers.headlessAssetLibrary.putAssetLibraryUserAccountRoles(
+		SITE_CMS_SPACE_EXTERNAL_REFERENCE_CODE,
+		spaceAdminUser.externalReferenceCode,
+		['Asset Library Administrator']
+	);
+
+	await apiHelpers.headlessAssetLibrary.putAssetLibraryUserAccount(
+		SITE_CMS_SPACE_EXTERNAL_REFERENCE_CODE,
+		spaceUser.externalReferenceCode
+	);
 
 	setupData = [...apiHelpers.data];
 

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/pages/FolderPage.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/pages/FolderPage.ts
@@ -40,9 +40,16 @@ export class FolderPage {
 
 		const spaceSelector = dialog.getByLabel('SpaceMandatory');
 
-		if (await spaceSelector.isVisible()) {
+		try {
+			await spaceSelector.waitFor({state: 'visible', timeout: 1000});
+
 			await spaceSelector.click();
 			await this.page.getByRole('option', {name: spaceName}).click();
+		}
+		catch {
+
+			// The Space selector is only rendered when the feature is enabled
+
 		}
 
 		await dialog.getByRole('button', {name: 'Save'}).click();

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/pages/FolderPage.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/pages/FolderPage.ts
@@ -25,7 +25,7 @@ export class FolderPage {
 		this.newButton = page.getByTestId('fdsCreationActionButton').first();
 	}
 
-	async createFolder(name: string) {
+	async createFolder(name: string, spaceName: string = 'Default') {
 		await clickAndExpectToBeVisible({
 			autoClick: true,
 			target: this.page.getByRole('menuitem', {name: 'Folder'}),
@@ -37,6 +37,13 @@ export class FolderPage {
 		await dialog.waitFor();
 
 		await dialog.getByLabel('Name').fill(name);
+
+		const spaceSelector = dialog.getByLabel('SpaceMandatory');
+
+		if (await spaceSelector.isVisible()) {
+			await spaceSelector.click();
+			await this.page.getByRole('option', {name: spaceName}).click();
+		}
 
 		await dialog.getByRole('button', {name: 'Save'}).click();
 

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/pages/SpaceSummaryPage.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/pages/SpaceSummaryPage.ts
@@ -74,9 +74,10 @@ export class SpaceSummaryPage {
 	}
 
 	async addRoleToSpaceMember(roleName: string, userName: string) {
-		await this.viewAllMembersLink.click();
-
-		await this.page.getByRole('dialog').waitFor();
+		await clickAndExpectToBeVisible({
+			target: this.page.getByRole('dialog'),
+			trigger: this.viewAllMembersLink,
+		});
 
 		const userRow = this.page
 			.getByRole('listitem')
@@ -105,9 +106,10 @@ export class SpaceSummaryPage {
 	}
 
 	async addUserOrUserGroup(name: string, type: UserOrUserGroupType) {
-		await this.viewAllMembersLink.click();
-
-		await this.page.getByRole('dialog').waitFor({state: 'visible'});
+		await clickAndExpectToBeVisible({
+			target: this.page.getByRole('dialog'),
+			trigger: this.viewAllMembersLink,
+		});
 
 		const dialog = this.page.getByRole('dialog');
 
@@ -243,6 +245,8 @@ export class SpaceSummaryPage {
 			.waitFor();
 
 		await this.closeButton.click();
+
+		await this.page.getByRole('dialog').waitFor({state: 'detached'});
 	}
 
 	async disconnectSiteFromModal(name: string) {

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/sharingPermissions.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/sharingPermissions.spec.ts
@@ -36,7 +36,7 @@ async function openShareModal(
 	const shareModalTitle = page.getByText(`Share "${objectEntryTitle}"`);
 
 	await expect(async () => {
-		if (!(await shareMenuItem.isVisible().catch(() => false))) {
+		if (!(await shareMenuItem.isVisible())) {
 			await actionsButton.click({timeout: 1000});
 
 			await expect(shareMenuItem).toBeVisible({timeout: 2000});

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/sharingPermissions.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/sharingPermissions.spec.ts
@@ -208,23 +208,31 @@ test(
 			await expect(assetRow).toBeVisible();
 
 			const actionsButton = assetRow.getByRole('button', {
-				name: `${objectEntryTitle} Actions`,
+				name: 'Actions',
 			});
 
-			await clickAndExpectToBeVisible({
-				autoClick: true,
-				target: page.getByRole('menuitem', {
-					exact: true,
-					name: 'Share',
-				}),
-				trigger: actionsButton,
+			const shareMenuItem = page.getByRole('menuitem', {
+				exact: true,
+				name: 'Share',
 			});
-		});
 
-		await test.step('Verify the share modal is open', async () => {
-			await expect(
-				page.getByText(`Share "${objectEntryTitle}"`)
-			).toBeVisible();
+			const shareModalTitle = page.getByText(
+				`Share "${objectEntryTitle}"`
+			);
+
+			await expect(async () => {
+				if (!(await shareMenuItem.isVisible().catch(() => false))) {
+					await actionsButton.click({timeout: 1000});
+
+					await expect(shareMenuItem).toBeVisible({
+						timeout: 2000,
+					});
+				}
+
+				await shareMenuItem.click({timeout: 1000});
+
+				await expect(shareModalTitle).toBeVisible({timeout: 5000});
+			}).toPass();
 		});
 
 		await test.step('Verify Allow Resharing and Remove Access are available', async () => {

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/sharingPermissions.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/sharingPermissions.spec.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {expect, mergeTests} from '@playwright/test';
+import {Locator, Page, expect, mergeTests} from '@playwright/test';
 
 import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
 import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
@@ -20,6 +20,33 @@ const test = mergeTests(
 	}),
 	loginTest()
 );
+
+async function openShareModal(
+	page: Page,
+	assetRow: Locator,
+	objectEntryTitle: string
+) {
+	const actionsButton = assetRow.getByRole('button', {name: 'Actions'});
+
+	const shareMenuItem = page.getByRole('menuitem', {
+		exact: true,
+		name: 'Share',
+	});
+
+	const shareModalTitle = page.getByText(`Share "${objectEntryTitle}"`);
+
+	await expect(async () => {
+		if (!(await shareMenuItem.isVisible().catch(() => false))) {
+			await actionsButton.click({timeout: 1000});
+
+			await expect(shareMenuItem).toBeVisible({timeout: 2000});
+		}
+
+		await shareMenuItem.click({timeout: 1000});
+
+		await expect(shareModalTitle).toBeVisible({timeout: 5000});
+	}).toPass();
+}
 
 test(
 	'User with Reshare permission should not see Allow Resharing or Remove Access actions',
@@ -92,32 +119,7 @@ test(
 
 			await expect(assetRow).toBeVisible();
 
-			const actionsButton = assetRow.getByRole('button', {
-				name: 'Actions',
-			});
-
-			const shareMenuItem = page.getByRole('menuitem', {
-				exact: true,
-				name: 'Share',
-			});
-
-			const shareModalTitle = page.getByText(
-				`Share "${objectEntryTitle}"`
-			);
-
-			await expect(async () => {
-				if (!(await shareMenuItem.isVisible().catch(() => false))) {
-					await actionsButton.click({timeout: 1000});
-
-					await expect(shareMenuItem).toBeVisible({
-						timeout: 2000,
-					});
-				}
-
-				await shareMenuItem.click({timeout: 1000});
-
-				await expect(shareModalTitle).toBeVisible({timeout: 5000});
-			}).toPass();
+			await openShareModal(page, assetRow, objectEntryTitle);
 		});
 
 		await test.step('Verify Allow Resharing and Remove Access are not available', async () => {
@@ -207,32 +209,7 @@ test(
 
 			await expect(assetRow).toBeVisible();
 
-			const actionsButton = assetRow.getByRole('button', {
-				name: 'Actions',
-			});
-
-			const shareMenuItem = page.getByRole('menuitem', {
-				exact: true,
-				name: 'Share',
-			});
-
-			const shareModalTitle = page.getByText(
-				`Share "${objectEntryTitle}"`
-			);
-
-			await expect(async () => {
-				if (!(await shareMenuItem.isVisible().catch(() => false))) {
-					await actionsButton.click({timeout: 1000});
-
-					await expect(shareMenuItem).toBeVisible({
-						timeout: 2000,
-					});
-				}
-
-				await shareMenuItem.click({timeout: 1000});
-
-				await expect(shareModalTitle).toBeVisible({timeout: 5000});
-			}).toPass();
+			await openShareModal(page, assetRow, objectEntryTitle);
 		});
 
 		await test.step('Verify Allow Resharing and Remove Access are available', async () => {

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/sharingPermissions.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/sharingPermissions.spec.ts
@@ -8,7 +8,6 @@ import {expect, mergeTests} from '@playwright/test';
 import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
 import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
 import {loginTest} from '../../../fixtures/loginTest';
-import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisible';
 import getRandomString from '../../../utils/getRandomString';
 import {performUserSwitch, userData} from '../../../utils/performLogin';
 import {cmsPagesTest} from './fixtures/cmsPagesTest';
@@ -94,23 +93,31 @@ test(
 			await expect(assetRow).toBeVisible();
 
 			const actionsButton = assetRow.getByRole('button', {
-				name: `${objectEntryTitle} Actions`,
+				name: 'Actions',
 			});
 
-			await clickAndExpectToBeVisible({
-				autoClick: true,
-				target: page.getByRole('menuitem', {
-					exact: true,
-					name: 'Share',
-				}),
-				trigger: actionsButton,
+			const shareMenuItem = page.getByRole('menuitem', {
+				exact: true,
+				name: 'Share',
 			});
-		});
 
-		await test.step('Verify the share modal is open', async () => {
-			await expect(
-				page.getByText(`Share "${objectEntryTitle}"`)
-			).toBeVisible();
+			const shareModalTitle = page.getByText(
+				`Share "${objectEntryTitle}"`
+			);
+
+			await expect(async () => {
+				if (!(await shareMenuItem.isVisible().catch(() => false))) {
+					await actionsButton.click({timeout: 1000});
+
+					await expect(shareMenuItem).toBeVisible({
+						timeout: 2000,
+					});
+				}
+
+				await shareMenuItem.click({timeout: 1000});
+
+				await expect(shareModalTitle).toBeVisible({timeout: 5000});
+			}).toPass();
 		});
 
 		await test.step('Verify Allow Resharing and Remove Access are not available', async () => {

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/connectSiteTemplates.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/connectSiteTemplates.spec.ts
@@ -161,7 +161,7 @@ test(
 
 test(
 	'Read-only space member cannot connect or disconnect site templates',
-	{tag: '@LPD-88037'},
+	{tag: ['@LPD-88037', '@LPD-92500']},
 	async ({apiHelpers, page, spaceSummaryPage}) => {
 		const spaceName = `Space ${getRandomString()}`;
 		const siteTemplateName = `Site Template ${getRandomString()}`;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92177
https://liferay.atlassian.net/browse/LPD-92349
https://liferay.atlassian.net/browse/LPD-92350
https://liferay.atlassian.net/browse/LPD-92353
https://liferay.atlassian.net/browse/LPD-92355
https://liferay.atlassian.net/browse/LPD-92364
https://liferay.atlassian.net/browse/LPD-92429
https://liferay.atlassian.net/browse/LPD-92437
https://liferay.atlassian.net/browse/LPD-92500

## What is being fixed

More Playwright tests under site-cms-site-initializer broke as the CMS UI kept evolving, and a race in the SpaceSummaryPage Members dialog was hanging the setup of home.spec.ts. Each commit fixes one test or hardens one helper.

The LPD-92177 fix already in #8355 (matching Quick Actions buttons by exact name) was not enough on its own — the home.spec.ts beforeAll still failed reproducibly on a different race in SpaceSummaryPage.addUserOrUserGroup, so a follow-up commit replaces the dialog-based provisioning with an API call.

## How it is being fixed

| Ticket | Fix | Test |
|---|---|---|
| LPD-92177 | Provision space members via API in home.spec.ts beforeAll | home.spec.ts › Can use Quick Actions to create new content |
| LPD-92349 | Scope tag name error assertion to the modal body to avoid the toast | tags.spec.ts › Validate that a UI error appears when attempting to create or edit a tag with an existing name |
| LPD-92350 | Fix redirect-to-folder space selector and disambiguate item locators | contentEditor.spec.ts › When publishing a content in a folder the browser is redirected to the folder |
| LPD-92353 | Type the repeatable text value sequentially and assert before publishing | contentEditor.spec.ts › Repetable text input is validated correctly |
| LPD-92355 | Assert the folder status cell directly to avoid the ambiguous dashes | folders.spec.ts › Folders should not show status |
| LPD-92364 | Target the content link and the selection footer in the Upload fragment test | contents.spec.ts › Content with Upload fragment opens new Item Selector |
| LPD-92429 | Retry the Share menuitem click until the share modal opens | sharingPermissions.spec.ts › User with Reshare permission should not see Allow Resharing or Remove Access actions |
| LPD-92437 | Retry the Share menuitem click until the share modal opens | sharingPermissions.spec.ts › User with Reshare and Update permission should see Allow Resharing and Remove Access actions |
| LPD-92500 | Harden the read-only space member Playwright test | spaces/connectSiteTemplates.spec.ts › Read-only space member cannot connect or disconnect site templates |