### PR TITLE
LPD-93826 Enable widget pages in Link to Page tests

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/messageboards/MBThread.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/messageboards/MBThread.testcase
@@ -21,6 +21,8 @@ definition {
 			groupName = "Guest",
 			layoutName = "Message Boards Page",
 			widgetName = "Message Boards");
+
+		PagesAdmin.enableWidgetPages();
 	}
 
 	tearDown {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/journal/WebContent.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/journal/WebContent.testcase
@@ -21,6 +21,10 @@ definition {
 		task ("Add a site") {
 			HeadlessSite.addSite(siteName = "Test Site Name");
 		}
+
+		task ("Enable widget pages") {
+			PagesAdmin.enableWidgetPages();
+		}
 	}
 
 	@description = "This is a test for LPS-81244. The web content can be assigned to the default display page."


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93826

## What Is Being Fixed

Widget page types are deprecated behind the LPD-76864 feature flag, so any functional test that creates or selects a widget page must enable that flag in its setUp. LPD-89086 added the enableWidgetPages task to the WebContentStructures and WebContentWithCustomStructures suites but missed WebContent.testcase (SelectThe12thPageInLinkToPage) and MBThread.testcase (CanAddLinkToPage), whose Link to Page tests also depend on widget pages and now fail.

## How It Is Being Fixed

Adds PagesAdmin.enableWidgetPages() to the setUp of both testcases, matching each file's existing setUp style: a task block in WebContent.testcase and a bare statement in MBThread.testcase, consistent with the sibling suites already covered by LPD-89086.

## Why Are There No Tests?

The change is to the Poshi tests themselves. It adds the required widget-page setUp to existing functional tests rather than introducing new product code.

## PR Check

**pr-check: SKIPPED** — Poshi .testcase-only change; no Java compilation, unit, or integration coverage applies.

<!-- pr-check {"reason": "Poshi .testcase-only change; no Java compilation, unit, or integration coverage applies.", "result": "skipped", "sha": "145b2d28c7c68889a0c4e6eed35eceb39d4a221a"} -->
