### PR TITLE
LPD-91525 Expose AssetListEntry through a headless-delivery endpoint

### DIFF
--- a/modules/apps/asset/asset-list-service/build.gradle
+++ b/modules/apps/asset/asset-list-service/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	compileOnly project(":apps:object:object-api")
 	compileOnly project(":apps:object:object-service")
 	compileOnly project(":apps:portal-search:portal-search-api")
+	compileOnly project(":apps:portal-search:portal-search-spi")
 	compileOnly project(":apps:portal:portal-aop-api")
 	compileOnly project(":apps:portal:portal-dao-orm-custom-sql-api")
 	compileOnly project(":apps:segments:segments-api")

--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/search/AssetListEntryModelSearchConfigurator.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/search/AssetListEntryModelSearchConfigurator.java
@@ -1,0 +1,57 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.asset.list.internal.search;
+
+import com.liferay.asset.list.model.AssetListEntry;
+import com.liferay.asset.list.service.AssetListEntryLocalService;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.search.spi.model.index.contributor.ModelIndexerWriterContributor;
+import com.liferay.portal.search.spi.model.registrar.ModelSearchConfigurator;
+
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Luis Ortiz
+ */
+@Component(service = ModelSearchConfigurator.class)
+public class AssetListEntryModelSearchConfigurator
+	implements ModelSearchConfigurator<AssetListEntry> {
+
+	@Override
+	public String getClassName() {
+		return AssetListEntry.class.getName();
+	}
+
+	@Override
+	public String[] getDefaultSelectedFieldNames() {
+		return new String[] {
+			Field.COMPANY_ID, Field.ENTRY_CLASS_NAME, Field.ENTRY_CLASS_PK,
+			Field.GROUP_ID, Field.UID
+		};
+	}
+
+	@Override
+	public ModelIndexerWriterContributor<AssetListEntry>
+		getModelIndexerWriterContributor() {
+
+		return _modelIndexerWriterContributor;
+	}
+
+	@Activate
+	protected void activate() {
+		_modelIndexerWriterContributor = new ModelIndexerWriterContributor<>(
+			_assetListEntryLocalService::getIndexableActionableDynamicQuery);
+	}
+
+	@Reference
+	private AssetListEntryLocalService _assetListEntryLocalService;
+
+	private ModelIndexerWriterContributor<AssetListEntry>
+		_modelIndexerWriterContributor;
+
+}

--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/search/spi/model/index/contributor/AssetListEntryModelDocumentContributor.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/search/spi/model/index/contributor/AssetListEntryModelDocumentContributor.java
@@ -1,0 +1,34 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.asset.list.internal.search.spi.model.index.contributor;
+
+import com.liferay.asset.list.model.AssetListEntry;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.search.spi.model.index.contributor.ModelDocumentContributor;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Luis Ortiz
+ */
+@Component(
+	property = "indexer.class.name=com.liferay.asset.list.model.AssetListEntry",
+	service = ModelDocumentContributor.class
+)
+public class AssetListEntryModelDocumentContributor
+	implements ModelDocumentContributor<AssetListEntry> {
+
+	@Override
+	public void contribute(Document document, AssetListEntry assetListEntry) {
+		document.addText(Field.TITLE, assetListEntry.getTitle());
+		document.addKeyword(
+			"assetEntrySubtype", assetListEntry.getAssetEntrySubtype());
+		document.addKeyword(
+			"assetEntryType", assetListEntry.getAssetEntryType());
+	}
+
+}

--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/search/spi/model/query/contributor/AssetListEntryKeywordQueryContributor.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/search/spi/model/query/contributor/AssetListEntryKeywordQueryContributor.java
@@ -1,0 +1,47 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.asset.list.internal.search.spi.model.query.contributor;
+
+import com.liferay.portal.kernel.search.BooleanQuery;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.search.query.QueryHelper;
+import com.liferay.portal.search.spi.model.query.contributor.KeywordQueryContributor;
+import com.liferay.portal.search.spi.model.query.contributor.helper.KeywordQueryContributorHelper;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Luis Ortiz
+ */
+@Component(
+	property = "indexer.class.name=com.liferay.asset.list.model.AssetListEntry",
+	service = KeywordQueryContributor.class
+)
+public class AssetListEntryKeywordQueryContributor
+	implements KeywordQueryContributor {
+
+	@Override
+	public void contribute(
+		String keywords, BooleanQuery booleanQuery,
+		KeywordQueryContributorHelper keywordQueryContributorHelper) {
+
+		SearchContext searchContext =
+			keywordQueryContributorHelper.getSearchContext();
+
+		_queryHelper.addSearchTerm(
+			booleanQuery, searchContext, "assetEntrySubtype", false);
+		_queryHelper.addSearchTerm(
+			booleanQuery, searchContext, "assetEntryType", false);
+		_queryHelper.addSearchTerm(
+			booleanQuery, searchContext, Field.TITLE, false);
+	}
+
+	@Reference
+	private QueryHelper _queryHelper;
+
+}

--- a/modules/apps/asset/asset-list-test/build.gradle
+++ b/modules/apps/asset/asset-list-test/build.gradle
@@ -25,6 +25,8 @@ dependencies {
 	testIntegrationImplementation project(":apps:object:object-api")
 	testIntegrationImplementation project(":apps:object:object-test-util")
 	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-test-util")
+	testIntegrationImplementation project(":apps:portal-search:portal-search-api")
+	testIntegrationImplementation project(":apps:portal-search:portal-search-test-util")
 	testIntegrationImplementation project(":apps:portal:portal-upgrade-test-util")
 	testIntegrationImplementation project(":apps:segments:segments-test-util")
 	testIntegrationImplementation project(":apps:static:portal:portal-upgrade-api")

--- a/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/search/test/AssetListEntryIndexerIndexedFieldsTest.java
+++ b/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/search/test/AssetListEntryIndexerIndexedFieldsTest.java
@@ -1,0 +1,204 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.asset.list.search.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.list.model.AssetListEntry;
+import com.liferay.asset.list.service.AssetListEntryLocalService;
+import com.liferay.asset.list.test.util.AssetListTestUtil;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.Indexer;
+import com.liferay.portal.kernel.search.SearchEngineHelper;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.search.model.uid.UIDFactory;
+import com.liferay.portal.search.searcher.SearchRequestBuilderFactory;
+import com.liferay.portal.search.searcher.Searcher;
+import com.liferay.portal.search.test.rule.SearchTestRule;
+import com.liferay.portal.search.test.util.FieldValuesAssert;
+import com.liferay.portal.search.test.util.IndexedFieldsFixture;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.util.Locale;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Luis Ortiz
+ */
+@RunWith(Arquillian.class)
+public class AssetListEntryIndexerIndexedFieldsTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE,
+			SynchronousDestinationTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_indexedFieldsFixture = new IndexedFieldsFixture(
+			_resourcePermissionLocalService, _searchEngineHelper, _uidFactory);
+	}
+
+	@Test
+	public void testIndexedFields() throws Exception {
+		String title = RandomTestUtil.randomString();
+
+		_assetListEntry = AssetListTestUtil.addAssetListEntry(
+			_group.getGroupId(), title);
+
+		_assetListEntry.setAssetEntrySubtype(RandomTestUtil.randomString());
+		_assetListEntry.setAssetEntryType(RandomTestUtil.randomString());
+
+		_assetListEntry = _assetListEntryLocalService.updateAssetListEntry(
+			_assetListEntry);
+
+		_assertFieldValues(
+			_expectedFieldValues(_assetListEntry), LocaleUtil.US, title);
+	}
+
+	@Rule
+	public SearchTestRule searchTestRule = new SearchTestRule();
+
+	private void _assertFieldValues(
+		Map<String, String> map, Locale locale, String searchTerm) {
+
+		FieldValuesAssert.assertFieldValues(
+			map,
+			name ->
+				!name.contains(StringPool.PERIOD) && !name.equals("score") &&
+				!name.equals("timestamp"),
+			_searcher.search(
+				_searchRequestBuilderFactory.builder(
+				).companyId(
+					_group.getCompanyId()
+				).fields(
+					StringPool.STAR
+				).groupIds(
+					_group.getGroupId()
+				).locale(
+					locale
+				).modelIndexerClasses(
+					AssetListEntry.class
+				).queryString(
+					searchTerm
+				).build()));
+	}
+
+	private Map<String, String> _expectedFieldValues(
+			AssetListEntry assetListEntry)
+		throws Exception {
+
+		Map<String, String> map = HashMapBuilder.put(
+			Field.COMPANY_ID, String.valueOf(assetListEntry.getCompanyId())
+		).put(
+			Field.ENTRY_CLASS_NAME, AssetListEntry.class.getName()
+		).put(
+			Field.ENTRY_CLASS_PK,
+			String.valueOf(assetListEntry.getAssetListEntryId())
+		).put(
+			Field.GROUP_ID, String.valueOf(assetListEntry.getGroupId())
+		).put(
+			Field.SCOPE_GROUP_ID, String.valueOf(assetListEntry.getGroupId())
+		).put(
+			Field.STAGING_GROUP, String.valueOf(_group.isStagingGroup())
+		).put(
+			Field.TITLE, assetListEntry.getTitle()
+		).put(
+			Field.USER_ID, String.valueOf(assetListEntry.getUserId())
+		).put(
+			Field.USER_NAME, StringUtil.lowerCase(assetListEntry.getUserName())
+		).put(
+			"assetEntrySubtype", assetListEntry.getAssetEntrySubtype()
+		).put(
+			"assetEntryType", assetListEntry.getAssetEntryType()
+		).put(
+			"externalReferenceCode", assetListEntry.getExternalReferenceCode()
+		).put(
+			"groupExternalReferenceCode", _group.getExternalReferenceCode()
+		).put(
+			"scopeGroupExternalReferenceCode", _group.getExternalReferenceCode()
+		).put(
+			"title_sortable", StringUtil.lowerCase(assetListEntry.getTitle())
+		).put(
+			"userExternalReferenceCode",
+			() -> {
+				User user = TestPropsValues.getUser();
+
+				return user.getExternalReferenceCode();
+			}
+		).build();
+
+		_indexedFieldsFixture.populateUID(assetListEntry, map);
+
+		_indexedFieldsFixture.populateDate(
+			Field.CREATE_DATE, assetListEntry.getCreateDate(), map);
+		_indexedFieldsFixture.populateDate(
+			Field.MODIFIED_DATE, assetListEntry.getModifiedDate(), map);
+
+		_indexedFieldsFixture.populateRoleIdFields(
+			assetListEntry.getCompanyId(), AssetListEntry.class.getName(),
+			assetListEntry.getAssetListEntryId(), assetListEntry.getGroupId(),
+			null, map);
+
+		return map;
+	}
+
+	@DeleteAfterTestRun
+	private AssetListEntry _assetListEntry;
+
+	@Inject
+	private AssetListEntryLocalService _assetListEntryLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	private IndexedFieldsFixture _indexedFieldsFixture;
+
+	@Inject(
+		filter = "indexer.class.name=com.liferay.asset.list.model.AssetListEntry"
+	)
+	private Indexer<AssetListEntry> _indexer;
+
+	@Inject
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Inject
+	private SearchEngineHelper _searchEngineHelper;
+
+	@Inject
+	private Searcher _searcher;
+
+	@Inject
+	private SearchRequestBuilderFactory _searchRequestBuilderFactory;
+
+	@Inject
+	private UIDFactory _uidFactory;
+
+}

--- a/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/search/test/AssetListEntryIndexerReindexTest.java
+++ b/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/search/test/AssetListEntryIndexerReindexTest.java
@@ -1,0 +1,133 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.asset.list.search.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.list.model.AssetListEntry;
+import com.liferay.asset.list.test.util.AssetListTestUtil;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.IndexWriterHelper;
+import com.liferay.portal.kernel.search.Indexer;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.search.model.uid.UIDFactory;
+import com.liferay.portal.search.searcher.SearchRequestBuilderFactory;
+import com.liferay.portal.search.searcher.Searcher;
+import com.liferay.portal.search.test.rule.SearchTestRule;
+import com.liferay.portal.search.test.util.FieldValuesAssert;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.util.Collections;
+import java.util.Locale;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Luis Ortiz
+ */
+@RunWith(Arquillian.class)
+public class AssetListEntryIndexerReindexTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE,
+			SynchronousDestinationTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	public void testReindex() throws Exception {
+		Locale locale = LocaleUtil.US;
+
+		String title = RandomTestUtil.randomString();
+
+		_assetListEntry = AssetListTestUtil.addAssetListEntry(
+			_group.getGroupId(), title);
+
+		Map<String, String> map = Collections.singletonMap(Field.TITLE, title);
+
+		_assertFieldValues(Field.TITLE, map, locale, title);
+
+		_indexWriterHelper.deleteDocument(
+			_assetListEntry.getCompanyId(), _uidFactory.getUID(_assetListEntry),
+			true);
+
+		_assertFieldValues(Field.TITLE, Collections.emptyMap(), locale, title);
+
+		_indexer.reindexCompany(_group.getCompanyId());
+
+		_assertFieldValues(Field.TITLE, map, locale, title);
+	}
+
+	@Rule
+	public SearchTestRule searchTestRule = new SearchTestRule();
+
+	private void _assertFieldValues(
+		String fieldName, Map<String, String> map, Locale locale,
+		String searchTerm) {
+
+		FieldValuesAssert.assertFieldValues(
+			map, fieldName::equals,
+			_searcher.search(
+				_searchRequestBuilderFactory.builder(
+				).companyId(
+					_group.getCompanyId()
+				).fields(
+					StringPool.STAR
+				).groupIds(
+					_group.getGroupId()
+				).locale(
+					locale
+				).modelIndexerClasses(
+					AssetListEntry.class
+				).queryString(
+					searchTerm
+				).build()));
+	}
+
+	@DeleteAfterTestRun
+	private AssetListEntry _assetListEntry;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject(
+		filter = "indexer.class.name=com.liferay.asset.list.model.AssetListEntry"
+	)
+	private Indexer<AssetListEntry> _indexer;
+
+	@Inject
+	private IndexWriterHelper _indexWriterHelper;
+
+	@Inject
+	private Searcher _searcher;
+
+	@Inject
+	private SearchRequestBuilderFactory _searchRequestBuilderFactory;
+
+	@Inject
+	private UIDFactory _uidFactory;
+
+}

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/AssetListEntry.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/AssetListEntry.java
@@ -1,0 +1,712 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.delivery.dto.v1_0;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.util.ObjectMapperUtil;
+
+import jakarta.annotation.Generated;
+
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+import java.io.Serializable;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+
+import java.util.Date;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Supplier;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+@GraphQLName(
+	description = "Represents a persisted Content Set (AssetListEntry) exposed for discovery by the Item Selector.",
+	value = "AssetListEntry"
+)
+@JsonFilter("Liferay.Vulcan")
+@XmlRootElement(name = "AssetListEntry")
+public class AssetListEntry implements Serializable {
+
+	public static AssetListEntry toDTO(String json) {
+		return ObjectMapperUtil.readValue(AssetListEntry.class, json);
+	}
+
+	public static AssetListEntry unsafeToDTO(String json) {
+		return ObjectMapperUtil.unsafeReadValue(AssetListEntry.class, json);
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The AssetListEntry's primary key. Equal to classPK; exposed explicitly because the field name is meaningful to callers reading the DTO."
+	)
+	public Long getAssetListEntryId() {
+		if (_assetListEntryIdSupplier != null) {
+			assetListEntryId = _assetListEntryIdSupplier.get();
+
+			_assetListEntryIdSupplier = null;
+		}
+
+		return assetListEntryId;
+	}
+
+	public void setAssetListEntryId(Long assetListEntryId) {
+		this.assetListEntryId = assetListEntryId;
+
+		_assetListEntryIdSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setAssetListEntryId(
+		UnsafeSupplier<Long, Exception> assetListEntryIdUnsafeSupplier) {
+
+		_assetListEntryIdSupplier = () -> {
+			try {
+				return assetListEntryIdUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(
+		description = "The AssetListEntry's primary key. Equal to classPK; exposed explicitly because the field name is meaningful to callers reading the DTO."
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Long assetListEntryId;
+
+	@JsonIgnore
+	private Supplier<Long> _assetListEntryIdSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The class name ID of AssetListEntry, mirrors the legacy click payload."
+	)
+	public Long getClassNameId() {
+		if (_classNameIdSupplier != null) {
+			classNameId = _classNameIdSupplier.get();
+
+			_classNameIdSupplier = null;
+		}
+
+		return classNameId;
+	}
+
+	public void setClassNameId(Long classNameId) {
+		this.classNameId = classNameId;
+
+		_classNameIdSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setClassNameId(
+		UnsafeSupplier<Long, Exception> classNameIdUnsafeSupplier) {
+
+		_classNameIdSupplier = () -> {
+			try {
+				return classNameIdUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(
+		description = "The class name ID of AssetListEntry, mirrors the legacy click payload."
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Long classNameId;
+
+	@JsonIgnore
+	private Supplier<Long> _classNameIdSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The AssetListEntry's id (=assetListEntryId), kept as classPK for legacy InfoListItemSelectorReturnType parity."
+	)
+	public Long getClassPK() {
+		if (_classPKSupplier != null) {
+			classPK = _classPKSupplier.get();
+
+			_classPKSupplier = null;
+		}
+
+		return classPK;
+	}
+
+	public void setClassPK(Long classPK) {
+		this.classPK = classPK;
+
+		_classPKSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setClassPK(
+		UnsafeSupplier<Long, Exception> classPKUnsafeSupplier) {
+
+		_classPKSupplier = () -> {
+			try {
+				return classPKUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(
+		description = "The AssetListEntry's id (=assetListEntryId), kept as classPK for legacy InfoListItemSelectorReturnType parity."
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Long classPK;
+
+	@JsonIgnore
+	private Supplier<Long> _classPKSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public Date getDateCreated() {
+		if (_dateCreatedSupplier != null) {
+			dateCreated = _dateCreatedSupplier.get();
+
+			_dateCreatedSupplier = null;
+		}
+
+		return dateCreated;
+	}
+
+	public void setDateCreated(Date dateCreated) {
+		this.dateCreated = dateCreated;
+
+		_dateCreatedSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setDateCreated(
+		UnsafeSupplier<Date, Exception> dateCreatedUnsafeSupplier) {
+
+		_dateCreatedSupplier = () -> {
+			try {
+				return dateCreatedUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Date dateCreated;
+
+	@JsonIgnore
+	private Supplier<Date> _dateCreatedSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public Date getDateModified() {
+		if (_dateModifiedSupplier != null) {
+			dateModified = _dateModifiedSupplier.get();
+
+			_dateModifiedSupplier = null;
+		}
+
+		return dateModified;
+	}
+
+	public void setDateModified(Date dateModified) {
+		this.dateModified = dateModified;
+
+		_dateModifiedSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setDateModified(
+		UnsafeSupplier<Date, Exception> dateModifiedUnsafeSupplier) {
+
+		_dateModifiedSupplier = () -> {
+			try {
+				return dateModifiedUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Date dateModified;
+
+	@JsonIgnore
+	private Supplier<Date> _dateModifiedSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "Standard Liferay headless field for portable cross-system references."
+	)
+	public String getExternalReferenceCode() {
+		if (_externalReferenceCodeSupplier != null) {
+			externalReferenceCode = _externalReferenceCodeSupplier.get();
+
+			_externalReferenceCodeSupplier = null;
+		}
+
+		return externalReferenceCode;
+	}
+
+	public void setExternalReferenceCode(String externalReferenceCode) {
+		this.externalReferenceCode = externalReferenceCode;
+
+		_externalReferenceCodeSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setExternalReferenceCode(
+		UnsafeSupplier<String, Exception> externalReferenceCodeUnsafeSupplier) {
+
+		_externalReferenceCodeSupplier = () -> {
+			try {
+				return externalReferenceCodeUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(
+		description = "Standard Liferay headless field for portable cross-system references."
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String externalReferenceCode;
+
+	@JsonIgnore
+	private Supplier<String> _externalReferenceCodeSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The AssetEntry subtype (DDM structure id, etc.); mirrors AssetListEntry.assetEntrySubtype."
+	)
+	public String getItemSubtype() {
+		if (_itemSubtypeSupplier != null) {
+			itemSubtype = _itemSubtypeSupplier.get();
+
+			_itemSubtypeSupplier = null;
+		}
+
+		return itemSubtype;
+	}
+
+	public void setItemSubtype(String itemSubtype) {
+		this.itemSubtype = itemSubtype;
+
+		_itemSubtypeSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setItemSubtype(
+		UnsafeSupplier<String, Exception> itemSubtypeUnsafeSupplier) {
+
+		_itemSubtypeSupplier = () -> {
+			try {
+				return itemSubtypeUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(
+		description = "The AssetEntry subtype (DDM structure id, etc.); mirrors AssetListEntry.assetEntrySubtype."
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String itemSubtype;
+
+	@JsonIgnore
+	private Supplier<String> _itemSubtypeSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The AssetEntry FQCN this list returns; mirrors AssetListEntry.assetEntryType."
+	)
+	public String getItemType() {
+		if (_itemTypeSupplier != null) {
+			itemType = _itemTypeSupplier.get();
+
+			_itemTypeSupplier = null;
+		}
+
+		return itemType;
+	}
+
+	public void setItemType(String itemType) {
+		this.itemType = itemType;
+
+		_itemTypeSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setItemType(
+		UnsafeSupplier<String, Exception> itemTypeUnsafeSupplier) {
+
+		_itemTypeSupplier = () -> {
+			try {
+				return itemTypeUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(
+		description = "The AssetEntry FQCN this list returns; mirrors AssetListEntry.assetEntryType."
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String itemType;
+
+	@JsonIgnore
+	private Supplier<String> _itemTypeSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public String getTitle() {
+		if (_titleSupplier != null) {
+			title = _titleSupplier.get();
+
+			_titleSupplier = null;
+		}
+
+		return title;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+
+		_titleSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setTitle(
+		UnsafeSupplier<String, Exception> titleUnsafeSupplier) {
+
+		_titleSupplier = () -> {
+			try {
+				return titleUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String title;
+
+	@JsonIgnore
+	private Supplier<String> _titleSupplier;
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof AssetListEntry)) {
+			return false;
+		}
+
+		AssetListEntry assetListEntry = (AssetListEntry)object;
+
+		return Objects.equals(toString(), assetListEntry.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		StringBundler sb = new StringBundler();
+
+		sb.append("{");
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+		Long assetListEntryId = getAssetListEntryId();
+
+		if (assetListEntryId != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"assetListEntryId\": ");
+
+			sb.append(assetListEntryId);
+		}
+
+		Long classNameId = getClassNameId();
+
+		if (classNameId != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"classNameId\": ");
+
+			sb.append(classNameId);
+		}
+
+		Long classPK = getClassPK();
+
+		if (classPK != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"classPK\": ");
+
+			sb.append(classPK);
+		}
+
+		Date dateCreated = getDateCreated();
+
+		if (dateCreated != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"dateCreated\": ");
+
+			sb.append("\"");
+
+			sb.append(liferayToJSONDateFormat.format(dateCreated));
+
+			sb.append("\"");
+		}
+
+		Date dateModified = getDateModified();
+
+		if (dateModified != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"dateModified\": ");
+
+			sb.append("\"");
+
+			sb.append(liferayToJSONDateFormat.format(dateModified));
+
+			sb.append("\"");
+		}
+
+		String externalReferenceCode = getExternalReferenceCode();
+
+		if (externalReferenceCode != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"externalReferenceCode\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(externalReferenceCode));
+
+			sb.append("\"");
+		}
+
+		String itemSubtype = getItemSubtype();
+
+		if (itemSubtype != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"itemSubtype\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(itemSubtype));
+
+			sb.append("\"");
+		}
+
+		String itemType = getItemType();
+
+		if (itemType != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"itemType\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(itemType));
+
+			sb.append("\"");
+		}
+
+		String title = getTitle();
+
+		if (title != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"title\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(title));
+
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		accessMode = io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY,
+		defaultValue = "com.liferay.headless.delivery.dto.v1_0.AssetListEntry",
+		name = "x-class-name"
+	)
+	public String xClassName;
+
+	private static String _escape(Object object) {
+		return StringUtil.replace(
+			String.valueOf(object), _JSON_ESCAPE_STRINGS[0],
+			_JSON_ESCAPE_STRINGS[1]);
+	}
+
+	private static boolean _isArray(Object value) {
+		if (value == null) {
+			return false;
+		}
+
+		Class<?> clazz = value.getClass();
+
+		return clazz.isArray();
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(_escape(entry.getKey()));
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			if (_isArray(value)) {
+				sb.append("[");
+
+				Object[] valueArray = (Object[])value;
+
+				for (int i = 0; i < valueArray.length; i++) {
+					if (valueArray[i] instanceof Map) {
+						sb.append(_toJSON((Map<String, ?>)valueArray[i]));
+					}
+					else if (valueArray[i] instanceof String) {
+						sb.append("\"");
+						sb.append(valueArray[i]);
+						sb.append("\"");
+					}
+					else {
+						sb.append(valueArray[i]);
+					}
+
+					if ((i + 1) < valueArray.length) {
+						sb.append(", ");
+					}
+				}
+
+				sb.append("]");
+			}
+			else if (value instanceof Map) {
+				sb.append(_toJSON((Map<String, ?>)value));
+			}
+			else if (value instanceof String) {
+				sb.append("\"");
+				sb.append(_escape(value));
+				sb.append("\"");
+			}
+			else {
+				sb.append(value);
+			}
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static final String[][] _JSON_ESCAPE_STRINGS = {
+		{"\\", "\"", "\b", "\f", "\n", "\r", "\t"},
+		{"\\\\", "\\\"", "\\b", "\\f", "\\n", "\\r", "\\t"}
+	};
+
+	private Map<String, Serializable> _extendedProperties;
+
+}
+// LIFERAY-REST-BUILDER-HASH:1651873942

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/AssetListEntryResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/AssetListEntryResource.java
@@ -1,0 +1,175 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.delivery.resource.v1_0;
+
+import com.liferay.headless.delivery.dto.v1_0.AssetListEntry;
+import com.liferay.portal.kernel.change.tracking.CTAware;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineExportTaskResource;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
+import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
+
+import jakarta.annotation.Generated;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.osgi.annotation.versioning.ProviderType;
+
+/**
+ * To access this resource, run:
+ *
+ *     curl -u your@email.com:yourpassword -D - http://localhost:8080/o/headless-delivery/v1.0
+ *
+ * @author Javier Gamarra
+ * @generated
+ */
+@CTAware
+@Generated("")
+@ProviderType
+public interface AssetListEntryResource {
+
+	public Page<AssetListEntry> getAssetLibraryAssetListEntriesPage(
+			Long assetLibraryId, String search,
+			com.liferay.portal.kernel.search.filter.Filter filter,
+			Pagination pagination,
+			com.liferay.portal.kernel.search.Sort[] sorts)
+		throws Exception;
+
+	public Page<AssetListEntry> getSiteAssetListEntriesPage(
+			Long siteId, String search,
+			com.liferay.portal.kernel.search.filter.Filter filter,
+			Pagination pagination,
+			com.liferay.portal.kernel.search.Sort[] sorts)
+		throws Exception;
+
+	public Response postAssetLibraryAssetListEntriesPageExportBatch(
+			Long assetLibraryId, String search,
+			com.liferay.portal.kernel.search.filter.Filter filter,
+			com.liferay.portal.kernel.search.Sort[] sorts, String callbackURL,
+			String contentType, String fieldNames)
+		throws Exception;
+
+	public Response postSiteAssetListEntriesPageExportBatch(
+			Long siteId, String search,
+			com.liferay.portal.kernel.search.filter.Filter filter,
+			com.liferay.portal.kernel.search.Sort[] sorts, String callbackURL,
+			String contentType, String fieldNames)
+		throws Exception;
+
+	public default void setContextAcceptLanguage(
+		AcceptLanguage contextAcceptLanguage) {
+	}
+
+	public void setContextCompany(
+		com.liferay.portal.kernel.model.Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
+
+	public void setContextUser(
+		com.liferay.portal.kernel.model.User contextUser);
+
+	public void setExpressionConvert(
+		ExpressionConvert<com.liferay.portal.kernel.search.filter.Filter>
+			expressionConvert);
+
+	public void setFilterParserProvider(
+		FilterParserProvider filterParserProvider);
+
+	public void setGroupLocalService(GroupLocalService groupLocalService);
+
+	public void setResourceActionLocalService(
+		ResourceActionLocalService resourceActionLocalService);
+
+	public void setResourcePermissionLocalService(
+		ResourcePermissionLocalService resourcePermissionLocalService);
+
+	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setSortParserProvider(SortParserProvider sortParserProvider);
+
+	public void setVulcanBatchEngineExportTaskResource(
+		VulcanBatchEngineExportTaskResource
+			vulcanBatchEngineExportTaskResource);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
+
+	public default com.liferay.portal.kernel.search.filter.Filter toFilter(
+		String filterString) {
+
+		return toFilter(
+			filterString, Collections.<String, List<String>>emptyMap());
+	}
+
+	public default com.liferay.portal.kernel.search.filter.Filter toFilter(
+		String filterString, Map<String, List<String>> multivaluedMap) {
+
+		return null;
+	}
+
+	public default com.liferay.portal.kernel.search.Sort[] toSorts(
+		String sortsString) {
+
+		return new com.liferay.portal.kernel.search.Sort[0];
+	}
+
+	@ProviderType
+	public interface Builder {
+
+		public AssetListEntryResource build();
+
+		public Builder checkPermissions(boolean checkPermissions);
+
+		public Builder httpServletRequest(
+			HttpServletRequest httpServletRequest);
+
+		public Builder httpServletResponse(
+			HttpServletResponse httpServletResponse);
+
+		public Builder preferredLocale(Locale preferredLocale);
+
+		public Builder uriInfo(UriInfo uriInfo);
+
+		public Builder user(com.liferay.portal.kernel.model.User user);
+
+	}
+
+	@ProviderType
+	public interface Factory {
+
+		public Builder create();
+
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:1489053438

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/AssetListEntry.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/AssetListEntry.java
@@ -1,0 +1,250 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.delivery.client.dto.v1_0;
+
+import com.liferay.headless.delivery.client.function.UnsafeSupplier;
+import com.liferay.headless.delivery.client.serdes.v1_0.AssetListEntrySerDes;
+
+import jakarta.annotation.Generated;
+
+import java.io.Serializable;
+
+import java.util.Date;
+import java.util.Objects;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+public class AssetListEntry implements Cloneable, Serializable {
+
+	public static AssetListEntry toDTO(String json) {
+		return AssetListEntrySerDes.toDTO(json);
+	}
+
+	public Long getAssetListEntryId() {
+		return assetListEntryId;
+	}
+
+	public void setAssetListEntryId(Long assetListEntryId) {
+		this.assetListEntryId = assetListEntryId;
+	}
+
+	public void setAssetListEntryId(
+		UnsafeSupplier<Long, Exception> assetListEntryIdUnsafeSupplier) {
+
+		try {
+			assetListEntryId = assetListEntryIdUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Long assetListEntryId;
+
+	public Long getClassNameId() {
+		return classNameId;
+	}
+
+	public void setClassNameId(Long classNameId) {
+		this.classNameId = classNameId;
+	}
+
+	public void setClassNameId(
+		UnsafeSupplier<Long, Exception> classNameIdUnsafeSupplier) {
+
+		try {
+			classNameId = classNameIdUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Long classNameId;
+
+	public Long getClassPK() {
+		return classPK;
+	}
+
+	public void setClassPK(Long classPK) {
+		this.classPK = classPK;
+	}
+
+	public void setClassPK(
+		UnsafeSupplier<Long, Exception> classPKUnsafeSupplier) {
+
+		try {
+			classPK = classPKUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Long classPK;
+
+	public Date getDateCreated() {
+		return dateCreated;
+	}
+
+	public void setDateCreated(Date dateCreated) {
+		this.dateCreated = dateCreated;
+	}
+
+	public void setDateCreated(
+		UnsafeSupplier<Date, Exception> dateCreatedUnsafeSupplier) {
+
+		try {
+			dateCreated = dateCreatedUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Date dateCreated;
+
+	public Date getDateModified() {
+		return dateModified;
+	}
+
+	public void setDateModified(Date dateModified) {
+		this.dateModified = dateModified;
+	}
+
+	public void setDateModified(
+		UnsafeSupplier<Date, Exception> dateModifiedUnsafeSupplier) {
+
+		try {
+			dateModified = dateModifiedUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Date dateModified;
+
+	public String getExternalReferenceCode() {
+		return externalReferenceCode;
+	}
+
+	public void setExternalReferenceCode(String externalReferenceCode) {
+		this.externalReferenceCode = externalReferenceCode;
+	}
+
+	public void setExternalReferenceCode(
+		UnsafeSupplier<String, Exception> externalReferenceCodeUnsafeSupplier) {
+
+		try {
+			externalReferenceCode = externalReferenceCodeUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String externalReferenceCode;
+
+	public String getItemSubtype() {
+		return itemSubtype;
+	}
+
+	public void setItemSubtype(String itemSubtype) {
+		this.itemSubtype = itemSubtype;
+	}
+
+	public void setItemSubtype(
+		UnsafeSupplier<String, Exception> itemSubtypeUnsafeSupplier) {
+
+		try {
+			itemSubtype = itemSubtypeUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String itemSubtype;
+
+	public String getItemType() {
+		return itemType;
+	}
+
+	public void setItemType(String itemType) {
+		this.itemType = itemType;
+	}
+
+	public void setItemType(
+		UnsafeSupplier<String, Exception> itemTypeUnsafeSupplier) {
+
+		try {
+			itemType = itemTypeUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String itemType;
+
+	public String getTitle() {
+		return title;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+	}
+
+	public void setTitle(
+		UnsafeSupplier<String, Exception> titleUnsafeSupplier) {
+
+		try {
+			title = titleUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String title;
+
+	@Override
+	public AssetListEntry clone() throws CloneNotSupportedException {
+		return (AssetListEntry)super.clone();
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof AssetListEntry)) {
+			return false;
+		}
+
+		AssetListEntry assetListEntry = (AssetListEntry)object;
+
+		return Objects.equals(toString(), assetListEntry.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		return AssetListEntrySerDes.toJSON(this);
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:46647418

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/AssetListEntryResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/AssetListEntryResource.java
@@ -1,0 +1,722 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.delivery.client.resource.v1_0;
+
+import com.liferay.headless.delivery.client.dto.v1_0.AssetListEntry;
+import com.liferay.headless.delivery.client.http.HttpInvoker;
+import com.liferay.headless.delivery.client.pagination.Page;
+import com.liferay.headless.delivery.client.pagination.Pagination;
+import com.liferay.headless.delivery.client.problem.Problem;
+import com.liferay.headless.delivery.client.serdes.v1_0.AssetListEntrySerDes;
+
+import jakarta.annotation.Generated;
+
+import java.net.URL;
+
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+public interface AssetListEntryResource {
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public Page<AssetListEntry> getAssetLibraryAssetListEntriesPage(
+			Long assetLibraryId, String search, String filterString,
+			Pagination pagination, String sortString)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse
+			getAssetLibraryAssetListEntriesPageHttpResponse(
+				Long assetLibraryId, String search, String filterString,
+				Pagination pagination, String sortString)
+		throws Exception;
+
+	public Page<AssetListEntry> getSiteAssetListEntriesPage(
+			Long siteId, String search, String filterString,
+			Pagination pagination, String sortString)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse getSiteAssetListEntriesPageHttpResponse(
+			Long siteId, String search, String filterString,
+			Pagination pagination, String sortString)
+		throws Exception;
+
+	public void postAssetLibraryAssetListEntriesPageExportBatch(
+			Long assetLibraryId, String search, String filterString,
+			String sortString, String callbackURL, String contentType,
+			String fieldNames)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse
+			postAssetLibraryAssetListEntriesPageExportBatchHttpResponse(
+				Long assetLibraryId, String search, String filterString,
+				String sortString, String callbackURL, String contentType,
+				String fieldNames)
+		throws Exception;
+
+	public void postSiteAssetListEntriesPageExportBatch(
+			Long siteId, String search, String filterString, String sortString,
+			String callbackURL, String contentType, String fieldNames)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse
+			postSiteAssetListEntriesPageExportBatchHttpResponse(
+				Long siteId, String search, String filterString,
+				String sortString, String callbackURL, String contentType,
+				String fieldNames)
+		throws Exception;
+
+	public static class Builder {
+
+		public Builder authentication(String login, String password) {
+			_login = login;
+			_password = password;
+
+			return this;
+		}
+
+		public Builder bearerToken(String token) {
+			return header("Authorization", "Bearer " + token);
+		}
+
+		public AssetListEntryResource build() {
+			return new AssetListEntryResourceImpl(this);
+		}
+
+		public Builder contextPath(String contextPath) {
+			_contextPath = contextPath;
+
+			return this;
+		}
+
+		public Builder endpoint(String address, String scheme) {
+			String[] addressParts = address.split(":");
+
+			String host = addressParts[0];
+
+			int port = 443;
+
+			if (addressParts.length > 1) {
+				String portString = addressParts[1];
+
+				try {
+					port = Integer.parseInt(portString);
+				}
+				catch (NumberFormatException numberFormatException) {
+					throw new IllegalArgumentException(
+						"Unable to parse port from " + portString);
+				}
+			}
+
+			return endpoint(host, port, scheme);
+		}
+
+		public Builder endpoint(String host, int port, String scheme) {
+			_host = host;
+			_port = port;
+			_scheme = scheme;
+
+			return this;
+		}
+
+		public Builder endpoint(URL url) {
+			return endpoint(url.getHost(), url.getPort(), url.getProtocol());
+		}
+
+		public Builder header(String key, String value) {
+			_headers.put(key, value);
+
+			return this;
+		}
+
+		public Builder locale(Locale locale) {
+			_locale = locale;
+
+			return this;
+		}
+
+		public Builder parameter(String key, String value) {
+			_parameters.put(key, value);
+
+			return this;
+		}
+
+		public Builder parameters(String... parameters) {
+			if ((parameters.length % 2) != 0) {
+				throw new IllegalArgumentException(
+					"Parameters length is not an even number");
+			}
+
+			for (int i = 0; i < parameters.length; i += 2) {
+				String parameterName = String.valueOf(parameters[i]);
+				String parameterValue = String.valueOf(parameters[i + 1]);
+
+				_parameters.put(parameterName, parameterValue);
+			}
+
+			return this;
+		}
+
+		private Builder() {
+		}
+
+		private String _contextPath = "";
+		private Map<String, String> _headers = new LinkedHashMap<>();
+		private String _host = "localhost";
+		private Locale _locale;
+		private String _login;
+		private String _password;
+		private Map<String, String> _parameters = new LinkedHashMap<>();
+		private int _port = 8080;
+		private String _scheme = "http";
+
+	}
+
+	public static class AssetListEntryResourceImpl
+		implements AssetListEntryResource {
+
+		public Page<AssetListEntry> getAssetLibraryAssetListEntriesPage(
+				Long assetLibraryId, String search, String filterString,
+				Pagination pagination, String sortString)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				getAssetLibraryAssetListEntriesPageHttpResponse(
+					assetLibraryId, search, filterString, pagination,
+					sortString);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return Page.of(content, AssetListEntrySerDes::toDTO);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				getAssetLibraryAssetListEntriesPageHttpResponse(
+					Long assetLibraryId, String search, String filterString,
+					Pagination pagination, String sortString)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
+
+			if (search != null) {
+				httpInvoker.parameter("search", String.valueOf(search));
+			}
+
+			if (filterString != null) {
+				httpInvoker.parameter("filter", filterString);
+			}
+
+			if (pagination != null) {
+				httpInvoker.parameter(
+					"page", String.valueOf(pagination.getPage()));
+				httpInvoker.parameter(
+					"pageSize", String.valueOf(pagination.getPageSize()));
+			}
+
+			if (sortString != null) {
+				httpInvoker.parameter("sort", sortString);
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/asset-list-entries");
+
+			httpInvoker.path("assetLibraryId", assetLibraryId);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public Page<AssetListEntry> getSiteAssetListEntriesPage(
+				Long siteId, String search, String filterString,
+				Pagination pagination, String sortString)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				getSiteAssetListEntriesPageHttpResponse(
+					siteId, search, filterString, pagination, sortString);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return Page.of(content, AssetListEntrySerDes::toDTO);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse getSiteAssetListEntriesPageHttpResponse(
+				Long siteId, String search, String filterString,
+				Pagination pagination, String sortString)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
+
+			if (search != null) {
+				httpInvoker.parameter("search", String.valueOf(search));
+			}
+
+			if (filterString != null) {
+				httpInvoker.parameter("filter", filterString);
+			}
+
+			if (pagination != null) {
+				httpInvoker.parameter(
+					"page", String.valueOf(pagination.getPage()));
+				httpInvoker.parameter(
+					"pageSize", String.valueOf(pagination.getPageSize()));
+			}
+
+			if (sortString != null) {
+				httpInvoker.parameter("sort", sortString);
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-delivery/v1.0/sites/{siteId}/asset-list-entries");
+
+			httpInvoker.path("siteId", siteId);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public void postAssetLibraryAssetListEntriesPageExportBatch(
+				Long assetLibraryId, String search, String filterString,
+				String sortString, String callbackURL, String contentType,
+				String fieldNames)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				postAssetLibraryAssetListEntriesPageExportBatchHttpResponse(
+					assetLibraryId, search, filterString, sortString,
+					callbackURL, contentType, fieldNames);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				postAssetLibraryAssetListEntriesPageExportBatchHttpResponse(
+					Long assetLibraryId, String search, String filterString,
+					String sortString, String callbackURL, String contentType,
+					String fieldNames)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body("[]", "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+
+			if (search != null) {
+				httpInvoker.parameter("search", String.valueOf(search));
+			}
+
+			if (filterString != null) {
+				httpInvoker.parameter("filter", filterString);
+			}
+
+			if (sortString != null) {
+				httpInvoker.parameter("sort", sortString);
+			}
+
+			if (callbackURL != null) {
+				httpInvoker.parameter(
+					"callbackURL", String.valueOf(callbackURL));
+			}
+
+			if (contentType != null) {
+				httpInvoker.parameter(
+					"contentType", String.valueOf(contentType));
+			}
+
+			if (fieldNames != null) {
+				httpInvoker.parameter("fieldNames", String.valueOf(fieldNames));
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/asset-list-entries/export-batch");
+
+			httpInvoker.path("assetLibraryId", assetLibraryId);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public void postSiteAssetListEntriesPageExportBatch(
+				Long siteId, String search, String filterString,
+				String sortString, String callbackURL, String contentType,
+				String fieldNames)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				postSiteAssetListEntriesPageExportBatchHttpResponse(
+					siteId, search, filterString, sortString, callbackURL,
+					contentType, fieldNames);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				postSiteAssetListEntriesPageExportBatchHttpResponse(
+					Long siteId, String search, String filterString,
+					String sortString, String callbackURL, String contentType,
+					String fieldNames)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body("[]", "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+
+			if (search != null) {
+				httpInvoker.parameter("search", String.valueOf(search));
+			}
+
+			if (filterString != null) {
+				httpInvoker.parameter("filter", filterString);
+			}
+
+			if (sortString != null) {
+				httpInvoker.parameter("sort", sortString);
+			}
+
+			if (callbackURL != null) {
+				httpInvoker.parameter(
+					"callbackURL", String.valueOf(callbackURL));
+			}
+
+			if (contentType != null) {
+				httpInvoker.parameter(
+					"contentType", String.valueOf(contentType));
+			}
+
+			if (fieldNames != null) {
+				httpInvoker.parameter("fieldNames", String.valueOf(fieldNames));
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-delivery/v1.0/sites/{siteId}/asset-list-entries/export-batch");
+
+			httpInvoker.path("siteId", siteId);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		private AssetListEntryResourceImpl(Builder builder) {
+			_builder = builder;
+		}
+
+		private static final Logger _logger = Logger.getLogger(
+			AssetListEntryResource.class.getName());
+
+		private Builder _builder;
+
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:-1452900354

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/AssetListEntrySerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/AssetListEntrySerDes.java
@@ -1,0 +1,460 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.delivery.client.serdes.v1_0;
+
+import com.liferay.headless.delivery.client.dto.v1_0.AssetListEntry;
+import com.liferay.headless.delivery.client.json.BaseJSONParser;
+
+import jakarta.annotation.Generated;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+public class AssetListEntrySerDes {
+
+	public static AssetListEntry toDTO(String json) {
+		AssetListEntryJSONParser assetListEntryJSONParser =
+			new AssetListEntryJSONParser();
+
+		return assetListEntryJSONParser.parseToDTO(json);
+	}
+
+	public static AssetListEntry[] toDTOs(String json) {
+		AssetListEntryJSONParser assetListEntryJSONParser =
+			new AssetListEntryJSONParser();
+
+		return assetListEntryJSONParser.parseToDTOs(json);
+	}
+
+	public static String toJSON(AssetListEntry assetListEntry) {
+		if (assetListEntry == null) {
+			return "null";
+		}
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ssXX");
+
+		if (assetListEntry.getAssetListEntryId() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"assetListEntryId\": ");
+
+			sb.append(assetListEntry.getAssetListEntryId());
+		}
+
+		if (assetListEntry.getClassNameId() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"classNameId\": ");
+
+			sb.append(assetListEntry.getClassNameId());
+		}
+
+		if (assetListEntry.getClassPK() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"classPK\": ");
+
+			sb.append(assetListEntry.getClassPK());
+		}
+
+		if (assetListEntry.getDateCreated() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"dateCreated\": ");
+
+			sb.append("\"");
+
+			sb.append(
+				liferayToJSONDateFormat.format(
+					assetListEntry.getDateCreated()));
+
+			sb.append("\"");
+		}
+
+		if (assetListEntry.getDateModified() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"dateModified\": ");
+
+			sb.append("\"");
+
+			sb.append(
+				liferayToJSONDateFormat.format(
+					assetListEntry.getDateModified()));
+
+			sb.append("\"");
+		}
+
+		if (assetListEntry.getExternalReferenceCode() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"externalReferenceCode\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(assetListEntry.getExternalReferenceCode()));
+
+			sb.append("\"");
+		}
+
+		if (assetListEntry.getItemSubtype() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"itemSubtype\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(assetListEntry.getItemSubtype()));
+
+			sb.append("\"");
+		}
+
+		if (assetListEntry.getItemType() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"itemType\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(assetListEntry.getItemType()));
+
+			sb.append("\"");
+		}
+
+		if (assetListEntry.getTitle() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"title\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(assetListEntry.getTitle()));
+
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	public static Map<String, Object> toMap(String json) {
+		AssetListEntryJSONParser assetListEntryJSONParser =
+			new AssetListEntryJSONParser();
+
+		return assetListEntryJSONParser.parseToMap(json);
+	}
+
+	public static Map<String, String> toMap(AssetListEntry assetListEntry) {
+		if (assetListEntry == null) {
+			return null;
+		}
+
+		Map<String, String> map = new TreeMap<>();
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ssXX");
+
+		if (assetListEntry.getAssetListEntryId() == null) {
+			map.put("assetListEntryId", null);
+		}
+		else {
+			map.put(
+				"assetListEntryId",
+				String.valueOf(assetListEntry.getAssetListEntryId()));
+		}
+
+		if (assetListEntry.getClassNameId() == null) {
+			map.put("classNameId", null);
+		}
+		else {
+			map.put(
+				"classNameId", String.valueOf(assetListEntry.getClassNameId()));
+		}
+
+		if (assetListEntry.getClassPK() == null) {
+			map.put("classPK", null);
+		}
+		else {
+			map.put("classPK", String.valueOf(assetListEntry.getClassPK()));
+		}
+
+		if (assetListEntry.getDateCreated() == null) {
+			map.put("dateCreated", null);
+		}
+		else {
+			map.put(
+				"dateCreated",
+				liferayToJSONDateFormat.format(
+					assetListEntry.getDateCreated()));
+		}
+
+		if (assetListEntry.getDateModified() == null) {
+			map.put("dateModified", null);
+		}
+		else {
+			map.put(
+				"dateModified",
+				liferayToJSONDateFormat.format(
+					assetListEntry.getDateModified()));
+		}
+
+		if (assetListEntry.getExternalReferenceCode() == null) {
+			map.put("externalReferenceCode", null);
+		}
+		else {
+			map.put(
+				"externalReferenceCode",
+				String.valueOf(assetListEntry.getExternalReferenceCode()));
+		}
+
+		if (assetListEntry.getItemSubtype() == null) {
+			map.put("itemSubtype", null);
+		}
+		else {
+			map.put(
+				"itemSubtype", String.valueOf(assetListEntry.getItemSubtype()));
+		}
+
+		if (assetListEntry.getItemType() == null) {
+			map.put("itemType", null);
+		}
+		else {
+			map.put("itemType", String.valueOf(assetListEntry.getItemType()));
+		}
+
+		if (assetListEntry.getTitle() == null) {
+			map.put("title", null);
+		}
+		else {
+			map.put("title", String.valueOf(assetListEntry.getTitle()));
+		}
+
+		return map;
+	}
+
+	public static class AssetListEntryJSONParser
+		extends BaseJSONParser<AssetListEntry> {
+
+		@Override
+		protected AssetListEntry createDTO() {
+			return new AssetListEntry();
+		}
+
+		@Override
+		protected AssetListEntry[] createDTOArray(int size) {
+			return new AssetListEntry[size];
+		}
+
+		@Override
+		protected boolean parseMaps(String jsonParserFieldName) {
+			if (Objects.equals(jsonParserFieldName, "assetListEntryId")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "classNameId")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "classPK")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "dateCreated")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "dateModified")) {
+				return false;
+			}
+			else if (Objects.equals(
+						jsonParserFieldName, "externalReferenceCode")) {
+
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "itemSubtype")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "itemType")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "title")) {
+				return false;
+			}
+
+			return false;
+		}
+
+		@Override
+		protected void setField(
+			AssetListEntry assetListEntry, String jsonParserFieldName,
+			Object jsonParserFieldValue) {
+
+			if (Objects.equals(jsonParserFieldName, "assetListEntryId")) {
+				if (jsonParserFieldValue != null) {
+					assetListEntry.setAssetListEntryId(
+						Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "classNameId")) {
+				if (jsonParserFieldValue != null) {
+					assetListEntry.setClassNameId(
+						Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "classPK")) {
+				if (jsonParserFieldValue != null) {
+					assetListEntry.setClassPK(
+						Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "dateCreated")) {
+				if (jsonParserFieldValue != null) {
+					assetListEntry.setDateCreated(
+						toDate((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "dateModified")) {
+				if (jsonParserFieldValue != null) {
+					assetListEntry.setDateModified(
+						toDate((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(
+						jsonParserFieldName, "externalReferenceCode")) {
+
+				if (jsonParserFieldValue != null) {
+					assetListEntry.setExternalReferenceCode(
+						(String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "itemSubtype")) {
+				if (jsonParserFieldValue != null) {
+					assetListEntry.setItemSubtype((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "itemType")) {
+				if (jsonParserFieldValue != null) {
+					assetListEntry.setItemType((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "title")) {
+				if (jsonParserFieldValue != null) {
+					assetListEntry.setTitle((String)jsonParserFieldValue);
+				}
+			}
+		}
+
+	}
+
+	private static String _escape(Object object) {
+		String string = String.valueOf(object);
+
+		for (String[] strings : BaseJSONParser.JSON_ESCAPE_STRINGS) {
+			string = string.replace(strings[0], strings[1]);
+		}
+
+		return string;
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(entry.getKey());
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			sb.append(_toJSON(value));
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static String _toJSON(Object value) {
+		if (value == null) {
+			return "null";
+		}
+
+		if (value instanceof Map) {
+			return _toJSON((Map)value);
+		}
+
+		Class<?> clazz = value.getClass();
+
+		if (clazz.isArray()) {
+			StringBuilder sb = new StringBuilder("[");
+
+			Object[] values = (Object[])value;
+
+			for (int i = 0; i < values.length; i++) {
+				sb.append(_toJSON(values[i]));
+
+				if ((i + 1) < values.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+
+			return sb.toString();
+		}
+
+		if (value instanceof String) {
+			return "\"" + _escape(value) + "\"";
+		}
+
+		return String.valueOf(value);
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:-1916371748

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
@@ -56,6 +56,57 @@ components:
                     readOnly: true
                     type: number
             type: object
+        AssetListEntry:
+            description:
+                Represents a persisted Content Set (AssetListEntry) exposed for discovery by the Item Selector.
+            properties:
+                assetListEntryId:
+                    description:
+                        The AssetListEntry's primary key. Equal to classPK; exposed explicitly because the field name is
+                        meaningful to callers reading the DTO.
+                    format: int64
+                    readOnly: true
+                    type: integer
+                classNameId:
+                    description:
+                        The class name ID of AssetListEntry, mirrors the legacy click payload.
+                    format: int64
+                    readOnly: true
+                    type: integer
+                classPK:
+                    description:
+                        The AssetListEntry's id (=assetListEntryId), kept as classPK for legacy
+                        InfoListItemSelectorReturnType parity.
+                    format: int64
+                    readOnly: true
+                    type: integer
+                dateCreated:
+                    format: date-time
+                    readOnly: true
+                    type: string
+                dateModified:
+                    format: date-time
+                    readOnly: true
+                    type: string
+                externalReferenceCode:
+                    description:
+                        Standard Liferay headless field for portable cross-system references.
+                    readOnly: true
+                    type: string
+                itemSubtype:
+                    description:
+                        The AssetEntry subtype (DDM structure id, etc.); mirrors AssetListEntry.assetEntrySubtype.
+                    readOnly: true
+                    type: string
+                itemType:
+                    description:
+                        The AssetEntry FQCN this list returns; mirrors AssetListEntry.assetEntryType.
+                    readOnly: true
+                    type: string
+                title:
+                    readOnly: true
+                    type: string
+            type: object
         BlogPosting:
             description:
                 Represents a blog post. See [BlogPosting](https://www.schema.org/BlogPosting) for more information.
@@ -6263,6 +6314,57 @@ info:
     version: v1.0
 openapi: 3.0.1
 paths:
+    "/asset-libraries/{assetLibraryId}/asset-list-entries":
+        get:
+            description:
+                Lists the asset library's persisted Content Sets (AssetListEntry). Results can be paginated, filtered,
+                searched, and sorted.
+            operationId: getAssetLibraryAssetListEntriesPage
+            parameters:
+                -   in: path
+                    name: assetLibraryId
+                    required: true
+                    schema:
+                        format: int64
+                        type: integer
+                -   in: query
+                    name: filter
+                    schema:
+                        type: string
+                -   in: query
+                    name: page
+                    schema:
+                        type: integer
+                -   in: query
+                    name: pageSize
+                    schema:
+                        type: integer
+                -   in: query
+                    name: search
+                    schema:
+                        type: string
+                -   in: query
+                    name: sort
+                    schema:
+                        type: string
+                -   in: header
+                    name: Accept-Language
+                    schema:
+                        type: string
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/AssetListEntry"
+                                type: array
+                        application/xml:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/AssetListEntry"
+                                type: array
+            tags: ["AssetListEntry"]
     "/asset-libraries/{assetLibraryId}/content-elements":
         get:
             operationId: getAssetLibraryContentElementsPage
@@ -12273,6 +12375,57 @@ paths:
                         application/json: {}
                         application/xml: {}
             tags: ["NavigationMenu"]
+    "/sites/{siteId}/asset-list-entries":
+        get:
+            description:
+                Lists the site's persisted Content Sets (AssetListEntry). Results can be paginated, filtered, searched,
+                and sorted.
+            operationId: getSiteAssetListEntriesPage
+            parameters:
+                -   in: path
+                    name: siteId
+                    required: true
+                    schema:
+                        format: int64
+                        type: integer
+                -   in: query
+                    name: filter
+                    schema:
+                        type: string
+                -   in: query
+                    name: page
+                    schema:
+                        type: integer
+                -   in: query
+                    name: pageSize
+                    schema:
+                        type: integer
+                -   in: query
+                    name: search
+                    schema:
+                        type: string
+                -   in: query
+                    name: sort
+                    schema:
+                        type: string
+                -   in: header
+                    name: Accept-Language
+                    schema:
+                        type: string
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/AssetListEntry"
+                                type: array
+                        application/xml:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/AssetListEntry"
+                                type: array
+            tags: ["AssetListEntry"]
     "/sites/{siteId}/blog-posting-images":
         get:
             description:

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/AssetListEntryDTOConverter.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/AssetListEntryDTOConverter.java
@@ -1,0 +1,73 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.delivery.internal.dto.v1_0.converter;
+
+import com.liferay.asset.list.service.AssetListEntryLocalService;
+import com.liferay.headless.delivery.dto.v1_0.AssetListEntry;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.vulcan.dto.converter.DTOConverter;
+import com.liferay.portal.vulcan.dto.converter.DTOConverterContext;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Luis Ortiz
+ */
+@Component(
+	property = "dto.class.name=com.liferay.asset.list.model.AssetListEntry",
+	service = DTOConverter.class
+)
+public class AssetListEntryDTOConverter
+	implements DTOConverter
+		<com.liferay.asset.list.model.AssetListEntry, AssetListEntry> {
+
+	@Override
+	public String getContentType() {
+		return AssetListEntry.class.getSimpleName();
+	}
+
+	@Override
+	public AssetListEntry toDTO(DTOConverterContext dtoConverterContext)
+		throws Exception {
+
+		return toDTO(
+			dtoConverterContext,
+			_assetListEntryLocalService.getAssetListEntry(
+				(Long)dtoConverterContext.getId()));
+	}
+
+	@Override
+	public AssetListEntry toDTO(
+			DTOConverterContext dtoConverterContext,
+			com.liferay.asset.list.model.AssetListEntry assetListEntry)
+		throws Exception {
+
+		return new AssetListEntry() {
+			{
+				setAssetListEntryId(assetListEntry::getAssetListEntryId);
+				setClassNameId(
+					() -> _portal.getClassNameId(
+						com.liferay.asset.list.model.AssetListEntry.class));
+				setClassPK(assetListEntry::getAssetListEntryId);
+				setDateCreated(assetListEntry::getCreateDate);
+				setDateModified(assetListEntry::getModifiedDate);
+				setExternalReferenceCode(
+					assetListEntry::getExternalReferenceCode);
+				setItemSubtype(assetListEntry::getAssetEntrySubtype);
+				setItemType(assetListEntry::getAssetEntryType);
+				setTitle(assetListEntry::getTitle);
+			}
+		};
+	}
+
+	@Reference
+	private AssetListEntryLocalService _assetListEntryLocalService;
+
+	@Reference
+	private Portal _portal;
+
+}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/mutation/v1_0/Mutation.java
@@ -28,6 +28,7 @@ import com.liferay.headless.delivery.dto.v1_0.StructuredContentFolder;
 import com.liferay.headless.delivery.dto.v1_0.WikiNode;
 import com.liferay.headless.delivery.dto.v1_0.WikiPage;
 import com.liferay.headless.delivery.dto.v1_0.WikiPageAttachment;
+import com.liferay.headless.delivery.resource.v1_0.AssetListEntryResource;
 import com.liferay.headless.delivery.resource.v1_0.BlogPostingImageResource;
 import com.liferay.headless.delivery.resource.v1_0.BlogPostingResource;
 import com.liferay.headless.delivery.resource.v1_0.CommentResource;
@@ -86,6 +87,14 @@ import org.osgi.service.component.ComponentServiceObjects;
  */
 @Generated("")
 public class Mutation {
+
+	public static void setAssetListEntryResourceComponentServiceObjects(
+		ComponentServiceObjects<AssetListEntryResource>
+			assetListEntryResourceComponentServiceObjects) {
+
+		_assetListEntryResourceComponentServiceObjects =
+			assetListEntryResourceComponentServiceObjects;
+	}
 
 	public static void setBlogPostingResourceComponentServiceObjects(
 		ComponentServiceObjects<BlogPostingResource>
@@ -296,6 +305,54 @@ public class Mutation {
 
 		_wikiPageAttachmentResourceComponentServiceObjects =
 			wikiPageAttachmentResourceComponentServiceObjects;
+	}
+
+	@GraphQLField
+	public Response createAssetLibraryAssetListEntriesPageExportBatch(
+			@GraphQLName("assetLibraryId") @NotEmpty String assetLibraryId,
+			@GraphQLName("search") String search,
+			@GraphQLName("filter") String filterString,
+			@GraphQLName("sort") String sortsString,
+			@GraphQLName("callbackURL") String callbackURL,
+			@GraphQLName("contentType") String contentType,
+			@GraphQLName("fieldNames") String fieldNames)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_assetListEntryResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			assetListEntryResource ->
+				assetListEntryResource.
+					postAssetLibraryAssetListEntriesPageExportBatch(
+						Long.valueOf(assetLibraryId), search,
+						_filterBiFunction.apply(
+							assetListEntryResource, filterString),
+						_sortsBiFunction.apply(
+							assetListEntryResource, sortsString),
+						callbackURL, contentType, fieldNames));
+	}
+
+	@GraphQLField
+	public Response createSiteAssetListEntriesPageExportBatch(
+			@GraphQLName("siteKey") @NotEmpty String siteKey,
+			@GraphQLName("search") String search,
+			@GraphQLName("filter") String filterString,
+			@GraphQLName("sort") String sortsString,
+			@GraphQLName("callbackURL") String callbackURL,
+			@GraphQLName("contentType") String contentType,
+			@GraphQLName("fieldNames") String fieldNames)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_assetListEntryResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			assetListEntryResource ->
+				assetListEntryResource.postSiteAssetListEntriesPageExportBatch(
+					Long.valueOf(siteKey), search,
+					_filterBiFunction.apply(
+						assetListEntryResource, filterString),
+					_sortsBiFunction.apply(assetListEntryResource, sortsString),
+					callbackURL, contentType, fieldNames));
 	}
 
 	@GraphQLField(
@@ -6274,6 +6331,28 @@ public class Mutation {
 	}
 
 	private void _populateResourceContext(
+			AssetListEntryResource assetListEntryResource)
+		throws Exception {
+
+		assetListEntryResource.setContextAcceptLanguage(_acceptLanguage);
+		assetListEntryResource.setContextCompany(_company);
+		assetListEntryResource.setContextHttpServletRequest(
+			_httpServletRequest);
+		assetListEntryResource.setContextHttpServletResponse(
+			_httpServletResponse);
+		assetListEntryResource.setContextUriInfo(_uriInfo);
+		assetListEntryResource.setContextUser(_user);
+		assetListEntryResource.setGroupLocalService(_groupLocalService);
+		assetListEntryResource.setRoleLocalService(_roleLocalService);
+
+		assetListEntryResource.setVulcanBatchEngineExportTaskResource(
+			_vulcanBatchEngineExportTaskResource);
+
+		assetListEntryResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
+	}
+
+	private void _populateResourceContext(
 			BlogPostingResource blogPostingResource)
 		throws Exception {
 
@@ -6836,6 +6915,8 @@ public class Mutation {
 			_vulcanBatchEngineImportTaskResource);
 	}
 
+	private static ComponentServiceObjects<AssetListEntryResource>
+		_assetListEntryResourceComponentServiceObjects;
 	private static ComponentServiceObjects<BlogPostingResource>
 		_blogPostingResourceComponentServiceObjects;
 	private static ComponentServiceObjects<BlogPostingImageResource>
@@ -6908,4 +6989,4 @@ public class Mutation {
 		_vulcanBatchEngineImportTaskResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:505624026
+// LIFERAY-REST-BUILDER-HASH:-1538584947

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/query/v1_0/Query.java
@@ -5,6 +5,7 @@
 
 package com.liferay.headless.delivery.internal.graphql.query.v1_0;
 
+import com.liferay.headless.delivery.dto.v1_0.AssetListEntry;
 import com.liferay.headless.delivery.dto.v1_0.BlogPosting;
 import com.liferay.headless.delivery.dto.v1_0.BlogPostingImage;
 import com.liferay.headless.delivery.dto.v1_0.Comment;
@@ -34,6 +35,7 @@ import com.liferay.headless.delivery.dto.v1_0.StructuredContentFolder;
 import com.liferay.headless.delivery.dto.v1_0.WikiNode;
 import com.liferay.headless.delivery.dto.v1_0.WikiPage;
 import com.liferay.headless.delivery.dto.v1_0.WikiPageAttachment;
+import com.liferay.headless.delivery.resource.v1_0.AssetListEntryResource;
 import com.liferay.headless.delivery.resource.v1_0.BlogPostingImageResource;
 import com.liferay.headless.delivery.resource.v1_0.BlogPostingResource;
 import com.liferay.headless.delivery.resource.v1_0.CommentResource;
@@ -98,6 +100,14 @@ import org.osgi.service.component.ComponentServiceObjects;
  */
 @Generated("")
 public class Query {
+
+	public static void setAssetListEntryResourceComponentServiceObjects(
+		ComponentServiceObjects<AssetListEntryResource>
+			assetListEntryResourceComponentServiceObjects) {
+
+		_assetListEntryResourceComponentServiceObjects =
+			assetListEntryResourceComponentServiceObjects;
+	}
 
 	public static void setBlogPostingResourceComponentServiceObjects(
 		ComponentServiceObjects<BlogPostingResource>
@@ -316,6 +326,66 @@ public class Query {
 
 		_wikiPageAttachmentResourceComponentServiceObjects =
 			wikiPageAttachmentResourceComponentServiceObjects;
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {assetLibraryAssetListEntries(assetLibraryId: ___, filter: ___, page: ___, pageSize: ___, search: ___, sorts: ___){items {__}, page, pageSize, totalCount}}"}' -u 'test@liferay.com:test'
+	 */
+	@GraphQLField(
+		description = "Lists the asset library's persisted Content Sets (AssetListEntry). Results can be paginated, filtered, searched, and sorted."
+	)
+	public AssetListEntryPage assetLibraryAssetListEntries(
+			@GraphQLName("assetLibraryId") @NotEmpty String assetLibraryId,
+			@GraphQLName("search") String search,
+			@GraphQLName("filter") String filterString,
+			@GraphQLName("pageSize") int pageSize,
+			@GraphQLName("page") int page,
+			@GraphQLName("sort") String sortsString)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_assetListEntryResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			assetListEntryResource -> new AssetListEntryPage(
+				assetListEntryResource.getAssetLibraryAssetListEntriesPage(
+					Long.valueOf(assetLibraryId), search,
+					_filterBiFunction.apply(
+						assetListEntryResource, filterString),
+					Pagination.of(page, pageSize),
+					_sortsBiFunction.apply(
+						assetListEntryResource, sortsString))));
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {assetListEntries(filter: ___, page: ___, pageSize: ___, search: ___, siteKey: ___, sorts: ___){items {__}, page, pageSize, totalCount}}"}' -u 'test@liferay.com:test'
+	 */
+	@GraphQLField(
+		description = "Lists the site's persisted Content Sets (AssetListEntry). Results can be paginated, filtered, searched, and sorted."
+	)
+	public AssetListEntryPage assetListEntries(
+			@GraphQLName("siteKey") @NotEmpty String siteKey,
+			@GraphQLName("search") String search,
+			@GraphQLName("filter") String filterString,
+			@GraphQLName("pageSize") int pageSize,
+			@GraphQLName("page") int page,
+			@GraphQLName("sort") String sortsString)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_assetListEntryResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			assetListEntryResource -> new AssetListEntryPage(
+				assetListEntryResource.getSiteAssetListEntriesPage(
+					Long.valueOf(siteKey), search,
+					_filterBiFunction.apply(
+						assetListEntryResource, filterString),
+					Pagination.of(page, pageSize),
+					_sortsBiFunction.apply(
+						assetListEntryResource, sortsString))));
 	}
 
 	/**
@@ -5758,6 +5828,44 @@ public class Query {
 
 	}
 
+	@GraphQLName("AssetListEntryPage")
+	public class AssetListEntryPage {
+
+		public AssetListEntryPage(Page assetListEntryPage) {
+			actions = assetListEntryPage.getActions();
+
+			facets = assetListEntryPage.getFacets();
+
+			items = assetListEntryPage.getItems();
+			lastPage = assetListEntryPage.getLastPage();
+			page = assetListEntryPage.getPage();
+			pageSize = assetListEntryPage.getPageSize();
+			totalCount = assetListEntryPage.getTotalCount();
+		}
+
+		@GraphQLField
+		protected Map<String, Map<String, String>> actions;
+
+		@GraphQLField
+		protected List<Facet> facets;
+
+		@GraphQLField
+		protected java.util.Collection<AssetListEntry> items;
+
+		@GraphQLField
+		protected long lastPage;
+
+		@GraphQLField
+		protected long page;
+
+		@GraphQLField
+		protected long pageSize;
+
+		@GraphQLField
+		protected long totalCount;
+
+	}
+
 	@GraphQLName("BlogPostingPage")
 	public class BlogPostingPage {
 
@@ -7031,6 +7139,26 @@ public class Query {
 	}
 
 	private void _populateResourceContext(
+			AssetListEntryResource assetListEntryResource)
+		throws Exception {
+
+		assetListEntryResource.setContextAcceptLanguage(_acceptLanguage);
+		assetListEntryResource.setContextCompany(_company);
+		assetListEntryResource.setContextHttpServletRequest(
+			_httpServletRequest);
+		assetListEntryResource.setContextHttpServletResponse(
+			_httpServletResponse);
+		assetListEntryResource.setContextUriInfo(_uriInfo);
+		assetListEntryResource.setContextUser(_user);
+		assetListEntryResource.setGroupLocalService(_groupLocalService);
+		assetListEntryResource.setResourceActionLocalService(
+			_resourceActionLocalService);
+		assetListEntryResource.setResourcePermissionLocalService(
+			_resourcePermissionLocalService);
+		assetListEntryResource.setRoleLocalService(_roleLocalService);
+	}
+
+	private void _populateResourceContext(
 			BlogPostingResource blogPostingResource)
 		throws Exception {
 
@@ -7559,6 +7687,8 @@ public class Query {
 		wikiPageAttachmentResource.setRoleLocalService(_roleLocalService);
 	}
 
+	private static ComponentServiceObjects<AssetListEntryResource>
+		_assetListEntryResourceComponentServiceObjects;
 	private static ComponentServiceObjects<BlogPostingResource>
 		_blogPostingResourceComponentServiceObjects;
 	private static ComponentServiceObjects<BlogPostingImageResource>
@@ -7633,4 +7763,4 @@ public class Query {
 	private com.liferay.portal.kernel.model.User _user;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1704935486
+// LIFERAY-REST-BUILDER-HASH:232318986

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -7,6 +7,7 @@ package com.liferay.headless.delivery.internal.graphql.servlet.v1_0;
 
 import com.liferay.headless.delivery.internal.graphql.mutation.v1_0.Mutation;
 import com.liferay.headless.delivery.internal.graphql.query.v1_0.Query;
+import com.liferay.headless.delivery.internal.resource.v1_0.AssetListEntryResourceImpl;
 import com.liferay.headless.delivery.internal.resource.v1_0.BlogPostingImageResourceImpl;
 import com.liferay.headless.delivery.internal.resource.v1_0.BlogPostingResourceImpl;
 import com.liferay.headless.delivery.internal.resource.v1_0.CommentResourceImpl;
@@ -34,6 +35,7 @@ import com.liferay.headless.delivery.internal.resource.v1_0.StructuredContentRes
 import com.liferay.headless.delivery.internal.resource.v1_0.WikiNodeResourceImpl;
 import com.liferay.headless.delivery.internal.resource.v1_0.WikiPageAttachmentResourceImpl;
 import com.liferay.headless.delivery.internal.resource.v1_0.WikiPageResourceImpl;
+import com.liferay.headless.delivery.resource.v1_0.AssetListEntryResource;
 import com.liferay.headless.delivery.resource.v1_0.BlogPostingImageResource;
 import com.liferay.headless.delivery.resource.v1_0.BlogPostingResource;
 import com.liferay.headless.delivery.resource.v1_0.CommentResource;
@@ -86,6 +88,8 @@ public class ServletDataImpl implements ServletData {
 
 	@Activate
 	public void activate(BundleContext bundleContext) {
+		Mutation.setAssetListEntryResourceComponentServiceObjects(
+			_assetListEntryResourceComponentServiceObjects);
 		Mutation.setBlogPostingResourceComponentServiceObjects(
 			_blogPostingResourceComponentServiceObjects);
 		Mutation.setBlogPostingImageResourceComponentServiceObjects(
@@ -139,6 +143,8 @@ public class ServletDataImpl implements ServletData {
 		Mutation.setWikiPageAttachmentResourceComponentServiceObjects(
 			_wikiPageAttachmentResourceComponentServiceObjects);
 
+		Query.setAssetListEntryResourceComponentServiceObjects(
+			_assetListEntryResourceComponentServiceObjects);
 		Query.setBlogPostingResourceComponentServiceObjects(
 			_blogPostingResourceComponentServiceObjects);
 		Query.setBlogPostingImageResourceComponentServiceObjects(
@@ -229,6 +235,16 @@ public class ServletDataImpl implements ServletData {
 		_resourceMethodObjectValuePairs =
 			new HashMap<String, ObjectValuePair<Class<?>, String>>() {
 				{
+					put(
+						"mutation#createAssetLibraryAssetListEntriesPageExportBatch",
+						new ObjectValuePair<>(
+							AssetListEntryResourceImpl.class,
+							"postAssetLibraryAssetListEntriesPageExportBatch"));
+					put(
+						"mutation#createSiteAssetListEntriesPageExportBatch",
+						new ObjectValuePair<>(
+							AssetListEntryResourceImpl.class,
+							"postSiteAssetListEntriesPageExportBatch"));
 					put(
 						"mutation#deleteBlogPosting",
 						new ObjectValuePair<>(
@@ -1866,6 +1882,16 @@ public class ServletDataImpl implements ServletData {
 							"postWikiPageWikiPageAttachmentsPageExportBatch"));
 
 					put(
+						"query#assetLibraryAssetListEntries",
+						new ObjectValuePair<>(
+							AssetListEntryResourceImpl.class,
+							"getAssetLibraryAssetListEntriesPage"));
+					put(
+						"query#assetListEntries",
+						new ObjectValuePair<>(
+							AssetListEntryResourceImpl.class,
+							"getSiteAssetListEntriesPage"));
+					put(
 						"query#blogPosting",
 						new ObjectValuePair<>(
 							BlogPostingResourceImpl.class, "getBlogPosting"));
@@ -2985,6 +3011,10 @@ public class ServletDataImpl implements ServletData {
 			};
 
 	@Reference(scope = ReferenceScope.PROTOTYPE_REQUIRED)
+	private ComponentServiceObjects<AssetListEntryResource>
+		_assetListEntryResourceComponentServiceObjects;
+
+	@Reference(scope = ReferenceScope.PROTOTYPE_REQUIRED)
 	private ComponentServiceObjects<BlogPostingResource>
 		_blogPostingResourceComponentServiceObjects;
 
@@ -3093,4 +3123,4 @@ public class ServletDataImpl implements ServletData {
 		_contentSetElementResourceComponentServiceObjects;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1122700236
+// LIFERAY-REST-BUILDER-HASH:1354618172

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/AssetListEntryEntityModel.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/AssetListEntryEntityModel.java
@@ -1,0 +1,44 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.delivery.internal.odata.entity.v1_0;
+
+import com.liferay.headless.common.spi.odata.entity.EntityFieldsMapFactory;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.odata.entity.DateTimeEntityField;
+import com.liferay.portal.odata.entity.EntityField;
+import com.liferay.portal.odata.entity.EntityModel;
+import com.liferay.portal.odata.entity.StringEntityField;
+
+import java.util.Map;
+
+/**
+ * @author Luis Ortiz
+ */
+public class AssetListEntryEntityModel implements EntityModel {
+
+	public AssetListEntryEntityModel() {
+		_entityFieldsMap = EntityFieldsMapFactory.create(
+			new DateTimeEntityField(
+				"dateCreated",
+				locale -> Field.getSortableFieldName(Field.CREATE_DATE),
+				locale -> Field.CREATE_DATE),
+			new DateTimeEntityField(
+				"dateModified",
+				locale -> Field.getSortableFieldName(Field.MODIFIED_DATE),
+				locale -> Field.MODIFIED_DATE),
+			new StringEntityField("itemSubtype", locale -> "assetEntrySubtype"),
+			new StringEntityField("itemType", locale -> "assetEntryType"),
+			new StringEntityField("title", locale -> Field.TITLE));
+	}
+
+	@Override
+	public Map<String, EntityField> getEntityFieldsMap() {
+		return _entityFieldsMap;
+	}
+
+	private final Map<String, EntityField> _entityFieldsMap;
+
+}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/AssetListEntryResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/AssetListEntryResourceImpl.java
@@ -1,0 +1,105 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.delivery.internal.resource.v1_0;
+
+import com.liferay.headless.delivery.dto.v1_0.AssetListEntry;
+import com.liferay.headless.delivery.internal.odata.entity.v1_0.AssetListEntryEntityModel;
+import com.liferay.headless.delivery.resource.v1_0.AssetListEntryResource;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.Sort;
+import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.odata.entity.EntityModel;
+import com.liferay.portal.vulcan.dto.converter.DTOConverter;
+import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
+import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.util.SearchUtil;
+
+import jakarta.ws.rs.core.MultivaluedMap;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ServiceScope;
+
+/**
+ * @author Luis Ortiz
+ */
+@Component(
+	properties = "OSGI-INF/liferay/rest/v1_0/asset-list-entry.properties",
+	scope = ServiceScope.PROTOTYPE, service = AssetListEntryResource.class
+)
+public class AssetListEntryResourceImpl extends BaseAssetListEntryResourceImpl {
+
+	@Override
+	public Page<AssetListEntry> getAssetLibraryAssetListEntriesPage(
+			Long assetLibraryId, String search, Filter filter,
+			Pagination pagination, Sort[] sorts)
+		throws Exception {
+
+		return _getAssetListEntriesPage(
+			assetLibraryId, search, filter, pagination, sorts);
+	}
+
+	@Override
+	public EntityModel getEntityModel(MultivaluedMap multivaluedMap) {
+		return _entityModel;
+	}
+
+	@Override
+	public Page<AssetListEntry> getSiteAssetListEntriesPage(
+			Long siteId, String search, Filter filter, Pagination pagination,
+			Sort[] sorts)
+		throws Exception {
+
+		return _getAssetListEntriesPage(
+			siteId, search, filter, pagination, sorts);
+	}
+
+	private Page<AssetListEntry> _getAssetListEntriesPage(
+			Long groupId, String search, Filter filter, Pagination pagination,
+			Sort[] sorts)
+		throws Exception {
+
+		return SearchUtil.search(
+			null,
+			booleanQuery -> {
+			},
+			filter, com.liferay.asset.list.model.AssetListEntry.class.getName(),
+			GetterUtil.getString(search), pagination,
+			queryConfig -> queryConfig.setSelectedFieldNames(
+				Field.ENTRY_CLASS_PK),
+			searchContext -> {
+				searchContext.setCompanyId(contextCompany.getCompanyId());
+				searchContext.setGroupIds(new long[] {groupId});
+				searchContext.setUserId(contextUser.getUserId());
+			},
+			sorts,
+			document -> _toAssetListEntry(
+				GetterUtil.getLong(document.get(Field.ENTRY_CLASS_PK))));
+	}
+
+	private AssetListEntry _toAssetListEntry(long assetListEntryId)
+		throws Exception {
+
+		return _assetListEntryDTOConverter.toDTO(
+			new DefaultDTOConverterContext(
+				null, assetListEntryId,
+				contextAcceptLanguage.getPreferredLocale(), contextUriInfo,
+				contextUser));
+	}
+
+	private static final EntityModel _entityModel =
+		new AssetListEntryEntityModel();
+
+	@Reference(
+		target = "(component.name=com.liferay.headless.delivery.internal.dto.v1_0.converter.AssetListEntryDTOConverter)"
+	)
+	private DTOConverter
+		<com.liferay.asset.list.model.AssetListEntry, AssetListEntry>
+			_assetListEntryDTOConverter;
+
+}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseAssetListEntryResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseAssetListEntryResourceImpl.java
@@ -1,0 +1,1052 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.delivery.internal.resource.v1_0;
+
+import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
+import com.liferay.headless.delivery.dto.v1_0.AssetListEntry;
+import com.liferay.headless.delivery.dto.v1_0.DefaultValue;
+import com.liferay.headless.delivery.resource.v1_0.AssetListEntryResource;
+import com.liferay.petra.function.UnsafeBiConsumer;
+import com.liferay.petra.function.UnsafeConsumer;
+import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.odata.entity.EntityModel;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParser;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortField;
+import com.liferay.portal.odata.sort.SortParser;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineExportTaskResource;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
+import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.resource.EntityModelResource;
+import com.liferay.portal.vulcan.util.ActionUtil;
+import com.liferay.portal.vulcan.util.UriInfoUtil;
+
+import jakarta.annotation.Generated;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import jakarta.ws.rs.NotSupportedException;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
+
+import java.io.Serializable;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+@jakarta.ws.rs.Path("/v1.0")
+public abstract class BaseAssetListEntryResourceImpl
+	implements AssetListEntryResource, EntityModelResource,
+			   VulcanBatchEngineTaskItemDelegate<AssetListEntry> {
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'GET' 'http://localhost:8080/o/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/asset-list-entries'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Lists the asset library's persisted Content Sets (AssetListEntry). Results can be paginated, filtered, searched, and sorted."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "assetLibraryId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "filter"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "page"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "pageSize"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "search"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "sort"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(name = "AssetListEntry")
+		}
+	)
+	@jakarta.ws.rs.GET
+	@jakarta.ws.rs.Path("/asset-libraries/{assetLibraryId}/asset-list-entries")
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public Page<AssetListEntry> getAssetLibraryAssetListEntriesPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.validation.constraints.NotNull
+			@jakarta.ws.rs.PathParam("assetLibraryId")
+			Long assetLibraryId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("search")
+			String search,
+			@jakarta.ws.rs.core.Context
+				com.liferay.portal.kernel.search.filter.Filter filter,
+			@jakarta.ws.rs.core.Context Pagination pagination,
+			@jakarta.ws.rs.core.Context com.liferay.portal.kernel.search.Sort[]
+				sorts)
+		throws Exception {
+
+		return Page.of(Collections.emptyList());
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'GET' 'http://localhost:8080/o/headless-delivery/v1.0/sites/{siteId}/asset-list-entries'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Lists the site's persisted Content Sets (AssetListEntry). Results can be paginated, filtered, searched, and sorted."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "siteId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "filter"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "page"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "pageSize"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "search"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "sort"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(name = "AssetListEntry")
+		}
+	)
+	@jakarta.ws.rs.GET
+	@jakarta.ws.rs.Path("/sites/{siteId}/asset-list-entries")
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public Page<AssetListEntry> getSiteAssetListEntriesPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.validation.constraints.NotNull
+			@jakarta.ws.rs.PathParam("siteId")
+			Long siteId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("search")
+			String search,
+			@jakarta.ws.rs.core.Context
+				com.liferay.portal.kernel.search.filter.Filter filter,
+			@jakarta.ws.rs.core.Context Pagination pagination,
+			@jakarta.ws.rs.core.Context com.liferay.portal.kernel.search.Sort[]
+				sorts)
+		throws Exception {
+
+		return Page.of(Collections.emptyList());
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/asset-list-entries/export-batch'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "assetLibraryId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "filter"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "search"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "sort"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "callbackURL"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "contentType"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "fieldNames"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(name = "AssetListEntry")
+		}
+	)
+	@jakarta.ws.rs.Consumes("application/json")
+	@jakarta.ws.rs.Path(
+		"/asset-libraries/{assetLibraryId}/asset-list-entries/export-batch"
+	)
+	@jakarta.ws.rs.POST
+	@jakarta.ws.rs.Produces("application/json")
+	@Override
+	public Response postAssetLibraryAssetListEntriesPageExportBatch(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.validation.constraints.NotNull
+			@jakarta.ws.rs.PathParam("assetLibraryId")
+			Long assetLibraryId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("search")
+			String search,
+			@jakarta.ws.rs.core.Context
+				com.liferay.portal.kernel.search.filter.Filter filter,
+			@jakarta.ws.rs.core.Context com.liferay.portal.kernel.search.Sort[]
+				sorts,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("callbackURL")
+			String callbackURL,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.DefaultValue("JSON")
+			@jakarta.ws.rs.QueryParam("contentType")
+			String contentType,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("fieldNames")
+			String fieldNames)
+		throws Exception {
+
+		vulcanBatchEngineExportTaskResource.setContextAcceptLanguage(
+			contextAcceptLanguage);
+		vulcanBatchEngineExportTaskResource.setContextCompany(contextCompany);
+		vulcanBatchEngineExportTaskResource.setContextHttpServletRequest(
+			contextHttpServletRequest);
+		vulcanBatchEngineExportTaskResource.setContextUriInfo(contextUriInfo);
+		vulcanBatchEngineExportTaskResource.setContextUser(contextUser);
+		vulcanBatchEngineExportTaskResource.setGroupLocalService(
+			groupLocalService);
+
+		Response.ResponseBuilder responseBuilder = Response.accepted();
+
+		return responseBuilder.entity(
+			vulcanBatchEngineExportTaskResource.postExportTask(
+				AssetListEntry.class.getName(), callbackURL, contentType,
+				fieldNames)
+		).build();
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-delivery/v1.0/sites/{siteId}/asset-list-entries/export-batch'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "siteId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "filter"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "search"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "sort"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "callbackURL"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "contentType"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "fieldNames"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(name = "AssetListEntry")
+		}
+	)
+	@jakarta.ws.rs.Consumes("application/json")
+	@jakarta.ws.rs.Path("/sites/{siteId}/asset-list-entries/export-batch")
+	@jakarta.ws.rs.POST
+	@jakarta.ws.rs.Produces("application/json")
+	@Override
+	public Response postSiteAssetListEntriesPageExportBatch(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.validation.constraints.NotNull
+			@jakarta.ws.rs.PathParam("siteId")
+			Long siteId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("search")
+			String search,
+			@jakarta.ws.rs.core.Context
+				com.liferay.portal.kernel.search.filter.Filter filter,
+			@jakarta.ws.rs.core.Context com.liferay.portal.kernel.search.Sort[]
+				sorts,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("callbackURL")
+			String callbackURL,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.DefaultValue("JSON")
+			@jakarta.ws.rs.QueryParam("contentType")
+			String contentType,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("fieldNames")
+			String fieldNames)
+		throws Exception {
+
+		vulcanBatchEngineExportTaskResource.setContextAcceptLanguage(
+			contextAcceptLanguage);
+		vulcanBatchEngineExportTaskResource.setContextCompany(contextCompany);
+		vulcanBatchEngineExportTaskResource.setContextHttpServletRequest(
+			contextHttpServletRequest);
+		vulcanBatchEngineExportTaskResource.setContextUriInfo(contextUriInfo);
+		vulcanBatchEngineExportTaskResource.setContextUser(contextUser);
+		vulcanBatchEngineExportTaskResource.setGroupLocalService(
+			groupLocalService);
+
+		Response.ResponseBuilder responseBuilder = Response.accepted();
+
+		return responseBuilder.entity(
+			vulcanBatchEngineExportTaskResource.postExportTask(
+				AssetListEntry.class.getName(), callbackURL, contentType,
+				fieldNames)
+		).build();
+	}
+
+	@Override
+	@SuppressWarnings("PMD.UnusedLocalVariable")
+	public void create(
+			Collection<AssetListEntry> assetListEntries,
+			Map<String, Serializable> parameters)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Override
+	public void delete(
+			Collection<AssetListEntry> assetListEntries,
+			Map<String, Serializable> parameters)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	@Override
+	public EntityModel getEntityModel(Map<String, List<String>> multivaluedMap)
+		throws Exception {
+
+		return getEntityModel(
+			new MultivaluedHashMap<String, Object>(multivaluedMap));
+	}
+
+	public String getResourceName() {
+		return "AssetListEntry";
+	}
+
+	public String getVersion() {
+		return "v1.0";
+	}
+
+	@Override
+	public Page<AssetListEntry> read(
+			com.liferay.portal.kernel.search.filter.Filter filter,
+			Pagination pagination,
+			com.liferay.portal.kernel.search.Sort[] sorts,
+			Map<String, Serializable> parameters, String search)
+		throws Exception {
+
+		if (parameters.containsKey("assetLibraryId")) {
+			return getAssetLibraryAssetListEntriesPage(
+				(Long)parameters.get("assetLibraryId"), search, filter,
+				pagination, sorts);
+		}
+		else if (parameters.containsKey("siteId")) {
+			return getSiteAssetListEntriesPage(
+				(Long)parameters.get("siteId"), search, filter, pagination,
+				sorts);
+		}
+		else {
+			throw new NotSupportedException(
+				"One of the following parameters must be specified: [assetLibraryId, siteId]");
+		}
+	}
+
+	@Override
+	public void setLanguageId(String languageId) {
+		this.contextAcceptLanguage = new AcceptLanguage() {
+
+			@Override
+			public List<Locale> getLocales() {
+				return null;
+			}
+
+			@Override
+			public String getPreferredLanguageId() {
+				return languageId;
+			}
+
+			@Override
+			public Locale getPreferredLocale() {
+				return LocaleUtil.fromLanguageId(languageId);
+			}
+
+			@Override
+			public boolean isAcceptAllLanguages() {
+				if (ExportImportThreadLocal.isExportInProcess()) {
+					return true;
+				}
+
+				return AcceptLanguage.super.isAcceptAllLanguages();
+			}
+
+		};
+	}
+
+	@Override
+	public void update(
+			Collection<AssetListEntry> assetListEntries,
+			Map<String, Serializable> parameters)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Override
+	public EntityModel getEntityModel(MultivaluedMap multivaluedMap)
+		throws Exception {
+
+		return null;
+	}
+
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
+		this.contextAcceptLanguage = contextAcceptLanguage;
+	}
+
+	public void setContextBatchUnsafeBiConsumer(
+		UnsafeBiConsumer
+			<Collection<AssetListEntry>,
+			 UnsafeFunction<AssetListEntry, AssetListEntry, Exception>,
+			 Exception> contextBatchUnsafeBiConsumer) {
+
+		this.contextBatchUnsafeBiConsumer = contextBatchUnsafeBiConsumer;
+	}
+
+	public void setContextBatchUnsafeConsumer(
+		UnsafeBiConsumer
+			<Collection<AssetListEntry>,
+			 UnsafeConsumer<AssetListEntry, Exception>, Exception>
+				contextBatchUnsafeConsumer) {
+
+		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
+	}
+
+	public void setContextCompany(
+		com.liferay.portal.kernel.model.Company contextCompany) {
+
+		this.contextCompany = contextCompany;
+	}
+
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = UriInfoUtil.getVulcanUriInfo(
+			getApplicationPath(), contextUriInfo);
+	}
+
+	public void setContextUser(
+		com.liferay.portal.kernel.model.User contextUser) {
+
+		this.contextUser = contextUser;
+	}
+
+	public void setExpressionConvert(
+		ExpressionConvert<com.liferay.portal.kernel.search.filter.Filter>
+			expressionConvert) {
+
+		this.expressionConvert = expressionConvert;
+	}
+
+	public void setFilterParserProvider(
+		FilterParserProvider filterParserProvider) {
+
+		this.filterParserProvider = filterParserProvider;
+	}
+
+	public void setGroupLocalService(GroupLocalService groupLocalService) {
+		this.groupLocalService = groupLocalService;
+	}
+
+	public void setResourceActionLocalService(
+		ResourceActionLocalService resourceActionLocalService) {
+
+		this.resourceActionLocalService = resourceActionLocalService;
+	}
+
+	public void setResourcePermissionLocalService(
+		ResourcePermissionLocalService resourcePermissionLocalService) {
+
+		this.resourcePermissionLocalService = resourcePermissionLocalService;
+	}
+
+	public void setRoleLocalService(RoleLocalService roleLocalService) {
+		this.roleLocalService = roleLocalService;
+	}
+
+	public void setSortParserProvider(SortParserProvider sortParserProvider) {
+		this.sortParserProvider = sortParserProvider;
+	}
+
+	protected String getApplicationPath() {
+		return "headless-delivery";
+	}
+
+	public void setVulcanBatchEngineExportTaskResource(
+		VulcanBatchEngineExportTaskResource
+			vulcanBatchEngineExportTaskResource) {
+
+		this.vulcanBatchEngineExportTaskResource =
+			vulcanBatchEngineExportTaskResource;
+	}
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
+	@Override
+	public com.liferay.portal.kernel.search.filter.Filter toFilter(
+		String filterString, Map<String, List<String>> multivaluedMap) {
+
+		try {
+			EntityModel entityModel = getEntityModel(multivaluedMap);
+
+			FilterParser filterParser = filterParserProvider.provide(
+				entityModel);
+
+			com.liferay.portal.odata.filter.Filter oDataFilter =
+				new com.liferay.portal.odata.filter.Filter(
+					filterParser.parse(filterString));
+
+			return expressionConvert.convert(
+				oDataFilter.getExpression(),
+				contextAcceptLanguage.getPreferredLocale(), entityModel);
+		}
+		catch (Exception exception) {
+			_log.error("Invalid filter " + filterString, exception);
+
+			return null;
+		}
+	}
+
+	@Override
+	public com.liferay.portal.kernel.search.Sort[] toSorts(String sortString) {
+		if (Validator.isNull(sortString)) {
+			return null;
+		}
+
+		try {
+			SortParser sortParser = sortParserProvider.provide(
+				getEntityModel(Collections.emptyMap()));
+
+			if (sortParser == null) {
+				return null;
+			}
+
+			com.liferay.portal.odata.sort.Sort oDataSort =
+				new com.liferay.portal.odata.sort.Sort(
+					sortParser.parse(sortString));
+
+			List<SortField> sortFields = oDataSort.getSortFields();
+			com.liferay.portal.kernel.search.Sort[] sorts =
+				new com.liferay.portal.kernel.search.Sort[sortFields.size()];
+
+			for (int i = 0; i < sortFields.size(); i++) {
+				SortField sortField = sortFields.get(i);
+
+				sorts[i] = new com.liferay.portal.kernel.search.Sort(
+					sortField.getSortableFieldName(
+						contextAcceptLanguage.getPreferredLocale()),
+					!sortField.isAscending());
+			}
+
+			return sorts;
+		}
+		catch (Exception exception) {
+			_log.error("Invalid sort " + sortString, exception);
+
+			return new com.liferay.portal.kernel.search.Sort[0];
+		}
+	}
+
+	protected Map<String, String> addAction(
+		String actionName,
+		com.liferay.portal.kernel.model.GroupedModel groupedModel,
+		String methodName) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), groupedModel, methodName,
+			contextScopeChecker, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, Long id, String methodName, Long ownerId,
+		String permissionName, Long siteId) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), id, methodName, contextScopeChecker,
+			ownerId, permissionName, siteId, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, Long id, String methodName,
+		ModelResourcePermission modelResourcePermission) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), id, methodName, contextScopeChecker,
+			modelResourcePermission, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, String methodName, String permissionName,
+		Long siteId) {
+
+		return addAction(
+			actionName, siteId, methodName, null, permissionName, siteId);
+	}
+
+	protected <T, R, E extends Throwable> List<R> transform(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transform(collection, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> R[] transform(
+		int[] array, UnsafeFunction<Integer, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transform(array, unsafeFunction, clazz);
+	}
+
+	public static <R, E extends Throwable> R[] transform(
+		long[] array, UnsafeFunction<Long, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] transform(
+		T[] array, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] transformToArray(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transformToArray(
+			collection, unsafeFunction, clazz);
+	}
+
+	public static <T, E extends Throwable> boolean[] transformToBooleanArray(
+		Collection<T> collection,
+		UnsafeFunction<T, Boolean, E> unsafeFunction) {
+
+		return TransformUtil.transformToBooleanArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> boolean[] transformToBooleanArray(
+		T[] array, UnsafeFunction<T, Boolean, E> unsafeFunction) {
+
+		return TransformUtil.transformToBooleanArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> byte[] transformToByteArray(
+		Collection<T> collection, UnsafeFunction<T, Byte, E> unsafeFunction) {
+
+		return TransformUtil.transformToByteArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> byte[] transformToByteArray(
+		T[] array, UnsafeFunction<T, Byte, E> unsafeFunction) {
+
+		return TransformUtil.transformToByteArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> double[] transformToDoubleArray(
+		Collection<T> collection, UnsafeFunction<T, Double, E> unsafeFunction) {
+
+		return TransformUtil.transformToDoubleArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> double[] transformToDoubleArray(
+		T[] array, UnsafeFunction<T, Double, E> unsafeFunction) {
+
+		return TransformUtil.transformToDoubleArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> float[] transformToFloatArray(
+		Collection<T> collection, UnsafeFunction<T, Float, E> unsafeFunction) {
+
+		return TransformUtil.transformToFloatArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> float[] transformToFloatArray(
+		T[] array, UnsafeFunction<T, Float, E> unsafeFunction) {
+
+		return TransformUtil.transformToFloatArray(array, unsafeFunction);
+	}
+
+	public static <T, R, E extends Throwable> int[] transformToIntArray(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToIntArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> int[] transformToIntArray(
+		T[] array, UnsafeFunction<T, Integer, E> unsafeFunction) {
+
+		return TransformUtil.transformToIntArray(array, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> List<R> transformToList(
+		int[] array, UnsafeFunction<Integer, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToList(array, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> List<R> transformToList(
+		long[] array, UnsafeFunction<Long, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> List<R> transformToList(
+		T[] array, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> long[] transformToLongArray(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToLongArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> long[] transformToLongArray(
+		T[] array, UnsafeFunction<T, Long, E> unsafeFunction) {
+
+		return TransformUtil.transformToLongArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> short[] transformToShortArray(
+		Collection<T> collection, UnsafeFunction<T, Short, E> unsafeFunction) {
+
+		return TransformUtil.transformToShortArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> short[] transformToShortArray(
+		T[] array, UnsafeFunction<T, Short, E> unsafeFunction) {
+
+		return TransformUtil.transformToShortArray(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> List<R> unsafeTransform(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransform(collection, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> R[] unsafeTransform(
+			int[] array, UnsafeFunction<Integer, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransform(array, unsafeFunction, clazz);
+	}
+
+	public static <R, E extends Throwable> R[] unsafeTransform(
+			long[] array, UnsafeFunction<Long, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] unsafeTransform(
+			T[] array, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransformToArray(
+			collection, unsafeFunction, clazz);
+	}
+
+	public static <T, E extends Throwable> boolean[]
+			unsafeTransformToBooleanArray(
+				Collection<T> collection,
+				UnsafeFunction<T, Boolean, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToBooleanArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> boolean[]
+			unsafeTransformToBooleanArray(
+				T[] array, UnsafeFunction<T, Boolean, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToBooleanArray(
+			array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> byte[] unsafeTransformToByteArray(
+			Collection<T> collection, UnsafeFunction<T, Byte, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToByteArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> byte[] unsafeTransformToByteArray(
+			T[] array, UnsafeFunction<T, Byte, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToByteArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> double[]
+			unsafeTransformToDoubleArray(
+				Collection<T> collection,
+				UnsafeFunction<T, Double, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToDoubleArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> double[]
+			unsafeTransformToDoubleArray(
+				T[] array, UnsafeFunction<T, Double, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToDoubleArray(
+			array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> float[] unsafeTransformToFloatArray(
+			Collection<T> collection,
+			UnsafeFunction<T, Float, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToFloatArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> float[] unsafeTransformToFloatArray(
+			T[] array, UnsafeFunction<T, Float, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToFloatArray(array, unsafeFunction);
+	}
+
+	public static <T, R, E extends Throwable> int[] unsafeTransformToIntArray(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToIntArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> int[] unsafeTransformToIntArray(
+			T[] array, UnsafeFunction<T, Integer, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToIntArray(array, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> List<R> unsafeTransformToList(
+			int[] array, UnsafeFunction<Integer, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToList(array, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> List<R> unsafeTransformToList(
+			long[] array, UnsafeFunction<Long, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> List<R> unsafeTransformToList(
+			T[] array, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> long[] unsafeTransformToLongArray(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToLongArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> long[] unsafeTransformToLongArray(
+			T[] array, UnsafeFunction<T, Long, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToLongArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> short[] unsafeTransformToShortArray(
+			Collection<T> collection,
+			UnsafeFunction<T, Short, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToShortArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> short[] unsafeTransformToShortArray(
+			T[] array, UnsafeFunction<T, Short, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToShortArray(array, unsafeFunction);
+	}
+
+	protected AcceptLanguage contextAcceptLanguage;
+	protected UnsafeBiConsumer
+		<Collection<AssetListEntry>,
+		 UnsafeFunction<AssetListEntry, AssetListEntry, Exception>, Exception>
+			contextBatchUnsafeBiConsumer;
+	protected UnsafeBiConsumer
+		<Collection<AssetListEntry>, UnsafeConsumer<AssetListEntry, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
+	protected com.liferay.portal.kernel.model.Company contextCompany;
+	protected HttpServletRequest contextHttpServletRequest;
+	protected HttpServletResponse contextHttpServletResponse;
+	protected Object contextScopeChecker;
+	protected UriInfo contextUriInfo;
+	protected com.liferay.portal.kernel.model.User contextUser;
+	protected ExpressionConvert<com.liferay.portal.kernel.search.filter.Filter>
+		expressionConvert;
+	protected FilterParserProvider filterParserProvider;
+	protected GroupLocalService groupLocalService;
+	protected ResourceActionLocalService resourceActionLocalService;
+	protected ResourcePermissionLocalService resourcePermissionLocalService;
+	protected RoleLocalService roleLocalService;
+	protected SortParserProvider sortParserProvider;
+	protected VulcanBatchEngineExportTaskResource
+		vulcanBatchEngineExportTaskResource;
+	protected VulcanBatchEngineImportTaskResource
+		vulcanBatchEngineImportTaskResource;
+
+	private static final com.liferay.portal.kernel.log.Log _log =
+		LogFactoryUtil.getLog(BaseAssetListEntryResourceImpl.class);
+
+}
+// LIFERAY-REST-BUILDER-HASH:224252006

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -85,6 +85,8 @@ public class OpenAPIResourceImpl {
 
 	private final Set<Class<?>> _resourceClasses = new HashSet<Class<?>>() {
 		{
+			add(AssetListEntryResourceImpl.class);
+
 			add(BlogPostingResourceImpl.class);
 
 			add(BlogPostingImageResourceImpl.class);
@@ -144,4 +146,4 @@ public class OpenAPIResourceImpl {
 	};
 
 }
-// LIFERAY-REST-BUILDER-HASH:-635059371
+// LIFERAY-REST-BUILDER-HASH:718231073

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/factory/AssetListEntryResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/factory/AssetListEntryResourceFactoryImpl.java
@@ -1,0 +1,333 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.delivery.internal.resource.v1_0.factory;
+
+import com.liferay.headless.delivery.internal.security.permission.LiberalPermissionChecker;
+import com.liferay.headless.delivery.resource.v1_0.AssetListEntryResource;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.ProxyUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+
+import jakarta.annotation.Generated;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import jakarta.ws.rs.core.UriInfo;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Function;
+
+import org.osgi.service.component.ComponentServiceObjects;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceScope;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Component(
+	property = "resource.locator.key=/headless-delivery/v1.0/AssetListEntry",
+	service = AssetListEntryResource.Factory.class
+)
+@Generated("")
+public class AssetListEntryResourceFactoryImpl
+	implements AssetListEntryResource.Factory {
+
+	@Override
+	public AssetListEntryResource.Builder create() {
+		return new AssetListEntryResource.Builder() {
+
+			@Override
+			public AssetListEntryResource build() {
+				if (_user == null) {
+					throw new IllegalArgumentException("User is not set");
+				}
+
+				Function<InvocationHandler, AssetListEntryResource>
+					assetListEntryResourceProxyProviderFunction =
+						ResourceProxyProviderFunctionHolder.
+							_assetListEntryResourceProxyProviderFunction;
+
+				return assetListEntryResourceProxyProviderFunction.apply(
+					(proxy, method, arguments) -> _invoke(
+						method, arguments, _checkPermissions,
+						_httpServletRequest, _httpServletResponse,
+						_preferredLocale, _uriInfo, _user));
+			}
+
+			@Override
+			public AssetListEntryResource.Builder checkPermissions(
+				boolean checkPermissions) {
+
+				_checkPermissions = checkPermissions;
+
+				return this;
+			}
+
+			@Override
+			public AssetListEntryResource.Builder httpServletRequest(
+				HttpServletRequest httpServletRequest) {
+
+				_httpServletRequest = httpServletRequest;
+
+				return this;
+			}
+
+			@Override
+			public AssetListEntryResource.Builder httpServletResponse(
+				HttpServletResponse httpServletResponse) {
+
+				_httpServletResponse = httpServletResponse;
+
+				return this;
+			}
+
+			@Override
+			public AssetListEntryResource.Builder preferredLocale(
+				Locale preferredLocale) {
+
+				_preferredLocale = preferredLocale;
+
+				return this;
+			}
+
+			@Override
+			public AssetListEntryResource.Builder uriInfo(UriInfo uriInfo) {
+				_uriInfo = uriInfo;
+
+				return this;
+			}
+
+			@Override
+			public AssetListEntryResource.Builder user(User user) {
+				_user = user;
+
+				return this;
+			}
+
+			private boolean _checkPermissions = true;
+			private HttpServletRequest _httpServletRequest;
+			private HttpServletResponse _httpServletResponse;
+			private Locale _preferredLocale;
+			private UriInfo _uriInfo;
+			private User _user;
+
+		};
+	}
+
+	private static Function<InvocationHandler, AssetListEntryResource>
+		_getProxyProviderFunction() {
+
+		Class<?> proxyClass = ProxyUtil.getProxyClass(
+			AssetListEntryResource.class.getClassLoader(),
+			AssetListEntryResource.class);
+
+		try {
+			Constructor<AssetListEntryResource> constructor =
+				(Constructor<AssetListEntryResource>)proxyClass.getConstructor(
+					InvocationHandler.class);
+
+			return invocationHandler -> {
+				try {
+					return constructor.newInstance(invocationHandler);
+				}
+				catch (ReflectiveOperationException
+							reflectiveOperationException) {
+
+					throw new InternalError(reflectiveOperationException);
+				}
+			};
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			throw new InternalError(noSuchMethodException);
+		}
+	}
+
+	private Object _invoke(
+			Method method, Object[] arguments, boolean checkPermissions,
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse, Locale preferredLocale,
+			UriInfo uriInfo, User user)
+		throws Throwable {
+
+		String name = PrincipalThreadLocal.getName();
+
+		PrincipalThreadLocal.setName(user.getUserId());
+
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		if (checkPermissions) {
+			PermissionThreadLocal.setPermissionChecker(
+				_defaultPermissionCheckerFactory.create(user));
+		}
+		else {
+			PermissionThreadLocal.setPermissionChecker(
+				new LiberalPermissionChecker(user));
+		}
+
+		AssetListEntryResource assetListEntryResource =
+			_componentServiceObjects.getService();
+
+		assetListEntryResource.setContextAcceptLanguage(
+			new AcceptLanguageImpl(httpServletRequest, preferredLocale, user));
+
+		Company company = _companyLocalService.getCompany(user.getCompanyId());
+
+		assetListEntryResource.setContextCompany(company);
+
+		assetListEntryResource.setContextHttpServletRequest(httpServletRequest);
+		assetListEntryResource.setContextHttpServletResponse(
+			httpServletResponse);
+		assetListEntryResource.setContextUriInfo(uriInfo);
+		assetListEntryResource.setContextUser(user);
+		assetListEntryResource.setExpressionConvert(_expressionConvert);
+		assetListEntryResource.setFilterParserProvider(_filterParserProvider);
+		assetListEntryResource.setGroupLocalService(_groupLocalService);
+		assetListEntryResource.setResourceActionLocalService(
+			_resourceActionLocalService);
+		assetListEntryResource.setResourcePermissionLocalService(
+			_resourcePermissionLocalService);
+		assetListEntryResource.setRoleLocalService(_roleLocalService);
+		assetListEntryResource.setSortParserProvider(_sortParserProvider);
+
+		try {
+			return method.invoke(assetListEntryResource, arguments);
+		}
+		catch (InvocationTargetException invocationTargetException) {
+			throw invocationTargetException.getTargetException();
+		}
+		finally {
+			_componentServiceObjects.ungetService(assetListEntryResource);
+
+			PrincipalThreadLocal.setName(name);
+
+			PermissionThreadLocal.setPermissionChecker(permissionChecker);
+		}
+	}
+
+	@Reference
+	private CompanyLocalService _companyLocalService;
+
+	@Reference(scope = ReferenceScope.PROTOTYPE_REQUIRED)
+	private ComponentServiceObjects<AssetListEntryResource>
+		_componentServiceObjects;
+
+	@Reference
+	private PermissionCheckerFactory _defaultPermissionCheckerFactory;
+
+	@Reference(
+		target = "(result.class.name=com.liferay.portal.kernel.search.filter.Filter)"
+	)
+	private ExpressionConvert<Filter> _expressionConvert;
+
+	@Reference
+	private FilterParserProvider _filterParserProvider;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private ResourceActionLocalService _resourceActionLocalService;
+
+	@Reference
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Reference
+	private RoleLocalService _roleLocalService;
+
+	@Reference
+	private SortParserProvider _sortParserProvider;
+
+	@Reference
+	private UserLocalService _userLocalService;
+
+	private static class ResourceProxyProviderFunctionHolder {
+
+		private static final Function<InvocationHandler, AssetListEntryResource>
+			_assetListEntryResourceProxyProviderFunction =
+				_getProxyProviderFunction();
+
+	}
+
+	private class AcceptLanguageImpl implements AcceptLanguage {
+
+		public AcceptLanguageImpl(
+			HttpServletRequest httpServletRequest, Locale preferredLocale,
+			User user) {
+
+			_httpServletRequest = httpServletRequest;
+			_preferredLocale = preferredLocale;
+			_user = user;
+		}
+
+		@Override
+		public List<Locale> getLocales() {
+			return Arrays.asList(getPreferredLocale());
+		}
+
+		@Override
+		public String getPreferredLanguageId() {
+			return LocaleUtil.toLanguageId(getPreferredLocale());
+		}
+
+		@Override
+		public Locale getPreferredLocale() {
+			if (_preferredLocale != null) {
+				return _preferredLocale;
+			}
+
+			if (_httpServletRequest != null) {
+				Locale locale = (Locale)_httpServletRequest.getAttribute(
+					WebKeys.LOCALE);
+
+				if (locale != null) {
+					return locale;
+				}
+			}
+
+			return _user.getLocale();
+		}
+
+		@Override
+		public boolean isAcceptAllLanguages() {
+			return false;
+		}
+
+		private final HttpServletRequest _httpServletRequest;
+		private final Locale _preferredLocale;
+		private final User _user;
+
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:847153472

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/asset-list-entry.properties
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/asset-list-entry.properties
@@ -1,0 +1,12 @@
+#
+# This is a generated file.
+#
+
+api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.delivery.dto.v1_0.AssetListEntry
+batch.engine.task.item.delegate=true
+batch.planner.export.enabled=true
+batch.planner.import.enabled=false
+entity.class.name=com.liferay.headless.delivery.dto.v1_0.AssetListEntry
+osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Delivery)
+osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/AssetListEntryResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/AssetListEntryResourceTest.java
@@ -1,0 +1,303 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.delivery.resource.v1_0.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.list.constants.AssetListEntryTypeConstants;
+import com.liferay.asset.list.service.AssetListEntryLocalService;
+import com.liferay.headless.delivery.client.dto.v1_0.AssetListEntry;
+import com.liferay.headless.delivery.client.pagination.Page;
+import com.liferay.headless.delivery.client.pagination.Pagination;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.test.rule.Inject;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Luis Ortiz
+ */
+@RunWith(Arquillian.class)
+public class AssetListEntryResourceTest
+	extends BaseAssetListEntryResourceTestCase {
+
+	@Test
+	public void testGetSiteAssetListEntriesPageWithItemSubtypeFilter()
+		throws Exception {
+
+		Long siteId = testGroup.getGroupId();
+
+		String itemSubtype1 = RandomTestUtil.randomString();
+		String itemSubtype2 = RandomTestUtil.randomString();
+		String itemType = RandomTestUtil.randomString();
+
+		AssetListEntry assetListEntry1 = _addAssetListEntryWithTypeAndSubtype(
+			itemSubtype1, itemType, siteId, RandomTestUtil.randomString());
+		AssetListEntry assetListEntry2 = _addAssetListEntryWithTypeAndSubtype(
+			itemSubtype2, itemType, siteId, RandomTestUtil.randomString());
+
+		String filter = StringBundler.concat(
+			"itemSubtype eq '", itemSubtype1, "'");
+
+		Page<AssetListEntry> page =
+			assetListEntryResource.getSiteAssetListEntriesPage(
+				siteId, null, filter, Pagination.of(1, 50), null);
+
+		List<AssetListEntry> assetListEntries =
+			(List<AssetListEntry>)page.getItems();
+
+		Assert.assertTrue(
+			_containsAssetListEntryId(
+				assetListEntries, assetListEntry1.getAssetListEntryId()));
+		Assert.assertFalse(
+			_containsAssetListEntryId(
+				assetListEntries, assetListEntry2.getAssetListEntryId()));
+	}
+
+	@Test
+	public void testGetSiteAssetListEntriesPageWithItemTypeFilter()
+		throws Exception {
+
+		Long siteId = testGroup.getGroupId();
+
+		String itemType1 = RandomTestUtil.randomString();
+		String itemType2 = RandomTestUtil.randomString();
+
+		AssetListEntry assetListEntry1 = _addAssetListEntryWithTypeAndSubtype(
+			null, itemType1, siteId, RandomTestUtil.randomString());
+		AssetListEntry assetListEntry2 = _addAssetListEntryWithTypeAndSubtype(
+			null, itemType2, siteId, RandomTestUtil.randomString());
+
+		String filter = StringBundler.concat("itemType eq '", itemType1, "'");
+
+		Page<AssetListEntry> page =
+			assetListEntryResource.getSiteAssetListEntriesPage(
+				siteId, null, filter, Pagination.of(1, 50), null);
+
+		List<AssetListEntry> assetListEntries =
+			(List<AssetListEntry>)page.getItems();
+
+		Assert.assertTrue(
+			_containsAssetListEntryId(
+				assetListEntries, assetListEntry1.getAssetListEntryId()));
+		Assert.assertFalse(
+			_containsAssetListEntryId(
+				assetListEntries, assetListEntry2.getAssetListEntryId()));
+	}
+
+	@Test
+	public void testGetSiteAssetListEntriesPageWithItemTypeInFilter()
+		throws Exception {
+
+		Long siteId = testGroup.getGroupId();
+
+		String itemType1 = RandomTestUtil.randomString();
+		String itemType2 = RandomTestUtil.randomString();
+		String itemType3 = RandomTestUtil.randomString();
+
+		AssetListEntry assetListEntry1 = _addAssetListEntryWithTypeAndSubtype(
+			null, itemType1, siteId, RandomTestUtil.randomString());
+		AssetListEntry assetListEntry2 = _addAssetListEntryWithTypeAndSubtype(
+			null, itemType2, siteId, RandomTestUtil.randomString());
+		AssetListEntry assetListEntry3 = _addAssetListEntryWithTypeAndSubtype(
+			null, itemType3, siteId, RandomTestUtil.randomString());
+
+		String filter = StringBundler.concat(
+			"itemType in ('", itemType1, "', '", itemType2, "')");
+
+		Page<AssetListEntry> page =
+			assetListEntryResource.getSiteAssetListEntriesPage(
+				siteId, null, filter, Pagination.of(1, 50), null);
+
+		List<AssetListEntry> assetListEntries =
+			(List<AssetListEntry>)page.getItems();
+
+		Assert.assertTrue(
+			_containsAssetListEntryId(
+				assetListEntries, assetListEntry1.getAssetListEntryId()));
+		Assert.assertTrue(
+			_containsAssetListEntryId(
+				assetListEntries, assetListEntry2.getAssetListEntryId()));
+		Assert.assertFalse(
+			_containsAssetListEntryId(
+				assetListEntries, assetListEntry3.getAssetListEntryId()));
+	}
+
+	@Test
+	public void testGetSiteAssetListEntriesPageWithSearch() throws Exception {
+		Long siteId = testGroup.getGroupId();
+
+		String keyword = RandomTestUtil.randomString();
+
+		AssetListEntry assetListEntry1 = _addAssetListEntry(
+			siteId, "Title " + keyword);
+
+		AssetListEntry assetListEntry2 = _addAssetListEntry(siteId, "Title");
+
+		Page<AssetListEntry> page =
+			assetListEntryResource.getSiteAssetListEntriesPage(
+				siteId, keyword, null, Pagination.of(1, 50), null);
+
+		List<AssetListEntry> assetListEntries =
+			(List<AssetListEntry>)page.getItems();
+
+		Assert.assertTrue(
+			_containsAssetListEntryId(
+				assetListEntries, assetListEntry1.getAssetListEntryId()));
+		Assert.assertFalse(
+			_containsAssetListEntryId(
+				assetListEntries, assetListEntry2.getAssetListEntryId()));
+	}
+
+	@Override
+	protected String[] getAdditionalAssertFieldNames() {
+		return new String[] {
+			"classNameId", "classPK", "externalReferenceCode", "itemSubtype",
+			"itemType", "title"
+		};
+	}
+
+	@Override
+	protected AssetListEntry
+			testGetAssetLibraryAssetListEntriesPage_addAssetListEntry(
+				Long assetLibraryId, AssetListEntry assetListEntry)
+		throws Exception {
+
+		return _addAssetListEntryFromDTO(assetListEntry, assetLibraryId);
+	}
+
+	@Override
+	protected Long testGetAssetLibraryAssetListEntriesPage_getAssetLibraryId()
+		throws Exception {
+
+		return testDepotEntryGroup.getGroupId();
+	}
+
+	@Override
+	protected Long
+			testGetAssetLibraryAssetListEntriesPage_getIrrelevantAssetLibraryId()
+		throws Exception {
+
+		return irrelevantDepotEntryGroup.getGroupId();
+	}
+
+	@Override
+	protected AssetListEntry testGetSiteAssetListEntriesPage_addAssetListEntry(
+			Long siteId, AssetListEntry assetListEntry)
+		throws Exception {
+
+		return _addAssetListEntryFromDTO(assetListEntry, siteId);
+	}
+
+	private AssetListEntry _addAssetListEntry(Long groupId, String title)
+		throws Exception {
+
+		com.liferay.asset.list.model.AssetListEntry assetListEntry =
+			_assetListEntryLocalService.addAssetListEntry(
+				RandomTestUtil.randomString(), TestPropsValues.getUserId(),
+				groupId, title, AssetListEntryTypeConstants.TYPE_MANUAL,
+				ServiceContextTestUtil.getServiceContext(
+					groupId, TestPropsValues.getUserId()));
+
+		return _toClientDTO(assetListEntry);
+	}
+
+	private AssetListEntry _addAssetListEntryFromDTO(
+			AssetListEntry assetListEntry, Long groupId)
+		throws Exception {
+
+		com.liferay.asset.list.model.AssetListEntry persistedAssetListEntry =
+			_assetListEntryLocalService.addAssetListEntry(
+				assetListEntry.getExternalReferenceCode(),
+				TestPropsValues.getUserId(), groupId, assetListEntry.getTitle(),
+				AssetListEntryTypeConstants.TYPE_MANUAL,
+				ServiceContextTestUtil.getServiceContext(
+					groupId, TestPropsValues.getUserId()));
+
+		if ((assetListEntry.getItemType() != null) ||
+			(assetListEntry.getItemSubtype() != null)) {
+
+			persistedAssetListEntry.setAssetEntrySubtype(
+				assetListEntry.getItemSubtype());
+			persistedAssetListEntry.setAssetEntryType(
+				assetListEntry.getItemType());
+
+			persistedAssetListEntry =
+				_assetListEntryLocalService.updateAssetListEntry(
+					persistedAssetListEntry);
+		}
+
+		return _toClientDTO(persistedAssetListEntry);
+	}
+
+	private AssetListEntry _addAssetListEntryWithTypeAndSubtype(
+			String assetEntrySubtype, String assetEntryType, Long groupId,
+			String title)
+		throws Exception {
+
+		com.liferay.asset.list.model.AssetListEntry assetListEntry =
+			_assetListEntryLocalService.addAssetListEntry(
+				RandomTestUtil.randomString(), TestPropsValues.getUserId(),
+				groupId, title, AssetListEntryTypeConstants.TYPE_MANUAL,
+				ServiceContextTestUtil.getServiceContext(
+					groupId, TestPropsValues.getUserId()));
+
+		assetListEntry.setAssetEntrySubtype(assetEntrySubtype);
+		assetListEntry.setAssetEntryType(assetEntryType);
+
+		assetListEntry = _assetListEntryLocalService.updateAssetListEntry(
+			assetListEntry);
+
+		return _toClientDTO(assetListEntry);
+	}
+
+	private boolean _containsAssetListEntryId(
+		List<AssetListEntry> assetListEntries, long assetListEntryId) {
+
+		for (AssetListEntry assetListEntry : assetListEntries) {
+			Long actualAssetListEntryId = assetListEntry.getAssetListEntryId();
+
+			if ((actualAssetListEntryId != null) &&
+				(actualAssetListEntryId == assetListEntryId)) {
+
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private AssetListEntry _toClientDTO(
+		com.liferay.asset.list.model.AssetListEntry assetListEntry) {
+
+		AssetListEntry dto = new AssetListEntry();
+
+		dto.setAssetListEntryId(assetListEntry.getAssetListEntryId());
+		dto.setClassNameId(
+			PortalUtil.getClassNameId(
+				com.liferay.asset.list.model.AssetListEntry.class));
+		dto.setClassPK(assetListEntry.getAssetListEntryId());
+		dto.setDateCreated(assetListEntry.getCreateDate());
+		dto.setDateModified(assetListEntry.getModifiedDate());
+		dto.setExternalReferenceCode(assetListEntry.getExternalReferenceCode());
+		dto.setItemSubtype(assetListEntry.getAssetEntrySubtype());
+		dto.setItemType(assetListEntry.getAssetEntryType());
+		dto.setTitle(assetListEntry.getTitle());
+
+		return dto;
+	}
+
+	@Inject
+	private AssetListEntryLocalService _assetListEntryLocalService;
+
+}

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseAssetListEntryResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseAssetListEntryResourceTestCase.java
@@ -1,0 +1,2133 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.delivery.resource.v1_0.test;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
+
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalServiceUtil;
+import com.liferay.headless.delivery.client.dto.v1_0.AssetListEntry;
+import com.liferay.headless.delivery.client.dto.v1_0.Field;
+import com.liferay.headless.delivery.client.http.HttpInvoker;
+import com.liferay.headless.delivery.client.pagination.Page;
+import com.liferay.headless.delivery.client.pagination.Pagination;
+import com.liferay.headless.delivery.client.resource.v1_0.AssetListEntryResource;
+import com.liferay.headless.delivery.client.serdes.v1_0.AssetListEntrySerDes;
+import com.liferay.petra.function.UnsafeTriConsumer;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.reflect.ReflectionUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Time;
+import com.liferay.portal.odata.entity.EntityField;
+import com.liferay.portal.odata.entity.EntityModel;
+import com.liferay.portal.search.test.rule.SearchTestRule;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.vulcan.resource.EntityModelResource;
+
+import jakarta.annotation.Generated;
+
+import jakarta.ws.rs.core.MultivaluedHashMap;
+
+import java.lang.reflect.Method;
+
+import java.text.Format;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+public abstract class BaseAssetListEntryResourceTestCase {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_format = FastDateFormatFactoryUtil.getSimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		irrelevantGroup = GroupTestUtil.addGroup();
+		testGroup = GroupTestUtil.addGroup();
+
+		testCompany = CompanyLocalServiceUtil.getCompany(
+			testGroup.getCompanyId());
+
+		irrelevantDepotEntry = DepotEntryLocalServiceUtil.addDepotEntry(
+			Collections.singletonMap(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
+			null, DepotConstants.TYPE_ASSET_LIBRARY,
+			new ServiceContext() {
+				{
+					setCompanyId(testCompany.getCompanyId());
+					setUserId(TestPropsValues.getUserId());
+				}
+			});
+		irrelevantDepotEntryGroup = irrelevantDepotEntry.getGroup();
+		testDepotEntry = DepotEntryLocalServiceUtil.addDepotEntry(
+			Collections.singletonMap(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
+			null, DepotConstants.TYPE_ASSET_LIBRARY,
+			new ServiceContext() {
+				{
+					setCompanyId(testCompany.getCompanyId());
+					setUserId(TestPropsValues.getUserId());
+				}
+			});
+		testDepotEntryGroup = testDepotEntry.getGroup();
+
+		_assetListEntryResource.setContextCompany(testCompany);
+
+		_testCompanyAdminUser = UserTestUtil.getAdminUser(
+			testCompany.getCompanyId());
+
+		assetListEntryResource = AssetListEntryResource.builder(
+		).authentication(
+			_testCompanyAdminUser.getEmailAddress(),
+			PropsValues.DEFAULT_ADMIN_PASSWORD
+		).endpoint(
+			testCompany.getVirtualHostname(),
+			PortalUtil.getPortalServerPort(false), "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		DepotEntryLocalServiceUtil.deleteDepotEntry(irrelevantDepotEntry);
+		DepotEntryLocalServiceUtil.deleteDepotEntry(testDepotEntry);
+
+		GroupTestUtil.deleteGroup(irrelevantGroup);
+		GroupTestUtil.deleteGroup(testGroup);
+	}
+
+	@Test
+	public void testClientSerDesToDTO() throws Exception {
+		ObjectMapper objectMapper = getClientSerDesObjectMapper();
+
+		AssetListEntry assetListEntry1 = randomAssetListEntry();
+
+		String json = objectMapper.writeValueAsString(assetListEntry1);
+
+		AssetListEntry assetListEntry2 = AssetListEntrySerDes.toDTO(json);
+
+		Assert.assertTrue(equals(assetListEntry1, assetListEntry2));
+	}
+
+	@Test
+	public void testClientSerDesToJSON() throws Exception {
+		ObjectMapper objectMapper = getClientSerDesObjectMapper();
+
+		AssetListEntry assetListEntry = randomAssetListEntry();
+
+		String json1 = objectMapper.writeValueAsString(assetListEntry);
+		String json2 = AssetListEntrySerDes.toJSON(assetListEntry);
+
+		Assert.assertEquals(
+			objectMapper.readTree(json1), objectMapper.readTree(json2));
+	}
+
+	protected ObjectMapper getClientSerDesObjectMapper() {
+		return new ObjectMapper() {
+			{
+				configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
+				configure(
+					SerializationFeature.WRITE_ENUMS_USING_TO_STRING, true);
+				enable(SerializationFeature.INDENT_OUTPUT);
+				setDateFormat(new ISO8601DateFormat());
+				setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+				setSerializationInclusion(JsonInclude.Include.NON_NULL);
+				setVisibility(
+					PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+				setVisibility(
+					PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE);
+			}
+		};
+	}
+
+	@Test
+	public void testEscapeRegexInStringFields() throws Exception {
+		String regex = "^[0-9]+(\\.[0-9]{1,2})\"?";
+
+		AssetListEntry assetListEntry = randomAssetListEntry();
+
+		assetListEntry.setExternalReferenceCode(regex);
+		assetListEntry.setItemSubtype(regex);
+		assetListEntry.setItemType(regex);
+		assetListEntry.setTitle(regex);
+
+		String json = AssetListEntrySerDes.toJSON(assetListEntry);
+
+		Assert.assertFalse(json.contains(regex));
+
+		assetListEntry = AssetListEntrySerDes.toDTO(json);
+
+		Assert.assertEquals(regex, assetListEntry.getExternalReferenceCode());
+		Assert.assertEquals(regex, assetListEntry.getItemSubtype());
+		Assert.assertEquals(regex, assetListEntry.getItemType());
+		Assert.assertEquals(regex, assetListEntry.getTitle());
+	}
+
+	@Test
+	public void testGetAssetLibraryAssetListEntriesPage() throws Exception {
+		Long assetLibraryId =
+			testGetAssetLibraryAssetListEntriesPage_getAssetLibraryId();
+		Long irrelevantAssetLibraryId =
+			testGetAssetLibraryAssetListEntriesPage_getIrrelevantAssetLibraryId();
+
+		Page<AssetListEntry> page =
+			assetListEntryResource.getAssetLibraryAssetListEntriesPage(
+				assetLibraryId, null, null, Pagination.of(1, 10), null);
+
+		long totalCount = page.getTotalCount();
+
+		if (irrelevantAssetLibraryId != null) {
+			AssetListEntry irrelevantAssetListEntry =
+				testGetAssetLibraryAssetListEntriesPage_addAssetListEntry(
+					irrelevantAssetLibraryId, randomIrrelevantAssetListEntry());
+
+			page = assetListEntryResource.getAssetLibraryAssetListEntriesPage(
+				irrelevantAssetLibraryId, null, null,
+				Pagination.of(1, (int)totalCount + 1), null);
+
+			Assert.assertEquals(totalCount + 1, page.getTotalCount());
+
+			assertContains(
+				irrelevantAssetListEntry,
+				(List<AssetListEntry>)page.getItems());
+			assertValid(
+				page,
+				testGetAssetLibraryAssetListEntriesPage_getExpectedActions(
+					irrelevantAssetLibraryId));
+		}
+
+		AssetListEntry assetListEntry1 =
+			testGetAssetLibraryAssetListEntriesPage_addAssetListEntry(
+				assetLibraryId, randomAssetListEntry());
+
+		AssetListEntry assetListEntry2 =
+			testGetAssetLibraryAssetListEntriesPage_addAssetListEntry(
+				assetLibraryId, randomAssetListEntry());
+
+		page = assetListEntryResource.getAssetLibraryAssetListEntriesPage(
+			assetLibraryId, null, null, Pagination.of(1, 10), null);
+
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
+
+		assertContains(assetListEntry1, (List<AssetListEntry>)page.getItems());
+		assertContains(assetListEntry2, (List<AssetListEntry>)page.getItems());
+		assertValid(
+			page,
+			testGetAssetLibraryAssetListEntriesPage_getExpectedActions(
+				assetLibraryId));
+	}
+
+	protected Map<String, Map<String, String>>
+			testGetAssetLibraryAssetListEntriesPage_getExpectedActions(
+				Long assetLibraryId)
+		throws Exception {
+
+		Map<String, Map<String, String>> expectedActions = new HashMap<>();
+
+		return expectedActions;
+	}
+
+	@Test
+	public void testGetAssetLibraryAssetListEntriesPageWithFilterDateTimeEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DATE_TIME);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long assetLibraryId =
+			testGetAssetLibraryAssetListEntriesPage_getAssetLibraryId();
+
+		AssetListEntry assetListEntry1 = randomAssetListEntry();
+
+		assetListEntry1 =
+			testGetAssetLibraryAssetListEntriesPage_addAssetListEntry(
+				assetLibraryId, assetListEntry1);
+
+		for (EntityField entityField : entityFields) {
+			Page<AssetListEntry> page =
+				assetListEntryResource.getAssetLibraryAssetListEntriesPage(
+					assetLibraryId, null,
+					getFilterString(entityField, "between", assetListEntry1),
+					Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(assetListEntry1),
+				(List<AssetListEntry>)page.getItems());
+		}
+	}
+
+	@Test
+	public void testGetAssetLibraryAssetListEntriesPageWithFilterDoubleEquals()
+		throws Exception {
+
+		testGetAssetLibraryAssetListEntriesPageWithFilter(
+			"eq", EntityField.Type.DOUBLE);
+	}
+
+	@Test
+	public void testGetAssetLibraryAssetListEntriesPageWithFilterStringContains()
+		throws Exception {
+
+		testGetAssetLibraryAssetListEntriesPageWithFilter(
+			"contains", EntityField.Type.STRING);
+	}
+
+	@Test
+	public void testGetAssetLibraryAssetListEntriesPageWithFilterStringEquals()
+		throws Exception {
+
+		testGetAssetLibraryAssetListEntriesPageWithFilter(
+			"eq", EntityField.Type.STRING);
+	}
+
+	@Test
+	public void testGetAssetLibraryAssetListEntriesPageWithFilterStringStartsWith()
+		throws Exception {
+
+		testGetAssetLibraryAssetListEntriesPageWithFilter(
+			"startswith", EntityField.Type.STRING);
+	}
+
+	protected void testGetAssetLibraryAssetListEntriesPageWithFilter(
+			String operator, EntityField.Type type)
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(type);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long assetLibraryId =
+			testGetAssetLibraryAssetListEntriesPage_getAssetLibraryId();
+
+		AssetListEntry assetListEntry1 =
+			testGetAssetLibraryAssetListEntriesPage_addAssetListEntry(
+				assetLibraryId, randomAssetListEntry());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		AssetListEntry assetListEntry2 =
+			testGetAssetLibraryAssetListEntriesPage_addAssetListEntry(
+				assetLibraryId, randomAssetListEntry());
+
+		for (EntityField entityField : entityFields) {
+			Page<AssetListEntry> page =
+				assetListEntryResource.getAssetLibraryAssetListEntriesPage(
+					assetLibraryId, null,
+					getFilterString(entityField, operator, assetListEntry1),
+					Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(assetListEntry1),
+				(List<AssetListEntry>)page.getItems());
+		}
+	}
+
+	@Test
+	public void testGetAssetLibraryAssetListEntriesPageWithPagination()
+		throws Exception {
+
+		Long assetLibraryId =
+			testGetAssetLibraryAssetListEntriesPage_getAssetLibraryId();
+
+		Page<AssetListEntry> assetListEntriesPage =
+			assetListEntryResource.getAssetLibraryAssetListEntriesPage(
+				assetLibraryId, null, null, null, null);
+
+		int totalCount = GetterUtil.getInteger(
+			assetListEntriesPage.getTotalCount());
+
+		AssetListEntry assetListEntry1 =
+			testGetAssetLibraryAssetListEntriesPage_addAssetListEntry(
+				assetLibraryId, randomAssetListEntry());
+
+		AssetListEntry assetListEntry2 =
+			testGetAssetLibraryAssetListEntriesPage_addAssetListEntry(
+				assetLibraryId, randomAssetListEntry());
+
+		AssetListEntry assetListEntry3 =
+			testGetAssetLibraryAssetListEntriesPage_addAssetListEntry(
+				assetLibraryId, randomAssetListEntry());
+
+		// See com.liferay.portal.vulcan.internal.configuration.HeadlessAPICompanyConfiguration#pageSizeLimit
+
+		int pageSizeLimit = 500;
+
+		if (totalCount >= (pageSizeLimit - 2)) {
+			Page<AssetListEntry> page1 =
+				assetListEntryResource.getAssetLibraryAssetListEntriesPage(
+					assetLibraryId, null, null,
+					Pagination.of(
+						(int)Math.ceil((totalCount + 1.0) / pageSizeLimit),
+						pageSizeLimit),
+					null);
+
+			Assert.assertEquals(totalCount + 3, page1.getTotalCount());
+
+			assertContains(
+				assetListEntry1, (List<AssetListEntry>)page1.getItems());
+
+			Page<AssetListEntry> page2 =
+				assetListEntryResource.getAssetLibraryAssetListEntriesPage(
+					assetLibraryId, null, null,
+					Pagination.of(
+						(int)Math.ceil((totalCount + 2.0) / pageSizeLimit),
+						pageSizeLimit),
+					null);
+
+			assertContains(
+				assetListEntry2, (List<AssetListEntry>)page2.getItems());
+
+			Page<AssetListEntry> page3 =
+				assetListEntryResource.getAssetLibraryAssetListEntriesPage(
+					assetLibraryId, null, null,
+					Pagination.of(
+						(int)Math.ceil((totalCount + 3.0) / pageSizeLimit),
+						pageSizeLimit),
+					null);
+
+			assertContains(
+				assetListEntry3, (List<AssetListEntry>)page3.getItems());
+		}
+		else {
+			Page<AssetListEntry> page1 =
+				assetListEntryResource.getAssetLibraryAssetListEntriesPage(
+					assetLibraryId, null, null,
+					Pagination.of(1, totalCount + 2), null);
+
+			List<AssetListEntry> assetListEntries1 =
+				(List<AssetListEntry>)page1.getItems();
+
+			Assert.assertEquals(
+				assetListEntries1.toString(), totalCount + 2,
+				assetListEntries1.size());
+
+			Page<AssetListEntry> page2 =
+				assetListEntryResource.getAssetLibraryAssetListEntriesPage(
+					assetLibraryId, null, null,
+					Pagination.of(2, totalCount + 2), null);
+
+			Assert.assertEquals(totalCount + 3, page2.getTotalCount());
+
+			List<AssetListEntry> assetListEntries2 =
+				(List<AssetListEntry>)page2.getItems();
+
+			Assert.assertEquals(
+				assetListEntries2.toString(), 1, assetListEntries2.size());
+
+			Page<AssetListEntry> page3 =
+				assetListEntryResource.getAssetLibraryAssetListEntriesPage(
+					assetLibraryId, null, null,
+					Pagination.of(1, (int)totalCount + 3), null);
+
+			assertContains(
+				assetListEntry1, (List<AssetListEntry>)page3.getItems());
+			assertContains(
+				assetListEntry2, (List<AssetListEntry>)page3.getItems());
+			assertContains(
+				assetListEntry3, (List<AssetListEntry>)page3.getItems());
+		}
+	}
+
+	@Test
+	public void testGetAssetLibraryAssetListEntriesPageWithSortDateTime()
+		throws Exception {
+
+		testGetAssetLibraryAssetListEntriesPageWithSort(
+			EntityField.Type.DATE_TIME,
+			(entityField, assetListEntry1, assetListEntry2) -> {
+				BeanTestUtil.setProperty(
+					assetListEntry1, entityField.getName(),
+					new Date(System.currentTimeMillis() - (2 * Time.MINUTE)));
+			});
+	}
+
+	@Test
+	public void testGetAssetLibraryAssetListEntriesPageWithSortDouble()
+		throws Exception {
+
+		testGetAssetLibraryAssetListEntriesPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, assetListEntry1, assetListEntry2) -> {
+				BeanTestUtil.setProperty(
+					assetListEntry1, entityField.getName(), 0.1);
+				BeanTestUtil.setProperty(
+					assetListEntry2, entityField.getName(), 0.5);
+			});
+	}
+
+	@Test
+	public void testGetAssetLibraryAssetListEntriesPageWithSortInteger()
+		throws Exception {
+
+		testGetAssetLibraryAssetListEntriesPageWithSort(
+			EntityField.Type.INTEGER,
+			(entityField, assetListEntry1, assetListEntry2) -> {
+				BeanTestUtil.setProperty(
+					assetListEntry1, entityField.getName(), 0);
+				BeanTestUtil.setProperty(
+					assetListEntry2, entityField.getName(), 1);
+			});
+	}
+
+	@Test
+	public void testGetAssetLibraryAssetListEntriesPageWithSortString()
+		throws Exception {
+
+		testGetAssetLibraryAssetListEntriesPageWithSort(
+			EntityField.Type.STRING,
+			(entityField, assetListEntry1, assetListEntry2) -> {
+				Class<?> clazz = assetListEntry1.getClass();
+
+				String entityFieldName = entityField.getName();
+
+				Method method = clazz.getMethod(
+					"get" + StringUtil.upperCaseFirstLetter(entityFieldName));
+
+				Class<?> returnType = method.getReturnType();
+
+				if (returnType.isAssignableFrom(Map.class)) {
+					BeanTestUtil.setProperty(
+						assetListEntry1, entityFieldName,
+						Collections.singletonMap("Aaa", "Aaa"));
+					BeanTestUtil.setProperty(
+						assetListEntry2, entityFieldName,
+						Collections.singletonMap("Bbb", "Bbb"));
+				}
+				else if (entityFieldName.contains("email")) {
+					BeanTestUtil.setProperty(
+						assetListEntry1, entityFieldName,
+						"aaa" +
+							StringUtil.toLowerCase(
+								RandomTestUtil.randomString()) +
+									"@liferay.com");
+					BeanTestUtil.setProperty(
+						assetListEntry2, entityFieldName,
+						"bbb" +
+							StringUtil.toLowerCase(
+								RandomTestUtil.randomString()) +
+									"@liferay.com");
+				}
+				else {
+					BeanTestUtil.setProperty(
+						assetListEntry1, entityFieldName,
+						"aaa" +
+							StringUtil.toLowerCase(
+								RandomTestUtil.randomString()));
+					BeanTestUtil.setProperty(
+						assetListEntry2, entityFieldName,
+						"bbb" +
+							StringUtil.toLowerCase(
+								RandomTestUtil.randomString()));
+				}
+			});
+	}
+
+	protected void testGetAssetLibraryAssetListEntriesPageWithSort(
+			EntityField.Type type,
+			UnsafeTriConsumer
+				<EntityField, AssetListEntry, AssetListEntry, Exception>
+					unsafeTriConsumer)
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(type);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long assetLibraryId =
+			testGetAssetLibraryAssetListEntriesPage_getAssetLibraryId();
+
+		AssetListEntry assetListEntry1 = randomAssetListEntry();
+		AssetListEntry assetListEntry2 = randomAssetListEntry();
+
+		for (EntityField entityField : entityFields) {
+			unsafeTriConsumer.accept(
+				entityField, assetListEntry1, assetListEntry2);
+		}
+
+		assetListEntry1 =
+			testGetAssetLibraryAssetListEntriesPage_addAssetListEntry(
+				assetLibraryId, assetListEntry1);
+
+		assetListEntry2 =
+			testGetAssetLibraryAssetListEntriesPage_addAssetListEntry(
+				assetLibraryId, assetListEntry2);
+
+		Page<AssetListEntry> page =
+			assetListEntryResource.getAssetLibraryAssetListEntriesPage(
+				assetLibraryId, null, null, null, null);
+
+		for (EntityField entityField : entityFields) {
+			Page<AssetListEntry> ascPage =
+				assetListEntryResource.getAssetLibraryAssetListEntriesPage(
+					assetLibraryId, null, null,
+					Pagination.of(1, (int)page.getTotalCount() + 1),
+					entityField.getName() + ":asc");
+
+			assertContains(
+				assetListEntry1, (List<AssetListEntry>)ascPage.getItems());
+			assertContains(
+				assetListEntry2, (List<AssetListEntry>)ascPage.getItems());
+
+			Page<AssetListEntry> descPage =
+				assetListEntryResource.getAssetLibraryAssetListEntriesPage(
+					assetLibraryId, null, null,
+					Pagination.of(1, (int)page.getTotalCount() + 1),
+					entityField.getName() + ":desc");
+
+			assertContains(
+				assetListEntry2, (List<AssetListEntry>)descPage.getItems());
+			assertContains(
+				assetListEntry1, (List<AssetListEntry>)descPage.getItems());
+		}
+	}
+
+	protected AssetListEntry
+			testGetAssetLibraryAssetListEntriesPage_addAssetListEntry(
+				Long assetLibraryId, AssetListEntry assetListEntry)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected Long testGetAssetLibraryAssetListEntriesPage_getAssetLibraryId()
+		throws Exception {
+
+		return testDepotEntry.getDepotEntryId();
+	}
+
+	protected Long
+			testGetAssetLibraryAssetListEntriesPage_getIrrelevantAssetLibraryId()
+		throws Exception {
+
+		return irrelevantDepotEntry.getDepotEntryId();
+	}
+
+	@Test
+	public void testGetSiteAssetListEntriesPage() throws Exception {
+		Long siteId = testGetSiteAssetListEntriesPage_getSiteId();
+		Long irrelevantSiteId =
+			testGetSiteAssetListEntriesPage_getIrrelevantSiteId();
+
+		Page<AssetListEntry> page =
+			assetListEntryResource.getSiteAssetListEntriesPage(
+				siteId, null, null, Pagination.of(1, 10), null);
+
+		long totalCount = page.getTotalCount();
+
+		if (irrelevantSiteId != null) {
+			AssetListEntry irrelevantAssetListEntry =
+				testGetSiteAssetListEntriesPage_addAssetListEntry(
+					irrelevantSiteId, randomIrrelevantAssetListEntry());
+
+			page = assetListEntryResource.getSiteAssetListEntriesPage(
+				irrelevantSiteId, null, null,
+				Pagination.of(1, (int)totalCount + 1), null);
+
+			Assert.assertEquals(totalCount + 1, page.getTotalCount());
+
+			assertContains(
+				irrelevantAssetListEntry,
+				(List<AssetListEntry>)page.getItems());
+			assertValid(
+				page,
+				testGetSiteAssetListEntriesPage_getExpectedActions(
+					irrelevantSiteId));
+		}
+
+		AssetListEntry assetListEntry1 =
+			testGetSiteAssetListEntriesPage_addAssetListEntry(
+				siteId, randomAssetListEntry());
+
+		AssetListEntry assetListEntry2 =
+			testGetSiteAssetListEntriesPage_addAssetListEntry(
+				siteId, randomAssetListEntry());
+
+		page = assetListEntryResource.getSiteAssetListEntriesPage(
+			siteId, null, null, Pagination.of(1, 10), null);
+
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
+
+		assertContains(assetListEntry1, (List<AssetListEntry>)page.getItems());
+		assertContains(assetListEntry2, (List<AssetListEntry>)page.getItems());
+		assertValid(
+			page, testGetSiteAssetListEntriesPage_getExpectedActions(siteId));
+	}
+
+	protected Map<String, Map<String, String>>
+			testGetSiteAssetListEntriesPage_getExpectedActions(Long siteId)
+		throws Exception {
+
+		Map<String, Map<String, String>> expectedActions = new HashMap<>();
+
+		return expectedActions;
+	}
+
+	@Test
+	public void testGetSiteAssetListEntriesPageWithFilterDateTimeEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DATE_TIME);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long siteId = testGetSiteAssetListEntriesPage_getSiteId();
+
+		AssetListEntry assetListEntry1 = randomAssetListEntry();
+
+		assetListEntry1 = testGetSiteAssetListEntriesPage_addAssetListEntry(
+			siteId, assetListEntry1);
+
+		for (EntityField entityField : entityFields) {
+			Page<AssetListEntry> page =
+				assetListEntryResource.getSiteAssetListEntriesPage(
+					siteId, null,
+					getFilterString(entityField, "between", assetListEntry1),
+					Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(assetListEntry1),
+				(List<AssetListEntry>)page.getItems());
+		}
+	}
+
+	@Test
+	public void testGetSiteAssetListEntriesPageWithFilterDoubleEquals()
+		throws Exception {
+
+		testGetSiteAssetListEntriesPageWithFilter(
+			"eq", EntityField.Type.DOUBLE);
+	}
+
+	@Test
+	public void testGetSiteAssetListEntriesPageWithFilterStringContains()
+		throws Exception {
+
+		testGetSiteAssetListEntriesPageWithFilter(
+			"contains", EntityField.Type.STRING);
+	}
+
+	@Test
+	public void testGetSiteAssetListEntriesPageWithFilterStringEquals()
+		throws Exception {
+
+		testGetSiteAssetListEntriesPageWithFilter(
+			"eq", EntityField.Type.STRING);
+	}
+
+	@Test
+	public void testGetSiteAssetListEntriesPageWithFilterStringStartsWith()
+		throws Exception {
+
+		testGetSiteAssetListEntriesPageWithFilter(
+			"startswith", EntityField.Type.STRING);
+	}
+
+	protected void testGetSiteAssetListEntriesPageWithFilter(
+			String operator, EntityField.Type type)
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(type);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long siteId = testGetSiteAssetListEntriesPage_getSiteId();
+
+		AssetListEntry assetListEntry1 =
+			testGetSiteAssetListEntriesPage_addAssetListEntry(
+				siteId, randomAssetListEntry());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		AssetListEntry assetListEntry2 =
+			testGetSiteAssetListEntriesPage_addAssetListEntry(
+				siteId, randomAssetListEntry());
+
+		for (EntityField entityField : entityFields) {
+			Page<AssetListEntry> page =
+				assetListEntryResource.getSiteAssetListEntriesPage(
+					siteId, null,
+					getFilterString(entityField, operator, assetListEntry1),
+					Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(assetListEntry1),
+				(List<AssetListEntry>)page.getItems());
+		}
+	}
+
+	@Test
+	public void testGetSiteAssetListEntriesPageWithPagination()
+		throws Exception {
+
+		Long siteId = testGetSiteAssetListEntriesPage_getSiteId();
+
+		Page<AssetListEntry> assetListEntriesPage =
+			assetListEntryResource.getSiteAssetListEntriesPage(
+				siteId, null, null, null, null);
+
+		int totalCount = GetterUtil.getInteger(
+			assetListEntriesPage.getTotalCount());
+
+		AssetListEntry assetListEntry1 =
+			testGetSiteAssetListEntriesPage_addAssetListEntry(
+				siteId, randomAssetListEntry());
+
+		AssetListEntry assetListEntry2 =
+			testGetSiteAssetListEntriesPage_addAssetListEntry(
+				siteId, randomAssetListEntry());
+
+		AssetListEntry assetListEntry3 =
+			testGetSiteAssetListEntriesPage_addAssetListEntry(
+				siteId, randomAssetListEntry());
+
+		// See com.liferay.portal.vulcan.internal.configuration.HeadlessAPICompanyConfiguration#pageSizeLimit
+
+		int pageSizeLimit = 500;
+
+		if (totalCount >= (pageSizeLimit - 2)) {
+			Page<AssetListEntry> page1 =
+				assetListEntryResource.getSiteAssetListEntriesPage(
+					siteId, null, null,
+					Pagination.of(
+						(int)Math.ceil((totalCount + 1.0) / pageSizeLimit),
+						pageSizeLimit),
+					null);
+
+			Assert.assertEquals(totalCount + 3, page1.getTotalCount());
+
+			assertContains(
+				assetListEntry1, (List<AssetListEntry>)page1.getItems());
+
+			Page<AssetListEntry> page2 =
+				assetListEntryResource.getSiteAssetListEntriesPage(
+					siteId, null, null,
+					Pagination.of(
+						(int)Math.ceil((totalCount + 2.0) / pageSizeLimit),
+						pageSizeLimit),
+					null);
+
+			assertContains(
+				assetListEntry2, (List<AssetListEntry>)page2.getItems());
+
+			Page<AssetListEntry> page3 =
+				assetListEntryResource.getSiteAssetListEntriesPage(
+					siteId, null, null,
+					Pagination.of(
+						(int)Math.ceil((totalCount + 3.0) / pageSizeLimit),
+						pageSizeLimit),
+					null);
+
+			assertContains(
+				assetListEntry3, (List<AssetListEntry>)page3.getItems());
+		}
+		else {
+			Page<AssetListEntry> page1 =
+				assetListEntryResource.getSiteAssetListEntriesPage(
+					siteId, null, null, Pagination.of(1, totalCount + 2), null);
+
+			List<AssetListEntry> assetListEntries1 =
+				(List<AssetListEntry>)page1.getItems();
+
+			Assert.assertEquals(
+				assetListEntries1.toString(), totalCount + 2,
+				assetListEntries1.size());
+
+			Page<AssetListEntry> page2 =
+				assetListEntryResource.getSiteAssetListEntriesPage(
+					siteId, null, null, Pagination.of(2, totalCount + 2), null);
+
+			Assert.assertEquals(totalCount + 3, page2.getTotalCount());
+
+			List<AssetListEntry> assetListEntries2 =
+				(List<AssetListEntry>)page2.getItems();
+
+			Assert.assertEquals(
+				assetListEntries2.toString(), 1, assetListEntries2.size());
+
+			Page<AssetListEntry> page3 =
+				assetListEntryResource.getSiteAssetListEntriesPage(
+					siteId, null, null, Pagination.of(1, (int)totalCount + 3),
+					null);
+
+			assertContains(
+				assetListEntry1, (List<AssetListEntry>)page3.getItems());
+			assertContains(
+				assetListEntry2, (List<AssetListEntry>)page3.getItems());
+			assertContains(
+				assetListEntry3, (List<AssetListEntry>)page3.getItems());
+		}
+	}
+
+	@Test
+	public void testGetSiteAssetListEntriesPageWithSortDateTime()
+		throws Exception {
+
+		testGetSiteAssetListEntriesPageWithSort(
+			EntityField.Type.DATE_TIME,
+			(entityField, assetListEntry1, assetListEntry2) -> {
+				BeanTestUtil.setProperty(
+					assetListEntry1, entityField.getName(),
+					new Date(System.currentTimeMillis() - (2 * Time.MINUTE)));
+			});
+	}
+
+	@Test
+	public void testGetSiteAssetListEntriesPageWithSortDouble()
+		throws Exception {
+
+		testGetSiteAssetListEntriesPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, assetListEntry1, assetListEntry2) -> {
+				BeanTestUtil.setProperty(
+					assetListEntry1, entityField.getName(), 0.1);
+				BeanTestUtil.setProperty(
+					assetListEntry2, entityField.getName(), 0.5);
+			});
+	}
+
+	@Test
+	public void testGetSiteAssetListEntriesPageWithSortInteger()
+		throws Exception {
+
+		testGetSiteAssetListEntriesPageWithSort(
+			EntityField.Type.INTEGER,
+			(entityField, assetListEntry1, assetListEntry2) -> {
+				BeanTestUtil.setProperty(
+					assetListEntry1, entityField.getName(), 0);
+				BeanTestUtil.setProperty(
+					assetListEntry2, entityField.getName(), 1);
+			});
+	}
+
+	@Test
+	public void testGetSiteAssetListEntriesPageWithSortString()
+		throws Exception {
+
+		testGetSiteAssetListEntriesPageWithSort(
+			EntityField.Type.STRING,
+			(entityField, assetListEntry1, assetListEntry2) -> {
+				Class<?> clazz = assetListEntry1.getClass();
+
+				String entityFieldName = entityField.getName();
+
+				Method method = clazz.getMethod(
+					"get" + StringUtil.upperCaseFirstLetter(entityFieldName));
+
+				Class<?> returnType = method.getReturnType();
+
+				if (returnType.isAssignableFrom(Map.class)) {
+					BeanTestUtil.setProperty(
+						assetListEntry1, entityFieldName,
+						Collections.singletonMap("Aaa", "Aaa"));
+					BeanTestUtil.setProperty(
+						assetListEntry2, entityFieldName,
+						Collections.singletonMap("Bbb", "Bbb"));
+				}
+				else if (entityFieldName.contains("email")) {
+					BeanTestUtil.setProperty(
+						assetListEntry1, entityFieldName,
+						"aaa" +
+							StringUtil.toLowerCase(
+								RandomTestUtil.randomString()) +
+									"@liferay.com");
+					BeanTestUtil.setProperty(
+						assetListEntry2, entityFieldName,
+						"bbb" +
+							StringUtil.toLowerCase(
+								RandomTestUtil.randomString()) +
+									"@liferay.com");
+				}
+				else {
+					BeanTestUtil.setProperty(
+						assetListEntry1, entityFieldName,
+						"aaa" +
+							StringUtil.toLowerCase(
+								RandomTestUtil.randomString()));
+					BeanTestUtil.setProperty(
+						assetListEntry2, entityFieldName,
+						"bbb" +
+							StringUtil.toLowerCase(
+								RandomTestUtil.randomString()));
+				}
+			});
+	}
+
+	protected void testGetSiteAssetListEntriesPageWithSort(
+			EntityField.Type type,
+			UnsafeTriConsumer
+				<EntityField, AssetListEntry, AssetListEntry, Exception>
+					unsafeTriConsumer)
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(type);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long siteId = testGetSiteAssetListEntriesPage_getSiteId();
+
+		AssetListEntry assetListEntry1 = randomAssetListEntry();
+		AssetListEntry assetListEntry2 = randomAssetListEntry();
+
+		for (EntityField entityField : entityFields) {
+			unsafeTriConsumer.accept(
+				entityField, assetListEntry1, assetListEntry2);
+		}
+
+		assetListEntry1 = testGetSiteAssetListEntriesPage_addAssetListEntry(
+			siteId, assetListEntry1);
+
+		assetListEntry2 = testGetSiteAssetListEntriesPage_addAssetListEntry(
+			siteId, assetListEntry2);
+
+		Page<AssetListEntry> page =
+			assetListEntryResource.getSiteAssetListEntriesPage(
+				siteId, null, null, null, null);
+
+		for (EntityField entityField : entityFields) {
+			Page<AssetListEntry> ascPage =
+				assetListEntryResource.getSiteAssetListEntriesPage(
+					siteId, null, null,
+					Pagination.of(1, (int)page.getTotalCount() + 1),
+					entityField.getName() + ":asc");
+
+			assertContains(
+				assetListEntry1, (List<AssetListEntry>)ascPage.getItems());
+			assertContains(
+				assetListEntry2, (List<AssetListEntry>)ascPage.getItems());
+
+			Page<AssetListEntry> descPage =
+				assetListEntryResource.getSiteAssetListEntriesPage(
+					siteId, null, null,
+					Pagination.of(1, (int)page.getTotalCount() + 1),
+					entityField.getName() + ":desc");
+
+			assertContains(
+				assetListEntry2, (List<AssetListEntry>)descPage.getItems());
+			assertContains(
+				assetListEntry1, (List<AssetListEntry>)descPage.getItems());
+		}
+	}
+
+	protected AssetListEntry testGetSiteAssetListEntriesPage_addAssetListEntry(
+			Long siteId, AssetListEntry assetListEntry)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected Long testGetSiteAssetListEntriesPage_getSiteId()
+		throws Exception {
+
+		return testGroup.getGroupId();
+	}
+
+	protected Long testGetSiteAssetListEntriesPage_getIrrelevantSiteId()
+		throws Exception {
+
+		return irrelevantGroup.getGroupId();
+	}
+
+	@Test
+	public void testBatchEngineDeleteImportTask() throws Exception {
+		Assert.assertTrue(true);
+	}
+
+	@Rule
+	public SearchTestRule searchTestRule = new SearchTestRule();
+
+	protected void assertContains(
+		AssetListEntry assetListEntry, List<AssetListEntry> assetListEntries) {
+
+		boolean contains = false;
+
+		for (AssetListEntry item : assetListEntries) {
+			if (equals(assetListEntry, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			assetListEntries + " does not contain " + assetListEntry, contains);
+	}
+
+	protected void assertHttpResponseStatusCode(
+		int expectedHttpResponseStatusCode,
+		HttpInvoker.HttpResponse actualHttpResponse) {
+
+		Assert.assertEquals(
+			expectedHttpResponseStatusCode, actualHttpResponse.getStatusCode());
+	}
+
+	protected void assertEquals(
+		AssetListEntry assetListEntry1, AssetListEntry assetListEntry2) {
+
+		Assert.assertTrue(
+			assetListEntry1 + " does not equal " + assetListEntry2,
+			equals(assetListEntry1, assetListEntry2));
+	}
+
+	protected void assertEquals(
+		List<AssetListEntry> assetListEntries1,
+		List<AssetListEntry> assetListEntries2) {
+
+		Assert.assertEquals(assetListEntries1.size(), assetListEntries2.size());
+
+		for (int i = 0; i < assetListEntries1.size(); i++) {
+			AssetListEntry assetListEntry1 = assetListEntries1.get(i);
+			AssetListEntry assetListEntry2 = assetListEntries2.get(i);
+
+			assertEquals(assetListEntry1, assetListEntry2);
+		}
+	}
+
+	protected void assertEqualsIgnoringOrder(
+		List<AssetListEntry> assetListEntries1,
+		List<AssetListEntry> assetListEntries2) {
+
+		Assert.assertEquals(assetListEntries1.size(), assetListEntries2.size());
+
+		for (AssetListEntry assetListEntry1 : assetListEntries1) {
+			boolean contains = false;
+
+			for (AssetListEntry assetListEntry2 : assetListEntries2) {
+				if (equals(assetListEntry1, assetListEntry2)) {
+					contains = true;
+
+					break;
+				}
+			}
+
+			Assert.assertTrue(
+				assetListEntries2 + " does not contain " + assetListEntry1,
+				contains);
+		}
+	}
+
+	protected void assertValid(AssetListEntry assetListEntry) throws Exception {
+		boolean valid = true;
+
+		if (assetListEntry.getDateCreated() == null) {
+			valid = false;
+		}
+
+		if (assetListEntry.getDateModified() == null) {
+			valid = false;
+		}
+
+		if (assetListEntry.getAssetListEntryId() == null) {
+			valid = false;
+		}
+
+		for (String additionalAssertFieldName :
+				getAdditionalAssertFieldNames()) {
+
+			if (Objects.equals("assetListEntryId", additionalAssertFieldName)) {
+				if (assetListEntry.getAssetListEntryId() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("classNameId", additionalAssertFieldName)) {
+				if (assetListEntry.getClassNameId() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("classPK", additionalAssertFieldName)) {
+				if (assetListEntry.getClassPK() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(
+					"externalReferenceCode", additionalAssertFieldName)) {
+
+				if (assetListEntry.getExternalReferenceCode() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("itemSubtype", additionalAssertFieldName)) {
+				if (assetListEntry.getItemSubtype() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("itemType", additionalAssertFieldName)) {
+				if (assetListEntry.getItemType() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("title", additionalAssertFieldName)) {
+				if (assetListEntry.getTitle() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			throw new IllegalArgumentException(
+				"Invalid additional assert field name " +
+					additionalAssertFieldName);
+		}
+
+		Assert.assertTrue(valid);
+	}
+
+	protected void assertValid(Page<AssetListEntry> page) {
+		assertValid(page, Collections.emptyMap());
+	}
+
+	protected void assertValid(
+		Page<AssetListEntry> page,
+		Map<String, Map<String, String>> expectedActions) {
+
+		boolean valid = false;
+
+		java.util.Collection<AssetListEntry> assetListEntries = page.getItems();
+
+		int size = assetListEntries.size();
+
+		if ((page.getLastPage() > 0) && (page.getPage() > 0) &&
+			(page.getPageSize() > 0) && (page.getTotalCount() > 0) &&
+			(size > 0)) {
+
+			valid = true;
+		}
+
+		Assert.assertTrue(valid);
+
+		assertValid(page.getActions(), expectedActions);
+	}
+
+	protected void assertValid(
+		Map<String, Map<String, String>> actions1,
+		Map<String, Map<String, String>> actions2) {
+
+		for (String key : actions2.keySet()) {
+			Map action = actions1.get(key);
+
+			Assert.assertNotNull(key + " does not contain an action", action);
+
+			Map<String, String> expectedAction = actions2.get(key);
+
+			Assert.assertEquals(
+				expectedAction.get("method"), action.get("method"));
+			Assert.assertEquals(expectedAction.get("href"), action.get("href"));
+		}
+	}
+
+	protected String[] getAdditionalAssertFieldNames() {
+		return new String[0];
+	}
+
+	protected List<GraphQLField> getGraphQLFields() throws Exception {
+		List<GraphQLField> graphQLFields = new ArrayList<>();
+
+		graphQLFields.add(new GraphQLField("externalReferenceCode"));
+
+		graphQLFields.add(new GraphQLField("assetListEntryId"));
+
+		for (java.lang.reflect.Field field :
+				getDeclaredFields(
+					com.liferay.headless.delivery.dto.v1_0.AssetListEntry.
+						class)) {
+
+			if (!ArrayUtil.contains(
+					getAdditionalAssertFieldNames(), field.getName())) {
+
+				continue;
+			}
+
+			graphQLFields.addAll(getGraphQLFields(field));
+		}
+
+		return graphQLFields;
+	}
+
+	protected List<GraphQLField> getGraphQLFields(
+			java.lang.reflect.Field... fields)
+		throws Exception {
+
+		List<GraphQLField> graphQLFields = new ArrayList<>();
+
+		for (java.lang.reflect.Field field : fields) {
+			com.liferay.portal.vulcan.graphql.annotation.GraphQLField
+				vulcanGraphQLField = field.getAnnotation(
+					com.liferay.portal.vulcan.graphql.annotation.GraphQLField.
+						class);
+
+			if (vulcanGraphQLField != null) {
+				Class<?> clazz = field.getType();
+
+				if (clazz.isArray()) {
+					clazz = clazz.getComponentType();
+				}
+
+				List<GraphQLField> childrenGraphQLFields = getGraphQLFields(
+					getDeclaredFields(clazz));
+
+				graphQLFields.add(
+					new GraphQLField(field.getName(), childrenGraphQLFields));
+			}
+		}
+
+		return graphQLFields;
+	}
+
+	protected String[] getIgnoredEntityFieldNames() {
+		return new String[0];
+	}
+
+	protected boolean equals(
+		AssetListEntry assetListEntry1, AssetListEntry assetListEntry2) {
+
+		if (assetListEntry1 == assetListEntry2) {
+			return true;
+		}
+
+		for (String additionalAssertFieldName :
+				getAdditionalAssertFieldNames()) {
+
+			if (Objects.equals("assetListEntryId", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						assetListEntry1.getAssetListEntryId(),
+						assetListEntry2.getAssetListEntryId())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("classNameId", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						assetListEntry1.getClassNameId(),
+						assetListEntry2.getClassNameId())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("classPK", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						assetListEntry1.getClassPK(),
+						assetListEntry2.getClassPK())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("dateCreated", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						assetListEntry1.getDateCreated(),
+						assetListEntry2.getDateCreated())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("dateModified", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						assetListEntry1.getDateModified(),
+						assetListEntry2.getDateModified())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(
+					"externalReferenceCode", additionalAssertFieldName)) {
+
+				if (!Objects.deepEquals(
+						assetListEntry1.getExternalReferenceCode(),
+						assetListEntry2.getExternalReferenceCode())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("itemSubtype", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						assetListEntry1.getItemSubtype(),
+						assetListEntry2.getItemSubtype())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("itemType", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						assetListEntry1.getItemType(),
+						assetListEntry2.getItemType())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("title", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						assetListEntry1.getTitle(),
+						assetListEntry2.getTitle())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			throw new IllegalArgumentException(
+				"Invalid additional assert field name " +
+					additionalAssertFieldName);
+		}
+
+		return true;
+	}
+
+	protected boolean equals(
+		Map<String, Object> map1, Map<String, Object> map2) {
+
+		if (Objects.equals(map1.keySet(), map2.keySet())) {
+			for (Map.Entry<String, Object> entry : map1.entrySet()) {
+				if (entry.getValue() instanceof Map) {
+					if (!equals(
+							(Map)entry.getValue(),
+							(Map)map2.get(entry.getKey()))) {
+
+						return false;
+					}
+				}
+				else if (!Objects.deepEquals(
+							entry.getValue(), map2.get(entry.getKey()))) {
+
+					return false;
+				}
+			}
+
+			return true;
+		}
+
+		return false;
+	}
+
+	protected java.lang.reflect.Field[] getDeclaredFields(Class clazz)
+		throws Exception {
+
+		if (clazz.getClassLoader() == null) {
+			return new java.lang.reflect.Field[0];
+		}
+
+		return TransformUtil.transform(
+			ReflectionUtil.getDeclaredFields(clazz),
+			field -> {
+				if (field.isSynthetic()) {
+					return null;
+				}
+
+				return field;
+			},
+			java.lang.reflect.Field.class);
+	}
+
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
+		if (!(_assetListEntryResource instanceof EntityModelResource)) {
+			throw new UnsupportedOperationException(
+				"Resource is not an instance of EntityModelResource");
+		}
+
+		EntityModelResource entityModelResource =
+			(EntityModelResource)_assetListEntryResource;
+
+		EntityModel entityModel = entityModelResource.getEntityModel(
+			new MultivaluedHashMap());
+
+		if (entityModel == null) {
+			return Collections.emptyList();
+		}
+
+		Map<String, EntityField> entityFieldsMap =
+			entityModel.getEntityFieldsMap();
+
+		return entityFieldsMap.values();
+	}
+
+	protected List<EntityField> getEntityFields(EntityField.Type type)
+		throws Exception {
+
+		return TransformUtil.transform(
+			getEntityFields(),
+			entityField -> {
+				if (!Objects.equals(entityField.getType(), type) ||
+					ArrayUtil.contains(
+						getIgnoredEntityFieldNames(), entityField.getName())) {
+
+					return null;
+				}
+
+				return entityField;
+			});
+	}
+
+	protected String getFilterString(
+		EntityField entityField, String operator,
+		AssetListEntry assetListEntry) {
+
+		StringBundler sb = new StringBundler();
+
+		String entityFieldName = entityField.getName();
+
+		sb.append(entityFieldName);
+
+		sb.append(" ");
+		sb.append(operator);
+		sb.append(" ");
+
+		if (entityFieldName.equals("assetListEntryId")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("classNameId")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("classPK")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("dateCreated")) {
+			if (operator.equals("between")) {
+				Date date = assetListEntry.getDateCreated();
+
+				sb = new StringBundler();
+
+				sb.append("(");
+				sb.append(entityFieldName);
+				sb.append(" gt ");
+				sb.append(_format.format(date.getTime() - (2 * Time.SECOND)));
+				sb.append(" and ");
+				sb.append(entityFieldName);
+				sb.append(" lt ");
+				sb.append(_format.format(date.getTime() + (2 * Time.SECOND)));
+				sb.append(")");
+			}
+			else {
+				sb.append(entityFieldName);
+
+				sb.append(" ");
+				sb.append(operator);
+				sb.append(" ");
+
+				sb.append(_format.format(assetListEntry.getDateCreated()));
+			}
+
+			return sb.toString();
+		}
+
+		if (entityFieldName.equals("dateModified")) {
+			if (operator.equals("between")) {
+				Date date = assetListEntry.getDateModified();
+
+				sb = new StringBundler();
+
+				sb.append("(");
+				sb.append(entityFieldName);
+				sb.append(" gt ");
+				sb.append(_format.format(date.getTime() - (2 * Time.SECOND)));
+				sb.append(" and ");
+				sb.append(entityFieldName);
+				sb.append(" lt ");
+				sb.append(_format.format(date.getTime() + (2 * Time.SECOND)));
+				sb.append(")");
+			}
+			else {
+				sb.append(entityFieldName);
+
+				sb.append(" ");
+				sb.append(operator);
+				sb.append(" ");
+
+				sb.append(_format.format(assetListEntry.getDateModified()));
+			}
+
+			return sb.toString();
+		}
+
+		if (entityFieldName.equals("externalReferenceCode")) {
+			Object object = assetListEntry.getExternalReferenceCode();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
+		if (entityFieldName.equals("itemSubtype")) {
+			Object object = assetListEntry.getItemSubtype();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
+		if (entityFieldName.equals("itemType")) {
+			Object object = assetListEntry.getItemType();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
+		if (entityFieldName.equals("title")) {
+			Object object = assetListEntry.getTitle();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
+		throw new IllegalArgumentException(
+			"Invalid entity field " + entityFieldName);
+	}
+
+	protected String invoke(String query) throws Exception {
+		HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+		httpInvoker.body(
+			JSONUtil.put(
+				"query", query
+			).toString(),
+			"application/json");
+		httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+		httpInvoker.path(
+			"http://localhost:" + PortalUtil.getPortalServerPort(false) +
+				"/o/graphql");
+		httpInvoker.userNameAndPassword(
+			"test@liferay.com:" + PropsValues.DEFAULT_ADMIN_PASSWORD);
+
+		HttpInvoker.HttpResponse httpResponse = httpInvoker.invoke();
+
+		return httpResponse.getContent();
+	}
+
+	protected JSONObject invokeGraphQLMutation(GraphQLField graphQLField)
+		throws Exception {
+
+		GraphQLField mutationGraphQLField = new GraphQLField(
+			"mutation", graphQLField);
+
+		return JSONFactoryUtil.createJSONObject(
+			invoke(mutationGraphQLField.toString()));
+	}
+
+	protected JSONObject invokeGraphQLQuery(GraphQLField graphQLField)
+		throws Exception {
+
+		GraphQLField queryGraphQLField = new GraphQLField(
+			"query", graphQLField);
+
+		return JSONFactoryUtil.createJSONObject(
+			invoke(queryGraphQLField.toString()));
+	}
+
+	protected AssetListEntry randomAssetListEntry() throws Exception {
+		return new AssetListEntry() {
+			{
+				assetListEntryId = RandomTestUtil.randomLong();
+				classNameId = RandomTestUtil.randomLong();
+				classPK = RandomTestUtil.randomLong();
+				dateCreated = RandomTestUtil.nextDate();
+				dateModified = RandomTestUtil.nextDate();
+				externalReferenceCode = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+				itemSubtype = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+				itemType = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+				title = StringUtil.toLowerCase(RandomTestUtil.randomString());
+			}
+		};
+	}
+
+	protected AssetListEntry randomIrrelevantAssetListEntry() throws Exception {
+		AssetListEntry randomIrrelevantAssetListEntry = randomAssetListEntry();
+
+		return randomIrrelevantAssetListEntry;
+	}
+
+	protected AssetListEntry randomPatchAssetListEntry() throws Exception {
+		return randomAssetListEntry();
+	}
+
+	protected AssetListEntryResource assetListEntryResource;
+	protected com.liferay.portal.kernel.model.Group irrelevantGroup;
+	protected com.liferay.portal.kernel.model.Company testCompany;
+	protected DepotEntry irrelevantDepotEntry;
+	protected com.liferay.portal.kernel.model.Group irrelevantDepotEntryGroup;
+	protected DepotEntry testDepotEntry;
+	protected com.liferay.portal.kernel.model.Group testDepotEntryGroup;
+	protected com.liferay.portal.kernel.model.Group testGroup;
+
+	protected static class BeanTestUtil {
+
+		public static void copyProperties(Object source, Object target)
+			throws Exception {
+
+			Class<?> sourceClass = source.getClass();
+
+			Class<?> targetClass = target.getClass();
+
+			for (java.lang.reflect.Field field :
+					_getAllDeclaredFields(sourceClass)) {
+
+				if (field.isSynthetic()) {
+					continue;
+				}
+
+				Method getMethod = _getMethod(
+					sourceClass, field.getName(), "get");
+
+				try {
+					Method setMethod = _getMethod(
+						targetClass, field.getName(), "set",
+						getMethod.getReturnType());
+
+					setMethod.invoke(target, getMethod.invoke(source));
+				}
+				catch (Exception e) {
+					continue;
+				}
+			}
+		}
+
+		public static boolean hasProperty(Object bean, String name) {
+			Method setMethod = _getMethod(
+				bean.getClass(), "set" + StringUtil.upperCaseFirstLetter(name));
+
+			if (setMethod != null) {
+				return true;
+			}
+
+			return false;
+		}
+
+		public static void setProperty(Object bean, String name, Object value)
+			throws Exception {
+
+			Class<?> clazz = bean.getClass();
+
+			Method setMethod = _getMethod(
+				clazz, "set" + StringUtil.upperCaseFirstLetter(name));
+
+			if (setMethod == null) {
+				throw new NoSuchMethodException();
+			}
+
+			Class<?>[] parameterTypes = setMethod.getParameterTypes();
+
+			setMethod.invoke(bean, _translateValue(parameterTypes[0], value));
+		}
+
+		private static List<java.lang.reflect.Field> _getAllDeclaredFields(
+			Class<?> clazz) {
+
+			List<java.lang.reflect.Field> fields = new ArrayList<>();
+
+			while ((clazz != null) && (clazz != Object.class)) {
+				for (java.lang.reflect.Field field :
+						clazz.getDeclaredFields()) {
+
+					fields.add(field);
+				}
+
+				clazz = clazz.getSuperclass();
+			}
+
+			return fields;
+		}
+
+		private static Method _getMethod(Class<?> clazz, String name) {
+			for (Method method : clazz.getMethods()) {
+				if (name.equals(method.getName()) &&
+					(method.getParameterCount() == 1) &&
+					_parameterTypes.contains(method.getParameterTypes()[0])) {
+
+					return method;
+				}
+			}
+
+			return null;
+		}
+
+		private static Method _getMethod(
+				Class<?> clazz, String fieldName, String prefix,
+				Class<?>... parameterTypes)
+			throws Exception {
+
+			return clazz.getMethod(
+				prefix + StringUtil.upperCaseFirstLetter(fieldName),
+				parameterTypes);
+		}
+
+		private static Object _translateValue(
+			Class<?> parameterType, Object value) {
+
+			if ((value instanceof Integer) &&
+				parameterType.equals(Long.class)) {
+
+				Integer intValue = (Integer)value;
+
+				return intValue.longValue();
+			}
+
+			return value;
+		}
+
+		private static final Set<Class<?>> _parameterTypes = new HashSet<>(
+			Arrays.asList(
+				Boolean.class, Date.class, Double.class, Integer.class,
+				Long.class, Map.class, String.class));
+
+	}
+
+	protected class GraphQLField {
+
+		public GraphQLField(String key, GraphQLField... graphQLFields) {
+			this(key, new HashMap<>(), graphQLFields);
+		}
+
+		public GraphQLField(String key, List<GraphQLField> graphQLFields) {
+			this(key, new HashMap<>(), graphQLFields);
+		}
+
+		public GraphQLField(
+			String key, Map<String, Object> parameterMap,
+			GraphQLField... graphQLFields) {
+
+			_key = key;
+			_parameterMap = parameterMap;
+			_graphQLFields = Arrays.asList(graphQLFields);
+		}
+
+		public GraphQLField(
+			String key, Map<String, Object> parameterMap,
+			List<GraphQLField> graphQLFields) {
+
+			_key = key;
+			_parameterMap = parameterMap;
+			_graphQLFields = graphQLFields;
+		}
+
+		@Override
+		public String toString() {
+			StringBuilder sb = new StringBuilder(_key);
+
+			if (!_parameterMap.isEmpty()) {
+				sb.append("(");
+
+				for (Map.Entry<String, Object> entry :
+						_parameterMap.entrySet()) {
+
+					sb.append(entry.getKey());
+					sb.append(": ");
+					sb.append(entry.getValue());
+					sb.append(", ");
+				}
+
+				sb.setLength(sb.length() - 2);
+
+				sb.append(")");
+			}
+
+			if (!_graphQLFields.isEmpty()) {
+				sb.append("{");
+
+				for (GraphQLField graphQLField : _graphQLFields) {
+					sb.append(graphQLField.toString());
+					sb.append(", ");
+				}
+
+				sb.setLength(sb.length() - 2);
+
+				sb.append("}");
+			}
+
+			return sb.toString();
+		}
+
+		private final List<GraphQLField> _graphQLFields;
+		private final String _key;
+		private final Map<String, Object> _parameterMap;
+
+	}
+
+	private static final com.liferay.portal.kernel.log.Log _log =
+		LogFactoryUtil.getLog(BaseAssetListEntryResourceTestCase.class);
+
+	private static Format _format;
+
+	private com.liferay.portal.kernel.model.User _testCompanyAdminUser;
+
+	@Inject
+	private com.liferay.headless.delivery.resource.v1_0.AssetListEntryResource
+		_assetListEntryResource;
+
+}
+// LIFERAY-REST-BUILDER-HASH:-686239852


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91525

## What Is Being Fixed

The new React Item Selector modal needs to list and discover persisted AssetListEntry (Content Set) instances, but no headless endpoint exposed them. The existing selector queried AssetListEntryService server-side through AssetListPortletItemSelectorView and JSP rendering, with no REST equivalent for the React modal to consume.

## How It Is Being Fixed

AssetListEntry is now searchable: a ModelSearchConfigurator, a ModelDocumentContributor, and a KeywordQueryContributor register it with the search framework and index its title, assetEntryType, and assetEntrySubtype.

On top of that, headless-delivery gains site- and asset-library-scoped GET endpoints — /sites/{siteId}/asset-list-entries and /asset-libraries/{assetLibraryId}/asset-list-entries — that run a paginated, search-backed lookup and convert each hit through a dedicated AssetListEntryDTOConverter. The response carries classNameId, classPK (= assetListEntryId), itemType, itemSubtype, and title, keeping callers compatible with the legacy InfoListItemSelectorReturnType payload. OData filtering on itemType and itemSubtype plus keyword search against the title cover the selector's filter dimensions.