### PR TITLE
LPD-93976 Avoid quadratic reindexing when expiring web content

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -1546,12 +1546,34 @@ public class JournalArticleLocalServiceImpl
 				groupId, articleId, QueryUtil.ALL_POS, QueryUtil.ALL_POS,
 				ArticleVersionComparator.getInstance(true));
 
-			for (JournalArticle article : articles) {
-				if (!article.isExpired()) {
-					journalArticleLocalService.expireArticle(
-						userId, groupId, article.getArticleId(),
-						article.getVersion(), articleURL, serviceContext);
+			boolean expired = false;
+			boolean indexingEnabled = serviceContext.isIndexingEnabled();
+
+			try {
+				serviceContext.setIndexingEnabled(false);
+
+				for (JournalArticle article : articles) {
+					if (!article.isExpired()) {
+						journalArticleLocalService.expireArticle(
+							userId, groupId, article.getArticleId(),
+							article.getVersion(), articleURL, serviceContext);
+
+						expired = true;
+					}
 				}
+			}
+			finally {
+				serviceContext.setIndexingEnabled(indexingEnabled);
+			}
+
+			if (expired && serviceContext.isIndexingEnabled()) {
+				Indexer<JournalArticle> indexer =
+					IndexerRegistryUtil.nullSafeGetIndexer(
+						JournalArticle.class);
+
+				indexer.reindex(
+					getLatestArticle(
+						groupId, articleId, WorkflowConstants.STATUS_ANY));
 			}
 		}
 		else {

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleIndexVersionsTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleIndexVersionsTest.java
@@ -164,6 +164,42 @@ public class JournalArticleIndexVersionsTest {
 	}
 
 	@Test
+	public void testExpireAllArticleVersionsWhenIndexAllArticleVersionsEnabled()
+		throws Exception {
+
+		_enableIndexAllArticleVersions();
+
+		assertSearchCount(0, true);
+		assertSearchCount(0, false);
+
+		JournalArticle article = JournalTestUtil.addArticle(
+			_group.getGroupId(),
+			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID);
+
+		JournalArticle updatedArticle = JournalTestUtil.updateArticle(
+			article, article.getTitleMap(), article.getContent(), true, true,
+			ServiceContextTestUtil.getServiceContext());
+
+		updatedArticle = JournalTestUtil.updateArticle(
+			updatedArticle, updatedArticle.getTitleMap(),
+			updatedArticle.getContent(), true, true,
+			ServiceContextTestUtil.getServiceContext());
+
+		// All three versions are indexed: one head and two non-head
+
+		assertSearchCount(1, true);
+		assertSearchCount(2, false);
+
+		JournalTestUtil.expireArticle(_group.getGroupId(), updatedArticle);
+
+		// After expiring all versions there is no head, but every version
+		// remains indexed (LPD-93976)
+
+		assertSearchCount(0, true);
+		assertSearchCount(3, false);
+	}
+
+	@Test
 	public void testExpireArticleVersion() throws Exception {
 		assertSearchCount(0, true);
 
@@ -267,6 +303,20 @@ public class JournalArticleIndexVersionsTest {
 			searchResponse.getRequestString() + "->" +
 				searchResponse.getDocuments(),
 			expectedCount, searchResponse.getCount());
+	}
+
+	private void _enableIndexAllArticleVersions() throws Exception {
+		PortalPreferences portalPreferences =
+			_portletPreferencesFactory.getPortalPreferences(
+				TestPropsValues.getUserId(), true);
+
+		portalPreferences.setValue(
+			"", "indexAllArticleVersionsEnabled", "true");
+
+		_portalPreferencesLocalService.updatePreferences(
+			TestPropsValues.getCompanyId(),
+			PortletKeys.PREFS_OWNER_TYPE_COMPANY,
+			PortletPreferencesFactoryUtil.toXML(portalPreferences));
 	}
 
 	@DeleteAfterTestRun

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleIndexVersionsTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleIndexVersionsTest.java
@@ -15,9 +15,12 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.portlet.PortalPreferences;
 import com.liferay.portal.kernel.portlet.PortletPreferencesFactory;
 import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
+import com.liferay.portal.kernel.search.BaseIndexerPostProcessor;
+import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Hits;
 import com.liferay.portal.kernel.search.Indexer;
+import com.liferay.portal.kernel.search.IndexerPostProcessor;
 import com.liferay.portal.kernel.search.IndexerRegistry;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.service.PortalPreferencesLocalService;
@@ -28,6 +31,7 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.SearchContextTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.search.legacy.searcher.SearchRequestBuilderFactory;
@@ -39,6 +43,7 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -47,6 +52,11 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceRegistration;
 
 /**
  * @author Eudaldo Alonso
@@ -164,6 +174,40 @@ public class JournalArticleIndexVersionsTest {
 	}
 
 	@Test
+	public void testExpireAllArticleVersionsReindexArticleOnce()
+		throws Exception {
+
+		_enableIndexAllArticleVersions();
+
+		JournalArticle article = JournalTestUtil.addArticle(
+			_group.getGroupId(),
+			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID);
+
+		JournalArticle updatedArticle = JournalTestUtil.updateArticle(
+			article, article.getTitleMap(), article.getContent(), true, true,
+			ServiceContextTestUtil.getServiceContext());
+
+		updatedArticle = JournalTestUtil.updateArticle(
+			updatedArticle, updatedArticle.getTitleMap(),
+			updatedArticle.getContent(), true, true,
+			ServiceContextTestUtil.getServiceContext());
+
+		AtomicInteger documentBuildCount = new AtomicInteger();
+
+		ServiceRegistration<IndexerPostProcessor> serviceRegistration =
+			_registerDocumentBuildCounter(documentBuildCount);
+
+		try {
+			JournalTestUtil.expireArticle(_group.getGroupId(), updatedArticle);
+		}
+		finally {
+			serviceRegistration.unregister();
+		}
+
+		Assert.assertEquals(3, documentBuildCount.get());
+	}
+
+	@Test
 	public void testExpireAllArticleVersionsWhenIndexAllArticleVersionsEnabled()
 		throws Exception {
 
@@ -185,15 +229,10 @@ public class JournalArticleIndexVersionsTest {
 			updatedArticle.getContent(), true, true,
 			ServiceContextTestUtil.getServiceContext());
 
-		// All three versions are indexed: one head and two non-head
-
 		assertSearchCount(1, true);
-		assertSearchCount(2, false);
+		assertSearchCount(3, false);
 
 		JournalTestUtil.expireArticle(_group.getGroupId(), updatedArticle);
-
-		// After expiring all versions there is no head, but every version
-		// remains indexed (LPD-93976)
 
 		assertSearchCount(0, true);
 		assertSearchCount(3, false);
@@ -317,6 +356,33 @@ public class JournalArticleIndexVersionsTest {
 			TestPropsValues.getCompanyId(),
 			PortletKeys.PREFS_OWNER_TYPE_COMPANY,
 			PortletPreferencesFactoryUtil.toXML(portalPreferences));
+	}
+
+	private ServiceRegistration<IndexerPostProcessor>
+		_registerDocumentBuildCounter(AtomicInteger documentBuildCount) {
+
+		Indexer<JournalArticle> indexer = _indexerRegistry.getIndexer(
+			JournalArticle.class);
+
+		Bundle bundle = FrameworkUtil.getBundle(
+			JournalArticleIndexVersionsTest.class);
+
+		BundleContext bundleContext = bundle.getBundleContext();
+
+		return bundleContext.registerService(
+			IndexerPostProcessor.class,
+			new BaseIndexerPostProcessor() {
+
+				@Override
+				public void postProcessDocument(
+					Document document, Object object) {
+
+					documentBuildCount.incrementAndGet();
+				}
+
+			},
+			MapUtil.singletonDictionary(
+				"indexer.class.name", indexer.getClassName()));
 	}
 
 	@DeleteAfterTestRun


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93976

## What Is Being Fixed

Expiring a web content article that has many versions was extremely slow. With "index all article versions" enabled, expiring an article triggered a reindex on every individual version's `expireArticle` call, and each of those passes rebuilt the document for every version. Expiring N versions therefore produced N reindex passes over N documents — quadratic work that made expiration of heavily-versioned articles drag.

## How It Is Being Fixed

When expiring all versions of an article, indexing is suppressed for the duration of the per-version expiration loop by temporarily turning off indexing on the `ServiceContext`, with the prior setting restored in a `finally` block. Once every version has been expired, the article is reindexed a single time through its latest version. This collapses the N reindex passes into one while preserving the resulting index state: every version stays indexed when "index all article versions" is enabled, and the reindex is skipped entirely when indexing was already disabled.

## PR Check

**pr-check: PASS** — tested on `b3252ac29d6505e6a8a9f724a02164a830207eaf`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Per-Module Deploy | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "b3252ac29d6505e6a8a9f724a02164a830207eaf"} -->
