### PR TITLE
LPD-92993 Fix strict mode locator violations in CMS Playwright tests

### DIFF
--- a/modules/test/playwright/tests/site-cms-site-initializer/main/categorization/categories.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/categorization/categories.spec.ts
@@ -428,7 +428,8 @@ test.describe("Category tests that don't focus on creation", () => {
 
 			await clickAndExpectToBeVisible({
 				target: page.getByText(
-					'Please enter a unique name. This one is already in use.'
+					'Please enter a unique name. This one is already in use.',
+					{exact: true}
 				),
 				trigger: editCategoryPage.saveButton,
 			});

--- a/modules/test/playwright/tests/site-cms-site-initializer/permissions/folder.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/permissions/folder.spec.ts
@@ -257,7 +257,9 @@ test(
 
 			await copyFolderModalPage.selectButton.click();
 
-			await waitForAlert(page, `was successfully copied to`);
+			await waitForAlert(page, `was successfully copied to`, {
+				first: true,
+			});
 
 			await assetsPage.gotoContents();
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92993

## What Is Being Fixed

Two `site-cms-site-initializer` Playwright tests fail with Playwright strict mode violations because their locators resolve to multiple elements. In `categories.spec.ts`, the duplicate-name validation message "Please enter a unique name. This one is already in use." matches four nested elements. In `folder.spec.ts`, the bulk folder copy raises two stacked `.alert-success` toasts that both contain "was successfully copied to".

## How It Is Being Fixed

The category test now asserts the validation message with `{exact: true}`, which matches the sibling assertion in `vocabularies.spec.ts` and excludes the `Error:`-prefixed ancestor element. The folder test passes `{first: true}` to `waitForAlert` — the option the helper already exposes for stacked alerts, and the same pattern used in `copyMove.spec.ts`.

## How To Run The Tests

cd modules/test/playwright
yarn test tests/site-cms-site-initializer/main/categorization/categories.spec.ts -g "Validate that a UI error appears when attempting to create a category with an existing name" --project=site-cms-site-initializer.main
yarn test tests/site-cms-site-initializer/permissions/folder.spec.ts -g "CMS Administrator can bulk copy a folder within the same parent folder" --project=site-cms-site-initializer.permissions
