### PR TITLE
LPD-92750 Fix NPE in server logs when rendering structured content by display page

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/StructuredContentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/StructuredContentResourceImpl.java
@@ -64,6 +64,7 @@ import com.liferay.journal.util.JournalContent;
 import com.liferay.journal.util.JournalConverter;
 import com.liferay.layout.display.page.LayoutDisplayPageProviderRegistry;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryService;
+import com.liferay.layout.util.LayoutServiceContextHelper;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -464,13 +465,18 @@ public class StructuredContentResourceImpl
 
 		DDMStructure ddmStructure = journalArticle.getDDMStructure();
 
-		return DisplayPageRendererUtil.toHTML(
-			JournalArticle.class.getName(), ddmStructure.getStructureId(),
-			displayPageKey, journalArticle.getGroupId(),
-			contextHttpServletRequest, contextHttpServletResponse,
-			journalArticle, _infoItemServiceRegistry,
-			_layoutDisplayPageProviderRegistry, _layoutService,
-			_layoutPageTemplateEntryService);
+		try (AutoCloseable autoCloseable =
+				_layoutServiceContextHelper.getServiceContextAutoCloseable(
+					contextCompany, contextUser)) {
+
+			return DisplayPageRendererUtil.toHTML(
+				JournalArticle.class.getName(), ddmStructure.getStructureId(),
+				displayPageKey, journalArticle.getGroupId(),
+				contextHttpServletRequest, contextHttpServletResponse,
+				journalArticle, _infoItemServiceRegistry,
+				_layoutDisplayPageProviderRegistry, _layoutService,
+				_layoutPageTemplateEntryService);
+		}
 	}
 
 	@Override
@@ -1664,6 +1670,9 @@ public class StructuredContentResourceImpl
 
 	@Reference
 	private LayoutService _layoutService;
+
+	@Reference
+	private LayoutServiceContextHelper _layoutServiceContextHelper;
 
 	@Reference
 	private Portal _portal;


### PR DESCRIPTION
# What is this trying to solve?

{[LPD-92750](https://liferay.atlassian.net/browse/LPD-92750)}

When calling `/o/headless-delivery/v1.0/structured-contents/{id}/rendered-content-by-display-page/{displayPageKey}`, a `NullPointerException` is continuously logged on the server. In the headless rendering path, `WebKeys.CTX` is never set on the request, so that cast yields `null` and `FileAvailabilityUtil._getAvailabilities(null)` throws an NPE. The API response is unaffected, but the error floods the server logs.

# How am I fixing it?

Wrap the `DisplayPageRendererUtil.toHTML()` call with  getServiceContextAutoCloseable(contextCompany, contextUser), which sets `WebKeys.CTX` (and `WebKeys.COMPANY_ID`) on the request before layout rendering begins.