### PR TITLE
LPD-94457 Fix XLIFF 1.2 import corrupting repeatable field order when an intermediate segment is empty

### DIFF
--- a/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/exporter/XLIFF12InfoFormTranslationExporter.java
+++ b/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/exporter/XLIFF12InfoFormTranslationExporter.java
@@ -26,6 +26,8 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
+import java.nio.charset.StandardCharsets;
+
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -124,14 +126,14 @@ public class XLIFF12InfoFormTranslationExporter
 
 			List<InfoFieldValue<Object>> infoFieldValues = entry.getValue();
 
-			StringBundler sb = new StringBundler(infoFieldValues.size() * 2);
+			StringBundler sb = new StringBundler(infoFieldValues.size());
 
 			for (InfoFieldValue<Object> infoFieldValue : infoFieldValues) {
-				sb.append(infoFieldValue.getValue(sourceLocale));
-				sb.append(StringPool.COMMA_AND_SPACE);
-			}
+				Object value = infoFieldValue.getValue(sourceLocale);
 
-			sb.setIndex(sb.index() - 1);
+				sb.append(
+					(value != null) ? value.toString() : StringPool.BLANK);
+			}
 
 			sourceElement.addCDATA(_getStringValue(sb));
 
@@ -180,9 +182,10 @@ public class XLIFF12InfoFormTranslationExporter
 			}
 		}
 
-		String formattedString = document.formattedString();
-
-		return new ByteArrayInputStream(formattedString.getBytes());
+		return new ByteArrayInputStream(
+			document.asXML(
+			).getBytes(
+				StandardCharsets.UTF_8));
 	}
 
 	@Override

--- a/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/exporter/XLIFF12InfoFormTranslationExporter.java
+++ b/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/exporter/XLIFF12InfoFormTranslationExporter.java
@@ -182,10 +182,9 @@ public class XLIFF12InfoFormTranslationExporter
 			}
 		}
 
-		return new ByteArrayInputStream(
-			document.asXML(
-			).getBytes(
-				StandardCharsets.UTF_8));
+		String xml = document.asXML();
+
+		return new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8));
 	}
 
 	@Override

--- a/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/snapshot/XLIFFTranslationSnapshotProvider.java
+++ b/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/snapshot/XLIFFTranslationSnapshotProvider.java
@@ -388,6 +388,10 @@ public class XLIFFTranslationSnapshotProvider
 					targetLocaleId);
 
 				for (TextPart targetTextPart : targetTextContainer.getParts()) {
+					if (!targetTextPart.isSegment()) {
+						continue;
+					}
+
 					TextFragment targetTextFragment =
 						targetTextPart.getContent();
 

--- a/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/snapshot/XLIFFTranslationSnapshotProvider.java
+++ b/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/snapshot/XLIFFTranslationSnapshotProvider.java
@@ -391,7 +391,7 @@ public class XLIFFTranslationSnapshotProvider
 					TextFragment targetTextFragment =
 						targetTextPart.getContent();
 
-					if (Validator.isNull(targetTextFragment.getText())) {
+					if (targetTextFragment.getText() == null) {
 						continue;
 					}
 

--- a/modules/apps/translation/translation-test/src/testIntegration/java/com/liferay/translation/info/item/updater/test/JournalArticleInfoItemFieldValuesUpdaterTest.java
+++ b/modules/apps/translation/translation-test/src/testIntegration/java/com/liferay/translation/info/item/updater/test/JournalArticleInfoItemFieldValuesUpdaterTest.java
@@ -204,6 +204,108 @@ public class JournalArticleInfoItemFieldValuesUpdaterTest {
 	}
 
 	@Test
+	public void testUpdateJournalArticleFromInfoItemFieldValuesPreservesEmptyIntermediateRepeatableField()
+		throws Exception {
+
+		JournalArticle journalArticle = _getRepeatableHtmlJournalArticle();
+
+		_translationEntryLocalService.addOrUpdateTranslationEntry(
+			_group.getGroupId(), JournalArticle.class.getName(),
+			journalArticle.getResourcePrimKey(),
+			StringUtil.replace(
+				TranslationTestUtil.readFileToString(
+					"test-journal-repeatable-html-empty-v12.xlf"),
+				"[$JOURNAL_ARTICLE_ID$]",
+				String.valueOf(journalArticle.getResourcePrimKey())),
+			"application/xliff+xml", LocaleUtil.toLanguageId(LocaleUtil.SPAIN),
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		journalArticle = _journalArticleLocalService.fetchLatestArticle(
+			journalArticle.getResourcePrimKey());
+
+		DDMFormValues ddmFormValues = journalArticle.getDDMFormValues();
+
+		Map<String, List<DDMFormFieldValue>> ddmFormFieldValuesMap =
+			ddmFormValues.getDDMFormFieldValuesMap(true);
+
+		List<DDMFormFieldValue> ddmFormFieldValues = ddmFormFieldValuesMap.get(
+			"RichText");
+
+		Assert.assertEquals(
+			ddmFormFieldValues.toString(), 3, ddmFormFieldValues.size());
+
+		DDMFormFieldValue ddmFormFieldValue0 = ddmFormFieldValues.get(0);
+
+		Value value0 = ddmFormFieldValue0.getValue();
+
+		Assert.assertEquals("Valor A", value0.getString(LocaleUtil.SPAIN));
+
+		DDMFormFieldValue ddmFormFieldValue1 = ddmFormFieldValues.get(1);
+
+		Value value1 = ddmFormFieldValue1.getValue();
+
+		Assert.assertEquals(
+			StringPool.BLANK, value1.getString(LocaleUtil.SPAIN));
+
+		DDMFormFieldValue ddmFormFieldValue2 = ddmFormFieldValues.get(2);
+
+		Value value2 = ddmFormFieldValue2.getValue();
+
+		Assert.assertEquals("Valor C", value2.getString(LocaleUtil.SPAIN));
+	}
+
+	@Test
+	public void testUpdateJournalArticleFromInfoItemFieldValuesPreservesEmptyIntermediateRepeatableTextField()
+		throws Exception {
+
+		JournalArticle journalArticle = _getRepeatableTextJournalArticle();
+
+		_translationEntryLocalService.addOrUpdateTranslationEntry(
+			_group.getGroupId(), JournalArticle.class.getName(),
+			journalArticle.getResourcePrimKey(),
+			StringUtil.replace(
+				TranslationTestUtil.readFileToString(
+					"test-journal-repeatable-text-empty-v12.xlf"),
+				"[$JOURNAL_ARTICLE_ID$]",
+				String.valueOf(journalArticle.getResourcePrimKey())),
+			"application/xliff+xml", LocaleUtil.toLanguageId(LocaleUtil.SPAIN),
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		journalArticle = _journalArticleLocalService.fetchLatestArticle(
+			journalArticle.getResourcePrimKey());
+
+		DDMFormValues ddmFormValues = journalArticle.getDDMFormValues();
+
+		Map<String, List<DDMFormFieldValue>> ddmFormFieldValuesMap =
+			ddmFormValues.getDDMFormFieldValuesMap(true);
+
+		List<DDMFormFieldValue> ddmFormFieldValues = ddmFormFieldValuesMap.get(
+			"TextField");
+
+		Assert.assertEquals(
+			ddmFormFieldValues.toString(), 3, ddmFormFieldValues.size());
+
+		DDMFormFieldValue ddmFormFieldValue0 = ddmFormFieldValues.get(0);
+
+		Value value0 = ddmFormFieldValue0.getValue();
+
+		Assert.assertEquals("Valor A", value0.getString(LocaleUtil.SPAIN));
+
+		DDMFormFieldValue ddmFormFieldValue1 = ddmFormFieldValues.get(1);
+
+		Value value1 = ddmFormFieldValue1.getValue();
+
+		Assert.assertEquals(
+			StringPool.BLANK, value1.getString(LocaleUtil.SPAIN));
+
+		DDMFormFieldValue ddmFormFieldValue2 = ddmFormFieldValues.get(2);
+
+		Value value2 = ddmFormFieldValue2.getValue();
+
+		Assert.assertEquals("Valor C", value2.getString(LocaleUtil.SPAIN));
+	}
+
+	@Test
 	public void testUpdateJournalArticleFromInfoItemFieldValuesUpdatesNewField()
 		throws Exception {
 
@@ -463,6 +565,48 @@ public class JournalArticleInfoItemFieldValuesUpdaterTest {
 			_group.getGroupId(),
 			TranslationTestUtil.readFileToString(
 				"test-journal-content-one-field.xml"),
+			ddmStructure.getStructureKey(), null);
+	}
+
+	private JournalArticle _getRepeatableHtmlJournalArticle() throws Exception {
+		DDMFormDeserializerDeserializeRequest.Builder builder =
+			DDMFormDeserializerDeserializeRequest.Builder.newBuilder(
+				TranslationTestUtil.readFileToString(
+					"test-ddm-structure-repeatable-html.json"));
+
+		DDMFormDeserializerDeserializeResponse
+			ddmFormDeserializerDeserializeResponse =
+				_ddmFormDeserializer.deserialize(builder.build());
+
+		DDMStructure ddmStructure = DDMStructureTestUtil.addStructure(
+			_group.getGroupId(), JournalArticle.class.getName(),
+			ddmFormDeserializerDeserializeResponse.getDDMForm());
+
+		return JournalTestUtil.addArticleWithXMLContent(
+			_group.getGroupId(),
+			TranslationTestUtil.readFileToString(
+				"test-journal-content-repeatable-html-three-fields.xml"),
+			ddmStructure.getStructureKey(), null);
+	}
+
+	private JournalArticle _getRepeatableTextJournalArticle() throws Exception {
+		DDMFormDeserializerDeserializeRequest.Builder builder =
+			DDMFormDeserializerDeserializeRequest.Builder.newBuilder(
+				TranslationTestUtil.readFileToString(
+					"test-ddm-structure-repeatable-text.json"));
+
+		DDMFormDeserializerDeserializeResponse
+			ddmFormDeserializerDeserializeResponse =
+				_ddmFormDeserializer.deserialize(builder.build());
+
+		DDMStructure ddmStructure = DDMStructureTestUtil.addStructure(
+			_group.getGroupId(), JournalArticle.class.getName(),
+			ddmFormDeserializerDeserializeResponse.getDDMForm());
+
+		return JournalTestUtil.addArticleWithXMLContent(
+			_group.getGroupId(),
+			TranslationTestUtil.readFileToString(
+				"test-journal-content-repeatable-text-three-fields.xml"),
 			ddmStructure.getStructureKey(), null);
 	}
 

--- a/modules/apps/translation/translation-test/src/testIntegration/resources/com/liferay/translation/dependencies/test-ddm-structure-repeatable-html.json
+++ b/modules/apps/translation/translation-test/src/testIntegration/resources/com/liferay/translation/dependencies/test-ddm-structure-repeatable-html.json
@@ -1,0 +1,42 @@
+{
+	"availableLanguageIds": [
+		"en_US"
+	],
+	"defaultLanguageId": "en_US",
+	"definitionSchemaVersion": "2.0",
+	"fields": [
+		{
+			"dataType": "html",
+			"fieldNamespace": "ddm",
+			"indexType": "text",
+			"label": {
+				"en_US": "Rich Text"
+			},
+			"localizable": true,
+			"name": "RichText",
+			"nativeField": false,
+			"predefinedValue": {
+				"en_US": ""
+			},
+			"readOnly": false,
+			"repeatable": true,
+			"required": false,
+			"showLabel": true,
+			"tip": {
+				"en_US": ""
+			},
+			"tooltip": {
+				"en_US": ""
+			},
+			"type": "ddm-text-html",
+			"visibilityExpression": ""
+		}
+	],
+	"successPage": {
+		"body": {
+		},
+		"enabled": false,
+		"title": {
+		}
+	}
+}

--- a/modules/apps/translation/translation-test/src/testIntegration/resources/com/liferay/translation/dependencies/test-ddm-structure-repeatable-text.json
+++ b/modules/apps/translation/translation-test/src/testIntegration/resources/com/liferay/translation/dependencies/test-ddm-structure-repeatable-text.json
@@ -1,0 +1,51 @@
+{
+	"availableLanguageIds": [
+		"en_US"
+	],
+	"defaultLanguageId": "en_US",
+	"definitionSchemaVersion": "2.0",
+	"fields": [
+		{
+			"autocomplete": false,
+			"dataSourceType": "manual",
+			"dataType": "string",
+			"ddmDataProviderInstanceId": "[]",
+			"ddmDataProviderInstanceOutput": "[]",
+			"displayStyle": "singleline",
+			"fieldNamespace": "",
+			"fieldReference": "TextField",
+			"indexType": "keyword",
+			"label": {
+				"en_US": "Text Field"
+			},
+			"localizable": true,
+			"name": "TextField",
+			"nativeField": false,
+			"placeholder": {
+				"en_US": ""
+			},
+			"predefinedValue": {
+				"en_US": ""
+			},
+			"readOnly": false,
+			"repeatable": true,
+			"required": false,
+			"showLabel": true,
+			"tip": {
+				"en_US": ""
+			},
+			"tooltip": {
+				"en_US": ""
+			},
+			"type": "text",
+			"visibilityExpression": ""
+		}
+	],
+	"successPage": {
+		"body": {
+		},
+		"enabled": false,
+		"title": {
+		}
+	}
+}

--- a/modules/apps/translation/translation-test/src/testIntegration/resources/com/liferay/translation/dependencies/test-journal-content-repeatable-html-three-fields.xml
+++ b/modules/apps/translation/translation-test/src/testIntegration/resources/com/liferay/translation/dependencies/test-journal-content-repeatable-html-three-fields.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" standalone="no"?>
+
+<root available-locales="en_US" default-locale="en_US">
+	<request />
+	<dynamic-element index-type="keyword" name="RichText" repeatable="true" type="html">
+		<dynamic-content language-id="en_US"><![CDATA[Value A]]></dynamic-content>
+	</dynamic-element>
+	<dynamic-element index-type="keyword" name="RichText" repeatable="true" type="html">
+		<dynamic-content language-id="en_US"><![CDATA[]]></dynamic-content>
+	</dynamic-element>
+	<dynamic-element index-type="keyword" name="RichText" repeatable="true" type="html">
+		<dynamic-content language-id="en_US"><![CDATA[Value C]]></dynamic-content>
+	</dynamic-element>
+</root>

--- a/modules/apps/translation/translation-test/src/testIntegration/resources/com/liferay/translation/dependencies/test-journal-content-repeatable-text-three-fields.xml
+++ b/modules/apps/translation/translation-test/src/testIntegration/resources/com/liferay/translation/dependencies/test-journal-content-repeatable-text-three-fields.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" standalone="no"?>
+
+<root available-locales="en_US" default-locale="en_US">
+	<request />
+	<dynamic-element index-type="keyword" name="TextField" repeatable="true" type="text">
+		<dynamic-content language-id="en_US"><![CDATA[Value A]]></dynamic-content>
+	</dynamic-element>
+	<dynamic-element index-type="keyword" name="TextField" repeatable="true" type="text">
+		<dynamic-content language-id="en_US"><![CDATA[]]></dynamic-content>
+	</dynamic-element>
+	<dynamic-element index-type="keyword" name="TextField" repeatable="true" type="text">
+		<dynamic-content language-id="en_US"><![CDATA[Value C]]></dynamic-content>
+	</dynamic-element>
+</root>

--- a/modules/apps/translation/translation-test/src/testIntegration/resources/com/liferay/translation/dependencies/test-journal-repeatable-html-empty-v12.xlf
+++ b/modules/apps/translation/translation-test/src/testIntegration/resources/com/liferay/translation/dependencies/test-journal-repeatable-html-empty-v12.xlf
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+	<file datatype="plaintext" original="com.liferay.journal.model.JournalArticle:[$JOURNAL_ARTICLE_ID$]" source-language="en-US" target-language="es-ES" tool="Liferay">
+		<body>
+			<trans-unit id="JournalArticle_title">
+				<source xml:lang="en-US"><![CDATA[Test Article]]></source>
+				<target xml:lang="es-ES"><![CDATA[Test Article ES]]></target>
+			</trans-unit>
+			<trans-unit id="JournalArticle_description">
+				<source xml:lang="en-US"><![CDATA[]]></source>
+				<target xml:lang="es-ES"><![CDATA[]]></target>
+			</trans-unit>
+			<trans-unit id="DDMStructure_RichText">
+				<source xml:lang="en-US"><![CDATA[Value AValue C]]></source>
+				<seg-source>
+					<mrk mid="0" mtype="seg"><![CDATA[Value A]]></mrk>
+					<mrk mid="1" mtype="seg"><![CDATA[]]></mrk>
+					<mrk mid="2" mtype="seg"><![CDATA[Value C]]></mrk>
+				</seg-source>
+				<target xml:lang="es-ES">
+					<mrk mid="0" mtype="seg"><![CDATA[Valor A]]></mrk>
+					<mrk mid="1" mtype="seg"><![CDATA[]]></mrk>
+					<mrk mid="2" mtype="seg"><![CDATA[Valor C]]></mrk>
+				</target>
+			</trans-unit>
+		</body>
+	</file>
+</xliff>

--- a/modules/apps/translation/translation-test/src/testIntegration/resources/com/liferay/translation/dependencies/test-journal-repeatable-text-empty-v12.xlf
+++ b/modules/apps/translation/translation-test/src/testIntegration/resources/com/liferay/translation/dependencies/test-journal-repeatable-text-empty-v12.xlf
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+	<file datatype="plaintext" original="com.liferay.journal.model.JournalArticle:[$JOURNAL_ARTICLE_ID$]" source-language="en-US" target-language="es-ES" tool="Liferay">
+		<body>
+			<trans-unit id="JournalArticle_title">
+				<source xml:lang="en-US"><![CDATA[Test Article]]></source>
+				<target xml:lang="es-ES"><![CDATA[Test Article ES]]></target>
+			</trans-unit>
+			<trans-unit id="JournalArticle_description">
+				<source xml:lang="en-US"><![CDATA[]]></source>
+				<target xml:lang="es-ES"><![CDATA[]]></target>
+			</trans-unit>
+			<trans-unit id="DDMStructure_TextField">
+				<source xml:lang="en-US"><![CDATA[Value AValue C]]></source>
+				<seg-source>
+					<mrk mid="0" mtype="seg"><![CDATA[Value A]]></mrk>
+					<mrk mid="1" mtype="seg"><![CDATA[]]></mrk>
+					<mrk mid="2" mtype="seg"><![CDATA[Value C]]></mrk>
+				</seg-source>
+				<target xml:lang="es-ES">
+					<mrk mid="0" mtype="seg"><![CDATA[Valor A]]></mrk>
+					<mrk mid="1" mtype="seg"><![CDATA[]]></mrk>
+					<mrk mid="2" mtype="seg"><![CDATA[Valor C]]></mrk>
+				</target>
+			</trans-unit>
+		</body>
+	</file>
+</xliff>


### PR DESCRIPTION
## What

Fixes two bugs in the XLIFF 1.2 translation pipeline that together caused repeatable DDM field values to shift when an intermediate repetition was intentionally empty.

## Why

When a web content article has a repeatable field (rich text or plain text) with values `["A", "", "C"]` and the XLIFF is round-tripped through export and import, the empty middle value was dropped, leaving `["A", "C"]` and shifting every subsequent repetition forward.

Two bugs contributed:

**Export (`XLIFF12InfoFormTranslationExporter`):** The `<source>` element was built by joining all repetition values with `", "`. Okapi validates that the `<seg-source>` segment concatenation equals `<source>`, so `"AValue C"` ≠ `"A, , C"` — it logged an error and fell back to unsegmented mode. Additionally, `formattedString()` added whitespace text nodes between `<mrk>` elements that Okapi counted as inter-segment content, widening the mismatch. Fixed by building `<source>` as a plain concatenation and switching to `asXML()` (compact output, no inter-element whitespace).

**Import (`XLIFFTranslationSnapshotProvider`):** `Validator.isNull` returns true for both null and empty string, so empty intermediate repetitions were silently dropped. Fixed by checking `== null` instead. A second issue: Okapi's `TextContainer.getParts()` returns both `Segment` instances (actual `<mrk>` content) and plain `TextPart` instances (whitespace between `<mrk>` elements). The whitespace parts have `getText() == ""` and were recorded as spurious empty field values after the null-check fix. Fixed by guarding on `isSegment()`.

## Test plan

- `JournalArticleInfoItemFieldValuesUpdaterTest#testUpdateJournalArticleFromInfoItemFieldValuesPreservesEmptyIntermediateRepeatableField` — repeatable rich text field
- `JournalArticleInfoItemFieldValuesUpdaterTest#testUpdateJournalArticleFromInfoItemFieldValuesPreservesEmptyIntermediateRepeatableTextField` — repeatable plain text field

---

**pr-check: PASS** — tested on `b5f8f8bff1a5e423d2213ddfe868279766e6425b`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile (translation-service deploy) | PASS |
| Integration Test Compile (translation-test) | PASS |