### PR TITLE
LPD-94641 Wait for the folder name field to prefill before editing it

### DIFF
--- a/modules/test/playwright/tests/site-cms-site-initializer/main/folders.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/folders.spec.ts
@@ -44,7 +44,11 @@ test(
 
 		const newFolderTitle = getRandomString();
 
-		await page.getByLabel('Name').fill(newFolderTitle);
+		const nameInput = page.getByLabel('Name');
+
+		await expect(nameInput).toHaveValue(folderTitle);
+
+		await nameInput.fill(newFolderTitle);
 		await page.getByLabel('Description').fill('folder description');
 		await page.getByRole('button', {name: 'Save'}).click();
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94641

## What Is Being Fixed

The Playwright test `site-cms-site-initializer/main/folders.spec.ts > Can edit a folder` was flaky in CI, failing intermittently with a 90s timeout on `waitForAlert` waiting for the success message.

## How It Is Being Fixed

The edit dialog prefills the Name field asynchronously with the folder's current title (via a GET request). The test filled the field with the new title without waiting for that prefill, so depending on timing the field ended up either with the old and new titles concatenated or with the new value overwritten back to the original. Either way the saved title — and therefore the success alert text — no longer matched what the test expected, so `waitForAlert` timed out. The fix waits for the Name field to hold the original title before overwriting it, which guarantees the prefill has settled so the new value replaces it cleanly.

## PR Check

**pr-check: PASS** — tested on `5d841a19b1f0328fcc1c81ccb7ef5ba6ecb28b6d`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "5d841a19b1f0328fcc1c81ccb7ef5ba6ecb28b6d"} -->