### PR TITLE
LPD-69202 Show selected categories and tags in the dropdown menu

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/components/AssetCategories.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/components/AssetCategories.tsx
@@ -126,6 +126,11 @@ const AssetCategories = ({
 		[groupedTaxonomies.taxonomyCategoryIds, updateObjectEntry]
 	);
 
+	const selectedCategories = useMemo(
+		() => Object.values(groupedTaxonomies.taxonomyVocabularies).flat(),
+		[groupedTaxonomies.taxonomyVocabularies]
+	);
+
 	const removeCategory = useCallback(
 		async (category: ITaxonomyCategoryFacade) => {
 			const {taxonomyCategoryIds} = groupedTaxonomies;
@@ -172,10 +177,11 @@ const AssetCategories = ({
 						apiURL={apiURL}
 						disabled={!hasUpdatePermission}
 						estimateSize={49}
+						items={selectedCategories}
 						locator={{
 							id: 'id',
 							label: 'name',
-							value: 'externalReferenceCode',
+							value: 'id',
 						}}
 						onChange={setValue}
 						onItemsChange={(newItems: any) => {
@@ -196,7 +202,7 @@ const AssetCategories = ({
 					>
 						{(item) => (
 							<ItemSelector.Item
-								key={item.name}
+								key={item.id}
 								textValue={item.name}
 							>
 								<div>

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/components/AssetTags.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/components/AssetTags.tsx
@@ -72,6 +72,11 @@ const AssetTags = ({
 		checkPermission();
 	}, [apiURL]);
 
+	const selectedKeywords = useMemo(
+		() => (objectEntry?.keywords || []).map((name) => ({id: name, name})),
+		[objectEntry?.keywords]
+	);
+
 	const addKeyword = useCallback(
 		async (keyword: TKeyword) => {
 			const {keywords = []} = objectEntry;
@@ -149,10 +154,11 @@ const AssetTags = ({
 				<ItemSelector<TKeyword>
 					apiURL={apiURL}
 					disabled={!hasUpdatePermission}
+					items={selectedKeywords}
 					locator={{
 						id: 'id',
 						label: 'name',
-						value: 'externalReferenceCode',
+						value: 'name',
 					}}
 					onChange={setValue}
 					onItemsChange={(newItems: TKeyword[]) => {

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/categorization/vocabularies.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/categorization/vocabularies.spec.ts
@@ -28,6 +28,22 @@ const test = mergeTests(
 	loginTest()
 );
 
+const createdVocabularyNames: string[] = [];
+
+test.afterEach(async ({vocabulariesPage}) => {
+	if (!createdVocabularyNames.length) {
+		return;
+	}
+
+	await vocabulariesPage.goto();
+
+	for (const name of createdVocabularyNames) {
+		await vocabulariesPage.deleteVocabulary(name);
+	}
+
+	createdVocabularyNames.length = 0;
+});
+
 const createScopedVocabularyAndContent = async ({
 	apiHelpers,
 	assetLibraries,
@@ -126,9 +142,11 @@ test(
 	'Assert can edit vocabulary from dropdown actions',
 	{tag: '@LPD-32750'},
 	async ({editVocabularyPage, page, vocabulariesPage}) => {
-		await editVocabularyPage.goto();
-
 		const name = `Vocabulary${getRandomInt()}`;
+
+		createdVocabularyNames.push(name);
+
+		await editVocabularyPage.goto();
 
 		await editVocabularyPage.changeGeneralInfo({
 			description: getRandomString(),
@@ -155,9 +173,11 @@ test(
 	'Assert can edit vocabulary permissions from dropdown actions',
 	{tag: '@LPD-32750'},
 	async ({editVocabularyPage, page, vocabulariesPage}) => {
-		editVocabularyPage.goto();
-
 		const name = `Vocabulary${getRandomInt()}`;
+
+		createdVocabularyNames.push(name);
+
+		editVocabularyPage.goto();
 
 		await editVocabularyPage.changeGeneralInfo({
 			description: getRandomString(),
@@ -237,9 +257,11 @@ test(
 	'Can create and update vocabulary',
 	{tag: ['@LPD-32750', '@LPD-66358']},
 	async ({editVocabularyPage, page, vocabulariesPage}) => {
-		editVocabularyPage.goto();
+		let name = `Vocabulary${getRandomInt()}`;
 
-		const name = `Vocabulary${getRandomInt()}`;
+		createdVocabularyNames.push(name);
+
+		editVocabularyPage.goto();
 
 		await editVocabularyPage.changeGeneralInfo({
 			description: getRandomString(),
@@ -311,11 +333,11 @@ test(
 
 		await expect(spacesInputLocator).toHaveAttribute('value', 'All Spaces');
 
-		const newName = `Vocabulary${getRandomInt()}`;
+		name = `Vocabulary${getRandomInt()}`;
 
 		await editVocabularyPage.changeGeneralInfo({
 			description: getRandomString(),
-			name: newName,
+			name,
 		});
 
 		await editVocabularyPage.assetTypesButton.click();
@@ -327,13 +349,13 @@ test(
 		await expect(editVocabularyPage.assetTypeToggle).toBeChecked();
 
 		await clickAndExpectToBeVisible({
-			target: page.getByText(
-				`Success:${newName} was updated successfully.`
-			),
+			target: page.getByText(`Success:${name} was updated successfully.`),
 			trigger: editVocabularyPage.saveButton,
 		});
 
-		await expect(vocabulariesPage.getItem(newName)).toBeVisible();
+		createdVocabularyNames[createdVocabularyNames.length - 1] = name;
+
+		await expect(vocabulariesPage.getItem(name)).toBeVisible();
 	}
 );
 
@@ -341,9 +363,11 @@ test(
 	'Validate change asset types when saving',
 	{tag: '@LPD-52591'},
 	async ({editVocabularyPage, page, vocabulariesPage}) => {
-		editVocabularyPage.goto();
-
 		const name = `Vocabulary${getRandomInt()}`;
+
+		createdVocabularyNames.push(name);
+
+		editVocabularyPage.goto();
 
 		await editVocabularyPage.changeGeneralInfo({
 			description: getRandomString(),
@@ -397,9 +421,11 @@ test(
 	'Validate change spaces when saving',
 	{tag: '@LPD-52592'},
 	async ({editVocabularyPage, page, vocabulariesPage}) => {
-		editVocabularyPage.goto();
-
 		const name = `Vocabulary${getRandomInt()}`;
+
+		createdVocabularyNames.push(name);
+
+		editVocabularyPage.goto();
 
 		await editVocabularyPage.changeGeneralInfo({
 			description: getRandomString(),
@@ -672,6 +698,8 @@ test(
 	async ({editVocabularyPage, page}) => {
 		const externalReferenceCode = `ERC${getRandomInt()}`;
 		const name = `Vocabulary${getRandomInt()}`;
+
+		createdVocabularyNames.push(name);
 
 		await editVocabularyPage.goto();
 

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/contentEditor.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/contentEditor.spec.ts
@@ -1082,6 +1082,41 @@ test.describe('Categorization Panel', () => {
 				await expect(tagLabel).toBeAttached();
 				await expect(categoryLabel).toBeAttached();
 
+				// Assert the applied category and tag are marked as selected
+				// in the dropdown menu
+
+				await page.getByPlaceholder('Add category').click();
+
+				const selectedCategoryOption = page.getByRole('option', {
+					name: categoryName,
+				});
+
+				await expect(selectedCategoryOption).toHaveAttribute(
+					'aria-selected',
+					'true'
+				);
+				await expect(
+					selectedCategoryOption.locator('.lexicon-icon-check-small')
+				).toBeVisible();
+
+				await page.keyboard.press('Escape');
+
+				await page.getByPlaceholder('Add tag').click();
+
+				const selectedTagOption = page.getByRole('option', {
+					name: secondTagName,
+				});
+
+				await expect(selectedTagOption).toHaveAttribute(
+					'aria-selected',
+					'true'
+				);
+				await expect(
+					selectedTagOption.locator('.lexicon-icon-check-small')
+				).toBeVisible();
+
+				await page.keyboard.press('Escape');
+
 				// Delete content
 
 				await contentsPage.goto();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-69202

## What Is Being Fixed

In the CMS info panel, the category and tag selectors did not indicate which categories and tags were already applied to the content. Reopening a selector showed every option as unselected, so an author could not tell what was already assigned and could re-select an item that was already there.

## How It Is Being Fixed

The already-applied categories and tags are now passed to the `ItemSelector` as its `items`, and the selector's `value` locator is aligned with a field those applied items actually carry — `id` for categories and `name` for tags (previously `externalReferenceCode`, which the applied briefs do not expose). With that match in place, the selector renders the applied options as selected, with a check icon and `aria-selected="true"`, when the dropdown is reopened.

A Playwright test in the Categorization panel suite verifies that, after publishing a content with a category and a tag, reopening both selectors shows the applied options with `aria-selected="true"` and the check icon. A separate commit (LPD-94622) hardens the `vocabularies` suite so each test deletes the vocabularies it creates via an `afterEach` hook, preventing leaked required vocabularies from breaking unrelated content tests.

## PR Check

**pr-check: PASS** — tested on `3f34a34c134f77d8d05c9bb54709ec3156d09df0`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "3f34a34c134f77d8d05c9bb54709ec3156d09df0"} -->
