### PR TITLE
LPD-92267 Return option reference from the content structure endpoint

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/ContentStructureUtil.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/ContentStructureUtil.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.vulcan.util.GroupUtil;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 
@@ -174,7 +175,21 @@ public class ContentStructureUtil {
 											() -> LocalizedMapUtil.getI18nMap(
 												acceptAllLanguage,
 												localizedValue.getValues()));
-										setValue(entry::getKey);
+										setValue(
+											() -> {
+												String optionReference =
+													ddmFormFieldOptions.
+														getOptionReference(
+															entry.getKey());
+
+												if (Validator.isNotNull(
+														optionReference)) {
+
+													return optionReference;
+												}
+
+												return entry.getKey();
+											});
 									}
 								};
 							},

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/ContentStructureResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/ContentStructureResourceTest.java
@@ -18,6 +18,8 @@ import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.storage.StorageType;
 import com.liferay.dynamic.data.mapping.test.util.DDMStructureTestHelper;
 import com.liferay.headless.delivery.client.dto.v1_0.ContentStructure;
+import com.liferay.headless.delivery.client.dto.v1_0.ContentStructureField;
+import com.liferay.headless.delivery.client.dto.v1_0.Option;
 import com.liferay.headless.delivery.client.pagination.Page;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.portal.kernel.model.Group;
@@ -30,6 +32,8 @@ import com.liferay.portal.test.rule.Inject;
 
 import java.io.InputStream;
 
+import java.util.Arrays;
+
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -40,6 +44,25 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 public class ContentStructureResourceTest
 	extends BaseContentStructureResourceTestCase {
+
+	@Override
+	@Test
+	public void testGetContentStructure() throws Exception {
+		super.testGetContentStructure();
+
+		DDMStructure ddmStructure = _addDDMStructure(
+			_portal.getClassNameId(JournalArticle.class), testGroup,
+			RandomTestUtil.randomString(), "test-ddm-structure-radio.json");
+
+		Option[] options = _getOptions(
+			contentStructureResource.getContentStructure(
+				ddmStructure.getStructureId()));
+
+		Assert.assertEquals(Arrays.toString(options), 3, options.length);
+		Assert.assertEquals("OptionReference1", options[0].getValue());
+		Assert.assertEquals("OptionReference2", options[1].getValue());
+		Assert.assertEquals("OptionReference3", options[2].getValue());
+	}
 
 	@Test
 	public void testGetSiteContentStructuresPageSearch() throws Exception {
@@ -166,13 +189,20 @@ public class ContentStructureResourceTest
 			long classNameId, Group group, String name)
 		throws Exception {
 
+		return _addDDMStructure(
+			classNameId, group, name, "test-ddm-structure.json");
+	}
+
+	private DDMStructure _addDDMStructure(
+			long classNameId, Group group, String name, String fileName)
+		throws Exception {
+
 		DDMStructureTestHelper ddmStructureTestHelper =
 			new DDMStructureTestHelper(classNameId, group);
 
 		return ddmStructureTestHelper.addStructure(
 			classNameId, RandomTestUtil.randomString(), name,
-			RandomTestUtil.randomString(),
-			_deserialize(_read("test-ddm-structure.json")),
+			RandomTestUtil.randomString(), _deserialize(_read(fileName)),
 			StorageType.DEFAULT.getValue(), DDMStructureConstants.TYPE_DEFAULT);
 	}
 
@@ -185,6 +215,23 @@ public class ContentStructureResourceTest
 				_jsonDDMFormDeserializer.deserialize(builder.build());
 
 		return ddmFormDeserializerDeserializeResponse.getDDMForm();
+	}
+
+	private Option[] _getOptions(ContentStructure contentStructure) {
+		ContentStructureField[] contentStructureFields =
+			contentStructure.getContentStructureFields();
+
+		for (ContentStructureField contentStructureField :
+				contentStructureFields) {
+
+			Option[] options = contentStructureField.getOptions();
+
+			if ((options != null) && (options.length > 0)) {
+				return options;
+			}
+		}
+
+		return new Option[0];
 	}
 
 	private String _read(String fileName) throws Exception {

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/resources/com/liferay/headless/delivery/resource/v1_0/test/dependencies/test-ddm-structure-radio.json
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/resources/com/liferay/headless/delivery/resource/v1_0/test/dependencies/test-ddm-structure-radio.json
@@ -3,6 +3,7 @@
 		"en_US"
 	],
 	"defaultLanguageId": "en_US",
+	"definitionSchemaVersion": "2.0",
 	"fields": [
 		{
 			"dataType": "string",
@@ -21,21 +22,21 @@
 					"label": {
 						"en_US": "Option1"
 					},
-					"reference": "",
+					"reference": "OptionReference1",
 					"value": "Option1"
 				},
 				{
 					"label": {
 						"en_US": "Option2"
 					},
-					"reference": "",
+					"reference": "OptionReference2",
 					"value": "Option2"
 				},
 				{
 					"label": {
 						"en_US": "Option3"
 					},
-					"reference": "",
+					"reference": "OptionReference3",
 					"value": "Option3"
 				}
 			],


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92267

## What is this trying to solve?

When a select or radio field option in a web content structure has a custom Option Reference, the two headless-delivery endpoints disagreed on the option's value. `GET /o/headless-delivery/v1.0/structured-contents/{id}` returned the option reference, while `GET /o/headless-delivery/v1.0/content-structures/{id}` returned the internal option value, so a consumer could not match a value selected in a structured content against the option list exposed by the content structure.

## How am I fixing it?

`ContentStructureUtil` now emits the option reference for each field option, falling back to the option value when no reference is set. This matches what `ContentFieldUtil` already returns on the structured-content side, so both endpoints agree. The fallback preserves the existing behavior for options without a custom reference.

## How can you verify that it works?

Run the included automated tests.
