### PR TITLE
LPD-94348 Verify the adaptive media binary exists before serving it

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/finder/AMImageFinderImpl.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/finder/AMImageFinderImpl.java
@@ -228,7 +228,8 @@ public class AMImageFinderImpl implements AMImageFinder {
 			return false;
 		}
 
-		return true;
+		return _amImageEntryLocalService.hasAMImageEntryContent(
+			amImageConfigurationEntry.getUUID(), fileVersion);
 	}
 
 	@Reference

--- a/modules/apps/adaptive-media/adaptive-media-image-impl/src/test/java/com/liferay/adaptive/media/image/internal/finder/AMImageFinderImplTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-impl/src/test/java/com/liferay/adaptive/media/image/internal/finder/AMImageFinderImplTest.java
@@ -149,7 +149,7 @@ public class AMImageFinderImplTest {
 		Mockito.when(
 			_fileVersion.getMimeType()
 		).thenReturn(
-			"image/jpeg"
+			ContentTypes.IMAGE_JPEG
 		);
 
 		AMImageEntry amImageEntry = _mockImage(800, 900, 1000L);
@@ -205,7 +205,7 @@ public class AMImageFinderImplTest {
 		Mockito.when(
 			_fileVersion.getMimeType()
 		).thenReturn(
-			"image/jpeg"
+			ContentTypes.IMAGE_JPEG
 		);
 
 		AMImageEntry amImageEntry = _mockImage(99, 199, 1000L);
@@ -284,7 +284,7 @@ public class AMImageFinderImplTest {
 		Mockito.when(
 			_fileVersion.getMimeType()
 		).thenReturn(
-			"image/jpeg"
+			ContentTypes.IMAGE_JPEG
 		);
 
 		AMImageEntry amImageEntry1 = _mockImage(99, 199, 1000L);
@@ -397,7 +397,7 @@ public class AMImageFinderImplTest {
 		Mockito.when(
 			_fileVersion.getMimeType()
 		).thenReturn(
-			"image/jpeg"
+			ContentTypes.IMAGE_JPEG
 		);
 
 		AMImageEntry amImageEntry1 = _mockImage(99, 199, 1000L);
@@ -537,7 +537,7 @@ public class AMImageFinderImplTest {
 		Mockito.when(
 			_fileVersion.getMimeType()
 		).thenReturn(
-			"image/jpeg"
+			ContentTypes.IMAGE_JPEG
 		);
 
 		AMImageEntry amImageEntry = _mockImage(800, 900, 1000L);
@@ -607,7 +607,7 @@ public class AMImageFinderImplTest {
 		Mockito.when(
 			_fileVersion.getMimeType()
 		).thenReturn(
-			"image/jpeg"
+			ContentTypes.IMAGE_JPEG
 		);
 
 		AMImageEntry amImageEntry = _mockImage(99, 1000, 1000L);
@@ -679,7 +679,7 @@ public class AMImageFinderImplTest {
 		Mockito.when(
 			_fileVersion.getMimeType()
 		).thenReturn(
-			"image/jpeg"
+			ContentTypes.IMAGE_JPEG
 		);
 
 		AMImageEntry amImageEntry1 = _mockImage(99, 199, 1000L);
@@ -766,7 +766,7 @@ public class AMImageFinderImplTest {
 		Mockito.when(
 			_fileVersion.getMimeType()
 		).thenReturn(
-			"image/jpeg"
+			ContentTypes.IMAGE_JPEG
 		);
 
 		AMImageEntry amImageEntry1 = _mockImage(99, 199, 1000L);
@@ -853,7 +853,7 @@ public class AMImageFinderImplTest {
 		Mockito.when(
 			_fileVersion.getMimeType()
 		).thenReturn(
-			"image/jpeg"
+			ContentTypes.IMAGE_JPEG
 		);
 
 		AMImageEntry amImageEntry1 = _mockImage(99, 199, 1000L);
@@ -940,7 +940,7 @@ public class AMImageFinderImplTest {
 		Mockito.when(
 			_fileVersion.getMimeType()
 		).thenReturn(
-			"image/jpeg"
+			ContentTypes.IMAGE_JPEG
 		);
 
 		AMImageEntry amImageEntry1 = _mockImage(99, 199, 1000L);
@@ -1039,7 +1039,7 @@ public class AMImageFinderImplTest {
 		Mockito.when(
 			_fileVersion.getMimeType()
 		).thenReturn(
-			"image/jpeg"
+			ContentTypes.IMAGE_JPEG
 		);
 
 		AMImageEntry amImageEntry1 = _mockImage(99, 199, 1000L);
@@ -1178,7 +1178,7 @@ public class AMImageFinderImplTest {
 		Mockito.when(
 			_fileVersion.getMimeType()
 		).thenReturn(
-			"image/jpeg"
+			ContentTypes.IMAGE_JPEG
 		);
 
 		AMImageEntry amImageEntry1 = _mockImage(100, 1000, 1000L);
@@ -1299,7 +1299,7 @@ public class AMImageFinderImplTest {
 		Mockito.when(
 			_fileVersion.getMimeType()
 		).thenReturn(
-			"image/jpeg"
+			ContentTypes.IMAGE_JPEG
 		);
 
 		AMImageEntry amImageEntry1 = _mockImage(99, 1000, 1000L);
@@ -1380,7 +1380,7 @@ public class AMImageFinderImplTest {
 		Mockito.when(
 			_fileVersion.getMimeType()
 		).thenReturn(
-			"image/jpeg"
+			ContentTypes.IMAGE_JPEG
 		);
 
 		AMImageEntry amImageEntry = _mockImage(800, 900, 1000L);
@@ -1525,7 +1525,7 @@ public class AMImageFinderImplTest {
 		Mockito.when(
 			_fileVersion.getMimeType()
 		).thenReturn(
-			"image/jpeg"
+			ContentTypes.IMAGE_JPEG
 		);
 
 		AMImageEntry amImageEntry = _mockImage(99, 99, 1000L);

--- a/modules/apps/adaptive-media/adaptive-media-image-impl/src/test/java/com/liferay/adaptive/media/image/internal/finder/AMImageFinderImplTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-impl/src/test/java/com/liferay/adaptive/media/image/internal/finder/AMImageFinderImplTest.java
@@ -68,6 +68,13 @@ public class AMImageFinderImplTest {
 			_amImageMimeTypeProvider);
 		ReflectionTestUtil.setFieldValue(
 			_amImageFinderImpl, "_amImageURLFactory", _amImageURLFactory);
+
+		Mockito.when(
+			_amImageEntryLocalService.hasAMImageEntryContent(
+				Mockito.anyString(), Mockito.any(FileVersion.class))
+		).thenReturn(
+			true
+		);
 	}
 
 	@Test(expected = PortalException.class)
@@ -1344,6 +1351,69 @@ public class AMImageFinderImplTest {
 			Integer.valueOf(199),
 			adaptiveMedia1.getValue(
 				AMImageAttribute.AM_IMAGE_ATTRIBUTE_HEIGHT));
+	}
+
+	@Test
+	public void testGetMediaWhenContentIsMissing() throws Exception {
+		AMImageConfigurationEntry amImageConfigurationEntry =
+			new AMImageConfigurationEntryImpl(
+				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+				new HashMap<>());
+
+		AMImageQueryBuilder.ConfigurationStatus enabledConfigurationStatus =
+			AMImageQueryBuilder.ConfigurationStatus.ENABLED;
+
+		Mockito.when(
+			_amImageConfigurationHelper.getAMImageConfigurationEntries(
+				_fileVersion.getCompanyId(),
+				enabledConfigurationStatus.getPredicate())
+		).thenReturn(
+			Collections.singleton(amImageConfigurationEntry)
+		);
+
+		Mockito.when(
+			_fileVersion.getFileName()
+		).thenReturn(
+			RandomTestUtil.randomString()
+		);
+
+		Mockito.when(
+			_fileVersion.getMimeType()
+		).thenReturn(
+			"image/jpeg"
+		);
+
+		AMImageEntry amImageEntry = _mockImage(800, 900, 1000L);
+
+		Mockito.when(
+			_amImageEntryLocalService.fetchAMImageEntry(
+				amImageConfigurationEntry.getUUID(),
+				_fileVersion.getFileVersionId())
+		).thenReturn(
+			amImageEntry
+		);
+
+		Mockito.when(
+			_amImageMimeTypeProvider.isMimeTypeSupported(Mockito.anyString())
+		).thenReturn(
+			true
+		);
+
+		Mockito.when(
+			_amImageEntryLocalService.hasAMImageEntryContent(
+				amImageConfigurationEntry.getUUID(), _fileVersion)
+		).thenReturn(
+			false
+		);
+
+		List<AdaptiveMedia<AMProcessor<FileVersion>>> adaptiveMedias =
+			_amImageFinderImpl.getAdaptiveMedias(
+				amImageQueryBuilder -> amImageQueryBuilder.forFileVersion(
+					_fileVersion
+				).done());
+
+		Assert.assertEquals(
+			adaptiveMedias.toString(), 0, adaptiveMedias.size());
 	}
 
 	@Test

--- a/modules/apps/adaptive-media/adaptive-media-image-service/src/main/java/com/liferay/adaptive/media/image/service/impl/AMImageEntryLocalServiceImpl.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-service/src/main/java/com/liferay/adaptive/media/image/service/impl/AMImageEntryLocalServiceImpl.java
@@ -16,13 +16,18 @@ import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.kernel.store.Store;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.aop.AopService;
+import com.liferay.portal.kernel.cache.MultiVMPool;
+import com.liferay.portal.kernel.cache.PortalCache;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.repository.model.FileVersion;
 
 import java.io.InputStream;
+import java.io.Serializable;
 
 import java.util.Date;
 import java.util.List;
@@ -124,6 +129,8 @@ public class AMImageEntryLocalServiceImpl
 			companyId, amImageConfigurationEntry.getUUID());
 
 		_imageStorage.delete(companyId, amImageConfigurationEntry.getUUID());
+
+		_portalCache.removeAll();
 	}
 
 	/**
@@ -148,6 +155,11 @@ public class AMImageEntryLocalServiceImpl
 
 				_imageStorage.delete(
 					fileVersion, amImageEntry.getConfigurationUuid());
+
+				_portalCache.remove(
+					_getKey(
+						fileVersion.getFileVersionId(),
+						amImageEntry.getConfigurationUuid()));
 			}
 			catch (AMRuntimeException.IOException ioException) {
 				_log.error(ioException);
@@ -178,6 +190,8 @@ public class AMImageEntryLocalServiceImpl
 		amImageEntryPersistence.remove(amImageEntry);
 
 		_imageStorage.delete(fileVersion, amImageEntry.getConfigurationUuid());
+
+		_portalCache.remove(_getKey(fileVersionId, configurationUuid));
 	}
 
 	/**
@@ -307,12 +321,30 @@ public class AMImageEntryLocalServiceImpl
 	public boolean hasAMImageEntryContent(
 		String configurationUuid, FileVersion fileVersion) {
 
-		return _imageStorage.hasContent(fileVersion, configurationUuid);
+		String key = _getKey(fileVersion.getFileVersionId(), configurationUuid);
+
+		Boolean hasContent = (Boolean)_portalCache.get(key);
+
+		if (hasContent != null) {
+			return hasContent;
+		}
+
+		hasContent = _imageStorage.hasContent(fileVersion, configurationUuid);
+
+		if (hasContent) {
+			_portalCache.put(key, hasContent);
+		}
+
+		return hasContent;
 	}
 
 	@Activate
 	protected void activate(BundleContext bundleContext) {
 		_imageStorage = new ImageStorage(_store);
+
+		_portalCache =
+			(PortalCache<String, Serializable>)_multiVMPool.getPortalCache(
+				AMImageEntryLocalServiceImpl.class.getName());
 
 		_serviceTrackerMap = ServiceTrackerMapFactory.openSingleValueMap(
 			bundleContext, AMImageCounter.class, "adaptive.media.key");
@@ -322,6 +354,11 @@ public class AMImageEntryLocalServiceImpl
 	@Override
 	protected void deactivate() {
 		super.deactivate();
+
+		_portalCache.removeAll();
+
+		_multiVMPool.removePortalCache(
+			AMImageEntryLocalServiceImpl.class.getName());
 
 		_serviceTrackerMap.close();
 	}
@@ -338,6 +375,11 @@ public class AMImageEntryLocalServiceImpl
 		}
 	}
 
+	private String _getKey(long fileVersionId, String configurationUuid) {
+		return StringBundler.concat(
+			fileVersionId, StringPool.POUND, configurationUuid);
+	}
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		AMImageEntryLocalServiceImpl.class);
 
@@ -345,6 +387,11 @@ public class AMImageEntryLocalServiceImpl
 	private DLAppLocalService _dlAppLocalService;
 
 	private ImageStorage _imageStorage;
+
+	@Reference
+	private MultiVMPool _multiVMPool;
+
+	private PortalCache<String, Serializable> _portalCache;
 	private ServiceTrackerMap<String, AMImageCounter> _serviceTrackerMap;
 
 	@Reference(target = "(default=true)")

--- a/modules/apps/adaptive-media/adaptive-media-image-test/src/testIntegration/java/com/liferay/adaptive/media/image/service/impl/test/AMImageEntryLocalServiceTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-test/src/testIntegration/java/com/liferay/adaptive/media/image/service/impl/test/AMImageEntryLocalServiceTest.java
@@ -570,6 +570,37 @@ public class AMImageEntryLocalServiceTest {
 	}
 
 	@Test
+	public void testHasAMImageEntryContentReturnsCachedResultWhenContentMissing()
+		throws Exception {
+
+		AMImageConfigurationEntry amImageConfigurationEntry =
+			_addAMImageConfigurationEntry("uuid", 100, 200);
+
+		byte[] bytes = _getImageBytes();
+
+		FileEntry fileEntry = _addFileEntry(
+			bytes,
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		FileVersion fileVersion = fileEntry.getFileVersion();
+
+		AMImageEntryLocalServiceUtil.addAMImageEntry(
+			amImageConfigurationEntry, fileVersion, 100, 300,
+			new UnsyncByteArrayInputStream(bytes), 12345);
+
+		Assert.assertTrue(
+			AMImageEntryLocalServiceUtil.hasAMImageEntryContent(
+				amImageConfigurationEntry.getUUID(), fileVersion));
+
+		DLStoreUtil.deleteDirectory(
+			fileEntry.getCompanyId(), CompanyConstants.SYSTEM, "adaptive");
+
+		Assert.assertTrue(
+			AMImageEntryLocalServiceUtil.hasAMImageEntryContent(
+				amImageConfigurationEntry.getUUID(), fileVersion));
+	}
+
+	@Test
 	public void testHasAMImageEntryContentWhenContentPresent()
 		throws Exception {
 


### PR DESCRIPTION
### What

Fixes adaptive media breaking after a database restore that excludes the generated `adaptive/` binaries (SaaS backups). The `AMImageEntry` rows survive but the files are gone, so `AMImageFinderImpl` reported the variation as available based only on the database row, and the request handler served a nonexistent file and threw `NoSuchFileException` instead of falling back to the source image.

The finder now verifies the binary actually exists before offering the variation, so the request handler falls back to the source image and triggers regeneration.

Jira: https://liferay.atlassian.net/browse/LPD-94348 (relates to LPP-64180)

### Commits

1. `Verify the adaptive media binary exists before serving it` — the fix: `AMImageFinderImpl` calls `hasAMImageEntryContent` instead of returning `true`.
1. `Test that a missing binary excludes the adaptive media` — finder unit test.
1. `Cache adaptive media binary existence checks in the service` — performance cache, in `AMImageEntryLocalServiceImpl.hasAMImageEntryContent`.
1. `Test that a cached binary existence check survives an out-of-band delete` — service integration test.
1. `Use the ContentTypes constant in the finder test` — review cleanup.

### Cache — addresses @adolfopa review

Verifying the binary adds a file store lookup per resolution on every render; on remote stores (S3, GCS, Azure) that is a remote HEAD request, multiplied across resolutions when building a srcset / `<picture>` or a headless response.

Per the review, the cache now lives in `AMImageEntryLocalService.hasAMImageEntryContent` (not in the finder), so **every** caller benefits — the finder, the processor (`_isUpdateImageEntry`) and the validator (`isProcessingRequired`) — and the finder unit test no longer needs to mock the cache.

- **Positive results only.** A missing binary is never cached, so the self-heal path rechecks on every request and picks up the regenerated binary immediately.
- **Invalidation.** Because the processor and the validator consult the cache without the finder's `fetchAMImageEntry == null` guard, every delete path invalidates the cache: a precise `remove(key)` on both `deleteAMImageEntryFileVersion` methods (the key is known), and `removeAll()` on the bulk `deleteAMImageEntries` (one configuration across all file versions — no per-entry key without an extra query) and on `@Deactivate`, matching the `removeAll()` convention in `WikiPageLocalServiceImpl` and `CommercePriceListLocalServiceImpl`.

The restore scenario this ticket is about is unaffected by the cache: a restore starts a fresh JVM with a cold cache.

### Test Plan

| Validation | Result |
| --- | --- |
| `AMImageFinderImplTest` (unit) | PASS |
| `AMImageEntryLocalServiceTest` (integration, 14/14) | PASS |
| `AMImageProcessorTest` (integration, 5/5) | PASS |
| `ThumbnailsOSGiCommandsTest` (integration, 4/4) | PASS |
