### PR TITLE
LPD-92973 Capture expected batch engine errors in import report tests

### DIFF
--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/exportimport/data/handler/test/AssetCategoryPortletDataHandlerTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/exportimport/data/handler/test/AssetCategoryPortletDataHandlerTest.java
@@ -43,6 +43,9 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LogEntry;
+import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
@@ -95,8 +98,15 @@ public class AssetCategoryPortletDataHandlerTest
 		ExportImportConfiguration exportImportConfiguration =
 			_setUpExportImportConfiguration();
 
-		_exportImportLocalService.importLayouts(
-			exportImportConfiguration, larFile);
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				_CLASS_NAME_BATCH_ENGINE_IMPORT_TASK_EXECUTOR_IMPL,
+				LoggerTestUtil.ERROR)) {
+
+			_exportImportLocalService.importLayouts(
+				exportImportConfiguration, larFile);
+
+			_assertBatchEngineImportTaskError(logCapture);
+		}
 
 		List<ExportImportReportEntry> exportImportReportEntries =
 			_exportImportReportEntryLocalService.getExportImportReportEntries(
@@ -136,8 +146,15 @@ public class AssetCategoryPortletDataHandlerTest
 		ExportImportConfiguration exportImportConfiguration =
 			_setUpExportImportConfiguration();
 
-		_exportImportLocalService.importLayouts(
-			exportImportConfiguration, larFile);
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				_CLASS_NAME_BATCH_ENGINE_IMPORT_TASK_EXECUTOR_IMPL,
+				LoggerTestUtil.ERROR)) {
+
+			_exportImportLocalService.importLayouts(
+				exportImportConfiguration, larFile);
+
+			_assertBatchEngineImportTaskError(logCapture);
+		}
 
 		List<ExportImportReportEntry> exportImportReportEntries =
 			_exportImportReportEntryLocalService.getExportImportReportEntries(
@@ -331,6 +348,16 @@ public class AssetCategoryPortletDataHandlerTest
 		return _enableLocalStaging(depotEntry);
 	}
 
+	private void _assertBatchEngineImportTaskError(LogCapture logCapture) {
+		List<LogEntry> logEntries = logCapture.getLogEntries();
+
+		Assert.assertEquals(logEntries.toString(), 1, logEntries.size());
+
+		LogEntry logEntry = logEntries.get(0);
+
+		Assert.assertEquals(LoggerTestUtil.ERROR, logEntry.getPriority());
+	}
+
 	private DepotEntry _enableLocalStaging(DepotEntry depotEntry)
 		throws Exception {
 
@@ -415,6 +442,11 @@ public class AssetCategoryPortletDataHandlerTest
 							new String[] {Boolean.TRUE.toString()}
 						).build()));
 	}
+
+	private static final String
+		_CLASS_NAME_BATCH_ENGINE_IMPORT_TASK_EXECUTOR_IMPL =
+			"com.liferay.batch.engine.internal." +
+				"BatchEngineImportTaskExecutorImpl";
 
 	@Inject
 	private AssetCategoryLocalService _assetCategoryLocalService;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92973

## What Is Being Fixed

`AssetCategoryPortletDataHandlerTest#testAssetCategoryExportImportReportEntriesDuplicateExternalReferenceCode` and `testAssetVocabularyExportImportReportEntriesDuplicateTitle` intentionally re-import a category/vocabulary that collides, to verify a `TYPE_ERROR` report entry is produced. `BatchEngineImportTaskExecutorImpl` logs every failed import item at ERROR (the report entry is the user-facing channel), so the expected `DuplicateCategoryException` / `DuplicateVocabularyException` is written to the log. The tests pass locally because `LogAssertionTestRule`'s assertion is swallowed inside log4j's appender error handling, but the ERROR still reaches the on-disk XML log that the separate `PortalLogAssertorTest#testScanXMLLog` scans in CI, failing it.

## How It Is Being Fixed

Both report-error tests now wrap the `importLayouts` call in a `LogCapture` on `BatchEngineImportTaskExecutorImpl` (ERROR), so the expected error is captured instead of written to the scanned log, and assert that the single expected error was captured so the suppression is explicit rather than a silent swallow. This follows the convention already used by `BatchEngineExportTaskExecutorTest` for the equivalent expected-error path. The happy-path import tests in the class are untouched.

## Why Are There No Tests?

This change is itself a fix to existing integration tests; it adjusts test setup only and adds no production code.
