### PR TITLE
LPD-93991 Defer AMImageEntry delete until a successful rescale

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-image-api/src/main/java/com/liferay/adaptive/media/image/optimizer/BaseAMImageOptimizer.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-api/src/main/java/com/liferay/adaptive/media/image/optimizer/BaseAMImageOptimizer.java
@@ -164,8 +164,8 @@ public abstract class BaseAMImageOptimizer implements AMImageOptimizer {
 					configurationEntryUuid, total, successCounter,
 					errorCounter));
 		}
-		catch (PortalException portalException) {
-			_log.error(portalException);
+		catch (Exception exception) {
+			_log.error(exception);
 		}
 	}
 

--- a/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/processor/AMImageAMProcessor.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/processor/AMImageAMProcessor.java
@@ -89,11 +89,6 @@ public final class AMImageAMProcessor implements AMProcessor<FileVersion> {
 				return;
 			}
 
-			if (amImageEntry != null) {
-				_amImageEntryLocalService.deleteAMImageEntry(
-					amImageEntry.getAmImageEntryId());
-			}
-
 			AMImageScaler amImageScaler =
 				_amImageScalerRegistry.getAMImageScaler(
 					fileVersion.getMimeType());
@@ -107,6 +102,11 @@ public final class AMImageAMProcessor implements AMProcessor<FileVersion> {
 
 			try (InputStream inputStream =
 					amImageScaledImage.getInputStream()) {
+
+				if (amImageEntry != null) {
+					_amImageEntryLocalService.deleteAMImageEntry(
+						amImageEntry.getAmImageEntryId());
+				}
 
 				_amImageEntryLocalService.addAMImageEntry(
 					amImageConfigurationEntry,

--- a/modules/apps/adaptive-media/adaptive-media-image-impl/src/test/java/com/liferay/adaptive/media/image/internal/processor/AMImageProcessorImplTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-impl/src/test/java/com/liferay/adaptive/media/image/internal/processor/AMImageProcessorImplTest.java
@@ -451,6 +451,100 @@ public class AMImageProcessorImplTest {
 		);
 	}
 
+	@Test(expected = AMRuntimeException.IOException.class)
+	public void testProcessDoesNotDeleteAMImageEntryWhenScaleFails()
+		throws Exception {
+
+		Mockito.when(
+			_amImageValidator.isProcessingSupported(_fileVersion)
+		).thenReturn(
+			true
+		);
+
+		Mockito.when(
+			_amImageConfigurationHelper.getAMImageConfigurationEntry(
+				Mockito.anyLong(), Mockito.nullable(String.class))
+		).thenReturn(
+			new AMImageConfigurationEntryImpl(
+				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+				Collections.emptyMap())
+		);
+
+		Mockito.when(
+			_amImageEntryLocalService.fetchAMImageEntry(
+				Mockito.nullable(String.class), Mockito.anyLong())
+		).thenReturn(
+			_amImageEntry
+		);
+
+		Mockito.when(
+			_fileVersion.getFileEntry()
+		).thenReturn(
+			_fileEntry
+		);
+
+		Date creationDate = new Date();
+
+		Date modifiedDate = new Date(
+			creationDate.getYear(), creationDate.getMonth(),
+			creationDate.getDate() + 1);
+
+		Mockito.when(
+			_amImageEntry.getCreateDate()
+		).thenReturn(
+			creationDate
+		);
+
+		Mockito.when(
+			_fileVersion.getModifiedDate()
+		).thenReturn(
+			modifiedDate
+		);
+
+		Mockito.when(
+			_fileEntry.isCheckedOut()
+		).thenReturn(
+			false
+		);
+
+		Mockito.when(
+			_amImageScalerRegistry.getAMImageScaler(
+				Mockito.nullable(String.class))
+		).thenReturn(
+			_amImageScaler
+		);
+
+		Mockito.doThrow(
+			AMRuntimeException.IOException.class
+		).when(
+			_amImageScaler
+		).scaleImage(
+			Mockito.any(FileVersion.class),
+			Mockito.any(AMImageConfigurationEntry.class)
+		);
+
+		try {
+			_amImageAMProcessor.process(
+				_fileVersion, RandomTestUtil.randomString());
+		}
+		finally {
+			Mockito.verify(
+				_amImageEntryLocalService, Mockito.never()
+			).deleteAMImageEntry(
+				Mockito.anyLong()
+			);
+
+			Mockito.verify(
+				_amImageEntryLocalService, Mockito.never()
+			).addAMImageEntry(
+				Mockito.any(AMImageConfigurationEntry.class),
+				Mockito.any(FileVersion.class), Mockito.anyInt(),
+				Mockito.anyInt(), Mockito.any(InputStream.class),
+				Mockito.anyLong()
+			);
+		}
+	}
+
 	@Test(expected = DuplicateAMImageEntryException.class)
 	public void testProcessDuplicateAMImageEntryExceptionInImageService()
 		throws Exception {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93991

## What Is Being Fixed

Adaptive Media's "Adapt Remaining" deletes the existing `AMImageEntry` before re-scaling an image. When the scale fails — for example a missing source file after a backup/restore that excluded generated DL files — the row is already gone and is never recreated. Because progress is computed as `getAMImageEntriesCount (rows) / expected`, the adapted count regresses and the bar sticks just below 100%. Separately, the optimize task processes configurations sequentially in alphabetical order, and `BaseAMImageOptimizer._optimize` caught only `PortalException`, so a `RuntimeException` escaping the file-entry iteration aborted the whole task and silently skipped every later resolution.

## How It Is Being Fixed

The delete is deferred until after a successful `scaleImage`: the `deleteAMImageEntry` call now runs inside the try-with-resources that opens the scaled image's stream, immediately before `addAMImageEntry`. On failure the existing entry is preserved; on success the delete-then-add ordering still satisfies the `_checkDuplicateAMImageEntry` unique constraint, so the change is behavior-preserving on the happy path and strictly safer on failure. In addition, `BaseAMImageOptimizer._optimize` is broadened from `catch (PortalException)` to `catch (Exception)` so a runtime exception from the file-entry iteration no longer aborts the whole task and skips alphabetically-later resolutions; system errors such as `OutOfMemoryError` are intentionally left to propagate, as those are an operational (JVM heap) concern rather than something to swallow and continue past.

## How To Test

```
gradlew -p modules/apps/adaptive-media/adaptive-media-image-impl test --tests "*AMImageProcessorImplTest"
```

## PR Check

**pr-check: SKIPPED** — Unit test verified by hand (AMImageProcessorImplTest passed, including the new testProcessDoesNotDeleteAMImageEntryWhenScaleFails); source formatting ran clean.

<!-- pr-check {"reason": "Unit test verified by hand (AMImageProcessorImplTest passed, including the new testProcessDoesNotDeleteAMImageEntryWhenScaleFails); source formatting ran clean.", "result": "skipped", "sha": "d9f5056cdc6e620c1a701ee55c98c6f6e457512b"} -->
