### PR TITLE
LPD-93662 Center CMS confirmation and alert modals on screen

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/components/Breadcrumb.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/components/Breadcrumb.tsx
@@ -181,6 +181,7 @@ function ActionDropdownItem({
 						},
 					},
 				],
+				center: true,
 				role: 'alertdialog',
 				status: 'danger',
 				title: confirmationTitle || Liferay.Language.get('delete'),

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/utils/genericOpenModalUtil.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/utils/genericOpenModalUtil.ts
@@ -60,6 +60,7 @@ const openGenericFDSDeleteConfirmationModal = (
 				},
 			},
 		],
+		center: true,
 		status: 'danger',
 		title: sub(Liferay.Language.get('delete-x'), '"' + itemName + '"'),
 	});

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/categorization/categories/EditCategoryPage.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/categorization/categories/EditCategoryPage.tsx
@@ -237,6 +237,7 @@ const EditCategoryPage = ({
 						},
 					},
 				],
+				center: true,
 				status: 'warning',
 				title: sub(
 					Liferay.Language.get('edit-x'),

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/categorization/tags/MergeTagsModal.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/categorization/tags/MergeTagsModal.tsx
@@ -147,6 +147,7 @@ export default function MergeTagsModalContent({
 							type: 'cancel',
 						},
 					],
+					center: true,
 					onClose: () => {
 						mergeModel?.removeAttribute('hidden');
 					},
@@ -176,6 +177,7 @@ export default function MergeTagsModalContent({
 						},
 					},
 				],
+				center: true,
 				onClose: () => {
 					mergeModel?.removeAttribute('hidden');
 				},

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/categorization/tags/ViewTags.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/categorization/tags/ViewTags.tsx
@@ -152,6 +152,7 @@ export default function ViewTags({
 					},
 				},
 			],
+			center: true,
 			status: 'danger',
 			title: sub(
 				Liferay.Language.get('delete-x'),

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/default_permission/ResetPermissionModalContent.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/default_permission/ResetPermissionModalContent.tsx
@@ -67,6 +67,7 @@ export default function openResetAssetPermissionModal({
 				},
 			},
 		],
+		center: true,
 		status: 'warning',
 		title: Liferay.Language.get('confirm-reset-to-default-permissions'),
 	});

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/actions/confirmAndDeleteEntryAction.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/actions/confirmAndDeleteEntryAction.ts
@@ -54,6 +54,7 @@ export default function confirmAndDeleteEntryAction({
 				},
 			},
 		],
+		center: true,
 		role: 'alert',
 		status: 'danger',
 		title,

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/actions/deleteStructureAction.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/actions/deleteStructureAction.ts
@@ -97,6 +97,7 @@ export default async function deleteStructureAction({
 					},
 				},
 			],
+			center: true,
 			size: 'md',
 			status: 'warning',
 			title: Liferay.Language.get('deletion-not-allowed'),
@@ -106,6 +107,7 @@ export default async function deleteStructureAction({
 	}
 
 	openCMSModal({
+		center: true,
 		contentComponent: ({closeModal}: {closeModal: () => void}) =>
 			DeleteStructureModalContent({
 				closeModal,

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/spaces/SpaceGeneralSettings.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/spaces/SpaceGeneralSettings.tsx
@@ -194,6 +194,7 @@ export default function SpaceGeneralSettings({
 						},
 					},
 				],
+				center: true,
 				role: 'alertdialog',
 				status: 'warning',
 				title: Liferay.Language.get('save-custom-friendly-url'),

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/all.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/all.spec.ts
@@ -79,6 +79,10 @@ test(
 				page.getByText('You are about to delete the asset')
 			).toBeVisible();
 
+			await expect(
+				page.locator('.liferay-modal .modal-dialog')
+			).toHaveClass(/modal-dialog-centered/);
+
 			await page.getByRole('button', {name: 'Delete'}).click();
 
 			await waitForAlert(page, `${file1Title} was successfully deleted.`);

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/categorization/tags.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/categorization/tags.spec.ts
@@ -206,6 +206,14 @@ test('Bulk Merge tags', {tag: '@LPD-43388'}, async ({page, tagsPage}) => {
 		trigger: tagsPage.saveButton,
 	});
 
+	await expect(
+		page
+			.locator('.liferay-modal', {
+				hasText: 'Please choose at least 2 tags.',
+			})
+			.locator('.modal-dialog')
+	).toHaveClass(/modal-dialog-centered/);
+
 	await page.getByRole('button', {name: 'OK'}).click();
 
 	await page.getByLabel('Select', {exact: true}).click();
@@ -318,6 +326,14 @@ test('Merge tags', {tag: '@LPD-43388'}, async ({page, tagsPage}) => {
 		target: page.getByRole('heading', {name: 'Confirm Merge Tags'}),
 		trigger: tagsPage.saveButton,
 	});
+
+	await expect(
+		page
+			.locator('.liferay-modal', {
+				has: page.getByRole('heading', {name: 'Confirm Merge Tags'}),
+			})
+			.locator('.modal-dialog')
+	).toHaveClass(/modal-dialog-centered/);
 
 	await clickAndExpectToBeVisible({
 		target: page.getByText(

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/categorization/vocabularies.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/categorization/vocabularies.spec.ts
@@ -96,6 +96,10 @@ test(
 			page.getByRole('heading', {name: `Delete "${name}"`})
 		).toBeVisible();
 
+		await expect(page.locator('.liferay-modal .modal-dialog')).toHaveClass(
+			/modal-dialog-centered/
+		);
+
 		await clickAndExpectToBeVisible({
 			target: page.getByText(
 				'Success:Your request completed successfully.'

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/pages/EditCategoryPage.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/pages/EditCategoryPage.ts
@@ -222,6 +222,10 @@ export class EditCategoryPage {
 	async handleEditConfirmationModal(clickSave: boolean) {
 		await expect(this.editConfirmationModal).toBeVisible();
 
+		await expect(
+			this.page.locator('.liferay-modal .modal-dialog')
+		).toHaveClass(/modal-dialog-centered/);
+
 		clickSave
 			? await this.editConfirmationModal
 					.getByRole('button', {name: 'Save'})

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/pages/TagsPage.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/pages/TagsPage.ts
@@ -80,6 +80,10 @@ export class TagsPage {
 			this.page.getByRole('heading', {name: `Delete Tag`})
 		).toBeVisible();
 
+		await expect(
+			this.page.locator('.liferay-modal .modal-dialog')
+		).toHaveClass(/modal-dialog-centered/);
+
 		await clickAndExpectToBeVisible({
 			target: this.page.getByText(
 				`Success:${name} was deleted successfully.`

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/structures.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/structures.spec.ts
@@ -87,6 +87,10 @@ test(
 			filter: structureName,
 		});
 
+		await expect(page.locator('.liferay-modal .modal-dialog')).toHaveClass(
+			/modal-dialog-centered/
+		);
+
 		await page
 			.getByPlaceholder('Confirm Content Structure Name')
 			.fill(structureName);
@@ -139,6 +143,10 @@ test(
 		await expect(
 			page.getByRole('heading', {name: 'Deletion Not Allowed'})
 		).toBeVisible();
+
+		await expect(page.locator('.liferay-modal .modal-dialog')).toHaveClass(
+			/modal-dialog-centered/
+		);
 
 		await clickAndExpectToBeHidden({
 			target: page.getByRole('button', {name: 'OK'}),

--- a/modules/test/playwright/tests/site-cms-site-initializer/permissions/defaultPermissions.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/permissions/defaultPermissions.spec.ts
@@ -75,6 +75,10 @@ async function resetPermissions(page, folderName?: string) {
 	await expect(async () => {
 		await clickMenuItem('Reset to Default Permissions', page, folderName);
 
+		await expect(page.locator('.liferay-modal .modal-dialog')).toHaveClass(
+			/modal-dialog-centered/
+		);
+
 		await page.getByRole('button', {name: 'Confirm'}).click();
 	}).toPass({timeout: 5000});
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93662

## What Is Being Fixed

The "Save Custom Friendly URL" confirmation modal in the CMS rendered anchored to the top of the viewport instead of vertically centered, unlike the rest of the CMS dialogs. The same inconsistency affected several other CMS confirmation and alert dialogs that were opened through openModal/openCMSModal without the center flag.

## How It Is Being Fixed

The center flag is set on the affected confirmation and alert modals so they render vertically centered, consistent with the rest of the CMS dialogs. Beyond the friendly URL confirmation, this covers the generic delete confirmation, the breadcrumb delete confirmation, reset to default permissions, the delete-entry confirmation, structure deletion (both the delete confirmation and the "deletion not allowed" alert), the category edit confirmation, the tag delete confirmation, and the tag merge flow. Playwright assertions verify the dialogs carry the centered class across the delete, reset, edit, merge, and friendly-URL flows wherever those modals are reachable from the UI.

## PR Check

**pr-check: PASS** — tested on `ba176824fbcea71c6472c157c58ea53fedce2578`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "ba176824fbcea71c6472c157c58ea53fedce2578"} -->
