### PR TITLE
LPD-91101 Bypass permission filter for CMS and Space administrators

### DIFF
--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/build.gradle
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/build.gradle
@@ -15,6 +15,7 @@ dependencies {
 	compileOnly project(":apps:batch-engine:batch-engine-api")
 	compileOnly project(":apps:client-extension:client-extension-api")
 	compileOnly project(":apps:client-extension:client-extension-type-api")
+	compileOnly project(":apps:depot:depot-api")
 	compileOnly project(":apps:document-library:document-library-api")
 	compileOnly project(":apps:export-import:export-import-api")
 	compileOnly project(":apps:fragment:fragment-api")

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SiteResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SiteResourceImpl.java
@@ -10,6 +10,7 @@ import com.liferay.headless.admin.site.dto.v1_0.AnalyticsConfiguration;
 import com.liferay.headless.admin.site.dto.v1_0.GoogleAnalyticsConfiguration;
 import com.liferay.headless.admin.site.dto.v1_0.RatingsTypes;
 import com.liferay.headless.admin.site.dto.v1_0.Site;
+import com.liferay.headless.admin.site.internal.util.CMSPermissionUtil;
 import com.liferay.headless.admin.site.resource.v1_0.SiteResource;
 import com.liferay.layout.util.LayoutServiceContextHelper;
 import com.liferay.petra.function.UnsafeFunction;
@@ -73,6 +74,7 @@ import java.io.File;
 import java.io.Serializable;
 
 import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -310,13 +312,14 @@ public class SiteResourceImpl extends BaseSiteResourceImpl {
 			Boolean active, String search, Pagination pagination)
 		throws Exception {
 
+		long companyId = contextCompany.getCompanyId();
+
 		long[] classNameIds = {
 			_portal.getClassNameId(Company.class.getName()),
 			_portal.getClassNameId(Group.class.getName())
 		};
 
-		List<Group> groups = _groupService.search(
-			contextCompany.getCompanyId(), classNameIds, search, null,
+		LinkedHashMap<String, Object> params =
 			LinkedHashMapBuilder.<String, Object>put(
 				"active",
 				() -> {
@@ -328,9 +331,24 @@ public class SiteResourceImpl extends BaseSiteResourceImpl {
 				}
 			).put(
 				"site", true
-			).build(),
-			true, QueryUtil.ALL_POS, QueryUtil.ALL_POS,
-			new GroupNameComparator());
+			).build();
+
+		List<Group> groups = null;
+
+		if (CMSPermissionUtil.isSpaceAdmin(
+				companyId, contextUser.getUserId())) {
+
+			groups = _groupLocalService.search(
+				companyId, classNameIds, search, null, params, true,
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS,
+				new GroupNameComparator());
+		}
+		else {
+			groups = _groupService.search(
+				companyId, classNameIds, search, null, params, true,
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS,
+				new GroupNameComparator());
+		}
 
 		return Page.of(
 			HashMapBuilder.put(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SiteTemplateResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SiteTemplateResourceImpl.java
@@ -6,9 +6,11 @@
 package com.liferay.headless.admin.site.internal.resource.v1_0;
 
 import com.liferay.headless.admin.site.dto.v1_0.SiteTemplate;
+import com.liferay.headless.admin.site.internal.util.CMSPermissionUtil;
 import com.liferay.headless.admin.site.resource.v1_0.SiteTemplateResource;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.LayoutSetPrototype;
+import com.liferay.portal.kernel.service.LayoutSetPrototypeLocalService;
 import com.liferay.portal.kernel.service.LayoutSetPrototypeService;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Localization;
@@ -35,16 +37,29 @@ public class SiteTemplateResourceImpl extends BaseSiteTemplateResourceImpl {
 			Boolean active, Pagination pagination)
 		throws Exception {
 
+		long companyId = contextCompany.getCompanyId();
+
+		if (CMSPermissionUtil.isSpaceAdmin(
+				companyId, contextUser.getUserId())) {
+
+			return Page.of(
+				transform(
+					_layoutSetPrototypeLocalService.search(
+						companyId, active, pagination.getStartPosition(),
+						pagination.getEndPosition(), null),
+					this::_toSiteTemplate),
+				pagination,
+				_layoutSetPrototypeLocalService.searchCount(companyId, active));
+		}
+
 		return Page.of(
 			transform(
 				_layoutSetPrototypeService.search(
-					contextCompany.getCompanyId(), active,
-					pagination.getStartPosition(), pagination.getEndPosition(),
-					null),
+					companyId, active, pagination.getStartPosition(),
+					pagination.getEndPosition(), null),
 				this::_toSiteTemplate),
 			pagination,
-			_layoutSetPrototypeService.searchCount(
-				contextCompany.getCompanyId(), active));
+			_layoutSetPrototypeService.searchCount(companyId, active));
 	}
 
 	private SiteTemplate _toSiteTemplate(
@@ -95,6 +110,9 @@ public class SiteTemplateResourceImpl extends BaseSiteTemplateResourceImpl {
 			}
 		};
 	}
+
+	@Reference
+	private LayoutSetPrototypeLocalService _layoutSetPrototypeLocalService;
 
 	@Reference
 	private LayoutSetPrototypeService _layoutSetPrototypeService;

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/util/CMSPermissionUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/util/CMSPermissionUtil.java
@@ -1,0 +1,63 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.site.internal.util;
+
+import com.liferay.depot.constants.DepotRolesConstants;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.UserGroupRole;
+import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
+import com.liferay.portal.kernel.service.UserGroupRoleLocalServiceUtil;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * @author Balázs Sáfrány-Kovalik
+ */
+public class CMSPermissionUtil {
+
+	public static boolean isSpaceAdmin(long companyId, long userId)
+		throws PortalException {
+
+		if (RoleLocalServiceUtil.hasUserRole(
+				userId, companyId, RoleConstants.CMS_ADMINISTRATOR, true)) {
+
+			return true;
+		}
+
+		Set<Long> siteScopedRoleIds = new HashSet<>();
+
+		for (String roleName : _CMS_ADMIN_SPACE_ROLE_NAMES) {
+			Role role = RoleLocalServiceUtil.fetchRole(companyId, roleName);
+
+			if (role != null) {
+				siteScopedRoleIds.add(role.getRoleId());
+			}
+		}
+
+		if (siteScopedRoleIds.isEmpty()) {
+			return false;
+		}
+
+		for (UserGroupRole userGroupRole :
+				UserGroupRoleLocalServiceUtil.getUserGroupRoles(userId)) {
+
+			if (siteScopedRoleIds.contains(userGroupRole.getRoleId())) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private static final String[] _CMS_ADMIN_SPACE_ROLE_NAMES = {
+		DepotRolesConstants.ASSET_LIBRARY_ADMINISTRATOR,
+		DepotRolesConstants.ASSET_LIBRARY_OWNER
+	};
+
+}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/build.gradle
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/build.gradle
@@ -46,6 +46,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:site-navigation:site-navigation-api")
 	testIntegrationImplementation project(":apps:site-navigation:site-navigation-menu-item-api")
 	testIntegrationImplementation project(":apps:site:site-api")
+	testIntegrationImplementation project(":apps:site:site-cms-site-initializer-test-util")
 	testIntegrationImplementation project(":apps:style-book:style-book-api")
 	testIntegrationImplementation project(":apps:template:template-api")
 	testIntegrationImplementation project(":apps:template:template-test-util")

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SiteResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SiteResourceTest.java
@@ -32,7 +32,6 @@ import com.liferay.portal.kernel.model.LayoutSetPrototype;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.role.RoleConstants;
-import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutSetPrototypeLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
@@ -40,6 +39,7 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserGroupRoleLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.constants.TestDataConstants;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.HTTPTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -60,6 +60,8 @@ import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LanguageIds;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.site.cms.site.initializer.test.util.CMSTestUtil;
 import com.liferay.site.initializer.SiteInitializer;
 
@@ -74,7 +76,6 @@ import java.util.Map;
 
 import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -98,18 +99,10 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 
 	@ClassRule
 	@Rule
-	public static final LazyReferencingTestRule lazyReferencingTestRule =
-		LazyReferencingTestRule.INSTANCE;
-
-	@Before
-	@Override
-	public void setUp() throws Exception {
-		super.setUp();
-
-		_originalName = PrincipalThreadLocal.getName();
-
-		PrincipalThreadLocal.setName(TestPropsValues.getUserId());
-	}
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			LazyReferencingTestRule.INSTANCE, new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
 
 	@After
 	@Override
@@ -135,8 +128,6 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 
 			_groupLocalService.deleteGroup(group);
 		}
-
-		PrincipalThreadLocal.setName(_originalName);
 	}
 
 	@Override
@@ -1749,8 +1740,6 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 
 	@Inject
 	private LayoutSetPrototypeLocalService _layoutSetPrototypeLocalService;
-
-	private String _originalName;
 
 	@Inject
 	private RoleLocalService _roleLocalService;

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SiteResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SiteResourceTest.java
@@ -7,6 +7,7 @@ package com.liferay.headless.admin.site.resource.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.constants.DepotRolesConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.exportimport.test.rule.LazyReferencing;
@@ -28,11 +29,15 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.LayoutSetPrototype;
+import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutSetPrototypeLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.UserGroupRoleLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.constants.TestDataConstants;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
@@ -55,6 +60,7 @@ import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LanguageIds;
+import com.liferay.site.cms.site.initializer.test.util.CMSTestUtil;
 import com.liferay.site.initializer.SiteInitializer;
 
 import java.io.File;
@@ -183,6 +189,10 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 		_testGetSitesPageWithoutSiteMembership();
 		_testGetSitesPageWithSearch();
 		_testGetSitesPageWithoutAuthentication();
+		_testGetSitesPageWithCMSAdministrator();
+		_testGetSitesPageWithSpaceAdministrator();
+		_testGetSitesPageWithSpaceOwner();
+		_testGetSitesPageWithSpaceMember();
 	}
 
 	@LazyReferencing
@@ -401,6 +411,34 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 		}
 	}
 
+	private User _addUserWithRegularRole(String roleName) throws Exception {
+		User user = UserTestUtil.addUser(
+			testCompany, RandomTestUtil.randomString());
+
+		Role role = _roleLocalService.getRole(
+			testCompany.getCompanyId(), roleName);
+
+		_userLocalService.addRoleUser(role.getRoleId(), user.getUserId());
+
+		return user;
+	}
+
+	private User _addUserWithSpaceRole(DepotEntry depotEntry, String roleName)
+		throws Exception {
+
+		User user = UserTestUtil.addUser(
+			testCompany, RandomTestUtil.randomString());
+
+		Role role = _roleLocalService.getRole(
+			testCompany.getCompanyId(), roleName);
+
+		_userGroupRoleLocalService.addUserGroupRoles(
+			user.getUserId(), depotEntry.getGroupId(),
+			new long[] {role.getRoleId()});
+
+		return user;
+	}
+
 	private void _assertEquals(Group group, Site site) throws Exception {
 		Assert.assertEquals(site.getActive(), group.isActive());
 		Assert.assertEquals(
@@ -428,6 +466,18 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 
 		Assert.assertEquals(
 			site.getName(), group.getName(LocaleUtil.getDefault()));
+	}
+
+	private SiteResource _buildSiteResource(User user) {
+		return SiteResource.builder(
+		).authentication(
+			user.getEmailAddress(), user.getPasswordUnencrypted()
+		).endpoint(
+			testCompany.getVirtualHostname(),
+			PortalUtil.getPortalServerPort(false), "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
 	}
 
 	private void _testGetSitesPageWithActiveAndInactiveSites()
@@ -473,6 +523,18 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 		List<Site> existingItems = (List<Site>)sitesPage.getItems();
 
 		Assert.assertEquals(originalItems, existingItems);
+	}
+
+	private void _testGetSitesPageWithCMSAdministrator() throws Exception {
+		Site site = _testPostSite_addSite(randomSite());
+
+		Page<Site> page = _buildSiteResource(
+			_addUserWithRegularRole(RoleConstants.CMS_ADMINISTRATOR)
+		).getSitesPage(
+			null, null, Pagination.of(1, 500)
+		);
+
+		assertContains(site, (List<Site>)page.getItems());
 	}
 
 	private void _testGetSitesPageWithDepotEntry() throws Exception {
@@ -580,6 +642,53 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 		Assert.assertEquals(items.toString(), 1, items.size());
 
 		assertEquals(postSite, items.get(0));
+	}
+
+	private void _testGetSitesPageWithSpaceAdministrator() throws Exception {
+		Site site = _testPostSite_addSite(randomSite());
+
+		Page<Site> page = _buildSiteResource(
+			_addUserWithSpaceRole(
+				CMSTestUtil.addSpaceDepotEntry(),
+				DepotRolesConstants.ASSET_LIBRARY_ADMINISTRATOR)
+		).getSitesPage(
+			null, null, Pagination.of(1, 500)
+		);
+
+		assertContains(site, (List<Site>)page.getItems());
+	}
+
+	private void _testGetSitesPageWithSpaceMember() throws Exception {
+		SiteResource siteResource = _buildSiteResource(
+			_addUserWithSpaceRole(
+				CMSTestUtil.addSpaceDepotEntry(),
+				DepotRolesConstants.ASSET_LIBRARY_MEMBER));
+
+		long initialTotalCount = siteResource.getSitesPage(
+			null, null, Pagination.of(1, 1)
+		).getTotalCount();
+
+		_testPostSite_addSite(randomSite());
+
+		Assert.assertEquals(
+			initialTotalCount,
+			siteResource.getSitesPage(
+				null, null, Pagination.of(1, 1)
+			).getTotalCount());
+	}
+
+	private void _testGetSitesPageWithSpaceOwner() throws Exception {
+		Site site = _testPostSite_addSite(randomSite());
+
+		Page<Site> page = _buildSiteResource(
+			_addUserWithSpaceRole(
+				CMSTestUtil.addSpaceDepotEntry(),
+				DepotRolesConstants.ASSET_LIBRARY_OWNER)
+		).getSitesPage(
+			null, null, Pagination.of(1, 500)
+		);
+
+		assertContains(site, (List<Site>)page.getItems());
 	}
 
 	private void _testGetSiteWithDollar() throws Exception {
@@ -1642,7 +1751,14 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 	private LayoutSetPrototypeLocalService _layoutSetPrototypeLocalService;
 
 	private String _originalName;
+
+	@Inject
+	private RoleLocalService _roleLocalService;
+
 	private final List<Site> _sites = new ArrayList<>();
+
+	@Inject
+	private UserGroupRoleLocalService _userGroupRoleLocalService;
 
 	@Inject
 	private UserLocalService _userLocalService;

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SiteTemplateResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SiteTemplateResourceTest.java
@@ -6,20 +6,37 @@
 package com.liferay.headless.admin.site.resource.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotRolesConstants;
+import com.liferay.depot.model.DepotEntry;
 import com.liferay.headless.admin.site.client.dto.v1_0.SiteTemplate;
+import com.liferay.headless.admin.site.client.pagination.Page;
+import com.liferay.headless.admin.site.client.pagination.Pagination;
+import com.liferay.headless.admin.site.client.resource.v1_0.SiteTemplateResource;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.service.LayoutSetPrototypeLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.UserGroupRoleLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.Inject;
+import com.liferay.site.cms.site.initializer.test.util.CMSTestUtil;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+import org.junit.Assert;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
@@ -27,6 +44,17 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 public class SiteTemplateResourceTest extends BaseSiteTemplateResourceTestCase {
+
+	@Override
+	@Test
+	public void testGetSiteTemplatesPage() throws Exception {
+		super.testGetSiteTemplatesPage();
+
+		_testGetSiteTemplatesPageWithCMSAdministrator();
+		_testGetSiteTemplatesPageWithSpaceAdministrator();
+		_testGetSiteTemplatesPageWithSpaceMember();
+		_testGetSiteTemplatesPageWithSpaceOwner();
+	}
 
 	@Override
 	protected SiteTemplate randomSiteTemplate() throws Exception {
@@ -81,7 +109,122 @@ public class SiteTemplateResourceTest extends BaseSiteTemplateResourceTestCase {
 		return siteTemplate;
 	}
 
+	private User _addUserWithRegularRole(String roleName) throws Exception {
+		User user = UserTestUtil.addUser(
+			testCompany, RandomTestUtil.randomString());
+
+		Role role = _roleLocalService.getRole(
+			testCompany.getCompanyId(), roleName);
+
+		_userLocalService.addRoleUser(role.getRoleId(), user.getUserId());
+
+		return user;
+	}
+
+	private User _addUserWithSpaceRole(DepotEntry depotEntry, String roleName)
+		throws Exception {
+
+		User user = UserTestUtil.addUser(
+			testCompany, RandomTestUtil.randomString());
+
+		Role role = _roleLocalService.getRole(
+			testCompany.getCompanyId(), roleName);
+
+		_userGroupRoleLocalService.addUserGroupRoles(
+			user.getUserId(), depotEntry.getGroupId(),
+			new long[] {role.getRoleId()});
+
+		return user;
+	}
+
+	private SiteTemplateResource _buildSiteTemplateResource(User user) {
+		return SiteTemplateResource.builder(
+		).authentication(
+			user.getEmailAddress(), user.getPasswordUnencrypted()
+		).endpoint(
+			testCompany.getVirtualHostname(),
+			PortalUtil.getPortalServerPort(false), "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
+	}
+
+	private void _testGetSiteTemplatesPageWithCMSAdministrator()
+		throws Exception {
+
+		SiteTemplate siteTemplate = testGetSiteTemplatesPage_addSiteTemplate(
+			randomSiteTemplate());
+
+		Page<SiteTemplate> page = _buildSiteTemplateResource(
+			_addUserWithRegularRole(RoleConstants.CMS_ADMINISTRATOR)
+		).getSiteTemplatesPage(
+			null, Pagination.of(1, 500)
+		);
+
+		assertContains(siteTemplate, (List<SiteTemplate>)page.getItems());
+	}
+
+	private void _testGetSiteTemplatesPageWithSpaceAdministrator()
+		throws Exception {
+
+		SiteTemplate siteTemplate = testGetSiteTemplatesPage_addSiteTemplate(
+			randomSiteTemplate());
+
+		Page<SiteTemplate> page = _buildSiteTemplateResource(
+			_addUserWithSpaceRole(
+				CMSTestUtil.addSpaceDepotEntry(),
+				DepotRolesConstants.ASSET_LIBRARY_ADMINISTRATOR)
+		).getSiteTemplatesPage(
+			null, Pagination.of(1, 500)
+		);
+
+		assertContains(siteTemplate, (List<SiteTemplate>)page.getItems());
+	}
+
+	private void _testGetSiteTemplatesPageWithSpaceMember() throws Exception {
+		testGetSiteTemplatesPage_addSiteTemplate(randomSiteTemplate());
+
+		Page<SiteTemplate> page = _buildSiteTemplateResource(
+			_addUserWithSpaceRole(
+				CMSTestUtil.addSpaceDepotEntry(),
+				DepotRolesConstants.ASSET_LIBRARY_MEMBER)
+		).getSiteTemplatesPage(
+			null, Pagination.of(1, 500)
+		);
+
+		Assert.assertEquals(
+			page.getItems(
+			).toString(),
+			0,
+			page.getItems(
+			).size());
+	}
+
+	private void _testGetSiteTemplatesPageWithSpaceOwner() throws Exception {
+		SiteTemplate siteTemplate = testGetSiteTemplatesPage_addSiteTemplate(
+			randomSiteTemplate());
+
+		Page<SiteTemplate> page = _buildSiteTemplateResource(
+			_addUserWithSpaceRole(
+				CMSTestUtil.addSpaceDepotEntry(),
+				DepotRolesConstants.ASSET_LIBRARY_OWNER)
+		).getSiteTemplatesPage(
+			null, Pagination.of(1, 500)
+		);
+
+		assertContains(siteTemplate, (List<SiteTemplate>)page.getItems());
+	}
+
 	@Inject
 	private LayoutSetPrototypeLocalService _layoutSetPrototypeLocalService;
+
+	@Inject
+	private RoleLocalService _roleLocalService;
+
+	@Inject
+	private UserGroupRoleLocalService _userGroupRoleLocalService;
+
+	@Inject
+	private UserLocalService _userLocalService;
 
 }

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SiteTemplateResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SiteTemplateResourceTest.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserGroupRoleLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
@@ -28,6 +29,8 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.site.cms.site.initializer.test.util.CMSTestUtil;
 
 import java.util.HashMap;
@@ -36,6 +39,8 @@ import java.util.Locale;
 import java.util.Map;
 
 import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -44,6 +49,13 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 public class SiteTemplateResourceTest extends BaseSiteTemplateResourceTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
 
 	@Override
 	@Test

--- a/modules/apps/site/site-cms-site-initializer-test-util/build.gradle
+++ b/modules/apps/site/site-cms-site-initializer-test-util/build.gradle
@@ -4,6 +4,7 @@ dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.test", version: "default"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:batch-engine:batch-engine-test-util")
+	compileOnly project(":apps:depot:depot-api")
 	compileOnly project(":apps:object:object-api")
 	compileOnly project(":apps:site:site-api")
 	compileOnly project(":apps:site:site-cms-site-initializer-api")

--- a/modules/apps/site/site-cms-site-initializer-test-util/src/main/java/com/liferay/site/cms/site/initializer/test/util/CMSTestUtil.java
+++ b/modules/apps/site/site-cms-site-initializer-test-util/src/main/java/com/liferay/site/cms/site/initializer/test/util/CMSTestUtil.java
@@ -6,6 +6,9 @@
 package com.liferay.site.cms.site.initializer.test.util;
 
 import com.liferay.batch.engine.test.util.BatchEngineTestUtil;
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalServiceUtil;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
@@ -20,6 +23,9 @@ import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.site.initializer.SiteInitializer;
 import com.liferay.site.initializer.SiteInitializerRegistry;
 
@@ -28,6 +34,18 @@ import com.liferay.site.initializer.SiteInitializerRegistry;
  * @author Stefano Motta
  */
 public class CMSTestUtil {
+
+	public static DepotEntry addSpaceDepotEntry() throws Exception {
+		return DepotEntryLocalServiceUtil.addDepotEntry(
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), StringUtil.randomString()
+			).build(),
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), StringUtil.randomString()
+			).build(),
+			DepotConstants.TYPE_SPACE,
+			ServiceContextTestUtil.getServiceContext());
+	}
 
 	public static Group getOrAddGroup(Class<?> clazz) throws Exception {
 		Group group = GroupLocalServiceUtil.fetchGroup(


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-91101

CMS Administrator and Space Administrator users cannot see Sites or Site Templates in the Connected Sites modal on a Space. The headless endpoints `/v1.0/sites` and `/v1.0/site-templates` apply a row-level VIEW filter at the persistence layer, and these roles have no explicit VIEW grant on individual `Group` / `LayoutSetPrototype` rows, so the autocomplete returns an empty list.

# How am I fixing it?

CMS Administrator, Asset Library Administrator, and Asset Library Owner users now hit `LocalService.search` from `/v1.0/sites` and `/v1.0/site-templates`, bypassing resource permission checking.

# How can you verify that it works?

Run the included automated tests:

```bash
cd modules/apps/headless/headless-admin-site/headless-admin-site-test
gw testIntegration --tests SiteResourceTest --tests SiteTemplateResourceTest
```