### PR TITLE
LPD-93736 Match structured content fields by reference or name

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/DDMFormValuesUtil.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/DDMFormValuesUtil.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.SetUtil;
+import com.liferay.portal.kernel.util.Validator;
 
 import jakarta.ws.rs.BadRequestException;
 
@@ -86,8 +87,7 @@ public class DDMFormValuesUtil {
 					_flattenDDMFormFieldValues(
 						rootDDMFormFields,
 						ddmFormField -> _toDDMFormFieldValues(
-							contentFieldMap.get(
-								ddmFormField.getFieldReference()),
+							_getContentFields(contentFieldMap, ddmFormField),
 							ddmFormField, dlAppService, groupId,
 							journalArticleService, layoutLocalService,
 							locale)));
@@ -143,6 +143,20 @@ public class DDMFormValuesUtil {
 		return locales;
 	}
 
+	private static List<ContentField> _getContentFields(
+		Map<String, List<ContentField>> contentFieldMap,
+		DDMFormField ddmFormField) {
+
+		List<ContentField> contentFields = contentFieldMap.get(
+			ddmFormField.getFieldReference());
+
+		if (contentFields != null) {
+			return contentFields;
+		}
+
+		return contentFieldMap.get(ddmFormField.getName());
+	}
+
 	private static Locale _getDefaultLocale(
 		DDMForm ddmForm, Locale defaultLocale) {
 
@@ -163,9 +177,15 @@ public class DDMFormValuesUtil {
 		Map<String, List<ContentField>> contentFieldsMap = new HashMap<>();
 
 		for (ContentField contentField : contentFields) {
+			String fieldReference = contentField.getFieldReference();
+
+			if (Validator.isNull(fieldReference)) {
+				fieldReference = contentField.getName();
+			}
+
 			List<ContentField> contentFieldsList =
 				contentFieldsMap.computeIfAbsent(
-					contentField.getFieldReference(), key -> new ArrayList<>());
+					fieldReference, key -> new ArrayList<>());
 
 			contentFieldsList.add(contentField);
 		}
@@ -190,8 +210,8 @@ public class DDMFormValuesUtil {
 					_flattenDDMFormFieldValues(
 						ddmFormField.getNestedDDMFormFields(),
 						field -> _toDDMFormFieldValues(
-							contentFieldMap.get(field.getFieldReference()),
-							field, dlAppService, groupId, journalArticleService,
+							_getContentFields(contentFieldMap, field), field,
+							dlAppService, groupId, journalArticleService,
 							layoutLocalService, locale)));
 				setValue(value);
 			}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/StructuredContentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/StructuredContentResourceImpl.java
@@ -1245,16 +1245,20 @@ public class StructuredContentResourceImpl
 		for (Map.Entry<String, List<ContentField>> entry :
 				contentFieldsMap.entrySet()) {
 
-			Field field = fields.get(entry.getKey());
+			DDMFormField ddmFormField = DDMFormFieldUtil.getDDMFormField(
+				_ddmStructureService, ddmStructure, entry.getKey());
+
+			if (ddmFormField == null) {
+				continue;
+			}
+
+			Field field = fields.get(ddmFormField.getName());
 
 			if (field == null) {
 				continue;
 			}
 
 			List<Serializable> fieldValues = new ArrayList<>();
-
-			DDMFormField ddmFormField = DDMFormFieldUtil.getDDMFormField(
-				_ddmStructureService, ddmStructure, entry.getKey());
 
 			for (ContentField contentField : entry.getValue()) {
 				Value value = DDMValueUtil.toDDMValue(
@@ -1315,14 +1319,18 @@ public class StructuredContentResourceImpl
 		for (Map.Entry<String, List<ContentField>> entry :
 				contentFieldsMap.entrySet()) {
 
-			Field field = fields.get(entry.getKey());
+			DDMFormField ddmFormField = DDMFormFieldUtil.getDDMFormField(
+				_ddmStructureService, ddmStructure, entry.getKey());
+
+			if (ddmFormField == null) {
+				continue;
+			}
+
+			Field field = fields.get(ddmFormField.getName());
 
 			if (field == null) {
 				continue;
 			}
-
-			DDMFormField ddmFormField = DDMFormFieldUtil.getDDMFormField(
-				_ddmStructureService, ddmStructure, entry.getKey());
 
 			for (ContentField contentField : entry.getValue()) {
 				Value value = DDMValueUtil.toDDMValue(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/StructuredContentResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/StructuredContentResourceTest.java
@@ -532,6 +532,7 @@ public class StructuredContentResourceTest
 	public void testPatchStructuredContent() throws Exception {
 		super.testPatchStructuredContent();
 
+		_testPatchStructuredContentWithContentFieldName();
 		_testPatchStructuredContentWithDateExpired();
 		_testPatchStructuredContentWithLocalizedContentFields();
 		_testPatchStructuredContentWithNestedContentFields();
@@ -688,6 +689,7 @@ public class StructuredContentResourceTest
 		assertValid(postStructuredContent4);
 
 		_testPostSiteStructuredContentBatch();
+		_testPostSiteStructuredContentWithContentFieldName();
 	}
 
 	@Override
@@ -779,6 +781,7 @@ public class StructuredContentResourceTest
 		_testPutStructuredContent(false);
 		_testPutStructuredContent(true);
 		_testPutStructuredContentWithComplexDDMStructure();
+		_testPutStructuredContentWithContentFieldName();
 	}
 
 	@Override
@@ -2749,6 +2752,46 @@ public class StructuredContentResourceTest
 		}
 	}
 
+	private void _testPatchStructuredContentWithContentFieldName()
+		throws Exception {
+
+		StructuredContent postStructuredContent =
+			structuredContentResource.postSiteStructuredContent(
+				testGroup.getGroupId(), randomStructuredContent());
+
+		String randomString = RandomTestUtil.randomString(10);
+
+		StructuredContent patchStructuredContent =
+			structuredContentResource.patchStructuredContent(
+				postStructuredContent.getId(),
+				new StructuredContent() {
+					{
+						setContentFields(
+							new ContentField[] {
+								new ContentField() {
+									{
+										contentFieldValue =
+											new ContentFieldValue() {
+												{
+													data = randomString;
+												}
+											};
+										name = "Foo";
+									}
+								}
+							});
+					}
+				});
+
+		ContentField contentField =
+			patchStructuredContent.getContentFields()[0];
+
+		ContentFieldValue contentFieldValue =
+			contentField.getContentFieldValue();
+
+		Assert.assertEquals(randomString, contentFieldValue.getData());
+	}
+
 	private void _testPatchStructuredContentWithDateExpired() throws Exception {
 		_testPatchStructuredContentWithDateExpiredExpire1();
 		_testPatchStructuredContentWithDateExpiredExpire2();
@@ -3185,6 +3228,39 @@ public class StructuredContentResourceTest
 
 		Assert.assertEquals(1, jsonObject.getLong("processedItemsCount"));
 		Assert.assertEquals(1, jsonObject.getLong("totalItemsCount"));
+	}
+
+	private void _testPostSiteStructuredContentWithContentFieldName()
+		throws Exception {
+
+		StructuredContent structuredContent = randomStructuredContent();
+
+		String randomString = RandomTestUtil.randomString(10);
+
+		structuredContent.setContentFields(
+			new ContentField[] {
+				new ContentField() {
+					{
+						contentFieldValue = new ContentFieldValue() {
+							{
+								data = randomString;
+							}
+						};
+						name = "Foo";
+					}
+				}
+			});
+
+		StructuredContent postStructuredContent =
+			structuredContentResource.postSiteStructuredContent(
+				testGroup.getGroupId(), structuredContent);
+
+		ContentField contentField = postStructuredContent.getContentFields()[0];
+
+		ContentFieldValue contentFieldValue =
+			contentField.getContentFieldValue();
+
+		Assert.assertEquals(randomString, contentFieldValue.getData());
 	}
 
 	private void _testPostStructuredContentFolderStructuredContentWithDisplayPageTemplate()
@@ -3628,6 +3704,41 @@ public class StructuredContentResourceTest
 
 		assertEquals(structuredContent, putStructuredContent);
 		assertValid(putStructuredContent);
+	}
+
+	private void _testPutStructuredContentWithContentFieldName()
+		throws Exception {
+
+		StructuredContent postStructuredContent =
+			structuredContentResource.postSiteStructuredContent(
+				testGroup.getGroupId(), randomStructuredContent());
+
+		String randomString = RandomTestUtil.randomString(10);
+
+		postStructuredContent.setContentFields(
+			new ContentField[] {
+				new ContentField() {
+					{
+						contentFieldValue = new ContentFieldValue() {
+							{
+								data = randomString;
+							}
+						};
+						name = "Foo";
+					}
+				}
+			});
+
+		StructuredContent putStructuredContent =
+			structuredContentResource.putStructuredContent(
+				postStructuredContent.getId(), postStructuredContent);
+
+		ContentField contentField = putStructuredContent.getContentFields()[0];
+
+		ContentFieldValue contentFieldValue =
+			contentField.getContentFieldValue();
+
+		Assert.assertEquals(randomString, contentFieldValue.getData());
 	}
 
 	private JSONObject _waitForFinish(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/StructuredContentResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/StructuredContentResourceTest.java
@@ -612,84 +612,12 @@ public class StructuredContentResourceTest
 	public void testPostSiteStructuredContent() throws Exception {
 		super.testPostSiteStructuredContent();
 
-		// Localized structured content populating just the default language
-
-		Locale locale = LocaleUtil.getDefault();
-
-		StructuredContent randomLocalizedStructuredContent1 =
-			_randomStructuredContent(locale, false);
-
-		StructuredContentResource englishStructuredContentResource =
-			_buildStructureContentResource(locale);
-
-		StructuredContent postStructuredContent1 =
-			englishStructuredContentResource.postSiteStructuredContent(
-				testGetSiteStructuredContentsPage_getSiteId(),
-				randomLocalizedStructuredContent1);
-
-		Assert.assertNotNull(postStructuredContent1.getTitle_i18n());
-		assertEquals(randomLocalizedStructuredContent1, postStructuredContent1);
-		assertValid(postStructuredContent1);
-
-		// Localized structured content with a different language from the
-		// default language
-
-		locale = LocaleUtil.fromLanguageId("es-ES");
-
-		StructuredContent randomLocalizedStructuredContent2 =
-			_randomStructuredContent(locale, true);
-
-		StructuredContentResource spanishStructuredContentResource =
-			_buildStructureContentResource(locale);
-
-		StructuredContent postStructuredContent2 =
-			spanishStructuredContentResource.postSiteStructuredContent(
-				testGetSiteStructuredContentsPage_getSiteId(),
-				randomLocalizedStructuredContent2);
-
-		_assertLocalizedValues(
-			postStructuredContent2, LocaleUtil.toW3cLanguageId(locale));
-		assertEquals(randomLocalizedStructuredContent2, postStructuredContent2);
-		assertValid(postStructuredContent2);
-
-		// Localized structured content with the default language
-
-		locale = LocaleUtil.getDefault();
-
-		StructuredContent randomLocalizedStructuredContent3 =
-			_randomStructuredContent(locale, true);
-
-		StructuredContent postStructuredContent3 =
-			englishStructuredContentResource.postSiteStructuredContent(
-				testGetSiteStructuredContentsPage_getSiteId(),
-				randomLocalizedStructuredContent3);
-
-		_assertLocalizedValues(
-			postStructuredContent3, LocaleUtil.toW3cLanguageId(locale));
-		assertEquals(randomLocalizedStructuredContent3, postStructuredContent3);
-		assertValid(postStructuredContent3);
-
-		// Structured content with the default priority
-
-		StructuredContent randomStructuredContent = _randomStructuredContent(
-			locale, true);
-
-		StructuredContentResource structuredContentResource =
-			_buildStructureContentResource(locale);
-
-		randomStructuredContent.setPriority((Double)null);
-
-		StructuredContent postStructuredContent4 =
-			structuredContentResource.postSiteStructuredContent(
-				testGetSiteStructuredContentsPage_getSiteId(),
-				randomStructuredContent);
-
-		Assert.assertEquals(
-			Double.valueOf(0.0), postStructuredContent4.getPriority());
-		assertValid(postStructuredContent4);
-
 		_testPostSiteStructuredContentBatch();
 		_testPostSiteStructuredContentWithContentFieldName();
+		_testPostSiteStructuredContentWithDefaultPriority();
+		_testPostSiteStructuredContentWithLocalizedDefaultLanguage();
+		_testPostSiteStructuredContentWithLocalizedDefaultLanguageOnly();
+		_testPostSiteStructuredContentWithLocalizedNondefaultLanguage();
 	}
 
 	@Override
@@ -3261,6 +3189,94 @@ public class StructuredContentResourceTest
 			contentField.getContentFieldValue();
 
 		Assert.assertEquals(randomString, contentFieldValue.getData());
+	}
+
+	private void _testPostSiteStructuredContentWithDefaultPriority()
+		throws Exception {
+
+		Locale locale = LocaleUtil.getDefault();
+
+		StructuredContent randomStructuredContent = _randomStructuredContent(
+			locale, true);
+
+		StructuredContentResource structuredContentResource =
+			_buildStructureContentResource(locale);
+
+		randomStructuredContent.setPriority((Double)null);
+
+		StructuredContent postStructuredContent =
+			structuredContentResource.postSiteStructuredContent(
+				testGetSiteStructuredContentsPage_getSiteId(),
+				randomStructuredContent);
+
+		Assert.assertEquals(
+			Double.valueOf(0.0), postStructuredContent.getPriority());
+		assertValid(postStructuredContent);
+	}
+
+	private void _testPostSiteStructuredContentWithLocalizedDefaultLanguage()
+		throws Exception {
+
+		Locale locale = LocaleUtil.getDefault();
+
+		StructuredContent randomLocalizedStructuredContent =
+			_randomStructuredContent(locale, true);
+
+		StructuredContentResource englishStructuredContentResource =
+			_buildStructureContentResource(locale);
+
+		StructuredContent postStructuredContent =
+			englishStructuredContentResource.postSiteStructuredContent(
+				testGetSiteStructuredContentsPage_getSiteId(),
+				randomLocalizedStructuredContent);
+
+		_assertLocalizedValues(
+			postStructuredContent, LocaleUtil.toW3cLanguageId(locale));
+		assertEquals(randomLocalizedStructuredContent, postStructuredContent);
+		assertValid(postStructuredContent);
+	}
+
+	private void _testPostSiteStructuredContentWithLocalizedDefaultLanguageOnly()
+		throws Exception {
+
+		Locale locale = LocaleUtil.getDefault();
+
+		StructuredContent randomLocalizedStructuredContent =
+			_randomStructuredContent(locale, false);
+
+		StructuredContentResource englishStructuredContentResource =
+			_buildStructureContentResource(locale);
+
+		StructuredContent postStructuredContent =
+			englishStructuredContentResource.postSiteStructuredContent(
+				testGetSiteStructuredContentsPage_getSiteId(),
+				randomLocalizedStructuredContent);
+
+		Assert.assertNotNull(postStructuredContent.getTitle_i18n());
+		assertEquals(randomLocalizedStructuredContent, postStructuredContent);
+		assertValid(postStructuredContent);
+	}
+
+	private void _testPostSiteStructuredContentWithLocalizedNondefaultLanguage()
+		throws Exception {
+
+		Locale locale = LocaleUtil.fromLanguageId("es-ES");
+
+		StructuredContent randomLocalizedStructuredContent =
+			_randomStructuredContent(locale, true);
+
+		StructuredContentResource spanishStructuredContentResource =
+			_buildStructureContentResource(locale);
+
+		StructuredContent postStructuredContent =
+			spanishStructuredContentResource.postSiteStructuredContent(
+				testGetSiteStructuredContentsPage_getSiteId(),
+				randomLocalizedStructuredContent);
+
+		_assertLocalizedValues(
+			postStructuredContent, LocaleUtil.toW3cLanguageId(locale));
+		assertEquals(randomLocalizedStructuredContent, postStructuredContent);
+		assertValid(postStructuredContent);
 	}
 
 	private void _testPostStructuredContentFolderStructuredContentWithDisplayPageTemplate()


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93736

## What is this trying to solve?

After LPD-71875, the headless-delivery structured content write endpoints (POST, PUT, and PATCH) matched the incoming content fields against the DDM structure by field reference only. Clients that identify a content field by name — which previously worked and mirrors how the GET endpoints represent fields — had their submitted values silently dropped, so the content was created or updated without the field data.

## How am I fixing it?

DDMFormValuesUtil now resolves each content field by field reference first and falls back to the field name when no reference matches, keying the content field map by name when the incoming field carries no reference. StructuredContentResourceImpl resolves the DDM form field through the structure (by reference or name) before looking up the value, so a field sent by name is matched and persisted. The testPostSiteStructuredContent scenarios were also extracted into separate private helpers to match the test convention.

## How can you verify that it works?

Integration tests (StructuredContentResourceTest): testPostSiteStructuredContent, testPutStructuredContent, and testPatchStructuredContent each exercise a content field identified by name and assert the value is saved.

Manually, against a running bundle as an admin:

1. Create a journal data definition with a text field named "Foo" (dataType string).
2. POST /o/headless-delivery/v1.0/sites/{siteId}/structured-contents with a contentFields entry that sets only "name": "Foo" (no fieldReference) and a contentFieldValue.
3. GET the structured content back and confirm the submitted data is present.
4. Repeat with PUT and PATCH.

Before the fix the value is dropped; after the fix it is persisted for all three verbs.
