### PR TITLE
LPD-94622 Scope space summary heading locator to the page title

### DIFF
--- a/modules/test/playwright/tests/site-cms-site-initializer/main/pages/SpaceSummaryPage.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/pages/SpaceSummaryPage.ts
@@ -69,7 +69,7 @@ export class SpaceSummaryPage {
 		await this.page.goto(PORTLET_URLS.cms);
 		await this.page.getByRole('menuitem', {name: spaceName}).click();
 		await this.page
-			.getByRole('heading', {exact: true, name: spaceName})
+			.getByRole('heading', {exact: true, level: 1, name: spaceName})
 			.waitFor();
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94622

## What Is Being Fixed

The Playwright test "View comments in the shared with me view comments panel" (site-cms-site-initializer) fails in SpaceSummaryPage.goto with a strict mode violation. The CMS space summary page renders the space name in two headings — the page-title `<h1>` and the Control Menu breadcrumb `<h2>` — so `getByRole('heading', {name: spaceName})` resolves to two elements and `waitFor()` throws.

## How It Is Being Fixed

Scope the locator to the level 1 heading, which targets the page title unambiguously regardless of whether the Control Menu breadcrumb is present.

## Why Are There No Tests?

The change is a fix to a Playwright Page Object locator (test infrastructure), not production code. It is exercised by the existing "View comments in the shared with me view comments panel" test, which previously failed at `goto`.

## PR Check

**pr-check: PASS** — tested on `8695fb483f7df101af17088aeb93c0b68469cf25`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "8695fb483f7df101af17088aeb93c0b68469cf25"} -->
