### PR TITLE
LPD-92798 Assert the localized Aspect Ratio label in the Spanish metadata test

### DIFF
--- a/modules/test/playwright/tests/site-cms-site-initializer/main/fileMetadata.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/fileMetadata.spec.ts
@@ -215,7 +215,7 @@ test(
 			});
 
 			await infoPanelPage.expectMetadata('Resolución', /.+/);
-			await infoPanelPage.expectMetadata('Aspect Ratio', /.+/);
+			await infoPanelPage.expectMetadata('Relación de aspecto', /.+/);
 		}
 		finally {
 			await apiHelpers.headlessAdminUser.patchMyUserAccountLanguage(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92798

## What

The test "File metadata buckets are localized when the user switches to Spanish" switches the user to `es-ES` and then asserts two info-panel metadata bucket labels. The Resolution assertion correctly used the Spanish label `Resolución`, but the Aspect Ratio assertion still used the English label `Aspect Ratio`, so its locator (`p.font-weight-bold` filtered by `hasText: 'Aspect Ratio'`) matched nothing once the panel rendered in Spanish, and the assertion timed out with "element(s) not found". The product localizes the label correctly; only the test was checking the wrong string. This asserts the Spanish label using the stable substring `Relación de aspecto`, mirroring the Resolution assertion above it.

## Test

cd modules/test/playwright && yarn test tests/site-cms-site-initializer/main/fileMetadata.spec.ts --project site-cms-site-initializer.main -g "localized when the user switches to Spanish"
