### PR TITLE
LPD-93071 Restore comment author edit and delete in CMS info panel

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/util/CommentUtil.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/util/CommentUtil.java
@@ -72,10 +72,12 @@ public class CommentUtil {
 			"edited", !createDate.equals(modifiedDate)
 		).put(
 			"hasDeletePermission",
+			(themeDisplay.getUserId() == comment.getUserId()) ||
 			discussionPermission.hasDeletePermission(
 				themeDisplay.getPermissionChecker(), comment.getCommentId())
 		).put(
 			"hasUpdatePermission",
+			(themeDisplay.getUserId() == comment.getUserId()) ||
 			discussionPermission.hasUpdatePermission(
 				themeDisplay.getPermissionChecker(), comment.getCommentId())
 		).put(

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/info-panel/comments.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/info-panel/comments.spec.ts
@@ -31,7 +31,7 @@ const test = mergeTests(
 
 test(
 	'Info Panel Comments and view Delete confirmation modal for added content',
-	{tag: ['@LPD-62554', '@LPD-86000']},
+	{tag: ['@LPD-62554', '@LPD-86000', '@LPD-93071']},
 	async ({apiHelpers, assetsPage, infoPanelPage, page, spaceSummaryPage}) => {
 		const applicationName = 'cms/basic-web-contents';
 		const spaceName = `Space ${getRandomString()}`;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93071

## What Is Being Fixed

In the CMS content info panel, a Space member could no longer edit or delete a comment they authored. The per-comment edit/delete actions are rendered only when the comment JSON carries `hasUpdatePermission`/`hasDeletePermission`. Since `70f981d0e43e7` ("LPD-90003 Filter comment actions by user permission") those flags came purely from the discussion permission check, dropping the comment-author exception that `EditContentItemCommentStrutsAction`/`DeleteContentItemCommentStrutsAction` already apply since LPD-86000. A member holds `ADD_DISCUSSION` but not `UPDATE_DISCUSSION`/`DELETE_DISCUSSION`, so the actions disappeared even though the backend would allow the operation — regressing LPD-86000 and contradicting LPD-90003's own criterion ("should only be able to edit their own comments").

## How It Is Being Fixed

`CommentUtil.getCommentJSONObject` now reports `hasUpdatePermission`/`hasDeletePermission` as `true` when the current user is the comment author, OR-ed with the existing discussion permission check. This mirrors the struts actions, restores the author's ability to edit/delete their own comment, and keeps the LPD-90003 leak closed for comments authored by others (a non-author still needs the discussion permission). The existing Playwright test is also tagged with `@LPD-93071`.

## Why Are There No Tests?

No new test is added: the behavior is already covered by the Playwright test `Info Panel Comments and view Delete confirmation modal for added content` (`comments.spec.ts`, now tagged `@LPD-86000 @LPD-93071`), which was failing before this change and passes after it (verified locally: 3 passed, 35s).
