### PR TITLE
LPD-94507 Fix default permissions after a Space ERC change

### DIFF
--- a/modules/apps/site/site-cms-site-initializer-api/bnd.bnd
+++ b/modules/apps/site/site-cms-site-initializer-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Site CMS Site Initializer API
 Bundle-SymbolicName: com.liferay.site.cms.site.initializer.api
-Bundle-Version: 4.2.1
+Bundle-Version: 4.3.0
 Export-Package:\
 	com.liferay.site.cms.site.initializer.bulk.selection,\
 	com.liferay.site.cms.site.initializer.configuration,\

--- a/modules/apps/site/site-cms-site-initializer-api/src/main/java/com/liferay/site/cms/site/initializer/util/CMSDefaultPermissionUtil.java
+++ b/modules/apps/site/site-cms-site-initializer-api/src/main/java/com/liferay/site/cms/site/initializer/util/CMSDefaultPermissionUtil.java
@@ -153,27 +153,25 @@ public class CMSDefaultPermissionUtil {
 			String className, FilterFactory<Predicate> filterFactory)
 		throws PortalException {
 
-		ObjectDefinition objectDefinition =
-			ObjectDefinitionLocalServiceUtil.
-				getObjectDefinitionByExternalReferenceCode(
-					"L_CMS_DEFAULT_PERMISSION", companyId);
-
-		Predicate predicate = filterFactory.create(
+		return _fetchObjectEntry(
+			companyId, userId,
 			StringBundler.concat(
 				"(classExternalReferenceCode eq '", classExternalReferenceCode,
 				"') and (className eq '", className, "')"),
-			objectDefinition);
+			filterFactory);
+	}
 
-		List<Long> primaryKeys = ObjectEntryLocalServiceUtil.getPrimaryKeys(
-			new Long[0], companyId, userId,
-			objectDefinition.getObjectDefinitionId(), predicate, false, null,
-			QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+	public static ObjectEntry fetchObjectEntryByDepotGroupId(
+			long companyId, long userId, long depotGroupId, String className,
+			FilterFactory<Predicate> filterFactory)
+		throws PortalException {
 
-		if (ListUtil.isEmpty(primaryKeys)) {
-			return null;
-		}
-
-		return ObjectEntryLocalServiceUtil.fetchObjectEntry(primaryKeys.get(0));
+		return _fetchObjectEntry(
+			companyId, userId,
+			StringBundler.concat(
+				"(depotGroupId eq ", depotGroupId, ") and (className eq '",
+				className, "')"),
+			filterFactory);
 	}
 
 	public static JSONObject getCMSDefaultPermissionJSONObject(
@@ -244,6 +242,56 @@ public class CMSDefaultPermissionUtil {
 
 		return JSONFactoryUtil.createJSONObject(
 			String.valueOf(values.getOrDefault("defaultPermissions", "{}")));
+	}
+
+	public static void updateClassExternalReferenceCode(
+			ObjectEntry objectEntry, String classExternalReferenceCode,
+			long userId)
+		throws PortalException {
+
+		Map<String, Serializable> values = objectEntry.getValues();
+
+		if (Objects.equals(
+				values.get("classExternalReferenceCode"),
+				classExternalReferenceCode)) {
+
+			return;
+		}
+
+		ObjectEntryLocalServiceUtil.updateObjectEntry(
+			userId, objectEntry.getObjectEntryId(),
+			objectEntry.getObjectEntryFolderId(),
+			HashMapBuilder.<String, Serializable>putAll(
+				values
+			).put(
+				"classExternalReferenceCode", classExternalReferenceCode
+			).build(),
+			new ServiceContext());
+	}
+
+	private static ObjectEntry _fetchObjectEntry(
+			long companyId, long userId, String filterString,
+			FilterFactory<Predicate> filterFactory)
+		throws PortalException {
+
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionLocalServiceUtil.
+				getObjectDefinitionByExternalReferenceCode(
+					"L_CMS_DEFAULT_PERMISSION", companyId);
+
+		Predicate predicate = filterFactory.create(
+			filterString, objectDefinition);
+
+		List<Long> primaryKeys = ObjectEntryLocalServiceUtil.getPrimaryKeys(
+			new Long[0], companyId, userId,
+			objectDefinition.getObjectDefinitionId(), predicate, false, null,
+			QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+
+		if (ListUtil.isEmpty(primaryKeys)) {
+			return null;
+		}
+
+		return ObjectEntryLocalServiceUtil.fetchObjectEntry(primaryKeys.get(0));
 	}
 
 }

--- a/modules/apps/site/site-cms-site-initializer-api/src/main/java/com/liferay/site/cms/site/initializer/util/CMSDefaultPermissionUtil.java
+++ b/modules/apps/site/site-cms-site-initializer-api/src/main/java/com/liferay/site/cms/site/initializer/util/CMSDefaultPermissionUtil.java
@@ -5,11 +5,15 @@
 
 package com.liferay.site.cms.site.initializer.util;
 
+import com.liferay.depot.constants.DepotRolesConstants;
+import com.liferay.depot.model.DepotEntry;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.rest.filter.factory.FilterFactory;
 import com.liferay.object.service.ObjectDefinitionLocalServiceUtil;
+import com.liferay.object.service.ObjectEntryFolderLocalServiceUtil;
 import com.liferay.object.service.ObjectEntryLocalServiceUtil;
 import com.liferay.petra.sql.dsl.expression.Predicate;
 import com.liferay.petra.string.StringBundler;
@@ -17,19 +21,102 @@ import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
+import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalServiceUtil;
+import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 
 import java.io.Serializable;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * @author Stefano Motta
  */
 public class CMSDefaultPermissionUtil {
+
+	public static void addCMSDefaultPermissions(
+			ObjectEntryFolder objectEntryFolder,
+			FilterFactory<Predicate> filterFactory)
+		throws PortalException {
+
+		JSONObject defaultPermissionsJSONObject =
+			getCMSDefaultPermissionJSONObject(objectEntryFolder, filterFactory);
+
+		if ((defaultPermissionsJSONObject == null) ||
+			JSONUtil.isEmpty(defaultPermissionsJSONObject)) {
+
+			return;
+		}
+
+		if (!Objects.equals(
+				objectEntryFolder.getExternalReferenceCode(),
+				ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS) &&
+			!Objects.equals(
+				objectEntryFolder.getExternalReferenceCode(),
+				ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_FILES)) {
+
+			addOrUpdateObjectEntry(
+				null, objectEntryFolder.getCompanyId(),
+				objectEntryFolder.getUserId(),
+				objectEntryFolder.getExternalReferenceCode(),
+				objectEntryFolder.getModelClassName(),
+				defaultPermissionsJSONObject, objectEntryFolder.getGroupId(),
+				objectEntryFolder.getTreePath());
+		}
+
+		JSONObject objectEntryFoldersJSONObject =
+			defaultPermissionsJSONObject.getJSONObject("OBJECT_ENTRY_FOLDERS");
+
+		if (objectEntryFoldersJSONObject == null) {
+			return;
+		}
+
+		List<String> resourceActions = ResourceActionsUtil.getResourceActions(
+			ObjectEntryFolder.class.getName());
+
+		List<Role> roles = RoleLocalServiceUtil.getGroupRolesAndTeamRoles(
+			objectEntryFolder.getCompanyId(), null,
+			Arrays.asList(
+				RoleConstants.ADMINISTRATOR,
+				DepotRolesConstants.ASSET_LIBRARY_OWNER),
+			null, null,
+			new int[] {RoleConstants.TYPE_REGULAR, RoleConstants.TYPE_DEPOT},
+			null, 0, 0, QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+
+		for (Role role : roles) {
+			String[] actionIds = JSONUtil.toStringArray(
+				objectEntryFoldersJSONObject.getJSONArray(role.getName()));
+
+			if (objectEntryFolder.getParentObjectEntryFolderId() ==
+					ObjectEntryFolderConstants.
+						PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT) {
+
+				actionIds = ArrayUtil.remove(actionIds, ActionKeys.DELETE);
+			}
+
+			ResourcePermissionLocalServiceUtil.setResourcePermissions(
+				objectEntryFolder.getCompanyId(),
+				ObjectEntryFolder.class.getName(),
+				ResourceConstants.SCOPE_INDIVIDUAL,
+				String.valueOf(objectEntryFolder.getObjectEntryFolderId()),
+				role.getRoleId(),
+				ArrayUtil.filter(actionIds, resourceActions::contains));
+		}
+	}
 
 	public static ObjectEntry addOrUpdateObjectEntry(
 			String externalReferenceCode, long companyId, long userId,
@@ -87,6 +174,49 @@ public class CMSDefaultPermissionUtil {
 		}
 
 		return ObjectEntryLocalServiceUtil.fetchObjectEntry(primaryKeys.get(0));
+	}
+
+	public static JSONObject getCMSDefaultPermissionJSONObject(
+			ObjectEntryFolder objectEntryFolder,
+			FilterFactory<Predicate> filterFactory)
+		throws PortalException {
+
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionLocalServiceUtil.
+				fetchObjectDefinitionByExternalReferenceCode(
+					"L_CMS_DEFAULT_PERMISSION",
+					objectEntryFolder.getCompanyId());
+
+		if (objectDefinition == null) {
+			return null;
+		}
+
+		if (objectEntryFolder.getParentObjectEntryFolderId() !=
+				ObjectEntryFolderConstants.
+					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT) {
+
+			ObjectEntryFolder parentObjectEntryFolder =
+				ObjectEntryFolderLocalServiceUtil.getObjectEntryFolder(
+					objectEntryFolder.getParentObjectEntryFolderId());
+
+			JSONObject jsonObject = getJSONObject(
+				parentObjectEntryFolder.getCompanyId(),
+				parentObjectEntryFolder.getUserId(),
+				parentObjectEntryFolder.getExternalReferenceCode(),
+				parentObjectEntryFolder.getModelClassName(), filterFactory);
+
+			if ((jsonObject != null) && !JSONUtil.isEmpty(jsonObject)) {
+				return jsonObject;
+			}
+		}
+
+		Group group = GroupLocalServiceUtil.getGroup(
+			objectEntryFolder.getGroupId());
+
+		return getJSONObject(
+			group.getCompanyId(), group.getCreatorUserId(),
+			group.getExternalReferenceCode(), DepotEntry.class.getName(),
+			filterFactory);
 	}
 
 	public static JSONObject getJSONObject(

--- a/modules/apps/site/site-cms-site-initializer-api/src/main/resources/com/liferay/site/cms/site/initializer/util/packageinfo
+++ b/modules/apps/site/site-cms-site-initializer-api/src/main/resources/com/liferay/site/cms/site/initializer/util/packageinfo
@@ -1,1 +1,1 @@
-version 3.2.0
+version 3.3.0

--- a/modules/apps/site/site-cms-site-initializer-test/build.gradle
+++ b/modules/apps/site/site-cms-site-initializer-test/build.gradle
@@ -36,6 +36,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:site:site-cms-site-initializer")
 	testIntegrationImplementation project(":apps:site:site-cms-site-initializer-api")
 	testIntegrationImplementation project(":apps:site:site-cms-site-initializer-test-util")
+	testIntegrationImplementation project(":apps:static:portal:portal-upgrade-api")
 	testIntegrationImplementation project(":apps:translation:translation-api")
 	testIntegrationImplementation project(":apps:trash:trash-api")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/upgrade/v1_0_0/test/CMSDefaultPermissionsUpgradeProcessTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/upgrade/v1_0_0/test/CMSDefaultPermissionsUpgradeProcessTest.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/upgrade/v1_0_0/test/CMSDefaultPermissionsUpgradeProcessTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/upgrade/v1_0_0/test/CMSDefaultPermissionsUpgradeProcessTest.java
@@ -1,0 +1,184 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.upgrade.v1_0_0.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectEntryFolder;
+import com.liferay.object.rest.filter.factory.FilterFactory;
+import com.liferay.object.service.ObjectEntryFolderLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.petra.sql.dsl.expression.Predicate;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.upgrade.UpgradeStep;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.site.cms.site.initializer.test.util.CMSTestUtil;
+import com.liferay.site.cms.site.initializer.util.CMSDefaultPermissionUtil;
+
+import java.util.Objects;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Marco Leo
+ */
+@FeatureFlag("LPD-17564")
+@RunWith(Arquillian.class)
+public class CMSDefaultPermissionsUpgradeProcessTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		CMSTestUtil.getOrAddGroup(
+			CMSDefaultPermissionsUpgradeProcessTest.class);
+
+		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
+			HashMapBuilder.put(
+				LocaleUtil.US, StringUtil.randomString()
+			).build(),
+			HashMapBuilder.put(
+				LocaleUtil.US, StringUtil.randomString()
+			).build(),
+			DepotConstants.TYPE_SPACE,
+			ServiceContextTestUtil.getServiceContext());
+
+		_group = depotEntry.getGroup();
+	}
+
+	@Test
+	public void testUpgrade() throws Exception {
+		ObjectEntryFolder objectEntryFolder =
+			_objectEntryFolderLocalService.addObjectEntryFolder(
+				RandomTestUtil.randomString(), _group.getGroupId(),
+				_group.getCreatorUserId(), 0, "",
+				HashMapBuilder.put(
+					LocaleUtil.ENGLISH, RandomTestUtil.randomString()
+				).build(),
+				RandomTestUtil.randomString(),
+				ServiceContextTestUtil.getServiceContext());
+
+		ObjectEntry objectEntryFolderObjectEntry = _fetchObjectEntry(
+			objectEntryFolder);
+
+		Assert.assertNotNull(objectEntryFolderObjectEntry);
+
+		ObjectEntry depotEntryObjectEntry = _fetchDepotEntryObjectEntry();
+
+		Assert.assertNotNull(depotEntryObjectEntry);
+
+		CMSDefaultPermissionUtil.updateClassExternalReferenceCode(
+			depotEntryObjectEntry, RandomTestUtil.randomString(),
+			_group.getCreatorUserId());
+
+		Assert.assertNull(_fetchDepotEntryObjectEntry());
+
+		_objectEntryLocalService.deleteObjectEntry(
+			objectEntryFolderObjectEntry.getObjectEntryId());
+
+		Assert.assertNull(_fetchObjectEntry(objectEntryFolder));
+
+		_runUpgrade();
+
+		Assert.assertNotNull(_fetchDepotEntryObjectEntry());
+
+		Assert.assertNotNull(_fetchObjectEntry(objectEntryFolder));
+	}
+
+	private ObjectEntry _fetchDepotEntryObjectEntry() throws Exception {
+		return CMSDefaultPermissionUtil.fetchObjectEntry(
+			_group.getCompanyId(), _group.getCreatorUserId(),
+			_group.getExternalReferenceCode(), DepotEntry.class.getName(),
+			_filterFactory);
+	}
+
+	private ObjectEntry _fetchObjectEntry(ObjectEntryFolder objectEntryFolder)
+		throws Exception {
+
+		return CMSDefaultPermissionUtil.fetchObjectEntry(
+			objectEntryFolder.getCompanyId(), objectEntryFolder.getUserId(),
+			objectEntryFolder.getExternalReferenceCode(),
+			objectEntryFolder.getModelClassName(), _filterFactory);
+	}
+
+	private UpgradeProcess _getUpgradeProcess() {
+		UpgradeProcess[] upgradeProcesses = new UpgradeProcess[1];
+
+		_upgradeStepRegistrator.register(
+			(fromSchemaVersionString, toSchemaVersionString, upgradeSteps) -> {
+				for (UpgradeStep upgradeStep : upgradeSteps) {
+					Class<? extends UpgradeStep> clazz = upgradeStep.getClass();
+
+					if (Objects.equals(clazz.getName(), _CLASS_NAME)) {
+						upgradeProcesses[0] = (UpgradeProcess)upgradeStep;
+
+						break;
+					}
+				}
+			});
+
+		return upgradeProcesses[0];
+	}
+
+	private void _runUpgrade() throws Exception {
+		UpgradeProcess upgradeProcess = _getUpgradeProcess();
+
+		upgradeProcess.upgrade();
+	}
+
+	private static final String _CLASS_NAME =
+		"com.liferay.site.cms.site.initializer.internal.upgrade.v1_0_0." +
+			"CMSDefaultPermissionsUpgradeProcess";
+
+	@Inject
+	private DepotEntryLocalService _depotEntryLocalService;
+
+	@Inject(
+		filter = "filter.factory.key=" + ObjectDefinitionConstants.STORAGE_TYPE_DEFAULT
+	)
+	private FilterFactory<Predicate> _filterFactory;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private ObjectEntryFolderLocalService _objectEntryFolderLocalService;
+
+	@Inject
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Inject(
+		filter = "component.name=com.liferay.site.cms.site.initializer.internal.upgrade.registry.SiteCMSSiteInitializerUpgradeStepRegistrator"
+	)
+	private UpgradeStepRegistrator _upgradeStepRegistrator;
+
+}

--- a/modules/apps/site/site-cms-site-initializer/build.gradle
+++ b/modules/apps/site/site-cms-site-initializer/build.gradle
@@ -49,6 +49,7 @@ dependencies {
 	compileOnly project(":apps:site:site-api")
 	compileOnly project(":apps:site:site-cms-site-initializer-api")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
+	compileOnly project(":apps:static:portal:portal-upgrade-api")
 	compileOnly project(":apps:subscription:subscription-api")
 	compileOnly project(":apps:translation:translation-api")
 	compileOnly project(":apps:trash:trash-api")

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/model/listener/GroupModelListener.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/model/listener/GroupModelListener.java
@@ -9,13 +9,14 @@ import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.rest.filter.factory.FilterFactory;
+import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.sql.dsl.expression.Predicate;
 import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
-import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
@@ -23,13 +24,9 @@ import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.ModelListener;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
-import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.site.cms.site.initializer.util.CMSDefaultPermissionUtil;
 import com.liferay.trash.TrashHelper;
 
-import java.io.Serializable;
-
-import java.util.Map;
 import java.util.Objects;
 
 import org.osgi.service.component.annotations.Component;
@@ -88,16 +85,7 @@ public class GroupModelListener extends BaseModelListener<Group> {
 			return;
 		}
 
-		String externalReferenceCode = group.getExternalReferenceCode();
-		String originalExternalReferenceCode =
-			originalGroup.getExternalReferenceCode();
-
-		if (!Objects.equals(
-				externalReferenceCode, originalExternalReferenceCode)) {
-
-			_updateCMSDefaultPermissionObjectEntry(
-				externalReferenceCode, group, originalExternalReferenceCode);
-		}
+		_updateCMSDefaultPermissionExternalReferenceCode(originalGroup, group);
 
 		if (Objects.equals(
 				originalGroup.getTypeSettingsProperty("trashEnabled"),
@@ -123,30 +111,38 @@ public class GroupModelListener extends BaseModelListener<Group> {
 		}
 	}
 
-	private void _updateCMSDefaultPermissionObjectEntry(
-			String externalReferenceCode, Group group,
-			String originalExternalReferenceCode)
+	private void _updateCMSDefaultPermissionExternalReferenceCode(
+			Group originalGroup, Group group)
 		throws Exception {
 
-		ObjectEntry objectEntry = CMSDefaultPermissionUtil.fetchObjectEntry(
-			group.getCompanyId(), group.getCreatorUserId(),
-			originalExternalReferenceCode, DepotEntry.class.getName(),
-			_filterFactory);
+		if (Objects.equals(
+				originalGroup.getExternalReferenceCode(),
+				group.getExternalReferenceCode())) {
+
+			return;
+		}
+
+		ObjectDefinition cmsDefaultPermissionObjectDefinition =
+			_objectDefinitionLocalService.
+				fetchObjectDefinitionByExternalReferenceCode(
+					"L_CMS_DEFAULT_PERMISSION", group.getCompanyId());
+
+		if (cmsDefaultPermissionObjectDefinition == null) {
+			return;
+		}
+
+		ObjectEntry objectEntry =
+			CMSDefaultPermissionUtil.fetchObjectEntryByDepotGroupId(
+				group.getCompanyId(), group.getCreatorUserId(),
+				group.getGroupId(), DepotEntry.class.getName(), _filterFactory);
 
 		if (objectEntry == null) {
 			return;
 		}
 
-		Map<String, Serializable> values = objectEntry.getValues();
-
-		CMSDefaultPermissionUtil.addOrUpdateObjectEntry(
-			objectEntry.getExternalReferenceCode(), group.getCompanyId(),
-			group.getCreatorUserId(), externalReferenceCode,
-			DepotEntry.class.getName(),
-			_jsonFactory.createJSONObject(
-				GetterUtil.getString(values.get("defaultPermissions"), "{}")),
-			GetterUtil.getLong(values.get("depotGroupId")),
-			GetterUtil.getString(values.get("treePath")));
+		CMSDefaultPermissionUtil.updateClassExternalReferenceCode(
+			objectEntry, group.getExternalReferenceCode(),
+			group.getCreatorUserId());
 	}
 
 	private void _updateRecycleBinLayout(Group group, boolean hidden)
@@ -176,10 +172,10 @@ public class GroupModelListener extends BaseModelListener<Group> {
 	private GroupLocalService _groupLocalService;
 
 	@Reference
-	private JSONFactory _jsonFactory;
+	private LayoutLocalService _layoutLocalService;
 
 	@Reference
-	private LayoutLocalService _layoutLocalService;
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
 
 	@Reference
 	private TrashHelper _trashHelper;

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/model/listener/ObjectEntryFolderModelListener.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/model/listener/ObjectEntryFolderModelListener.java
@@ -5,19 +5,14 @@
 
 package com.liferay.site.cms.site.initializer.internal.model.listener;
 
-import com.liferay.depot.constants.DepotRolesConstants;
-import com.liferay.depot.model.DepotEntry;
 import com.liferay.object.constants.ObjectDefinitionConstants;
-import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.rest.filter.factory.FilterFactory;
 import com.liferay.object.service.ObjectDefinitionLocalService;
-import com.liferay.object.service.ObjectEntryFolderLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.petra.sql.dsl.expression.Predicate;
-import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
@@ -25,17 +20,7 @@ import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.BaseModelListener;
-import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.ModelListener;
-import com.liferay.portal.kernel.model.ResourceConstants;
-import com.liferay.portal.kernel.model.Role;
-import com.liferay.portal.kernel.model.role.RoleConstants;
-import com.liferay.portal.kernel.security.permission.ActionKeys;
-import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
-import com.liferay.portal.kernel.service.GroupLocalService;
-import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
-import com.liferay.portal.kernel.service.RoleLocalService;
-import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.sharing.service.SharingEntryLocalService;
@@ -43,8 +28,6 @@ import com.liferay.site.cms.site.initializer.util.CMSDefaultPermissionUtil;
 
 import java.io.Serializable;
 
-import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -111,113 +94,6 @@ public class ObjectEntryFolderModelListener
 		}
 	}
 
-	private void _addCMSDefaultPermissions(ObjectEntryFolder objectEntryFolder)
-		throws Exception {
-
-		JSONObject defaultPermissionsJSONObject =
-			_getCMSDefaultPermissionJSONObject(objectEntryFolder);
-
-		if ((defaultPermissionsJSONObject == null) ||
-			JSONUtil.isEmpty(defaultPermissionsJSONObject)) {
-
-			return;
-		}
-
-		if (!Objects.equals(
-				objectEntryFolder.getExternalReferenceCode(),
-				ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS) &&
-			!Objects.equals(
-				objectEntryFolder.getExternalReferenceCode(),
-				ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_FILES)) {
-
-			CMSDefaultPermissionUtil.addOrUpdateObjectEntry(
-				null, objectEntryFolder.getCompanyId(),
-				objectEntryFolder.getUserId(),
-				objectEntryFolder.getExternalReferenceCode(),
-				objectEntryFolder.getModelClassName(),
-				defaultPermissionsJSONObject, objectEntryFolder.getGroupId(),
-				objectEntryFolder.getTreePath());
-		}
-
-		JSONObject objectEntryFoldersJSONObject =
-			defaultPermissionsJSONObject.getJSONObject("OBJECT_ENTRY_FOLDERS");
-
-		if (objectEntryFoldersJSONObject == null) {
-			return;
-		}
-
-		List<String> resourceActions = ResourceActionsUtil.getResourceActions(
-			ObjectEntryFolder.class.getName());
-
-		List<Role> roles = _roleLocalService.getGroupRolesAndTeamRoles(
-			objectEntryFolder.getCompanyId(), null,
-			Arrays.asList(
-				RoleConstants.ADMINISTRATOR,
-				DepotRolesConstants.ASSET_LIBRARY_OWNER),
-			null, null,
-			new int[] {RoleConstants.TYPE_REGULAR, RoleConstants.TYPE_DEPOT},
-			null, 0, 0, QueryUtil.ALL_POS, QueryUtil.ALL_POS);
-
-		for (Role role : roles) {
-			String[] actionIds = JSONUtil.toStringArray(
-				objectEntryFoldersJSONObject.getJSONArray(role.getName()));
-
-			if (objectEntryFolder.getParentObjectEntryFolderId() ==
-					ObjectEntryFolderConstants.
-						PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT) {
-
-				actionIds = ArrayUtil.remove(actionIds, ActionKeys.DELETE);
-			}
-
-			_resourcePermissionLocalService.setResourcePermissions(
-				objectEntryFolder.getCompanyId(),
-				ObjectEntryFolder.class.getName(),
-				ResourceConstants.SCOPE_INDIVIDUAL,
-				String.valueOf(objectEntryFolder.getObjectEntryFolderId()),
-				role.getRoleId(),
-				ArrayUtil.filter(actionIds, resourceActions::contains));
-		}
-	}
-
-	private JSONObject _getCMSDefaultPermissionJSONObject(
-			ObjectEntryFolder objectEntryFolder)
-		throws Exception {
-
-		ObjectDefinition cmsDefaultPermissionObjectDefinition =
-			_objectDefinitionLocalService.
-				fetchObjectDefinitionByExternalReferenceCode(
-					"L_CMS_DEFAULT_PERMISSION",
-					objectEntryFolder.getCompanyId());
-
-		if (cmsDefaultPermissionObjectDefinition == null) {
-			return null;
-		}
-
-		if (objectEntryFolder.getParentObjectEntryFolderId() != 0) {
-			ObjectEntryFolder parentObjectEntryFolder =
-				_objectEntryFolderLocalService.getObjectEntryFolder(
-					objectEntryFolder.getParentObjectEntryFolderId());
-
-			JSONObject jsonObject = CMSDefaultPermissionUtil.getJSONObject(
-				parentObjectEntryFolder.getCompanyId(),
-				parentObjectEntryFolder.getUserId(),
-				parentObjectEntryFolder.getExternalReferenceCode(),
-				parentObjectEntryFolder.getModelClassName(), _filterFactory);
-
-			if ((jsonObject != null) && !JSONUtil.isEmpty(jsonObject)) {
-				return jsonObject;
-			}
-		}
-
-		Group group = _groupLocalService.getGroup(
-			objectEntryFolder.getGroupId());
-
-		return CMSDefaultPermissionUtil.getJSONObject(
-			group.getCompanyId(), group.getCreatorUserId(),
-			group.getExternalReferenceCode(), DepotEntry.class.getName(),
-			_filterFactory);
-	}
-
 	private void _onAfterCreate(ObjectEntryFolder objectEntryFolder)
 		throws Exception {
 
@@ -227,7 +103,8 @@ public class ObjectEntryFolderModelListener
 			return;
 		}
 
-		_addCMSDefaultPermissions(objectEntryFolder);
+		CMSDefaultPermissionUtil.addCMSDefaultPermissions(
+			objectEntryFolder, _filterFactory);
 	}
 
 	private void _onAfterRemove(ObjectEntryFolder objectEntryFolder)
@@ -309,7 +186,8 @@ public class ObjectEntryFolderModelListener
 		}
 
 		JSONObject defaultPermissionsJSONObject =
-			_getCMSDefaultPermissionJSONObject(objectEntryFolder);
+			CMSDefaultPermissionUtil.getCMSDefaultPermissionJSONObject(
+				objectEntryFolder, _filterFactory);
 
 		if ((defaultPermissionsJSONObject == null) ||
 			JSONUtil.isEmpty(defaultPermissionsJSONObject)) {
@@ -327,7 +205,8 @@ public class ObjectEntryFolderModelListener
 				objectEntry.getObjectEntryId());
 		}
 
-		_addCMSDefaultPermissions(objectEntryFolder);
+		CMSDefaultPermissionUtil.addCMSDefaultPermissions(
+			objectEntryFolder, _filterFactory);
 	}
 
 	@Reference(
@@ -336,28 +215,16 @@ public class ObjectEntryFolderModelListener
 	private FilterFactory<Predicate> _filterFactory;
 
 	@Reference
-	private GroupLocalService _groupLocalService;
-
-	@Reference
 	private JSONFactory _jsonFactory;
 
 	@Reference
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;
 
 	@Reference
-	private ObjectEntryFolderLocalService _objectEntryFolderLocalService;
-
-	@Reference
 	private ObjectEntryLocalService _objectEntryLocalService;
 
 	@Reference
 	private Portal _portal;
-
-	@Reference
-	private ResourcePermissionLocalService _resourcePermissionLocalService;
-
-	@Reference
-	private RoleLocalService _roleLocalService;
 
 	@Reference
 	private SharingEntryLocalService _sharingEntryLocalService;

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/model/listener/ObjectEntryFolderModelListener.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/model/listener/ObjectEntryFolderModelListener.java
@@ -16,19 +16,14 @@ import com.liferay.petra.sql.dsl.expression.Predicate;
 import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
-import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.ModelListener;
-import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.sharing.service.SharingEntryLocalService;
 import com.liferay.site.cms.site.initializer.util.CMSDefaultPermissionUtil;
 
-import java.io.Serializable;
-
-import java.util.Map;
 import java.util.Objects;
 
 import org.osgi.service.component.annotations.Component;
@@ -163,16 +158,8 @@ public class ObjectEntryFolderModelListener
 			return;
 		}
 
-		Map<String, Serializable> values = objectEntry.getValues();
-
-		CMSDefaultPermissionUtil.addOrUpdateObjectEntry(
-			objectEntry.getExternalReferenceCode(),
-			objectEntryFolder.getCompanyId(), objectEntryFolder.getUserId(),
-			externalReferenceCode, objectEntryFolder.getModelClassName(),
-			_jsonFactory.createJSONObject(
-				GetterUtil.getString(values.get("defaultPermissions"), "{}")),
-			GetterUtil.getLong(values.get("depotGroupId")),
-			GetterUtil.getString(values.get("treePath")));
+		CMSDefaultPermissionUtil.updateClassExternalReferenceCode(
+			objectEntry, externalReferenceCode, objectEntryFolder.getUserId());
 	}
 
 	private void _updateCMSDefaultPermissions(
@@ -213,9 +200,6 @@ public class ObjectEntryFolderModelListener
 		target = "(filter.factory.key=" + ObjectDefinitionConstants.STORAGE_TYPE_DEFAULT + ")"
 	)
 	private FilterFactory<Predicate> _filterFactory;
-
-	@Reference
-	private JSONFactory _jsonFactory;
 
 	@Reference
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/upgrade/registry/SiteCMSSiteInitializerUpgradeStepRegistrator.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/upgrade/registry/SiteCMSSiteInitializerUpgradeStepRegistrator.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/upgrade/registry/SiteCMSSiteInitializerUpgradeStepRegistrator.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/upgrade/registry/SiteCMSSiteInitializerUpgradeStepRegistrator.java
@@ -1,0 +1,50 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.upgrade.registry;
+
+import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.rest.filter.factory.FilterFactory;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryFolderLocalService;
+import com.liferay.petra.sql.dsl.expression.Predicate;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.site.cms.site.initializer.internal.upgrade.v1_0_0.CMSDefaultPermissionsUpgradeProcess;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Adolfo Pérez
+ */
+@Component(service = UpgradeStepRegistrator.class)
+public class SiteCMSSiteInitializerUpgradeStepRegistrator
+	implements UpgradeStepRegistrator {
+
+	@Override
+	public void register(Registry registry) {
+		registry.register(
+			"0.0.0", "1.0.0",
+			new CMSDefaultPermissionsUpgradeProcess(
+				_filterFactory, _groupLocalService,
+				_objectDefinitionLocalService, _objectEntryFolderLocalService));
+	}
+
+	@Reference(
+		target = "(filter.factory.key=" + ObjectDefinitionConstants.STORAGE_TYPE_DEFAULT + ")"
+	)
+	private FilterFactory<Predicate> _filterFactory;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Reference
+	private ObjectEntryFolderLocalService _objectEntryFolderLocalService;
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/upgrade/v1_0_0/CMSDefaultPermissionsUpgradeProcess.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/upgrade/v1_0_0/CMSDefaultPermissionsUpgradeProcess.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/upgrade/v1_0_0/CMSDefaultPermissionsUpgradeProcess.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/upgrade/v1_0_0/CMSDefaultPermissionsUpgradeProcess.java
@@ -1,0 +1,127 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.upgrade.v1_0_0;
+
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectEntryFolder;
+import com.liferay.object.rest.filter.factory.FilterFactory;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryFolderLocalService;
+import com.liferay.petra.sql.dsl.expression.Predicate;
+import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.site.cms.site.initializer.util.CMSDefaultPermissionUtil;
+
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * @author Adolfo Pérez
+ */
+public class CMSDefaultPermissionsUpgradeProcess extends UpgradeProcess {
+
+	public CMSDefaultPermissionsUpgradeProcess(
+		FilterFactory<Predicate> filterFactory,
+		GroupLocalService groupLocalService,
+		ObjectDefinitionLocalService objectDefinitionLocalService,
+		ObjectEntryFolderLocalService objectEntryFolderLocalService) {
+
+		_filterFactory = filterFactory;
+		_groupLocalService = groupLocalService;
+		_objectDefinitionLocalService = objectDefinitionLocalService;
+		_objectEntryFolderLocalService = objectEntryFolderLocalService;
+	}
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		ActionableDynamicQuery actionableDynamicQuery =
+			_objectEntryFolderLocalService.getActionableDynamicQuery();
+
+		Set<Long> groupIds = new HashSet<>();
+
+		actionableDynamicQuery.setPerformActionMethod(
+			(ObjectEntryFolder objectEntryFolder) -> {
+				ObjectDefinition objectDefinition =
+					_objectDefinitionLocalService.
+						fetchObjectDefinitionByExternalReferenceCode(
+							"L_CMS_DEFAULT_PERMISSION",
+							objectEntryFolder.getCompanyId());
+
+				if (objectDefinition == null) {
+					return;
+				}
+
+				Group group = _groupLocalService.fetchGroup(
+					objectEntryFolder.getGroupId());
+
+				if (group == null) {
+					return;
+				}
+
+				if (groupIds.add(objectEntryFolder.getGroupId())) {
+					_updateCMSDefaultPermissionExternalReferenceCode(group);
+				}
+
+				if (Objects.equals(
+						objectEntryFolder.getExternalReferenceCode(),
+						ObjectEntryFolderConstants.
+							EXTERNAL_REFERENCE_CODE_CONTENTS) ||
+					Objects.equals(
+						objectEntryFolder.getExternalReferenceCode(),
+						ObjectEntryFolderConstants.
+							EXTERNAL_REFERENCE_CODE_FILES)) {
+
+					return;
+				}
+
+				ObjectEntry objectEntry =
+					CMSDefaultPermissionUtil.fetchObjectEntry(
+						objectEntryFolder.getCompanyId(),
+						objectEntryFolder.getUserId(),
+						objectEntryFolder.getExternalReferenceCode(),
+						objectEntryFolder.getModelClassName(), _filterFactory);
+
+				if (objectEntry != null) {
+					return;
+				}
+
+				CMSDefaultPermissionUtil.addCMSDefaultPermissions(
+					objectEntryFolder, _filterFactory);
+			});
+
+		actionableDynamicQuery.performActions();
+	}
+
+	private void _updateCMSDefaultPermissionExternalReferenceCode(Group group)
+		throws PortalException {
+
+		ObjectEntry objectEntry =
+			CMSDefaultPermissionUtil.fetchObjectEntryByDepotGroupId(
+				group.getCompanyId(), group.getCreatorUserId(),
+				group.getGroupId(), DepotEntry.class.getName(), _filterFactory);
+
+		if (objectEntry == null) {
+			return;
+		}
+
+		CMSDefaultPermissionUtil.updateClassExternalReferenceCode(
+			objectEntry, group.getExternalReferenceCode(),
+			group.getCreatorUserId());
+	}
+
+	private final FilterFactory<Predicate> _filterFactory;
+	private final GroupLocalService _groupLocalService;
+	private final ObjectDefinitionLocalService _objectDefinitionLocalService;
+	private final ObjectEntryFolderLocalService _objectEntryFolderLocalService;
+
+}

--- a/modules/apps/site/source-formatter-suppressions.xml
+++ b/modules/apps/site/source-formatter-suppressions.xml
@@ -5,4 +5,7 @@
 		<suppress checks="PersistenceCallCheck" files="site-memberships-test/src/testIntegration/java/com/liferay/site/memberships/service/persistence/test/UserGroupGroupRoleFinderTest\.java" />
 		<suppress checks="PersistenceCallCheck" files="site-test/src/testIntegration/java/com/liferay/site/service/persistence/test/GroupFinderTest\.java" />
 	</checkstyle>
+	<source-check>
+		<suppress checks="JavaUpgradeVersionCheck" files="site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/upgrade/registry/SiteCMSSiteInitializerUpgradeStepRegistrator\.java" />
+	</source-check>
 </suppressions>

--- a/modules/test/playwright/tests/site-cms-site-initializer/permissions/defaultPermissions.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/permissions/defaultPermissions.spec.ts
@@ -20,6 +20,7 @@ import {
 	getTableRowByText,
 	goToAllSpaces,
 	handleClickMenuItem,
+	updateSpaceExternalReferenceCode,
 } from './utils/permissions';
 
 const test = mergeTests(
@@ -1115,6 +1116,140 @@ test(
 				page,
 				permissions: permissionsByRole2,
 			});
+		}
+		finally {
+			await goToAllSpaces(page);
+
+			await deleteSpace(page, spaceName);
+		}
+	}
+);
+
+test(
+	'Space default permissions remain available after changing the Space ERC',
+	{tag: '@LPD-94507'},
+	async ({apiHelpers, defaultPermissionsPage, page}) => {
+		test.setTimeout(90000);
+
+		const spaceName = 'Space' + getRandomInt();
+
+		// Create a Space and configure its default permissions
+
+		await goToAllSpaces(page);
+
+		await createSpace(page, spaceName);
+
+		try {
+			await goToAllSpaces(page);
+
+			await clickMenuItem('Default Permissions', page, spaceName);
+
+			const permissions = [
+				{action: 'DELETE', checked: true, role: 'Power User'},
+				{action: 'PERMISSIONS', checked: true, role: 'User'},
+			];
+
+			await defaultPermissionsPage.checkPermissionsAndSave(permissions);
+
+			// Change the Space ERC from Space Settings
+
+			await updateSpaceExternalReferenceCode(
+				apiHelpers,
+				spaceName,
+				'erc-' + getRandomInt()
+			);
+
+			// LPP-64409: the previously configured default permissions are
+			// still visible after the change
+
+			await goToAllSpaces(page);
+
+			await verifyPermissions({
+				menuitem: 'Default Permissions',
+				objectName: spaceName,
+				page,
+				permissions,
+			});
+
+			// New default permissions can still be added without a system error
+
+			await clickMenuItem('Default Permissions', page, spaceName);
+
+			await defaultPermissionsPage.checkPermissionsAndSave([
+				{action: 'VIEW', role: 'User'},
+			]);
+		}
+		finally {
+			await goToAllSpaces(page);
+
+			await deleteSpace(page, spaceName);
+		}
+	}
+);
+
+test(
+	'Folder default permission management works after changing the Space ERC',
+	{tag: '@LPD-94507'},
+	async ({apiHelpers, defaultPermissionsPage, page, spaceSummaryPage}) => {
+		test.setTimeout(120000);
+
+		const spaceName = 'Space' + getRandomInt();
+
+		await goToAllSpaces(page);
+
+		await createSpace(page, spaceName);
+
+		try {
+
+			// Create a folder before the ERC change
+
+			await spaceSummaryPage.goto(spaceName);
+
+			const folderBefore = 'Folder' + getRandomInt();
+
+			await spaceSummaryPage.createContentFolder(folderBefore);
+
+			// Change the Space ERC from Space Settings
+
+			await updateSpaceExternalReferenceCode(
+				apiHelpers,
+				spaceName,
+				'erc-' + getRandomInt()
+			);
+
+			// Create a folder after the ERC change
+
+			await spaceSummaryPage.goto(spaceName);
+
+			const folderAfter = 'Folder' + getRandomInt();
+
+			await spaceSummaryPage.createContentFolder(folderAfter);
+
+			await spaceSummaryPage.viewAllContentLink.click();
+
+			// LPP-64362: folder Default Permissions and Edit and Propagate
+			// Default Permissions stay usable for folders created both before
+			// and after the ERC change
+
+			for (const folderName of [folderBefore, folderAfter]) {
+				await clickMenuItem('Default Permissions', page, folderName);
+
+				await defaultPermissionsPage.checkPermissionsAndSave([
+					{action: 'VIEW', role: 'User'},
+				]);
+
+				await clickMenuItem(
+					'Edit and Propagate Default Permissions',
+					page,
+					folderName
+				);
+
+				await defaultPermissionsPage.checkPermissionsAndSave(
+					[{action: 'UPDATE', role: 'Power User'}],
+					false,
+					true
+				);
+			}
 		}
 		finally {
 			await goToAllSpaces(page);

--- a/modules/test/playwright/tests/site-cms-site-initializer/permissions/utils/permissions.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/permissions/utils/permissions.ts
@@ -94,3 +94,21 @@ export async function handleClickMenuItem(menuitem: string, page) {
 		}
 	}).toPass({timeout: 5000});
 }
+
+export async function updateSpaceExternalReferenceCode(
+	apiHelpers,
+	spaceName: string,
+	externalReferenceCode: string
+) {
+	const assetLibraries =
+		await apiHelpers.headlessAssetLibrary.getAssetLibrariesPage(
+			`type eq 'Space'`
+		);
+
+	const assetLibrary = assetLibraries.find(({name}) => name === spaceName);
+
+	await apiHelpers.headlessAssetLibrary.patchAssetLibrary(
+		assetLibrary.externalReferenceCode,
+		{externalReferenceCode}
+	);
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94507

## What Is Being Fixed

A Space's default permissions are stored in an L_CMS_DEFAULT_PERMISSION object entry keyed by the Space group's external reference code (ERC). Changing the Space ERC left that entry orphaned under the old code, so lookups by the new code resolved nothing. Folder Default Permissions and Edit & Propagate Default Permissions then failed with a system error (LPP-64362), the Space's own default permissions disappeared from the UI and could not be re-added (LPP-64409), and Space members lost VIEW on affected content. Environments where the ERC had already been changed stayed broken.

## How It Is Being Fixed

The CMS default-permission seeding logic moves into the shared CMSDefaultPermissionUtil so it can be reused. When a Space ERC changes, the listener now resolves the entry by its immutable depotGroupId and updates the classExternalReferenceCode in place, which is resilient to an already-stale code; the same in-place update is applied to the folder ERC re-key. An upgrade process repairs environments that were already broken, walking the object entry folders with an ActionableDynamicQuery to re-sync each Space entry's class ERC and backfill the per-folder entries that were never created while the code was mismatched. The exported util package and bundle versions are bumped for the new public API. Coverage is added at both surfaces: an integration test for the repair upgrade and Playwright tests for the Space-level (LPP-64409) and folder-level (LPP-64362) flows.

## PR Check

**pr-check: PASS** — tested on `415411d95bb09353c1e855d28132a781503ba6e7`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |

<!-- pr-check {"result": "success", "sha": "415411d95bb09353c1e855d28132a781503ba6e7"} -->