### PR TITLE
LPD-95770 Assert folder membership is preserved on empty upsert

### DIFF
--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/object/definitions/portlet/action/test/ObjectFolderExportImportTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/object/definitions/portlet/action/test/ObjectFolderExportImportTest.java
@@ -127,10 +127,8 @@ public class ObjectFolderExportImportTest extends BaseExportImportTestCase {
 			"TestObjectFolder2",
 			Collections.singletonList("TESTOBJECTDEFINITION1"));
 		_assertObjectFolder(
-			0, Collections.emptyList(), "TestObjectFolder3",
-			Collections.emptyList());
-		_assertDefaultObjectFolder(
-			Collections.singletonList("TESTOBJECTDEFINITION1"),
+			2, Collections.singletonList("TESTOBJECTDEFINITION1"),
+			"TestObjectFolder3",
 			Collections.singletonList("TESTOBJECTDEFINITION2"));
 	}
 


### PR DESCRIPTION
### What

Updates the `ObjectFolderExportImportTest.testExportImportObjectFolder` integration test to match the behavior introduced by [LPD-89355](https://liferay.atlassian.net/browse/LPD-89355).

### Why

LPD-89355 (`b7a093679964b` — *Preserve folder membership on no-op upsert*) changed `ObjectFolderResourceImpl` to **skip eviction** when an upsert supplies no `objectFolderItems`, so the folder's existing object definitions are now preserved instead of being moved to the default folder.

The test was not updated alongside that change. Its *"duplicate external reference code"* scenario still asserted the old eviction behavior (`TestObjectFolder3` emptied to 0 items, definitions moved to the default folder), so it fails on a clean database:

```
java.lang.AssertionError: ... expected:<0> but was:<2>
  at ObjectFolderExportImportTest._assertObjectFolder(:226)
  at ObjectFolderExportImportTest.testExportImportObjectFolder(:129)
```

(On upgraded bundles the same test instead throws `IndexOutOfBoundsException` earlier, because the upgrade-created default folder is not indexed — which is why CI reported it as flaky rather than a hard failure.)

### Change

In the duplicate-ERC scenario, assert that `TestObjectFolder3` **keeps** its two object definitions (`TESTOBJECTDEFINITION1` linked, `TESTOBJECTDEFINITION2` unlinked). The retention assertion already proves no eviction happened, so the now-obsolete `_assertDefaultObjectFolder` check (which verified the eviction) is removed.

### Verification

`testExportImportObjectFolder` passes on a clean database against the corrected code (the `ObjectFolderResourceImpl` logic is byte-identical between `master` and the q1 release branch).

cc @adolfo.perez — this is the test counterpart to your LPD-89355 change. A matching fix for `release-2026.q1` will follow.