### PR TITLE
LPD-94204 Honor structuredContentFolderId in structured content draft

### DIFF
--- a/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/resource/v1_0/StructuredContentResourceImpl.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/resource/v1_0/StructuredContentResourceImpl.java
@@ -304,7 +304,10 @@ public class StructuredContentResourceImpl
 
 		return _toExtensionStructuredContent(
 			_journalArticleService.addArticle(
-				null, siteId, JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+				null, siteId,
+				GetterUtil.getLong(
+					structuredContent.getStructuredContentFolderId(),
+					JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID),
 				0, 0, null, true, titleMap, descriptionMap, friendlyUrlMap,
 				StructuredContentUtil.getJournalArticleContent(
 					_ddm,

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-test/src/testIntegration/java/com/liferay/headless/admin/content/resource/v1_0/test/StructuredContentResourceTest.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-test/src/testIntegration/java/com/liferay/headless/admin/content/resource/v1_0/test/StructuredContentResourceTest.java
@@ -25,6 +25,7 @@ import com.liferay.headless.admin.content.client.dto.v1_0.StructuredContent;
 import com.liferay.headless.admin.content.client.pagination.Page;
 import com.liferay.headless.admin.content.client.pagination.Pagination;
 import com.liferay.headless.delivery.client.resource.v1_0.StructuredContentResource;
+import com.liferay.journal.constants.JournalFolderConstants;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.model.JournalFolder;
 import com.liferay.journal.service.JournalArticleLocalService;
@@ -493,19 +494,22 @@ public class StructuredContentResourceTest
 		// Localized structured content with the default language
 
 		_testPostSiteStructuredContentDraft(
-			LocaleUtil.getDefault(), RandomTestUtil.randomDouble());
+			LocaleUtil.getDefault(), RandomTestUtil.randomDouble(),
+			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID);
 
 		// Localized structured content with a different language from the
 		// default language
 
 		_testPostSiteStructuredContentDraft(
-			LocaleUtil.fromLanguageId("es-ES"), RandomTestUtil.randomDouble());
+			LocaleUtil.fromLanguageId("es-ES"), RandomTestUtil.randomDouble(),
+			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID);
 
 		// Structured content with a priority
 
 		StructuredContent structuredContent1 =
 			_testPostSiteStructuredContentDraft(
-				LocaleUtil.getDefault(), Double.valueOf(1));
+				LocaleUtil.getDefault(), Double.valueOf(1),
+				JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID);
 
 		Assert.assertEquals(
 			Double.valueOf(1.0), structuredContent1.getPriority());
@@ -513,10 +517,20 @@ public class StructuredContentResourceTest
 		// Structured content with the default priority
 
 		StructuredContent structuredContent2 =
-			_testPostSiteStructuredContentDraft(LocaleUtil.getDefault(), null);
+			_testPostSiteStructuredContentDraft(
+				LocaleUtil.getDefault(), null,
+				JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID);
 
 		Assert.assertEquals(
 			Double.valueOf(0.0), structuredContent2.getPriority());
+
+		// Structured content draft in a folder
+
+		JournalFolder journalFolder = JournalTestUtil.addFolder(
+			testGroup.getGroupId(), RandomTestUtil.randomString());
+
+		_testPostSiteStructuredContentDraft(
+			LocaleUtil.getDefault(), null, journalFolder.getFolderId());
 	}
 
 	@Override
@@ -550,6 +564,8 @@ public class StructuredContentResourceTest
 		StructuredContent structuredContent = super.randomStructuredContent();
 
 		structuredContent.setContentStructureId(_ddmStructure.getStructureId());
+		structuredContent.setStructuredContentFolderId(
+			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID);
 
 		return structuredContent;
 	}
@@ -762,7 +778,7 @@ public class StructuredContentResourceTest
 	private StructuredContent _randomStructuredContent(Locale locale)
 		throws Exception {
 
-		StructuredContent structuredContent = super.randomStructuredContent();
+		StructuredContent structuredContent = randomStructuredContent();
 
 		String w3cLanguageId = LocaleUtil.toW3cLanguageId(locale);
 
@@ -841,13 +857,15 @@ public class StructuredContentResourceTest
 	}
 
 	private StructuredContent _testPostSiteStructuredContentDraft(
-			Locale locale, Double priority)
+			Locale locale, Double priority, Long structuredContentFolderId)
 		throws Exception {
 
 		StructuredContent randomStructuredContent = _randomStructuredContent(
 			locale);
 
 		randomStructuredContent.setPriority(priority);
+		randomStructuredContent.setStructuredContentFolderId(
+			structuredContentFolderId);
 
 		com.liferay.headless.admin.content.client.resource.v1_0.
 			StructuredContentResource structuredContentResource =
@@ -864,6 +882,11 @@ public class StructuredContentResourceTest
 		if (priority != null) {
 			assertEquals(randomStructuredContent, postStructuredContent);
 		}
+
+		Assert.assertEquals(
+			GetterUtil.getLong(structuredContentFolderId),
+			GetterUtil.getLong(
+				postStructuredContent.getStructuredContentFolderId()));
 
 		assertValid(postStructuredContent);
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94204

## What is this trying to solve?

When creating a Structured Content draft via POST /o/headless-admin-content/v1.0/sites/{siteId}/structured-contents/draft, the structuredContentFolderId in the request body was silently ignored. The draft was always created at the site root, and there was no way through the Headless API to create a draft inside a specific folder.

## How am I fixing it?

postSiteStructuredContentDraft now reads structuredContentFolderId from the request and passes it to JournalArticleService.addArticle, falling back to the site root only when the field is null. This mirrors the non-draft creation path already used in headless-delivery, and delegates folder validation and permission checks to addArticle the same way.

## How can you verify that it works?

Run the integration test