### PR TITLE
LPD-92859 Fix Spanish translation of display-date language key

### DIFF
--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
@@ -6626,7 +6626,7 @@ display-at-least-one-localizable-form-field-on-the-page-to-activate-this-configu
 display-availability=Mostrar disponibilidad
 display-chart-as-table=Mostrar gráfico como tabla
 display-current-locale=Mostrar idioma actual
-display-date=Fecha de publicación
+display-date=Fecha de visualización
 display-date-range=Mostrar rango de fechas
 display-depth=Mostrar profundidad
 display-did-you-mean-if-the-number-of-search-results-does-not-meet-the-threshold=Mostrar "Quiso decir: ..." si el número de resultados no alcanza el umbral.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_AR.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_AR.properties
@@ -6626,7 +6626,7 @@ display-at-least-one-localizable-form-field-on-the-page-to-activate-this-configu
 display-availability=Mostrar disponibilidad
 display-chart-as-table=Mostrar gráfico como tabla
 display-current-locale=Mostrar idioma actual
-display-date=Fecha de publicación
+display-date=Fecha de visualización
 display-date-range=Mostrar rango de fechas
 display-depth=Mostrar profundidad
 display-did-you-mean-if-the-number-of-search-results-does-not-meet-the-threshold=Mostrar "Quiso decir: ..." si el número de resultados no alcanza el umbral.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_CO.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_CO.properties
@@ -6626,7 +6626,7 @@ display-at-least-one-localizable-form-field-on-the-page-to-activate-this-configu
 display-availability=Mostrar disponibilidad
 display-chart-as-table=Mostrar gráfico como tabla
 display-current-locale=Mostrar idioma actual
-display-date=Fecha de publicación
+display-date=Fecha de visualización
 display-date-range=Mostrar rango de fechas
 display-depth=Mostrar profundidad
 display-did-you-mean-if-the-number-of-search-results-does-not-meet-the-threshold=Mostrar "Quiso decir: ..." si el número de resultados no alcanza el umbral.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_MX.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_MX.properties
@@ -6626,7 +6626,7 @@ display-at-least-one-localizable-form-field-on-the-page-to-activate-this-configu
 display-availability=Mostrar disponibilidad
 display-chart-as-table=Mostrar gráfico como tabla
 display-current-locale=Mostrar idioma actual
-display-date=Fecha de publicación
+display-date=Fecha de visualización
 display-date-range=Mostrar rango de fechas
 display-depth=Mostrar profundidad
 display-did-you-mean-if-the-number-of-search-results-does-not-meet-the-threshold=Mostrar "Quiso decir: ..." si el número de resultados no alcanza el umbral.


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92859

## What Is Being Fixed

The `display-date` language key was translated in Spanish as "Fecha de publicación", the same text used for the publish date key. As a result, Spanish users saw the publish date filter appear twice, with no way to tell which one referred to the display date.

## How It Is Being Fixed

The Spanish translation of `display-date` is corrected to "Fecha de visualización" so the label reflects the display date instead of duplicating the publish date one. The fix is applied to the base Spanish locale and its regional variants (`es_AR`, `es_CO`, and `es_MX`), which carried the same wrong value.

## Why Are There No Tests?

This PR only updates language key values, with no code changes.

## PR Check

**pr-check: PASS** — tested on `34a03d5e90417d2a8f3f246f360a9ca8750de9aa`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |

<!-- pr-check {"result": "success", "sha": "34a03d5e90417d2a8f3f246f360a9ca8750de9aa"} -->