### PR TITLE
LPD-94636 Use the depot entry as the members summary test info item

### DIFF
--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewSpaceMembersSummarySectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewSpaceMembersSummarySectionDisplayContextTest.java
@@ -11,8 +11,6 @@ import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.fragment.renderer.FragmentRenderer;
 import com.liferay.info.constants.InfoDisplayWebKeys;
-import com.liferay.object.rest.test.util.ObjectEntryTestUtil;
-import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Group;
@@ -29,8 +27,6 @@ import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
-
-import java.io.Serializable;
 
 import java.util.List;
 import java.util.Map;
@@ -67,19 +63,7 @@ public class ViewSpaceMembersSummarySectionDisplayContextTest
 			ServiceContextTestUtil.getServiceContext());
 
 		mockHttpServletRequest.setAttribute(
-			InfoDisplayWebKeys.INFO_ITEM,
-			ObjectEntryTestUtil.addObjectEntry(
-				depotEntry.getGroupId(),
-				_objectDefinitionLocalService.
-					fetchObjectDefinitionByExternalReferenceCode(
-						"L_CMS_BASIC_WEB_CONTENT",
-						TestPropsValues.getCompanyId()),
-				HashMapBuilder.<String, Serializable>put(
-					"title_i18n",
-					HashMapBuilder.put(
-						"en_US", RandomTestUtil.randomString()
-					).build()
-				).build()));
+			InfoDisplayWebKeys.INFO_ITEM, depotEntry);
 
 		_assertHeaderProps(null, depotEntry.getGroup());
 
@@ -89,19 +73,7 @@ public class ViewSpaceMembersSummarySectionDisplayContextTest
 			ServiceContextTestUtil.getServiceContext());
 
 		mockHttpServletRequest.setAttribute(
-			InfoDisplayWebKeys.INFO_ITEM,
-			ObjectEntryTestUtil.addObjectEntry(
-				projectDepotEntry.getGroupId(),
-				_objectDefinitionLocalService.
-					fetchObjectDefinitionByExternalReferenceCode(
-						"L_CMS_BASIC_WEB_CONTENT",
-						TestPropsValues.getCompanyId()),
-				HashMapBuilder.<String, Serializable>put(
-					"title_i18n",
-					HashMapBuilder.put(
-						"en_US", RandomTestUtil.randomString()
-					).build()
-				).build()));
+			InfoDisplayWebKeys.INFO_ITEM, projectDepotEntry);
 
 		_assertHeaderProps(
 			HashMapBuilder.<String, Object>put(
@@ -175,8 +147,5 @@ public class ViewSpaceMembersSummarySectionDisplayContextTest
 		filter = "component.name=com.liferay.site.cms.site.initializer.internal.fragment.renderer.ViewSpaceMembersSummaryJSPSectionFragmentRenderer"
 	)
 	private FragmentRenderer _fragmentRenderer;
-
-	@Inject
-	private ObjectDefinitionLocalService _objectDefinitionLocalService;
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94636

## What Is Being Fixed

The integration test ViewSpaceMembersSummarySectionDisplayContextTest#testGetHeaderProps fails during setup with ObjectEntryGroupIdException$InvalidGroupIdForDomain: "Group ID ... is not valid for domain space". This is a semantic conflict between two independently green commits that landed on master a day apart: LPD-93941 changed the test's project case to add an L_CMS_BASIC_WEB_CONTENT object entry into a TYPE_PROJECT depot, and LPD-88820 then added validation in ObjectEntryLocalServiceImpl that rejects a depot-scoped object entry whose domain setting does not match the depot subtype. Every CMS depot-scoped object definition is pinned to the "space" domain, so adding one to a project depot is now correctly rejected. The production code and the validation are both correct; the test data is what became invalid.

## How It Is Being Fixed

The display context only needs the group ID, which the fragment renderer resolves through InfoItemUtil.getGroupId. That method already accepts a DepotEntry as the info item, so the test now sets the depot entry itself as the info item for both the space and project cases. This exercises the same code path (fetchGroupDepotEntry(groupId).getType()) without creating an object entry, removing the dependency on the object definition's domain entirely. It is also more faithful to production, where the space/project summary page's info item is the depot entry. The unused ObjectEntryTestUtil, ObjectDefinitionLocalService, and Serializable references were removed.

## PR Check

**pr-check: PASS** — tested on `a61d82b0c651c06972d4429f43dec695de6bc2f6`

| Validation | Result |
| --- | --- |
| Integration Test Compile | PASS |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "a61d82b0c651c06972d4429f43dec695de6bc2f6"} -->