### PR TITLE
LPD-89560 Show the confirmation modal when deleting a structure usage

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewStructureUsagesDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewStructureUsagesDisplayContext.java
@@ -132,12 +132,9 @@ public class ViewStructureUsagesDisplayContext {
 				_language.get(_httpServletRequest, "permissions"), "get", null,
 				"modal-permissions"),
 			new FDSActionDropdownItem(
-				_language.get(
-					_httpServletRequest,
-					"are-you-sure-you-want-to-delete-this-entry"),
 				null, "trash", "delete",
-				_language.get(_httpServletRequest, "delete"), "delete",
-				"delete", "headless"));
+				_language.get(_httpServletRequest, "delete"), null, "delete",
+				null));
 	}
 
 	private static final String _STATUSES = StringUtil.merge(

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/StructureUsagesFDSPropsTransformer.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/StructureUsagesFDSPropsTransformer.ts
@@ -4,9 +4,11 @@
  */
 
 import {IInternalRenderer} from '@liferay/frontend-data-set-web';
+import {sub} from 'frontend-js-web';
 
 import StatusLabel from '../../common/components/StatusLabel';
 import {getScopeExternalReferenceCode} from '../../common/utils/getScopeExternalReferenceCode';
+import confirmAndDeleteEntryAction from './actions/confirmAndDeleteEntryAction';
 import AuthorRenderer from './cell_renderers/AuthorRenderer';
 import SpaceRendererWithCache from './cell_renderers/SpaceRendererWithCache';
 import TypeRenderer from './cell_renderers/TypeRenderer';
@@ -48,5 +50,38 @@ export default function StructureUsagesFDSPropsTransformer({
 			],
 		},
 		hideManagementBarInEmptyState: true,
+		onActionDropdownItemClick({
+			action,
+			event,
+			itemData,
+			loadData,
+		}: {
+			action: {data: {id: string}};
+			event: Event;
+			itemData: {
+				embedded: {
+					actions: {delete: {href: string; method: string}};
+				};
+				title: string;
+			};
+			loadData: () => void;
+		}) {
+			if (action?.data?.id === 'delete') {
+				event?.preventDefault();
+
+				confirmAndDeleteEntryAction({
+					bodyHTML: Liferay.Language.get(
+						'are-you-sure-you-want-to-delete-this-entry'
+					),
+					deleteAction: itemData.embedded.actions.delete,
+					loadData,
+					successMessage: sub(
+						Liferay.Language.get('x-was-successfully-deleted'),
+						`<strong>${Liferay.Util.escapeHTML(itemData.title)}</strong>`
+					),
+					title: Liferay.Language.get('delete-entry'),
+				});
+			}
+		},
 	};
 }

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/structures.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/structures.spec.ts
@@ -732,13 +732,13 @@ test(
 );
 
 test(
-	'Basic Web Content usages list includes assets that use the structure',
-	{tag: '@LPD-89302'},
+	'View Usages lists the assets using the structure and deletes them with the CMS confirmation modal',
+	{tag: ['@LPD-89302', '@LPD-89560']},
 	async ({apiHelpers, page, structuresPage}) => {
 		const applicationName = 'cms/basic-web-contents';
 		const title = `Content ${getRandomString()}`;
 
-		const objectEntry = await apiHelpers.objectEntry.postObjectEntry(
+		await apiHelpers.objectEntry.postObjectEntry(
 			{
 				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
 				title,
@@ -747,53 +747,22 @@ test(
 			'Default'
 		);
 
-		try {
-			await structuresPage.goto();
+		// Open the usages list of the structure
 
-			await structuresPage.execItemAction({
-				action: 'View Usages',
-				filter: 'Basic Web Content',
-			});
+		await structuresPage.goto();
 
+		await structuresPage.execItemAction({
+			action: 'View Usages',
+			filter: 'Basic Web Content',
+		});
+
+		await test.step('Usages list includes the asset', async () => {
 			await page.locator('.fds').waitFor();
 
 			await expect(page.getByRole('row', {name: title})).toBeVisible();
-		}
-		finally {
-			await apiHelpers.objectEntry.deleteObjectEntry(
-				applicationName,
-				String(objectEntry.id)
-			);
-		}
-	}
-);
+		});
 
-test(
-	'View Usages delete action opens the CMS confirmation modal instead of a native confirm dialog',
-	{tag: '@LPD-89560'},
-	async ({apiHelpers, page, structuresPage}) => {
-		const applicationName = 'cms/basic-web-contents';
-		const title = `Content ${getRandomString()}`;
-
-		const objectEntry = await apiHelpers.objectEntry.postObjectEntry(
-			{
-				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
-				title,
-			},
-			applicationName,
-			'Default'
-		);
-
-		try {
-
-			// Open the usages list of the structure
-
-			await structuresPage.goto();
-
-			await structuresPage.execItemAction({
-				action: 'View Usages',
-				filter: 'Basic Web Content',
-			});
+		await test.step('Delete shows the CMS confirmation modal', async () => {
 
 			// Open the delete action of the usage entry
 
@@ -819,13 +788,7 @@ test(
 			await waitForAlert(page, `${title} was successfully deleted`, {
 				type: 'success',
 			});
-		}
-		finally {
-			await apiHelpers.objectEntry.deleteObjectEntry(
-				applicationName,
-				String(objectEntry.id)
-			);
-		}
+		});
 	}
 );
 

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/structures.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/structures.spec.ts
@@ -769,6 +769,67 @@ test(
 );
 
 test(
+	'View Usages delete action opens the CMS confirmation modal instead of a native confirm dialog',
+	{tag: '@LPD-89560'},
+	async ({apiHelpers, page, structuresPage}) => {
+		const applicationName = 'cms/basic-web-contents';
+		const title = `Content ${getRandomString()}`;
+
+		const objectEntry = await apiHelpers.objectEntry.postObjectEntry(
+			{
+				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				title,
+			},
+			applicationName,
+			'Default'
+		);
+
+		try {
+
+			// Open the usages list of the structure
+
+			await structuresPage.goto();
+
+			await structuresPage.execItemAction({
+				action: 'View Usages',
+				filter: 'Basic Web Content',
+			});
+
+			// Open the delete action of the usage entry
+
+			await structuresPage.dataSetFragmentPage.execItemAction({
+				action: 'Delete',
+				filter: title,
+			});
+
+			// The CMS confirmation modal must appear instead of a native
+			// confirm dialog
+
+			await expect(
+				page.getByText('Are you sure you want to delete this entry?')
+			).toBeVisible();
+
+			// Confirm the deletion
+
+			await page
+				.locator('.liferay-modal')
+				.getByRole('button', {exact: true, name: 'Delete'})
+				.click();
+
+			await waitForAlert(page, `${title} was successfully deleted`, {
+				type: 'success',
+			});
+		}
+		finally {
+			await apiHelpers.objectEntry.deleteObjectEntry(
+				applicationName,
+				String(objectEntry.id)
+			);
+		}
+	}
+);
+
+test(
 	'Permissions of a Content Structure can be modified',
 	{tag: '@LPD-89302'},
 	async ({apiHelpers, page, structuresPage}) => {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89560

## What Is Being Fixed

In CMS → Content Structures → View Usages, deleting a usage entry showed the browser's native confirm() dialog instead of the Liferay confirmation modal. The delete action carried a confirmationMessage, which routes through openConfirmModal and falls back to the native confirm() when Liferay.CustomDialogs.enabled is false.

## How It Is Being Fixed

The delete action is now declared as a plain button in ViewStructureUsagesDisplayContext, without an href, method, target, or confirmationMessage, matching the other CMS listings such as View Categories and View Vocabularies. The FDS props transformer intercepts the delete action click, prevents the default behavior, and runs the shared confirmAndDeleteEntryAction flow, which always opens the Clay modal. A Playwright test covers the regression by asserting the Clay confirmation modal appears and the entry is deleted.

## PR Check

**pr-check: PASS** — tested on `395e1fe031f4fff2c035aa4542932d618d71e614`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "395e1fe031f4fff2c035aa4542932d618d71e614"} -->
