### PR TITLE
LPD-95115 Reduce roles request payload in workflow assignments

### DIFF
--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/sidebar/sections/shared-components/BaseNotificationsInfo.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/sidebar/sections/shared-components/BaseNotificationsInfo.js
@@ -95,7 +95,7 @@ const BaseNotificationsInfo = ({
 			headers: HEADERS,
 		},
 		fetchPolicy: 'cache-first',
-		link: `${window.location.origin}${contextUrl}${userBaseURL}/roles?restrictFields=rolePermissions`,
+		link: `${window.location.origin}${contextUrl}${userBaseURL}/roles?fields=id,name,roleType`,
 		onNetworkStatusChange: setNetworkStatus,
 		variables: {
 			pageSize: -1,

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/sidebar/sections/shared-components/BaseRole.tsx
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/sidebar/sections/shared-components/BaseRole.tsx
@@ -52,8 +52,8 @@ export default function BaseRole({
 			setLoading(true);
 
 			const params = new URLSearchParams({
+				fields: 'id,name,roleType',
 				pageSize: '-1',
-				restrictedFields: 'rolePermissions',
 			});
 
 			const response = await fetch(

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/sidebar/sections/timers/select-reassignment/RoleType.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/sidebar/sections/timers/select-reassignment/RoleType.js
@@ -27,7 +27,7 @@ const RoleType = ({subSectionIdentifier, subSectionsLength, ...otherProps}) => {
 			headers: HEADERS,
 		},
 		fetchPolicy: 'cache-first',
-		link: `${window.location.origin}${contextUrl}${userBaseURL}/roles?restrictFields=rolePermissions`,
+		link: `${window.location.origin}${contextUrl}${userBaseURL}/roles?fields=id,name,roleType`,
 		onNetworkStatusChange: setNetworkStatus,
 		variables: {
 			pageSize: -1,

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/util/fetchUtil.ts
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/util/fetchUtil.ts
@@ -78,7 +78,7 @@ export function retrieveRoleById(roleId: number) {
 
 export function retrieveRoles() {
 	return fetch(
-		`${window.location.origin}${contextUrl}${userBaseURL}/roles?restrictFields=rolePermissions&pageSize=-1`,
+		`${window.location.origin}${contextUrl}${userBaseURL}/roles?fields=id,name,roleType&pageSize=-1`,
 		{
 			headers: HEADERS,
 			method: 'GET',

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/test/js/designer/definition-builder/diagram-builder/components/sidebar/sections/shared-components/BaseRole.spec.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/test/js/designer/definition-builder/diagram-builder/components/sidebar/sections/shared-components/BaseRole.spec.js
@@ -37,7 +37,7 @@ describe('The BaseRole component should', () => {
 		});
 
 		expect(frontendJSWebFetchSpier).toHaveBeenCalledWith(
-			'/o/headless-admin-user/v1.0/roles?pageSize=-1&restrictedFields=rolePermissions',
+			'/o/headless-admin-user/v1.0/roles?fields=id%2Cname%2CroleType&pageSize=-1',
 			expect.any(Object)
 		);
 	});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95115

## What Is Being Fixed

The role selector in the workflow node Assignments section requested
`/o/headless-admin-user/v1.0/roles` with `pageSize=-1` and
`restrictFields=rolePermissions`. `restrictFields` only drops a single field, so
every role was still returned in full — including the heavy `actions`,
`permissions`, and i18n maps — for all roles at once, which is the performance
issue reported when selecting a Role. In `BaseRole.tsx` and its spec the
parameter was additionally misspelled as `restrictedFields`, which Vulcan
ignores, so that call returned the entire role payload.

## How It Is Being Fixed

The four role-selector call sites now pass `fields=id,name,roleType` instead of
`restrictFields=rolePermissions`, whitelisting only the three properties the UI
consumes. `pageSize=-1` is kept on purpose: each selector loads the full list
once and filters client-side, so paginating would break the autocomplete
without a larger move to server-side search. The `BaseRole` jest spec is updated
to assert the new request.

## Why Are There No Tests?

The change is a query-parameter swap on existing fetch calls. Its effect —
a smaller response payload — is observable only at the network level (the
ticket's reproduction steps), not in a unit test; a jest test asserting the
literal request URL is a change-detector that mirrors the implementation string
rather than verifying behavior. The existing `BaseRole` spec is updated to keep
the suite green, and adding equivalent URL assertions to the other call sites
would be redundant.

## PR Check

**pr-check: PASS** — tested on `9cc6f1de12ab3be194e9db348fc537b4ad4f92e7`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "9cc6f1de12ab3be194e9db348fc537b4ad4f92e7"} -->
