### PR TITLE
LPD-90074 Align CMS standalone page title with the back button

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-cms/src/templates/portlet.ftl
+++ b/modules/apps/frontend-theme/frontend-theme-cms/src/templates/portlet.ftl
@@ -1,0 +1,53 @@
+<#assign
+	portlet_display = portletDisplay
+
+	portlet_back_url = htmlUtil.escapeHREF(portlet_display.getURLBack())
+	portlet_display_root_portlet_id = htmlUtil.escapeAttribute(portlet_display.getRootPortletId())
+	portlet_id = htmlUtil.escapeAttribute(portlet_display.getId())
+	portlet_title = htmlUtil.escape(portlet_display.getTitle())
+/>
+
+<section class="portlet" id="portlet_${portlet_id}">
+	<div class="portlet-content">
+		<@liferay_util["buffer"] var="portlet_header">
+			<@liferay_util["dynamic-include"] key="portlet_header_${portlet_display_root_portlet_id}" />
+		</@>
+
+		<#assign portlet_header = portlet_header?trim />
+
+		<#if portlet_display.isShowBackIcon() || portlet_display.isShowPortletTitle() || portlet_header?has_content>
+			<div class="bg-white cms-control-menu component-tbar portlet-header px-md-4 tbar top-bar">
+				<div class="container-fluid">
+					<ul class="tbar-nav">
+						<#if portlet_display.isShowBackIcon()>
+							<li class="tbar-item">
+								<a class="component-action" href="${portlet_back_url}" title="<@liferay.language key="back" />">
+									<@liferay_ui["icon"]
+										icon="angle-left"
+										markupView="lexicon"
+									/>
+								</a>
+							</li>
+						</#if>
+
+						<#if portlet_display.isShowPortletTitle()>
+							<li class="tbar-item tbar-item-expand text-left">
+								<div class="tbar-section">
+									<h1 class="font-weight-semi-bold m-0 tbar-section text-5 text-dark">${portlet_title}</h1>
+								</div>
+							</li>
+						</#if>
+
+						<#if portlet_header?has_content>
+							<li class="tbar-item">
+								${portlet_header}
+							</li>
+						</#if>
+					</ul>
+				</div>
+			</div>
+		</#if>
+
+		${portlet_display.writeContent(writer)}
+	</div>
+</section>

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/home.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/home.spec.ts
@@ -110,7 +110,7 @@ test.afterAll(async ({browser}) => {
 
 test(
 	'My Workflow Tasks full view preserves the back button when switching tabs',
-	{tag: '@LPD-78912'},
+	{tag: ['@LPD-78912', '@LPD-92859']},
 	async ({context, homePage, page}) => {
 		await homePage.goto();
 
@@ -125,8 +125,16 @@ test(
 
 		await fullViewPage.waitForLoadState();
 
-		const backButton = fullViewPage.getByRole('link', {
-			name: 'Return to Full Page',
+		const toolbar = fullViewPage.locator(
+			'.cms-control-menu.portlet-header'
+		);
+
+		await expect(
+			toolbar.getByRole('heading', {name: 'My Workflow Tasks'})
+		).toBeVisible();
+
+		const backButton = toolbar.getByRole('link', {
+			name: 'Back',
 		});
 
 		await expect(backButton).toBeVisible();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90074

## What Is Being Fixed

On standalone portlet pages of the CMS site (for example "My Workflow Tasks" opened in full view), the page title renders below the back button instead of vertically aligned with it. The CMS theme inherits the unstyled theme's `portlet.ftl`, which places the back link above the title row.

## How It Is Being Fixed

The CMS theme now ships its own `portlet.ftl`. The header is rendered as a Clay toolbar — the same markup the CMS React `Toolbar` component produces — with the back button and the portlet title as items of the same `tbar` row, reusing the styles the theme already defines for `.cms-control-menu` and `.top-bar`, so no new CSS is added. The template keeps only what the CMS site needs, dropping the widget-page portlet topper machinery the base template carries, following the admin theme's minimal approach.

The second commit updates the existing Playwright test covering the My Workflow Tasks full view in the CMS suite: the back button's accessible name changes from "Return to Full Page" to "Back", and the test now asserts that both the title heading and the back button render inside the same toolbar.

## PR Check

**pr-check: PASS** — tested on `5b494c4603b25f380a74a5147d9c0ee800f0a2dc`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |

<!-- pr-check {"result": "success", "sha": "5b494c4603b25f380a74a5147d9c0ee800f0a2dc"} -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
