### PR TITLE
LPD-92888 Sync CMS default permissions on space and folder ERC change

### DIFF
--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/model/listener/test/GroupModelListenerTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/model/listener/test/GroupModelListenerTest.java
@@ -9,12 +9,17 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.rest.filter.factory.FilterFactory;
+import com.liferay.petra.sql.dsl.expression.Predicate;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -26,6 +31,7 @@ import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.site.cms.site.initializer.test.util.CMSTestUtil;
+import com.liferay.site.cms.site.initializer.util.CMSDefaultPermissionUtil;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -57,26 +63,14 @@ public class GroupModelListenerTest {
 	}
 
 	@Test
+	@TestInfo("LPD-92888")
 	public void testUpdateDepotEntry() throws Exception {
-		Layout layout = _getRecycleBinLayout(_cmsGroup);
-
-		Assert.assertFalse(layout.isHidden());
-
 		DepotEntry depotEntry = _addDepotEntry();
 
 		Group depotGroup = depotEntry.getGroup();
 
-		_setTrashEnabled(depotGroup, Boolean.TRUE.toString());
-
-		Assert.assertTrue(
-			GetterUtil.getBoolean(
-				depotGroup.getTypeSettingsProperty("trashEnabled")));
-
-		_setTrashEnabled(depotGroup, Boolean.FALSE.toString());
-
-		Assert.assertFalse(
-			GetterUtil.getBoolean(
-				depotGroup.getTypeSettingsProperty("trashEnabled")));
+		_testSetTrashEnabled(depotGroup);
+		_testUpdateExternalReferenceCode(depotEntry, depotGroup);
 	}
 
 	private DepotEntry _addDepotEntry() throws Exception {
@@ -114,6 +108,56 @@ public class GroupModelListenerTest {
 			group.getGroupId(), unicodeProperties.toString());
 	}
 
+	private void _testSetTrashEnabled(Group depotGroup) throws Exception {
+		Layout layout = _getRecycleBinLayout(_cmsGroup);
+
+		Assert.assertFalse(layout.isHidden());
+
+		_setTrashEnabled(depotGroup, Boolean.TRUE.toString());
+
+		Assert.assertTrue(
+			GetterUtil.getBoolean(
+				depotGroup.getTypeSettingsProperty("trashEnabled")));
+
+		_setTrashEnabled(depotGroup, Boolean.FALSE.toString());
+
+		Assert.assertFalse(
+			GetterUtil.getBoolean(
+				depotGroup.getTypeSettingsProperty("trashEnabled")));
+	}
+
+	private void _testUpdateExternalReferenceCode(
+			DepotEntry depotEntry, Group depotGroup)
+		throws Exception {
+
+		String originalExternalReferenceCode =
+			depotGroup.getExternalReferenceCode();
+
+		Assert.assertNotNull(
+			CMSDefaultPermissionUtil.fetchObjectEntry(
+				depotGroup.getCompanyId(), depotGroup.getCreatorUserId(),
+				originalExternalReferenceCode, depotEntry.getModelClassName(),
+				_filterFactory));
+
+		String externalReferenceCode = RandomTestUtil.randomString();
+
+		depotGroup.setExternalReferenceCode(externalReferenceCode);
+
+		depotGroup = _groupLocalService.updateGroup(depotGroup);
+
+		Assert.assertNull(
+			CMSDefaultPermissionUtil.fetchObjectEntry(
+				depotGroup.getCompanyId(), depotGroup.getCreatorUserId(),
+				originalExternalReferenceCode, depotEntry.getModelClassName(),
+				_filterFactory));
+
+		Assert.assertNotNull(
+			CMSDefaultPermissionUtil.fetchObjectEntry(
+				depotGroup.getCompanyId(), depotGroup.getCreatorUserId(),
+				externalReferenceCode, depotEntry.getModelClassName(),
+				_filterFactory));
+	}
+
 	private Group _cmsGroup;
 
 	@DeleteAfterTestRun
@@ -121,6 +165,11 @@ public class GroupModelListenerTest {
 
 	@Inject
 	private DepotEntryLocalService _depotEntryLocalService;
+
+	@Inject(
+		filter = "filter.factory.key=" + ObjectDefinitionConstants.STORAGE_TYPE_DEFAULT
+	)
+	private FilterFactory<Predicate> _filterFactory;
 
 	@Inject
 	private GroupLocalService _groupLocalService;

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/model/listener/test/GroupModelListenerTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/model/listener/test/GroupModelListenerTest.java
@@ -65,12 +65,9 @@ public class GroupModelListenerTest {
 	@Test
 	@TestInfo("LPD-92888")
 	public void testUpdateDepotEntry() throws Exception {
-		DepotEntry depotEntry = _addDepotEntry();
+		_testSetTrashEnabled();
 
-		Group depotGroup = depotEntry.getGroup();
-
-		_testSetTrashEnabled(depotGroup);
-		_testUpdateExternalReferenceCode(depotEntry, depotGroup);
+		_testUpdateExternalReferenceCode();
 	}
 
 	private DepotEntry _addDepotEntry() throws Exception {
@@ -108,27 +105,30 @@ public class GroupModelListenerTest {
 			group.getGroupId(), unicodeProperties.toString());
 	}
 
-	private void _testSetTrashEnabled(Group depotGroup) throws Exception {
+	private void _testSetTrashEnabled() throws Exception {
+		Group depotGroup = _addDepotEntry().getGroup();
+
 		Layout layout = _getRecycleBinLayout(_cmsGroup);
 
 		Assert.assertFalse(layout.isHidden());
-
-		_setTrashEnabled(depotGroup, Boolean.TRUE.toString());
-
-		Assert.assertTrue(
-			GetterUtil.getBoolean(
-				depotGroup.getTypeSettingsProperty("trashEnabled")));
 
 		_setTrashEnabled(depotGroup, Boolean.FALSE.toString());
 
 		Assert.assertFalse(
 			GetterUtil.getBoolean(
 				depotGroup.getTypeSettingsProperty("trashEnabled")));
+
+		_setTrashEnabled(depotGroup, Boolean.TRUE.toString());
+
+		Assert.assertTrue(
+			GetterUtil.getBoolean(
+				depotGroup.getTypeSettingsProperty("trashEnabled")));
 	}
 
-	private void _testUpdateExternalReferenceCode(
-			DepotEntry depotEntry, Group depotGroup)
-		throws Exception {
+	private void _testUpdateExternalReferenceCode() throws Exception {
+		DepotEntry depotEntry = _addDepotEntry();
+
+		Group depotGroup = depotEntry.getGroup();
 
 		String originalExternalReferenceCode =
 			depotGroup.getExternalReferenceCode();

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/model/listener/test/ObjectEntryFolderModelListenerTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/model/listener/test/ObjectEntryFolderModelListenerTest.java
@@ -32,6 +32,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -95,6 +96,7 @@ public class ObjectEntryFolderModelListenerTest {
 	}
 
 	@Test
+	@TestInfo("LPD-92888")
 	public void testAddObjectEntryFolder() throws Exception {
 		JSONObject rootJSONObject = CMSDefaultPermissionUtil.getJSONObject(
 			_group.getCompanyId(), _group.getCreatorUserId(),
@@ -198,60 +200,11 @@ public class ObjectEntryFolderModelListenerTest {
 	}
 
 	@Test
+	@TestInfo("LPD-92888")
 	public void testUpdateObjectEntryFolder() throws Exception {
-		ObjectEntryFolder objectEntryFolder1 =
-			_objectEntryFolderLocalService.
-				getObjectEntryFolderByExternalReferenceCode(
-					ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS,
-					_group.getGroupId(), _group.getCompanyId());
+		_testMoveObjectEntryFolder();
 
-		ObjectEntryFolder objectEntryFolder2 = _addObjectEntryFolder(
-			objectEntryFolder1.getObjectEntryFolderId());
-
-		JSONObject jsonObject = CMSDefaultPermissionUtil.getJSONObject(
-			objectEntryFolder2.getCompanyId(), objectEntryFolder2.getUserId(),
-			objectEntryFolder2.getExternalReferenceCode(),
-			objectEntryFolder2.getModelClassName(), _filterFactory);
-
-		_assertResourcePermissions(jsonObject, objectEntryFolder2, null);
-
-		ObjectEntryFolder objectEntryFolder3 = _addObjectEntryFolder(
-			objectEntryFolder1.getObjectEntryFolderId());
-
-		_assertResourcePermissions(jsonObject, objectEntryFolder3, null);
-
-		ObjectEntry objectEntry = _fetchObjectEntry(objectEntryFolder2);
-
-		Assert.assertNotNull(objectEntry);
-
-		String randomActionId = RandomTestUtil.randomString();
-
-		jsonObject.put(
-			ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS,
-			JSONUtil.put(
-				RoleConstants.CMS_ADMINISTRATOR,
-				JSONUtil.putAll(
-					ActionKeys.UPDATE, ActionKeys.VIEW, randomActionId)
-			).put(
-				RoleConstants.USER, JSONUtil.putAll(ActionKeys.VIEW)
-			));
-
-		CMSDefaultPermissionUtil.addOrUpdateObjectEntry(
-			objectEntry.getExternalReferenceCode(),
-			objectEntryFolder2.getCompanyId(), objectEntryFolder2.getUserId(),
-			objectEntryFolder2.getExternalReferenceCode(),
-			objectEntryFolder2.getModelClassName(), jsonObject,
-			objectEntryFolder2.getGroupId(), objectEntryFolder2.getTreePath());
-
-		objectEntryFolder3 =
-			_objectEntryFolderLocalService.moveObjectEntryFolder(
-				objectEntryFolder3.getUserId(),
-				objectEntryFolder3.getObjectEntryFolderId(),
-				objectEntryFolder2.getObjectEntryFolderId(), false,
-				ServiceContextTestUtil.getServiceContext());
-
-		_assertResourcePermissions(
-			jsonObject, objectEntryFolder3, randomActionId);
+		_testUpdateExternalReferenceCode();
 	}
 
 	private ObjectEntryFolder _addObjectEntryFolder(
@@ -339,6 +292,93 @@ public class ObjectEntryFolderModelListenerTest {
 			ResourceConstants.SCOPE_INDIVIDUAL,
 			String.valueOf(objectEntryFolder.getObjectEntryFolderId()),
 			role.getRoleId());
+	}
+
+	private void _testMoveObjectEntryFolder() throws Exception {
+		ObjectEntryFolder objectEntryFolder1 =
+			_objectEntryFolderLocalService.
+				getObjectEntryFolderByExternalReferenceCode(
+					ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS,
+					_group.getGroupId(), _group.getCompanyId());
+
+		ObjectEntryFolder objectEntryFolder2 = _addObjectEntryFolder(
+			objectEntryFolder1.getObjectEntryFolderId());
+
+		JSONObject jsonObject = CMSDefaultPermissionUtil.getJSONObject(
+			objectEntryFolder2.getCompanyId(), objectEntryFolder2.getUserId(),
+			objectEntryFolder2.getExternalReferenceCode(),
+			objectEntryFolder2.getModelClassName(), _filterFactory);
+
+		_assertResourcePermissions(jsonObject, objectEntryFolder2, null);
+
+		ObjectEntryFolder objectEntryFolder3 = _addObjectEntryFolder(
+			objectEntryFolder1.getObjectEntryFolderId());
+
+		_assertResourcePermissions(jsonObject, objectEntryFolder3, null);
+
+		ObjectEntry objectEntry = _fetchObjectEntry(objectEntryFolder2);
+
+		Assert.assertNotNull(objectEntry);
+
+		String randomActionId = RandomTestUtil.randomString();
+
+		jsonObject.put(
+			ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS,
+			JSONUtil.put(
+				RoleConstants.CMS_ADMINISTRATOR,
+				JSONUtil.putAll(
+					ActionKeys.UPDATE, ActionKeys.VIEW, randomActionId)
+			).put(
+				RoleConstants.USER, JSONUtil.putAll(ActionKeys.VIEW)
+			));
+
+		CMSDefaultPermissionUtil.addOrUpdateObjectEntry(
+			objectEntry.getExternalReferenceCode(),
+			objectEntryFolder2.getCompanyId(), objectEntryFolder2.getUserId(),
+			objectEntryFolder2.getExternalReferenceCode(),
+			objectEntryFolder2.getModelClassName(), jsonObject,
+			objectEntryFolder2.getGroupId(), objectEntryFolder2.getTreePath());
+
+		objectEntryFolder3 =
+			_objectEntryFolderLocalService.moveObjectEntryFolder(
+				objectEntryFolder3.getUserId(),
+				objectEntryFolder3.getObjectEntryFolderId(),
+				objectEntryFolder2.getObjectEntryFolderId(), false,
+				ServiceContextTestUtil.getServiceContext());
+
+		_assertResourcePermissions(
+			jsonObject, objectEntryFolder3, randomActionId);
+	}
+
+	private void _testUpdateExternalReferenceCode() throws Exception {
+		ObjectEntryFolder rootObjectEntryFolder =
+			_objectEntryFolderLocalService.
+				getObjectEntryFolderByExternalReferenceCode(
+					ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS,
+					_group.getGroupId(), _group.getCompanyId());
+
+		ObjectEntryFolder objectEntryFolder = _addObjectEntryFolder(
+			rootObjectEntryFolder.getObjectEntryFolderId());
+
+		String originalExternalReferenceCode =
+			objectEntryFolder.getExternalReferenceCode();
+
+		Assert.assertNotNull(_fetchObjectEntry(objectEntryFolder));
+
+		objectEntryFolder.setExternalReferenceCode(
+			RandomTestUtil.randomString());
+
+		objectEntryFolder =
+			_objectEntryFolderLocalService.updateObjectEntryFolder(
+				objectEntryFolder);
+
+		Assert.assertNull(
+			CMSDefaultPermissionUtil.fetchObjectEntry(
+				objectEntryFolder.getCompanyId(), objectEntryFolder.getUserId(),
+				originalExternalReferenceCode,
+				objectEntryFolder.getModelClassName(), _filterFactory));
+
+		Assert.assertNotNull(_fetchObjectEntry(objectEntryFolder));
 	}
 
 	@Inject

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/model/listener/GroupModelListener.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/model/listener/GroupModelListener.java
@@ -8,9 +8,14 @@ package com.liferay.site.cms.site.initializer.internal.model.listener;
 import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.rest.filter.factory.FilterFactory;
 import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.sql.dsl.expression.Predicate;
 import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
@@ -18,8 +23,13 @@ import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.ModelListener;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.site.cms.site.initializer.util.CMSDefaultPermissionUtil;
 import com.liferay.trash.TrashHelper;
 
+import java.io.Serializable;
+
+import java.util.Map;
 import java.util.Objects;
 
 import org.osgi.service.component.annotations.Component;
@@ -63,38 +73,80 @@ public class GroupModelListener extends BaseModelListener<Group> {
 	private void _onAfterUpdate(Group originalGroup, Group group)
 		throws Exception {
 
-		if (group.isDepot()) {
-			DepotEntry depotEntry =
-				_depotEntryLocalService.fetchGroupDepotEntry(
-					group.getGroupId());
-
-			if ((depotEntry == null) ||
-				!(depotEntry.getType() == DepotConstants.TYPE_SPACE) ||
-				Objects.equals(
-					originalGroup.getTypeSettingsProperty("trashEnabled"),
-					group.getTypeSettingsProperty("trashEnabled")) ||
-				!FeatureFlagManagerUtil.isEnabled(
-					group.getCompanyId(), "LPD-17564")) {
-
-				return;
-			}
-
-			Group siteGroup = _groupLocalService.fetchGroup(
-				group.getCompanyId(), GroupConstants.CMS);
-
-			if (siteGroup == null) {
-				return;
-			}
-
-			Long[] groupIds = _getDepotGroupIds(group.getCompanyId());
-
-			if (groupIds.length > 0) {
-				_updateRecycleBinLayout(siteGroup, false);
-			}
-			else {
-				_updateRecycleBinLayout(siteGroup, true);
-			}
+		if (!group.isDepot()) {
+			return;
 		}
+
+		DepotEntry depotEntry = _depotEntryLocalService.fetchGroupDepotEntry(
+			group.getGroupId());
+
+		if ((depotEntry == null) ||
+			(depotEntry.getType() != DepotConstants.TYPE_SPACE) ||
+			!FeatureFlagManagerUtil.isEnabled(
+				group.getCompanyId(), "LPD-17564")) {
+
+			return;
+		}
+
+		String externalReferenceCode = group.getExternalReferenceCode();
+		String originalExternalReferenceCode =
+			originalGroup.getExternalReferenceCode();
+
+		if (!Objects.equals(
+				externalReferenceCode, originalExternalReferenceCode)) {
+
+			_updateCMSDefaultPermissionObjectEntry(
+				externalReferenceCode, group, originalExternalReferenceCode);
+		}
+
+		if (Objects.equals(
+				originalGroup.getTypeSettingsProperty("trashEnabled"),
+				group.getTypeSettingsProperty("trashEnabled"))) {
+
+			return;
+		}
+
+		Group siteGroup = _groupLocalService.fetchGroup(
+			group.getCompanyId(), GroupConstants.CMS);
+
+		if (siteGroup == null) {
+			return;
+		}
+
+		Long[] groupIds = _getDepotGroupIds(group.getCompanyId());
+
+		if (groupIds.length > 0) {
+			_updateRecycleBinLayout(siteGroup, false);
+		}
+		else {
+			_updateRecycleBinLayout(siteGroup, true);
+		}
+	}
+
+	private void _updateCMSDefaultPermissionObjectEntry(
+			String externalReferenceCode, Group group,
+			String originalExternalReferenceCode)
+		throws Exception {
+
+		ObjectEntry objectEntry = CMSDefaultPermissionUtil.fetchObjectEntry(
+			group.getCompanyId(), group.getCreatorUserId(),
+			originalExternalReferenceCode, DepotEntry.class.getName(),
+			_filterFactory);
+
+		if (objectEntry == null) {
+			return;
+		}
+
+		Map<String, Serializable> values = objectEntry.getValues();
+
+		CMSDefaultPermissionUtil.addOrUpdateObjectEntry(
+			objectEntry.getExternalReferenceCode(), group.getCompanyId(),
+			group.getCreatorUserId(), externalReferenceCode,
+			DepotEntry.class.getName(),
+			_jsonFactory.createJSONObject(
+				GetterUtil.getString(values.get("defaultPermissions"), "{}")),
+			GetterUtil.getLong(values.get("depotGroupId")),
+			GetterUtil.getString(values.get("treePath")));
 	}
 
 	private void _updateRecycleBinLayout(Group group, boolean hidden)
@@ -115,8 +167,16 @@ public class GroupModelListener extends BaseModelListener<Group> {
 	@Reference
 	private DepotEntryLocalService _depotEntryLocalService;
 
+	@Reference(
+		target = "(filter.factory.key=" + ObjectDefinitionConstants.STORAGE_TYPE_DEFAULT + ")"
+	)
+	private FilterFactory<Predicate> _filterFactory;
+
 	@Reference
 	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private JSONFactory _jsonFactory;
 
 	@Reference
 	private LayoutLocalService _layoutLocalService;

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/model/listener/ObjectEntryFolderModelListener.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/model/listener/ObjectEntryFolderModelListener.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.BaseModelListener;
@@ -35,12 +36,16 @@ import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.sharing.service.SharingEntryLocalService;
 import com.liferay.site.cms.site.initializer.util.CMSDefaultPermissionUtil;
 
+import java.io.Serializable;
+
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import org.osgi.service.component.annotations.Component;
@@ -85,6 +90,16 @@ public class ObjectEntryFolderModelListener
 		throws ModelListenerException {
 
 		try {
+			if (!Objects.equals(
+					originalObjectEntryFolder.getExternalReferenceCode(),
+					objectEntryFolder.getExternalReferenceCode())) {
+
+				_updateCMSDefaultPermissionObjectEntry(
+					objectEntryFolder.getExternalReferenceCode(),
+					objectEntryFolder,
+					originalObjectEntryFolder.getExternalReferenceCode());
+			}
+
 			if (originalObjectEntryFolder.getParentObjectEntryFolderId() !=
 					objectEntryFolder.getParentObjectEntryFolderId()) {
 
@@ -251,6 +266,38 @@ public class ObjectEntryFolderModelListener
 			objectEntry.getObjectEntryId());
 	}
 
+	private void _updateCMSDefaultPermissionObjectEntry(
+			String externalReferenceCode, ObjectEntryFolder objectEntryFolder,
+			String originalExternalReferenceCode)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled(
+				objectEntryFolder.getCompanyId(), "LPD-17564")) {
+
+			return;
+		}
+
+		ObjectEntry objectEntry = CMSDefaultPermissionUtil.fetchObjectEntry(
+			objectEntryFolder.getCompanyId(), objectEntryFolder.getUserId(),
+			originalExternalReferenceCode,
+			objectEntryFolder.getModelClassName(), _filterFactory);
+
+		if (objectEntry == null) {
+			return;
+		}
+
+		Map<String, Serializable> values = objectEntry.getValues();
+
+		CMSDefaultPermissionUtil.addOrUpdateObjectEntry(
+			objectEntry.getExternalReferenceCode(),
+			objectEntryFolder.getCompanyId(), objectEntryFolder.getUserId(),
+			externalReferenceCode, objectEntryFolder.getModelClassName(),
+			_jsonFactory.createJSONObject(
+				GetterUtil.getString(values.get("defaultPermissions"), "{}")),
+			GetterUtil.getLong(values.get("depotGroupId")),
+			GetterUtil.getString(values.get("treePath")));
+	}
+
 	private void _updateCMSDefaultPermissions(
 			ObjectEntryFolder objectEntryFolder)
 		throws Exception {
@@ -290,6 +337,9 @@ public class ObjectEntryFolderModelListener
 
 	@Reference
 	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private JSONFactory _jsonFactory;
 
 	@Reference
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92888

## What Is Being Fixed

The CMS object entry default permissions are stored per Space (and per
folder) in an L_CMS_DEFAULT_PERMISSION object entry keyed by the external
reference code of the Space group (or the object entry folder). When a
Space's external reference code changes — through Space Settings, or when a
Space asset library is created via the headless API with an explicit
external reference code (the group is created with an auto-generated code,
the default-permission entry is created under it, and the explicit code is
assigned afterwards) — the default-permission entry is left orphaned under
the old code. New object entries then resolve no default permissions and
only grant Owner and CMS Administrator VIEW, so space members lose VIEW on
the content.

## How It Is Being Fixed

GroupModelListener now re-keys the L_CMS_DEFAULT_PERMISSION entry to the new
external reference code whenever a Space group's external reference code
changes, covering both vectors. The same re-key is applied to
ObjectEntryFolderModelListener for object entry folders so the design is not
fragile if folder external reference code editing is ever exposed (it is not
mutable through the public headless API today). The configuration stays
external-reference-code keyed — the portable key the content-promotion
strategy relies on — rather than switching to a non-portable group id. Both
listeners read the existing entry by the old code and re-save it under the
new code, preserving the stored permissions, depot group id, and tree path.
Integration tests cover the re-key for both the Space group and the object
entry folder.
