### PR TITLE
LPD-93844 Prevent inline serving of browser-executable uploads

### DIFF
--- a/modules/apps/portal/portal-webserver-test/src/testIntegration/java/com/liferay/portal/webserver/test/WebServerServletTest.java
+++ b/modules/apps/portal/portal-webserver-test/src/testIntegration/java/com/liferay/portal/webserver/test/WebServerServletTest.java
@@ -17,20 +17,24 @@ import com.liferay.portal.image.ImageToolUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Image;
+import com.liferay.portal.kernel.model.ImageConstants;
 import com.liferay.portal.kernel.model.Repository;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.portletfilerepository.PortletFileRepositoryUtil;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ImageLocalServiceUtil;
 import com.liferay.portal.kernel.service.RepositoryLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalServiceUtil;
 import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
+import com.liferay.portal.kernel.servlet.HttpHeaders;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.constants.TestDataConstants;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
@@ -98,6 +102,50 @@ public class WebServerServletTest {
 			mockHttpServletRequest, 0L);
 
 		Assert.assertEquals(ImageToolUtil.getDefaultOrganizationLogo(), image);
+	}
+
+	@Test
+	public void testGetImage() throws Exception {
+		FileEntry fileEntry = _dlAppLocalService.addFileEntry(
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			RandomTestUtil.randomString() + ".html", ContentTypes.TEXT_HTML,
+			TestDataConstants.TEST_BYTE_ARRAY, null, null, null,
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setAttribute(WebKeys.USER, _user);
+		mockHttpServletRequest.setParameter(
+			"groupId", String.valueOf(_group.getGroupId()));
+		mockHttpServletRequest.setParameter("uuid", fileEntry.getUuid());
+
+		Assert.assertNotNull(
+			ReflectionTestUtil.invoke(
+				_webServerServlet, "getImage",
+				new Class<?>[] {HttpServletRequest.class, boolean.class},
+				mockHttpServletRequest, false));
+
+		fileEntry = _dlAppLocalService.addFileEntry(
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			RandomTestUtil.randomString() + ".png", ContentTypes.IMAGE_PNG,
+			TestDataConstants.TEST_BYTE_ARRAY, null, null, null,
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		mockHttpServletRequest = new MockHttpServletRequest();
+
+		mockHttpServletRequest.setAttribute(WebKeys.USER, _user);
+		mockHttpServletRequest.setParameter(
+			"groupId", String.valueOf(_group.getGroupId()));
+		mockHttpServletRequest.setParameter("uuid", fileEntry.getUuid());
+
+		Assert.assertNotNull(
+			ReflectionTestUtil.invoke(
+				_webServerServlet, "getImage",
+				new Class<?>[] {HttpServletRequest.class, boolean.class},
+				mockHttpServletRequest, false));
 	}
 
 	@Test
@@ -195,6 +243,91 @@ public class WebServerServletTest {
 		Assert.assertNotEquals(
 			HttpServletResponse.SC_SERVICE_UNAVAILABLE,
 			mockHttpServletResponse.getStatus());
+	}
+
+	@Test
+	public void testService() throws Exception {
+		_testServiceGroupIdUUID();
+		_testServicePortletFileEntry();
+	}
+
+	@Test
+	public void testWriteImage() throws Exception {
+		Image image1 = ImageLocalServiceUtil.createImage(0);
+
+		image1.setType(ImageConstants.TYPE_PNG);
+		image1.setTextObj(TestDataConstants.TEST_BYTE_ARRAY);
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setParameter(
+			"groupId", String.valueOf(_group.getGroupId()));
+		mockHttpServletRequest.setParameter(
+			"uuid", RandomTestUtil.randomString());
+
+		MockHttpServletResponse mockHttpServletResponse =
+			new MockHttpServletResponse();
+
+		ReflectionTestUtil.invoke(
+			_webServerServlet, "writeImage",
+			new Class<?>[] {
+				Image.class, HttpServletRequest.class, HttpServletResponse.class
+			},
+			image1, mockHttpServletRequest, mockHttpServletResponse);
+
+		Assert.assertNull(
+			mockHttpServletResponse.getHeader(HttpHeaders.CONTENT_DISPOSITION));
+
+		Image image2 = ImageLocalServiceUtil.createImage(0);
+
+		image2.setType("svg");
+		image2.setTextObj(TestDataConstants.TEST_BYTE_ARRAY);
+
+		mockHttpServletRequest = new MockHttpServletRequest();
+
+		mockHttpServletRequest.setParameter(
+			"groupId", String.valueOf(_group.getGroupId()));
+		mockHttpServletRequest.setParameter(
+			"uuid", RandomTestUtil.randomString());
+
+		mockHttpServletResponse = new MockHttpServletResponse();
+
+		ReflectionTestUtil.invoke(
+			_webServerServlet, "writeImage",
+			new Class<?>[] {
+				Image.class, HttpServletRequest.class, HttpServletResponse.class
+			},
+			image2, mockHttpServletRequest, mockHttpServletResponse);
+
+		Assert.assertEquals(
+			HttpHeaders.CONTENT_DISPOSITION_ATTACHMENT,
+			mockHttpServletResponse.getHeader(HttpHeaders.CONTENT_DISPOSITION));
+
+		Image image3 = ImageLocalServiceUtil.createImage(0);
+
+		image3.setType("html");
+		image3.setTextObj(TestDataConstants.TEST_BYTE_ARRAY);
+
+		mockHttpServletRequest = new MockHttpServletRequest();
+
+		mockHttpServletRequest.setParameter(
+			"groupId", String.valueOf(_group.getGroupId()));
+		mockHttpServletRequest.setParameter(
+			"uuid", RandomTestUtil.randomString());
+
+		mockHttpServletResponse = new MockHttpServletResponse();
+
+		ReflectionTestUtil.invoke(
+			_webServerServlet, "writeImage",
+			new Class<?>[] {
+				Image.class, HttpServletRequest.class, HttpServletResponse.class
+			},
+			image3, mockHttpServletRequest, mockHttpServletResponse);
+
+		Assert.assertEquals(
+			HttpHeaders.CONTENT_DISPOSITION_ATTACHMENT,
+			mockHttpServletResponse.getHeader(HttpHeaders.CONTENT_DISPOSITION));
 	}
 
 	private FileEntry _addFileEntry() throws Exception {
@@ -330,6 +463,58 @@ public class WebServerServletTest {
 			mockHttpServletRequest, mockHttpServletResponse);
 
 		Assert.assertEquals(status, mockHttpServletResponse.getStatus());
+	}
+
+	private void _testService(String requestURI) throws Exception {
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.USER, TestPropsValues.getUser());
+		mockHttpServletRequest.setRequestURI(requestURI);
+
+		MockHttpServletResponse mockHttpServletResponse =
+			new MockHttpServletResponse();
+
+		_webServerServlet.service(
+			mockHttpServletRequest, mockHttpServletResponse);
+
+		Assert.assertEquals(
+			HttpServletResponse.SC_OK, mockHttpServletResponse.getStatus());
+		Assert.assertTrue(
+			mockHttpServletResponse.getHeader(
+				HttpHeaders.CONTENT_DISPOSITION
+			).startsWith(
+				HttpHeaders.CONTENT_DISPOSITION_ATTACHMENT
+			));
+	}
+
+	private void _testServiceGroupIdUUID() throws Exception {
+		FileEntry fileEntry = _dlAppLocalService.addFileEntry(
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			RandomTestUtil.randomString() + ".html", ContentTypes.TEXT_HTML,
+			TestDataConstants.TEST_BYTE_ARRAY, null, null, null,
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		_testService(
+			StringBundler.concat(
+				"/", fileEntry.getGroupId(), "/", fileEntry.getUuid()));
+	}
+
+	private void _testServicePortletFileEntry() throws Exception {
+		FileEntry fileEntry = PortletFileRepositoryUtil.addPortletFileEntry(
+			_group.getGroupId(), TestPropsValues.getUserId(),
+			WebServerServletTest.class.getName(), _group.getGroupId(),
+			"TEST_PORTLET", DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			TestDataConstants.TEST_BYTE_ARRAY,
+			RandomTestUtil.randomString() + ".html", ContentTypes.TEXT_HTML,
+			false);
+
+		_testService(
+			StringBundler.concat(
+				"/portlet_file_entry/", _group.getGroupId(), "/test.html/",
+				fileEntry.getUuid()));
 	}
 
 	@Inject

--- a/portal-impl/src/com/liferay/portal/webdav/methods/GetMethodImpl.java
+++ b/portal-impl/src/com/liferay/portal/webdav/methods/GetMethodImpl.java
@@ -7,7 +7,9 @@ package com.liferay.portal.webdav.methods;
 
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.servlet.HttpHeaders;
 import com.liferay.portal.kernel.servlet.ServletResponseUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.webdav.Resource;
 import com.liferay.portal.kernel.webdav.WebDAVException;
 import com.liferay.portal.kernel.webdav.WebDAVRequest;
@@ -45,14 +47,26 @@ public class GetMethodImpl implements Method {
 			}
 
 			if (inputStream != null) {
+				String contentType = resource.getContentType();
 				String fileName = resource.getDisplayName();
 
+				HttpServletResponse httpServletResponse =
+					webDAVRequest.getHttpServletResponse();
+
 				try {
-					ServletResponseUtil.sendFileWithRangeHeader(
-						webDAVRequest.getHttpServletRequest(),
-						webDAVRequest.getHttpServletResponse(), fileName,
-						inputStream, resource.getSize(),
-						resource.getContentType());
+					if (_isBrowserExecutableContentType(contentType)) {
+						ServletResponseUtil.sendFile(
+							webDAVRequest.getHttpServletRequest(),
+							httpServletResponse, fileName, inputStream,
+							resource.getSize(), contentType,
+							HttpHeaders.CONTENT_DISPOSITION_ATTACHMENT);
+					}
+					else {
+						ServletResponseUtil.sendFileWithRangeHeader(
+							webDAVRequest.getHttpServletRequest(),
+							httpServletResponse, fileName, inputStream,
+							resource.getSize(), contentType);
+					}
 				}
 				catch (Exception exception) {
 					if (_log.isWarnEnabled()) {
@@ -68,6 +82,25 @@ public class GetMethodImpl implements Method {
 		catch (Exception exception) {
 			throw new WebDAVException(exception);
 		}
+	}
+
+	private boolean _isBrowserExecutableContentType(String contentType) {
+		if (contentType == null) {
+			return false;
+		}
+
+		String lowerCaseContentType = StringUtil.toLowerCase(contentType);
+
+		if (lowerCaseContentType.startsWith("application/javascript") ||
+			lowerCaseContentType.startsWith("application/xhtml+xml") ||
+			lowerCaseContentType.startsWith("image/svg+xml") ||
+			lowerCaseContentType.startsWith("text/html") ||
+			lowerCaseContentType.startsWith("text/javascript")) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(GetMethodImpl.class);

--- a/portal-impl/src/com/liferay/portal/webdav/methods/GetMethodImpl.java
+++ b/portal-impl/src/com/liferay/portal/webdav/methods/GetMethodImpl.java
@@ -9,6 +9,8 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.servlet.HttpHeaders;
 import com.liferay.portal.kernel.servlet.ServletResponseUtil;
+import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.webdav.Resource;
 import com.liferay.portal.kernel.webdav.WebDAVException;
@@ -19,6 +21,8 @@ import com.liferay.portal.kernel.webdav.methods.Method;
 import jakarta.servlet.http.HttpServletResponse;
 
 import java.io.InputStream;
+
+import java.util.Set;
 
 /**
  * @author Brian Wing Shun Chan
@@ -47,25 +51,24 @@ public class GetMethodImpl implements Method {
 			}
 
 			if (inputStream != null) {
-				String contentType = resource.getContentType();
-				String fileName = resource.getDisplayName();
-
-				HttpServletResponse httpServletResponse =
-					webDAVRequest.getHttpServletResponse();
-
 				try {
-					if (_isBrowserExecutableContentType(contentType)) {
+					if (_browserExecutableContentTypes.contains(
+							StringUtil.toLowerCase(
+								resource.getContentType()))) {
+
 						ServletResponseUtil.sendFile(
 							webDAVRequest.getHttpServletRequest(),
-							httpServletResponse, fileName, inputStream,
-							resource.getSize(), contentType,
+							webDAVRequest.getHttpServletResponse(),
+							resource.getDisplayName(), inputStream,
+							resource.getSize(), resource.getContentType(),
 							HttpHeaders.CONTENT_DISPOSITION_ATTACHMENT);
 					}
 					else {
 						ServletResponseUtil.sendFileWithRangeHeader(
 							webDAVRequest.getHttpServletRequest(),
-							httpServletResponse, fileName, inputStream,
-							resource.getSize(), contentType);
+							webDAVRequest.getHttpServletResponse(),
+							resource.getDisplayName(), inputStream,
+							resource.getSize(), resource.getContentType());
 					}
 				}
 				catch (Exception exception) {
@@ -84,25 +87,12 @@ public class GetMethodImpl implements Method {
 		}
 	}
 
-	private boolean _isBrowserExecutableContentType(String contentType) {
-		if (contentType == null) {
-			return false;
-		}
-
-		String lowerCaseContentType = StringUtil.toLowerCase(contentType);
-
-		if (lowerCaseContentType.startsWith("application/javascript") ||
-			lowerCaseContentType.startsWith("application/xhtml+xml") ||
-			lowerCaseContentType.startsWith("image/svg+xml") ||
-			lowerCaseContentType.startsWith("text/html") ||
-			lowerCaseContentType.startsWith("text/javascript")) {
-
-			return true;
-		}
-
-		return false;
-	}
-
 	private static final Log _log = LogFactoryUtil.getLog(GetMethodImpl.class);
+
+	private static final Set<String> _browserExecutableContentTypes =
+		SetUtil.fromArray(
+			ContentTypes.APPLICATION_JAVASCRIPT, ContentTypes.IMAGE_SVG_XML,
+			ContentTypes.TEXT_HTML, ContentTypes.TEXT_JAVASCRIPT,
+			"application/xhtml+xml");
 
 }

--- a/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
+++ b/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
@@ -1230,6 +1230,10 @@ public class WebServerServlet extends HttpServlet {
 
 		boolean download = ParamUtil.getBoolean(httpServletRequest, "download");
 
+		if (!download && _isBrowserExecutableContentType(contentType)) {
+			download = true;
+		}
+
 		if (download) {
 			cacheControlValue = HttpHeaders.CACHE_CONTROL_NO_CACHE_VALUE;
 		}
@@ -1273,10 +1277,13 @@ public class WebServerServlet extends HttpServlet {
 				fileEntry, HttpHeaders.CACHE_CONTROL,
 				HttpHeaders.CACHE_CONTROL_PRIVATE_VALUE));
 
+		String mimeType = fileEntry.getMimeType();
+
 		ServletResponseUtil.sendFile(
 			null, httpServletResponse, fileEntry.getTitle(),
-			fileEntry.getContentStream(), fileEntry.getSize(),
-			fileEntry.getMimeType());
+			fileEntry.getContentStream(), fileEntry.getSize(), mimeType,
+			_isBrowserExecutableContentType(mimeType) ?
+				HttpHeaders.CONTENT_DISPOSITION_ATTACHMENT : null);
 	}
 
 	protected void sendGroups(
@@ -1374,18 +1381,18 @@ public class WebServerServlet extends HttpServlet {
 
 		boolean download = ParamUtil.getBoolean(httpServletRequest, "download");
 
-		if (download) {
+		String mimeType = fileEntry.getMimeType();
+
+		if (download || !mimeType.startsWith("image/")) {
 			ServletResponseUtil.sendFile(
 				httpServletRequest, httpServletResponse, fileName,
-				fileEntry.getContentStream(), fileEntry.getSize(),
-				fileEntry.getMimeType(),
+				fileEntry.getContentStream(), fileEntry.getSize(), mimeType,
 				HttpHeaders.CONTENT_DISPOSITION_ATTACHMENT);
 		}
 		else {
 			ServletResponseUtil.sendFile(
 				httpServletRequest, httpServletResponse, fileName,
-				fileEntry.getContentStream(), fileEntry.getSize(),
-				fileEntry.getMimeType());
+				fileEntry.getContentStream(), fileEntry.getSize(), mimeType);
 		}
 	}
 
@@ -1409,6 +1416,17 @@ public class WebServerServlet extends HttpServlet {
 		}
 
 		String fileName = ParamUtil.getString(httpServletRequest, "fileName");
+
+		long groupId = ParamUtil.getLong(httpServletRequest, "groupId");
+		String uuid = ParamUtil.getString(httpServletRequest, "uuid");
+
+		if (Validator.isNotNull(uuid) && (groupId > 0) &&
+			_isBrowserExecutableContentType(contentType)) {
+
+			httpServletResponse.setHeader(
+				HttpHeaders.CONTENT_DISPOSITION,
+				HttpHeaders.CONTENT_DISPOSITION_ATTACHMENT);
+		}
 
 		byte[] bytes = getImageBytes(httpServletRequest, image);
 
@@ -1980,6 +1998,25 @@ public class WebServerServlet extends HttpServlet {
 
 		return PortletProviderUtil.getPortletId(
 			FileEntry.class.getName(), PortletProvider.Action.VIEW);
+	}
+
+	private boolean _isBrowserExecutableContentType(String contentType) {
+		if (contentType == null) {
+			return false;
+		}
+
+		String lowerCaseContentType = StringUtil.toLowerCase(contentType);
+
+		if (lowerCaseContentType.startsWith("application/javascript") ||
+			lowerCaseContentType.startsWith("application/xhtml+xml") ||
+			lowerCaseContentType.startsWith("image/svg+xml") ||
+			lowerCaseContentType.startsWith("text/html") ||
+			lowerCaseContentType.startsWith("text/javascript")) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 	private boolean _processCompanyInactiveRequest(

--- a/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
+++ b/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
@@ -1230,7 +1230,7 @@ public class WebServerServlet extends HttpServlet {
 
 		boolean download = ParamUtil.getBoolean(httpServletRequest, "download");
 
-		if (!download && _isBrowserExecutableContentType(contentType)) {
+		if (_isBrowserExecutableContentType(contentType)) {
 			download = true;
 		}
 
@@ -1277,13 +1277,14 @@ public class WebServerServlet extends HttpServlet {
 				fileEntry, HttpHeaders.CACHE_CONTROL,
 				HttpHeaders.CACHE_CONTROL_PRIVATE_VALUE));
 
-		String mimeType = fileEntry.getMimeType();
+		String contentDispositionType =
+			_isBrowserExecutableContentType(fileEntry.getMimeType()) ?
+				HttpHeaders.CONTENT_DISPOSITION_ATTACHMENT : null;
 
 		ServletResponseUtil.sendFile(
 			null, httpServletResponse, fileEntry.getTitle(),
-			fileEntry.getContentStream(), fileEntry.getSize(), mimeType,
-			_isBrowserExecutableContentType(mimeType) ?
-				HttpHeaders.CONTENT_DISPOSITION_ATTACHMENT : null);
+			fileEntry.getContentStream(), fileEntry.getSize(),
+			fileEntry.getMimeType(), contentDispositionType);
 	}
 
 	protected void sendGroups(
@@ -1420,7 +1421,7 @@ public class WebServerServlet extends HttpServlet {
 		long groupId = ParamUtil.getLong(httpServletRequest, "groupId");
 		String uuid = ParamUtil.getString(httpServletRequest, "uuid");
 
-		if (Validator.isNotNull(uuid) && (groupId > 0) &&
+		if ((groupId > 0) && Validator.isNotNull(uuid) &&
 			_isBrowserExecutableContentType(contentType)) {
 
 			httpServletResponse.setHeader(
@@ -2001,22 +2002,8 @@ public class WebServerServlet extends HttpServlet {
 	}
 
 	private boolean _isBrowserExecutableContentType(String contentType) {
-		if (contentType == null) {
-			return false;
-		}
-
-		String lowerCaseContentType = StringUtil.toLowerCase(contentType);
-
-		if (lowerCaseContentType.startsWith("application/javascript") ||
-			lowerCaseContentType.startsWith("application/xhtml+xml") ||
-			lowerCaseContentType.startsWith("image/svg+xml") ||
-			lowerCaseContentType.startsWith("text/html") ||
-			lowerCaseContentType.startsWith("text/javascript")) {
-
-			return true;
-		}
-
-		return false;
+		return _browserExecutableContentTypes.contains(
+			StringUtil.toLowerCase(contentType));
 	}
 
 	private boolean _processCompanyInactiveRequest(
@@ -2101,6 +2088,11 @@ public class WebServerServlet extends HttpServlet {
 
 	private static final Set<String> _acceptRangesMimeTypes = SetUtil.fromArray(
 		PropsValues.WEB_SERVER_SERVLET_ACCEPT_RANGES_MIME_TYPES);
+	private static final Set<String> _browserExecutableContentTypes =
+		SetUtil.fromArray(
+			ContentTypes.APPLICATION_JAVASCRIPT, ContentTypes.IMAGE_SVG_XML,
+			ContentTypes.TEXT_HTML, ContentTypes.TEXT_JAVASCRIPT,
+			"application/xhtml+xml");
 	private static final Snapshot<FileEntryFriendlyURLResolver>
 		_fileEntryFriendlyURLResolverSnapshot = new Snapshot<>(
 			WebServerServlet.class, FileEntryFriendlyURLResolver.class);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93844

## What Is Being Fixed

A low-privileged user with Add Document permission can upload an HTML (or SVG / JavaScript) file via WebDAV and retrieve it through paths such as `/image/?uuid=<file-uuid>&groupId=<id>`, the document library web server path, or a WebDAV GET. Because these paths serve the file with its stored content type and no `Content-Disposition` header, the browser renders the markup inline, enabling Stored XSS. The XSS payload can silently enable Groovy execution, resulting in RCE.

## How It Is Being Fixed

Both servlet paths now treat a fixed set of browser-executable content types — `text/html`, `image/svg+xml`, `application/javascript`, `text/javascript`, and `application/xhtml+xml` — as never-inline. `WebServerServlet` forces `download` for these types when serving document library files and sets `Content-Disposition: attachment` on the uuid+groupId image path and the `/image/` servlet path. `GetMethodImpl` (WebDAV GET) likewise sends the file as an attachment rather than with a range header when the content type is browser-executable. Files outside that set are served as before, so normal image and document delivery is unaffected.

## PR Check

**pr-check: PASS** — tested on `9fee0a3cfb515f81e7e1d1ac477ceb50e8fbe5a7`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Full Portal Build | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |

<!-- pr-check {"result": "success", "sha": "9fee0a3cfb515f81e7e1d1ac477ceb50e8fbe5a7"} -->
