### PR TITLE
LPD-93228 Add test

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewHomeRecentAssetsSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewHomeRecentAssetsSectionDisplayContext.java
@@ -10,8 +10,13 @@ import com.liferay.document.library.configuration.DLConfiguration;
 import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
 import com.liferay.object.service.ObjectDefinitionService;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -44,11 +49,45 @@ public class ViewHomeRecentAssetsSectionDisplayContext
 			translationInfoItemFieldValuesExporterRegistry);
 	}
 
+	@Override
+	public Map<String, Object> getAdditionalProps() {
+		Map<String, Object> additionalProps = super.getAdditionalProps();
+
+		try {
+			additionalProps.put("breadcrumbProps", getBreadcrumbProps());
+		}
+		catch (PortalException portalException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(portalException);
+			}
+		}
+
+		return additionalProps;
+	}
+
 	public String getAssetsAllURL() throws PortalException {
 		return PortalUtil.getLayoutFullURL(
 			LayoutLocalServiceUtil.getLayoutByFriendlyURL(
 				themeDisplay.getScopeGroupId(), false, "/all"),
 			themeDisplay);
+	}
+
+	@Override
+	public Map<String, Object> getBreadcrumbProps() throws PortalException {
+		JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
+
+		Layout layout = LayoutLocalServiceUtil.getLayoutByFriendlyURL(
+			themeDisplay.getScopeGroupId(), false, "/all");
+
+		addBreadcrumbItem(
+			jsonArray, false, null,
+			layout.getName(themeDisplay.getLocale(), true));
+
+		return HashMapBuilder.<String, Object>put(
+			"breadcrumbItems", jsonArray
+		).put(
+			"hideSpace", true
+		).build();
 	}
 
 	@Override
@@ -84,5 +123,8 @@ public class ViewHomeRecentAssetsSectionDisplayContext
 				"cmsKind eq 'object' and (cmsSection eq 'contents' or " +
 					"cmsSection eq 'files')"));
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		ViewHomeRecentAssetsSectionDisplayContext.class);
 
 }

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/home.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/home.spec.ts
@@ -781,6 +781,61 @@ test(
 );
 
 test(
+	'Can view an asset from Recent Assets',
+	{tag: '@LPD-93228'},
+	async ({apiHelpers, homePage, page}) => {
+		const contentApplicationName = 'cms/basic-web-contents';
+		const contentTitle = `content ${getRandomString()}`;
+
+		let contentEntry;
+
+		try {
+			contentEntry = await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: contentTitle,
+				},
+				contentApplicationName,
+				'Default'
+			);
+
+			const dataSetFragmentPage: DataSetPage = new DataSetPage(page);
+
+			await homePage.goto();
+
+			await test.step('Can open the asset navigation modal with the View action', async () => {
+				await dataSetFragmentPage.execItemAction({
+					action: 'View',
+					filter: contentTitle,
+				});
+
+				await expect(page.getByTestId('modal-header-name')).toHaveText(
+					contentTitle
+				);
+			});
+
+			await test.step('Details panel shows the metadata with the location breadcrumb', async () => {
+				await page.getByRole('button', {name: 'Show Details'}).click();
+
+				const spaceBreadcrumb = page.locator(
+					'.asset-metadata .space-breadcrumb'
+				);
+
+				await expect(spaceBreadcrumb).toBeVisible();
+			});
+		}
+		finally {
+			if (contentEntry) {
+				await apiHelpers.objectEntry.deleteObjectEntry(
+					contentApplicationName,
+					String(contentEntry.id)
+				);
+			}
+		}
+	}
+);
+
+test(
 	'Can use Quick Actions to create new content',
 	{tag: '@LPD-58793'},
 	async ({apiHelpers, homePage, page}) => {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93228

### What Is Being Fixed

Clicking the View action on an asset in the Recent Assets section of the CMS Home page threw a JavaScript error in the Breadcrumb component, breaking the asset navigation modal. The section did not include `breadcrumbProps` in its additional props, so the metadata info panel passed `undefined` items to `ClayBreadcrumb`. As a consequence, the Location section was also missing from the details panel, unlike when the same asset is viewed from the All, Contents, or Files sections.

### How It Is Being Fixed
`ViewHomeRecentAssetsSectionDisplayContext` now overrides `getAdditionalProps` to include `breadcrumbProps`, following the same pattern as the other section display contexts. Since Recent Assets aggregates the same contents and files sections as the All page, the breadcrumb is built from the `/all` layout — the same layout the section's View All button already points to, so the details panel shows the asset location consistently with the All section.

A Playwright test covers the previously untested entry point: it opens the View modal from a Recent Assets row and asserts that the details panel renders the metadata with the location breadcrumb.