### PR TITLE
LPD-90904 Stop suffixing categories matched by external reference code

### DIFF
--- a/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/exportimport/data/handler/AssetCategoryStagedModelDataHandler.java
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/exportimport/data/handler/AssetCategoryStagedModelDataHandler.java
@@ -28,7 +28,6 @@ import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.xml.Element;
 
 import java.util.List;
@@ -270,8 +269,9 @@ public class AssetCategoryStagedModelDataHandler
 		}
 		else {
 			String name = _getCategoryName(
-				category.getUuid(), portletDataContext.getScopeGroupId(),
-				parentCategoryId, category.getName(), vocabularyId, 2);
+				category.getExternalReferenceCode(),
+				portletDataContext.getScopeGroupId(), parentCategoryId,
+				category.getName(), vocabularyId, 2);
 
 			importedCategory = _assetCategoryLocalService.updateCategory(
 				existingCategory.getExternalReferenceCode(), userId,
@@ -336,15 +336,15 @@ public class AssetCategoryStagedModelDataHandler
 	}
 
 	private String _getCategoryName(
-			String uuid, long groupId, long parentCategoryId, String name,
-			long vocabularyId, int count)
-		throws Exception {
+		String externalReferenceCode, long groupId, long parentCategoryId,
+		String name, long vocabularyId, int count) {
 
 		AssetCategory category = _assetCategoryLocalService.fetchCategory(
 			groupId, parentCategoryId, name, vocabularyId);
 
 		if ((category == null) ||
-			(Validator.isNotNull(uuid) && uuid.equals(category.getUuid()))) {
+			Objects.equals(
+				externalReferenceCode, category.getExternalReferenceCode())) {
 
 			return name;
 		}
@@ -352,7 +352,8 @@ public class AssetCategoryStagedModelDataHandler
 		name = StringUtil.appendParentheticalSuffix(name, count);
 
 		return _getCategoryName(
-			uuid, groupId, parentCategoryId, name, vocabularyId, ++count);
+			externalReferenceCode, groupId, parentCategoryId, name,
+			vocabularyId, ++count);
 	}
 
 	private Map<Locale, String> _getCategoryTitleMap(

--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/exportimport/data/handler/test/AssetCategoryStagedModelDataHandlerTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/exportimport/data/handler/test/AssetCategoryStagedModelDataHandlerTest.java
@@ -7,6 +7,7 @@ package com.liferay.asset.categories.exportimport.data.handler.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.asset.kernel.model.AssetCategory;
+import com.liferay.asset.kernel.model.AssetCategoryConstants;
 import com.liferay.asset.kernel.model.AssetVocabulary;
 import com.liferay.asset.kernel.service.AssetCategoryLocalServiceUtil;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalServiceUtil;
@@ -16,15 +17,22 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.StagedModel;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Rule;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
@@ -38,6 +46,54 @@ public class AssetCategoryStagedModelDataHandlerTest
 	@Rule
 	public static final AggregateTestRule aggregateTestRule =
 		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testImportStagedModelWithSameNameAndExternalReferenceCode()
+		throws Exception {
+
+		String externalReferenceCode = RandomTestUtil.randomString();
+		String name = RandomTestUtil.randomString();
+
+		Locale locale = LocaleUtil.getSiteDefault();
+
+		Map<Locale, String> titleMap = Collections.singletonMap(locale, name);
+
+		String vocabularyExternalReferenceCode = RandomTestUtil.randomString();
+
+		AssetVocabulary stagingVocabulary = AssetTestUtil.addVocabulary(
+			vocabularyExternalReferenceCode, stagingGroup.getGroupId());
+
+		AssetCategory stagingCategory =
+			AssetCategoryLocalServiceUtil.addCategory(
+				externalReferenceCode, TestPropsValues.getUserId(),
+				stagingGroup.getGroupId(),
+				AssetCategoryConstants.DEFAULT_PARENT_CATEGORY_ID, titleMap,
+				Collections.emptyMap(), stagingVocabulary.getVocabularyId(),
+				null,
+				ServiceContextTestUtil.getServiceContext(
+					stagingGroup.getGroupId()));
+
+		exportStagedModel(stagingCategory);
+
+		AssetVocabulary liveVocabulary = AssetTestUtil.addVocabulary(
+			vocabularyExternalReferenceCode, liveGroup.getGroupId());
+
+		AssetCategoryLocalServiceUtil.addCategory(
+			externalReferenceCode, TestPropsValues.getUserId(),
+			liveGroup.getGroupId(),
+			AssetCategoryConstants.DEFAULT_PARENT_CATEGORY_ID, titleMap,
+			Collections.emptyMap(), liveVocabulary.getVocabularyId(), null,
+			ServiceContextTestUtil.getServiceContext(liveGroup.getGroupId()));
+
+		importStagedModel(stagingCategory);
+
+		AssetCategory importedCategory =
+			AssetCategoryLocalServiceUtil.
+				fetchAssetCategoryByExternalReferenceCode(
+					externalReferenceCode, liveGroup.getGroupId());
+
+		Assert.assertEquals(name, importedCategory.getName());
+	}
 
 	@Override
 	protected Map<String, List<StagedModel>> addDependentStagedModelsMap(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90904

## What Is Being Fixed

During Export-Import (for example, importing a site LAR into a new instance), an asset category that already exists in the target with the same external reference code and name but a different UUID has its name silently suffixed with " (2)". The external reference code on the row is unchanged, so it is the same entity, yet its name diverges from the source — reproducible by importing a site whose vocabulary and category share an external reference code with categories already present in the target, alongside a Web Content that links the category.

## How It Is Being Fixed

The handler resolves the existing target category by external reference code (fetchExistingStagedModel is ERC-first) and takes the update branch, but the duplicate-name guard in _getCategoryName still compared identity by UUID, so a same-external-reference-code, different-UUID match failed the guard and the name was suffixed. This was an incomplete migration from LPD-72325, which switched the lookup to external reference code and updated AssetVocabularyStagedModelDataHandler's guard to match but left AssetCategoryStagedModelDataHandler's guard on UUID. The fix aligns _getCategoryName's guard to external reference code, mirroring the already-corrected vocabulary handler, so a category recognized as the same entity by external reference code is no longer renamed. It also adds an integration test that imports a category whose target counterpart shares its name and external reference code but has a different UUID, asserting the name is preserved.

## PR Check

**pr-check: SKIPPED** — Source Format, module compile and deploy of asset-categories-admin-web, and the AssetCategoryStagedModelDataHandlerTest integration test were all run and passed manually this session; the change is a one-line guard plus its integration test.

<!-- pr-check {"reason": "Source Format, module compile and deploy of asset-categories-admin-web, and the AssetCategoryStagedModelDataHandlerTest integration test were all run and passed manually this session; the change is a one-line guard plus its integration test.", "result": "skipped", "sha": "6dda0f12e95f2e13715089751130ba16514d87e2"} -->