### PR TITLE
LPD-95424 Fix web content category helpers for inline selector modal

### DIFF
--- a/modules/test/playwright/tests/journal-web/main/pages/JournalEditArticlePage.ts
+++ b/modules/test/playwright/tests/journal-web/main/pages/JournalEditArticlePage.ts
@@ -161,21 +161,13 @@ export class JournalEditArticlePage {
 	}
 
 	async clearAllCategories(vocabulary: string) {
-		await this.openFieldSet('Categories', 'categorization');
+		await this.openFieldSet('Categorization', 'categorization');
 
 		await this.page
-			.getByRole('button', {name: `Select ${vocabulary}`})
-			.click();
-
-		const selectVocabularyIframe = this.page.frameLocator(
-			`iframe[title="Select ${vocabulary}"]`
-		);
-
-		await selectVocabularyIframe
+			.locator('.form-group')
+			.filter({has: this.page.getByLabel(vocabulary, {exact: true})})
 			.getByRole('button', {name: 'Clear All'})
 			.click();
-
-		await this.page.getByRole('button', {name: 'Done'}).click();
 	}
 
 	async createAndPublishBasicArticle(title?: string) {
@@ -509,24 +501,27 @@ export class JournalEditArticlePage {
 	}
 
 	async selectCategories(vocabulary: string, categories: string[]) {
-		await this.openFieldSet('Categories', 'categorization');
+		await this.openFieldSet('Categorization', 'categorization');
 
 		await this.page
 			.getByRole('button', {name: `Select ${vocabulary}`})
 			.click();
 
-		const selectVocabularyIframe = this.page.frameLocator(
-			`iframe[title="Select ${vocabulary}"]`
-		);
-
-		categories.forEach((category) => {
-			selectVocabularyIframe
-				.locator('li')
-				.filter({hasText: category})
-				.click();
+		const selectVocabularyModal = this.page.getByRole('dialog', {
+			name: `Select ${vocabulary}`,
 		});
 
-		await this.page.getByRole('button', {name: 'Done'}).click();
+		for (const category of categories) {
+			await expect(async () => {
+				await selectVocabularyModal
+					.locator('li')
+					.filter({hasText: category})
+					.getByRole('checkbox')
+					.check({timeout: 2000});
+			}).toPass({timeout: 10000});
+		}
+
+		await selectVocabularyModal.getByRole('button', {name: 'Done'}).click();
 	}
 
 	async selectSpecificDisplayPage(displayPageName: string) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95424

This is fixed because while working on https://github.com/liferay-page-management/liferay-portal/pull/18624 Claude detected the same issue on this test, so I fixed both.

## What Is Being Fixed

The JournalEditArticlePage Playwright helpers selectCategories and clearAllCategories drive web content categorization through an iframe-based category selector. The test "Can add and remove all categories from a Web Content" (@LPD-67395) fails on master because the "Select <vocabulary>" picker moved to the inline Clay TreeItemSelectorModal in LPD-88409 and categorization moved into the right-rail Properties panel.

## How It Is Being Fixed

selectCategories opens the Categorization section and selects categories in the inline dialog, mirroring the existing AccountCategorySelectorPage pattern. Because the new modal disables its Done button at zero selections, the old in-modal "Clear All then Done" flow can no longer commit an empty selection, so clearAllCategories now removes categories via the form's ClayMultiSelect Clear All control. Verified locally: @LPD-67395 passes.

The same LPD-88409 migration also broke the master pages categorization test (masterPagesEdition.spec.ts). Because that test is owned by the page management team, its fix is sent separately as LPD-95422; this PR is scoped to the content-owned web content categorization helpers so each team reviews its own area.

## Why Are There No Tests?

This change is itself a test-only fix — it repairs an existing Playwright page object broken by the LPD-88409 UI migration. There is no product code change, so no additional test coverage is warranted.

## PR Check

**pr-check: PASS** — tested on `ab73a0c25b101e3389b05c539cb1cdf20bb4d055`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "ab73a0c25b101e3389b05c539cb1cdf20bb4d055"} -->
