### PR TITLE
LPD-91035 Space setting "Trash entries max age" should handle days

### DIFF
--- a/modules/apps/depot/depot-service/bnd.bnd
+++ b/modules/apps/depot/depot-service/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Depot Service
 Bundle-SymbolicName: com.liferay.depot.service
 Bundle-Version: 3.0.86
-Liferay-Require-SchemaVersion: 2.3.0
+Liferay-Require-SchemaVersion: 2.4.0
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/upgrade/registry/DepotServiceUpgradeStepRegistrator.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/upgrade/registry/DepotServiceUpgradeStepRegistrator.java
@@ -7,11 +7,15 @@ package com.liferay.depot.internal.upgrade.registry;
 
 import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.internal.upgrade.v2_2_0.util.DepotEntryPinTable;
+import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.upgrade.CTModelUpgradeProcess;
 import com.liferay.portal.kernel.upgrade.UpgradeProcessFactory;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Alejandro Tardín
@@ -56,6 +60,22 @@ public class DepotServiceUpgradeStepRegistrator
 			UpgradeProcessFactory.runSQL(
 				"update DepotEntryGroupRel set type_ = " +
 					DepotConstants.TYPE_ASSET_LIBRARY));
+
+		registry.register(
+			"2.3.0", "2.4.0",
+			new com.liferay.depot.internal.upgrade.v2_4_0.
+				TrashEntriesMaxAgeUpgradeProcess(
+					_companyLocalService, _depotEntryLocalService,
+					_groupLocalService));
 	}
+
+	@Reference
+	private CompanyLocalService _companyLocalService;
+
+	@Reference
+	private DepotEntryLocalService _depotEntryLocalService;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
 
 }

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/upgrade/v2_4_0/TrashEntriesMaxAgeUpgradeProcess.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/upgrade/v2_4_0/TrashEntriesMaxAgeUpgradeProcess.java
@@ -1,0 +1,105 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.depot.internal.upgrade.v2_4_0;
+
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.PrefsPropsUtil;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.util.List;
+
+/**
+ * @author Alicia García
+ */
+public class TrashEntriesMaxAgeUpgradeProcess extends UpgradeProcess {
+
+	public TrashEntriesMaxAgeUpgradeProcess(
+		CompanyLocalService companyLocalService,
+		DepotEntryLocalService depotEntryLocalService,
+		GroupLocalService groupLocalService) {
+
+		_companyLocalService = companyLocalService;
+		_depotEntryLocalService = depotEntryLocalService;
+		_groupLocalService = groupLocalService;
+	}
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		_companyLocalService.forEachCompanyId(
+			companyId -> {
+				int trashEntriesMaxAgeCompany = PrefsPropsUtil.getInteger(
+					companyId, PropsKeys.TRASH_ENTRIES_MAX_AGE,
+					PropsValues.TRASH_ENTRIES_MAX_AGE);
+
+				if (trashEntriesMaxAgeCompany <= 0) {
+					return;
+				}
+
+				List<DepotEntry> depotEntries =
+					_depotEntryLocalService.getDepotEntries(
+						companyId, DepotConstants.TYPE_SPACE);
+
+				for (DepotEntry depotEntry : depotEntries) {
+					Group group = _groupLocalService.fetchGroup(
+						depotEntry.getGroupId());
+
+					if (group == null) {
+						continue;
+					}
+
+					_updateTrashEntriesMaxAge(group, trashEntriesMaxAgeCompany);
+				}
+			});
+	}
+
+	private void _updateTrashEntriesMaxAge(
+			Group group, int trashEntriesMaxAgeCompany)
+		throws Exception {
+
+		UnicodeProperties typeSettingsUnicodeProperties =
+			group.getTypeSettingsProperties();
+
+		String trashEntriesMaxAgeGroup =
+			typeSettingsUnicodeProperties.getProperty("trashEntriesMaxAge");
+
+		if (Validator.isNotNull(trashEntriesMaxAgeGroup) &&
+			(GetterUtil.getInteger(trashEntriesMaxAgeGroup) > 0)) {
+
+			return;
+		}
+
+		typeSettingsUnicodeProperties.setProperty(
+			"trashEntriesMaxAge", String.valueOf(trashEntriesMaxAgeCompany));
+
+		_groupLocalService.updateGroup(
+			group.getGroupId(), typeSettingsUnicodeProperties.toString());
+
+		if (_log.isDebugEnabled()) {
+			_log.debug(
+				"Set trash entries max age for group ID " + group.getGroupId());
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		TrashEntriesMaxAgeUpgradeProcess.class);
+
+	private final CompanyLocalService _companyLocalService;
+	private final DepotEntryLocalService _depotEntryLocalService;
+	private final GroupLocalService _groupLocalService;
+
+}

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/upgrade/v2_4_0/TrashEntriesMaxAgeUpgradeProcess.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/upgrade/v2_4_0/TrashEntriesMaxAgeUpgradeProcess.java
@@ -8,6 +8,9 @@ package com.liferay.depot.internal.upgrade.v2_4_0;
 import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
+import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
@@ -19,9 +22,6 @@ import com.liferay.portal.kernel.util.PrefsPropsUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.UnicodeProperties;
-import com.liferay.portal.kernel.util.Validator;
-
-import java.util.List;
 
 /**
  * @author Alicia García
@@ -42,49 +42,56 @@ public class TrashEntriesMaxAgeUpgradeProcess extends UpgradeProcess {
 	protected void doUpgrade() throws Exception {
 		_companyLocalService.forEachCompanyId(
 			companyId -> {
-				int trashEntriesMaxAgeCompany = PrefsPropsUtil.getInteger(
+				int trashEntriesMaxAge = PrefsPropsUtil.getInteger(
 					companyId, PropsKeys.TRASH_ENTRIES_MAX_AGE,
 					PropsValues.TRASH_ENTRIES_MAX_AGE);
 
-				if (trashEntriesMaxAgeCompany <= 0) {
+				if (trashEntriesMaxAge <= 0) {
 					return;
 				}
 
-				List<DepotEntry> depotEntries =
-					_depotEntryLocalService.getDepotEntries(
-						companyId, DepotConstants.TYPE_SPACE);
+				ActionableDynamicQuery actionableDynamicQuery =
+					_depotEntryLocalService.getActionableDynamicQuery();
 
-				for (DepotEntry depotEntry : depotEntries) {
-					Group group = _groupLocalService.fetchGroup(
-						depotEntry.getGroupId());
+				actionableDynamicQuery.setAddCriteriaMethod(
+					dynamicQuery -> dynamicQuery.add(
+						PropertyFactoryUtil.forName(
+							"type"
+						).eq(
+							DepotConstants.TYPE_SPACE
+						)));
+				actionableDynamicQuery.setCompanyId(companyId);
+				actionableDynamicQuery.setPerformActionMethod(
+					(DepotEntry depotEntry) -> {
+						Group group = _groupLocalService.fetchGroup(
+							depotEntry.getGroupId());
 
-					if (group == null) {
-						continue;
-					}
+						if (group == null) {
+							return;
+						}
 
-					_updateTrashEntriesMaxAge(group, trashEntriesMaxAgeCompany);
-				}
+						_updateTrashEntriesMaxAge(group, trashEntriesMaxAge);
+					});
+
+				actionableDynamicQuery.performActions();
 			});
 	}
 
-	private void _updateTrashEntriesMaxAge(
-			Group group, int trashEntriesMaxAgeCompany)
-		throws Exception {
+	private void _updateTrashEntriesMaxAge(Group group, int trashEntriesMaxAge)
+		throws PortalException {
 
 		UnicodeProperties typeSettingsUnicodeProperties =
 			group.getTypeSettingsProperties();
 
-		String trashEntriesMaxAgeGroup =
-			typeSettingsUnicodeProperties.getProperty("trashEntriesMaxAge");
+		int currentTrashEntriesMaxAge = GetterUtil.getInteger(
+			typeSettingsUnicodeProperties.getProperty("trashEntriesMaxAge"));
 
-		if (Validator.isNotNull(trashEntriesMaxAgeGroup) &&
-			(GetterUtil.getInteger(trashEntriesMaxAgeGroup) > 0)) {
-
+		if (currentTrashEntriesMaxAge > 0) {
 			return;
 		}
 
 		typeSettingsUnicodeProperties.setProperty(
-			"trashEntriesMaxAge", String.valueOf(trashEntriesMaxAgeCompany));
+			"trashEntriesMaxAge", String.valueOf(trashEntriesMaxAge));
 
 		_groupLocalService.updateGroup(
 			group.getGroupId(), typeSettingsUnicodeProperties.toString());

--- a/modules/apps/depot/depot-test/build.gradle
+++ b/modules/apps/depot/depot-test/build.gradle
@@ -22,8 +22,10 @@ dependencies {
 	testIntegrationImplementation project(":apps:portal-search:portal-search-test-util")
 	testIntegrationImplementation project(":apps:portal-search:portal-search-web-api")
 	testIntegrationImplementation project(":apps:portal-vulcan:portal-vulcan-api")
+	testIntegrationImplementation project(":apps:portal:portal-upgrade-test-util")
 	testIntegrationImplementation project(":apps:site:site-api")
 	testIntegrationImplementation project(":apps:site:site-memberships-api")
 	testIntegrationImplementation project(":apps:staging:staging-api")
+	testIntegrationImplementation project(":apps:static:portal:portal-upgrade-api")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/upgrade/v2_4_0/test/TrashEntriesMaxAgeUpgradeProcessTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/upgrade/v2_4_0/test/TrashEntriesMaxAgeUpgradeProcessTest.java
@@ -1,0 +1,188 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.depot.internal.upgrade.v2_4_0.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.portal.kernel.cache.MultiVMPool;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PrefsPropsUtil;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Alicia García
+ */
+@RunWith(Arquillian.class)
+public class TrashEntriesMaxAgeUpgradeProcessTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Test
+	@TestInfo("LPD-91035")
+	public void testUpgrade() throws Exception {
+		_testUpgradeWithAssetLibraryDepotEntry();
+		_testUpgradeWithCustomMaxAge();
+		_testUpgradeWithMissingMaxAge();
+		_testUpgradeWithZeroMaxAge();
+	}
+
+	private DepotEntry _addDepotEntry(int type) throws Exception {
+		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
+			Collections.singletonMap(
+				LocaleUtil.US, RandomTestUtil.randomString()),
+			Collections.singletonMap(
+				LocaleUtil.US, RandomTestUtil.randomString()),
+			type, ServiceContextTestUtil.getServiceContext());
+
+		_depotEntries.add(depotEntry);
+
+		return depotEntry;
+	}
+
+	private int _getTrashEntriesMaxAgeCompany() throws Exception {
+		return PrefsPropsUtil.getInteger(
+			TestPropsValues.getCompanyId(), PropsKeys.TRASH_ENTRIES_MAX_AGE,
+			PropsValues.TRASH_ENTRIES_MAX_AGE);
+	}
+
+	private String _getTrashEntriesMaxAgeGroup(DepotEntry depotEntry) {
+		Group group = _groupLocalService.fetchGroup(depotEntry.getGroupId());
+
+		UnicodeProperties typeSettingsUnicodeProperties =
+			group.getTypeSettingsProperties();
+
+		return typeSettingsUnicodeProperties.getProperty("trashEntriesMaxAge");
+	}
+
+	private void _runUpgradeProcess() throws Exception {
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				_CLASS_NAME, LoggerTestUtil.OFF)) {
+
+			UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
+				_upgradeStepRegistrator, _CLASS_NAME);
+
+			upgradeProcess.upgrade();
+
+			_multiVMPool.clear();
+		}
+	}
+
+	private void _setTrashEntriesMaxAgeGroup(
+			DepotEntry depotEntry, String trashEntriesMaxAge)
+		throws Exception {
+
+		Group group = _groupLocalService.fetchGroup(depotEntry.getGroupId());
+
+		UnicodeProperties typeSettingsUnicodeProperties =
+			group.getTypeSettingsProperties();
+
+		typeSettingsUnicodeProperties.setProperty(
+			"trashEntriesMaxAge", trashEntriesMaxAge);
+
+		_groupLocalService.updateGroup(
+			group.getGroupId(), typeSettingsUnicodeProperties.toString());
+	}
+
+	private void _testUpgradeWithAssetLibraryDepotEntry() throws Exception {
+		DepotEntry depotEntry = _addDepotEntry(
+			DepotConstants.TYPE_ASSET_LIBRARY);
+
+		_setTrashEntriesMaxAgeGroup(depotEntry, "0");
+
+		_runUpgradeProcess();
+
+		Assert.assertEquals("0", _getTrashEntriesMaxAgeGroup(depotEntry));
+	}
+
+	private void _testUpgradeWithCustomMaxAge() throws Exception {
+		DepotEntry depotEntry = _addDepotEntry(DepotConstants.TYPE_SPACE);
+
+		_setTrashEntriesMaxAgeGroup(depotEntry, "1440");
+
+		_runUpgradeProcess();
+
+		Assert.assertEquals("1440", _getTrashEntriesMaxAgeGroup(depotEntry));
+	}
+
+	private void _testUpgradeWithMissingMaxAge() throws Exception {
+		DepotEntry depotEntry = _addDepotEntry(DepotConstants.TYPE_SPACE);
+
+		_runUpgradeProcess();
+
+		Assert.assertEquals(
+			String.valueOf(_getTrashEntriesMaxAgeCompany()),
+			_getTrashEntriesMaxAgeGroup(depotEntry));
+	}
+
+	private void _testUpgradeWithZeroMaxAge() throws Exception {
+		DepotEntry depotEntry = _addDepotEntry(DepotConstants.TYPE_SPACE);
+
+		_setTrashEntriesMaxAgeGroup(depotEntry, "0");
+
+		_runUpgradeProcess();
+
+		Assert.assertEquals(
+			String.valueOf(_getTrashEntriesMaxAgeCompany()),
+			_getTrashEntriesMaxAgeGroup(depotEntry));
+	}
+
+	private static final String _CLASS_NAME =
+		"com.liferay.depot.internal.upgrade.v2_4_0." +
+			"TrashEntriesMaxAgeUpgradeProcess";
+
+	@DeleteAfterTestRun
+	private final List<DepotEntry> _depotEntries = new ArrayList<>();
+
+	@Inject
+	private DepotEntryLocalService _depotEntryLocalService;
+
+	@Inject
+	private GroupLocalService _groupLocalService;
+
+	@Inject
+	private MultiVMPool _multiVMPool;
+
+	@Inject(
+		filter = "component.name=com.liferay.depot.internal.upgrade.registry.DepotServiceUpgradeStepRegistrator"
+	)
+	private UpgradeStepRegistrator _upgradeStepRegistrator;
+
+}

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/dto/v1_0/converter/AssetLibraryDTOConverter.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/dto/v1_0/converter/AssetLibraryDTOConverter.java
@@ -26,6 +26,9 @@ import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.PrefsPropsUtil;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
@@ -224,8 +227,20 @@ public class AssetLibraryDTOConverter
 					() -> GetterUtil.getBoolean(
 						unicodeProperties.get("trashEnabled"), true));
 				setTrashEntriesMaxAge(
-					() -> GetterUtil.getInteger(
-						unicodeProperties.getProperty("trashEntriesMaxAge")));
+					() -> {
+						int trashEntriesMaxAge = GetterUtil.getInteger(
+							unicodeProperties.getProperty(
+								"trashEntriesMaxAge"));
+
+						if (trashEntriesMaxAge > 0) {
+							return trashEntriesMaxAge;
+						}
+
+						return PrefsPropsUtil.getInteger(
+							group.getCompanyId(),
+							PropsKeys.TRASH_ENTRIES_MAX_AGE,
+							PropsValues.TRASH_ENTRIES_MAX_AGE);
+					});
 				setUseCustomLanguages(
 					() -> !GetterUtil.getBoolean(
 						unicodeProperties.get("inheritLocales")));

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/AssetLibraryResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/AssetLibraryResourceTest.java
@@ -36,6 +36,9 @@ import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PrefsPropsUtil;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.odata.entity.EntityField;
@@ -191,6 +194,7 @@ public class AssetLibraryResourceTest extends BaseAssetLibraryResourceTestCase {
 		_testPostAssetLibrary(new MimeTypeLimit[0]);
 		_testPostAssetLibraryWithDuplicateExternalReferenceCode();
 		_testPostAssetLibraryWithExternalReferenceCode();
+		_testPostAssetLibraryWithMissingTrashEntriesMaxAge();
 		_testPostAssetLibraryWithNoSettings();
 
 		AssetLibrary randomAssetLibrary = randomAssetLibrary();
@@ -796,6 +800,28 @@ public class AssetLibraryResourceTest extends BaseAssetLibraryResourceTestCase {
 		Assert.assertNotNull(
 			_groupLocalService.fetchGroupByExternalReferenceCode(
 				externalReferenceCode, testCompany.getCompanyId()));
+	}
+
+	private void _testPostAssetLibraryWithMissingTrashEntriesMaxAge()
+		throws Exception {
+
+		AssetLibrary randomAssetLibrary = randomAssetLibrary();
+
+		randomAssetLibrary.setSettings(new Settings());
+		randomAssetLibrary.setType(AssetLibrary.Type.SPACE);
+
+		AssetLibrary postedAssetLibrary = assetLibraryResource.postAssetLibrary(
+			randomAssetLibrary);
+
+		Settings settings = postedAssetLibrary.getSettings();
+
+		Assert.assertEquals(
+			Integer.valueOf(
+				PrefsPropsUtil.getInteger(
+					TestPropsValues.getCompanyId(),
+					PropsKeys.TRASH_ENTRIES_MAX_AGE,
+					PropsValues.TRASH_ENTRIES_MAX_AGE)),
+			settings.getTrashEntriesMaxAge());
 	}
 
 	private void _testPostAssetLibraryWithNoSettings() throws Exception {

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/AssetLibraryResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/AssetLibraryResourceTest.java
@@ -816,12 +816,10 @@ public class AssetLibraryResourceTest extends BaseAssetLibraryResourceTestCase {
 		Settings settings = postedAssetLibrary.getSettings();
 
 		Assert.assertEquals(
-			Integer.valueOf(
-				PrefsPropsUtil.getInteger(
-					TestPropsValues.getCompanyId(),
-					PropsKeys.TRASH_ENTRIES_MAX_AGE,
-					PropsValues.TRASH_ENTRIES_MAX_AGE)),
-			settings.getTrashEntriesMaxAge());
+			PrefsPropsUtil.getInteger(
+				TestPropsValues.getCompanyId(), PropsKeys.TRASH_ENTRIES_MAX_AGE,
+				PropsValues.TRASH_ENTRIES_MAX_AGE),
+			(int)settings.getTrashEntriesMaxAge());
 	}
 
 	private void _testPostAssetLibraryWithNoSettings() throws Exception {

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/components/forms/validations.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/components/forms/validations.ts
@@ -41,6 +41,24 @@ const maxLength =
 		}
 	};
 
+const minValue =
+	(min: number): ValidationFunction =>
+	(value) => {
+		if (
+			value !== '' &&
+			value !== undefined &&
+			value !== null &&
+			Number(value) < min
+		) {
+			return sub(
+				Liferay.Language.get(
+					'please-enter-a-value-greater-than-or-equal-to-x'
+				),
+				min
+			);
+		}
+	};
+
 const notNull: ValidationFunction = (value) => {
 	if (value === 'null') {
 		return Liferay.Language.get('name-cannot-be-null');
@@ -102,6 +120,7 @@ export {
 	alphanumeric,
 	invalidCharacters,
 	maxLength,
+	minValue,
 	notNull,
 	nonNumeric,
 	required,

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/spaces/SpaceGeneralSettings.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/spaces/SpaceGeneralSettings.tsx
@@ -16,6 +16,7 @@ import {
 	Errors,
 	invalidCharacters,
 	maxLength,
+	minValue,
 	nonNumeric,
 	notNull,
 	required,
@@ -28,6 +29,8 @@ import {ERC_MAX_LENGTH} from '../../common/utils/constants';
 import focusInvalidElement from '../../common/utils/focusInvalidElement';
 import SpaceBaseFields from './SpaceBaseFields';
 import SpacePanel from './SpacePanel';
+
+const MINUTES_PER_DAY = 1440;
 
 export default function SpaceGeneralSettings({
 	backURL,
@@ -67,7 +70,9 @@ export default function SpaceGeneralSettings({
 			sharingEnabled: space.settings?.sharingEnabled ?? false,
 			trashEnabled: space.settings?.trashEnabled ?? true,
 			trashEntriesMaxAge: String(
-				space.settings?.trashEntriesMaxAge ?? ''
+				Math.round(
+					(space.settings?.trashEntriesMaxAge ?? 0) / MINUTES_PER_DAY
+				)
 			),
 		},
 		onSubmit: async (values) => {
@@ -93,7 +98,8 @@ export default function SpaceGeneralSettings({
 						logoColor,
 						sharingEnabled,
 						trashEnabled,
-						trashEntriesMaxAge: Number(trashEntriesMaxAge),
+						trashEntriesMaxAge:
+							Number(trashEntriesMaxAge) * MINUTES_PER_DAY,
 					},
 				}
 			);
@@ -156,7 +162,7 @@ export default function SpaceGeneralSettings({
 						maxLength(150),
 					],
 					trashEntriesMaxAge: values.trashEnabled
-						? [required, validNumber]
+						? [minValue(1), required, validNumber]
 						: [],
 				},
 				values,

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/spaces/SpaceGeneralSettings.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/spaces/SpaceGeneralSettings.test.tsx
@@ -37,7 +37,7 @@ const SPACE: Partial<Space> = {
 		logoColor: 'outline-2',
 		sharingEnabled: true,
 		trashEnabled: true,
-		trashEntriesMaxAge: 0,
+		trashEntriesMaxAge: 2880,
 	},
 };
 
@@ -196,6 +196,65 @@ describe('SpaceGeneralSettings', () => {
 		});
 
 		await closeToast();
+	});
+
+	describe('Trash entries max age', () => {
+		it('displays the value in days converted from the stored minutes', () => {
+			renderComponent({
+				space: {
+					...SPACE,
+					settings: {
+						...SPACE.settings!,
+						trashEntriesMaxAge: 7200,
+					},
+				} as Partial<Space>,
+			});
+
+			expect(screen.getByLabelText('trash-entries-max-age')).toHaveValue(
+				5
+			);
+		});
+
+		it('converts the value to minutes on save', async () => {
+			renderComponent();
+
+			const trashEntriesMaxAgeField = screen.getByLabelText(
+				'trash-entries-max-age'
+			);
+
+			await userEvent.clear(trashEntriesMaxAgeField);
+			await userEvent.type(trashEntriesMaxAgeField, '5');
+
+			await userEvent.click(screen.getByRole('button', {name: 'save'}));
+
+			await waitFor(() => {
+				expect(SpaceService.updateSpace).toBeCalledWith(
+					expect.any(String),
+					expect.objectContaining({
+						settings: expect.objectContaining({
+							trashEntriesMaxAge: 7200,
+						}),
+					})
+				);
+			});
+
+			await closeToast();
+		});
+
+		it('does not save when the value is less than 1', async () => {
+			renderComponent();
+
+			const trashEntriesMaxAgeField = screen.getByLabelText(
+				'trash-entries-max-age'
+			);
+
+			await userEvent.clear(trashEntriesMaxAgeField);
+			await userEvent.type(trashEntriesMaxAgeField, '0');
+
+			await userEvent.click(screen.getByRole('button', {name: 'save'}));
+
+			expect(SpaceService.updateSpace).not.toHaveBeenCalled();
+		});
 	});
 
 	describe('Errors', () => {

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/spaceManagement.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/spaceManagement.spec.ts
@@ -99,6 +99,50 @@ test(
 );
 
 test(
+	'Trash entries max age field shows the company default in days and rejects values below 1',
+	{tag: '@LPD-91035'},
+	async ({apiHelpers, page, spaceSummaryPage}) => {
+		const spaceName = `Space ${getRandomString()}`;
+
+		await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			settings: {},
+			type: 'Space',
+		});
+
+		await spaceSummaryPage.goto(spaceName);
+
+		await page.getByRole('button', {name: 'More Actions'}).click();
+		await page.getByRole('menuitem', {name: 'Settings'}).click();
+
+		const trashEntriesMaxAgeField = page.getByRole('spinbutton', {
+			name: 'Trash Entries Max Age',
+		});
+
+		await expect(trashEntriesMaxAgeField).toHaveValue('30');
+
+		await trashEntriesMaxAgeField.fill('0');
+		await page.getByRole('button', {name: 'Save'}).click();
+
+		await expect(
+			page.getByText('Please enter a value greater than or equal to 1')
+		).toBeVisible();
+
+		await trashEntriesMaxAgeField.fill('7');
+		await page.getByRole('button', {name: 'Save'}).click();
+
+		await waitForAlert(page, 'Success');
+
+		await spaceSummaryPage.goto(spaceName);
+
+		await page.getByRole('button', {name: 'More Actions'}).click();
+		await page.getByRole('menuitem', {name: 'Settings'}).click();
+
+		await expect(trashEntriesMaxAgeField).toHaveValue('7');
+	}
+);
+
+test(
 	'The Permissions modal can be opened from the All Spaces row actions',
 	{tag: '@LPD-85670'},
 	async ({apiHelpers, page}) => {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91035

## What Is Being Fixed

Space-type groups created before this change carried no `trashEntriesMaxAge` value, so their trash retention silently diverged from the company-wide `TRASH_ENTRIES_MAX_AGE` preference instead of inheriting it, and the asset library Settings API reported `0` for those spaces rather than the configured company default. The Space general settings UI also did not present or validate the value as a number of days.

## How It Is Being Fixed

A new depot 2.4.0 upgrade process backfills `trashEntriesMaxAge` on existing Space depot entries from each company's `TRASH_ENTRIES_MAX_AGE` preference, walking companies with `forEachCompanyId` and paginating the per-company depot entries through an `ActionableDynamicQuery` so the migration scales without loading every entry into memory. `AssetLibraryDTOConverter` now returns the company default whenever a space has no positive `trashEntriesMaxAge`, so the API value stays consistent with portal configuration. On the front end, the Space general settings form shows the value in days and validates the input.

## How to Run the Tests

`cd modules/apps/depot/depot-test && gradlew testIntegration --tests TrashEntriesMaxAgeUpgradeProcessTest`

`cd modules/apps/headless/headless-asset-library/headless-asset-library-test && gradlew testIntegration --tests AssetLibraryResourceTest`

The Jest suite `SpaceGeneralSettings.test.tsx` and the Playwright spec `spaceManagement.spec.ts` cover the front-end changes.

## PR Check

**pr-check: SKIPPED** — Depot upgrade integration test verified locally; the AssetLibraryResourceTest failure is an environmental "cms administrator" role-provisioning gap on the freshly created test company, not a branch regression.

<!-- pr-check {"reason": "Depot upgrade integration test verified locally; the AssetLibraryResourceTest failure is an environmental cms administrator role-provisioning gap on the test company, not a branch regression.", "result": "skipped", "sha": "406e2c1f469075dc0e7399f80f678928d013688b"} -->
