### PR TITLE
LPD-85676 Reindex asset entries by primary key when not a base model

### DIFF
--- a/modules/apps/asset/asset-auto-tagger-service/src/main/java/com/liferay/asset/auto/tagger/internal/AssetAutoTaggerImpl.java
+++ b/modules/apps/asset/asset-auto-tagger-service/src/main/java/com/liferay/asset/auto/tagger/internal/AssetAutoTaggerImpl.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.change.tracking.CTAware;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistry;
 import com.liferay.portal.kernel.service.GroupLocalService;
@@ -180,13 +181,17 @@ public class AssetAutoTaggerImpl implements AopService, AssetAutoTagger {
 
 		AssetRenderer<?> assetRenderer = assetEntry.getAssetRenderer();
 
-		if (assetRenderer == null) {
-			indexer.reindex(assetEntry.getClassName(), assetEntry.getClassPK());
+		if (assetRenderer != null) {
+			Object assetObject = assetRenderer.getAssetObject();
 
-			return;
+			if (assetObject instanceof BaseModel) {
+				indexer.reindex(assetObject);
+
+				return;
+			}
 		}
 
-		indexer.reindex(assetRenderer.getAssetObject());
+		indexer.reindex(assetEntry.getClassName(), assetEntry.getClassPK());
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/asset/asset-entry-rel-service/src/main/java/com/liferay/asset/entry/rel/service/impl/AssetEntryAssetCategoryRelLocalServiceImpl.java
+++ b/modules/apps/asset/asset-entry-rel-service/src/main/java/com/liferay/asset/entry/rel/service/impl/AssetEntryAssetCategoryRelLocalServiceImpl.java
@@ -18,6 +18,7 @@ import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.mass.delete.MassDeleteCacheThreadLocal;
+import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistry;
 import com.liferay.portal.kernel.search.SearchException;
@@ -283,7 +284,15 @@ public class AssetEntryAssetCategoryRelLocalServiceImpl
 				return;
 			}
 
-			indexer.reindex(assetRenderer.getAssetObject());
+			Object assetObject = assetRenderer.getAssetObject();
+
+			if (assetObject instanceof BaseModel) {
+				indexer.reindex(assetObject);
+			}
+			else {
+				indexer.reindex(
+					assetEntry.getClassName(), assetEntry.getClassPK());
+			}
 		}
 		catch (SearchException searchException) {
 			_log.error("Unable to reindex asset entry", searchException);

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFileEntryAssetEntryTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFileEntryAssetEntryTest.java
@@ -1,0 +1,140 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.document.library.search.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.kernel.model.AssetCategory;
+import com.liferay.asset.kernel.model.AssetVocabulary;
+import com.liferay.asset.kernel.service.AssetCategoryLocalService;
+import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
+import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.document.library.kernel.model.DLFolderConstants;
+import com.liferay.document.library.kernel.service.DLAppLocalService;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.search.legacy.searcher.SearchRequestBuilderFactory;
+import com.liferay.portal.search.test.util.IndexerFixture;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.util.Locale;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Jürgen Kappler
+ */
+@RunWith(Arquillian.class)
+public class DLFileEntryAssetEntryTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE,
+			SynchronousDestinationTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_indexerFixture = new IndexerFixture<>(
+			DLFileEntry.class, _searchRequestBuilderFactory);
+	}
+
+	@Test
+	public void testUpdateAssetCategoryTitle() throws Exception {
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId());
+
+		AssetVocabulary assetVocabulary =
+			_assetVocabularyLocalService.addVocabulary(
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				RandomTestUtil.randomString(), serviceContext);
+
+		AssetCategory assetCategory = _assetCategoryLocalService.addCategory(
+			TestPropsValues.getUserId(), _group.getGroupId(),
+			RandomTestUtil.randomString(), assetVocabulary.getVocabularyId(),
+			serviceContext);
+
+		serviceContext.setAssetCategoryIds(
+			new long[] {assetCategory.getCategoryId()});
+
+		FileEntry fileEntry = _dlAppLocalService.addFileEntry(
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			RandomTestUtil.randomString() + ".txt", ContentTypes.TEXT_PLAIN,
+			RandomTestUtil.randomString(), StringPool.BLANK, StringPool.BLANK,
+			StringPool.BLANK, RandomTestUtil.randomBytes(), null, null, null,
+			serviceContext);
+
+		Locale locale = PortalUtil.getSiteDefaultLocale(_group.getGroupId());
+
+		_assertSearch(assetCategory.getTitle(locale), fileEntry);
+
+		String updatedAssetCategoryTitle = RandomTestUtil.randomString();
+
+		_assetCategoryLocalService.updateCategory(
+			assetCategory.getExternalReferenceCode(),
+			TestPropsValues.getUserId(), assetCategory.getCategoryId(),
+			assetCategory.getParentCategoryId(),
+			HashMapBuilder.put(
+				locale, updatedAssetCategoryTitle
+			).build(),
+			assetCategory.getDescriptionMap(), assetCategory.getVocabularyId(),
+			null, serviceContext);
+
+		_assertSearch(updatedAssetCategoryTitle, fileEntry);
+	}
+
+	private void _assertSearch(String keyword, FileEntry fileEntry) {
+		Document document = _indexerFixture.searchOnlyOne(keyword);
+
+		Assert.assertEquals(
+			String.valueOf(fileEntry.getFileEntryId()),
+			document.get(Field.ENTRY_CLASS_PK));
+	}
+
+	@Inject
+	private AssetCategoryLocalService _assetCategoryLocalService;
+
+	@Inject
+	private AssetVocabularyLocalService _assetVocabularyLocalService;
+
+	@Inject
+	private DLAppLocalService _dlAppLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	private IndexerFixture<DLFileEntry> _indexerFixture;
+
+	@Inject
+	private SearchRequestBuilderFactory _searchRequestBuilderFactory;
+
+}

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetEntryLocalServiceImpl.java
@@ -34,6 +34,7 @@ import com.liferay.portal.kernel.dao.orm.Session;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.mass.delete.MassDeleteCacheThreadLocal;
+import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.User;
@@ -1315,13 +1316,17 @@ public class AssetEntryLocalServiceImpl extends AssetEntryLocalServiceBaseImpl {
 
 		AssetRenderer<?> assetRenderer = entry.getAssetRenderer();
 
-		if (assetRenderer == null) {
-			indexer.reindex(entry.getClassName(), entry.getClassPK());
+		if (assetRenderer != null) {
+			Object assetObject = assetRenderer.getAssetObject();
 
-			return;
+			if (assetObject instanceof BaseModel) {
+				indexer.reindex(assetObject);
+
+				return;
+			}
 		}
 
-		indexer.reindex(assetRenderer.getAssetObject());
+		indexer.reindex(entry.getClassName(), entry.getClassPK());
 	}
 
 	private AssetEntry _deleteEntry(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-85676

## What Is Being Fixed

Renaming or deleting an asset category applied to a Documents and Media file entry logged a `ClassCastException` and aborted the reindex of the affected asset entries. `AssetCategoryAssetEntriesReindexMessageListener` reindexes every asset entry related to the category through `AssetEntryLocalServiceImpl.reindex(AssetEntry)`, which since LPS-181849 reindexes `assetRenderer.getAssetObject()` directly. For a file entry that object is a `LiferayFileEntry`, which is not a `BaseModel`, so the `DLFileEntry` indexer's `reindex(T extends BaseModel)` threw `LiferayFileEntry cannot be cast to BaseModel`. The exception was swallowed and logged, leaving those file entries silently unindexed under the renamed category.

## How It Is Being Fixed

The asset object is handed to the indexer only when it actually is a `BaseModel`; otherwise the reindex falls back to the pre-LPS-181849 path that reindexes by class name and primary key. This preserves the LPS-181849 behavior for `JournalArticle` (still a `BaseModel`, so related tag and category edits keep propagating) while routing file entries through the safe reload-by-primary-key path. The same guard is applied to the two sibling reindex methods that share the identical pattern, `AssetEntryAssetCategoryRelLocalServiceImpl` and `AssetAutoTaggerImpl`.

## Tests

`DLFileEntryAssetEntryTest` assigns a category to a file entry, renames the category, and asserts the file entry's indexed document reflects the new category title — it fails with the `ClassCastException` before the fix and passes after.

```bash
gradlew -p modules/apps/document-library/document-library-test testIntegration --tests DLFileEntryAssetEntryTest
```
