### PR TITLE
LPD-94200 Fix flaky alert dismissal in waitForAlert autoClose

### DIFF
--- a/modules/test/playwright/utils/waitForAlert.ts
+++ b/modules/test/playwright/utils/waitForAlert.ts
@@ -1,5 +1,7 @@
 import {FrameLocator, Page, expect} from '@playwright/test';
 
+import {clickAndExpectToBeHidden} from './clickAndExpectToBeHidden';
+
 /**
  * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
@@ -57,8 +59,9 @@ export async function waitForAlert(
 	}
 
 	if (autoClose) {
-		await alert.getByLabel(closeText).click();
-
-		await alert.waitFor({state: 'hidden'});
+		await clickAndExpectToBeHidden({
+			target: alert,
+			trigger: alert.getByLabel(closeText),
+		});
 	}
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94200

## Failing Test

`site-cms-site-initializer/main/spaces/dynamicCollectionSpaceScope.spec.ts > Dynamic Collection scoped to a Space saves and displays the Space, not the CMS group`

`modules/test/playwright/tests/site-cms-site-initializer/main/spaces/dynamicCollectionSpaceScope.spec.ts`

```
› site-cms-site-initializer/main/spaces/dynamicCollectionSpaceScope.spec.ts:27:1 › Dynamic Collection scoped to a Space saves and displays the Space, not the CMS group @LPD-89353

Test timeout of 90000ms exceeded.

Error: locator.waitFor: Test timeout of 90000ms exceeded.
Call log:
  - waiting for locator('.alert-success').filter({ hasText: 'Success:Your request completed successfully.' }) to be hidden
    171 × locator resolved to visible
```

## Root Cause

This is a flaky timing failure, not a regression — the case has been failing intermittently on the `ci:test:content-management` routine for weeks (passing and failing across unrelated commits). The `waitForAlert` utility's `autoClose` branch clicked the alert's Close button once and then waited for the alert to become hidden. When the click landed before the toast was interactive, or when a post-save re-render of the collection editor remounted the toast right after the click, the single click was lost and the alert stayed visible until the 90s timeout. The product alert behaves correctly; only the test utility was fragile.

## Fix

`autoClose` now uses `clickAndExpectToBeHidden`, which retries the Close click until the alert is actually hidden — the flaky-proofing pattern already used elsewhere in the suite. Reproduced the exact failure locally (2/2) before the change; after the change the test passed 13/13 consecutive runs.

- `modules/test/playwright/utils/waitForAlert.ts`

## PR Check

**pr-check: PASS** — tested on `171596ff8aaccccf403036da41ef99a13dc47146`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "171596ff8aaccccf403036da41ef99a13dc47146"} -->
