### PR TITLE
LPD-91062 Distinguish staging and live sites in the Spaces section

### DIFF
--- a/modules/apps/headless/headless-asset-library/headless-asset-library-api/src/main/java/com/liferay/headless/asset/library/dto/v1_0/ConnectedSite.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-api/src/main/java/com/liferay/headless/asset/library/dto/v1_0/ConnectedSite.java
@@ -391,6 +391,62 @@ public class ConnectedSite implements Serializable {
 	@JsonIgnore
 	private Supplier<Boolean> _searchableSupplier;
 
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The connected site's staging type."
+	)
+	@JsonGetter("stagingType")
+	@Valid
+	public StagingType getStagingType() {
+		if (_stagingTypeSupplier != null) {
+			stagingType = _stagingTypeSupplier.get();
+
+			_stagingTypeSupplier = null;
+		}
+
+		return stagingType;
+	}
+
+	@JsonIgnore
+	public String getStagingTypeAsString() {
+		StagingType stagingType = getStagingType();
+
+		if (stagingType == null) {
+			return null;
+		}
+
+		return stagingType.toString();
+	}
+
+	public void setStagingType(StagingType stagingType) {
+		this.stagingType = stagingType;
+
+		_stagingTypeSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setStagingType(
+		UnsafeSupplier<StagingType, Exception> stagingTypeUnsafeSupplier) {
+
+		_stagingTypeSupplier = () -> {
+			try {
+				return stagingTypeUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(description = "The connected site's staging type.")
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected StagingType stagingType;
+
+	@JsonIgnore
+	private Supplier<StagingType> _stagingTypeSupplier;
+
 	@io.swagger.v3.oas.annotations.media.Schema
 	@JsonGetter("type")
 	@Valid
@@ -582,6 +638,20 @@ public class ConnectedSite implements Serializable {
 			sb.append(searchable);
 		}
 
+		StagingType stagingType = getStagingType();
+
+		if (stagingType != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"stagingType\": ");
+
+			sb.append("\"");
+			sb.append(stagingType);
+			sb.append("\"");
+		}
+
 		Type type = getType();
 
 		if (type != null) {
@@ -607,6 +677,44 @@ public class ConnectedSite implements Serializable {
 		name = "x-class-name"
 	)
 	public String xClassName;
+
+	@GraphQLName("StagingType")
+	public static enum StagingType {
+
+		LIVE("LIVE"), STAGING("STAGING");
+
+		@JsonCreator
+		public static StagingType create(String value) {
+			if ((value == null) || value.equals("")) {
+				return null;
+			}
+
+			for (StagingType stagingType : values()) {
+				if (Objects.equals(stagingType.getValue(), value)) {
+					return stagingType;
+				}
+			}
+
+			throw new IllegalArgumentException("Invalid enum value: " + value);
+		}
+
+		@JsonValue
+		public String getValue() {
+			return _value;
+		}
+
+		@Override
+		public String toString() {
+			return _value;
+		}
+
+		private StagingType(String value) {
+			_value = value;
+		}
+
+		private final String _value;
+
+	}
 
 	@GraphQLName("Type")
 	public static enum Type {
@@ -735,4 +843,4 @@ public class ConnectedSite implements Serializable {
 	private Map<String, Serializable> _extendedProperties;
 
 }
-// LIFERAY-REST-BUILDER-HASH:109143184
+// LIFERAY-REST-BUILDER-HASH:-460521873

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-client/src/main/java/com/liferay/headless/asset/library/client/dto/v1_0/ConnectedSite.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-client/src/main/java/com/liferay/headless/asset/library/client/dto/v1_0/ConnectedSite.java
@@ -192,6 +192,35 @@ public class ConnectedSite implements Cloneable, Serializable {
 
 	protected Boolean searchable;
 
+	public StagingType getStagingType() {
+		return stagingType;
+	}
+
+	public String getStagingTypeAsString() {
+		if (stagingType == null) {
+			return null;
+		}
+
+		return stagingType.toString();
+	}
+
+	public void setStagingType(StagingType stagingType) {
+		this.stagingType = stagingType;
+	}
+
+	public void setStagingType(
+		UnsafeSupplier<StagingType, Exception> stagingTypeUnsafeSupplier) {
+
+		try {
+			stagingType = stagingTypeUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected StagingType stagingType;
+
 	public Type getType() {
 		return type;
 	}
@@ -250,6 +279,39 @@ public class ConnectedSite implements Cloneable, Serializable {
 		return ConnectedSiteSerDes.toJSON(this);
 	}
 
+	public static enum StagingType {
+
+		LIVE("LIVE"), STAGING("STAGING");
+
+		public static StagingType create(String value) {
+			for (StagingType stagingType : values()) {
+				if (Objects.equals(stagingType.getValue(), value) ||
+					Objects.equals(stagingType.name(), value)) {
+
+					return stagingType;
+				}
+			}
+
+			return null;
+		}
+
+		public String getValue() {
+			return _value;
+		}
+
+		@Override
+		public String toString() {
+			return _value;
+		}
+
+		private StagingType(String value) {
+			_value = value;
+		}
+
+		private final String _value;
+
+	}
+
 	public static enum Type {
 
 		SITE("Site"), SITE_TEMPLATE("SiteTemplate");
@@ -284,4 +346,4 @@ public class ConnectedSite implements Cloneable, Serializable {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1771151761
+// LIFERAY-REST-BUILDER-HASH:787305991

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-client/src/main/java/com/liferay/headless/asset/library/client/serdes/v1_0/ConnectedSiteSerDes.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-client/src/main/java/com/liferay/headless/asset/library/client/serdes/v1_0/ConnectedSiteSerDes.java
@@ -142,6 +142,18 @@ public class ConnectedSiteSerDes {
 			sb.append(connectedSite.getSearchable());
 		}
 
+		if (connectedSite.getStagingType() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"stagingType\": ");
+
+			sb.append("\"");
+			sb.append(connectedSite.getStagingType());
+			sb.append("\"");
+		}
+
 		if (connectedSite.getType() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -236,6 +248,14 @@ public class ConnectedSiteSerDes {
 				"searchable", String.valueOf(connectedSite.getSearchable()));
 		}
 
+		if (connectedSite.getStagingType() == null) {
+			map.put("stagingType", null);
+		}
+		else {
+			map.put(
+				"stagingType", String.valueOf(connectedSite.getStagingType()));
+		}
+
 		if (connectedSite.getType() == null) {
 			map.put("type", null);
 		}
@@ -287,6 +307,9 @@ public class ConnectedSiteSerDes {
 				return true;
 			}
 			else if (Objects.equals(jsonParserFieldName, "searchable")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "stagingType")) {
 				return false;
 			}
 			else if (Objects.equals(jsonParserFieldName, "type")) {
@@ -348,6 +371,13 @@ public class ConnectedSiteSerDes {
 			else if (Objects.equals(jsonParserFieldName, "searchable")) {
 				if (jsonParserFieldValue != null) {
 					connectedSite.setSearchable((Boolean)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "stagingType")) {
+				if (jsonParserFieldValue != null) {
+					connectedSite.setStagingType(
+						ConnectedSite.StagingType.create(
+							(String)jsonParserFieldValue));
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "type")) {
@@ -438,4 +468,4 @@ public class ConnectedSiteSerDes {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1796380456
+// LIFERAY-REST-BUILDER-HASH:-1334680686

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/build.gradle
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/build.gradle
@@ -18,6 +18,7 @@ dependencies {
 	compileOnly project(":apps:portal-odata:portal-odata-api")
 	compileOnly project(":apps:portal-vulcan:portal-vulcan-api")
 	compileOnly project(":apps:sharing:sharing-api")
+	compileOnly project(":apps:staging:staging-api")
 	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-sql-dsl-api")

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/rest-openapi.yaml
@@ -172,6 +172,12 @@ components:
                 searchable:
                     default: true
                     type: boolean
+                stagingType:
+                    description:
+                        The connected site's staging type.
+                    enum: [LIVE, STAGING]
+                    readOnly: true
+                    type: string
                 type:
                     enum: [Site, SiteTemplate]
                     readOnly: true

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/dto/v1_0/converter/ConnectedSiteDTOConverter.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/dto/v1_0/converter/ConnectedSiteDTOConverter.java
@@ -18,6 +18,7 @@ import com.liferay.portal.vulcan.dto.converter.DTOConverter;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterContext;
 import com.liferay.portal.vulcan.util.JaxRsLinkUtil;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
+import com.liferay.staging.StagingGroupHelper;
 
 import jakarta.ws.rs.core.UriInfo;
 
@@ -84,6 +85,18 @@ public class ConnectedSiteDTOConverter
 						dtoConverterContext.isAcceptAllLanguages(),
 						group.getNameMap()));
 				setSearchable(depotEntryGroupRel::isSearchable);
+				setStagingType(
+					() -> {
+						if (_stagingGroupHelper.isStagingGroup(group)) {
+							return ConnectedSite.StagingType.STAGING;
+						}
+
+						if (_stagingGroupHelper.isLiveGroup(group)) {
+							return ConnectedSite.StagingType.LIVE;
+						}
+
+						return null;
+					});
 				setType(
 					() -> {
 						if (group.isLayoutSetPrototype()) {
@@ -107,5 +120,8 @@ public class ConnectedSiteDTOConverter
 
 	@Reference
 	private Portal _portal;
+
+	@Reference
+	private StagingGroupHelper _stagingGroupHelper;
 
 }

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/BaseConnectedSiteResourceTestCase.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/BaseConnectedSiteResourceTestCase.java
@@ -732,6 +732,14 @@ public abstract class BaseConnectedSiteResourceTestCase {
 				continue;
 			}
 
+			if (Objects.equals("stagingType", additionalAssertFieldName)) {
+				if (connectedSite.getStagingType() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals("type", additionalAssertFieldName)) {
 				if (connectedSite.getType() == null) {
 					valid = false;
@@ -945,6 +953,17 @@ public abstract class BaseConnectedSiteResourceTestCase {
 				if (!Objects.deepEquals(
 						connectedSite1.getSearchable(),
 						connectedSite2.getSearchable())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("stagingType", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						connectedSite1.getStagingType(),
+						connectedSite2.getStagingType())) {
 
 					return false;
 				}
@@ -1273,6 +1292,11 @@ public abstract class BaseConnectedSiteResourceTestCase {
 				"Invalid entity field " + entityFieldName);
 		}
 
+		if (entityFieldName.equals("stagingType")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
 		if (entityFieldName.equals("type")) {
 			throw new IllegalArgumentException(
 				"Invalid entity field " + entityFieldName);
@@ -1585,4 +1609,4 @@ public abstract class BaseConnectedSiteResourceTestCase {
 			_connectedSiteResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-335932348
+// LIFERAY-REST-BUILDER-HASH:1439985572

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/ConnectedSiteResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/ConnectedSiteResourceTest.java
@@ -6,25 +6,32 @@
 package com.liferay.headless.asset.library.resource.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.exportimport.kernel.service.StagingLocalService;
 import com.liferay.headless.asset.library.client.dto.v1_0.ConnectedSite;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.LayoutSetPrototype;
 import com.liferay.portal.kernel.service.LayoutSetPrototypeLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 
 import java.util.HashMap;
 
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -35,6 +42,13 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 public class ConnectedSiteResourceTest
 	extends BaseConnectedSiteResourceTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
 
 	@Before
 	@Override
@@ -55,6 +69,7 @@ public class ConnectedSiteResourceTest
 	public void testPutAssetLibraryConnectedSite() throws Exception {
 		super.testPutAssetLibraryConnectedSite();
 
+		_testPutAssetLibraryConnectedSiteReturnsStagingType();
 		_testPutAssetLibraryConnectedSiteReturnsTypeSite();
 		_testPutAssetLibraryConnectedSiteReturnsTypeSiteTemplate();
 	}
@@ -162,6 +177,52 @@ public class ConnectedSiteResourceTest
 		};
 	}
 
+	private void _enableLocalStaging(Group group) throws Exception {
+		_stagingLocalService.enableLocalStaging(
+			TestPropsValues.getUserId(), group, true, false,
+			ServiceContextTestUtil.getServiceContext(
+				group, TestPropsValues.getUserId()));
+	}
+
+	private void _testPutAssetLibraryConnectedSiteReturnsStagingType()
+		throws Exception {
+
+		Group assetLibraryGroup = testDepotEntry.getGroup();
+
+		String assetLibraryExternalReferenceCode =
+			assetLibraryGroup.getExternalReferenceCode();
+
+		Group group = GroupTestUtil.addGroup();
+
+		ConnectedSite connectedSite =
+			connectedSiteResource.putAssetLibraryConnectedSite(
+				assetLibraryExternalReferenceCode,
+				group.getExternalReferenceCode(), new ConnectedSite());
+
+		Assert.assertNull(connectedSite.getStagingType());
+
+		_enableLocalStaging(group);
+
+		ConnectedSite liveConnectedSite =
+			connectedSiteResource.getAssetLibraryConnectedSite(
+				assetLibraryExternalReferenceCode,
+				group.getExternalReferenceCode());
+
+		Assert.assertEquals(
+			ConnectedSite.StagingType.LIVE, liveConnectedSite.getStagingType());
+
+		Group stagingGroup = group.getStagingGroup();
+
+		ConnectedSite stagingConnectedSite =
+			connectedSiteResource.getAssetLibraryConnectedSite(
+				assetLibraryExternalReferenceCode,
+				stagingGroup.getExternalReferenceCode());
+
+		Assert.assertEquals(
+			ConnectedSite.StagingType.STAGING,
+			stagingConnectedSite.getStagingType());
+	}
+
 	private void _testPutAssetLibraryConnectedSiteReturnsTypeSite()
 		throws Exception {
 
@@ -201,6 +262,9 @@ public class ConnectedSiteResourceTest
 
 	@Inject
 	private LayoutSetPrototypeLocalService _layoutSetPrototypeLocalService;
+
+	@Inject
+	private StagingLocalService _stagingLocalService;
 
 	private ConnectedSite _testConnectedSite;
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/types/Site.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/types/Site.ts
@@ -10,5 +10,6 @@ export type Site = {
 	logo: string;
 	name: string;
 	searchable: boolean;
+	stagingType?: 'LIVE' | 'STAGING';
 	type?: 'Site' | 'SiteTemplate';
 };

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/cell_renderers/SiteRenderer.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/cell_renderers/SiteRenderer.tsx
@@ -9,10 +9,14 @@ import React from 'react';
 import {SITE_TEMPLATE_TYPE} from '../../../common/utils/constants';
 
 const SiteRenderer = ({itemData, value}: {itemData: any; value: string}) => {
-	const label =
-		itemData.type === SITE_TEMPLATE_TYPE
-			? `${value} (${Liferay.Language.get('site-template')})`
-			: value;
+	let label = value;
+
+	if (itemData.type === SITE_TEMPLATE_TYPE) {
+		label = `${value} (${Liferay.Language.get('site-template')})`;
+	}
+	else if (itemData.stagingType && itemData.stagingType === 'STAGING') {
+		label = `${value} (${Liferay.Language.get('staging')})`;
+	}
 
 	return (
 		<span className="align-items-center d-flex">

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/spaces/SpaceConnectedSitesModal.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/spaces/SpaceConnectedSitesModal.tsx
@@ -39,10 +39,17 @@ const showSuccessMessage = (message: string) => {
 
 const isSiteTemplate = (site: Site) => site.type === SITE_TEMPLATE_TYPE;
 
-const getConnectionLabel = (site: Site) =>
-	isSiteTemplate(site)
-		? `${site.descriptiveName} (${Liferay.Language.get('site-template')})`
-		: site.descriptiveName;
+const getConnectionLabel = (site: Site) => {
+	if (isSiteTemplate(site)) {
+		return `${site.descriptiveName} (${Liferay.Language.get('site-template')})`;
+	}
+
+	if (site.stagingType && site.stagingType === 'STAGING') {
+		return `${site.descriptiveName} (${Liferay.Language.get('staging')})`;
+	}
+
+	return site.descriptiveName;
+};
 
 const ConnectableActions = ({
 	externalReferenceCode,

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/connectStagedSite.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/connectStagedSite.spec.ts
@@ -1,0 +1,77 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
+import {isolatedSiteTest} from '../../../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import getRandomString from '../../../../utils/getRandomString';
+import {enableLocalStaging} from '../../../../utils/staging';
+import {cmsPagesTest} from '../fixtures/cmsPagesTest';
+
+const test = mergeTests(
+	cmsPagesTest,
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+	}),
+	isolatedSiteTest,
+	loginTest()
+);
+
+test(
+	'Distinguishes live and staging rows in the connected sites list',
+	{tag: ['@LPD-91062']},
+	async ({apiHelpers, page, site, spaceSummaryPage}) => {
+		const spaceName = `Space ${getRandomString()}`;
+
+		// Create the Space and connect the site while it is unstaged
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			settings: {logoColor: 'outline-3'},
+			type: 'Space',
+		});
+
+		await apiHelpers.headlessAssetLibrary.connectSite(
+			space.externalReferenceCode,
+			site.externalReferenceCode
+		);
+
+		// Enabling staging copies the connection onto the staging group, so the
+		// site appears twice
+
+		await enableLocalStaging(apiHelpers, page, site);
+
+		await spaceSummaryPage.goto(spaceName);
+
+		const stagingWord = await page.evaluate(() =>
+			Liferay.Language.get('staging')
+		);
+
+		const connectedSites = page.getByTestId(
+			'space-summary-connected-sites'
+		);
+
+		const liveRow = connectedSites.getByRole('row').filter({
+			has: page.getByText(site.name, {exact: true}),
+		});
+		const stagingRow = connectedSites.getByRole('row').filter({
+			hasText: `${site.name} (${stagingWord})`,
+		});
+
+		// The live and staging rows are listed with distinct labels once the
+		// initial staging publish has copied the connection
+
+		await expect(async () => {
+			await page.reload();
+
+			await expect(liveRow).toBeVisible();
+			await expect(stagingRow).toBeVisible();
+		}).toPass();
+	}
+);


### PR DESCRIPTION
Resending this after fixing the `stagingType` field description that the review bot flagged on the previous PR (https://github.com/brianchandotcom/liferay-portal/pull/175717#issuecomment-4598329119): the description now reads "The connected site's staging type." to match the sibling-field naming convention.

# What is this trying to solve?
https://liferay.atlassian.net/browse/LPD-91062

When a CMS Space is connected to a site that uses Staging, the live site and its staging site show the same name in the Spaces "View All Sites" view. A user cannot tell which row is the live site and which is the staging site.

# How am I fixing it?
The ConnectedSite response now carries a read-only `stagingType` value (`LIVE` or `STAGING`) that the converter derives from the connected site's group. A plain, unstaged connection returns no value.

In the Spaces "View All Sites" view, the staging row is labeled "(Staging)" so it is easy to tell apart from its live counterpart.

# How can you verify that it works?
Run the included automated tests:

- `ConnectedSiteResourceTest` (headless-asset-library-test, integration)
- `connectStagedSite.spec.ts` (Playwright, site-cms-site-initializer)

To verify by hand, connect a Space to a site, enable Staging on that site, then open the Spaces "View All Sites" view and confirm the staging site is labeled "(Staging)". The reproduction steps are in https://liferay.atlassian.net/browse/LPD-91062.