### PR TITLE
LPD-95073 Show an error message when required categories are missing

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/components/ContentEditorSidePanel.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/components/ContentEditorSidePanel.tsx
@@ -74,6 +74,7 @@ type BaseScheduleData = {
 
 export type CategorizationFields = {
 	assetCategoryIds: {
+		error?: string;
 		serverValue: string;
 		value: IAssetObjectEntry['taxonomyCategoryBriefs'];
 	};
@@ -92,10 +93,9 @@ export type ScheduleFields = {
 	reviewDate: ScheduleFieldData;
 };
 
-export type UpdateCategorizationProps = [
-	keyof CategorizationFields,
-	CategorizationFields[keyof CategorizationFields],
-];
+export type UpdateCategorizationProps = {
+	[K in keyof CategorizationFields]: [K, Partial<CategorizationFields[K]>];
+}[keyof CategorizationFields];
 
 export type UpdateScheduleProps = BaseScheduleData & {
 	name: keyof ScheduleFields;
@@ -161,7 +161,9 @@ export default function ContentEditorSidePanel(props: Props) {
 	const onUpdateCategorization = useCallback(
 		([name, value]: UpdateCategorizationProps) => {
 			setCategorizationFields((fields) =>
-				fields ? {...fields, [name]: value} : fields
+				fields
+					? {...fields, [name]: {...fields[name], ...value}}
+					: fields
 			);
 		},
 		[]
@@ -312,10 +314,13 @@ export default function ContentEditorSidePanel(props: Props) {
 
 function SidePanel(props: SidePanelProps) {
 	const buttonRef = useRef<HTMLButtonElement>(null);
-	const [hasCategoriesError, setHasCategoriesError] =
-		useState<boolean>(false);
 	const [hasError, setHasError] = useState<boolean>(false);
 	const [panel, setPanel] = useState<React.Key | null>(null);
+
+	const showErrorInPanel = useCallback((panelId: React.Key) => {
+		setPanel(panelId);
+		setHasError(true);
+	}, []);
 
 	useEffect(() => {
 		const validateScheduleFields = ({event}: {event: MouseEvent}) => {
@@ -326,8 +331,7 @@ function SidePanel(props: SidePanelProps) {
 			if (hasError) {
 				event.preventDefault();
 
-				setPanel('schedule');
-				setHasError(true);
+				showErrorInPanel('schedule');
 			}
 		};
 
@@ -336,9 +340,22 @@ function SidePanel(props: SidePanelProps) {
 		return () => {
 			Liferay.detach(EVENT_VALIDATE_FORM, validateScheduleFields);
 		};
-	}, [props.scheduleFields]);
+	}, [props.scheduleFields, showErrorInPanel]);
+
+	const {onUpdateCategorization} = props;
 
 	useEffect(() => {
+		if (
+			props.categorizationFields?.assetCategoryIds?.error &&
+			props.requiredVocabularyIds &&
+			!hasMissingRequiredVocabulary(
+				props.categorizationFields,
+				props.requiredVocabularyIds
+			)
+		) {
+			onUpdateCategorization(['assetCategoryIds', {error: ''}]);
+		}
+
 		const validateCategorizationFields = ({event}: {event: MouseEvent}) => {
 			if (props.requiredVocabularyIds === null) {
 				event.preventDefault();
@@ -346,28 +363,24 @@ function SidePanel(props: SidePanelProps) {
 				return;
 			}
 
-			if (!props.requiredVocabularyIds.length) {
-				return;
-			}
-
-			const selectedVocabularyIds = new Set(
-				(props.categorizationFields?.assetCategoryIds?.value || []).map(
-					({embeddedTaxonomyCategory}) =>
-						embeddedTaxonomyCategory?.taxonomyVocabularyId
+			if (
+				hasMissingRequiredVocabulary(
+					props.categorizationFields,
+					props.requiredVocabularyIds
 				)
-			);
-
-			const hasMissingRequiredVocabulary =
-				props.requiredVocabularyIds.some(
-					(id) => !selectedVocabularyIds.has(id)
-				);
-
-			if (hasMissingRequiredVocabulary) {
+			) {
 				event.preventDefault();
 
-				setPanel('categorization');
-				setHasCategoriesError(true);
-				setHasError(true);
+				onUpdateCategorization([
+					'assetCategoryIds',
+					{
+						error: Liferay.Language.get(
+							'please-enter-at-least-one-category-for-all-mandatory-vocabularies'
+						),
+					},
+				]);
+
+				showErrorInPanel('categorization');
 			}
 		};
 
@@ -376,7 +389,12 @@ function SidePanel(props: SidePanelProps) {
 		return () => {
 			Liferay.detach(EVENT_VALIDATE_FORM, validateCategorizationFields);
 		};
-	}, [props.categorizationFields, props.requiredVocabularyIds]);
+	}, [
+		onUpdateCategorization,
+		props.categorizationFields,
+		props.requiredVocabularyIds,
+		showErrorInPanel,
+	]);
 
 	useEffect(() => {
 		if (hasError) {
@@ -384,16 +402,6 @@ function SidePanel(props: SidePanelProps) {
 			setHasError(false);
 		}
 	}, [hasError]);
-
-	useEffect(() => {
-		if (
-			hasCategoriesError &&
-			(props.categorizationFields?.assetCategoryIds?.value?.length || 0) >
-				0
-		) {
-			setHasCategoriesError(false);
-		}
-	}, [hasCategoriesError, props.categorizationFields]);
 
 	return (
 		<VerticalBar
@@ -440,14 +448,7 @@ function SidePanel(props: SidePanelProps) {
 								</div>
 							</div>
 
-							{item.id === 'categorization' ? (
-								<CategorizationPanel
-									{...props}
-									hasCategoriesError={hasCategoriesError}
-								/>
-							) : (
-								<Component {...props} />
-							)}
+							<Component {...props} />
 						</VerticalBar.Panel>
 					);
 				}}
@@ -537,4 +538,18 @@ function SubscribeButton({
 			title={title}
 		/>
 	);
+}
+
+function hasMissingRequiredVocabulary(
+	categorizationFields: CategorizationFields | null,
+	requiredVocabularyIds: number[]
+) {
+	const selectedVocabularyIds = new Set(
+		(categorizationFields?.assetCategoryIds?.value || []).map(
+			({embeddedTaxonomyCategory}) =>
+				embeddedTaxonomyCategory?.taxonomyVocabularyId
+		)
+	);
+
+	return requiredVocabularyIds.some((id) => !selectedVocabularyIds.has(id));
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/components/panels/CategorizationPanel.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/components/panels/CategorizationPanel.tsx
@@ -18,7 +18,6 @@ export default function CategorizationPanel({
 	categorizationFields,
 	cmsGroupId,
 	contentAPIURL,
-	hasCategoriesError = false,
 	hasUpdatePermission,
 	onUpdateCategorization,
 }: {
@@ -27,7 +26,6 @@ export default function CategorizationPanel({
 	categorizationFields: CategorizationFields | null;
 	cmsGroupId: number | string;
 	contentAPIURL: string;
-	hasCategoriesError?: boolean;
 	hasUpdatePermission: boolean;
 	onUpdateCategorization: (props: UpdateCategorizationProps) => void;
 }) {
@@ -57,6 +55,9 @@ export default function CategorizationPanel({
 		<div className="px-3">
 			<AssetCategorization
 				assetLibraryId={assetLibraryId}
+				categoriesErrorMessage={
+					categorizationFields?.assetCategoryIds?.error
+				}
 				categorization={{
 					keywords: categorizationFields?.assetTagNames?.value || [],
 					systemProperties: {
@@ -69,7 +70,6 @@ export default function CategorizationPanel({
 				}}
 				cmsGroupId={cmsGroupId}
 				getObjectEntryURL={contentAPIURL}
-				hasCategoriesError={hasCategoriesError}
 				hasUpdatePermission={hasUpdatePermission}
 				inputSize="sm"
 				onUpdateCategorization={updateCategorization}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/components/AssetCategories.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/components/AssetCategories.tsx
@@ -3,11 +3,13 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import ClayForm from '@clayui/form';
 import Label from '@clayui/label';
 import ClayPanel from '@clayui/panel';
 import {ItemSelector} from '@liferay/frontend-js-item-selector-web';
 import React, {useCallback, useMemo, useState} from 'react';
 
+import ErrorFeedback from '../../../common/components/forms/ErrorFeedback';
 import {
 	IAssetObjectEntry,
 	IGroupedTaxonomies,
@@ -20,7 +22,7 @@ import type {EntryCategorizationDTO} from '../services/ObjectEntryService';
 const AssetCategories = ({
 	cmsGroupId,
 	collapsable = true,
-	hasError = false,
+	errorMessage,
 	hasUpdatePermission,
 	inputSize,
 	objectEntry,
@@ -28,7 +30,7 @@ const AssetCategories = ({
 }: {
 	cmsGroupId: number | string;
 	collapsable?: boolean;
-	hasError?: boolean;
+	errorMessage?: string;
 	hasUpdatePermission?: boolean;
 	inputSize?: CategorizationInputSize;
 	objectEntry: IAssetObjectEntry | EntryCategorizationDTO;
@@ -172,7 +174,11 @@ const AssetCategories = ({
 			showCollapseIcon={collapsable}
 		>
 			<ClayPanel.Body>
-				<div className={hasError ? 'form-group has-error' : undefined}>
+				<div
+					className={
+						errorMessage ? 'form-group has-error' : undefined
+					}
+				>
 					<ItemSelector<any>
 						apiURL={apiURL}
 						disabled={!hasUpdatePermission}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/components/AssetCategories.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/components/AssetCategories.tsx
@@ -7,7 +7,7 @@ import ClayForm from '@clayui/form';
 import Label from '@clayui/label';
 import ClayPanel from '@clayui/panel';
 import {ItemSelector} from '@liferay/frontend-js-item-selector-web';
-import React, {useCallback, useMemo, useState} from 'react';
+import React, {useCallback, useId, useMemo, useState} from 'react';
 
 import ErrorFeedback from '../../../common/components/forms/ErrorFeedback';
 import {
@@ -37,6 +37,8 @@ const AssetCategories = ({
 	updateObjectEntry: (object: EntryCategorizationDTO) => void | Promise<void>;
 }) => {
 	const [value, setValue] = useState('');
+
+	const feedbackId = useId();
 
 	const apiURL = useMemo(() => {
 		const {
@@ -181,6 +183,7 @@ const AssetCategories = ({
 				>
 					<ItemSelector<any>
 						apiURL={apiURL}
+						aria-describedby={errorMessage ? feedbackId : undefined}
 						disabled={!hasUpdatePermission}
 						estimateSize={49}
 						items={selectedCategories}
@@ -226,6 +229,12 @@ const AssetCategories = ({
 							</ItemSelector.Item>
 						)}
 					</ItemSelector>
+
+					{errorMessage && (
+						<ClayForm.FeedbackGroup id={feedbackId} role="alert">
+							<ErrorFeedback message={errorMessage} />
+						</ClayForm.FeedbackGroup>
+					)}
 				</div>
 
 				{groupedTaxonomies.taxonomyVocabularies &&

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/components/AssetCategorization.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/components/AssetCategorization.tsx
@@ -26,19 +26,19 @@ export type CategorizationInputSize = ComponentProps<
 
 export default function AssetCategorization({
 	assetLibraryId,
+	categoriesErrorMessage,
 	categorization,
 	cmsGroupId,
 	getObjectEntryURL,
-	hasCategoriesError = false,
 	hasUpdatePermission,
 	inputSize,
 	onUpdateCategorization,
 }: {
 	assetLibraryId: number | string;
+	categoriesErrorMessage?: string;
 	categorization: Categorization;
 	cmsGroupId: number | string;
 	getObjectEntryURL: string;
-	hasCategoriesError?: boolean;
 	hasUpdatePermission: boolean;
 	inputSize?: CategorizationInputSize;
 	onUpdateCategorization?: (data: IAssetObjectEntry) => void;
@@ -153,7 +153,7 @@ export default function AssetCategorization({
 		<>
 			<AssetCategories
 				cmsGroupId={cmsGroupId}
-				hasError={hasCategoriesError}
+				errorMessage={categoriesErrorMessage}
 				hasUpdatePermission={hasUpdatePermission}
 				inputSize={inputSize}
 				objectEntry={objectEntry}

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/contentEditor.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/contentEditor.spec.ts
@@ -1213,6 +1213,12 @@ test.describe('Categorization Panel', () => {
 				).toBeFocused();
 
 				await expect(
+					page.getByText(
+						'Please enter at least one category for all mandatory vocabularies.'
+					)
+				).toBeVisible();
+
+				await expect(
 					page.locator('.label-item', {hasText: tagName})
 				).toBeAttached();
 
@@ -1230,6 +1236,12 @@ test.describe('Categorization Panel', () => {
 
 				await expect(
 					page.locator('.form-group.has-error')
+				).toBeHidden();
+
+				await expect(
+					page.getByText(
+						'Please enter at least one category for all mandatory vocabularies.'
+					)
 				).toBeHidden();
 
 				await contentsPage.publishButton.click();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95073

## What Is Being Fixed

When publishing CMS content that belongs to a vocabulary marked as required for all assets, the publish action is correctly blocked and the category input turns red, but no error message was displayed. The user was left without any explanation of why the content could not be saved.

## How It Is Being Fixed

The categories error is now stored inside the categorization field data, mirroring how the schedule fields carry their own error. When the form is validated on publish and a required vocabulary has no selected category, the validator writes the error message into the field and switches to the categorization panel; the message is rendered below the category input and cleared automatically once a category satisfies the requirement. The message is announced to screen readers through a `role="alert"` live region and associated with the input via `aria-describedby`, following the existing form-field convention. The side panel error handling was refactored to drop the duplicated boolean state and derive the panel error from the field data.

The Playwright test for the required-vocabulary flow was extended to assert that the error message text appears on a blocked publish and disappears once a category is selected.

## PR Check

**pr-check: PASS** — tested on `b8d719fdef19197d7dc8c95edc6430eee3e37001`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "b8d719fdef19197d7dc8c95edc6430eee3e37001"} -->
