### PR TITLE
LPD-92148 Scope Shared With Me folder breadcrumb to the shared root

### DIFF
--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewFolderSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewFolderSectionDisplayContextTest.java
@@ -13,13 +13,20 @@ import com.liferay.fragment.renderer.FragmentRenderer;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectEntryFolderLocalService;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.context.ContextUserReplace;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -28,6 +35,8 @@ import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.sharing.security.permission.SharingEntryAction;
+import com.liferay.sharing.service.SharingEntryService;
 
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -106,8 +115,164 @@ public class ViewFolderSectionDisplayContextTest
 		Assert.assertEquals(Boolean.FALSE, additionalProps.get("trashEnabled"));
 	}
 
+	@Test
+	public void testGetBreadcrumbProps() throws Exception {
+		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
+			Collections.singletonMap(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
+			null, DepotConstants.TYPE_SPACE,
+			ServiceContextTestUtil.getServiceContext());
+
+		Group depotEntryGroup = _groupLocalService.getGroup(
+			depotEntry.getGroupId());
+
+		ObjectEntryFolder rootObjectEntryFolder =
+			_objectEntryFolderLocalService.
+				getObjectEntryFolderByExternalReferenceCode(
+					ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS,
+					depotEntry.getGroupId(), depotEntry.getCompanyId());
+
+		ObjectEntryFolder parentObjectEntryFolder = _addObjectEntryFolder(
+			depotEntry, rootObjectEntryFolder.getObjectEntryFolderId());
+
+		ObjectEntryFolder sharedObjectEntryFolder = _addObjectEntryFolder(
+			depotEntry, parentObjectEntryFolder.getObjectEntryFolderId());
+
+		ObjectEntryFolder childObjectEntryFolder = _addObjectEntryFolder(
+			depotEntry, sharedObjectEntryFolder.getObjectEntryFolderId());
+
+		Map<String, Object> breadcrumbProps = _getBreadcrumbProps(
+			getMockHttpServletRequest(childObjectEntryFolder));
+
+		Assert.assertEquals(
+			breadcrumbProps.toString(), Boolean.FALSE,
+			breadcrumbProps.get("hideSpace"));
+
+		_assertBreadcrumbLabels(
+			breadcrumbProps, depotEntryGroup.getName(LocaleUtil.getDefault()),
+			rootObjectEntryFolder.getLabel(LocaleUtil.getDefault()),
+			parentObjectEntryFolder.getLabel(LocaleUtil.getDefault()),
+			sharedObjectEntryFolder.getLabel(LocaleUtil.getDefault()),
+			childObjectEntryFolder.getLabel(LocaleUtil.getDefault()));
+
+		User user = UserTestUtil.addUser();
+
+		_sharingEntryService.addSharingEntry(
+			null, 0, 0, user.getUserId(),
+			portal.getClassNameId(ObjectEntryFolder.class.getName()),
+			sharedObjectEntryFolder.getObjectEntryFolderId(),
+			depotEntry.getGroupId(), true,
+			Collections.singletonList(SharingEntryAction.VIEW), null,
+			ServiceContextTestUtil.getServiceContext(depotEntry.getGroupId()));
+
+		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
+				user)) {
+
+			breadcrumbProps = _getBreadcrumbProps(
+				getMockHttpServletRequest(childObjectEntryFolder, user));
+
+			Assert.assertEquals(
+				breadcrumbProps.toString(), Boolean.TRUE,
+				breadcrumbProps.get("hideSpace"));
+
+			_assertBreadcrumbLabels(
+				breadcrumbProps,
+				sharedObjectEntryFolder.getLabel(LocaleUtil.getDefault()),
+				childObjectEntryFolder.getLabel(LocaleUtil.getDefault()));
+
+			breadcrumbProps = _getBreadcrumbProps(
+				getMockHttpServletRequest(sharedObjectEntryFolder, user));
+
+			Assert.assertEquals(
+				breadcrumbProps.toString(), Boolean.TRUE,
+				breadcrumbProps.get("hideSpace"));
+
+			_assertBreadcrumbLabels(
+				breadcrumbProps,
+				sharedObjectEntryFolder.getLabel(LocaleUtil.getDefault()));
+		}
+
+		User cmsAdministratorUser = UserTestUtil.addCompanyUser(
+			companyLocalService.getCompany(TestPropsValues.getCompanyId()),
+			RoleConstants.CMS_ADMINISTRATOR);
+
+		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
+				cmsAdministratorUser)) {
+
+			breadcrumbProps = _getBreadcrumbProps(
+				getMockHttpServletRequest(
+					childObjectEntryFolder, cmsAdministratorUser));
+
+			Assert.assertEquals(
+				breadcrumbProps.toString(), Boolean.FALSE,
+				breadcrumbProps.get("hideSpace"));
+
+			_assertBreadcrumbLabels(
+				breadcrumbProps,
+				depotEntryGroup.getName(LocaleUtil.getDefault()),
+				rootObjectEntryFolder.getLabel(LocaleUtil.getDefault()),
+				parentObjectEntryFolder.getLabel(LocaleUtil.getDefault()),
+				sharedObjectEntryFolder.getLabel(LocaleUtil.getDefault()),
+				childObjectEntryFolder.getLabel(LocaleUtil.getDefault()));
+		}
+	}
+
+	private ObjectEntryFolder _addObjectEntryFolder(
+			DepotEntry depotEntry, long parentObjectEntryFolderId)
+		throws Exception {
+
+		return _objectEntryFolderLocalService.addObjectEntryFolder(
+			null, depotEntry.getGroupId(), TestPropsValues.getUserId(),
+			parentObjectEntryFolderId, RandomTestUtil.randomString(),
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()
+			).build(),
+			RandomTestUtil.randomString(),
+			ServiceContextTestUtil.getServiceContext(depotEntry.getGroupId()));
+	}
+
+	private void _assertBreadcrumbLabels(
+		Map<String, Object> breadcrumbProps, String... expectedLabels) {
+
+		JSONArray jsonArray = (JSONArray)breadcrumbProps.get("breadcrumbItems");
+
+		Assert.assertEquals(
+			jsonArray.toString(), expectedLabels.length, jsonArray.length());
+
+		for (int i = 0; i < expectedLabels.length; i++) {
+			JSONObject jsonObject = jsonArray.getJSONObject(i);
+
+			Assert.assertEquals(
+				jsonArray.toString(), expectedLabels[i],
+				jsonObject.getString("label"));
+		}
+
+		JSONObject lastJSONObject = jsonArray.getJSONObject(
+			expectedLabels.length - 1);
+
+		Assert.assertTrue(
+			jsonArray.toString(), lastJSONObject.getBoolean("active"));
+	}
+
 	private Map<String, Object> _getAdditionalProps(
 			HttpServletRequest httpServletRequest)
+		throws Exception {
+
+		return ReflectionTestUtil.invoke(
+			_getDisplayContext(httpServletRequest), "getAdditionalProps",
+			new Class<?>[0]);
+	}
+
+	private Map<String, Object> _getBreadcrumbProps(
+			HttpServletRequest httpServletRequest)
+		throws Exception {
+
+		return ReflectionTestUtil.invoke(
+			_getDisplayContext(httpServletRequest), "getBreadcrumbProps",
+			new Class<?>[0]);
+	}
+
+	private Object _getDisplayContext(HttpServletRequest httpServletRequest)
 		throws Exception {
 
 		_fragmentRenderer.render(
@@ -120,9 +285,7 @@ public class ViewFolderSectionDisplayContextTest
 
 		Assert.assertNotNull(viewFolderSectionDisplayContext);
 
-		return ReflectionTestUtil.invoke(
-			viewFolderSectionDisplayContext, "getAdditionalProps",
-			new Class<?>[0]);
+		return viewFolderSectionDisplayContext;
 	}
 
 	private void _setTrashEnabled(DepotEntry depotEntry, boolean trashEnabled)
@@ -153,5 +316,11 @@ public class ViewFolderSectionDisplayContextTest
 
 	@Inject
 	private ObjectEntryFolderLocalService _objectEntryFolderLocalService;
+
+	@Inject
+	private SharingEntryService _sharingEntryService;
+
+	@Inject
+	private UserLocalService _userLocalService;
 
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewFolderSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewFolderSectionDisplayContext.java
@@ -5,6 +5,7 @@
 
 package com.liferay.site.cms.site.initializer.internal.display.context;
 
+import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.document.library.configuration.DLConfiguration;
 import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
@@ -20,12 +21,17 @@ import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.sharing.security.permission.SharingEntryAction;
+import com.liferay.sharing.service.SharingEntryLocalService;
 import com.liferay.site.cms.site.initializer.internal.constants.CMSSiteInitializerFDSNames;
 import com.liferay.site.cms.site.initializer.internal.util.ActionUtil;
 import com.liferay.translation.exporter.TranslationInfoItemFieldValuesExporterRegistry;
@@ -49,7 +55,7 @@ public class ViewFolderSectionDisplayContext extends BaseSectionDisplayContext {
 		HttpServletRequest httpServletRequest, Language language,
 		ObjectDefinitionService objectDefinitionService,
 		ObjectEntryFolderLocalService objectEntryFolderLocalService,
-		Portal portal,
+		Portal portal, SharingEntryLocalService sharingEntryLocalService,
 		TranslationInfoItemFieldValuesExporterRegistry
 			translationInfoItemFieldValuesExporterRegistry,
 		TrashHelper trashHelper) {
@@ -60,6 +66,7 @@ public class ViewFolderSectionDisplayContext extends BaseSectionDisplayContext {
 			translationInfoItemFieldValuesExporterRegistry);
 
 		_objectEntryFolderLocalService = objectEntryFolderLocalService;
+		_sharingEntryLocalService = sharingEntryLocalService;
 		_trashHelper = trashHelper;
 	}
 
@@ -117,27 +124,47 @@ public class ViewFolderSectionDisplayContext extends BaseSectionDisplayContext {
 		Group group = groupLocalService.fetchGroup(
 			objectEntryFolder.getGroupId());
 
-		addBreadcrumbItem(
-			jsonArray, false,
-			ActionUtil.getSpaceURL(group.getClassPK(), themeDisplay),
-			group.getName(themeDisplay.getLocale()));
+		boolean hideSpace = true;
 
 		String[] parts = StringUtil.split(
 			objectEntryFolder.getTreePath(), CharPool.SLASH);
 
-		if (parts.length > 2) {
-			for (int i = 1; i < (parts.length - 1); i++) {
-				ObjectEntryFolder objectEntryFolder =
-					_objectEntryFolderLocalService.fetchObjectEntryFolder(
-						GetterUtil.getLong(parts[i]));
+		int firstAncestorIndex = 1;
 
-				addBreadcrumbItem(
-					jsonArray, false,
-					ActionUtil.getViewFolderURL(
-						objectEntryFolder.getObjectEntryFolderId(),
-						themeDisplay),
-					objectEntryFolder.getLabel(themeDisplay.getLocale()));
+		PermissionChecker permissionChecker =
+			themeDisplay.getPermissionChecker();
+
+		if (permissionChecker.hasPermission(
+				group, DepotEntry.class.getName(), group.getClassPK(),
+				ActionKeys.VIEW)) {
+
+			hideSpace = false;
+
+			addBreadcrumbItem(
+				jsonArray, false,
+				ActionUtil.getSpaceURL(group.getClassPK(), themeDisplay),
+				group.getName(themeDisplay.getLocale()));
+		}
+		else {
+			firstAncestorIndex = _getSharedRootIndex(
+				parts, permissionChecker.getUserId());
+		}
+
+		for (int i = firstAncestorIndex; i < (parts.length - 1); i++) {
+			ObjectEntryFolder ancestorObjectEntryFolder =
+				_objectEntryFolderLocalService.fetchObjectEntryFolder(
+					GetterUtil.getLong(parts[i]));
+
+			if (ancestorObjectEntryFolder == null) {
+				continue;
 			}
+
+			addBreadcrumbItem(
+				jsonArray, false,
+				ActionUtil.getViewFolderURL(
+					ancestorObjectEntryFolder.getObjectEntryFolderId(),
+					themeDisplay),
+				ancestorObjectEntryFolder.getLabel(themeDisplay.getLocale()));
 		}
 
 		addBreadcrumbItem(
@@ -155,6 +182,8 @@ public class ViewFolderSectionDisplayContext extends BaseSectionDisplayContext {
 				return GetterUtil.get(
 					unicodeProperties.get("logoColor"), "outline-0");
 			}
+		).put(
+			"hideSpace", hideSpace
 		).put(
 			"size", "sm"
 		).build();
@@ -331,6 +360,22 @@ public class ViewFolderSectionDisplayContext extends BaseSectionDisplayContext {
 		return true;
 	}
 
+	private int _getSharedRootIndex(String[] parts, long userId) {
+		long classNameId = PortalUtil.getClassNameId(
+			ObjectEntryFolder.class.getName());
+
+		for (int i = 1; i < (parts.length - 1); i++) {
+			if (_sharingEntryLocalService.hasSharingPermission(
+					userId, classNameId, GetterUtil.getLong(parts[i]),
+					SharingEntryAction.VIEW)) {
+
+				return i;
+			}
+		}
+
+		return parts.length - 1;
+	}
+
 	private boolean _isContentsFolder() {
 		return Objects.equals(
 			getRootObjectEntryFolderExternalReferenceCode(),
@@ -340,6 +385,7 @@ public class ViewFolderSectionDisplayContext extends BaseSectionDisplayContext {
 	private final ObjectEntryFolderLocalService _objectEntryFolderLocalService;
 	private String _objectFolderExternalReferenceCode;
 	private String _rootObjectEntryFolderExternalReferenceCode;
+	private final SharingEntryLocalService _sharingEntryLocalService;
 	private final TrashHelper _trashHelper;
 
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ViewFolderJSPSectionFragmentRenderer.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ViewFolderJSPSectionFragmentRenderer.java
@@ -13,6 +13,7 @@ import com.liferay.object.service.ObjectEntryFolderLocalService;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.sharing.service.SharingEntryLocalService;
 import com.liferay.site.cms.site.initializer.internal.display.context.ViewFolderSectionDisplayContext;
 import com.liferay.trash.TrashHelper;
 
@@ -54,7 +55,7 @@ public class ViewFolderJSPSectionFragmentRenderer
 		return new ViewFolderSectionDisplayContext(
 			_depotEntryLocalService, _dlConfiguration, _groupLocalService,
 			httpServletRequest, language, _objectDefinitionService,
-			_objectEntryFolderLocalService, _portal,
+			_objectEntryFolderLocalService, _portal, _sharingEntryLocalService,
 			translationInfoItemFieldValuesExporterRegistry, _trashHelper);
 	}
 
@@ -79,6 +80,9 @@ public class ViewFolderJSPSectionFragmentRenderer
 
 	@Reference
 	private Portal _portal;
+
+	@Reference
+	private SharingEntryLocalService _sharingEntryLocalService;
 
 	@Reference
 	private TrashHelper _trashHelper;


### PR DESCRIPTION
**LPD-92148** — Shared With Me: recipient could see the origin space structure via breadcrumbs.

When a CMS folder shared from another space was opened from Shared With Me, the breadcrumb rendered the full origin hierarchy (e.g. `Space > Folder > Subfolder`), exposing structure the recipient has no access to.

`ViewFolderSectionDisplayContext#getBreadcrumbProps` now scopes the breadcrumb:

- If the user can view the origin space (owner, member, CMS administrator), the full breadcrumb is shown.
- Otherwise the folder was reached through a share, so the origin space is hidden (`hideSpace=true`) and the breadcrumb is scoped to the shared subtree — only the shared folder and the folders below it — using `SharingEntry` to locate the shared root (folder `VIEW` is granted to the USER role by default, so it cannot be used as the discriminator).

Covered by the integration test `ViewFolderSectionDisplayContextTest#testGetBreadcrumbProps`: owner, share recipient (shared folder and its subfolder), and CMS administrator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)