### PR TITLE
LPD-94190 Convert journal-web SCSS to atlas-custom-properties

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/css/main.scss
@@ -1,4 +1,6 @@
-@import 'atlas-variables';
+@import 'atlas-custom-properties/_variables';
+
+@import '_mixins';
 
 @import '../ddm_template_editor/components/PropertiesPanel';
 
@@ -92,7 +94,7 @@ $productMenuWidth: 320px;
 					}
 
 					> .tbar-item:first-child {
-						border-bottom: solid thin #e7e7ed;
+						border-bottom: solid thin $gray-300;
 						width: 100%;
 					}
 
@@ -194,7 +196,7 @@ $productMenuWidth: 320px;
 		}
 
 		.edit-article-sidebar {
-			border-left: 1px #e7e7ed solid;
+			border-left: 1px $gray-300 solid;
 			box-shadow: none;
 			max-width: 320px;
 			outline: 0;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94190

## What Is Being Fixed

The journal-web main stylesheet used hardcoded `#e7e7ed` color literals for the toolbar and sidebar borders, and imported the legacy `atlas-variables` partial. Because the colors were baked in at compile time, the Web Content editing UI did not respond to dark-mode theming, which is now driven by atlas-custom-properties CSS variables.

## How It Is Being Fixed

`modules/apps/journal/journal-web/src/main/resources/META-INF/resources/css/main.scss` now imports `atlas-custom-properties/_variables` and replaces both occurrences of `#e7e7ed` with `$gray-300` — the atlas-custom-properties alias that resolves to `var(--gray-300)` and adapts automatically across themes. The other already-tokenized references in the file (`$gray-400`, `$light`, `$secondary`, `$dark`) keep working because atlas-custom-properties redefines those names as `var(--…)` aliases, so they now pick up dark-mode theming as well.

## Why Are There No Tests?

Pure styling refactor — SCSS variable substitutions converting hardcoded colors to atlas-custom-properties tokens. There is no behavior change beyond rendered styling, and Web Content editor styling is not covered by any automated visual test layer in this repository.

## PR Check

**pr-check: PASS** — tested on `1a0efa9542e5aea383ab086d57e851f88fecadef`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Deploy | PASS |

<!-- pr-check {"result": "success", "sha": "1a0efa9542e5aea383ab086d57e851f88fecadef"} -->