### PR TITLE
LPD-93785 Add test

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/editor/config/RichTextFragmentCKEditor5EditorConfigContributor.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/editor/config/RichTextFragmentCKEditor5EditorConfigContributor.java
@@ -67,8 +67,8 @@ public class RichTextFragmentCKEditor5EditorConfigContributor
 					"|", "removeFormat", "|", "numberedList", "bulletedList",
 					"|", "indent", "outdent", "|", "blockQuote", "|", "link",
 					"insertTable", "headlessImageSelector",
-					"headlessVideoSelector", "|", "alignment", "|", "aiCreator",
-					"|", "sourceEditing"
+					"headlessVideoSelector", "|", "alignment", "|",
+					"sourceEditing"
 				}
 			).put(
 				"shouldNotGroupWhenFull", true

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/contentEditor.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/contentEditor.spec.ts
@@ -1526,7 +1526,7 @@ test.describe('Schedule Publication', () => {
 
 test(
 	'The Rich Text required error only occurs when the field has no value',
-	{tag: '@LPD-69695'},
+	{tag: ['@LPD-69695', '@LPD-93785']},
 	async ({contentsPage, page, structureBuilderPage}) => {
 
 		// Create a structure with a required Rich Text field
@@ -1563,6 +1563,10 @@ test(
 		await expect(
 			page.locator('.rich-text-input [data-required-error]')
 		).toHaveText('This field is required.');
+
+		// The AI Creator button is not available in the CMS Rich Text editor
+
+		await expect(page.getByTitle('Create AI Content')).toBeHidden();
 
 		// Fill the Rich Text field and publish the content
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93785

## What Is Being Changed
When creating or editing rich text content in a CMS site, the CKEditor 5 toolbar showed an AI Creator button. This action is not meant to be available inside the CMS content editor, so it is being removed from that toolbar.

## How It Is Being Changed
The CMS rich text editor toolbar is defined in `RichTextFragmentCKEditor5EditorConfigContributor`, which contributes the toolbar configuration for the `richTextFragmentCKEditor5` editor config key and only applies in CMS scope (`scopeGroup.isCMS()`). The aiCreator item was listed in that toolbar's items array, so the button appeared in every CMS rich text field. It is now removed from the array, which scopes the change strictly to CMS rich text editing.
