### PR TITLE
LPD-89720 Return Space-scoped tags when filtering CMS tags by Space

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/categorization/tags/ViewTags.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/categorization/tags/ViewTags.tsx
@@ -68,7 +68,7 @@ export default function ViewTags({
 			apiURL: "/o/headless-asset-library/v1.0/asset-libraries?filter=type eq 'Space'",
 			entityFieldType: 'string',
 			id: 'groupIds',
-			itemKey: 'id',
+			itemKey: 'siteId',
 			itemLabel: 'name',
 			label: 'Space',
 			multiple: true,

--- a/modules/test/playwright/helpers/HeadlessAdminTaxonomyApiHelper.ts
+++ b/modules/test/playwright/helpers/HeadlessAdminTaxonomyApiHelper.ts
@@ -51,6 +51,11 @@ interface postAssetLibraryKeywordProps {
 }
 
 interface postSiteKeywordProps {
+	assetLibraries?: Array<{
+		externalReferenceCode?: string;
+		id?: number;
+		scopeKey?: string;
+	}>;
 	name: string;
 	siteId: string;
 }
@@ -211,15 +216,18 @@ export class HeadlessAdminTaxonomyApiHelper {
 	 *
 	 * @param name the name of the tag
 	 * @param siteId the id of the site in which the tag will be created
+	 * @param assetLibraries the spaces the tag is scoped to (CMS only); omit to
+	 * make the tag available in all spaces
 	 */
 
 	async postSiteKeyword({
+		assetLibraries,
 		name,
 		siteId,
 	}: postSiteKeywordProps): Promise<{id: number}> {
 		const keyword = await this.apiHelpers.post(
 			`${this.apiHelpers.baseUrl}${this.basePath}/sites/${siteId}/keywords`,
-			{data: {name}}
+			{data: {assetLibraries, name}}
 		);
 
 		if (this.apiHelpers instanceof DataApiHelpers) {

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/categorization/tags.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/categorization/tags.spec.ts
@@ -8,6 +8,7 @@ import {expect, mergeTests} from '@playwright/test';
 import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
 import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
 import {loginTest} from '../../../../fixtures/loginTest';
+import {applyFDSSelectionFilter} from '../../../../utils/applyFDSSelectionFilter';
 import {checkAccessibility} from '../../../../utils/checkAccessibility';
 import {clickAndExpectToBeHidden} from '../../../../utils/clickAndExpectToBeHidden';
 import {clickAndExpectToBeVisible} from '../../../../utils/clickAndExpectToBeVisible';
@@ -590,5 +591,66 @@ test(
 				);
 			}
 		}
+	}
+);
+
+test(
+	'Filtering tags by Space shows the tags scoped to that Space',
+	{tag: '@LPD-89720'},
+	async ({apiHelpers, page, tagsPage}) => {
+		const {id: siteId} =
+			await apiHelpers.headlessAdminUser.getSiteByFriendlyUrlPath('cms');
+
+		// Create two Spaces, with one tag scoped to each one
+
+		const spaceName = getRandomString();
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			type: 'Space',
+		});
+
+		const anotherSpace =
+			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+				name: getRandomString(),
+				type: 'Space',
+			});
+
+		const tagName = getRandomString();
+
+		await apiHelpers.headlessAdminTaxonomy.postSiteKeyword({
+			assetLibraries: [
+				{externalReferenceCode: space.externalReferenceCode},
+			],
+			name: tagName,
+			siteId,
+		});
+
+		const anotherTagName = getRandomString();
+
+		await apiHelpers.headlessAdminTaxonomy.postSiteKeyword({
+			assetLibraries: [
+				{externalReferenceCode: anotherSpace.externalReferenceCode},
+			],
+			name: anotherTagName,
+			siteId,
+		});
+
+		// Both tags are listed before filtering
+
+		await tagsPage.goto();
+
+		await expect(tagsPage.getItem(tagName)).toBeVisible();
+		await expect(tagsPage.getItem(anotherTagName)).toBeVisible();
+
+		// Filtering by a Space keeps the tag scoped to it and hides the rest
+
+		await applyFDSSelectionFilter(page, {
+			filter: 'Space',
+			value: spaceName,
+		});
+
+		await expect(tagsPage.getItem(tagName)).toBeVisible();
+		await expect(tagsPage.getItem(anotherTagName)).toBeHidden();
 	}
 );


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89720

## What Is Being Fixed

In CMS Categorization > Tags, filtering the list by Space showed "No Results Found" even for tags that were scoped to the selected Space.

## How It Is Being Fixed

The Space filter in the Tags list was sending the asset library's `id` (the depot entry ID) as the `groupIds` filter value, while the keyword search indexes the `groupIds` field with the space's group ID (from `AssetTagGroupRel`). The two identifiers never matched, so the filter excluded every space-scoped tag. The filter now keys on `siteId` (the space group ID), consistent with `SpaceSelectionFDSFilter`, so the filter value lines up with the indexed value.

The test commit adds a Playwright test that creates two Spaces with a tag scoped to each, then verifies that filtering the Tags list by one Space keeps its tag and hides the other. It also extends the `postSiteKeyword` API helper to accept `assetLibraries` so a Space-scoped tag can be created from setup.

## PR Check

**pr-check: PASS** — tested on `df30f8d605dd412eca5ee93c0c8740b1116b95bd`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Deploy | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "df30f8d605dd412eca5ee93c0c8740b1116b95bd"} -->
