### PR TITLE
LPD-94758 Replace the selector with a Picker

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/css/components/InputGroupWithSelect.scss
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/css/components/InputGroupWithSelect.scss
@@ -1,8 +1,4 @@
 .input-group-with-select {
-	select.form-control {
-		z-index: 1;
-	}
-
 	.input-group-append .input-group-item > .form-control {
 		border-bottom-left-radius: 0;
 		border-top-left-radius: 0;

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/components/InputGroupWithSelect.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/components/InputGroupWithSelect.tsx
@@ -5,7 +5,8 @@
 
 import '../../../css/components/InputGroupWithSelect.scss';
 
-import ClayForm, {ClayInput, ClaySelectWithOption} from '@clayui/form';
+import {Option, Picker} from '@clayui/core';
+import ClayForm, {ClayInput} from '@clayui/form';
 import classNames from 'classnames';
 import React, {useId} from 'react';
 
@@ -18,6 +19,31 @@ export interface InputGroupWithSelectProps {
 	selectValue: string;
 }
 
+const SelectTrigger = React.forwardRef(
+	(
+		{
+			id,
+			label,
+			...otherProps
+		}: {
+			id: string;
+			label: string;
+		},
+		ref: React.Ref<HTMLButtonElement>
+	) => {
+		return (
+			<button
+				{...otherProps}
+				className="btn font-weight-semi-bold form-control form-control-select form-control-select-secondary rounded-left"
+				id={id}
+				ref={ref}
+			>
+				{label}
+			</button>
+		);
+	}
+);
+
 export function InputGroupWithSelect({
 	children,
 	className,
@@ -27,6 +53,10 @@ export function InputGroupWithSelect({
 	selectValue,
 }: InputGroupWithSelectProps) {
 	const selectId = useId();
+
+	const selectedOption = options.find(
+		(option) => option.value === selectValue
+	);
 
 	return (
 		<ClayForm.Group
@@ -40,15 +70,20 @@ export function InputGroupWithSelect({
 
 			<ClayInput.Group>
 				<ClayInput.GroupItem prepend shrink>
-					<ClaySelectWithOption
-						className="font-weight-semi-bold form-control form-control-select-secondary rounded-left"
+					<Picker
+						as={SelectTrigger}
 						id={selectId}
-						onChange={(event) => {
-							onSelectChange?.(event.target.value);
+						items={options}
+						label={selectedOption?.label ?? ''}
+						onSelectionChange={(key: React.Key) => {
+							onSelectChange?.(key as string);
 						}}
-						options={options}
-						value={selectValue}
-					/>
+						selectedKey={selectValue}
+					>
+						{(item: {label: string; value: string}) => (
+							<Option key={item.value}>{item.label}</Option>
+						)}
+					</Picker>
 				</ClayInput.GroupItem>
 
 				<ClayInput.GroupItem append>{children}</ClayInput.GroupItem>

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/spaces/SearcheableSpaceMembersList.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/spaces/SearcheableSpaceMembersList.test.tsx
@@ -78,6 +78,8 @@ describe('SearcheableSpaceMembersList', () => {
 	});
 
 	it('calls onSelectChange when the select value is changed', async () => {
+		jest.useRealTimers();
+
 		const onSelectChange = jest.fn();
 
 		render(
@@ -88,11 +90,11 @@ describe('SearcheableSpaceMembersList', () => {
 			/>
 		);
 
-		const select = screen.getByRole('combobox');
+		await userEvent.click(screen.getByRole('combobox'));
 
-		await userEvent.selectOptions(select, SelectOptions.GROUPS, {
-			delay: null,
-		});
+		await userEvent.click(
+			screen.getByRole('option', {name: SelectOptions.GROUPS})
+		);
 
 		expect(onSelectChange).toHaveBeenCalledWith(SelectOptions.GROUPS);
 		expect(onSelectChange).toHaveBeenCalledTimes(1);

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/spaces/SpaceConnectedSitesModal.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/spaces/SpaceConnectedSitesModal.test.tsx
@@ -564,9 +564,10 @@ describe('SpaceConnectedSitesModal', () => {
 				`${mockConnectedSiteTemplate.descriptiveName} (site-template)`
 			);
 
-			await userEvent.selectOptions(
-				screen.getByLabelText('sites'),
-				'site-templates'
+			await userEvent.click(screen.getByLabelText('sites'));
+
+			await userEvent.click(
+				screen.getByRole('option', {name: 'site-templates'})
 			);
 
 			await userEvent.click(
@@ -596,9 +597,10 @@ describe('SpaceConnectedSitesModal', () => {
 				screen.getByPlaceholderText('select-a-site')
 			).toBeInTheDocument();
 
-			await userEvent.selectOptions(
-				screen.getByLabelText('sites'),
-				'site-templates'
+			await userEvent.click(screen.getByLabelText('sites'));
+
+			await userEvent.click(
+				screen.getByRole('option', {name: 'site-templates'})
 			);
 
 			expect(
@@ -638,9 +640,10 @@ describe('SpaceConnectedSitesModal', () => {
 			renderComponent();
 			await waitForComponentRendering();
 
-			await userEvent.selectOptions(
-				screen.getByLabelText('sites'),
-				'site-templates'
+			await userEvent.click(screen.getByLabelText('sites'));
+
+			await userEvent.click(
+				screen.getByRole('option', {name: 'site-templates'})
 			);
 
 			await userEvent.click(
@@ -704,9 +707,10 @@ describe('SpaceConnectedSitesModal', () => {
 			renderComponent();
 			await waitForComponentRendering();
 
-			await userEvent.selectOptions(
-				screen.getByLabelText('sites'),
-				'site-templates'
+			await userEvent.click(screen.getByLabelText('sites'));
+
+			await userEvent.click(
+				screen.getByRole('option', {name: 'site-templates'})
 			);
 
 			await userEvent.click(
@@ -766,9 +770,10 @@ describe('SpaceConnectedSitesModal', () => {
 				)
 			).toBeInTheDocument();
 
-			await userEvent.selectOptions(
-				screen.getByLabelText('sites'),
-				'site-templates'
+			await userEvent.click(screen.getByLabelText('sites'));
+
+			await userEvent.click(
+				screen.getByRole('option', {name: 'site-templates'})
 			);
 
 			await userEvent.click(

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/spaces/SpaceMembersSelectOptions.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/spaces/SpaceMembersSelectOptions.test.tsx
@@ -59,9 +59,10 @@ describe('SpaceMembersSelectOptions', () => {
 
 		expect(onSelectChange).not.toHaveBeenCalled();
 
-		await userEvent.selectOptions(
-			screen.getByRole('combobox', {name: label}),
-			SelectOptions.GROUPS
+		await userEvent.click(screen.getByRole('combobox', {name: label}));
+
+		await userEvent.click(
+			screen.getByRole('option', {name: SelectOptions.GROUPS})
 		);
 
 		expect(onSelectChange).toHaveBeenCalledTimes(1);

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/spaces/SpaceMembersWithList.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/spaces/SpaceMembersWithList.test.tsx
@@ -205,9 +205,12 @@ describe('SpaceMembersWithList', () => {
 	it('lists user groups from a space', async () => {
 		render(<SpaceMembersWithList {...props} />);
 
-		await userEvent.selectOptions(
-			screen.getByRole('combobox', {name: 'add-people-to-collaborate'}),
-			SelectOptions.GROUPS
+		await userEvent.click(
+			screen.getByRole('combobox', {name: 'add-people-to-collaborate'})
+		);
+
+		await userEvent.click(
+			screen.getByRole('option', {name: SelectOptions.GROUPS})
 		);
 
 		const userGroupsList = screen.getByLabelText('who-has-access');
@@ -264,9 +267,12 @@ describe('SpaceMembersWithList', () => {
 			screen.getByText('add-members-to-this-space')
 		).toBeInTheDocument();
 
-		await userEvent.selectOptions(
-			screen.getByRole('combobox', {name: 'add-people-to-collaborate'}),
-			SelectOptions.GROUPS
+		await userEvent.click(
+			screen.getByRole('combobox', {name: 'add-people-to-collaborate'})
+		);
+
+		await userEvent.click(
+			screen.getByRole('option', {name: SelectOptions.GROUPS})
 		);
 
 		expect(screen.getByText('no-members-yet')).toBeInTheDocument();
@@ -307,11 +313,14 @@ describe('SpaceMembersWithList', () => {
 	it('excludes added group members from the autocomplete list', async () => {
 		render(<SpaceMembersWithList {...props} />);
 
-		await userEvent.selectOptions(
+		await userEvent.click(
 			screen.getByRole('combobox', {
 				name: 'add-people-to-collaborate',
-			}),
-			SelectOptions.GROUPS
+			})
+		);
+
+		await userEvent.click(
+			screen.getByRole('option', {name: SelectOptions.GROUPS})
 		);
 
 		const input = screen.getByPlaceholderText('enter-name-or-email');
@@ -417,11 +426,14 @@ describe('SpaceMembersWithList', () => {
 		it('calls updateMemberRoles when a role for user group is changed', async () => {
 			render(<SpaceMembersWithList {...props} />);
 
-			await userEvent.selectOptions(
+			await userEvent.click(
 				screen.getByRole('combobox', {
 					name: 'add-people-to-collaborate',
-				}),
-				SelectOptions.GROUPS
+				})
+			);
+
+			await userEvent.click(
+				screen.getByRole('option', {name: SelectOptions.GROUPS})
 			);
 
 			const groupItem = await screen.findByText(testUserGroups[0].name);

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/pages/SpaceSummaryPage.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/pages/SpaceSummaryPage.ts
@@ -119,9 +119,16 @@ export class SpaceSummaryPage {
 
 		const dialog = this.page.getByRole('dialog');
 
-		await dialog
+		await this.page
 			.getByLabel('Add People to Collaborate', {exact: true})
-			.selectOption(type);
+			.click();
+
+		await this.page
+			.getByRole('option', {
+				exact: true,
+				name: type === 'groups' ? 'Groups' : 'Users',
+			})
+			.click();
 
 		const input = dialog.getByPlaceholder('Enter name or email.', {
 			exact: true,
@@ -150,9 +157,17 @@ export class SpaceSummaryPage {
 		await this.viewAllMembersLink.click();
 
 		await this.page.getByRole('dialog').waitFor();
+
 		await this.page
 			.getByLabel('Add People to Collaborate', {exact: true})
-			.selectOption(type);
+			.click();
+
+		await this.page
+			.getByRole('option', {
+				exact: true,
+				name: type === 'groups' ? 'Groups' : 'Users',
+			})
+			.click();
 
 		await this.page
 			.locator('li')
@@ -210,9 +225,11 @@ export class SpaceSummaryPage {
 	async connectSite(siteName: string) {
 		await this.openConnectSitesDialog();
 
+		await this.page.getByLabel('Sites', {exact: true}).click();
+
 		await this.page
-			.getByLabel('Sites', {exact: true})
-			.selectOption('sites');
+			.getByRole('option', {exact: true, name: 'Sites'})
+			.click();
 
 		await this.page
 			.getByPlaceholder('Select a Site', {exact: true})
@@ -233,9 +250,11 @@ export class SpaceSummaryPage {
 	async connectSiteTemplate(siteTemplateName: string) {
 		await this.openConnectSitesDialog();
 
+		await this.page.getByLabel('Sites', {exact: true}).click();
+
 		await this.page
-			.getByLabel('Sites', {exact: true})
-			.selectOption('site-templates');
+			.getByRole('option', {exact: true, name: 'Site Templates'})
+			.click();
 
 		await this.page
 			.getByPlaceholder('Select a Site Template', {exact: true})

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/connectSiteTemplates.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/connectSiteTemplates.spec.ts
@@ -292,9 +292,11 @@ test(
 
 		await spaceSummaryPage.openConnectedSitesModal();
 
+		await page.getByLabel('Sites', {exact: true}).click();
+
 		await page
-			.getByLabel('Sites', {exact: true})
-			.selectOption('site-templates');
+			.getByRole('option', {exact: true, name: 'Site Templates'})
+			.click();
 
 		const siteTemplateAutocomplete = page.getByPlaceholder(
 			'Select a Site Template',
@@ -329,7 +331,9 @@ test(
 			page.getByRole('option', {exact: true, name: connectedTemplateName})
 		).toHaveCount(0);
 
-		await page.getByLabel('Sites', {exact: true}).selectOption('sites');
+		await page.getByLabel('Sites', {exact: true}).click();
+
+		await page.getByRole('option', {exact: true, name: 'Sites'}).click();
 
 		await page.getByPlaceholder('Select a Site', {exact: true}).click();
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94758

## What Is Being Fixed

The "Connect sites and site templates to this space" and "Add People to Collaborate" controls in the spaces UI used a native HTML select (ClaySelectWithOption) as the prepended selector inside the input group. The selector is migrated to Clay's accessible Picker for consistency with the design system.

## How It Is Being Fixed

The native select in InputGroupWithSelect is replaced with the Picker from @clayui/core, rendering an accessible button plus listbox while preserving the input-group join (prepend item and the existing border-radius styling). The affected Jest suites are updated to drive the Picker — clicking the combobox and then the option instead of selectOptions — adding the ResizeObserver mock and real timers where the Picker menu opens. The Playwright SpaceSummaryPage page object and the connectSiteTemplates spec are adapted to the same click-then-option interaction.

## Why Are There No Tests?

This is a UI refactor of an existing component already covered by Jest and Playwright suites. The migration preserves behavior, so the existing tests are adapted to drive the Picker rather than the native select, keeping the same coverage; no new behavior was introduced that would warrant new tests.

## PR Check

**pr-check: PASS** — tested on `1a298d74055f055574bf35d9acfa6b6603d0b81b`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "1a298d74055f055574bf35d9acfa6b6603d0b81b"} -->
