### PR TITLE
LPD-89997 Render shared read-mode content read-only consistently

### DIFF
--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/renderer/LayoutStructureRenderer.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/renderer/LayoutStructureRenderer.java
@@ -1338,9 +1338,14 @@ public class LayoutStructureRenderer {
 
 		boolean readOnly = false;
 
-		if ((layoutDisplayPageObjectProvider != null) &&
-			!_hasPermission(
-				ActionKeys.UPDATE, layoutDisplayPageObjectProvider)) {
+		String layoutMode = ParamUtil.getString(
+			PortalUtil.getOriginalServletRequest(_httpServletRequest),
+			"p_l_mode", Constants.VIEW);
+
+		if (Objects.equals(layoutMode, Constants.READ) ||
+			((layoutDisplayPageObjectProvider != null) &&
+			 !_hasPermission(
+				 ActionKeys.UPDATE, layoutDisplayPageObjectProvider))) {
 
 			readOnly = true;
 		}

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/taglib/test/RenderLayoutStructureTagTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/taglib/test/RenderLayoutStructureTagTest.java
@@ -2438,6 +2438,57 @@ public class RenderLayoutStructureTagTest {
 	}
 
 	@Test
+	@TestInfo("LPD-89997")
+	public void testRenderEditionFormInReadLayoutMode() throws Exception {
+		MockObject mockObject = new MockObject(RandomTestUtil.randomLong());
+
+		InfoField<TextInfoFieldType> infoField1 = _getInfoField(false);
+
+		String infoField1Value = RandomTestUtil.randomString();
+
+		mockObject.addInfoField(infoField1, infoField1Value);
+
+		InfoField<TextInfoFieldType> infoField2 = _getInfoField(false);
+
+		String infoField2Value = RandomTestUtil.randomString();
+
+		mockObject.addInfoField(infoField2, infoField2Value);
+
+		try (MockInfoServiceRegistrationHolder
+				mockInfoServiceRegistrationHolder =
+					new MockInfoServiceRegistrationHolder(
+						InfoFieldSet.builder(
+						).infoFieldSetEntries(
+							ListUtil.fromArray(infoField1, infoField2)
+						).build(),
+						mockObject, _portal, _displayPageInfoItemCapability,
+						_editPageInfoItemCapability)) {
+
+			Layout layout = _addDisplayPageWithFormAndGetLayout(
+				infoField1, infoField2);
+
+			MockHttpServletResponse mockHttpServletResponse = _renderLayout(
+				layout,
+				_getMockHttpServletRequest(
+					layout,
+					mockInfoServiceRegistrationHolder.
+						getMockObjectLayoutDisplayPageObjectProvider(),
+					HashMapBuilder.put(
+						"p_l_mode", Constants.READ
+					).build(),
+					null));
+
+			String content = mockHttpServletResponse.getContentAsString();
+
+			Assert.assertTrue(
+				content.contains("<fieldset disabled=\"disabled\">"));
+
+			_assertInfoFieldInput(infoField1, content, infoField1Value);
+			_assertInfoFieldInput(infoField2, content, infoField2Value);
+		}
+	}
+
+	@Test
 	@TestInfo("LPS-169924")
 	public void testRenderEditionFormWithAddPermissionAndWithViewPermission()
 		throws Exception {

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/sharedWithMe.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/sharedWithMe.spec.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {expect, mergeTests} from '@playwright/test';
+import {Locator, Page, expect, mergeTests} from '@playwright/test';
 
 import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
 import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
@@ -19,6 +19,171 @@ const test = mergeTests(
 		'LPD-17564': {enabled: true},
 	}),
 	loginTest()
+);
+
+async function expectViewModalToBeReadOnly(
+	page: Page,
+	assetRow: Locator,
+	objectEntryTitle: string
+) {
+	const previewFrame = page.frameLocator('iframe[title="Preview"]');
+
+	const titleInput = previewFrame.getByRole('textbox', {
+		name: /Title \(Read Only\)/,
+	});
+
+	const quickViewButton = assetRow
+		.locator('button:has(.lexicon-icon-view), a:has(.lexicon-icon-view)')
+		.first();
+
+	const actionsButton = assetRow.getByRole('button', {name: 'Actions'});
+
+	const viewMenuItem = page.getByRole('menuitem', {
+		exact: true,
+		name: 'View',
+	});
+
+	await expect(async () => {
+		await assetRow.hover();
+
+		if (await quickViewButton.isVisible()) {
+			await quickViewButton.click({timeout: 1000});
+		}
+		else {
+			await actionsButton.click({timeout: 1000});
+
+			await viewMenuItem.click({timeout: 1000});
+		}
+
+		await expect(titleInput).toHaveValue(objectEntryTitle, {timeout: 5000});
+	}).toPass();
+
+	await expect(titleInput).toBeDisabled();
+
+	await expect(previewFrame.locator('fieldset[disabled]')).toHaveCount(1);
+
+	await page.getByRole('button', {exact: true, name: 'Close'}).click();
+}
+
+test(
+	'Shared entries show the same read-only state in the View modal regardless of permissions',
+	{tag: '@LPD-89997'},
+	async ({apiHelpers, page, sharedWithMePage}) => {
+		const memberSpaceName = `Space ${getRandomString()}`;
+		let memberSpace = null;
+		const nonMemberSpaceName = `Space ${getRandomString()}`;
+
+		await test.step('Create two spaces', async () => {
+			memberSpace =
+				await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+					name: memberSpaceName,
+					type: 'Space',
+				});
+
+			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+				name: nonMemberSpaceName,
+				type: 'Space',
+			});
+		});
+
+		const editableObjectEntryTitle = `Content ${getRandomString()}`;
+		let editableObjectEntry = null;
+		const viewOnlyObjectEntryTitle = `Content ${getRandomString()}`;
+		let viewOnlyObjectEntry = null;
+
+		await test.step('Create a content in each space', async () => {
+			editableObjectEntry = await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: editableObjectEntryTitle,
+				},
+				'cms/basic-web-contents',
+				memberSpaceName
+			);
+
+			viewOnlyObjectEntry = await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: viewOnlyObjectEntryTitle,
+				},
+				'cms/basic-web-contents',
+				nonMemberSpaceName
+			);
+		});
+
+		let user = null;
+
+		await test.step('Create a user and add as member of the first space', async () => {
+			user = await apiHelpers.headlessAdminUser.postUserAccount();
+
+			userData[user.alternateName] = {
+				name: user.givenName,
+				password: 'test',
+				surname: user.familyName,
+			};
+
+			await apiHelpers.jsonWebServicesUser.agreeToTermsOfUse(user.id);
+			await apiHelpers.jsonWebServicesUser.answerReminderQuery(user.id);
+
+			await apiHelpers.jsonWebServicesUser.addGroupUsers(
+				memberSpace.siteId,
+				[user.id]
+			);
+		});
+
+		await test.step('Share the content from the member space with UPDATE permission and the content from the non-member space with VIEW permission', async () => {
+			await apiHelpers.objectEntry.postObjectEntryCollaborators(
+				[
+					{
+						actionIds: ['UPDATE', 'VIEW'],
+						id: user.id,
+						share: false,
+						type: 'User',
+					},
+				],
+				'cms/basic-web-contents',
+				editableObjectEntry.id
+			);
+
+			await apiHelpers.objectEntry.postObjectEntryCollaborators(
+				[
+					{
+						actionIds: ['VIEW'],
+						id: user.id,
+						share: false,
+						type: 'User',
+					},
+				],
+				'cms/basic-web-contents',
+				viewOnlyObjectEntry.id
+			);
+		});
+
+		await test.step('Switch to the user', async () => {
+			await performUserSwitch(page, user.alternateName);
+
+			await sharedWithMePage.goto();
+		});
+
+		for (const objectEntryTitle of [
+			editableObjectEntryTitle,
+			viewOnlyObjectEntryTitle,
+		]) {
+			await test.step(`Verify ${objectEntryTitle} renders read-only inputs in the View modal`, async () => {
+				const assetRow = page.getByRole('row', {
+					name: objectEntryTitle,
+				});
+
+				await expect(assetRow).toBeVisible();
+
+				await expectViewModalToBeReadOnly(
+					page,
+					assetRow,
+					objectEntryTitle
+				);
+			});
+		}
+	}
 );
 
 test(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89997

## What Is Being Fixed

In the CMS "Shared with Me" section, content is opened in a full-screen View modal that loads the edit page with `p_l_mode=read`. The input fragments were already flagged read-only by the layout mode (read-only attributes and "(Read Only)" labels), but the form-level `<fieldset disabled>` wrapper was added only when the user lacked UPDATE permission on the object entry. As a result, two items opened in the same read-only modal looked fundamentally different: an item shared from a Space the user belongs to (UPDATE) rendered as an active, editable-looking form, while an item shared from a Space the user does not belong to (VIEW only) rendered fully grayed out. The UI pattern shifted with permissions even though both items are strictly read-only in that modal.

## How It Is Being Fixed

`LayoutStructureRenderer._renderFormStyledLayoutStructureItem` now treats read layout mode (`p_l_mode=read`) as read-only at the form level, in addition to the existing missing-UPDATE-permission case. The disabled fieldset therefore wraps the form for every read-mode render, so shared content renders with the same consistent read-only/disabled state regardless of the user's permission on the underlying entry. The read mode is read from the original servlet request, matching how the FreeMarker fragment processor resolves the layout mode. No change was needed for the rich-text input: its fragment script already calls `editor.setReadOnly(true)` when the input is read-only, identically for both permission levels.

Coverage: a new integration test renders the display-page form with UPDATE permission but `p_l_mode=read` and asserts the disabled fieldset is present; a Playwright test shares two contents (one from a member Space with UPDATE, one from a non-member Space with VIEW) and confirms both open in the View modal with the same disabled read-only state.

## PR Check

**pr-check: PASS** — tested on `41b059801411c04c61db2b7271c258f440625d3f`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Deploy | PASS |
| Integration Test Compile | PASS |
| JavaScript Unit Tests | PASS |
| Structural Smoke | PASS* |

\* Structural Smoke reported two failures, both pre-existing baseline drift in the local checkout and unrelated to this diff (neither target is touched by the change): `LibraryReferenceTest` (`lib/versions.xml` / `nbproject/project.properties` missing a reference to `spring-instrument-tomcat.jar`) and `Log4jConfigUtilTest.testGetPriorities` ("Log4jConfigUtil is not fully covered" coverage-assertor artifact). The other smoke classes (`ConfigurationEnvBuilderTest`, `ModulesStructureTest`, `SampleSQLBuilderTest`) passed.

<!-- pr-check {"result": "success", "sha": "41b059801411c04c61db2b7271c258f440625d3f"} -->
