### PR TITLE
LPD-95045 Support obtaining hidden DLFolders through search

### DIFF
--- a/modules/apps/document-library/document-library-api/bnd.bnd
+++ b/modules/apps/document-library/document-library-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Document Library API
 Bundle-SymbolicName: com.liferay.document.library.api
-Bundle-Version: 29.0.1
+Bundle-Version: 29.1.0
 Export-Package:\
 	com.liferay.document.library.asset,\
 	com.liferay.document.library.asset.model,\

--- a/modules/apps/document-library/document-library-api/src/main/java/com/liferay/document/library/constants/DLFolderSearchConstants.java
+++ b/modules/apps/document-library/document-library-api/src/main/java/com/liferay/document/library/constants/DLFolderSearchConstants.java
@@ -1,0 +1,15 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.document.library.constants;
+
+/**
+ * @author Rubén Pulido
+ */
+public class DLFolderSearchConstants {
+
+	public static final String SHOW_HIDDEN = "showHidden";
+
+}

--- a/modules/apps/document-library/document-library-api/src/main/resources/com/liferay/document/library/constants/packageinfo
+++ b/modules/apps/document-library/document-library-api/src/main/resources/com/liferay/document/library/constants/packageinfo
@@ -1,1 +1,1 @@
-version 2.1.0
+version 2.2.0

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/spi/model/query/contributor/DLFolderModelPreFilterContributor.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/spi/model/query/contributor/DLFolderModelPreFilterContributor.java
@@ -5,9 +5,11 @@
 
 package com.liferay.document.library.internal.search.spi.model.query.contributor;
 
+import com.liferay.document.library.constants.DLFolderSearchConstants;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.filter.BooleanFilter;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.search.spi.model.query.contributor.ModelPreFilterContributor;
 import com.liferay.portal.search.spi.model.registrar.ModelSearchSettings;
 
@@ -29,13 +31,20 @@ public class DLFolderModelPreFilterContributor
 		BooleanFilter booleanFilter, ModelSearchSettings modelSearchSettings,
 		SearchContext searchContext) {
 
-		addHiddenFilter(booleanFilter);
+		addHiddenFilter(booleanFilter, searchContext);
 		addWorkflowStatusFilter(
 			booleanFilter, modelSearchSettings, searchContext);
 	}
 
-	protected void addHiddenFilter(BooleanFilter booleanFilter) {
-		booleanFilter.addRequiredTerm(Field.HIDDEN, false);
+	protected void addHiddenFilter(
+		BooleanFilter booleanFilter, SearchContext searchContext) {
+
+		if (!GetterUtil.getBoolean(
+				searchContext.getAttribute(
+					DLFolderSearchConstants.SHOW_HIDDEN))) {
+
+			booleanFilter.addRequiredTerm(Field.HIDDEN, false);
+		}
 	}
 
 	protected void addWorkflowStatusFilter(

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/search/spi/model/query/contributor/test/DLFolderModelPreFilterContributorTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/search/spi/model/query/contributor/test/DLFolderModelPreFilterContributorTest.java
@@ -1,0 +1,80 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.document.library.internal.search.spi.model.query.contributor.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.document.library.constants.DLFolderSearchConstants;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.search.filter.BooleanFilter;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.SearchContextTestUtil;
+import com.liferay.portal.search.spi.model.query.contributor.ModelPreFilterContributor;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Rubén Pulido
+ */
+@RunWith(Arquillian.class)
+public class DLFolderModelPreFilterContributorTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	public void testContribute() throws Exception {
+		BooleanFilter booleanFilter = new BooleanFilter();
+
+		SearchContext searchContext = SearchContextTestUtil.getSearchContext(
+			_group.getGroupId());
+
+		_dlFolderModelPreFilterContributor.contribute(
+			booleanFilter, null, searchContext);
+
+		String booleanFilterString = booleanFilter.toString();
+
+		Assert.assertTrue(
+			booleanFilterString, booleanFilterString.contains("hidden"));
+
+		booleanFilter = new BooleanFilter();
+
+		searchContext.setAttribute(
+			DLFolderSearchConstants.SHOW_HIDDEN, Boolean.TRUE);
+
+		_dlFolderModelPreFilterContributor.contribute(
+			booleanFilter, null, searchContext);
+
+		booleanFilterString = booleanFilter.toString();
+
+		Assert.assertFalse(
+			booleanFilterString, booleanFilterString.contains("hidden"));
+	}
+
+	@Inject(
+		filter = "indexer.class.name=com.liferay.document.library.kernel.model.DLFolder"
+	)
+	private ModelPreFilterContributor _dlFolderModelPreFilterContributor;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+}

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/search/spi/model/query/contributor/test/DLFolderModelPreFilterContributorTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/search/spi/model/query/contributor/test/DLFolderModelPreFilterContributorTest.java
@@ -10,6 +10,7 @@ import com.liferay.document.library.constants.DLFolderSearchConstants;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.filter.BooleanFilter;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.SearchContextTestUtil;
@@ -41,6 +42,7 @@ public class DLFolderModelPreFilterContributorTest {
 	}
 
 	@Test
+	@TestInfo("LPD-95045")
 	public void testContribute() throws Exception {
 		BooleanFilter booleanFilter = new BooleanFilter();
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95045

## What Is Being Fixed

The DLFolder search pre-filter always excluded hidden folders by adding a required `hidden=false` term to every query. There was no way for a caller to include hidden DLFolders in search results.

## How It Is Being Fixed

A new `showHidden` search attribute is introduced as `DLFolderSearchConstants.SHOW_HIDDEN` in the API. `DLFolderModelPreFilterContributor` now reads this attribute from the `SearchContext` and only applies the `hidden=false` required term when `showHidden` is not set, so a caller that sets the attribute receives hidden folders alongside the rest. The constant lives in the API module so callers can set the attribute without depending on the implementation.

## PR Check

**pr-check: PASS** — tested on `8b799ee2eb65ba8b318bc406316b6dd61831b806`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "8b799ee2eb65ba8b318bc406316b6dd61831b806"} -->
