### PR TITLE
LPD-92291 Technical Task | [Frontend] Review and Fix small things and testing

### DIFF
--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/share_modal_content/ShareModalContent.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/share_modal_content/ShareModalContent.tsx
@@ -643,7 +643,7 @@ export default function ShareModalContent({
 								</span>
 							)}
 
-							{Liferay.Language.get('save')}
+							{Liferay.Language.get('share')}
 						</ClayButton>
 					</ClayButton.Group>
 				}

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/share_modal_content/ShareModalContent.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/share_modal_content/ShareModalContent.tsx
@@ -73,6 +73,10 @@ const _defaultCollaboratorBadgeText = ({
 }: CollaboratorBadgeProps): string | null =>
 	toBeShared ? Liferay.Language.get('to-be-shared') : null;
 
+const _defaultCollaboratorNameSuffix = (
+	_props: CollaboratorIconProps
+): string | null => null;
+
 const _defaultAutocompleteItem = ({type, user}: CollaboratorIconProps) => (
 	<div className="autofit-row autofit-row-center">
 		<div className="autofit-col c-mr-1">
@@ -110,6 +114,7 @@ function CollaboratorListItem({
 	alwaysShowPermissionSelector = false,
 	canManageCollaborators = true,
 	collaboratorBadgeText,
+	collaboratorNameSuffix,
 	collaboratorStickerIcon,
 	dateExpired,
 	error,
@@ -127,6 +132,7 @@ function CollaboratorListItem({
 	alwaysShowPermissionSelector?: boolean;
 	canManageCollaborators?: boolean;
 	collaboratorBadgeText: (props: CollaboratorBadgeProps) => string | null;
+	collaboratorNameSuffix: (props: CollaboratorIconProps) => string | null;
 	collaboratorStickerIcon: (props: CollaboratorIconProps) => React.ReactNode;
 	dateExpired?: string;
 	error?: string;
@@ -148,6 +154,7 @@ function CollaboratorListItem({
 	};
 
 	const badgeText = collaboratorBadgeText({toBeShared, type, user});
+	const nameSuffix = collaboratorNameSuffix({type, user});
 
 	return (
 		<li
@@ -166,6 +173,12 @@ function CollaboratorListItem({
 						<span className="text-3 text-truncate text-weight-semi-bold">
 							{user.name}
 						</span>
+
+						{nameSuffix ? (
+							<span className="c-ml-1 text-3 text-secondary">
+								{nameSuffix}
+							</span>
+						) : null}
 
 						{badgeText ? (
 							<ClayBadge
@@ -310,6 +323,7 @@ export default function ShareModalContent({
 	canManageCollaborators = true,
 	closeModal,
 	collaboratorBadgeText = _defaultCollaboratorBadgeText,
+	collaboratorNameSuffix = _defaultCollaboratorNameSuffix,
 	collaboratorStickerIcon = _defaultCollaboratorStickerIcon,
 	collaboratorsListTitle = Liferay.Language.get('who-has-access'),
 	creator,
@@ -550,6 +564,9 @@ export default function ShareModalContent({
 										}
 										collaboratorBadgeText={
 											collaboratorBadgeText
+										}
+										collaboratorNameSuffix={
+											collaboratorNameSuffix
 										}
 										collaboratorStickerIcon={
 											collaboratorStickerIcon

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/share_modal_content/types.ts
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/share_modal_content/types.ts
@@ -67,6 +67,7 @@ export interface ShareModalContentProps {
 	canManageCollaborators?: boolean;
 	closeModal: () => void;
 	collaboratorBadgeText?: (props: CollaboratorBadgeProps) => string | null;
+	collaboratorNameSuffix?: (props: CollaboratorIconProps) => string | null;
 	collaboratorStickerIcon?: (props: CollaboratorIconProps) => ReactNode;
 	collaboratorsListTitle?: string;
 	creator: ShareModalCreator;

--- a/modules/apps/frontend-js/frontend-js-components-web/test/share_modal_content/ShareModalContent.test.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/test/share_modal_content/ShareModalContent.test.tsx
@@ -205,15 +205,15 @@ describe('ShareModalContent', () => {
 		).toHaveTextContent(/owner/);
 	});
 
-	it('renders the cancel and save buttons', () => {
+	it('renders the cancel and share buttons', () => {
 		const {getByText} = renderComponent();
 
 		expect(getByText('cancel')).toBeInTheDocument();
 
-		const saveButton = getByText('save');
+		const shareButton = getByText('share');
 
-		expect(saveButton).toBeInTheDocument();
-		expect(saveButton).toBeDisabled();
+		expect(shareButton).toBeInTheDocument();
+		expect(shareButton).toBeDisabled();
 	});
 
 	it('calls search when the autocomplete input changes', async () => {
@@ -246,7 +246,7 @@ describe('ShareModalContent', () => {
 		});
 	});
 
-	it('calls submission when save is clicked', async () => {
+	it('calls submission when share is clicked', async () => {
 		const {getByLabelText, getByRole, getByText} = renderComponent();
 
 		fireEvent.click(getByLabelText('more-options'));
@@ -262,11 +262,11 @@ describe('ShareModalContent', () => {
 		});
 
 		waitFor(() => {
-			expect(getByText('save')).toBeEnabled();
+			expect(getByText('share')).toBeEnabled();
 		});
 
 		await act(async () => {
-			fireEvent.click(getByText('save'));
+			fireEvent.click(getByText('share'));
 		});
 
 		expect(mockOnCollaboratorsUpdate).toHaveBeenCalledWith([

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/modal/share_modal_content/CMSShareModalContent.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/modal/share_modal_content/CMSShareModalContent.tsx
@@ -282,6 +282,11 @@ export default function CMSShareModalContent({
 		return toBeShared ? Liferay.Language.get('to-be-shared') : null;
 	};
 
+	const collaboratorNameSuffix = ({type}: {type: CollaboratorType}) =>
+		externalUserSharingEnabled && type === COLLABORATOR_TYPE.EXTERNAL_USER
+			? `(${Liferay.Language.get('guest').toLocaleLowerCase()})`
+			: null;
+
 	const collaboratorStickerIcon = ({
 		type,
 		user,
@@ -333,6 +338,7 @@ export default function CMSShareModalContent({
 			canManageCollaborators={canManageCollaborators}
 			closeModal={closeModal}
 			collaboratorBadgeText={collaboratorBadgeText}
+			collaboratorNameSuffix={collaboratorNameSuffix}
 			collaboratorStickerIcon={collaboratorStickerIcon}
 			creator={creator}
 			initialCollaborators={

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/modal/share_modal_content/CMSShareModalContent.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/modal/share_modal_content/CMSShareModalContent.tsx
@@ -272,11 +272,10 @@ export default function CMSShareModalContent({
 	}): string | null => {
 		if (
 			externalUserSharingEnabled &&
-			type === COLLABORATOR_TYPE.EXTERNAL_USER
+			type === COLLABORATOR_TYPE.EXTERNAL_USER &&
+			!toBeShared
 		) {
-			return toBeShared
-				? Liferay.Language.get('pending')
-				: Liferay.Language.get('invited');
+			return Liferay.Language.get('invited');
 		}
 
 		return toBeShared ? Liferay.Language.get('to-be-shared') : null;

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/modal/share_modal_content/CMSShareModalContent.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/modal/share_modal_content/CMSShareModalContent.tsx
@@ -281,7 +281,12 @@ export default function CMSShareModalContent({
 		return toBeShared ? Liferay.Language.get('to-be-shared') : null;
 	};
 
-	const collaboratorNameSuffix = ({type}: {type: CollaboratorType}) =>
+	const collaboratorNameSuffix = ({
+		type,
+	}: {
+		type: CollaboratorType;
+		user: ShareModalUserAccount | ShareModalUserGroup;
+	}): string | null =>
 		externalUserSharingEnabled && type === COLLABORATOR_TYPE.EXTERNAL_USER
 			? `(${Liferay.Language.get('guest').toLocaleLowerCase()})`
 			: null;

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/modal/CMSShareModalContent.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/modal/CMSShareModalContent.test.tsx
@@ -125,15 +125,15 @@ describe('CMSShareModalContent', () => {
 		).toHaveTextContent(/owner/);
 	});
 
-	it('renders the cancel and save buttons', () => {
+	it('renders the cancel and share buttons', () => {
 		const {getByText} = renderComponent();
 
 		expect(getByText('cancel')).toBeInTheDocument();
 
-		const saveButton = getByText('save');
+		const shareButton = getByText('share');
 
-		expect(saveButton).toBeInTheDocument();
-		expect(saveButton).toBeDisabled();
+		expect(shareButton).toBeInTheDocument();
+		expect(shareButton).toBeDisabled();
 	});
 
 	it('calls search when the autocomplete input changes', async () => {
@@ -166,7 +166,7 @@ describe('CMSShareModalContent', () => {
 		});
 	});
 
-	it('calls submission when save is clicked', async () => {
+	it('calls submission when share is clicked', async () => {
 		const {getByLabelText, getByRole, getByText} = renderComponent();
 
 		fireEvent.click(getByLabelText('more-options'));
@@ -182,11 +182,11 @@ describe('CMSShareModalContent', () => {
 		});
 
 		waitFor(() => {
-			expect(getByText('save')).toBeEnabled();
+			expect(getByText('share')).toBeEnabled();
 		});
 
 		await act(async () => {
-			fireEvent.click(getByText('save'));
+			fireEvent.click(getByText('share'));
 		});
 
 		const fetchMock = global.fetch as jest.Mock;
@@ -457,7 +457,7 @@ describe('CMSShareModalContent', () => {
 		});
 
 		await act(async () => {
-			fireEvent.click(getByText('save'));
+			fireEvent.click(getByText('share'));
 		});
 
 		const fetchMock = global.fetch as jest.Mock;
@@ -514,7 +514,7 @@ describe('CMSShareModalContent', () => {
 		});
 
 		await act(async () => {
-			fireEvent.click(getByText('save'));
+			fireEvent.click(getByText('share'));
 		});
 
 		const fetchMock = global.fetch as jest.Mock;

--- a/modules/test/playwright/helpers/ObjectEntryApiHelper.ts
+++ b/modules/test/playwright/helpers/ObjectEntryApiHelper.ts
@@ -164,6 +164,17 @@ export class ObjectEntryApiHelper {
 		);
 	}
 
+	async getObjectEntryCollaboratorsPage(
+		applicationName: string,
+		objectEntryId: number
+	) {
+		const response = await this.apiHelpers.get(
+			`${this.apiHelpers.baseUrl}${applicationName}/${objectEntryId}/collaborators`
+		);
+
+		return response?.items;
+	}
+
 	async postObjectEntryCollaborators(
 		data: DataObject[],
 		applicationName: string,

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/emailSharing.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/emailSharing.spec.ts
@@ -1,0 +1,215 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
+import {loginTest} from '../../../fixtures/loginTest';
+import getRandomString from '../../../utils/getRandomString';
+import {cmsPagesTest} from './fixtures/cmsPagesTest';
+
+const test = mergeTests(
+	cmsPagesTest,
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+		'LPD-34594': {enabled: true},
+		'LPD-52006': {enabled: true},
+	}),
+	loginTest()
+);
+
+test(
+	'External email collaborator is added as a guest with VIEW-only access',
+	{tag: '@LPD-85836'},
+	async ({apiHelpers, assetsPage, page, shareModalPage}) => {
+		const spaceName = `Space ${getRandomString()}`;
+
+		await test.step('Create a new space', async () => {
+			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+				name: spaceName,
+				type: 'Space',
+			});
+		});
+
+		const objectEntryTitle = `Content ${getRandomString()}`;
+
+		const objectEntry =
+			await test.step('Create a content in the space', async () => {
+				return await apiHelpers.objectEntry.postObjectEntry(
+					{
+						objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+						title: objectEntryTitle,
+					},
+					'cms/basic-web-contents',
+					spaceName
+				);
+			});
+
+		const emailAddress = 'external@example.com';
+
+		await test.step('Open the Share modal on the content', async () => {
+			await assetsPage.gotoContents(spaceName);
+
+			await assetsPage.execItemAction({
+				action: 'Share',
+				filter: objectEntryTitle,
+			});
+
+			await expect(
+				shareModalPage.getHeader(objectEntryTitle)
+			).toBeVisible();
+		});
+
+		await test.step('Type the external email and pick the invite option', async () => {
+			await shareModalPage.typeInCollaboratorInput(emailAddress);
+
+			await expect(shareModalPage.inviteExternalUserOption).toBeVisible();
+
+			await shareModalPage.inviteExternalUserOption.click();
+		});
+
+		await test.step('Verify the guest chip is rendered with VIEW-only access', async () => {
+			await expect(
+				page.getByText(emailAddress, {exact: false})
+			).toBeVisible();
+
+			await expect(page.getByText('(guest)')).toBeVisible();
+
+			await expect(page.getByText('To Be Shared')).toBeVisible();
+
+			await expect(page.getByLabel('Allow Resharing')).not.toBeVisible();
+		});
+
+		await test.step('Submit the share modal', async () => {
+			await shareModalPage.submit();
+
+			await expect(
+				shareModalPage.getHeader(objectEntryTitle)
+			).not.toBeVisible();
+		});
+
+		await test.step('Verify the collaborator is persisted as type=Email', async () => {
+			const collaborators =
+				await apiHelpers.objectEntry.getObjectEntryCollaboratorsPage(
+					'cms/basic-web-contents',
+					objectEntry.id
+				);
+
+			expect(collaborators).toHaveLength(1);
+			expect(collaborators[0]).toMatchObject({
+				actionIds: ['VIEW'],
+				emailAddress,
+				type: 'Email',
+			});
+		});
+	}
+);
+
+test(
+	'Email matching an existing user resolves to a User collaborator instead of a guest',
+	{tag: '@LPD-85836'},
+	async ({apiHelpers, assetsPage, page, shareModalPage}) => {
+		const spaceName = `Space ${getRandomString()}`;
+
+		await test.step('Create a new space', async () => {
+			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+				name: spaceName,
+				type: 'Space',
+			});
+		});
+
+		const objectEntryTitle = `Content ${getRandomString()}`;
+
+		await test.step('Create a content in the space', async () => {
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: objectEntryTitle,
+				},
+				'cms/basic-web-contents',
+				spaceName
+			);
+		});
+
+		const user =
+			await test.step('Create a user that already exists in the system', async () => {
+				return await apiHelpers.headlessAdminUser.postUserAccount();
+			});
+
+		await test.step('Open the Share modal on the content', async () => {
+			await assetsPage.gotoContents(spaceName);
+
+			await assetsPage.execItemAction({
+				action: 'Share',
+				filter: objectEntryTitle,
+			});
+
+			await expect(
+				shareModalPage.getHeader(objectEntryTitle)
+			).toBeVisible();
+		});
+
+		await test.step('Type the existing user email', async () => {
+			await shareModalPage.typeInCollaboratorInput(user.emailAddress);
+		});
+
+		await test.step('Verify the autocomplete offers the User option, not the Invite external user option', async () => {
+			await expect(
+				page.getByText(user.name, {exact: false})
+			).toBeVisible();
+
+			await expect(
+				shareModalPage.inviteExternalUserOption
+			).not.toBeVisible();
+		});
+	}
+);
+
+test(
+	'Folders cannot be shared with an external email',
+	{tag: '@LPD-85836'},
+	async ({apiHelpers, assetsPage, shareModalPage}) => {
+		const spaceName = `Space ${getRandomString()}`;
+
+		const space = await test.step('Create a new space', async () => {
+			return await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+				name: spaceName,
+				type: 'Space',
+			});
+		});
+
+		const folderName = `Folder ${getRandomString()}`;
+
+		await test.step('Create a folder in the space', async () => {
+			await apiHelpers.objectFolder.createObjectEntryFolder({
+				scopeKey: String(space.siteId),
+				title: folderName,
+			});
+		});
+
+		await test.step('Open the Share modal on the folder', async () => {
+			await assetsPage.gotoSpaceFiles(spaceName);
+
+			await assetsPage.execItemAction({
+				action: 'Share',
+				filter: folderName,
+			});
+
+			await expect(shareModalPage.getHeader(folderName)).toBeVisible();
+		});
+
+		await test.step('Type a valid external email and verify the invite option is not offered', async () => {
+			await shareModalPage.typeInCollaboratorInput(
+				'external@example.com'
+			);
+
+			await expect(
+				shareModalPage.inviteExternalUserOption
+			).not.toBeVisible();
+		});
+	}
+);

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/fixtures/cmsPagesTest.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/fixtures/cmsPagesTest.ts
@@ -15,6 +15,7 @@ import {HomePage} from '../pages/HomePage';
 import {InfoPanelPage} from '../pages/InfoPanelPage';
 import {PicklistBuilderPage} from '../pages/PicklistBuilderPage';
 import {RecycleBinPage} from '../pages/RecycleBinPage';
+import {ShareModalPage} from '../pages/ShareModalPage';
 import {SharedWithMePage} from '../pages/SharedWithMePage';
 import {SpaceSummaryPage} from '../pages/SpaceSummaryPage';
 import {StructuresPage} from '../pages/StructuresPage';
@@ -32,6 +33,7 @@ const cmsPagesTest = test.extend<{
 	infoPanelPage: InfoPanelPage;
 	picklistBuilderPage: PicklistBuilderPage;
 	recycleBinPage: RecycleBinPage;
+	shareModalPage: ShareModalPage;
 	sharedWithMePage: SharedWithMePage;
 	spaceSummaryPage: SpaceSummaryPage;
 	structuresPage: StructuresPage;
@@ -67,6 +69,9 @@ const cmsPagesTest = test.extend<{
 	},
 	recycleBinPage: async ({page}, use) => {
 		await use(new RecycleBinPage(page));
+	},
+	shareModalPage: async ({page}, use) => {
+		await use(new ShareModalPage(page));
 	},
 	sharedWithMePage: async ({page}, use) => {
 		await use(new SharedWithMePage(page));

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/pages/ShareModalPage.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/pages/ShareModalPage.ts
@@ -1,0 +1,40 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Locator, Page} from '@playwright/test';
+
+export class ShareModalPage {
+	readonly collaboratorInput: Locator;
+	readonly inviteExternalUserOption: Locator;
+	readonly page: Page;
+	readonly submitButton: Locator;
+
+	constructor(page: Page) {
+		this.collaboratorInput = page.getByPlaceholder(
+			'Enter name, email, or groups'
+		);
+		this.inviteExternalUserOption = page.getByText('Invite external user', {
+			exact: false,
+		});
+		this.page = page;
+		this.submitButton = page
+			.getByRole('dialog')
+			.getByRole('button', {exact: true, name: 'Share'});
+	}
+
+	getHeader(title: string) {
+		return this.page.getByText(`Share "${title}"`);
+	}
+
+	async submit() {
+		await this.submitButton.click();
+	}
+
+	async typeInCollaboratorInput(value: string) {
+		await this.collaboratorInput.click();
+
+		await this.collaboratorInput.fill(value);
+	}
+}


### PR DESCRIPTION
LPD-92291 Polish external email sharing UI and add Playwright tests
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-92291 part of : https://liferay.atlassian.net/browse/LPD-85836

Several small frontend issues remained after the initial implementation of external email sharing (LPD-85836): the share modal submit button was still labeled "Save" instead of "Share"; external collaborators (type `Email`) were not showing the `(guest)` suffix in their name chip; the badge for a newly added but not-yet-submitted external invite was showing `"invited"` instead of `"To Be Shared"`; and the `collaboratorNameSuffix` render-prop signature was missing the `user` parameter and return-type annotation that its sibling `collaboratorBadgeText` already declared. This task also had no Playwright coverage.

The root cause is that the badge and suffix logic for external collaborators handled the `toBeShared` state inconsistently: the original code returned `"pending"` or `"invited"` based on `toBeShared`, but the correct design (aligned with Figma) is to delegate `"To Be Shared"` to the shared badge path and only show `"invited"` once the invite is confirmed. The `(guest)` suffix was simply missing — the prop existed but was never wired to return a value for `COLLABORATOR_TYPE.EXTERNAL_USER`.

# How am I fixing it?

- Rename the submit button label from `save` to `share` in `ShareModalContent.tsx`.
- Add a default `_defaultCollaboratorNameSuffix` implementation that returns `(guest)` for external collaborators when the feature flag is on, and wire it into `CMSShareModalContent` so the CMS layer passes it through.
- Fix `collaboratorBadgeText` in `CMSShareModalContent` to only return `"invited"` when `!toBeShared`, letting the shared `"To Be Shared"` path handle the pending state.
- Align `collaboratorNameSuffix` signature with its sibling by adding the `user` param and `string | null` return-type annotation.
- Add a `getObjectEntryCollaboratorsPage` helper to `ObjectEntryApiHelper` to allow Playwright tests to assert the persisted collaborator shape via the REST API.
- Add a `ShareModalPage` POM and three Playwright specs covering: external email → guest chip + VIEW-only, email matching existing user → resolves to User (no invite option), and folder → no invite option for external email.

# How can you verify that it works?

Run the included automated tests.

# Commits

- LPD-92291 Add Playwright tests for external email sharing
- LPD-92291 Add getObjectEntryCollaboratorsPage helper
- LPD-92291 Match collaboratorNameSuffix signature to sibling render-props
- LPD-92291 Show "to be shared" badge for pending external invites
- LPD-92291 Suffix (guest) after external collaborator
- LPD-92291 fix test after 'save' to 'share' button
- LPD-92291 change button Save to Share
