### PR TITLE
LPD-92720 Fix document upload modal not closing in nested folders

### DIFF
--- a/modules/apps/item-selector/item-selector-taglib/src/main/java/com/liferay/item/selector/taglib/internal/display/context/ItemSelectorRepositoryEntryManagementToolbarDisplayContext.java
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/java/com/liferay/item/selector/taglib/internal/display/context/ItemSelectorRepositoryEntryManagementToolbarDisplayContext.java
@@ -99,8 +99,31 @@ public class ItemSelectorRepositoryEntryManagementToolbarDisplayContext {
 				WebKeys.DOCUMENT_LIBRARY_FOLDER, folder);
 		}
 
-		List<Menu> menus = dlPortletToolbarContributor.getPortletTitleMenus(
-			_liferayPortletRequest, _liferayPortletResponse);
+		String currentURL = (String)_liferayPortletRequest.getAttribute(
+			WebKeys.CURRENT_URL);
+
+		PortletURL portletURL = _getPortletURL();
+
+		boolean overrideCurrentURL = false;
+
+		if (Validator.isNull(currentURL) && (portletURL != null)) {
+			overrideCurrentURL = true;
+
+			_liferayPortletRequest.setAttribute(
+				WebKeys.CURRENT_URL, portletURL.toString());
+		}
+
+		List<Menu> menus = null;
+
+		try {
+			menus = dlPortletToolbarContributor.getPortletTitleMenus(
+				_liferayPortletRequest, _liferayPortletResponse);
+		}
+		finally {
+			if (overrideCurrentURL) {
+				_liferayPortletRequest.removeAttribute(WebKeys.CURRENT_URL);
+			}
+		}
 
 		if (menus.isEmpty()) {
 			return null;

--- a/modules/apps/item-selector/item-selector-taglib/src/test/java/com/liferay/item/selector/taglib/internal/display/context/ItemSelectorRepositoryEntryManagementToolbarDisplayContextTest.java
+++ b/modules/apps/item-selector/item-selector-taglib/src/test/java/com/liferay/item/selector/taglib/internal/display/context/ItemSelectorRepositoryEntryManagementToolbarDisplayContextTest.java
@@ -1,0 +1,253 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.item.selector.taglib.internal.display.context;
+
+import com.liferay.portal.kernel.module.service.Snapshot;
+import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
+import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
+import com.liferay.portal.kernel.portlet.PortletURLUtil;
+import com.liferay.portal.kernel.portlet.toolbar.contributor.PortletToolbarContributor;
+import com.liferay.portal.kernel.servlet.taglib.ui.Menu;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletRenderRequest;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import jakarta.portlet.PortletRequest;
+import jakarta.portlet.PortletResponse;
+import jakarta.portlet.PortletURL;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * @author Jürgen Kappler
+ */
+public class ItemSelectorRepositoryEntryManagementToolbarDisplayContextTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@BeforeClass
+	public static void setUpClass() {
+		_snapshot = _createSnapshot();
+
+		_snapshotAutoCloseable =
+			ReflectionTestUtil.setFieldValueWithAutoCloseable(
+				ItemSelectorRepositoryEntryManagementToolbarDisplayContext.
+					class,
+				"_dlPortletToolbarContributorSnapshot", _snapshot);
+	}
+
+	@AfterClass
+	public static void tearDownClass() throws Exception {
+		_portletPreferencesFactoryUtilMockedStatic.close();
+		_portletURLUtilMockedStatic.close();
+		_snapshotAutoCloseable.close();
+	}
+
+	@Test
+	@TestInfo("LPD-92720")
+	public void testGetCreationMenu() {
+		_testGetCreationMenuWhenContributorThrowsException();
+		_testGetCreationMenuWithExistingCurrentURL();
+		_testGetCreationMenuWithMissingCurrentURL();
+		_testGetCreationMenuWithoutPortletURL();
+	}
+
+	@SuppressWarnings("unchecked")
+	private static Snapshot<PortletToolbarContributor> _createSnapshot() {
+		return Mockito.mock(Snapshot.class);
+	}
+
+	private PortletURL _getPortletURL(String url) {
+		PortletURL portletURL = Mockito.mock(PortletURL.class);
+
+		Mockito.when(
+			portletURL.toString()
+		).thenReturn(
+			url
+		);
+
+		return portletURL;
+	}
+
+	private void _invokeGetCreationMenu(
+		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest,
+		PortletToolbarContributor portletToolbarContributor,
+		PortletURL portletURL) {
+
+		Mockito.when(
+			_snapshot.get()
+		).thenReturn(
+			portletToolbarContributor
+		);
+
+		HttpServletRequest httpServletRequest =
+			mockLiferayPortletRenderRequest.getHttpServletRequest();
+
+		if (portletURL != null) {
+			httpServletRequest.setAttribute(
+				"liferay-item-selector:repository-entry-browser:portletURL",
+				portletURL);
+		}
+
+		ItemSelectorRepositoryEntryManagementToolbarDisplayContext
+			itemSelectorRepositoryEntryManagementToolbarDisplayContext =
+				new ItemSelectorRepositoryEntryManagementToolbarDisplayContext(
+					httpServletRequest, mockLiferayPortletRenderRequest,
+					Mockito.mock(LiferayPortletResponse.class),
+					Mockito.mock(RepositoryEntryBrowserDisplayContext.class));
+
+		itemSelectorRepositoryEntryManagementToolbarDisplayContext.
+			getCreationMenu();
+	}
+
+	private void _testGetCreationMenuWhenContributorThrowsException() {
+		TestPortletToolbarContributor testPortletToolbarContributor =
+			new TestPortletToolbarContributor(true);
+
+		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest =
+			new TestMockLiferayPortletRenderRequest();
+
+		Assert.assertThrows(
+			RuntimeException.class,
+			() -> _invokeGetCreationMenu(
+				mockLiferayPortletRenderRequest, testPortletToolbarContributor,
+				_getPortletURL(RandomTestUtil.randomString())));
+
+		Assert.assertNull(
+			mockLiferayPortletRenderRequest.getAttribute(WebKeys.CURRENT_URL));
+	}
+
+	private void _testGetCreationMenuWithExistingCurrentURL() {
+		TestPortletToolbarContributor testPortletToolbarContributor =
+			new TestPortletToolbarContributor(false);
+
+		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest =
+			new TestMockLiferayPortletRenderRequest();
+
+		String currentURL = RandomTestUtil.randomString();
+
+		mockLiferayPortletRenderRequest.setAttribute(
+			WebKeys.CURRENT_URL, currentURL);
+
+		_invokeGetCreationMenu(
+			mockLiferayPortletRenderRequest, testPortletToolbarContributor,
+			_getPortletURL(RandomTestUtil.randomString()));
+
+		Assert.assertEquals(
+			currentURL,
+			mockLiferayPortletRenderRequest.getAttribute(WebKeys.CURRENT_URL));
+		Assert.assertEquals(
+			currentURL, testPortletToolbarContributor.getCapturedCurrentURL());
+	}
+
+	private void _testGetCreationMenuWithMissingCurrentURL() {
+		TestPortletToolbarContributor testPortletToolbarContributor =
+			new TestPortletToolbarContributor(false);
+
+		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest =
+			new TestMockLiferayPortletRenderRequest();
+
+		String currentURL = RandomTestUtil.randomString();
+
+		_invokeGetCreationMenu(
+			mockLiferayPortletRenderRequest, testPortletToolbarContributor,
+			_getPortletURL(currentURL));
+
+		Assert.assertEquals(
+			currentURL, testPortletToolbarContributor.getCapturedCurrentURL());
+
+		Assert.assertNull(
+			mockLiferayPortletRenderRequest.getAttribute(WebKeys.CURRENT_URL));
+	}
+
+	private void _testGetCreationMenuWithoutPortletURL() {
+		TestPortletToolbarContributor testPortletToolbarContributor =
+			new TestPortletToolbarContributor(false);
+
+		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest =
+			new TestMockLiferayPortletRenderRequest();
+
+		_invokeGetCreationMenu(
+			mockLiferayPortletRenderRequest, testPortletToolbarContributor,
+			null);
+
+		Assert.assertNull(
+			mockLiferayPortletRenderRequest.getAttribute(WebKeys.CURRENT_URL));
+
+		Assert.assertNull(
+			testPortletToolbarContributor.getCapturedCurrentURL());
+	}
+
+	private static final MockedStatic<PortletPreferencesFactoryUtil>
+		_portletPreferencesFactoryUtilMockedStatic = Mockito.mockStatic(
+			PortletPreferencesFactoryUtil.class);
+	private static final MockedStatic<PortletURLUtil>
+		_portletURLUtilMockedStatic = Mockito.mockStatic(PortletURLUtil.class);
+	private static Snapshot<PortletToolbarContributor> _snapshot;
+	private static AutoCloseable _snapshotAutoCloseable;
+
+	private static class TestMockLiferayPortletRenderRequest
+		extends MockLiferayPortletRenderRequest {
+
+		@Override
+		public void removeAttribute(String name) {
+			HttpServletRequest httpServletRequest = getHttpServletRequest();
+
+			httpServletRequest.removeAttribute(name);
+		}
+
+	}
+
+	private static class TestPortletToolbarContributor
+		implements PortletToolbarContributor {
+
+		public TestPortletToolbarContributor(boolean throwException) {
+			_throwException = throwException;
+		}
+
+		public Object getCapturedCurrentURL() {
+			return _capturedCurrentURL;
+		}
+
+		@Override
+		public List<Menu> getPortletTitleMenus(
+			PortletRequest portletRequest, PortletResponse portletResponse) {
+
+			_capturedCurrentURL = portletRequest.getAttribute(
+				WebKeys.CURRENT_URL);
+
+			if (_throwException) {
+				throw new RuntimeException();
+			}
+
+			return Collections.emptyList();
+		}
+
+		private Object _capturedCurrentURL;
+		private final boolean _throwException;
+
+	}
+
+}


### PR DESCRIPTION
Follow-up to https://github.com/brianchandotcom/liferay-portal/pull/175665. That PR was flagged by the review bot for a Rule 202 violation: the helper calls inside `testGetCreationMenu` were not in alphabetical order. This resubmission reorders them so `_testGetCreationMenuWhenContributorThrowsException` ("When") leads the three "With..." helpers. No production-code change versus the original PR.

https://liferay.atlassian.net/browse/LPD-92720

## What Is Being Fixed

When a custom document type defines an upload field, opening its item selector, navigating into a nested folder, and uploading a new file (New → File Upload → Publish) created the document but left the modal open and the field empty. The same flow works correctly at the root folder.

## How It Is Being Fixed

The item selector builds its "File Upload" menu item with a redirect taken from the current URL, which the portal resolves only from the CURRENT_URL request attribute. On the selector's initial full render that attribute is set, but on the subfolder PJAX render it is null, so the redirect parameter is dropped and the upload action never returns to the selector — the new file is never auto-selected and the modal stays open.

The fix scopes a guarded override to the item selector toolbar's creation menu: when CURRENT_URL is missing and a folder-aware portlet URL is available, it temporarily supplies that URL as CURRENT_URL while the document library contributor builds the menus, then removes it afterward. Every flow that already has CURRENT_URL set is left untouched, so the change is a no-op for the cases that work today and only restores the redirect in the broken subfolder render.

## How To Test

```
gradlew -p modules/apps/item-selector/item-selector-taglib test --tests ItemSelectorRepositoryEntryManagementToolbarDisplayContextTest
```
