### PR TITLE
LPD-93912 Update Recent Assets section test for breadcrumb props

### DIFF
--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewHomeRecentAssetsFilesSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewHomeRecentAssetsFilesSectionDisplayContextTest.java
@@ -13,6 +13,9 @@ import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu;
 import com.liferay.object.constants.ObjectFolderConstants;
 import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.test.AssertUtils;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -59,7 +62,19 @@ public class ViewHomeRecentAssetsFilesSectionDisplayContextTest
 
 		baseAdditionalProps.remove("additionalAPIURLParameters");
 
+		baseAdditionalProps.put("breadcrumbProps", _getBreadcrumbProps());
+
 		return baseAdditionalProps;
+	}
+
+	@Override
+	@Test
+	public void testGetBreadcrumbProps() throws Exception {
+		AssertUtils.assertEquals(
+			_getBreadcrumbProps(),
+			ReflectionTestUtil.invoke(
+				getSectionDisplayContext(getMockHttpServletRequest()),
+				"getBreadcrumbProps", new Class<?>[0]));
 	}
 
 	@Override
@@ -238,6 +253,22 @@ public class ViewHomeRecentAssetsFilesSectionDisplayContextTest
 		Assert.assertNotNull(viewHomeRecentAssetsSectionDisplayContext);
 
 		return viewHomeRecentAssetsSectionDisplayContext;
+	}
+
+	private Map<String, Object> _getBreadcrumbProps() {
+		return HashMapBuilder.<String, Object>put(
+			"breadcrumbItems",
+			JSONUtil.putAll(
+				JSONUtil.put(
+					"active", false
+				).put(
+					"href", (String)null
+				).put(
+					"label", "All"
+				))
+		).put(
+			"hideSpace", true
+		).build();
 	}
 
 	@Inject(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93912

## What Is Being Fixed

The `ViewHomeRecentAssetsFilesSectionDisplayContextTest` integration test has been failing on the CMS team routine since the 2026-06-04 build — both `testGetAdditionalProps` and `testGetBreadcrumbProps`. Commit `e038b59` ("LPD-93228 Pass breadcrumb props to the Recent Assets section") added a `getAdditionalProps` override that injects a `breadcrumbProps` entry and a `getBreadcrumbProps` override that builds the breadcrumb from the `/all` layout instead of the current layout. The inherited test expectations were never updated for that contract change, so both assertions started failing.

## How It Is Being Fixed

Update the test expectations to match the section's intended behavior: `getBaseAdditionalProps` now includes the `breadcrumbProps` entry that the production `getAdditionalProps` adds, and a `testGetBreadcrumbProps` override expects the "All" breadcrumb (from the `/all` layout) the section now produces, rather than the inherited current-layout breadcrumb. This mirrors the existing pattern in `ViewAllSectionDisplayContextTest`. The full `ViewHomeRecentAssetsFilesSectionDisplayContextTest` now passes (7/7).

## PR Check

**pr-check: PASS** — tested on `3329ba5a808623e54b687d8f6b31ca91ef001feb`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Deploy | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "3329ba5a808623e54b687d8f6b31ca91ef001feb"} -->