### PR TITLE
LPD-92977 Remove duplicate tags from the asset tags autocomplete

### DIFF
--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/js/asset_tags_selector/AssetTagsSelector.js
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/js/asset_tags_selector/AssetTagsSelector.js
@@ -12,7 +12,7 @@ import {useId} from 'frontend-js-components-web';
 import {fetch, sub} from 'frontend-js-web';
 import {openItemSelectorModal} from 'item-selector-web';
 import PropTypes from 'prop-types';
-import React, {useEffect, useRef, useState} from 'react';
+import React, {useEffect, useMemo, useRef, useState} from 'react';
 
 const noop = () => {};
 
@@ -75,6 +75,25 @@ function AssetTagsSelector({
 		// `useEffect` when the value changes.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [groupIds, inputValue, previousInputValue]);
+
+	const sourceItems = useMemo(() => {
+		if (!resource) {
+			return [];
+		}
+
+		const itemsByName = new Map();
+
+		for (const tag of resource) {
+			if (!itemsByName.has(tag.value)) {
+				itemsByName.set(tag.value, {
+					label: tag.text,
+					value: tag.value,
+				});
+			}
+		}
+
+		return Array.from(itemsByName.values());
+	}, [resource]);
 
 	const callGlobalCallback = (callback, item) => {
 		if (callback && typeof window[callback] === 'function') {
@@ -258,16 +277,7 @@ function AssetTagsSelector({
 							onBlur={handleInputBlur}
 							onChange={onInputValueChange}
 							onItemsChange={handleItemsChange}
-							sourceItems={
-								resource
-									? resource.map((tag) => {
-											return {
-												label: tag.text,
-												value: tag.value,
-											};
-										})
-									: []
-							}
+							sourceItems={sourceItems}
 							value={inputValue}
 						/>
 					</ClayInput.GroupItem>

--- a/modules/apps/asset/asset-taglib/test/asset_tags_selector/AssetTagsSelector.js
+++ b/modules/apps/asset/asset-taglib/test/asset_tags_selector/AssetTagsSelector.js
@@ -1,0 +1,75 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import '@testing-library/jest-dom';
+import {useResource} from '@clayui/data-provider';
+import {render} from '@testing-library/react';
+import React from 'react';
+
+import AssetTagsSelector from '../../src/main/resources/META-INF/resources/js/asset_tags_selector/AssetTagsSelector';
+
+const DEFAULT_PROPS = {
+	groupIds: [],
+	inputName: 'tags',
+	inputValue: '',
+	portletURL: '',
+	selectedItems: [],
+};
+
+let capturedSourceItems;
+
+jest.mock('@clayui/multi-select', () => ({
+	__esModule: true,
+	default: (props) => {
+		capturedSourceItems = props.sourceItems;
+
+		return null;
+	},
+}));
+
+jest.mock('@clayui/data-provider', () => {
+	const originalModule = jest.requireActual('@clayui/data-provider');
+
+	return {
+		__esModule: true,
+		...originalModule,
+		useResource: jest.fn(),
+	};
+});
+
+const setResource = (resource) =>
+	useResource.mockImplementation(() => ({refetch: jest.fn(), resource}));
+
+describe('AssetTagsSelector', () => {
+	beforeEach(() => {
+		capturedSourceItems = undefined;
+	});
+
+	it('Remove duplicates from the list', () => {
+		setResource([
+			{text: 'apple', value: 'apple'},
+			{text: 'apple', value: 'apple'},
+			{text: 'banana', value: 'banana'},
+			{text: 'banana', value: 'banana'},
+			{text: 'carrot', value: 'carrot'},
+		]);
+
+		render(<AssetTagsSelector {...DEFAULT_PROPS} />);
+
+		expect(capturedSourceItems).toEqual([
+			{label: 'apple', value: 'apple'},
+			{label: 'banana', value: 'banana'},
+			{label: 'carrot', value: 'carrot'},
+		]);
+	});
+
+	it('Passes an empty array when the resource is null', () => {
+		setResource(null);
+
+		render(<AssetTagsSelector {...DEFAULT_PROPS} />);
+
+		expect(capturedSourceItems).toEqual([]);
+	});
+});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92977

## What Is Being Fixed

The asset tags selector built its autocomplete source list directly from the resource returned by the data provider, which could contain the same tag more than once. Those duplicate entries surfaced in the autocomplete dropdown during web content editing, showing the same tag label multiple times.

## How It Is Being Fixed

The source items are now derived in a `useMemo` that deduplicates the resource by tag value, keeping the first occurrence of each. The memoized list replaces the inline `resource.map(...)` previously passed to the multi-select, so each tag appears once and the list is recomputed only when the resource changes.