### PR TITLE
LPD-94569 Add the modifiedBy nested field to the expected section API parameters

### DIFF
--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/BaseSectionDisplayContextTestCase.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/BaseSectionDisplayContextTestCase.java
@@ -724,7 +724,7 @@ public abstract class BaseSectionDisplayContextTestCase
 			appendStatus(appendGroupIds(getFilterString())),
 			"&nestedFields=embedded,embeddedTaxonomyCategory,",
 			"file.metadata,file.previewURL,file.thumbnailURL,",
-			"numberOfObjectEntries,numberOfObjectEntryFolders,",
+			"modifiedBy,numberOfObjectEntries,numberOfObjectEntryFolders,",
 			"systemProperties.collaboratorBrief,",
 			"systemProperties.objectDefinitionBrief&sort=dateModified:desc");
 	}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94569

## What Is Being Fixed

LPD-89977 added the "modifiedBy" nested field to the section API URL parameters produced by SectionDisplayContextUtil, but the expected value in the shared BaseSectionDisplayContextTestCase test helper was not updated. As a result, testGetAdditionalProps failed for every section subclass that extends it — ViewAllSectionDisplayContextTest, ViewContentsSectionDisplayContextTest, and ViewFilesSectionDisplayContextTest.

## How It Is Being Fixed

Added "modifiedBy" to the expected nested fields string in BaseSectionDisplayContextTestCase.getAdditionalAPIURLParameters(), in its alphabetical position between "file.thumbnailURL" and "numberOfObjectEntries", so the expectation matches what the product now emits.

## Why Are There No Tests?

This change only updates the expected value of existing integration tests to match a product change already merged in LPD-89977. The affected tests are the coverage and now pass; no new test is warranted.

## PR Check

**pr-check: PASS** — tested on `f9cc13740667c3aaae3544281f78f86a985d3770`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "f9cc13740667c3aaae3544281f78f86a985d3770"} -->
