### PR TITLE
LPD-94457 Fix XLIFF 1.2 import dropping empty intermediate segments

### DIFF
--- a/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/exporter/XLIFF12InfoFormTranslationExporter.java
+++ b/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/exporter/XLIFF12InfoFormTranslationExporter.java
@@ -26,6 +26,8 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
+import java.nio.charset.StandardCharsets;
+
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -124,14 +126,14 @@ public class XLIFF12InfoFormTranslationExporter
 
 			List<InfoFieldValue<Object>> infoFieldValues = entry.getValue();
 
-			StringBundler sb = new StringBundler(infoFieldValues.size() * 2);
+			StringBundler sb = new StringBundler(infoFieldValues.size());
 
 			for (InfoFieldValue<Object> infoFieldValue : infoFieldValues) {
-				sb.append(infoFieldValue.getValue(sourceLocale));
-				sb.append(StringPool.COMMA_AND_SPACE);
-			}
+				Object value = infoFieldValue.getValue(sourceLocale);
 
-			sb.setIndex(sb.index() - 1);
+				sb.append(
+					(value != null) ? value.toString() : StringPool.BLANK);
+			}
 
 			sourceElement.addCDATA(_getStringValue(sb));
 
@@ -180,9 +182,10 @@ public class XLIFF12InfoFormTranslationExporter
 			}
 		}
 
-		String formattedString = document.formattedString();
-
-		return new ByteArrayInputStream(formattedString.getBytes());
+		return new ByteArrayInputStream(
+			document.asXML(
+			).getBytes(
+				StandardCharsets.UTF_8));
 	}
 
 	@Override

--- a/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/exporter/XLIFF12InfoFormTranslationExporter.java
+++ b/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/exporter/XLIFF12InfoFormTranslationExporter.java
@@ -182,10 +182,9 @@ public class XLIFF12InfoFormTranslationExporter
 			}
 		}
 
-		return new ByteArrayInputStream(
-			document.asXML(
-			).getBytes(
-				StandardCharsets.UTF_8));
+		String xml = document.asXML();
+
+		return new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8));
 	}
 
 	@Override

--- a/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/snapshot/XLIFFTranslationSnapshotProvider.java
+++ b/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/snapshot/XLIFFTranslationSnapshotProvider.java
@@ -388,6 +388,10 @@ public class XLIFFTranslationSnapshotProvider
 					targetLocaleId);
 
 				for (TextPart targetTextPart : targetTextContainer.getParts()) {
+					if (!targetTextPart.isSegment()) {
+						continue;
+					}
+
 					TextFragment targetTextFragment =
 						targetTextPart.getContent();
 

--- a/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/snapshot/XLIFFTranslationSnapshotProvider.java
+++ b/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/snapshot/XLIFFTranslationSnapshotProvider.java
@@ -391,7 +391,7 @@ public class XLIFFTranslationSnapshotProvider
 					TextFragment targetTextFragment =
 						targetTextPart.getContent();
 
-					if (Validator.isNull(targetTextFragment.getText())) {
+					if (targetTextFragment.getText() == null) {
 						continue;
 					}
 

--- a/modules/apps/translation/translation-test/src/testIntegration/java/com/liferay/translation/info/item/updater/test/JournalArticleInfoItemFieldValuesUpdaterTest.java
+++ b/modules/apps/translation/translation-test/src/testIntegration/java/com/liferay/translation/info/item/updater/test/JournalArticleInfoItemFieldValuesUpdaterTest.java
@@ -207,102 +207,13 @@ public class JournalArticleInfoItemFieldValuesUpdaterTest {
 	public void testUpdateJournalArticleFromInfoItemFieldValuesPreservesEmptyIntermediateRepeatableField()
 		throws Exception {
 
-		JournalArticle journalArticle = _getRepeatableHtmlJournalArticle();
+		_testUpdateJournalArticleFromInfoItemFieldValuesPreservesEmptyIntermediateRepeatableField(
+			_getRepeatableHtmlJournalArticle(),
+			"test-journal-repeatable-html-empty-v12.xlf", "RichText");
 
-		_translationEntryLocalService.addOrUpdateTranslationEntry(
-			_group.getGroupId(), JournalArticle.class.getName(),
-			journalArticle.getResourcePrimKey(),
-			StringUtil.replace(
-				TranslationTestUtil.readFileToString(
-					"test-journal-repeatable-html-empty-v12.xlf"),
-				"[$JOURNAL_ARTICLE_ID$]",
-				String.valueOf(journalArticle.getResourcePrimKey())),
-			"application/xliff+xml", LocaleUtil.toLanguageId(LocaleUtil.SPAIN),
-			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
-
-		journalArticle = _journalArticleLocalService.fetchLatestArticle(
-			journalArticle.getResourcePrimKey());
-
-		DDMFormValues ddmFormValues = journalArticle.getDDMFormValues();
-
-		Map<String, List<DDMFormFieldValue>> ddmFormFieldValuesMap =
-			ddmFormValues.getDDMFormFieldValuesMap(true);
-
-		List<DDMFormFieldValue> ddmFormFieldValues = ddmFormFieldValuesMap.get(
-			"RichText");
-
-		Assert.assertEquals(
-			ddmFormFieldValues.toString(), 3, ddmFormFieldValues.size());
-
-		DDMFormFieldValue ddmFormFieldValue0 = ddmFormFieldValues.get(0);
-
-		Value value0 = ddmFormFieldValue0.getValue();
-
-		Assert.assertEquals("Valor A", value0.getString(LocaleUtil.SPAIN));
-
-		DDMFormFieldValue ddmFormFieldValue1 = ddmFormFieldValues.get(1);
-
-		Value value1 = ddmFormFieldValue1.getValue();
-
-		Assert.assertEquals(
-			StringPool.BLANK, value1.getString(LocaleUtil.SPAIN));
-
-		DDMFormFieldValue ddmFormFieldValue2 = ddmFormFieldValues.get(2);
-
-		Value value2 = ddmFormFieldValue2.getValue();
-
-		Assert.assertEquals("Valor C", value2.getString(LocaleUtil.SPAIN));
-	}
-
-	@Test
-	public void testUpdateJournalArticleFromInfoItemFieldValuesPreservesEmptyIntermediateRepeatableTextField()
-		throws Exception {
-
-		JournalArticle journalArticle = _getRepeatableTextJournalArticle();
-
-		_translationEntryLocalService.addOrUpdateTranslationEntry(
-			_group.getGroupId(), JournalArticle.class.getName(),
-			journalArticle.getResourcePrimKey(),
-			StringUtil.replace(
-				TranslationTestUtil.readFileToString(
-					"test-journal-repeatable-text-empty-v12.xlf"),
-				"[$JOURNAL_ARTICLE_ID$]",
-				String.valueOf(journalArticle.getResourcePrimKey())),
-			"application/xliff+xml", LocaleUtil.toLanguageId(LocaleUtil.SPAIN),
-			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
-
-		journalArticle = _journalArticleLocalService.fetchLatestArticle(
-			journalArticle.getResourcePrimKey());
-
-		DDMFormValues ddmFormValues = journalArticle.getDDMFormValues();
-
-		Map<String, List<DDMFormFieldValue>> ddmFormFieldValuesMap =
-			ddmFormValues.getDDMFormFieldValuesMap(true);
-
-		List<DDMFormFieldValue> ddmFormFieldValues = ddmFormFieldValuesMap.get(
-			"TextField");
-
-		Assert.assertEquals(
-			ddmFormFieldValues.toString(), 3, ddmFormFieldValues.size());
-
-		DDMFormFieldValue ddmFormFieldValue0 = ddmFormFieldValues.get(0);
-
-		Value value0 = ddmFormFieldValue0.getValue();
-
-		Assert.assertEquals("Valor A", value0.getString(LocaleUtil.SPAIN));
-
-		DDMFormFieldValue ddmFormFieldValue1 = ddmFormFieldValues.get(1);
-
-		Value value1 = ddmFormFieldValue1.getValue();
-
-		Assert.assertEquals(
-			StringPool.BLANK, value1.getString(LocaleUtil.SPAIN));
-
-		DDMFormFieldValue ddmFormFieldValue2 = ddmFormFieldValues.get(2);
-
-		Value value2 = ddmFormFieldValue2.getValue();
-
-		Assert.assertEquals("Valor C", value2.getString(LocaleUtil.SPAIN));
+		_testUpdateJournalArticleFromInfoItemFieldValuesPreservesEmptyIntermediateRepeatableField(
+			_getRepeatableTextJournalArticle(),
+			"test-journal-repeatable-text-empty-v12.xlf", "TextField");
 	}
 
 	@Test
@@ -608,6 +519,56 @@ public class JournalArticleInfoItemFieldValuesUpdaterTest {
 			TranslationTestUtil.readFileToString(
 				"test-journal-content-repeatable-text-three-fields.xml"),
 			ddmStructure.getStructureKey(), null);
+	}
+
+	private void
+			_testUpdateJournalArticleFromInfoItemFieldValuesPreservesEmptyIntermediateRepeatableField(
+				JournalArticle journalArticle, String xliffFileName,
+				String ddmFormFieldName)
+		throws Exception {
+
+		_translationEntryLocalService.addOrUpdateTranslationEntry(
+			_group.getGroupId(), JournalArticle.class.getName(),
+			journalArticle.getResourcePrimKey(),
+			StringUtil.replace(
+				TranslationTestUtil.readFileToString(xliffFileName),
+				"[$JOURNAL_ARTICLE_ID$]",
+				String.valueOf(journalArticle.getResourcePrimKey())),
+			"application/xliff+xml", LocaleUtil.toLanguageId(LocaleUtil.SPAIN),
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		journalArticle = _journalArticleLocalService.fetchLatestArticle(
+			journalArticle.getResourcePrimKey());
+
+		DDMFormValues ddmFormValues = journalArticle.getDDMFormValues();
+
+		Map<String, List<DDMFormFieldValue>> ddmFormFieldValuesMap =
+			ddmFormValues.getDDMFormFieldValuesMap(true);
+
+		List<DDMFormFieldValue> ddmFormFieldValues = ddmFormFieldValuesMap.get(
+			ddmFormFieldName);
+
+		Assert.assertEquals(
+			ddmFormFieldValues.toString(), 3, ddmFormFieldValues.size());
+
+		DDMFormFieldValue ddmFormFieldValue0 = ddmFormFieldValues.get(0);
+
+		Value value0 = ddmFormFieldValue0.getValue();
+
+		Assert.assertEquals("Valor A", value0.getString(LocaleUtil.SPAIN));
+
+		DDMFormFieldValue ddmFormFieldValue1 = ddmFormFieldValues.get(1);
+
+		Value value1 = ddmFormFieldValue1.getValue();
+
+		Assert.assertEquals(
+			StringPool.BLANK, value1.getString(LocaleUtil.SPAIN));
+
+		DDMFormFieldValue ddmFormFieldValue2 = ddmFormFieldValues.get(2);
+
+		Value value2 = ddmFormFieldValue2.getValue();
+
+		Assert.assertEquals("Valor C", value2.getString(LocaleUtil.SPAIN));
 	}
 
 	private static String _originalName;

--- a/modules/apps/translation/translation-test/src/testIntegration/java/com/liferay/translation/info/item/updater/test/JournalArticleInfoItemFieldValuesUpdaterTest.java
+++ b/modules/apps/translation/translation-test/src/testIntegration/java/com/liferay/translation/info/item/updater/test/JournalArticleInfoItemFieldValuesUpdaterTest.java
@@ -204,6 +204,108 @@ public class JournalArticleInfoItemFieldValuesUpdaterTest {
 	}
 
 	@Test
+	public void testUpdateJournalArticleFromInfoItemFieldValuesPreservesEmptyIntermediateRepeatableField()
+		throws Exception {
+
+		JournalArticle journalArticle = _getRepeatableHtmlJournalArticle();
+
+		_translationEntryLocalService.addOrUpdateTranslationEntry(
+			_group.getGroupId(), JournalArticle.class.getName(),
+			journalArticle.getResourcePrimKey(),
+			StringUtil.replace(
+				TranslationTestUtil.readFileToString(
+					"test-journal-repeatable-html-empty-v12.xlf"),
+				"[$JOURNAL_ARTICLE_ID$]",
+				String.valueOf(journalArticle.getResourcePrimKey())),
+			"application/xliff+xml", LocaleUtil.toLanguageId(LocaleUtil.SPAIN),
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		journalArticle = _journalArticleLocalService.fetchLatestArticle(
+			journalArticle.getResourcePrimKey());
+
+		DDMFormValues ddmFormValues = journalArticle.getDDMFormValues();
+
+		Map<String, List<DDMFormFieldValue>> ddmFormFieldValuesMap =
+			ddmFormValues.getDDMFormFieldValuesMap(true);
+
+		List<DDMFormFieldValue> ddmFormFieldValues = ddmFormFieldValuesMap.get(
+			"RichText");
+
+		Assert.assertEquals(
+			ddmFormFieldValues.toString(), 3, ddmFormFieldValues.size());
+
+		DDMFormFieldValue ddmFormFieldValue0 = ddmFormFieldValues.get(0);
+
+		Value value0 = ddmFormFieldValue0.getValue();
+
+		Assert.assertEquals("Valor A", value0.getString(LocaleUtil.SPAIN));
+
+		DDMFormFieldValue ddmFormFieldValue1 = ddmFormFieldValues.get(1);
+
+		Value value1 = ddmFormFieldValue1.getValue();
+
+		Assert.assertEquals(
+			StringPool.BLANK, value1.getString(LocaleUtil.SPAIN));
+
+		DDMFormFieldValue ddmFormFieldValue2 = ddmFormFieldValues.get(2);
+
+		Value value2 = ddmFormFieldValue2.getValue();
+
+		Assert.assertEquals("Valor C", value2.getString(LocaleUtil.SPAIN));
+	}
+
+	@Test
+	public void testUpdateJournalArticleFromInfoItemFieldValuesPreservesEmptyIntermediateRepeatableTextField()
+		throws Exception {
+
+		JournalArticle journalArticle = _getRepeatableTextJournalArticle();
+
+		_translationEntryLocalService.addOrUpdateTranslationEntry(
+			_group.getGroupId(), JournalArticle.class.getName(),
+			journalArticle.getResourcePrimKey(),
+			StringUtil.replace(
+				TranslationTestUtil.readFileToString(
+					"test-journal-repeatable-text-empty-v12.xlf"),
+				"[$JOURNAL_ARTICLE_ID$]",
+				String.valueOf(journalArticle.getResourcePrimKey())),
+			"application/xliff+xml", LocaleUtil.toLanguageId(LocaleUtil.SPAIN),
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		journalArticle = _journalArticleLocalService.fetchLatestArticle(
+			journalArticle.getResourcePrimKey());
+
+		DDMFormValues ddmFormValues = journalArticle.getDDMFormValues();
+
+		Map<String, List<DDMFormFieldValue>> ddmFormFieldValuesMap =
+			ddmFormValues.getDDMFormFieldValuesMap(true);
+
+		List<DDMFormFieldValue> ddmFormFieldValues = ddmFormFieldValuesMap.get(
+			"TextField");
+
+		Assert.assertEquals(
+			ddmFormFieldValues.toString(), 3, ddmFormFieldValues.size());
+
+		DDMFormFieldValue ddmFormFieldValue0 = ddmFormFieldValues.get(0);
+
+		Value value0 = ddmFormFieldValue0.getValue();
+
+		Assert.assertEquals("Valor A", value0.getString(LocaleUtil.SPAIN));
+
+		DDMFormFieldValue ddmFormFieldValue1 = ddmFormFieldValues.get(1);
+
+		Value value1 = ddmFormFieldValue1.getValue();
+
+		Assert.assertEquals(
+			StringPool.BLANK, value1.getString(LocaleUtil.SPAIN));
+
+		DDMFormFieldValue ddmFormFieldValue2 = ddmFormFieldValues.get(2);
+
+		Value value2 = ddmFormFieldValue2.getValue();
+
+		Assert.assertEquals("Valor C", value2.getString(LocaleUtil.SPAIN));
+	}
+
+	@Test
 	public void testUpdateJournalArticleFromInfoItemFieldValuesUpdatesNewField()
 		throws Exception {
 
@@ -463,6 +565,48 @@ public class JournalArticleInfoItemFieldValuesUpdaterTest {
 			_group.getGroupId(),
 			TranslationTestUtil.readFileToString(
 				"test-journal-content-one-field.xml"),
+			ddmStructure.getStructureKey(), null);
+	}
+
+	private JournalArticle _getRepeatableHtmlJournalArticle() throws Exception {
+		DDMFormDeserializerDeserializeRequest.Builder builder =
+			DDMFormDeserializerDeserializeRequest.Builder.newBuilder(
+				TranslationTestUtil.readFileToString(
+					"test-ddm-structure-repeatable-html.json"));
+
+		DDMFormDeserializerDeserializeResponse
+			ddmFormDeserializerDeserializeResponse =
+				_ddmFormDeserializer.deserialize(builder.build());
+
+		DDMStructure ddmStructure = DDMStructureTestUtil.addStructure(
+			_group.getGroupId(), JournalArticle.class.getName(),
+			ddmFormDeserializerDeserializeResponse.getDDMForm());
+
+		return JournalTestUtil.addArticleWithXMLContent(
+			_group.getGroupId(),
+			TranslationTestUtil.readFileToString(
+				"test-journal-content-repeatable-html-three-fields.xml"),
+			ddmStructure.getStructureKey(), null);
+	}
+
+	private JournalArticle _getRepeatableTextJournalArticle() throws Exception {
+		DDMFormDeserializerDeserializeRequest.Builder builder =
+			DDMFormDeserializerDeserializeRequest.Builder.newBuilder(
+				TranslationTestUtil.readFileToString(
+					"test-ddm-structure-repeatable-text.json"));
+
+		DDMFormDeserializerDeserializeResponse
+			ddmFormDeserializerDeserializeResponse =
+				_ddmFormDeserializer.deserialize(builder.build());
+
+		DDMStructure ddmStructure = DDMStructureTestUtil.addStructure(
+			_group.getGroupId(), JournalArticle.class.getName(),
+			ddmFormDeserializerDeserializeResponse.getDDMForm());
+
+		return JournalTestUtil.addArticleWithXMLContent(
+			_group.getGroupId(),
+			TranslationTestUtil.readFileToString(
+				"test-journal-content-repeatable-text-three-fields.xml"),
 			ddmStructure.getStructureKey(), null);
 	}
 

--- a/modules/apps/translation/translation-test/src/testIntegration/resources/com/liferay/translation/dependencies/test-ddm-structure-repeatable-html.json
+++ b/modules/apps/translation/translation-test/src/testIntegration/resources/com/liferay/translation/dependencies/test-ddm-structure-repeatable-html.json
@@ -1,0 +1,42 @@
+{
+	"availableLanguageIds": [
+		"en_US"
+	],
+	"defaultLanguageId": "en_US",
+	"definitionSchemaVersion": "2.0",
+	"fields": [
+		{
+			"dataType": "html",
+			"fieldNamespace": "ddm",
+			"indexType": "text",
+			"label": {
+				"en_US": "Rich Text"
+			},
+			"localizable": true,
+			"name": "RichText",
+			"nativeField": false,
+			"predefinedValue": {
+				"en_US": ""
+			},
+			"readOnly": false,
+			"repeatable": true,
+			"required": false,
+			"showLabel": true,
+			"tip": {
+				"en_US": ""
+			},
+			"tooltip": {
+				"en_US": ""
+			},
+			"type": "ddm-text-html",
+			"visibilityExpression": ""
+		}
+	],
+	"successPage": {
+		"body": {
+		},
+		"enabled": false,
+		"title": {
+		}
+	}
+}

--- a/modules/apps/translation/translation-test/src/testIntegration/resources/com/liferay/translation/dependencies/test-ddm-structure-repeatable-text.json
+++ b/modules/apps/translation/translation-test/src/testIntegration/resources/com/liferay/translation/dependencies/test-ddm-structure-repeatable-text.json
@@ -1,0 +1,51 @@
+{
+	"availableLanguageIds": [
+		"en_US"
+	],
+	"defaultLanguageId": "en_US",
+	"definitionSchemaVersion": "2.0",
+	"fields": [
+		{
+			"autocomplete": false,
+			"dataSourceType": "manual",
+			"dataType": "string",
+			"ddmDataProviderInstanceId": "[]",
+			"ddmDataProviderInstanceOutput": "[]",
+			"displayStyle": "singleline",
+			"fieldNamespace": "",
+			"fieldReference": "TextField",
+			"indexType": "keyword",
+			"label": {
+				"en_US": "Text Field"
+			},
+			"localizable": true,
+			"name": "TextField",
+			"nativeField": false,
+			"placeholder": {
+				"en_US": ""
+			},
+			"predefinedValue": {
+				"en_US": ""
+			},
+			"readOnly": false,
+			"repeatable": true,
+			"required": false,
+			"showLabel": true,
+			"tip": {
+				"en_US": ""
+			},
+			"tooltip": {
+				"en_US": ""
+			},
+			"type": "text",
+			"visibilityExpression": ""
+		}
+	],
+	"successPage": {
+		"body": {
+		},
+		"enabled": false,
+		"title": {
+		}
+	}
+}

--- a/modules/apps/translation/translation-test/src/testIntegration/resources/com/liferay/translation/dependencies/test-journal-content-repeatable-html-three-fields.xml
+++ b/modules/apps/translation/translation-test/src/testIntegration/resources/com/liferay/translation/dependencies/test-journal-content-repeatable-html-three-fields.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" standalone="no"?>
+
+<root available-locales="en_US" default-locale="en_US">
+	<request />
+	<dynamic-element index-type="keyword" name="RichText" repeatable="true" type="html">
+		<dynamic-content language-id="en_US"><![CDATA[Value A]]></dynamic-content>
+	</dynamic-element>
+	<dynamic-element index-type="keyword" name="RichText" repeatable="true" type="html">
+		<dynamic-content language-id="en_US"><![CDATA[]]></dynamic-content>
+	</dynamic-element>
+	<dynamic-element index-type="keyword" name="RichText" repeatable="true" type="html">
+		<dynamic-content language-id="en_US"><![CDATA[Value C]]></dynamic-content>
+	</dynamic-element>
+</root>

--- a/modules/apps/translation/translation-test/src/testIntegration/resources/com/liferay/translation/dependencies/test-journal-content-repeatable-text-three-fields.xml
+++ b/modules/apps/translation/translation-test/src/testIntegration/resources/com/liferay/translation/dependencies/test-journal-content-repeatable-text-three-fields.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" standalone="no"?>
+
+<root available-locales="en_US" default-locale="en_US">
+	<request />
+	<dynamic-element index-type="keyword" name="TextField" repeatable="true" type="text">
+		<dynamic-content language-id="en_US"><![CDATA[Value A]]></dynamic-content>
+	</dynamic-element>
+	<dynamic-element index-type="keyword" name="TextField" repeatable="true" type="text">
+		<dynamic-content language-id="en_US"><![CDATA[]]></dynamic-content>
+	</dynamic-element>
+	<dynamic-element index-type="keyword" name="TextField" repeatable="true" type="text">
+		<dynamic-content language-id="en_US"><![CDATA[Value C]]></dynamic-content>
+	</dynamic-element>
+</root>

--- a/modules/apps/translation/translation-test/src/testIntegration/resources/com/liferay/translation/dependencies/test-journal-repeatable-html-empty-v12.xlf
+++ b/modules/apps/translation/translation-test/src/testIntegration/resources/com/liferay/translation/dependencies/test-journal-repeatable-html-empty-v12.xlf
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+	<file datatype="plaintext" original="com.liferay.journal.model.JournalArticle:[$JOURNAL_ARTICLE_ID$]" source-language="en-US" target-language="es-ES" tool="Liferay">
+		<body>
+			<trans-unit id="JournalArticle_title">
+				<source xml:lang="en-US"><![CDATA[Test Article]]></source>
+				<target xml:lang="es-ES"><![CDATA[Test Article ES]]></target>
+			</trans-unit>
+			<trans-unit id="JournalArticle_description">
+				<source xml:lang="en-US"><![CDATA[]]></source>
+				<target xml:lang="es-ES"><![CDATA[]]></target>
+			</trans-unit>
+			<trans-unit id="DDMStructure_RichText">
+				<source xml:lang="en-US"><![CDATA[Value AValue C]]></source>
+				<seg-source>
+					<mrk mid="0" mtype="seg"><![CDATA[Value A]]></mrk>
+					<mrk mid="1" mtype="seg"><![CDATA[]]></mrk>
+					<mrk mid="2" mtype="seg"><![CDATA[Value C]]></mrk>
+				</seg-source>
+				<target xml:lang="es-ES">
+					<mrk mid="0" mtype="seg"><![CDATA[Valor A]]></mrk>
+					<mrk mid="1" mtype="seg"><![CDATA[]]></mrk>
+					<mrk mid="2" mtype="seg"><![CDATA[Valor C]]></mrk>
+				</target>
+			</trans-unit>
+		</body>
+	</file>
+</xliff>

--- a/modules/apps/translation/translation-test/src/testIntegration/resources/com/liferay/translation/dependencies/test-journal-repeatable-text-empty-v12.xlf
+++ b/modules/apps/translation/translation-test/src/testIntegration/resources/com/liferay/translation/dependencies/test-journal-repeatable-text-empty-v12.xlf
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+	<file datatype="plaintext" original="com.liferay.journal.model.JournalArticle:[$JOURNAL_ARTICLE_ID$]" source-language="en-US" target-language="es-ES" tool="Liferay">
+		<body>
+			<trans-unit id="JournalArticle_title">
+				<source xml:lang="en-US"><![CDATA[Test Article]]></source>
+				<target xml:lang="es-ES"><![CDATA[Test Article ES]]></target>
+			</trans-unit>
+			<trans-unit id="JournalArticle_description">
+				<source xml:lang="en-US"><![CDATA[]]></source>
+				<target xml:lang="es-ES"><![CDATA[]]></target>
+			</trans-unit>
+			<trans-unit id="DDMStructure_TextField">
+				<source xml:lang="en-US"><![CDATA[Value AValue C]]></source>
+				<seg-source>
+					<mrk mid="0" mtype="seg"><![CDATA[Value A]]></mrk>
+					<mrk mid="1" mtype="seg"><![CDATA[]]></mrk>
+					<mrk mid="2" mtype="seg"><![CDATA[Value C]]></mrk>
+				</seg-source>
+				<target xml:lang="es-ES">
+					<mrk mid="0" mtype="seg"><![CDATA[Valor A]]></mrk>
+					<mrk mid="1" mtype="seg"><![CDATA[]]></mrk>
+					<mrk mid="2" mtype="seg"><![CDATA[Valor C]]></mrk>
+				</target>
+			</trans-unit>
+		</body>
+	</file>
+</xliff>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94457

## What Is Being Fixed

When a repeatable field is exported and reimported via XLIFF 1.2, a field whose intermediate value is empty had its segments corrupted: the empty middle segment was dropped and the remaining values collapsed. The root cause was on the export side — the `<source>` element for repeatable fields was assembled by joining the values with `", "` (comma-space). Okapi validates that the concatenation of the `<mrk>` segments equals the `<source>` text, so `"Value AValue C"` did not match `"Value A, , Value C"` and Okapi fell back to the unsegmented source, losing the empty middle segment.

## How It Is Being Fixed

The `<source>` element is now built as a plain concatenation of the raw field values, matching what Okapi expects from the concatenation of the `<mrk>` segments. The document is serialized with compact XML output (`asXML`) so formatted whitespace between `<mrk>` elements is not counted as inter-segment content during Okapi's validation. On the import side, non-segment TextParts are skipped so repeatable fields with empty intermediate values round-trip correctly.

## Bot Review

The Brian-review bot left two comments on the CI-forward PR:

- Comment 1 (use `GetterUtil.getString` in the exporter): intentionally **not** applied. `GetterUtil.getString` trims and CRLF-normalizes String values, which would make the `<source>` diverge from the raw `(String)` cast used to build the `<mrk>` segments and reintroduce the exact Okapi source-vs-segment mismatch this ticket fixes. The original `value.toString()` with a null guard is the consistent and correct form.
- Comment 2 (consolidate the two near-identical empty-intermediate tests into a helper): applied — the HTML/RichText and Text/TextField cases now share a single helper called twice.

## PR Check

**pr-check: PASS** — tested on `7ed2807493075e4478074ebcb4c7f29cf572e42e`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "7ed2807493075e4478074ebcb4c7f29cf572e42e"} -->
