### PR TITLE
LPD-92788 Update StatusLabel test to expect the inverse Clay label variant

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/test/js/common/components/StatusLabel.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/common/components/StatusLabel.test.tsx
@@ -31,7 +31,7 @@ describe('StatusLabel', () => {
 		expect(labelElement).toBeInTheDocument();
 		expect(labelElement.parentElement).toHaveClass(
 			'label',
-			`label-${displayType}`
+			`label-inverse-${displayType}`
 		);
 	});
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92788

## What

`StatusLabel.test.tsx` asserted the non-inverse Clay label class (`label-${displayType}`), but commit `9576a8338ad3` (LPD-88103, "Use inverse Clay label variant in CMS site initializer") switched every `<Label>` in `StatusLabel.tsx` to the `inverse` variant, which renders `label-inverse-${displayType}`. As a result all nine parametrized status renders failed in CI. This updates the assertion to expect the inverse variant so it matches the component's current output.

## Test

cd modules/apps/site/site-cms-site-initializer && yarn test test/js/common/components/StatusLabel.test.tsx
