### PR TITLE
LPD-92654 Headless asset-library Space created with an explicit ERC has no CMS default permissions, hiding content from Space roles (2nd try)

### DIFF
--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/impl/DepotEntryLocalServiceImpl.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/impl/DepotEntryLocalServiceImpl.java
@@ -119,10 +119,12 @@ public class DepotEntryLocalServiceImpl extends DepotEntryLocalServiceBaseImpl {
 		depotEntry.setUuid(serviceContext.getUuid());
 
 		Group group = _groupLocalService.addGroup(
-			StringPool.BLANK, serviceContext.getUserId(),
-			GroupConstants.DEFAULT_PARENT_GROUP_ID, DepotEntry.class.getName(),
-			depotEntry.getDepotEntryId(), GroupConstants.DEFAULT_LIVE_GROUP_ID,
-			nameMap, descriptionMap, GroupConstants.TYPE_DEPOT, null, true,
+			GetterUtil.getString(
+				serviceContext.getAttribute("groupExternalReferenceCode")),
+			serviceContext.getUserId(), GroupConstants.DEFAULT_PARENT_GROUP_ID,
+			DepotEntry.class.getName(), depotEntry.getDepotEntryId(),
+			GroupConstants.DEFAULT_LIVE_GROUP_ID, nameMap, descriptionMap,
+			GroupConstants.TYPE_DEPOT, null, true,
 			GroupConstants.DEFAULT_MEMBERSHIP_RESTRICTION,
 			"/asset-library-" + depotEntry.getDepotEntryId(), false, false,
 			true, serviceContext);

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/test/DepotEntryLocalServiceTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/test/DepotEntryLocalServiceTest.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserGroupLocalService;
 import com.liferay.portal.kernel.service.UserGroupRoleLocalService;
 import com.liferay.portal.kernel.test.AssertUtils;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.CompanyTestUtil;
@@ -116,6 +117,36 @@ public class DepotEntryLocalServiceTest {
 		_addDepotEntry(
 			group.getName(LocaleUtil.getDefault()),
 			RandomTestUtil.randomString());
+	}
+
+	@Test
+	@TestInfo("LPD-92654")
+	public void testAddDepotEntryWithGroupExternalReferenceCode()
+		throws Exception {
+
+		String groupExternalReferenceCode = RandomTestUtil.randomString();
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext();
+
+		serviceContext.setAttribute(
+			"groupExternalReferenceCode", groupExternalReferenceCode);
+
+		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()
+			).build(),
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()
+			).build(),
+			DepotConstants.TYPE_ASSET_LIBRARY, serviceContext);
+
+		_depotEntries.add(depotEntry);
+
+		Group group = _groupLocalService.getGroup(depotEntry.getGroupId());
+
+		Assert.assertEquals(
+			groupExternalReferenceCode, group.getExternalReferenceCode());
 	}
 
 	@Test(expected = DepotEntryNameException.class)

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/test/DepotEntryLocalServiceTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/test/DepotEntryLocalServiceTest.java
@@ -124,13 +124,13 @@ public class DepotEntryLocalServiceTest {
 	public void testAddDepotEntryWithGroupExternalReferenceCode()
 		throws Exception {
 
-		String groupExternalReferenceCode = RandomTestUtil.randomString();
+		String externalReferenceCode = RandomTestUtil.randomString();
 
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext();
 
 		serviceContext.setAttribute(
-			"groupExternalReferenceCode", groupExternalReferenceCode);
+			"groupExternalReferenceCode", externalReferenceCode);
 
 		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
 			HashMapBuilder.put(
@@ -146,7 +146,7 @@ public class DepotEntryLocalServiceTest {
 		Group group = _groupLocalService.getGroup(depotEntry.getGroupId());
 
 		Assert.assertEquals(
-			groupExternalReferenceCode, group.getExternalReferenceCode());
+			externalReferenceCode, group.getExternalReferenceCode());
 	}
 
 	@Test(expected = DepotEntryNameException.class)

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/AssetLibraryResourceImpl.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/AssetLibraryResourceImpl.java
@@ -436,6 +436,11 @@ public class AssetLibraryResourceImpl extends BaseAssetLibraryResourceImpl {
 			return updatedDepotEntry;
 		}
 
+		if (Validator.isNotNull(externalReferenceCode)) {
+			serviceContext.setAttribute(
+				"groupExternalReferenceCode", externalReferenceCode);
+		}
+
 		DepotEntry depotEntry = _depotEntryService.addDepotEntry(
 			nameMap, descriptionMap,
 			AssetLibraryUtil.getDepotEntryType(
@@ -446,21 +451,13 @@ public class AssetLibraryResourceImpl extends BaseAssetLibraryResourceImpl {
 
 		group = depotEntry.getGroup();
 
-		if (Validator.isNotNull(externalReferenceCode) ||
-			((unicodeProperties != null) && !unicodeProperties.isEmpty())) {
-
-			if (Validator.isNotNull(externalReferenceCode)) {
-				group.setExternalReferenceCode(externalReferenceCode);
-			}
-
-			if ((unicodeProperties != null) && !unicodeProperties.isEmpty()) {
-				group.setTypeSettingsProperties(
-					UnicodePropertiesBuilder.create(
-						group.getTypeSettingsProperties(), true
-					).putAll(
-						unicodeProperties
-					).build());
-			}
+		if ((unicodeProperties != null) && !unicodeProperties.isEmpty()) {
+			group.setTypeSettingsProperties(
+				UnicodePropertiesBuilder.create(
+					group.getTypeSettingsProperties(), true
+				).putAll(
+					unicodeProperties
+				).build());
 
 			group = _groupLocalService.updateGroup(group);
 		}

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/AssetLibraryResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/AssetLibraryResourceTest.java
@@ -793,11 +793,9 @@ public class AssetLibraryResourceTest extends BaseAssetLibraryResourceTestCase {
 			externalReferenceCode,
 			postedAssetLibrary.getExternalReferenceCode());
 
-		Group group = _groupLocalService.getGroupByExternalReferenceCode(
-			externalReferenceCode, testCompany.getCompanyId());
-
-		Assert.assertEquals(
-			externalReferenceCode, group.getExternalReferenceCode());
+		Assert.assertNotNull(
+			_groupLocalService.fetchGroupByExternalReferenceCode(
+				externalReferenceCode, testCompany.getCompanyId()));
 	}
 
 	private void _testPostAssetLibraryWithNoSettings() throws Exception {

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/AssetLibraryResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/AssetLibraryResourceTest.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
@@ -174,6 +175,7 @@ public class AssetLibraryResourceTest extends BaseAssetLibraryResourceTestCase {
 
 	@Override
 	@Test
+	@TestInfo("LPD-92654")
 	public void testPostAssetLibrary() throws Exception {
 		super.testPostAssetLibrary();
 
@@ -188,6 +190,7 @@ public class AssetLibraryResourceTest extends BaseAssetLibraryResourceTestCase {
 			});
 		_testPostAssetLibrary(new MimeTypeLimit[0]);
 		_testPostAssetLibraryWithDuplicateExternalReferenceCode();
+		_testPostAssetLibraryWithExternalReferenceCode();
 		_testPostAssetLibraryWithNoSettings();
 
 		AssetLibrary randomAssetLibrary = randomAssetLibrary();
@@ -771,6 +774,30 @@ public class AssetLibraryResourceTest extends BaseAssetLibraryResourceTestCase {
 					"this-external-reference-code-is-already-in-use"),
 				problem.getTitle());
 		}
+	}
+
+	private void _testPostAssetLibraryWithExternalReferenceCode()
+		throws Exception {
+
+		String externalReferenceCode = RandomTestUtil.randomString();
+
+		AssetLibrary randomAssetLibrary = randomAssetLibrary();
+
+		randomAssetLibrary.setExternalReferenceCode(externalReferenceCode);
+		randomAssetLibrary.setType(AssetLibrary.Type.SPACE);
+
+		AssetLibrary postedAssetLibrary =
+			testGetAssetLibrariesPage_addAssetLibrary(randomAssetLibrary);
+
+		Assert.assertEquals(
+			externalReferenceCode,
+			postedAssetLibrary.getExternalReferenceCode());
+
+		Group group = _groupLocalService.getGroupByExternalReferenceCode(
+			externalReferenceCode, testCompany.getCompanyId());
+
+		Assert.assertEquals(
+			externalReferenceCode, group.getExternalReferenceCode());
 	}
 
 	private void _testPostAssetLibraryWithNoSettings() throws Exception {

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/util/test/CMSDefaultPermissionUtilTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/util/test/CMSDefaultPermissionUtilTest.java
@@ -190,13 +190,13 @@ public class CMSDefaultPermissionUtilTest {
 	public void testGetJSONObjectWhenSpaceCreatedWithGroupExternalReferenceCode()
 		throws Exception {
 
-		String groupExternalReferenceCode = RandomTestUtil.randomString();
+		String externalReferenceCode = RandomTestUtil.randomString();
 
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext();
 
 		serviceContext.setAttribute(
-			"groupExternalReferenceCode", groupExternalReferenceCode);
+			"groupExternalReferenceCode", externalReferenceCode);
 
 		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
 			HashMapBuilder.put(
@@ -212,7 +212,7 @@ public class CMSDefaultPermissionUtilTest {
 		Group group = depotEntry.getGroup();
 
 		Assert.assertEquals(
-			groupExternalReferenceCode, group.getExternalReferenceCode());
+			externalReferenceCode, group.getExternalReferenceCode());
 
 		Assert.assertFalse(
 			JSONUtil.isEmpty(

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/util/test/CMSDefaultPermissionUtilTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/util/test/CMSDefaultPermissionUtilTest.java
@@ -20,8 +20,8 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
-import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
-import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -38,6 +38,8 @@ import com.liferay.site.cms.site.initializer.util.CMSDefaultPermissionUtil;
 
 import java.io.Serializable;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.Assert;
@@ -183,6 +185,46 @@ public class CMSDefaultPermissionUtilTest {
 		Assert.assertEquals(2, jsonArray.length());
 	}
 
+	@Test
+	@TestInfo("LPD-92654")
+	public void testGetJSONObjectWhenSpaceCreatedWithGroupExternalReferenceCode()
+		throws Exception {
+
+		String groupExternalReferenceCode = RandomTestUtil.randomString();
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext();
+
+		serviceContext.setAttribute(
+			"groupExternalReferenceCode", groupExternalReferenceCode);
+
+		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()
+			).build(),
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()
+			).build(),
+			DepotConstants.TYPE_SPACE, serviceContext);
+
+		_depotEntries.add(depotEntry);
+
+		Group group = depotEntry.getGroup();
+
+		Assert.assertEquals(
+			groupExternalReferenceCode, group.getExternalReferenceCode());
+
+		Assert.assertFalse(
+			JSONUtil.isEmpty(
+				CMSDefaultPermissionUtil.getJSONObject(
+					group.getCompanyId(), group.getCreatorUserId(),
+					group.getExternalReferenceCode(),
+					depotEntry.getModelClassName(), _filterFactory)));
+	}
+
+	@DeleteAfterTestRun
+	private final List<DepotEntry> _depotEntries = new ArrayList<>();
+
 	@DeleteAfterTestRun
 	private DepotEntry _depotEntry;
 
@@ -193,11 +235,5 @@ public class CMSDefaultPermissionUtilTest {
 		filter = "filter.factory.key=" + ObjectDefinitionConstants.STORAGE_TYPE_DEFAULT
 	)
 	private FilterFactory<Predicate> _filterFactory;
-
-	@Inject
-	private ResourcePermissionLocalService _resourcePermissionLocalService;
-
-	@Inject
-	private RoleLocalService _roleLocalService;
 
 }


### PR DESCRIPTION
Follow up https://github.com/liferay-content-management/liferay-portal/pull/8372

Addressed problems found by bchan-bot in https://github.com/brianchandotcom/liferay-portal/pull/175601#issuecomment-4587277191 

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-92654

When a CMS Space is created through the Headless Asset Library API (POST /o/headless-asset-library/v1.0/asset-libraries, type "Space") with an explicit external reference code, the Space has no CMS default permissions. This means that the content that we create is hidden from users others than the owner.

# How am I fixing it?

Setting the expected ERC by passing it through the ServiceContext. If not passed the ERC will be auto generated as usual.

# How can you verify that it works?

Execute the 3 new integration tests.
