### PR TITLE
LPD-92150 Keep the Publish modal open for errors before submission

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/modals/PublishModal.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/modals/PublishModal.js
@@ -45,13 +45,13 @@ export default function PublishModal({
 
 	useEffect(() => {
 		const handler = Liferay.on('ddmFormError', (event) => {
-			if (event.error?.statusCode) {
+			if (event.error?.statusCode && isSubmitting) {
 				onClose();
 			}
 		});
 
 		return () => handler.detach();
-	}, [onClose]);
+	}, [isSubmitting, onClose]);
 
 	const handleButtonClick = () => {
 		if (isSubmitting) {

--- a/modules/apps/journal/journal-web/test/js/modals/PublishModal.test.js
+++ b/modules/apps/journal/journal-web/test/js/modals/PublishModal.test.js
@@ -4,7 +4,8 @@
  */
 
 import '@testing-library/jest-dom';
-import {act, render, waitFor} from '@testing-library/react';
+import {act, render, screen, waitFor} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import PublishModal from '../../../src/main/resources/META-INF/resources/js/modals/PublishModal';
@@ -23,6 +24,13 @@ const DEFAULT_PROPS = {
 	workflowEnabled: false,
 };
 
+const STATUS_CODE_ERROR = {
+	error: {
+		message: 'upload-size-limit-has-been-exceeded',
+		statusCode: 413,
+	},
+};
+
 describe('PublishModal', () => {
 	let ddmFormErrorHandler;
 
@@ -38,25 +46,34 @@ describe('PublishModal', () => {
 		});
 	});
 
-	it('closes when a ddmFormError event with statusCode is fired', async () => {
+	it('closes when a ddmFormError event with statusCode is fired after the publish button is clicked', async () => {
 		const onCloseModal = jest.fn();
 
 		render(<PublishModal {...DEFAULT_PROPS} onCloseModal={onCloseModal} />);
 
 		expect(ddmFormErrorHandler).not.toBeNull();
 
+		userEvent.click(await screen.findByText('publish'));
+
 		act(() => {
-			ddmFormErrorHandler({
-				error: {
-					message: 'upload-size-limit-has-been-exceeded',
-					statusCode: 413,
-				},
-			});
+			ddmFormErrorHandler(STATUS_CODE_ERROR);
 		});
 
 		await waitFor(() => {
 			expect(onCloseModal).toHaveBeenCalled();
 		});
+	});
+
+	it('does not close when a ddmFormError event with statusCode is fired before the publish button is clicked', () => {
+		const onCloseModal = jest.fn();
+
+		render(<PublishModal {...DEFAULT_PROPS} onCloseModal={onCloseModal} />);
+
+		act(() => {
+			ddmFormErrorHandler(STATUS_CODE_ERROR);
+		});
+
+		expect(onCloseModal).not.toHaveBeenCalled();
 	});
 
 	it('does not close when a ddmFormError event without statusCode is fired', () => {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92150

Extends the original LPD-92150 fix (merged in https://github.com/liferay-content-management/liferay-portal/pull/8348) and replaces the closed https://github.com/liferay-content-management/liferay-portal/pull/8364, which was closed because its base lagged behind master and dragged in unrelated commits. Now that master is synchronized, this PR is rebased on it and contains only the two relevant commits.

## What Is Being Fixed

The original LPD-92150 fix closes the Publish modal on any global `ddmFormError` event that carries a `statusCode`. Because `Liferay.on('ddmFormError', …)` is global, the listener also fires for errors that happen before the user clicks Publish — for example a 413 `upload-size-limit-has-been-exceeded` returned by `dynamic-data-mapping-form-context-provider` while the modal is opening with a large article state. The modal then closes immediately and the user never sees the Publish-with-permissions UI. This was caught in 2025.q1.15, where the form context POST grows to ~2 MB on certain articles and the server replies with 413.

## How It Is Being Fixed

The close is now gated on `isSubmitting`, which is set to `true` only inside `handleButtonClick` right before `onPublishButtonClick`. The listener therefore closes the modal only when the error is the result of a user-initiated submit. A pre-submit `ddmFormError` (such as the 413 while opening) leaves the modal open, while a 413 after the user clicks Publish still closes it so the error toast becomes visible. Events without a `statusCode` keep the previous behaviour.

The tests were updated accordingly: the existing "closes when a ddmFormError event with statusCode is fired" case now clicks Publish first, a new case asserts the modal stays open when the same event fires before Publish is clicked, and the no-`statusCode` case is unchanged.