### PR TITLE
LPD-95405 Fix failing JS unit tests

### DIFF
--- a/modules/apps/content-dashboard/content-dashboard-web/test/js/components/SidebarPanelInfoView/__snapshots__/SidebarPanelInfoView.test.js.snap
+++ b/modules/apps/content-dashboard/content-dashboard-web/test/js/components/SidebarPanelInfoView/__snapshots__/SidebarPanelInfoView.test.js.snap
@@ -210,7 +210,6 @@ exports[`SidebarPanelInfoView renders 1`] = `
             innerprops="[object Object]"
           >
             <li
-              aria-controls="clay-dropdown-menu-1"
               aria-expanded="false"
               aria-haspopup="true"
               class="nav-item dropdown-toggle"

--- a/modules/apps/document-library/document-library-video/test/DLVideoExternalShortcutURLItemSelectorView.tsx
+++ b/modules/apps/document-library/document-library-video/test/DLVideoExternalShortcutURLItemSelectorView.tsx
@@ -116,6 +116,7 @@ describe('DLVideoExternalShortcutURLItemSelectorView', () => {
 							value: {
 								html: responseFields.HTML,
 								title: responseFields.TITLE,
+								url: responseFields.URL,
 							},
 						},
 					}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95405

## What Is Being Fixed

Two frontend unit tests were failing because their expectations no longer matched the current component output. In content-dashboard-web, the `SidebarPanelInfoView` snapshot still expected an `aria-controls="clay-dropdown-menu-1"` attribute on the dropdown toggle that Clay no longer renders. In document-library-video, the `DLVideoExternalShortcutURLItemSelectorView` test asserted the fired value without the `url` field that the component now includes.

## How It Is Being Fixed

The `SidebarPanelInfoView` snapshot is regenerated to drop the obsolete `aria-controls` attribute, and the `DLVideoExternalShortcutURLItemSelectorView` test's expected value gains the `url: responseFields.URL` entry so it matches what the component fires. Both changes are confined to test code and realign the assertions with current behavior.

## PR Check

**pr-check: PASS** — tested on `7730da26ddbf0728ebc5e7a922c26a70ca9856ac`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "7730da26ddbf0728ebc5e7a922c26a70ca9856ac"} -->
