### PR TITLE
LPD-95045 Support obtaining hidden DLFolders through search

### DIFF
--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/spi/model/query/contributor/DLFolderModelPreFilterContributor.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/spi/model/query/contributor/DLFolderModelPreFilterContributor.java
@@ -8,6 +8,7 @@ package com.liferay.document.library.internal.search.spi.model.query.contributor
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.filter.BooleanFilter;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.search.spi.model.query.contributor.ModelPreFilterContributor;
 import com.liferay.portal.search.spi.model.registrar.ModelSearchSettings;
 
@@ -29,13 +30,17 @@ public class DLFolderModelPreFilterContributor
 		BooleanFilter booleanFilter, ModelSearchSettings modelSearchSettings,
 		SearchContext searchContext) {
 
-		addHiddenFilter(booleanFilter);
+		addHiddenFilter(booleanFilter, searchContext);
 		addWorkflowStatusFilter(
 			booleanFilter, modelSearchSettings, searchContext);
 	}
 
-	protected void addHiddenFilter(BooleanFilter booleanFilter) {
-		booleanFilter.addRequiredTerm(Field.HIDDEN, false);
+	protected void addHiddenFilter(
+		BooleanFilter booleanFilter, SearchContext searchContext) {
+
+		if (!GetterUtil.getBoolean(searchContext.getAttribute("showHidden"))) {
+			booleanFilter.addRequiredTerm(Field.HIDDEN, false);
+		}
 	}
 
 	protected void addWorkflowStatusFilter(

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/search/spi/model/query/contributor/test/DLFolderModelPreFilterContributorTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/search/spi/model/query/contributor/test/DLFolderModelPreFilterContributorTest.java
@@ -9,6 +9,7 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.filter.BooleanFilter;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.SearchContextTestUtil;
@@ -40,6 +41,7 @@ public class DLFolderModelPreFilterContributorTest {
 	}
 
 	@Test
+	@TestInfo("LPD-95045")
 	public void testContribute() throws Exception {
 		BooleanFilter booleanFilter = new BooleanFilter();
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/search/spi/model/query/contributor/test/DLFolderModelPreFilterContributorTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/search/spi/model/query/contributor/test/DLFolderModelPreFilterContributorTest.java
@@ -1,0 +1,78 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.document.library.internal.search.spi.model.query.contributor.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.search.filter.BooleanFilter;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.SearchContextTestUtil;
+import com.liferay.portal.search.spi.model.query.contributor.ModelPreFilterContributor;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Rubén Pulido
+ */
+@RunWith(Arquillian.class)
+public class DLFolderModelPreFilterContributorTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	public void testContribute() throws Exception {
+		BooleanFilter booleanFilter = new BooleanFilter();
+
+		SearchContext searchContext = SearchContextTestUtil.getSearchContext(
+			_group.getGroupId());
+
+		_dlFolderModelPreFilterContributor.contribute(
+			booleanFilter, null, searchContext);
+
+		String booleanFilterString = booleanFilter.toString();
+
+		Assert.assertTrue(
+			booleanFilterString, booleanFilterString.contains("hidden"));
+
+		booleanFilter = new BooleanFilter();
+
+		searchContext.setAttribute("showHidden", Boolean.TRUE);
+
+		_dlFolderModelPreFilterContributor.contribute(
+			booleanFilter, null, searchContext);
+
+		booleanFilterString = booleanFilter.toString();
+
+		Assert.assertFalse(
+			booleanFilterString, booleanFilterString.contains("hidden"));
+	}
+
+	@Inject(
+		filter = "indexer.class.name=com.liferay.document.library.kernel.model.DLFolder"
+	)
+	private ModelPreFilterContributor _dlFolderModelPreFilterContributor;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95045

This is a follow-up of https://github.com/brianchandotcom/liferay-portal/pull/177241, addressing the change Brian requested in https://github.com/brianchandotcom/liferay-portal/pull/177241#issuecomment-4756509902: remove `DLFolderSearchConstants` and use an inline constant instead.

## What Is Being Fixed

DLFolder search always applied a `hidden=false` filter, so hidden DLFolders could never be retrieved through search.

## How It Is Being Fixed

`DLFolderModelPreFilterContributor` now skips the hidden filter when the search context carries a `showHidden` attribute set to `true`; otherwise it still requires `hidden=false` as before. The `showHidden` attribute is referenced as an inline `"showHidden"` literal at both the production and test call sites rather than through a dedicated `DLFolderSearchConstants` API class, per Brian's review feedback. A new integration test, `DLFolderModelPreFilterContributorTest`, verifies both the default-filtered and `showHidden` paths.

## PR Check

**pr-check: PASS** — tested on `6b14c7ca288c0`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "6b14c7ca288c0217294907037d72fe207b4505a2"} -->
