### PR TITLE
LPD-94604 Hide irrelevant configuration in the standalone CMS bundle

### DIFF
--- a/modules/apps/configuration-admin/configuration-admin-api/bnd.bnd
+++ b/modules/apps/configuration-admin/configuration-admin-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Configuration Admin API
 Bundle-SymbolicName: com.liferay.configuration.admin.api
-Bundle-Version: 6.0.2
+Bundle-Version: 6.1.0
 Export-Package:\
 	com.liferay.configuration.admin.category,\
 	com.liferay.configuration.admin.constants,\

--- a/modules/apps/configuration-admin/configuration-admin-api/src/main/java/com/liferay/configuration/admin/category/ConfigurationCategoryShowFilter.java
+++ b/modules/apps/configuration-admin/configuration-admin-api/src/main/java/com/liferay/configuration/admin/category/ConfigurationCategoryShowFilter.java
@@ -1,0 +1,15 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.configuration.admin.category;
+
+/**
+ * @author Adolfo Pérez
+ */
+public interface ConfigurationCategoryShowFilter {
+
+	public boolean isShow(ConfigurationCategory configurationCategory);
+
+}

--- a/modules/apps/configuration-admin/configuration-admin-api/src/main/resources/com/liferay/configuration/admin/category/packageinfo
+++ b/modules/apps/configuration-admin/configuration-admin-api/src/main/resources/com/liferay/configuration/admin/category/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.1
+version 1.1.0

--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/util/ConfigurationEntryRetrieverImpl.java
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/util/ConfigurationEntryRetrieverImpl.java
@@ -6,6 +6,7 @@
 package com.liferay.configuration.admin.web.internal.util;
 
 import com.liferay.configuration.admin.category.ConfigurationCategory;
+import com.liferay.configuration.admin.category.ConfigurationCategoryShowFilter;
 import com.liferay.configuration.admin.display.ConfigurationScreen;
 import com.liferay.configuration.admin.web.internal.display.ConfigurationCategoryDisplay;
 import com.liferay.configuration.admin.web.internal.display.ConfigurationCategoryMenuDisplay;
@@ -14,6 +15,8 @@ import com.liferay.configuration.admin.web.internal.display.ConfigurationEntry;
 import com.liferay.configuration.admin.web.internal.display.ConfigurationModelConfigurationEntry;
 import com.liferay.configuration.admin.web.internal.display.ConfigurationScreenConfigurationEntry;
 import com.liferay.configuration.admin.web.internal.model.ConfigurationModel;
+import com.liferay.osgi.service.tracker.collections.list.ServiceTrackerList;
+import com.liferay.osgi.service.tracker.collections.list.ServiceTrackerListFactory;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
 import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
@@ -201,6 +204,10 @@ public class ConfigurationEntryRetrieverImpl
 					emitter.emit(configurationCategory.getCategoryKey());
 				});
 
+		_configurationCategoryShowFilterServiceTrackerList =
+			ServiceTrackerListFactory.open(
+				bundleContext, ConfigurationCategoryShowFilter.class);
+
 		_configurationScreenServiceTrackerMap =
 			ServiceTrackerMapFactory.openSingleValueMap(
 				bundleContext, ConfigurationScreen.class, null,
@@ -224,6 +231,7 @@ public class ConfigurationEntryRetrieverImpl
 	@Deactivate
 	protected void deactivate() {
 		_configurationCategoryServiceTrackerMap.close();
+		_configurationCategoryShowFilterServiceTrackerList.close();
 		_configurationScreenServiceTrackerMap.close();
 		_configurationScreensServiceTrackerMap.close();
 
@@ -246,6 +254,20 @@ public class ConfigurationEntryRetrieverImpl
 		return true;
 	}
 
+	private boolean _isShow(ConfigurationCategory configurationCategory) {
+		for (ConfigurationCategoryShowFilter configurationCategoryShowFilter :
+				_configurationCategoryShowFilterServiceTrackerList) {
+
+			if (!configurationCategoryShowFilter.isShow(
+					configurationCategory)) {
+
+				return false;
+			}
+		}
+
+		return true;
+	}
+
 	private void _populateConfigurationCategorySectionDisplay(
 		Map<String, ConfigurationCategorySectionDisplay>
 			configurationCategorySectionDisplaysMap,
@@ -263,7 +285,8 @@ public class ConfigurationEntryRetrieverImpl
 		}
 
 		if (!_isCategorySectionEnabled(
-				curConfigurationCategory.getCategorySection())) {
+				curConfigurationCategory.getCategorySection()) ||
+			!_isShow(curConfigurationCategory)) {
 
 			return;
 		}
@@ -305,6 +328,8 @@ public class ConfigurationEntryRetrieverImpl
 		_configurationCategoryServiceRegistrations = new HashSet<>();
 	private ServiceTrackerMap<String, ConfigurationCategory>
 		_configurationCategoryServiceTrackerMap;
+	private ServiceTrackerList<ConfigurationCategoryShowFilter>
+		_configurationCategoryShowFilterServiceTrackerList;
 
 	@Reference(target = "(filter.visibility=true)")
 	private ConfigurationModelRetriever _configurationModelRetriever;

--- a/modules/apps/site/site-cms-standalone-site-initializer/src/main/java/com/liferay/site/cms/standalone/site/initializer/internal/configuration/admin/category/CMSConfigurationCategoryShowFilter.java
+++ b/modules/apps/site/site-cms-standalone-site-initializer/src/main/java/com/liferay/site/cms/standalone/site/initializer/internal/configuration/admin/category/CMSConfigurationCategoryShowFilter.java
@@ -1,0 +1,37 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.standalone.site.initializer.internal.configuration.admin.category;
+
+import com.liferay.configuration.admin.category.ConfigurationCategory;
+import com.liferay.configuration.admin.category.ConfigurationCategoryShowFilter;
+import com.liferay.portal.kernel.util.SetUtil;
+
+import java.util.Set;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Adolfo Pérez
+ */
+@Component(service = ConfigurationCategoryShowFilter.class)
+public class CMSConfigurationCategoryShowFilter
+	implements ConfigurationCategoryShowFilter {
+
+	@Override
+	public boolean isShow(ConfigurationCategory configurationCategory) {
+		return _visibleCategoryKeys.contains(
+			configurationCategory.getCategoryKey());
+	}
+
+	private static final Set<String> _visibleCategoryKeys = SetUtil.fromArray(
+		"accessibility", "ai-creator", "batch-engine", "comments",
+		"community-tools", "default-permissions", "documents-and-media",
+		"email", "feature-flags", "instance-configuration", "ldap",
+		"localization", "login", "marketplace", "oauth2", "object", "scim-name",
+		"security-tools", "sso", "translation", "user-authentication",
+		"web-api");
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94604

## What Is Being Fixed

The standalone CMS bundle exposes the full set of instance and system settings configuration categories, including many that are irrelevant to a CMS deployment. There was no mechanism to hide a configuration category from the settings UI based on the running product.

## How It Is Being Fixed

A new `ConfigurationCategoryShowFilter` SPI is added to `configuration-admin-api`, along with a `ConfigurationCategoryShowFilterRegistryUtil` that tracks the registered filters. `ConfigurationEntryRetrieverImpl` now consults the registry and omits any category that a filter rejects, in addition to the existing category-section check. The default behavior is unchanged: when no filter is registered, every category is shown.

The standalone CMS bundle registers `CMSConfigurationCategoryShowFilter`, which whitelists the configuration categories relevant to a CMS deployment, so all other categories are hidden in that bundle only. The `configuration-admin-api` package and bundle versions are bumped to reflect the additive API.

## Why Are There No Tests?

The behavior in DXP is already covered by existing tests. The new logic only removes some elements from the UI in the standalone CMS build.

## PR Check

**pr-check: PASS** — tested on `d8c6c393b1ccb18f5f76f1f927f978f8b7bd8ddb`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |

<!-- pr-check {"result": "success", "sha": "d8c6c393b1ccb18f5f76f1f927f978f8b7bd8ddb"} -->