### PR TITLE
LPD-93222 Provision space members via API in the comment permissions test

### DIFF
--- a/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/commentsPermissions.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/commentsPermissions.spec.ts
@@ -28,7 +28,7 @@ const test = mergeTests(
 
 test(
 	'Comment actions are restricted to users with permission over the content',
-	{tag: '@LPD-90003'},
+	{tag: ['@LPD-90003', '@LPD-93064']},
 	async ({apiHelpers, contentsPage, page, spaceSummaryPage}) => {
 		const spaceName = getRandomString();
 		const commentBody = getRandomString();

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/commentsPermissions.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/commentsPermissions.spec.ts
@@ -29,7 +29,7 @@ const test = mergeTests(
 test(
 	'Comment actions are restricted to users with permission over the content',
 	{tag: ['@LPD-90003', '@LPD-93064']},
-	async ({apiHelpers, contentsPage, page, spaceSummaryPage}) => {
+	async ({apiHelpers, contentsPage, page}) => {
 		const spaceName = getRandomString();
 		const commentBody = getRandomString();
 		const contentTitle = 'Untitled Asset';
@@ -103,8 +103,6 @@ test(
 		await test.step('Space Administrator can edit and delete the admin comment', async () => {
 			await performUserSwitchViaApi(page, spaceAdmin.alternateName);
 
-			await spaceSummaryPage.goto(spaceName);
-
 			await contentsPage.goto();
 
 			await contentRow.getByRole('link', {name: contentTitle}).click();
@@ -117,8 +115,6 @@ test(
 
 		await test.step('Space Member cannot edit or delete the admin comment', async () => {
 			await performUserSwitchViaApi(page, spaceMember.alternateName);
-
-			await spaceSummaryPage.goto(spaceName);
 
 			await page.goto(PORTLET_URLS.cmsContents);
 

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/commentsPermissions.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/commentsPermissions.spec.ts
@@ -34,11 +34,12 @@ test(
 		const commentBody = getRandomString();
 		const contentTitle = 'Untitled Asset';
 
-		await apiHelpers.headlessAssetLibrary.createAssetLibrary({
-			name: spaceName,
-			settings: {},
-			type: 'Space',
-		});
+		const assetLibrary =
+			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+				name: spaceName,
+				settings: {},
+				type: 'Space',
+			});
 
 		await contentsPage.goto();
 
@@ -65,7 +66,6 @@ test(
 		await expect(comment.getByTitle('actions')).toBeVisible();
 
 		const spaceAdmin = await apiHelpers.headlessAdminUser.postUserAccount();
-		const spaceAdminFullName = `${spaceAdmin.givenName} ${spaceAdmin.familyName}`;
 
 		userData[spaceAdmin.alternateName] = {
 			name: spaceAdmin.givenName,
@@ -75,7 +75,6 @@ test(
 
 		const spaceMember =
 			await apiHelpers.headlessAdminUser.postUserAccount();
-		const spaceMemberFullName = `${spaceMember.givenName} ${spaceMember.familyName}`;
 
 		userData[spaceMember.alternateName] = {
 			name: spaceMember.givenName,
@@ -83,13 +82,19 @@ test(
 			surname: spaceMember.familyName,
 		};
 
-		await spaceSummaryPage.goto(spaceName);
-		await spaceSummaryPage.addUserOrUserGroup(spaceAdminFullName, 'users');
-		await spaceSummaryPage.addRoleToSpaceMember(
-			'Space Administrator',
-			spaceAdminFullName
+		await apiHelpers.headlessAssetLibrary.putAssetLibraryUserAccount(
+			assetLibrary.externalReferenceCode,
+			spaceAdmin.externalReferenceCode
 		);
-		await spaceSummaryPage.addUserOrUserGroup(spaceMemberFullName, 'users');
+		await apiHelpers.headlessAssetLibrary.putAssetLibraryUserAccountRoles(
+			assetLibrary.externalReferenceCode,
+			spaceAdmin.externalReferenceCode,
+			['Asset Library Administrator']
+		);
+		await apiHelpers.headlessAssetLibrary.putAssetLibraryUserAccount(
+			assetLibrary.externalReferenceCode,
+			spaceMember.externalReferenceCode
+		);
 
 		const contentRow = page
 			.locator('.fds table tbody tr')


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93222

## What Is Being Fixed

The Playwright test "Comment actions are restricted to users with permission over the content" failed reproducibly during setup. The space member and role provisioning ran through the "View All Members" modal dialog in SpaceSummaryPage; on the second member add the dialog reopened but its input never became interactable and the page navigated away, so the test timed out before exercising the behavior it covers.

## How It Is Being Fixed

The UI member and role setup is replaced with the headless asset library API (putAssetLibraryUserAccount and putAssetLibraryUserAccountRoles), capturing the created asset library's external reference code. This removes the flaky modal interaction so the test reliably reaches its assertions: comment actions are visible to the space administrator and hidden from the space member. The test is also tagged with @LPD-93064.