### PR TITLE
LPD-92121 Make sharing permission read-only without UPDATE

### DIFF
--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/share_modal_content/ShareModalContent.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/share_modal_content/ShareModalContent.tsx
@@ -192,11 +192,22 @@ function CollaboratorListItem({
 					{alwaysShowPermissionSelector ||
 					permissionOptions.length > 1 ? (
 						<div>
-							<PermissionSelector
-								actionIds={actionIds}
-								onChange={handleChangeUserProperties}
-								options={permissionOptions}
-							/>
+							{canManageCollaborators ? (
+								<PermissionSelector
+									actionIds={actionIds}
+									onChange={handleChangeUserProperties}
+									options={permissionOptions}
+								/>
+							) : (
+								<span className="permissions-picker text-2 text-secondary text-weight-semi-bold">
+									{
+										permissionOptions.find(
+											(option) =>
+												option.value === actionIds
+										)?.label
+									}
+								</span>
+							)}
 						</div>
 					) : null}
 				</div>

--- a/modules/apps/frontend-js/frontend-js-components-web/test/share_modal_content/ShareModalContent.test.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/test/share_modal_content/ShareModalContent.test.tsx
@@ -306,6 +306,16 @@ describe('ShareModalContent', () => {
 		expect(queryByLabelText('edit-permissions')).not.toBeInTheDocument();
 	});
 
+	it('renders the permission as read-only text when the user cannot manage collaborators', () => {
+		const {getByText, queryByLabelText} = renderComponent({
+			...DEFAULT_PROPS,
+			canManageCollaborators: false,
+		});
+
+		expect(queryByLabelText('edit-permissions')).not.toBeInTheDocument();
+		expect(getByText('view-and-download')).toBeInTheDocument();
+	});
+
 	it('renders only the permission options the caller provides', () => {
 		const folderProps = {
 			...DEFAULT_PROPS,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92121

## What Is Being Fixed

A user holding only the Reshare permission (VIEW plus share, without UPDATE) could still open the interactive permission picker for any collaborator in the Share modal and attempt to change their sharing constraints. Every other collaborator control was already gated by canManageCollaborators, but the permission picker was not, so it stayed interactive even when the current user could not legitimately manage collaborators.

## How It Is Being Fixed

The permission picker in CollaboratorListItem is now gated by canManageCollaborators. When the current user cannot manage collaborators, the picker renders the collaborator's current permission as read-only text instead of the interactive PermissionSelector, so the value remains visible without inviting an action the user cannot perform.

## PR Check

**pr-check: PASS** — tested on `eea4c22f675900343d5d4c3abcab400d7c005d02`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Deploy | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "eea4c22f675900343d5d4c3abcab400d7c005d02"} -->