### PR TITLE
LPD-92077 | Prevent access to folders outside configured root folder

### DIFF
--- a/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/portlet/action/test/IGDisplayViewMVCRenderCommandTest.java
+++ b/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/portlet/action/test/IGDisplayViewMVCRenderCommandTest.java
@@ -1,0 +1,170 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.document.library.web.internal.portlet.action.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.document.library.constants.DLPortletKeys;
+import com.liferay.document.library.kernel.service.DLAppLocalService;
+import com.liferay.document.library.test.util.DLAppTestUtil;
+import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
+import com.liferay.portal.kernel.repository.model.Folder;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletRenderRequest;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletRenderResponse;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.theme.PortletDisplay;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import jakarta.portlet.PortletPreferences;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * @author Ankita Malik
+ */
+@RunWith(Arquillian.class)
+public class IGDisplayViewMVCRenderCommandTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_company = _companyLocalService.getCompany(_group.getCompanyId());
+
+		_layout = LayoutTestUtil.addTypePortletLayout(_group);
+
+		_layoutWithoutRootFolder = LayoutTestUtil.addTypePortletLayout(_group);
+
+		_rootFolder = DLAppTestUtil.addFolder(_group.getGroupId());
+
+		_childFolder = _dlAppLocalService.addFolder(
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
+			_rootFolder.getFolderId(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(),
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId()));
+
+		_folderOutsideRootFolder = DLAppTestUtil.addFolder(_group.getGroupId());
+
+		PortletPreferences portletPreferences =
+			PortletPreferencesFactoryUtil.getStrictPortletSetup(
+				_layout, DLPortletKeys.MEDIA_GALLERY_DISPLAY);
+
+		portletPreferences.setValue(
+			"rootFolderExternalReferenceCode",
+			_rootFolder.getExternalReferenceCode());
+
+		portletPreferences.store();
+	}
+
+	@Test
+	@TestInfo("LPD-92077")
+	public void testRender() throws Exception {
+		Assert.assertEquals(
+			"/image_gallery_display/view.jsp",
+			_render(_layout, _rootFolder.getFolderId()));
+
+		Assert.assertEquals(
+			"/image_gallery_display/view.jsp",
+			_render(_layout, _childFolder.getFolderId()));
+
+		Assert.assertEquals(
+			"/image_gallery_display/view.jsp",
+			_render(
+				_layoutWithoutRootFolder,
+				_folderOutsideRootFolder.getFolderId()));
+
+		Assert.assertEquals(
+			"/document_library/error.jsp",
+			_render(_layout, _folderOutsideRootFolder.getFolderId()));
+	}
+
+	private ThemeDisplay _getThemeDisplay(Layout layout) throws Exception {
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		themeDisplay.setCompany(_company);
+		themeDisplay.setLayout(layout);
+		themeDisplay.setPermissionChecker(
+			PermissionThreadLocal.getPermissionChecker());
+		themeDisplay.setRealUser(TestPropsValues.getUser());
+		themeDisplay.setScopeGroupId(_group.getGroupId());
+		themeDisplay.setUser(TestPropsValues.getUser());
+
+		PortletDisplay portletDisplay = themeDisplay.getPortletDisplay();
+
+		portletDisplay.setId(DLPortletKeys.MEDIA_GALLERY_DISPLAY);
+
+		return themeDisplay;
+	}
+
+	private String _render(Layout layout, long folderId) throws Exception {
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, _getThemeDisplay(layout));
+		mockHttpServletRequest.setParameter(
+			"folderId", String.valueOf(folderId));
+
+		return _igDisplayViewMVCRenderCommand.render(
+			new MockLiferayPortletRenderRequest(mockHttpServletRequest),
+			new MockLiferayPortletRenderResponse());
+	}
+
+	private Folder _childFolder;
+	private Company _company;
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
+
+	@Inject
+	private DLAppLocalService _dlAppLocalService;
+
+	private Folder _folderOutsideRootFolder;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject(
+		filter = "component.name=com.liferay.document.library.web.internal.portlet.action.IGDisplayViewMVCRenderCommand"
+	)
+	private MVCRenderCommand _igDisplayViewMVCRenderCommand;
+
+	private Layout _layout;
+	private Layout _layoutWithoutRootFolder;
+	private Folder _rootFolder;
+
+}

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/ActionUtil.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/ActionUtil.java
@@ -9,6 +9,7 @@ import com.liferay.document.library.constants.DLFileVersionPreviewConstants;
 import com.liferay.document.library.kernel.exception.NoSuchFileEntryException;
 import com.liferay.document.library.kernel.exception.NoSuchFileShortcutException;
 import com.liferay.document.library.kernel.exception.NoSuchFolderException;
+import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.processor.RawMetadataProcessorUtil;
 import com.liferay.document.library.kernel.service.DLAppServiceUtil;
 import com.liferay.document.library.service.DLFileVersionPreviewLocalServiceUtil;
@@ -205,18 +206,20 @@ public class ActionUtil {
 		boolean ignoreRootFolder = ParamUtil.getBoolean(
 			httpServletRequest, "ignoreRootFolder");
 
+		long rootFolderId = DLFolderConstants.DEFAULT_PARENT_FOLDER_ID;
+
+		try (SafeCloseable safeCloseable =
+				CTCollectionThreadLocal.setProductionModeWithSafeCloseable()) {
+
+			DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper =
+				new DLPortletInstanceSettingsHelper(
+					new DLRequestHelper(httpServletRequest));
+
+			rootFolderId = dlPortletInstanceSettingsHelper.getRootFolderId();
+		}
+
 		if ((folderId <= 0) && !ignoreRootFolder) {
-			try (SafeCloseable safeCloseable =
-					CTCollectionThreadLocal.
-						setProductionModeWithSafeCloseable()) {
-
-				DLPortletInstanceSettingsHelper
-					dlPortletInstanceSettingsHelper =
-						new DLPortletInstanceSettingsHelper(
-							new DLRequestHelper(httpServletRequest));
-
-				folderId = dlPortletInstanceSettingsHelper.getRootFolderId();
-			}
+			folderId = rootFolderId;
 		}
 
 		if (folderId <= 0) {
@@ -228,6 +231,8 @@ public class ActionUtil {
 		}
 
 		Folder folder = DLAppServiceUtil.getFolder(folderId);
+
+		DLFolderUtil.validateFolder(folder, rootFolderId);
 
 		DLFolderUtil.validateDepotFolder(
 			folderId, folder.getGroupId(), themeDisplay.getScopeGroupId());

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/util/DLFolderUtil.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/util/DLFolderUtil.java
@@ -9,6 +9,7 @@ import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalServiceUtil;
 import com.liferay.document.library.kernel.exception.NoSuchFolderException;
+import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
@@ -58,6 +59,29 @@ public class DLFolderUtil {
 		if (!groupConnectedDepotEntries.contains(groupId)) {
 			throw new NoSuchFolderException("{folderId=" + folderId + "}");
 		}
+	}
+
+	public static void validateFolder(Folder folder, long rootFolderId)
+		throws PortalException {
+
+		if ((folder == null) ||
+			(rootFolderId == DLFolderConstants.DEFAULT_PARENT_FOLDER_ID)) {
+
+			return;
+		}
+
+		Folder ancestorFolder = folder;
+
+		while (ancestorFolder != null) {
+			if (ancestorFolder.getFolderId() == rootFolderId) {
+				return;
+			}
+
+			ancestorFolder = ancestorFolder.getParentFolder();
+		}
+
+		throw new NoSuchFolderException(
+			"{folderId=" + folder.getFolderId() + "}");
 	}
 
 }

--- a/modules/apps/document-library/document-library-web/src/test/java/com/liferay/document/library/web/internal/util/DLFolderUtilTest.java
+++ b/modules/apps/document-library/document-library-web/src/test/java/com/liferay/document/library/web/internal/util/DLFolderUtilTest.java
@@ -9,9 +9,11 @@ import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.depot.service.DepotEntryLocalServiceUtil;
 import com.liferay.document.library.kernel.exception.NoSuchFolderException;
+import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.module.service.Snapshot;
+import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
@@ -137,6 +139,59 @@ public class DLFolderUtilTest {
 			RandomTestUtil.randomLong());
 	}
 
+	@Test
+	public void testValidateFolderInsideRootFolder() throws PortalException {
+		long rootFolderId = RandomTestUtil.randomLong();
+
+		Folder rootFolder = _mockFolder(rootFolderId, null);
+
+		Folder folder = _mockFolder(RandomTestUtil.randomLong(), rootFolder);
+
+		DLFolderUtil.validateFolder(folder, rootFolderId);
+	}
+
+	@Test
+	public void testValidateFolderNestedUnderRootFolder()
+		throws PortalException {
+
+		long rootFolderId = RandomTestUtil.randomLong();
+
+		Folder rootFolder = _mockFolder(rootFolderId, null);
+
+		Folder parentFolder = _mockFolder(
+			RandomTestUtil.randomLong(), rootFolder);
+
+		Folder folder = _mockFolder(RandomTestUtil.randomLong(), parentFolder);
+
+		DLFolderUtil.validateFolder(folder, rootFolderId);
+	}
+
+	@Test(expected = NoSuchFolderException.class)
+	public void testValidateFolderOutsideRootFolder() throws PortalException {
+		Folder topFolder = _mockFolder(RandomTestUtil.randomLong(), null);
+
+		Folder folder = _mockFolder(RandomTestUtil.randomLong(), topFolder);
+
+		DLFolderUtil.validateFolder(folder, RandomTestUtil.randomLong());
+	}
+
+	@Test
+	public void testValidateFolderRootFolder() throws PortalException {
+		long rootFolderId = RandomTestUtil.randomLong();
+
+		Folder folder = _mockFolder(rootFolderId, null);
+
+		DLFolderUtil.validateFolder(folder, rootFolderId);
+	}
+
+	@Test
+	public void testValidateFolderWithoutRootFolder() throws PortalException {
+		Folder folder = _mockFolder(RandomTestUtil.randomLong(), null);
+
+		DLFolderUtil.validateFolder(
+			folder, DLFolderConstants.DEFAULT_PARENT_FOLDER_ID);
+	}
+
 	private DepotEntry _addDepotEntry(long depotGroupId) {
 		DepotEntry depotEntry = Mockito.mock(DepotEntry.class);
 
@@ -169,6 +224,26 @@ public class DLFolderUtilTest {
 
 	private List<DepotEntry> _getGroupConnectedDepotEntries(long depotGroupId) {
 		return ListUtil.fromArray(_addDepotEntry(depotGroupId));
+	}
+
+	private Folder _mockFolder(long folderId, Folder parentFolder)
+		throws PortalException {
+
+		Folder folder = Mockito.mock(Folder.class);
+
+		Mockito.doReturn(
+			folderId
+		).when(
+			folder
+		).getFolderId();
+
+		Mockito.doReturn(
+			parentFolder
+		).when(
+			folder
+		).getParentFolder();
+
+		return folder;
 	}
 
 }


### PR DESCRIPTION
{[LPD-92077](https://liferay.atlassian.net/browse/LPD-92077)}

Restrict access so that only folders within the configured root folder can be accessed, and prevent requests from reaching folders outside that allowed hierarchy.

# How am I fixing it?

Capture the configured root folder upfront and validate that the requested folder belongs to the same folder tree before allowing access. If the folder falls outside the configured root hierarchy, treat it as inaccessible.