### PR TITLE
LPD-66064 Release image streams when the image type is unsupported

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/util/RenderedImageUtil.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/util/RenderedImageUtil.java
@@ -102,6 +102,8 @@ public class RenderedImageUtil {
 			}
 		}
 
+		StreamUtil.cleanUp(imageInputStream, inputStream);
+
 		throw new IOException("Unsupported image type");
 	}
 

--- a/modules/apps/adaptive-media/adaptive-media-image-impl/src/test/java/com/liferay/adaptive/media/image/internal/util/RenderedImageUtilTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-impl/src/test/java/com/liferay/adaptive/media/image/internal/util/RenderedImageUtilTest.java
@@ -1,0 +1,69 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.adaptive.media.image.internal.util;
+
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Akhash Ramprakash
+ */
+public class RenderedImageUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testReadImageClosesStreamWhenImageTypeIsUnsupported()
+		throws Exception {
+
+		CloseTrackingInputStream closeTrackingInputStream =
+			new CloseTrackingInputStream("unsupported image type".getBytes());
+
+		try {
+			RenderedImageUtil.readImage(closeTrackingInputStream);
+
+			Assert.fail();
+		}
+		catch (IOException ioException) {
+			Assert.assertEquals(
+				"Unsupported image type", ioException.getMessage());
+		}
+
+		Assert.assertTrue(closeTrackingInputStream.isClosed());
+	}
+
+	private static class CloseTrackingInputStream extends ByteArrayInputStream {
+
+		public CloseTrackingInputStream(byte[] bytes) {
+			super(bytes);
+		}
+
+		@Override
+		public void close() throws IOException {
+			_closed = true;
+
+			super.close();
+		}
+
+		public boolean isClosed() {
+			return _closed;
+		}
+
+		private boolean _closed;
+
+	}
+
+}


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-66064

When Adaptive Media tries to adapt an image type with no registered `ImageReader` (such as WEBP), the source input stream is never released. With the S3 store, each leaked stream holds a leased HTTP connection, eventually exhausting the pool and breaking previews for every subsequent image.

# How am I fixing it?

`RenderedImageUtil.readImage` only closed its streams inside the reader loop's `finally` block, which never runs when `ImageIO.getImageReaders` returns no readers. The streams are now also cleaned up on the unsupported-type path before the exception is thrown.

# How can you verify that it works?

Run the included automated tests.
