### PR TITLE
LPD-93287 Provision the vocabularies permissions test users via API

### DIFF
--- a/modules/test/playwright/tests/site-cms-site-initializer/permissions/vocabularies.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/permissions/vocabularies.spec.ts
@@ -8,6 +8,7 @@ import {expect, mergeTests} from '@playwright/test';
 import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
 import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
 import {loginTest} from '../../../fixtures/loginTest';
+import {DataApiHelpers} from '../../../helpers/ApiHelpers';
 import getRandomString from '../../../utils/getRandomString';
 import {performUserSwitchViaApi} from '../../../utils/performLogin';
 import {PORTLET_URLS} from '../../../utils/portletUrls';
@@ -24,32 +25,44 @@ const test = mergeTests(
 	loginTest()
 );
 
+async function createSpaceMember(
+	apiHelpers: DataApiHelpers,
+	spaceRoleNames: string[] = []
+) {
+	const assetLibrary =
+		await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: getRandomString(),
+			settings: {},
+			type: 'Space',
+		});
+
+	const user = await apiHelpers.headlessAdminUser.postUserAccount();
+
+	registerUserCredentials(user);
+
+	await apiHelpers.headlessAssetLibrary.putAssetLibraryUserAccount(
+		assetLibrary.externalReferenceCode,
+		user.externalReferenceCode
+	);
+
+	if (spaceRoleNames.length) {
+		await apiHelpers.headlessAssetLibrary.putAssetLibraryUserAccountRoles(
+			assetLibrary.externalReferenceCode,
+			user.externalReferenceCode,
+			spaceRoleNames
+		);
+	}
+
+	return {assetLibrary, user};
+}
+
 test(
 	'A Space Content Reviewer cannot access the Vocabularies admin page',
 	{tag: ['@LPD-89497', '@LPD-93287']},
 	async ({apiHelpers, page}) => {
-		const spaceName = getRandomString();
-
-		const assetLibrary =
-			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
-				name: spaceName,
-				settings: {},
-				type: 'Space',
-			});
-
-		const user = await apiHelpers.headlessAdminUser.postUserAccount();
-
-		registerUserCredentials(user);
-
-		await apiHelpers.headlessAssetLibrary.putAssetLibraryUserAccount(
-			assetLibrary.externalReferenceCode,
-			user.externalReferenceCode
-		);
-		await apiHelpers.headlessAssetLibrary.putAssetLibraryUserAccountRoles(
-			assetLibrary.externalReferenceCode,
-			user.externalReferenceCode,
-			['Asset Library Content Reviewer']
-		);
+		const {user} = await createSpaceMember(apiHelpers, [
+			'Asset Library Content Reviewer',
+		]);
 
 		await performUserSwitchViaApi(page, user.alternateName);
 
@@ -65,28 +78,9 @@ test(
 	'A Space Content Reviewer does not see the Vocabulary Quick Action on the CMS Home Page',
 	{tag: ['@LPD-90072', '@LPD-93287']},
 	async ({apiHelpers, homePage, page}) => {
-		const spaceName = getRandomString();
-
-		const assetLibrary =
-			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
-				name: spaceName,
-				settings: {},
-				type: 'Space',
-			});
-
-		const user = await apiHelpers.headlessAdminUser.postUserAccount();
-
-		registerUserCredentials(user);
-
-		await apiHelpers.headlessAssetLibrary.putAssetLibraryUserAccount(
-			assetLibrary.externalReferenceCode,
-			user.externalReferenceCode
-		);
-		await apiHelpers.headlessAssetLibrary.putAssetLibraryUserAccountRoles(
-			assetLibrary.externalReferenceCode,
-			user.externalReferenceCode,
-			['Asset Library Content Reviewer']
-		);
+		const {user} = await createSpaceMember(apiHelpers, [
+			'Asset Library Content Reviewer',
+		]);
 
 		await performUserSwitchViaApi(page, user.alternateName);
 
@@ -104,18 +98,7 @@ test(
 	'A CMS Administrator sees the Vocabulary Quick Action on the CMS Home Page',
 	{tag: ['@LPD-90072', '@LPD-93287']},
 	async ({apiHelpers, homePage, page}) => {
-		const spaceName = getRandomString();
-
-		const assetLibrary =
-			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
-				name: spaceName,
-				settings: {},
-				type: 'Space',
-			});
-
-		const user = await apiHelpers.headlessAdminUser.postUserAccount();
-
-		registerUserCredentials(user);
+		const {user} = await createSpaceMember(apiHelpers);
 
 		const cmsAdministratorRole =
 			await apiHelpers.headlessAdminUser.getRoleByName(
@@ -125,11 +108,6 @@ test(
 		await apiHelpers.headlessAdminUser.postRoleUserAccountAssociation(
 			cmsAdministratorRole.id,
 			Number(user.id)
-		);
-
-		await apiHelpers.headlessAssetLibrary.putAssetLibraryUserAccount(
-			assetLibrary.externalReferenceCode,
-			user.externalReferenceCode
 		);
 
 		await performUserSwitchViaApi(page, user.alternateName);

--- a/modules/test/playwright/tests/site-cms-site-initializer/permissions/vocabularies.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/permissions/vocabularies.spec.ts
@@ -9,9 +9,9 @@ import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
 import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
 import {loginTest} from '../../../fixtures/loginTest';
 import getRandomString from '../../../utils/getRandomString';
-import {performUserSwitch, userData} from '../../../utils/performLogin';
+import {performUserSwitchViaApi} from '../../../utils/performLogin';
 import {PORTLET_URLS} from '../../../utils/portletUrls';
-import {addRoleMemberAndSwitch} from '../main/spaces/helpers/roleMembership';
+import {registerUserCredentials} from '../main/spaces/helpers/roleMembership';
 import {cmsPagesTest} from './fixtures/cmsPagesTest';
 
 const test = mergeTests(
@@ -26,23 +26,32 @@ const test = mergeTests(
 
 test(
 	'A Space Content Reviewer cannot access the Vocabularies admin page',
-	{tag: '@LPD-89497'},
-	async ({apiHelpers, page, spaceSummaryPage}) => {
+	{tag: ['@LPD-89497', '@LPD-93287']},
+	async ({apiHelpers, page}) => {
 		const spaceName = getRandomString();
 
-		await apiHelpers.headlessAssetLibrary.createAssetLibrary({
-			name: spaceName,
-			settings: {},
-			type: 'Space',
-		});
+		const assetLibrary =
+			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+				name: spaceName,
+				settings: {},
+				type: 'Space',
+			});
 
-		await addRoleMemberAndSwitch({
-			apiHelpers,
-			page,
-			role: 'Space Content Reviewer',
-			spaceName,
-			spaceSummaryPage,
-		});
+		const user = await apiHelpers.headlessAdminUser.postUserAccount();
+
+		registerUserCredentials(user);
+
+		await apiHelpers.headlessAssetLibrary.putAssetLibraryUserAccount(
+			assetLibrary.externalReferenceCode,
+			user.externalReferenceCode
+		);
+		await apiHelpers.headlessAssetLibrary.putAssetLibraryUserAccountRoles(
+			assetLibrary.externalReferenceCode,
+			user.externalReferenceCode,
+			['Asset Library Content Reviewer']
+		);
+
+		await performUserSwitchViaApi(page, user.alternateName);
 
 		await page.goto(PORTLET_URLS.cmsVocabularies);
 
@@ -54,23 +63,32 @@ test(
 
 test(
 	'A Space Content Reviewer does not see the Vocabulary Quick Action on the CMS Home Page',
-	{tag: '@LPD-90072'},
-	async ({apiHelpers, homePage, page, spaceSummaryPage}) => {
+	{tag: ['@LPD-90072', '@LPD-93287']},
+	async ({apiHelpers, homePage, page}) => {
 		const spaceName = getRandomString();
 
-		await apiHelpers.headlessAssetLibrary.createAssetLibrary({
-			name: spaceName,
-			settings: {},
-			type: 'Space',
-		});
+		const assetLibrary =
+			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+				name: spaceName,
+				settings: {},
+				type: 'Space',
+			});
 
-		await addRoleMemberAndSwitch({
-			apiHelpers,
-			page,
-			role: 'Space Content Reviewer',
-			spaceName,
-			spaceSummaryPage,
-		});
+		const user = await apiHelpers.headlessAdminUser.postUserAccount();
+
+		registerUserCredentials(user);
+
+		await apiHelpers.headlessAssetLibrary.putAssetLibraryUserAccount(
+			assetLibrary.externalReferenceCode,
+			user.externalReferenceCode
+		);
+		await apiHelpers.headlessAssetLibrary.putAssetLibraryUserAccountRoles(
+			assetLibrary.externalReferenceCode,
+			user.externalReferenceCode,
+			['Asset Library Content Reviewer']
+		);
+
+		await performUserSwitchViaApi(page, user.alternateName);
 
 		await homePage.goto();
 
@@ -84,23 +102,20 @@ test(
 
 test(
 	'A CMS Administrator sees the Vocabulary Quick Action on the CMS Home Page',
-	{tag: '@LPD-90072'},
-	async ({apiHelpers, homePage, page, spaceSummaryPage}) => {
+	{tag: ['@LPD-90072', '@LPD-93287']},
+	async ({apiHelpers, homePage, page}) => {
 		const spaceName = getRandomString();
 
-		await apiHelpers.headlessAssetLibrary.createAssetLibrary({
-			name: spaceName,
-			settings: {},
-			type: 'Space',
-		});
+		const assetLibrary =
+			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+				name: spaceName,
+				settings: {},
+				type: 'Space',
+			});
 
 		const user = await apiHelpers.headlessAdminUser.postUserAccount();
 
-		userData[user.alternateName] = {
-			name: user.givenName,
-			password: 'test',
-			surname: user.familyName,
-		};
+		registerUserCredentials(user);
 
 		const cmsAdministratorRole =
 			await apiHelpers.headlessAdminUser.getRoleByName(
@@ -112,11 +127,12 @@ test(
 			Number(user.id)
 		);
 
-		await spaceSummaryPage.goto(spaceName);
+		await apiHelpers.headlessAssetLibrary.putAssetLibraryUserAccount(
+			assetLibrary.externalReferenceCode,
+			user.externalReferenceCode
+		);
 
-		await spaceSummaryPage.addUserOrUserGroup(user.name, 'users');
-
-		await performUserSwitch(page, user.alternateName);
+		await performUserSwitchViaApi(page, user.alternateName);
 
 		await homePage.goto();
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93287

## What Is Being Fixed

The vocabularies permission tests provisioned their users by clicking through the SpaceSummaryPage UI to add the user to the space and grant its role. That UI loaded slower than Playwright fired its actions, so the tests — in particular "A Space Content Reviewer does not see the Vocabulary Quick Action on the CMS Home Page" — failed intermittently in CI.

## How It Is Being Fixed

All three tests now provision their data through the headless asset library API instead of the UI: the user, the space membership, and the role assignment all go through API calls, and the user switch uses performUserSwitchViaApi. Because the three tests shared the same create-space, create-user, register-credentials, and add-member sequence, that common setup is pulled into a createSpaceMember helper that optionally assigns space roles, while each test keeps its distinct role assignment and assertions at the call site.

## Why Are There No Tests?

This change only modifies existing Playwright tests to remove a flaky UI-based setup; there is no production code change. The three affected tests were run three times consecutively and all passed.