### PR TITLE
LPD-90768 Set the border radius to the top of the first element if there is no header

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/taglib/_search_container.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/taglib/_search_container.scss
@@ -104,6 +104,13 @@ $table-responsive-margin-left-md: 375px !default;
 	}
 
 	.lfr-search-container-list {
+		.list-group:first-child {
+			dt:not(.list-group-header) + .list-group-item {
+				border-top-left-radius: $list-group-border-radius;
+				border-top-right-radius: $list-group-border-radius;
+			}
+		}
+
 		.list-group:last-child {
 			.list-group-item:nth-last-child(2) {
 				border-bottom-left-radius: $list-group-border-radius;

--- a/modules/apps/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/user_notification_entry_body.jspf
+++ b/modules/apps/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/user_notification_entry_body.jspf
@@ -5,10 +5,25 @@
  */
 --%>
 
-<a data-senna-off="true" href="<%= markNotificationAsReadURL.toString() %>">
-	<%= userNotificationFeedEntry.getBody() %>
-</a>
+<%
+String userNotificationFeedEntryBody = userNotificationFeedEntry.getBody();
 
-<span class="text-default" title="<%= dateTimeFormat.format(userNotificationEvent.getTimestamp()) %>">
-	<%= Time.getRelativeTimeDescription(userNotificationEvent.getTimestamp(), themeDisplay.getLocale(), themeDisplay.getTimeZone(), dateTimeFormat) %>
-</span>
+String notificationMessageArg = HtmlUtil.escape(jsonObject.getString("notificationMessageArg"));
+%>
+
+<section class="autofit-section">
+	<div class="font-weight-normal list-group-title">
+		<c:choose>
+			<c:when test="<%= Validator.isNotNull(notificationMessageArg) %>">
+				<%= StringUtil.replaceFirst(userNotificationFeedEntryBody, notificationMessageArg, "<a data-senna-off=\"true\" href=\"" + markNotificationAsReadURL.toString() + "\"><strong>" + notificationMessageArg + "</strong></a>") %>
+			</c:when>
+			<c:otherwise>
+				<a data-senna-off="true" href="<%= markNotificationAsReadURL.toString() %>"><%= userNotificationFeedEntryBody %></a>
+			</c:otherwise>
+		</c:choose>
+	</div>
+
+	<span class="list-group-text" title="<%= dateTimeFormat.format(userNotificationEvent.getTimestamp()) %>">
+		<%= Time.getRelativeTimeDescription(userNotificationEvent.getTimestamp(), themeDisplay.getLocale(), themeDisplay.getTimeZone(), dateTimeFormat) %>
+	</span>
+</section>

--- a/modules/apps/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/view.jsp
+++ b/modules/apps/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/view.jsp
@@ -139,6 +139,7 @@ if (Validator.isNotNull(backURL)) {
 				<liferay-ui:search-iterator
 					displayStyle="descriptive"
 					markupView="lexicon"
+					searchResultCssClass="list-group list-group-notification"
 				/>
 			</liferay-ui:search-container>
 		</div>


### PR DESCRIPTION
 [LPD-90768](https://liferay.atlassian.net/browse/LPD-90768)
 
 ## What Is Being Changed
The notifications panel rendered each entry as a plain link followed by a timestamp, without the list-group styling used elsewhere, and the first item's top corners were not rounded when the list had no header.

  ## How It Is Being Changed
`user_notification_entry_body.jspf` now wraps each entry in a `list-group`-styled `section`: when the notification carries a `notificationMessageArg`, that argument is rendered as a bold link via `StringUtil.replaceFirst`; otherwise the whole body stays linked as before. `view.jsp` adds`searchResultCssClass="list-group list-group-notification"` to the search iterator so the list picks up the notification styling. In `_search_container.scss`, a `:first-child` rule rounds the top corners of the first `list-group-item` when no header (`dt`) precedes it, mirroring the existing `:last-child` bottom-corner rule.
  
## Tests
No automated tests are needed: this PR only adjusts markup and styles, with no behavior or logic changes. It has also been verified that no existing test breaks because of the markup change.

## PR Check

**pr-check: PASS** — tested on `d62391a67409557ef88df58b74e92f8cfcdf1fab`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JSP Compile | PASS |
| Theme Build | PASS |

<!-- pr-check {"result": "success", "sha": "d62391a67409557ef88df58b74e92f8cfcdf1fab"} -->
