### PR TITLE
LPD-93941 Remove CMP dependency from CMS site initializer tests

### DIFF
--- a/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/model/listener/test/ObjectEntryAuditModelListenerTest.java
+++ b/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/model/listener/test/ObjectEntryAuditModelListenerTest.java
@@ -1,0 +1,232 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cmp.site.initializer.internal.model.listener.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.portal.kernel.audit.AuditMessage;
+import com.liferay.portal.kernel.audit.AuditRouter;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.model.ModelListener;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.ProxyUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.site.cmp.site.initializer.test.util.CMPTestUtil;
+
+import java.io.Serializable;
+
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.Queue;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+
+/**
+ * @author Stefano Motta
+ */
+@FeatureFlags(
+	featureFlags = {@FeatureFlag("LPD-17564"), @FeatureFlag("LPD-58677")}
+)
+@RunWith(Arquillian.class)
+public class ObjectEntryAuditModelListenerTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_auditRouter = (AuditRouter)ReflectionTestUtil.getAndSetFieldValue(
+			_objectEntryModelListener, "_auditRouter",
+			ProxyUtil.newProxyInstance(
+				AuditRouter.class.getClassLoader(),
+				new Class<?>[] {AuditRouter.class},
+				(proxy, method, arguments) -> {
+					_auditMessages.add((AuditMessage)arguments[0]);
+
+					return null;
+				}));
+
+		CMPTestUtil.getOrAddGroup(ObjectEntryAuditModelListenerTest.class);
+
+		_cmpTaskObjectEntry = CMPTestUtil.addTaskObjectEntry();
+
+		_cmpTaskObjectEntry = _objectEntryLocalService.partialUpdateObjectEntry(
+			_cmpTaskObjectEntry.getUserId(),
+			_cmpTaskObjectEntry.getObjectEntryId(),
+			_cmpTaskObjectEntry.getObjectEntryFolderId(),
+			HashMapBuilder.<String, Serializable>put(
+				"title", RandomTestUtil.randomString()
+			).build(),
+			_getServiceContext("L_CMP_TASK_123"));
+
+		ServiceContextThreadLocal.pushServiceContext(
+			ServiceContextTestUtil.getServiceContext());
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		ReflectionTestUtil.setFieldValue(
+			_objectEntryModelListener, "_auditRouter", _auditRouter);
+
+		_objectEntryLocalService.deleteObjectEntry(_cmpTaskObjectEntry);
+
+		ServiceContextThreadLocal.popServiceContext();
+	}
+
+	@Test
+	public void testOnAfterCreate() throws Exception {
+		String title = RandomTestUtil.randomString();
+
+		_addObjectEntry(title, "L_CMP_TASK_123");
+
+		_assertAuditMessage("CMP_ADD_ASSET", title);
+	}
+
+	@Test
+	public void testOnAfterRemove() throws Exception {
+		String title = RandomTestUtil.randomString();
+
+		ObjectEntry objectEntry = _addObjectEntry(title, "L_CMP_TASK_123");
+
+		_assertAuditMessage("CMP_ADD_ASSET", title);
+
+		_objectEntryLocalService.deleteObjectEntry(objectEntry);
+
+		_assertAuditMessage("CMP_REMOVE_ASSET", title);
+	}
+
+	@Test
+	public void testOnAfterUpdate() throws Exception {
+		String title = RandomTestUtil.randomString();
+
+		ObjectEntry objectEntry = _addObjectEntry(title, "L_CMP_TASK_123");
+
+		_assertAuditMessage("CMP_ADD_ASSET", title);
+
+		_objectEntryLocalService.partialUpdateObjectEntry(
+			objectEntry.getUserId(), objectEntry.getObjectEntryId(),
+			objectEntry.getObjectEntryFolderId(), Collections.emptyMap(),
+			_getServiceContext(RandomTestUtil.randomString()));
+
+		_assertAuditMessage("CMP_REMOVE_ASSET", title);
+	}
+
+	private ObjectEntry _addObjectEntry(String title, String... assetTagNames)
+		throws Exception {
+
+		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), StringUtil.randomString()
+			).build(),
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), StringUtil.randomString()
+			).build(),
+			DepotConstants.TYPE_SPACE,
+			ServiceContextTestUtil.getServiceContext());
+
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.
+				getObjectDefinitionByExternalReferenceCode(
+					"L_CMS_BASIC_WEB_CONTENT", depotEntry.getCompanyId());
+
+		return _objectEntryLocalService.addObjectEntry(
+			depotEntry.getGroupId(), depotEntry.getUserId(),
+			objectDefinition.getObjectDefinitionId(), 0, "en_US",
+			HashMapBuilder.<String, Serializable>put(
+				"title_i18n",
+				HashMapBuilder.put(
+					"en_US", title
+				).build()
+			).build(),
+			_getServiceContext(assetTagNames));
+	}
+
+	private void _assertAuditMessage(
+			String expectedEventType, String exptectedTitle)
+		throws Exception {
+
+		AuditMessage auditMessage = _auditMessages.poll();
+
+		JSONAssert.assertEquals(
+			JSONUtil.put(
+				"attributes",
+				JSONUtil.putAll(JSONUtil.put("name", exptectedTitle))
+			).toString(),
+			String.valueOf(auditMessage.getAdditionalInfo()),
+			JSONCompareMode.STRICT_ORDER);
+		Assert.assertEquals(
+			_cmpTaskObjectEntry.getModelClassName(),
+			auditMessage.getClassName());
+		Assert.assertEquals(
+			_cmpTaskObjectEntry.getObjectEntryId(),
+			GetterUtil.getLong(auditMessage.getClassPK()));
+		Assert.assertEquals(expectedEventType, auditMessage.getEventType());
+
+		_auditMessages.clear();
+	}
+
+	private ServiceContext _getServiceContext(String... assetTagNames)
+		throws Exception {
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext();
+
+		serviceContext.setAssetTagNames(assetTagNames);
+
+		return serviceContext;
+	}
+
+	private final Queue<AuditMessage> _auditMessages = new LinkedList<>();
+	private AuditRouter _auditRouter;
+	private ObjectEntry _cmpTaskObjectEntry;
+
+	@Inject
+	private DepotEntryLocalService _depotEntryLocalService;
+
+	@Inject
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Inject
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Inject(
+		filter = "component.name=com.liferay.site.cms.site.initializer.internal.model.listener.ObjectEntryModelListener"
+	)
+	private ModelListener<ObjectEntry> _objectEntryModelListener;
+
+}

--- a/modules/apps/site/site-cms-site-initializer-test/build.gradle
+++ b/modules/apps/site/site-cms-site-initializer-test/build.gradle
@@ -32,7 +32,6 @@ dependencies {
 	testIntegrationImplementation project(":apps:segments:segments-api")
 	testIntegrationImplementation project(":apps:sharing:sharing-api")
 	testIntegrationImplementation project(":apps:site:site-api")
-	testIntegrationImplementation project(":apps:site:site-cmp-site-initializer-test-util")
 	testIntegrationImplementation project(":apps:site:site-cms-site-initializer")
 	testIntegrationImplementation project(":apps:site:site-cms-site-initializer-api")
 	testIntegrationImplementation project(":apps:site:site-cms-site-initializer-test-util")

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewSpaceMembersSummarySectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewSpaceMembersSummarySectionDisplayContextTest.java
@@ -11,13 +11,11 @@ import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.fragment.renderer.FragmentRenderer;
 import com.liferay.info.constants.InfoDisplayWebKeys;
-import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.rest.test.util.ObjectEntryTestUtil;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.test.AssertUtils;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -31,14 +29,12 @@ import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
-import com.liferay.site.cmp.site.initializer.test.util.CMPTestUtil;
 
 import java.io.Serializable;
 
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -62,15 +58,6 @@ public class ViewSpaceMembersSummarySectionDisplayContextTest
 		new AggregateTestRule(
 			new LiferayIntegrationTestRule(),
 			PermissionCheckerMethodTestRule.INSTANCE);
-
-	@Before
-	@Override
-	public void setUp() throws Exception {
-		super.setUp();
-
-		CMPTestUtil.getOrAddGroup(
-			ViewSpaceMembersSummarySectionDisplayContextTest.class);
-	}
 
 	@Test
 	public void testGetHeaderProps() throws Exception {
@@ -96,10 +83,25 @@ public class ViewSpaceMembersSummarySectionDisplayContextTest
 
 		_assertHeaderProps(null, depotEntry.getGroup());
 
-		ObjectEntry objectEntry = CMPTestUtil.addProjectObjectEntry();
+		DepotEntry projectDepotEntry = _depotEntryLocalService.addDepotEntry(
+			RandomTestUtil.randomLocaleStringMap(),
+			RandomTestUtil.randomLocaleStringMap(), DepotConstants.TYPE_PROJECT,
+			ServiceContextTestUtil.getServiceContext());
 
 		mockHttpServletRequest.setAttribute(
-			InfoDisplayWebKeys.INFO_ITEM, objectEntry);
+			InfoDisplayWebKeys.INFO_ITEM,
+			ObjectEntryTestUtil.addObjectEntry(
+				projectDepotEntry.getGroupId(),
+				_objectDefinitionLocalService.
+					fetchObjectDefinitionByExternalReferenceCode(
+						"L_CMS_BASIC_WEB_CONTENT",
+						TestPropsValues.getCompanyId()),
+				HashMapBuilder.<String, Serializable>put(
+					"title_i18n",
+					HashMapBuilder.put(
+						"en_US", RandomTestUtil.randomString()
+					).build()
+				).build()));
 
 		_assertHeaderProps(
 			HashMapBuilder.<String, Object>put(
@@ -113,7 +115,7 @@ public class ViewSpaceMembersSummarySectionDisplayContextTest
 						StringUtil.merge(depotEntryGroupIds) + ")";
 				}
 			).build(),
-			_groupLocalService.fetchGroup(objectEntry.getGroupId()));
+			projectDepotEntry.getGroup());
 	}
 
 	private void _assertHeaderProps(
@@ -173,9 +175,6 @@ public class ViewSpaceMembersSummarySectionDisplayContextTest
 		filter = "component.name=com.liferay.site.cms.site.initializer.internal.fragment.renderer.ViewSpaceMembersSummaryJSPSectionFragmentRenderer"
 	)
 	private FragmentRenderer _fragmentRenderer;
-
-	@Inject
-	private GroupLocalService _groupLocalService;
 
 	@Inject
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/model/listener/test/ObjectEntryModelListenerTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/model/listener/test/ObjectEntryModelListenerTest.java
@@ -23,12 +23,9 @@ import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryFolderLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.petra.sql.dsl.expression.Predicate;
-import com.liferay.portal.kernel.audit.AuditMessage;
-import com.liferay.portal.kernel.audit.AuditRouter;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.model.ModelListener;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.model.Role;
@@ -38,32 +35,25 @@ import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
-import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.constants.TestDataConstants;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
-import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
-import com.liferay.portal.kernel.util.ProxyUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
-import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
-import com.liferay.site.cmp.site.initializer.test.util.CMPTestUtil;
+import com.liferay.site.cms.site.initializer.test.util.CMSTestUtil;
 import com.liferay.site.cms.site.initializer.util.CMSDefaultPermissionUtil;
 
 import java.io.ByteArrayInputStream;
 import java.io.Serializable;
 
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.Queue;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -73,15 +63,10 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import org.skyscreamer.jsonassert.JSONAssert;
-import org.skyscreamer.jsonassert.JSONCompareMode;
-
 /**
  * @author Stefano Motta
  */
-@FeatureFlags(
-	featureFlags = {@FeatureFlag("LPD-17564"), @FeatureFlag("LPD-58677")}
-)
+@FeatureFlag("LPD-17564")
 @RunWith(Arquillian.class)
 public class ObjectEntryModelListenerTest {
 
@@ -94,29 +79,7 @@ public class ObjectEntryModelListenerTest {
 
 	@Before
 	public void setUp() throws Exception {
-		_auditRouter = (AuditRouter)ReflectionTestUtil.getAndSetFieldValue(
-			_objectEntryModelListener, "_auditRouter",
-			ProxyUtil.newProxyInstance(
-				AuditRouter.class.getClassLoader(),
-				new Class<?>[] {AuditRouter.class},
-				(proxy, method, arguments) -> {
-					_auditMessages.add((AuditMessage)arguments[0]);
-
-					return null;
-				}));
-
-		CMPTestUtil.getOrAddGroup(ObjectEntryModelListenerTest.class);
-
-		_cmpTaskObjectEntry = CMPTestUtil.addTaskObjectEntry();
-
-		_cmpTaskObjectEntry = _objectEntryLocalService.partialUpdateObjectEntry(
-			_cmpTaskObjectEntry.getUserId(),
-			_cmpTaskObjectEntry.getObjectEntryId(),
-			_cmpTaskObjectEntry.getObjectEntryFolderId(),
-			HashMapBuilder.<String, Serializable>put(
-				"title", RandomTestUtil.randomString()
-			).build(),
-			_getServiceContext("L_CMP_TASK_123"));
+		CMSTestUtil.getOrAddGroup(ObjectEntryModelListenerTest.class);
 
 		_cmsAdministratorRole = _getOrAddCMSAdministratorRole(
 			TestPropsValues.getCompanyId(), TestPropsValues.getUserId());
@@ -131,27 +94,11 @@ public class ObjectEntryModelListenerTest {
 
 	@After
 	public void tearDown() throws Exception {
-		ReflectionTestUtil.setFieldValue(
-			_objectEntryModelListener, "_auditRouter", _auditRouter);
-
-		_objectEntryLocalService.deleteObjectEntry(_cmpTaskObjectEntry);
-
 		ServiceContextThreadLocal.popServiceContext();
 	}
 
 	@Test
 	public void testOnAfterCreate() throws Exception {
-
-		// Audit router
-
-		String title = RandomTestUtil.randomString();
-
-		_addObjectEntry(title, "L_CMP_TASK_123");
-
-		_assertAuditMessage("CMP_ADD_ASSET", title);
-
-		// Resource permissions
-
 		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), StringUtil.randomString()
@@ -379,38 +326,7 @@ public class ObjectEntryModelListenerTest {
 	}
 
 	@Test
-	public void testOnAfterRemove() throws Exception {
-		String title = RandomTestUtil.randomString();
-
-		ObjectEntry objectEntry = _addObjectEntry(title, "L_CMP_TASK_123");
-
-		_assertAuditMessage("CMP_ADD_ASSET", title);
-
-		_objectEntryLocalService.deleteObjectEntry(objectEntry);
-
-		_assertAuditMessage("CMP_REMOVE_ASSET", title);
-	}
-
-	@Test
 	public void testOnAfterUpdate() throws Exception {
-
-		// Audit router
-
-		String title = RandomTestUtil.randomString();
-
-		ObjectEntry objectEntry1 = _addObjectEntry(title, "L_CMP_TASK_123");
-
-		_assertAuditMessage("CMP_ADD_ASSET", title);
-
-		_objectEntryLocalService.partialUpdateObjectEntry(
-			objectEntry1.getUserId(), objectEntry1.getObjectEntryId(),
-			objectEntry1.getObjectEntryFolderId(), Collections.emptyMap(),
-			_getServiceContext(RandomTestUtil.randomString()));
-
-		_assertAuditMessage("CMP_REMOVE_ASSET", title);
-
-		// Resource permissions
-
 		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), StringUtil.randomString()
@@ -603,60 +519,6 @@ public class ObjectEntryModelListenerTest {
 		Assert.assertFalse(resourcePermission.hasActionId(ActionKeys.VIEW));
 	}
 
-	private ObjectEntry _addObjectEntry(String title, String... assetTagNames)
-		throws Exception {
-
-		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
-			HashMapBuilder.put(
-				LocaleUtil.getDefault(), StringUtil.randomString()
-			).build(),
-			HashMapBuilder.put(
-				LocaleUtil.getDefault(), StringUtil.randomString()
-			).build(),
-			DepotConstants.TYPE_SPACE,
-			ServiceContextTestUtil.getServiceContext());
-
-		ObjectDefinition objectDefinition =
-			_objectDefinitionLocalService.
-				getObjectDefinitionByExternalReferenceCode(
-					"L_CMS_BASIC_WEB_CONTENT", depotEntry.getCompanyId());
-
-		return _objectEntryLocalService.addObjectEntry(
-			depotEntry.getGroupId(), depotEntry.getUserId(),
-			objectDefinition.getObjectDefinitionId(), 0, "en_US",
-			HashMapBuilder.<String, Serializable>put(
-				"title_i18n",
-				HashMapBuilder.put(
-					"en_US", title
-				).build()
-			).build(),
-			_getServiceContext(assetTagNames));
-	}
-
-	private void _assertAuditMessage(
-			String expectedEventType, String exptectedTitle)
-		throws Exception {
-
-		AuditMessage auditMessage = _auditMessages.poll();
-
-		JSONAssert.assertEquals(
-			JSONUtil.put(
-				"attributes",
-				JSONUtil.putAll(JSONUtil.put("name", exptectedTitle))
-			).toString(),
-			String.valueOf(auditMessage.getAdditionalInfo()),
-			JSONCompareMode.STRICT_ORDER);
-		Assert.assertEquals(
-			_cmpTaskObjectEntry.getModelClassName(),
-			auditMessage.getClassName());
-		Assert.assertEquals(
-			_cmpTaskObjectEntry.getObjectEntryId(),
-			GetterUtil.getLong(auditMessage.getClassPK()));
-		Assert.assertEquals(expectedEventType, auditMessage.getEventType());
-
-		_auditMessages.clear();
-	}
-
 	private Role _getOrAddCMSAdministratorRole(long companyId, long userId)
 		throws Exception {
 
@@ -672,20 +534,6 @@ public class ObjectEntryModelListenerTest {
 			RoleConstants.TYPE_REGULAR, null, null);
 	}
 
-	private ServiceContext _getServiceContext(String... assetTagNames)
-		throws Exception {
-
-		ServiceContext serviceContext =
-			ServiceContextTestUtil.getServiceContext();
-
-		serviceContext.setAssetTagNames(assetTagNames);
-
-		return serviceContext;
-	}
-
-	private final Queue<AuditMessage> _auditMessages = new LinkedList<>();
-	private AuditRouter _auditRouter;
-	private ObjectEntry _cmpTaskObjectEntry;
 	private Role _cmsAdministratorRole;
 
 	@Inject
@@ -707,11 +555,6 @@ public class ObjectEntryModelListenerTest {
 
 	@Inject
 	private ObjectEntryLocalService _objectEntryLocalService;
-
-	@Inject(
-		filter = "component.name=com.liferay.site.cms.site.initializer.internal.model.listener.ObjectEntryModelListener"
-	)
-	private ModelListener<ObjectEntry> _objectEntryModelListener;
 
 	private Role _ownerRole;
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93941

## What Is Being Fixed

The site-cms-site-initializer-test module depended on site-cmp-site-initializer-test-util through CMPTestUtil, coupling the CMS test bundle to the CMP product. The two affected tests used CMP for different reasons, so neither could be cleaned up by a single mechanical change.

## How It Is Being Fixed

ViewSpaceMembersSummarySectionDisplayContextTest only needs an object entry in a TYPE_PROJECT depot to exercise the display context, since the production code branches solely on the depot type. It now builds a TYPE_PROJECT depot with a CMS basic web content entry instead of a CMP project, preserving the same code path without the CMP dependency.

ObjectEntryModelListenerTest mixed CMS resource-permission scenarios with CMP audit-routing scenarios. The audit routing genuinely requires the CMP task object definition, so those scenarios moved to a new ObjectEntryAuditModelListenerTest in site-cmp-site-initializer-test, where the CMP concepts are owned. The CMS test keeps only the resource-permission coverage and no longer references CMP. With both tests cleaned up, the CMP test-util dependency is dropped from the CMS test module.

## PR Check

**pr-check: PASS** — tested on `3b846840062a0c41cc40331702be95aebbe56939`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |
| Structural Smoke | PASS |

<!-- pr-check {"result": "success", "sha": "3b846840062a0c41cc40331702be95aebbe56939"} -->