### PR TITLE
LPD-95039 Propagate default permissions to existing folders and entries

### DIFF
--- a/modules/apps/site/site-cms-site-initializer-api/bnd.bnd
+++ b/modules/apps/site/site-cms-site-initializer-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Site CMS Site Initializer API
 Bundle-SymbolicName: com.liferay.site.cms.site.initializer.api
-Bundle-Version: 4.2.1
+Bundle-Version: 4.3.0
 Export-Package:\
 	com.liferay.site.cms.site.initializer.bulk.selection,\
 	com.liferay.site.cms.site.initializer.configuration,\

--- a/modules/apps/site/site-cms-site-initializer-api/src/main/java/com/liferay/site/cms/site/initializer/util/CMSDefaultPermissionUtil.java
+++ b/modules/apps/site/site-cms-site-initializer-api/src/main/java/com/liferay/site/cms/site/initializer/util/CMSDefaultPermissionUtil.java
@@ -5,29 +5,51 @@
 
 package com.liferay.site.cms.site.initializer.util;
 
+import com.liferay.depot.constants.DepotRolesConstants;
+import com.liferay.depot.model.DepotEntry;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.rest.filter.factory.FilterFactory;
 import com.liferay.object.service.ObjectDefinitionLocalServiceUtil;
+import com.liferay.object.service.ObjectEntryFolderLocalServiceUtil;
 import com.liferay.object.service.ObjectEntryLocalServiceUtil;
 import com.liferay.petra.sql.dsl.expression.Predicate;
+import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
+import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalServiceUtil;
+import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 
 import java.io.Serializable;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * @author Stefano Motta
+ * @author Mikel Lorza
  */
 public class CMSDefaultPermissionUtil {
 
@@ -89,6 +111,46 @@ public class CMSDefaultPermissionUtil {
 		return ObjectEntryLocalServiceUtil.fetchObjectEntry(primaryKeys.get(0));
 	}
 
+	public static JSONObject getDefaultPermissionsJSONObject(
+			ObjectEntryFolder objectEntryFolder,
+			FilterFactory<Predicate> filterFactory)
+		throws PortalException {
+
+		ObjectDefinition cmsDefaultPermissionObjectDefinition =
+			ObjectDefinitionLocalServiceUtil.
+				fetchObjectDefinitionByExternalReferenceCode(
+					"L_CMS_DEFAULT_PERMISSION",
+					objectEntryFolder.getCompanyId());
+
+		if (cmsDefaultPermissionObjectDefinition == null) {
+			return null;
+		}
+
+		if (objectEntryFolder.getParentObjectEntryFolderId() != 0) {
+			ObjectEntryFolder parentObjectEntryFolder =
+				ObjectEntryFolderLocalServiceUtil.getObjectEntryFolder(
+					objectEntryFolder.getParentObjectEntryFolderId());
+
+			JSONObject jsonObject = getJSONObject(
+				parentObjectEntryFolder.getCompanyId(),
+				parentObjectEntryFolder.getUserId(),
+				parentObjectEntryFolder.getExternalReferenceCode(),
+				parentObjectEntryFolder.getModelClassName(), filterFactory);
+
+			if ((jsonObject != null) && !JSONUtil.isEmpty(jsonObject)) {
+				return jsonObject;
+			}
+		}
+
+		Group group = GroupLocalServiceUtil.getGroup(
+			objectEntryFolder.getGroupId());
+
+		return getJSONObject(
+			group.getCompanyId(), group.getCreatorUserId(),
+			group.getExternalReferenceCode(), DepotEntry.class.getName(),
+			filterFactory);
+	}
+
 	public static JSONObject getJSONObject(
 			long companyId, long userId, String classExternalReferenceCode,
 			String className, FilterFactory<Predicate> filterFactory)
@@ -114,6 +176,184 @@ public class CMSDefaultPermissionUtil {
 
 		return JSONFactoryUtil.createJSONObject(
 			String.valueOf(values.getOrDefault("defaultPermissions", "{}")));
+	}
+
+	public static void setObjectEntryFolderResourcePermissions(
+			ObjectEntryFolder objectEntryFolder,
+			JSONObject defaultPermissionsJSONObject)
+		throws PortalException {
+
+		if ((defaultPermissionsJSONObject == null) ||
+			JSONUtil.isEmpty(defaultPermissionsJSONObject)) {
+
+			return;
+		}
+
+		JSONObject objectEntryFoldersJSONObject =
+			defaultPermissionsJSONObject.getJSONObject("OBJECT_ENTRY_FOLDERS");
+
+		if (objectEntryFoldersJSONObject == null) {
+			return;
+		}
+
+		List<String> resourceActions = ResourceActionsUtil.getResourceActions(
+			ObjectEntryFolder.class.getName());
+
+		for (Role role : _getRoles(objectEntryFolder.getCompanyId())) {
+			String[] actionIds = JSONUtil.toStringArray(
+				objectEntryFoldersJSONObject.getJSONArray(role.getName()));
+
+			if (objectEntryFolder.getParentObjectEntryFolderId() ==
+					ObjectEntryFolderConstants.
+						PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT) {
+
+				actionIds = ArrayUtil.remove(actionIds, ActionKeys.DELETE);
+			}
+
+			ResourcePermissionLocalServiceUtil.setResourcePermissions(
+				objectEntryFolder.getCompanyId(),
+				ObjectEntryFolder.class.getName(),
+				ResourceConstants.SCOPE_INDIVIDUAL,
+				String.valueOf(objectEntryFolder.getObjectEntryFolderId()),
+				role.getRoleId(),
+				ArrayUtil.filter(actionIds, resourceActions::contains));
+		}
+	}
+
+	public static void setObjectEntryResourcePermissions(
+			ObjectEntry objectEntry, FilterFactory<Predicate> filterFactory)
+		throws PortalException {
+
+		setObjectEntryResourcePermissions(
+			objectEntry,
+			_getDefaultPermissionsJSONObject(objectEntry, filterFactory));
+	}
+
+	public static void setObjectEntryResourcePermissions(
+			ObjectEntry objectEntry, JSONObject defaultPermissionsJSONObject)
+		throws PortalException {
+
+		if ((defaultPermissionsJSONObject == null) ||
+			JSONUtil.isEmpty(defaultPermissionsJSONObject)) {
+
+			return;
+		}
+
+		ObjectEntryFolder rootObjectEntryFolder = _getRootObjectEntryFolder(
+			objectEntry);
+
+		if (rootObjectEntryFolder == null) {
+			return;
+		}
+
+		JSONObject objectEntryJSONObject =
+			defaultPermissionsJSONObject.getJSONObject(
+				rootObjectEntryFolder.getExternalReferenceCode());
+
+		if (objectEntryJSONObject == null) {
+			return;
+		}
+
+		List<String> resourceActions = ResourceActionsUtil.getResourceActions(
+			objectEntry.getModelClassName());
+
+		for (Role role : _getRoles(objectEntry.getCompanyId())) {
+			JSONArray jsonArray = objectEntryJSONObject.getJSONArray(
+				role.getName());
+
+			if ((jsonArray == null) || JSONUtil.isEmpty(jsonArray)) {
+				jsonArray = JSONFactoryUtil.createJSONArray();
+			}
+
+			ResourcePermissionLocalServiceUtil.setResourcePermissions(
+				objectEntry.getCompanyId(), objectEntry.getModelClassName(),
+				ResourceConstants.SCOPE_INDIVIDUAL,
+				String.valueOf(objectEntry.getObjectEntryId()),
+				role.getRoleId(),
+				ArrayUtil.filter(
+					JSONUtil.toStringArray(jsonArray),
+					resourceActions::contains));
+		}
+	}
+
+	private static JSONObject _getDefaultPermissionsJSONObject(
+			ObjectEntry objectEntry, FilterFactory<Predicate> filterFactory)
+		throws PortalException {
+
+		ObjectDefinition cmsDefaultPermissionObjectDefinition =
+			ObjectDefinitionLocalServiceUtil.
+				fetchObjectDefinitionByExternalReferenceCode(
+					"L_CMS_DEFAULT_PERMISSION", objectEntry.getCompanyId());
+
+		if (cmsDefaultPermissionObjectDefinition == null) {
+			return null;
+		}
+
+		if (objectEntry.getObjectEntryFolderId() != 0) {
+			ObjectEntryFolder parentObjectEntryFolder =
+				ObjectEntryFolderLocalServiceUtil.getObjectEntryFolder(
+					objectEntry.getObjectEntryFolderId());
+
+			JSONObject jsonObject = getJSONObject(
+				parentObjectEntryFolder.getCompanyId(),
+				parentObjectEntryFolder.getUserId(),
+				parentObjectEntryFolder.getExternalReferenceCode(),
+				parentObjectEntryFolder.getModelClassName(), filterFactory);
+
+			if ((jsonObject != null) && !JSONUtil.isEmpty(jsonObject)) {
+				return jsonObject;
+			}
+		}
+
+		Group group = GroupLocalServiceUtil.getGroup(objectEntry.getGroupId());
+
+		return getJSONObject(
+			group.getCompanyId(), group.getCreatorUserId(),
+			group.getExternalReferenceCode(), DepotEntry.class.getName(),
+			filterFactory);
+	}
+
+	private static List<Role> _getRoles(long companyId) {
+		return RoleLocalServiceUtil.getGroupRolesAndTeamRoles(
+			companyId, null,
+			Arrays.asList(
+				RoleConstants.ADMINISTRATOR,
+				DepotRolesConstants.ASSET_LIBRARY_OWNER),
+			null, null,
+			new int[] {RoleConstants.TYPE_REGULAR, RoleConstants.TYPE_DEPOT},
+			null, 0, 0, QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+	}
+
+	private static ObjectEntryFolder _getRootObjectEntryFolder(
+		ObjectEntry objectEntry) {
+
+		ObjectEntryFolder objectEntryFolder =
+			ObjectEntryFolderLocalServiceUtil.fetchObjectEntryFolder(
+				objectEntry.getObjectEntryFolderId());
+
+		if (objectEntryFolder == null) {
+			return null;
+		}
+
+		if (Objects.equals(
+				objectEntryFolder.getExternalReferenceCode(),
+				ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS) ||
+			Objects.equals(
+				objectEntryFolder.getExternalReferenceCode(),
+				ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_FILES)) {
+
+			return objectEntryFolder;
+		}
+
+		String[] parts = StringUtil.split(
+			objectEntryFolder.getTreePath(), CharPool.SLASH);
+
+		if (parts.length <= 2) {
+			return null;
+		}
+
+		return ObjectEntryFolderLocalServiceUtil.fetchObjectEntryFolder(
+			GetterUtil.getLong(parts[1]));
 	}
 
 }

--- a/modules/apps/site/site-cms-site-initializer-api/src/main/resources/com/liferay/site/cms/site/initializer/util/packageinfo
+++ b/modules/apps/site/site-cms-site-initializer-api/src/main/resources/com/liferay/site/cms/site/initializer/util/packageinfo
@@ -1,1 +1,1 @@
-version 3.2.0
+version 3.3.0

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/bulk/selection/test/DefaultPermissionObjectBulkSelectionActionTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/bulk/selection/test/DefaultPermissionObjectBulkSelectionActionTest.java
@@ -1,0 +1,260 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.bulk.selection.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.bulk.selection.BulkSelectionAction;
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectEntryFolder;
+import com.liferay.object.rest.filter.factory.FilterFactory;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryFolderLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.petra.sql.dsl.expression.Predicate;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.site.cms.site.initializer.test.util.CMSTestUtil;
+import com.liferay.site.cms.site.initializer.util.CMSDefaultPermissionUtil;
+import com.liferay.site.cms.site.initializer.util.RoleUtil;
+
+import java.io.Serializable;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Mikel Lorza
+ */
+@FeatureFlag("LPD-17564")
+@RunWith(Arquillian.class)
+public class DefaultPermissionObjectBulkSelectionActionTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		CMSTestUtil.getOrAddGroup(
+			DefaultPermissionObjectBulkSelectionActionTest.class);
+
+		_cmsAdministratorRole = RoleUtil.getOrAddCMSAdministratorRole(
+			TestPropsValues.getCompanyId(), TestPropsValues.getUserId());
+
+		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), StringUtil.randomString()
+			).build(),
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), StringUtil.randomString()
+			).build(),
+			DepotConstants.TYPE_SPACE,
+			ServiceContextTestUtil.getServiceContext());
+
+		_group = depotEntry.getGroup();
+
+		ServiceContextThreadLocal.pushServiceContext(
+			ServiceContextTestUtil.getServiceContext());
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		ServiceContextThreadLocal.popServiceContext();
+	}
+
+	@Test
+	public void testDoExecutePropagatesResourcePermissions() throws Exception {
+		ObjectEntryFolder contentsObjectEntryFolder =
+			_objectEntryFolderLocalService.
+				getObjectEntryFolderByExternalReferenceCode(
+					ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS,
+					_group.getGroupId(), _group.getCompanyId());
+
+		ObjectEntryFolder objectEntryFolder = _addObjectEntryFolder(
+			contentsObjectEntryFolder.getObjectEntryFolderId());
+
+		ObjectEntry objectEntry = _addBasicWebContentObjectEntry(
+			objectEntryFolder);
+
+		String actionId = RandomTestUtil.randomString();
+
+		ObjectEntry defaultPermissionObjectEntry =
+			CMSDefaultPermissionUtil.fetchObjectEntry(
+				objectEntryFolder.getCompanyId(), objectEntryFolder.getUserId(),
+				objectEntryFolder.getExternalReferenceCode(),
+				objectEntryFolder.getModelClassName(), _filterFactory);
+
+		Assert.assertNotNull(defaultPermissionObjectEntry);
+
+		ReflectionTestUtil.invoke(
+			_defaultPermissionObjectBulkSelectionAction, "doExecute",
+			new Class<?>[] {User.class, Map.class, Object.class},
+			TestPropsValues.getUser(),
+			HashMapBuilder.<String, Serializable>put(
+				"defaultPermissions",
+				() -> JSONUtil.put(
+					ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS,
+					JSONUtil.put(
+						RoleConstants.CMS_ADMINISTRATOR,
+						JSONUtil.putAll(
+							actionId, ActionKeys.UPDATE, ActionKeys.VIEW))
+				).put(
+					"OBJECT_ENTRY_FOLDERS",
+					JSONUtil.put(
+						RoleConstants.CMS_ADMINISTRATOR,
+						JSONUtil.putAll(
+							actionId, ActionKeys.UPDATE, ActionKeys.VIEW))
+				).toString()
+			).build(),
+			defaultPermissionObjectEntry);
+
+		ResourcePermission objectEntryFolderResourcePermission =
+			_resourcePermissionLocalService.getResourcePermission(
+				objectEntryFolder.getCompanyId(),
+				ObjectEntryFolder.class.getName(),
+				ResourceConstants.SCOPE_INDIVIDUAL,
+				String.valueOf(objectEntryFolder.getObjectEntryFolderId()),
+				_cmsAdministratorRole.getRoleId());
+
+		Assert.assertFalse(
+			objectEntryFolderResourcePermission.hasActionId(ActionKeys.DELETE));
+		Assert.assertTrue(
+			objectEntryFolderResourcePermission.hasActionId(ActionKeys.UPDATE));
+		Assert.assertTrue(
+			objectEntryFolderResourcePermission.hasActionId(ActionKeys.VIEW));
+		Assert.assertFalse(
+			objectEntryFolderResourcePermission.hasActionId(actionId));
+
+		ResourcePermission objectEntryResourcePermission =
+			_resourcePermissionLocalService.getResourcePermission(
+				objectEntry.getCompanyId(), objectEntry.getModelClassName(),
+				ResourceConstants.SCOPE_INDIVIDUAL,
+				String.valueOf(objectEntry.getObjectEntryId()),
+				_cmsAdministratorRole.getRoleId());
+
+		Assert.assertFalse(
+			objectEntryResourcePermission.hasActionId(ActionKeys.DELETE));
+		Assert.assertTrue(
+			objectEntryResourcePermission.hasActionId(ActionKeys.UPDATE));
+		Assert.assertTrue(
+			objectEntryResourcePermission.hasActionId(ActionKeys.VIEW));
+		Assert.assertFalse(objectEntryResourcePermission.hasActionId(actionId));
+	}
+
+	private ObjectEntry _addBasicWebContentObjectEntry(
+			ObjectEntryFolder objectEntryFolder)
+		throws Exception {
+
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.
+				getObjectDefinitionByExternalReferenceCode(
+					"L_CMS_BASIC_WEB_CONTENT",
+					objectEntryFolder.getCompanyId());
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext();
+
+		serviceContext.setAttribute(
+			"friendlyUrlMap", new HashMap<String, String>());
+
+		return _objectEntryLocalService.addObjectEntry(
+			objectEntryFolder.getGroupId(), objectEntryFolder.getUserId(),
+			objectDefinition.getObjectDefinitionId(),
+			objectEntryFolder.getObjectEntryFolderId(), "en_US",
+			HashMapBuilder.<String, Serializable>put(
+				"title_i18n",
+				HashMapBuilder.put(
+					"en_US", RandomTestUtil.randomString()
+				).build()
+			).build(),
+			serviceContext);
+	}
+
+	private ObjectEntryFolder _addObjectEntryFolder(
+			long parentObjectEntryFolderId)
+		throws Exception {
+
+		return _objectEntryFolderLocalService.addObjectEntryFolder(
+			RandomTestUtil.randomString(), _group.getGroupId(),
+			_group.getCreatorUserId(), parentObjectEntryFolderId, "",
+			HashMapBuilder.put(
+				LocaleUtil.ENGLISH, RandomTestUtil.randomString()
+			).build(),
+			RandomTestUtil.randomString(),
+			ServiceContextTestUtil.getServiceContext());
+	}
+
+	private Role _cmsAdministratorRole;
+
+	@Inject(
+		filter = "component.name=com.liferay.site.cms.site.initializer.internal.bulk.selection.DefaultPermissionObjectBulkSelectionAction"
+	)
+	private BulkSelectionAction<Object>
+		_defaultPermissionObjectBulkSelectionAction;
+
+	@Inject
+	private DepotEntryLocalService _depotEntryLocalService;
+
+	@Inject(
+		filter = "filter.factory.key=" + ObjectDefinitionConstants.STORAGE_TYPE_DEFAULT
+	)
+	private FilterFactory<Predicate> _filterFactory;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Inject
+	private ObjectEntryFolderLocalService _objectEntryFolderLocalService;
+
+	@Inject
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Inject
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/bulk/selection/DefaultPermissionObjectBulkSelectionAction.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/bulk/selection/DefaultPermissionObjectBulkSelectionAction.java
@@ -8,7 +8,9 @@ package com.liferay.site.cms.site.initializer.internal.bulk.selection;
 import com.liferay.bulk.selection.BulkSelectionAction;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.model.ObjectEntry;
-import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.object.model.ObjectEntryFolder;
+import com.liferay.object.service.ObjectEntryFolderLocalService;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.model.User;
@@ -16,6 +18,7 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.site.cms.site.initializer.bulk.selection.BaseObjectBulkSelectionAction;
+import com.liferay.site.cms.site.initializer.util.CMSDefaultPermissionUtil;
 
 import java.io.Serializable;
 
@@ -37,7 +40,7 @@ public class DefaultPermissionObjectBulkSelectionAction
 	@Override
 	protected void doExecute(
 			User user, Map<String, Serializable> inputMap, Object object)
-		throws PortalException {
+		throws Exception {
 
 		ObjectEntry objectObjectEntry = (ObjectEntry)object;
 
@@ -94,6 +97,9 @@ public class DefaultPermissionObjectBulkSelectionAction
 
 		partialUpdateObjectEntry(
 			user.getUserId(), objectObjectEntry, objectObjectEntryValues);
+
+		_propagateResourcePermissions(
+			objectObjectEntry, objectObjectEntryValues);
 	}
 
 	private JSONObject _getJSONObject(
@@ -112,7 +118,47 @@ public class DefaultPermissionObjectBulkSelectionAction
 		return jsonObject1;
 	}
 
+	private void _propagateResourcePermissions(
+			ObjectEntry objectObjectEntry,
+			Map<String, Serializable> objectObjectEntryValues)
+		throws Exception {
+
+		ObjectEntryFolder objectEntryFolder =
+			_objectEntryFolderLocalService.
+				fetchObjectEntryFolderByExternalReferenceCode(
+					GetterUtil.getString(
+						objectObjectEntryValues.get(
+							"classExternalReferenceCode")),
+					GetterUtil.getLong(
+						objectObjectEntryValues.get("depotGroupId")),
+					objectObjectEntry.getCompanyId());
+
+		if (objectEntryFolder == null) {
+			return;
+		}
+
+		JSONObject defaultPermissionsJSONObject = _jsonFactory.createJSONObject(
+			GetterUtil.getString(
+				objectObjectEntryValues.get("defaultPermissions"), "{}"));
+
+		CMSDefaultPermissionUtil.setObjectEntryFolderResourcePermissions(
+			objectEntryFolder, defaultPermissionsJSONObject);
+
+		for (ObjectEntry objectEntry :
+				objectEntryLocalService.getObjectEntryFolderObjectEntries(
+					objectEntryFolder.getGroupId(),
+					objectEntryFolder.getObjectEntryFolderId(),
+					QueryUtil.ALL_POS, QueryUtil.ALL_POS)) {
+
+			CMSDefaultPermissionUtil.setObjectEntryResourcePermissions(
+				objectEntry, defaultPermissionsJSONObject);
+		}
+	}
+
 	@Reference
 	private JSONFactory _jsonFactory;
+
+	@Reference
+	private ObjectEntryFolderLocalService _objectEntryFolderLocalService;
 
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/model/listener/ObjectEntryFolderModelListener.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/model/listener/ObjectEntryFolderModelListener.java
@@ -5,8 +5,6 @@
 
 package com.liferay.site.cms.site.initializer.internal.model.listener;
 
-import com.liferay.depot.constants.DepotRolesConstants;
-import com.liferay.depot.model.DepotEntry;
 import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.model.ObjectDefinition;
@@ -14,10 +12,8 @@ import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.rest.filter.factory.FilterFactory;
 import com.liferay.object.service.ObjectDefinitionLocalService;
-import com.liferay.object.service.ObjectEntryFolderLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.petra.sql.dsl.expression.Predicate;
-import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
@@ -25,17 +21,7 @@ import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.BaseModelListener;
-import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.ModelListener;
-import com.liferay.portal.kernel.model.ResourceConstants;
-import com.liferay.portal.kernel.model.Role;
-import com.liferay.portal.kernel.model.role.RoleConstants;
-import com.liferay.portal.kernel.security.permission.ActionKeys;
-import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
-import com.liferay.portal.kernel.service.GroupLocalService;
-import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
-import com.liferay.portal.kernel.service.RoleLocalService;
-import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.sharing.service.SharingEntryLocalService;
@@ -43,8 +29,6 @@ import com.liferay.site.cms.site.initializer.util.CMSDefaultPermissionUtil;
 
 import java.io.Serializable;
 
-import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -115,7 +99,8 @@ public class ObjectEntryFolderModelListener
 		throws Exception {
 
 		JSONObject defaultPermissionsJSONObject =
-			_getCMSDefaultPermissionJSONObject(objectEntryFolder);
+			CMSDefaultPermissionUtil.getDefaultPermissionsJSONObject(
+				objectEntryFolder, _filterFactory);
 
 		if ((defaultPermissionsJSONObject == null) ||
 			JSONUtil.isEmpty(defaultPermissionsJSONObject)) {
@@ -139,83 +124,8 @@ public class ObjectEntryFolderModelListener
 				objectEntryFolder.getTreePath());
 		}
 
-		JSONObject objectEntryFoldersJSONObject =
-			defaultPermissionsJSONObject.getJSONObject("OBJECT_ENTRY_FOLDERS");
-
-		if (objectEntryFoldersJSONObject == null) {
-			return;
-		}
-
-		List<String> resourceActions = ResourceActionsUtil.getResourceActions(
-			ObjectEntryFolder.class.getName());
-
-		List<Role> roles = _roleLocalService.getGroupRolesAndTeamRoles(
-			objectEntryFolder.getCompanyId(), null,
-			Arrays.asList(
-				RoleConstants.ADMINISTRATOR,
-				DepotRolesConstants.ASSET_LIBRARY_OWNER),
-			null, null,
-			new int[] {RoleConstants.TYPE_REGULAR, RoleConstants.TYPE_DEPOT},
-			null, 0, 0, QueryUtil.ALL_POS, QueryUtil.ALL_POS);
-
-		for (Role role : roles) {
-			String[] actionIds = JSONUtil.toStringArray(
-				objectEntryFoldersJSONObject.getJSONArray(role.getName()));
-
-			if (objectEntryFolder.getParentObjectEntryFolderId() ==
-					ObjectEntryFolderConstants.
-						PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT) {
-
-				actionIds = ArrayUtil.remove(actionIds, ActionKeys.DELETE);
-			}
-
-			_resourcePermissionLocalService.setResourcePermissions(
-				objectEntryFolder.getCompanyId(),
-				ObjectEntryFolder.class.getName(),
-				ResourceConstants.SCOPE_INDIVIDUAL,
-				String.valueOf(objectEntryFolder.getObjectEntryFolderId()),
-				role.getRoleId(),
-				ArrayUtil.filter(actionIds, resourceActions::contains));
-		}
-	}
-
-	private JSONObject _getCMSDefaultPermissionJSONObject(
-			ObjectEntryFolder objectEntryFolder)
-		throws Exception {
-
-		ObjectDefinition cmsDefaultPermissionObjectDefinition =
-			_objectDefinitionLocalService.
-				fetchObjectDefinitionByExternalReferenceCode(
-					"L_CMS_DEFAULT_PERMISSION",
-					objectEntryFolder.getCompanyId());
-
-		if (cmsDefaultPermissionObjectDefinition == null) {
-			return null;
-		}
-
-		if (objectEntryFolder.getParentObjectEntryFolderId() != 0) {
-			ObjectEntryFolder parentObjectEntryFolder =
-				_objectEntryFolderLocalService.getObjectEntryFolder(
-					objectEntryFolder.getParentObjectEntryFolderId());
-
-			JSONObject jsonObject = CMSDefaultPermissionUtil.getJSONObject(
-				parentObjectEntryFolder.getCompanyId(),
-				parentObjectEntryFolder.getUserId(),
-				parentObjectEntryFolder.getExternalReferenceCode(),
-				parentObjectEntryFolder.getModelClassName(), _filterFactory);
-
-			if ((jsonObject != null) && !JSONUtil.isEmpty(jsonObject)) {
-				return jsonObject;
-			}
-		}
-
-		Group group = _groupLocalService.getGroup(
-			objectEntryFolder.getGroupId());
-
-		return CMSDefaultPermissionUtil.getJSONObject(
-			group.getCompanyId(), group.getCreatorUserId(),
-			group.getExternalReferenceCode(), DepotEntry.class.getName(),
-			_filterFactory);
+		CMSDefaultPermissionUtil.setObjectEntryFolderResourcePermissions(
+			objectEntryFolder, defaultPermissionsJSONObject);
 	}
 
 	private void _onAfterCreate(ObjectEntryFolder objectEntryFolder)
@@ -309,7 +219,8 @@ public class ObjectEntryFolderModelListener
 		}
 
 		JSONObject defaultPermissionsJSONObject =
-			_getCMSDefaultPermissionJSONObject(objectEntryFolder);
+			CMSDefaultPermissionUtil.getDefaultPermissionsJSONObject(
+				objectEntryFolder, _filterFactory);
 
 		if ((defaultPermissionsJSONObject == null) ||
 			JSONUtil.isEmpty(defaultPermissionsJSONObject)) {
@@ -336,28 +247,16 @@ public class ObjectEntryFolderModelListener
 	private FilterFactory<Predicate> _filterFactory;
 
 	@Reference
-	private GroupLocalService _groupLocalService;
-
-	@Reference
 	private JSONFactory _jsonFactory;
 
 	@Reference
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;
 
 	@Reference
-	private ObjectEntryFolderLocalService _objectEntryFolderLocalService;
-
-	@Reference
 	private ObjectEntryLocalService _objectEntryLocalService;
 
 	@Reference
 	private Portal _portal;
-
-	@Reference
-	private ResourcePermissionLocalService _resourcePermissionLocalService;
-
-	@Reference
-	private RoleLocalService _roleLocalService;
 
 	@Reference
 	private SharingEntryLocalService _sharingEntryLocalService;

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/model/listener/ObjectEntryModelListener.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/model/listener/ObjectEntryModelListener.java
@@ -10,43 +10,26 @@ import com.liferay.asset.kernel.model.AssetTag;
 import com.liferay.asset.kernel.service.AssetEntryLocalService;
 import com.liferay.asset.kernel.service.AssetTagLocalService;
 import com.liferay.depot.constants.DepotConstants;
-import com.liferay.depot.constants.DepotRolesConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.object.constants.ObjectDefinitionConstants;
-import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
-import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.rest.filter.factory.FilterFactory;
 import com.liferay.object.service.ObjectDefinitionLocalService;
-import com.liferay.object.service.ObjectEntryFolderLocalService;
 import com.liferay.petra.sql.dsl.expression.Predicate;
-import com.liferay.petra.string.CharPool;
 import com.liferay.portal.kernel.audit.AuditRouter;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
-import com.liferay.portal.kernel.json.JSONArray;
-import com.liferay.portal.kernel.json.JSONFactory;
-import com.liferay.portal.kernel.json.JSONObject;
-import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.ModelListener;
-import com.liferay.portal.kernel.model.ResourceConstants;
-import com.liferay.portal.kernel.model.Role;
-import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistryUtil;
-import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.service.GroupLocalService;
-import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
-import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
-import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.security.audit.event.generators.util.Attribute;
@@ -55,10 +38,8 @@ import com.liferay.portal.workflow.kaleo.model.KaleoTaskInstanceToken;
 import com.liferay.portal.workflow.kaleo.service.KaleoTaskInstanceTokenLocalService;
 import com.liferay.site.cms.site.initializer.util.CMSDefaultPermissionUtil;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 
 import org.osgi.service.component.annotations.Component;
@@ -77,7 +58,9 @@ public class ObjectEntryModelListener extends BaseModelListener<ObjectEntry> {
 		try {
 			if (_isCMSObjectEntry(objectEntry)) {
 				_route(objectEntry);
-				_setResourcePermissions(objectEntry);
+
+				CMSDefaultPermissionUtil.setObjectEntryResourcePermissions(
+					objectEntry, _filterFactory);
 			}
 		}
 		catch (Exception exception) {
@@ -114,7 +97,8 @@ public class ObjectEntryModelListener extends BaseModelListener<ObjectEntry> {
 			if (originalObjectEntry.getObjectEntryFolderId() !=
 					objectEntry.getObjectEntryFolderId()) {
 
-				_setResourcePermissions(objectEntry);
+				CMSDefaultPermissionUtil.setObjectEntryResourcePermissions(
+					objectEntry, _filterFactory);
 			}
 
 			Indexer<KaleoTaskInstanceToken> indexer =
@@ -133,75 +117,6 @@ public class ObjectEntryModelListener extends BaseModelListener<ObjectEntry> {
 		catch (Exception exception) {
 			throw new ModelListenerException(exception);
 		}
-	}
-
-	private JSONObject _getCMSDefaultPermissionJSONObject(
-			ObjectEntry objectEntry)
-		throws Exception {
-
-		ObjectDefinition cmsDefaultPermissionObjectDefinition =
-			_objectDefinitionLocalService.
-				fetchObjectDefinitionByExternalReferenceCode(
-					"L_CMS_DEFAULT_PERMISSION", objectEntry.getCompanyId());
-
-		if (cmsDefaultPermissionObjectDefinition == null) {
-			return null;
-		}
-
-		if (objectEntry.getObjectEntryFolderId() != 0) {
-			ObjectEntryFolder parentObjectEntryFolder =
-				_objectEntryFolderLocalService.getObjectEntryFolder(
-					objectEntry.getObjectEntryFolderId());
-
-			JSONObject jsonObject = CMSDefaultPermissionUtil.getJSONObject(
-				parentObjectEntryFolder.getCompanyId(),
-				parentObjectEntryFolder.getUserId(),
-				parentObjectEntryFolder.getExternalReferenceCode(),
-				parentObjectEntryFolder.getModelClassName(), _filterFactory);
-
-			if ((jsonObject != null) && !JSONUtil.isEmpty(jsonObject)) {
-				return jsonObject;
-			}
-		}
-
-		Group group = _groupLocalService.getGroup(objectEntry.getGroupId());
-
-		return CMSDefaultPermissionUtil.getJSONObject(
-			group.getCompanyId(), group.getCreatorUserId(),
-			group.getExternalReferenceCode(), DepotEntry.class.getName(),
-			_filterFactory);
-	}
-
-	private ObjectEntryFolder _getRootObjectEntryFolder(
-		ObjectEntry objectEntry) {
-
-		ObjectEntryFolder objectEntryFolder =
-			_objectEntryFolderLocalService.fetchObjectEntryFolder(
-				objectEntry.getObjectEntryFolderId());
-
-		if (objectEntryFolder == null) {
-			return null;
-		}
-
-		if (Objects.equals(
-				objectEntryFolder.getExternalReferenceCode(),
-				ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS) ||
-			Objects.equals(
-				objectEntryFolder.getExternalReferenceCode(),
-				ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_FILES)) {
-
-			return objectEntryFolder;
-		}
-
-		String[] parts = StringUtil.split(
-			objectEntryFolder.getTreePath(), CharPool.SLASH);
-
-		if (parts.length <= 2) {
-			return null;
-		}
-
-		return _objectEntryFolderLocalService.fetchObjectEntryFolder(
-			GetterUtil.getLong(parts[1]));
 	}
 
 	private boolean _isCMSObjectEntry(ObjectEntry objectEntry)
@@ -323,64 +238,6 @@ public class ObjectEntryModelListener extends BaseModelListener<ObjectEntry> {
 		}
 	}
 
-	private void _setResourcePermissions(ObjectEntry objectEntry)
-		throws Exception {
-
-		JSONObject defaultPermissionsJSONObject =
-			_getCMSDefaultPermissionJSONObject(objectEntry);
-
-		if ((defaultPermissionsJSONObject == null) ||
-			JSONUtil.isEmpty(defaultPermissionsJSONObject)) {
-
-			return;
-		}
-
-		ObjectEntryFolder rootObjectEntryFolder = _getRootObjectEntryFolder(
-			objectEntry);
-
-		if (rootObjectEntryFolder == null) {
-			return;
-		}
-
-		JSONObject objectEntryJSONObject =
-			defaultPermissionsJSONObject.getJSONObject(
-				rootObjectEntryFolder.getExternalReferenceCode());
-
-		if (objectEntryJSONObject == null) {
-			return;
-		}
-
-		List<String> resourceActions = ResourceActionsUtil.getResourceActions(
-			objectEntry.getModelClassName());
-
-		List<Role> roles = _roleLocalService.getGroupRolesAndTeamRoles(
-			objectEntry.getCompanyId(), null,
-			Arrays.asList(
-				RoleConstants.ADMINISTRATOR,
-				DepotRolesConstants.ASSET_LIBRARY_OWNER),
-			null, null,
-			new int[] {RoleConstants.TYPE_REGULAR, RoleConstants.TYPE_DEPOT},
-			null, 0, 0, QueryUtil.ALL_POS, QueryUtil.ALL_POS);
-
-		for (Role role : roles) {
-			JSONArray jsonArray = objectEntryJSONObject.getJSONArray(
-				role.getName());
-
-			if ((jsonArray == null) || JSONUtil.isEmpty(jsonArray)) {
-				jsonArray = _jsonFactory.createJSONArray();
-			}
-
-			_resourcePermissionLocalService.setResourcePermissions(
-				objectEntry.getCompanyId(), objectEntry.getModelClassName(),
-				ResourceConstants.SCOPE_INDIVIDUAL,
-				String.valueOf(objectEntry.getObjectEntryId()),
-				role.getRoleId(),
-				ArrayUtil.filter(
-					JSONUtil.toStringArray(jsonArray),
-					action -> resourceActions.contains(action)));
-		}
-	}
-
 	@Reference
 	private AssetEntryLocalService _assetEntryLocalService;
 
@@ -402,22 +259,10 @@ public class ObjectEntryModelListener extends BaseModelListener<ObjectEntry> {
 	private GroupLocalService _groupLocalService;
 
 	@Reference
-	private JSONFactory _jsonFactory;
-
-	@Reference
 	private KaleoTaskInstanceTokenLocalService
 		_kaleoTaskInstanceTokenLocalService;
 
 	@Reference
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;
-
-	@Reference
-	private ObjectEntryFolderLocalService _objectEntryFolderLocalService;
-
-	@Reference
-	private ResourcePermissionLocalService _resourcePermissionLocalService;
-
-	@Reference
-	private RoleLocalService _roleLocalService;
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95039

## What Is Being Fixed

In a CMS Space, using "Edit and Propagate Default Permissions" on a folder and confirming with "Save and propagate" completed without any UI error, but the configured permissions were never applied: neither the folders nor the content entries inside them received them. The action only updated the stored default permissions object entry; it never set the resource permissions on the existing folders and entries.

## How It Is Being Fixed

The logic that applies the CMS default permissions to a folder and to an entry, previously private to the model listeners, is moved into CMSDefaultPermissionUtil so it can be reused. After updating the default permissions object entry, the bulk selection action now resolves the object entry folder from that configuration and applies the folder's own (just updated) permissions to the folder itself and to every entry it contains, reusing the same logic the model listeners run at creation time. The bulk selection is already recursive across the folder subtree, so each descendant folder is handled by its own invocation.

## On Fetching Entries Without Pagination

The automated review flagged the use of `QueryUtil.ALL_POS` when fetching a folder's entries and suggested paginating to avoid a potential `OutOfMemoryError`. This intentionally follows the established convention for `ObjectEntryLocalService.getObjectEntryFolderObjectEntries`: every existing caller fetches with `QueryUtil.ALL_POS`, including the closest analog `BulkActionResourceImpl` (which recursively collects a folder subtree for bulk actions) and `DownloadObjectEntryFolderCMSServlet`. Paginating only this call site would make it the single inconsistent one; if pagination is desired it should be a cross-cutting change applied to all of those callers rather than introduced here in isolation.

## PR Check

**pr-check: PASS** — tested on `6f5c8ad0fe6353cf9e5d23aa9a24437d45fbe125`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |

<!-- pr-check {"result": "success", "sha": "6f5c8ad0fe6353cf9e5d23aa9a24437d45fbe125"} -->
