### PR TITLE
LPD-95307 Fix questions-web Playwright Tags selectors

### DIFF
--- a/modules/test/playwright/tests/questions-web/main/pages/QuestionsPage.ts
+++ b/modules/test/playwright/tests/questions-web/main/pages/QuestionsPage.ts
@@ -34,7 +34,7 @@ export class QuestionsPage {
 			.fill(questionBody);
 		await fillAndClickOutside(
 			this.page,
-			this.page.getByLabel('Tags', {exact: true}),
+			this.page.getByRole('combobox', {name: 'Tags'}),
 			tagName
 		);
 		await this.page.getByLabel('Source').click();
@@ -88,7 +88,7 @@ export class QuestionsPage {
 			.fill(questionBody);
 		await this.page.getByLabel('Source').click();
 
-		const tagsInput = this.page.getByLabel('Tags', {exact: true});
+		const tagsInput = this.page.getByRole('combobox', {name: 'Tags'});
 
 		for (const tagName of tagNames) {
 			await tagsInput.fill(tagName);

--- a/modules/test/playwright/tests/questions-web/main/questionsSubscriptions.spec.ts
+++ b/modules/test/playwright/tests/questions-web/main/questionsSubscriptions.spec.ts
@@ -97,7 +97,7 @@ test(
 
 		// The user can unsubscribe from the tag
 
-		await page.locator('.navbar').getByText('Tags', {exact: true}).click();
+		await page.locator('a').filter({hasText: 'Tags'}).click();
 
 		await page.getByLabel('Subscribed', {exact: true}).click();
 

--- a/modules/test/playwright/tests/questions-web/main/questionsTags.spec.ts
+++ b/modules/test/playwright/tests/questions-web/main/questionsTags.spec.ts
@@ -55,7 +55,7 @@ test(
 			.fill(getRandomString());
 		await page.getByLabel('Source').click();
 
-		const tagsInput = page.getByLabel('Tags', {exact: true});
+		const tagsInput = page.getByRole('combobox', {name: 'Tags'});
 
 		for (let i = 0; i < 5; i++) {
 			await tagsInput.fill(getRandomString());
@@ -369,7 +369,7 @@ test(
 			.fill(getRandomString());
 		await page.getByLabel('Source').click();
 
-		const tagsInput = page.getByLabel('Tags', {exact: true});
+		const tagsInput = page.getByRole('combobox', {name: 'Tags'});
 
 		await tagsInput.fill('<script>alert(123);</script>');
 		await tagsInput.press('Enter');


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95307

## What Is Being Fixed

The Playwright tests under `questions-web` (`questionsTags` and
`questionsSubscriptions`) were failing because their locators no longer matched
the current Questions UI. The Tags input is now rendered as a combobox, so
`getByLabel('Tags', {exact: true})` no longer resolves it, and the navbar "Tags"
link was no longer reachable through the previous `.navbar` text locator.

## How It Is Being Fixed

The Tags input locators in `QuestionsPage` and in the
`questionsTags`/`questionsSubscriptions` specs were updated to
`getByRole('combobox', {name: 'Tags'})`, matching the field's current role. The
navbar unsubscribe step now selects the link with
`page.locator('a').filter({hasText: 'Tags'})`. These are locator-only changes;
the test flows and assertions are unchanged.

## PR Check

**pr-check: PASS** — tested on `dc6ddda3285e491a197957a6f2908abcc960eab0`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "dc6ddda3285e491a197957a6f2908abcc960eab0"} -->
