### PR TITLE
LPD-95031 Disable remote access to the headless delivery API

### DIFF
--- a/modules/apps/site/site-cms-standalone-site-initializer/build.gradle
+++ b/modules/apps/site/site-cms-standalone-site-initializer/build.gradle
@@ -2,6 +2,7 @@ dependencies {
 	compileOnly group: "com.liferay.jakarta.portlet", name: "com.liferay.jakarta.portlet-api", version: "4.0.0"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "jakarta.servlet", name: "jakarta.servlet-api", version: "6.0.0"
+	compileOnly group: "org.osgi", name: "org.osgi.service.cm", version: "1.6.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:application-list:application-list-api")
@@ -40,6 +41,7 @@ dependencies {
 	compileOnly project(":apps:site:site-api")
 	compileOnly project(":apps:site:site-memberships-api")
 	compileOnly project(":apps:staging:staging-api")
+	compileOnly project(":apps:static:portal-configuration:portal-configuration-persistence-api")
 	compileOnly project(":apps:style-book:style-book-api")
 	compileOnly project(":apps:template:template-api")
 	compileOnly project(":apps:translation:translation-api")

--- a/modules/apps/site/site-cms-standalone-site-initializer/src/main/java/com/liferay/site/cms/standalone/site/initializer/internal/configuration/persistence/listener/CMSVulcanConfigurationModelListener.java
+++ b/modules/apps/site/site-cms-standalone-site-initializer/src/main/java/com/liferay/site/cms/standalone/site/initializer/internal/configuration/persistence/listener/CMSVulcanConfigurationModelListener.java
@@ -1,0 +1,50 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.standalone.site.initializer.internal.configuration.persistence.listener;
+
+import com.liferay.portal.configuration.persistence.listener.ConfigurationModelListener;
+import com.liferay.portal.configuration.persistence.listener.ConfigurationModelListenerException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+
+import java.util.Dictionary;
+import java.util.Objects;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Adolfo Pérez
+ */
+@Component(
+	property = "model.class.name=com.liferay.portal.vulcan.internal.configuration.VulcanConfiguration",
+	service = ConfigurationModelListener.class
+)
+public class CMSVulcanConfigurationModelListener
+	implements ConfigurationModelListener {
+
+	@Override
+	public void onBeforeSave(String pid, Dictionary<String, Object> properties)
+		throws ConfigurationModelListenerException {
+
+		if (!Objects.equals(properties.get("path"), "/headless-delivery") ||
+			!FeatureFlagManagerUtil.isEnabled(
+				PortalUtil.getDefaultCompanyId(), "LPD-17564")) {
+
+			return;
+		}
+
+		if (GetterUtil.getBoolean(properties.get("graphQLEnabled"), true) ||
+			GetterUtil.getBoolean(properties.get("restEnabled"), true)) {
+
+			throw new ConfigurationModelListenerException(
+				"Remote access to the headless delivery API cannot be " +
+					"enabled in the standalone CMS",
+				getClass(), getClass(), properties);
+		}
+	}
+
+}

--- a/modules/apps/site/site-cms-standalone-site-initializer/src/main/java/com/liferay/site/cms/standalone/site/initializer/internal/instance/lifecycle/CMSPortalInstanceLifecycleListener.java
+++ b/modules/apps/site/site-cms-standalone-site-initializer/src/main/java/com/liferay/site/cms/standalone/site/initializer/internal/instance/lifecycle/CMSPortalInstanceLifecycleListener.java
@@ -1,0 +1,58 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.standalone.site.initializer.internal.instance.lifecycle;
+
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.instance.lifecycle.BasePortalInstanceLifecycleListener;
+import com.liferay.portal.instance.lifecycle.PortalInstanceLifecycleListener;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Adolfo Pérez
+ */
+@Component(service = PortalInstanceLifecycleListener.class)
+public class CMSPortalInstanceLifecycleListener
+	extends BasePortalInstanceLifecycleListener {
+
+	@Override
+	public void portalInstanceRegistered(Company company) throws Exception {
+		if (!FeatureFlagManagerUtil.isEnabled(
+				company.getCompanyId(), "LPD-17564")) {
+
+			return;
+		}
+
+		Configuration configuration =
+			_configurationAdmin.createFactoryConfiguration(
+				"com.liferay.portal.vulcan.internal.configuration." +
+					"VulcanConfiguration",
+				StringPool.QUESTION);
+
+		configuration.update(
+			HashMapDictionaryBuilder.<String, Object>put(
+				"graphQLEnabled", false
+			).put(
+				"path", "/headless-delivery"
+			).put(
+				"restEnabled", false
+			).build());
+	}
+
+	@Reference
+	private ConfigurationAdmin _configurationAdmin;
+
+	@Reference(target = ModuleServiceLifecycle.PORTAL_INITIALIZED)
+	private ModuleServiceLifecycle _moduleServiceLifecycle;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95031

## What Is Being Fixed

The standalone CMS must not expose the headless delivery REST and GraphQL endpoints to remote clients. The bundles cannot simply be removed, because the bundle site initializer imports content (blog postings, documents, knowledge base articles, structured content folders, and so on) through the headless delivery resource factories, and removing them would require a major refactor of the site initializer extender.

## How It Is Being Fixed

A portal instance lifecycle listener, gated on the LPD-17564 feature flag and waiting for portal.initialized, saves a Vulcan headless API endpoint configuration for the /headless-delivery path with the REST and GraphQL APIs turned off. The Vulcan configuration listener reacts by disabling the JAX-RS application component, which severs HTTP and GraphQL routing while leaving the resource factory components available to local callers such as the bundle site initializer. Because the disable is applied imperatively on save and is not replayed when configurations load at startup, the configuration is recreated on every boot.

A second configuration listener guards that configuration: its onBeforeSave vetoes any save for the /headless-delivery path that would leave either API enabled, so an administrator cannot turn the REST or GraphQL API back on from System Settings. Saves that keep both APIs off, such as the lifecycle listener's own, are allowed.

## Why Are There No Tests?

The change is OSGi configuration glue deployed only in the standalone CMS build profile, and its behavior depends on the full Vulcan and headless delivery runtime, so coverage would require a heavyweight integration test the module is not set up for. It was verified manually on a running bundle: the headless delivery REST endpoints return 404 and the GraphQL operations are removed from the schema while the resource factories stay available to the bundle site initializer, the disable survives a server restart, and an attempt to re-enable the API through configuration is rejected.

## PR Check

**pr-check: PASS** — tested on `9d40ab28ec7577bb5526f0af741839228b5ec4e4`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Structural Smoke | PASS |

<!-- pr-check {"result": "success", "sha": "9d40ab28ec7577bb5526f0af741839228b5ec4e4"} -->
