### PR TITLE
LPD-92150 Show the error toast when pre-publish validation fails

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/SaveButtons.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/SaveButtons.js
@@ -244,9 +244,19 @@ export default function SaveButtons({
 			`${portletNamespace}dataEngineLayoutRenderer`
 		);
 
-		const [, isValid] = await renderer.reactComponentRef.current.validate();
+		try {
+			const [, isValid] =
+				await renderer.reactComponentRef.current.validate();
 
-		return isValid;
+			return isValid;
+		}
+		catch (error) {
+			if (error?.message && error.name !== 'AbortError') {
+				showAlert(error.message);
+			}
+
+			return false;
+		}
 	};
 
 	useEffect(() => {

--- a/modules/apps/journal/journal-web/test/js/SaveButtons.test.js
+++ b/modules/apps/journal/journal-web/test/js/SaveButtons.test.js
@@ -4,7 +4,7 @@
  */
 
 import '@testing-library/jest-dom';
-import {render, screen, waitFor} from '@testing-library/react';
+import {act, render, screen, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
@@ -249,6 +249,64 @@ describe('SaveButtons', () => {
 		expect(screen.getByText(yearToCheck)).toBeInTheDocument();
 
 		jest.useRealTimers();
+	});
+
+	it('shows an error alert when the publish validation request fails', async () => {
+		global.Liferay.componentReady = jest.fn().mockResolvedValue({
+			reactComponentRef: {
+				current: {
+					getFields: () => [{valid: true}],
+					validate: jest
+						.fn()
+						.mockRejectedValue(
+							new Error('Upload size is too large.')
+						),
+				},
+			},
+		});
+
+		renderComponent({
+			...DEFAULT_PROPS,
+			articleId: null,
+		});
+
+		userEvent.click(screen.getByText('publish'));
+
+		expect(
+			await screen.findByText('Upload size is too large.')
+		).toBeInTheDocument();
+	});
+
+	it('does not show an error alert when the publish validation request is aborted', async () => {
+		const validate = jest
+			.fn()
+			.mockRejectedValue(
+				new DOMException('The user aborted a request.', 'AbortError')
+			);
+
+		global.Liferay.componentReady = jest.fn().mockResolvedValue({
+			reactComponentRef: {
+				current: {
+					getFields: () => [{valid: true}],
+					validate,
+				},
+			},
+		});
+
+		renderComponent({
+			...DEFAULT_PROPS,
+			articleId: null,
+		});
+
+		userEvent.click(screen.getByText('publish'));
+
+		await waitFor(() => expect(validate).toHaveBeenCalled());
+
+		await act(async () => {});
+
+		expect(
+			screen.queryByText('The user aborted a request.')
+		).not.toBeInTheDocument();
 	});
 
 	it('does not proceed if required fields validation fails', async () => {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92150

## What Is Being Fixed

When publishing a Basic Web Content whose payload exceeds the upload size limit, the pre-publish validation request to the form context provider returns a 413, and no feedback was shown — the publish silently did nothing and the user was left guessing. This is the unfixed path of customer issue LPP-63989 / regression of LPS-198515: the earlier LPD-92150 work only handled the case where the modal was already open, not the validation request that runs before the modal opens.

## How It Is Being Fixed

`SaveButtons.validateRequiredFields` awaits the form's `validate()` call, which rejects when the validation request fails. That rejection was uncaught, so the publish flow ended silently. The call is now wrapped in a try/catch that surfaces the server message through the existing journal alert. Aborted or superseded validation requests are excluded by name (`AbortError`) so transient races don't raise a spurious toast — `instanceof Error` is deliberately not used, since modern browsers make `DOMException` an `Error` subclass and it would let aborts through.

## How To Test

cd modules/apps/journal/journal-web && yarn test SaveButtons

## PR Check

**pr-check: SKIPPED** — Frontend-only change; Jest tests pass and behavior verified live in the browser

<!-- pr-check {"reason": "Frontend-only change; Jest tests pass and behavior verified live in the browser", "result": "skipped", "sha": "296fd65712787ed57961045de607ebbe7084d519"} -->
