### PR TITLE
LPD-92951 Set companyId when swapping the Journal content config

### DIFF
--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/web/internal/display/context/test/JournalContentDisplayContextTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/web/internal/display/context/test/JournalContentDisplayContextTest.java
@@ -225,6 +225,8 @@ public class JournalContentDisplayContextTest {
 					"com.liferay.journal.content.web.internal.configuration." +
 						"JournalContentPortletInstanceConfiguration",
 					HashMapDictionaryBuilder.<String, Object>put(
+						"companyId", String.valueOf(childGroup.getCompanyId())
+					).put(
 						"groupId", String.valueOf(childGroup.getGroupId())
 					).build())) {
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92951

## What Is Being Fixed

`JournalContentDisplayContextTest#testGetArticleGroupId` saved a `JournalContentPortletInstanceConfiguration` (scope `PORTLET_INSTANCE`) with only a `groupId` property. The warning added in LPD-75854 (`ConfigurationImportGlobalConfigurationModelListener`) infers "group scoped" from the presence of a `groupId` property — whose key collides with the `GROUP` scope key — and logs an ERROR because no `companyId` is present. `LogAssertionTestRule` turns that ERROR into an `AssertionError` that leaks into the integration-test log scanned by `PortalLogAssertorTest#testScanXMLLog`, failing it.

## How It Is Being Fixed

The `ConfigurationTemporarySwapper` dictionary now also sets `companyId` alongside the existing `groupId`, so the listener's `companyId`-missing branch no longer fires. `companyId` is an undeclared property that the typed configuration ignores, so the test's assertion (the display context resolves the article's `groupId`) is unchanged; the scanned log stays clean and `PortalLogAssertorTest#testScanXMLLog` passes.

## Why Are There No Tests?

This change is itself a fix to an existing integration test; it adjusts test setup only and adds no production code.
