### PR TITLE
LPD-94507 Retry the default permission checkbox check on re-render

### DIFF
--- a/modules/test/playwright/tests/site-cms-site-initializer/permissions/pages/DefaultPermissionsPage.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/permissions/pages/DefaultPermissionsPage.ts
@@ -37,11 +37,19 @@ export class DefaultPermissionsPage {
 		await expect(this.permissionsModal).toBeVisible();
 
 		for (const permission of permissions) {
-			await this.permissionsModal
-				.getByTestId(
-					`row-checkbox-${permission.role}_${permission.action}`
-				)
-				.check();
+			const checkbox = this.permissionsModal.getByTestId(
+				`row-checkbox-${permission.role}_${permission.action}`
+			);
+
+			// The permissions table can re-render right after the modal opens,
+			// detaching the checkbox mid-click. Retry until the check sticks so
+			// the row re-resolves against the latest render.
+
+			await expect(async () => {
+				await checkbox.check({timeout: 5000});
+
+				await expect(checkbox).toBeChecked({timeout: 5000});
+			}).toPass({timeout: 15000});
 		}
 
 		if (propagate) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94507

## What Is Being Fixed

The `@LPD-94507` Playwright test "Folder default permission management works after changing the Space ERC" is flaky. Across 19 baseline runs it failed once (~5%) at the checkbox `.check()` in `DefaultPermissionsPage.checkPermissionsAndSave`, after the modal-visible assertion had already passed, with the page captured mid-re-render. The default permissions table re-renders just after the modal opens, detaching the checkbox while Playwright clicks it, so the action hits a stale element.

## How It Is Being Fixed

The checkbox interaction is wrapped in `expect(async () => {...}).toPass()` with explicit per-call timeouts, the repo's documented pattern for this class of flake. On each retry the locator re-resolves against the latest render and the check is confirmed with `toBeChecked`, so a transient detach is retried instead of failing the test. The change preserves the original regression signal: if the checkbox is ever disabled again (the bug this ticket fixed), `check()` still cannot change its state and the test fails. Verified with 26 consecutive green repeat-runs after the change, versus the 1-in-19 failure rate before.

## Why Are There No Tests?

The change is a reliability fix to the existing `@LPD-94507` Playwright test's page object; it adds no production behavior, so there is nothing new to cover. It is validated by repeat-running the existing test 26 times without failure.

## PR Check

**pr-check: PASS** — tested on `e7ac1e7dc5c3cc30218d1c0732680bdc37aa5665`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "e7ac1e7dc5c3cc30218d1c0732680bdc37aa5665"} -->
