### PR TITLE
LPD-94218 Fix test

### DIFF
--- a/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/collectionFiltersCMSCategorization.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/collectionFiltersCMSCategorization.spec.ts
@@ -155,24 +155,24 @@ test(
 		});
 
 		await test.step('CMS category is available in the category filter selector', async () => {
-			await page
-				.getByLabel('of the following')
-				.selectOption('assetCategories');
+			const filterFieldSelect = page.getByLabel('of the following');
+
+			await expect(async () => {
+				if (!(await filterFieldSelect.isVisible())) {
+					await page.getByRole('button', {name: 'Filter'}).click();
+				}
+
+				await expect(filterFieldSelect).toBeVisible({timeout: 2000});
+			}).toPass({timeout: 2000});
+
+			await filterFieldSelect.selectOption('assetCategories');
 
 			await page
 				.getByRole('button', {exact: true, name: 'Select'})
 				.click();
 
-			const categoryFrame = page.frameLocator(
-				'iframe[title="Select Categories"]'
-			);
-
-			await categoryFrame
-				.getByRole('button', {name: vocabularyName})
-				.click();
-
 			await expect(
-				categoryFrame.getByText(categoryName, {exact: true})
+				page.getByText(categoryName, {exact: true})
 			).toBeVisible();
 		});
 	}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94218

## What Is Being Changed
The Playwright test `collectionFiltersCMSCategorization.spec.ts` was failing intermittently in the step that verifies a CMS category is available in the category filter selector. The test assumed the filter field selector was always immediately visible and that the category picker opened inside a Select Categories iframe, neither of which holds reliably anymore, so the step would fail when the filter panel was not yet open or when the picker rendered inline.

## How It Is Being Changed
The step now waits for the filter field selector to be ready instead of interacting with it blindly. It wraps the visibility check in an `expect(...).toPass()` retry that opens the filter panel by clicking the Filter button when the of the following select is not yet visible, and only then selects the assetCategories option. The category selection logic is also updated to match the current UI: the assertions no longer reach into the Select Categories iframe via frameLocator, but operate directly on the page when clicking Select and verifying the category name is visible. This realigns the test with how the category filter selector actually renders and removes the flakiness.