### PR TITLE
LPD-93652 Fix intermittent Share modal failure for shared users

### DIFF
--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/service/test/CMSPermissionsObjectDefinitionLocalServiceWrapperTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/service/test/CMSPermissionsObjectDefinitionLocalServiceWrapperTest.java
@@ -75,6 +75,25 @@ public class CMSPermissionsObjectDefinitionLocalServiceWrapperTest {
 			ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_FILE_TYPES);
 	}
 
+	@Test
+	public void testPublishSystemObjectDefinition() throws Exception {
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.
+				getObjectDefinitionByExternalReferenceCode(
+					"L_CMS_BASIC_WEB_CONTENT", TestPropsValues.getCompanyId());
+
+		_assertResourcePermission(
+			ActionKeys.VIEW, objectDefinition.getObjectDefinitionId(),
+			ObjectDefinition.class.getName(),
+			_roleLocalService.getRole(
+				TestPropsValues.getCompanyId(), RoleConstants.GUEST));
+		_assertResourcePermission(
+			ActionKeys.VIEW, objectDefinition.getObjectDefinitionId(),
+			ObjectDefinition.class.getName(),
+			_roleLocalService.getRole(
+				TestPropsValues.getCompanyId(), RoleConstants.USER));
+	}
+
 	private void _assertResourcePermission(
 			String actionId, long classPK, String resourceName, Role role)
 		throws Exception {

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/service/CMSPermissionsObjectDefinitionLocalServiceWrapper.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/service/CMSPermissionsObjectDefinitionLocalServiceWrapper.java
@@ -54,53 +54,30 @@ public class CMSPermissionsObjectDefinitionLocalServiceWrapper
 	}
 
 	private void _addResourcePermission(
-			ObjectDefinition objectDefinition, String roleName)
-		throws PortalException {
+		ObjectDefinition objectDefinition, String roleName) {
 
-		Role role = _roleLocalService.fetchRole(
-			objectDefinition.getCompanyId(), roleName);
+		try {
+			Role role = _roleLocalService.fetchRole(
+				objectDefinition.getCompanyId(), roleName);
 
-		if (role == null) {
-			return;
+			if (role == null) {
+				return;
+			}
+
+			_resourcePermissionLocalService.addResourcePermission(
+				objectDefinition.getCompanyId(),
+				objectDefinition.getResourceName(),
+				ResourceConstants.SCOPE_GROUP_TEMPLATE,
+				String.valueOf(GroupConstants.DEFAULT_PARENT_GROUP_ID),
+				role.getRoleId(), ObjectActionKeys.ADD_OBJECT_ENTRY);
 		}
-
-		_resourcePermissionLocalService.addResourcePermission(
-			objectDefinition.getCompanyId(), objectDefinition.getResourceName(),
-			ResourceConstants.SCOPE_GROUP_TEMPLATE,
-			String.valueOf(GroupConstants.DEFAULT_PARENT_GROUP_ID),
-			role.getRoleId(), ObjectActionKeys.ADD_OBJECT_ENTRY);
+		catch (Exception exception) {
+			_log.error(exception);
+		}
 	}
 
-	private void _setObjectDefinitionResourcePermissions(
-			ObjectDefinition objectDefinition, String roleName)
-		throws PortalException {
-
-		Role role = _roleLocalService.getRole(
-			objectDefinition.getCompanyId(), roleName);
-
-		_resourcePermissionLocalService.setResourcePermissions(
-			objectDefinition.getCompanyId(), ObjectDefinition.class.getName(),
-			ResourceConstants.SCOPE_INDIVIDUAL,
-			String.valueOf(objectDefinition.getObjectDefinitionId()),
-			role.getRoleId(), new String[] {ActionKeys.VIEW});
-	}
-
-	private ObjectDefinition _setResourcePermissions(
+	private void _setCMSAdministratorResourcePermissions(
 		ObjectDefinition objectDefinition) {
-
-		String objectFolderExternalReferenceCode =
-			objectDefinition.getObjectFolderExternalReferenceCode();
-
-		if (!Objects.equals(
-				objectFolderExternalReferenceCode,
-				ObjectFolderConstants.
-					EXTERNAL_REFERENCE_CODE_CONTENT_STRUCTURES) &&
-			!Objects.equals(
-				objectFolderExternalReferenceCode,
-				ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_FILE_TYPES)) {
-
-			return objectDefinition;
-		}
 
 		try {
 			Role role = RoleUtil.getOrAddCMSAdministratorRole(
@@ -123,22 +100,64 @@ public class CMSPermissionsObjectDefinitionLocalServiceWrapper
 					ActionKeys.DELETE, ActionKeys.PERMISSIONS,
 					ActionKeys.UPDATE, ActionKeys.VIEW
 				});
-
-			_setObjectDefinitionResourcePermissions(
-				objectDefinition, RoleConstants.GUEST);
-			_setObjectDefinitionResourcePermissions(
-				objectDefinition, RoleConstants.USER);
-
-			_addResourcePermission(
-				objectDefinition,
-				DepotRolesConstants.ASSET_LIBRARY_ADMINISTRATOR);
-			_addResourcePermission(
-				objectDefinition,
-				DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER);
 		}
 		catch (Exception exception) {
 			_log.error(exception);
 		}
+	}
+
+	private void _setObjectDefinitionResourcePermissions(
+		ObjectDefinition objectDefinition, String roleName) {
+
+		try {
+			Role role = _roleLocalService.fetchRole(
+				objectDefinition.getCompanyId(), roleName);
+
+			if (role == null) {
+				return;
+			}
+
+			_resourcePermissionLocalService.setResourcePermissions(
+				objectDefinition.getCompanyId(),
+				ObjectDefinition.class.getName(),
+				ResourceConstants.SCOPE_INDIVIDUAL,
+				String.valueOf(objectDefinition.getObjectDefinitionId()),
+				role.getRoleId(), new String[] {ActionKeys.VIEW});
+		}
+		catch (Exception exception) {
+			_log.error(exception);
+		}
+	}
+
+	private ObjectDefinition _setResourcePermissions(
+		ObjectDefinition objectDefinition) {
+
+		String objectFolderExternalReferenceCode =
+			objectDefinition.getObjectFolderExternalReferenceCode();
+
+		if (!Objects.equals(
+				objectFolderExternalReferenceCode,
+				ObjectFolderConstants.
+					EXTERNAL_REFERENCE_CODE_CONTENT_STRUCTURES) &&
+			!Objects.equals(
+				objectFolderExternalReferenceCode,
+				ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_FILE_TYPES)) {
+
+			return objectDefinition;
+		}
+
+		_setCMSAdministratorResourcePermissions(objectDefinition);
+
+		_setObjectDefinitionResourcePermissions(
+			objectDefinition, RoleConstants.GUEST);
+		_setObjectDefinitionResourcePermissions(
+			objectDefinition, RoleConstants.USER);
+
+		_addResourcePermission(
+			objectDefinition, DepotRolesConstants.ASSET_LIBRARY_ADMINISTRATOR);
+		_addResourcePermission(
+			objectDefinition,
+			DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER);
 
 		return objectDefinition;
 	}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/util/SiteInitializerUtil.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/util/SiteInitializerUtil.java
@@ -82,10 +82,12 @@ public class SiteInitializerUtil {
 
 			ServiceContextThreadLocal.pushServiceContext(new ServiceContext());
 
+			Role role = RoleUtil.getOrAddCMSAdministratorRole(
+				companyId, user.getUserId());
+
 			siteInitializer.initialize(group.getGroupId());
 
-			_addResourcePermissions(
-				companyId, group.getGroupId(), user.getUserId());
+			_addResourcePermissions(companyId, group.getGroupId(), role);
 		}
 		catch (Exception exception) {
 			throw new PortalException(exception);
@@ -100,10 +102,8 @@ public class SiteInitializerUtil {
 	}
 
 	private static void _addResourcePermissions(
-			long companyId, long groupId, long userId)
-		throws Exception {
-
-		Role role = RoleUtil.getOrAddCMSAdministratorRole(companyId, userId);
+			long companyId, long groupId, Role role)
+		throws PortalException {
 
 		ResourcePermissionLocalServiceUtil.addResourcePermission(
 			companyId, Layout.class.getName(), ResourceConstants.SCOPE_GROUP,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93652

## What Is Being Fixed

The "Shared With Me" Share modal intermittently failed to open for non-owner (reshare) users, throwing "Cannot read properties of undefined (reading 'replace')" and never showing the collaborators. The collaborator URL is built from the CMS object definitions the viewing user can VIEW, and that VIEW is granted to the GUEST and USER roles by CMSPermissionsObjectDefinitionLocalServiceWrapper when each definition is published. The grant was unreliable because of an initialization ordering problem: the object definitions are published by the batch engine before roles.json creates the CMS Administrator role, so the wrapper fell back to creating that role lazily, concurrently, inside the transactional publish. When two definitions published at once, one publish hit DuplicateRoleException; because that is a PortalException thrown inside the publish transaction, the transaction was marked rollback-only and the definition's user-facing grants did not stick, leaving it invisible to regular users for the rest of that boot.

## How It Is Being Fixed

The CMS Administrator role is now created up front in SiteInitializerUtil.initialize(), before siteInitializer.initialize() runs the object-definition batch. That method runs in a non-transactional lifecycle context, so the role is committed before the batch starts and every concurrent publish simply fetches it instead of creating it. With no addRole in the transactional publish path, there is no DuplicateRoleException and no rollback-only transaction. The grants in CMSPermissionsObjectDefinitionLocalServiceWrapper are also decoupled into independent, self-guarding steps, and the GUEST/USER grant now uses fetchRole with a null check so a missing role can never throw a NoSuchRoleException that would poison the transaction. The result is that the GUEST/USER VIEW grants always land, so the definitions stay visible to non-owner users and the Share modal opens reliably.

## How To Test

gradlew -p modules/apps/site/site-cms-site-initializer-test testIntegration --tests CMSPermissionsObjectDefinitionLocalServiceWrapperTest

The @LPD-86111 Playwright tests in modules/test/playwright/tests/site-cms-site-initializer/main/sharingPermissions.spec.ts also exercise the end-to-end behavior.

