### PR TITLE
LPD-92792 Match the bulk Expire alert convention with first: true

### DIFF
--- a/modules/test/playwright/tests/site-cms-site-initializer/main/bulkActions.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/bulkActions.spec.ts
@@ -1943,7 +1943,8 @@ test(
 
 			await waitForAlert(
 				page,
-				`Success:${basicDocumentTitle} was successfully expired.`
+				`Success:${basicDocumentTitle} was successfully expired.`,
+				{first: true}
 			);
 
 			await expect(
@@ -1979,7 +1980,8 @@ test(
 
 			await waitForAlert(
 				page,
-				'Success:2 assets were successfully expired.'
+				'Success:2 assets were successfully expired.',
+				{first: true}
 			);
 
 			for (const row of rows) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92792

## What

The two "Expire" success-alert assertions in `bulkActions.spec.ts` called `waitForAlert` without `{first: true}`, so they matched every `.alert-success` carrying the success text. Under CI timing two identical success alerts coexist (the transient toast and the async-task completion notification), which produced a strict-mode violation: `locator('.alert-success').filter(...) resolved to 2 elements`. Every other async bulk action in this file (delete-all, move, copy, duplicate) already passes `{first: true}` for exactly this reason; the Expire steps were the only ones that omitted it. This aligns them with that convention. The assertion is unchanged — a success alert with the exact text must still appear; `{first: true}` only resolves the multi-match ambiguity.

## Test

cd modules/test/playwright && yarn test tests/site-cms-site-initializer/main/bulkActions.spec.ts --project site-cms-site-initializer.main -g "Expire CMS assets in bulk"
