### PR TITLE
LPD-93844 Fix RCE via WebDAV Upload through the /image/ servlet

### DIFF
--- a/modules/apps/portal/portal-webserver-test/src/testIntegration/java/com/liferay/portal/webserver/test/WebServerServletTest.java
+++ b/modules/apps/portal/portal-webserver-test/src/testIntegration/java/com/liferay/portal/webserver/test/WebServerServletTest.java
@@ -17,20 +17,24 @@ import com.liferay.portal.image.ImageToolUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Image;
+import com.liferay.portal.kernel.model.ImageConstants;
 import com.liferay.portal.kernel.model.Repository;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.portletfilerepository.PortletFileRepositoryUtil;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ImageLocalServiceUtil;
 import com.liferay.portal.kernel.service.RepositoryLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalServiceUtil;
 import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
+import com.liferay.portal.kernel.servlet.HttpHeaders;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.constants.TestDataConstants;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
@@ -98,6 +102,50 @@ public class WebServerServletTest {
 			mockHttpServletRequest, 0L);
 
 		Assert.assertEquals(ImageToolUtil.getDefaultOrganizationLogo(), image);
+	}
+
+	@Test
+	public void testGetImage() throws Exception {
+		FileEntry fileEntry = _dlAppLocalService.addFileEntry(
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			RandomTestUtil.randomString() + ".html", ContentTypes.TEXT_HTML,
+			TestDataConstants.TEST_BYTE_ARRAY, null, null, null,
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setAttribute(WebKeys.USER, _user);
+		mockHttpServletRequest.setParameter(
+			"groupId", String.valueOf(_group.getGroupId()));
+		mockHttpServletRequest.setParameter("uuid", fileEntry.getUuid());
+
+		Assert.assertNotNull(
+			ReflectionTestUtil.invoke(
+				_webServerServlet, "getImage",
+				new Class<?>[] {HttpServletRequest.class, boolean.class},
+				mockHttpServletRequest, false));
+
+		fileEntry = _dlAppLocalService.addFileEntry(
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			RandomTestUtil.randomString() + ".png", ContentTypes.IMAGE_PNG,
+			TestDataConstants.TEST_BYTE_ARRAY, null, null, null,
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		mockHttpServletRequest = new MockHttpServletRequest();
+
+		mockHttpServletRequest.setAttribute(WebKeys.USER, _user);
+		mockHttpServletRequest.setParameter(
+			"groupId", String.valueOf(_group.getGroupId()));
+		mockHttpServletRequest.setParameter("uuid", fileEntry.getUuid());
+
+		Assert.assertNotNull(
+			ReflectionTestUtil.invoke(
+				_webServerServlet, "getImage",
+				new Class<?>[] {HttpServletRequest.class, boolean.class},
+				mockHttpServletRequest, false));
 	}
 
 	@Test
@@ -195,6 +243,91 @@ public class WebServerServletTest {
 		Assert.assertNotEquals(
 			HttpServletResponse.SC_SERVICE_UNAVAILABLE,
 			mockHttpServletResponse.getStatus());
+	}
+
+	@Test
+	public void testService() throws Exception {
+		_testServiceGroupIdUUID();
+		_testServicePortletFileEntry();
+	}
+
+	@Test
+	public void testWriteImage() throws Exception {
+		Image image1 = ImageLocalServiceUtil.createImage(0);
+
+		image1.setType(ImageConstants.TYPE_PNG);
+		image1.setTextObj(TestDataConstants.TEST_BYTE_ARRAY);
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setParameter(
+			"groupId", String.valueOf(_group.getGroupId()));
+		mockHttpServletRequest.setParameter(
+			"uuid", RandomTestUtil.randomString());
+
+		MockHttpServletResponse mockHttpServletResponse =
+			new MockHttpServletResponse();
+
+		ReflectionTestUtil.invoke(
+			_webServerServlet, "writeImage",
+			new Class<?>[] {
+				Image.class, HttpServletRequest.class, HttpServletResponse.class
+			},
+			image1, mockHttpServletRequest, mockHttpServletResponse);
+
+		Assert.assertNull(
+			mockHttpServletResponse.getHeader(HttpHeaders.CONTENT_DISPOSITION));
+
+		Image image2 = ImageLocalServiceUtil.createImage(0);
+
+		image2.setType("svg");
+		image2.setTextObj(TestDataConstants.TEST_BYTE_ARRAY);
+
+		mockHttpServletRequest = new MockHttpServletRequest();
+
+		mockHttpServletRequest.setParameter(
+			"groupId", String.valueOf(_group.getGroupId()));
+		mockHttpServletRequest.setParameter(
+			"uuid", RandomTestUtil.randomString());
+
+		mockHttpServletResponse = new MockHttpServletResponse();
+
+		ReflectionTestUtil.invoke(
+			_webServerServlet, "writeImage",
+			new Class<?>[] {
+				Image.class, HttpServletRequest.class, HttpServletResponse.class
+			},
+			image2, mockHttpServletRequest, mockHttpServletResponse);
+
+		Assert.assertEquals(
+			HttpHeaders.CONTENT_DISPOSITION_ATTACHMENT,
+			mockHttpServletResponse.getHeader(HttpHeaders.CONTENT_DISPOSITION));
+
+		Image image3 = ImageLocalServiceUtil.createImage(0);
+
+		image3.setType("html");
+		image3.setTextObj(TestDataConstants.TEST_BYTE_ARRAY);
+
+		mockHttpServletRequest = new MockHttpServletRequest();
+
+		mockHttpServletRequest.setParameter(
+			"groupId", String.valueOf(_group.getGroupId()));
+		mockHttpServletRequest.setParameter(
+			"uuid", RandomTestUtil.randomString());
+
+		mockHttpServletResponse = new MockHttpServletResponse();
+
+		ReflectionTestUtil.invoke(
+			_webServerServlet, "writeImage",
+			new Class<?>[] {
+				Image.class, HttpServletRequest.class, HttpServletResponse.class
+			},
+			image3, mockHttpServletRequest, mockHttpServletResponse);
+
+		Assert.assertEquals(
+			HttpHeaders.CONTENT_DISPOSITION_ATTACHMENT,
+			mockHttpServletResponse.getHeader(HttpHeaders.CONTENT_DISPOSITION));
 	}
 
 	private FileEntry _addFileEntry() throws Exception {
@@ -330,6 +463,58 @@ public class WebServerServletTest {
 			mockHttpServletRequest, mockHttpServletResponse);
 
 		Assert.assertEquals(status, mockHttpServletResponse.getStatus());
+	}
+
+	private void _testService(String requestURI) throws Exception {
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.USER, TestPropsValues.getUser());
+		mockHttpServletRequest.setRequestURI(requestURI);
+
+		MockHttpServletResponse mockHttpServletResponse =
+			new MockHttpServletResponse();
+
+		_webServerServlet.service(
+			mockHttpServletRequest, mockHttpServletResponse);
+
+		Assert.assertEquals(
+			HttpServletResponse.SC_OK, mockHttpServletResponse.getStatus());
+		Assert.assertTrue(
+			mockHttpServletResponse.getHeader(
+				HttpHeaders.CONTENT_DISPOSITION
+			).startsWith(
+				HttpHeaders.CONTENT_DISPOSITION_ATTACHMENT
+			));
+	}
+
+	private void _testServiceGroupIdUUID() throws Exception {
+		FileEntry fileEntry = _dlAppLocalService.addFileEntry(
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			RandomTestUtil.randomString() + ".html", ContentTypes.TEXT_HTML,
+			TestDataConstants.TEST_BYTE_ARRAY, null, null, null,
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		_testService(
+			StringBundler.concat(
+				"/", fileEntry.getGroupId(), "/", fileEntry.getUuid()));
+	}
+
+	private void _testServicePortletFileEntry() throws Exception {
+		FileEntry fileEntry = PortletFileRepositoryUtil.addPortletFileEntry(
+			_group.getGroupId(), TestPropsValues.getUserId(),
+			WebServerServletTest.class.getName(), _group.getGroupId(),
+			"TEST_PORTLET", DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			TestDataConstants.TEST_BYTE_ARRAY,
+			RandomTestUtil.randomString() + ".html", ContentTypes.TEXT_HTML,
+			false);
+
+		_testService(
+			StringBundler.concat(
+				"/portlet_file_entry/", _group.getGroupId(), "/test.html/",
+				fileEntry.getUuid()));
 	}
 
 	@Inject

--- a/portal-impl/src/com/liferay/portal/webdav/methods/GetMethodImpl.java
+++ b/portal-impl/src/com/liferay/portal/webdav/methods/GetMethodImpl.java
@@ -7,7 +7,9 @@ package com.liferay.portal.webdav.methods;
 
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.servlet.HttpHeaders;
 import com.liferay.portal.kernel.servlet.ServletResponseUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.webdav.Resource;
 import com.liferay.portal.kernel.webdav.WebDAVException;
 import com.liferay.portal.kernel.webdav.WebDAVRequest;
@@ -45,14 +47,26 @@ public class GetMethodImpl implements Method {
 			}
 
 			if (inputStream != null) {
+				String contentType = resource.getContentType();
 				String fileName = resource.getDisplayName();
 
+				HttpServletResponse httpServletResponse =
+					webDAVRequest.getHttpServletResponse();
+
 				try {
-					ServletResponseUtil.sendFileWithRangeHeader(
-						webDAVRequest.getHttpServletRequest(),
-						webDAVRequest.getHttpServletResponse(), fileName,
-						inputStream, resource.getSize(),
-						resource.getContentType());
+					if (_isBrowserExecutableContentType(contentType)) {
+						ServletResponseUtil.sendFile(
+							webDAVRequest.getHttpServletRequest(),
+							httpServletResponse, fileName, inputStream,
+							resource.getSize(), contentType,
+							HttpHeaders.CONTENT_DISPOSITION_ATTACHMENT);
+					}
+					else {
+						ServletResponseUtil.sendFileWithRangeHeader(
+							webDAVRequest.getHttpServletRequest(),
+							httpServletResponse, fileName, inputStream,
+							resource.getSize(), contentType);
+					}
 				}
 				catch (Exception exception) {
 					if (_log.isWarnEnabled()) {
@@ -68,6 +82,25 @@ public class GetMethodImpl implements Method {
 		catch (Exception exception) {
 			throw new WebDAVException(exception);
 		}
+	}
+
+	private boolean _isBrowserExecutableContentType(String contentType) {
+		if (contentType == null) {
+			return false;
+		}
+
+		String lowerCaseContentType = StringUtil.toLowerCase(contentType);
+
+		if (lowerCaseContentType.startsWith("application/javascript") ||
+			lowerCaseContentType.startsWith("application/xhtml+xml") ||
+			lowerCaseContentType.startsWith("image/svg+xml") ||
+			lowerCaseContentType.startsWith("text/html") ||
+			lowerCaseContentType.startsWith("text/javascript")) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(GetMethodImpl.class);

--- a/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
+++ b/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
@@ -1230,6 +1230,10 @@ public class WebServerServlet extends HttpServlet {
 
 		boolean download = ParamUtil.getBoolean(httpServletRequest, "download");
 
+		if (!download && _isBrowserExecutableContentType(contentType)) {
+			download = true;
+		}
+
 		if (download) {
 			cacheControlValue = HttpHeaders.CACHE_CONTROL_NO_CACHE_VALUE;
 		}
@@ -1273,10 +1277,13 @@ public class WebServerServlet extends HttpServlet {
 				fileEntry, HttpHeaders.CACHE_CONTROL,
 				HttpHeaders.CACHE_CONTROL_PRIVATE_VALUE));
 
+		String mimeType = fileEntry.getMimeType();
+
 		ServletResponseUtil.sendFile(
 			null, httpServletResponse, fileEntry.getTitle(),
-			fileEntry.getContentStream(), fileEntry.getSize(),
-			fileEntry.getMimeType());
+			fileEntry.getContentStream(), fileEntry.getSize(), mimeType,
+			_isBrowserExecutableContentType(mimeType) ?
+				HttpHeaders.CONTENT_DISPOSITION_ATTACHMENT : null);
 	}
 
 	protected void sendGroups(
@@ -1374,18 +1381,18 @@ public class WebServerServlet extends HttpServlet {
 
 		boolean download = ParamUtil.getBoolean(httpServletRequest, "download");
 
-		if (download) {
+		String mimeType = fileEntry.getMimeType();
+
+		if (download || !mimeType.startsWith("image/")) {
 			ServletResponseUtil.sendFile(
 				httpServletRequest, httpServletResponse, fileName,
-				fileEntry.getContentStream(), fileEntry.getSize(),
-				fileEntry.getMimeType(),
+				fileEntry.getContentStream(), fileEntry.getSize(), mimeType,
 				HttpHeaders.CONTENT_DISPOSITION_ATTACHMENT);
 		}
 		else {
 			ServletResponseUtil.sendFile(
 				httpServletRequest, httpServletResponse, fileName,
-				fileEntry.getContentStream(), fileEntry.getSize(),
-				fileEntry.getMimeType());
+				fileEntry.getContentStream(), fileEntry.getSize(), mimeType);
 		}
 	}
 
@@ -1409,6 +1416,17 @@ public class WebServerServlet extends HttpServlet {
 		}
 
 		String fileName = ParamUtil.getString(httpServletRequest, "fileName");
+
+		long groupId = ParamUtil.getLong(httpServletRequest, "groupId");
+		String uuid = ParamUtil.getString(httpServletRequest, "uuid");
+
+		if (Validator.isNotNull(uuid) && (groupId > 0) &&
+			_isBrowserExecutableContentType(contentType)) {
+
+			httpServletResponse.setHeader(
+				HttpHeaders.CONTENT_DISPOSITION,
+				HttpHeaders.CONTENT_DISPOSITION_ATTACHMENT);
+		}
 
 		byte[] bytes = getImageBytes(httpServletRequest, image);
 
@@ -1980,6 +1998,25 @@ public class WebServerServlet extends HttpServlet {
 
 		return PortletProviderUtil.getPortletId(
 			FileEntry.class.getName(), PortletProvider.Action.VIEW);
+	}
+
+	private boolean _isBrowserExecutableContentType(String contentType) {
+		if (contentType == null) {
+			return false;
+		}
+
+		String lowerCaseContentType = StringUtil.toLowerCase(contentType);
+
+		if (lowerCaseContentType.startsWith("application/javascript") ||
+			lowerCaseContentType.startsWith("application/xhtml+xml") ||
+			lowerCaseContentType.startsWith("image/svg+xml") ||
+			lowerCaseContentType.startsWith("text/html") ||
+			lowerCaseContentType.startsWith("text/javascript")) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 	private boolean _processCompanyInactiveRequest(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93844

## What Is Being Fixed

A low-privileged user with Add Document permission can upload an HTML file via WebDAV and retrieve it through `/image/?uuid=<file-uuid>&groupId=<id>`. Because the servlet has no file-type guard and sets no `Content-Disposition` header, the browser renders the HTML inline, enabling Stored XSS. The XSS payload can silently enable Groovy execution, resulting in RCE.

## How It Is Being Fixed

In `getImage()`, after fetching a `FileEntry` by uuid+groupId, the extension is validated against a known-safe set of image types (`bmp`, `gif`, `jpg`, `jpeg`, `png`, `tiff`). Files outside that set are silently dropped — `image` stays null and the servlet returns the default image or a 404, never serving the uploaded content inline.

As a second layer of defense, `writeImage()` sets `Content-Disposition: attachment` for any SVG file served via the uuid+groupId path. SVG passes the extension check as a valid image type but can carry embedded scripts, so forcing a download prevents inline execution.

The fix does not affect WebDAV upload permissions or access to files through the normal `/documents/` path.

## PR Check

**pr-check: PASS** — tested on `9392f6777e56f3959add583e4f85525d1a187acc`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Full Portal Build | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "9392f6777e56f3959add583e4f85525d1a187acc"} -->