### PR TITLE
LPD-94087 Preserve configured vocabulary order in Category Filter

### DIFF
--- a/modules/apps/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/internal/display/context/AssetCategoriesNavigationDisplayContext.java
+++ b/modules/apps/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/internal/display/context/AssetCategoriesNavigationDisplayContext.java
@@ -107,16 +107,22 @@ public class AssetCategoriesNavigationDisplayContext {
 			return _assetVocabularies;
 		}
 
-		List<AssetVocabulary> assetVocabularies = new ArrayList<>();
-
 		if (_vocabularyIds == null) {
-			assetVocabularies = AssetVocabularyServiceUtil.getGroupVocabularies(
-				SiteConnectedGroupGroupProviderUtil.
-					getCurrentAndAncestorSiteAndDepotGroupIds(
-						_themeDisplay.getScopeGroupId()),
-				new int[] {AssetVocabularyConstants.VISIBILITY_TYPE_PUBLIC});
+			_assetVocabularies = ListUtil.sort(
+				AssetVocabularyServiceUtil.getGroupVocabularies(
+					SiteConnectedGroupGroupProviderUtil.
+						getCurrentAndAncestorSiteAndDepotGroupIds(
+							_themeDisplay.getScopeGroupId()),
+					new int[] {
+						AssetVocabularyConstants.VISIBILITY_TYPE_PUBLIC
+					}),
+				new AssetVocabularyGroupLocalizedTitleComparator(
+					_themeDisplay.getScopeGroupId(), _themeDisplay.getLocale(),
+					true));
 		}
 		else {
+			List<AssetVocabulary> assetVocabularies = new ArrayList<>();
+
 			for (long vocabularyId : _vocabularyIds) {
 				AssetVocabulary vocabulary =
 					AssetVocabularyServiceUtil.fetchVocabulary(vocabularyId);
@@ -125,13 +131,9 @@ public class AssetCategoriesNavigationDisplayContext {
 					assetVocabularies.add(vocabulary);
 				}
 			}
-		}
 
-		_assetVocabularies = ListUtil.sort(
-			assetVocabularies,
-			new AssetVocabularyGroupLocalizedTitleComparator(
-				_themeDisplay.getScopeGroupId(), _themeDisplay.getLocale(),
-				true));
+			_assetVocabularies = assetVocabularies;
+		}
 
 		return _assetVocabularies;
 	}

--- a/modules/apps/asset/asset-taglib/src/test/java/com/liferay/asset/taglib/internal/display/context/AssetCategoriesNavigationDisplayContextTest.java
+++ b/modules/apps/asset/asset-taglib/src/test/java/com/liferay/asset/taglib/internal/display/context/AssetCategoriesNavigationDisplayContextTest.java
@@ -1,0 +1,221 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.asset.taglib.internal.display.context;
+
+import com.liferay.asset.kernel.model.AssetVocabulary;
+import com.liferay.asset.kernel.model.AssetVocabularyConstants;
+import com.liferay.asset.kernel.service.AssetVocabularyServiceUtil;
+import com.liferay.depot.util.SiteConnectedGroupGroupProviderUtil;
+import com.liferay.portal.kernel.module.util.SystemBundleUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import jakarta.portlet.RenderResponse;
+
+import java.util.Arrays;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * @author Shakir Shamim
+ */
+public class AssetCategoriesNavigationDisplayContextTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		_assetVocabularyServiceUtilMockedStatic = Mockito.mockStatic(
+			AssetVocabularyServiceUtil.class);
+		_frameworkUtilMockedStatic = Mockito.mockStatic(FrameworkUtil.class);
+
+		_scopeGroupId = RandomTestUtil.randomLong();
+
+		_setUpSiteConnectedGroupProviderUtil();
+		_setUpThemeDisplay();
+	}
+
+	@After
+	public void tearDown() {
+		_assetVocabularyServiceUtilMockedStatic.close();
+		_frameworkUtilMockedStatic.close();
+		_siteConnectedGroupGroupProviderUtilMockedStatic.close();
+	}
+
+	@Test
+	public void testGetVocabularies() throws Exception {
+		_testGetVocabulariesWhenFilteredByVocabularyIds();
+		_testGetVocabulariesWhenShowingAllVocabularies();
+	}
+
+	private AssetCategoriesNavigationDisplayContext _createDisplayContext(
+		long[] vocabularyIds) {
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, _themeDisplay);
+
+		if (vocabularyIds != null) {
+			mockHttpServletRequest.setAttribute(
+				"liferay-asset:asset-tags-navigation:vocabularyIds",
+				vocabularyIds);
+		}
+
+		return new AssetCategoriesNavigationDisplayContext(
+			mockHttpServletRequest, Mockito.mock(RenderResponse.class));
+	}
+
+	private AssetVocabulary _mockAssetVocabulary(String assetVocabularyTitle) {
+		AssetVocabulary assetVocabulary = Mockito.mock(AssetVocabulary.class);
+
+		Mockito.when(
+			assetVocabulary.getGroupId()
+		).thenReturn(
+			_scopeGroupId
+		);
+
+		Mockito.when(
+			assetVocabulary.getTitle(_themeDisplay.getLocale())
+		).thenReturn(
+			assetVocabularyTitle
+		);
+
+		return assetVocabulary;
+	}
+
+	private void _mockFetchVocabulary(
+		long vocabularyId, AssetVocabulary assetVocabulary) {
+
+		_assetVocabularyServiceUtilMockedStatic.when(
+			() -> AssetVocabularyServiceUtil.fetchVocabulary(vocabularyId)
+		).thenReturn(
+			assetVocabulary
+		);
+	}
+
+	private void _setUpSiteConnectedGroupProviderUtil() {
+		BundleContext bundleContext = SystemBundleUtil.getBundleContext();
+
+		_frameworkUtilMockedStatic.when(
+			() -> FrameworkUtil.getBundle(
+				SiteConnectedGroupGroupProviderUtil.class)
+		).thenReturn(
+			bundleContext.getBundle()
+		);
+
+		_siteConnectedGroupGroupProviderUtilMockedStatic = Mockito.mockStatic(
+			SiteConnectedGroupGroupProviderUtil.class);
+
+		_siteConnectedGroupGroupProviderUtilMockedStatic.when(
+			() ->
+				SiteConnectedGroupGroupProviderUtil.
+					getCurrentAndAncestorSiteAndDepotGroupIds(_scopeGroupId)
+		).thenReturn(
+			new long[] {_scopeGroupId}
+		);
+	}
+
+	private void _setUpThemeDisplay() {
+		_themeDisplay = Mockito.mock(ThemeDisplay.class);
+
+		Mockito.when(
+			_themeDisplay.getLocale()
+		).thenReturn(
+			LocaleUtil.US
+		);
+
+		Mockito.when(
+			_themeDisplay.getScopeGroupId()
+		).thenReturn(
+			_scopeGroupId
+		);
+	}
+
+	private void _testGetVocabulariesWhenFilteredByVocabularyIds()
+		throws Exception {
+
+		long vocabularyId1 = RandomTestUtil.randomLong();
+		AssetVocabulary assetVocabulary1 = _mockAssetVocabulary(
+			RandomTestUtil.randomString());
+
+		_mockFetchVocabulary(vocabularyId1, assetVocabulary1);
+
+		long vocabularyId2 = RandomTestUtil.randomLong();
+		AssetVocabulary assetVocabulary2 = _mockAssetVocabulary(
+			RandomTestUtil.randomString());
+
+		_mockFetchVocabulary(vocabularyId2, assetVocabulary2);
+
+		long vocabularyId3 = RandomTestUtil.randomLong();
+		AssetVocabulary assetVocabulary3 = _mockAssetVocabulary(
+			RandomTestUtil.randomString());
+
+		_mockFetchVocabulary(vocabularyId3, assetVocabulary3);
+
+		AssetCategoriesNavigationDisplayContext
+			assetCategoriesNavigationDisplayContext = _createDisplayContext(
+				new long[] {vocabularyId3, vocabularyId1, vocabularyId2});
+
+		Assert.assertEquals(
+			Arrays.asList(assetVocabulary3, assetVocabulary1, assetVocabulary2),
+			assetCategoriesNavigationDisplayContext.getVocabularies());
+	}
+
+	private void _testGetVocabulariesWhenShowingAllVocabularies()
+		throws Exception {
+
+		AssetVocabulary assetVocabulary1 = _mockAssetVocabulary(
+			"A-" + RandomTestUtil.randomString());
+		AssetVocabulary assetVocabulary2 = _mockAssetVocabulary(
+			"B-" + RandomTestUtil.randomString());
+
+		_assetVocabularyServiceUtilMockedStatic.when(
+			() -> AssetVocabularyServiceUtil.getGroupVocabularies(
+				new long[] {_scopeGroupId},
+				new int[] {AssetVocabularyConstants.VISIBILITY_TYPE_PUBLIC})
+		).thenReturn(
+			Arrays.asList(assetVocabulary2, assetVocabulary1)
+		);
+
+		AssetCategoriesNavigationDisplayContext
+			assetCategoriesNavigationDisplayContext = _createDisplayContext(
+				null);
+
+		Assert.assertEquals(
+			Arrays.asList(assetVocabulary1, assetVocabulary2),
+			assetCategoriesNavigationDisplayContext.getVocabularies());
+	}
+
+	private MockedStatic<AssetVocabularyServiceUtil>
+		_assetVocabularyServiceUtilMockedStatic;
+	private MockedStatic<FrameworkUtil> _frameworkUtilMockedStatic;
+	private long _scopeGroupId;
+	private MockedStatic<SiteConnectedGroupGroupProviderUtil>
+		_siteConnectedGroupGroupProviderUtilMockedStatic;
+	private ThemeDisplay _themeDisplay;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94087

> **Resent from liferay-content-management#8476** (CI-forwarded as brianchandotcom#176561), closed over a variable-ordering point — the local declarations in `_testGetVocabulariesWhenFilteredByVocabularyIds` were grouped at the top instead of declared next to their first use. This version declares each local immediately before its first use, in the downstream call's argument order (Rule 203 ). Re-raised on top of the same fix + tests.

## What Is Being Fixed

The Category Filter widget ignored the vocabulary order configured by the editor and displayed vocabularies alphabetically instead. When an editor disabled "All Vocabularies", selected specific vocabularies, and arranged them in the configuration's "In Use" list, that order was lost in the rendered filter dropdown — the vocabularies always came back sorted by title.

## How It Is Being Fixed

AssetCategoriesNavigationDisplayContext.getVocabularies() always re-sorted the vocabulary list alphabetically with AssetVocabularyGroupLocalizedTitleComparator, even when an explicit, user-ordered list of vocabulary IDs was supplied. The alphabetical sort now applies only in the default "all vocabularies" mode (when no vocabulary IDs are configured); when an explicit ordered selection is provided, the configured order is preserved.

## How Can You Verify That It Works?

Run the unit test:

```
cd modules/apps/asset/asset-taglib
../../../../gradlew test --tests AssetCategoriesNavigationDisplayContextTest
```

The test asserts getVocabularies() preserves the configured order when filtered by vocabulary IDs, and sorts alphabetically when showing all vocabularies. Alternatively, add the Category Filter widget to a page, disable "All Vocabularies", arrange several vocabularies in the "In Use" list in a deliberately non-alphabetical order, save, and confirm the rendered filter lists them in the configured order rather than sorted by title.
