### PR TITLE
LPD-93944 Add rel="nofollow" to Asset Publisher back button links

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_asset_entry_full_content.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_asset_entry_full_content.jsp
@@ -95,6 +95,7 @@ boolean viewMode = Objects.equals(ParamUtil.getString(PortalUtil.getOriginalServ
 						cssClass="header-back-to lfr-portal-tooltip"
 						href="<%= redirect %>"
 						icon="angle-left"
+						rel="nofollow"
 						title='<%= LanguageUtil.get(request, "back") %>'
 					/>
 				</c:if>


### PR DESCRIPTION
# What is this trying to solve?

[LPD-93944](https://liferay.atlassian.net/browse/LPD-93944)

Prevent search engines from following Asset Publisher back button links, which are intended only for navigation.

# How am I fixing it?

Mark the back button link as non-crawlable so search engines treat it as a navigation-only link.