### PR TITLE
LPD-90910 Maintain parentClassPK on moves, backfill, and staging

### DIFF
--- a/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/feature/flag/AssetCategoryFriendlyURLEntryFeatureFlagListener.java
+++ b/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/feature/flag/AssetCategoryFriendlyURLEntryFeatureFlagListener.java
@@ -1,0 +1,157 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.asset.categories.internal.feature.flag;
+
+import com.liferay.asset.kernel.model.AssetCategory;
+import com.liferay.asset.kernel.model.AssetCategoryConstants;
+import com.liferay.asset.kernel.service.AssetCategoryLocalService;
+import com.liferay.friendly.url.model.FriendlyURLEntry;
+import com.liferay.friendly.url.model.FriendlyURLEntryLocalization;
+import com.liferay.friendly.url.service.FriendlyURLEntryLocalService;
+import com.liferay.petra.reflect.ReflectionUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
+import com.liferay.portal.kernel.dao.orm.RestrictionsFactoryUtil;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagListener;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Roberto Díaz
+ */
+@Component(
+	property = "feature.flag.key=LPD-70396", service = FeatureFlagListener.class
+)
+public class AssetCategoryFriendlyURLEntryFeatureFlagListener
+	implements FeatureFlagListener {
+
+	@Override
+	public void onValue(
+		long companyId, String featureFlagKey, boolean enabled) {
+
+		long classNameId = _classNameLocalService.getClassNameId(
+			AssetCategory.class);
+
+		List<FriendlyURLEntry> orphanedFriendlyURLEntries = new ArrayList<>();
+
+		ActionableDynamicQuery actionableDynamicQuery =
+			_friendlyURLEntryLocalService.getActionableDynamicQuery();
+
+		actionableDynamicQuery.setAddCriteriaMethod(
+			dynamicQuery -> {
+				dynamicQuery.add(
+					RestrictionsFactoryUtil.eq("classNameId", classNameId));
+
+				if (enabled) {
+					dynamicQuery.add(
+						RestrictionsFactoryUtil.eq(
+							"parentClassPK",
+							AssetCategoryConstants.DEFAULT_PARENT_CATEGORY_ID));
+				}
+				else {
+					dynamicQuery.add(
+						RestrictionsFactoryUtil.ne(
+							"parentClassPK",
+							AssetCategoryConstants.DEFAULT_PARENT_CATEGORY_ID));
+				}
+			});
+		actionableDynamicQuery.setCompanyId(companyId);
+		actionableDynamicQuery.setPerformActionMethod(
+			(FriendlyURLEntry friendlyURLEntry) -> _updateParentClassPK(
+				enabled, friendlyURLEntry, orphanedFriendlyURLEntries));
+
+		try {
+			actionableDynamicQuery.performActions();
+		}
+		catch (PortalException portalException) {
+			ReflectionUtil.throwException(portalException);
+		}
+
+		for (FriendlyURLEntry orphanedFriendlyURLEntry :
+				orphanedFriendlyURLEntries) {
+
+			_friendlyURLEntryLocalService.deleteFriendlyURLEntry(
+				orphanedFriendlyURLEntry);
+		}
+	}
+
+	private void _updateParentClassPK(
+		boolean enabled, FriendlyURLEntry friendlyURLEntry,
+		List<FriendlyURLEntry> orphanedFriendlyURLEntries) {
+
+		long parentClassPK = AssetCategoryConstants.DEFAULT_PARENT_CATEGORY_ID;
+
+		if (enabled) {
+			AssetCategory assetCategory =
+				_assetCategoryLocalService.fetchAssetCategory(
+					friendlyURLEntry.getClassPK());
+
+			if (assetCategory == null) {
+				orphanedFriendlyURLEntries.add(friendlyURLEntry);
+
+				return;
+			}
+
+			parentClassPK = assetCategory.getParentCategoryId();
+
+			if (parentClassPK ==
+					AssetCategoryConstants.DEFAULT_PARENT_CATEGORY_ID) {
+
+				parentClassPK = assetCategory.getVocabularyId();
+			}
+
+			if (parentClassPK ==
+					AssetCategoryConstants.DEFAULT_PARENT_CATEGORY_ID) {
+
+				return;
+			}
+		}
+
+		friendlyURLEntry.setParentClassPK(parentClassPK);
+
+		friendlyURLEntry = _friendlyURLEntryLocalService.updateFriendlyURLEntry(
+			friendlyURLEntry);
+
+		for (FriendlyURLEntryLocalization friendlyURLEntryLocalization :
+				_friendlyURLEntryLocalService.getFriendlyURLEntryLocalizations(
+					friendlyURLEntry.getFriendlyURLEntryId())) {
+
+			friendlyURLEntryLocalization.setParentClassPK(parentClassPK);
+
+			_friendlyURLEntryLocalService.updateFriendlyURLLocalization(
+				friendlyURLEntryLocalization);
+		}
+
+		if (_log.isDebugEnabled()) {
+			_log.debug(
+				StringBundler.concat(
+					"Updated parentClassPK to ", parentClassPK,
+					" for friendly URL entry ",
+					friendlyURLEntry.getFriendlyURLEntryId()));
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		AssetCategoryFriendlyURLEntryFeatureFlagListener.class);
+
+	@Reference
+	private AssetCategoryLocalService _assetCategoryLocalService;
+
+	@Reference
+	private ClassNameLocalService _classNameLocalService;
+
+	@Reference
+	private FriendlyURLEntryLocalService _friendlyURLEntryLocalService;
+
+}

--- a/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/model/listener/AssetCategoryFriendlyURLModelListener.java
+++ b/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/model/listener/AssetCategoryFriendlyURLModelListener.java
@@ -8,6 +8,8 @@ package com.liferay.asset.categories.internal.model.listener;
 import com.liferay.asset.kernel.model.AssetCategory;
 import com.liferay.asset.kernel.model.AssetCategoryConstants;
 import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
+import com.liferay.friendly.url.model.FriendlyURLEntry;
+import com.liferay.friendly.url.model.FriendlyURLEntryLocalization;
 import com.liferay.friendly.url.service.FriendlyURLEntryLocalService;
 import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -59,6 +61,52 @@ public class AssetCategoryFriendlyURLModelListener
 		}
 		catch (PortalException portalException) {
 			throw new ModelListenerException(portalException);
+		}
+	}
+
+	@Override
+	public void onAfterUpdate(
+			AssetCategory originalAssetCategory, AssetCategory assetCategory)
+		throws ModelListenerException {
+
+		if (!FeatureFlagManagerUtil.isEnabled(
+				assetCategory.getCompanyId(), "LPD-70396") ||
+			ExportImportThreadLocal.isImportInProcess() ||
+			ExportImportThreadLocal.isStagingInProcess()) {
+
+			return;
+		}
+
+		long originalParentClassPK = _getAssetCategoryParentClassPK(
+			originalAssetCategory);
+		long parentClassPK = _getAssetCategoryParentClassPK(assetCategory);
+
+		if (originalParentClassPK == parentClassPK) {
+			return;
+		}
+
+		FriendlyURLEntry friendlyURLEntry =
+			_friendlyURLEntryLocalService.fetchMainFriendlyURLEntry(
+				_classNameLocalService.getClassNameId(AssetCategory.class),
+				assetCategory.getCategoryId());
+
+		if (friendlyURLEntry == null) {
+			return;
+		}
+
+		friendlyURLEntry.setParentClassPK(parentClassPK);
+
+		friendlyURLEntry = _friendlyURLEntryLocalService.updateFriendlyURLEntry(
+			friendlyURLEntry);
+
+		for (FriendlyURLEntryLocalization friendlyURLEntryLocalization :
+				_friendlyURLEntryLocalService.getFriendlyURLEntryLocalizations(
+					friendlyURLEntry.getFriendlyURLEntryId())) {
+
+			friendlyURLEntryLocalization.setParentClassPK(parentClassPK);
+
+			_friendlyURLEntryLocalService.updateFriendlyURLLocalization(
+				friendlyURLEntryLocalization);
 		}
 	}
 

--- a/modules/apps/asset/asset-categories-test/build.gradle
+++ b/modules/apps/asset/asset-categories-test/build.gradle
@@ -15,6 +15,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:export-import:export-import-api")
 	testIntegrationImplementation project(":apps:export-import:export-import-report-api")
 	testIntegrationImplementation project(":apps:export-import:export-import-test-util")
+	testIntegrationImplementation project(":apps:friendly-url:friendly-url-api")
 	testIntegrationImplementation project(":apps:info:info-api")
 	testIntegrationImplementation project(":apps:journal:journal-api")
 	testIntegrationImplementation project(":apps:journal:journal-test-util")

--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/internal/feature/flag/test/AssetCategoryFriendlyURLEntryFeatureFlagListenerTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/internal/feature/flag/test/AssetCategoryFriendlyURLEntryFeatureFlagListenerTest.java
@@ -1,0 +1,249 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.asset.categories.internal.feature.flag.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.kernel.model.AssetCategory;
+import com.liferay.asset.kernel.model.AssetCategoryConstants;
+import com.liferay.asset.kernel.model.AssetVocabulary;
+import com.liferay.asset.kernel.service.AssetCategoryLocalService;
+import com.liferay.asset.test.util.AssetTestUtil;
+import com.liferay.friendly.url.model.FriendlyURLEntry;
+import com.liferay.friendly.url.model.FriendlyURLEntryLocalization;
+import com.liferay.friendly.url.service.FriendlyURLEntryLocalService;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagListener;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.HashMap;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Roberto Díaz
+ */
+@RunWith(Arquillian.class)
+public class AssetCategoryFriendlyURLEntryFeatureFlagListenerTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	@TestInfo("LPD-90910")
+	public void testDisablingFeatureFlagResetsParentClassPK() throws Exception {
+		AssetVocabulary assetVocabulary = AssetTestUtil.addVocabulary(
+			_group.getGroupId(),
+			StringUtil.toLowerCase(StringUtil.randomString()));
+
+		AssetCategory assetCategory = _addAssetCategory(
+			assetVocabulary.getVocabularyId(),
+			AssetCategoryConstants.DEFAULT_PARENT_CATEGORY_ID);
+
+		_setParentClassPK(assetCategory, assetVocabulary.getVocabularyId());
+
+		_featureFlagListener.onValue(
+			TestPropsValues.getCompanyId(), "LPD-70396", false);
+
+		_assertParentClassPK(
+			assetCategory, AssetCategoryConstants.DEFAULT_PARENT_CATEGORY_ID);
+	}
+
+	@FeatureFlag("LPD-70396")
+	@Test
+	@TestInfo("LPD-90910")
+	public void testEnablingFeatureFlagAddsParentCategoryToParentClassPK()
+		throws Exception {
+
+		AssetVocabulary assetVocabulary = AssetTestUtil.addVocabulary(
+			_group.getGroupId(),
+			StringUtil.toLowerCase(StringUtil.randomString()));
+
+		AssetCategory parentAssetCategory = _addAssetCategory(
+			assetVocabulary.getVocabularyId(),
+			AssetCategoryConstants.DEFAULT_PARENT_CATEGORY_ID);
+
+		AssetCategory assetCategory = _addAssetCategory(
+			assetVocabulary.getVocabularyId(),
+			parentAssetCategory.getCategoryId());
+
+		_setParentClassPK(
+			assetCategory, AssetCategoryConstants.DEFAULT_PARENT_CATEGORY_ID);
+
+		_featureFlagListener.onValue(
+			TestPropsValues.getCompanyId(), "LPD-70396", true);
+
+		_assertParentClassPK(
+			assetCategory, parentAssetCategory.getCategoryId());
+	}
+
+	@FeatureFlag("LPD-70396")
+	@Test
+	@TestInfo("LPD-90910")
+	public void testEnablingFeatureFlagAddsVocabularyIdToParentClassPK()
+		throws Exception {
+
+		AssetVocabulary assetVocabulary = AssetTestUtil.addVocabulary(
+			_group.getGroupId(),
+			StringUtil.toLowerCase(StringUtil.randomString()));
+
+		AssetCategory assetCategory = _addAssetCategory(
+			assetVocabulary.getVocabularyId(),
+			AssetCategoryConstants.DEFAULT_PARENT_CATEGORY_ID);
+
+		_setParentClassPK(
+			assetCategory, AssetCategoryConstants.DEFAULT_PARENT_CATEGORY_ID);
+
+		_featureFlagListener.onValue(
+			TestPropsValues.getCompanyId(), "LPD-70396", true);
+
+		_assertParentClassPK(assetCategory, assetVocabulary.getVocabularyId());
+	}
+
+	@FeatureFlag("LPD-70396")
+	@Test
+	@TestInfo("LPD-90910")
+	public void testEnablingFeatureFlagDeletesOrphanedFriendlyURLEntry()
+		throws Exception {
+
+		FriendlyURLEntry friendlyURLEntry =
+			_friendlyURLEntryLocalService.addFriendlyURLEntry(
+				_group.getGroupId(),
+				_classNameLocalService.getClassNameId(AssetCategory.class),
+				AssetCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
+				RandomTestUtil.nextLong(),
+				LocaleUtil.toLanguageId(LocaleUtil.getDefault()),
+				HashMapBuilder.put(
+					LocaleUtil.toLanguageId(LocaleUtil.getDefault()),
+					StringUtil.randomString()
+				).build(),
+				ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		long friendlyURLEntryId = friendlyURLEntry.getFriendlyURLEntryId();
+
+		Assert.assertFalse(
+			_friendlyURLEntryLocalService.getFriendlyURLEntryLocalizations(
+				friendlyURLEntryId
+			).isEmpty());
+
+		_triggerFeatureFlag(true);
+
+		Assert.assertNull(
+			_friendlyURLEntryLocalService.fetchFriendlyURLEntry(
+				friendlyURLEntryId));
+
+		Assert.assertTrue(
+			_friendlyURLEntryLocalService.getFriendlyURLEntryLocalizations(
+				friendlyURLEntryId
+			).isEmpty());
+	}
+
+	private AssetCategory _addAssetCategory(
+			long assetVocabularyId, long parentAssetCategoryId)
+		throws Exception {
+
+		return _assetCategoryLocalService.addCategory(
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
+			parentAssetCategoryId,
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), StringUtil.randomString()
+			).build(),
+			new HashMap<>(), assetVocabularyId, null,
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+	}
+
+	private void _assertParentClassPK(
+		AssetCategory assetCategory, long parentClassPK) {
+
+		FriendlyURLEntry friendlyURLEntry =
+			_friendlyURLEntryLocalService.fetchMainFriendlyURLEntry(
+				_classNameLocalService.getClassNameId(AssetCategory.class),
+				assetCategory.getCategoryId());
+
+		Assert.assertEquals(parentClassPK, friendlyURLEntry.getParentClassPK());
+
+		for (FriendlyURLEntryLocalization friendlyURLEntryLocalization :
+				_friendlyURLEntryLocalService.getFriendlyURLEntryLocalizations(
+					friendlyURLEntry.getFriendlyURLEntryId())) {
+
+			Assert.assertEquals(
+				parentClassPK, friendlyURLEntryLocalization.getParentClassPK());
+		}
+	}
+
+	private void _setParentClassPK(
+		AssetCategory assetCategory, long parentClassPK) {
+
+		FriendlyURLEntry friendlyURLEntry =
+			_friendlyURLEntryLocalService.fetchMainFriendlyURLEntry(
+				_classNameLocalService.getClassNameId(AssetCategory.class),
+				assetCategory.getCategoryId());
+
+		Assert.assertNotNull(friendlyURLEntry);
+
+		friendlyURLEntry.setParentClassPK(parentClassPK);
+
+		friendlyURLEntry = _friendlyURLEntryLocalService.updateFriendlyURLEntry(
+			friendlyURLEntry);
+
+		for (FriendlyURLEntryLocalization friendlyURLEntryLocalization :
+				_friendlyURLEntryLocalService.getFriendlyURLEntryLocalizations(
+					friendlyURLEntry.getFriendlyURLEntryId())) {
+
+			friendlyURLEntryLocalization.setParentClassPK(parentClassPK);
+
+			_friendlyURLEntryLocalService.updateFriendlyURLLocalization(
+				friendlyURLEntryLocalization);
+		}
+	}
+
+	private void _triggerFeatureFlag(boolean enabled) throws Exception {
+		_featureFlagListener.onValue(
+			TestPropsValues.getCompanyId(), "LPD-70396", enabled);
+	}
+
+	@Inject
+	private AssetCategoryLocalService _assetCategoryLocalService;
+
+	@Inject
+	private ClassNameLocalService _classNameLocalService;
+
+	@Inject(
+		filter = "component.name=com.liferay.asset.categories.internal.feature.flag.AssetCategoryFriendlyURLEntryFeatureFlagListener"
+	)
+	private FeatureFlagListener _featureFlagListener;
+
+	@Inject
+	private FriendlyURLEntryLocalService _friendlyURLEntryLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+}

--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/internal/model/listener/test/AssetCategoryFriendlyURLModelListenerTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/internal/model/listener/test/AssetCategoryFriendlyURLModelListenerTest.java
@@ -1,0 +1,267 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.asset.categories.internal.model.listener.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.kernel.model.AssetCategory;
+import com.liferay.asset.kernel.model.AssetCategoryConstants;
+import com.liferay.asset.kernel.model.AssetVocabulary;
+import com.liferay.asset.kernel.service.AssetCategoryLocalService;
+import com.liferay.asset.test.util.AssetTestUtil;
+import com.liferay.friendly.url.model.FriendlyURLEntry;
+import com.liferay.friendly.url.service.FriendlyURLEntryLocalService;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.HashMap;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Roberto Díaz
+ */
+@RunWith(Arquillian.class)
+public class AssetCategoryFriendlyURLModelListenerTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+	}
+
+	@FeatureFlag("LPD-70396")
+	@Test
+	@TestInfo("LPD-90910")
+	public void testOnAfterUpdate() throws Exception {
+		_testOnAfterUpdateWhenMovedToDifferentParentCategory();
+		_testOnAfterUpdateWhenMovedToRoot();
+		_testOnAfterUpdateWhenSameParentCategory();
+	}
+
+	@FeatureFlag("LPD-70396")
+	@Test
+	@TestInfo("LPD-90910")
+	public void testOnAfterUpdateMovingCategoryFreesURLTitleUnderOldParent()
+		throws Exception {
+
+		AssetVocabulary assetVocabulary = AssetTestUtil.addVocabulary(
+			_group.getGroupId(),
+			StringUtil.toLowerCase(StringUtil.randomString()));
+
+		AssetCategory parentAssetCategory1 = _addAssetCategory(
+			assetVocabulary.getVocabularyId(),
+			AssetCategoryConstants.DEFAULT_PARENT_CATEGORY_ID);
+
+		AssetCategory parentAssetCategory2 = _addAssetCategory(
+			assetVocabulary.getVocabularyId(),
+			AssetCategoryConstants.DEFAULT_PARENT_CATEGORY_ID);
+
+		String name = StringUtil.randomString();
+
+		AssetCategory assetCategory = _addAssetCategory(
+			name, assetVocabulary.getVocabularyId(),
+			parentAssetCategory1.getCategoryId());
+
+		String urlTitle = _getURLTitle(assetCategory);
+
+		assetCategory.setParentCategoryId(parentAssetCategory2.getCategoryId());
+
+		_assetCategoryLocalService.updateAssetCategory(assetCategory);
+
+		AssetCategory siblingAssetCategory = _addAssetCategory(
+			name, assetVocabulary.getVocabularyId(),
+			parentAssetCategory1.getCategoryId());
+
+		Assert.assertEquals(urlTitle, _getURLTitle(siblingAssetCategory));
+	}
+
+	private AssetCategory _addAssetCategory(
+			long assetVocabularyId, long parentAssetCategoryId)
+		throws Exception {
+
+		return _assetCategoryLocalService.addCategory(
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
+			parentAssetCategoryId,
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), StringUtil.randomString()
+			).build(),
+			new HashMap<>(), assetVocabularyId, null,
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+	}
+
+	private AssetCategory _addAssetCategory(
+			String name, long assetVocabularyId, long parentAssetCategoryId)
+		throws Exception {
+
+		return _assetCategoryLocalService.addCategory(
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
+			parentAssetCategoryId,
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), name
+			).build(),
+			new HashMap<>(), assetVocabularyId, null,
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+	}
+
+	private String _getURLTitle(AssetCategory assetCategory) {
+		FriendlyURLEntry friendlyURLEntry =
+			_friendlyURLEntryLocalService.fetchMainFriendlyURLEntry(
+				_classNameLocalService.getClassNameId(AssetCategory.class),
+				assetCategory.getCategoryId());
+
+		return friendlyURLEntry.getUrlTitle(
+			LocaleUtil.toLanguageId(LocaleUtil.getDefault()));
+	}
+
+	private void _testOnAfterUpdateWhenMovedToDifferentParentCategory()
+		throws Exception {
+
+		AssetVocabulary assetVocabulary = AssetTestUtil.addVocabulary(
+			_group.getGroupId(),
+			StringUtil.toLowerCase(StringUtil.randomString()));
+
+		AssetCategory parentAssetCategory1 = _addAssetCategory(
+			assetVocabulary.getVocabularyId(),
+			AssetCategoryConstants.DEFAULT_PARENT_CATEGORY_ID);
+
+		AssetCategory assetCategory = _addAssetCategory(
+			assetVocabulary.getVocabularyId(),
+			parentAssetCategory1.getCategoryId());
+
+		FriendlyURLEntry friendlyURLEntry =
+			_friendlyURLEntryLocalService.fetchMainFriendlyURLEntry(
+				_classNameLocalService.getClassNameId(AssetCategory.class),
+				assetCategory.getCategoryId());
+
+		Assert.assertEquals(
+			parentAssetCategory1.getCategoryId(),
+			friendlyURLEntry.getParentClassPK());
+
+		AssetCategory parentAssetCategory2 = _addAssetCategory(
+			assetVocabulary.getVocabularyId(),
+			AssetCategoryConstants.DEFAULT_PARENT_CATEGORY_ID);
+
+		assetCategory.setParentCategoryId(parentAssetCategory2.getCategoryId());
+
+		assetCategory = _assetCategoryLocalService.updateAssetCategory(
+			assetCategory);
+
+		FriendlyURLEntry updatedFriendlyURLEntry =
+			_friendlyURLEntryLocalService.fetchMainFriendlyURLEntry(
+				_classNameLocalService.getClassNameId(AssetCategory.class),
+				assetCategory.getCategoryId());
+
+		Assert.assertEquals(
+			parentAssetCategory2.getCategoryId(),
+			updatedFriendlyURLEntry.getParentClassPK());
+	}
+
+	private void _testOnAfterUpdateWhenMovedToRoot() throws Exception {
+		AssetVocabulary assetVocabulary = AssetTestUtil.addVocabulary(
+			_group.getGroupId(),
+			StringUtil.toLowerCase(StringUtil.randomString()));
+
+		AssetCategory parentAssetCategory = _addAssetCategory(
+			assetVocabulary.getVocabularyId(),
+			AssetCategoryConstants.DEFAULT_PARENT_CATEGORY_ID);
+
+		AssetCategory assetCategory = _addAssetCategory(
+			assetVocabulary.getVocabularyId(),
+			parentAssetCategory.getCategoryId());
+
+		FriendlyURLEntry friendlyURLEntry =
+			_friendlyURLEntryLocalService.fetchMainFriendlyURLEntry(
+				_classNameLocalService.getClassNameId(AssetCategory.class),
+				assetCategory.getCategoryId());
+
+		Assert.assertEquals(
+			parentAssetCategory.getCategoryId(),
+			friendlyURLEntry.getParentClassPK());
+
+		assetCategory.setParentCategoryId(
+			AssetCategoryConstants.DEFAULT_PARENT_CATEGORY_ID);
+
+		assetCategory = _assetCategoryLocalService.updateAssetCategory(
+			assetCategory);
+
+		FriendlyURLEntry updatedFriendlyURLEntry =
+			_friendlyURLEntryLocalService.fetchMainFriendlyURLEntry(
+				_classNameLocalService.getClassNameId(AssetCategory.class),
+				assetCategory.getCategoryId());
+
+		Assert.assertEquals(
+			assetVocabulary.getVocabularyId(),
+			updatedFriendlyURLEntry.getParentClassPK());
+	}
+
+	private void _testOnAfterUpdateWhenSameParentCategory() throws Exception {
+		AssetVocabulary assetVocabulary = AssetTestUtil.addVocabulary(
+			_group.getGroupId(),
+			StringUtil.toLowerCase(StringUtil.randomString()));
+
+		AssetCategory assetCategory = _addAssetCategory(
+			assetVocabulary.getVocabularyId(),
+			AssetCategoryConstants.DEFAULT_PARENT_CATEGORY_ID);
+
+		FriendlyURLEntry friendlyURLEntry =
+			_friendlyURLEntryLocalService.fetchMainFriendlyURLEntry(
+				_classNameLocalService.getClassNameId(AssetCategory.class),
+				assetCategory.getCategoryId());
+
+		Assert.assertNotNull(friendlyURLEntry);
+		Assert.assertEquals(
+			assetVocabulary.getVocabularyId(),
+			friendlyURLEntry.getParentClassPK());
+
+		assetCategory.setTitle(StringUtil.randomString());
+
+		assetCategory = _assetCategoryLocalService.updateAssetCategory(
+			assetCategory);
+
+		FriendlyURLEntry updatedFriendlyURLEntry =
+			_friendlyURLEntryLocalService.fetchMainFriendlyURLEntry(
+				_classNameLocalService.getClassNameId(AssetCategory.class),
+				assetCategory.getCategoryId());
+
+		Assert.assertEquals(
+			assetVocabulary.getVocabularyId(),
+			updatedFriendlyURLEntry.getParentClassPK());
+	}
+
+	@Inject
+	private AssetCategoryLocalService _assetCategoryLocalService;
+
+	@Inject
+	private ClassNameLocalService _classNameLocalService;
+
+	@Inject
+	private FriendlyURLEntryLocalService _friendlyURLEntryLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+}

--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/internal/model/listener/test/AssetCategoryFriendlyURLModelListenerTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/internal/model/listener/test/AssetCategoryFriendlyURLModelListenerTest.java
@@ -56,6 +56,31 @@ public class AssetCategoryFriendlyURLModelListenerTest {
 	@FeatureFlag("LPD-70396")
 	@Test
 	@TestInfo("LPD-90910")
+	public void testOnAfterCreate() throws Exception {
+		AssetVocabulary assetVocabulary = AssetTestUtil.addVocabulary(
+			_group.getGroupId(),
+			StringUtil.toLowerCase(StringUtil.randomString()));
+
+		AssetCategory assetCategory = _addAssetCategory(
+			assetVocabulary.getVocabularyId(),
+			AssetCategoryConstants.DEFAULT_PARENT_CATEGORY_ID);
+
+		FriendlyURLEntry friendlyURLEntry =
+			_friendlyURLEntryLocalService.fetchMainFriendlyURLEntry(
+				_classNameLocalService.getClassNameId(AssetCategory.class),
+				assetCategory.getCategoryId());
+
+		Assert.assertNotNull(friendlyURLEntry);
+		Assert.assertEquals(
+			assetCategory.getCategoryId(), friendlyURLEntry.getClassPK());
+		Assert.assertEquals(
+			assetVocabulary.getVocabularyId(),
+			friendlyURLEntry.getParentClassPK());
+	}
+
+	@FeatureFlag("LPD-70396")
+	@Test
+	@TestInfo("LPD-90910")
 	public void testOnAfterUpdate() throws Exception {
 		_testOnAfterUpdateWhenMovedToDifferentParentCategory();
 		_testOnAfterUpdateWhenMovedToRoot();
@@ -97,6 +122,32 @@ public class AssetCategoryFriendlyURLModelListenerTest {
 			parentAssetCategory1.getCategoryId());
 
 		Assert.assertEquals(urlTitle, _getURLTitle(siblingAssetCategory));
+	}
+
+	@FeatureFlag("LPD-70396")
+	@Test
+	@TestInfo("LPD-90910")
+	public void testOnBeforeRemove() throws Exception {
+		AssetVocabulary assetVocabulary = AssetTestUtil.addVocabulary(
+			_group.getGroupId(),
+			StringUtil.toLowerCase(StringUtil.randomString()));
+
+		AssetCategory assetCategory = _addAssetCategory(
+			assetVocabulary.getVocabularyId(),
+			AssetCategoryConstants.DEFAULT_PARENT_CATEGORY_ID);
+
+		long classNameId = _classNameLocalService.getClassNameId(
+			AssetCategory.class);
+
+		Assert.assertNotNull(
+			_friendlyURLEntryLocalService.fetchMainFriendlyURLEntry(
+				classNameId, assetCategory.getCategoryId()));
+
+		_assetCategoryLocalService.deleteCategory(assetCategory);
+
+		Assert.assertNull(
+			_friendlyURLEntryLocalService.fetchMainFriendlyURLEntry(
+				classNameId, assetCategory.getCategoryId()));
 	}
 
 	private AssetCategory _addAssetCategory(

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/model/listener/AssetCategoryModelListener.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/model/listener/AssetCategoryModelListener.java
@@ -11,6 +11,7 @@ import com.liferay.commerce.product.service.CPDisplayLayoutLocalService;
 import com.liferay.friendly.url.service.FriendlyURLEntryLocalService;
 import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.BaseModelListener;
@@ -37,6 +38,12 @@ public class AssetCategoryModelListener
 	public void onAfterCreate(AssetCategory assetCategory)
 		throws ModelListenerException {
 
+		if (FeatureFlagManagerUtil.isEnabled(
+				assetCategory.getCompanyId(), "LPD-70396")) {
+
+			return;
+		}
+
 		try {
 			_friendlyURLEntryLocalService.addFriendlyURLEntry(
 				assetCategory.getGroupId(),
@@ -59,6 +66,12 @@ public class AssetCategoryModelListener
 
 			_cpDisplayLayoutLocalService.deleteCPDisplayLayouts(
 				AssetCategory.class, assetCategory.getCategoryId());
+
+			if (FeatureFlagManagerUtil.isEnabled(
+					assetCategory.getCompanyId(), "LPD-70396")) {
+
+				return;
+			}
 
 			_friendlyURLEntryLocalService.deleteFriendlyURLEntry(
 				assetCategory.getGroupId(),

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/exportimport/staged/model/repository/FriendlyURLEntryStagedModelRepository.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/exportimport/staged/model/repository/FriendlyURLEntryStagedModelRepository.java
@@ -52,7 +52,8 @@ public class FriendlyURLEntryStagedModelRepository
 
 		return _friendlyURLEntryLocalService.addFriendlyURLEntry(
 			friendlyURLEntry.getGroupId(), friendlyURLEntry.getClassNameId(),
-			friendlyURLEntry.getClassPK(),
+			friendlyURLEntry.getParentClassPK(), friendlyURLEntry.getClassPK(),
+			friendlyURLEntry.getDefaultLanguageId(),
 			_getLocalizationMap(portletDataContext, friendlyURLEntry),
 			serviceContext);
 	}

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
@@ -27,6 +27,7 @@ import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.ModelHintsUtil;
@@ -102,6 +103,16 @@ public class FriendlyURLEntryLocalServiceImpl
 
 		if ((friendlyURLEntry != null) &&
 			_containsAllURLTitles(existingUrlTitleMap, urlTitleMap)) {
+
+			if (FeatureFlagManagerUtil.isEnabled(
+					friendlyURLEntry.getCompanyId(), "LPD-70396") &&
+				(friendlyURLEntry.getParentClassPK() != parentClassPK)) {
+
+				friendlyURLEntry.setParentClassPK(parentClassPK);
+
+				friendlyURLEntry = friendlyURLEntryPersistence.update(
+					friendlyURLEntry);
+			}
 
 			_updateAssetEntry(friendlyURLEntry, serviceContext);
 

--- a/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/service/test/FriendlyURLEntryLocalServiceTest.java
+++ b/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/service/test/FriendlyURLEntryLocalServiceTest.java
@@ -38,6 +38,7 @@ import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
@@ -189,6 +190,43 @@ public class FriendlyURLEntryLocalServiceTest {
 				urlTitle, _getServiceContext());
 
 		Assert.assertEquals(urlTitle, finalFriendlyURL.getUrlTitle());
+	}
+
+	@FeatureFlag("LPD-70396")
+	@Test
+	@TestInfo("LPD-90910")
+	public void testAddFriendlyURLEntryUpdatesParentClassPK() throws Exception {
+		long classNameId = _classNameLocalService.getClassNameId(User.class);
+		long classPK = TestPropsValues.getUserId();
+		String defaultLanguageId = LocaleUtil.toLanguageId(
+			LocaleUtil.getSiteDefault());
+		long originalParentClassPK = RandomTestUtil.nextLong();
+		long updatedParentClassPK = RandomTestUtil.nextLong();
+
+		String urlTitle = _getRandomURLTitle();
+
+		FriendlyURLEntry originalFriendlyURLEntry =
+			_friendlyURLEntryLocalService.addFriendlyURLEntry(
+				_group.getGroupId(), classNameId, originalParentClassPK,
+				classPK, defaultLanguageId,
+				Collections.singletonMap(defaultLanguageId, urlTitle),
+				_getServiceContext());
+
+		Assert.assertEquals(
+			originalParentClassPK, originalFriendlyURLEntry.getParentClassPK());
+
+		FriendlyURLEntry updatedFriendlyURLEntry =
+			_friendlyURLEntryLocalService.addFriendlyURLEntry(
+				_group.getGroupId(), classNameId, updatedParentClassPK, classPK,
+				defaultLanguageId,
+				Collections.singletonMap(defaultLanguageId, urlTitle),
+				_getServiceContext());
+
+		Assert.assertEquals(
+			originalFriendlyURLEntry.getFriendlyURLEntryId(),
+			updatedFriendlyURLEntry.getFriendlyURLEntryId());
+		Assert.assertEquals(
+			updatedParentClassPK, updatedFriendlyURLEntry.getParentClassPK());
 	}
 
 	@Test


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90910

## What Is Being Fixed

The initial LPD-90910 work added the `parentClassPK` column for per-parent friendly URL uniqueness, but review surfaced follow-up gaps: the model listener did not maintain `parentClassPK` when a category moves, legacy `FriendlyURLEntry` rows kept `parentClassPK = 0`, the `addFriendlyURLEntry` early return preserved a stale parent on move, staging dropped `parentClassPK`, the commerce listener needed gating, and listener test coverage was incomplete.

## How It Is Being Fixed

`onAfterUpdate` now updates `parentClassPK` on move and `addFriendlyURLEntry` refreshes it instead of returning a stale entry. A portal instance lifecycle listener backfills `parentClassPK` for legacy entries and resets it to the default when `LPD-70396` is disabled, acting as a switch. The commerce `AssetCategoryModelListener` is gated behind `LPD-70396`, and staging preserves `parentClassPK`. Integration tests cover create, update on move, backfill, reset, and the staging path. All behavior is gated behind `LPD-70396`.
