### PR TITLE
LPD-93944 Exclude Asset Publisher friendly URLs from canonical URLs

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_asset_entry_full_content.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_asset_entry_full_content.jsp
@@ -95,6 +95,7 @@ boolean viewMode = Objects.equals(ParamUtil.getString(PortalUtil.getOriginalServ
 						cssClass="header-back-to lfr-portal-tooltip"
 						href="<%= redirect %>"
 						icon="angle-left"
+						rel="nofollow"
 						title='<%= LanguageUtil.get(request, "back") %>'
 					/>
 				</c:if>

--- a/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalImplCanonicalURLTest.java
+++ b/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalImplCanonicalURLTest.java
@@ -312,6 +312,33 @@ public class PortalImplCanonicalURLTest {
 	}
 
 	@Test
+	@TestInfo("LPD-93944")
+	public void testCanonicalURLWithFriendlyURLForAssetPublisher()
+		throws Exception {
+
+		String portalDomain = "localhost";
+
+		ThemeDisplay themeDisplay = _createThemeDisplay(
+			portalDomain, _group, 8080, false);
+
+		String completeURL = _generateURL(
+			portalDomain, "8080", StringPool.BLANK, _group.getFriendlyURL(),
+			_layout1.getFriendlyURL() + Portal.FRIENDLY_URL_SEPARATOR +
+				"asset_publisher/content-name",
+			false);
+
+		Assert.assertEquals(
+			_generateURL(
+				portalDomain, "8080", StringPool.BLANK, _group.getFriendlyURL(),
+				_layout1.getFriendlyURL(), false),
+			_portal.getCanonicalURL(
+				HttpComponentsUtil.addParameter(
+					completeURL, "_ga",
+					"2.237928582.786466685.1515402734-1365236376"),
+				themeDisplay, _layout1, false, false));
+	}
+
+	@Test
 	public void testCanonicalURLWithFriendlyURLForBlogs() throws Exception {
 		String portalDomain = "localhost";
 

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -1534,11 +1534,15 @@ public class PortalImpl implements Portal {
 				String friendlyURL = layout.getFriendlyURL();
 
 				if (!friendlyURL.contains(urlSeparator)) {
+					String parametersURLString = completeURL.substring(index);
+
 					groupFriendlyURL = groupFriendlyURL.substring(0, index);
 
-					includeParametersURL = true;
+					if (!_isAssetPublisherFriendlyURL(parametersURLString)) {
+						includeParametersURL = true;
 
-					parametersURL = completeURL.substring(index);
+						parametersURL = parametersURLString;
+					}
 
 					break;
 				}
@@ -8086,6 +8090,22 @@ public class PortalImpl implements Portal {
 		return company.getVirtualHostname();
 	}
 
+	private boolean _isAssetPublisherFriendlyURL(String url) {
+		PortletFriendlyURLMapperMatch portletFriendlyURLMapperMatch =
+			PortletLocalServiceUtil.getPortletFriendlyURLMapperMatch(url);
+
+		if (portletFriendlyURLMapperMatch == null) {
+			return false;
+		}
+
+		FriendlyURLMapper friendlyURLMapper =
+			portletFriendlyURLMapperMatch.getFriendlyURLMapper();
+
+		return Objects.equals(
+			friendlyURLMapper.getMapping(),
+			_ASSET_PUBLISHER_FRIENDLY_URL_MAPPING);
+	}
+
 	private boolean _isSignedIn(HttpServletRequest httpServletRequest) {
 		PermissionChecker permissionChecker =
 			PermissionThreadLocal.getPermissionChecker();
@@ -8153,6 +8173,9 @@ public class PortalImpl implements Portal {
 
 		return false;
 	}
+
+	private static final String _ASSET_PUBLISHER_FRIENDLY_URL_MAPPING =
+		"asset_publisher";
 
 	private static final String[] _CUSTOM_SQL_KEYS = {
 		"[$CLASS_NAME_ID_COM.LIFERAY.PORTAL.MODEL.GROUP$]",

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -1535,10 +1535,11 @@ public class PortalImpl implements Portal {
 
 				if (!friendlyURL.contains(urlSeparator)) {
 					String parametersURLString = completeURL.substring(index);
+					String pathURLString = groupFriendlyURL.substring(index);
 
 					groupFriendlyURL = groupFriendlyURL.substring(0, index);
 
-					if (!_isAssetPublisherFriendlyURL(parametersURLString)) {
+					if (!_isAssetPublisherFriendlyURL(pathURLString)) {
 						includeParametersURL = true;
 
 						parametersURL = parametersURLString;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93944

## What Is Being Fixed

The Asset Publisher widget re-displays content that already has its own page, yet its friendly URL segment (for example `/-/asset_publisher/content-name`) and any appended query parameters were folded into the page's canonical URL. This let the same content be reached under more than one canonical URL, creating duplicate-content paths that search engines could index. The Asset Publisher "back" button link was also followable by crawlers.

## How It Is Being Fixed

When `PortalImpl.getCanonicalURL` builds the canonical URL, the friendly URL segment is now resolved against the registered portlet friendly URL mappers; when it matches the Asset Publisher mapping, the segment and its parameters are excluded so the canonical URL points at the base page. Content widgets that own their URLs (blogs, message boards, knowledge base, and so on) are unaffected and keep their distinct canonical URLs. The query string is stripped before the mapper lookup, so the cached lookup is keyed by the friendly URL path rather than by visitor-specific tracking parameters such as `_ga`. Finally, the Asset Publisher back button link now carries `rel="nofollow"`. An integration test covers the canonical URL behavior.

## PR Check

**pr-check: PASS** — tested on `e01cef36fe3790eb49149a04ae01a324e1d0f952`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Full Portal Build | PASS |
| JSP Compile | PASS |
| Integration Test Compile | PASS |

_Full Portal Build: `portal-impl` compiled cleanly; the all-modules `ant all` deploy hit an unrelated Gradle daemon out-of-memory crash, so the portal-core compile was verified directly via `ant compile install-portal-snapshot`._

<!-- pr-check {"result": "success", "sha": "e01cef36fe3790eb49149a04ae01a324e1d0f952"} -->
