### PR TITLE
LPD-91266 Exclude connected items and show logos in connect-sites

### DIFF
--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/Site.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/Site.java
@@ -745,6 +745,47 @@ public class Site implements Serializable {
 	@JsonIgnore
 	private Supplier<String[]> _localesSupplier;
 
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The site's logo URL."
+	)
+	public String getLogo() {
+		if (_logoSupplier != null) {
+			logo = _logoSupplier.get();
+
+			_logoSupplier = null;
+		}
+
+		return logo;
+	}
+
+	public void setLogo(String logo) {
+		this.logo = logo;
+
+		_logoSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setLogo(UnsafeSupplier<String, Exception> logoUnsafeSupplier) {
+		_logoSupplier = () -> {
+			try {
+				return logoUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(description = "The site's logo URL.")
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String logo;
+
+	@JsonIgnore
+	private Supplier<String> _logoSupplier;
+
 	@io.swagger.v3.oas.annotations.media.Schema
 	public Boolean getManualMembership() {
 		if (_manualMembershipSupplier != null) {
@@ -1693,6 +1734,22 @@ public class Site implements Serializable {
 			sb.append("]");
 		}
 
+		String logo = getLogo();
+
+		if (logo != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"logo\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(logo));
+
+			sb.append("\"");
+		}
+
 		Boolean manualMembership = getManualMembership();
 
 		if (manualMembership != null) {
@@ -2118,4 +2175,4 @@ public class Site implements Serializable {
 	private Map<String, Serializable> _extendedProperties;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1164686952
+// LIFERAY-REST-BUILDER-HASH:2055044039

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/SiteTemplate.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/SiteTemplate.java
@@ -270,6 +270,47 @@ public class SiteTemplate implements Serializable {
 	private Supplier<Long> _idSupplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The site template's logo URL."
+	)
+	public String getLogo() {
+		if (_logoSupplier != null) {
+			logo = _logoSupplier.get();
+
+			_logoSupplier = null;
+		}
+
+		return logo;
+	}
+
+	public void setLogo(String logo) {
+		this.logo = logo;
+
+		_logoSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setLogo(UnsafeSupplier<String, Exception> logoUnsafeSupplier) {
+		_logoSupplier = () -> {
+			try {
+				return logoUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(description = "The site template's logo URL.")
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String logo;
+
+	@JsonIgnore
+	private Supplier<String> _logoSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema(
 		description = "The site template's name."
 	)
 	public String getName() {
@@ -590,6 +631,22 @@ public class SiteTemplate implements Serializable {
 			sb.append(id);
 		}
 
+		String logo = getLogo();
+
+		if (logo != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"logo\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(logo));
+
+			sb.append("\"");
+		}
+
 		String name = getName();
 
 		if (name != null) {
@@ -770,4 +827,4 @@ public class SiteTemplate implements Serializable {
 	private Map<String, Serializable> _extendedProperties;
 
 }
-// LIFERAY-REST-BUILDER-HASH:942551449
+// LIFERAY-REST-BUILDER-HASH:1730452494

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/resource/v1_0/SiteResource.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/resource/v1_0/SiteResource.java
@@ -63,7 +63,8 @@ public interface SiteResource {
 		throws Exception;
 
 	public Page<Site> getSitesPage(
-			Boolean active, String search, Pagination pagination)
+			Boolean active, String[] excludedExternalReferenceCodes,
+			String search, Pagination pagination)
 		throws Exception;
 
 	public Site postSite(Site site) throws Exception;
@@ -75,8 +76,9 @@ public interface SiteResource {
 		throws Exception;
 
 	public Response postSitesPageExportBatch(
-			Boolean active, String search, String callbackURL,
-			String contentType, String fieldNames)
+			Boolean active, String[] excludedExternalReferenceCodes,
+			String search, String callbackURL, String contentType,
+			String fieldNames)
 		throws Exception;
 
 	public Site putSite(String siteExternalReferenceCode, Site site)
@@ -197,4 +199,4 @@ public interface SiteResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:1430547821
+// LIFERAY-REST-BUILDER-HASH:-521558797

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/resource/v1_0/SiteTemplateResource.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/resource/v1_0/SiteTemplateResource.java
@@ -47,12 +47,13 @@ import org.osgi.annotation.versioning.ProviderType;
 public interface SiteTemplateResource {
 
 	public Page<SiteTemplate> getSiteTemplatesPage(
-			Boolean active, Pagination pagination)
+			Boolean active, String[] excludedSiteExternalReferenceCodes,
+			Pagination pagination)
 		throws Exception;
 
 	public Response postSiteTemplatesPageExportBatch(
-			Boolean active, String callbackURL, String contentType,
-			String fieldNames)
+			Boolean active, String[] excludedSiteExternalReferenceCodes,
+			String callbackURL, String contentType, String fieldNames)
 		throws Exception;
 
 	public default void setContextAcceptLanguage(
@@ -151,4 +152,4 @@ public interface SiteTemplateResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:1873868301
+// LIFERAY-REST-BUILDER-HASH:1961746381

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/Site.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/Site.java
@@ -374,6 +374,25 @@ public class Site implements Cloneable, Serializable {
 
 	protected String[] locales;
 
+	public String getLogo() {
+		return logo;
+	}
+
+	public void setLogo(String logo) {
+		this.logo = logo;
+	}
+
+	public void setLogo(UnsafeSupplier<String, Exception> logoUnsafeSupplier) {
+		try {
+			logo = logoUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String logo;
+
 	public Boolean getManualMembership() {
 		return manualMembership;
 	}
@@ -858,4 +877,4 @@ public class Site implements Cloneable, Serializable {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:1854504143
+// LIFERAY-REST-BUILDER-HASH:1045296917

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/SiteTemplate.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/SiteTemplate.java
@@ -130,6 +130,25 @@ public class SiteTemplate implements Cloneable, Serializable {
 
 	protected Long id;
 
+	public String getLogo() {
+		return logo;
+	}
+
+	public void setLogo(String logo) {
+		this.logo = logo;
+	}
+
+	public void setLogo(UnsafeSupplier<String, Exception> logoUnsafeSupplier) {
+		try {
+			logo = logoUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String logo;
+
 	public String getName() {
 		return name;
 	}
@@ -276,4 +295,4 @@ public class SiteTemplate implements Cloneable, Serializable {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-592031663
+// LIFERAY-REST-BUILDER-HASH:2070902475

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/resource/v1_0/SiteResource.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/resource/v1_0/SiteResource.java
@@ -74,11 +74,13 @@ public interface SiteResource {
 		throws Exception;
 
 	public Page<Site> getSitesPage(
-			Boolean active, String search, Pagination pagination)
+			Boolean active, String[] excludedExternalReferenceCodes,
+			String search, Pagination pagination)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse getSitesPageHttpResponse(
-			Boolean active, String search, Pagination pagination)
+			Boolean active, String[] excludedExternalReferenceCodes,
+			String search, Pagination pagination)
 		throws Exception;
 
 	public Site postSite(Site site) throws Exception;
@@ -102,13 +104,15 @@ public interface SiteResource {
 		throws Exception;
 
 	public void postSitesPageExportBatch(
-			Boolean active, String search, String callbackURL,
-			String contentType, String fieldNames)
+			Boolean active, String[] excludedExternalReferenceCodes,
+			String search, String callbackURL, String contentType,
+			String fieldNames)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse postSitesPageExportBatchHttpResponse(
-			Boolean active, String search, String callbackURL,
-			String contentType, String fieldNames)
+			Boolean active, String[] excludedExternalReferenceCodes,
+			String search, String callbackURL, String contentType,
+			String fieldNames)
 		throws Exception;
 
 	public Site putSite(String siteExternalReferenceCode, Site site)
@@ -782,11 +786,12 @@ public interface SiteResource {
 		}
 
 		public Page<Site> getSitesPage(
-				Boolean active, String search, Pagination pagination)
+				Boolean active, String[] excludedExternalReferenceCodes,
+				String search, Pagination pagination)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse = getSitesPageHttpResponse(
-				active, search, pagination);
+				active, excludedExternalReferenceCodes, search, pagination);
 
 			String content = httpResponse.getContent();
 
@@ -848,7 +853,8 @@ public interface SiteResource {
 		}
 
 		public HttpInvoker.HttpResponse getSitesPageHttpResponse(
-				Boolean active, String search, Pagination pagination)
+				Boolean active, String[] excludedExternalReferenceCodes,
+				String search, Pagination pagination)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
@@ -874,6 +880,16 @@ public interface SiteResource {
 
 			if (active != null) {
 				httpInvoker.parameter("active", String.valueOf(active));
+			}
+
+			if (excludedExternalReferenceCodes != null) {
+				for (int i = 0; i < excludedExternalReferenceCodes.length;
+					 i++) {
+
+					httpInvoker.parameter(
+						"excludedExternalReferenceCodes",
+						String.valueOf(excludedExternalReferenceCodes[i]));
+				}
 			}
 
 			if (search != null) {
@@ -1213,13 +1229,15 @@ public interface SiteResource {
 		}
 
 		public void postSitesPageExportBatch(
-				Boolean active, String search, String callbackURL,
-				String contentType, String fieldNames)
+				Boolean active, String[] excludedExternalReferenceCodes,
+				String search, String callbackURL, String contentType,
+				String fieldNames)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
 				postSitesPageExportBatchHttpResponse(
-					active, search, callbackURL, contentType, fieldNames);
+					active, excludedExternalReferenceCodes, search, callbackURL,
+					contentType, fieldNames);
 
 			String content = httpResponse.getContent();
 
@@ -1270,8 +1288,9 @@ public interface SiteResource {
 		}
 
 		public HttpInvoker.HttpResponse postSitesPageExportBatchHttpResponse(
-				Boolean active, String search, String callbackURL,
-				String contentType, String fieldNames)
+				Boolean active, String[] excludedExternalReferenceCodes,
+				String search, String callbackURL, String contentType,
+				String fieldNames)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
@@ -1299,6 +1318,16 @@ public interface SiteResource {
 
 			if (active != null) {
 				httpInvoker.parameter("active", String.valueOf(active));
+			}
+
+			if (excludedExternalReferenceCodes != null) {
+				for (int i = 0; i < excludedExternalReferenceCodes.length;
+					 i++) {
+
+					httpInvoker.parameter(
+						"excludedExternalReferenceCodes",
+						String.valueOf(excludedExternalReferenceCodes[i]));
+				}
 			}
 
 			if (search != null) {
@@ -2001,4 +2030,4 @@ public interface SiteResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:91890992
+// LIFERAY-REST-BUILDER-HASH:388246280

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/resource/v1_0/SiteTemplateResource.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/resource/v1_0/SiteTemplateResource.java
@@ -35,22 +35,24 @@ public interface SiteTemplateResource {
 	}
 
 	public Page<SiteTemplate> getSiteTemplatesPage(
-			Boolean active, Pagination pagination)
+			Boolean active, String[] excludedSiteExternalReferenceCodes,
+			Pagination pagination)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse getSiteTemplatesPageHttpResponse(
-			Boolean active, Pagination pagination)
+			Boolean active, String[] excludedSiteExternalReferenceCodes,
+			Pagination pagination)
 		throws Exception;
 
 	public void postSiteTemplatesPageExportBatch(
-			Boolean active, String callbackURL, String contentType,
-			String fieldNames)
+			Boolean active, String[] excludedSiteExternalReferenceCodes,
+			String callbackURL, String contentType, String fieldNames)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
 			postSiteTemplatesPageExportBatchHttpResponse(
-				Boolean active, String callbackURL, String contentType,
-				String fieldNames)
+				Boolean active, String[] excludedSiteExternalReferenceCodes,
+				String callbackURL, String contentType, String fieldNames)
 		throws Exception;
 
 	public static class Builder {
@@ -163,11 +165,13 @@ public interface SiteTemplateResource {
 		implements SiteTemplateResource {
 
 		public Page<SiteTemplate> getSiteTemplatesPage(
-				Boolean active, Pagination pagination)
+				Boolean active, String[] excludedSiteExternalReferenceCodes,
+				Pagination pagination)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				getSiteTemplatesPageHttpResponse(active, pagination);
+				getSiteTemplatesPageHttpResponse(
+					active, excludedSiteExternalReferenceCodes, pagination);
 
 			String content = httpResponse.getContent();
 
@@ -229,7 +233,8 @@ public interface SiteTemplateResource {
 		}
 
 		public HttpInvoker.HttpResponse getSiteTemplatesPageHttpResponse(
-				Boolean active, Pagination pagination)
+				Boolean active, String[] excludedSiteExternalReferenceCodes,
+				Pagination pagination)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
@@ -257,6 +262,16 @@ public interface SiteTemplateResource {
 				httpInvoker.parameter("active", String.valueOf(active));
 			}
 
+			if (excludedSiteExternalReferenceCodes != null) {
+				for (int i = 0; i < excludedSiteExternalReferenceCodes.length;
+					 i++) {
+
+					httpInvoker.parameter(
+						"excludedSiteExternalReferenceCodes",
+						String.valueOf(excludedSiteExternalReferenceCodes[i]));
+				}
+			}
+
 			if (pagination != null) {
 				httpInvoker.parameter(
 					"page", String.valueOf(pagination.getPage()));
@@ -278,13 +293,14 @@ public interface SiteTemplateResource {
 		}
 
 		public void postSiteTemplatesPageExportBatch(
-				Boolean active, String callbackURL, String contentType,
-				String fieldNames)
+				Boolean active, String[] excludedSiteExternalReferenceCodes,
+				String callbackURL, String contentType, String fieldNames)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
 				postSiteTemplatesPageExportBatchHttpResponse(
-					active, callbackURL, contentType, fieldNames);
+					active, excludedSiteExternalReferenceCodes, callbackURL,
+					contentType, fieldNames);
 
 			String content = httpResponse.getContent();
 
@@ -336,8 +352,8 @@ public interface SiteTemplateResource {
 
 		public HttpInvoker.HttpResponse
 				postSiteTemplatesPageExportBatchHttpResponse(
-					Boolean active, String callbackURL, String contentType,
-					String fieldNames)
+					Boolean active, String[] excludedSiteExternalReferenceCodes,
+					String callbackURL, String contentType, String fieldNames)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
@@ -365,6 +381,16 @@ public interface SiteTemplateResource {
 
 			if (active != null) {
 				httpInvoker.parameter("active", String.valueOf(active));
+			}
+
+			if (excludedSiteExternalReferenceCodes != null) {
+				for (int i = 0; i < excludedSiteExternalReferenceCodes.length;
+					 i++) {
+
+					httpInvoker.parameter(
+						"excludedSiteExternalReferenceCodes",
+						String.valueOf(excludedSiteExternalReferenceCodes[i]));
+				}
 			}
 
 			if (callbackURL != null) {
@@ -406,4 +432,4 @@ public interface SiteTemplateResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:337816008
+// LIFERAY-REST-BUILDER-HASH:709383156

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/SiteSerDes.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/SiteSerDes.java
@@ -238,6 +238,20 @@ public class SiteSerDes {
 			sb.append("]");
 		}
 
+		if (site.getLogo() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"logo\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(site.getLogo()));
+
+			sb.append("\"");
+		}
+
 		if (site.getManualMembership() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -563,6 +577,13 @@ public class SiteSerDes {
 			map.put("locales", String.valueOf(site.getLocales()));
 		}
 
+		if (site.getLogo() == null) {
+			map.put("logo", null);
+		}
+		else {
+			map.put("logo", String.valueOf(site.getLogo()));
+		}
+
 		if (site.getManualMembership() == null) {
 			map.put("manualMembership", null);
 		}
@@ -754,6 +775,9 @@ public class SiteSerDes {
 			else if (Objects.equals(jsonParserFieldName, "locales")) {
 				return false;
 			}
+			else if (Objects.equals(jsonParserFieldName, "logo")) {
+				return false;
+			}
 			else if (Objects.equals(jsonParserFieldName, "manualMembership")) {
 				return false;
 			}
@@ -913,6 +937,11 @@ public class SiteSerDes {
 			else if (Objects.equals(jsonParserFieldName, "locales")) {
 				if (jsonParserFieldValue != null) {
 					site.setLocales(toStrings((Object[])jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "logo")) {
+				if (jsonParserFieldValue != null) {
+					site.setLogo((String)jsonParserFieldValue);
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "manualMembership")) {
@@ -1103,4 +1132,4 @@ public class SiteSerDes {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-2028564599
+// LIFERAY-REST-BUILDER-HASH:1709493374

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/SiteTemplateSerDes.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/SiteTemplateSerDes.java
@@ -104,6 +104,20 @@ public class SiteTemplateSerDes {
 			sb.append(siteTemplate.getId());
 		}
 
+		if (siteTemplate.getLogo() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"logo\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(siteTemplate.getLogo()));
+
+			sb.append("\"");
+		}
+
 		if (siteTemplate.getName() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -231,6 +245,13 @@ public class SiteTemplateSerDes {
 			map.put("id", String.valueOf(siteTemplate.getId()));
 		}
 
+		if (siteTemplate.getLogo() == null) {
+			map.put("logo", null);
+		}
+		else {
+			map.put("logo", String.valueOf(siteTemplate.getLogo()));
+		}
+
 		if (siteTemplate.getName() == null) {
 			map.put("name", null);
 		}
@@ -304,6 +325,9 @@ public class SiteTemplateSerDes {
 			else if (Objects.equals(jsonParserFieldName, "id")) {
 				return false;
 			}
+			else if (Objects.equals(jsonParserFieldName, "logo")) {
+				return false;
+			}
 			else if (Objects.equals(jsonParserFieldName, "name")) {
 				return false;
 			}
@@ -356,6 +380,11 @@ public class SiteTemplateSerDes {
 				if (jsonParserFieldValue != null) {
 					siteTemplate.setId(
 						Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "logo")) {
+				if (jsonParserFieldValue != null) {
+					siteTemplate.setLogo((String)jsonParserFieldValue);
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "name")) {
@@ -484,4 +513,4 @@ public class SiteTemplateSerDes {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1701914520
+// LIFERAY-REST-BUILDER-HASH:-449461425

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/rest-openapi.yaml
@@ -9359,6 +9359,12 @@ paths:
                     schema:
                         type: boolean
                 -   in: query
+                    name: excludedSiteExternalReferenceCodes
+                    schema:
+                        items:
+                            type: string
+                        type: array
+                -   in: query
                     name: page
                     schema:
                         type: integer
@@ -9392,6 +9398,12 @@ paths:
                     name: active
                     schema:
                         type: boolean
+                -   in: query
+                    name: excludedExternalReferenceCodes
+                    schema:
+                        items:
+                            type: string
+                        type: array
                 -   in: query
                     name: page
                     schema:

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/rest-openapi.yaml
@@ -3382,6 +3382,11 @@ components:
                     items:
                         type: string
                     type: array
+                logo:
+                    description:
+                        The site's logo URL.
+                    readOnly: true
+                    type: string
                 manualMembership:
                     type: boolean
                 mapProviderKey:
@@ -3647,6 +3652,11 @@ components:
                     format: int64
                     readOnly: true
                     type: integer
+                logo:
+                    description:
+                        The site template's logo URL.
+                    readOnly: true
+                    type: string
                 name:
                     description:
                         The site template's name.

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/BaseSiteResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/BaseSiteResourceImpl.java
@@ -308,7 +308,8 @@ public abstract class BaseSiteResourceImpl
 	}
 
 	protected abstract Page<Site> doGetSitesPage(
-			Boolean active, String search, Pagination pagination)
+			Boolean active, String[] excludedExternalReferenceCodes,
+			String search, Pagination pagination)
 		throws Exception;
 
 	/**
@@ -324,6 +325,10 @@ public abstract class BaseSiteResourceImpl
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
 				name = "active"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "excludedExternalReferenceCodes"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -351,12 +356,16 @@ public abstract class BaseSiteResourceImpl
 			@jakarta.ws.rs.QueryParam("active")
 			Boolean active,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("excludedExternalReferenceCodes")
+			String[] excludedExternalReferenceCodes,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.ws.rs.QueryParam("search")
 			String search,
 			@jakarta.ws.rs.core.Context Pagination pagination)
 		throws Exception {
 
-		Page<Site> sitesPage = doGetSitesPage(active, search, pagination);
+		Page<Site> sitesPage = doGetSitesPage(
+			active, excludedExternalReferenceCodes, search, pagination);
 
 		for (Site site : sitesPage.getItems()) {
 			site.setPermissions(
@@ -498,6 +507,10 @@ public abstract class BaseSiteResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "excludedExternalReferenceCodes"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
 				name = "search"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
@@ -526,6 +539,9 @@ public abstract class BaseSiteResourceImpl
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.ws.rs.QueryParam("active")
 			Boolean active,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("excludedExternalReferenceCodes")
+			String[] excludedExternalReferenceCodes,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.ws.rs.QueryParam("search")
 			String search,
@@ -960,7 +976,8 @@ public abstract class BaseSiteResourceImpl
 		throws Exception {
 
 		return getSitesPage(
-			_parseBoolean((String)parameters.get("active")), search,
+			_parseBoolean((String)parameters.get("active")),
+			(String[])parameters.get("excludedExternalReferenceCodes"), search,
 			pagination);
 	}
 
@@ -1757,4 +1774,4 @@ public abstract class BaseSiteResourceImpl
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:1439273677
+// LIFERAY-REST-BUILDER-HASH:-998732090

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/BaseSiteTemplateResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/BaseSiteTemplateResourceImpl.java
@@ -83,6 +83,10 @@ public abstract class BaseSiteTemplateResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "excludedSiteExternalReferenceCodes"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
 				name = "page"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
@@ -102,6 +106,9 @@ public abstract class BaseSiteTemplateResourceImpl
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.ws.rs.QueryParam("active")
 			Boolean active,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("excludedSiteExternalReferenceCodes")
+			String[] excludedSiteExternalReferenceCodes,
 			@jakarta.ws.rs.core.Context Pagination pagination)
 		throws Exception {
 
@@ -118,6 +125,10 @@ public abstract class BaseSiteTemplateResourceImpl
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
 				name = "active"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "excludedSiteExternalReferenceCodes"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -145,6 +156,9 @@ public abstract class BaseSiteTemplateResourceImpl
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.ws.rs.QueryParam("active")
 			Boolean active,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("excludedSiteExternalReferenceCodes")
+			String[] excludedSiteExternalReferenceCodes,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.ws.rs.QueryParam("callbackURL")
 			String callbackURL,
@@ -230,7 +244,9 @@ public abstract class BaseSiteTemplateResourceImpl
 		throws Exception {
 
 		return getSiteTemplatesPage(
-			_parseBoolean((String)parameters.get("active")), pagination);
+			_parseBoolean((String)parameters.get("active")),
+			(String[])parameters.get("excludedSiteExternalReferenceCodes"),
+			pagination);
 	}
 
 	@Override
@@ -843,4 +859,4 @@ public abstract class BaseSiteTemplateResourceImpl
 		LogFactoryUtil.getLog(BaseSiteTemplateResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:98562846
+// LIFERAY-REST-BUILDER-HASH:-1704394203

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SiteResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SiteResourceImpl.java
@@ -42,6 +42,7 @@ import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
 import com.liferay.portal.kernel.servlet.DummyHttpServletResponse;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -308,7 +309,8 @@ public class SiteResourceImpl extends BaseSiteResourceImpl {
 
 	@Override
 	protected Page<Site> doGetSitesPage(
-			Boolean active, String search, Pagination pagination)
+			Boolean active, String[] excludedExternalReferenceCodes,
+			String search, Pagination pagination)
 		throws Exception {
 
 		long[] classNameIds = {
@@ -332,6 +334,14 @@ public class SiteResourceImpl extends BaseSiteResourceImpl {
 			).build(),
 			true, QueryUtil.ALL_POS, QueryUtil.ALL_POS,
 			new GroupNameComparator());
+
+		if (ArrayUtil.isNotEmpty(excludedExternalReferenceCodes)) {
+			groups = ListUtil.filter(
+				groups,
+				group -> !ArrayUtil.contains(
+					excludedExternalReferenceCodes,
+					group.getExternalReferenceCode()));
+		}
 
 		return Page.of(
 			HashMapBuilder.put(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SiteResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SiteResourceImpl.java
@@ -32,6 +32,7 @@ import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.GroupService;
 import com.liferay.portal.kernel.service.LayoutSetPrototypeLocalService;
@@ -1001,6 +1002,19 @@ public class SiteResourceImpl extends BaseSiteResourceImpl {
 					() -> LocaleUtil.toW3cLanguageIds(
 						StringUtil.split(
 							group.getTypeSettingsProperty("locales"))));
+				setLogo(
+					() -> {
+						ThemeDisplay themeDisplay = new ThemeDisplay() {
+							{
+								setCompany(
+									_companyLocalService.getCompany(
+										group.getCompanyId()));
+								setPathImage(_portal.getPathImage());
+							}
+						};
+
+						return group.getLogoURL(themeDisplay, true);
+					});
 				setManualMembership(group::getManualMembership);
 				setMapProviderKey(
 					() -> MapProviderKey.create(
@@ -1085,6 +1099,9 @@ public class SiteResourceImpl extends BaseSiteResourceImpl {
 		GooglePlacesWebKeys.GOOGLE_PLACES_API_KEY, "defaultSiteRoleIds",
 		"defaultTeamIds", "googleMapsAPIKey"
 	};
+
+	@Reference
+	private CompanyLocalService _companyLocalService;
 
 	@Reference
 	private GroupLocalService _groupLocalService;

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SiteResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SiteResourceImpl.java
@@ -32,7 +32,6 @@ import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
-import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.GroupService;
 import com.liferay.portal.kernel.service.LayoutSetPrototypeLocalService;
@@ -1016,9 +1015,7 @@ public class SiteResourceImpl extends BaseSiteResourceImpl {
 					() -> {
 						ThemeDisplay themeDisplay = new ThemeDisplay() {
 							{
-								setCompany(
-									_companyLocalService.getCompany(
-										group.getCompanyId()));
+								setCompany(contextCompany);
 								setPathImage(_portal.getPathImage());
 							}
 						};
@@ -1109,9 +1106,6 @@ public class SiteResourceImpl extends BaseSiteResourceImpl {
 		GooglePlacesWebKeys.GOOGLE_PLACES_API_KEY, "defaultSiteRoleIds",
 		"defaultTeamIds", "googleMapsAPIKey"
 	};
-
-	@Reference
-	private CompanyLocalService _companyLocalService;
 
 	@Reference
 	private GroupLocalService _groupLocalService;

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SiteTemplateResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SiteTemplateResourceImpl.java
@@ -7,18 +7,24 @@ package com.liferay.headless.admin.site.internal.resource.v1_0;
 
 import com.liferay.headless.admin.site.dto.v1_0.SiteTemplate;
 import com.liferay.headless.admin.site.resource.v1_0.SiteTemplateResource;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.LayoutSetPrototype;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.LayoutSetPrototypeService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.Localization;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -35,19 +41,40 @@ public class SiteTemplateResourceImpl extends BaseSiteTemplateResourceImpl {
 
 	@Override
 	public Page<SiteTemplate> getSiteTemplatesPage(
-			Boolean active, Pagination pagination)
+			Boolean active, String[] excludedSiteExternalReferenceCodes,
+			Pagination pagination)
 		throws Exception {
+
+		List<LayoutSetPrototype> layoutSetPrototypes =
+			_layoutSetPrototypeService.search(
+				contextCompany.getCompanyId(), active, QueryUtil.ALL_POS,
+				QueryUtil.ALL_POS, null);
+
+		if (ArrayUtil.isNotEmpty(excludedSiteExternalReferenceCodes)) {
+			List<LayoutSetPrototype> filteredLayoutSetPrototypes =
+				new ArrayList<>();
+
+			for (LayoutSetPrototype layoutSetPrototype : layoutSetPrototypes) {
+				Group group = layoutSetPrototype.getGroup();
+
+				if (!ArrayUtil.contains(
+						excludedSiteExternalReferenceCodes,
+						group.getExternalReferenceCode())) {
+
+					filteredLayoutSetPrototypes.add(layoutSetPrototype);
+				}
+			}
+
+			layoutSetPrototypes = filteredLayoutSetPrototypes;
+		}
 
 		return Page.of(
 			transform(
-				_layoutSetPrototypeService.search(
-					contextCompany.getCompanyId(), active,
-					pagination.getStartPosition(), pagination.getEndPosition(),
-					null),
+				ListUtil.subList(
+					layoutSetPrototypes, pagination.getStartPosition(),
+					pagination.getEndPosition()),
 				this::_toSiteTemplate),
-			pagination,
-			_layoutSetPrototypeService.searchCount(
-				contextCompany.getCompanyId(), active));
+			pagination, layoutSetPrototypes.size());
 	}
 
 	private SiteTemplate _toSiteTemplate(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SiteTemplateResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SiteTemplateResourceImpl.java
@@ -9,9 +9,12 @@ import com.liferay.headless.admin.site.dto.v1_0.SiteTemplate;
 import com.liferay.headless.admin.site.resource.v1_0.SiteTemplateResource;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.LayoutSetPrototype;
+import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.LayoutSetPrototypeService;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Localization;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
@@ -71,6 +74,21 @@ public class SiteTemplateResourceImpl extends BaseSiteTemplateResourceImpl {
 					() -> LocalizedMapUtil.getI18nMap(
 						layoutSetPrototype.getDescriptionMap()));
 				setId(layoutSetPrototype::getLayoutSetPrototypeId);
+				setLogo(
+					() -> {
+						Group group = layoutSetPrototype.getGroup();
+
+						ThemeDisplay themeDisplay = new ThemeDisplay() {
+							{
+								setCompany(
+									_companyLocalService.getCompany(
+										group.getCompanyId()));
+								setPathImage(_portal.getPathImage());
+							}
+						};
+
+						return group.getLogoURL(themeDisplay, true);
+					});
 				setName(
 					() -> layoutSetPrototype.getName(
 						contextAcceptLanguage.getPreferredLocale()));
@@ -97,9 +115,15 @@ public class SiteTemplateResourceImpl extends BaseSiteTemplateResourceImpl {
 	}
 
 	@Reference
+	private CompanyLocalService _companyLocalService;
+
+	@Reference
 	private LayoutSetPrototypeService _layoutSetPrototypeService;
 
 	@Reference
 	private Localization _localization;
+
+	@Reference
+	private Portal _portal;
 
 }

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SiteTemplateResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SiteTemplateResourceImpl.java
@@ -10,7 +10,6 @@ import com.liferay.headless.admin.site.resource.v1_0.SiteTemplateResource;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.LayoutSetPrototype;
-import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.LayoutSetPrototypeService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
@@ -107,9 +106,7 @@ public class SiteTemplateResourceImpl extends BaseSiteTemplateResourceImpl {
 
 						ThemeDisplay themeDisplay = new ThemeDisplay() {
 							{
-								setCompany(
-									_companyLocalService.getCompany(
-										group.getCompanyId()));
+								setCompany(contextCompany);
 								setPathImage(_portal.getPathImage());
 							}
 						};
@@ -140,9 +137,6 @@ public class SiteTemplateResourceImpl extends BaseSiteTemplateResourceImpl {
 			}
 		};
 	}
-
-	@Reference
-	private CompanyLocalService _companyLocalService;
 
 	@Reference
 	private LayoutSetPrototypeService _layoutSetPrototypeService;

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SiteTemplateResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SiteTemplateResourceImpl.java
@@ -22,7 +22,6 @@ import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import org.osgi.service.component.annotations.Component;
@@ -50,21 +49,15 @@ public class SiteTemplateResourceImpl extends BaseSiteTemplateResourceImpl {
 				QueryUtil.ALL_POS, null);
 
 		if (ArrayUtil.isNotEmpty(excludedSiteExternalReferenceCodes)) {
-			List<LayoutSetPrototype> filteredLayoutSetPrototypes =
-				new ArrayList<>();
+			layoutSetPrototypes = ListUtil.filter(
+				layoutSetPrototypes,
+				layoutSetPrototype -> {
+					Group group = layoutSetPrototype.getGroup();
 
-			for (LayoutSetPrototype layoutSetPrototype : layoutSetPrototypes) {
-				Group group = layoutSetPrototype.getGroup();
-
-				if (!ArrayUtil.contains(
+					return !ArrayUtil.contains(
 						excludedSiteExternalReferenceCodes,
-						group.getExternalReferenceCode())) {
-
-					filteredLayoutSetPrototypes.add(layoutSetPrototype);
-				}
-			}
-
-			layoutSetPrototypes = filteredLayoutSetPrototypes;
+						group.getExternalReferenceCode());
+				});
 		}
 
 		return Page.of(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BaseSiteResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BaseSiteResourceTestCase.java
@@ -207,6 +207,7 @@ public abstract class BaseSiteResourceTestCase {
 		site.setExternalReferenceCode(regex);
 		site.setFriendlyUrlPath(regex);
 		site.setKey(regex);
+		site.setLogo(regex);
 		site.setName(regex);
 		site.setParentSiteExternalReferenceCode(regex);
 		site.setTemplateKey(regex);
@@ -223,6 +224,7 @@ public abstract class BaseSiteResourceTestCase {
 		Assert.assertEquals(regex, site.getExternalReferenceCode());
 		Assert.assertEquals(regex, site.getFriendlyUrlPath());
 		Assert.assertEquals(regex, site.getKey());
+		Assert.assertEquals(regex, site.getLogo());
 		Assert.assertEquals(regex, site.getName());
 		Assert.assertEquals(regex, site.getParentSiteExternalReferenceCode());
 		Assert.assertEquals(regex, site.getTemplateKey());
@@ -913,6 +915,14 @@ public abstract class BaseSiteResourceTestCase {
 				continue;
 			}
 
+			if (Objects.equals("logo", additionalAssertFieldName)) {
+				if (site.getLogo() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals("manualMembership", additionalAssertFieldName)) {
 				if (site.getManualMembership() == null) {
 					valid = false;
@@ -1339,6 +1349,14 @@ public abstract class BaseSiteResourceTestCase {
 				if (!Objects.deepEquals(
 						site1.getLocales(), site2.getLocales())) {
 
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("logo", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(site1.getLogo(), site2.getLogo())) {
 					return false;
 				}
 
@@ -1938,6 +1956,52 @@ public abstract class BaseSiteResourceTestCase {
 				"Invalid entity field " + entityFieldName);
 		}
 
+		if (entityFieldName.equals("logo")) {
+			Object object = site.getLogo();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
 		if (entityFieldName.equals("manualMembership")) {
 			throw new IllegalArgumentException(
 				"Invalid entity field " + entityFieldName);
@@ -2208,6 +2272,7 @@ public abstract class BaseSiteResourceTestCase {
 				id = RandomTestUtil.randomLong();
 				inheritLocales = RandomTestUtil.randomBoolean();
 				key = StringUtil.toLowerCase(RandomTestUtil.randomString());
+				logo = StringUtil.toLowerCase(RandomTestUtil.randomString());
 				manualMembership = RandomTestUtil.randomBoolean();
 				membershipRestriction = RandomTestUtil.randomInt();
 				mentionsEnabled = RandomTestUtil.randomBoolean();
@@ -2486,4 +2551,4 @@ public abstract class BaseSiteResourceTestCase {
 		_siteResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:385866049
+// LIFERAY-REST-BUILDER-HASH:1579821345

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BaseSiteResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BaseSiteResourceTestCase.java
@@ -336,7 +336,7 @@ public abstract class BaseSiteResourceTestCase {
 	@Test
 	public void testGetSitesPage() throws Exception {
 		Page<Site> page = siteResource.getSitesPage(
-			null, null, Pagination.of(1, 10));
+			null, null, null, Pagination.of(1, 10));
 
 		long totalCount = page.getTotalCount();
 
@@ -344,7 +344,8 @@ public abstract class BaseSiteResourceTestCase {
 
 		Site site2 = testGetSitesPage_addSite(randomSite());
 
-		page = siteResource.getSitesPage(null, null, Pagination.of(1, 10));
+		page = siteResource.getSitesPage(
+			null, null, null, Pagination.of(1, 10));
 
 		Assert.assertEquals(totalCount + 2, page.getTotalCount());
 
@@ -357,7 +358,7 @@ public abstract class BaseSiteResourceTestCase {
 		}
 
 		page = permissionsSiteResource.getSitesPage(
-			null, null, Pagination.of(1, 10));
+			null, null, null, Pagination.of(1, 10));
 
 		for (Site site : page.getItems()) {
 			Assert.assertNotNull(site.getPermissions());
@@ -379,7 +380,8 @@ public abstract class BaseSiteResourceTestCase {
 
 	@Test
 	public void testGetSitesPageWithPagination() throws Exception {
-		Page<Site> sitesPage = siteResource.getSitesPage(null, null, null);
+		Page<Site> sitesPage = siteResource.getSitesPage(
+			null, null, null, null);
 
 		int totalCount = GetterUtil.getInteger(sitesPage.getTotalCount());
 
@@ -395,7 +397,7 @@ public abstract class BaseSiteResourceTestCase {
 
 		if (totalCount >= (pageSizeLimit - 2)) {
 			Page<Site> page1 = siteResource.getSitesPage(
-				null, null,
+				null, null, null,
 				Pagination.of(
 					(int)Math.ceil((totalCount + 1.0) / pageSizeLimit),
 					pageSizeLimit));
@@ -405,7 +407,7 @@ public abstract class BaseSiteResourceTestCase {
 			assertContains(site1, (List<Site>)page1.getItems());
 
 			Page<Site> page2 = siteResource.getSitesPage(
-				null, null,
+				null, null, null,
 				Pagination.of(
 					(int)Math.ceil((totalCount + 2.0) / pageSizeLimit),
 					pageSizeLimit));
@@ -413,7 +415,7 @@ public abstract class BaseSiteResourceTestCase {
 			assertContains(site2, (List<Site>)page2.getItems());
 
 			Page<Site> page3 = siteResource.getSitesPage(
-				null, null,
+				null, null, null,
 				Pagination.of(
 					(int)Math.ceil((totalCount + 3.0) / pageSizeLimit),
 					pageSizeLimit));
@@ -422,7 +424,7 @@ public abstract class BaseSiteResourceTestCase {
 		}
 		else {
 			Page<Site> page1 = siteResource.getSitesPage(
-				null, null, Pagination.of(1, totalCount + 2));
+				null, null, null, Pagination.of(1, totalCount + 2));
 
 			List<Site> sites1 = (List<Site>)page1.getItems();
 
@@ -430,7 +432,7 @@ public abstract class BaseSiteResourceTestCase {
 				sites1.toString(), totalCount + 2, sites1.size());
 
 			Page<Site> page2 = siteResource.getSitesPage(
-				null, null, Pagination.of(2, totalCount + 2));
+				null, null, null, Pagination.of(2, totalCount + 2));
 
 			Assert.assertEquals(totalCount + 3, page2.getTotalCount());
 
@@ -439,7 +441,7 @@ public abstract class BaseSiteResourceTestCase {
 			Assert.assertEquals(sites2.toString(), 1, sites2.size());
 
 			Page<Site> page3 = siteResource.getSitesPage(
-				null, null, Pagination.of(1, (int)totalCount + 3));
+				null, null, null, Pagination.of(1, (int)totalCount + 3));
 
 			assertContains(site1, (List<Site>)page3.getItems());
 			assertContains(site2, (List<Site>)page3.getItems());
@@ -2551,4 +2553,4 @@ public abstract class BaseSiteResourceTestCase {
 		_siteResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1579821345
+// LIFERAY-REST-BUILDER-HASH:2076733421

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BaseSiteTemplateResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BaseSiteTemplateResourceTestCase.java
@@ -191,7 +191,7 @@ public abstract class BaseSiteTemplateResourceTestCase {
 	@Test
 	public void testGetSiteTemplatesPage() throws Exception {
 		Page<SiteTemplate> page = siteTemplateResource.getSiteTemplatesPage(
-			null, Pagination.of(1, 10));
+			null, null, Pagination.of(1, 10));
 
 		long totalCount = page.getTotalCount();
 
@@ -202,7 +202,7 @@ public abstract class BaseSiteTemplateResourceTestCase {
 			randomSiteTemplate());
 
 		page = siteTemplateResource.getSiteTemplatesPage(
-			null, Pagination.of(1, 10));
+			null, null, Pagination.of(1, 10));
 
 		Assert.assertEquals(totalCount + 2, page.getTotalCount());
 
@@ -223,7 +223,7 @@ public abstract class BaseSiteTemplateResourceTestCase {
 	@Test
 	public void testGetSiteTemplatesPageWithPagination() throws Exception {
 		Page<SiteTemplate> siteTemplatesPage =
-			siteTemplateResource.getSiteTemplatesPage(null, null);
+			siteTemplateResource.getSiteTemplatesPage(null, null, null);
 
 		int totalCount = GetterUtil.getInteger(
 			siteTemplatesPage.getTotalCount());
@@ -244,7 +244,7 @@ public abstract class BaseSiteTemplateResourceTestCase {
 		if (totalCount >= (pageSizeLimit - 2)) {
 			Page<SiteTemplate> page1 =
 				siteTemplateResource.getSiteTemplatesPage(
-					null,
+					null, null,
 					Pagination.of(
 						(int)Math.ceil((totalCount + 1.0) / pageSizeLimit),
 						pageSizeLimit));
@@ -255,7 +255,7 @@ public abstract class BaseSiteTemplateResourceTestCase {
 
 			Page<SiteTemplate> page2 =
 				siteTemplateResource.getSiteTemplatesPage(
-					null,
+					null, null,
 					Pagination.of(
 						(int)Math.ceil((totalCount + 2.0) / pageSizeLimit),
 						pageSizeLimit));
@@ -264,7 +264,7 @@ public abstract class BaseSiteTemplateResourceTestCase {
 
 			Page<SiteTemplate> page3 =
 				siteTemplateResource.getSiteTemplatesPage(
-					null,
+					null, null,
 					Pagination.of(
 						(int)Math.ceil((totalCount + 3.0) / pageSizeLimit),
 						pageSizeLimit));
@@ -274,7 +274,7 @@ public abstract class BaseSiteTemplateResourceTestCase {
 		else {
 			Page<SiteTemplate> page1 =
 				siteTemplateResource.getSiteTemplatesPage(
-					null, Pagination.of(1, totalCount + 2));
+					null, null, Pagination.of(1, totalCount + 2));
 
 			List<SiteTemplate> siteTemplates1 =
 				(List<SiteTemplate>)page1.getItems();
@@ -285,7 +285,7 @@ public abstract class BaseSiteTemplateResourceTestCase {
 
 			Page<SiteTemplate> page2 =
 				siteTemplateResource.getSiteTemplatesPage(
-					null, Pagination.of(2, totalCount + 2));
+					null, null, Pagination.of(2, totalCount + 2));
 
 			Assert.assertEquals(totalCount + 3, page2.getTotalCount());
 
@@ -297,7 +297,7 @@ public abstract class BaseSiteTemplateResourceTestCase {
 
 			Page<SiteTemplate> page3 =
 				siteTemplateResource.getSiteTemplatesPage(
-					null, Pagination.of(1, (int)totalCount + 3));
+					null, null, Pagination.of(1, (int)totalCount + 3));
 
 			assertContains(siteTemplate1, (List<SiteTemplate>)page3.getItems());
 			assertContains(siteTemplate2, (List<SiteTemplate>)page3.getItems());
@@ -1374,4 +1374,4 @@ public abstract class BaseSiteTemplateResourceTestCase {
 		_siteTemplateResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:869651006
+// LIFERAY-REST-BUILDER-HASH:1518444496

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BaseSiteTemplateResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BaseSiteTemplateResourceTestCase.java
@@ -171,6 +171,7 @@ public abstract class BaseSiteTemplateResourceTestCase {
 
 		siteTemplate.setDefaultLanguageId(regex);
 		siteTemplate.setDescription(regex);
+		siteTemplate.setLogo(regex);
 		siteTemplate.setName(regex);
 		siteTemplate.setSiteExternalReferenceCode(regex);
 
@@ -182,6 +183,7 @@ public abstract class BaseSiteTemplateResourceTestCase {
 
 		Assert.assertEquals(regex, siteTemplate.getDefaultLanguageId());
 		Assert.assertEquals(regex, siteTemplate.getDescription());
+		Assert.assertEquals(regex, siteTemplate.getLogo());
 		Assert.assertEquals(regex, siteTemplate.getName());
 		Assert.assertEquals(regex, siteTemplate.getSiteExternalReferenceCode());
 	}
@@ -428,6 +430,14 @@ public abstract class BaseSiteTemplateResourceTestCase {
 				continue;
 			}
 
+			if (Objects.equals("logo", additionalAssertFieldName)) {
+				if (siteTemplate.getLogo() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals("name", additionalAssertFieldName)) {
 				if (siteTemplate.getName() == null) {
 					valid = false;
@@ -639,6 +649,16 @@ public abstract class BaseSiteTemplateResourceTestCase {
 			if (Objects.equals("id", additionalAssertFieldName)) {
 				if (!Objects.deepEquals(
 						siteTemplate1.getId(), siteTemplate2.getId())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("logo", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						siteTemplate1.getLogo(), siteTemplate2.getLogo())) {
 
 					return false;
 				}
@@ -916,6 +936,52 @@ public abstract class BaseSiteTemplateResourceTestCase {
 				"Invalid entity field " + entityFieldName);
 		}
 
+		if (entityFieldName.equals("logo")) {
+			Object object = siteTemplate.getLogo();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
 		if (entityFieldName.equals("name")) {
 			Object object = siteTemplate.getName();
 
@@ -1076,6 +1142,7 @@ public abstract class BaseSiteTemplateResourceTestCase {
 				description = StringUtil.toLowerCase(
 					RandomTestUtil.randomString());
 				id = RandomTestUtil.randomLong();
+				logo = StringUtil.toLowerCase(RandomTestUtil.randomString());
 				name = StringUtil.toLowerCase(RandomTestUtil.randomString());
 				pagesUpdateable = RandomTestUtil.randomBoolean();
 				siteExternalReferenceCode =
@@ -1307,4 +1374,4 @@ public abstract class BaseSiteTemplateResourceTestCase {
 		_siteTemplateResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1396951316
+// LIFERAY-REST-BUILDER-HASH:869651006

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SiteResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SiteResourceTest.java
@@ -176,10 +176,10 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 		super.testGetSitesPage();
 
 		_testGetSitesPageWithActiveAndInactiveSites();
-		_testGetSitesPageWithExcludedExternalReferenceCodes();
 		_testGetSitesPageWithActiveOrSiteGroups(false, true);
 		_testGetSitesPageWithActiveOrSiteGroups(true, false);
 		_testGetSitesPageWithDepotEntry();
+		_testGetSitesPageWithExcludedExternalReferenceCodes();
 		_testGetSitesPageWithInactiveSites();
 		_testGetSitesPageWithoutSiteMembership();
 		_testGetSitesPageWithSearch();
@@ -500,15 +500,15 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 	private void _testGetSitesPageWithExcludedExternalReferenceCodes()
 		throws Exception {
 
-		Site excludedSite = new Site();
+		Site excludedSite = randomSite();
 
-		excludedSite.setName(RandomTestUtil.randomString());
+		excludedSite.setActive(true);
 
 		Site postExcludedSite = _testPostSite_addSite(excludedSite);
 
-		Site includedSite = new Site();
+		Site includedSite = randomSite();
 
-		includedSite.setName(RandomTestUtil.randomString());
+		includedSite.setActive(true);
 
 		Site postIncludedSite = _testPostSite_addSite(includedSite);
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SiteResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SiteResourceTest.java
@@ -176,6 +176,7 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 		super.testGetSitesPage();
 
 		_testGetSitesPageWithActiveAndInactiveSites();
+		_testGetSitesPageWithExcludedExternalReferenceCodes();
 		_testGetSitesPageWithActiveOrSiteGroups(false, true);
 		_testGetSitesPageWithActiveOrSiteGroups(true, false);
 		_testGetSitesPageWithDepotEntry();
@@ -434,7 +435,7 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 		throws Exception {
 
 		Page<Site> page = siteResource.getSitesPage(
-			null, null, Pagination.of(1, 100));
+			null, null, null, Pagination.of(1, 100));
 
 		long totalCount = page.getTotalCount();
 
@@ -444,7 +445,8 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 
 		testGetSitesPage_addSite(site);
 
-		page = siteResource.getSitesPage(null, null, Pagination.of(1, 100));
+		page = siteResource.getSitesPage(
+			null, null, null, Pagination.of(1, 100));
 
 		Assert.assertEquals(totalCount + 1, page.getTotalCount());
 	}
@@ -454,7 +456,7 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 		throws Exception {
 
 		Page<Site> sitesPage = siteResource.getSitesPage(
-			true, null, Pagination.of(1, 100));
+			true, null, null, Pagination.of(1, 100));
 
 		List<Site> originalItems = (List<Site>)sitesPage.getItems();
 
@@ -468,7 +470,7 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 		_groupLocalService.updateGroup(group);
 
 		sitesPage = siteResource.getSitesPage(
-			true, null, Pagination.of(1, 100));
+			true, null, null, Pagination.of(1, 100));
 
 		List<Site> existingItems = (List<Site>)sitesPage.getItems();
 
@@ -477,7 +479,7 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 
 	private void _testGetSitesPageWithDepotEntry() throws Exception {
 		Page<Site> sitesPage = siteResource.getSitesPage(
-			true, null, Pagination.of(1, 100));
+			true, null, null, Pagination.of(1, 100));
 
 		List<Site> originalItems = (List<Site>)sitesPage.getItems();
 
@@ -488,16 +490,57 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 			ServiceContextTestUtil.getServiceContext());
 
 		sitesPage = siteResource.getSitesPage(
-			true, null, Pagination.of(1, 100));
+			true, null, null, Pagination.of(1, 100));
 
 		List<Site> existingItems = (List<Site>)sitesPage.getItems();
 
 		Assert.assertEquals(originalItems, existingItems);
 	}
 
+	private void _testGetSitesPageWithExcludedExternalReferenceCodes()
+		throws Exception {
+
+		Site excludedSite = new Site();
+
+		excludedSite.setName(RandomTestUtil.randomString());
+
+		Site postExcludedSite = _testPostSite_addSite(excludedSite);
+
+		Site includedSite = new Site();
+
+		includedSite.setName(RandomTestUtil.randomString());
+
+		Site postIncludedSite = _testPostSite_addSite(includedSite);
+
+		Page<Site> sitesPage = siteResource.getSitesPage(
+			true, new String[] {postExcludedSite.getExternalReferenceCode()},
+			null, Pagination.of(1, 100));
+
+		boolean excludedSiteFound = false;
+		boolean includedSiteFound = false;
+
+		for (Site site : sitesPage.getItems()) {
+			String externalReferenceCode = site.getExternalReferenceCode();
+
+			if (externalReferenceCode.equals(
+					postExcludedSite.getExternalReferenceCode())) {
+
+				excludedSiteFound = true;
+			}
+			else if (externalReferenceCode.equals(
+						postIncludedSite.getExternalReferenceCode())) {
+
+				includedSiteFound = true;
+			}
+		}
+
+		Assert.assertFalse(excludedSiteFound);
+		Assert.assertTrue(includedSiteFound);
+	}
+
 	private void _testGetSitesPageWithInactiveSites() throws Exception {
 		Page<Site> page = siteResource.getSitesPage(
-			false, null, Pagination.of(1, 100));
+			false, null, null, Pagination.of(1, 100));
 
 		long totalCount = page.getTotalCount();
 
@@ -507,7 +550,8 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 
 		testGetSitesPage_addSite(site1);
 
-		page = siteResource.getSitesPage(false, null, Pagination.of(1, 100));
+		page = siteResource.getSitesPage(
+			false, null, null, Pagination.of(1, 100));
 
 		Assert.assertEquals(totalCount + 1, page.getTotalCount());
 
@@ -524,7 +568,7 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 		SiteResource siteResource = builder.build();
 
 		try {
-			siteResource.getSitesPage(true, null, Pagination.of(1, 1));
+			siteResource.getSitesPage(true, null, null, Pagination.of(1, 1));
 
 			Assert.fail();
 		}
@@ -555,7 +599,7 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 		).build();
 
 		Page<Site> page = siteResource.getSitesPage(
-			null, null, Pagination.of(1, 100));
+			null, null, null, Pagination.of(1, 100));
 
 		Collection<Site> sites = page.getItems();
 
@@ -573,7 +617,7 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 		Site postSite = _testPostSite_addSite(randomSite);
 
 		Page<Site> sitesPage = siteResource.getSitesPage(
-			true, name, Pagination.of(1, 10));
+			true, null, name, Pagination.of(1, 10));
 
 		List<Site> items = (List<Site>)sitesPage.getItems();
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SiteTemplateResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SiteTemplateResourceTest.java
@@ -7,6 +7,8 @@ package com.liferay.headless.admin.site.resource.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.headless.admin.site.client.dto.v1_0.SiteTemplate;
+import com.liferay.headless.admin.site.client.pagination.Page;
+import com.liferay.headless.admin.site.client.pagination.Pagination;
 import com.liferay.portal.kernel.service.LayoutSetPrototypeLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -19,7 +21,10 @@ import com.liferay.portal.test.rule.Inject;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 
+import org.junit.Assert;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
@@ -27,6 +32,14 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 public class SiteTemplateResourceTest extends BaseSiteTemplateResourceTestCase {
+
+	@Override
+	@Test
+	public void testGetSiteTemplatesPage() throws Exception {
+		super.testGetSiteTemplatesPage();
+
+		_testGetSiteTemplatesPageWithExcludedSiteExternalReferenceCodes();
+	}
 
 	@Override
 	protected SiteTemplate randomSiteTemplate() throws Exception {
@@ -79,6 +92,74 @@ public class SiteTemplateResourceTest extends BaseSiteTemplateResourceTestCase {
 			siteTemplate.getPagesUpdateable(), new ServiceContext());
 
 		return siteTemplate;
+	}
+
+	private void _testGetSiteTemplatesPageWithExcludedSiteExternalReferenceCodes()
+		throws Exception {
+
+		SiteTemplate siteTemplate1 = randomSiteTemplate();
+
+		siteTemplate1.setActive(true);
+
+		testGetSiteTemplatesPage_addSiteTemplate(siteTemplate1);
+
+		SiteTemplate siteTemplate2 = randomSiteTemplate();
+
+		siteTemplate2.setActive(true);
+
+		testGetSiteTemplatesPage_addSiteTemplate(siteTemplate2);
+
+		Page<SiteTemplate> siteTemplatesPage =
+			siteTemplateResource.getSiteTemplatesPage(
+				true, null, Pagination.of(1, 100));
+
+		String excludedSiteExternalReferenceCode = null;
+		String includedSiteExternalReferenceCode = null;
+
+		for (SiteTemplate siteTemplate : siteTemplatesPage.getItems()) {
+			if (Objects.equals(
+					siteTemplate1.getName(), siteTemplate.getName())) {
+
+				excludedSiteExternalReferenceCode =
+					siteTemplate.getSiteExternalReferenceCode();
+			}
+			else if (Objects.equals(
+						siteTemplate2.getName(), siteTemplate.getName())) {
+
+				includedSiteExternalReferenceCode =
+					siteTemplate.getSiteExternalReferenceCode();
+			}
+		}
+
+		Assert.assertNotNull(excludedSiteExternalReferenceCode);
+		Assert.assertNotNull(includedSiteExternalReferenceCode);
+
+		Page<SiteTemplate> filteredSiteTemplatesPage =
+			siteTemplateResource.getSiteTemplatesPage(
+				true, new String[] {excludedSiteExternalReferenceCode},
+				Pagination.of(1, 100));
+
+		boolean excludedSiteTemplateFound = false;
+		boolean includedSiteTemplateFound = false;
+
+		for (SiteTemplate siteTemplate : filteredSiteTemplatesPage.getItems()) {
+			String siteExternalReferenceCode =
+				siteTemplate.getSiteExternalReferenceCode();
+
+			if (excludedSiteExternalReferenceCode.equals(
+					siteExternalReferenceCode)) {
+
+				excludedSiteTemplateFound = true;
+			}
+			else if (includedSiteExternalReferenceCode.equals(
+						siteExternalReferenceCode)) {
+
+				includedSiteTemplateFound = true;
+			}
+		}
+
+		Assert.assertFalse(excludedSiteTemplateFound);
+		Assert.assertTrue(includedSiteTemplateFound);
 	}
 
 	@Inject

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SiteTemplateResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SiteTemplateResourceTest.java
@@ -131,9 +131,6 @@ public class SiteTemplateResourceTest extends BaseSiteTemplateResourceTestCase {
 			}
 		}
 
-		Assert.assertNotNull(excludedSiteExternalReferenceCode);
-		Assert.assertNotNull(includedSiteExternalReferenceCode);
-
 		siteTemplatesPage = siteTemplateResource.getSiteTemplatesPage(
 			true, new String[] {excludedSiteExternalReferenceCode},
 			Pagination.of(1, 100));

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SiteTemplateResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SiteTemplateResourceTest.java
@@ -134,15 +134,14 @@ public class SiteTemplateResourceTest extends BaseSiteTemplateResourceTestCase {
 		Assert.assertNotNull(excludedSiteExternalReferenceCode);
 		Assert.assertNotNull(includedSiteExternalReferenceCode);
 
-		Page<SiteTemplate> filteredSiteTemplatesPage =
-			siteTemplateResource.getSiteTemplatesPage(
-				true, new String[] {excludedSiteExternalReferenceCode},
-				Pagination.of(1, 100));
+		siteTemplatesPage = siteTemplateResource.getSiteTemplatesPage(
+			true, new String[] {excludedSiteExternalReferenceCode},
+			Pagination.of(1, 100));
 
 		boolean excludedSiteTemplateFound = false;
 		boolean includedSiteTemplateFound = false;
 
-		for (SiteTemplate siteTemplate : filteredSiteTemplatesPage.getItems()) {
+		for (SiteTemplate siteTemplate : siteTemplatesPage.getItems()) {
 			String siteExternalReferenceCode =
 				siteTemplate.getSiteExternalReferenceCode();
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/types/SiteTemplate.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/types/SiteTemplate.ts
@@ -6,6 +6,7 @@
 export type SiteTemplate = {
 	description?: string;
 	id: string;
+	logo?: string;
 	name: string;
 	siteExternalReferenceCode?: string;
 };

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/spaces/SpaceConnectedSitesModal.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/spaces/SpaceConnectedSitesModal.tsx
@@ -10,7 +10,7 @@ import ClaySticker from '@clayui/sticker';
 import {ItemSelector} from '@liferay/frontend-js-item-selector-web';
 import {openToast} from 'frontend-js-components-web';
 import {sub} from 'frontend-js-web';
-import React, {useEffect, useId, useState} from 'react';
+import React, {useEffect, useId, useMemo, useState} from 'react';
 
 import {InputGroupWithSelect} from '../../common/components/InputGroupWithSelect';
 import ConnectedSiteService from '../../common/services/ConnectedSiteService';
@@ -22,6 +22,10 @@ enum ConnectableKind {
 	SITES = 'sites',
 	SITE_TEMPLATES = 'site-templates',
 }
+
+const SITES_API_URL = `${location.origin}/o/headless-admin-site/v1.0/sites`;
+
+const SITE_TEMPLATES_API_URL = `${location.origin}/o/headless-admin-site/v1.0/site-templates`;
 
 const showErrorMessage = (message: string) => {
 	openToast({
@@ -170,6 +174,45 @@ const ConnectableSelector = ({
 					(kind === ConnectableKind.SITE_TEMPLATES)
 		);
 
+	// The /sites and /site-templates endpoints exclude already-connected items
+	// via repeated query params. Rebuilding the URL when a connection changes
+	// also remounts the ItemSelector (keyed by apiURL), which clears the input
+	// and refetches the autocomplete results.
+
+	const sitesAPIURL = useMemo(() => {
+		const url = new URL(SITES_API_URL);
+
+		url.searchParams.set('active', 'true');
+
+		connections
+			.filter((connection) => !isSiteTemplate(connection))
+			.forEach((connection) =>
+				url.searchParams.append(
+					'excludedExternalReferenceCodes',
+					connection.externalReferenceCode
+				)
+			);
+
+		return url.toString();
+	}, [connections]);
+
+	const siteTemplatesAPIURL = useMemo(() => {
+		const url = new URL(SITE_TEMPLATES_API_URL);
+
+		url.searchParams.set('active', 'true');
+
+		connections
+			.filter((connection) => isSiteTemplate(connection))
+			.forEach((connection) =>
+				url.searchParams.append(
+					'excludedSiteExternalReferenceCodes',
+					connection.externalReferenceCode
+				)
+			);
+
+		return url.toString();
+	}, [connections]);
+
 	const resetSelection = () => {
 		setSite(undefined);
 		setSiteTemplate(undefined);
@@ -256,10 +299,10 @@ const ConnectableSelector = ({
 				>
 					{kind === ConnectableKind.SITES ? (
 						<ItemSelector
-							apiURL={`${location.origin}/o/headless-admin-site/v1.0/sites?active=true`}
+							apiURL={sitesAPIURL}
 							id="connectableSelector"
 							items={site ? [site] : []}
-							key="sites"
+							key={sitesAPIURL}
 							onItemsChange={(items: Site[]) => {
 								if (items.length) {
 									const item = items[0];
@@ -279,11 +322,24 @@ const ConnectableSelector = ({
 						>
 							{(item: Site) => (
 								<ItemSelector.Item
+									className="align-items-center d-flex"
 									key={item.id}
 									textValue={Liferay.Util.escapeHTML(
 										item.descriptiveName
 									)}
 								>
+									<ClaySticker
+										className="c-mr-2"
+										displayType="secondary"
+										shape="circle"
+										size="sm"
+									>
+										<ClaySticker.Image
+											alt=""
+											src={item.logo}
+										/>
+									</ClaySticker>
+
 									{Liferay.Util.escapeHTML(
 										item.descriptiveName
 									)}
@@ -292,10 +348,10 @@ const ConnectableSelector = ({
 						</ItemSelector>
 					) : (
 						<ItemSelector
-							apiURL={`${location.origin}/o/headless-admin-site/v1.0/site-templates?active=true`}
+							apiURL={siteTemplatesAPIURL}
 							id="connectableSelector"
 							items={siteTemplate ? [siteTemplate] : []}
-							key="site-templates"
+							key={siteTemplatesAPIURL}
 							onItemsChange={(items: SiteTemplate[]) => {
 								if (items.length) {
 									const item = items[0];
@@ -318,11 +374,24 @@ const ConnectableSelector = ({
 						>
 							{(item: SiteTemplate) => (
 								<ItemSelector.Item
+									className="align-items-center d-flex"
 									key={item.id}
 									textValue={Liferay.Util.escapeHTML(
 										item.name
 									)}
 								>
+									<ClaySticker
+										className="c-mr-2"
+										displayType="secondary"
+										shape="circle"
+										size="sm"
+									>
+										<ClaySticker.Image
+											alt=""
+											src={item.logo}
+										/>
+									</ClaySticker>
+
 									{Liferay.Util.escapeHTML(item.name)}
 								</ItemSelector.Item>
 							)}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/spaces/SpaceConnectedSitesModal.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/spaces/SpaceConnectedSitesModal.tsx
@@ -174,11 +174,6 @@ const ConnectableSelector = ({
 					(kind === ConnectableKind.SITE_TEMPLATES)
 		);
 
-	// The /sites and /site-templates endpoints exclude already-connected items
-	// via repeated query params. Rebuilding the URL when a connection changes
-	// also remounts the ItemSelector (keyed by apiURL), which clears the input
-	// and refetches the autocomplete results.
-
 	const sitesAPIURL = useMemo(() => {
 		const url = new URL(SITES_API_URL);
 

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/spaces/SpaceConnectedSitesModal.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/spaces/SpaceConnectedSitesModal.test.tsx
@@ -290,6 +290,31 @@ describe('SpaceConnectedSitesModal', () => {
 			).toBeInTheDocument();
 		});
 
+		it('renders the site logo in the autocomplete options', async () => {
+			mockFetch.mockImplementation(async () => {
+				return {
+					headers: new Headers([
+						['Content-Type', 'application/json'],
+					]),
+					json: async () => ({items: [mockUnconnectedSite]}),
+				} as Response;
+			});
+
+			renderComponent();
+			await waitForComponentRendering();
+
+			await userEvent.click(screen.getByPlaceholderText('select-a-site'));
+
+			const option = await screen.findByRole('option', {
+				name: mockUnconnectedSite.descriptiveName,
+			});
+
+			expect(option.querySelector('img')).toHaveAttribute(
+				'src',
+				mockUnconnectedSite.logo
+			);
+		});
+
 		it('shows an error toast if connecting a site fails', async () => {
 			mockFetch.mockImplementation(async () => {
 				return {
@@ -505,7 +530,7 @@ describe('SpaceConnectedSitesModal', () => {
 
 			await waitFor(() => {
 				const sitesURLs = mockFetch.mock.calls
-					.map((call) => String(call[0]))
+					.map((call: unknown[]) => String(call[0]))
 					.filter((url) => url.includes('/sites'));
 
 				expect(
@@ -550,7 +575,7 @@ describe('SpaceConnectedSitesModal', () => {
 
 			await waitFor(() => {
 				const siteTemplatesURLs = mockFetch.mock.calls
-					.map((call) => String(call[0]))
+					.map((call: unknown[]) => String(call[0]))
 					.filter((url) => url.includes('/site-templates'));
 
 				expect(

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/spaces/SpaceConnectedSitesModal.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/spaces/SpaceConnectedSitesModal.test.tsx
@@ -488,6 +488,81 @@ describe('SpaceConnectedSitesModal', () => {
 			).toBeDisabled();
 		});
 
+		it('excludes already-connected sites from the autocomplete request', async () => {
+			mockFetch.mockImplementation(async () => {
+				return {
+					headers: new Headers([
+						['Content-Type', 'application/json'],
+					]),
+					json: async () => ({items: []}),
+				} as Response;
+			});
+
+			renderComponent();
+			await waitForComponentRendering();
+
+			await userEvent.click(screen.getByPlaceholderText('select-a-site'));
+
+			await waitFor(() => {
+				const sitesURLs = mockFetch.mock.calls
+					.map((call) => String(call[0]))
+					.filter((url) => url.includes('/sites'));
+
+				expect(
+					sitesURLs.some(
+						(url) =>
+							url.includes('excludedExternalReferenceCodes=1') &&
+							url.includes('excludedExternalReferenceCodes=2')
+					)
+				).toBe(true);
+			});
+		});
+
+		it('excludes already-connected site templates from the autocomplete request', async () => {
+			mockGetConnectedSitesFromSpace.mockResolvedValue({
+				data: {items: [mockConnectedSiteTemplate]},
+				error: null,
+			});
+
+			mockFetch.mockImplementation(async () => {
+				return {
+					headers: new Headers([
+						['Content-Type', 'application/json'],
+					]),
+					json: async () => ({items: []}),
+				} as Response;
+			});
+
+			renderComponent();
+
+			await screen.findByText(
+				`${mockConnectedSiteTemplate.descriptiveName} (site-template)`
+			);
+
+			await userEvent.selectOptions(
+				screen.getByLabelText('sites'),
+				'site-templates'
+			);
+
+			await userEvent.click(
+				screen.getByPlaceholderText('select-a-site-template')
+			);
+
+			await waitFor(() => {
+				const siteTemplatesURLs = mockFetch.mock.calls
+					.map((call) => String(call[0]))
+					.filter((url) => url.includes('/site-templates'));
+
+				expect(
+					siteTemplatesURLs.some((url) =>
+						url.includes(
+							`excludedSiteExternalReferenceCodes=${mockConnectedSiteTemplate.externalReferenceCode}`
+						)
+					)
+				).toBe(true);
+			});
+		});
+
 		it('switches the autocomplete placeholder when toggled to site templates', async () => {
 			renderComponent();
 			await waitForComponentRendering();

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/connectSiteTemplates.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/connectSiteTemplates.spec.ts
@@ -317,12 +317,7 @@ test(
 			.getByText(templateLabel(connectedTemplateName), {exact: true})
 			.waitFor();
 
-		// The input clears after connecting.
-
 		await expect(siteTemplateAutocomplete).toHaveValue('');
-
-		// The connected template is no longer offered, but the other one still
-		// is.
 
 		await siteTemplateAutocomplete.click();
 
@@ -332,9 +327,6 @@ test(
 		await expect(
 			page.getByRole('option', {exact: true, name: connectedTemplateName})
 		).toHaveCount(0);
-
-		// The connected site is excluded from the sites autocomplete, which
-		// uses a separate query param.
 
 		await page.getByLabel('Sites', {exact: true}).selectOption('sites');
 

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/connectSiteTemplates.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/connectSiteTemplates.spec.ts
@@ -14,6 +14,7 @@ import {
 	performLogout,
 	userData,
 } from '../../../../utils/performLogin';
+import {waitForAlert} from '../../../../utils/waitForAlert';
 import {cmsPagesTest} from '../fixtures/cmsPagesTest';
 
 const test = mergeTests(

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/connectSiteTemplates.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/connectSiteTemplates.spec.ts
@@ -255,3 +255,95 @@ test(
 		).toBeVisible();
 	}
 );
+
+test(
+	'Excludes already-connected sites and site templates from the autocomplete and clears the input',
+	{tag: '@LPD-91266'},
+	async ({apiHelpers, page, spaceSummaryPage}) => {
+		const spaceName = `Space ${getRandomString()}`;
+		const connectedTemplateName = `Site Template ${getRandomString()}`;
+		const otherTemplateName = `Site Template ${getRandomString()}`;
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			settings: {logoColor: 'outline-3'},
+			type: 'Space',
+		});
+
+		for (const name of [connectedTemplateName, otherTemplateName]) {
+			const layoutSetPrototype =
+				await apiHelpers.jsonWebServicesLayoutSetPrototype.addLayoutSetPrototypes(
+					{name}
+				);
+
+			apiHelpers.data.push({
+				id: layoutSetPrototype.layoutSetPrototypeId,
+				type: 'layoutSetPrototype',
+			});
+		}
+
+		await apiHelpers.headlessAssetLibrary.connectSite(
+			space.externalReferenceCode,
+			'L_GLOBAL'
+		);
+
+		await spaceSummaryPage.goto(spaceName);
+
+		await spaceSummaryPage.openConnectedSitesModal();
+
+		await page
+			.getByLabel('Sites', {exact: true})
+			.selectOption('site-templates');
+
+		const siteTemplateAutocomplete = page.getByPlaceholder(
+			'Select a Site Template',
+			{exact: true}
+		);
+
+		await siteTemplateAutocomplete.click();
+		await page
+			.getByRole('option', {exact: true, name: connectedTemplateName})
+			.click();
+		await page.getByRole('button', {exact: true, name: 'Connect'}).click();
+
+		await waitForAlert(
+			page,
+			`Success:Site template ${connectedTemplateName} was successfully connected to the space.`,
+			{autoClose: false}
+		);
+
+		await page
+			.getByLabel('Connected Sites')
+			.getByText(templateLabel(connectedTemplateName), {exact: true})
+			.waitFor();
+
+		// The input clears after connecting.
+
+		await expect(siteTemplateAutocomplete).toHaveValue('');
+
+		// The connected template is no longer offered, but the other one still
+		// is.
+
+		await siteTemplateAutocomplete.click();
+
+		await expect(
+			page.getByRole('option', {exact: true, name: otherTemplateName})
+		).toBeVisible();
+		await expect(
+			page.getByRole('option', {exact: true, name: connectedTemplateName})
+		).toHaveCount(0);
+
+		// The connected site is excluded from the sites autocomplete, which
+		// uses a separate query param.
+
+		await page.getByLabel('Sites', {exact: true}).selectOption('sites');
+
+		await page.getByPlaceholder('Select a Site', {exact: true}).click();
+
+		await page.getByRole('option').first().waitFor();
+
+		await expect(
+			page.getByRole('option', {exact: true, name: 'Global'})
+		).toHaveCount(0);
+	}
+);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91266

## What Is Being Fixed

The connect-sites autocomplete listed sites and site templates that were already connected, and it did not surface their logos — making the picker harder to scan and allowing duplicate connections.

## How It Is Being Fixed

The Site and SiteTemplate REST schemas gained a logo field populated from the group logo URL, built against the context company so the URLs resolve correctly. The list endpoints accept excluded reference code filters, so already-connected sites and site templates are dropped from the results via ListUtil.filter. The autocomplete now renders the logos and excludes connected items, with functional coverage added for the exclusion. The remaining commits reuse the site templates page variable and align the test with conventions, including removing redundant null assertions already guaranteed by later dereferences.

## PR Check

**pr-check: SKIPPED** — Branch passed CI on PR #175952; the only change since is a 3-line test cleanup addressing review feedback, with no production code touched.

<!-- pr-check {"reason": "Branch passed CI on PR #175952; the only change since is a 3-line test cleanup addressing review feedback, with no production code touched.", "result": "skipped", "sha": "7f73bf4c7447ef32f645c98aea0724aacbc9688e"} -->
