### PR TITLE
LPD-93315 Prevent flaky object field name in the trash entry test

### DIFF
--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/service/test/TrashEntryLocalServiceTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/service/test/TrashEntryLocalServiceTest.java
@@ -85,8 +85,7 @@ public class TrashEntryLocalServiceTest {
 				ObjectFieldUtil.createObjectField(
 					ObjectFieldConstants.BUSINESS_TYPE_TEXT,
 					ObjectFieldConstants.DB_TYPE_STRING,
-					StringUtil.toLowerCase(RandomTestUtil.randomString()),
-					StringUtil.toLowerCase(RandomTestUtil.randomString()))),
+					RandomTestUtil.randomString(), StringUtil.randomId())),
 			ObjectDefinitionConstants.SCOPE_DEPOT);
 
 		_objectDefinitionSettingLocalService.addObjectDefinitionSetting(
@@ -97,7 +96,7 @@ public class TrashEntryLocalServiceTest {
 	}
 
 	@Test
-	@TestInfo("LPD-89104")
+	@TestInfo({"LPD-89104", "LPD-93315"})
 	public void testCheckEntriesWithExpiredObjectEntry() throws Exception {
 		ObjectEntry expiredObjectEntry = CMSObjectEntryTestUtil.addObjectEntry(
 			_depotEntry.getGroupId(), _objectDefinition,
@@ -127,7 +126,7 @@ public class TrashEntryLocalServiceTest {
 	}
 
 	@Test
-	@TestInfo("LPD-89104")
+	@TestInfo({"LPD-89104", "LPD-93315"})
 	public void testDeleteEntriesForGroup() throws Exception {
 		ObjectEntry objectEntry1 = CMSObjectEntryTestUtil.addObjectEntry(
 			_depotEntry.getGroupId(), _objectDefinition,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93315

## What Is Being Fixed

TrashEntryLocalServiceTest intermittently failed in its setUp. The object field name was generated with StringUtil.toLowerCase(RandomTestUtil.randomString()), but RandomTestUtil.randomString() can return a string starting with a digit and toLowerCase only affects letters. When the name began with a digit, ObjectFieldLocalServiceImpl rejected it with ObjectFieldNameException$MustBeginWithLowerCaseLetter, failing the test roughly a third of the time.

## How It Is Being Fixed

The object field name now uses StringUtil.randomId(), which emits only lowercase letters a-z and can never begin with a digit. The label keeps RandomTestUtil.randomString() since it carries no such restriction. This matches the convention already used by ObjectDefinitionTestUtil and the rest of the object module tests. The two test methods are also tagged with @TestInfo("LPD-93315").

## Why Are There No Tests?

This change only touches test code — it fixes a flaky setUp in an existing integration test, so there is no production behavior to cover with a new test.