### PR TITLE
LPD-93185 Fix scope check in DLFileEntryDataCleanupPreupgradeProcess

### DIFF
--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/data/cleanup/test/DLFileEntryDataCleanupPreupgradeProcessTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/data/cleanup/test/DLFileEntryDataCleanupPreupgradeProcessTest.java
@@ -13,6 +13,7 @@ import com.liferay.counter.kernel.service.CounterLocalServiceUtil;
 import com.liferay.document.library.constants.DLFileVersionPreviewConstants;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFileEntryMetadata;
+import com.liferay.document.library.kernel.model.DLFileShortcut;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLAppService;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
@@ -40,6 +41,7 @@ import com.liferay.portal.kernel.dao.db.DBType;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.model.ClassName;
+import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.SystemEvent;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.FileVersion;
@@ -64,6 +66,8 @@ import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.portal.upgrade.data.cleanup.DLFileEntryDataCleanupPreupgradeProcess;
 
 import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 
 import java.util.HashMap;
 import java.util.List;
@@ -254,6 +258,230 @@ public class DLFileEntryDataCleanupPreupgradeProcessTest
 				"delete from DLFileEntry where fileEntryId = " + fileEntryId1);
 			runSQL(
 				"delete from DLFileEntry where fileEntryId = " + fileEntryId2);
+		}
+	}
+
+	@Test
+	public void testUpgradeDLFileEntryResourcePermissionScopeCheck()
+		throws Exception {
+
+		long primKeyId = RandomTestUtil.nextLong();
+		long individualPermissionId = CounterLocalServiceUtil.increment();
+		long companyPermissionId = CounterLocalServiceUtil.increment();
+		long companyId = TestPropsValues.getCompanyId();
+		long roleId = RandomTestUtil.nextLong();
+
+		String insertSQL = StringBundler.concat(
+			"insert into ResourcePermission (mvccVersion, ctCollectionId, ",
+			"resourcePermissionId, companyId, name, scope, primKey, ",
+			"primKeyId, roleId, ownerId, actionIds, viewActionId) values (0, ",
+			"0, ?, ?, ?, ?, ?, ?, ?, 0, 1, 0)");
+
+		try {
+			try (Connection connection = DataAccess.getConnection()) {
+				try (PreparedStatement preparedStatement =
+						connection.prepareStatement(insertSQL)) {
+
+					preparedStatement.setLong(1, individualPermissionId);
+					preparedStatement.setLong(2, companyId);
+					preparedStatement.setString(3, DLFileEntry.class.getName());
+					preparedStatement.setInt(
+						4, ResourceConstants.SCOPE_INDIVIDUAL);
+					preparedStatement.setString(5, String.valueOf(primKeyId));
+					preparedStatement.setLong(6, primKeyId);
+					preparedStatement.setLong(7, roleId);
+
+					preparedStatement.executeUpdate();
+				}
+
+				try (PreparedStatement preparedStatement =
+						connection.prepareStatement(insertSQL)) {
+
+					preparedStatement.setLong(1, companyPermissionId);
+					preparedStatement.setLong(2, companyId);
+					preparedStatement.setString(3, DLFileEntry.class.getName());
+					preparedStatement.setInt(
+						4, ResourceConstants.SCOPE_COMPANY);
+					preparedStatement.setString(5, String.valueOf(primKeyId));
+					preparedStatement.setLong(6, primKeyId);
+					preparedStatement.setLong(7, roleId);
+
+					preparedStatement.executeUpdate();
+				}
+			}
+
+			try (Connection connection = DataAccess.getConnection();
+
+				PreparedStatement preparedStatement =
+					connection.prepareStatement(
+						"select count(*) from ResourcePermission where " +
+							"resourcePermissionId in (?, ?)")) {
+
+				preparedStatement.setLong(1, individualPermissionId);
+				preparedStatement.setLong(2, companyPermissionId);
+
+				try (ResultSet resultSet = preparedStatement.executeQuery()) {
+					resultSet.next();
+
+					Assert.assertEquals(2, resultSet.getInt("count(*)"));
+				}
+			}
+
+			upgrade();
+
+			try (Connection connection = DataAccess.getConnection()) {
+				try (PreparedStatement preparedStatement =
+						connection.prepareStatement(
+							"select count(*) from ResourcePermission where " +
+								"resourcePermissionId = ?")) {
+
+					preparedStatement.setLong(1, individualPermissionId);
+
+					try (ResultSet resultSet =
+							preparedStatement.executeQuery()) {
+
+						resultSet.next();
+
+						Assert.assertEquals(0, resultSet.getInt("count(*)"));
+					}
+				}
+
+				try (PreparedStatement preparedStatement =
+						connection.prepareStatement(
+							"select count(*) from ResourcePermission where " +
+								"resourcePermissionId = ?")) {
+
+					preparedStatement.setLong(1, companyPermissionId);
+
+					try (ResultSet resultSet =
+							preparedStatement.executeQuery()) {
+
+						resultSet.next();
+
+						Assert.assertEquals(1, resultSet.getInt("count(*)"));
+					}
+				}
+			}
+		}
+		finally {
+			runSQL(
+				StringBundler.concat(
+					"delete from ResourcePermission where ",
+					"resourcePermissionId in (", individualPermissionId, ", ",
+					companyPermissionId, ")"));
+		}
+	}
+
+	@Test
+	public void testUpgradeDLFileShortcutResourcePermissionScopeCheck()
+		throws Exception {
+
+		long primKeyId = RandomTestUtil.nextLong();
+		long individualPermissionId = CounterLocalServiceUtil.increment();
+		long companyPermissionId = CounterLocalServiceUtil.increment();
+		long companyId = TestPropsValues.getCompanyId();
+		long roleId = RandomTestUtil.nextLong();
+
+		String insertSQL = StringBundler.concat(
+			"insert into ResourcePermission (mvccVersion, ctCollectionId, ",
+			"resourcePermissionId, companyId, name, scope, primKey, ",
+			"primKeyId, roleId, ownerId, actionIds, viewActionId) values (0, ",
+			"0, ?, ?, ?, ?, ?, ?, ?, 0, 1, 0)");
+
+		try {
+			try (Connection connection = DataAccess.getConnection()) {
+				try (PreparedStatement preparedStatement =
+						connection.prepareStatement(insertSQL)) {
+
+					preparedStatement.setLong(1, individualPermissionId);
+					preparedStatement.setLong(2, companyId);
+					preparedStatement.setString(
+						3, DLFileShortcut.class.getName());
+					preparedStatement.setInt(
+						4, ResourceConstants.SCOPE_INDIVIDUAL);
+					preparedStatement.setString(5, String.valueOf(primKeyId));
+					preparedStatement.setLong(6, primKeyId);
+					preparedStatement.setLong(7, roleId);
+
+					preparedStatement.executeUpdate();
+				}
+
+				try (PreparedStatement preparedStatement =
+						connection.prepareStatement(insertSQL)) {
+
+					preparedStatement.setLong(1, companyPermissionId);
+					preparedStatement.setLong(2, companyId);
+					preparedStatement.setString(
+						3, DLFileShortcut.class.getName());
+					preparedStatement.setInt(
+						4, ResourceConstants.SCOPE_COMPANY);
+					preparedStatement.setString(5, String.valueOf(primKeyId));
+					preparedStatement.setLong(6, primKeyId);
+					preparedStatement.setLong(7, roleId);
+
+					preparedStatement.executeUpdate();
+				}
+			}
+
+			try (Connection connection = DataAccess.getConnection();
+
+				PreparedStatement preparedStatement =
+					connection.prepareStatement(
+						"select count(*) from ResourcePermission where " +
+							"resourcePermissionId in (?, ?)")) {
+
+				preparedStatement.setLong(1, individualPermissionId);
+				preparedStatement.setLong(2, companyPermissionId);
+
+				try (ResultSet resultSet = preparedStatement.executeQuery()) {
+					resultSet.next();
+
+					Assert.assertEquals(2, resultSet.getInt("count(*)"));
+				}
+			}
+
+			upgrade();
+
+			try (Connection connection = DataAccess.getConnection()) {
+				try (PreparedStatement preparedStatement =
+						connection.prepareStatement(
+							"select count(*) from ResourcePermission where " +
+								"resourcePermissionId = ?")) {
+
+					preparedStatement.setLong(1, individualPermissionId);
+
+					try (ResultSet resultSet =
+							preparedStatement.executeQuery()) {
+
+						resultSet.next();
+
+						Assert.assertEquals(0, resultSet.getInt("count(*)"));
+					}
+				}
+
+				try (PreparedStatement preparedStatement =
+						connection.prepareStatement(
+							"select count(*) from ResourcePermission where " +
+								"resourcePermissionId = ?")) {
+
+					preparedStatement.setLong(1, companyPermissionId);
+
+					try (ResultSet resultSet =
+							preparedStatement.executeQuery()) {
+
+						resultSet.next();
+
+						Assert.assertEquals(1, resultSet.getInt("count(*)"));
+					}
+				}
+			}
+		}
+		finally {
+			runSQL(
+				StringBundler.concat(
+					"delete from ResourcePermission where ",
+					"resourcePermissionId in (", individualPermissionId, ", ",
+					companyPermissionId, ")"));
 		}
 	}
 

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/data/cleanup/test/DLFileEntryDataCleanupPreupgradeProcessTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/data/cleanup/test/DLFileEntryDataCleanupPreupgradeProcessTest.java
@@ -42,12 +42,15 @@ import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.model.ClassName;
 import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.model.SystemEvent;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.FileVersion;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.SystemEventLocalService;
+import com.liferay.portal.kernel.service.persistence.ResourcePermissionPersistence;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DataGuard;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -66,8 +69,6 @@ import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.portal.upgrade.data.cleanup.DLFileEntryDataCleanupPreupgradeProcess;
 
 import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
 
 import java.util.HashMap;
 import java.util.List;
@@ -265,103 +266,61 @@ public class DLFileEntryDataCleanupPreupgradeProcessTest
 	public void testUpgradeDLFileEntryResourcePermissionScopeCheck()
 		throws Exception {
 
-		long primKeyId = RandomTestUtil.nextLong();
-		long individualPermissionId = CounterLocalServiceUtil.increment();
-		long companyPermissionId = CounterLocalServiceUtil.increment();
 		long companyId = TestPropsValues.getCompanyId();
+		long companyPermissionId = CounterLocalServiceUtil.increment();
+		long individualPermissionId = CounterLocalServiceUtil.increment();
+		long primKeyId = RandomTestUtil.nextLong();
 		long roleId = RandomTestUtil.nextLong();
 
-		String insertSQL = StringBundler.concat(
-			"insert into ResourcePermission (mvccVersion, ctCollectionId, ",
-			"resourcePermissionId, companyId, name, scope, primKey, ",
-			"primKeyId, roleId, ownerId, actionIds, viewActionId) values (0, ",
-			"0, ?, ?, ?, ?, ?, ?, ?, 0, 1, 0)");
-
 		try {
-			try (Connection connection = DataAccess.getConnection()) {
-				try (PreparedStatement preparedStatement =
-						connection.prepareStatement(insertSQL)) {
+			ResourcePermission companyResourcePermission =
+				_resourcePermissionLocalService.createResourcePermission(
+					companyPermissionId);
 
-					preparedStatement.setLong(1, individualPermissionId);
-					preparedStatement.setLong(2, companyId);
-					preparedStatement.setString(3, DLFileEntry.class.getName());
-					preparedStatement.setInt(
-						4, ResourceConstants.SCOPE_INDIVIDUAL);
-					preparedStatement.setString(5, String.valueOf(primKeyId));
-					preparedStatement.setLong(6, primKeyId);
-					preparedStatement.setLong(7, roleId);
+			companyResourcePermission.setCompanyId(companyId);
+			companyResourcePermission.setName(DLFileEntry.class.getName());
+			companyResourcePermission.setScope(ResourceConstants.SCOPE_COMPANY);
+			companyResourcePermission.setPrimKey(String.valueOf(primKeyId));
+			companyResourcePermission.setPrimKeyId(primKeyId);
+			companyResourcePermission.setRoleId(roleId);
+			companyResourcePermission.setActionIds(1);
 
-					preparedStatement.executeUpdate();
-				}
+			_resourcePermissionLocalService.addResourcePermission(
+				companyResourcePermission);
 
-				try (PreparedStatement preparedStatement =
-						connection.prepareStatement(insertSQL)) {
+			ResourcePermission individualResourcePermission =
+				_resourcePermissionLocalService.createResourcePermission(
+					individualPermissionId);
 
-					preparedStatement.setLong(1, companyPermissionId);
-					preparedStatement.setLong(2, companyId);
-					preparedStatement.setString(3, DLFileEntry.class.getName());
-					preparedStatement.setInt(
-						4, ResourceConstants.SCOPE_COMPANY);
-					preparedStatement.setString(5, String.valueOf(primKeyId));
-					preparedStatement.setLong(6, primKeyId);
-					preparedStatement.setLong(7, roleId);
+			individualResourcePermission.setCompanyId(companyId);
+			individualResourcePermission.setName(DLFileEntry.class.getName());
+			individualResourcePermission.setScope(
+				ResourceConstants.SCOPE_INDIVIDUAL);
+			individualResourcePermission.setPrimKey(String.valueOf(primKeyId));
+			individualResourcePermission.setPrimKeyId(primKeyId);
+			individualResourcePermission.setRoleId(roleId);
+			individualResourcePermission.setActionIds(1);
 
-					preparedStatement.executeUpdate();
-				}
-			}
+			_resourcePermissionLocalService.addResourcePermission(
+				individualResourcePermission);
 
-			try (Connection connection = DataAccess.getConnection();
-
-				PreparedStatement preparedStatement =
-					connection.prepareStatement(
-						"select count(*) from ResourcePermission where " +
-							"resourcePermissionId in (?, ?)")) {
-
-				preparedStatement.setLong(1, individualPermissionId);
-				preparedStatement.setLong(2, companyPermissionId);
-
-				try (ResultSet resultSet = preparedStatement.executeQuery()) {
-					resultSet.next();
-
-					Assert.assertEquals(2, resultSet.getInt("count(*)"));
-				}
-			}
+			Assert.assertNotNull(
+				_resourcePermissionLocalService.fetchResourcePermission(
+					companyPermissionId));
+			Assert.assertNotNull(
+				_resourcePermissionLocalService.fetchResourcePermission(
+					individualPermissionId));
 
 			upgrade();
 
-			try (Connection connection = DataAccess.getConnection()) {
-				try (PreparedStatement preparedStatement =
-						connection.prepareStatement(
-							"select count(*) from ResourcePermission where " +
-								"resourcePermissionId = ?")) {
+			_resourcePermissionPersistence.clearCache();
 
-					preparedStatement.setLong(1, individualPermissionId);
-
-					try (ResultSet resultSet =
-							preparedStatement.executeQuery()) {
-
-						resultSet.next();
-
-						Assert.assertEquals(0, resultSet.getInt("count(*)"));
-					}
-				}
-
-				try (PreparedStatement preparedStatement =
-						connection.prepareStatement(
-							"select count(*) from ResourcePermission where " +
-								"resourcePermissionId = ?")) {
-
-					preparedStatement.setLong(1, companyPermissionId);
-
-					try (ResultSet resultSet =
-							preparedStatement.executeQuery()) {
-
-						resultSet.next();
-
-						Assert.assertEquals(1, resultSet.getInt("count(*)"));
-					}
-				}
-			}
+			Assert.assertNotNull(
+				_resourcePermissionLocalService.fetchResourcePermission(
+					companyPermissionId));
+			Assert.assertNull(
+				_resourcePermissionLocalService.fetchResourcePermission(
+					individualPermissionId));
 		}
 		finally {
 			runSQL(
@@ -376,105 +335,62 @@ public class DLFileEntryDataCleanupPreupgradeProcessTest
 	public void testUpgradeDLFileShortcutResourcePermissionScopeCheck()
 		throws Exception {
 
-		long primKeyId = RandomTestUtil.nextLong();
-		long individualPermissionId = CounterLocalServiceUtil.increment();
-		long companyPermissionId = CounterLocalServiceUtil.increment();
 		long companyId = TestPropsValues.getCompanyId();
+		long companyPermissionId = CounterLocalServiceUtil.increment();
+		long individualPermissionId = CounterLocalServiceUtil.increment();
+		long primKeyId = RandomTestUtil.nextLong();
 		long roleId = RandomTestUtil.nextLong();
 
-		String insertSQL = StringBundler.concat(
-			"insert into ResourcePermission (mvccVersion, ctCollectionId, ",
-			"resourcePermissionId, companyId, name, scope, primKey, ",
-			"primKeyId, roleId, ownerId, actionIds, viewActionId) values (0, ",
-			"0, ?, ?, ?, ?, ?, ?, ?, 0, 1, 0)");
-
 		try {
-			try (Connection connection = DataAccess.getConnection()) {
-				try (PreparedStatement preparedStatement =
-						connection.prepareStatement(insertSQL)) {
+			ResourcePermission companyResourcePermission =
+				_resourcePermissionLocalService.createResourcePermission(
+					companyPermissionId);
 
-					preparedStatement.setLong(1, individualPermissionId);
-					preparedStatement.setLong(2, companyId);
-					preparedStatement.setString(
-						3, DLFileShortcut.class.getName());
-					preparedStatement.setInt(
-						4, ResourceConstants.SCOPE_INDIVIDUAL);
-					preparedStatement.setString(5, String.valueOf(primKeyId));
-					preparedStatement.setLong(6, primKeyId);
-					preparedStatement.setLong(7, roleId);
+			companyResourcePermission.setCompanyId(companyId);
+			companyResourcePermission.setName(DLFileShortcut.class.getName());
+			companyResourcePermission.setScope(ResourceConstants.SCOPE_COMPANY);
+			companyResourcePermission.setPrimKey(String.valueOf(primKeyId));
+			companyResourcePermission.setPrimKeyId(primKeyId);
+			companyResourcePermission.setRoleId(roleId);
+			companyResourcePermission.setActionIds(1);
 
-					preparedStatement.executeUpdate();
-				}
+			_resourcePermissionLocalService.addResourcePermission(
+				companyResourcePermission);
 
-				try (PreparedStatement preparedStatement =
-						connection.prepareStatement(insertSQL)) {
+			ResourcePermission individualResourcePermission =
+				_resourcePermissionLocalService.createResourcePermission(
+					individualPermissionId);
 
-					preparedStatement.setLong(1, companyPermissionId);
-					preparedStatement.setLong(2, companyId);
-					preparedStatement.setString(
-						3, DLFileShortcut.class.getName());
-					preparedStatement.setInt(
-						4, ResourceConstants.SCOPE_COMPANY);
-					preparedStatement.setString(5, String.valueOf(primKeyId));
-					preparedStatement.setLong(6, primKeyId);
-					preparedStatement.setLong(7, roleId);
+			individualResourcePermission.setCompanyId(companyId);
+			individualResourcePermission.setName(
+				DLFileShortcut.class.getName());
+			individualResourcePermission.setScope(
+				ResourceConstants.SCOPE_INDIVIDUAL);
+			individualResourcePermission.setPrimKey(String.valueOf(primKeyId));
+			individualResourcePermission.setPrimKeyId(primKeyId);
+			individualResourcePermission.setRoleId(roleId);
+			individualResourcePermission.setActionIds(1);
 
-					preparedStatement.executeUpdate();
-				}
-			}
+			_resourcePermissionLocalService.addResourcePermission(
+				individualResourcePermission);
 
-			try (Connection connection = DataAccess.getConnection();
-
-				PreparedStatement preparedStatement =
-					connection.prepareStatement(
-						"select count(*) from ResourcePermission where " +
-							"resourcePermissionId in (?, ?)")) {
-
-				preparedStatement.setLong(1, individualPermissionId);
-				preparedStatement.setLong(2, companyPermissionId);
-
-				try (ResultSet resultSet = preparedStatement.executeQuery()) {
-					resultSet.next();
-
-					Assert.assertEquals(2, resultSet.getInt("count(*)"));
-				}
-			}
+			Assert.assertNotNull(
+				_resourcePermissionLocalService.fetchResourcePermission(
+					companyPermissionId));
+			Assert.assertNotNull(
+				_resourcePermissionLocalService.fetchResourcePermission(
+					individualPermissionId));
 
 			upgrade();
 
-			try (Connection connection = DataAccess.getConnection()) {
-				try (PreparedStatement preparedStatement =
-						connection.prepareStatement(
-							"select count(*) from ResourcePermission where " +
-								"resourcePermissionId = ?")) {
+			_resourcePermissionPersistence.clearCache();
 
-					preparedStatement.setLong(1, individualPermissionId);
-
-					try (ResultSet resultSet =
-							preparedStatement.executeQuery()) {
-
-						resultSet.next();
-
-						Assert.assertEquals(0, resultSet.getInt("count(*)"));
-					}
-				}
-
-				try (PreparedStatement preparedStatement =
-						connection.prepareStatement(
-							"select count(*) from ResourcePermission where " +
-								"resourcePermissionId = ?")) {
-
-					preparedStatement.setLong(1, companyPermissionId);
-
-					try (ResultSet resultSet =
-							preparedStatement.executeQuery()) {
-
-						resultSet.next();
-
-						Assert.assertEquals(1, resultSet.getInt("count(*)"));
-					}
-				}
-			}
+			Assert.assertNotNull(
+				_resourcePermissionLocalService.fetchResourcePermission(
+					companyPermissionId));
+			Assert.assertNull(
+				_resourcePermissionLocalService.fetchResourcePermission(
+					individualPermissionId));
 		}
 		finally {
 			runSQL(
@@ -593,6 +509,12 @@ public class DLFileEntryDataCleanupPreupgradeProcessTest
 
 	@Inject
 	private DLFileVersionPreviewLocalService _dlFileVersionPreviewLocalService;
+
+	@Inject
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Inject
+	private ResourcePermissionPersistence _resourcePermissionPersistence;
 
 	@Inject
 	private SystemEventLocalService _systemEventLocalService;

--- a/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/DLFileEntryDataCleanupPreupgradeProcess.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/DLFileEntryDataCleanupPreupgradeProcess.java
@@ -14,6 +14,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.db.DBInspector;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.upgrade.data.cleanup.DataCleanupPreupgradeProcess;
 import com.liferay.portal.kernel.upgrade.data.cleanup.FilterableAllTablesOrphanReferencesDataCleanupPreupgradeProcess;
@@ -102,6 +103,8 @@ public class DLFileEntryDataCleanupPreupgradeProcess
 			new TableOrphanReferencesDataCleanupPreupgradeProcess(
 				null,
 				StringBundler.concat(
+					"[$SOURCE_TABLE_ALIAS$].scope = ",
+					ResourceConstants.SCOPE_INDIVIDUAL, " and ",
 					"[$SOURCE_TABLE_ALIAS$].name = '",
 					DLFileEntry.class.getName(), "'"),
 				"primKeyId", "ResourcePermission", "fileEntryId",
@@ -209,6 +212,8 @@ public class DLFileEntryDataCleanupPreupgradeProcess
 			new TableOrphanReferencesDataCleanupPreupgradeProcess(
 				null,
 				StringBundler.concat(
+					"[$SOURCE_TABLE_ALIAS$].scope = ",
+					ResourceConstants.SCOPE_INDIVIDUAL, " and ",
 					"[$SOURCE_TABLE_ALIAS$].name = '",
 					DLFileShortcut.class.getName(), "'"),
 				"primKeyId", "ResourcePermission", "fileShortcutId",


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93185

## What Is Being Fixed

DLFileEntryDataCleanupPreupgradeProcess was deleting ResourcePermission rows for DLFileEntry and DLFileShortcut without checking the scope column. This caused individual-scoped permissions (Document View, Document Download, Shortcut View) to be dropped during upgrade, while also potentially removing non-individual-scoped permissions that happened to share a primKeyId with a deleted file entry or shortcut.

## How It Is Being Fixed

A scope = SCOPE_INDIVIDUAL filter is added to both TableOrphanReferencesDataCleanupPreupgradeProcess instances — one inside _getDLFileEntryDataCleanupPreupgradeProcess() and one inside _getDLFileShortcutDataCleanupPreupgradeProcess(). The cleanup now only removes SCOPE_INDIVIDUAL orphaned permissions, leaving broader-scoped permissions untouched. Two integration tests are added to DLFileEntryDataCleanupPreupgradeProcessTest to verify that SCOPE_INDIVIDUAL orphaned permissions are deleted and SCOPE_COMPANY permissions with the same primKeyId are preserved.

## PR Check

**pr-check: PASS** — tested on `5b85d9ebc9be0e3603842e949eb21b08a0f9f9c3`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Full Portal Build | PASS |
| Integration Test Compile | PASS |
| Structural Smoke | PASS |

<!-- pr-check {"result": "success", "sha": "5b85d9ebc9be0e3603842e949eb21b08a0f9f9c3"} -->